### PR TITLE
fix(docs): reduce local variables in Python lnurl_pay snippet

### DIFF
--- a/docs/breez-sdk/snippets/python/src/lnurl_pay.py
+++ b/docs/breez-sdk/snippets/python/src/lnurl_pay.py
@@ -20,22 +20,17 @@ async def prepare_pay(sdk: BreezSdk):
         parsed_input = await sdk.parse(lnurl_pay_url)
         if isinstance(parsed_input, InputType.LIGHTNING_ADDRESS):
             details = parsed_input[0]
-            amount_sats = 5_000
-            optional_comment = "<comment>"
-            pay_request = details.pay_request
-            optional_validate_success_action_url = True
 
             request = PrepareLnurlPayRequest(
-                amount_sats=amount_sats,
-                pay_request=pay_request,
-                comment=optional_comment,
-                validate_success_action_url=optional_validate_success_action_url,
+                amount_sats=5_000,
+                pay_request=details.pay_request,
+                comment="<comment>",
+                validate_success_action_url=True,
             )
             prepare_response = await sdk.prepare_lnurl_pay(request=request)
 
             # If the fees are acceptable, continue to create the LNURL Pay
-            fee_sats = prepare_response.fee_sats
-            logging.debug(f"Fees: {fee_sats} sats")
+            logging.debug(f"Fees: {prepare_response.fee_sats} sats")
             return prepare_response
     except Exception as error:
         logging.error(error)


### PR DESCRIPTION
The function now uses fewer than the 15 local variable limit.