### PR TITLE
Fix Lightning payment seen as Spark HTLC

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
+++ b/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
@@ -228,7 +228,7 @@ async fn test_02_htlc_refund(
     info!("Waiting for HTLC to expire...");
 
     // HTLC fails and is returned a little bit after the expiry
-    tokio::time::sleep(Duration::from_secs(30)).await;
+    tokio::time::sleep(Duration::from_secs(60)).await;
 
     info!("Verifying Bob's failed payment...");
 

--- a/crates/breez-sdk/core/src/models/adaptors.rs
+++ b/crates/breez-sdk/core/src/models/adaptors.rs
@@ -16,16 +16,29 @@ use crate::{
 
 impl PaymentMethod {
     fn from_transfer(transfer: &WalletTransfer) -> Self {
-        // HTLC transfers share PreimageSwap type with Lightning payments.
-        // We can tell them apart by checking if they have an htlc.
-        if transfer.htlc_preimage_request.is_some() {
-            return PaymentMethod::Spark;
+        // HTLC transfers share PreimageSwap type with Lightning payments and both have an htlc_preimage_request.
+        // We can only tell them apart by checking the SSP user request.
+        if let Some(user_request) = &transfer.user_request {
+            match user_request {
+                SspUserRequest::LightningReceiveRequest(_)
+                | SspUserRequest::LightningSendRequest(_) => {
+                    return PaymentMethod::Lightning;
+                }
+                SspUserRequest::LeavesSwapRequest(_) => {
+                    return PaymentMethod::Spark;
+                }
+                SspUserRequest::CoopExitRequest(_) => {
+                    return PaymentMethod::Withdraw;
+                }
+                SspUserRequest::ClaimStaticDeposit(_) => {
+                    return PaymentMethod::Deposit;
+                }
+            }
         }
 
         match transfer.transfer_type {
-            TransferType::PreimageSwap => PaymentMethod::Lightning,
+            TransferType::PreimageSwap | TransferType::Transfer => PaymentMethod::Spark, // No user request means it's a Spark HTLC payment
             TransferType::CooperativeExit => PaymentMethod::Withdraw,
-            TransferType::Transfer => PaymentMethod::Spark,
             TransferType::UtxoSwap => PaymentMethod::Deposit,
             _ => PaymentMethod::Unknown,
         }
@@ -34,6 +47,54 @@ impl PaymentMethod {
 
 impl PaymentDetails {
     fn from_transfer(transfer: &WalletTransfer) -> Result<Option<Self>, SdkError> {
+        if let Some(user_request) = &transfer.user_request {
+            let details = match user_request {
+                SspUserRequest::LightningReceiveRequest(request) => {
+                    let invoice_details = input::parse_invoice(&request.invoice.encoded_invoice)
+                        .ok_or(SdkError::Generic(
+                            "Invalid invoice in SspUserRequest::LightningReceiveRequest"
+                                .to_string(),
+                        ))?;
+                    PaymentDetails::Lightning {
+                        description: invoice_details.description,
+                        preimage: request.lightning_receive_payment_preimage.clone(),
+                        invoice: request.invoice.encoded_invoice.clone(),
+                        payment_hash: request.invoice.payment_hash.clone(),
+                        destination_pubkey: invoice_details.payee_pubkey,
+                        lnurl_pay_info: None,
+                        lnurl_withdraw_info: None,
+                    }
+                }
+                SspUserRequest::LightningSendRequest(request) => {
+                    let invoice_details =
+                        input::parse_invoice(&request.encoded_invoice).ok_or(SdkError::Generic(
+                            "Invalid invoice in SspUserRequest::LightningSendRequest".to_string(),
+                        ))?;
+                    PaymentDetails::Lightning {
+                        description: invoice_details.description,
+                        preimage: request.lightning_send_payment_preimage.clone(),
+                        invoice: request.encoded_invoice.clone(),
+                        payment_hash: invoice_details.payment_hash,
+                        destination_pubkey: invoice_details.payee_pubkey,
+                        lnurl_pay_info: None,
+                        lnurl_withdraw_info: None,
+                    }
+                }
+                SspUserRequest::CoopExitRequest(request) => PaymentDetails::Withdraw {
+                    tx_id: request.coop_exit_txid.clone(),
+                },
+                SspUserRequest::LeavesSwapRequest(_) => PaymentDetails::Spark {
+                    invoice_details: None,
+                    htlc_details: None,
+                },
+                SspUserRequest::ClaimStaticDeposit(request) => PaymentDetails::Deposit {
+                    tx_id: request.transaction_id.clone(),
+                },
+            };
+            return Ok(Some(details));
+        }
+
+        // Check for Spark invoice payments
         if let Some(spark_invoice) = &transfer.spark_invoice {
             let Some(InputType::SparkInvoice(invoice_details)) =
                 parse_spark_address(spark_invoice, &PaymentRequestSource::default())
@@ -45,60 +106,18 @@ impl PaymentDetails {
                 invoice_details: Some(invoice_details.into()),
                 htlc_details: None,
             }));
-        } else if let Some(htlc_preimage_request) = &transfer.htlc_preimage_request {
+        }
+
+        // Check for Spark HTLC payments (when no user request is present)
+        if let Some(htlc_preimage_request) = &transfer.htlc_preimage_request {
             return Ok(Some(PaymentDetails::Spark {
                 invoice_details: None,
                 htlc_details: Some(htlc_preimage_request.clone().try_into()?),
             }));
         }
 
-        let Some(user_request) = &transfer.user_request else {
-            return Ok(None);
-        };
-
-        let details = match user_request {
-            SspUserRequest::CoopExitRequest(request) => PaymentDetails::Withdraw {
-                tx_id: request.coop_exit_txid.clone(),
-            },
-            SspUserRequest::LeavesSwapRequest(_) => PaymentDetails::Spark {
-                invoice_details: None,
-                htlc_details: None,
-            },
-            SspUserRequest::LightningReceiveRequest(request) => {
-                let invoice_details = input::parse_invoice(&request.invoice.encoded_invoice)
-                    .ok_or(SdkError::Generic(
-                        "Invalid invoice in SspUserRequest::LightningReceiveRequest".to_string(),
-                    ))?;
-                PaymentDetails::Lightning {
-                    description: invoice_details.description,
-                    preimage: request.lightning_receive_payment_preimage.clone(),
-                    invoice: request.invoice.encoded_invoice.clone(),
-                    payment_hash: request.invoice.payment_hash.clone(),
-                    destination_pubkey: invoice_details.payee_pubkey,
-                    lnurl_pay_info: None,
-                    lnurl_withdraw_info: None,
-                }
-            }
-            SspUserRequest::LightningSendRequest(request) => {
-                let invoice_details =
-                    input::parse_invoice(&request.encoded_invoice).ok_or(SdkError::Generic(
-                        "Invalid invoice in SspUserRequest::LightningSendRequest".to_string(),
-                    ))?;
-                PaymentDetails::Lightning {
-                    description: invoice_details.description,
-                    preimage: request.lightning_send_payment_preimage.clone(),
-                    invoice: request.encoded_invoice.clone(),
-                    payment_hash: invoice_details.payment_hash,
-                    destination_pubkey: invoice_details.payee_pubkey,
-                    lnurl_pay_info: None,
-                    lnurl_withdraw_info: None,
-                }
-            }
-            SspUserRequest::ClaimStaticDeposit(request) => PaymentDetails::Deposit {
-                tx_id: request.transaction_id.clone(),
-            },
-        };
-        Ok(Some(details))
+        // No details available
+        Ok(None)
     }
 }
 

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -1788,8 +1788,8 @@ impl BreezSdk {
             .await
             .unwrap_or(payment);
 
-        // TODO: We get incomplete payments here from the ssp so better not to persist for now.
-        //self.storage.insert_payment(payment.clone()).await?;
+        // Insert the payment into storage to make it immediately available for listing
+        self.storage.insert_payment(payment.clone()).await?;
 
         Ok(SendPaymentResponse { payment })
     }


### PR DESCRIPTION
This fixes an issue introduced in #376 where all Lightning payments are seen as Spark HTLC payments in the payments list. It was caused by using the presence of `htlc_preimage_request` to distinguish both cases, but both have it. 

This proposes using the SSP user requests. Before we couldn't always rely on it due to delays from payment until the user requests was available, but now it seems to have been fixed on the SSP side. 