### PR TITLE
improve breez-itest performance

### DIFF
--- a/crates/breez-sdk/breez-itest/src/helpers.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers.rs
@@ -95,12 +95,9 @@ pub async fn wait_for_balance(
     timeout_secs: u64,
 ) -> Result<u64> {
     let start = std::time::Instant::now();
-    let poll_interval = std::time::Duration::from_secs(3);
+    let poll_interval = std::time::Duration::from_millis(100);
 
     loop {
-        // Sync wallet to get latest state
-        let _ = sdk.sync_wallet(SyncWalletRequest {}).await?;
-
         // Check current balance
         let info = sdk
             .get_info(GetInfoRequest {

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -1565,6 +1565,11 @@ async fn update_balances(
             token_balances,
         })
         .await?;
+    let identity_public_key = spark_wallet.get_identity_public_key();
+    info!(
+        "Balance updated successfully {} for identity {}",
+        balance_sats, identity_public_key
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Some fixes to make the long timelock tests run in 24 minutes. In total 400 payments.
Total time ~24 minutes (3.7 seconds in average per payment).
Every payment time split into:
1. ~1.5 seconds sending
2. ~2 seconds claiming and updating balance

Changes:
1. Remove explicit sync on every iteration (balances should be updated as part of the payment/claiming).
2. Add one extra wait_for_payment for Alice (for the initial deposit) otherwise it is receives mistakenly as the spark payment later.
3. Reduce poll interval to 100 milliseconds.

Let's see how it performs on the CI.
