### PR TITLE
refactor(lnurl-auth): remove dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ checksum = "43d193de1f7487df1914d3a568b772458861d33f9c54249612cc2893d6915054"
 dependencies = [
  "bitcoin_hashes 0.13.0",
  "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand_core 0.4.2",
  "serde",
  "unicode-normalization",
 ]
@@ -709,7 +709,6 @@ dependencies = [
  "ecies",
  "frost-secp256k1-tr-unofficial",
  "hex",
- "hmac",
  "lnurl-models",
  "macros",
  "nostr",
@@ -719,7 +718,6 @@ dependencies = [
  "rusqlite_migration",
  "serde",
  "serde_json",
- "sha2",
  "spark-wallet",
  "thiserror 2.0.14",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ glob = "0.3.1"
 graphql_client = { version = "0.14.0" }
 hex = "0.4.3"
 hickory-resolver = "0.25.2"
-hmac = "0.12"
 http = "1.3.1"
 http-body = "1.0.1"
 http-body-util = "0.1.3"
@@ -101,7 +100,6 @@ rusqlite_migration = { version = "1.2.0" }
 rustls = { version = "0.23.28", default-features = false, features = ["ring"] }
 rustyline = "16.0.0"
 serde = "1.0.219"
-sha2 = "0.10"
 serde_json = "1.0.140"
 serde-wasm-bindgen = "0.6.5"
 serde_with = "3.13.0"

--- a/crates/breez-sdk/core/Cargo.toml
+++ b/crates/breez-sdk/core/Cargo.toml
@@ -34,7 +34,6 @@ breez-sdk-common.workspace = true
 chrono.workspace = true
 ecies.workspace = true
 hex.workspace = true
-hmac.workspace = true
 lnurl-models.workspace = true
 macros.workspace = true
 nostr.workspace = true
@@ -42,7 +41,6 @@ openssl = { workspace = true, optional = true }
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-sha2.workspace = true
 spark-wallet.workspace = true
 thiserror.workspace = true
 tokio_with_wasm.workspace = true


### PR DESCRIPTION
Replace standalone sha2 and hmac crate dependencies with the HMAC implementation already provided by bitcoin::hashes. This reduces the dependency footprint by reusing existing crypto primitives from the bitcoin crate.