### PR TITLE
Remove strict `use_spark` check

### DIFF
--- a/crates/breez-sdk/cli/src/commands.rs
+++ b/crates/breez-sdk/cli/src/commands.rs
@@ -408,10 +408,14 @@ fn read_payment_options(
                 println!("2. Lightning fee: {lightning_fee_sats} sats");
                 let line = rl.readline_with_initial("", ("1", ""))?.to_lowercase();
                 if line == "1" {
-                    return Ok(Some(SendPaymentOptions::Bolt11Invoice { use_spark: true }));
+                    return Ok(Some(SendPaymentOptions::Bolt11Invoice {
+                        prefer_spark: true,
+                    }));
                 }
             }
-            Ok(Some(SendPaymentOptions::Bolt11Invoice { use_spark: false }))
+            Ok(Some(SendPaymentOptions::Bolt11Invoice {
+                prefer_spark: false,
+            }))
         }
         SendPaymentMethod::SparkAddress { .. } => Ok(None),
     }

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -736,7 +736,7 @@ pub enum SendPaymentOptions {
         confirmation_speed: OnchainConfirmationSpeed,
     },
     Bolt11Invoice {
-        use_spark: bool,
+        prefer_spark: bool,
     },
 }
 

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -841,7 +841,7 @@ impl BreezSdk {
                     None => Some(request.prepare_response.amount_sats),
                 };
                 let prefer_spark = match request.options {
-                    Some(SendPaymentOptions::Bolt11Invoice { use_spark }) => use_spark,
+                    Some(SendPaymentOptions::Bolt11Invoice { prefer_spark }) => prefer_spark,
                     _ => self.config.prefer_spark_over_lightning,
                 };
                 let fee_sats = match (prefer_spark, spark_transfer_fee_sats, lightning_fee_sats) {

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -592,7 +592,7 @@ pub enum SendPaymentOptions {
         confirmation_speed: OnchainConfirmationSpeed,
     },
     Bolt11Invoice {
-        use_spark: bool,
+        prefer_spark: bool,
     },
 }
 

--- a/docs/breez-sdk/snippets/flutter/lib/send_payment.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/send_payment.dart
@@ -77,7 +77,7 @@ Future<PrepareSendPaymentResponse> prepareSendPaymentSpark(BreezSdk sdk) async {
 Future<SendPaymentResponse> sendPaymentLightningBolt11(
     BreezSdk sdk, PrepareSendPaymentResponse prepareResponse) async {
   // ANCHOR: send-payment-lightning-bolt11
-  final options = SendPaymentOptions.bolt11Invoice(useSpark: true);
+  final options = SendPaymentOptions.bolt11Invoice(preferSpark: true);
   final request =
       SendPaymentRequest(prepareResponse: prepareResponse, options: options);
   SendPaymentResponse response = await sdk.sendPayment(request: request);

--- a/docs/breez-sdk/snippets/go/send_payment.go
+++ b/docs/breez-sdk/snippets/go/send_payment.go
@@ -96,7 +96,7 @@ func PrepareSendPaymentSpark(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.Pr
 func SendPaymentLightningBolt11(sdk *breez_sdk_spark.BreezSdk, prepareResponse breez_sdk_spark.PrepareSendPaymentResponse) (*breez_sdk_spark.Payment, error) {
 	// ANCHOR: send-payment-lightning-bolt11
 	var options breez_sdk_spark.SendPaymentOptions = breez_sdk_spark.SendPaymentOptionsBolt11Invoice{
-		UseSpark: true,
+		PreferSpark: true,
 	}
 
 	request := breez_sdk_spark.SendPaymentRequest{

--- a/docs/breez-sdk/snippets/python/src/send_payment.py
+++ b/docs/breez-sdk/snippets/python/src/send_payment.py
@@ -102,7 +102,7 @@ async def send_payment_lightning_bolt11(
 ):
     # ANCHOR: send-payment-lightning-bolt11
     try:
-        options = SendPaymentOptions.BOLT11_INVOICE(use_spark=True)
+        options = SendPaymentOptions.BOLT11_INVOICE(prefer_spark=True)
         request = SendPaymentRequest(prepare_response=prepare_response, options=options)
         send_response = await sdk.send_payment(request=request)
         payment = send_response.payment

--- a/docs/breez-sdk/snippets/react-native/send_payment.ts
+++ b/docs/breez-sdk/snippets/react-native/send_payment.ts
@@ -77,7 +77,7 @@ const exampleSendPaymentLightningBolt11 = async (
   prepareResponse: PrepareSendPaymentResponse
 ) => {
   // ANCHOR: send-payment-lightning-bolt11
-  const options = new SendPaymentOptions.Bolt11Invoice({ useSpark: true })
+  const options = new SendPaymentOptions.Bolt11Invoice({ preferSpark: true })
   const sendResponse = await sdk.sendPayment({
     prepareResponse,
     options

--- a/docs/breez-sdk/snippets/rust/src/send_payment.rs
+++ b/docs/breez-sdk/snippets/rust/src/send_payment.rs
@@ -80,8 +80,7 @@ async fn send_payment_lightning_bolt11(
     prepare_response: PrepareSendPaymentResponse,
 ) -> Result<()> {
     // ANCHOR: send-payment-lightning-bolt11
-    // Only set to use spark if the spark transfer fee is available (Default = false)
-    let options = Some(SendPaymentOptions::Bolt11Invoice { use_spark: true });
+    let options = Some(SendPaymentOptions::Bolt11Invoice { prefer_spark: true });
     let send_response = sdk
         .send_payment(SendPaymentRequest {
             prepare_response,

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SendPayment.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SendPayment.swift
@@ -66,7 +66,7 @@ func prepareSendPaymentSpark(sdk: BreezSdk) async throws {
 
 func sendPaymentLightningBolt11(sdk: BreezSdk, prepareResponse: PrepareSendPaymentResponse) async throws {
     // ANCHOR: send-payment-lightning-bolt11
-    let options = SendPaymentOptions.bolt11Invoice(useSpark: true)
+    let options = SendPaymentOptions.bolt11Invoice(preferSpark: true)
     let sendResponse = try await sdk.sendPayment(request: SendPaymentRequest (
         prepareResponse: prepareResponse,
         options: options

--- a/docs/breez-sdk/snippets/wasm/send_payment.ts
+++ b/docs/breez-sdk/snippets/wasm/send_payment.ts
@@ -75,7 +75,7 @@ const exampleSendPaymentLightningBolt11 = async (
   prepareResponse: PrepareSendPaymentResponse
 ) => {
   // ANCHOR: send-payment-lightning-bolt11
-  const options: SendPaymentOptions = { type: 'bolt11Invoice', useSpark: true }
+  const options: SendPaymentOptions = { type: 'bolt11Invoice', preferSpark: true }
   const sendResponse = await sdk.sendPayment({
     prepareResponse,
     options

--- a/docs/breez-sdk/src/guide/send_payment.md
+++ b/docs/breez-sdk/src/guide/send_payment.md
@@ -239,7 +239,7 @@ Once the payment has been prepared, pass the prepare response as an argument to 
 
 ### Lightning
 
-In the send payment options for BOLT11 invoices, you can set whether to use Spark to transfer the payment. This should only be enabled if the prepare response contains a Spark transfer fee. By default, Spark usage is disabled.
+In the send payment options for BOLT11 invoices, you can set whether to use Spark to transfer the payment if the invoice contains a Spark address. By default, using Spark transfers are disabled.
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>

--- a/docs/breez-sdk/src/guide/send_payment.md
+++ b/docs/breez-sdk/src/guide/send_payment.md
@@ -239,7 +239,7 @@ Once the payment has been prepared, pass the prepare response as an argument to 
 
 ### Lightning
 
-In the send payment options for BOLT11 invoices, you can set whether to use Spark to transfer the payment if the invoice contains a Spark address. By default, using Spark transfers are disabled.
+In the send payment options for BOLT11 invoices, you can set whether to prefer to use Spark to transfer the payment if the invoice contains a Spark address. By default, using Spark transfers are disabled.
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -257,7 +257,7 @@ pub enum _SendPaymentOptions {
         confirmation_speed: OnchainConfirmationSpeed,
     },
     Bolt11Invoice {
-        use_spark: bool,
+        prefer_spark: bool,
     },
 }
 

--- a/packages/wasm/examples/node/src/action.js
+++ b/packages/wasm/examples/node/src/action.js
@@ -135,7 +135,7 @@ const sendPayment = async (options) => {
         if (await confirm(message)) {
             const res = await sdk.sendPayment({
                 prepareResponse,
-                options: { type: 'bolt11Invoice', useSpark: paymentMethod.sparkTransferFeeSats != null }
+                options: { type: 'bolt11Invoice', preferSpark: paymentMethod.sparkTransferFeeSats != null }
             })
             console.log(JSON.stringify(res, null, 2))
         }


### PR DESCRIPTION
Currently there is a burden on the implementer to only set `use_spark` to true in the send BOLT11 payment options if the invoice contains a Spark address. This PR replaces `use_spark` with `prefer_spark` and removes the error in case there is no Spark address present.

Update: [PR 244](https://github.com/breez/spark-sdk/pull/244) introduced using `prefer_spark_over_lightning` as the default, so this PR just renames the overriding option and softens the checking