### PR TITLE
Patch deprecated graphql inputs

### DIFF
--- a/crates/spark/schema/queries.graphql
+++ b/crates/spark/schema/queries.graphql
@@ -195,7 +195,7 @@ mutation CompleteCoopExit($input: CompleteCoopExitInput!) {
   }
 }
 
-mutation CompleteLeavesSwap($input: CompleteLeavesSwapInput!) {
+mutation CompleteLeavesSwap($input: CompleteLeavesSwapInputDeprecated!) {
   complete_leaves_swap(input: $input) {
     request {
       ...LeavesSwapRequestFragment
@@ -217,7 +217,7 @@ mutation RequestCoopExit($input: RequestCoopExitInput!) {
   }
 }
 
-mutation RequestLeavesSwap($input: RequestLeavesSwapInput!) {
+mutation RequestLeavesSwap($input: RequestLeavesSwapInputDeprecated!) {
   request_leaves_swap(input: $input) {
     request {
       ...LeavesSwapRequestFragment

--- a/crates/spark/schema/spark.graphql
+++ b/crates/spark/schema/spark.graphql
@@ -123,7 +123,7 @@ type CompleteCoopExitOutput {
   request: CoopExitRequest!
 }
 
-input CompleteLeavesSwapInput {
+input CompleteLeavesSwapInputDeprecated {
   adaptor_secret_key: String!
   user_outbound_transfer_external_id: UUID!
   leaves_swap_request_id: ID!
@@ -584,7 +584,7 @@ type Mutation {
   complete_coop_exit(input: CompleteCoopExitInput!): CompleteCoopExitOutput!
 
   """For spark users to complete a leaves swap."""
-  complete_leaves_swap(input: CompleteLeavesSwapInput!): CompleteLeavesSwapOutput!
+  complete_leaves_swap(input: CompleteLeavesSwapInputDeprecated!): CompleteLeavesSwapOutput!
 
   """Complete the process to request releasing seed."""
   complete_seed_release(input: CompleteSeedReleaseInput!): CompleteSeedReleaseOutput!
@@ -605,7 +605,7 @@ type Mutation {
   request_lightning_receive(input: RequestLightningReceiveInput!): RequestLightningReceiveOutput!
 
   """For spark users to initiate a leaves swap."""
-  request_leaves_swap(input: RequestLeavesSwapInput!): RequestLeavesSwapOutput!
+  request_leaves_swap(input: RequestLeavesSwapInputDeprecated!): RequestLeavesSwapOutput!
 
   """
   This function sends regtest funds to a specified address. It is only available in test mode.
@@ -707,7 +707,7 @@ type RequestCoopExitOutput {
   request: CoopExitRequest!
 }
 
-input RequestLeavesSwapInput {
+input RequestLeavesSwapInputDeprecated {
   adaptor_pubkey: PublicKey!
   total_amount_sats: Long!
   target_amount_sats: Long!

--- a/crates/spark/src/services/swap.rs
+++ b/crates/spark/src/services/swap.rs
@@ -12,7 +12,10 @@ use crate::{
     },
     services::{LeafKeyTweak, ServiceError, Transfer, TransferId, TransferService},
     signer::{PrivateKeySource, Signer, from_bytes_to_scalar},
-    ssp::{CompleteLeavesSwapInput, RequestLeavesSwapInput, ServiceProvider, UserLeafInput},
+    ssp::{
+        CompleteLeavesSwapInputDeprecated, RequestLeavesSwapInputDeprecated, ServiceProvider,
+        UserLeafInput,
+    },
     tree::TreeNode,
     utils::{
         refund::{
@@ -250,7 +253,7 @@ impl<S: Signer> Swap<S> {
         }
         let swap_response = self
             .ssp_client
-            .request_leaves_swap(RequestLeavesSwapInput {
+            .request_leaves_swap(RequestLeavesSwapInputDeprecated {
                 adaptor_pubkey: hex::encode(cpfp_adaptor_private_key.public_key().to_sec1_bytes()),
                 direct_adaptor_pubkey: maybe_direct_adaptor
                     .as_ref()
@@ -275,7 +278,7 @@ impl<S: Signer> Swap<S> {
             .await?;
         let complete_response = self
             .ssp_client
-            .complete_leaves_swap(CompleteLeavesSwapInput {
+            .complete_leaves_swap(CompleteLeavesSwapInputDeprecated {
                 adaptor_secret_key: hex::encode(cpfp_adaptor_private_key.to_bytes()),
                 direct_adaptor_secret_key: maybe_direct_adaptor
                     .as_ref()

--- a/crates/spark/src/ssp/graphql/client.rs
+++ b/crates/spark/src/ssp/graphql/client.rs
@@ -19,8 +19,9 @@ use crate::ssp::graphql::{
     LeavesSwapRequest, LightningReceiveRequest, LightningSendRequest, StaticDepositQuote,
 };
 use crate::ssp::{
-    ClaimStaticDepositInput, CompleteLeavesSwapInput, CoopExitFeeQuote, RequestCoopExitInput,
-    RequestLeavesSwapInput, RequestLightningReceiveInput, RequestLightningSendInput, SspTransfer,
+    ClaimStaticDepositInput, CompleteLeavesSwapInputDeprecated, CoopExitFeeQuote,
+    RequestCoopExitInput, RequestLeavesSwapInputDeprecated, RequestLightningReceiveInput,
+    RequestLightningSendInput, SspTransfer,
 };
 
 /// GraphQL client for interacting with the Spark server
@@ -322,7 +323,7 @@ impl<S: Signer> GraphQLClient<S> {
     /// Request a leaves swap
     pub async fn request_leaves_swap(
         &self,
-        input: RequestLeavesSwapInput,
+        input: RequestLeavesSwapInputDeprecated,
     ) -> GraphQLResult<LeavesSwapRequest> {
         let vars = request_leaves_swap::Variables { input };
 
@@ -336,7 +337,7 @@ impl<S: Signer> GraphQLClient<S> {
     /// Complete a leaves swap
     pub async fn complete_leaves_swap(
         &self,
-        input: CompleteLeavesSwapInput,
+        input: CompleteLeavesSwapInputDeprecated,
     ) -> GraphQLResult<LeavesSwapRequest> {
         let vars = complete_leaves_swap::Variables { input };
 

--- a/crates/spark/src/ssp/graphql/models.rs
+++ b/crates/spark/src/ssp/graphql/models.rs
@@ -82,9 +82,9 @@ use enum_to_enum::FromEnum;
 use serde::{Deserialize, Serialize};
 
 pub use crate::ssp::graphql::queries::claim_static_deposit::ClaimStaticDepositInput;
-pub use crate::ssp::graphql::queries::complete_leaves_swap::CompleteLeavesSwapInput;
+pub use crate::ssp::graphql::queries::complete_leaves_swap::CompleteLeavesSwapInputDeprecated;
 pub use crate::ssp::graphql::queries::request_coop_exit::RequestCoopExitInput;
-pub use crate::ssp::graphql::queries::request_leaves_swap::RequestLeavesSwapInput;
+pub use crate::ssp::graphql::queries::request_leaves_swap::RequestLeavesSwapInputDeprecated;
 pub use crate::ssp::graphql::queries::request_leaves_swap::UserLeafInput;
 pub use crate::ssp::graphql::queries::request_lightning_receive::RequestLightningReceiveInput;
 pub use crate::ssp::graphql::queries::request_lightning_send::RequestLightningSendInput;

--- a/crates/spark/src/ssp/service_provider.rs
+++ b/crates/spark/src/ssp/service_provider.rs
@@ -5,10 +5,10 @@ use bitcoin::secp256k1::PublicKey;
 use crate::{
     signer::Signer,
     ssp::{
-        BitcoinNetwork, ClaimStaticDeposit, ClaimStaticDepositInput, CompleteLeavesSwapInput,
-        CoopExitFeeQuote, CurrencyAmount, LeavesSwapRequest, RequestCoopExitInput,
-        RequestLeavesSwapInput, RequestLightningReceiveInput, RequestLightningSendInput,
-        ServiceProviderConfig, SspTransfer, StaticDepositQuote,
+        BitcoinNetwork, ClaimStaticDeposit, ClaimStaticDepositInput,
+        CompleteLeavesSwapInputDeprecated, CoopExitFeeQuote, CurrencyAmount, LeavesSwapRequest,
+        RequestCoopExitInput, RequestLeavesSwapInputDeprecated, RequestLightningReceiveInput,
+        RequestLightningSendInput, ServiceProviderConfig, SspTransfer, StaticDepositQuote,
         error::ServiceProviderResult,
         graphql::{CoopExitRequest, GraphQLClient, LightningReceiveRequest, LightningSendRequest},
     },
@@ -103,7 +103,7 @@ impl<S: Signer> ServiceProvider<S> {
     /// Request leaves swap
     pub async fn request_leaves_swap(
         &self,
-        input: RequestLeavesSwapInput,
+        input: RequestLeavesSwapInputDeprecated,
     ) -> ServiceProviderResult<LeavesSwapRequest> {
         Ok(self.gql_client.request_leaves_swap(input).await?)
     }
@@ -111,7 +111,7 @@ impl<S: Signer> ServiceProvider<S> {
     /// Complete a leaves swap
     pub async fn complete_leaves_swap(
         &self,
-        input: CompleteLeavesSwapInput,
+        input: CompleteLeavesSwapInputDeprecated,
     ) -> ServiceProviderResult<LeavesSwapRequest> {
         Ok(self.gql_client.complete_leaves_swap(input).await?)
     }


### PR DESCRIPTION
The graphql schema has been updated deprecating some inputs:
- CompleteLeavesSwapInput -> CompleteLeavesSwapInputDeprecated
- RequestLeavesSwapInput -> RequestLeavesSwapInputDeprecated