### PR TITLE
Allow sequence timelock to run down to 0

### DIFF
--- a/crates/spark/src/core/constants.rs
+++ b/crates/spark/src/core/constants.rs
@@ -24,14 +24,6 @@ pub fn next_sequence(current_sequence: Sequence) -> Option<Sequence> {
         return None;
     };
 
-    if new_blocks < TIME_LOCK_INTERVAL {
-        trace!(
-            "new_blocks {} is less than TIME_LOCK_INTERVAL {}, cannot calculate next sequence for {}",
-            new_blocks, TIME_LOCK_INTERVAL, current_sequence
-        );
-        return None;
-    }
-
     Some(to_sequence(new_blocks))
 }
 
@@ -63,7 +55,7 @@ mod test {
     fn test_next_sequence() {
         let mut sequence = initial_sequence();
 
-        for i in 1u16..20 {
+        for i in 1u16..21 {
             let next = next_sequence(sequence);
             let next = next.unwrap();
             assert!(next.is_height_locked());
@@ -80,7 +72,7 @@ mod test {
             panic!("Expected a block height locktime");
         };
 
-        assert_eq!(height.value(), TIME_LOCK_INTERVAL);
+        assert_eq!(height.value(), 0);
         let next = next_sequence(sequence);
         assert!(next.is_none());
     }

--- a/crates/spark/src/services/models.rs
+++ b/crates/spark/src/services/models.rs
@@ -129,7 +129,7 @@ pub(crate) fn map_public_keys(
         )
         .map_err(|_| ServiceError::InvalidIdentifier)?;
         let public_key =
-            PublicKey::from_slice(&public_key).map_err(|_| ServiceError::InvalidPublicKey)?;
+            PublicKey::from_slice(public_key).map_err(|_| ServiceError::InvalidPublicKey)?;
         public_keys.insert(identifier, public_key);
     }
 
@@ -145,7 +145,7 @@ pub(crate) fn map_signature_shares(
             &hex::decode(identifier).map_err(|_| ServiceError::InvalidIdentifier)?,
         )
         .map_err(|_| ServiceError::InvalidIdentifier)?;
-        let signature_share = SignatureShare::deserialize(&signature_share)
+        let signature_share = SignatureShare::deserialize(signature_share)
             .map_err(|_| ServiceError::InvalidSignatureShare)?;
         signature_shares.insert(identifier, signature_share);
     }

--- a/crates/spark/src/services/timelock_manager.rs
+++ b/crates/spark/src/services/timelock_manager.rs
@@ -97,7 +97,7 @@ impl<S: Signer> TimelockManager<S> {
         let mut node_ids_to_nodes_map: HashMap<TreeNodeId, TreeNode> = HashMap::new();
         for node in query_nodes_response.nodes.values() {
             node_ids_to_nodes_map.insert(
-                TreeNodeId::from_str(&node.id).map_err(|e| ServiceError::ValidationError(e))?,
+                TreeNodeId::from_str(&node.id).map_err(ServiceError::ValidationError)?,
                 node.clone().try_into()?,
             );
         }
@@ -324,7 +324,7 @@ impl<S: Signer> TimelockManager<S> {
             ));
         }
 
-        Ok(response.nodes[0].clone().try_into()?)
+        response.nodes[0].clone().try_into()
     }
 
     /// Checks and extends timelock nodes if needed

--- a/crates/spark/src/tree/state.rs
+++ b/crates/spark/src/tree/state.rs
@@ -40,7 +40,7 @@ impl TreeState {
         for (key, reserved_leaves) in self.leaves_reservations.clone().iter() {
             // remove leaves not existing in the main pool
             let mut filtered_leaves: Vec<TreeNode> = reserved_leaves
-                .into_iter()
+                .iter()
                 .filter(|l| self.leaves.contains_key(&l.id))
                 .cloned()
                 .collect();

--- a/examples/spark-cli/src/command/leaves.rs
+++ b/examples/spark-cli/src/command/leaves.rs
@@ -1,5 +1,5 @@
 use clap::Subcommand;
-use spark_wallet::{SparkWallet, TreeNodeId};
+use spark_wallet::SparkWallet;
 
 use crate::config::Config;
 


### PR DESCRIPTION
To be inline with the JS SDK, we should allow the sequence timelock to run down to 0. 

@JssDWt @roeierez 