### PR TITLE
Use builder only to create sdk instance

### DIFF
--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -11,5 +11,5 @@ pub use error::SdkError;
 pub use events::{EventEmitter, EventListener, SdkEvent};
 pub use models::*;
 pub use persist::{SqliteStorage, Storage};
-pub use sdk::{BreezSdk, connect, init_logging, parse_input};
+pub use sdk::{BreezSdk, default_config, default_storage, init_logging, parse_input};
 pub use sdk_builder::SdkBuilder;

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -259,8 +259,6 @@ impl From<Network> for SparkNetwork {
 #[derive(Debug, Clone)]
 pub struct Config {
     pub network: Network,
-    pub mnemonic: String,
-    pub data_dir: String,
 }
 
 /// Request to get the balance of the wallet

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -1,65 +1,45 @@
 use spark_wallet::DefaultSigner;
-use std::{path::PathBuf, str::FromStr, sync::Arc};
 use tokio::sync::watch;
 
-use crate::{
-    error::SdkError,
-    models::Config,
-    persist::{SqliteStorage, Storage},
-    sdk::BreezSdk,
-};
+use crate::{error::SdkError, models::Config, persist::Storage, sdk::BreezSdk};
 
 /// Builder for creating `BreezSdk` instances with customizable components.
 pub struct SdkBuilder {
     config: Config,
-    storage: Option<Arc<dyn Storage + Send + Sync>>,
+    mnemonic: String,
+    storage: Box<dyn Storage + Send + Sync>,
 }
 
 impl SdkBuilder {
     /// Creates a new `SdkBuilder` with the provided configuration.
-    pub fn new(config: Config) -> Self {
+    pub fn new(config: Config, mnemonic: String, storage: Box<dyn Storage + Send + Sync>) -> Self {
         SdkBuilder {
             config,
-            storage: None,
+            mnemonic,
+            storage,
         }
-    }
-
-    /// Sets a custom storage implementation.
-    #[must_use]
-    pub fn with_storage(mut self, storage: Arc<dyn Storage + Send + Sync>) -> Self {
-        self.storage = Some(storage);
-        self
     }
 
     /// Builds the `BreezSdk` instance with the configured components.
     pub async fn build(self) -> Result<BreezSdk, SdkError> {
         // Create the signer from mnemonic
-        let mnemonic = bip39::Mnemonic::parse(&self.config.mnemonic)
+        let mnemonic = bip39::Mnemonic::parse(&self.mnemonic)
             .map_err(|e| SdkError::GenericError(e.to_string()))?;
         let signer = DefaultSigner::new(&mnemonic.to_seed(""), self.config.network.clone().into())
             .map_err(|e| SdkError::GenericError(e.to_string()))?;
-
-        // Use provided storage or create default SqliteStorage
-        let storage = if let Some(storage) = self.storage {
-            storage
-        } else {
-            // Create default SQLite storage in the data directory
-            let db_path = PathBuf::from_str(&self.config.data_dir)?;
-            let storage = SqliteStorage::new(&db_path)?;
-            Arc::new(storage)
-        };
 
         let (shutdown_sender, shutdown_receiver) = watch::channel::<()>(());
         // Create the SDK instance
         let sdk = BreezSdk::new(
             self.config,
             signer,
-            storage,
+            self.storage.into(),
             shutdown_sender,
             shutdown_receiver,
         )
         .await?;
 
+        sdk.start()?;
         Ok(sdk)
     }
 }


### PR DESCRIPTION
In order to provide more flexibility also to the binding layer in implementing traits (such as Storage, Signer, ChainWatcher, etc...)
I am trying this approach of using the builder and some default helper functions.