### PR TITLE
return error when logging is set again

### DIFF
--- a/crates/breez-sdk/core/src/error.rs
+++ b/crates/breez-sdk/core/src/error.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use spark_wallet::SparkWalletError;
 use std::{convert::Infallible, num::TryFromIntError};
 use thiserror::Error;
+use tracing_subscriber::util::TryInitError;
 
 /// Error type for the `BreezSdk`
 #[derive(Debug, Error, Clone)]
@@ -163,6 +164,12 @@ impl From<LnurlServerError> for SdkError {
 impl From<ReqwestLnurlServerClientError> for SdkError {
     fn from(value: ReqwestLnurlServerClientError) -> Self {
         SdkError::Generic(value.to_string())
+    }
+}
+
+impl From<TryInitError> for SdkError {
+    fn from(_value: TryInitError) -> Self {
+        SdkError::Generic("Logging can only be initialized once".to_string())
     }
 }
 

--- a/crates/breez-sdk/core/src/logger.rs
+++ b/crates/breez-sdk/core/src/logger.rs
@@ -66,9 +66,9 @@ pub(super) fn init_logging(
                     .with_line_number(true)
                     .with_writer(log_file),
             )
-            .init();
+            .try_init()?;
     } else {
-        registry.init();
+        registry.try_init()?;
     }
 
     Ok(())

--- a/crates/breez-sdk/wasm/src/error.rs
+++ b/crates/breez-sdk/wasm/src/error.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use breez_sdk_spark::{ParseError, SdkError};
+use tracing_subscriber::util::TryInitError;
 use wasm_bindgen::{JsError, JsValue};
 
 #[derive(Clone, Debug)]
@@ -23,6 +24,12 @@ impl From<WasmError> for JsValue {
 impl From<JsValue> for WasmError {
     fn from(err: JsValue) -> Self {
         Self(err)
+    }
+}
+
+impl From<TryInitError> for WasmError {
+    fn from(value: TryInitError) -> Self {
+        SdkError::from(value).into()
     }
 }
 

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -29,7 +29,7 @@ pub async fn init_logging(logger: Logger, filter: Option<String>) -> WasmResult<
         .with(filter)
         .with(WasmTracingLayer {});
 
-    subscriber.init();
+    subscriber.try_init()?;
 
     Ok(())
 }


### PR DESCRIPTION
The `init` call for `tracing_subscriber` panics when the global default log dispatcher has already been set. Calling `try_init` prevents the panic and returns a human readable error to the user.

Fixes #285