### PR TITLE
Claim pending transfer on event stream reconnection

### DIFF
--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -21,7 +21,7 @@ use spark_wallet::{
     SparkWallet, WalletEvent, WalletTransfer,
 };
 use std::{str::FromStr, sync::Arc};
-use tracing::{error, info};
+use tracing::{error, info, trace};
 use web_time::{Duration, SystemTime};
 
 use tokio::sync::watch;
@@ -186,7 +186,8 @@ impl BreezSdk {
                     event = subscription.recv() => {
                         match event {
                             Ok(event) => {
-                                info!("Received event: {event:?}");
+                                info!("Received event: {event}");
+                                trace!("Received event: {:?}", event);
                                 sdk.handle_wallet_event(event);
                             }
                             Err(e) => {

--- a/crates/spark-wallet/src/model.rs
+++ b/crates/spark-wallet/src/model.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{
+    fmt::Display,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use bitcoin::{Transaction, secp256k1::PublicKey};
 use serde::{Deserialize, Serialize};
@@ -21,6 +24,16 @@ pub enum WalletEvent {
     StreamDisconnected,
     Synced,
     TransferClaimed(WalletTransfer),
+}
+
+impl Display for WalletEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let WalletEvent::TransferClaimed(transfer) = self {
+            write!(f, "TransferClaimed({})", transfer.id)
+        } else {
+            write!(f, "{:?}", self)
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/spark/src/events/models.rs
+++ b/crates/spark/src/events/models.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use tokio::sync::broadcast;
 
 use crate::{services::Transfer, tree::TreeNode};
@@ -11,4 +13,15 @@ pub enum SparkEvent {
     Disconnected,
     Transfer(Box<Transfer>),
     Deposit(Box<TreeNode>),
+}
+
+impl Display for SparkEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SparkEvent::Connected => write!(f, "Connected"),
+            SparkEvent::Disconnected => write!(f, "Disconnected"),
+            SparkEvent::Transfer(transfer) => write!(f, "Transfer({})", transfer.id),
+            SparkEvent::Deposit(deposit) => write!(f, "Deposit({})", deposit.id),
+        }
+    }
 }

--- a/crates/spark/src/ssp/graphql/client.rs
+++ b/crates/spark/src/ssp/graphql/client.rs
@@ -75,7 +75,7 @@ impl<S: Signer> GraphQLClient<S> {
 
         let status_code = response.status();
         let text = response.text().await?;
-        tracing::debug!("Response: {text:?}");
+        tracing::trace!("Response: {text:?}");
         if status_code.is_client_error() {
             return Err(GraphQLError::Network {
                 reason: text,
@@ -169,7 +169,7 @@ impl<S: Signer> GraphQLClient<S> {
             .decode(&challenge_response.get_challenge.protected_challenge)
             .map_err(|e| GraphQLError::serialization(e.to_string()))?;
 
-        tracing::debug!("Decoded challenge bytes: {}", challenge_bytes.len());
+        tracing::debug!("Decoded challenge bytes length: {}", challenge_bytes.len());
         // Sign the challenge with the identity key
         let signature = self
             .signer


### PR DESCRIPTION
This fixes an issue where, if a transfer is received while the stream is disconnected, we would miss the transfer event and not claim it (it would only be claimed on restart). Now, we attempt to claim pending transfers whenever we reconnect to the stream, ensuring that we gracefully handle any missed events.

Previously, we stored the IDs of transfers claimed on startup to ensure we didn't attempt to claim them again if we received an event for them. Now there's no protection against it. In my tests, I never received an event for a transfer that was received while offline or disconnected; however, if this does happen, we shouldn't encounter any issues. The background processor processes events sequentially, so it won't ever try to claim the same transfer concurrently. It may try it sequentially, but we should get a harmless error about the transfer already having been claimed.

**Misc**: this also includes some logging improvements:
- Not logging complete transfers and other big types on debug/info, just on trace level
- More expressive logging in `claim_pending_transfers`. Once I faced a weird situation where it hanged, but I haven't been able to reproduce it again yet. The logging will be helpful if we reencounter it.

cc @dangeross 