### PR TITLE
insert pending payment on withdraw

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/deposit_withdraw.rs
+++ b/crates/breez-sdk/breez-itest/tests/deposit_withdraw.rs
@@ -99,6 +99,17 @@ async fn test_onchain_withdraw_to_static_address(
     assert!(matches!(send_resp.payment.method, PaymentMethod::Withdraw));
     assert!(matches!(send_resp.payment.payment_type, PaymentType::Send));
 
+    let stored_payment = alice
+        .sdk
+        .get_payment(GetPaymentRequest {
+            payment_id: send_resp.payment.id.clone(),
+        })
+        .await?;
+    assert!(matches!(
+        stored_payment.payment.status,
+        PaymentStatus::Pending
+    ));
+
     // Trigger Bob sync and wait for receive + claim
     bob.sdk.sync_wallet(SyncWalletRequest {}).await?;
     let recv_payment =

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -2200,8 +2200,7 @@ impl BreezSdk {
 
         let payment: Payment = response.try_into()?;
 
-        // TODO: We get incomplete payments here from the ssp so better not to persist for now.
-        //self.storage.insert_payment(payment.clone()).await?;
+        self.storage.insert_payment(payment.clone()).await?;
 
         Ok(SendPaymentResponse { payment })
     }


### PR DESCRIPTION
Partially addresses #453 for the outgoing case.

Ensures a pending payment is shown for a waithdrawal.

@danielgranhao I wasn't sure what the missing piece was in the SSP data in the comment. Could it be the data is there now?