### PR TITLE
Poll send lightning

### DIFF
--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -883,14 +883,12 @@ impl BreezSdk {
                     return;
                   },
                     p = spark_wallet.fetch_lightning_send_payment(&payment_id) => {
-                      if let Ok(Some(p)) = p {
-                        if p.payment_preimage.is_some() {
-                            info!("Pollling payment preimage found");
-                            if let Err(e) = sync_trigger.send(SyncType::PaymentsOnly) {
-                                error!("Failed to send sync trigger: {e:?}");
-                            }
-                            return;
-                        }
+                      if let Ok(Some(p)) = p  && p.payment_preimage.is_some(){
+                          info!("Pollling payment preimage found");
+                          if let Err(e) = sync_trigger.send(SyncType::PaymentsOnly) {
+                              error!("Failed to send sync trigger: {e:?}");
+                          }
+                          return;
                     }
                     let sleep_time = if i < 5 {
                         Duration::from_secs(1)


### PR DESCRIPTION
When sending lightning payments the payments enter a pending state and it stays pending until next sync (which might be a minute after).
For the correct UX we need to poll the lightning payment until completion and then trigger sync payments.