### PR TITLE
use wasm32-unknown-unknown target for wasm project

### DIFF
--- a/crates/breez-sdk/wasm/rust-analyzer.json
+++ b/crates/breez-sdk/wasm/rust-analyzer.json
@@ -1,0 +1,10 @@
+{
+    "cargo": {
+        "target": "wasm32-unknown-unknown",
+        "features": []
+    },
+    "check": {
+        "command": "clippy",
+        "targets": ["wasm32-unknown-unknown"]
+    }
+}


### PR DESCRIPTION
For me this eliminates the IDE errors rust-analyzer gives on the wasm project.