### PR TITLE
Fix taproot signer identity

### DIFF
--- a/crates/spark/src/services/lightning.rs
+++ b/crates/spark/src/services/lightning.rs
@@ -73,9 +73,9 @@ pub struct LightningSendPayment {
 #[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 pub enum LightningSendStatus {
     Created,
-    UserTransferValidationFailed,    
+    UserTransferValidationFailed,
     LightningPaymentInitiated,
-    LightningPaymentFailed,    
+    LightningPaymentFailed,
     LightningPaymentSucceeded,
     PreimageProvided,
     PreimageProvidingFailed,

--- a/crates/spark/src/signer/default_signer.rs
+++ b/crates/spark/src/signer/default_signer.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv};
-use bitcoin::key::Parity;
+use bitcoin::key::{Parity, TapTweak};
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::rand::thread_rng;
 use bitcoin::secp256k1::{self, All, Keypair, Message, PublicKey, SecretKey, schnorr};
@@ -167,6 +167,10 @@ impl KeySet {
         let derived_key_set = DerivedKeySet::new(seed, network, derivation_path)?;
         let mut key_set = derived_key_set.to_key_set(None)?;
         let secp = Secp256k1::new();
+        key_set.identity_key_pair = key_set
+            .identity_key_pair
+            .tap_tweak(&secp, None)
+            .to_keypair();
         if let (_, Parity::Odd) = key_set
             .identity_key_pair
             .secret_key()

--- a/crates/spark/src/ssp/graphql/models.rs
+++ b/crates/spark/src/ssp/graphql/models.rs
@@ -187,7 +187,7 @@ pub enum LightningReceiveRequestStatus {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum LightningSendRequestStatus {
-    Created,    
+    Created,
     UserTransferValidationFailed,
     LightningPaymentInitiated,
     LightningPaymentFailed,
@@ -271,7 +271,7 @@ pub struct CurrencyAmount {
 }
 
 impl Default for CurrencyAmount {
-    fn default() -> Self {      
+    fn default() -> Self {
         Self {
             original_value: 0,
             original_unit: CurrencyUnit::Satoshi,


### PR DESCRIPTION
The taproot signer identity was missing the taptweak. Now the taproot signer is compatible with the JS SDK.