### PR TITLE
lnurl: store allowed domains in database

### DIFF
--- a/crates/breez-sdk/lnurl/migrations/postgres/20251204_allowed_domains.sql
+++ b/crates/breez-sdk/lnurl/migrations/postgres/20251204_allowed_domains.sql
@@ -1,0 +1,3 @@
+CREATE TABLE allowed_domains(
+	domain VARCHAR(255) PRIMARY KEY
+);

--- a/crates/breez-sdk/lnurl/migrations/sqlite/20251204_allowed_domains.sql
+++ b/crates/breez-sdk/lnurl/migrations/sqlite/20251204_allowed_domains.sql
@@ -1,0 +1,3 @@
+CREATE TABLE allowed_domains(
+	domain VARCHAR(255) PRIMARY KEY
+);

--- a/crates/breez-sdk/lnurl/src/postgresql/repository.rs
+++ b/crates/breez-sdk/lnurl/src/postgresql/repository.rs
@@ -244,4 +244,29 @@ impl crate::repository::LnurlRepository for LnurlRepository {
             .collect::<Result<Vec<_>, sqlx::Error>>()?;
         Ok(metadata)
     }
+
+    async fn list_domains(&self) -> Result<Vec<String>, LnurlRepositoryError> {
+        let rows = sqlx::query("SELECT domain FROM allowed_domains")
+            .fetch_all(&self.pool)
+            .await?;
+
+        let domains = rows
+            .into_iter()
+            .map(|row| row.try_get(0))
+            .collect::<Result<Vec<String>, sqlx::Error>>()?;
+
+        Ok(domains)
+    }
+
+    async fn add_domain(&self, domain: &str) -> Result<(), LnurlRepositoryError> {
+        sqlx::query(
+            "INSERT INTO allowed_domains (domain)
+             VALUES ($1)
+             ON CONFLICT(domain) DO NOTHING",
+        )
+        .bind(domain)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
 }

--- a/crates/breez-sdk/lnurl/src/repository.rs
+++ b/crates/breez-sdk/lnurl/src/repository.rs
@@ -52,4 +52,10 @@ pub trait LnurlRepository {
         offset: u32,
         limit: u32,
     ) -> Result<Vec<ListMetadataMetadata>, LnurlRepositoryError>;
+
+    /// Get all allowed domains from the database
+    async fn list_domains(&self) -> Result<Vec<String>, LnurlRepositoryError>;
+
+    /// Insert a domain if it doesn't already exist
+    async fn add_domain(&self, domain: &str) -> Result<(), LnurlRepositoryError>;
 }


### PR DESCRIPTION
Move allowed domains from config-only to database storage with config bootstrap. Domains are loaded from the database at startup, to avoid doing database calls every time. Newly configured domains through the --domains config variable are inserted in the database if they don't exist yet.