### PR TITLE
Fix direct refund tx value

### DIFF
--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -576,17 +576,10 @@ impl DepositService {
             direct_tx: direct_refund_tx,
             direct_from_cpfp_tx: direct_from_cpfp_refund_tx,
         } = create_refund_txs(
+            &cpfp_root_tx,
+            Some(&direct_root_tx),
             initial_cpfp_sequence(),
             initial_direct_sequence(),
-            OutPoint {
-                txid: cpfp_root_tx.compute_txid(),
-                vout: 0,
-            },
-            Some(OutPoint {
-                txid: direct_root_tx.compute_txid(),
-                vout: 0,
-            }),
-            deposit_tx_out.value.to_sat(),
             &signing_public_key,
             self.network,
         );

--- a/crates/spark/src/services/timelock_manager.rs
+++ b/crates/spark/src/services/timelock_manager.rs
@@ -192,7 +192,6 @@ impl TimelockManager {
 
         let node_tx = &node.node_tx;
         let node_outpoint = node_tx.input[0].previous_output;
-        let node_tx_out = &node_tx.output[0];
 
         let direct_tx = node.direct_tx;
         let direct_outpoint = direct_tx.as_ref().map(|tx| tx.input[0].previous_output);
@@ -220,17 +219,10 @@ impl TimelockManager {
             direct_tx: direct_refund_tx,
             direct_from_cpfp_tx: direct_from_cpfp_refund_tx,
         } = create_refund_txs(
+            &cpfp_node_tx,
+            direct_node_tx.as_ref(),
             initial_cpfp_sequence(),
             initial_direct_sequence(),
-            OutPoint {
-                txid: cpfp_node_tx.compute_txid(),
-                vout: 0,
-            },
-            direct_node_tx.as_ref().map(|tx| OutPoint {
-                txid: tx.compute_txid(),
-                vout: 0,
-            }),
-            node_tx_out.value.to_sat(),
             &signing_public_key,
             self.network,
         );
@@ -491,7 +483,6 @@ impl TimelockManager {
             .refund_tx
             .clone()
             .ok_or(ServiceError::Generic("No refund tx".to_string()))?;
-        let refund_tx_out = &refund_tx.output[0];
 
         let (cpfp_sequence, direct_sequence) = next_sequence(refund_tx.input[0].sequence).ok_or(
             ServiceError::Generic("Failed to get next sequence".to_string()),
@@ -515,17 +506,10 @@ impl TimelockManager {
             direct_tx: direct_refund_tx,
             direct_from_cpfp_tx: direct_from_cpfp_refund_tx,
         } = create_refund_txs(
+            &cpfp_node_tx,
+            direct_node_tx.as_ref(),
             initial_cpfp_sequence(),
             initial_direct_sequence(),
-            OutPoint {
-                txid: cpfp_node_tx.compute_txid(),
-                vout: 0,
-            },
-            direct_node_tx.as_ref().map(|tx| OutPoint {
-                txid: tx.compute_txid(),
-                vout: 0,
-            }),
-            refund_tx_out.value.to_sat(),
             &signing_public_key,
             self.network,
         );


### PR DESCRIPTION
Uses the direct tx output value for the direct refund tx.

Fixes this error in the [Breez SDK integration tests PR](https://github.com/breez/spark-sdk/pull/309):
```
Error: SparkSdkError: Service error: service connection error: Connection error: status: Internal, message: "unable to build htlc refund maps: direct leaf refund tx mismatch,
expected: 0300000001002d5b8341dea7bcbf96788370e2f22d50c13c99be5aba4c98f5c343efe011dc00000000009506004001451c000000000000225120003b51d296c140845fa21381ec64ec2d99e546b0a0f73c50fb9124ebcf9e8d8f00000000, 
got: 0300000001002d5b8341dea7bcbf96788370e2f22d50c13c99be5aba4c98f5c343efe011dc000000000095060040018a18000000000000225120003b51d296c140845fa21381ec64ec2d99e546b0a0f73c50fb9124ebcf9e8d8f00000000", 
details: [], metadata: MetadataMap { headers: {"server": "awselb/2.0", "date": "Sun, 12 Oct 2025 16:58:47 GMT", "content-type": "application/grpc", "trailer": "Grpc-Status", "trailer": "Grpc-Message", "trailer": "Grpc-Status-Details-Bin"} }
```

~Got some failures running the breez-itest locally, but the CI looks fine~ (running a second time worked locally)
```
thread 'test_02_deposit_claim' panicked at crates/breez-sdk/breez-itest/tests/breez_sdk_tests.rs:230:5:
Balance should increase after deposit claim

thread 'test_03_lightning_invoice_payment::case_2_zero_amount' panicked at crates/breez-sdk/breez-itest/tests/breez_sdk_tests.rs:410:5:
Alice's balance should decrease

failures:
    test_02_deposit_claim
    test_03_lightning_invoice_payment::case_2_zero_amount

test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 284.71s
```