### PR TITLE
Allow configuring if we include spark addr in invoice

### DIFF
--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -406,6 +406,11 @@ pub struct Config {
 
     /// The domain used for receiving through lnurl-pay and lightning address.
     pub lnurl_domain: Option<String>,
+
+    /// When this is set to `true` we will prefer to use spark payments over
+    /// lightning when sending and receiving. This has the benefit of lower fees
+    /// but is at the cost of privacy.
+    pub prefer_spark_over_lightning: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -133,6 +133,7 @@ pub fn default_config(network: Network) -> Config {
         sync_interval_secs: 60, // every 1 minute
         max_deposit_claim_fee: None,
         lnurl_domain: Some("breez.tips".to_string()),
+        prefer_spark_over_lightning: false,
     }
 }
 
@@ -615,7 +616,7 @@ impl BreezSdk {
                         amount_sats.unwrap_or_default(),
                         Some(InvoiceDescription::Memo(description.clone())),
                         None,
-                        true,
+                        self.config.prefer_spark_over_lightning,
                     )
                     .await?
                     .invoice,
@@ -842,7 +843,7 @@ impl BreezSdk {
                 };
                 let use_spark = match request.options {
                     Some(SendPaymentOptions::Bolt11Invoice { use_spark }) => use_spark,
-                    _ => false,
+                    _ => self.config.prefer_spark_over_lightning,
                 };
                 let fee_sats = match (use_spark, spark_transfer_fee_sats, lightning_fee_sats) {
                     (true, Some(fee), _) => fee,

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -615,6 +615,7 @@ impl BreezSdk {
                         amount_sats.unwrap_or_default(),
                         Some(InvoiceDescription::Memo(description.clone())),
                         None,
+                        true,
                     )
                     .await?
                     .invoice,

--- a/crates/breez-sdk/lnurl/src/main.rs
+++ b/crates/breez-sdk/lnurl/src/main.rs
@@ -73,6 +73,12 @@ struct Args {
     #[arg(long, default_value = "4000000000")]
     pub max_sendable: u64,
 
+    /// Whether to include the spark address in the invoices generated.
+    /// If included this can reduce fees for wallets that support it at the
+    /// cost of privacy.
+    #[arg(long, default_value = "false")]
+    pub include_spark_address: bool,
+
     /// List of domains that are allowed to use the lnurl server. Comma separated.
     #[arg(long, default_value = "localhost:8080")]
     pub domains: String,
@@ -176,6 +182,7 @@ where
         scheme: args.scheme,
         min_sendable: args.min_sendable,
         max_sendable: args.max_sendable,
+        include_spark_address: args.include_spark_address,
         domains,
         ca_cert,
     };

--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -298,6 +298,7 @@ where
                     desc_hash.to_byte_array(),
                 )),
                 Some(pubkey),
+                false, // don't include spark address, we want to keep it private here
             )
             .await
             .map_err(|e| {

--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -298,7 +298,7 @@ where
                     desc_hash.to_byte_array(),
                 )),
                 Some(pubkey),
-                false, // don't include spark address, we want to keep it private here
+                state.include_spark_address,
             )
             .await
             .map_err(|e| {

--- a/crates/breez-sdk/lnurl/src/state.rs
+++ b/crates/breez-sdk/lnurl/src/state.rs
@@ -6,6 +6,7 @@ pub struct State<DB> {
     pub scheme: String,
     pub min_sendable: u64,
     pub max_sendable: u64,
+    pub include_spark_address: bool,
     pub domains: HashSet<String>,
     pub ca_cert: Option<Vec<u8>>,
 }
@@ -21,6 +22,7 @@ where
             scheme: self.scheme.clone(),
             min_sendable: self.min_sendable,
             max_sendable: self.max_sendable,
+            include_spark_address: self.include_spark_address,
             domains: self.domains.clone(),
             ca_cert: self.ca_cert.clone(),
         }

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -444,6 +444,7 @@ pub struct Config {
     pub sync_interval_secs: u32,
     pub max_deposit_claim_fee: Option<Fee>,
     pub lnurl_domain: Option<String>,
+    pub prefer_spark_over_lightning: bool,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::Fee)]

--- a/crates/internal/src/command/lightning.rs
+++ b/crates/internal/src/command/lightning.rs
@@ -49,7 +49,7 @@ pub async fn handle_command(
         } => {
             let desc = description.map(InvoiceDescription::Memo);
             let payment = wallet
-                .create_lightning_invoice(amount_sat, desc, None)
+                .create_lightning_invoice(amount_sat, desc, None, true)
                 .await?;
             let qr = QrCode::with_error_correction_level(&payment.invoice, EcLevel::L)
                 .unwrap()

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -270,10 +270,18 @@ impl SparkWallet {
         amount_sat: u64,
         description: Option<InvoiceDescription>,
         public_key: Option<PublicKey>,
+        include_spark_address: bool,
     ) -> Result<LightningReceivePayment, SparkWalletError> {
         Ok(self
             .lightning_service
-            .create_lightning_invoice(amount_sat, description, None, None, public_key)
+            .create_lightning_invoice(
+                amount_sat,
+                description,
+                None,
+                None,
+                include_spark_address,
+                public_key,
+            )
             .await?)
     }
 

--- a/crates/spark/src/services/lightning.rs
+++ b/crates/spark/src/services/lightning.rs
@@ -241,6 +241,7 @@ impl LightningService {
         description: Option<InvoiceDescription>,
         preimage: Option<Vec<u8>>,
         expiry_secs: Option<u32>,
+        include_spark_address: bool,
         identity_pubkey: Option<PublicKey>,
     ) -> Result<LightningReceivePayment, ServiceError> {
         let identity_pubkey = match identity_pubkey {
@@ -270,7 +271,7 @@ impl LightningService {
                 description_hash: description_hash.map(|h| h.encode_hex()),
                 expiry_secs: Some(expiry.into()),
                 memo,
-                include_spark_address: true,
+                include_spark_address,
             })
             .await?;
         let decoded_invoice = Bolt11Invoice::from_str(&invoice.invoice.encoded_invoice)

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -28,6 +28,7 @@ pub struct _Config {
     pub sync_interval_secs: u32,
     pub max_deposit_claim_fee: Option<Fee>,
     pub lnurl_domain: Option<String>,
+    pub prefer_spark_over_lightning: bool,
 }
 
 #[frb(mirror(ConnectRequest))]


### PR DESCRIPTION
As we have been doing more research into spark we've found that revealing our spark address has a lot of privacy implications. Would be good to have the option to not include this in the invoice.