### PR TITLE
Fix events for lightning payments

### DIFF
--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -23,6 +23,9 @@ pub enum SdkEvent {
     PaymentSucceeded {
         payment: Payment,
     },
+    PaymentFailed {
+        payment: Payment,
+    },
 }
 
 impl fmt::Display for SdkEvent {
@@ -37,6 +40,9 @@ impl fmt::Display for SdkEvent {
             }
             SdkEvent::PaymentSucceeded { payment } => {
                 write!(f, "PaymentSucceeded: {payment:?}")
+            }
+            SdkEvent::PaymentFailed { payment } => {
+                write!(f, "PaymentFailed: {payment:?}")
             }
         }
     }

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -17,8 +17,8 @@ use breez_sdk_common::{
     rest::RestClient,
 };
 use spark_wallet::{
-    ExitSpeed, InvoiceDescription, Order, PagingFilter, PayLightningInvoiceResult, SparkAddress,
-    SparkWallet, WalletEvent, WalletTransfer,
+    ExitSpeed, InvoiceDescription, Order, PagingFilter, SparkAddress, SparkWallet, WalletEvent,
+    WalletTransfer,
 };
 use std::{str::FromStr, sync::Arc};
 use tracing::{error, info, trace};
@@ -718,9 +718,8 @@ impl BreezSdk {
                 },
             )
             .await?;
-        self.event_emitter.emit(&SdkEvent::PaymentSucceeded {
-            payment: payment.clone(),
-        });
+
+        emit_optionaly_payment_complete(&self.event_emitter, payment.clone());
         Ok(LnurlPayResponse {
             payment,
             success_action,
@@ -865,12 +864,18 @@ impl BreezSdk {
                         use_spark,
                     )
                     .await?;
-                let payment = match payment_response {
-                    PayLightningInvoiceResult::LightningPayment(payment) => {
-                        self.poll_lightning_send_payment(&payment.id);
-                        Payment::from_lightning(payment, request.prepare_response.amount_sats)?
+                let payment = match payment_response.lightning_payment {
+                    Some(lightning_payment) => {
+                        let ssp_id = lightning_payment.id.clone();
+                        let payment = Payment::from_lightning(
+                            lightning_payment,
+                            request.prepare_response.amount_sats,
+                            payment_response.transfer.id.to_string(),
+                        )?;
+                        self.poll_lightning_send_payment(&payment, ssp_id);
+                        payment
                     }
-                    PayLightningInvoiceResult::Transfer(payment) => payment.try_into()?,
+                    None => payment_response.transfer.try_into()?,
                 };
                 Ok(SendPaymentResponse { payment })
             }
@@ -903,9 +908,7 @@ impl BreezSdk {
             // we trigger the sync here anyway to get the fresh payment.
             //self.storage.insert_payment(response.payment.clone()).await?;
             if !suppress_payment_event {
-                self.event_emitter.emit(&SdkEvent::PaymentSucceeded {
-                    payment: response.payment.clone(),
-                });
+                emit_optionaly_payment_complete(&self.event_emitter, response.payment.clone());
             }
             if let Err(e) = self.sync_trigger.send(SyncType::PaymentsOnly) {
                 error!("Failed to send sync trigger: {e:?}");
@@ -915,12 +918,15 @@ impl BreezSdk {
     }
 
     // Pools the lightning send payment untill it is in completed state.
-    fn poll_lightning_send_payment(&self, payment_id: &str) {
-        const MAX_POLL_ATTEMPTS: u32 = 10;
+    fn poll_lightning_send_payment(&self, payment: &Payment, ssp_id: String) {
+        const MAX_POLL_ATTEMPTS: u32 = 20;
+        let payment_id = payment.id.clone();
         info!("Polling lightning send payment {}", payment_id);
 
         let spark_wallet = self.spark_wallet.clone();
         let sync_trigger = self.sync_trigger.clone();
+        let event_emitter = self.event_emitter.clone();
+        let payment = payment.clone();
         let payment_id = payment_id.to_string();
         let mut shutdown = self.shutdown_receiver.clone();
 
@@ -935,14 +941,22 @@ impl BreezSdk {
                     info!("Shutdown signal received");
                     return;
                   },
-                    p = spark_wallet.fetch_lightning_send_payment(&payment_id) => {
-                      if let Ok(Some(p)) = p  && p.payment_preimage.is_some(){
-                          info!("Pollling payment preimage found");
-                          if let Err(e) = sync_trigger.send(SyncType::PaymentsOnly) {
-                              error!("Failed to send sync trigger: {e:?}");
-                          }
-                          return;
-                    }
+                    p = spark_wallet.fetch_lightning_send_payment(&ssp_id) => {
+                      if let Ok(Some(p)) = p && let Ok(payment) = Payment::from_lightning(p.clone(), payment.amount, payment.id.clone()) {
+                        info!("Pollling payment status = {} {:?}", payment.status, p.status);
+                        match payment.status {
+                          s if s != PaymentStatus::Pending => {
+                              info!("Pollling payment completed status = {}", s);
+                              emit_optionaly_payment_complete(&event_emitter, payment.clone());
+                              if let Err(e) = sync_trigger.send(SyncType::PaymentsOnly) {
+                                error!("Failed to send sync trigger: {e:?}");
+                              }
+                              return;
+                            },
+                            _ => {}
+                        }
+                      }
+
                     let sleep_time = if i < 5 {
                         Duration::from_secs(1)
                     } else {
@@ -1216,6 +1230,14 @@ fn process_success_action(
     };
 
     Ok(Some(SuccessActionProcessed::Aes { result }))
+}
+
+fn emit_optionaly_payment_complete(event_emitter: &EventEmitter, payment: Payment) {
+    match payment.status {
+        PaymentStatus::Completed => event_emitter.emit(&SdkEvent::PaymentSucceeded { payment }),
+        PaymentStatus::Failed => event_emitter.emit(&SdkEvent::PaymentFailed { payment }),
+        PaymentStatus::Pending => (),
+    }
 }
 
 fn validate_breez_api_key(api_key: &str) -> Result<(), SdkError> {

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -16,6 +16,15 @@ pub enum SdkEvent {
     },
 }
 
+#[macros::extern_wasm_bindgen(breez_sdk_spark::KeySetType)]
+pub enum KeySetType {
+    Default,
+    Taproot,
+    NativeSegwit,
+    WrappedSegwit,
+    Legacy,
+}
+
 #[macros::extern_wasm_bindgen(breez_sdk_spark::ConnectRequest)]
 pub struct ConnectRequest {
     pub config: Config,

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -11,6 +11,9 @@ pub enum SdkEvent {
     PaymentSucceeded {
         payment: Payment,
     },
+    PaymentFailed {
+        payment: Payment,
+    },
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::ConnectRequest)]

--- a/crates/breez-sdk/wasm/src/sdk_builder.rs
+++ b/crates/breez-sdk/wasm/src/sdk_builder.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     error::WasmResult,
-    models::{Config, Credentials},
+    models::{Config, Credentials, KeySetType},
     persist::{Storage, WasmStorage},
     sdk::BreezSdk,
 };
@@ -36,6 +36,14 @@ impl SdkBuilder {
         self.builder = self
             .builder
             .with_rest_chain_service(url, credentials.map(|c| c.into()));
+        self
+    }
+
+    #[wasm_bindgen(js_name = "withKeySet")]
+    pub fn with_key_set(mut self, key_set_type: KeySetType, use_address_index: bool) -> Self {
+        self.builder = self
+            .builder
+            .with_key_set(key_set_type.into(), use_address_index);
         self
     }
 

--- a/crates/spark-wallet/src/model.rs
+++ b/crates/spark-wallet/src/model.rs
@@ -92,11 +92,12 @@ impl WalletTransfer {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Serialize)]
-pub enum PayLightningInvoiceResult {
-    LightningPayment(LightningSendPayment),
-    Transfer(WalletTransfer),
+pub struct PayLightningInvoiceResult {
+    // The transfer associated with this lightinng payment.
+    pub transfer: WalletTransfer,
+    // The optional ssp lightning payment if the payment was created with the ssp.
+    pub lightning_payment: Option<LightningSendPayment>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]

--- a/packages/flutter/rust/src/events.rs
+++ b/packages/flutter/rust/src/events.rs
@@ -15,6 +15,9 @@ pub enum _SdkEvent {
     PaymentSucceeded {
         payment: Payment,
     },
+    PaymentFailed {
+        payment: Payment,
+    },
 }
 
 pub struct BindingEventListener {


### PR DESCRIPTION
This PR has several fixes for lightning payments:
1. Consistently use payment_id as the transfer id, previously it was sometimes the ssp id which contained some string prefix followed by a UUID that is different than the spark id. 
2. Emit PaymentSucceed only after perimage is retrieved.
3. Emit PaymentFailed in case it is relevant.

Update:
Added the various signer configurations (taproot, etc..) to WASM.
