### PR TITLE
lnurl client - register and recover lightning address

### DIFF
--- a/crates/breez-sdk/cli/src/commands.rs
+++ b/crates/breez-sdk/cli/src/commands.rs
@@ -1,9 +1,9 @@
 use breez_sdk_spark::{
-    BreezSdk, ClaimDepositRequest, Fee, GetInfoRequest, GetPaymentRequest, InputType,
-    ListPaymentsRequest, ListUnclaimedDepositsRequest, LnurlPayRequest, OnchainConfirmationSpeed,
-    PrepareLnurlPayRequest, PrepareSendPaymentRequest, ReceivePaymentMethod, ReceivePaymentRequest,
-    RefundDepositRequest, SendPaymentMethod, SendPaymentOptions, SendPaymentRequest,
-    SyncWalletRequest, parse,
+    BreezSdk, CheckLightningAddressRequest, ClaimDepositRequest, Fee, GetInfoRequest,
+    GetPaymentRequest, InputType, ListPaymentsRequest, ListUnclaimedDepositsRequest,
+    LnurlPayRequest, OnchainConfirmationSpeed, PrepareLnurlPayRequest, PrepareSendPaymentRequest,
+    ReceivePaymentMethod, ReceivePaymentRequest, RefundDepositRequest, SendPaymentMethod,
+    SendPaymentOptions, SendPaymentRequest, SetLightningAddressRequest, SyncWalletRequest, parse,
 };
 use clap::Parser;
 use rustyline::{
@@ -111,6 +111,19 @@ pub enum Command {
         sat_per_vbyte: Option<u64>,
     },
     ListUnclaimedDeposits,
+    CheckLightningAddressAvailable {
+        /// The username to check
+        username: String,
+    },
+    GetLightningAddress,
+    SetLightningAddress {
+        /// The lightning address username
+        username: String,
+
+        /// Description in the lnurl response and the invoice.
+        description: String,
+    },
+    DeleteLightningAddress,
 }
 
 #[derive(Helper, Completer, Hinter, Validator)]
@@ -319,6 +332,35 @@ pub(crate) async fn execute_command(
             }?;
 
             print_value(&res)?;
+            Ok(true)
+        }
+        Command::CheckLightningAddressAvailable { username } => {
+            let res = sdk
+                .check_lightning_address_available(CheckLightningAddressRequest { username })
+                .await?;
+            print_value(&res)?;
+            Ok(true)
+        }
+        Command::GetLightningAddress => {
+            let res = sdk.get_lightning_address().await?;
+            print_value(&res)?;
+            Ok(true)
+        }
+        Command::SetLightningAddress {
+            username,
+            description,
+        } => {
+            let res = sdk
+                .set_lightning_address(SetLightningAddressRequest {
+                    username,
+                    description,
+                })
+                .await?;
+            print_value(&res)?;
+            Ok(true)
+        }
+        Command::DeleteLightningAddress => {
+            sdk.delete_lightning_address().await?;
             Ok(true)
         }
     }

--- a/crates/breez-sdk/common/src/rest/rest_client.rs
+++ b/crates/breez-sdk/common/src/rest/rest_client.rs
@@ -11,6 +11,12 @@ pub struct RestResponse {
     pub body: String,
 }
 
+impl RestResponse {
+    pub fn is_success(&self) -> bool {
+        self.status >= 200 && self.status < 300
+    }
+}
+
 #[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
 #[macros::async_trait]
 pub trait RestClient: Send + Sync {

--- a/crates/breez-sdk/common/src/test_utils/mock_rest_client.rs
+++ b/crates/breez-sdk/common/src/test_utils/mock_rest_client.rs
@@ -74,4 +74,23 @@ impl RestClient for MockRestClient {
 
         Ok(RestResponse { status, body })
     }
+
+    async fn delete(
+        &self,
+        _url: String,
+        _headers: Option<HashMap<String, String>>,
+        _body: Option<String>,
+    ) -> Result<RestResponse, ServiceConnectivityError> {
+        let mut responses = self.responses.lock().unwrap();
+        let response = responses.pop_front().ok_or_else(|| {
+            ServiceConnectivityError::Other(String::from(
+                "No response available for DELETE request",
+            ))
+        })?;
+        debug!("Pop DELETE response: {response:?}");
+        let status = response.status_code;
+        let body = response.text;
+
+        Ok(RestResponse { status, body })
+    }
 }

--- a/crates/breez-sdk/core/src/error.rs
+++ b/crates/breez-sdk/core/src/error.rs
@@ -3,6 +3,7 @@ use crate::{
     persist::{self},
 };
 use bitcoin::consensus::encode::FromHexError;
+use breez_sdk_common::error::ServiceConnectivityError;
 use serde::{Deserialize, Serialize};
 use spark_wallet::SparkWalletError;
 use std::{convert::Infallible, num::TryFromIntError};
@@ -128,6 +129,12 @@ impl From<FromHexError> for SdkError {
 impl From<uuid::Error> for SdkError {
     fn from(e: uuid::Error) -> Self {
         SdkError::InvalidUuid(e.to_string())
+    }
+}
+
+impl From<ServiceConnectivityError> for SdkError {
+    fn from(value: ServiceConnectivityError) -> Self {
+        SdkError::NetworkError(value.to_string())
     }
 }
 

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -769,3 +769,25 @@ pub struct LogEntry {
     pub line: String,
     pub level: String,
 }
+
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetLightningAddressRequest {
+    pub username: String,
+    pub description: String,
+}
+
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetLightningAddressResponse {
+    pub lnurl: String,
+    pub lightning_address: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct RecoverLnurlPayResponse {
+    pub lnurl: String,
+    pub lightning_address: String,
+    pub username: String,
+    pub description: String,
+}

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -772,6 +772,12 @@ pub struct LogEntry {
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckLightningAddressRequest {
+    pub username: String,
+}
+
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetLightningAddressRequest {
     pub username: String,
     pub description: String,

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -390,6 +390,9 @@ pub struct Config {
     // The maximum fee that can be paid for a static deposit claim
     // If not set then any fee is allowed
     pub max_deposit_claim_fee: Option<Fee>,
+
+    /// The domain used for receiving through lnurl-pay and lightning address.
+    pub lnurl_domain: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -7,9 +7,14 @@ use macros::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{DepositClaimError, DepositInfo, LnurlPayInfo, models::Payment};
+use crate::{
+    DepositClaimError, DepositInfo, GetLightningAddressResponse, LnurlPayInfo,
+    SetLightningAddressRequest, models::Payment,
+};
 
 const ACCOUNT_INFO_KEY: &str = "account_info";
+const LIGHTNING_ADDRESS_KEY: &str = "lightning_address";
+const LIGHTNING_ADDRESS_CONFIG_KEY: &str = "lightning_address_config";
 const SYNC_OFFSET_KEY: &str = "sync_offset";
 const TX_CACHE_KEY: &str = "tx_cache";
 const STATIC_DEPOSIT_ADDRESS_CACHE_KEY: &str = "static_deposit_address";
@@ -254,6 +259,58 @@ impl ObjectCacheRepository {
         let value = self
             .storage
             .get_cached_item(STATIC_DEPOSIT_ADDRESS_CACHE_KEY.to_string())
+            .await?;
+        match value {
+            Some(value) => Ok(Some(serde_json::from_str(&value)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub(crate) async fn save_lightning_address_config(
+        &self,
+        value: &SetLightningAddressRequest,
+    ) -> Result<(), StorageError> {
+        self.storage
+            .set_cached_item(
+                LIGHTNING_ADDRESS_CONFIG_KEY.to_string(),
+                serde_json::to_string(value)?,
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn fetch_lightning_address_config(
+        &self,
+    ) -> Result<Option<SetLightningAddressRequest>, StorageError> {
+        let value = self
+            .storage
+            .get_cached_item(LIGHTNING_ADDRESS_CONFIG_KEY.to_string())
+            .await?;
+        match value {
+            Some(value) => Ok(Some(serde_json::from_str(&value)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub(crate) async fn save_lightning_address(
+        &self,
+        value: &GetLightningAddressResponse,
+    ) -> Result<(), StorageError> {
+        self.storage
+            .set_cached_item(
+                LIGHTNING_ADDRESS_KEY.to_string(),
+                serde_json::to_string(value)?,
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn fetch_lightning_address(
+        &self,
+    ) -> Result<Option<GetLightningAddressResponse>, StorageError> {
+        let value = self
+            .storage
+            .get_cached_item(LIGHTNING_ADDRESS_KEY.to_string())
             .await?;
         match value {
             Some(value) => Ok(Some(serde_json::from_str(&value)?)),

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -62,6 +62,7 @@ pub struct PaymentMetadata {
 #[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
 #[async_trait]
 pub trait Storage: Send + Sync {
+    async fn delete_cached_item(&self, key: String) -> Result<(), StorageError>;
     async fn get_cached_item(&self, key: String) -> Result<Option<String>, StorageError>;
     async fn set_cached_item(&self, key: String, value: String) -> Result<(), StorageError>;
     /// Lists payments with pagination
@@ -279,6 +280,13 @@ impl ObjectCacheRepository {
         Ok(())
     }
 
+    pub(crate) async fn delete_lightning_address_config(&self) -> Result<(), StorageError> {
+        self.storage
+            .delete_cached_item(LIGHTNING_ADDRESS_CONFIG_KEY.to_string())
+            .await?;
+        Ok(())
+    }
+
     pub(crate) async fn fetch_lightning_address_config(
         &self,
     ) -> Result<Option<SetLightningAddressRequest>, StorageError> {
@@ -301,6 +309,13 @@ impl ObjectCacheRepository {
                 LIGHTNING_ADDRESS_KEY.to_string(),
                 serde_json::to_string(value)?,
             )
+            .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn delete_lightning_address(&self) -> Result<(), StorageError> {
+        self.storage
+            .delete_cached_item(LIGHTNING_ADDRESS_KEY.to_string())
             .await?;
         Ok(())
     }

--- a/crates/breez-sdk/core/src/persist/sqlite/mod.rs
+++ b/crates/breez-sdk/core/src/persist/sqlite/mod.rs
@@ -213,6 +213,15 @@ impl Storage for SqliteStorage {
         }
     }
 
+    async fn delete_cached_item(&self, key: String) -> Result<(), StorageError> {
+        sqlx::query("DELETE FROM settings WHERE key = ?")
+            .bind(&key)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+
     async fn get_payment_by_id(&self, id: String) -> Result<Payment, StorageError> {
         let query = "SELECT id, payment_type, status, amount, fees, timestamp, details, method, pm.lnurl_pay_info 
                      FROM payments 

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -129,6 +129,7 @@ pub fn default_config(network: Network) -> Config {
         network,
         sync_interval_secs: 60, // every 1 minute
         max_deposit_claim_fee: None,
+        lnurl_domain: None,
     }
 }
 

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -131,7 +131,7 @@ pub fn default_config(network: Network) -> Config {
         network,
         sync_interval_secs: 60, // every 1 minute
         max_deposit_claim_fee: None,
-        lnurl_domain: None,
+        lnurl_domain: Some("spark-lnurl.fly.dev".to_string()),
     }
 }
 
@@ -1247,7 +1247,14 @@ impl BreezSdk {
             "username": config.username,
             "signature": sig,
         }))?;
-        let resp = self.lnurl_client.delete(url, None, Some(body)).await?;
+        let resp = self
+            .lnurl_client
+            .delete(
+                url,
+                Some([("Content-Type".to_string(), "application/json".to_string())].into()),
+                Some(body),
+            )
+            .await?;
         if !resp.is_success() {
             return Err(SdkError::Generic(format!(
                 "Failed to delete lightning address: {}",

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -636,3 +636,15 @@ pub enum UpdateDepositPayload {
         refund_tx: String,
     },
 }
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::SetLightningAddressRequest)]
+pub struct SetLightningAddressRequest {
+    pub username: String,
+    pub description: String,
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::GetLightningAddressResponse)]
+pub struct GetLightningAddressResponse {
+    pub lnurl: String,
+    pub lightning_address: String,
+}

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -443,6 +443,7 @@ pub struct Config {
     pub network: Network,
     pub sync_interval_secs: u32,
     pub max_deposit_claim_fee: Option<Fee>,
+    pub lnurl_domain: Option<String>,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::Fee)]

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -637,6 +637,11 @@ pub enum UpdateDepositPayload {
     },
 }
 
+#[macros::extern_wasm_bindgen(breez_sdk_spark::CheckLightningAddressRequest)]
+pub struct CheckLightningAddressRequest {
+    pub username: String,
+}
+
 #[macros::extern_wasm_bindgen(breez_sdk_spark::SetLightningAddressRequest)]
 pub struct SetLightningAddressRequest {
     pub username: String,

--- a/crates/breez-sdk/wasm/src/persist/mod.rs
+++ b/crates/breez-sdk/wasm/src/persist/mod.rs
@@ -214,6 +214,9 @@ extern "C" {
     #[wasm_bindgen(structural, method, js_name = setCachedItem, catch)]
     pub fn set_cached_item(this: &Storage, key: String, value: String) -> Result<Promise, JsValue>;
 
+    #[wasm_bindgen(structural, method, js_name = deleteCachedItem, catch)]
+    pub fn delete_cached_item(this: &Storage, key: String) -> Result<Promise, JsValue>;
+
     #[wasm_bindgen(structural, method, js_name = listPayments, catch)]
     pub fn list_payments(
         this: &Storage,

--- a/crates/breez-sdk/wasm/src/persist/mod.rs
+++ b/crates/breez-sdk/wasm/src/persist/mod.rs
@@ -58,6 +58,16 @@ impl breez_sdk_spark::Storage for WasmStorage {
         Ok(())
     }
 
+    async fn delete_cached_item(&self, key: String) -> Result<(), breez_sdk_spark::StorageError> {
+        let promise = self
+            .storage
+            .delete_cached_item(key)
+            .map_err(js_error_to_storage_error)?;
+        let future = JsFuture::from(promise);
+        future.await.map_err(js_error_to_storage_error)?;
+        Ok(())
+    }
+
     async fn list_payments(
         &self,
         offset: Option<u32>,

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -192,4 +192,22 @@ impl BreezSdk {
             .await?
             .into())
     }
+
+    #[wasm_bindgen(js_name = "getLightningAddress")]
+    pub async fn get_lightning_address(&self) -> WasmResult<Option<GetLightningAddressResponse>> {
+        Ok(self.sdk.get_lightning_address().await?.map(|resp| resp.into()))
+    }
+
+    #[wasm_bindgen(js_name = "setLightningAddress")]
+    pub async fn set_lightning_address(
+        &self,
+        request: SetLightningAddressRequest,
+    ) -> WasmResult<GetLightningAddressResponse> {
+        Ok(self.sdk.set_lightning_address(request.into()).await?.into())
+    }
+
+    #[wasm_bindgen(js_name = "deleteLightningAddress")]
+    pub async fn delete_lightning_address(&self) -> WasmResult<()> {
+        Ok(self.sdk.delete_lightning_address().await?)
+    }
 }

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -193,9 +193,24 @@ impl BreezSdk {
             .into())
     }
 
+    #[wasm_bindgen(js_name = "checkLightningAddressAvailable")]
+    pub async fn check_lightning_address_available(
+        &self,
+        request: CheckLightningAddressRequest,
+    ) -> WasmResult<bool> {
+        Ok(self
+            .sdk
+            .check_lightning_address_available(request.into())
+            .await?)
+    }
+
     #[wasm_bindgen(js_name = "getLightningAddress")]
     pub async fn get_lightning_address(&self) -> WasmResult<Option<GetLightningAddressResponse>> {
-        Ok(self.sdk.get_lightning_address().await?.map(|resp| resp.into()))
+        Ok(self
+            .sdk
+            .get_lightning_address()
+            .await?
+            .map(|resp| resp.into()))
     }
 
     #[wasm_bindgen(js_name = "setLightningAddress")]

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -593,3 +593,15 @@ pub struct _SilentPaymentAddressDetails {
     pub network: BitcoinNetwork,
     pub source: PaymentRequestSource,
 }
+
+#[frb(mirror(SetLightningAddressRequest))]
+pub struct _SetLightningAddressRequest {
+    pub username: String,
+    pub description: String,
+}
+
+#[frb(mirror(GetLightningAddressResponse))]
+pub struct _GetLightningAddressResponse {
+    pub lnurl: String,
+    pub lightning_address: String,
+}

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -594,6 +594,11 @@ pub struct _SilentPaymentAddressDetails {
     pub source: PaymentRequestSource,
 }
 
+#[frb(mirror(CheckLightningAddressRequest))]
+pub struct _CheckLightningAddressRequest {
+    pub username: String,
+}
+
 #[frb(mirror(SetLightningAddressRequest))]
 pub struct _SetLightningAddressRequest {
     pub username: String,

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -143,4 +143,21 @@ impl BreezSdk {
     ) -> Result<ListUnclaimedDepositsResponse, SdkError> {
         self.inner.list_unclaimed_deposits(request).await
     }
+
+    pub async fn get_lightning_address(
+        &self,
+    ) -> Result<Option<GetLightningAddressResponse>, SdkError> {
+        self.inner.get_lightning_address().await
+    }
+
+    pub async fn set_lightning_address(
+        &self,
+        request: SetLightningAddressRequest,
+    ) -> Result<GetLightningAddressResponse, SdkError> {
+        self.inner.set_lightning_address(request).await
+    }
+
+    pub async fn delete_lightning_address(&self) -> Result<(), SdkError> {
+        self.inner.delete_lightning_address().await
+    }
 }

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -144,6 +144,13 @@ impl BreezSdk {
         self.inner.list_unclaimed_deposits(request).await
     }
 
+    pub async fn check_lightning_address_available(
+        &self,
+    ) -> Result<Option<CheckLightningAddressResponse>, SdkError> {
+        self.inner.check_lightning_address_available().await
+    }
+
+
     pub async fn get_lightning_address(
         &self,
     ) -> Result<Option<GetLightningAddressResponse>, SdkError> {


### PR DESCRIPTION
The lightning address domain is configured in the connect configuration.

Register lightning address
- when the function is called by the client
- on every startup

Recover the lightning address
- on startup if no lightning address information was found

Possibility to 
- check if a lightning address is available
- get the lightning address
- delete the lightning address