### PR TITLE
Fix token txid hex encoding

### DIFF
--- a/crates/breez-sdk/core/src/models/payment_observer.rs
+++ b/crates/breez-sdk/core/src/models/payment_observer.rs
@@ -118,7 +118,7 @@ impl spark_wallet::TransferObserver for SparkTransferObserver {
 
     async fn before_send_token(
         &self,
-        tx_id: &bitcoin::Txid,
+        tx_id: &str,
         token_id: &str,
         receiver_outputs: Vec<spark_wallet::ReceiverTokenOutput>,
     ) -> Result<(), TransferObserverError> {

--- a/crates/spark/src/services/transfer_observer.rs
+++ b/crates/spark/src/services/transfer_observer.rs
@@ -1,4 +1,4 @@
-use bitcoin::{Address, Txid};
+use bitcoin::Address;
 use thiserror::Error;
 
 use crate::services::TransferId;
@@ -32,7 +32,7 @@ pub trait TransferObserver: Send + Sync {
     ) -> Result<(), TransferObserverError>;
     async fn before_send_token(
         &self,
-        tx_id: &Txid,
+        tx_id: &str,
         token_id: &str,
         receiver_outputs: Vec<ReceiverTokenOutput>,
     ) -> Result<(), TransferObserverError>;


### PR DESCRIPTION
Closes #383

`Txid::to_string()` encodes the txid in hex but in the reverse order of what we need.

This also fixes the payment observer as it was previously also using the reversed hex string.