### PR TITLE
Fix: prevent paying LNURL-Pay when spark over lightning is prefered

### DIFF
--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -1284,7 +1284,14 @@ impl BreezSdk {
     }
 
     pub async fn lnurl_pay(&self, request: LnurlPayRequest) -> Result<LnurlPayResponse, SdkError> {
+        if self.config.prefer_spark_over_lightning {
+            return Err(SdkError::Generic(
+                "Prefer Spark over Lightning is not compatible with LNURL-Pay. Please disable it and try again.".to_string(),
+            ));
+        }
+
         self.ensure_spark_private_mode_initialized().await?;
+
         let mut payment = Box::pin(self.send_payment_internal(
             SendPaymentRequest {
                 prepare_response: PrepareSendPaymentResponse {

--- a/docs/breez-sdk/src/guide/lnurl_pay.md
+++ b/docs/breez-sdk/src/guide/lnurl_pay.md
@@ -18,6 +18,7 @@ and also returns the fees related to the payment so they can be confirmed.
 </h2>
 
 Once the payment has been prepared and the fees are accepted, the payment can be sent by passing:
+
 - **Prepare Response** - The response from the [Preparing LNURL Payments](lnurl_pay.md#preparing-lnurl-payments) step.
 - **Idempotency Key** - An optional UUID that identifies the payment. If set, providing the same idempotency key for multiple requests will ensure that only one payment is made.
 
@@ -26,6 +27,11 @@ Once the payment has been prepared and the fees are accepted, the payment can be
 <div class="warning">
 <h4>Developer note</h4>
 By default when the LNURL-pay results in a success action with a URL, the URL is validated to check if there is a mismatch with the LNURL callback domain. You can disable this behaviour by setting the optional validation <code>PrepareLnurlPayRequest</code> param to false.
+</div>
+
+<div class="warning">
+<h4>Developer note</h4>
+Currently, the "Prefer Spark over Lightning" <a href="config.md#prefer-spark-over-lightning">configuration option</a> is incompatible with sending LNURL-Pay payments. Enabling this option will cause LNURL-Pay payment attempts to fail with an error.
 </div>
 
 ## Supported Specs


### PR DESCRIPTION
This fixes an issue where paying an LNURL-pay or a lightning address of a Spark wallet could result in the following error:

```
SdkError::Generic("Expected Lightning payment details")
```

This would occur if the recipient included a Spark address in the Bolt11 invoice, and we (sender) have `prefer_spark_over_lightning` enabled. The payment would still go through.

