### PR TITLE
RN: Patch fbjni usage

### DIFF
--- a/packages/react-native/android/cpp-adapter.cpp
+++ b/packages/react-native/android/cpp-adapter.cpp
@@ -24,34 +24,14 @@ Java_com_breeztech_breezsdkspark_BreezSdkSparkReactNativeModule_nativeInstallRus
     jlong rtPtr,
     jobject callInvokerHolderJavaObj
 ) {
-    // https://github.com/realm/realm-js/blob/main/packages/realm/binding/android/src/main/cpp/io_realm_react_RealmReactModule.cpp#L122-L145
-    // React Native uses the fbjni library for handling JNI, which has the concept of "hybrid objects",
-    // which are Java objects containing a pointer to a C++ object. The CallInvokerHolder, which has the
-    // invokeAsync method we want access to, is one such hybrid object.
-    // Rather than reworking our code to use fbjni throughout, this code unpacks the C++ object from the Java
-    // object `callInvokerHolderJavaObj` manually, based on reverse engineering the fbjni code.
+    using JCallInvokerHolder = facebook::react::CallInvokerHolder;
 
-    // 1. Get the Java object referred to by the mHybridData field of the Java holder object
-    auto callInvokerHolderClass = env->GetObjectClass(callInvokerHolderJavaObj);
-    auto hybridDataField = env->GetFieldID(callInvokerHolderClass, "mHybridData", "Lcom/facebook/jni/HybridData;");
-    auto hybridDataObj = env->GetObjectField(callInvokerHolderJavaObj, hybridDataField);
-
-    // 2. Get the destructor Java object referred to by the mDestructor field from the myHybridData Java object
-    auto hybridDataClass = env->FindClass("com/facebook/jni/HybridData");
-    auto destructorField =
-        env->GetFieldID(hybridDataClass, "mDestructor", "Lcom/facebook/jni/HybridData$Destructor;");
-    auto destructorObj = env->GetObjectField(hybridDataObj, destructorField);
-
-    // 3. Get the mNativePointer field from the mDestructor Java object
-    auto destructorClass = env->FindClass("com/facebook/jni/HybridData$Destructor");
-    auto nativePointerField = env->GetFieldID(destructorClass, "mNativePointer", "J");
-    auto nativePointerValue = env->GetLongField(destructorObj, nativePointerField);
-
-    // 4. Cast the mNativePointer back to its C++ type
-    auto nativePointer = reinterpret_cast<facebook::react::CallInvokerHolder*>(nativePointerValue);
-    auto jsCallInvoker = nativePointer->getCallInvoker();
-
+    auto holderLocal = facebook::jni::make_local(callInvokerHolderJavaObj);
+    auto holderRef = facebook::jni::static_ref_cast<JCallInvokerHolder::javaobject>(holderLocal);
+    auto* holderCxx = holderRef->cthis();
+    auto jsCallInvoker = holderCxx->getCallInvoker();
     auto runtime = reinterpret_cast<jsi::Runtime *>(rtPtr);
+
     return breeztech_breezsdksparkreactnative::installRustCrate(*runtime, jsCallInvoker);
 }
 

--- a/packages/react-native/patches/uniffi-bindgen-react-native+0.28.3-5.patch
+++ b/packages/react-native/patches/uniffi-bindgen-react-native+0.28.3-5.patch
@@ -165,6 +165,51 @@ index 3a8d733..f4b2079 100644
  
  # Add ReactAndroid libraries, being careful to account for different versions.
  find_package(ReactAndroid REQUIRED CONFIG)
+diff --git a/node_modules/uniffi-bindgen-react-native/crates/ubrn_cli/src/codegen/templates/cpp-adapter.cpp b/node_modules/uniffi-bindgen-react-native/crates/ubrn_cli/src/codegen/templates/cpp-adapter.cpp
+index d8d1c1a..41172a0 100644
+--- a/node_modules/uniffi-bindgen-react-native/crates/ubrn_cli/src/codegen/templates/cpp-adapter.cpp
++++ b/node_modules/uniffi-bindgen-react-native/crates/ubrn_cli/src/codegen/templates/cpp-adapter.cpp
+@@ -29,34 +29,14 @@ JNIEXPORT jboolean JNICALL
+     jlong rtPtr,
+     jobject callInvokerHolderJavaObj
+ ) {
+-    // https://github.com/realm/realm-js/blob/main/packages/realm/binding/android/src/main/cpp/io_realm_react_RealmReactModule.cpp#L122-L145
+-    // React Native uses the fbjni library for handling JNI, which has the concept of "hybrid objects",
+-    // which are Java objects containing a pointer to a C++ object. The CallInvokerHolder, which has the
+-    // invokeAsync method we want access to, is one such hybrid object.
+-    // Rather than reworking our code to use fbjni throughout, this code unpacks the C++ object from the Java
+-    // object `callInvokerHolderJavaObj` manually, based on reverse engineering the fbjni code.
+-
+-    // 1. Get the Java object referred to by the mHybridData field of the Java holder object
+-    auto callInvokerHolderClass = env->GetObjectClass(callInvokerHolderJavaObj);
+-    auto hybridDataField = env->GetFieldID(callInvokerHolderClass, "mHybridData", "Lcom/facebook/jni/HybridData;");
+-    auto hybridDataObj = env->GetObjectField(callInvokerHolderJavaObj, hybridDataField);
+-
+-    // 2. Get the destructor Java object referred to by the mDestructor field from the myHybridData Java object
+-    auto hybridDataClass = env->FindClass("com/facebook/jni/HybridData");
+-    auto destructorField =
+-        env->GetFieldID(hybridDataClass, "mDestructor", "Lcom/facebook/jni/HybridData$Destructor;");
+-    auto destructorObj = env->GetObjectField(hybridDataObj, destructorField);
+-
+-    // 3. Get the mNativePointer field from the mDestructor Java object
+-    auto destructorClass = env->FindClass("com/facebook/jni/HybridData$Destructor");
+-    auto nativePointerField = env->GetFieldID(destructorClass, "mNativePointer", "J");
+-    auto nativePointerValue = env->GetLongField(destructorObj, nativePointerField);
+-
+-    // 4. Cast the mNativePointer back to its C++ type
+-    auto nativePointer = reinterpret_cast<facebook::react::CallInvokerHolder*>(nativePointerValue);
+-    auto jsCallInvoker = nativePointer->getCallInvoker();
++    using JCallInvokerHolder = facebook::react::CallInvokerHolder;
+ 
++    auto holderLocal = facebook::jni::make_local(callInvokerHolderJavaObj);
++    auto holderRef = facebook::jni::static_ref_cast<JCallInvokerHolder::javaobject>(holderLocal);
++    auto* holderCxx = holderRef->cthis();
++    auto jsCallInvoker = holderCxx->getCallInvoker();
+     auto runtime = reinterpret_cast<jsi::Runtime *>(rtPtr);
++
+     return {{ ns }}::installRustCrate(*runtime, jsCallInvoker);
+ }
+ 
 diff --git a/node_modules/uniffi-bindgen-react-native/crates/ubrn_cli/src/ios.rs b/node_modules/uniffi-bindgen-react-native/crates/ubrn_cli/src/ios.rs
 index 42d21cf..72113f6 100644
 --- a/node_modules/uniffi-bindgen-react-native/crates/ubrn_cli/src/ios.rs


### PR DESCRIPTION
The PR patches [uniffi-bindgen-react-native 0.28.3-5](https://github.com/jhugman/uniffi-bindgen-react-native) based on [this PR](https://github.com/jhugman/uniffi-bindgen-react-native/pull/298) to fix the usage of fbjni from react-native 0.80.0.

Tested on react-native 0.78.0 and 0.82.1.

Fixes #356 