### PR TITLE
Drop emsdk

### DIFF
--- a/.github/workflows/build-bindings-wasm.yml
+++ b/.github/workflows/build-bindings-wasm.yml
@@ -43,9 +43,6 @@ jobs:
           rustup target add wasm32-unknown-unknown
           cargo install wasm-pack
 
-      - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
-
       - name: Build Wasm packages
         working-directory: crates/breez-sdk/wasm
         run: make build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,9 +98,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
-
       - name: Run Clippy
         run: make wasm-clippy-check
 
@@ -114,9 +111,6 @@ jobs:
         uses: ./.github/actions/setup-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
 
       - name: Run Tests
         run: make wasm-test


### PR DESCRIPTION
emsdk was used by [`sqlite-wasm-rs`](https://crates.io/crates/sqlite-wasm-rs), which we dropped in #151 