### PR TITLE
RN: clean generated bindings

### DIFF
--- a/.github/workflows/publish-react-native.yml
+++ b/.github/workflows/publish-react-native.yml
@@ -94,9 +94,10 @@ jobs:
           path: |
             packages/react-native/ubrn.config.yaml
             packages/react-native/android/generated
-            packages/react-native/cpp/generated
+            packages/react-native/android/CMakeLists.txt
+            packages/react-native/cpp
             packages/react-native/lib
-            packages/react-native/src/generated
+            packages/react-native/src
 
       - name: Compress Android binaries
         working-directory: packages/react-native
@@ -143,9 +144,10 @@ jobs:
       - name: Remove existing bindings
         run: |
           git rm -r android/generated || true
-          git rm -r cpp/generated || true
+          git rm android/CMakeLists.txt || true
+          git rm -r cpp || true
           git rm -r lib || true
-          git rm -r src/generated || true
+          git rm -r src || true
 
       - name: Download React Native bindings
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Removes the previously generated files from the release repository before updating them