### PR TITLE
Fix private methods exposed to uniffi

### DIFF
--- a/docs/breez-sdk/snippets/go/getting_started.go
+++ b/docs/breez-sdk/snippets/go/getting_started.go
@@ -65,10 +65,11 @@ func InitSdkAdvanced() (*breez_sdk_spark.BreezSdk, error) {
 
 func FetchBalance(sdk *breez_sdk_spark.BreezSdk) error {
 	// ANCHOR: fetch-balance
+	ensureSynced := false
 	info, err := sdk.GetInfo(breez_sdk_spark.GetInfoRequest{
 		// EnsureSynced: true will ensure the SDK is synced with the Spark network
 		// before returning the balance
-		EnsureSynced: false,
+		EnsureSynced: &ensureSynced,
 	})
 
 	if sdkErr := err.(*breez_sdk_spark.SdkError); sdkErr != nil {

--- a/docs/breez-sdk/snippets/go/lightning_address.go
+++ b/docs/breez-sdk/snippets/go/lightning_address.go
@@ -12,7 +12,7 @@ func ConfigLightningAddress() *breez_sdk_spark.Config {
 	config.ApiKey = &apiKey
 	config.LnurlDomain = &lnurlDomain
 	// ANCHOR_END: config-lightning-address
-	return config
+	return &config
 }
 
 func CheckLightningAddressAvailability(sdk *breez_sdk_spark.BreezSdk) (bool, error) {
@@ -39,7 +39,7 @@ func RegisterLightningAddress(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.L
 	// ANCHOR: register-lightning-address
 	request := breez_sdk_spark.RegisterLightningAddressRequest{
 		Username:    username,
-		Description: description,
+		Description: &description,
 	}
 
 	addressInfo, err := sdk.RegisterLightningAddress(request)
@@ -51,7 +51,7 @@ func RegisterLightningAddress(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.L
 	_ = addressInfo.Lnurl
 	// ANCHOR_END: register-lightning-address
 
-	return addressInfo, nil
+	return &addressInfo, nil
 }
 
 func GetLightningAddress(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.LightningAddressInfo, error) {

--- a/docs/breez-sdk/snippets/go/receive_payment.go
+++ b/docs/breez-sdk/snippets/go/receive_payment.go
@@ -78,7 +78,7 @@ func WaitForPayment(sdk *breez_sdk_spark.BreezSdk, paymentRequest string) (*bree
 	// Wait for a payment to be completed using a payment request
 	request := breez_sdk_spark.WaitForPaymentRequest{
 		Identifier: breez_sdk_spark.WaitForPaymentIdentifierPaymentRequest{
-			PaymentRequest: paymentRequest,
+			Field0: paymentRequest,
 		},
 	}
 
@@ -88,7 +88,7 @@ func WaitForPayment(sdk *breez_sdk_spark.BreezSdk, paymentRequest string) (*bree
 		return nil, err
 	}
 
-	log.Printf("Payment received with ID: %v", response.payment.Id)
+	log.Printf("Payment received with ID: %v", response.Payment.Id)
 	// ANCHOR_END: wait-for-payment
-	return &response.payment, nil
+	return &response.Payment, nil
 }


### PR DESCRIPTION
This PR fixes an issue that caused the latest published release (0.2.6) to be broken on its golang version.

We were exposing private methods to uniffi by mistake. In this latest release, that caused issues because methods like `send_bolt11_invoice` use `sdk_common` types (`Bolt11InvoiceDetails`) as params. This caused conflicts in the go bindings.

Additionally, I also fixed some small issues with the go snippets that I found while testing this fix.

To prevent this kind of issue in the future we should work on https://github.com/breez/spark-sdk/issues/302.