### PR TITLE
Use the transfer intermediate txs when claiming

### DIFF
--- a/crates/spark/src/services/models.rs
+++ b/crates/spark/src/services/models.rs
@@ -332,6 +332,17 @@ pub struct TransferLeaf {
     pub intermediate_direct_from_cpfp_refund_tx: Option<Transaction>,
 }
 
+impl TransferLeaf {
+    pub fn leaf_with_intermediate_txs(&self) -> TreeNode {
+        TreeNode {
+            refund_tx: Some(self.intermediate_refund_tx.clone()),
+            direct_refund_tx: self.intermediate_direct_refund_tx.clone(),
+            direct_from_cpfp_refund_tx: self.intermediate_direct_from_cpfp_refund_tx.clone(),
+            ..self.leaf.clone()
+        }
+    }
+}
+
 impl TryFrom<operator_rpc::spark::TransferLeaf> for TransferLeaf {
     type Error = ServiceError;
 

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -652,7 +652,7 @@ impl TransferService {
             };
 
             leaves_to_claim.push(LeafKeyTweak {
-                node: leaf.leaf.clone(),
+                node: leaf.leaf_with_intermediate_txs(),
                 signing_key: leaf_key.clone(),
                 new_signing_key: PrivateKeySource::Derived(leaf.leaf.id.clone()),
             });


### PR DESCRIPTION
Fixes an issue where when claiming leaves of a transfer, the current refund txs are used instead of the transfer's intermediate refund txs, causing the refund tx sequences to never decrement when receiving.