### PR TITLE
allow allowsNostr to be null

### DIFF
--- a/crates/breez-sdk/common/src/lnurl/pay.rs
+++ b/crates/breez-sdk/common/src/lnurl/pay.rs
@@ -174,9 +174,7 @@ pub struct LnurlPayRequestDetails {
     /// Value indicating whether the recipient supports Nostr Zaps through NIP-57.
     ///
     /// See <https://github.com/nostr-protocol/nips/blob/master/57.md>
-    #[serde(default)]
-    pub allows_nostr: bool,
-
+    pub allows_nostr: Option<bool>,
     /// Optional recipient's lnurl provider's Nostr pubkey for NIP-57. If it exists it should be a
     /// valid BIP 340 public key in hex.
     ///
@@ -432,7 +430,7 @@ pub(crate) mod tests {
             metadata_str: String::new(),
             callback: "http://localhost:8080/callback".into(),
             domain: "localhost".into(),
-            allows_nostr: false,
+            allows_nostr: Some(false),
             nostr_pubkey: None,
             url: "http://localhost:8080/pay".into(),
             address: None,

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -262,7 +262,7 @@ pub struct LnurlPayRequestDetails {
     pub domain: String,
     pub url: String,
     pub address: Option<String>,
-    pub allows_nostr: bool,
+    pub allows_nostr: Option<bool>,
     pub nostr_pubkey: Option<String>,
 }
 

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -574,7 +574,7 @@ pub struct _LnurlPayRequestDetails {
     pub domain: String,
     pub url: String,
     pub address: Option<String>,
-    pub allows_nostr: bool,
+    pub allows_nostr: Option<bool>,
     pub nostr_pubkey: Option<String>,
 }
 


### PR DESCRIPTION
the lnurl-rs crate may serialize allows_nostr as null if unset. Let's support that case.