### PR TITLE
Remove confirmed refunded transactions.

### DIFF
--- a/crates/breez-sdk/core/src/chain/mod.rs
+++ b/crates/breez-sdk/core/src/chain/mod.rs
@@ -31,6 +31,7 @@ impl From<bitcoin::address::ParseError> for ChainServiceError {
 #[macros::async_trait]
 pub trait BitcoinChainService: Send + Sync {
     async fn get_address_utxos(&self, address: String) -> Result<Vec<Utxo>, ChainServiceError>;
+    async fn get_transaction_status(&self, txid: String) -> Result<TxStatus, ChainServiceError>;
     async fn get_transaction_hex(&self, txid: String) -> Result<String, ChainServiceError>;
     async fn broadcast_transaction(&self, tx: String) -> Result<(), ChainServiceError>;
 }

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -1088,7 +1088,7 @@ impl BreezSdk {
             .await?;
         let deposit: DepositInfo = detailed_utxo.into();
         let tx_hex = serialize(&tx).as_hex().to_string();
-        let tx_id = tx.compute_txid().to_string();
+        let tx_id = tx.compute_txid().as_raw_hash().to_string();
 
         // Store the refund transaction details separately
         self.storage


### PR DESCRIPTION
This PR adds a part we have missed regarding refunded deposits.
These deposits were kept in the db and not removed (as opposed to those that were claimed) so they were always returned by the unclaimed_deposits even though they are not relevant any more.
We now verify confirmation on chain and remove them from the storage.