### PR TITLE
optional ln address description with default

### DIFF
--- a/crates/breez-sdk/cli/src/commands.rs
+++ b/crates/breez-sdk/cli/src/commands.rs
@@ -125,7 +125,7 @@ pub enum Command {
         username: String,
 
         /// Description in the lnurl response and the invoice.
-        description: String,
+        description: Option<String>,
     },
     DeleteLightningAddress,
     /// List fiat currencies

--- a/crates/breez-sdk/core/src/lnurl.rs
+++ b/crates/breez-sdk/core/src/lnurl.rs
@@ -18,14 +18,12 @@ pub enum LnurlServerError {
     SigningError(String),
 }
 
-// Public-facing request types that don't expose signature details
 #[derive(Debug, Clone)]
 pub struct RegisterLightningAddressRequest {
     pub username: String,
     pub description: String,
 }
 
-// No signature parameter needed for unregister
 #[derive(Debug, Clone)]
 pub struct UnregisterLightningAddressRequest {
     pub username: String,
@@ -33,6 +31,7 @@ pub struct UnregisterLightningAddressRequest {
 
 #[macros::async_trait]
 pub trait LnurlServerClient: Send + Sync {
+    fn domain(&self) -> &str;
     async fn check_username_available(&self, username: &str) -> Result<bool, LnurlServerError>;
     async fn recover_lightning_address(
         &self,
@@ -98,6 +97,10 @@ impl ReqwestLnurlServerClient {
 
 #[macros::async_trait]
 impl LnurlServerClient for ReqwestLnurlServerClient {
+    fn domain(&self) -> &str {
+        &self.domain
+    }
+
     async fn check_username_available(&self, username: &str) -> Result<bool, LnurlServerError> {
         let url = format!("https://{}/lnurlpay/available/{}", self.domain, username);
         let result = self.client.get(url).send().await;

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -808,7 +808,8 @@ pub struct CheckLightningAddressRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegisterLightningAddressRequest {
     pub username: String,
-    pub description: String,
+    #[cfg_attr(feature = "uniffi", uniffi(default=None))]
+    pub description: Option<String>,
 }
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -1161,15 +1161,19 @@ impl BreezSdk {
             ));
         };
 
+        let description = match request.description {
+            Some(description) => description,
+            None => format!("Pay to {}@{}", request.username, client.domain()),
+        };
         let params = crate::lnurl::RegisterLightningAddressRequest {
             username: request.username.clone(),
-            description: request.description.clone(),
+            description: description.clone(),
         };
 
         let response = client.register_lightning_address(&params).await?;
         let address_info = LightningAddressInfo {
             lightning_address: response.lightning_address,
-            description: request.description,
+            description,
             lnurl: response.lnurl,
             username: request.username,
         };

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -671,7 +671,7 @@ pub struct CheckLightningAddressRequest {
 #[macros::extern_wasm_bindgen(breez_sdk_spark::RegisterLightningAddressRequest)]
 pub struct RegisterLightningAddressRequest {
     pub username: String,
-    pub description: String,
+    pub description: Option<String>,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::LightningAddressInfo)]

--- a/docs/breez-sdk/snippets/rust/src/lightning_address.rs
+++ b/docs/breez-sdk/snippets/rust/src/lightning_address.rs
@@ -28,7 +28,7 @@ pub async fn check_lightning_address_availability(sdk: &BreezSdk, username: Stri
 pub async fn register_lightning_address(
     sdk: &BreezSdk,
     username: String,
-    description: String,
+    description: Option<String>,
 ) -> anyhow::Result<(String, String)> {
     // Define the parameters
     let username = username;

--- a/docs/breez-sdk/src/guide/receive_lnurl_pay.md
+++ b/docs/breez-sdk/src/guide/receive_lnurl_pay.md
@@ -182,7 +182,7 @@ Before registering a Lightning address, you can check if the username is availab
     <a class="header" href="#registering-address">Registering a Lightning address</a>
 </h3>
 
-Once you've confirmed a username is available, you can register it by passing a username and a description. The username will be used in `username@domain.com`. The description will be included in lnurl metadata and as the invoice description, so this is what the sender will see.
+Once you've confirmed a username is available, you can register it by passing a username and a description. The username will be used in `username@domain.com`. The description will be included in lnurl metadata and as the invoice description, so this is what the sender will see. The description is optional, and will default to `Pay to username@domain.com`.
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1,5 +1,5 @@
-pub use breez_sdk_common::input::*;
 pub use breez_sdk_common::fiat::*;
+pub use breez_sdk_common::input::*;
 pub use breez_sdk_common::lnurl::auth::*;
 pub use breez_sdk_common::lnurl::pay::*;
 pub use breez_sdk_common::network::BitcoinNetwork;
@@ -614,7 +614,7 @@ pub struct _CheckLightningAddressRequest {
 #[frb(mirror(RegisterLightningAddressRequest))]
 pub struct _RegisterLightningAddressRequest {
     pub username: String,
-    pub description: String,
+    pub description: Option<String>,
 }
 
 #[frb(mirror(LightningAddressInfo))]

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -4,13 +4,13 @@ use breez_sdk_common::input::InputType;
 use breez_sdk_spark::{
     CheckLightningAddressRequest, ClaimDepositRequest, ClaimDepositResponse, Config,
     ConnectRequest, GetInfoRequest, GetInfoResponse, GetPaymentRequest, GetPaymentResponse,
-    LightningAddressInfo, ListPaymentsRequest, ListPaymentsResponse, ListUnclaimedDepositsRequest,
-    ListUnclaimedDepositsResponse, LnurlPayRequest, LnurlPayResponse, LogEntry, Logger, Network,
-    PrepareLnurlPayRequest, PrepareLnurlPayResponse, PrepareSendPaymentRequest,
-    PrepareSendPaymentResponse, ReceivePaymentRequest, ReceivePaymentResponse,
-    RefundDepositRequest, RefundDepositResponse, RegisterLightningAddressRequest, SdkError,
-    SdkEvent, SendPaymentRequest, SendPaymentResponse, Storage, SyncWalletRequest,
-    SyncWalletResponse, ListFiatCurrenciesResponse, ListFiatRatesResponse,
+    LightningAddressInfo, ListFiatCurrenciesResponse, ListFiatRatesResponse, ListPaymentsRequest,
+    ListPaymentsResponse, ListUnclaimedDepositsRequest, ListUnclaimedDepositsResponse,
+    LnurlPayRequest, LnurlPayResponse, LogEntry, Logger, Network, PrepareLnurlPayRequest,
+    PrepareLnurlPayResponse, PrepareSendPaymentRequest, PrepareSendPaymentResponse,
+    ReceivePaymentRequest, ReceivePaymentResponse, RefundDepositRequest, RefundDepositResponse,
+    RegisterLightningAddressRequest, SdkError, SdkEvent, SendPaymentRequest, SendPaymentResponse,
+    Storage, SyncWalletRequest, SyncWalletResponse,
 };
 use flutter_rust_bridge::frb;
 


### PR DESCRIPTION
Default is now 'Pay to {user}@{domain}'.

This default is set on the client side, in the sdk. Another option could be to set these default descriptions on the server side instead. That could be more flexible if we want to change this default in the future?