### PR TITLE
lnurl server: use native tls

### DIFF
--- a/crates/breez-sdk/lnurl/Cargo.toml
+++ b/crates/breez-sdk/lnurl/Cargo.toml
@@ -19,7 +19,7 @@ regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_with.workspace = true
-spark-wallet.workspace = true
+spark-wallet = { workspace = true, features = ["native-tls"] }
 sqlx = { workspace = true, features = ["postgres", "runtime-tokio", "sqlite", "tls-native-tls"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }


### PR DESCRIPTION
The tls features are disabled by default in the workspace. So explicitly enable tls features for the lnurl server.

This fixes the error on invoice creation: `failed to create lightning invoice: Service error: service provider error: network error: error sending request for url (https://api.lightspark.com/graphql/spark/2025-03-19) : client error (Connect) : invalid URL, scheme is not http (code: None)`