### PR TITLE
Fix payment events emission on sync

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
+++ b/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use anyhow::Result;
 use breez_sdk_itest::*;
 use breez_sdk_spark::*;
@@ -228,7 +226,7 @@ async fn test_02_htlc_refund(
     info!("Waiting for HTLC to expire...");
 
     // HTLC fails and is returned a little bit after the expiry
-    tokio::time::sleep(Duration::from_secs(60)).await;
+    wait_for_payment_failed_event(&mut bob.events, PaymentType::Receive, 120).await?;
 
     info!("Verifying Bob's failed payment...");
 


### PR DESCRIPTION
This fixes a bug introduced in #493 that causes payments events to never be emitted during sync. 

Additionally, it increases the time we wait for HTLCs to be returned in the itest and uses the failed event to detect their return. 