### PR TITLE
fix(signer): use single SHA256 for ecdsa_recoverable API authentication

### DIFF
--- a/crates/breez-sdk/core/src/signer/breez.rs
+++ b/crates/breez-sdk/core/src/signer/breez.rs
@@ -81,9 +81,11 @@ impl BreezSigner for BreezSignerImpl {
             .identity_master_key
             .derive_priv(&self.secp, path)
             .map_err(|e| SdkError::Generic(e.to_string()))?;
-        let digest = bitcoin::hashes::sha256::Hash::hash(
-            bitcoin::hashes::sha256::Hash::hash(message).as_ref(),
-        );
+
+        // - Single SHA256 is standard for ECDSA message/API authentication
+        // - Consistent with sign_ecdsa() which also uses single SHA256
+
+        let digest = bitcoin::hashes::sha256::Hash::hash(message);
         let (recovery_id, sig) = self
             .secp
             .sign_ecdsa_recoverable(


### PR DESCRIPTION
- Change sign_ecdsa_recoverable from double SHA256 to single SHA256
- Single SHA256 is correct for API authentication (SyncSigner requests)
- Double SHA256 is only for Bitcoin transaction signing
- Ensures consistency with sign_ecdsa() which already uses single SHA256
- Fixes incompatibility with API server signature verification