### PR TITLE
validate mnemonic

### DIFF
--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -151,6 +151,9 @@ pub async fn connect(request: crate::ConnectRequest) -> Result<BreezSdk, SdkErro
             mnemonic,
             passphrase,
         } => {
+            // Ensure mnemonic is valid before proceeding
+            bip39::Mnemonic::parse(mnemonic)
+                .map_err(|e| SdkError::InvalidInput(format!("Invalid mnemonic: {e}")))?;
             let str = format!("{mnemonic}:{passphrase:?}");
             sha256::Hash::hash(str.as_bytes())
                 .to_string()


### PR DESCRIPTION
A user was trying random words as a mnemonic and did not get an error. I think it makes sense to disallow invalid mnemonics as a parameter. If you want to use an invalid mnemonic, you can use the Entropy option instead. 