### PR TITLE
Remove 3 dependencies from breez-sdk-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ chrono = { version = "0.4.37", features = ["serde"] }
 clap = "4.5.40"
 dirs = "6.0.0"
 dns-parser = "0.8.0"
-dotenvy = "0.15.7"
 ecies = { version = "0.2.7", default-features = false, features = ["pure"] }
 enum_to_enum = "0.1.0"
 figment = "0.10.19"
@@ -87,7 +86,6 @@ openssl = { version = "0.10.70", default-features = false, features = ["vendored
 proc-macro2 = "1.0.97"
 prost = "0.13.4"
 prost-types = "0.13.4"
-qrcode-rs = { version = "0.1", default-features = false }
 quote = "1.0.40"
 rand = "0.8"
 rayon = "1.10"
@@ -105,7 +103,6 @@ serde = "1.0.219"
 serde_json = "1.0.140"
 serde-wasm-bindgen = "0.6.5"
 serde_with = "3.13.0"
-shellwords = "1.1.0"
 shlex = "1.3.0"
 spark = { path = "crates/spark", default-features = false }
 spark-wallet = { path = "crates/spark-wallet", default-features = false }

--- a/crates/breez-sdk/breez-itest/Cargo.toml
+++ b/crates/breez-sdk/breez-itest/Cargo.toml
@@ -30,7 +30,7 @@ tempdir = "0.3.7"
 testcontainers.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-dotenvy.workspace = true
+dotenvy = "0.15.7"
 rand.workspace = true
 uuid.workspace = true
 futures.workspace = true

--- a/crates/internal/Cargo.toml
+++ b/crates/internal/Cargo.toml
@@ -7,16 +7,16 @@ edition = "2024"
 bip39.workspace = true
 bitcoin.workspace = true
 clap = { workspace = true, features = ["derive"] }
-dotenvy.workspace = true
+dotenvy = "0.15.7"
 figment = { workspace = true, features = ["env", "yaml"] }
 hex.workspace = true
-qrcode-rs.workspace = true
+qrcode-rs = { version = "0.1", default-features = false }
 rand.workspace = true
 reqwest = { workspace = true, features = ["default-tls"] }
 rustyline = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-shellwords.workspace = true
+shellwords = "1.1.0"
 spark-wallet.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }


### PR DESCRIPTION
Starting to address: https://github.com/breez/spark-sdk/issues/497
Went first for some quick wins by removing 3 dependencies from the workspace(were actually unused in  breez-sdk-core) and declaring them only where they are used (internal testing and internal tool):
* dotenvy
* qrcode-rs
* shellwords

