### PR TITLE
Prefer lightning address over BIP353 in parser implementation

### DIFF
--- a/crates/breez-sdk/common/src/input/parser.rs
+++ b/crates/breez-sdk/common/src/input/parser.rs
@@ -91,12 +91,12 @@ where
 
     pub async fn parse_core(&self, input: &str) -> Result<Option<InputType>, ParseError> {
         if input.contains('@') {
-            if let Some(bip_21) = self.parse_bip_353(input).await? {
-                return Ok(Some(InputType::Bip21(bip_21)));
-            }
-
             if let Some(lightning_address) = self.parse_lightning_address(input).await {
                 return Ok(Some(InputType::LightningAddress(lightning_address)));
+            }
+
+            if let Some(bip_21) = self.parse_bip_353(input).await? {
+                return Ok(Some(InputType::Bip21(bip_21)));
             }
         }
 


### PR DESCRIPTION
When parsing e.g. Misty Breez lightning address, which is also a valid BIP353 address, we should prefer resolving to a lightning address given that's what spark SDK supports at the moment. 