### PR TITLE
Re-export spark_wallet::models

### DIFF
--- a/crates/spark-wallet/src/lib.rs
+++ b/crates/spark-wallet/src/lib.rs
@@ -6,7 +6,7 @@ mod wallet;
 
 pub use config::*;
 pub use error::*;
-pub use model::TransferDirection;
+pub use model::*;
 pub use spark::{
     Network,
     address::SparkAddress,


### PR DESCRIPTION
Updated to main and saw more things needed to be re-exported, namely `PayLightningInvoiceResult` and its sub types. Just doing all of `model` to make things more future proof