### PR TITLE
Retry payments when leafs are already spent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4740,6 +4740,7 @@ dependencies = [
  "thiserror 2.0.14",
  "tokio",
  "tokio_with_wasm",
+ "tonic",
  "tracing",
  "uuid",
  "web-time",

--- a/crates/breez-sdk/lnurl/Cargo.lock
+++ b/crates/breez-sdk/lnurl/Cargo.lock
@@ -3689,6 +3689,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tokio_with_wasm",
+ "tonic",
  "tracing",
  "uuid",
  "web-time",

--- a/crates/spark-wallet/Cargo.toml
+++ b/crates/spark-wallet/Cargo.toml
@@ -21,6 +21,7 @@ spark.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time"] }
 tokio_with_wasm.workspace = true
+tonic.workspace = true
 tracing.workspace = true
 web-time.workspace = true
 


### PR DESCRIPTION
Closes #484 

Attempting to make 2 payments of the same amount in 2 concurrent instances at approximately the same time would consistently result in a `ServiceConnection` error because we attempt to reuse leaves. 

This adds retries to address the issue. 