### PR TITLE
Don't force default features for spark crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,8 +93,8 @@ serde-wasm-bindgen = "0.6.5"
 serde_with = "3.13.0"
 shellwords = "1.1.0"
 shlex = "1.3.0"
-spark = { path = "crates/spark" }
-spark-wallet = { path = "crates/spark-wallet" }
+spark = { path = "crates/spark", default-features = false }
+spark-wallet = { path = "crates/spark-wallet", default-features = false }
 sqlx = "0.8.6"
 strum = "0.27.1"
 strum_macros = "0.27.1"

--- a/crates/breez-sdk/common/Cargo.toml
+++ b/crates/breez-sdk/common/Cargo.toml
@@ -10,9 +10,9 @@ browser-tests = [] # Enable browser wasm-pack tests
 test-utils = []
 uniffi = ["dep:uniffi"]
 # TLS features
-default-tls = ["spark-wallet/default-tls"]
-rustls-tls = ["spark-wallet/rustls-tls"]
-native-tls = ["spark-wallet/native-tls"]
+default-tls = ["reqwest/default-tls", "spark-wallet/default-tls"]
+rustls-tls = ["reqwest/rustls-tls", "spark-wallet/rustls-tls"]
+native-tls = ["reqwest/native-tls", "spark-wallet/native-tls"]
 
 [lib]
 crate-type = ["staticlib", "cdylib", "lib"]

--- a/crates/breez-sdk/common/Cargo.toml
+++ b/crates/breez-sdk/common/Cargo.toml
@@ -10,9 +10,9 @@ browser-tests = [] # Enable browser wasm-pack tests
 test-utils = []
 uniffi = ["dep:uniffi"]
 # TLS features
-default-tls = ["reqwest/default-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
-native-tls = ["reqwest/native-tls"]
+default-tls = ["spark-wallet/default-tls"]
+rustls-tls = ["spark-wallet/rustls-tls"]
+native-tls = ["spark-wallet/native-tls"]
 
 [lib]
 crate-type = ["staticlib", "cdylib", "lib"]


### PR DESCRIPTION
#219 Did not fix my issue because `spark` still was forced to have default features which brought in openssl again. This fixes the issue for me