### PR TITLE
Option to wait for payment to complete

### DIFF
--- a/crates/breez-sdk/cli/src/commands.rs
+++ b/crates/breez-sdk/cli/src/commands.rs
@@ -429,13 +429,13 @@ fn read_payment_options(
                 if line == "1" {
                     return Ok(Some(SendPaymentOptions::Bolt11Invoice {
                         prefer_spark: true,
-                        return_pending_after_secs: Some(0),
+                        completion_timeout_secs: Some(0),
                     }));
                 }
             }
             Ok(Some(SendPaymentOptions::Bolt11Invoice {
                 prefer_spark: false,
-                return_pending_after_secs: Some(0),
+                completion_timeout_secs: Some(0),
             }))
         }
         SendPaymentMethod::SparkAddress { .. } => Ok(None),

--- a/crates/breez-sdk/cli/src/commands.rs
+++ b/crates/breez-sdk/cli/src/commands.rs
@@ -429,11 +429,13 @@ fn read_payment_options(
                 if line == "1" {
                     return Ok(Some(SendPaymentOptions::Bolt11Invoice {
                         prefer_spark: true,
+                        return_pending_after_secs: Some(0),
                     }));
                 }
             }
             Ok(Some(SendPaymentOptions::Bolt11Invoice {
                 prefer_spark: false,
+                return_pending_after_secs: Some(0),
             }))
         }
         SendPaymentMethod::SparkAddress { .. } => Ok(None),

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -767,6 +767,11 @@ pub enum SendPaymentOptions {
     },
     Bolt11Invoice {
         prefer_spark: bool,
+
+        /// If set, the function will return the payment if it is still pending after this
+        /// number of seconds. If unset, the function will wait indefinitely until the payment is completed or failed.
+        /// To always return immediately, set to 0.
+        return_pending_after_secs: Option<u32>,
     },
 }
 

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -910,3 +910,19 @@ pub struct ListFiatRatesResponse {
     /// The list of fiat rates
     pub rates: Vec<Rate>,
 }
+
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct WaitForPaymentRequest {
+    pub identifier: WaitForPaymentIdentifier,
+}
+
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum WaitForPaymentIdentifier {
+    PaymentId(String),
+    PaymentRequest(String),
+}
+
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct WaitForPaymentResponse {
+    pub payment: Payment,
+}

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -769,8 +769,7 @@ pub enum SendPaymentOptions {
         prefer_spark: bool,
 
         /// If set, the function will return the payment if it is still pending after this
-        /// number of seconds. If unset, the function will wait indefinitely until the payment is completed or failed.
-        /// To always return immediately, set to 0.
+        /// number of seconds. If unset, the function will return immediately after initiating the payment.
         completion_timeout_secs: Option<u32>,
     },
 }

--- a/crates/breez-sdk/core/src/models.rs
+++ b/crates/breez-sdk/core/src/models.rs
@@ -771,7 +771,7 @@ pub enum SendPaymentOptions {
         /// If set, the function will return the payment if it is still pending after this
         /// number of seconds. If unset, the function will wait indefinitely until the payment is completed or failed.
         /// To always return immediately, set to 0.
-        return_pending_after_secs: Option<u32>,
+        completion_timeout_secs: Option<u32>,
     },
 }
 

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -115,6 +115,18 @@ pub trait Storage: Send + Sync {
     /// The payment if found or None if not found
     async fn get_payment_by_id(&self, id: String) -> Result<Payment, StorageError>;
 
+    /// Gets a payment by its invoice
+    /// # Arguments
+    ///
+    /// * `invoice` - The invoice of the payment to retrieve
+    /// # Returns
+    ///
+    /// The payment if found or None if not found
+    async fn get_payment_by_invoice(
+        &self,
+        invoice: String,
+    ) -> Result<Option<Payment>, StorageError>;
+
     /// Add a deposit to storage
     /// # Arguments
     ///

--- a/crates/breez-sdk/core/src/persist/sqlite.rs
+++ b/crates/breez-sdk/core/src/persist/sqlite.rs
@@ -1,6 +1,6 @@
 use macros::async_trait;
 use rusqlite::{
-    Connection, ToSql, params,
+    Connection, Row, ToSql, params,
     types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef},
 };
 use rusqlite_migration::{M, Migrations, SchemaVersion};
@@ -124,7 +124,8 @@ impl SqliteStorage {
             );",
             "CREATE TABLE IF NOT EXISTS payment_metadata (
               payment_id TEXT PRIMARY KEY,
-              lnurl_pay_info TEXT);",
+              lnurl_pay_info TEXT
+            );",
             "CREATE TABLE IF NOT EXISTS deposit_refunds (
               deposit_tx_id TEXT NOT NULL,
               deposit_vout INTEGER NOT NULL,
@@ -133,6 +134,35 @@ impl SqliteStorage {
               PRIMARY KEY (deposit_tx_id, deposit_vout)              
             );",
             "ALTER TABLE payment_metadata ADD COLUMN lnurl_description TEXT;",
+            "
+            ALTER TABLE payments ADD COLUMN withdraw_tx_id TEXT;
+            ALTER TABLE payments ADD COLUMN deposit_tx_id TEXT;
+            ALTER TABLE payments ADD COLUMN spark INTEGER;
+            CREATE TABLE payment_details_lightning (
+              payment_id TEXT PRIMARY KEY,
+              invoice TEXT NOT NULL,
+              payment_hash TEXT NOT NULL,
+              destination_pubkey TEXT NOT NULL,
+              description TEXT,
+              preimage TEXT,
+              FOREIGN KEY (payment_id) REFERENCES payments(id) ON DELETE CASCADE
+            );
+            INSERT INTO payment_details_lightning (payment_id, invoice, payment_hash, destination_pubkey, description, preimage)
+            SELECT id, json_extract(details, '$.Lightning.invoice'), json_extract(details, '$.Lightning.payment_hash'), 
+                json_extract(details, '$.Lightning.destination_pubkey'), json_extract(details, '$.Lightning.description'), 
+                json_extract(details, '$.Lightning.preimage') 
+            FROM payments WHERE json_extract(details, '$.Lightning.invoice') IS NOT NULL;
+
+            UPDATE payments SET withdraw_tx_id = json_extract(details, '$.Withdraw.tx_id')
+            WHERE json_extract(details, '$.Withdraw.tx_id') IS NOT NULL;
+
+            UPDATE payments SET deposit_tx_id = json_extract(details, '$.Deposit.tx_id')
+            WHERE json_extract(details, '$.Deposit.tx_id') IS NOT NULL;
+
+            ALTER TABLE payments DROP COLUMN details;
+
+            CREATE INDEX idx_payment_details_lightning_invoice ON payment_details_lightning(invoice);
+            ",
         ]
     }
 }
@@ -159,8 +189,24 @@ impl Storage for SqliteStorage {
         let connection = self.get_connection()?;
 
         let query = format!(
-            "SELECT p.id, p.payment_type, p.status, p.amount, p.fees, p.timestamp, p.details, p.method, pm.lnurl_pay_info, pm.lnurl_description
+            "SELECT p.id
+            ,       p.payment_type
+            ,       p.status
+            ,       p.amount
+            ,       p.fees
+            ,       p.timestamp
+            ,       p.method
+            ,       p.withdraw_tx_id
+            ,       p.deposit_tx_id
+            ,       p.spark
+            ,       l.invoice AS lightning_invoice
+            ,       l.payment_hash AS lightning_payment_hash
+            ,       l.destination_pubkey AS lightning_destination_pubkey
+            ,       COALESCE(l.description, pm.lnurl_description) AS lightning_description
+            ,       l.preimage AS lightning_preimage
+            ,       pm.lnurl_pay_info
              FROM payments p
+             LEFT JOIN payment_details_lightning l ON p.id = l.payment_id
              LEFT JOIN payment_metadata pm ON p.id = pm.payment_id
              ORDER BY p.timestamp DESC 
              LIMIT {} OFFSET {}",
@@ -169,47 +215,18 @@ impl Storage for SqliteStorage {
         );
 
         let mut stmt = connection.prepare(&query)?;
-
-        let payment_iter = stmt.query_map(params![], |row| {
-            let mut details: Option<PaymentDetails> = row.get(6)?;
-            if let Some(PaymentDetails::Lightning {
-                lnurl_pay_info,
-                description,
-                ..
-            }) = &mut details
-            {
-                *lnurl_pay_info = row.get(8)?;
-                if description.is_none() {
-                    *description = row.get(9)?;
-                }
-            }
-
-            Ok(Payment {
-                id: row.get(0)?,
-                payment_type: PaymentType::from(row.get::<_, String>(1)?.as_str()),
-                status: PaymentStatus::from(row.get::<_, String>(2)?.as_str()),
-                amount: row.get(3)?,
-                fees: row.get(4)?,
-                timestamp: row.get(5)?,
-                details,
-                method: row.get(7)?,
-            })
-        })?;
-
-        let mut payments = Vec::new();
-        for payment in payment_iter {
-            payments.push(payment?);
-        }
-
+        let payments = stmt
+            .query_map(params![], map_payment)?
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(payments)
     }
 
     async fn insert_payment(&self, payment: Payment) -> Result<(), StorageError> {
-        let connection = self.get_connection()?;
-
-        connection.execute(
-            "INSERT OR REPLACE INTO payments (id, payment_type, status, amount, fees, timestamp, details, method) 
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        let mut connection = self.get_connection()?;
+        let tx = connection.transaction()?;
+        tx.execute(
+            "INSERT OR REPLACE INTO payments (id, payment_type, status, amount, fees, timestamp, method) 
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
             params![
                 payment.id,
                 payment.payment_type.to_string(),
@@ -217,11 +234,54 @@ impl Storage for SqliteStorage {
                 payment.amount,
                 payment.fees,
                 payment.timestamp,
-                payment.details,
                 payment.method,
             ],
         )?;
 
+        match payment.details {
+            Some(PaymentDetails::Withdraw { tx_id }) => {
+                tx.execute(
+                    "UPDATE payments SET withdraw_tx_id = ? WHERE id = ?",
+                    params![tx_id, payment.id],
+                )?;
+            }
+            Some(PaymentDetails::Deposit { tx_id }) => {
+                tx.execute(
+                    "UPDATE payments SET deposit_tx_id = ? WHERE id = ?",
+                    params![tx_id, payment.id],
+                )?;
+            }
+            Some(PaymentDetails::Spark) => {
+                tx.execute(
+                    "UPDATE payments SET spark = 1 WHERE id = ?",
+                    params![payment.id],
+                )?;
+            }
+            Some(PaymentDetails::Lightning {
+                invoice,
+                payment_hash,
+                destination_pubkey,
+                description,
+                preimage,
+                lnurl_pay_info: _,
+            }) => {
+                tx.execute(
+                    "INSERT OR REPLACE INTO payment_details_lightning (payment_id, invoice, payment_hash, destination_pubkey, description, preimage) 
+                     VALUES (?, ?, ?, ?, ?, ?)",
+                    params![
+                        payment.id,
+                        invoice,
+                        payment_hash,
+                        destination_pubkey,
+                        description,
+                        preimage,
+                    ],
+                )?;
+            }
+            None => {}
+        }
+
+        tx.commit()?;
         Ok(())
     }
 
@@ -280,37 +340,30 @@ impl Storage for SqliteStorage {
         let connection = self.get_connection()?;
 
         let mut stmt = connection.prepare(
-            "SELECT id, payment_type, status, amount, fees, timestamp, details, method, pm.lnurl_pay_info, pm.lnurl_description
-             FROM payments 
-             LEFT JOIN payment_metadata pm ON payments.id = pm.payment_id WHERE payments.id = ?",
+            "SELECT p.id
+            ,       p.payment_type
+            ,       p.status
+            ,       p.amount
+            ,       p.fees
+            ,       p.timestamp
+            ,       p.method
+            ,       p.withdraw_tx_id
+            ,       p.deposit_tx_id
+            ,       p.spark
+            ,       l.invoice AS lightning_invoice
+            ,       l.payment_hash AS lightning_payment_hash
+            ,       l.destination_pubkey AS lightning_destination_pubkey
+            ,       COALESCE(l.description, pm.lnurl_description) AS lightning_description
+            ,       l.preimage AS lightning_preimage
+            ,       pm.lnurl_pay_info
+             FROM payments p
+             LEFT JOIN payment_details_lightning l ON p.id = l.payment_id
+             LEFT JOIN payment_metadata pm ON p.id = pm.payment_id
+             WHERE p.id = ?",
         )?;
 
-        let result = stmt.query_row(params![id], |row| {
-            let mut details: Option<PaymentDetails> = row.get(6)?;
-            if let Some(PaymentDetails::Lightning {
-                lnurl_pay_info,
-                description,
-                ..
-            }) = &mut details
-            {
-                *lnurl_pay_info = row.get(8)?;
-                if description.is_none() {
-                    *description = row.get(9)?;
-                }
-            }
-
-            Ok(Payment {
-                id: row.get(0)?,
-                payment_type: PaymentType::from(row.get::<_, String>(1)?.as_str()),
-                status: PaymentStatus::from(row.get::<_, String>(2)?.as_str()),
-                amount: row.get(3)?,
-                fees: row.get(4)?,
-                timestamp: row.get(5)?,
-                details,
-                method: row.get(7)?,
-            })
-        });
-        result.map_err(StorageError::from)
+        let payment = stmt.query_row(params![id], map_payment)?;
+        Ok(payment)
     }
 
     async fn add_deposit(
@@ -384,6 +437,45 @@ impl Storage for SqliteStorage {
         }
         Ok(())
     }
+}
+
+fn map_payment(row: &Row<'_>) -> Result<Payment, rusqlite::Error> {
+    let withdraw_tx_id: Option<String> = row.get(7)?;
+    let deposit_tx_id: Option<String> = row.get(8)?;
+    let spark: Option<i32> = row.get(9)?;
+    let lightning_invoice: Option<String> = row.get(10)?;
+    let details = match (lightning_invoice, withdraw_tx_id, deposit_tx_id, spark) {
+        (Some(invoice), _, _, _) => {
+            let payment_hash: String = row.get(11)?;
+            let destination_pubkey: String = row.get(12)?;
+            let description: Option<String> = row.get(13)?;
+            let preimage: Option<String> = row.get(14)?;
+            let lnurl_pay_info: Option<LnurlPayInfo> = row.get(15)?;
+
+            Some(PaymentDetails::Lightning {
+                invoice,
+                payment_hash,
+                destination_pubkey,
+                description,
+                preimage,
+                lnurl_pay_info,
+            })
+        }
+        (_, Some(tx_id), _, _) => Some(PaymentDetails::Withdraw { tx_id }),
+        (_, _, Some(tx_id), _) => Some(PaymentDetails::Deposit { tx_id }),
+        (_, _, _, Some(_)) => Some(PaymentDetails::Spark),
+        _ => None,
+    };
+    Ok(Payment {
+        id: row.get(0)?,
+        payment_type: PaymentType::from(row.get::<_, String>(1)?.as_str()),
+        status: PaymentStatus::from(row.get::<_, String>(2)?.as_str()),
+        amount: row.get(3)?,
+        fees: row.get(4)?,
+        timestamp: row.get(5)?,
+        details,
+        method: row.get(6)?,
+    })
 }
 
 impl ToSql for PaymentDetails {

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -5,7 +5,10 @@ use bitcoin::{
     hex::DisplayHex,
 };
 pub use breez_sdk_common::input::parse as parse_input;
-use breez_sdk_common::{fiat::FiatService, input::InputType};
+use breez_sdk_common::{
+    fiat::FiatService,
+    input::{BitcoinAddressDetails, Bolt11InvoiceDetails, InputType},
+};
 use breez_sdk_common::{
     lnurl::{
         error::LnurlError,
@@ -27,6 +30,7 @@ use web_time::{Duration, SystemTime};
 use tokio::{
     select,
     sync::{Mutex, mpsc, oneshot, watch},
+    time::timeout,
 };
 use tokio_with_wasm::alias as tokio;
 use web_time::Instant;
@@ -910,85 +914,26 @@ impl BreezSdk {
         request: SendPaymentRequest,
         suppress_payment_event: bool,
     ) -> Result<SendPaymentResponse, SdkError> {
-        let res = match request.prepare_response.payment_method {
+        let res = match &request.prepare_response.payment_method {
             SendPaymentMethod::SparkAddress { address, .. } => {
-                let spark_address = address
-                    .parse::<SparkAddress>()
-                    .map_err(|_| SdkError::InvalidInput("Invalid spark address".to_string()))?;
-                let transfer = self
-                    .spark_wallet
-                    .transfer(request.prepare_response.amount_sats, &spark_address)
-                    .await?;
-                Ok(SendPaymentResponse {
-                    payment: transfer.try_into()?,
-                })
+                self.send_spark_address(address, &request).await
             }
             SendPaymentMethod::Bolt11Invoice {
                 invoice_details,
                 spark_transfer_fee_sats,
                 lightning_fee_sats,
             } => {
-                let amount_to_send = match invoice_details.amount_msat {
-                    // We are not sending amount in case the invoice contains it.
-                    Some(_) => None,
-                    // We are sending amount for zero amount invoice
-                    None => Some(request.prepare_response.amount_sats),
-                };
-                let prefer_spark = match request.options {
-                    Some(SendPaymentOptions::Bolt11Invoice { prefer_spark }) => prefer_spark,
-                    _ => self.config.prefer_spark_over_lightning,
-                };
-                let fee_sats = match (prefer_spark, spark_transfer_fee_sats, lightning_fee_sats) {
-                    (true, Some(fee), _) => fee,
-                    _ => lightning_fee_sats,
-                };
-
-                let payment_response = self
-                    .spark_wallet
-                    .pay_lightning_invoice(
-                        &invoice_details.invoice.bolt11,
-                        amount_to_send,
-                        Some(fee_sats),
-                        prefer_spark,
-                    )
-                    .await?;
-                let payment = match payment_response.lightning_payment {
-                    Some(lightning_payment) => {
-                        let ssp_id = lightning_payment.id.clone();
-                        let payment = Payment::from_lightning(
-                            lightning_payment,
-                            request.prepare_response.amount_sats,
-                            payment_response.transfer.id.to_string(),
-                        )?;
-                        self.poll_lightning_send_payment(&payment, ssp_id);
-                        payment
-                    }
-                    None => payment_response.transfer.try_into()?,
-                };
-                Ok(SendPaymentResponse { payment })
+                self.send_bolt11_invoice(
+                    invoice_details,
+                    *spark_transfer_fee_sats,
+                    *lightning_fee_sats,
+                    &request,
+                )
+                .await
             }
             SendPaymentMethod::BitcoinAddress { address, fee_quote } => {
-                let exit_speed: ExitSpeed = match request.options {
-                    Some(SendPaymentOptions::BitcoinAddress { confirmation_speed }) => {
-                        confirmation_speed.into()
-                    }
-                    None => ExitSpeed::Fast,
-                    _ => {
-                        return Err(SdkError::InvalidInput("Invalid options".to_string()));
-                    }
-                };
-                let response = self
-                    .spark_wallet
-                    .withdraw(
-                        &address.address,
-                        Some(request.prepare_response.amount_sats),
-                        exit_speed,
-                        fee_quote.into(),
-                    )
-                    .await?;
-                Ok(SendPaymentResponse {
-                    payment: response.try_into()?,
-                })
+                self.send_bitcoin_address(address, fee_quote, &request)
+                    .await
             }
         };
         if let Ok(response) = &res {
@@ -1003,6 +948,123 @@ impl BreezSdk {
             }
         }
         res
+    }
+
+    async fn send_spark_address(
+        &self,
+        address: &str,
+        request: &SendPaymentRequest,
+    ) -> Result<SendPaymentResponse, SdkError> {
+        let spark_address = address
+            .parse::<SparkAddress>()
+            .map_err(|_| SdkError::InvalidInput("Invalid spark address".to_string()))?;
+        let transfer = self
+            .spark_wallet
+            .transfer(request.prepare_response.amount_sats, &spark_address)
+            .await?;
+        Ok(SendPaymentResponse {
+            payment: transfer.try_into()?,
+        })
+    }
+
+    async fn send_bolt11_invoice(
+        &self,
+        invoice_details: &Bolt11InvoiceDetails,
+        spark_transfer_fee_sats: Option<u64>,
+        lightning_fee_sats: u64,
+        request: &SendPaymentRequest,
+    ) -> Result<SendPaymentResponse, SdkError> {
+        let amount_to_send = match invoice_details.amount_msat {
+            // We are not sending amount in case the invoice contains it.
+            Some(_) => None,
+            // We are sending amount for zero amount invoice
+            None => Some(request.prepare_response.amount_sats),
+        };
+        let (prefer_spark, return_pending_after_secs) = match request.options {
+            Some(SendPaymentOptions::Bolt11Invoice {
+                prefer_spark,
+                return_pending_after_secs,
+            }) => (prefer_spark, return_pending_after_secs),
+            _ => (self.config.prefer_spark_over_lightning, None),
+        };
+        let fee_sats = match (prefer_spark, spark_transfer_fee_sats, lightning_fee_sats) {
+            (true, Some(fee), _) => fee,
+            _ => lightning_fee_sats,
+        };
+
+        let payment_response = self
+            .spark_wallet
+            .pay_lightning_invoice(
+                &invoice_details.invoice.bolt11,
+                amount_to_send,
+                Some(fee_sats),
+                prefer_spark,
+            )
+            .await?;
+        let payment = match payment_response.lightning_payment {
+            Some(lightning_payment) => {
+                let ssp_id = lightning_payment.id.clone();
+                let payment = Payment::from_lightning(
+                    lightning_payment,
+                    request.prepare_response.amount_sats,
+                    payment_response.transfer.id.to_string(),
+                )?;
+                self.poll_lightning_send_payment(&payment, ssp_id);
+                payment
+            }
+            None => payment_response.transfer.try_into()?,
+        };
+
+        // Short-circuit and return the pending payment immediately.
+        if let Some(secs) = return_pending_after_secs
+            && secs == 0
+        {
+            return Ok(SendPaymentResponse { payment });
+        }
+
+        let fut = self.wait_for_payment(WaitForPaymentRequest {
+            identifier: WaitForPaymentIdentifier::PaymentId(payment.id.clone()),
+        });
+        let payment = if let Some(secs) = return_pending_after_secs {
+            match timeout(Duration::from_secs(secs.into()), fut).await {
+                Ok(res) => res?.payment,
+                // On timeout return the pending payment.
+                Err(_) => payment,
+            }
+        } else {
+            fut.await?.payment
+        };
+
+        Ok(SendPaymentResponse { payment })
+    }
+
+    async fn send_bitcoin_address(
+        &self,
+        address: &BitcoinAddressDetails,
+        fee_quote: &SendOnchainFeeQuote,
+        request: &SendPaymentRequest,
+    ) -> Result<SendPaymentResponse, SdkError> {
+        let exit_speed: ExitSpeed = match &request.options {
+            Some(SendPaymentOptions::BitcoinAddress { confirmation_speed }) => {
+                confirmation_speed.clone().into()
+            }
+            None => ExitSpeed::Fast,
+            _ => {
+                return Err(SdkError::InvalidInput("Invalid options".to_string()));
+            }
+        };
+        let response = self
+            .spark_wallet
+            .withdraw(
+                &address.address,
+                Some(request.prepare_response.amount_sats),
+                exit_speed,
+                fee_quote.clone().into(),
+            )
+            .await?;
+        Ok(SendPaymentResponse {
+            payment: response.try_into()?,
+        })
     }
 
     // Pools the lightning send payment untill it is in completed state.

--- a/crates/breez-sdk/wasm/js/web-storage/index.js
+++ b/crates/breez-sdk/wasm/js/web-storage/index.js
@@ -98,6 +98,13 @@ class MigrationManager {
             });
             depositStore.createIndex("txid", "txid", { unique: false });
           }
+
+          const paymentStore = db.transaction("payments", "readwrite").objectStore("payments");
+          if (!paymentStore.indexNames.contains("invoice")) {
+            paymentStore.createIndex("invoice", "details.invoice", {
+              unique: false,
+            });
+          }
         },
       },
     ];
@@ -427,6 +434,58 @@ class IndexedDBStorage {
         reject(
           new StorageError(
             `Failed to get payment by id '${id}': ${
+              paymentRequest.error?.message || "Unknown error"
+            }`,
+            paymentRequest.error
+          )
+        );
+      };
+    });
+  }
+
+  async getPaymentByInvoice(invoice) {
+    if (!this.db) {
+      throw new StorageError("Database not initialized");
+    }
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction(
+        ["payments", "payment_metadata"],
+        "readonly"
+      );
+      const paymentStore = transaction.objectStore("payments");
+      const invoiceIndex = paymentStore.index("invoice");
+      const metadataStore = transaction.objectStore("payment_metadata");
+
+      const paymentRequest = invoiceIndex.get(invoice);
+
+      paymentRequest.onsuccess = () => {
+        const payment = paymentRequest.result;
+        if (!payment) {
+          resolve(null);
+          return;
+        }
+
+        // Get metadata for this payment
+        const metadataRequest = metadataStore.get(invoice);
+        metadataRequest.onsuccess = () => {
+          const metadata = metadataRequest.result;
+          const paymentWithMetadata = this._mergePaymentMetadata(
+            payment,
+            metadata
+          );
+          resolve(paymentWithMetadata);
+        };
+        metadataRequest.onerror = () => {
+          // Return payment without metadata if metadata fetch fails
+          resolve(payment);
+        };
+      };
+
+      paymentRequest.onerror = () => {
+        reject(
+          new StorageError(
+            `Failed to get payment by invoice '${invoice}': ${
               paymentRequest.error?.message || "Unknown error"
             }`,
             paymentRequest.error

--- a/crates/breez-sdk/wasm/js/web-storage/index.js
+++ b/crates/breez-sdk/wasm/js/web-storage/index.js
@@ -98,15 +98,19 @@ class MigrationManager {
             });
             depositStore.createIndex("txid", "txid", { unique: false });
           }
-
-          const paymentStore = db.transaction("payments", "readwrite").objectStore("payments");
+        },
+      },
+      {
+        name: "Create invoice index",
+        upgrade: (db, transaction) => {
+          const paymentStore = transaction.objectStore("payments");
           if (!paymentStore.indexNames.contains("invoice")) {
             paymentStore.createIndex("invoice", "details.invoice", {
               unique: false,
             });
           }
-        },
-      },
+        }
+      }
     ];
   }
 }

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -738,3 +738,19 @@ pub struct Symbol {
     pub rtl: Option<bool>,
     pub position: Option<u32>,
 }
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::WaitForPaymentRequest)]
+pub struct WaitForPaymentRequest {
+    pub identifier: WaitForPaymentIdentifier,
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::WaitForPaymentIdentifier)]
+pub enum WaitForPaymentIdentifier {
+    PaymentId(String),
+    PaymentRequest(String),
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::WaitForPaymentResponse)]
+pub struct WaitForPaymentResponse {
+    pub payment: Payment,
+}

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -608,7 +608,7 @@ pub enum SendPaymentOptions {
     },
     Bolt11Invoice {
         prefer_spark: bool,
-        return_pending_after_secs: Option<u32>,
+        completion_timeout_secs: Option<u32>,
     },
 }
 

--- a/crates/breez-sdk/wasm/src/models.rs
+++ b/crates/breez-sdk/wasm/src/models.rs
@@ -608,6 +608,7 @@ pub enum SendPaymentOptions {
     },
     Bolt11Invoice {
         prefer_spark: bool,
+        return_pending_after_secs: Option<u32>,
     },
 }
 

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -254,4 +254,12 @@ impl BreezSdk {
     pub async fn list_fiat_rates(&self) -> WasmResult<ListFiatRatesResponse> {
         Ok(self.sdk.list_fiat_rates().await?.into())
     }
+
+    #[wasm_bindgen(js_name = "waitForPayment")]
+    pub async fn wait_for_payment(
+        &self,
+        request: WaitForPaymentRequest,
+    ) -> WasmResult<WaitForPaymentResponse> {
+        Ok(self.sdk.wait_for_payment(request.into()).await?.into())
+    }
 }

--- a/docs/breez-sdk/snippets/flutter/lib/receive_payment.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/receive_payment.dart
@@ -55,3 +55,17 @@ Future<ReceivePaymentResponse> receivePaymentSpark(BreezSdk sdk) async {
   // ANCHOR_END: receive-payment-spark
   return response;
 }
+
+Future<Payment> waitForPayment(BreezSdk sdk, String paymentRequest) async {
+  // ANCHOR: wait-for-payment
+  // Wait for a payment to be completed using a payment request
+  WaitForPaymentResponse response = await sdk.waitForPayment(
+    request: WaitForPaymentRequest(
+      identifier: WaitForPaymentIdentifier.paymentRequest(paymentRequest),
+    ),
+  );
+  
+  print("Payment received with ID: ${response.payment.id}");
+  // ANCHOR_END: wait-for-payment
+  return response.payment;
+}

--- a/docs/breez-sdk/snippets/flutter/lib/send_payment.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/send_payment.dart
@@ -79,7 +79,7 @@ Future<SendPaymentResponse> sendPaymentLightningBolt11(
   // ANCHOR: send-payment-lightning-bolt11
   final options = SendPaymentOptions.bolt11Invoice(
     preferSpark: true,
-    returnPendingAfterSecs: 0,
+    completionTimeoutSecs: 0,
   );
   final request =
       SendPaymentRequest(prepareResponse: prepareResponse, options: options);

--- a/docs/breez-sdk/snippets/flutter/lib/send_payment.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/send_payment.dart
@@ -79,7 +79,7 @@ Future<SendPaymentResponse> sendPaymentLightningBolt11(
   // ANCHOR: send-payment-lightning-bolt11
   final options = SendPaymentOptions.bolt11Invoice(
     preferSpark: true,
-    completionTimeoutSecs: 0,
+    completionTimeoutSecs: 10,
   );
   final request =
       SendPaymentRequest(prepareResponse: prepareResponse, options: options);

--- a/docs/breez-sdk/snippets/flutter/lib/send_payment.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/send_payment.dart
@@ -77,7 +77,10 @@ Future<PrepareSendPaymentResponse> prepareSendPaymentSpark(BreezSdk sdk) async {
 Future<SendPaymentResponse> sendPaymentLightningBolt11(
     BreezSdk sdk, PrepareSendPaymentResponse prepareResponse) async {
   // ANCHOR: send-payment-lightning-bolt11
-  final options = SendPaymentOptions.bolt11Invoice(preferSpark: true);
+  final options = SendPaymentOptions.bolt11Invoice(
+    preferSpark: true,
+    returnPendingAfterSecs: 0,
+  );
   final request =
       SendPaymentRequest(prepareResponse: prepareResponse, options: options);
   SendPaymentResponse response = await sdk.sendPayment(request: request);

--- a/docs/breez-sdk/snippets/go/receive_payment.go
+++ b/docs/breez-sdk/snippets/go/receive_payment.go
@@ -72,3 +72,23 @@ func ReceiveSpark(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.ReceivePaymen
 	// ANCHOR_END: receive-payment-spark
 	return &response, nil
 }
+
+func WaitForPayment(sdk *breez_sdk_spark.BreezSdk, paymentRequest string) (*breez_sdk_spark.Payment, error) {
+	// ANCHOR: wait-for-payment
+	// Wait for a payment to be completed using a payment request
+	request := breez_sdk_spark.WaitForPaymentRequest{
+		Identifier: breez_sdk_spark.WaitForPaymentIdentifierPaymentRequest{
+			PaymentRequest: paymentRequest,
+		},
+	}
+
+	response, err := sdk.WaitForPayment(request)
+
+	if sdkErr := err.(*breez_sdk_spark.SdkError); sdkErr != nil {
+		return nil, err
+	}
+
+	log.Printf("Payment received with ID: %v", response.payment.Id)
+	// ANCHOR_END: wait-for-payment
+	return &response.payment, nil
+}

--- a/docs/breez-sdk/snippets/go/send_payment.go
+++ b/docs/breez-sdk/snippets/go/send_payment.go
@@ -95,7 +95,7 @@ func PrepareSendPaymentSpark(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.Pr
 
 func SendPaymentLightningBolt11(sdk *breez_sdk_spark.BreezSdk, prepareResponse breez_sdk_spark.PrepareSendPaymentResponse) (*breez_sdk_spark.Payment, error) {
 	// ANCHOR: send-payment-lightning-bolt11
-	var completionTimeoutSecs uint32 = 0
+	var completionTimeoutSecs uint32 = 10
 	var options breez_sdk_spark.SendPaymentOptions = breez_sdk_spark.SendPaymentOptionsBolt11Invoice{
 		PreferSpark:           true,
 		CompletionTimeoutSecs: &completionTimeoutSecs,

--- a/docs/breez-sdk/snippets/go/send_payment.go
+++ b/docs/breez-sdk/snippets/go/send_payment.go
@@ -95,8 +95,10 @@ func PrepareSendPaymentSpark(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.Pr
 
 func SendPaymentLightningBolt11(sdk *breez_sdk_spark.BreezSdk, prepareResponse breez_sdk_spark.PrepareSendPaymentResponse) (*breez_sdk_spark.Payment, error) {
 	// ANCHOR: send-payment-lightning-bolt11
+	var returnPendingAfterSecs uint32 = 0
 	var options breez_sdk_spark.SendPaymentOptions = breez_sdk_spark.SendPaymentOptionsBolt11Invoice{
-		PreferSpark: true,
+		PreferSpark:            true,
+		ReturnPendingAfterSecs: &returnPendingAfterSecs,
 	}
 
 	request := breez_sdk_spark.SendPaymentRequest{

--- a/docs/breez-sdk/snippets/go/send_payment.go
+++ b/docs/breez-sdk/snippets/go/send_payment.go
@@ -95,10 +95,10 @@ func PrepareSendPaymentSpark(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.Pr
 
 func SendPaymentLightningBolt11(sdk *breez_sdk_spark.BreezSdk, prepareResponse breez_sdk_spark.PrepareSendPaymentResponse) (*breez_sdk_spark.Payment, error) {
 	// ANCHOR: send-payment-lightning-bolt11
-	var returnPendingAfterSecs uint32 = 0
+	var completionTimeoutSecs uint32 = 0
 	var options breez_sdk_spark.SendPaymentOptions = breez_sdk_spark.SendPaymentOptionsBolt11Invoice{
-		PreferSpark:            true,
-		ReturnPendingAfterSecs: &returnPendingAfterSecs,
+		PreferSpark:           true,
+		CompletionTimeoutSecs: &completionTimeoutSecs,
 	}
 
 	request := breez_sdk_spark.SendPaymentRequest{

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
@@ -59,4 +59,21 @@ class ReceivePayment {
         }
         // ANCHOR_END: receive-payment-spark
     }
+
+    suspend fun waitForPayment(sdk: BreezSdk, paymentRequest: String) {
+        // ANCHOR: wait-for-payment
+        try {
+            // Wait for a payment to be completed using a payment request
+            val response = sdk.waitForPayment(
+                WaitForPaymentRequest(
+                    WaitForPaymentIdentifier.PaymentRequest(paymentRequest)
+                )
+            )
+            
+            // Log.v("Breez", "Payment received with ID: ${response.payment.id}")
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: wait-for-payment
+    }
 }

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
@@ -78,7 +78,7 @@ class SendPayment {
     suspend fun sendPaymentLightningBolt11(sdk: BreezSdk, prepareResponse: PrepareSendPaymentResponse) {
         // ANCHOR: send-payment-lightning-bolt11
         try {
-            val options = SendPaymentOptions.Bolt11Invoice(preferSpark = true, returnPendingAfterSecs = 0u)
+            val options = SendPaymentOptions.Bolt11Invoice(preferSpark = true, completionTimeoutSecs = 0u)
             val sendResponse = sdk.sendPayment(SendPaymentRequest(prepareResponse, options))
             val payment = sendResponse.payment
         } catch (e: Exception) {

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
@@ -78,7 +78,7 @@ class SendPayment {
     suspend fun sendPaymentLightningBolt11(sdk: BreezSdk, prepareResponse: PrepareSendPaymentResponse) {
         // ANCHOR: send-payment-lightning-bolt11
         try {
-            val options = SendPaymentOptions.Bolt11Invoice(preferSpark = true, completionTimeoutSecs = 0u)
+            val options = SendPaymentOptions.Bolt11Invoice(preferSpark = true, completionTimeoutSecs = 10u)
             val sendResponse = sdk.sendPayment(SendPaymentRequest(prepareResponse, options))
             val payment = sendResponse.payment
         } catch (e: Exception) {

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
@@ -78,7 +78,7 @@ class SendPayment {
     suspend fun sendPaymentLightningBolt11(sdk: BreezSdk, prepareResponse: PrepareSendPaymentResponse) {
         // ANCHOR: send-payment-lightning-bolt11
         try {
-            val options = SendPaymentOptions.Bolt11Invoice(true)
+            val options = SendPaymentOptions.Bolt11Invoice(preferSpark = true, returnPendingAfterSecs = 0u)
             val sendResponse = sdk.sendPayment(SendPaymentRequest(prepareResponse, options))
             val payment = sendResponse.payment
         } catch (e: Exception) {

--- a/docs/breez-sdk/snippets/python/src/receive_payment.py
+++ b/docs/breez-sdk/snippets/python/src/receive_payment.py
@@ -1,5 +1,5 @@
 import logging
-from breez_sdk_spark import BreezSdk, ReceivePaymentMethod, ReceivePaymentRequest
+from breez_sdk_spark import BreezSdk, ReceivePaymentMethod, ReceivePaymentRequest, WaitForPaymentRequest, WaitForPaymentIdentifier
 
 
 async def receive_lightning(sdk: BreezSdk):
@@ -61,3 +61,21 @@ async def receive_spark(sdk: BreezSdk):
         logging.error(error)
         raise
     # ANCHOR_END: receive-payment-spark
+
+
+async def wait_for_payment(sdk: BreezSdk, payment_request: str):
+    # ANCHOR: wait-for-payment
+    try:
+        # Wait for a payment to be completed using a payment request
+        response = await sdk.wait_for_payment(
+            request=WaitForPaymentRequest(
+                identifier=WaitForPaymentIdentifier.PAYMENT_REQUEST(payment_request)
+            )
+        )
+        
+        logging.debug(f"Payment received with ID: {response.payment.id}")
+        return response.payment
+    except Exception as error:
+        logging.error(error)
+        raise
+    # ANCHOR_END: wait-for-payment

--- a/docs/breez-sdk/snippets/python/src/send_payment.py
+++ b/docs/breez-sdk/snippets/python/src/send_payment.py
@@ -102,7 +102,10 @@ async def send_payment_lightning_bolt11(
 ):
     # ANCHOR: send-payment-lightning-bolt11
     try:
-        options = SendPaymentOptions.BOLT11_INVOICE(prefer_spark=True)
+        options = SendPaymentOptions.BOLT11_INVOICE(
+            prefer_spark=True,
+            return_pending_after_secs=0
+        )
         request = SendPaymentRequest(prepare_response=prepare_response, options=options)
         send_response = await sdk.send_payment(request=request)
         payment = send_response.payment

--- a/docs/breez-sdk/snippets/python/src/send_payment.py
+++ b/docs/breez-sdk/snippets/python/src/send_payment.py
@@ -104,7 +104,7 @@ async def send_payment_lightning_bolt11(
     try:
         options = SendPaymentOptions.BOLT11_INVOICE(
             prefer_spark=True,
-            return_pending_after_secs=0
+            completion_timeout_secs=0
         )
         request = SendPaymentRequest(prepare_response=prepare_response, options=options)
         send_response = await sdk.send_payment(request=request)

--- a/docs/breez-sdk/snippets/python/src/send_payment.py
+++ b/docs/breez-sdk/snippets/python/src/send_payment.py
@@ -104,7 +104,7 @@ async def send_payment_lightning_bolt11(
     try:
         options = SendPaymentOptions.BOLT11_INVOICE(
             prefer_spark=True,
-            completion_timeout_secs=0
+            completion_timeout_secs=10
         )
         request = SendPaymentRequest(prepare_response=prepare_response, options=options)
         send_response = await sdk.send_payment(request=request)

--- a/docs/breez-sdk/snippets/react-native/receive_payment.ts
+++ b/docs/breez-sdk/snippets/react-native/receive_payment.ts
@@ -1,4 +1,4 @@
-import { ReceivePaymentMethod, type BreezSdk } from '@breeztech/breez-sdk-spark-react-native'
+import { ReceivePaymentMethod, WaitForPaymentIdentifier, type BreezSdk } from '@breeztech/breez-sdk-spark-react-native'
 
 const exampleReceiveLightningPayment = async (sdk: BreezSdk) => {
   // ANCHOR: receive-payment-lightning-bolt11
@@ -44,4 +44,15 @@ const exampleReceiveSparkPayment = async (sdk: BreezSdk) => {
   const receiveFeeSats = response.feeSats
   console.log(`Fees: ${receiveFeeSats} sats`)
   // ANCHOR_END: receive-payment-spark
+}
+
+const exampleWaitForPayment = async (sdk: BreezSdk, paymentRequest: string) => {
+  // ANCHOR: wait-for-payment
+  // Wait for a payment to be completed using a payment request
+  const response = await sdk.waitForPayment({
+    identifier: new WaitForPaymentIdentifier.PaymentRequest(paymentRequest)
+  })
+
+  console.log(`Payment received with ID: ${response.payment.id}`)
+  // ANCHOR_END: wait-for-payment
 }

--- a/docs/breez-sdk/snippets/react-native/send_payment.ts
+++ b/docs/breez-sdk/snippets/react-native/send_payment.ts
@@ -79,7 +79,7 @@ const exampleSendPaymentLightningBolt11 = async (
   // ANCHOR: send-payment-lightning-bolt11
   const options = new SendPaymentOptions.Bolt11Invoice({ 
     preferSpark: true,
-    returnPendingAfterSecs: 0
+    completionTimeoutSecs: 0
   })
   const sendResponse = await sdk.sendPayment({
     prepareResponse,

--- a/docs/breez-sdk/snippets/react-native/send_payment.ts
+++ b/docs/breez-sdk/snippets/react-native/send_payment.ts
@@ -79,7 +79,7 @@ const exampleSendPaymentLightningBolt11 = async (
   // ANCHOR: send-payment-lightning-bolt11
   const options = new SendPaymentOptions.Bolt11Invoice({ 
     preferSpark: true,
-    completionTimeoutSecs: 0
+    completionTimeoutSecs: 10
   })
   const sendResponse = await sdk.sendPayment({
     prepareResponse,

--- a/docs/breez-sdk/snippets/react-native/send_payment.ts
+++ b/docs/breez-sdk/snippets/react-native/send_payment.ts
@@ -77,7 +77,10 @@ const exampleSendPaymentLightningBolt11 = async (
   prepareResponse: PrepareSendPaymentResponse
 ) => {
   // ANCHOR: send-payment-lightning-bolt11
-  const options = new SendPaymentOptions.Bolt11Invoice({ preferSpark: true })
+  const options = new SendPaymentOptions.Bolt11Invoice({ 
+    preferSpark: true,
+    returnPendingAfterSecs: 0
+  })
   const sendResponse = await sdk.sendPayment({
     prepareResponse,
     options

--- a/docs/breez-sdk/snippets/rust/src/receive_payment.rs
+++ b/docs/breez-sdk/snippets/rust/src/receive_payment.rs
@@ -56,3 +56,17 @@ async fn receive_spark(sdk: &BreezSdk) -> Result<()> {
     // ANCHOR_END: receive-payment-spark
     Ok(())
 }
+
+async fn wait_for_payment_example(sdk: &BreezSdk, payment_request: String) -> Result<()> {
+    // ANCHOR: wait-for-payment
+    // Wait for a payment to be completed using a payment request
+    let response = sdk
+        .wait_for_payment(WaitForPaymentRequest {
+            identifier: WaitForPaymentIdentifier::PaymentRequest(payment_request),
+        })
+        .await?;
+
+    info!("Payment received with ID: {}", response.payment.id);
+    // ANCHOR_END: wait-for-payment
+    Ok(())
+}

--- a/docs/breez-sdk/snippets/rust/src/send_payment.rs
+++ b/docs/breez-sdk/snippets/rust/src/send_payment.rs
@@ -82,7 +82,7 @@ async fn send_payment_lightning_bolt11(
     // ANCHOR: send-payment-lightning-bolt11
     let options = Some(SendPaymentOptions::Bolt11Invoice { 
         prefer_spark: true,
-        completion_timeout_secs: Some(0),
+        completion_timeout_secs: Some(10),
     });
     let send_response = sdk
         .send_payment(SendPaymentRequest {

--- a/docs/breez-sdk/snippets/rust/src/send_payment.rs
+++ b/docs/breez-sdk/snippets/rust/src/send_payment.rs
@@ -82,7 +82,7 @@ async fn send_payment_lightning_bolt11(
     // ANCHOR: send-payment-lightning-bolt11
     let options = Some(SendPaymentOptions::Bolt11Invoice { 
         prefer_spark: true,
-        return_pending_after_secs: Some(0),
+        completion_timeout_secs: Some(0),
     });
     let send_response = sdk
         .send_payment(SendPaymentRequest {

--- a/docs/breez-sdk/snippets/rust/src/send_payment.rs
+++ b/docs/breez-sdk/snippets/rust/src/send_payment.rs
@@ -80,7 +80,10 @@ async fn send_payment_lightning_bolt11(
     prepare_response: PrepareSendPaymentResponse,
 ) -> Result<()> {
     // ANCHOR: send-payment-lightning-bolt11
-    let options = Some(SendPaymentOptions::Bolt11Invoice { prefer_spark: true });
+    let options = Some(SendPaymentOptions::Bolt11Invoice { 
+        prefer_spark: true,
+        return_pending_after_secs: Some(0),
+    });
     let send_response = sdk
         .send_payment(SendPaymentRequest {
             prepare_response,

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ReceivePayment.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ReceivePayment.swift
@@ -53,3 +53,18 @@ func receiveSpark(sdk: BreezSdk) async throws -> ReceivePaymentResponse {
 
     return response
 }
+
+func waitForPayment(sdk: BreezSdk, paymentRequest: String) async throws -> Payment {
+    // ANCHOR: wait-for-payment
+    // Wait for a payment to be completed using a payment request
+    let response = try await sdk.waitForPayment(
+        request: WaitForPaymentRequest(
+            identifier: WaitForPaymentIdentifier.paymentRequest(value: paymentRequest)
+        )
+    )
+    
+    print("Payment received with ID: \(response.payment.id)")
+    // ANCHOR_END: wait-for-payment
+    
+    return payment
+}

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SendPayment.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SendPayment.swift
@@ -66,7 +66,7 @@ func prepareSendPaymentSpark(sdk: BreezSdk) async throws {
 
 func sendPaymentLightningBolt11(sdk: BreezSdk, prepareResponse: PrepareSendPaymentResponse) async throws {
     // ANCHOR: send-payment-lightning-bolt11
-    let options = SendPaymentOptions.bolt11Invoice(preferSpark: true)
+    let options = SendPaymentOptions.bolt11Invoice(preferSpark: true, returnPendingAfterSecs: 0)
     let sendResponse = try await sdk.sendPayment(request: SendPaymentRequest (
         prepareResponse: prepareResponse,
         options: options

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SendPayment.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SendPayment.swift
@@ -66,7 +66,7 @@ func prepareSendPaymentSpark(sdk: BreezSdk) async throws {
 
 func sendPaymentLightningBolt11(sdk: BreezSdk, prepareResponse: PrepareSendPaymentResponse) async throws {
     // ANCHOR: send-payment-lightning-bolt11
-    let options = SendPaymentOptions.bolt11Invoice(preferSpark: true, completionTimeoutSecs: 0)
+    let options = SendPaymentOptions.bolt11Invoice(preferSpark: true, completionTimeoutSecs: 10)
     let sendResponse = try await sdk.sendPayment(request: SendPaymentRequest (
         prepareResponse: prepareResponse,
         options: options

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SendPayment.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SendPayment.swift
@@ -66,7 +66,7 @@ func prepareSendPaymentSpark(sdk: BreezSdk) async throws {
 
 func sendPaymentLightningBolt11(sdk: BreezSdk, prepareResponse: PrepareSendPaymentResponse) async throws {
     // ANCHOR: send-payment-lightning-bolt11
-    let options = SendPaymentOptions.bolt11Invoice(preferSpark: true, returnPendingAfterSecs: 0)
+    let options = SendPaymentOptions.bolt11Invoice(preferSpark: true, completionTimeoutSecs: 0)
     let sendResponse = try await sdk.sendPayment(request: SendPaymentRequest (
         prepareResponse: prepareResponse,
         options: options

--- a/docs/breez-sdk/snippets/wasm/receive_payment.ts
+++ b/docs/breez-sdk/snippets/wasm/receive_payment.ts
@@ -46,3 +46,17 @@ const exampleReceiveSparkPayment = async (sdk: BreezSdk) => {
   console.log(`Fees: ${receiveFeeSats} sats`)
   // ANCHOR_END: receive-payment-spark
 }
+
+const exampleWaitForPayment = async (sdk: BreezSdk, paymentRequest: string) => {
+  // ANCHOR: wait-for-payment
+  // Wait for a payment to be completed using a payment request
+  const response = await sdk.waitForPayment({
+    identifier: {
+      type: 'paymentRequest',
+      paymentRequest: paymentRequest
+    }
+  })
+
+  console.log(`Payment received with ID: ${response.payment.id}`)
+  // ANCHOR_END: wait-for-payment
+}

--- a/docs/breez-sdk/snippets/wasm/send_payment.ts
+++ b/docs/breez-sdk/snippets/wasm/send_payment.ts
@@ -78,7 +78,7 @@ const exampleSendPaymentLightningBolt11 = async (
   const options: SendPaymentOptions = { 
     type: 'bolt11Invoice', 
     preferSpark: true,
-    completionTimeoutSecs: 0
+    completionTimeoutSecs: 10
   }
   const sendResponse = await sdk.sendPayment({
     prepareResponse,

--- a/docs/breez-sdk/snippets/wasm/send_payment.ts
+++ b/docs/breez-sdk/snippets/wasm/send_payment.ts
@@ -75,7 +75,11 @@ const exampleSendPaymentLightningBolt11 = async (
   prepareResponse: PrepareSendPaymentResponse
 ) => {
   // ANCHOR: send-payment-lightning-bolt11
-  const options: SendPaymentOptions = { type: 'bolt11Invoice', preferSpark: true }
+  const options: SendPaymentOptions = { 
+    type: 'bolt11Invoice', 
+    preferSpark: true,
+    returnPendingAfterSecs: 0
+  }
   const sendResponse = await sdk.sendPayment({
     prepareResponse,
     options

--- a/docs/breez-sdk/snippets/wasm/send_payment.ts
+++ b/docs/breez-sdk/snippets/wasm/send_payment.ts
@@ -78,7 +78,7 @@ const exampleSendPaymentLightningBolt11 = async (
   const options: SendPaymentOptions = { 
     type: 'bolt11Invoice', 
     preferSpark: true,
-    returnPendingAfterSecs: 0
+    completionTimeoutSecs: 0
   }
   const sendResponse = await sdk.sendPayment({
     prepareResponse,

--- a/docs/breez-sdk/src/guide/receive_payment.md
+++ b/docs/breez-sdk/src/guide/receive_payment.md
@@ -220,6 +220,77 @@ For payments between Spark users, you can use the static Spark address to receiv
 </section>
 </custom-tabs>
 
+## Waiting for a lightning payment
+Generally it is recommended to use [event flows] to react to payment completion. There is a convenience function to wait for a lightning payment to be paid.
+
+<custom-tabs category="lang">
+<div slot="title">Rust</div>
+<section>
+
+```rust,ignore
+{{#include ../../snippets/rust/src/receive_payment.rs:wait-for-payment}}
+```
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+```swift,ignore
+{{#include ../../snippets/swift/BreezSdkSnippets/Sources/ReceivePayment.swift:wait-for-payment}}
+```
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+```kotlin,ignore
+{{#include ../../snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt:wait-for-payment}}
+```
+</section>
+
+<div slot="title">Javascript</div>
+<section>
+
+```typescript
+{{#include ../../snippets/wasm/receive_payment.ts:wait-for-payment}}
+```
+</section>
+
+<div slot="title">React Native</div>
+<section>
+
+```typescript
+{{#include ../../snippets/react-native/receive_payment.ts:wait-for-payment}}
+```
+</section>
+
+<div slot="title">Flutter</div>
+<section>
+
+```dart,ignore
+{{#include ../../snippets/flutter/lib/receive_payment.dart:wait-for-payment}}
+```
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+```python,ignore 
+{{#include ../../snippets/python/src/receive_payment.py:wait-for-payment}}
+```
+</section>
+
+<div slot="title">Go</div>
+<section>
+
+```go,ignore
+{{#include ../../snippets/go/receive_payment.go:wait-for-payment}}
+```
+</section>
+</custom-tabs>
+
+[event flows]: #event-flows
+
 ## Event Flows
 Once a receive payment is initiated, you can follow and react to the different payment events using the guide below for each payment method. See [Listening to events](/guide/events.md) for how to subscribe to events.
 

--- a/docs/breez-sdk/src/guide/send_payment.md
+++ b/docs/breez-sdk/src/guide/send_payment.md
@@ -241,7 +241,7 @@ Once the payment has been prepared, pass the prepare response as an argument to 
 
 In the send payment options for BOLT11 invoices, you can set whether to prefer to use Spark to transfer the payment if the invoice contains a Spark address. By default, using Spark transfers are disabled.
 
-By default, this function waits until the Lightning payment is complete before returning. You can override this behavior by specifying a timeout in seconds, after which the function will return even if the payment is still pending. This is useful if you want to display the payment as 'pending' after a certain period. Setting the timeout to 0 will cause the function to return a pending payment immediately after initiating it.
+By default, this function returns immediately. You can override this behavior by specifying a completion timeout in seconds. If the completion timeout is hit, a pending payment object is returned. If the payment completes, the completed payment object is returned.
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>

--- a/docs/breez-sdk/src/guide/send_payment.md
+++ b/docs/breez-sdk/src/guide/send_payment.md
@@ -241,6 +241,8 @@ Once the payment has been prepared, pass the prepare response as an argument to 
 
 In the send payment options for BOLT11 invoices, you can set whether to prefer to use Spark to transfer the payment if the invoice contains a Spark address. By default, using Spark transfers are disabled.
 
+By default, this function waits until the Lightning payment is complete before returning. You can override this behavior by specifying a timeout in seconds, after which the function will return even if the payment is still pending. This is useful if you want to display the payment as 'pending' after a certain period. Setting the timeout to 0 will cause the function to return a pending payment immediately after initiating it.
+
 <custom-tabs category="lang">
 <div slot="title">Rust</div>
 <section>

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -270,7 +270,7 @@ pub enum _SendPaymentOptions {
     },
     Bolt11Invoice {
         prefer_spark: bool,
-        return_pending_after_secs: Option<u32>,
+        completion_timeout_secs: Option<u32>,
     },
 }
 

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -690,3 +690,19 @@ pub struct _Symbol {
     pub rtl: Option<bool>,
     pub position: Option<u32>,
 }
+
+#[frb(mirror(WaitForPaymentRequest))]
+pub struct _WaitForPaymentRequest {
+    pub identifier: WaitForPaymentIdentifier,
+}
+
+#[frb(mirror(WaitForPaymentIdentifier))]
+pub enum _WaitForPaymentIdentifier {
+    PaymentId(String),
+    PaymentRequest(String),
+}
+
+#[frb(mirror(WaitForPaymentResponse))]
+pub struct _WaitForPaymentResponse {
+    pub payment: Payment,
+}

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -270,6 +270,7 @@ pub enum _SendPaymentOptions {
     },
     Bolt11Invoice {
         prefer_spark: bool,
+        return_pending_after_secs: Option<u32>,
     },
 }
 

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -10,7 +10,7 @@ use breez_sdk_spark::{
     PrepareLnurlPayResponse, PrepareSendPaymentRequest, PrepareSendPaymentResponse,
     ReceivePaymentRequest, ReceivePaymentResponse, RefundDepositRequest, RefundDepositResponse,
     RegisterLightningAddressRequest, SdkError, SdkEvent, SendPaymentRequest, SendPaymentResponse,
-    Storage, SyncWalletRequest, SyncWalletResponse,
+    Storage, SyncWalletRequest, SyncWalletResponse, WaitForPaymentRequest, WaitForPaymentResponse,
 };
 use flutter_rust_bridge::frb;
 
@@ -172,5 +172,12 @@ impl BreezSdk {
 
     pub async fn list_fiat_rates(&self) -> Result<ListFiatRatesResponse, SdkError> {
         self.inner.list_fiat_rates().await
+    }
+
+    pub async fn wait_for_payment(
+        &self,
+        request: WaitForPaymentRequest,
+    ) -> Result<WaitForPaymentResponse, SdkError> {
+        self.inner.wait_for_payment(request).await
     }
 }

--- a/packages/flutter/rust/src/sdk_builder.rs
+++ b/packages/flutter/rust/src/sdk_builder.rs
@@ -19,9 +19,17 @@ impl SdkBuilder {
     }
 
     #[frb(sync)]
-    pub fn with_key_set(self, key_set_type: KeySetType, use_address_index: bool, account_number: Option<u32>) -> Self {
-        let builder = <breez_sdk_spark::SdkBuilder as Clone>::clone(&self.inner)
-            .with_key_set(key_set_type, use_address_index, account_number);
+    pub fn with_key_set(
+        self,
+        key_set_type: KeySetType,
+        use_address_index: bool,
+        account_number: Option<u32>,
+    ) -> Self {
+        let builder = <breez_sdk_spark::SdkBuilder as Clone>::clone(&self.inner).with_key_set(
+            key_set_type,
+            use_address_index,
+            account_number,
+        );
         Self {
             inner: Arc::new(builder),
         }


### PR DESCRIPTION
This PR does the following:
- Flatten the database structure of the payment details (to allow querying by invoice)
- Added a `wait_for_payment` function to allow waiting for lightning payments, whether it's sending or receiving. Mostly useful for external users for waiting for receiving a specific payment.
- Added `return_pending_after_secs` to the `send_payment` function. By default the `send_payment` function will now wait for the payment to complete, rather than returning 'pending' immediately. This can be overridden with the `return_pending_after_secs` field. Setting to 0 will make the function return immediately.