### PR TITLE
sanitize lightning address username client side

### DIFF
--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -19,6 +19,7 @@ use breez_sdk_common::{
     },
     rest::RestClient,
 };
+use lnurl_models::sanitize_username;
 use spark_wallet::{
     ExitSpeed, InvoiceDescription, SparkAddress, SparkWallet, TransferTokenOutput, WalletEvent,
     WalletTransfer,
@@ -1069,7 +1070,8 @@ impl BreezSdk {
             ));
         };
 
-        let available = client.check_username_available(&req.username).await?;
+        let username = sanitize_username(&req.username);
+        let available = client.check_username_available(&username).await?;
         Ok(available)
     }
 
@@ -1089,12 +1091,14 @@ impl BreezSdk {
             ));
         };
 
+        let username = sanitize_username(&request.username);
+
         let description = match request.description {
             Some(description) => description,
-            None => format!("Pay to {}@{}", request.username, client.domain()),
+            None => format!("Pay to {}@{}", username, client.domain()),
         };
         let params = crate::lnurl::RegisterLightningAddressRequest {
-            username: request.username.clone(),
+            username: username.clone(),
             description: description.clone(),
         };
 
@@ -1103,7 +1107,7 @@ impl BreezSdk {
             lightning_address: response.lightning_address,
             description,
             lnurl: response.lnurl,
-            username: request.username,
+            username,
         };
         cache.save_lightning_address(&address_info).await?;
         Ok(address_info)

--- a/crates/breez-sdk/lnurl-models/src/lib.rs
+++ b/crates/breez-sdk/lnurl-models/src/lib.rs
@@ -36,3 +36,7 @@ pub struct RegisterLnurlPayResponse {
     pub lnurl: String,
     pub lightning_address: String,
 }
+
+pub fn sanitize_username(username: &str) -> String {
+    username.trim().to_lowercase()
+}

--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -13,6 +13,7 @@ use bitcoin::{
 use lnurl_models::{
     CheckUsernameAvailableResponse, RecoverLnurlPayRequest, RecoverLnurlPayResponse,
     RegisterLnurlPayRequest, RegisterLnurlPayResponse, UnregisterLnurlPayRequest,
+    sanitize_username,
 };
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -431,8 +432,4 @@ fn sanitize_domain<DB>(
         return Err((StatusCode::NOT_FOUND, Json(Value::String(String::new()))));
     }
     Ok(domain)
-}
-
-fn sanitize_username(username: &str) -> String {
-    username.trim().to_lowercase()
 }


### PR DESCRIPTION
Fixes #352

Note another option could be to do everything on the server side. By validating the request with the passed username, but use the sanitized username for storage etc.