### PR TITLE
Use on conflict instead of replacing payment table rows

### DIFF
--- a/crates/breez-sdk/wasm/js/node-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/node-storage/index.cjs
@@ -251,23 +251,46 @@ class SqliteStorage {
       }
 
       const paymentInsert = this.db.prepare(
-        `INSERT OR REPLACE INTO payments (id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark) 
-         VALUES (@id, @paymentType, @status, @amount, @fees, @timestamp, @method, @withdrawTxId, @depositTxId, @spark)`
+        `INSERT INTO payments (id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark) 
+         VALUES (@id, @paymentType, @status, @amount, @fees, @timestamp, @method, @withdrawTxId, @depositTxId, @spark)
+         ON CONFLICT(id) DO UPDATE SET
+           payment_type=excluded.payment_type,
+           status=excluded.status,
+           amount=excluded.amount,
+           fees=excluded.fees,
+           timestamp=excluded.timestamp,
+           method=excluded.method,
+           withdraw_tx_id=excluded.withdraw_tx_id,
+           deposit_tx_id=excluded.deposit_tx_id,
+           spark=excluded.spark`
       );
       const lightningInsert = this.db.prepare(
-        `INSERT OR REPLACE INTO payment_details_lightning 
+        `INSERT INTO payment_details_lightning 
           (payment_id, invoice, payment_hash, destination_pubkey, description, preimage) 
-          VALUES (@id, @invoice, @paymentHash, @destinationPubkey, @description, @preimage)`
+          VALUES (@id, @invoice, @paymentHash, @destinationPubkey, @description, @preimage)
+          ON CONFLICT(payment_id) DO UPDATE SET
+            invoice=excluded.invoice,
+            payment_hash=excluded.payment_hash,
+            destination_pubkey=excluded.destination_pubkey,
+            description=excluded.description,
+            preimage=excluded.preimage`
       );
       const tokenInsert = this.db.prepare(
-        `INSERT OR REPLACE INTO payment_details_token 
+        `INSERT INTO payment_details_token 
           (payment_id, metadata, tx_hash, invoice_details) 
-          VALUES (@id, @metadata, @txHash, @invoiceDetails)`
+          VALUES (@id, @metadata, @txHash, @invoiceDetails)
+          ON CONFLICT(payment_id) DO UPDATE SET
+            metadata=excluded.metadata,
+            tx_hash=excluded.tx_hash,
+            invoice_details=COALESCE(excluded.invoice_details, payment_details_token.invoice_details)`
       );
       const sparkInsert = this.db.prepare(
-        `INSERT OR REPLACE INTO payment_details_spark 
+        `INSERT INTO payment_details_spark 
           (payment_id, invoice_details, htlc_details) 
-          VALUES (@id, @invoiceDetails, @htlcDetails)`
+          VALUES (@id, @invoiceDetails, @htlcDetails)
+          ON CONFLICT(payment_id) DO UPDATE SET
+            invoice_details=COALESCE(excluded.invoice_details, payment_details_spark.invoice_details),
+            htlc_details=COALESCE(excluded.htlc_details, payment_details_spark.htlc_details)`
       );
       const transaction = this.db.transaction(() => {
         paymentInsert.run({

--- a/crates/breez-sdk/wasm/src/persist/tests/node.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/node.rs
@@ -107,6 +107,14 @@ async fn test_payment_request_metadata() {
 }
 
 #[wasm_bindgen_test]
+async fn test_payment_details_update_persistence() {
+    let storage = create_test_storage("payment_details_update").await;
+
+    breez_sdk_spark::storage_tests::test_payment_details_update_persistence(Box::new(storage))
+        .await;
+}
+
+#[wasm_bindgen_test]
 async fn test_spark_htlc_status_filtering() {
     let storage = create_test_storage("spark_htlc_status_filtering").await;
 

--- a/crates/breez-sdk/wasm/src/persist/tests/web.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/web.rs
@@ -101,6 +101,14 @@ async fn test_payment_request_metadata() {
 }
 
 #[wasm_bindgen_test]
+async fn test_payment_details_update_persistence() {
+    let storage = create_test_storage("payment_details_update").await;
+
+    breez_sdk_spark::storage_tests::test_payment_details_update_persistence(Box::new(storage))
+        .await;
+}
+
+#[wasm_bindgen_test]
 async fn test_spark_htlc_status_filtering() {
     let storage = create_test_storage("spark_htlc_status_filtering").await;
 


### PR DESCRIPTION
Updates the persistence of payments to use "ON CONFLICT" instead of "OR REPLACE" to avoid payment and foreign table rows being dropped when a payment is updated. For example spark invoice details or HTLC statuses are persisted between payment updates. This allows syncing payment data from multiple sources without losing data (e.g. syncing data from spark and flashnet) or storing a payment with non spark data before the initial transfer is synced