### PR TITLE
Fix connect fn for bindings

### DIFF
--- a/crates/breez-sdk/cli/src/main.rs
+++ b/crates/breez-sdk/cli/src/main.rs
@@ -4,8 +4,7 @@ mod persist;
 use crate::commands::CliHelper;
 use crate::persist::CliPersistence;
 use anyhow::{Result, anyhow};
-use breez_sdk_spark::{BreezSdk, ConnectRequest, EventListener, SdkEvent};
-use breez_sdk_spark::{Network, default_config};
+use breez_sdk_spark::{ConnectRequest, EventListener, Network, SdkEvent, connect, default_config};
 use clap::Parser;
 use commands::{Command, execute_command};
 use rustyline::Editor;
@@ -93,7 +92,7 @@ async fn run_interactive_mode(data_dir: PathBuf, network: Network) -> Result<()>
         .map(|var| var.into_string().expect("Expected valid API key string"));
     let mut config = default_config(network);
     config.api_key = breez_api_key;
-    let sdk = BreezSdk::connect(ConnectRequest {
+    let sdk = connect(ConnectRequest {
         config,
         mnemonic: mnemonic.to_string(),
         storage_dir: data_dir.to_string_lossy().to_string(),

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -23,7 +23,10 @@ pub use sdk::{BreezSdk, default_config, init_logging, parse_input};
 pub use sdk_builder::SdkBuilder;
 
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-pub use {persist::sqlite::SqliteStorage, sdk::default_storage};
+pub use {
+    persist::sqlite::SqliteStorage,
+    sdk::{connect, default_storage},
+};
 
 #[cfg(feature = "test-utils")]
 pub use persist::tests as storage_tests;

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -14,6 +14,7 @@ use std::time::UNIX_EPOCH;
 
 use crate::{SdkError, error::DepositClaimError};
 
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct ConnectRequest {
     pub config: Config,
     pub mnemonic: String,

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -85,6 +85,33 @@ pub fn init_logging(
     logger::init_logging(log_dir, app_logger, log_filter)
 }
 
+/// Connects to the Spark network using the provided configuration and mnemonic.
+///
+/// # Arguments
+///
+/// * `request` - The connection request object
+///
+/// # Returns
+///
+/// Result containing either the initialized `BreezSdk` or an `SdkError`
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub async fn connect(request: crate::ConnectRequest) -> Result<BreezSdk, SdkError> {
+    let db_path = std::path::PathBuf::from_str(&request.storage_dir)?;
+    let path_suffix: String = sha256::Hash::hash(request.mnemonic.as_bytes())
+        .to_string()
+        .chars()
+        .take(8)
+        .collect();
+    let storage_dir = db_path
+        .join(request.config.network.to_string().to_lowercase())
+        .join(path_suffix);
+
+    let storage = default_storage(storage_dir.to_string_lossy().to_string())?;
+    let builder = crate::SdkBuilder::new(request.config, request.mnemonic, storage);
+    builder.build().await
+}
+
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 #[cfg_attr(feature = "uniffi", uniffi::export)]
 #[allow(clippy::needless_pass_by_value)]
@@ -154,32 +181,6 @@ impl BreezSdk {
             sync_trigger: tokio::sync::broadcast::channel(10).0,
         };
         Ok(sdk)
-    }
-
-    /// Connects to the Spark network using the provided configuration and mnemonic.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The connection request object
-    ///
-    /// # Returns
-    ///
-    /// Result containing either the initialized `BreezSdk` or an `SdkError`
-    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-    pub async fn connect(request: crate::ConnectRequest) -> Result<Self, SdkError> {
-        let db_path = std::path::PathBuf::from_str(&request.storage_dir)?;
-        let path_suffix: String = sha256::Hash::hash(request.mnemonic.as_bytes())
-            .to_string()
-            .chars()
-            .take(8)
-            .collect();
-        let storage_dir = db_path
-            .join(request.config.network.to_string().to_lowercase())
-            .join(path_suffix);
-
-        let storage = default_storage(storage_dir.to_string_lossy().to_string())?;
-        let builder = crate::SdkBuilder::new(request.config, request.mnemonic, storage);
-        builder.build().await
     }
 
     /// Starts the SDK's background tasks

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
@@ -12,7 +12,7 @@ class GettingStarted {
 
         try {
             // Connect to the SDK using the simplified connect method
-            val sdk = BreezSdk.connect(ConnectRequest(
+            val sdk = connect(ConnectRequest(
                 config = config,
                 mnemonic = mnemonic,
                 storageDir = "./.data"

--- a/docs/breez-sdk/snippets/python/src/getting_started.py
+++ b/docs/breez-sdk/snippets/python/src/getting_started.py
@@ -1,5 +1,5 @@
 import logging
-from breez_sdk_spark import BreezSdk, ConnectRequest, default_config, default_storage, EventListener, GetInfoRequest, init_logging, LogEntry, Logger, Network, SdkBuilder, SdkEvent
+from breez_sdk_spark import BreezSdk, connect, ConnectRequest, default_config, default_storage, EventListener, GetInfoRequest, init_logging, LogEntry, Logger, Network, SdkBuilder, SdkEvent
 
 async def init_sdk():
     # ANCHOR: init-sdk
@@ -10,7 +10,7 @@ async def init_sdk():
 
     try:
         # Connect to the SDK using the simplified connect method
-        sdk = await BreezSdk.connect(request=ConnectRequest(
+        sdk = await connect(request=ConnectRequest(
             config=config,
             mnemonic=mnemonic,
             storage_dir="./.data"

--- a/docs/breez-sdk/snippets/rust/src/getting_started.rs
+++ b/docs/breez-sdk/snippets/rust/src/getting_started.rs
@@ -13,7 +13,7 @@ pub(crate) async fn init_sdk() -> Result<BreezSdk> {
     config.api_key = Some("<breez api key>".to_string());
 
     // Connect to the SDK using the simplified connect method
-    let sdk = BreezSdk::connect(ConnectRequest {
+    let sdk = connect(ConnectRequest {
         config,
         mnemonic,
         storage_dir: "./.data".to_string(),

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
@@ -8,7 +8,7 @@ func initSdk() async throws -> BreezSdk {
     config.apiKey = "<breez api key>"
 
     // Connect to the SDK using the simplified connect method
-    let sdk = try await BreezSdk.connect(request: ConnectRequest(
+    let sdk = try await connect(request: ConnectRequest(
         config: config,
         mnemonic: mnemonic,
         storageDir: "./.data"

--- a/docs/breez-sdk/snippets/wasm/getting_started.ts
+++ b/docs/breez-sdk/snippets/wasm/getting_started.ts
@@ -1,5 +1,6 @@
 import {
   BreezSdk,
+  connect,
   defaultConfig,
   defaultStorage,
   initLogging,
@@ -25,7 +26,7 @@ const exampleGettingStarted = async () => {
   config.apiKey = '<breez api key>'
 
   // Connect to the SDK using the simplified connect method
-  const sdk = await BreezSdk.connect({
+  const sdk = await connect({
     config,
     mnemonic,
     storageDir: './.data'


### PR DESCRIPTION
This PR fixes the connect method for bindings:
- Move `connect` outside of `BreezSdk` impl (UniFFI doesn't support associated static functions)
- Expose `ConnectRequest` struct to UniFFI
- Update Wasm and docs