### PR TITLE
do not retry subscribing to private users

### DIFF
--- a/crates/breez-sdk/lnurl/Cargo.lock
+++ b/crates/breez-sdk/lnurl/Cargo.lock
@@ -2284,6 +2284,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.16",
  "tokio",
+ "tonic",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/crates/breez-sdk/lnurl/Cargo.toml
+++ b/crates/breez-sdk/lnurl/Cargo.toml
@@ -29,6 +29,7 @@ spark-wallet = { path = "../../spark-wallet", features = ["native-tls"] }
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio", "sqlite", "tls-native-tls"] }
 thiserror = "2.0.12"
 tokio = { version = "1.45.1", features = ["rt-multi-thread", "macros", "signal"] }
+tonic = "0.12.3"
 tower-http = { version = "0.6.6", features = ["cors"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }


### PR DESCRIPTION
The server may not know a user is private, but when PermissionDenied is returned, always stop trying.