### PR TITLE
Android: Fix use of webpki roots

### DIFF
--- a/crates/spark/src/operator/rpc/transport/grpc_client.rs
+++ b/crates/spark/src/operator/rpc/transport/grpc_client.rs
@@ -25,7 +25,7 @@ impl GrpcClient {
     fn create_endpoint(server_url: &str) -> Result<tonic::transport::Endpoint, OperatorRpcError> {
         Ok(
             tonic::transport::Endpoint::from_shared(server_url.to_string())?
-                .tls_config(ClientTlsConfig::new().with_enabled_roots())?
+                .tls_config(ClientTlsConfig::new().with_webpki_roots())?
                 .http2_keep_alive_interval(Duration::new(5, 0))
                 .tcp_keepalive(Some(Duration::from_secs(5)))
                 .keep_alive_timeout(Duration::from_secs(5))


### PR DESCRIPTION
For some reason `with_enabled_roots()` is not activating use of webpki roots. Using `with_webpki_roots()` directly fixes it.

Fixes #207 

```
A Dart VM Service on sdk gphone64 arm64 is available at: http://127.0.0.1:52857/svB2kxdMSfc=/
I/flutter (16164): INFO: Sync trigger changed: Full
I/flutter (16164): INFO: sync_wallet_internal: Syncing with Spark network
The Flutter DevTools debugger and profiler on sdk gphone64 arm64 is available at: http://127.0.0.1:9105?uri=http://127.0.0.1:52857/svB2kxdMSfc=/
I/Choreographer(16164): Skipped 32 frames!  The application may be doing too much work on its main thread.
D/WindowLayoutComponentImpl(16164): Register WindowLayoutInfoListener on Context=com.example.breez_spark_example.MainActivity@da499bf, of which baseContext=android.app.ContextImpl@a4850b6
D/InsetsController(16164): hide(ime(), fromIme=false)
I/ImeTracker(16164): com.example.breez_spark_example:b822db0c: onCancelled at PHASE_CLIENT_ALREADY_HIDDEN
I/flutter (16164): INFO: Received event: StreamConnected
I/flutter (16164): INFO: Stream connected
I/flutter (16164): INFO: Received event: Synced
I/flutter (16164): INFO: Synced
I/flutter (16164): INFO: Sync trigger changed: Full
I/flutter (16164): INFO: sync_wallet_internal: Syncing with Spark network
D/ProfileInstaller(16164): Installing profile for com.example.breez_spark_example
I/flutter (16164): INFO: sync_wallet_internal: Synced with Spark network completed
I/flutter (16164): INFO: Syncing payments to storage, offset = 1
I/flutter (16164): INFO: Syncing payments to storage, offset = 1, transfers = 0
I/flutter (16164): INFO: sync_wallet_internal: Synced payments to storage completed
I/flutter (16164): INFO: Checking static deposit address: bc1p2sha2kls8g535cjd4hu0hqgxqpgxlsqskex0xyrhwn8fnhewjhns29wrm7
I/flutter (16164): INFO: background claim completed, unclaimed deposits: []
I/flutter (16164): INFO: sync_wallet_internal: Checked and claimed static deposits completed
I/flutter (16164): INFO: sync_wallet_internal: Wallet sync completed in 4.608863169s
I/flutter (16164): Received SDK event: SdkEvent_Synced
```