### PR TITLE
Fix LNURL signer usage

### DIFF
--- a/crates/breez-sdk/lnurl/src/main.rs
+++ b/crates/breez-sdk/lnurl/src/main.rs
@@ -149,7 +149,7 @@ where
     let wallet = Arc::new(
         spark_wallet::SparkWallet::connect(
             SparkWalletConfig::default_config(args.network),
-            DefaultSigner::new(&auth_seed, args.network)?,
+            Arc::new(DefaultSigner::new(&auth_seed, args.network)?),
         )
         .await?,
     );

--- a/crates/breez-sdk/lnurl/src/state.rs
+++ b/crates/breez-sdk/lnurl/src/state.rs
@@ -1,10 +1,8 @@
 use std::{collections::HashSet, sync::Arc};
 
-use spark_wallet::DefaultSigner;
-
 pub struct State<DB> {
     pub db: DB,
-    pub wallet: Arc<spark_wallet::SparkWallet<DefaultSigner>>,
+    pub wallet: Arc<spark_wallet::SparkWallet>,
     pub scheme: String,
     pub min_sendable: u64,
     pub max_sendable: u64,


### PR DESCRIPTION
This fixes compilation errors introduced in [2788b37](https://github.com/breez/spark-sdk/commit/2788b377908a0b70fa560bcdd669e3384f3551f2)