### PR TITLE
Fix iOS duplicate symbols building RN 0.82

### DIFF
--- a/packages/react-native/breeztech-breez-sdk-spark-react-native.podspec
+++ b/packages/react-native/breeztech-breez-sdk-spark-react-native.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => "https://github.com/breez/spark-sdk.git", :tag => "#{s.version}" }
 
-  s.source_files = "ios/**/*.{h,m,mm,swift}", "ios/generated/**/*.{h,m,mm}", "cpp/**/*.{hpp,cpp,c,h}", "cpp/generated/**/*.{hpp,cpp,c,h}"
+  s.source_files = "ios/*.{h,m,mm,swift}", "ios/generated/**/*.{h}", "cpp/**/*.{hpp,cpp,c,h}", "cpp/generated/**/*.{hpp,cpp,c,h}"
   s.vendored_frameworks = "build/RnBreezSdkSpark.xcframework"
   s.dependency    "uniffi-bindgen-react-native", "0.28.3-5"
 


### PR DESCRIPTION
Fixes an issue building React Native 0.82+ where the codegen files are being included in both the library and the app's ReactCodegen target. Tested this change building with both React Native 0.78.0 and 0.82.1

```
duplicate symbol '_OBJC_CLASS_$_NativeBreezSdkSparkReactNativeSpecBase' in:
    /Users/rosssavage/Library/Developer/Xcode/DerivedData/BreezSdkSparkReactNativeExample-akqmchbnoeyutuhetxddzskhbdke/Build/Products/Debug-iphonesimulator/breeztech-breez-sdk-spark-react-native/libbreeztech-breez-sdk-spark-react-native.a[5](BreezSdkSparkReactNativeSpec-generated.o)
    /Users/rosssavage/Library/Developer/Xcode/DerivedData/BreezSdkSparkReactNativeExample-akqmchbnoeyutuhetxddzskhbdke/Build/Products/Debug-iphonesimulator/ReactCodegen/libReactCodegen.a[2](BreezSdkSparkReactNativeSpec-generated.o)
duplicate symbol 'facebook::react::NativeBreezSdkSparkReactNativeSpecJSI::NativeBreezSdkSparkReactNativeSpecJSI(facebook::react::ObjCTurboModule::InitParams const&)' in:
    /Users/rosssavage/Library/Developer/Xcode/DerivedData/BreezSdkSparkReactNativeExample-akqmchbnoeyutuhetxddzskhbdke/Build/Products/Debug-iphonesimulator/breeztech-breez-sdk-spark-react-native/libbreeztech-breez-sdk-spark-react-native.a[5](BreezSdkSparkReactNativeSpec-generated.o)
    /Users/rosssavage/Library/Developer/Xcode/DerivedData/BreezSdkSparkReactNativeExample-akqmchbnoeyutuhetxddzskhbdke/Build/Products/Debug-iphonesimulator/ReactCodegen/libReactCodegen.a[2](BreezSdkSparkReactNativeSpec-generated.o)
```