### PR TITLE
Set default None on Option fields

### DIFF
--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -407,6 +407,7 @@ pub struct DepositInfo {
 pub struct ClaimDepositRequest {
     pub txid: String,
     pub vout: u32,
+    #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub max_fee: Option<Fee>,
 }
 
@@ -589,8 +590,10 @@ pub struct ReceivePaymentResponse {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PrepareLnurlPayRequest {
     pub amount_sats: u64,
-    pub comment: Option<String>,
     pub pay_request: LnurlPayRequestDetails,
+    #[cfg_attr(feature = "uniffi", uniffi(default=None))]
+    pub comment: Option<String>,
+    #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub validate_success_action_url: Option<bool>,
 }
 
@@ -660,6 +663,7 @@ impl From<ExitSpeed> for OnchainConfirmationSpeed {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PrepareSendPaymentRequest {
     pub payment_request: String,
+    #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub amount_sats: Option<u64>,
 }
 
@@ -683,6 +687,7 @@ pub enum SendPaymentOptions {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SendPaymentRequest {
     pub prepare_response: PrepareSendPaymentResponse,
+    #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub options: Option<SendPaymentOptions>,
 }
 
@@ -697,8 +702,10 @@ pub struct SendPaymentResponse {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct ListPaymentsRequest {
     /// Number of records to skip
+    #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub offset: Option<u32>,
     /// Maximum number of records to return
+    #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub limit: Option<u32>,
 }
 

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/LnurlPay.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/LnurlPay.kt
@@ -20,8 +20,8 @@ class LnurlPay {
 
                 val req = PrepareLnurlPayRequest(
                     amountSats,
-                    optionalComment,
                     payRequest,
+                    optionalComment,
                     optionalValidateSuccessActionUrl
                 )
                 val prepareResponse = sdk.prepareLnurlPay(req)

--- a/docs/breez-sdk/snippets/python/src/lnurl_pay.py
+++ b/docs/breez-sdk/snippets/python/src/lnurl_pay.py
@@ -19,8 +19,8 @@ async def prepare_pay(sdk: BreezSdk):
 
             request = PrepareLnurlPayRequest(
                 amount_sats=amount_sats,
-                comment=optional_comment,
                 pay_request=pay_request,
+                comment=optional_comment,
                 validate_success_action_url=optional_validate_success_action_url
             )
             prepare_response = await sdk.prepare_lnurl_pay(request=request)

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/LnurlPay.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/LnurlPay.swift
@@ -17,8 +17,8 @@ func preparePay(sdk: BreezSdk) async throws {
 
         let request = PrepareLnurlPayRequest(
             amountSats: amountSats,
-            comment: optionalComment,
             payRequest: payRequest,
+            comment: optionalComment,
             validateSuccessActionUrl: optionalValidateSuccessActionUrl
         )
         let response = try await sdk.prepareLnurlPay(request: request)

--- a/docs/breez-sdk/snippets/wasm/lnurl_pay.ts
+++ b/docs/breez-sdk/snippets/wasm/lnurl_pay.ts
@@ -16,8 +16,8 @@ const examplePrepareLnurlPay = async (sdk: BreezSdk) => {
 
     const prepareResponse = await sdk.prepareLnurlPay({
       amountSats,
-      comment: optionalComment,
       payRequest,
+      comment: optionalComment,
       validateSuccessActionUrl: optionalValidateSuccessActionUrl
     })
 


### PR DESCRIPTION
Sets defaults for request structs so they are not explicitly required in the bindings