### PR TITLE
Change sync method to return synchronously 

### DIFF
--- a/crates/breez-sdk/cli/src/commands.rs
+++ b/crates/breez-sdk/cli/src/commands.rs
@@ -172,7 +172,7 @@ pub(crate) async fn execute_command(
             Ok(true)
         }
         Command::Sync => {
-            let value = sdk.sync_wallet(SyncWalletRequest {})?;
+            let value = sdk.sync_wallet(SyncWalletRequest {}).await?;
             print_value(&value)?;
             Ok(true)
         }

--- a/crates/breez-sdk/cli/src/commands.rs
+++ b/crates/breez-sdk/cli/src/commands.rs
@@ -23,7 +23,7 @@ pub enum Command {
     GetInfo {
         /// Force sync
         #[arg(short, long)]
-        force_sync: bool,
+        ensure_synced: bool,
     },
 
     /// Get the payment with the given ID
@@ -158,8 +158,8 @@ pub(crate) async fn execute_command(
 ) -> Result<bool, anyhow::Error> {
     match command {
         Command::Exit => Ok(false),
-        Command::GetInfo { force_sync } => {
-            let value = sdk.get_info(GetInfoRequest { force_sync }).await?;
+        Command::GetInfo { ensure_synced } => {
+            let value = sdk.get_info(GetInfoRequest { ensure_synced }).await?;
             print_value(&value)?;
             Ok(true)
         }

--- a/crates/breez-sdk/cli/src/commands.rs
+++ b/crates/breez-sdk/cli/src/commands.rs
@@ -20,7 +20,11 @@ pub enum Command {
     Exit,
 
     /// Get balance information
-    GetInfo,
+    GetInfo {
+        /// Force sync
+        #[arg(short, long)]
+        force_sync: bool,
+    },
 
     /// Get the payment with the given ID
     GetPayment {
@@ -154,8 +158,8 @@ pub(crate) async fn execute_command(
 ) -> Result<bool, anyhow::Error> {
     match command {
         Command::Exit => Ok(false),
-        Command::GetInfo => {
-            let value = sdk.get_info(GetInfoRequest {}).await?;
+        Command::GetInfo { force_sync } => {
+            let value = sdk.get_info(GetInfoRequest { force_sync }).await?;
             print_value(&value)?;
             Ok(true)
         }

--- a/crates/breez-sdk/cli/src/commands.rs
+++ b/crates/breez-sdk/cli/src/commands.rs
@@ -23,7 +23,7 @@ pub enum Command {
     GetInfo {
         /// Force sync
         #[arg(short, long)]
-        ensure_synced: bool,
+        ensure_synced: Option<bool>,
     },
 
     /// Get the payment with the given ID

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -522,7 +522,7 @@ pub struct Credentials {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct GetInfoRequest {
-    pub force_sync: bool,
+    pub ensure_synced: bool,
 }
 
 /// Response containing the balance of the wallet

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -521,7 +521,9 @@ pub struct Credentials {
 /// Request to get the balance of the wallet
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
-pub struct GetInfoRequest {}
+pub struct GetInfoRequest {
+    pub force_sync: bool,
+}
 
 /// Response containing the balance of the wallet
 #[derive(Debug, Clone, Serialize)]

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -522,7 +522,7 @@ pub struct Credentials {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct GetInfoRequest {
-    pub ensure_synced: bool,
+    pub ensure_synced: Option<bool>,
 }
 
 /// Response containing the balance of the wallet

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -619,7 +619,7 @@ impl BreezSdk {
     /// Returns the balance of the wallet in satoshis
     #[allow(unused_variables)]
     pub async fn get_info(&self, request: GetInfoRequest) -> Result<GetInfoResponse, SdkError> {
-        if request.ensure_synced {
+        if request.ensure_synced.unwrap_or_default() {
             self.initial_synced_watcher
                 .clone()
                 .changed()

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -610,6 +610,9 @@ impl BreezSdk {
     /// Returns the balance of the wallet in satoshis
     #[allow(unused_variables)]
     pub async fn get_info(&self, request: GetInfoRequest) -> Result<GetInfoResponse, SdkError> {
+        if request.force_sync {
+            self.sync_wallet(SyncWalletRequest {}).await?;
+        }
         let object_repository = ObjectCacheRepository::new(self.storage.clone());
         let account_info = object_repository
             .fetch_account_info()

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -1320,7 +1320,7 @@ impl EventListener for BalanceWatcher {
         match event {
             SdkEvent::PaymentSucceeded { .. } | SdkEvent::ClaimDepositsSucceeded { .. } => {
                 match update_balance(self.spark_wallet.clone(), self.storage.clone()).await {
-                    Ok(_) => info!("Balance updated successfully"),
+                    Ok(()) => info!("Balance updated successfully"),
                     Err(e) => error!("Failed to update balance: {e:?}"),
                 }
             }

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -243,7 +243,7 @@ impl SdkBuilder {
         let (shutdown_sender, shutdown_receiver) = watch::channel::<()>(());
 
         // Create the SDK instance
-        let sdk = BreezSdk::new(BreezSdkParams {
+        let sdk = BreezSdk::init_and_start(BreezSdkParams {
             config: self.config,
             storage: self.storage,
             chain_service,
@@ -255,7 +255,6 @@ impl SdkBuilder {
             spark_wallet,
         })?;
 
-        sdk.start();
         Ok(sdk)
     }
 }

--- a/crates/breez-sdk/core/src/utils/mod.rs
+++ b/crates/breez-sdk/core/src/utils/mod.rs
@@ -1,2 +1,23 @@
 pub(crate) mod deposit_chain_syncer;
 pub(crate) mod utxo_fetcher;
+
+/// Runs a future until completion or until a shutdown signal is received.
+/// When shutdown is received, logs the exit message and returns.
+pub(crate) async fn run_with_shutdown<F, T>(
+    mut shutdown: tokio::sync::watch::Receiver<()>,
+    exit_message: &str,
+    future: F,
+) -> Option<T>
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::select! {
+        t = future => {
+          Some(t)
+        }
+        _ = shutdown.changed() => {
+            tracing::info!("{exit_message}");
+            None
+        }
+    }
+}

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -486,7 +486,7 @@ pub struct Credentials {
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::GetInfoRequest)]
 pub struct GetInfoRequest {
-    pub force_sync: bool,
+    pub ensure_synced: bool,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::GetInfoResponse)]

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -485,7 +485,9 @@ pub struct Credentials {
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::GetInfoRequest)]
-pub struct GetInfoRequest {}
+pub struct GetInfoRequest {
+    pub force_sync: bool,
+}
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::GetInfoResponse)]
 pub struct GetInfoResponse {

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -486,7 +486,7 @@ pub struct Credentials {
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::GetInfoRequest)]
 pub struct GetInfoRequest {
-    pub ensure_synced: bool,
+    pub ensure_synced: Option<bool>,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::GetInfoResponse)]

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -163,7 +163,7 @@ impl BreezSdk {
     }
 
     #[wasm_bindgen(js_name = "syncWallet")]
-    pub fn sync_wallet(&self, request: SyncWalletRequest) -> WasmResult<SyncWalletResponse> {
+    pub async fn sync_wallet(&self, request: SyncWalletRequest) -> WasmResult<SyncWalletResponse> {
         Ok(self.sdk.sync_wallet(request.into()).await?.into())
     }
 

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -164,7 +164,7 @@ impl BreezSdk {
 
     #[wasm_bindgen(js_name = "syncWallet")]
     pub fn sync_wallet(&self, request: SyncWalletRequest) -> WasmResult<SyncWalletResponse> {
-        Ok(self.sdk.sync_wallet(request.into())?.into())
+        Ok(self.sdk.sync_wallet(request.into()).await?.into())
     }
 
     #[wasm_bindgen(js_name = "listPayments")]

--- a/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
@@ -53,7 +53,9 @@ Future<void> initSdkAdvanced() async {
 
 Future<void> fetchBalance(BreezSdk sdk) async {
   // ANCHOR: fetch-balance
-  final info = await sdk.getInfo(request: GetInfoRequest());
+  // forceSync: true will force the SDK to sync with the Spark network
+  // before returning the balance
+  final info = await sdk.getInfo(request: GetInfoRequest(forceSync: false));
   final balanceSats = info.balanceSats;
   // ANCHOR_END: fetch-balance
   print(balanceSats);

--- a/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
@@ -53,9 +53,9 @@ Future<void> initSdkAdvanced() async {
 
 Future<void> fetchBalance(BreezSdk sdk) async {
   // ANCHOR: fetch-balance
-  // forceSync: true will force the SDK to sync with the Spark network
+  // ensureSynced: true will ensure the SDK is synced with the Spark network
   // before returning the balance
-  final info = await sdk.getInfo(request: GetInfoRequest(forceSync: false));
+  final info = await sdk.getInfo(request: GetInfoRequest(ensureSynced: false));
   final balanceSats = info.balanceSats;
   // ANCHOR_END: fetch-balance
   print(balanceSats);

--- a/docs/breez-sdk/snippets/go/getting_started.go
+++ b/docs/breez-sdk/snippets/go/getting_started.go
@@ -65,7 +65,11 @@ func InitSdkAdvanced() (*breez_sdk_spark.BreezSdk, error) {
 
 func FetchBalance(sdk *breez_sdk_spark.BreezSdk) error {
 	// ANCHOR: fetch-balance
-	info, err := sdk.GetInfo(breez_sdk_spark.GetInfoRequest{})
+	info, err := sdk.GetInfo(breez_sdk_spark.GetInfoRequest{
+		// ForceSync: true will force the SDK to sync with the Spark network
+		// before returning the balance
+		ForceSync: false,
+	})
 
 	if sdkErr := err.(*breez_sdk_spark.SdkError); sdkErr != nil {
 		return err
@@ -74,6 +78,7 @@ func FetchBalance(sdk *breez_sdk_spark.BreezSdk) error {
 	balanceSats := info.BalanceSats
 	log.Printf("Balance: %v sats", balanceSats)
 	// ANCHOR_END: fetch-balance
+	return nil
 }
 
 // ANCHOR: logging

--- a/docs/breez-sdk/snippets/go/getting_started.go
+++ b/docs/breez-sdk/snippets/go/getting_started.go
@@ -66,9 +66,9 @@ func InitSdkAdvanced() (*breez_sdk_spark.BreezSdk, error) {
 func FetchBalance(sdk *breez_sdk_spark.BreezSdk) error {
 	// ANCHOR: fetch-balance
 	info, err := sdk.GetInfo(breez_sdk_spark.GetInfoRequest{
-		// ForceSync: true will force the SDK to sync with the Spark network
+		// EnsureSynced: true will ensure the SDK is synced with the Spark network
 		// before returning the balance
-		ForceSync: false,
+		EnsureSynced: false,
 	})
 
 	if sdkErr := err.(*breez_sdk_spark.SdkError); sdkErr != nil {

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
@@ -54,7 +54,7 @@ class GettingStarted {
     suspend fun fetchBalance(sdk: BreezSdk) {
         // ANCHOR: fetch-balance
         try {
-            // forceSync: true will force the SDK to sync with the Spark network
+            // ensureSynced: true will ensure the SDK is synced with the Spark network
             // before returning the balance
             val info = sdk.getInfo(GetInfoRequest(false))
             val balanceSats = info.balanceSats

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
@@ -54,7 +54,9 @@ class GettingStarted {
     suspend fun fetchBalance(sdk: BreezSdk) {
         // ANCHOR: fetch-balance
         try {
-            val info = sdk.getInfo(GetInfoRequest)
+            // forceSync: true will force the SDK to sync with the Spark network
+            // before returning the balance
+            val info = sdk.getInfo(GetInfoRequest(false))
             val balanceSats = info.balanceSats
         } catch (e: Exception) {
             // handle error

--- a/docs/breez-sdk/snippets/python/src/getting_started.py
+++ b/docs/breez-sdk/snippets/python/src/getting_started.py
@@ -65,8 +65,9 @@ async def init_sdk_advanced():
 async def fetch_balance(sdk: BreezSdk):
     # ANCHOR: fetch-balance
     try:
-        # forceSync: True will force the SDK to sync with the Spark network
-        info = await sdk.get_info(request=GetInfoRequest(force_sync=False))
+        # ensure_synced: True will ensure the SDK is synced with the Spark network
+        # before returning the balance
+        info = await sdk.get_info(request=GetInfoRequest(ensure_synced=False))
         balance_sats = info.balance_sats
     except Exception as error:
         logging.error(error)

--- a/docs/breez-sdk/snippets/python/src/getting_started.py
+++ b/docs/breez-sdk/snippets/python/src/getting_started.py
@@ -65,8 +65,7 @@ async def init_sdk_advanced():
 async def fetch_balance(sdk: BreezSdk):
     # ANCHOR: fetch-balance
     try:
-        # forceSync: true will force the SDK to sync with the Spark network
-        
+        # forceSync: True will force the SDK to sync with the Spark network
         info = await sdk.get_info(request=GetInfoRequest(force_sync=False))
         balance_sats = info.balance_sats
     except Exception as error:

--- a/docs/breez-sdk/snippets/python/src/getting_started.py
+++ b/docs/breez-sdk/snippets/python/src/getting_started.py
@@ -65,7 +65,9 @@ async def init_sdk_advanced():
 async def fetch_balance(sdk: BreezSdk):
     # ANCHOR: fetch-balance
     try:
-        info = await sdk.get_info(request=GetInfoRequest())
+        # forceSync: true will force the SDK to sync with the Spark network
+        
+        info = await sdk.get_info(request=GetInfoRequest(force_sync=False))
         balance_sats = info.balance_sats
     except Exception as error:
         logging.error(error)

--- a/docs/breez-sdk/snippets/react-native/getting_started.ts
+++ b/docs/breez-sdk/snippets/react-native/getting_started.ts
@@ -55,10 +55,10 @@ const exampleGettingStartedAdvanced = async () => {
 
 const exampleFetchNodeInfo = async (sdk: BreezSdk) => {
   // ANCHOR: fetch-balance
-  // forceSync: true will force the SDK to sync with the Spark network
+  // ensureSynced: true will ensure the SDK is synced with the Spark network
   // before returning the balance
   const info = await sdk.getInfo({
-    forceSync: false,
+    ensureSynced: false,
   })
   const balanceSats = info.balanceSats
   // ANCHOR_END: fetch-balance

--- a/docs/breez-sdk/snippets/react-native/getting_started.ts
+++ b/docs/breez-sdk/snippets/react-native/getting_started.ts
@@ -55,7 +55,11 @@ const exampleGettingStartedAdvanced = async () => {
 
 const exampleFetchNodeInfo = async (sdk: BreezSdk) => {
   // ANCHOR: fetch-balance
-  const info = await sdk.getInfo({})
+  // forceSync: true will force the SDK to sync with the Spark network
+  // before returning the balance
+  const info = await sdk.getInfo({
+    forceSync: false,
+  })
   const balanceSats = info.balanceSats
   // ANCHOR_END: fetch-balance
 }

--- a/docs/breez-sdk/snippets/rust/src/getting_started.rs
+++ b/docs/breez-sdk/snippets/rust/src/getting_started.rs
@@ -61,7 +61,11 @@ pub(crate) async fn init_sdk_advanced() -> Result<BreezSdk> {
 
 pub(crate) async fn getting_started_node_info(sdk: &BreezSdk) -> Result<()> {
     // ANCHOR: fetch-balance
-    let info = sdk.get_info(GetInfoRequest {}).await?;
+    let info = sdk.get_info(GetInfoRequest {
+      // force_sync: true will force the SDK to sync with the Spark network
+      // before returning the balance
+      force_sync: false,
+    }).await?;
     let balance_sats = info.balance_sats;
     // ANCHOR_END: fetch-balance
     info!("Balance: {balance_sats} sats");

--- a/docs/breez-sdk/snippets/rust/src/getting_started.rs
+++ b/docs/breez-sdk/snippets/rust/src/getting_started.rs
@@ -64,7 +64,7 @@ pub(crate) async fn getting_started_node_info(sdk: &BreezSdk) -> Result<()> {
     let info = sdk.get_info(GetInfoRequest {
       // ensure_synced: true will ensure the SDK is synced with the Spark network
       // before returning the balance
-      ensure_synced: false,
+      ensure_synced: Some(false),
     }).await?;
     let balance_sats = info.balance_sats;
     // ANCHOR_END: fetch-balance

--- a/docs/breez-sdk/snippets/rust/src/getting_started.rs
+++ b/docs/breez-sdk/snippets/rust/src/getting_started.rs
@@ -62,9 +62,9 @@ pub(crate) async fn init_sdk_advanced() -> Result<BreezSdk> {
 pub(crate) async fn getting_started_node_info(sdk: &BreezSdk) -> Result<()> {
     // ANCHOR: fetch-balance
     let info = sdk.get_info(GetInfoRequest {
-      // force_sync: true will force the SDK to sync with the Spark network
+      // ensure_synced: true will ensure the SDK is synced with the Spark network
       // before returning the balance
-      force_sync: false,
+      ensure_synced: false,
     }).await?;
     let balance_sats = info.balance_sats;
     // ANCHOR_END: fetch-balance

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
@@ -48,10 +48,10 @@ func initSdkAdvanced() async throws -> BreezSdk {
 
 func gettingStartedNodeInfo(sdk: BreezSdk) async throws {
     // ANCHOR: fetch-balance
-    // forceSync: true will force the SDK to sync with the Spark network
+    // ensureSynced: true will ensure the SDK is synced with the Spark network
     // before returning the balance
     let info = try await sdk.getInfo(request: GetInfoRequest(
-      forceSync: false
+      ensureSynced: false
     ))
     let balanceSats = info.balanceSats
     // ANCHOR_END: fetch-balance

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
@@ -48,7 +48,11 @@ func initSdkAdvanced() async throws -> BreezSdk {
 
 func gettingStartedNodeInfo(sdk: BreezSdk) async throws {
     // ANCHOR: fetch-balance
-    let info = try await sdk.getInfo(request: GetInfoRequest())
+    // forceSync: true will force the SDK to sync with the Spark network
+    // before returning the balance
+    let info = try await sdk.getInfo(request: GetInfoRequest(
+      forceSync: false
+    ))
     let balanceSats = info.balanceSats
     // ANCHOR_END: fetch-balance
     print(balanceSats)

--- a/docs/breez-sdk/snippets/wasm/getting_started.ts
+++ b/docs/breez-sdk/snippets/wasm/getting_started.ts
@@ -69,9 +69,9 @@ const exampleGettingStartedAdvanced = async () => {
 const exampleFetchNodeInfo = async (sdk: BreezSdk) => {
   // ANCHOR: fetch-balance
   const info = await sdk.getInfo({
-    // forceSync: true will force the SDK to sync with the Spark network
+    // ensureSynced: true will ensure the SDK is synced with the Spark network
     // before returning the balance
-    forceSync: false,
+    ensureSynced: false,
   })
   const balanceSats = info.balanceSats
   // ANCHOR_END: fetch-balance

--- a/docs/breez-sdk/snippets/wasm/getting_started.ts
+++ b/docs/breez-sdk/snippets/wasm/getting_started.ts
@@ -11,7 +11,7 @@ import {
 } from '@breeztech/breez-sdk-spark'
 
 // Init stub
-const init = async () => {}
+const init = async () => { }
 
 const exampleGettingStarted = async () => {
   // ANCHOR: init-sdk
@@ -68,7 +68,11 @@ const exampleGettingStartedAdvanced = async () => {
 
 const exampleFetchNodeInfo = async (sdk: BreezSdk) => {
   // ANCHOR: fetch-balance
-  const info = await sdk.getInfo({})
+  const info = await sdk.getInfo({
+    // forceSync: true will force the SDK to sync with the Spark network
+    // before returning the balance
+    forceSync: false,
+  })
   const balanceSats = info.balanceSats
   // ANCHOR_END: fetch-balance
 }

--- a/docs/breez-sdk/src/guide/get_info.md
+++ b/docs/breez-sdk/src/guide/get_info.md
@@ -77,7 +77,7 @@ The SDK maintains a cached balance for fast responses and updates it on every ch
 
 Right after startup, the cache may not yet reflect the latest state from the network. Depends on your use case you can use one of the following options to get the fully up to date balance:
 
-- If your application runs continuously in the background, wait for `SdkEvent::Synced` before calling `get_info`.
-- If you're only briefly using the SDK to fetch the balance, call `get_info` with `force_sync = true` before disconnecting.
+- If your application runs continuously in the background, call `get_info` after each `SdkEvent::Synced` event.
+- If you're only briefly using the SDK to fetch the balance, call `get_info` with `ensure_synced = true` before disconnecting.
 
 </div>

--- a/docs/breez-sdk/src/guide/get_info.md
+++ b/docs/breez-sdk/src/guide/get_info.md
@@ -75,9 +75,9 @@ Once connected, the balance can be retrieved at any time.
 <h4>Developer note</h4>
 The SDK maintains a cached balance for fast responses and updates it on every change. The `get_info` call returns the value from this cache to provide a low-latency user experience.
 
-Right after startup, the cache may not yet reflect the latest state from the network. To get the fully up to date balance when fetching immediately after startup, use one of the following options:
+Right after startup, the cache may not yet reflect the latest state from the network. Depends on your use case you can use one of the following options to get the fully up to date balance:
 
-- Wait for the `SdkEvent::Synced` event before calling `get_info`.
-- Call `get_info` with `force_sync = true` to trigger a sync before reading the balance.
+- If your application runs continuously in the background, wait for `SdkEvent::Synced` before calling `get_info`.
+- If you're only briefly using the SDK to fetch the balance, call `get_info` with `force_sync = true` before disconnecting.
 
 </div>

--- a/docs/breez-sdk/src/guide/get_info.md
+++ b/docs/breez-sdk/src/guide/get_info.md
@@ -71,5 +71,13 @@ Once connected, the balance can be retrieved at any time.
 </section>
 </custom-tabs>
 
-You are now ready to receive a Lightning [payment](payments.md).
+<div class="warning">
+<h4>Developer note</h4>
+The SDK maintains a cached balance for fast responses and updates it on every change. The `get_info` call returns the value from this cache to provide a low-latency user experience.
 
+Right after startup, the cache may not yet reflect the latest state from the network. To get the fully up to date balance when fetching immediately after startup, use one of the following options:
+
+- Wait for the `SdkEvent::Synced` event before calling `get_info`.
+- Call `get_info` with `force_sync = true` to trigger a sync before reading the balance.
+
+</div>

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -84,7 +84,7 @@ pub enum _Fee {
 
 #[frb(mirror(GetInfoRequest))]
 pub struct _GetInfoRequest {
-    pub force_sync: bool,
+    pub ensure_synced: bool,
 }
 
 #[frb(mirror(GetInfoResponse))]

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -83,7 +83,9 @@ pub enum _Fee {
 }
 
 #[frb(mirror(GetInfoRequest))]
-pub struct _GetInfoRequest {}
+pub struct _GetInfoRequest {
+    pub force_sync: bool,
+}
 
 #[frb(mirror(GetInfoResponse))]
 pub struct _GetInfoResponse {

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -84,7 +84,7 @@ pub enum _Fee {
 
 #[frb(mirror(GetInfoRequest))]
 pub struct _GetInfoRequest {
-    pub ensure_synced: bool,
+    pub ensure_synced: Option<bool>,
 }
 
 #[frb(mirror(GetInfoResponse))]

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -106,7 +106,7 @@ impl BreezSdk {
     }
     
     pub async fn sync_wallet(&self, request: SyncWalletRequest) -> Result<SyncWalletResponse, SdkError> {
-        self.inner.sync_wallet(request)
+        self.inner.sync_wallet(request).await
     }
 
     pub async fn list_payments(

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -104,9 +104,8 @@ impl BreezSdk {
     ) -> Result<SendPaymentResponse, SdkError> {
         self.inner.send_payment(request).await
     }
-
-    #[frb(sync)]
-    pub fn sync_wallet(&self, request: SyncWalletRequest) -> Result<SyncWalletResponse, SdkError> {
+    
+    pub async fn sync_wallet(&self, request: SyncWalletRequest) -> Result<SyncWalletResponse, SdkError> {
         self.inner.sync_wallet(request)
     }
 


### PR DESCRIPTION
Also added a flag (force_sync) to the get_info API which will force sync before fetching the info.
This is useful for use cases that haven't enough time to sync or not running in the background. 