### PR TITLE
Reuse connections across instances

### DIFF
--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -11,7 +11,10 @@ use spark::{
     address::SparkAddress,
     bitcoin::BitcoinService,
     events::{SparkEvent, subscribe_server_events},
-    operator::{OperatorPool, rpc::ConnectionManager},
+    operator::{
+        OperatorPool,
+        rpc::{ConnectionManager, DefaultConnectionManager},
+    },
     services::{
         CoopExitFeeQuote, CoopExitService, CpfpUtxo, DepositService, ExitSpeed, Fee,
         InvoiceDescription, LeafTxCpfpPsbts, LightningReceivePayment, LightningSendPayment,
@@ -68,6 +71,8 @@ impl SparkWallet {
             signer,
             Arc::new(InMemorySessionManager::default()),
             Arc::new(InMemoryTreeStore::default()),
+            Arc::new(DefaultConnectionManager::new()),
+            true,
         )
         .await
     }
@@ -77,10 +82,11 @@ impl SparkWallet {
         signer: Arc<dyn Signer>,
         session_manager: Arc<dyn SessionManager>,
         tree_store: Arc<dyn TreeStore>,
+        connection_manager: Arc<dyn ConnectionManager>,
+        with_background_processing: bool,
     ) -> Result<Self, SparkWalletError> {
         config.validate()?;
         let identity_public_key = signer.get_identity_public_key()?;
-        let connection_manager = ConnectionManager::new();
 
         let bitcoin_service = BitcoinService::new(config.network);
         let service_provider = Arc::new(ServiceProvider::new(
@@ -92,7 +98,7 @@ impl SparkWallet {
         let operator_pool = Arc::new(
             OperatorPool::connect(
                 &config.operator_pool,
-                &connection_manager,
+                connection_manager,
                 Arc::clone(&session_manager),
                 Arc::clone(&signer),
             )
@@ -173,21 +179,22 @@ impl SparkWallet {
 
         let event_manager = Arc::new(EventManager::new());
         let (cancel, cancellation_token) = watch::channel(());
-        let reconnect_interval = Duration::from_secs(config.reconnect_interval_seconds);
-        let background_processor = Arc::new(BackgroundProcessor::new(
-            Arc::clone(&operator_pool),
-            Arc::clone(&event_manager),
-            identity_public_key,
-            reconnect_interval,
-            Arc::clone(&tree_service),
-            Arc::clone(&service_provider),
-            Arc::clone(&transfer_service),
-            Arc::clone(&deposit_service),
-        ));
-        background_processor
-            .run_background_tasks(cancellation_token.clone())
-            .await;
-
+        if with_background_processing {
+            let reconnect_interval = Duration::from_secs(config.reconnect_interval_seconds);
+            let background_processor = Arc::new(BackgroundProcessor::new(
+                Arc::clone(&operator_pool),
+                Arc::clone(&event_manager),
+                identity_public_key,
+                reconnect_interval,
+                Arc::clone(&tree_service),
+                Arc::clone(&service_provider),
+                Arc::clone(&transfer_service),
+                Arc::clone(&deposit_service),
+            ));
+            background_processor
+                .run_background_tasks(cancellation_token.clone())
+                .await;
+        }
         Ok(Self {
             cancel,
             config,

--- a/crates/spark-wallet/src/wallet_builder.rs
+++ b/crates/spark-wallet/src/wallet_builder.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use spark::{
+    operator::rpc::{ConnectionManager, DefaultConnectionManager},
     session_manager::{InMemorySessionManager, SessionManager},
     signer::Signer,
     tree::{InMemoryTreeStore, TreeStore},
@@ -14,6 +15,8 @@ pub struct WalletBuilder {
     signer: Arc<dyn Signer>,
     session_manager: Option<Arc<dyn SessionManager>>,
     tree_store: Option<Arc<dyn TreeStore>>,
+    connection_manager: Option<Arc<dyn ConnectionManager>>,
+    with_background_processing: bool,
 }
 
 impl WalletBuilder {
@@ -23,6 +26,8 @@ impl WalletBuilder {
             signer,
             session_manager: None,
             tree_store: None,
+            connection_manager: None,
+            with_background_processing: true,
         }
     }
 
@@ -36,6 +41,19 @@ impl WalletBuilder {
         self
     }
 
+    pub fn with_connection_manager(
+        mut self,
+        connection_manager: Arc<dyn ConnectionManager>,
+    ) -> Self {
+        self.connection_manager = Some(connection_manager);
+        self
+    }
+
+    pub fn with_background_processing(mut self, with_background_processing: bool) -> Self {
+        self.with_background_processing = with_background_processing;
+        self
+    }
+
     pub async fn build(self) -> Result<SparkWallet, SparkWalletError> {
         SparkWallet::new(
             self.config,
@@ -44,6 +62,9 @@ impl WalletBuilder {
                 .unwrap_or(Arc::new(InMemorySessionManager::default())),
             self.tree_store
                 .unwrap_or(Arc::new(InMemoryTreeStore::default())),
+            self.connection_manager
+                .unwrap_or(Arc::new(DefaultConnectionManager::new())),
+            self.with_background_processing,
         )
         .await
     }

--- a/crates/spark/src/operator/pool.rs
+++ b/crates/spark/src/operator/pool.rs
@@ -92,7 +92,7 @@ pub struct OperatorPool {
 impl OperatorPool {
     pub async fn connect(
         config: &OperatorPoolConfig,
-        connection_manager: &ConnectionManager,
+        connection_manager: Arc<dyn ConnectionManager>,
         session_manager: Arc<dyn SessionManager>,
         signer: Arc<dyn Signer>,
     ) -> Result<Self, OperatorRpcError> {

--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -610,7 +610,7 @@ impl SparkRpcClient {
         let valid_session = match current_session {
             Ok(session) => self.auth.get_authenticated_session(Some(session)).await,
             Err(e) => {
-                error!("Failed to get session from session manager: {}", e);
+                error!("Failed to get operator session from session manager: {}", e);
                 self.auth.get_authenticated_session(None).await
             }
         }?;

--- a/crates/spark/src/ssp/graphql/client.rs
+++ b/crates/spark/src/ssp/graphql/client.rs
@@ -510,7 +510,7 @@ impl GraphQLClient {
                 }
             }
             Err(e) => {
-                error!("Failed to get session from session manager: {}", e);
+                error!("Failed to get ssp session from session manager: {}", e);
                 self.authenticate().await?
             }
         };


### PR DESCRIPTION
This PR allows passing external ConnectionManager so operator grpc connections can be reused in multiple instances.
This is particularly useful in a service environment where wallet instances are instantiated as per request in high frequency. 
In addition the background processing is now optional given the fact there are times only sending funds is needed and claiming transfers is executed elsewhere in its own service. 