### PR TITLE
Implement different key sets (TaprootSparkSigner)

### DIFF
--- a/crates/breez-sdk/core/src/bindings.rs
+++ b/crates/breez-sdk/core/src/bindings.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use breez_sdk_common::rest::RestClient;
 use tokio::sync::Mutex;
 
-use crate::{BitcoinChainService, BreezSdk, Config, Credentials, SdkError, Storage};
+use crate::{BitcoinChainService, BreezSdk, Config, Credentials, KeySetType, SdkError, Storage};
 
 /// Builder for creating `BreezSdk` instances with customizable components.
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
@@ -25,6 +25,17 @@ impl SdkBuilder {
         SdkBuilder {
             inner: Mutex::new(inner),
         }
+    }
+
+    /// Sets the key set type to be used by the SDK.
+    /// Arguments:
+    /// - `key_set_type`: The key set type which determines the derivation path.
+    /// - `use_address_index`: Controls the structure of the BIP derivation path.
+    pub async fn with_key_set(&self, key_set_type: KeySetType, use_address_index: bool) {
+        let mut builder = self.inner.lock().await;
+        *builder = builder
+            .clone()
+            .with_key_set(key_set_type, use_address_index);
     }
 
     /// Sets the chain service to be used by the SDK.

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -815,3 +815,38 @@ impl From<RecoverLnurlPayResponse> for LightningAddressInfo {
         }
     }
 }
+
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum KeySetType {
+    #[default]
+    Default,
+    Taproot,
+    NativeSegwit,
+    WrappedSegwit,
+    Legacy,
+}
+
+impl From<spark_wallet::KeySetType> for KeySetType {
+    fn from(value: spark_wallet::KeySetType) -> Self {
+        match value {
+            spark_wallet::KeySetType::Default => KeySetType::Default,
+            spark_wallet::KeySetType::Taproot => KeySetType::Taproot,
+            spark_wallet::KeySetType::NativeSegwit => KeySetType::NativeSegwit,
+            spark_wallet::KeySetType::WrappedSegwit => KeySetType::WrappedSegwit,
+            spark_wallet::KeySetType::Legacy => KeySetType::Legacy,
+        }
+    }
+}
+
+impl From<KeySetType> for spark_wallet::KeySetType {
+    fn from(value: KeySetType) -> Self {
+        match value {
+            KeySetType::Default => spark_wallet::KeySetType::Default,
+            KeySetType::Taproot => spark_wallet::KeySetType::Taproot,
+            KeySetType::NativeSegwit => spark_wallet::KeySetType::NativeSegwit,
+            KeySetType::WrappedSegwit => spark_wallet::KeySetType::WrappedSegwit,
+            KeySetType::Legacy => spark_wallet::KeySetType::Legacy,
+        }
+    }
+}

--- a/crates/spark-wallet/src/lib.rs
+++ b/crates/spark-wallet/src/lib.rs
@@ -21,7 +21,7 @@ pub use spark::{
         TransferType, Utxo,
     },
     session_manager::*,
-    signer::{DefaultSigner, DefaultSignerError, Signer},
+    signer::{DefaultSigner, DefaultSignerError, KeySet, KeySetType, Signer},
     ssp::*,
     tree::{SigningKeyshare, TreeNodeId},
     utils::{

--- a/crates/spark/src/signer/default_signer.rs
+++ b/crates/spark/src/signer/default_signer.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv};
+use bitcoin::key::Parity;
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::rand::thread_rng;
 use bitcoin::secp256k1::{self, All, Keypair, Message, PublicKey, SecretKey, schnorr};
@@ -30,44 +31,11 @@ use crate::{
 
 use super::VerifiableSecretShare;
 
-const PURPOSE: u32 = 8797555;
-
-fn identity_derivation_path(network: Network) -> DerivationPath {
-    DerivationPath::from(vec![
-        purpose(),
-        coin_type(network),
-        ChildNumber::from_hardened_idx(0).expect("Hardened zero is invalid"),
-    ])
-}
-
-fn signing_derivation_path(network: Network) -> DerivationPath {
-    DerivationPath::from(vec![
-        purpose(),
-        coin_type(network),
-        ChildNumber::from_hardened_idx(1).expect("Hardened one is invalid"),
-    ])
-}
-
-fn static_deposit_derivation_path(network: Network) -> DerivationPath {
-    DerivationPath::from(vec![
-        purpose(),
-        coin_type(network),
-        ChildNumber::from_hardened_idx(3).expect("Hardened one is invalid"),
-    ])
-}
-
-fn coin_type(network: Network) -> ChildNumber {
-    let coin_type: u32 = match network {
+fn account_number(network: Network) -> u32 {
+    match network {
         Network::Regtest => 0,
         _ => 1,
-    };
-    ChildNumber::from_hardened_idx(coin_type)
-        .unwrap_or_else(|_| panic!("Hardened coin type {coin_type} is invalid"))
-}
-
-fn purpose() -> ChildNumber {
-    ChildNumber::from_hardened_idx(PURPOSE)
-        .unwrap_or_else(|_| panic!("Hardened purpose {PURPOSE} is invalid"))
+    }
 }
 
 fn frost_signing_package(
@@ -117,11 +85,150 @@ fn frost_signing_package(
     ))
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum KeySetType {
+    #[default]
+    Default,
+    Taproot,
+    NativeSegwit,
+    WrappedSegwit,
+    Legacy,
+}
+
+struct DerivedKeySet {
+    derivation_path: DerivationPath,
+    master_key: Xpriv,
+}
+
+impl DerivedKeySet {
+    fn new(
+        seed: &[u8],
+        network: Network,
+        derivation_path: DerivationPath,
+    ) -> Result<Self, bitcoin::bip32::Error> {
+        let master_key = Xpriv::new_master(network, seed)?;
+
+        Ok(DerivedKeySet {
+            derivation_path,
+            master_key,
+        })
+    }
+
+    fn to_key_set(
+        &self,
+        identity_child_number: Option<ChildNumber>,
+    ) -> Result<KeySet, DefaultSignerError> {
+        let secp = Secp256k1::new();
+        let mut identity_master_key = self.master_key.derive_priv(&secp, &self.derivation_path)?;
+
+        let signing_master_key =
+            identity_master_key.derive_priv(&secp, &[ChildNumber::from_hardened_idx(1)?])?;
+        let static_deposit_master_key =
+            identity_master_key.derive_priv(&secp, &[ChildNumber::from_hardened_idx(3)?])?;
+        if let Some(child_number) = identity_child_number {
+            identity_master_key =
+                identity_master_key.derive_priv(&secp, &DerivationPath::from(vec![child_number]))?
+        }
+        Ok(KeySet {
+            identity_key_pair: identity_master_key.private_key.keypair(&secp),
+            signing_master_key,
+            static_deposit_master_key,
+        })
+    }
+}
+
 #[derive(Clone)]
-struct KeySet {
-    identity_key_pair: Keypair,
-    signing_master_key: Xpriv,
-    static_deposit_master_key: Xpriv,
+pub struct KeySet {
+    pub identity_key_pair: Keypair,
+    pub signing_master_key: Xpriv,
+    pub static_deposit_master_key: Xpriv,
+}
+
+impl KeySet {
+    fn default_keys(seed: &[u8], network: Network) -> Result<Self, DefaultSignerError> {
+        let account_number = account_number(network);
+        let derivation_path = format!("m/8797555'/{account_number}'").parse()?;
+        let derived_key_set = DerivedKeySet::new(seed, network, derivation_path)?;
+        derived_key_set.to_key_set(ChildNumber::from_hardened_idx(0).ok())
+    }
+
+    fn taproot_keys(
+        seed: &[u8],
+        network: Network,
+        use_address_index: bool,
+    ) -> Result<Self, DefaultSignerError> {
+        let account_number = account_number(network);
+        let derivation_path = if use_address_index {
+            format!("m/86'/0'/0'/0/{account_number}")
+        } else {
+            format!("m/86'/0'/{account_number}'/0/0")
+        }
+        .parse()?;
+        let derived_key_set = DerivedKeySet::new(seed, network, derivation_path)?;
+        let mut key_set = derived_key_set.to_key_set(None)?;
+        let secp = Secp256k1::new();
+        if let (_, Parity::Odd) = key_set
+            .identity_key_pair
+            .secret_key()
+            .x_only_public_key(&secp)
+        {
+            key_set.identity_key_pair = key_set
+                .identity_key_pair
+                .secret_key()
+                .negate()
+                .keypair(&secp)
+        }
+
+        Ok(key_set)
+    }
+
+    fn native_segwit_keys(
+        seed: &[u8],
+        network: Network,
+        use_address_index: bool,
+    ) -> Result<Self, DefaultSignerError> {
+        let account_number = account_number(network);
+        let derivation_path = if use_address_index {
+            format!("m/84'/0'/0'/0/{account_number}")
+        } else {
+            format!("m/84'/0'/{account_number}'/0/0")
+        }
+        .parse()?;
+        let derived_key_set = DerivedKeySet::new(seed, network, derivation_path)?;
+        derived_key_set.to_key_set(None)
+    }
+
+    fn wrapped_segwit_keys(
+        seed: &[u8],
+        network: Network,
+        use_address_index: bool,
+    ) -> Result<Self, DefaultSignerError> {
+        let account_number = account_number(network);
+        let derivation_path = if use_address_index {
+            format!("m/49'/0'/0'/0/{account_number}")
+        } else {
+            format!("m/49'/0'/{account_number}'/0/0")
+        }
+        .parse()?;
+        let derived_key_set = DerivedKeySet::new(seed, network, derivation_path)?;
+        derived_key_set.to_key_set(None)
+    }
+
+    fn legacy_bitcoin_keys(
+        seed: &[u8],
+        network: Network,
+        use_address_index: bool,
+    ) -> Result<Self, DefaultSignerError> {
+        let account_number = account_number(network);
+        let derivation_path = if use_address_index {
+            format!("m/44'/0'/0'/0/{account_number}")
+        } else {
+            format!("m/44'/0'/{account_number}'/0/0")
+        }
+        .parse()?;
+        let derived_key_set = DerivedKeySet::new(seed, network, derivation_path)?;
+        derived_key_set.to_key_set(None)
+    }
 }
 
 #[derive(Clone)]
@@ -153,23 +260,32 @@ impl From<bitcoin::bip32::Error> for DefaultSignerError {
 
 impl DefaultSigner {
     pub fn new(seed: &[u8], network: Network) -> Result<Self, DefaultSignerError> {
-        let master_key =
-            Xpriv::new_master(network, seed).map_err(|_| DefaultSignerError::InvalidSeed)?;
+        Self::with_keyset_type(seed, network, KeySetType::Default, false)
+    }
+
+    pub fn with_keyset_type(
+        seed: &[u8],
+        network: Network,
+        key_type: KeySetType,
+        use_address_index: bool,
+    ) -> Result<Self, DefaultSignerError> {
+        let key_set = match key_type {
+            KeySetType::Default => KeySet::default_keys(seed, network),
+            KeySetType::Taproot => KeySet::taproot_keys(seed, network, use_address_index),
+            KeySetType::NativeSegwit => {
+                KeySet::native_segwit_keys(seed, network, use_address_index)
+            }
+            KeySetType::WrappedSegwit => {
+                KeySet::wrapped_segwit_keys(seed, network, use_address_index)
+            }
+            KeySetType::Legacy => KeySet::legacy_bitcoin_keys(seed, network, use_address_index),
+        }?;
+        Ok(Self::from_key_set(key_set))
+    }
+
+    pub fn from_key_set(key_set: KeySet) -> Self {
         let secp = Secp256k1::new();
-        let identity_key = master_key
-            .derive_priv(&secp, &identity_derivation_path(network))?
-            .private_key;
-        let identity_key_pair = identity_key.keypair(&secp);
-        let signing_master_key =
-            master_key.derive_priv(&secp, &signing_derivation_path(network))?;
-        let static_deposit_master_key =
-            master_key.derive_priv(&secp, &static_deposit_derivation_path(network))?;
-        let key_set = KeySet {
-            identity_key_pair,
-            signing_master_key,
-            static_deposit_master_key,
-        };
-        Ok(DefaultSigner { key_set, secp })
+        DefaultSigner { key_set, secp }
     }
 }
 
@@ -620,35 +736,10 @@ mod tests {
     use crate::signer::{EncryptedPrivateKey, PrivateKeySource, Signer, SignerError};
     use crate::tree::TreeNodeId;
     use crate::utils::verify_signature::verify_signature_ecdsa;
-    use crate::{
-        Network,
-        signer::default_signer::DefaultSigner,
-        signer::default_signer::{
-            identity_derivation_path, signing_derivation_path, static_deposit_derivation_path,
-        },
-    };
+    use crate::{Network, signer::default_signer::DefaultSigner};
 
     #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
-
-    /// Ensure constants are defined correctly and don't panic.
-    #[test_all]
-    fn test_constant_derivation_paths() {
-        identity_derivation_path(Network::Mainnet);
-        identity_derivation_path(Network::Testnet);
-        identity_derivation_path(Network::Regtest);
-        identity_derivation_path(Network::Signet);
-
-        signing_derivation_path(Network::Mainnet);
-        signing_derivation_path(Network::Testnet);
-        signing_derivation_path(Network::Regtest);
-        signing_derivation_path(Network::Signet);
-
-        static_deposit_derivation_path(Network::Mainnet);
-        static_deposit_derivation_path(Network::Testnet);
-        static_deposit_derivation_path(Network::Regtest);
-        static_deposit_derivation_path(Network::Signet);
-    }
 
     fn create_test_signer() -> DefaultSigner {
         let test_seed = [42u8; 32]; // Deterministic seed for testing

--- a/crates/spark/src/signer/mod.rs
+++ b/crates/spark/src/signer/mod.rs
@@ -8,7 +8,7 @@ use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::{PublicKey, SecretKey, schnorr};
 use frost_secp256k1_tr::round2::SignatureShare;
 
-pub use default_signer::{DefaultSigner, DefaultSignerError};
+pub use default_signer::{DefaultSigner, DefaultSignerError, KeySet, KeySetType};
 pub use error::SignerError;
 pub use models::*;
 pub(crate) use secret_sharing::from_bytes_to_scalar;


### PR DESCRIPTION
This implements the different keysets available in https://github.com/buildonspark/spark/blob/4879fb883ca02ad7753da1c92759b70e97894a82/sdks/js/packages/spark-sdk/src/signer/signer.ts

Fixes #238

Equivalents of these signers are now supported using the SDK builder's `with_key_set` function:
LegacyBitcoinSparkSigner
NativeSegwitSparkSigner
TaprootSparkSigner
WrappedSegwitSparkSigner

I did not implement UnsafeStatelessSparkSigner, because I don't think it is useful.