### PR TITLE
add timestamp to lnurl api signatures

### DIFF
--- a/crates/breez-sdk/lnurl-models/src/lib.rs
+++ b/crates/breez-sdk/lnurl-models/src/lib.rs
@@ -10,6 +10,7 @@ pub struct CheckUsernameAvailableResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RecoverLnurlPayRequest {
     pub signature: String,
+    pub timestamp: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -25,6 +26,7 @@ pub struct RecoverLnurlPayResponse {
 pub struct RegisterLnurlPayRequest {
     pub username: String,
     pub signature: String,
+    pub timestamp: Option<u64>,
     pub description: String,
     pub nostr_pubkey: Option<String>,
 }
@@ -33,6 +35,7 @@ pub struct RegisterLnurlPayRequest {
 pub struct UnregisterLnurlPayRequest {
     pub username: String,
     pub signature: String,
+    pub timestamp: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -44,6 +47,7 @@ pub struct RegisterLnurlPayResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ListMetadataRequest {
     pub signature: String,
+    pub timestamp: Option<u64>,
     pub offset: Option<u32>,
     pub limit: Option<u32>,
 }
@@ -67,6 +71,7 @@ pub struct ListMetadataMetadata {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PublishZapReceiptRequest {
     pub signature: String,
+    pub timestamp: Option<u64>,
     pub zap_receipt: String,
 }
 

--- a/crates/breez-sdk/lnurl/src/time.rs
+++ b/crates/breez-sdk/lnurl/src/time.rs
@@ -1,12 +1,14 @@
 use std::time::SystemTime;
 
 pub fn now() -> i64 {
+    now_u64().try_into().expect("SystemTime overflow")
+}
+
+pub fn now_u64() -> u64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("Time went backwards")
         .as_secs()
-        .try_into()
-        .expect("SystemTime overflow")
 }
 
 pub fn now_millis() -> i64 {


### PR DESCRIPTION
The timestamp is optional temporarily, so old clients can still work. We'll have to remove the backward compatibility after some time.