### PR TITLE
Add ToC sidebar to docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,7 @@ jobs:
           cargo install mdbook --vers "^0.4" --locked
           cargo install --path ./snippets-processor
           cargo install mdbook-variables --vers "^0.2" --locked
+          cargo install mdbook-pagetoc --vers "^0.2" --locked
 
       - name: Get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1

--- a/docs/breez-sdk/README.md
+++ b/docs/breez-sdk/README.md
@@ -14,6 +14,7 @@ To locally serve the docs run:
 cargo install mdbook
 cargo install --path ./snippets-processor
 cargo install mdbook-variables
+cargo install mdbook-pagetoc
 mdbook build
 mdbook serve --open
 

--- a/docs/breez-sdk/book.toml
+++ b/docs/breez-sdk/book.toml
@@ -6,8 +6,8 @@ title = "Breez SDK - Nodeless (Spark)"
 
 [output.html]
 theme = "theme"
-additional-css = ["styles.css"]
-additional-js = ["tabs.js"]
+additional-css = ["styles.css", "theme/pagetoc.css"]
+additional-js = ["tabs.js", "theme/pagetoc.js"]
 git-repository-url = "https://github.com/breez/spark-sdk"
 edit-url-template = "https://github.com/breez/spark-sdk/edit/main/crates/breez-sdk/docs/{path}"
 no-section-label = true
@@ -23,3 +23,7 @@ after = ["links"]
 
 [preprocessor.variables.variables]
 api_key_form_uri = "https://breez.technology/request-api-key/#contact-us-form-sdk"
+
+[preprocessor.pagetoc]
+command = "mdbook-pagetoc"
+renderer = "html"

--- a/docs/breez-sdk/theme/pagetoc.css
+++ b/docs/breez-sdk/theme/pagetoc.css
@@ -1,0 +1,111 @@
+/* Hide table of contents on smaller screens */
+@media only screen and (max-width:1439px) {
+    .sidetoc {
+        display: none;
+    }
+}
+
+/* Table of contents sidebar for larger screens */
+@media only screen and (min-width:1440px) {
+    main {
+        position: relative;
+    }
+    
+    .sidetoc {
+        margin-left: auto;
+        margin-right: auto;
+        left: calc(100% + (var(--content-max-width))/4 - 140px);
+        position: absolute;
+        top: 0;
+    }
+    
+    .pagetoc {
+        position: fixed;
+        width: 220px;
+        max-height: calc(100vh - var(--menu-bar-height) - 2rem);
+        overflow-y: auto;
+        overflow-x: hidden;
+        padding: 1rem 0;
+        background: var(--bg);
+        border-left: 1px solid var(--table-border-color);
+        border-radius: 4px;
+        
+        /* Custom scrollbar styling */
+        scrollbar-width: thin;
+        scrollbar-color: var(--scrollbar) transparent;
+    }
+    
+    .pagetoc::-webkit-scrollbar {
+        width: 6px;
+    }
+    
+    .pagetoc::-webkit-scrollbar-track {
+        background: transparent;
+    }
+    
+    .pagetoc::-webkit-scrollbar-thumb {
+        background-color: var(--scrollbar);
+        border-radius: 3px;
+    }
+    
+    .pagetoc a {
+        display: block;
+        color: var(--sidebar-fg);
+        text-decoration: none;
+        padding: 0.4rem 1rem;
+        margin: 0;
+        border-left: 3px solid transparent;
+        font-size: 0.9em;
+        line-height: 1.4;
+        transition: color 0.1s ease;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+    }
+    
+    .pagetoc a:link,
+    .pagetoc a:visited {
+        color: var(--sidebar-fg);
+    }
+    
+    .pagetoc a:hover {
+        color: var(--sidebar-active);
+        text-decoration: none;
+    }
+    
+    .pagetoc a.active {
+        color: var(--sidebar-active);
+        border-left-color: var(--sidebar-active);
+    }
+    
+    /* Hierarchical indentation for different heading levels */
+    .pagetoc .pagetoc-H1 {
+        padding-left: 1rem;
+        font-weight: 600;
+        margin-top: 0.5rem;
+    }
+    
+    .pagetoc .pagetoc-H2 {
+        padding-left: 1.5rem;
+    }
+    
+    .pagetoc .pagetoc-H3 {
+        padding-left: 2rem;
+        font-size: 0.85em;
+    }
+    
+    .pagetoc .pagetoc-H4 {
+        padding-left: 2.5rem;
+        font-size: 0.8em;
+        opacity: 0.9;
+    }
+    
+    /* Hide H5 and H6 to avoid clutter */
+    .pagetoc .pagetoc-H5,
+    .pagetoc .pagetoc-H6 {
+        display: none;
+    }
+}
+
+a[class^='pagetoc-H']:only-child {
+    display: none;
+  }

--- a/docs/breez-sdk/theme/pagetoc.js
+++ b/docs/breez-sdk/theme/pagetoc.js
@@ -1,0 +1,189 @@
+/**
+ * Page Table of Contents (TOC) Manager
+ * Handles the dynamic sidebar navigation for the current page
+ */
+(function () {
+  "use strict";
+
+  let scrollTimeout = null;
+  const SCROLL_COOLDOWN = 150; // ms to wait after manual click before auto-updating
+  const SCROLL_OFFSET = 60; // px offset for active section detection
+
+  /**
+   * Attach click listeners to TOC links
+   */
+  const attachClickListeners = () => {
+    const pagetoc = document.querySelector(".pagetoc");
+    if (!pagetoc) return;
+
+    const links = [...pagetoc.children];
+    links.forEach((link) => {
+      link.addEventListener("click", (event) => {
+        // Clear any existing timeout
+        if (scrollTimeout) clearTimeout(scrollTimeout);
+
+        // Set active state immediately on click
+        links.forEach((l) => l.classList.remove("active"));
+        link.classList.add("active");
+
+        // Prevent auto-update during smooth scroll
+        scrollTimeout = setTimeout(() => {
+          scrollTimeout = null;
+        }, SCROLL_COOLDOWN);
+      });
+    });
+  };
+
+  /**
+   * Get or create the page TOC container
+   */
+  const getPageToc = () => {
+    return document.querySelector(".pagetoc") || createPageToc();
+  };
+
+  /**
+   * Create the page TOC container if it doesn't exist
+   */
+  const createPageToc = () => {
+    const main = document.querySelector("#content > main");
+    if (!main) return null;
+
+    // Wrap existing content
+    const contentWrap = document.createElement("div");
+    contentWrap.className = "content-wrap";
+    contentWrap.append(...main.childNodes);
+    main.appendChild(contentWrap);
+
+    // Insert TOC container at the beginning
+    main.insertAdjacentHTML(
+      "afterbegin",
+      '<div class="sidetoc"><nav class="pagetoc" aria-label="Page navigation"></nav></div>'
+    );
+
+    return document.querySelector(".pagetoc");
+  };
+
+  /**
+   * Update active TOC link based on scroll position
+   */
+  const updateActiveTocLink = () => {
+    // Skip if we're in cooldown after a manual click
+    if (scrollTimeout) return;
+
+    const pagetoc = document.querySelector(".pagetoc");
+    if (!pagetoc) return;
+
+    const headers = [...document.getElementsByClassName("header")];
+    const scrollPosition = window.scrollY + SCROLL_OFFSET;
+    let activeHeader = null;
+
+    // Find the last header that's above the current scroll position
+    for (let i = headers.length - 1; i >= 0; i--) {
+      const headerTop = headers[i].offsetTop;
+      if (scrollPosition >= headerTop) {
+        activeHeader = headers[i];
+        break;
+      }
+    }
+
+    // Update active states
+    const tocLinks = [...pagetoc.children];
+    tocLinks.forEach((link) => link.classList.remove("active"));
+
+    if (activeHeader) {
+      const activeLink = tocLinks.find(
+        (link) => link.href === activeHeader.href
+      );
+      if (activeLink) {
+        activeLink.classList.add("active");
+
+        // Ensure the active link is visible in the TOC
+        activeLink.scrollIntoView({
+          block: "nearest",
+          behavior: "smooth",
+        });
+      }
+    }
+  };
+
+  /**
+   * Populate the TOC with links to page headers
+   */
+  const populateToc = () => {
+    const pagetoc = getPageToc();
+    if (!pagetoc) return;
+
+    const headers = [...document.getElementsByClassName("header")];
+
+    headers.forEach((header) => {
+      const parent = header.parentElement;
+
+      // Skip headers marked with toc-ignore class
+      if (!parent || parent.classList.contains("toc-ignore")) {
+        return;
+      }
+
+      // Skip headers inside warning/note boxes or other special containers
+      if (parent.closest(".warning, .note, blockquote")) {
+        return;
+      }
+
+      // Extract text content from the header (excluding tags and other non-header elements)
+      const textContent = [...parent.childNodes]
+        .filter((node) => {
+          // Exclude elements with 'tag' class (like API docs tags)
+          if (
+            node.nodeType === Node.ELEMENT_NODE &&
+            node.classList.contains("tag")
+          ) {
+            return false;
+          }
+          return true;
+        })
+        .map((node) => node.textContent || "")
+        .join("")
+        .trim();
+
+      if (!textContent) return;
+
+      // Create TOC link
+      const link = document.createElement("a");
+      link.textContent = textContent;
+      link.href = header.href;
+      link.className = `pagetoc-${parent.tagName}`;
+
+      pagetoc.appendChild(link);
+    });
+  };
+
+  /**
+   * Initialize the page TOC
+   */
+  const initPageToc = () => {
+    populateToc();
+    attachClickListeners();
+    updateActiveTocLink();
+
+    // Listen for scroll events
+    let rafId = null;
+    window.addEventListener(
+      "scroll",
+      () => {
+        // Use requestAnimationFrame for better performance
+        if (rafId) return;
+        rafId = requestAnimationFrame(() => {
+          updateActiveTocLink();
+          rafId = null;
+        });
+      },
+      { passive: true }
+    );
+  };
+
+  // Initialize when DOM is ready
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initPageToc);
+  } else {
+    initPageToc();
+  }
+})();


### PR DESCRIPTION
This proposes adding a ToC sidebar to the docs page to help with navigating within each page.

- Side bar theme matches existing one
- Side bar hides when page gets narrower
- Side bar hides if there's a single header
- Closest section is highlighted automatically while user scrolls

Screenshots for review:

<img width="1709" height="854" alt="Screenshot 2025-11-04 at 18 22 09" src="https://github.com/user-attachments/assets/c2896e41-9463-4142-b124-74af379590eb" />

<img width="1719" height="882" alt="Screenshot 2025-11-04 at 18 24 51" src="https://github.com/user-attachments/assets/296ce453-8473-4f93-a0a8-eab0cd376057" />
