### PR TITLE
gracefully handle already claimed transfers

### DIFF
--- a/crates/spark/src/services/models.rs
+++ b/crates/spark/src/services/models.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::str::FromStr;
 
 use bitcoin::secp256k1::ecdsa::Signature;
@@ -571,6 +571,25 @@ pub enum TransferStatus {
     SenderInitiatedCoordinator,
     ReceiverKeyTweakLocked,
     ReceiverKeyTweakApplied,
+}
+
+impl Display for TransferStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let status_str = match self {
+            TransferStatus::SenderInitiated => "SenderInitiated",
+            TransferStatus::SenderKeyTweakPending => "SenderKeyTweakPending",
+            TransferStatus::SenderKeyTweaked => "SenderKeyTweaked",
+            TransferStatus::ReceiverKeyTweaked => "ReceiverKeyTweaked",
+            TransferStatus::ReceiverRefundSigned => "ReceiverRefundSigned",
+            TransferStatus::Completed => "Completed",
+            TransferStatus::Expired => "Expired",
+            TransferStatus::Returned => "Returned",
+            TransferStatus::SenderInitiatedCoordinator => "SenderInitiatedCoordinator",
+            TransferStatus::ReceiverKeyTweakLocked => "ReceiverKeyTweakLocked",
+            TransferStatus::ReceiverKeyTweakApplied => "ReceiverKeyTweakApplied",
+        };
+        write!(f, "{status_str}")
+    }
 }
 
 impl From<operator_rpc::spark::TransferStatus> for TransferStatus {


### PR DESCRIPTION
A common case is that a transfer has already been claimed by another instance of the sdk, or even the same instance, in another flow. Currently the claim_transfer function then errors. This can leave payments in a pending state until the next sync round.

In order to fix this, we'll gracefully handle already claimed incoming transfers. If there is an error from the operator, we'll check what the state of the transfer is on the operator, by querying the transfer and determining its state. If the state is already past the expected state, we'll return OK. The TransferAlreadyClaimed error is now handled inside claim_transfer, to minimize the amount of code paths that have to handle this error.

Fixes #282