### PR TITLE
Tree service cleanup

### DIFF
--- a/crates/spark/src/services/coop_exit.rs
+++ b/crates/spark/src/services/coop_exit.rs
@@ -155,7 +155,7 @@ where
 
         // Build leaf key tweaks for all leaves with new signing keys
         let all_leaves = [leaves, fee_leaves.unwrap_or_default()].concat();
-        let leaf_key_tweaks = prepare_leaf_key_tweaks_to_send(&self.signer, all_leaves)?;
+        let leaf_key_tweaks = prepare_leaf_key_tweaks_to_send(&self.signer, all_leaves, None)?;
 
         // Request cooperative exit from the SSP
         trace!("Requesting cooperative exit");

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -205,7 +205,7 @@ impl<S: Signer> DepositService<S> {
                 vout,
             )
             .await?;
-        Ok(nodes)
+        self.collect_leaves(nodes).await
     }
 
     pub async fn collect_leaves(

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -9,7 +9,7 @@ use bitcoin::{
     secp256k1::{Message, PublicKey, ecdsa::Signature, schnorr},
 };
 use serde::Serialize;
-use tracing::{error, trace};
+use tracing::{error, trace, warn};
 
 use crate::{
     Network,
@@ -22,10 +22,10 @@ use crate::{
             spark::{GetUtxosForAddressRequest, TransferFilter, transfer_filter::Participant},
         },
     },
-    services::{Transfer, Utxo},
+    services::{TimelockManager, Transfer, TransferService, Utxo},
     signer::{PrivateKeySource, Signer},
     ssp::{ClaimStaticDepositInput, ClaimStaticDepositRequestType, ServiceProvider},
-    tree::{TreeNode, TreeNodeId},
+    tree::{TreeNode, TreeNodeId, TreeNodeStatus},
     utils::{
         frost::{SignAggregateFrostParams, sign_aggregate_frost},
         paging::{PagingFilter, PagingResult, pager},
@@ -131,9 +131,12 @@ pub struct DepositService<S> {
     operator_pool: Arc<OperatorPool<S>>,
     ssp_client: Arc<ServiceProvider<S>>,
     signer: Arc<S>,
+    timelock_manager: Arc<TimelockManager<S>>,
+    transfer_service: Arc<TransferService<S>>,
 }
 
 impl<S: Signer> DepositService<S> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         bitcoin_service: BitcoinService,
         identity_public_key: PublicKey,
@@ -141,6 +144,8 @@ impl<S: Signer> DepositService<S> {
         operator_pool: Arc<OperatorPool<S>>,
         ssp_client: Arc<ServiceProvider<S>>,
         signer: Arc<S>,
+        timelock_manager: Arc<TimelockManager<S>>,
+        transfer_service: Arc<TransferService<S>>,
     ) -> Self {
         DepositService {
             bitcoin_service,
@@ -149,6 +154,8 @@ impl<S: Signer> DepositService<S> {
             operator_pool,
             ssp_client,
             signer,
+            timelock_manager,
+            transfer_service,
         }
     }
 
@@ -199,6 +206,58 @@ impl<S: Signer> DepositService<S> {
             )
             .await?;
         Ok(nodes)
+    }
+
+    pub async fn collect_leaves(
+        &self,
+        nodes: Vec<TreeNode>,
+    ) -> Result<Vec<TreeNode>, ServiceError> {
+        let mut resulting_nodes = Vec::new();
+        for node in nodes.into_iter() {
+            if node.status != TreeNodeStatus::Available {
+                warn!("Leaf is not available: {:?}", node.clone());
+                // TODO: Handle other statuses appropriately.
+                resulting_nodes.push(node.clone());
+                continue;
+            }
+
+            let nodes = self.timelock_manager.extend_time_lock(&node).await?;
+
+            for n in nodes {
+                let node_id = n.id.clone();
+                if n.status != TreeNodeStatus::Available {
+                    warn!("Leaf resulting from extend_time_lock is not available: {n:?}",);
+                    // TODO: Handle other statuses appropriately.
+                    resulting_nodes.push(n);
+                    continue;
+                }
+
+                let transfer_res = self
+                    .transfer_service
+                    .transfer_leaves_to_self(
+                        vec![n],
+                        Some(PrivateKeySource::Derived(node.id.clone())),
+                    )
+                    .await;
+
+                let transfer = match transfer_res {
+                    Ok(transfer) => transfer,
+                    Err(e) => {
+                        if let ServiceError::TransferAlreadyClaimed = e {
+                            warn!("Transfer for leaf {} is already claimed", node_id);
+                            continue;
+                        }
+                        return Err(ServiceError::Generic(format!(
+                            "Failed to transfer leaves to self: {e:?}"
+                        )))?;
+                    }
+                };
+
+                resulting_nodes.extend(transfer.into_iter());
+            }
+        }
+
+        Ok(resulting_nodes)
     }
 
     pub async fn claim_static_deposit(

--- a/crates/spark/src/services/lightning.rs
+++ b/crates/spark/src/services/lightning.rs
@@ -333,7 +333,7 @@ impl<S: Signer> LightningService<S> {
         let payment_hash = decoded_invoice.payment_hash();
 
         // prepare leaf tweaks
-        let leaf_tweaks = prepare_leaf_key_tweaks_to_send(&self.signer, leaves.to_vec())?;
+        let leaf_tweaks = prepare_leaf_key_tweaks_to_send(&self.signer, leaves.to_vec(), None)?;
 
         let swap_response = self
             .swap_nodes_for_preimage(SwapNodesForPreimageRequest {

--- a/crates/spark/src/services/lightning.rs
+++ b/crates/spark/src/services/lightning.rs
@@ -7,7 +7,7 @@ use crate::operator::rpc::spark::{
     InvoiceAmount, InvoiceAmountProof, SecretShare, StartUserSignedTransferRequest,
     StorePreimageShareRequest,
 };
-use crate::services::{ServiceError, Transfer, TransferId};
+use crate::services::{ServiceError, Transfer, TransferId, TransferService};
 use crate::signer::SecretToSplit;
 use crate::ssp::{
     LightningReceiveRequestStatus, RequestLightningReceiveInput, RequestLightningSendInput,
@@ -49,10 +49,9 @@ impl InvoiceDescription {
     }
 }
 
-pub struct LightningSwap {
+struct LightningSwap {
     pub transfer: Transfer,
     pub leaves: Vec<LeafKeyTweak>,
-    pub receiver_identity_public_key: PublicKey,
     pub bolt11_invoice: String,
     pub user_amount_sat: Option<u64>,
 }
@@ -213,6 +212,7 @@ pub struct LightningService<S> {
     ssp_client: Arc<ServiceProvider<S>>,
     network: Network,
     signer: Arc<S>,
+    transfer_service: Arc<TransferService<S>>,
     split_secret_threshold: u32,
 }
 
@@ -222,6 +222,7 @@ impl<S: Signer> LightningService<S> {
         ssp_client: Arc<ServiceProvider<S>>,
         network: Network,
         signer: Arc<S>,
+        transfer_service: Arc<TransferService<S>>,
         split_secret_threshold: u32,
     ) -> Self {
         LightningService {
@@ -229,6 +230,7 @@ impl<S: Signer> LightningService<S> {
             ssp_client,
             network,
             signer,
+            transfer_service,
             split_secret_threshold,
         }
     }
@@ -321,7 +323,23 @@ impl<S: Signer> LightningService<S> {
         invoice.try_into()
     }
 
-    pub async fn start_lightning_swap(
+    pub async fn pay_lightning_invoice(
+        &self,
+        invoice: &str,
+        amount_to_send: Option<u64>,
+        leaves: &[TreeNode],
+    ) -> Result<LightningSendPayment, ServiceError> {
+        let swap = self
+            .start_lightning_swap(invoice, amount_to_send, leaves)
+            .await?;
+        let _ = self
+            .transfer_service
+            .deliver_transfer_package(&swap.transfer, &swap.leaves, Default::default())
+            .await?;
+        self.finalize_lightning_swap(&swap).await
+    }
+
+    async fn start_lightning_swap(
         &self,
         invoice: &str,
         amount_to_send: Option<u64>,
@@ -354,13 +372,12 @@ impl<S: Signer> LightningService<S> {
         Ok(LightningSwap {
             transfer: transfer.try_into()?,
             leaves: leaf_tweaks,
-            receiver_identity_public_key: self.ssp_client.identity_public_key(),
             bolt11_invoice: invoice.to_string(),
             user_amount_sat: amount_to_send,
         })
     }
 
-    pub async fn finalize_lightning_swap(
+    async fn finalize_lightning_swap(
         &self,
         swap: &LightningSwap,
     ) -> Result<LightningSendPayment, ServiceError> {

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -692,6 +692,15 @@ impl<S: Signer> TransferService<S> {
                             },
                         )
                         .await
+                        .map_err(|e| {
+                            if let OperatorRpcError::Connection(status) = &e
+                                && status.code() == Code::AlreadyExists
+                            {
+                                return ServiceError::TransferAlreadyClaimed;
+                            }
+
+                            e.into()
+                        })
                 };
                 tasks.push(task);
             }

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -311,6 +311,15 @@ impl<S: Signer> TreeService<S> {
         leaves.len() > optimal_leaves_length * 5
     }
 
+    pub async fn reserve_new_leaves(
+        &self,
+        leaves: Vec<TreeNode>,
+    ) -> Result<LeavesReservation, TreeServiceError> {
+        let mut state = self.state.lock().await;
+        let reservation_id = state.reserve_leaves(&leaves, true)?;
+        Ok(LeavesReservation::new(leaves, reservation_id))
+    }
+
     pub async fn reserve_leaves(
         &self,
         target_amounts: Option<&TargetAmounts>,
@@ -555,89 +564,6 @@ impl<S: Signer> TreeService<S> {
         }
 
         Ok(Some(result))
-    }
-
-    async fn collect_leaves_inner(
-        &self,
-        nodes: Vec<TreeNode>,
-    ) -> Result<Vec<TreeNode>, TreeServiceError> {
-        let mut resulting_nodes = Vec::new();
-        for node in nodes.into_iter() {
-            if node.status != TreeNodeStatus::Available {
-                warn!("Leaf is not available: {node:?}");
-                // TODO: Handle other statuses appropriately.
-                resulting_nodes.push(node);
-                continue;
-            }
-
-            let nodes = self
-                .timelock_manager
-                .extend_time_lock(&node)
-                .await
-                .map_err(|e| {
-                    TreeServiceError::Generic(format!("Failed to extend time lock: {e:?}"))
-                })?;
-
-            for n in nodes {
-                let node_id = n.id.clone();
-                if n.status != TreeNodeStatus::Available {
-                    warn!("Leaf resulting from extend_time_lock is not available: {n:?}",);
-                    // TODO: Handle other statuses appropriately.
-                    resulting_nodes.push(n);
-                    continue;
-                }
-
-                let transfer_res = self.timelock_manager.transfer_leaves_to_self(vec![n]).await;
-
-                let transfer = match transfer_res {
-                    Ok(transfer) => transfer,
-                    Err(e) => {
-                        if let ServiceError::TransferAlreadyClaimed = e {
-                            warn!("Transfer for leaf {} is already claimed", node_id);
-                            continue;
-                        }
-                        return Err(TreeServiceError::Generic(format!(
-                            "Failed to transfer leaves to self: {e:?}"
-                        )))?;
-                    }
-                };
-
-                resulting_nodes.extend(transfer.into_iter());
-            }
-        }
-
-        Ok(resulting_nodes)
-    }
-
-    // TODO: right now, this looks tighly coupled to claiming a deposit.
-    //  We should either move this to the deposit service or make it more general.
-    //  If made more general, should also be moved to timelock manager.
-    pub async fn collect_leaves(
-        &self,
-        nodes: Vec<TreeNode>,
-    ) -> Result<Vec<TreeNode>, TreeServiceError> {
-        if nodes.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let mut state = self.state.lock().await;
-        // Immediately reserve the new leaves, even though they are not in the main pool
-        let reservation_id = state.reserve_leaves(&nodes, true)?;
-
-        match self.collect_leaves_inner(nodes).await {
-            Ok(collected_nodes) => {
-                // Finalize the reservation, disgarding the new leaves for the collected leaves
-                state.finalize_reservation(reservation_id);
-                state.add_leaves(&collected_nodes);
-                Ok(collected_nodes)
-            }
-            Err(e) => {
-                error!("Failed to collect leaves: {e:?}");
-                // Cancel the reservation, moving the new leaves to the main pool
-                state.cancel_reservation(reservation_id);
-                Err(e)
-            }
-        }
     }
 
     /// Returns the total balance of all available leaves in the tree.

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -311,15 +311,6 @@ impl<S: Signer> TreeService<S> {
         leaves.len() > optimal_leaves_length * 5
     }
 
-    pub async fn reserve_new_leaves(
-        &self,
-        leaves: Vec<TreeNode>,
-    ) -> Result<LeavesReservation, TreeServiceError> {
-        let mut state = self.state.lock().await;
-        let reservation_id = state.reserve_leaves(&leaves, true)?;
-        Ok(LeavesReservation::new(leaves, reservation_id))
-    }
-
     pub async fn reserve_leaves(
         &self,
         target_amounts: Option<&TargetAmounts>,

--- a/crates/spark/src/utils/leaf_key_tweak.rs
+++ b/crates/spark/src/utils/leaf_key_tweak.rs
@@ -9,12 +9,15 @@ use crate::{
 pub fn prepare_leaf_key_tweaks_to_send<S: Signer>(
     signer: &Arc<S>,
     leaves: Vec<TreeNode>,
+    signing_key_source: Option<PrivateKeySource>,
 ) -> Result<Vec<LeafKeyTweak>, SignerError> {
     // Build leaf key tweaks with new signing keys that we will sent to the receiver
     leaves
         .iter()
         .map(|leaf| {
-            let our_key = PrivateKeySource::Derived(leaf.id.clone());
+            let our_key = signing_key_source
+                .clone()
+                .unwrap_or(PrivateKeySource::Derived(leaf.id.clone()));
             let ephemeral_key = signer.generate_random_key()?;
 
             Ok(LeafKeyTweak {


### PR DESCRIPTION
Starting to address #206 
This PR cleanup the TreeService:
1. Move `collect_leaves` to the deposit service where it is only used. By that also makes the deposit service covers all deposit flow.
2. Move the `transfer_leaves_to_self` to the transfer service (now uses internally `transfer_leaves_to`)
3. Better encapsulate lightning payments inside lightning service (remove friction from the wallet).

Everything in Spark ultimately maps to a Transfer, which suggests that the TransferService operates at a lower level than higher-level services like Deposit or Lightning. The idea is for these higher-level services to use the TransferService internally, allowing them to encapsulate the entire flow rather than use the wallet as facade that adds friction. 
This way, SparkWallet only needs to handle the final results (ideally reserving leaves only, responding to events, etc...) and can delegate the detailed processes to the services themselves.

Wishful thinking: I believe the flakiness issue with the deposit integration tests might also be resolved.