### PR TITLE
Flutter: Fix publish

### DIFF
--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -63,8 +63,9 @@ jobs:
       - name: Set cargo version
         working-directory: packages/flutter/rust
         run: |
-          sed -i.bak -e 's/^breez-sdk-common = .*/breez-sdk-common = { git = "https:\/\/github.com\/breez\/spark-sdk.git", rev = "${{ github.sha }}" }/' Cargo.toml
-          sed -i.bak -e 's/^breez-sdk-spark = .*/breez-sdk-spark = { git = "https:\/\/github.com\/breez\/spark-sdk.git", rev = "${{ github.sha }}", features = ["openssl-vendored"] }/' Cargo.toml
+          HASH=$(git rev-parse HEAD)
+          sed -i.bak -e 's/^breez-sdk-common = .*/breez-sdk-common = { git = "https:\/\/github.com\/breez\/spark-sdk.git", rev = "'"$HASH"'" }/' Cargo.toml
+          sed -i.bak -e 's/^breez-sdk-spark = .*/breez-sdk-spark = { git = "https:\/\/github.com\/breez\/spark-sdk.git", rev = "'"$HASH"'", features = ["openssl-vendored"] }/' Cargo.toml
           rm Cargo.toml.bak
 
       - name: Generate bindings


### PR DESCRIPTION
When publishing flutter we were using the workflow git SHA (usually `main`) as the revision to reference in the Flutter package's Cargo.toml file. We should be using the git SHA of the checked out ref (e.g. `0.1.5`)