### PR TITLE
Passkey (Seedless Restore)

### DIFF
--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           HASH=$(git rev-parse HEAD)
           sed -i.bak -e 's/^breez-sdk-common = .*/breez-sdk-common = { git = "https:\/\/github.com\/breez\/spark-sdk.git", rev = "'"$HASH"'" }/' Cargo.toml
-          sed -i.bak -e 's/^breez-sdk-spark = .*/breez-sdk-spark = { git = "https:\/\/github.com\/breez\/spark-sdk.git", rev = "'"$HASH"'", features = ["openssl-vendored"] }/' Cargo.toml
+          sed -i.bak -e 's/^breez-sdk-spark = .*/breez-sdk-spark = { git = "https:\/\/github.com\/breez\/spark-sdk.git", rev = "'"$HASH"'", features = [/' Cargo.toml
           rm Cargo.toml.bak
 
       - name: Install flutter_rust_bridge_codegen

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "serde",
  "syn 2.0.105",
 ]
@@ -203,7 +203,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.5.1",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -214,13 +214,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.14",
+ "time",
+]
+
+[[package]]
 name = "asn1-rs-derive"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
+ "syn 2.0.105",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
  "syn 2.0.105",
  "synstructure",
 ]
@@ -232,7 +260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -267,7 +295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -278,9 +306,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
+
+[[package]]
+name = "async-utility"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34a3b57207a7a1007832416c3e4862378c8451b4e8e093e436f48c2d3d2c151"
+dependencies = [
+ "futures-util",
+ "gloo-timers",
+ "tokio",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-wsocket"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c92385c7c8b3eb2de1b78aeca225212e4c9a69a78b802832759b108681a5069"
+dependencies = [
+ "async-utility",
+ "futures",
+ "futures-util",
+ "js-sys",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-socks",
+ "tokio-tungstenite 0.26.2",
+ "url",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "atomic-destructor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef49f5882e4b6afaac09ad239a4f8c70a24b8f2b0897edb1f706008efd109cf4"
 
 [[package]]
 name = "atomic-polyfill"
@@ -549,6 +614,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-modes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2211b0817f061502a8dd9f11a37e879e79763e3c698d2418cf824d8cb2f21e"
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +805,8 @@ dependencies = [
  "k256",
  "lnurl-models",
  "macros",
+ "nostr",
+ "nostr-sdk",
  "openssl",
  "platform-utils",
  "rcgen",
@@ -757,7 +830,7 @@ dependencies = [
  "wasm-bindgen-test",
  "web-time",
  "webpki-roots 1.0.2",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -923,6 +996,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "challenge_response"
+version = "0.5.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128b8ad9d33424e9831113f628655a99ddcb9a8d8d4f68271b8a8b7641354265"
+dependencies = [
+ "aes",
+ "bitflags 2.10.0",
+ "block-modes",
+ "hmac",
+ "rand 0.9.2",
+ "rusb",
+ "sha-1",
+ "structure",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +1024,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -978,7 +1094,7 @@ checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -997,10 +1113,13 @@ dependencies = [
  "bip39",
  "bitcoin",
  "breez-sdk-spark",
+ "challenge_response",
  "clap",
+ "ctap-hid-fido2",
  "dirs",
  "hex",
  "rand 0.8.5",
+ "rpassword",
  "rustyline",
  "serde",
  "serde_json",
@@ -1151,6 +1270,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctap-hid-fido2"
+version = "3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b1d1ba802b7e50be2c6e007fe01d25f4a00060fee1920ce714f93a5285890f4"
+dependencies = [
+ "aes",
+ "anyhow",
+ "base64 0.22.1",
+ "byteorder",
+ "cbc",
+ "ciborium",
+ "hex",
+ "hidapi",
+ "num",
+ "pad",
+ "rand 0.9.2",
+ "ring",
+ "strum",
+ "strum_macros",
+ "x509-parser 0.17.0",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,7 +1320,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "strsim",
  "syn 2.0.105",
 ]
@@ -1190,7 +1332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -1259,7 +1401,21 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs 0.7.1",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1274,7 +1430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -1295,7 +1451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -1348,7 +1504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -1500,7 +1656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51953530e29a0e9abfb23af10748b0328cabf3d0d0e1ffd34b61144c0e0440b1"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -1787,7 +1943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -1899,6 +2055,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "goblin"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,7 +2118,7 @@ dependencies = [
  "heck 0.4.1",
  "lazy_static",
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "serde",
  "serde_json",
  "syn 1.0.109",
@@ -2014,6 +2182,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2143,6 +2322,19 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "hidapi"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565dd4c730b8f8b2c0fb36df6be12e5470ae10895ddcc4e9dcfbfb495de202b0"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "hkdf"
@@ -2745,6 +2937,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libusb1-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da050ade7ac4ff1ba5379af847a10a10a8e284181e060105bf8d86960ce9ce0f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,6 +3038,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+
+[[package]]
 name = "macro_test"
 version = "0.1.0"
 dependencies = [
@@ -2845,7 +3055,7 @@ name = "macros"
 version = "0.1.0"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -2955,7 +3165,7 @@ checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
 dependencies = [
  "cfg-if",
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -2982,6 +3192,12 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "negentropy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 
 [[package]]
 name = "nibble_vec"
@@ -3039,6 +3255,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "nostr-database"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
+dependencies = [
+ "lru",
+ "nostr",
+ "tokio",
+]
+
+[[package]]
+name = "nostr-relay-pool"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2f43b70d13dfc50508a13cd902e11f4625312b2ce0e4b7c4c2283fd04001bd"
+dependencies = [
+ "async-utility",
+ "async-wsocket",
+ "atomic-destructor",
+ "lru",
+ "negentropy",
+ "nostr",
+ "nostr-database",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "nostr-sdk"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599f8963d6a1522a13b1a2b0ea6e168acfc367706606f1d33fa595e91fa22db0"
+dependencies = [
+ "async-utility",
+ "nostr",
+ "nostr-database",
+ "nostr-relay-pool",
+ "tokio",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,12 +3315,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -3079,6 +3359,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3116,7 +3418,16 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs 0.7.1",
 ]
 
 [[package]]
@@ -3163,7 +3474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -3208,6 +3519,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "pad"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
+dependencies = [
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3248,7 +3568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "regex",
  "regex-syntax 0.8.5",
  "structmeta",
@@ -3342,7 +3662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -3548,6 +3868,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f95648580798cc44ff8efb9bb0d7ee5205ea32e087b31b0732f3e8c2648ee2"
+dependencies = [
+ "proc-macro-hack-impl",
+]
+
+[[package]]
+name = "proc-macro-hack-impl"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be55bf0ae1635f4d7c7ddd6efc05c631e98a82104a73d35550bbc52db960027"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,7 +3930,7 @@ dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -3613,6 +3948,12 @@ name = "qrcode-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2ead539a9857a2a4e45ec7285812734740c12014cb62e3d1567b1676106afcf"
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -3813,7 +4154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -3937,6 +4278,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3957,7 +4309,7 @@ dependencies = [
  "glob",
  "proc-macro-crate",
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "regex",
  "relative-path",
  "rustc_version",
@@ -3971,9 +4323,29 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
 dependencies = [
- "quote",
+ "quote 1.0.40",
  "rand 0.8.5",
  "syn 2.0.105",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusb"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9f9ff05b63a786553a4c02943b74b34a988448671001e9a27e2f0565cc05a4"
+dependencies = [
+ "libc",
+ "libusb1-sys",
 ]
 
 [[package]]
@@ -4138,7 +4510,7 @@ dependencies = [
  "radix_trie",
  "rustyline-derive",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.1",
  "utf8parse",
  "windows-sys 0.59.0",
 ]
@@ -4150,7 +4522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d66de233f908aebf9cc30ac75ef9103185b4b715c6f2fb7a626aa5e5ede53ab"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -4239,7 +4611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -4370,7 +4742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -4381,7 +4753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -4417,7 +4789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -4461,7 +4833,7 @@ checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -4473,6 +4845,17 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4762,7 +5145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "structmeta-derive",
  "syn 2.0.105",
 ]
@@ -4774,8 +5157,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
+]
+
+[[package]]
+name = "structure"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8379aeb9cf8935b018b14d9191b15096e984ad8b77424b9bce075ea15d1fa59"
+dependencies = [
+ "byteorder",
+ "proc-macro-hack",
+ "structure-macro-impl",
+]
+
+[[package]]
+name = "structure-macro-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c0529f2429c8bb5878688fffab7f700087f4bd47906e6acf03fd7361f77aca"
+dependencies = [
+ "proc-macro-hack",
+ "quote 0.3.15",
 ]
 
 [[package]]
@@ -4795,7 +5199,7 @@ checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -4812,7 +5216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "unicode-ident",
 ]
 
@@ -4823,7 +5227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "unicode-ident",
 ]
 
@@ -4843,7 +5247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -4928,7 +5332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -5019,7 +5423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -5030,7 +5434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -5050,7 +5454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585e5ef40a784ce60b49c67d762110688d211d395d39e096be204535cf64590e"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -5136,7 +5540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -5167,7 +5571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -5233,6 +5637,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5280,7 +5696,23 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.31",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tungstenite 0.26.2",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5316,7 +5748,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e04c1865c281139e5ccf633cb9f76ffdaabeebfe53b703984cf82878e2aabb"
 dependencies = [
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -5390,7 +5822,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "prost-types",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -5503,7 +5935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -5571,7 +6003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81253930d0d388a3ab8fa4ae56da9973ab171ef833d1be2e9080fc3ce502bd6"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "serde_derive_internals",
  "syn 2.0.105",
 ]
@@ -5592,6 +6024,25 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls 0.23.31",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.14",
  "utf-8",
 ]
 
@@ -5639,6 +6090,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -5699,7 +6156,7 @@ name = "uniffi_checksum_derive"
 version = "0.28.3"
 source = "git+https://github.com/breez/uniffi-rs?branch=fix-python-async-protocol#aeb4aeff5fda878973cd673c95225f8301286ff1"
 dependencies = [
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -5727,7 +6184,7 @@ dependencies = [
  "fs-err",
  "once_cell",
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "serde",
  "syn 2.0.105",
  "toml",
@@ -5851,7 +6308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -5897,7 +6354,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.21.0",
  "tokio-util",
  "tower-service",
  "tracing",
@@ -5945,7 +6402,7 @@ dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
  "wasm-bindgen-shared",
 ]
@@ -5969,7 +6426,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
- "quote",
+ "quote 1.0.40",
  "wasm-bindgen-macro-support",
 ]
 
@@ -5980,7 +6437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -6015,7 +6472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -6147,7 +6604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -6158,7 +6615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -6199,6 +6656,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6222,6 +6688,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6259,6 +6740,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6271,6 +6758,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6280,6 +6773,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6307,6 +6806,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6316,6 +6821,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6331,6 +6842,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6340,6 +6857,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6395,14 +6918,31 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
  "data-encoding",
- "der-parser",
+ "der-parser 9.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.7.1",
  "rusticata-macros",
  "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+dependencies = [
+ "asn1-rs 0.7.1",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.8.1",
+ "rusticata-macros",
+ "thiserror 2.0.14",
  "time",
 ]
 
@@ -6471,7 +7011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
  "synstructure",
 ]
@@ -6492,7 +7032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -6512,7 +7052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
  "synstructure",
 ]
@@ -6533,7 +7073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]
 
@@ -6566,6 +7106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.40",
  "syn 2.0.105",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,8 @@ lightning = "0.1.3"
 lightning-invoice = "0.33.1"
 lnurl-models = { path = "crates/breez-sdk/lnurl-models" }
 macros = { path = "crates/macros" }
+nostr = { version = "0.43.1", default-features = false, features = ["std"] }
+nostr-sdk = { version = "0.43.0", default-features = false }
 openssl = { version = "0.10.70", default-features = false, features = ["vendored"] }
 platform-utils = { path = "crates/platform-utils" }
 proc-macro2 = "1.0.97"

--- a/crates/breez-sdk/bindings/Cargo.toml
+++ b/crates/breez-sdk/bindings/Cargo.toml
@@ -19,7 +19,7 @@ name = "breez_sdk_spark_bindings"
 crate-type = ["staticlib", "cdylib", "lib"]
 
 [dependencies]
-breez-sdk-spark = { workspace = true, features = ["uniffi"] }
+breez-sdk-spark = { workspace = true, features = ["uniffi", "passkey"] }
 uniffi = { workspace = true, features = ["tokio"] }
 
 [build-dependencies]

--- a/crates/breez-sdk/cli/Cargo.toml
+++ b/crates/breez-sdk/cli/Cargo.toml
@@ -3,16 +3,23 @@ name = "cli"
 edition = "2024"
 version.workspace = true
 
+[features]
+default = []
+fido2 = ["dep:ctap-hid-fido2", "dep:rpassword"]
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
 bip39 = { workspace = true, features = ["rand"] }
 bitcoin.workspace = true
-breez-sdk-spark = { workspace = true, features = ["postgres"] }
+breez-sdk-spark = { workspace = true, features = ["postgres", "passkey"] }
+challenge_response = "0.5"
 clap = { workspace = true, features = ["derive"] }
+ctap-hid-fido2 = { version = "3.5", optional = true }
 dirs.workspace = true
 hex.workspace = true
 rand.workspace = true
+rpassword = { version = "7.3", optional = true }
 rustyline = { workspace = true, features = ["derive"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/breez-sdk/cli/README.md
+++ b/crates/breez-sdk/cli/README.md
@@ -18,6 +18,11 @@ cargo run -- [OPTIONS]
 | `--postgres-connection-string` | - | PostgreSQL connection string (uses SQLite by default) |
 | `--stable-balance-token-identifier` | - | Stable balance token identifier |
 | `--stable-balance-threshold` | - | Stable balance threshold in sats |
+| `--passkey` | - | Use Passkey with PRF provider (`file`, `yubikey` or `fido2`) |
+| `--wallet-name` | `Default` | Requires `--passkey`. The wallet name to use |
+| `--list-wallet-names` | false | Requires `--passkey`. Select wallet name from NOSTR |
+| `--store-wallet-name` | false | Requires `--passkey`. Publish wallet name to NOSTR |
+| `rpid` | `keys.breez.technology` | Requires `--passkey`. Relying party ID for FIDO2 provider |
 
 ### Data Directory
 
@@ -74,3 +79,222 @@ This Rust CLI is the source of truth. Automated ports are maintained in [`bindin
 | [Dart](../bindings/examples/cli/langs/dart/) | `bindings/examples/cli/langs/dart/` |
 
 Changes to this CLI trigger a [sync workflow](../../../.github/workflows/sync-cli-langs.yml) that automatically opens PRs to update each language port.
+
+## Passkey
+
+Using a passkey enables a deterministic seed to be derived without storing a mnemonic on disk. Instead, a hardware key (YubiKey) or file-based secret is used to deterministically derive wallet seeds via HMAC challenge-response.
+
+Wallet names are stored on Nostr relays, allowing discovery during restore. If no `--wallet-name` is specified, the default wallet name ("Default") is used.
+
+### How It Works
+
+1. **Account master derivation**: `PRF(key, magic_salt)` produces a 32-byte account master used to derive a Nostr identity at `m/44'/1237'/55'/0/0`.
+2. **Wallet name storage**: Wallet names are published as Nostr events, allowing discovery during restore.
+3. **Wallet seed derivation**: `PRF(key, user_salt)` produces 32 bytes that are converted to a 24-word BIP39 mnemonic.
+
+The PRF function differs by provider:
+- **File**: `HMAC-SHA256(file_secret, wallet_name)`
+- **YubiKey**: `SHA256(HMAC-SHA1(slot2_secret, wallet_name))` - OTP challenge-response
+- **FIDO2**: `HMAC-SHA256(credential_key, SHA256("WebAuthn PRF" || 0x00 || wallet_name))` - WebAuthn PRF
+
+The FIDO2 provider applies the [WebAuthn PRF salt transformation](https://w3c.github.io/webauthn/#prf-extension) for browser compatibility.
+
+Each `derive_prf_seed` call requires a physical touch. The `--list-wallet-names` flow requires one derivation (for Nostr identity), and the seed derivation requires an additional derivation (for the seed).
+
+### PRF Providers
+
+#### File Provider
+
+Uses a random 32-byte secret stored in `<data-dir>/seedless-restore-secret`. The secret is generated on first use. Suitable for development and testing.
+
+```bash
+# Use passkey with the default wallet name
+cargo run -- --passkey file
+
+# Use passkey with a specific wallet name
+cargo run -- --passkey file --wallet-name personal
+
+# Use passkey after selecting a wallet name published to Nostr
+cargo run -- --passkey file --list-wallet-names
+
+# Use passkey with a specific wallet name and publish the wallet name to Nostr
+cargo run -- --passkey file --wallet-name personal --store-wallet-name
+```
+
+#### YubiKey Provider
+
+Uses YubiKey HMAC-SHA1 challenge-response (Slot 2) as the PRF.
+
+```bash
+# Use passkey with the default wallet name
+cargo run -- --passkey yubikey
+
+# Use passkey with a specific wallet name
+cargo run -- --passkey yubikey --wallet-name personal
+
+# Use passkey after selecting a wallet name published to Nostr
+cargo run -- --passkey yubikey --list-wallet-names
+
+# Use passkey with a specific wallet name and publish the wallet name to Nostr
+cargo run -- --passkey yubikey --wallet-name personal --store-wallet-name
+```
+
+> **Note**: This provider is **not compatible** with browser WebAuthn PRF. Use the FIDO2 provider for cross-platform compatibility.
+
+#### FIDO2 Provider
+
+Uses FIDO2/WebAuthn PRF via the CTAP2 hmac-secret extension. This is **compatible with browser-based passkeys** - the same credential can derive identical seeds in both CLI and browser when using the same relying party ID (rpId).
+
+> **Note**: The FIDO2 provider requires the `fido2` feature flag (uses `hidapi` which needs system HID libraries).
+
+```bash
+# Use passkey with the default wallet name (uses default rpId: keys.breez.technology)
+cargo run --features fido2 -- --passkey fido2
+
+# Use passkey with a specific wallet name
+cargo run --features fido2 -- --passkey fido2 --wallet-name personal
+
+# Use custom rpId for compatibility with a specific web app
+cargo run --features fido2 -- --passkey fido2 --rpid localhost --wallet-name personal
+
+# Use passkey after selecting a wallet name published to Nostr
+cargo run --features fido2 -- --passkey fido2 --list-wallet-names
+
+# Use passkey with a specific wallet name and publish the wallet name to Nostr
+cargo run --features fido2 -- --passkey fido2 --wallet-name personal --store-wallet-name
+```
+
+**Requirements:**
+- YubiKey 5 series with **firmware 5.2+** (supports hmac-secret extension)
+- Or any FIDO2 authenticator that supports the hmac-secret extension
+- System HID libraries (libhidapi on Linux, included on macOS/Windows)
+
+**PIN Configuration:**
+
+The FIDO2 provider requires a PIN. You can provide it via:
+
+1. **Interactive prompt** (default): Enter PIN when prompted
+2. **Environment variable**: Set `FIDO2_PIN` for non-interactive/CI use
+
+```bash
+# Interactive (prompts for PIN)
+cargo run --features fido2 -- --passkey fido2 --wallet-name personal
+
+# Non-interactive via environment variable
+FIDO2_PIN=123456 cargo run --features fido2 -- --passkey fido2 --wallet-name personal
+```
+
+**Cross-platform compatibility:**
+
+For the CLI and browser to derive the same seed:
+1. Use the same relying party ID (`--rpid` must match browser's `rpId`)
+2. Use the same credential (registered on the same authenticator)
+3. Use the same wallet name
+
+### Yubikey Setup
+
+#### OTP Setup (for `--passkey yubikey`)
+
+The YubiKey provider requires HMAC-SHA1 challenge-response to be configured on **Slot 2**.
+
+##### Prerequisites
+
+Install the YubiKey Manager CLI:
+
+```bash
+# macOS
+brew install ykman
+
+# Debian/Ubuntu
+apt install yubikey-manager
+
+# Arch Linux
+pacman -S yubikey-manager
+```
+
+##### Check current slot configuration
+
+```bash
+ykman otp info
+```
+
+Example output:
+
+```
+Slot 1: programmed    # Typically Yubico OTP
+Slot 2: empty         # Needs to be configured
+```
+
+##### Program Slot 2 for HMAC challenge-response
+
+Generate a random secret key and program it into Slot 2:
+
+```bash
+# Without touch requirement (responds immediately)
+ykman otp chalresp -g 2
+
+# With touch requirement (requires physical touch for each challenge)
+ykman otp chalresp -g -t 2
+```
+
+> **Warning**: This overwrites whatever is currently in Slot 2. If Slot 2 is already programmed, make sure you no longer need its current configuration.
+
+> **Important**: The secret key programmed into the YubiKey is what makes your wallet derivation unique. If you reprogram Slot 2 with a different key, you will derive different wallets for the same wallet names. There is no way to recover the previous key.
+
+##### Verify the configuration
+
+```bash
+ykman otp info
+```
+
+Both slots should now show `programmed`:
+
+```
+Slot 1: programmed
+Slot 2: programmed
+```
+
+##### Disable OTP output (optional)
+
+If your YubiKey outputs random characters (like `ccccc...`) when touched, you can disable Slot 1 OTP:
+
+```bash
+ykman otp delete 1
+```
+
+#### FIDO2 Setup (for `--passkey fido2`)
+
+The FIDO2 provider uses the CTAP2 hmac-secret extension for WebAuthn-compatible PRF.
+
+##### Requirements
+
+- **YubiKey 5 series** with firmware **5.2 or later**
+- Or any FIDO2 security key supporting the `hmac-secret` extension
+
+Check your YubiKey firmware version:
+
+```bash
+ykman info
+```
+
+Look for `Firmware version: 5.x.x` (must be 5.2+).
+
+##### Set a FIDO2 PIN
+
+A PIN is required for hmac-secret operations. Set one if you haven't:
+
+```bash
+ykman fido access change-pin
+```
+
+##### Verify hmac-secret support
+
+```bash
+ykman fido info
+```
+
+Look for `hmac-secret` in the extensions list.
+
+##### First use
+
+On first use with a new rpId, the CLI will automatically register a discoverable credential (passkey) on your authenticator. This requires one touch. Subsequent uses only require one touch for PRF evaluation.

--- a/crates/breez-sdk/cli/src/main.rs
+++ b/crates/breez-sdk/cli/src/main.rs
@@ -1,8 +1,10 @@
 mod command;
+mod passkey;
 mod persist;
 
-use crate::command::CliHelper;
-use crate::persist::CliPersistence;
+use std::fs;
+use std::path::PathBuf;
+
 use anyhow::{Result, anyhow};
 use breez_sdk_spark::{
     EventListener, Network, SdkBuilder, SdkEvent, Seed, StableBalanceConfig, default_config,
@@ -13,8 +15,11 @@ use command::{Command, execute_command};
 use rustyline::Editor;
 use rustyline::error::ReadlineError;
 use rustyline::hint::HistoryHinter;
-use std::{fs, path::PathBuf};
 use tracing::{error, info};
+
+use crate::command::CliHelper;
+use crate::passkey::{PasskeyConfig, PasskeyProvider};
+use crate::persist::CliPersistence;
 
 #[derive(Parser)]
 #[command(version, about = "CLI client for Breez SDK with Spark", long_about = None)]
@@ -43,6 +48,26 @@ struct Cli {
     /// Stable balance threshold, in sats
     #[arg(long)]
     stable_balance_threshold: Option<u64>,
+
+    /// Use passkey with `file`, `yubikey`, or `fido2` provider
+    #[arg(long, value_name = "PROVIDER")]
+    passkey: Option<PasskeyProvider>,
+
+    /// Wallet name for seed derivation (defaults to "Default" if omitted)
+    #[arg(long, requires = "passkey")]
+    wallet_name: Option<String>,
+
+    /// List and select from wallet names published to Nostr
+    #[arg(long, requires = "passkey", conflicts_with_all = ["wallet_name", "store_wallet_name"])]
+    list_wallet_names: bool,
+
+    /// Publish the wallet name to Nostr (requires --wallet-name)
+    #[arg(long, requires_all = ["passkey", "wallet_name"], conflicts_with = "list_wallet_names")]
+    store_wallet_name: bool,
+
+    /// Relying party ID for FIDO2 provider (default: keys.breez.technology)
+    #[arg(long, requires = "passkey")]
+    rpid: Option<String>,
 }
 
 fn expand_path(path: &str) -> PathBuf {
@@ -89,12 +114,14 @@ impl EventListener for CliEventListener {
     }
 }
 
+#[allow(clippy::too_many_lines, clippy::arithmetic_side_effects)]
 async fn run_interactive_mode(
     data_dir: PathBuf,
     network: Network,
     account_number: Option<u32>,
     postgres_connection_string: Option<String>,
     stable_balance_config: Option<StableBalanceConfig>,
+    passkey_config: Option<PasskeyConfig>,
 ) -> Result<()> {
     breez_sdk_spark::init_logging(Some(data_dir.to_string_lossy().into()), None, None)?;
     let persistence = CliPersistence {
@@ -111,18 +138,33 @@ async fn run_interactive_mode(
         info!("No history found");
     }
 
-    let mnemonic = persistence.get_or_create_mnemonic()?;
     fs::create_dir_all(&data_dir)?;
 
     let breez_api_key = std::env::var_os("BREEZ_API_KEY")
         .map(|var| var.into_string().expect("Expected valid API key string"));
     let mut config = default_config(network);
-    config.api_key = breez_api_key;
+    config.api_key = breez_api_key.clone();
     config.stable_balance_config = stable_balance_config;
 
-    let seed = Seed::Mnemonic {
-        mnemonic: mnemonic.to_string(),
-        passphrase: None,
+    let seed = if let Some(config) = passkey_config {
+        let prf = config
+            .provider
+            .into_provider(&data_dir, config.rpid)
+            .map_err(|e| anyhow!("PRF initialization failed: {e}"))?;
+        passkey::resolve_passkey_seed(
+            prf,
+            breez_api_key,
+            config.wallet_name,
+            config.list_wallet_names,
+            config.store_wallet_name,
+        )
+        .await?
+    } else {
+        let mnemonic = persistence.get_or_create_mnemonic()?;
+        Seed::Mnemonic {
+            mnemonic: mnemonic.to_string(),
+            passphrase: None,
+        }
     };
 
     let mut sdk_builder = SdkBuilder::new(config, seed);
@@ -229,12 +271,21 @@ async fn main() -> Result<(), anyhow::Error> {
                 reserved_sats: None,
             });
 
+    let passkey_config = cli.passkey.map(|provider| PasskeyConfig {
+        provider,
+        wallet_name: cli.wallet_name,
+        list_wallet_names: cli.list_wallet_names,
+        store_wallet_name: cli.store_wallet_name,
+        rpid: cli.rpid,
+    });
+
     Box::pin(run_interactive_mode(
         data_dir,
         network,
         cli.account_number,
         cli.postgres_connection_string,
         stable_balance_config,
+        passkey_config,
     ))
     .await?;
 

--- a/crates/breez-sdk/cli/src/passkey/fido2_prf.rs
+++ b/crates/breez-sdk/cli/src/passkey/fido2_prf.rs
@@ -1,0 +1,281 @@
+use bitcoin::hashes::{Hash, sha256};
+use breez_sdk_spark::passkey::{PasskeyPrfError, PasskeyPrfProvider};
+use ctap_hid_fido2::fidokey::get_assertion::get_assertion_params::{
+    Extension as GetExtension, GetAssertionArgsBuilder,
+};
+use ctap_hid_fido2::fidokey::make_credential::make_credential_params::Extension as MakeExtension;
+use ctap_hid_fido2::fidokey::make_credential::make_credential_params::MakeCredentialArgsBuilder;
+use ctap_hid_fido2::public_key_credential_user_entity::PublicKeyCredentialUserEntity;
+use ctap_hid_fido2::{Cfg, FidoKeyHidFactory};
+use std::sync::{Arc, Mutex};
+
+/// `WebAuthn` PRF salt prefix for domain separation.
+/// Per W3C spec: actualSalt = SHA-256("WebAuthn PRF" || 0x00 || developerSalt)
+const WEBAUTHN_PRF_PREFIX: &[u8] = b"WebAuthn PRF";
+
+/// Default relying party ID for passkeys.
+pub const DEFAULT_RP_ID: &str = "keys.breez.technology";
+
+/// Default relying party name.
+const DEFAULT_RP_NAME: &str = "Breez SDK";
+
+/// Create FIDO2 config with our custom touch prompts (suppress library's default message).
+fn fido2_cfg() -> Cfg {
+    Cfg {
+        keep_alive_msg: String::new(), // We print our own touch prompts
+        ..Cfg::init()
+    }
+}
+
+/// Cached state shared across calls (PIN only - credential is discoverable).
+#[derive(Default)]
+struct CachedState {
+    pin: Option<String>,
+}
+
+/// FIDO2 hmac-secret implementation of `PasskeyPrfProvider`.
+///
+/// Uses CTAP2 hmac-secret extension for browser-compatible PRF.
+/// Applies `WebAuthn` salt transformation for cross-platform compatibility.
+///
+/// Uses discoverable credentials (resident keys) so no credential storage is needed.
+/// The credential lives on the authenticator and is discovered by rpId.
+pub struct Fido2PrfProvider {
+    rp_id: String,
+    rp_name: String,
+    cache: Arc<Mutex<CachedState>>,
+}
+
+impl Fido2PrfProvider {
+    /// Create a new `Fido2PrfProvider`.
+    ///
+    /// # Arguments
+    /// * `rp_id` - The relying party ID (must match web app for cross-platform compatibility)
+    pub fn new(rp_id: Option<String>) -> Self {
+        Self {
+            rp_id: rp_id.unwrap_or_else(|| DEFAULT_RP_ID.to_string()),
+            rp_name: DEFAULT_RP_NAME.to_string(),
+            cache: Arc::new(Mutex::new(CachedState::default())),
+        }
+    }
+
+    /// Transform developer salt to `WebAuthn`-compatible salt.
+    ///
+    /// Implements: actualSalt = SHA-256("WebAuthn PRF" || 0x00 || developerSalt)
+    /// This matches what browsers do internally for the `WebAuthn` PRF extension.
+    #[allow(clippy::arithmetic_side_effects)]
+    fn transform_salt(salt: &[u8]) -> [u8; 32] {
+        let mut input = Vec::with_capacity(WEBAUTHN_PRF_PREFIX.len() + 1 + salt.len());
+        input.extend_from_slice(WEBAUTHN_PRF_PREFIX);
+        input.push(0x00);
+        input.extend_from_slice(salt);
+
+        sha256::Hash::hash(&input).to_byte_array()
+    }
+
+    /// Get PIN from cache, environment variable, or interactive prompt.
+    fn get_pin(cache: &Arc<Mutex<CachedState>>) -> Result<String, PasskeyPrfError> {
+        // Check cached PIN first
+        if let Some(pin) = cache.lock().unwrap().pin.as_ref() {
+            return Ok(pin.clone());
+        }
+
+        // Check environment variable for non-interactive use
+        if let Ok(pin) = std::env::var("FIDO2_PIN") {
+            cache.lock().unwrap().pin = Some(pin.clone());
+            return Ok(pin);
+        }
+
+        // Interactive prompt
+        eprint!("Enter FIDO2 PIN: ");
+        let pin = rpassword::read_password()
+            .map_err(|e| PasskeyPrfError::Generic(format!("Failed to read PIN: {e}")))?;
+
+        // Cache for session
+        cache.lock().unwrap().pin = Some(pin.clone());
+
+        Ok(pin)
+    }
+
+    /// Register a discoverable credential with hmac-secret extension enabled.
+    fn register_discoverable_credential(
+        rp_id: &str,
+        rp_name: &str,
+        pin: &str,
+    ) -> Result<(), PasskeyPrfError> {
+        eprintln!("Creating new passkey for {rp_id}. Touch your authenticator...");
+
+        let device = FidoKeyHidFactory::create(&fido2_cfg())
+            .map_err(|e| PasskeyPrfError::Generic(format!("No FIDO2 device found: {e}")))?;
+
+        // Random challenge (not used for verification, just required by protocol)
+        let challenge: [u8; 32] = rand::random();
+
+        // Random user ID
+        let user_id: [u8; 16] = rand::random();
+
+        let user_entity =
+            PublicKeyCredentialUserEntity::new(Some(&user_id), Some(rp_name), Some(rp_name));
+
+        let args = MakeCredentialArgsBuilder::new(rp_id, &challenge)
+            .pin(pin)
+            .user_entity(&user_entity)
+            .extensions(&[MakeExtension::HmacSecret(Some(true))])
+            .resident_key()
+            .build();
+
+        let result = device
+            .make_credential_with_args(&args)
+            .map_err(|e| map_fido2_error(e, "Credential creation failed"))?;
+
+        // Verify hmac-secret was enabled
+        let hmac_enabled = result
+            .extensions
+            .iter()
+            .any(|ext| matches!(ext, MakeExtension::HmacSecret(Some(true))));
+
+        if !hmac_enabled {
+            return Err(PasskeyPrfError::PrfNotSupported);
+        }
+
+        eprintln!("Passkey created successfully with PRF support.");
+        Ok(())
+    }
+
+    /// Get assertion using discoverable credential with hmac-secret PRF.
+    ///
+    /// Uses `get_assertion_with_args` with empty credential list for discoverable + PRF
+    /// in a single step (like browser `WebAuthn` with `allowCredentials: []`).
+    fn get_assertion_with_prf(
+        rp_id: &str,
+        transformed_salt: [u8; 32],
+        pin: &str,
+    ) -> Result<Vec<u8>, PasskeyPrfError> {
+        let device = FidoKeyHidFactory::create(&fido2_cfg())
+            .map_err(|e| PasskeyPrfError::Generic(format!("No FIDO2 device found: {e}")))?;
+
+        eprintln!("Touch your authenticator...");
+        let challenge: [u8; 32] = rand::random();
+
+        // Use get_assertion_with_args with empty credential list (discoverable)
+        // and hmac-secret extension - single step like browser WebAuthn
+        let args = GetAssertionArgsBuilder::new(rp_id, &challenge)
+            .pin(pin)
+            .extensions(&[GetExtension::HmacSecret(Some(transformed_salt))])
+            .build();
+
+        let assertions = device
+            .get_assertion_with_args(&args)
+            .map_err(|e| map_fido2_error(e, "PRF assertion failed"))?;
+
+        let assertion = assertions
+            .first()
+            .ok_or(PasskeyPrfError::CredentialNotFound)?;
+
+        // Extract hmac-secret output from extensions
+        for ext in &assertion.extensions {
+            if let GetExtension::HmacSecret(Some(hmac_output)) = ext {
+                return Ok(hmac_output.to_vec());
+            }
+        }
+
+        Err(PasskeyPrfError::PrfNotSupported)
+    }
+}
+
+#[async_trait::async_trait]
+impl PasskeyPrfProvider for Fido2PrfProvider {
+    async fn derive_prf_seed(&self, salt: String) -> Result<Vec<u8>, PasskeyPrfError> {
+        let rp_id = self.rp_id.clone();
+        let rp_name = self.rp_name.clone();
+        let cache = Arc::clone(&self.cache);
+
+        // Transform salt for WebAuthn compatibility
+        let transformed_salt = Self::transform_salt(salt.as_bytes());
+
+        // Use spawn_blocking for HID operations
+        tokio::task::spawn_blocking(move || {
+            let pin = Self::get_pin(&cache)?;
+
+            // Try to get assertion first (credential may already exist)
+            match Self::get_assertion_with_prf(&rp_id, transformed_salt, &pin) {
+                Ok(output) => Ok(output),
+                Err(PasskeyPrfError::CredentialNotFound) => {
+                    // No credential for this rpId - register one
+                    eprintln!("No passkey found for {rp_id}.");
+                    Self::register_discoverable_credential(&rp_id, &rp_name, &pin)?;
+                    // Now try again
+                    Self::get_assertion_with_prf(&rp_id, transformed_salt, &pin)
+                }
+                Err(e) => Err(e),
+            }
+        })
+        .await
+        .map_err(|e| PasskeyPrfError::Generic(format!("Task join error: {e}")))?
+    }
+
+    async fn is_prf_available(&self) -> Result<bool, PasskeyPrfError> {
+        // Check if a FIDO2 device is connected
+        match FidoKeyHidFactory::create(&fido2_cfg()) {
+            Ok(device) => {
+                // Check device supports hmac-secret
+                let info = device
+                    .get_info()
+                    .map_err(|e| PasskeyPrfError::Generic(e.to_string()))?;
+                Ok(info.extensions.iter().any(|ext| ext == "hmac-secret"))
+            }
+            Err(_) => Ok(false),
+        }
+    }
+}
+
+/// Map ctap-hid-fido2 errors to `PasskeyPrfError`.
+fn map_fido2_error(e: impl std::fmt::Display, context: &str) -> PasskeyPrfError {
+    let msg = format!("{e}");
+
+    if msg.contains("NO_CREDENTIALS") || msg.contains("no credential") {
+        PasskeyPrfError::CredentialNotFound
+    } else if msg.contains("PIN") && (msg.contains("invalid") || msg.contains("Invalid")) {
+        PasskeyPrfError::AuthenticationFailed("Invalid PIN".into())
+    } else if msg.contains("PIN") && msg.contains("blocked") {
+        PasskeyPrfError::AuthenticationFailed("PIN blocked - reset required".into())
+    } else if msg.contains("cancel") || msg.contains("Cancel") {
+        PasskeyPrfError::UserCancelled
+    } else if msg.contains("hmac-secret") && msg.contains("not supported") {
+        PasskeyPrfError::PrfNotSupported
+    } else {
+        PasskeyPrfError::PrfEvaluationFailed(format!("{context}: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_salt_transformation() {
+        // Test that our salt transformation matches the WebAuthn PRF spec
+        // actualSalt = SHA-256("WebAuthn PRF" || 0x00 || developerSalt)
+        let salt = b"test-salt";
+        let transformed = Fido2PrfProvider::transform_salt(salt);
+
+        // Verify it's 32 bytes
+        assert_eq!(transformed.len(), 32);
+
+        // Manually compute expected value
+        let mut expected_input = b"WebAuthn PRF".to_vec();
+        expected_input.push(0x00);
+        expected_input.extend_from_slice(salt);
+        let expected = sha256::Hash::hash(&expected_input).to_byte_array();
+
+        assert_eq!(transformed, expected);
+    }
+
+    #[test]
+    fn test_different_salts_produce_different_outputs() {
+        let salt1 = Fido2PrfProvider::transform_salt(b"wallet-1");
+        let salt2 = Fido2PrfProvider::transform_salt(b"wallet-2");
+
+        assert_ne!(salt1, salt2);
+    }
+}

--- a/crates/breez-sdk/cli/src/passkey/file_prf.rs
+++ b/crates/breez-sdk/cli/src/passkey/file_prf.rs
@@ -1,0 +1,91 @@
+use std::fs;
+use std::path::PathBuf;
+
+use bitcoin::hashes::{Hash, HashEngine, Hmac, HmacEngine, sha256};
+use breez_sdk_spark::passkey::{PasskeyPrfError, PasskeyPrfProvider};
+use rand::{RngCore, thread_rng};
+
+/// File name for the seed restore secret.
+const SECRET_FILE_NAME: &str = "seedless-restore-secret";
+
+/// File-based implementation of `PasskeyPrfProvider`.
+///
+/// Uses HMAC-SHA256 with a secret stored in a file. The secret is generated
+/// randomly on first use and persisted to disk.
+///
+/// # Security Notes
+///
+/// - The secret file should be protected with appropriate file permissions
+/// - This is less secure than hardware-backed solutions like `YubiKey`
+/// - Suitable for development/testing or when hardware keys are unavailable
+pub struct FilePrfProvider {
+    secret: [u8; 32],
+}
+
+impl FilePrfProvider {
+    /// Create a new `FilePrfProvider` using a secret from the specified data directory.
+    ///
+    /// If the secret file doesn't exist, a random 32-byte secret is generated and saved.
+    ///
+    /// # Arguments
+    /// * `data_dir` - The data directory where the secret file is stored
+    ///
+    /// # Errors
+    /// Returns `PasskeyPrfError::Generic` if file operations fail.
+    pub fn new(data_dir: &PathBuf) -> Result<Self, PasskeyPrfError> {
+        let secret_path = data_dir.join(SECRET_FILE_NAME);
+
+        let secret = if secret_path.exists() {
+            // Read existing secret
+            let bytes = fs::read(&secret_path).map_err(|e| {
+                PasskeyPrfError::Generic(format!("Failed to read secret file: {e}"))
+            })?;
+
+            if bytes.len() != 32 {
+                return Err(PasskeyPrfError::Generic(format!(
+                    "Invalid secret file: expected 32 bytes, got {}",
+                    bytes.len()
+                )));
+            }
+
+            let mut secret = [0u8; 32];
+            secret.copy_from_slice(&bytes);
+            secret
+        } else {
+            // Generate new random secret
+            let mut secret = [0u8; 32];
+            thread_rng().fill_bytes(&mut secret);
+
+            // Ensure data directory exists
+            fs::create_dir_all(data_dir).map_err(|e| {
+                PasskeyPrfError::Generic(format!("Failed to create data directory: {e}"))
+            })?;
+
+            // Save secret to file
+            fs::write(&secret_path, secret).map_err(|e| {
+                PasskeyPrfError::Generic(format!("Failed to write secret file: {e}"))
+            })?;
+
+            secret
+        };
+
+        Ok(Self { secret })
+    }
+}
+
+#[async_trait::async_trait]
+impl PasskeyPrfProvider for FilePrfProvider {
+    async fn derive_prf_seed(&self, salt: String) -> Result<Vec<u8>, PasskeyPrfError> {
+        // Use HMAC-SHA256(secret, salt) as the PRF output
+        let mut engine = HmacEngine::<sha256::Hash>::new(&self.secret);
+        engine.input(salt.as_bytes());
+        let hmac: Hmac<sha256::Hash> = Hmac::from_engine(engine);
+
+        Ok(hmac.to_byte_array().to_vec())
+    }
+
+    async fn is_prf_available(&self) -> Result<bool, PasskeyPrfError> {
+        // File-based PRF is always available once initialized
+        Ok(true)
+    }
+}

--- a/crates/breez-sdk/cli/src/passkey/mod.rs
+++ b/crates/breez-sdk/cli/src/passkey/mod.rs
@@ -1,0 +1,147 @@
+use std::io;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Result, anyhow};
+use breez_sdk_spark::Seed;
+use breez_sdk_spark::passkey::{NostrRelayConfig, Passkey, PasskeyPrfError, PasskeyPrfProvider};
+
+#[cfg(feature = "fido2")]
+pub mod fido2_prf;
+pub mod file_prf;
+pub mod yubikey_prf;
+
+#[cfg(feature = "fido2")]
+use fido2_prf::Fido2PrfProvider;
+use file_prf::FilePrfProvider;
+use yubikey_prf::YubiKeyPrfProvider;
+
+/// Passkey PRF provider type.
+#[derive(Clone)]
+pub enum PasskeyProvider {
+    File,
+    YubiKey,
+    /// FIDO2/WebAuthn PRF using CTAP2 hmac-secret extension.
+    /// Compatible with browser `WebAuthn` PRF for cross-platform seed derivation.
+    #[cfg(feature = "fido2")]
+    Fido2,
+}
+
+/// Configuration for passkey seed derivation.
+#[derive(Clone)]
+pub struct PasskeyConfig {
+    /// The PRF provider to use.
+    pub provider: PasskeyProvider,
+    /// Optional wallet name for seed derivation. If omitted, the core uses the default name.
+    pub wallet_name: Option<String>,
+    /// Whether to list and select from wallet names published to Nostr.
+    pub list_wallet_names: bool,
+    /// Whether to publish the wallet name to Nostr.
+    pub store_wallet_name: bool,
+    /// Optional relying party ID for FIDO2 provider (default: keys.breez.technology).
+    pub rpid: Option<String>,
+}
+
+impl std::str::FromStr for PasskeyProvider {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s.to_lowercase().as_str() {
+            "file" => PasskeyProvider::File,
+            "yubikey" => PasskeyProvider::YubiKey,
+            #[cfg(feature = "fido2")]
+            "fido2" => PasskeyProvider::Fido2,
+            #[cfg(not(feature = "fido2"))]
+            "fido2" => {
+                return Err(
+                    "fido2 provider requires the 'fido2' feature (cargo run --features fido2)"
+                        .to_string(),
+                );
+            }
+            _ => return Err(format!("invalid passkey provider '{s}'")),
+        })
+    }
+}
+
+impl PasskeyProvider {
+    #[allow(unused_variables, clippy::needless_pass_by_value)]
+    pub fn into_provider(
+        self,
+        data_dir: &PathBuf,
+        fido2_rp_id: Option<String>,
+    ) -> Result<Arc<dyn PasskeyPrfProvider>, PasskeyPrfError> {
+        match self {
+            PasskeyProvider::File => Ok(Arc::new(FilePrfProvider::new(data_dir)?)),
+            PasskeyProvider::YubiKey => Ok(Arc::new(YubiKeyPrfProvider::new()?)),
+            #[cfg(feature = "fido2")]
+            PasskeyProvider::Fido2 => Ok(Arc::new(Fido2PrfProvider::new(fido2_rp_id))),
+        }
+    }
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+pub async fn resolve_passkey_seed(
+    provider: Arc<dyn PasskeyPrfProvider>,
+    breez_api_key: Option<String>,
+    wallet_name: Option<String>,
+    list_wallet_names: bool,
+    store_wallet_name: bool,
+) -> Result<Seed> {
+    let relay_config = NostrRelayConfig {
+        breez_api_key,
+        ..NostrRelayConfig::default()
+    };
+    let passkey = Passkey::new(provider, Some(relay_config));
+
+    // --store-wallet-name: publish the wallet name to Nostr and exit
+    if store_wallet_name && let Some(wallet_name) = &wallet_name {
+        println!("Publishing wallet name '{wallet_name}' to Nostr...");
+        passkey
+            .store_wallet_name(wallet_name.clone())
+            .await
+            .map_err(|e| anyhow!("Failed to store wallet name: {e}"))?;
+        println!("Wallet name '{wallet_name}' published successfully.");
+    }
+
+    // --list-wallet-names: query Nostr and prompt user to select
+    let wallet_name = if list_wallet_names {
+        println!("Querying Nostr for available wallet names...");
+        let wallet_names = passkey
+            .list_wallet_names()
+            .await
+            .map_err(|e| anyhow!("Failed to list wallet names: {e}"))?;
+
+        if wallet_names.is_empty() {
+            return Err(anyhow!("No wallet names found on Nostr for this identity"));
+        }
+
+        println!("Available wallet names:");
+        for (i, name) in wallet_names.iter().enumerate() {
+            println!("  {}: {}", i + 1, name);
+        }
+
+        print!("Select wallet name (1-{}): ", wallet_names.len());
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        let idx: usize = input
+            .trim()
+            .parse()
+            .map_err(|_| anyhow!("Invalid selection"))?;
+
+        if idx < 1 || idx > wallet_names.len() {
+            return Err(anyhow!("Selection out of range"));
+        }
+
+        Some(wallet_names[idx - 1].clone())
+    } else {
+        wallet_name
+    };
+
+    let wallet = passkey
+        .get_wallet(wallet_name)
+        .await
+        .map_err(|e| anyhow!("Failed to derive wallet: {e}"))?;
+    Ok(wallet.seed)
+}

--- a/crates/breez-sdk/cli/src/passkey/yubikey_prf.rs
+++ b/crates/breez-sdk/cli/src/passkey/yubikey_prf.rs
@@ -1,0 +1,79 @@
+use bitcoin::hashes::{Hash, sha256};
+use breez_sdk_spark::passkey::{PasskeyPrfError, PasskeyPrfProvider};
+use challenge_response::ChallengeResponse;
+use challenge_response::config::{Config, Mode, Slot};
+
+/// `YubiKey` HMAC challenge-response implementation of `PasskeyPrfProvider`.
+///
+/// Uses HMAC-SHA1 from `YubiKey` Slot 2, then expands to 32 bytes via SHA256.
+/// The expansion is performed using `SHA256(hmac_output)` for cross-implementation
+/// portability.
+///
+/// # Security Notes
+///
+/// - The 20-byte HMAC-SHA1 output is expanded to 32 bytes using SHA256
+/// - Different salts produce different outputs (deterministically)
+/// - If Slot 2 was programmed with `-t`, each derivation requires physical touch
+pub struct YubiKeyPrfProvider;
+
+impl YubiKeyPrfProvider {
+    /// Create a new `YubiKeyPrfProvider`.
+    ///
+    /// Verifies that a `YubiKey` is connected during construction.
+    ///
+    /// # Errors
+    /// Returns `PasskeyPrfError::CredentialNotFound` if no `YubiKey` is connected.
+    pub fn new() -> Result<Self, PasskeyPrfError> {
+        let mut cr = ChallengeResponse::new()
+            .map_err(|e| PasskeyPrfError::Generic(format!("Failed to init YubiKey: {e}")))?;
+        cr.find_device()
+            .map_err(|_| PasskeyPrfError::CredentialNotFound)?;
+        Ok(Self)
+    }
+}
+
+#[async_trait::async_trait]
+impl PasskeyPrfProvider for YubiKeyPrfProvider {
+    async fn derive_prf_seed(&self, salt: String) -> Result<Vec<u8>, PasskeyPrfError> {
+        eprintln!("Touch your YubiKey (if configured)...");
+
+        tokio::task::spawn_blocking(move || {
+            let mut cr = ChallengeResponse::new()
+                .map_err(|e| PasskeyPrfError::Generic(format!("YubiKey init failed: {e}")))?;
+            let device = cr
+                .find_device()
+                .map_err(|_| PasskeyPrfError::CredentialNotFound)?;
+
+            let config = Config::new_from(device)
+                .set_mode(Mode::Sha1)
+                .set_slot(Slot::Slot2);
+
+            let challenge = salt.as_bytes();
+            let hmac_result = cr.challenge_response_hmac(challenge, config).map_err(|e| {
+                let msg = format!("{e}");
+                if msg.contains("Wrong CRC") {
+                    PasskeyPrfError::PrfEvaluationFailed(
+                        "YubiKey Slot 2 is not configured for HMAC challenge-response. \
+                             Program it with: ykman otp chalresp -g 2"
+                            .to_string(),
+                    )
+                } else {
+                    PasskeyPrfError::PrfEvaluationFailed(format!("HMAC failed: {e}"))
+                }
+            })?;
+
+            // Expand 20-byte HMAC-SHA1 output to 32 bytes via SHA256
+            let hash = sha256::Hash::hash(&hmac_result);
+
+            Ok(hash.to_byte_array().to_vec())
+        })
+        .await
+        .map_err(|e| PasskeyPrfError::Generic(format!("Task join error: {e}")))?
+    }
+
+    async fn is_prf_available(&self) -> Result<bool, PasskeyPrfError> {
+        let mut cr = ChallengeResponse::new()
+            .map_err(|_| PasskeyPrfError::Generic("YubiKey init failed".into()))?;
+        Ok(cr.find_device().is_ok())
+    }
+}

--- a/crates/breez-sdk/core/Cargo.toml
+++ b/crates/breez-sdk/core/Cargo.toml
@@ -4,15 +4,21 @@ edition = "2024"
 version.workspace = true
 
 [features]
-browser-tests = [] # Enable browser wasm-pack tests
-uniffi = [
-    "dep:uniffi",
-    "openssl-vendored",
-]
+browser-tests = ["passkey"]                 # Enable browser wasm-pack tests
+uniffi = ["dep:uniffi", "openssl-vendored"]
 openssl-vendored = ["openssl"]
 test-utils = ["spark-wallet/test-utils"]
+# Passkey functionality
+passkey = ["dep:nostr", "dep:nostr-sdk"]
 # PostgreSQL storage backend (optional, for server-side use cases)
-postgres = ["dep:tokio-postgres", "dep:deadpool-postgres", "dep:deadpool", "dep:tokio-postgres-rustls", "dep:rustls", "dep:webpki-roots"]
+postgres = [
+    "dep:tokio-postgres",
+    "dep:deadpool-postgres",
+    "dep:deadpool",
+    "dep:tokio-postgres-rustls",
+    "dep:rustls",
+    "dep:webpki-roots",
+]
 
 [lib]
 crate-type = ["staticlib", "cdylib", "lib"]
@@ -35,6 +41,8 @@ flashnet.workspace = true
 hex.workspace = true
 lnurl-models.workspace = true
 macros.workspace = true
+nostr = { workspace = true, optional = true }
+nostr-sdk = { workspace = true, optional = true }
 openssl = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -8,6 +8,8 @@ mod issuer;
 mod lnurl;
 mod logger;
 mod models;
+#[cfg(feature = "passkey")]
+pub mod passkey;
 mod persist;
 mod realtime_sync;
 mod sdk;

--- a/crates/breez-sdk/core/src/passkey/derivation.rs
+++ b/crates/breez-sdk/core/src/passkey/derivation.rs
@@ -1,0 +1,217 @@
+use super::error::PasskeyError;
+use base64::{Engine, engine::general_purpose::STANDARD};
+use bitcoin::{
+    Network,
+    bip32::{DerivationPath, Xpriv},
+    hashes::{Hash, sha256},
+    secp256k1::Secp256k1,
+};
+
+/// The magic salt for deriving the account master.
+///
+/// This is the hex-encoded ASCII string "NYOASTRTSAOYN", used as a domain separator
+/// to derive the Nostr identity keypair. The account master is produced by
+/// `PRF(passkey, ACCOUNT_MASTER_SALT)` and then used for BIP32 derivation of the
+/// Nostr signing key at [`NOSTR_SALT_DERIVATION_PATH`].
+pub const ACCOUNT_MASTER_SALT: &str = "4e594f415354525453414f594e";
+
+/// Nostr derivation path for salt storage identity.
+/// Uses account 55 which is dedicated to salt storage per the seedless-restore spec.
+const NOSTR_SALT_DERIVATION_PATH: &str = "m/44'/1237'/55'/0/0";
+
+/// Derives the Nostr keypair for salt storage from the account master.
+///
+/// The account master (32 bytes from PRF) is used as the seed for BIP32 derivation.
+/// The Nostr key is derived at path `m/44'/1237'/55'/0/0` (account 55).
+///
+/// # Arguments
+/// * `account_master` - The 32-byte PRF output from the magic salt
+///
+/// # Returns
+/// * `Ok(nostr::Keys)` - The Nostr keypair for signing salt events
+/// * `Err(PasskeyError)` - If derivation fails
+pub fn derive_nostr_keypair(account_master: &[u8]) -> Result<nostr::Keys, PasskeyError> {
+    if account_master.len() != 32 {
+        return Err(PasskeyError::InvalidPrfOutput(format!(
+            "Account master must be 32 bytes, got {}",
+            account_master.len()
+        )));
+    }
+
+    let secp = Secp256k1::new();
+
+    // Use account_master as seed for BIP32 master key
+    let master = Xpriv::new_master(Network::Bitcoin, account_master)?;
+
+    // Derive at Nostr salt path: m/44'/1237'/55'/0/0
+    let path: DerivationPath = NOSTR_SALT_DERIVATION_PATH
+        .parse()
+        .map_err(|e| PasskeyError::KeyDerivationError(format!("Invalid derivation path: {e}")))?;
+
+    let derived = master.derive_priv(&secp, &path)?;
+
+    // Convert to nostr secret key
+    let secret_key = nostr::SecretKey::from_slice(&derived.private_key.secret_bytes())
+        .map_err(|e| PasskeyError::KeyDerivationError(e.to_string()))?;
+
+    Ok(nostr::Keys::new(secret_key))
+}
+
+/// Derives a Nostr keypair for NIP-42 authentication from a Breez API key.
+///
+/// The derivation is: `sha256(base64_decode(api_key))` → 32-byte secret key → Nostr keypair.
+/// This keypair is used to authenticate with the Breez relay via NIP-42.
+///
+/// # Arguments
+/// * `api_key` - The Breez API key (base64 encoded)
+///
+/// # Returns
+/// * `Ok(nostr::Keys)` - The Nostr keypair for NIP-42 authentication
+/// * `Err(PasskeyError)` - If the API key is invalid base64 or derivation fails
+pub fn derive_nip42_keypair(api_key: &str) -> Result<nostr::Keys, PasskeyError> {
+    // 1. Base64 decode the API key
+    let decoded = STANDARD
+        .decode(api_key)
+        .map_err(|e| PasskeyError::KeyDerivationError(format!("Invalid base64 API key: {e}")))?;
+
+    // 2. SHA256 hash to get 32-byte secret key
+    let hash = sha256::Hash::hash(&decoded);
+
+    // 3. Create Nostr keypair from hash
+    let secret_key = nostr::SecretKey::from_slice(hash.as_byte_array())
+        .map_err(|e| PasskeyError::KeyDerivationError(e.to_string()))?;
+
+    Ok(nostr::Keys::new(secret_key))
+}
+
+/// Converts PRF output to a BIP39 mnemonic.
+///
+/// The PRF output (32 bytes) is used directly as entropy for a 24-word mnemonic.
+///
+/// # Arguments
+/// * `prf_output` - The 32-byte PRF output from the wallet salt
+///
+/// # Returns
+/// * `Ok(String)` - The 24-word BIP39 mnemonic
+/// * `Err(PasskeyError)` - If conversion fails
+pub fn prf_to_mnemonic(prf_output: &[u8]) -> Result<String, PasskeyError> {
+    if prf_output.len() != 32 {
+        return Err(PasskeyError::InvalidPrfOutput(format!(
+            "PRF output must be 32 bytes for 24-word mnemonic, got {}",
+            prf_output.len()
+        )));
+    }
+
+    let mnemonic = bip39::Mnemonic::from_entropy(prf_output)?;
+    Ok(mnemonic.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "browser-tests")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[macros::test_all]
+    fn test_derive_nostr_keypair() {
+        // Use a deterministic 32-byte account master
+        let account_master = [0u8; 32];
+
+        let keys = derive_nostr_keypair(&account_master).expect("Should derive keypair");
+
+        // Verify we get a valid public key
+        let pubkey = keys.public_key();
+        assert!(!pubkey.to_string().is_empty());
+    }
+
+    #[macros::test_all]
+    fn test_derive_nostr_keypair_invalid_length() {
+        let short_master = [0u8; 16];
+        let result = derive_nostr_keypair(&short_master);
+        assert!(result.is_err());
+    }
+
+    #[macros::test_all]
+    fn test_prf_to_mnemonic() {
+        // Use deterministic 32-byte PRF output
+        let prf_output = [0u8; 32];
+
+        let mnemonic = prf_to_mnemonic(&prf_output).expect("Should create mnemonic");
+
+        // Verify it's a 24-word mnemonic
+        let words: Vec<&str> = mnemonic.split_whitespace().collect();
+        assert_eq!(words.len(), 24);
+    }
+
+    #[macros::test_all]
+    fn test_prf_to_mnemonic_invalid_length() {
+        let short_output = [0u8; 16];
+        let result = prf_to_mnemonic(&short_output);
+        assert!(result.is_err());
+    }
+
+    #[macros::test_all]
+    fn test_deterministic_derivation() {
+        // Same input should always produce same output
+        let account_master = [42u8; 32];
+
+        let keys1 = derive_nostr_keypair(&account_master).unwrap();
+        let keys2 = derive_nostr_keypair(&account_master).unwrap();
+
+        assert_eq!(keys1.public_key(), keys2.public_key());
+    }
+
+    #[macros::test_all]
+    fn test_deterministic_mnemonic() {
+        // Same input should always produce same mnemonic
+        let prf_output = [42u8; 32];
+
+        let mnemonic1 = prf_to_mnemonic(&prf_output).unwrap();
+        let mnemonic2 = prf_to_mnemonic(&prf_output).unwrap();
+
+        assert_eq!(mnemonic1, mnemonic2);
+    }
+
+    #[macros::test_all]
+    fn test_derive_nip42_keypair() {
+        // Use a sample base64-encoded API key
+        let api_key = base64::engine::general_purpose::STANDARD.encode(b"test-api-key");
+
+        let keys = derive_nip42_keypair(&api_key).expect("Should derive keypair");
+
+        // Verify we get a valid public key
+        let pubkey = keys.public_key();
+        assert!(!pubkey.to_string().is_empty());
+    }
+
+    #[macros::test_all]
+    fn test_derive_nip42_keypair_deterministic() {
+        // Same API key should always produce same keypair
+        let api_key = base64::engine::general_purpose::STANDARD.encode(b"test-api-key");
+
+        let keys1 = derive_nip42_keypair(&api_key).unwrap();
+        let keys2 = derive_nip42_keypair(&api_key).unwrap();
+
+        assert_eq!(keys1.public_key(), keys2.public_key());
+    }
+
+    #[macros::test_all]
+    fn test_derive_nip42_keypair_different_keys() {
+        // Different API keys should produce different keypairs
+        let api_key1 = base64::engine::general_purpose::STANDARD.encode(b"api-key-1");
+        let api_key2 = base64::engine::general_purpose::STANDARD.encode(b"api-key-2");
+
+        let keys1 = derive_nip42_keypair(&api_key1).unwrap();
+        let keys2 = derive_nip42_keypair(&api_key2).unwrap();
+
+        assert_ne!(keys1.public_key(), keys2.public_key());
+    }
+
+    #[macros::test_all]
+    fn test_derive_nip42_keypair_invalid_base64() {
+        let invalid_api_key = "not-valid-base64!!!";
+        let result = derive_nip42_keypair(invalid_api_key);
+        assert!(result.is_err());
+    }
+}

--- a/crates/breez-sdk/core/src/passkey/error.rs
+++ b/crates/breez-sdk/core/src/passkey/error.rs
@@ -1,0 +1,84 @@
+use thiserror::Error;
+
+/// Error type for passkey PRF operations.
+/// Platforms implement `PasskeyPrfProvider` and return this error type.
+#[derive(Debug, Error, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
+pub enum PasskeyPrfError {
+    /// PRF extension is not supported by the authenticator
+    #[error("PRF not supported by authenticator")]
+    PrfNotSupported,
+
+    /// User cancelled the authentication
+    #[error("User cancelled authentication")]
+    UserCancelled,
+
+    /// No credential found
+    #[error("Credential not found")]
+    CredentialNotFound,
+
+    /// Authentication failed
+    #[error("Authentication failed: {0}")]
+    AuthenticationFailed(String),
+
+    /// PRF evaluation failed
+    #[error("PRF evaluation failed: {0}")]
+    PrfEvaluationFailed(String),
+
+    /// Generic error
+    #[error("Passkey error: {0}")]
+    Generic(String),
+}
+
+/// Error type for passkey operations.
+#[derive(Debug, Error, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
+pub enum PasskeyError {
+    /// Passkey PRF provider error
+    #[error("PRF error: {0}")]
+    PrfError(#[from] PasskeyPrfError),
+
+    /// Nostr relay connection failed
+    #[error("Nostr relay connection failed: {0}")]
+    RelayConnectionFailed(String),
+
+    /// Failed to publish to Nostr
+    #[error("Nostr write failed: {0}")]
+    NostrWriteFailed(String),
+
+    /// Failed to query from Nostr
+    #[error("Nostr read failed: {0}")]
+    NostrReadFailed(String),
+
+    /// Key derivation error
+    #[error("Key derivation error: {0}")]
+    KeyDerivationError(String),
+
+    /// Invalid PRF output (wrong size, etc.)
+    #[error("Invalid PRF output: {0}")]
+    InvalidPrfOutput(String),
+
+    /// BIP39 mnemonic generation error
+    #[error("Mnemonic error: {0}")]
+    MnemonicError(String),
+
+    /// Invalid salt input
+    #[error("Invalid salt: {0}")]
+    InvalidSalt(String),
+
+    /// Generic error
+    #[error("Passkey error: {0}")]
+    Generic(String),
+}
+
+impl From<bip39::Error> for PasskeyError {
+    fn from(e: bip39::Error) -> Self {
+        PasskeyError::MnemonicError(e.to_string())
+    }
+}
+
+impl From<bitcoin::bip32::Error> for PasskeyError {
+    fn from(e: bitcoin::bip32::Error) -> Self {
+        PasskeyError::KeyDerivationError(e.to_string())
+    }
+}

--- a/crates/breez-sdk/core/src/passkey/mod.rs
+++ b/crates/breez-sdk/core/src/passkey/mod.rs
@@ -1,0 +1,547 @@
+//! Passkey-based wallet operations using `WebAuthn` PRF extension.
+//!
+//! This module implements the [seedless-restore spec](https://github.com/breez/seedless-restore)
+//! for deriving wallet seeds from passkey PRF outputs and storing/discovering
+//! salts via Nostr relays.
+//!
+//! # Overview
+//!
+//! The passkey flow works as follows:
+//!
+//! 1. **Account Master Derivation**: `PRF(passkey, magic_salt)` produces a 32-byte
+//!    account master used to derive the Nostr identity at `m/44'/1237'/55'/0/0`.
+//!
+//! 2. **Salt Storage**: User-provided salts are published as Nostr kind-1 events,
+//!    allowing discovery during wallet restore.
+//!
+//! 3. **Wallet Seed Derivation**: `PRF(passkey, user_salt)` produces 32 bytes that
+//!    are converted to a 24-word BIP39 mnemonic.
+//!
+//! # Platform Implementation
+//!
+//! Platforms must implement the [`PasskeyPrfProvider`] trait to provide passkey
+//! PRF functionality. The SDK orchestrates the flow, while platforms handle the
+//! actual passkey authentication.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use breez_sdk_spark::passkey::{Passkey, NostrRelayConfig};
+//!
+//! // Platform provides a PasskeyPrfProvider implementation
+//! let prf_provider = Arc::new(MyPasskeyPrfProvider::new());
+//!
+//! let passkey = Passkey::new(prf_provider, None);
+//!
+//! // Get a wallet (creates or restores)
+//! let wallet = passkey.get_wallet(Some("my-wallet".to_string())).await?;
+//!
+//! // List available wallet names for restore
+//! let wallet_names = passkey.list_wallet_names().await?;
+//!
+//! // Store a wallet name to Nostr
+//! passkey.store_wallet_name("my-wallet".to_string()).await?;
+//! ```
+
+mod derivation;
+mod error;
+mod models;
+mod nostr_client;
+mod passkey_prf_provider;
+
+pub use derivation::ACCOUNT_MASTER_SALT;
+use derivation::prf_to_mnemonic;
+pub use error::{PasskeyError, PasskeyPrfError};
+pub use models::{NostrRelayConfig, Wallet};
+pub use passkey_prf_provider::PasskeyPrfProvider;
+
+use std::sync::Arc;
+
+use tokio::sync::OnceCell;
+use tokio_with_wasm::alias as tokio;
+
+use crate::Seed;
+use derivation::derive_nostr_keypair;
+use nostr_client::NostrSaltClient;
+
+/// The default wallet name used when none is provided to [`Passkey::get_wallet`].
+const DEFAULT_WALLET_NAME: &str = "Default";
+
+/// Maximum allowed wallet name length in bytes.
+const MAX_WALLET_NAME_LENGTH: usize = 1024;
+
+/// Validate a user-provided wallet name string.
+fn validate_wallet_name(wallet_name: &str) -> Result<(), PasskeyError> {
+    if wallet_name.is_empty() {
+        return Err(PasskeyError::InvalidSalt(
+            "wallet name must not be empty".to_string(),
+        ));
+    }
+    if wallet_name.len() > MAX_WALLET_NAME_LENGTH {
+        return Err(PasskeyError::InvalidSalt(format!(
+            "wallet name exceeds maximum length of {MAX_WALLET_NAME_LENGTH} bytes"
+        )));
+    }
+    Ok(())
+}
+
+/// Orchestrates passkey-based wallet creation and restore operations.
+///
+/// This struct coordinates between the platform's passkey PRF provider and
+/// Nostr relays to derive wallet mnemonics and manage wallet names.
+///
+/// The Nostr identity (derived from the passkey's magic salt) is cached after
+/// the first derivation so that subsequent calls to [`Passkey::list_wallet_names`]
+/// and [`Passkey::store_wallet_name`] do not require additional PRF interactions.
+#[derive(Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct Passkey {
+    prf_provider: Arc<dyn PasskeyPrfProvider>,
+    nostr_client: NostrSaltClient,
+    /// Cached Nostr identity derived from the passkey's magic salt.
+    /// Populated on first use, avoiding repeated PRF calls for Nostr operations.
+    nostr_keys: Arc<OnceCell<nostr::Keys>>,
+}
+
+impl Passkey {
+    /// Derive or retrieve the cached Nostr keypair from the passkey using the magic salt.
+    ///
+    /// The identity is derived on first call and cached for subsequent use,
+    /// so only one PRF interaction (user authentication) is needed.
+    async fn derive_nostr_identity(&self) -> Result<nostr::Keys, PasskeyError> {
+        self.nostr_keys
+            .get_or_try_init(|| async {
+                let account_master = self
+                    .prf_provider
+                    .derive_prf_seed(ACCOUNT_MASTER_SALT.to_string())
+                    .await?;
+                derive_nostr_keypair(&account_master)
+            })
+            .await
+            .cloned()
+    }
+}
+
+#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+impl Passkey {
+    /// Create a new `Passkey` instance.
+    ///
+    /// # Arguments
+    /// * `prf_provider` - Platform implementation of passkey PRF operations
+    /// * `relay_config` - Optional configuration for Nostr relay connections (uses default if None)
+    #[cfg_attr(feature = "uniffi", uniffi::constructor)]
+    pub fn new(
+        prf_provider: Arc<dyn PasskeyPrfProvider>,
+        relay_config: Option<NostrRelayConfig>,
+    ) -> Self {
+        Self {
+            prf_provider,
+            nostr_client: NostrSaltClient::new(relay_config.unwrap_or_default()),
+            nostr_keys: Arc::new(OnceCell::new()),
+        }
+    }
+
+    /// Derive a wallet for a given wallet name.
+    ///
+    /// Uses the passkey PRF to derive a 24-word BIP39 mnemonic from the wallet name
+    /// and returns it as a [`Wallet`] containing the seed and resolved name.
+    /// This works for both creating a new wallet and restoring an existing one.
+    ///
+    /// # Arguments
+    /// * `wallet_name` - A user-chosen wallet name (e.g., "personal", "business").
+    ///   If `None`, defaults to [`DEFAULT_WALLET_NAME`].
+    pub async fn get_wallet(&self, wallet_name: Option<String>) -> Result<Wallet, PasskeyError> {
+        let name = wallet_name.unwrap_or_else(|| DEFAULT_WALLET_NAME.to_string());
+        validate_wallet_name(&name)?;
+        let root_key = self.prf_provider.derive_prf_seed(name.clone()).await?;
+        let mnemonic = prf_to_mnemonic(&root_key)?;
+        Ok(Wallet {
+            seed: Seed::Mnemonic {
+                mnemonic,
+                passphrase: None,
+            },
+            name,
+        })
+    }
+
+    /// List all wallet names published to Nostr for this passkey's identity.
+    ///
+    /// Queries Nostr relays for all wallet names associated with the Nostr identity
+    /// derived from this passkey. Requires 1 PRF call.
+    pub async fn list_wallet_names(&self) -> Result<Vec<String>, PasskeyError> {
+        let nostr_keys = self.derive_nostr_identity().await?;
+        self.nostr_client.query_wallet_names(&nostr_keys).await
+    }
+
+    /// Publish a wallet name to Nostr relays for this passkey's identity.
+    ///
+    /// Idempotent: if the wallet name already exists, it is not published again.
+    /// Requires 1 PRF call.
+    ///
+    /// # Arguments
+    /// * `wallet_name` - A user-chosen wallet name (e.g., "personal", "business")
+    pub async fn store_wallet_name(&self, wallet_name: String) -> Result<(), PasskeyError> {
+        validate_wallet_name(&wallet_name)?;
+        let nostr_keys = self.derive_nostr_identity().await?;
+
+        let exists = self
+            .nostr_client
+            .wallet_name_exists(&nostr_keys, &wallet_name)
+            .await?;
+        if !exists {
+            self.nostr_client
+                .publish_wallet_name(&nostr_keys, &wallet_name)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Check if passkey PRF is available on this device.
+    ///
+    /// Delegates to the platform's `PasskeyPrfProvider` implementation.
+    pub async fn is_available(&self) -> Result<bool, PasskeyError> {
+        self.prf_provider
+            .is_prf_available()
+            .await
+            .map_err(PasskeyError::from)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::arithmetic_side_effects)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[cfg(feature = "browser-tests")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    // Mock implementation of PasskeyPrfProvider for testing
+    struct MockPasskeyPrfProvider {
+        seed: [u8; 32],
+    }
+
+    impl MockPasskeyPrfProvider {
+        fn new(seed: [u8; 32]) -> Self {
+            Self { seed }
+        }
+    }
+
+    #[macros::async_trait]
+    impl PasskeyPrfProvider for MockPasskeyPrfProvider {
+        async fn derive_prf_seed(&self, _salt: String) -> Result<Vec<u8>, PasskeyPrfError> {
+            Ok(self.seed.to_vec())
+        }
+
+        async fn is_prf_available(&self) -> Result<bool, PasskeyPrfError> {
+            Ok(true)
+        }
+    }
+
+    // Enhanced mock that returns salt-specific outputs (simulates real PRF behavior)
+    struct SaltAwareMockProvider {
+        base_seed: [u8; 32],
+        salt_outputs: Mutex<HashMap<String, Vec<u8>>>,
+    }
+
+    impl SaltAwareMockProvider {
+        fn new(base_seed: [u8; 32]) -> Self {
+            Self {
+                base_seed,
+                salt_outputs: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    #[macros::async_trait]
+    impl PasskeyPrfProvider for SaltAwareMockProvider {
+        async fn derive_prf_seed(&self, salt: String) -> Result<Vec<u8>, PasskeyPrfError> {
+            let mut outputs = self.salt_outputs.lock().unwrap();
+            if let Some(output) = outputs.get(&salt) {
+                return Ok(output.clone());
+            }
+
+            let salt_bytes = salt.as_bytes();
+            let mut salt_hash = [0u8; 32];
+            for (i, &byte) in salt_bytes.iter().enumerate() {
+                salt_hash[i % 32] ^= byte;
+                salt_hash[(i + 1) % 32] = salt_hash[(i + 1) % 32].wrapping_add(byte);
+            }
+
+            let mut output = [0u8; 32];
+            for i in 0..32 {
+                output[i] = self.base_seed[i] ^ salt_hash[i];
+            }
+
+            outputs.insert(salt, output.to_vec());
+            Ok(output.to_vec())
+        }
+
+        async fn is_prf_available(&self) -> Result<bool, PasskeyPrfError> {
+            Ok(true)
+        }
+    }
+
+    // Mock that always fails - for testing error propagation
+    struct FailingPasskeyPrfProvider {
+        error: PasskeyPrfError,
+    }
+
+    impl FailingPasskeyPrfProvider {
+        fn new(error: PasskeyPrfError) -> Self {
+            Self { error }
+        }
+    }
+
+    #[macros::async_trait]
+    impl PasskeyPrfProvider for FailingPasskeyPrfProvider {
+        async fn derive_prf_seed(&self, _salt: String) -> Result<Vec<u8>, PasskeyPrfError> {
+            Err(self.error.clone())
+        }
+
+        async fn is_prf_available(&self) -> Result<bool, PasskeyPrfError> {
+            Err(self.error.clone())
+        }
+    }
+
+    // Mock that returns PRF not available
+    struct UnavailablePrfProvider;
+
+    #[macros::async_trait]
+    impl PasskeyPrfProvider for UnavailablePrfProvider {
+        async fn derive_prf_seed(&self, _salt: String) -> Result<Vec<u8>, PasskeyPrfError> {
+            Err(PasskeyPrfError::PrfNotSupported)
+        }
+
+        async fn is_prf_available(&self) -> Result<bool, PasskeyPrfError> {
+            Ok(false)
+        }
+    }
+
+    #[macros::test_all]
+    fn test_passkey_new() {
+        let prf_provider = Arc::new(MockPasskeyPrfProvider::new([0u8; 32]));
+        let config = NostrRelayConfig::default();
+
+        let _passkey = Passkey::new(prf_provider, Some(config));
+    }
+
+    #[macros::async_test_all]
+    async fn test_is_available() {
+        let prf_provider = Arc::new(MockPasskeyPrfProvider::new([0u8; 32]));
+        let passkey = Passkey::new(prf_provider, None);
+
+        let available = passkey.is_available().await.unwrap();
+        assert!(available);
+    }
+
+    #[macros::async_test_all]
+    async fn test_is_available_false() {
+        let prf_provider = Arc::new(UnavailablePrfProvider);
+        let passkey = Passkey::new(prf_provider, None);
+
+        let available = passkey.is_available().await.unwrap();
+        assert!(!available);
+    }
+
+    #[macros::async_test_all]
+    async fn test_is_available_error() {
+        let prf_provider = Arc::new(FailingPasskeyPrfProvider::new(
+            PasskeyPrfError::AuthenticationFailed("Test error".to_string()),
+        ));
+        let passkey = Passkey::new(prf_provider, None);
+
+        let result = passkey.is_available().await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            PasskeyError::PrfError(PasskeyPrfError::AuthenticationFailed(_))
+        ));
+    }
+
+    /// Extract the mnemonic string from a `Wallet`.
+    fn unwrap_mnemonic(wallet: Wallet) -> String {
+        match wallet.seed {
+            Seed::Mnemonic { mnemonic, .. } => mnemonic,
+            Seed::Entropy(_) => panic!("Expected Seed::Mnemonic"),
+        }
+    }
+
+    #[macros::async_test_all]
+    async fn test_get_wallet_deterministic() {
+        let prf_provider1 = Arc::new(MockPasskeyPrfProvider::new([42u8; 32]));
+        let prf_provider2 = Arc::new(MockPasskeyPrfProvider::new([42u8; 32]));
+
+        let passkey1 = Passkey::new(prf_provider1, None);
+        let passkey2 = Passkey::new(prf_provider2, None);
+
+        let mnemonic1 =
+            unwrap_mnemonic(passkey1.get_wallet(Some("test".to_string())).await.unwrap());
+        let mnemonic2 =
+            unwrap_mnemonic(passkey2.get_wallet(Some("test".to_string())).await.unwrap());
+
+        assert_eq!(mnemonic1, mnemonic2);
+    }
+
+    #[macros::async_test_all]
+    async fn test_get_wallet_different_providers() {
+        let prf_provider1 = Arc::new(MockPasskeyPrfProvider::new([1u8; 32]));
+        let prf_provider2 = Arc::new(MockPasskeyPrfProvider::new([2u8; 32]));
+
+        let passkey1 = Passkey::new(prf_provider1, None);
+        let passkey2 = Passkey::new(prf_provider2, None);
+
+        let mnemonic1 =
+            unwrap_mnemonic(passkey1.get_wallet(Some("test".to_string())).await.unwrap());
+        let mnemonic2 =
+            unwrap_mnemonic(passkey2.get_wallet(Some("test".to_string())).await.unwrap());
+
+        assert_ne!(mnemonic1, mnemonic2);
+    }
+
+    #[macros::async_test_all]
+    async fn test_get_wallet_produces_24_words() {
+        let prf_provider = Arc::new(MockPasskeyPrfProvider::new([0u8; 32]));
+        let passkey = Passkey::new(prf_provider, None);
+
+        let mnemonic = unwrap_mnemonic(passkey.get_wallet(Some("test".to_string())).await.unwrap());
+
+        let word_count = mnemonic.split_whitespace().count();
+        assert_eq!(word_count, 24, "Mnemonic should be 24 words");
+    }
+
+    #[macros::async_test_all]
+    async fn test_get_wallet_default_name() {
+        let prf_provider = Arc::new(MockPasskeyPrfProvider::new([0u8; 32]));
+        let passkey = Passkey::new(prf_provider, None);
+
+        // None wallet_name should default to "Default" and not error
+        let wallet = passkey.get_wallet(None).await.unwrap();
+        assert_eq!(wallet.name, "Default");
+    }
+
+    #[macros::async_test_all]
+    async fn test_get_wallet_custom_name() {
+        let prf_provider = Arc::new(MockPasskeyPrfProvider::new([0u8; 32]));
+        let passkey = Passkey::new(prf_provider, None);
+
+        let wallet = passkey
+            .get_wallet(Some("personal".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(wallet.name, "personal");
+    }
+
+    #[macros::async_test_all]
+    async fn test_get_wallet_error_propagation() {
+        let prf_provider = Arc::new(FailingPasskeyPrfProvider::new(
+            PasskeyPrfError::UserCancelled,
+        ));
+        let passkey = Passkey::new(prf_provider, None);
+
+        let result = passkey.get_wallet(Some("test".to_string())).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            PasskeyError::PrfError(PasskeyPrfError::UserCancelled)
+        ));
+    }
+
+    #[macros::async_test_all]
+    async fn test_different_wallet_names_produce_different_mnemonics() {
+        let prf_provider = Arc::new(SaltAwareMockProvider::new([0u8; 32]));
+        let passkey = Passkey::new(prf_provider, None);
+
+        let mnemonic1 = unwrap_mnemonic(
+            passkey
+                .get_wallet(Some("personal".to_string()))
+                .await
+                .unwrap(),
+        );
+        let mnemonic2 = unwrap_mnemonic(
+            passkey
+                .get_wallet(Some("business".to_string()))
+                .await
+                .unwrap(),
+        );
+
+        assert_ne!(
+            mnemonic1, mnemonic2,
+            "Different wallet names should produce different mnemonics"
+        );
+    }
+
+    #[macros::async_test_all]
+    async fn test_same_wallet_name_deterministic() {
+        let prf_provider = Arc::new(SaltAwareMockProvider::new([0u8; 32]));
+        let passkey = Passkey::new(prf_provider, None);
+
+        let mnemonic1 =
+            unwrap_mnemonic(passkey.get_wallet(Some("test".to_string())).await.unwrap());
+        let mnemonic2 =
+            unwrap_mnemonic(passkey.get_wallet(Some("test".to_string())).await.unwrap());
+
+        assert_eq!(
+            mnemonic1, mnemonic2,
+            "Same wallet name should produce same mnemonic"
+        );
+    }
+
+    #[macros::test_all]
+    fn test_nostr_relay_config_default() {
+        let config = NostrRelayConfig::default();
+        assert!(
+            config.breez_api_key.is_none(),
+            "Default should have no API key"
+        );
+        assert_eq!(config.timeout_secs(), 30, "Should have 30 sec timeout");
+    }
+
+    #[macros::test_all]
+    fn test_account_master_salt_is_valid_hex() {
+        let decoded = hex::decode(ACCOUNT_MASTER_SALT);
+        assert!(decoded.is_ok(), "ACCOUNT_MASTER_SALT should be valid hex");
+
+        let decoded_bytes = decoded.unwrap();
+        let decoded_str = String::from_utf8(decoded_bytes);
+        assert!(decoded_str.is_ok());
+        assert_eq!(decoded_str.unwrap(), "NYOASTRTSAOYN");
+    }
+
+    #[macros::async_test_all]
+    async fn test_derive_nostr_identity_deterministic() {
+        let prf_provider1 = Arc::new(MockPasskeyPrfProvider::new([99u8; 32]));
+        let prf_provider2 = Arc::new(MockPasskeyPrfProvider::new([99u8; 32]));
+
+        let passkey1 = Passkey::new(prf_provider1, None);
+        let passkey2 = Passkey::new(prf_provider2, None);
+
+        let keys1 = passkey1.derive_nostr_identity().await.unwrap();
+        let keys2 = passkey2.derive_nostr_identity().await.unwrap();
+
+        assert_eq!(
+            keys1.public_key(),
+            keys2.public_key(),
+            "Same PRF output should produce same Nostr identity"
+        );
+    }
+
+    #[macros::async_test_all]
+    async fn test_derive_nostr_identity_different_providers() {
+        let prf_provider1 = Arc::new(MockPasskeyPrfProvider::new([1u8; 32]));
+        let prf_provider2 = Arc::new(MockPasskeyPrfProvider::new([2u8; 32]));
+
+        let passkey1 = Passkey::new(prf_provider1, None);
+        let passkey2 = Passkey::new(prf_provider2, None);
+
+        let keys1 = passkey1.derive_nostr_identity().await.unwrap();
+        let keys2 = passkey2.derive_nostr_identity().await.unwrap();
+
+        assert_ne!(
+            keys1.public_key(),
+            keys2.public_key(),
+            "Different PRF outputs should produce different Nostr identities"
+        );
+    }
+}

--- a/crates/breez-sdk/core/src/passkey/models.rs
+++ b/crates/breez-sdk/core/src/passkey/models.rs
@@ -1,0 +1,40 @@
+use serde::{Deserialize, Serialize};
+
+use crate::Seed;
+
+const DEFAULT_TIMEOUT_SECS: u32 = 30;
+
+/// A wallet derived from a passkey.
+///
+/// Contains the derived seed and the wallet name used during derivation.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct Wallet {
+    /// The derived seed.
+    pub seed: Seed,
+    /// The wallet name used for derivation (either user-provided or the default).
+    pub name: String,
+}
+
+/// Configuration for Nostr relay connections used in `Passkey`.
+///
+/// Relay URLs are managed internally by the client:
+/// - Public relays are always included
+/// - Breez relay is added when `breez_api_key` is provided (enables NIP-42 auth)
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct NostrRelayConfig {
+    /// Optional Breez API key for authenticated access to the Breez relay.
+    /// When provided, the Breez relay is added and NIP-42 authentication is enabled.
+    #[cfg_attr(feature = "uniffi", uniffi(default=None))]
+    pub breez_api_key: Option<String>,
+    /// Connection timeout in seconds. Defaults to 30 when `None`.
+    #[cfg_attr(feature = "uniffi", uniffi(default=None))]
+    pub timeout_secs: Option<u32>,
+}
+
+impl NostrRelayConfig {
+    pub(crate) fn timeout_secs(&self) -> u32 {
+        self.timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS)
+    }
+}

--- a/crates/breez-sdk/core/src/passkey/nostr_client.rs
+++ b/crates/breez-sdk/core/src/passkey/nostr_client.rs
@@ -1,0 +1,589 @@
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use nostr::nips::nip65;
+use nostr::{Event, Filter, Kind, PublicKey, RelayUrl};
+use nostr_sdk::Client;
+use tokio_with_wasm::alias as tokio;
+use tracing::{info, warn};
+
+use super::derivation::derive_nip42_keypair;
+use super::error::PasskeyError;
+use super::models::NostrRelayConfig;
+
+/// Public relays used as fallback when NIP-65 lists cannot be fetched.
+/// The first entry doubles as the preferred read relay for non-API-key users.
+const STATIC_RELAYS: &[&str] = &[
+    "wss://relay.primal.net",
+    "wss://relay.damus.io",
+    "wss://relay.nostr.watch",
+    "wss://relaypag.es",
+    "wss://monitorlizard.nostr1.com",
+];
+
+/// Breez-operated relay URL (requires NIP-42 authentication).
+const BREEZ_RELAY: &str = "wss://nr1.breez.technology";
+
+/// Hex-encoded public key of the well-known Breez identity that publishes
+/// the authoritative NIP-65 relay list.
+const BREEZ_NIP65_PUBKEY: &str = "0478caf9d25260b7603154c4227d4af5c2e4937092fbdbc9958aef9ea8856e23";
+
+/// Client for publishing and discovering wallet names on Nostr relays.
+///
+/// Wallet names are stored as kind-1 (text note) events with plain text content.
+/// The Nostr identity is derived from the passkey PRF at account 55.
+///
+/// Relay URLs are managed internally:
+/// - Public relays are always included for redundancy
+/// - Breez relay is added when an API key is configured (enables NIP-42 auth)
+#[derive(Clone)]
+pub struct NostrSaltClient {
+    config: NostrRelayConfig,
+    /// Flag ensuring the NIP-65 relay sync is only spawned once per client lifetime.
+    relay_sync_triggered: Arc<AtomicBool>,
+    /// Server-provided relay list, set once by the relay sync task.
+    server_relays: Arc<OnceLock<Vec<String>>>,
+}
+
+impl NostrSaltClient {
+    /// Create a new Nostr salt client with the given relay configuration.
+    pub fn new(config: NostrRelayConfig) -> Self {
+        Self {
+            config,
+            relay_sync_triggered: Arc::new(AtomicBool::new(false)),
+            server_relays: Arc::new(OnceLock::new()),
+        }
+    }
+
+    /// Publish a wallet name to Nostr relays.
+    ///
+    /// The wallet name is published as a kind-1 text note event, signed by the provided keys.
+    /// Per the seedless-restore spec, the content is plain text (the wallet name itself).
+    ///
+    /// # Arguments
+    /// * `keys` - The Nostr keypair derived from the account master
+    /// * `wallet_name` - The wallet name string to publish
+    ///
+    /// # Returns
+    /// * `Ok(())` - Wallet name was published successfully
+    /// * `Err(PasskeyError)` - Publication failed
+    pub async fn publish_wallet_name(
+        &self,
+        keys: &nostr::Keys,
+        wallet_name: &str,
+    ) -> Result<(), PasskeyError> {
+        let builder = nostr::EventBuilder::text_note(wallet_name);
+        self.write_event(keys, builder).await
+    }
+
+    /// Query all wallet names published by the given Nostr identity.
+    ///
+    /// Returns all kind-1 text note events authored by the pubkey.
+    /// The wallet name values are extracted from the event content.
+    ///
+    /// On the first call, spawns a background task to sync the NIP-65 relay list
+    /// with the breez server's authoritative list. This does not block the response.
+    ///
+    /// # Arguments
+    /// * `keys` - The Nostr keypair (used to identify the pubkey to query)
+    ///
+    /// # Returns
+    /// * `Ok(Vec<String>)` - List of wallet names found
+    /// * `Err(PasskeyError)` - Query failed
+    pub async fn query_wallet_names(
+        &self,
+        keys: &nostr::Keys,
+    ) -> Result<Vec<String>, PasskeyError> {
+        let filter = Filter::new()
+            .author(keys.public_key())
+            .kind(nostr::Kind::TextNote);
+
+        let events_vec = self.read_events(keys, filter).await?;
+
+        // Extract wallet name content from events
+        let wallet_names: Vec<String> = events_vec
+            .iter()
+            .map(|event| event.content.clone())
+            .collect();
+
+        // Trigger one-time NIP-65 relay sync in the background
+        self.spawn_relay_sync(keys, events_vec);
+
+        Ok(wallet_names)
+    }
+
+    /// Check if a specific wallet name has already been published.
+    ///
+    /// # Arguments
+    /// * `keys` - The Nostr keypair
+    /// * `wallet_name` - The wallet name to check for
+    ///
+    /// # Returns
+    /// * `Ok(true)` - Wallet name already exists
+    /// * `Ok(false)` - Wallet name not found
+    /// * `Err(PasskeyError)` - Query failed
+    pub async fn wallet_name_exists(
+        &self,
+        keys: &nostr::Keys,
+        wallet_name: &str,
+    ) -> Result<bool, PasskeyError> {
+        let wallet_names = self.query_wallet_names(keys).await?;
+        Ok(wallet_names.iter().any(|w| w == wallet_name))
+    }
+
+    /// Spawn the NIP-65 relay sync task if it hasn't been triggered yet.
+    fn spawn_relay_sync(&self, keys: &nostr::Keys, events: Vec<Event>) {
+        if self
+            .relay_sync_triggered
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let client = self.clone();
+        let keys = keys.clone();
+
+        tokio::spawn(async move {
+            if let Err(e) = client.sync_relay_list(&keys, events).await {
+                warn!("NIP-65 relay sync failed: {e}");
+                client.relay_sync_triggered.store(false, Ordering::Release);
+            }
+        });
+    }
+
+    /// Ensure the server relay list is populated, fetching it if necessary.
+    ///
+    /// Returns the cached list if already set (by a prior call or background sync).
+    /// Otherwise fetches from the Breez NIP-65 event (falling back to static relays),
+    /// caches the result, and returns it.
+    async fn ensure_server_relays(&self, keys: &nostr::Keys) -> Vec<String> {
+        if let Some(relays) = self.server_relays.get() {
+            return relays.clone();
+        }
+
+        let relays = self.fetch_server_relay_list(keys).await;
+
+        if let Err(existing) = self.server_relays.set(relays.clone()) {
+            warn!("Server relay list already set: {existing:?}");
+        }
+        relays
+    }
+
+    /// Synchronize the NIP-65 relay list with the breez server's authoritative list.
+    ///
+    /// 1. Fetches the relay list (populating `server_relays` if not already set).
+    /// 2. Queries the user's published NIP-65 event.
+    /// 3. If they differ, re-publishes all wallet name events and updates the NIP-65 event.
+    async fn sync_relay_list(
+        &self,
+        keys: &nostr::Keys,
+        existing_events: Vec<Event>,
+    ) -> Result<(), PasskeyError> {
+        let server_relays = self.ensure_server_relays(keys).await;
+
+        // Query the currently published NIP-65 relay list
+        let published_relays = self.query_nip65_relay_list(keys).await?;
+
+        let needs_update = match &published_relays {
+            None => true,
+            Some(published) => {
+                let server_set: HashSet<&str> = server_relays.iter().map(String::as_str).collect();
+                let published_set: HashSet<&str> = published.iter().map(String::as_str).collect();
+                server_set != published_set
+            }
+        };
+
+        if needs_update {
+            info!(
+                "NIP-65 relay list mismatch detected. Re-publishing {} events to {} relays.",
+                existing_events.len(),
+                server_relays.len()
+            );
+
+            // Re-publish all existing events to the new relay set
+            if !existing_events.is_empty() {
+                self.republish_events_to_relays(keys, &existing_events)
+                    .await?;
+            }
+
+            // Publish updated NIP-65 event
+            self.publish_nip65_relay_list(keys, &server_relays).await?;
+
+            info!("NIP-65 relay list sync completed successfully.");
+        }
+
+        Ok(())
+    }
+
+    /// Fetch the recommended relay list from the Breez NIP-65 event.
+    ///
+    /// Queries relays (Breez first if API key set, then static) for the well-known
+    /// Breez pubkey's kind-10002 event and extracts the relay URLs.
+    ///
+    /// Returns `None` on any failure (logged as warnings); the caller falls back
+    /// to the static relay list.
+    async fn fetch_breez_nip65(&self, keys: &nostr::Keys) -> Option<Vec<String>> {
+        let breez_pubkey = match PublicKey::from_hex(BREEZ_NIP65_PUBKEY) {
+            Ok(pk) => pk,
+            Err(e) => {
+                warn!("Invalid Breez NIP-65 pubkey constant: {e}");
+                return None;
+            }
+        };
+
+        let filter = Filter::new()
+            .author(breez_pubkey)
+            .kind(Kind::RelayList)
+            .limit(1);
+
+        let relays = self.read_relay_candidates();
+
+        let events = match self.fetch_events_with_fallback(keys, &relays, filter).await {
+            Ok(events) => events,
+            Err(e) => {
+                warn!("Failed to fetch Breez NIP-65 event: {e}");
+                return None;
+            }
+        };
+
+        let event = events.into_iter().next()?;
+
+        let relay_urls: Vec<String> = nip65::extract_relay_list(&event)
+            .map(|(url, _metadata)| url.to_string())
+            .collect();
+
+        if relay_urls.is_empty() {
+            None
+        } else {
+            Some(relay_urls)
+        }
+    }
+
+    /// Fetch the authoritative relay list.
+    ///
+    /// Fallback chain: Breez NIP-65 → user's own published NIP-65 → static list.
+    /// Using the user's NIP-65 as a middle fallback avoids overwriting a previously
+    /// synced relay list with the static list when the Breez NIP-65 is temporarily
+    /// unavailable.
+    async fn fetch_server_relay_list(&self, keys: &nostr::Keys) -> Vec<String> {
+        if let Some(relays) = self.fetch_breez_nip65(keys).await {
+            info!("Fetched {} relays from Breez NIP-65 event", relays.len());
+            return relays;
+        }
+
+        // Try the user's own published NIP-65 list before falling back to static
+        match self.query_nip65_relay_list(keys).await {
+            Ok(Some(relays)) => {
+                info!(
+                    "Using user's published NIP-65 relay list ({} relays)",
+                    relays.len()
+                );
+                return relays;
+            }
+            Ok(None) => {}
+            Err(e) => warn!("Failed to query user NIP-65 relay list: {e}"),
+        }
+
+        info!("Falling back to static relay list");
+        let mut relays: Vec<String> = Vec::new();
+        if self.config.breez_api_key.is_some() {
+            relays.push(BREEZ_RELAY.to_string());
+        }
+        relays.extend(STATIC_RELAYS.iter().map(|s| (*s).to_string()));
+        relays
+    }
+
+    /// Query the user's published NIP-65 relay list from read relays.
+    ///
+    /// Returns the set of relay URLs from the most recent event, or `None` if
+    /// no NIP-65 event has been published.
+    async fn query_nip65_relay_list(
+        &self,
+        keys: &nostr::Keys,
+    ) -> Result<Option<Vec<String>>, PasskeyError> {
+        let filter = Filter::new()
+            .author(keys.public_key())
+            .kind(Kind::RelayList)
+            .limit(1);
+
+        let events = self.read_events(keys, filter).await?;
+
+        // NIP-65 is a replaceable event, so there should be at most one
+        let Some(event) = events.into_iter().next() else {
+            return Ok(None);
+        };
+
+        let relay_urls: Vec<String> = nip65::extract_relay_list(&event)
+            .map(|(url, _metadata)| url.to_string())
+            .collect();
+
+        if relay_urls.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(relay_urls))
+        }
+    }
+
+    /// Publish a NIP-65 relay list metadata event.
+    async fn publish_nip65_relay_list(
+        &self,
+        keys: &nostr::Keys,
+        relay_urls: &[String],
+    ) -> Result<(), PasskeyError> {
+        let relay_entries: Vec<(RelayUrl, Option<nip65::RelayMetadata>)> = relay_urls
+            .iter()
+            .filter_map(|url| RelayUrl::parse(url).ok().map(|r| (r, None)))
+            .collect();
+
+        let builder = nostr::EventBuilder::relay_list(relay_entries);
+        self.write_event(keys, builder).await
+    }
+
+    /// Re-publish existing wallet name events to the current write relay set.
+    async fn republish_events_to_relays(
+        &self,
+        keys: &nostr::Keys,
+        events: &[Event],
+    ) -> Result<(), PasskeyError> {
+        let client = self.create_write_client(keys).await?;
+
+        for event in events {
+            if let Err(e) = client.send_event(event).await {
+                warn!("Failed to republish event {}: {e}", event.id);
+            }
+        }
+
+        client.disconnect().await;
+        Ok(())
+    }
+
+    /// Sign and publish an event to write relays.
+    async fn write_event(
+        &self,
+        keys: &nostr::Keys,
+        builder: nostr::EventBuilder,
+    ) -> Result<(), PasskeyError> {
+        let client = self.create_write_client(keys).await?;
+
+        let event = builder
+            .sign_with_keys(keys)
+            .map_err(|e| PasskeyError::NostrWriteFailed(format!("Failed to sign event: {e}")))?;
+
+        client
+            .send_event(&event)
+            .await
+            .map_err(|e| PasskeyError::NostrWriteFailed(e.to_string()))?;
+
+        client.disconnect().await;
+        Ok(())
+    }
+
+    /// Build the ordered list of relay candidates for read operations.
+    ///
+    /// Priority: Breez relay (if API key set), then static relays.
+    fn read_relay_candidates(&self) -> Vec<String> {
+        let mut candidates: Vec<String> = Vec::new();
+        if self.config.breez_api_key.is_some() {
+            candidates.push(BREEZ_RELAY.to_string());
+        }
+        candidates.extend(STATIC_RELAYS.iter().map(|s| (*s).to_string()));
+        candidates
+    }
+
+    /// Fetch events matching a filter, trying relays in batches of 2 with cascading fallback.
+    ///
+    /// Queries relays in pairs for redundancy: if one relay is missing events the other
+    /// may have them. The nostr-sdk `Client` fans out queries to all connected relays
+    /// and merges results internally.
+    ///
+    /// On batch failure (all relays in the batch error), tries the next batch.
+    /// On success (even empty results), returns immediately.
+    /// Errors only if all batches fail.
+    async fn fetch_events_with_fallback(
+        &self,
+        keys: &nostr::Keys,
+        relays: &[String],
+        filter: Filter,
+    ) -> Result<Vec<Event>, PasskeyError> {
+        let timeout = Duration::from_secs(u64::from(self.config.timeout_secs()));
+        let mut last_err = None;
+
+        for chunk in relays.chunks(2) {
+            let client = self.new_client(keys)?;
+            let mut added = 0usize;
+
+            for relay_url in chunk {
+                match client.add_relay(relay_url.as_str()).await {
+                    #[allow(clippy::arithmetic_side_effects)]
+                    Ok(_) => added += 1,
+                    Err(e) => {
+                        warn!("Failed to add relay {relay_url}: {e}");
+                        last_err = Some(e.to_string());
+                    }
+                }
+            }
+
+            if added == 0 {
+                continue;
+            }
+
+            client.connect().await;
+
+            match client.fetch_events(filter.clone(), timeout).await {
+                Ok(events) => {
+                    client.disconnect().await;
+                    return Ok(events.into_iter().collect());
+                }
+                Err(e) => {
+                    client.disconnect().await;
+                    warn!("Failed to fetch events from relay batch: {e}");
+                    last_err = Some(e.to_string());
+                }
+            }
+        }
+
+        Err(PasskeyError::NostrReadFailed(
+            last_err.unwrap_or_else(|| "no relays available".to_string()),
+        ))
+    }
+
+    /// Fetch events matching a filter from read relays, with cascading fallback.
+    ///
+    /// Tries Breez relay first (if API key set), then static relays one at a time.
+    /// Falls through to the next relay only on connection or fetch errors.
+    async fn read_events(
+        &self,
+        keys: &nostr::Keys,
+        filter: Filter,
+    ) -> Result<Vec<Event>, PasskeyError> {
+        let relays = self.read_relay_candidates();
+        self.fetch_events_with_fallback(keys, &relays, filter).await
+    }
+
+    /// Create a Nostr client connected to all relays for write operations.
+    ///
+    /// Ensures `server_relays` is populated before writing (fetches if needed).
+    /// Tolerates individual relay failures — only errors if no relays could be added.
+    async fn create_write_client(&self, keys: &nostr::Keys) -> Result<Client, PasskeyError> {
+        let client = self.new_client(keys)?;
+        let write_relays = self.ensure_server_relays(keys).await;
+
+        let mut added = 0usize;
+        for relay_url in &write_relays {
+            match client.add_relay(relay_url.as_str()).await {
+                #[allow(clippy::arithmetic_side_effects)]
+                Ok(_) => added += 1,
+                Err(e) => {
+                    warn!("Failed to add relay {relay_url}: {e}");
+                }
+            }
+        }
+
+        if added == 0 {
+            return Err(PasskeyError::RelayConnectionFailed(
+                "failed to add any relay".to_string(),
+            ));
+        }
+
+        client.connect().await;
+        Ok(client)
+    }
+
+    /// Create a new Nostr client with the appropriate signing keys.
+    ///
+    /// When an API key is configured, uses API key-derived keys for NIP-42
+    /// authentication. Content events are signed manually with passkey-derived
+    /// keys via `sign_with_keys()`.
+    fn new_client(&self, keys: &nostr::Keys) -> Result<Client, PasskeyError> {
+        Ok(if let Some(ref api_key) = self.config.breez_api_key {
+            let auth_keys = derive_nip42_keypair(api_key)?;
+            Client::new(auth_keys)
+        } else {
+            Client::new(keys.clone())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "browser-tests")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[macros::test_all]
+    fn test_nostr_salt_client_new_default() {
+        let config = NostrRelayConfig::default();
+        let client = NostrSaltClient::new(config);
+
+        assert!(client.config.breez_api_key.is_none());
+        assert_eq!(client.config.timeout_secs(), 30);
+    }
+
+    #[macros::test_all]
+    fn test_nostr_salt_client_with_api_key() {
+        let config = NostrRelayConfig {
+            breez_api_key: Some("dGVzdC1hcGkta2V5".to_string()),
+            ..Default::default()
+        };
+        let client = NostrSaltClient::new(config);
+
+        assert!(client.config.breez_api_key.is_some());
+        assert_eq!(client.config.timeout_secs(), 30);
+    }
+
+    #[macros::test_all]
+    fn test_relay_sync_state_shared_across_clones() {
+        let config = NostrRelayConfig::default();
+        let client1 = NostrSaltClient::new(config);
+        let client2 = client1.clone();
+
+        assert!(Arc::ptr_eq(
+            &client1.relay_sync_triggered,
+            &client2.relay_sync_triggered
+        ));
+        assert!(Arc::ptr_eq(&client1.server_relays, &client2.server_relays));
+    }
+
+    #[macros::test_all]
+    fn test_breez_nip65_pubkey_is_valid_hex() {
+        let result = PublicKey::from_hex(BREEZ_NIP65_PUBKEY);
+        assert!(
+            result.is_ok(),
+            "BREEZ_NIP65_PUBKEY must be a valid hex pubkey"
+        );
+    }
+
+    #[macros::test_all]
+    fn test_static_relays_first_is_preferred_read() {
+        assert_eq!(STATIC_RELAYS[0], "wss://relay.primal.net");
+    }
+
+    #[macros::test_all]
+    fn test_read_relay_candidates_without_api_key() {
+        let config = NostrRelayConfig::default();
+        let client = NostrSaltClient::new(config);
+        let candidates = client.read_relay_candidates();
+
+        assert_eq!(candidates.len(), STATIC_RELAYS.len());
+        assert_eq!(candidates[0], STATIC_RELAYS[0]);
+        assert!(!candidates.contains(&BREEZ_RELAY.to_string()));
+    }
+
+    #[macros::test_all]
+    fn test_read_relay_candidates_with_api_key() {
+        let config = NostrRelayConfig {
+            breez_api_key: Some("dGVzdC1hcGkta2V5".to_string()),
+            ..Default::default()
+        };
+        let client = NostrSaltClient::new(config);
+        let candidates = client.read_relay_candidates();
+
+        // Breez relay should be first
+        assert_eq!(candidates[0], BREEZ_RELAY);
+        assert_eq!(candidates.len(), STATIC_RELAYS.len() + 1);
+    }
+}

--- a/crates/breez-sdk/core/src/passkey/passkey_prf_provider.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_prf_provider.rs
@@ -1,0 +1,35 @@
+use super::error::PasskeyPrfError;
+
+/// Trait for passkey PRF (Pseudo-Random Function) operations.
+///
+/// Platforms must implement this trait to provide passkey PRF functionality.
+/// The implementation is responsible for:
+/// - Authenticating the user via platform-specific passkey APIs (`WebAuthn`, native passkey managers)
+/// - Evaluating the PRF extension with the provided salt
+/// - Returning the 32-byte PRF output
+#[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
+#[macros::async_trait]
+pub trait PasskeyPrfProvider: Send + Sync {
+    /// Derive a 32-byte seed from passkey PRF with the given salt.
+    ///
+    /// The platform authenticates the user via passkey and evaluates the PRF extension.
+    /// The salt is used as input to the PRF to derive a deterministic output.
+    ///
+    /// # Arguments
+    /// * `salt` - The salt string to use for PRF evaluation
+    ///
+    /// # Returns
+    /// * `Ok(Vec<u8>)` - The 32-byte PRF output
+    /// * `Err(PasskeyPrfError)` - If authentication fails or PRF is not supported
+    async fn derive_prf_seed(&self, salt: String) -> Result<Vec<u8>, PasskeyPrfError>;
+
+    /// Check if a PRF-capable passkey is available on this device.
+    ///
+    /// This allows applications to gracefully degrade if passkey PRF is not supported.
+    ///
+    /// # Returns
+    /// * `Ok(true)` - PRF-capable passkey is available
+    /// * `Ok(false)` - No PRF-capable passkey available
+    /// * `Err(PasskeyPrfError)` - If the check fails
+    async fn is_prf_available(&self) -> Result<bool, PasskeyPrfError>;
+}

--- a/crates/breez-sdk/wasm/Cargo.toml
+++ b/crates/breez-sdk/wasm/Cargo.toml
@@ -13,14 +13,14 @@ crate-type = ["cdylib"]
 [dependencies]
 async-trait.workspace = true
 bitcoin.workspace = true
-breez-sdk-spark.workspace = true
+breez-sdk-spark = { workspace = true, features = ["passkey"] }
 js-sys.workspace = true
 macros.workspace = true
 serde.workspace = true
 serde-wasm-bindgen.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-tsify-next = {workspace = true, default-features = false, features = ["js"]}
+tsify-next = { workspace = true, default-features = false, features = ["js"] }
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
 web-sys.workspace = true

--- a/crates/breez-sdk/wasm/src/error.rs
+++ b/crates/breez-sdk/wasm/src/error.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use breez_sdk_spark::{ParseError, SdkError};
+use breez_sdk_spark::{ParseError, SdkError, passkey::PasskeyError};
 use tracing_subscriber::util::TryInitError;
 use wasm_bindgen::{JsError, JsValue};
 
@@ -45,4 +45,4 @@ macro_rules! wasm_error_wrapper {
     }
 }
 
-wasm_error_wrapper!(SdkError, ParseError);
+wasm_error_wrapper!(SdkError, ParseError, PasskeyError);

--- a/crates/breez-sdk/wasm/src/lib.rs
+++ b/crates/breez-sdk/wasm/src/lib.rs
@@ -3,6 +3,7 @@ mod event;
 mod issuer;
 mod logger;
 mod models;
+mod passkey;
 mod persist;
 mod sdk;
 mod sdk_builder;

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -2,6 +2,7 @@ pub mod chain_service;
 mod error;
 pub mod fiat_service;
 pub mod issuer;
+pub mod passkey_prf_provider;
 pub mod payment_observer;
 pub mod rest_client;
 

--- a/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
+++ b/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
@@ -1,0 +1,113 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::{JsFuture, js_sys::Promise};
+
+use breez_sdk_spark::passkey::PasskeyPrfError;
+
+pub(crate) fn js_error_to_passkey_prf_error(js_error: JsValue) -> PasskeyPrfError {
+    let error_message = js_error
+        .as_string()
+        .unwrap_or_else(|| "Passkey PRF error occurred".to_string());
+    PasskeyPrfError::Generic(error_message)
+}
+
+pub struct WasmPasskeyPrfProvider {
+    pub inner: PasskeyPrfProvider,
+}
+
+// This assumes that we'll always be running in a single thread (true for Wasm environments)
+unsafe impl Send for WasmPasskeyPrfProvider {}
+unsafe impl Sync for WasmPasskeyPrfProvider {}
+
+#[macros::async_trait]
+impl breez_sdk_spark::passkey::PasskeyPrfProvider for WasmPasskeyPrfProvider {
+    async fn derive_prf_seed(&self, salt: String) -> Result<Vec<u8>, PasskeyPrfError> {
+        let promise = self
+            .inner
+            .derive_prf_seed(salt)
+            .map_err(js_error_to_passkey_prf_error)?;
+        let future = JsFuture::from(promise);
+        let result = future.await.map_err(js_error_to_passkey_prf_error)?;
+
+        // Convert Uint8Array to Vec<u8>
+        let array = js_sys::Uint8Array::new(&result);
+        Ok(array.to_vec())
+    }
+
+    async fn is_prf_available(&self) -> Result<bool, PasskeyPrfError> {
+        let promise = self
+            .inner
+            .is_prf_available()
+            .map_err(js_error_to_passkey_prf_error)?;
+        let future = JsFuture::from(promise);
+        let result = future.await.map_err(js_error_to_passkey_prf_error)?;
+
+        result
+            .as_bool()
+            .ok_or_else(|| PasskeyPrfError::Generic("Expected boolean result".to_string()))
+    }
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const PASSKEY_PRF_PROVIDER_INTERFACE: &'static str = r#"/**
+ * Interface for passkey PRF (Pseudo-Random Function) operations.
+ *
+ * Implement this interface to provide passkey PRF functionality for seedless wallet restore.
+ *
+ * @example
+ * ```typescript
+ * class BrowserPasskeyPrfProvider implements PasskeyPrfProvider {
+ *     async derivePrfSeed(salt: string): Promise<Uint8Array> {
+ *         const credential = await navigator.credentials.get({
+ *             publicKey: {
+ *                 challenge: new Uint8Array(32),
+ *                 rpId: window.location.hostname,
+ *                 allowCredentials: [], // or specific credential IDs
+ *                 extensions: {
+ *                     prf: { eval: { first: new TextEncoder().encode(salt) } }
+ *                 }
+ *             }
+ *         });
+ *         const results = credential.getClientExtensionResults();
+ *         return new Uint8Array(results.prf.results.first);
+ *     }
+ *
+ *     async isPrfAvailable(): Promise<boolean> {
+ *         return window.PublicKeyCredential?.isUserVerifyingPlatformAuthenticatorAvailable?.() ?? false;
+ *     }
+ * }
+ * ```
+ */
+export interface PasskeyPrfProvider {
+    /**
+     * Derive a 32-byte seed from passkey PRF with the given salt.
+     *
+     * The platform authenticates the user via passkey and evaluates the PRF extension.
+     * The salt is used as input to the PRF to derive a deterministic output.
+     *
+     * @param salt - The salt string to use for PRF evaluation
+     * @returns A Promise resolving to the 32-byte PRF output
+     * @throws If authentication fails or PRF is not supported
+     */
+    derivePrfSeed(salt: string): Promise<Uint8Array>;
+
+    /**
+     * Check if a PRF-capable passkey is available on this device.
+     *
+     * This allows applications to gracefully degrade if passkey PRF is not supported.
+     *
+     * @returns A Promise resolving to true if PRF-capable passkey is available
+     */
+    isPrfAvailable(): Promise<boolean>;
+}"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "PasskeyPrfProvider")]
+    pub type PasskeyPrfProvider;
+
+    #[wasm_bindgen(structural, method, js_name = "derivePrfSeed", catch)]
+    pub fn derive_prf_seed(this: &PasskeyPrfProvider, salt: String) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(structural, method, js_name = "isPrfAvailable", catch)]
+    pub fn is_prf_available(this: &PasskeyPrfProvider) -> Result<Promise, JsValue>;
+}

--- a/crates/breez-sdk/wasm/src/passkey.rs
+++ b/crates/breez-sdk/wasm/src/passkey.rs
@@ -1,0 +1,94 @@
+use std::sync::Arc;
+
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    error::WasmResult,
+    models::{
+        Seed,
+        passkey_prf_provider::{PasskeyPrfProvider, WasmPasskeyPrfProvider},
+    },
+};
+
+/// Nostr relay configuration for passkey wallet name operations.
+///
+/// Used by `Passkey.listWalletNames` and `Passkey.storeWalletName`.
+#[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::NostrRelayConfig)]
+pub struct NostrRelayConfig {
+    /// Optional Breez API key for authenticated access to the Breez relay.
+    /// When provided, the Breez relay is added and NIP-42 authentication is enabled.
+    pub breez_api_key: Option<String>,
+    /// Connection timeout in seconds. Defaults to 30 when `None`.
+    pub timeout_secs: Option<u32>,
+}
+
+/// A wallet derived from a passkey.
+#[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::Wallet)]
+pub struct Wallet {
+    /// The derived seed.
+    pub seed: Seed,
+    /// The wallet name used for derivation.
+    pub name: String,
+}
+
+/// Passkey-based wallet operations using WebAuthn PRF extension.
+///
+/// Wraps a `PasskeyPrfProvider` and optional relay configuration to provide
+/// wallet derivation and name management via Nostr relays.
+#[wasm_bindgen]
+pub struct Passkey {
+    inner: breez_sdk_spark::passkey::Passkey,
+}
+
+#[wasm_bindgen]
+impl Passkey {
+    /// Create a new `Passkey` instance.
+    ///
+    /// @param prfProvider - Platform implementation of passkey PRF operations
+    /// @param relayConfig - Optional configuration for Nostr relay connections
+    #[wasm_bindgen(constructor)]
+    pub fn new(prf_provider: PasskeyPrfProvider, relay_config: Option<NostrRelayConfig>) -> Self {
+        let wasm_provider = WasmPasskeyPrfProvider {
+            inner: prf_provider,
+        };
+        Self {
+            inner: breez_sdk_spark::passkey::Passkey::new(
+                Arc::new(wasm_provider),
+                relay_config.map(|rc| rc.into()),
+            ),
+        }
+    }
+
+    /// Derive a wallet for a given wallet name.
+    ///
+    /// Uses the passkey PRF to derive a `Wallet` containing the seed and resolved name.
+    ///
+    /// @param walletName - Optional wallet name string (defaults to "Default")
+    #[wasm_bindgen(js_name = "getWallet")]
+    pub async fn get_wallet(&self, wallet_name: Option<String>) -> WasmResult<Wallet> {
+        Ok(self.inner.get_wallet(wallet_name).await?.into())
+    }
+
+    /// List all wallet names published to Nostr for this passkey's identity.
+    ///
+    /// Requires 1 PRF call (for Nostr identity derivation).
+    #[wasm_bindgen(js_name = "listWalletNames")]
+    pub async fn list_wallet_names(&self) -> WasmResult<Vec<String>> {
+        Ok(self.inner.list_wallet_names().await?)
+    }
+
+    /// Publish a wallet name to Nostr relays for this passkey's identity.
+    ///
+    /// Idempotent: if the wallet name already exists, it is not published again.
+    /// Requires 1 PRF call.
+    #[wasm_bindgen(js_name = "storeWalletName")]
+    pub async fn store_wallet_name(&self, wallet_name: String) -> WasmResult<()> {
+        Ok(self.inner.store_wallet_name(wallet_name).await?)
+    }
+
+    /// Check if passkey PRF is available on this device.
+    #[wasm_bindgen(js_name = "isAvailable")]
+    pub async fn is_available(&self) -> WasmResult<bool> {
+        Ok(self.inner.is_available().await?)
+    }
+}

--- a/docs/breez-sdk/snippets/csharp/GettingStarted.cs
+++ b/docs/breez-sdk/snippets/csharp/GettingStarted.cs
@@ -7,7 +7,7 @@ namespace BreezSdkSnippets
         async Task InitSdk()
         {
             // ANCHOR: init-sdk
-            // Construct the seed using mnemonic words or entropy bytes
+            // Construct the seed using a mnemonic, entropy or passkey
             var mnemonic = "<mnemonic words>";
             var seed = new Seed.Mnemonic(mnemonic: mnemonic, passphrase: null);
             // Create the default config

--- a/docs/breez-sdk/snippets/csharp/Passkey.cs
+++ b/docs/breez-sdk/snippets/csharp/Passkey.cs
@@ -1,0 +1,79 @@
+using Breez.Sdk.Spark;
+
+namespace BreezSdkSnippets
+{
+    // ANCHOR: implement-prf-provider
+    // In practice, implement using platform-specific passkey APIs.
+    class ExamplePasskeyPrfProvider : PasskeyPrfProvider
+    {
+        public async Task<byte[]> DerivePrfSeed(string salt)
+        {
+            // Call platform passkey API with PRF extension
+            // Returns 32-byte PRF output
+            throw new NotImplementedException("Implement using WebAuthn or native passkey APIs");
+        }
+
+        public async Task<bool> IsPrfAvailable()
+        {
+            // Check if PRF-capable passkey exists
+            throw new NotImplementedException("Check platform passkey availability");
+        }
+    }
+    // ANCHOR_END: implement-prf-provider
+
+    class PasskeySnippets
+    {
+        async Task<BreezSdk> ConnectWithPasskey()
+        {
+            // ANCHOR: connect-with-passkey
+            var prfProvider = new ExamplePasskeyPrfProvider();
+            var passkey = new Passkey(prfProvider, null);
+
+            // Derive the wallet from the passkey (pass null for the default wallet)
+            var wallet = await passkey.GetWallet(walletName: "personal");
+
+            var config = BreezSdkSparkMethods.DefaultConfig(network: Network.Mainnet);
+            var sdk = await BreezSdkSparkMethods.Connect(new ConnectRequest(
+                config: config,
+                seed: wallet.seed,
+                storageDir: "./.data"
+            ));
+            // ANCHOR_END: connect-with-passkey
+            return sdk;
+        }
+
+        async Task<List<string>> ListWalletNames()
+        {
+            // ANCHOR: list-wallet-names
+            var prfProvider = new ExamplePasskeyPrfProvider();
+            var relayConfig = new NostrRelayConfig(
+                breezApiKey: "<breez api key>"
+            );
+            var passkey = new Passkey(prfProvider, relayConfig);
+
+            // Query Nostr for wallet names associated with this passkey
+            var walletNames = await passkey.ListWalletNames();
+
+            foreach (var walletName in walletNames)
+            {
+                Console.WriteLine($"Found wallet: {walletName}");
+            }
+            // ANCHOR_END: list-wallet-names
+            return walletNames;
+        }
+
+        async Task StoreWalletName()
+        {
+            // ANCHOR: store-wallet-name
+            var prfProvider = new ExamplePasskeyPrfProvider();
+            var relayConfig = new NostrRelayConfig(
+                breezApiKey: "<breez api key>"
+            );
+            var passkey = new Passkey(prfProvider, relayConfig);
+
+            // Publish the wallet name to Nostr for later discovery
+            await passkey.StoreWalletName(walletName: "personal");
+            // ANCHOR_END: store-wallet-name
+        }
+    }
+}

--- a/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
+++ b/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
@@ -7,7 +7,7 @@ namespace BreezSdkSnippets
         async Task InitSdkAdvanced()
         {
             // ANCHOR: init-sdk-advanced
-            // Construct the seed using mnemonic words or entropy bytes
+            // Construct the seed using a mnemonic, entropy or passkey
             var mnemonic = "<mnemonic words>";
             var seed = new Seed.Mnemonic(mnemonic: mnemonic, passphrase: null);
             // Create the default config
@@ -84,7 +84,7 @@ namespace BreezSdkSnippets
         async Task InitSdkPostgres()
         {
             // ANCHOR: init-sdk-postgres
-            // Construct the seed using mnemonic words or entropy bytes
+            // Construct the seed using a mnemonic, entropy or passkey
             var mnemonic = "<mnemonic words>";
             var seed = new Seed.Mnemonic(mnemonic: mnemonic, passphrase: null);
 

--- a/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
@@ -8,7 +8,7 @@ Future<void> initSdk() async {
   // of the SDK across your Flutter app.
   await BreezSdkSparkLib.init();
 
-  // Construct the seed using mnemonic words or entropy bytes
+  // Construct the seed using a mnemonic, entropy or passkey
   String mnemonic = "<mnemonic words>";
   final seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: null);
 

--- a/docs/breez-sdk/snippets/flutter/lib/passkey.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/passkey.dart
@@ -1,0 +1,71 @@
+import 'dart:typed_data';
+import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
+
+// ANCHOR: implement-prf-provider
+// Implement these functions using platform passkey APIs.
+Future<Uint8List> derivePrfSeed(String salt) async {
+  // Call platform passkey API with PRF extension
+  // Returns 32-byte PRF output
+  throw UnimplementedError('Implement using platform passkey APIs');
+}
+
+Future<bool> isPrfAvailable() async {
+  // Check if PRF-capable passkey exists
+  throw UnimplementedError('Check platform passkey availability');
+}
+// ANCHOR_END: implement-prf-provider
+
+Future<BreezSdk> connectWithPasskey() async {
+  // ANCHOR: connect-with-passkey
+  final passkey = Passkey(
+    derivePrfSeed: derivePrfSeed,
+    isPrfAvailable: isPrfAvailable,
+  );
+
+  // Derive the wallet from the passkey (pass null for the default wallet)
+  final wallet = await passkey.getWallet(walletName: "personal");
+
+  final config = defaultConfig(network: Network.mainnet);
+  final sdk = await connect(
+      request: ConnectRequest(
+          config: config, seed: wallet.seed, storageDir: "./.data"));
+  // ANCHOR_END: connect-with-passkey
+  return sdk;
+}
+
+Future<List<String>> listWalletNames() async {
+  // ANCHOR: list-wallet-names
+  final relayConfig = NostrRelayConfig(
+    breezApiKey: '<breez api key>',
+  );
+  final passkey = Passkey(
+    derivePrfSeed: derivePrfSeed,
+    isPrfAvailable: isPrfAvailable,
+    relayConfig: relayConfig,
+  );
+
+  // Query Nostr for wallet names associated with this passkey
+  final walletNames = await passkey.listWalletNames();
+
+  for (final walletName in walletNames) {
+    print("Found wallet: $walletName");
+  }
+  // ANCHOR_END: list-wallet-names
+  return walletNames;
+}
+
+Future<void> storeWalletName() async {
+  // ANCHOR: store-wallet-name
+  final relayConfig = NostrRelayConfig(
+    breezApiKey: '<breez api key>',
+  );
+  final passkey = Passkey(
+    derivePrfSeed: derivePrfSeed,
+    isPrfAvailable: isPrfAvailable,
+    relayConfig: relayConfig,
+  );
+
+  // Publish the wallet name to Nostr for later discovery
+  await passkey.storeWalletName(walletName: "personal");
+  // ANCHOR_END: store-wallet-name
+}

--- a/docs/breez-sdk/snippets/flutter/lib/sdk_building.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/sdk_building.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 
 Future<void> initSdkAdvanced() async {
   // ANCHOR: init-sdk-advanced
-  // Construct the seed using mnemonic words or entropy bytes
+  // Construct the seed using a mnemonic, entropy or passkey
   String mnemonic = "<mnemonic words>";
   final seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: null);
 

--- a/docs/breez-sdk/snippets/go/getting_started.go
+++ b/docs/breez-sdk/snippets/go/getting_started.go
@@ -9,7 +9,7 @@ import (
 
 func InitSdk() (*breez_sdk_spark.BreezSdk, error) {
 	// ANCHOR: init-sdk
-	// Construct the seed using mnemonic words or entropy bytes
+	// Construct the seed using a mnemonic, entropy or passkey
 	mnemonic := "<mnemonic words>"
 	var seed breez_sdk_spark.Seed = breez_sdk_spark.SeedMnemonic{
 		Mnemonic:   mnemonic,

--- a/docs/breez-sdk/snippets/go/passkey.go
+++ b/docs/breez-sdk/snippets/go/passkey.go
@@ -1,0 +1,89 @@
+package example
+
+import (
+	"log"
+
+	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
+)
+
+// ANCHOR: implement-prf-provider
+// In practice, implement using platform-specific passkey APIs.
+type ExamplePasskeyPrfProvider struct{}
+
+func (p *ExamplePasskeyPrfProvider) DerivePrfSeed(salt string) ([]byte, error) {
+	// Call platform passkey API with PRF extension
+	// Returns 32-byte PRF output
+	panic("Implement using WebAuthn or native passkey APIs")
+}
+
+func (p *ExamplePasskeyPrfProvider) IsPrfAvailable() (bool, error) {
+	// Check if PRF-capable passkey exists
+	panic("Check platform passkey availability")
+}
+
+// ANCHOR_END: implement-prf-provider
+
+func ConnectWithPasskey() (*breez_sdk_spark.BreezSdk, error) {
+	// ANCHOR: connect-with-passkey
+	prfProvider := &ExamplePasskeyPrfProvider{}
+	passkey := breez_sdk_spark.NewPasskey(prfProvider, nil)
+
+	// Derive the wallet from the passkey (pass nil for the default wallet)
+	walletName := "personal"
+	wallet, err := passkey.GetWallet(&walletName)
+	if err != nil {
+		return nil, err
+	}
+
+	config := breez_sdk_spark.DefaultConfig(breez_sdk_spark.NetworkMainnet)
+	sdk, err := breez_sdk_spark.Connect(breez_sdk_spark.ConnectRequest{
+		Config:     config,
+		Seed:       wallet.Seed,
+		StorageDir: "./.data",
+	})
+	if err != nil {
+		return nil, err
+	}
+	// ANCHOR_END: connect-with-passkey
+	return sdk, nil
+}
+
+func ListWalletNames() ([]string, error) {
+	// ANCHOR: list-wallet-names
+	prfProvider := &ExamplePasskeyPrfProvider{}
+	breezApiKey := "<breez api key>"
+	relayConfig := &breez_sdk_spark.NostrRelayConfig{
+		BreezApiKey: &breezApiKey,
+	}
+	passkey := breez_sdk_spark.NewPasskey(prfProvider, relayConfig)
+
+	// Query Nostr for wallet names associated with this passkey
+	walletNames, err := passkey.ListWalletNames()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, walletName := range walletNames {
+		log.Printf("Found wallet: %s", walletName)
+	}
+	// ANCHOR_END: list-wallet-names
+	return walletNames, nil
+}
+
+func StoreWalletName() error {
+	// ANCHOR: store-wallet-name
+	prfProvider := &ExamplePasskeyPrfProvider{}
+	breezApiKey := "<breez api key>"
+	relayConfig := &breez_sdk_spark.NostrRelayConfig{
+		BreezApiKey: &breezApiKey,
+	}
+	passkey := breez_sdk_spark.NewPasskey(prfProvider, relayConfig)
+
+	// Publish the wallet name to Nostr for later discovery
+	err := passkey.StoreWalletName("personal")
+	if err != nil {
+		return err
+	}
+	// ANCHOR_END: store-wallet-name
+	return nil
+}

--- a/docs/breez-sdk/snippets/go/sdk_building.go
+++ b/docs/breez-sdk/snippets/go/sdk_building.go
@@ -8,7 +8,7 @@ import (
 
 func InitSdkAdvanced() (*breez_sdk_spark.BreezSdk, error) {
 	// ANCHOR: init-sdk-advanced
-	// Construct the seed using mnemonic words or entropy bytes
+	// Construct the seed using a mnemonic, entropy or passkey
 	mnemonic := "<mnemonic words>"
 	var seed breez_sdk_spark.Seed = breez_sdk_spark.SeedMnemonic{
 		Mnemonic:   mnemonic,
@@ -82,7 +82,7 @@ func WithPaymentObserver(builder *breez_sdk_spark.SdkBuilder) {
 
 func InitSdkPostgres() (*breez_sdk_spark.BreezSdk, error) {
 	// ANCHOR: init-sdk-postgres
-	// Construct the seed using mnemonic words or entropy bytes
+	// Construct the seed using a mnemonic, entropy or passkey
 	mnemonic := "<mnemonic words>"
 	var seed breez_sdk_spark.Seed = breez_sdk_spark.SeedMnemonic{
 		Mnemonic:   mnemonic,

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
@@ -4,7 +4,7 @@ import breez_sdk_spark.*
 class GettingStarted {
     suspend fun initSdk() {
         // ANCHOR: init-sdk
-        // Construct the seed using mnemonic words or entropy bytes
+        // Construct the seed using a mnemonic, entropy or passkey
         val mnemonic = "<mnemonic words>"
         val seed = Seed.Mnemonic(mnemonic, null)
 

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Passkey.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Passkey.kt
@@ -1,0 +1,62 @@
+package com.example.kotlinmpplib
+
+import breez_sdk_spark.*
+
+// ANCHOR: implement-prf-provider
+// In practice, implement PRF provider using platform passkey APIs
+class ExamplePasskeyPrfProvider : PasskeyPrfProvider {
+    override suspend fun derivePrfSeed(salt: String): ByteArray {
+        // Call platform passkey API with PRF extension
+        // Returns 32-byte PRF output
+        TODO("Implement using WebAuthn or native passkey APIs")
+    }
+
+    override suspend fun isPrfAvailable(): Boolean {
+        // Check if PRF-capable passkey exists
+        TODO("Check platform passkey availability")
+    }
+}
+// ANCHOR_END: implement-prf-provider
+
+class PasskeySnippets {
+    suspend fun connectWithPasskey(): BreezSdk {
+        // ANCHOR: connect-with-passkey
+        val prfProvider = ExamplePasskeyPrfProvider()
+        val passkey = Passkey(prfProvider, null)
+
+        // Derive the wallet from the passkey (pass null for the default wallet)
+        val wallet = passkey.getWallet("personal")
+
+        val config = defaultConfig(Network.MAINNET)
+        val sdk = connect(ConnectRequest(config, wallet.seed, "./.data"))
+        // ANCHOR_END: connect-with-passkey
+        return sdk
+    }
+
+    suspend fun listWalletNames(): List<String> {
+        // ANCHOR: list-wallet-names
+        val prfProvider = ExamplePasskeyPrfProvider()
+        val relayConfig = NostrRelayConfig(breezApiKey = "<breez api key>")
+        val passkey = Passkey(prfProvider, relayConfig)
+
+        // Query Nostr for wallet names associated with this passkey
+        val walletNames = passkey.listWalletNames()
+
+        for (walletName in walletNames) {
+            // Log.v("Breez", "Found wallet: $walletName")
+        }
+        // ANCHOR_END: list-wallet-names
+        return walletNames
+    }
+
+    suspend fun storeWalletName() {
+        // ANCHOR: store-wallet-name
+        val prfProvider = ExamplePasskeyPrfProvider()
+        val relayConfig = NostrRelayConfig(breezApiKey = "<breez api key>")
+        val passkey = Passkey(prfProvider, relayConfig)
+
+        // Publish the wallet name to Nostr for later discovery
+        passkey.storeWalletName("personal")
+        // ANCHOR_END: store-wallet-name
+    }
+}

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
@@ -4,7 +4,7 @@ import breez_sdk_spark.*
 class SdkBuilding {
     suspend fun initSdkAdvanced() {
         // ANCHOR: init-sdk-advanced
-        // Construct the seed using mnemonic words or entropy bytes
+        // Construct the seed using a mnemonic, entropy or passkey
         val mnemonic = "<mnemonic words>"
         val seed = Seed.Mnemonic(mnemonic, null)
 
@@ -78,7 +78,7 @@ class SdkBuilding {
 
     suspend fun initSdkPostgres() {
         // ANCHOR: init-sdk-postgres
-        // Construct the seed using mnemonic words or entropy bytes
+        // Construct the seed using a mnemonic, entropy or passkey
         val mnemonic = "<mnemonic words>"
         val seed = Seed.Mnemonic(mnemonic, null)
 

--- a/docs/breez-sdk/snippets/python/src/getting_started.py
+++ b/docs/breez-sdk/snippets/python/src/getting_started.py
@@ -19,7 +19,7 @@ from breez_sdk_spark import (
 
 async def init_sdk():
     # ANCHOR: init-sdk
-    # Construct the seed using mnemonic words or entropy bytes
+    # Construct the seed using a mnemonic, entropy or passkey
     mnemonic = "<mnemonic words>"
     seed = Seed.MNEMONIC(mnemonic=mnemonic, passphrase=None)
     # Create the default config

--- a/docs/breez-sdk/snippets/python/src/passkey.py
+++ b/docs/breez-sdk/snippets/python/src/passkey.py
@@ -1,0 +1,64 @@
+# pylint: disable=duplicate-code
+from breez_sdk_spark import (
+    ConnectRequest,
+    NostrRelayConfig,
+    PasskeyPrfProvider,
+    Passkey,
+    connect,
+    default_config,
+    Network,
+)
+
+
+# ANCHOR: implement-prf-provider
+# In practice, implement using platform-specific passkey APIs.
+class ExamplePasskeyPrfProvider(PasskeyPrfProvider):
+    async def derive_prf_seed(self, salt: str):
+        # Call platform passkey API with PRF extension
+        # Returns 32-byte PRF output
+        raise NotImplementedError("Implement using WebAuthn or native passkey APIs")
+
+    async def is_prf_available(self):
+        # Check if PRF-capable passkey exists
+        raise NotImplementedError("Check platform passkey availability")
+# ANCHOR_END: implement-prf-provider
+
+
+async def connect_with_passkey():
+    # ANCHOR: connect-with-passkey
+    prf_provider = ExamplePasskeyPrfProvider()
+    passkey = Passkey(prf_provider, None)
+
+    # Derive the wallet from the passkey (pass None for the default wallet)
+    wallet = await passkey.get_wallet("personal")
+
+    config = default_config(network=Network.MAINNET)
+    sdk = await connect(ConnectRequest(config=config, seed=wallet.seed, storage_dir="./.data"))
+    # ANCHOR_END: connect-with-passkey
+    return sdk
+
+
+async def list_wallet_names() -> list[str]:
+    # ANCHOR: list-wallet-names
+    prf_provider = ExamplePasskeyPrfProvider()
+    relay_config = NostrRelayConfig(breez_api_key="<breez api key>")
+    passkey = Passkey(prf_provider, relay_config)
+
+    # Query Nostr for wallet names associated with this passkey
+    wallet_names = await passkey.list_wallet_names()
+
+    for wallet_name in wallet_names:
+        print(f"Found wallet: {wallet_name}")
+    # ANCHOR_END: list-wallet-names
+    return wallet_names
+
+
+async def store_wallet_name():
+    # ANCHOR: store-wallet-name
+    prf_provider = ExamplePasskeyPrfProvider()
+    relay_config = NostrRelayConfig(breez_api_key="<breez api key>")
+    passkey = Passkey(prf_provider, relay_config)
+
+    # Publish the wallet name to Nostr for later discovery
+    await passkey.store_wallet_name(wallet_name="personal")
+    # ANCHOR_END: store-wallet-name

--- a/docs/breez-sdk/snippets/python/src/sdk_building.py
+++ b/docs/breez-sdk/snippets/python/src/sdk_building.py
@@ -17,7 +17,7 @@ from breez_sdk_spark import (
 
 async def init_sdk_advanced():
     # ANCHOR: init-sdk-advanced
-    # Construct the seed using mnemonic words or entropy bytes
+    # Construct the seed using a mnemonic, entropy or passkey
     mnemonic = "<mnemonic words>"
     seed = Seed.MNEMONIC(mnemonic=mnemonic, passphrase=None)
     # Create the default config
@@ -88,7 +88,7 @@ async def with_payment_observer(builder: SdkBuilder):
 
 # ANCHOR: init-sdk-postgres
 async def init_sdk_postgres():
-    # Construct the seed using mnemonic words or entropy bytes
+    # Construct the seed using a mnemonic, entropy or passkey
     mnemonic = "<mnemonic words>"
     seed = Seed.MNEMONIC(mnemonic=mnemonic, passphrase=None)
 

--- a/docs/breez-sdk/snippets/react-native/getting_started.ts
+++ b/docs/breez-sdk/snippets/react-native/getting_started.ts
@@ -16,7 +16,7 @@ import RNFS from 'react-native-fs'
 
 const exampleGettingStarted = async () => {
   // ANCHOR: init-sdk
-  // Construct the seed using mnemonic words or entropy bytes
+  // Construct the seed using a mnemonic, entropy or passkey
   const mnemonic = '<mnemonics words>'
   const seed = new Seed.Mnemonic({ mnemonic, passphrase: undefined })
 

--- a/docs/breez-sdk/snippets/react-native/passkey.ts
+++ b/docs/breez-sdk/snippets/react-native/passkey.ts
@@ -1,0 +1,70 @@
+import type { NostrRelayConfig } from '@breeztech/breez-sdk-spark-react-native'
+import {
+  Passkey,
+  connect,
+  defaultConfig,
+  Network
+} from '@breeztech/breez-sdk-spark-react-native'
+
+// ANCHOR: implement-prf-provider
+// In practice, implement PRF provider using platform passkey APIs
+class ExamplePasskeyPrfProvider {
+  derivePrfSeed = async (salt: string): Promise<ArrayBuffer> => {
+    // Call platform passkey API with PRF extension
+    // Returns 32-byte PRF output
+    throw new Error('Implement using WebAuthn or native passkey APIs')
+  }
+
+  isPrfAvailable = async (): Promise<boolean> => {
+    // Check if PRF-capable passkey exists
+    throw new Error('Check platform passkey availability')
+  }
+}
+// ANCHOR_END: implement-prf-provider
+
+const exampleConnectWithPasskey = async () => {
+  // ANCHOR: connect-with-passkey
+  const prfProvider = new ExamplePasskeyPrfProvider()
+  const passkey = new Passkey(prfProvider, undefined)
+
+  // Construct the wallet using the passkey (pass undefined for the default wallet)
+  const wallet = await passkey.getWallet('personal')
+
+  const config = defaultConfig(Network.Mainnet)
+  const sdk = await connect({ config, seed: wallet.seed, storageDir: './.data' })
+  // ANCHOR_END: connect-with-passkey
+  return sdk
+}
+
+const exampleListWalletNames = async (): Promise<string[]> => {
+  // ANCHOR: list-wallet-names
+  const prfProvider = new ExamplePasskeyPrfProvider()
+  const relayConfig: NostrRelayConfig = {
+    breezApiKey: '<breez api key>',
+    timeoutSecs: undefined
+  }
+  const passkey = new Passkey(prfProvider, relayConfig)
+
+  // Query Nostr for wallet names associated with this passkey
+  const walletNames = await passkey.listWalletNames()
+
+  for (const walletName of walletNames) {
+    console.log(`Found wallet: ${walletName}`)
+  }
+  // ANCHOR_END: list-wallet-names
+  return walletNames
+}
+
+const exampleStoreWalletName = async () => {
+  // ANCHOR: store-wallet-name
+  const prfProvider = new ExamplePasskeyPrfProvider()
+  const relayConfig: NostrRelayConfig = {
+    breezApiKey: '<breez api key>',
+    timeoutSecs: undefined
+  }
+  const passkey = new Passkey(prfProvider, relayConfig)
+
+  // Publish the wallet name to Nostr for later discovery
+  await passkey.storeWalletName('personal')
+  // ANCHOR_END: store-wallet-name
+}

--- a/docs/breez-sdk/snippets/react-native/sdk_building.ts
+++ b/docs/breez-sdk/snippets/react-native/sdk_building.ts
@@ -13,7 +13,7 @@ import RNFS from 'react-native-fs'
 
 const exampleGettingStartedAdvanced = async () => {
   // ANCHOR: init-sdk-advanced
-  // Construct the seed using mnemonic words or entropy bytes
+  // Construct the seed using a mnemonic, entropy or passkey
   const mnemonic = '<mnemonics words>'
   const seed = new Seed.Mnemonic({ mnemonic, passphrase: undefined })
 

--- a/docs/breez-sdk/snippets/rust/Cargo.lock
+++ b/docs/breez-sdk/snippets/rust/Cargo.lock
@@ -158,6 +158,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-utility"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34a3b57207a7a1007832416c3e4862378c8451b4e8e093e436f48c2d3d2c151"
+dependencies = [
+ "futures-util",
+ "gloo-timers",
+ "tokio",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-wsocket"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7d8c7d34a225ba919dd9ba44d4b9106d20142da545e086be8ae21d1897e043"
+dependencies = [
+ "async-utility",
+ "futures",
+ "futures-util",
+ "js-sys",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-socks",
+ "tokio-tungstenite",
+ "url",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "atomic-destructor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef49f5882e4b6afaac09ad239a4f8c70a24b8f2b0897edb1f706008efd109cf4"
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +464,8 @@ dependencies = [
  "k256",
  "lnurl-models",
  "macros",
+ "nostr",
+ "nostr-sdk",
  "platform-utils",
  "rusqlite",
  "rusqlite_migration",
@@ -515,6 +554,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +599,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -635,6 +699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1164,6 +1229,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1232,6 +1298,18 @@ dependencies = [
  "libgit2-sys",
  "log",
  "url",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1727,6 +1805,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,6 +2082,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+
+[[package]]
 name = "macros"
 version = "0.1.0"
 dependencies = [
@@ -2061,6 +2157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "negentropy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,6 +2170,71 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nostr"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62a97d745f1bd8d5e05a978632bbb87b0614567d5142906fe7c86fb2440faac6"
+dependencies = [
+ "aes",
+ "base64 0.22.1",
+ "bech32",
+ "bip39",
+ "bitcoin_hashes",
+ "cbc",
+ "chacha20",
+ "chacha20poly1305",
+ "getrandom 0.2.16",
+ "instant",
+ "scrypt",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+ "url",
+]
+
+[[package]]
+name = "nostr-database"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
+dependencies = [
+ "lru",
+ "nostr",
+ "tokio",
+]
+
+[[package]]
+name = "nostr-relay-pool"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2f43b70d13dfc50508a13cd902e11f4625312b2ce0e4b7c4c2283fd04001bd"
+dependencies = [
+ "async-utility",
+ "async-wsocket",
+ "atomic-destructor",
+ "lru",
+ "negentropy",
+ "nostr",
+ "nostr-database",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "nostr-sdk"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599f8963d6a1522a13b1a2b0ea6e168acfc367706606f1d33fa595e91fa22db0"
+dependencies = [
+ "async-utility",
+ "nostr",
+ "nostr-database",
+ "nostr-relay-pool",
+ "tokio",
 ]
 
 [[package]]
@@ -2178,6 +2345,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,6 +2461,17 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tracing",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2778,6 +2977,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,6 +3023,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "sct"
@@ -2997,6 +3217,17 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3528,6 +3759,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3536,6 +3779,22 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3781,6 +4040,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.17",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3839,7 +4117,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/docs/breez-sdk/snippets/rust/Cargo.toml
+++ b/docs/breez-sdk/snippets/rust/Cargo.toml
@@ -8,7 +8,10 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.89"
-breez-sdk-spark = { path = "../../../../crates/breez-sdk/core", features = ["postgres"] }
+breez-sdk-spark = { path = "../../../../crates/breez-sdk/core", features = [
+    "postgres",
+    "passkey",
+] }
 log = "0.4"
 tokio = "1.42.0"
 hex = "0.4.3"

--- a/docs/breez-sdk/snippets/rust/src/getting_started.rs
+++ b/docs/breez-sdk/snippets/rust/src/getting_started.rs
@@ -7,7 +7,7 @@ use log::info;
 
 pub(crate) async fn init_sdk() -> Result<BreezSdk> {
     // ANCHOR: init-sdk
-    // Construct the seed using mnemonic words or entropy bytes
+    // Construct the seed using a mnemonic, entropy or passkey
     let mnemonic = "<mnemonic words>".to_string();
     let seed = Seed::Mnemonic {
         mnemonic,

--- a/docs/breez-sdk/snippets/rust/src/main.rs
+++ b/docs/breez-sdk/snippets/rust/src/main.rs
@@ -17,6 +17,7 @@ mod parsing_inputs;
 mod receive_payment;
 mod refunding_payments;
 mod sdk_building;
+mod passkey;
 mod send_payment;
 mod tokens;
 mod user_settings;

--- a/docs/breez-sdk/snippets/rust/src/passkey.rs
+++ b/docs/breez-sdk/snippets/rust/src/passkey.rs
@@ -1,0 +1,78 @@
+use anyhow::Result;
+use breez_sdk_spark::passkey::{
+    NostrRelayConfig, PasskeyPrfError, PasskeyPrfProvider, Passkey,
+};
+use breez_sdk_spark::{connect, default_config, ConnectRequest, Network};
+use std::sync::Arc;
+
+// ANCHOR: implement-prf-provider
+/// In practice, implement using platform-specific passkey APIs.
+struct ExamplePasskeyPrfProvider;
+
+#[async_trait::async_trait]
+impl PasskeyPrfProvider for ExamplePasskeyPrfProvider {
+    async fn derive_prf_seed(&self, _salt: String) -> Result<Vec<u8>, PasskeyPrfError> {
+        // Call platform passkey API with PRF extension
+        // Returns 32-byte PRF output
+        todo!("Implement using WebAuthn or native passkey APIs")
+    }
+
+    async fn is_prf_available(&self) -> Result<bool, PasskeyPrfError> {
+        // Check if PRF-capable passkey exists
+        todo!("Check platform passkey availability")
+    }
+}
+// ANCHOR_END: implement-prf-provider
+
+async fn connect_with_passkey() -> Result<breez_sdk_spark::BreezSdk> {
+    // ANCHOR: connect-with-passkey
+    let prf_provider = Arc::new(ExamplePasskeyPrfProvider);
+    let passkey = Passkey::new(prf_provider, None);
+
+    // Derive the wallet from the passkey (pass None for the default wallet)
+    let wallet = passkey.get_wallet(Some("personal".to_string())).await?;
+
+    let config = default_config(Network::Mainnet);
+    let sdk = connect(ConnectRequest {
+        config,
+        seed: wallet.seed,
+        storage_dir: "./.data".to_string(),
+    })
+    .await?;
+    // ANCHOR_END: connect-with-passkey
+    Ok(sdk)
+}
+
+async fn list_wallet_names() -> Result<Vec<String>> {
+    // ANCHOR: list-wallet-names
+    let prf_provider = Arc::new(ExamplePasskeyPrfProvider);
+    let relay_config = NostrRelayConfig {
+        breez_api_key: Some("<breez api key>".to_string()),
+        ..NostrRelayConfig::default()
+    };
+    let passkey = Passkey::new(prf_provider, Some(relay_config));
+
+    // Query Nostr for wallet names associated with this passkey
+    let wallet_names = passkey.list_wallet_names().await?;
+
+    for wallet_name in &wallet_names {
+        println!("Found wallet: {}", wallet_name);
+    }
+    // ANCHOR_END: list-wallet-names
+    Ok(wallet_names)
+}
+
+async fn store_wallet_name() -> Result<()> {
+    // ANCHOR: store-wallet-name
+    let prf_provider = Arc::new(ExamplePasskeyPrfProvider);
+    let relay_config = NostrRelayConfig {
+        breez_api_key: Some("<breez api key>".to_string()),
+        ..NostrRelayConfig::default()
+    };
+    let passkey = Passkey::new(prf_provider, Some(relay_config));
+
+    // Publish the wallet name to Nostr for later discovery
+    passkey.store_wallet_name("personal".to_string()).await?;
+    // ANCHOR_END: store-wallet-name
+    Ok(())
+}

--- a/docs/breez-sdk/snippets/rust/src/sdk_building.rs
+++ b/docs/breez-sdk/snippets/rust/src/sdk_building.rs
@@ -7,7 +7,7 @@ use log::info;
 
 pub(crate) async fn init_sdk_advanced() -> Result<BreezSdk> {
     // ANCHOR: init-sdk-advanced
-    // Construct the seed using mnemonic words or entropy bytes
+    // Construct the seed using a mnemonic, entropy or passkey
     let mnemonic = "<mnemonic words>".to_string();
     let seed = Seed::Mnemonic {
         mnemonic,
@@ -84,7 +84,7 @@ pub(crate) fn with_payment_observer(builder: SdkBuilder) -> SdkBuilder {
 
 pub(crate) async fn init_sdk_postgres() -> Result<BreezSdk> {
     // ANCHOR: init-sdk-postgres
-    // Construct the seed using mnemonic words or entropy bytes
+    // Construct the seed using a mnemonic, entropy or passkey
     let mnemonic = "<mnemonic words>".to_string();
     let seed = Seed::Mnemonic {
         mnemonic,

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
@@ -2,7 +2,7 @@ import BreezSdkSpark
 
 func initSdk() async throws -> BreezSdk {
     // ANCHOR: init-sdk
-    // Construct the seed using mnemonic words or entropy bytes
+    // Construct the seed using a mnemonic, entropy or passkey
     let mnemonic = "<mnemonic words>"
     let seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: nil)
 

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
@@ -1,0 +1,64 @@
+import BreezSdkSpark
+import Foundation
+
+// ANCHOR: implement-prf-provider
+// In practice, implement using platform-specific passkey APIs.
+class ExamplePasskeyPrfProvider: PasskeyPrfProvider {
+    func derivePrfSeed(salt: String) async throws -> Data {
+        // Call platform passkey API with PRF extension
+        // Returns 32-byte PRF output
+        fatalError("Implement using WebAuthn or native passkey APIs")
+    }
+
+    func isPrfAvailable() async throws -> Bool {
+        // Check if PRF-capable passkey exists
+        fatalError("Check platform passkey availability")
+    }
+}
+// ANCHOR_END: implement-prf-provider
+
+func connectWithPasskey() async throws -> BreezSdk {
+    // ANCHOR: connect-with-passkey
+    let prfProvider = ExamplePasskeyPrfProvider()
+    let passkey = Passkey(prfProvider: prfProvider, relayConfig: nil)
+
+    // Derive the wallet from the passkey (pass nil for the default wallet)
+    let wallet = try await passkey.getWallet(walletName: "personal")
+
+    let config = defaultConfig(network: .mainnet)
+    let sdk = try await connect(
+        request: ConnectRequest(
+            config: config,
+            seed: wallet.seed,
+            storageDir: "./.data"
+        ))
+    // ANCHOR_END: connect-with-passkey
+    return sdk
+}
+
+func listWalletNames() async throws -> [String] {
+    // ANCHOR: list-wallet-names
+    let prfProvider = ExamplePasskeyPrfProvider()
+    let relayConfig = NostrRelayConfig(breezApiKey: "<breez api key>")
+    let passkey = Passkey(prfProvider: prfProvider, relayConfig: relayConfig)
+
+    // Query Nostr for wallet names associated with this passkey
+    let walletNames = try await passkey.listWalletNames()
+
+    for walletName in walletNames {
+        print("Found wallet: \(walletName)")
+    }
+    // ANCHOR_END: list-wallet-names
+    return walletNames
+}
+
+func storeWalletName() async throws {
+    // ANCHOR: store-wallet-name
+    let prfProvider = ExamplePasskeyPrfProvider()
+    let relayConfig = NostrRelayConfig(breezApiKey: "<breez api key>")
+    let passkey = Passkey(prfProvider: prfProvider, relayConfig: relayConfig)
+
+    // Publish the wallet name to Nostr for later discovery
+    try await passkey.storeWalletName(walletName: "personal")
+    // ANCHOR_END: store-wallet-name
+}

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
@@ -2,7 +2,7 @@ import BreezSdkSpark
 
 func initSdkAdvanced() async throws -> BreezSdk {
     // ANCHOR: init-sdk-advanced
-    // Construct the seed using mnemonic words or entropy bytes
+    // Construct the seed using a mnemonic, entropy or passkey
     let mnemonic = "<mnemonic words>"
     let seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: nil)
 
@@ -74,7 +74,7 @@ func withPaymentObserver(builder: SdkBuilder) async {
 
 func initSdkPostgres() async throws -> BreezSdk {
     // ANCHOR: init-sdk-postgres
-    // Construct the seed using mnemonic words or entropy bytes
+    // Construct the seed using a mnemonic, entropy or passkey
     let mnemonic = "<mnemonic words>"
     let seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: nil)
 

--- a/docs/breez-sdk/snippets/wasm/getting_started.ts
+++ b/docs/breez-sdk/snippets/wasm/getting_started.ts
@@ -21,7 +21,7 @@ const exampleGettingStarted = async () => {
   // import init, { BreezSdk, defaultConfig } from '@breeztech/breez-sdk-spark'
   await init()
 
-  // Construct the seed using mnemonic words or entropy bytes
+  // Construct the seed using a mnemonic, entropy or passkey
   const mnemonic = '<mnemonic words>'
   const seed: Seed = { type: 'mnemonic', mnemonic, passphrase: undefined }
 

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -1,0 +1,63 @@
+import type { NostrRelayConfig } from '@breeztech/breez-sdk-spark'
+import { Passkey, connect, defaultConfig } from '@breeztech/breez-sdk-spark'
+
+// ANCHOR: implement-prf-provider
+// In practice, implement PRF provider using WebAuthn API
+class ExamplePasskeyPrfProvider {
+  derivePrfSeed = async (salt: string): Promise<Uint8Array> => {
+    // Call platform passkey API with PRF extension
+    // Returns 32-byte PRF output
+    throw new Error('Implement using WebAuthn or native passkey APIs')
+  }
+
+  isPrfAvailable = async (): Promise<boolean> => {
+    // Check if PRF-capable passkey exists
+    throw new Error('Check platform passkey availability')
+  }
+}
+// ANCHOR_END: implement-prf-provider
+
+const exampleConnectWithPasskey = async () => {
+  // ANCHOR: connect-with-passkey
+  const prfProvider = new ExamplePasskeyPrfProvider()
+  const passkey = new Passkey(prfProvider, undefined)
+
+  // Construct the wallet using the passkey (pass undefined for the default wallet)
+  const wallet = await passkey.getWallet('personal')
+
+  const config = defaultConfig('mainnet')
+  const sdk = await connect({ config, seed: wallet.seed, storageDir: './.data' })
+  // ANCHOR_END: connect-with-passkey
+  return sdk
+}
+
+const exampleListWalletNames = async (): Promise<string[]> => {
+  // ANCHOR: list-wallet-names
+  const prfProvider = new ExamplePasskeyPrfProvider()
+  const relayConfig: NostrRelayConfig = {
+    breezApiKey: '<breez api key>'
+  }
+  const passkey = new Passkey(prfProvider, relayConfig)
+
+  // Query Nostr for wallet names associated with this passkey
+  const walletNames = await passkey.listWalletNames()
+
+  for (const walletName of walletNames) {
+    console.log(`Found wallet: ${walletName}`)
+  }
+  // ANCHOR_END: list-wallet-names
+  return walletNames
+}
+
+const exampleStoreWalletName = async () => {
+  // ANCHOR: store-wallet-name
+  const prfProvider = new ExamplePasskeyPrfProvider()
+  const relayConfig: NostrRelayConfig = {
+    breezApiKey: '<breez api key>'
+  }
+  const passkey = new Passkey(prfProvider, relayConfig)
+
+  // Publish the wallet name to Nostr for later discovery
+  await passkey.storeWalletName('personal')
+  // ANCHOR_END: store-wallet-name
+}

--- a/docs/breez-sdk/snippets/wasm/sdk_building.ts
+++ b/docs/breez-sdk/snippets/wasm/sdk_building.ts
@@ -28,7 +28,7 @@ const exampleGettingStartedAdvanced = async () => {
   // methods. This is not needed when using the SDK in a Node.js/Deno environment.
   await init()
 
-  // Construct the seed using mnemonic words or entropy bytes
+  // Construct the seed using a mnemonic, entropy or passkey
   const mnemonic = '<mnemonic words>'
   const seed: Seed = { type: 'mnemonic', mnemonic, passphrase: undefined }
 
@@ -51,7 +51,7 @@ const exampleGettingStartedAdvanced = async () => {
 
 const exampleWithPostgresStorage = async () => {
   // ANCHOR: init-sdk-postgres
-  // Construct the seed using mnemonic words or entropy bytes
+  // Construct the seed using a mnemonic, entropy or passkey
   const mnemonic = '<mnemonic words>'
   const seed: Seed = { type: 'mnemonic', mnemonic, passphrase: undefined }
 

--- a/docs/breez-sdk/src/SUMMARY.md
+++ b/docs/breez-sdk/src/SUMMARY.md
@@ -17,6 +17,7 @@
     - [C#](guide/install_csharp.md)
   - [Testing and development](guide/testing.md)
   - [Initializing the SDK](guide/initializing.md)
+    - [Connecting with a Passkey](guide/passkey.md)
     - [Customizing the SDK](guide/customizing.md)
   - [Getting the SDK info](guide/get_info.md)
   - [Listening to events](guide/events.md)

--- a/docs/breez-sdk/src/guide/getting_started.md
+++ b/docs/breez-sdk/src/guide/getting_started.md
@@ -5,6 +5,7 @@ Integrating Breez SDK into your application takes just a few minutes. Follow the
 - **[Installing the SDK](/guide/install.md)**
 - **[Testing and development](/guide/testing.md)**
 - **[Initializing the SDK](/guide/initializing.md)**
+  - **[Connecting with a Passkey](/guide/passkey.md)**
   - **[Customizing the SDK](/guide/customizing.md)**
 - **[Getting the SDK info](/guide/get_info.md)**
 - **[Listening to events](/guide/events.md)**

--- a/docs/breez-sdk/src/guide/initializing.md
+++ b/docs/breez-sdk/src/guide/initializing.md
@@ -28,6 +28,12 @@ On some platforms (e.g., Android, iOS), you must use an application-specific wri
 
 </div>
 
+### Connecting with a Passkey
+
+Instead of managing mnemonics directly, you can use passkeys to derive wallet seeds deterministically. This eliminates the need for mnemonic backup and provides a seamless authentication experience using biometrics or device PIN.
+
+See [Connecting with a Passkey](passkey.md) for the full setup guide including PRF provider implementation, platform configuration, and wallet name management.
+
 ## Advanced Initialization
 
 For advanced use cases where you need more control, you can configure the SDK using the Builder pattern. With the SDK Builder you can define:

--- a/docs/breez-sdk/src/guide/install_react_native.md
+++ b/docs/breez-sdk/src/guide/install_react_native.md
@@ -30,4 +30,20 @@ Add the plugin to your `app.json` or `app.config.js`:
 }
 ```
 
+### Plugin Options
+
+To enable [Passkey](passkey.md#ios-apple-app-site-association) support, set `enablePasskey` to `true`. Your app must have the <a target="_blank" href="https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.associated-domains">Associated Domains</a> capability enabled. This adds `webcredentials:keys.breez.technology` to the iOS Associated Domains entitlement:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      ["@breeztech/breez-sdk-spark-react-native", {
+        "enablePasskey": true
+      }]
+    ]
+  }
+}
+```
+
 **Note:** This package contains native code and requires a custom development build. It will not work with Expo Go.

--- a/docs/breez-sdk/src/guide/passkey.md
+++ b/docs/breez-sdk/src/guide/passkey.md
@@ -1,0 +1,203 @@
+# Connecting with a Passkey
+
+Using passkeys eliminates the need to backup mnemonic phrases. Seeds are instead derived deterministically from a passkey, using a default or user-chosen wallet name. Wallet names can be discovered and stored on Nostr relays using a passkey derived Nostr key.
+
+## Overview
+
+The passkey flow uses the <a target="_blank" href="https://w3c.github.io/webauthn/#prf-extension">WebAuthn PRF extension</a> (Pseudo-Random Function), which allows a passkey to deterministically derive secret bytes from a given salt. Two key derivations are used:
+
+1. **Nostr Identity**: `PRF(passkey, magic_salt)` derives a Nostr keypair used to publish and discover wallet names
+2. **Wallet Seed**: `PRF(passkey, wallet_name)` derives a 24-word BIP39 mnemonic
+
+Wallet names are published as Nostr kind-1 events, allowing users to discover their wallets on any device with access to their passkey.
+
+```
+┌─────────────┐     ┌──────────────────┐     ┌───────────────────┐     ┌───────────────┐
+│ Application │────▶│ PRF Provider     │────▶│ SDK               │────▶│ Nostr Relays  │
+│             │     │ (platform-       │     │ Passkey           │     │ (wallet name  │
+│             │     │  specific)       │     │                   │     │  discovery)   │
+└─────────────┘     └──────────────────┘     └───────────────────┘     └───────────────┘
+```
+
+<div class="warning">
+<h4>Developer note</h4>
+The passkey PRF functionality must be implemented by your application using platform-specific APIs (WebAuthn in browsers, native passkey APIs on mobile). The SDK orchestrates the flow but requires you to provide a PRF provider implementation.
+</div>
+
+## Application configuration
+
+### Relying Party ID
+
+The domain `keys.breez.technology` serves as a common Relying Party (RP) that enables cross-app passkey sharing. Applications that use this RP ID allow users to access the same passkey credentials across different platforms and apps.
+
+To enable this cross-domain passkey sharing, `keys.breez.technology` serves three configuration files that declare which origins and apps are authorized to use it as an RP ID.
+
+#### Web: Related Origins
+
+**File**: `https://keys.breez.technology/.well-known/webauthn`
+
+Declares which web origins can use the centralized RP ID for WebAuthn operations:
+
+```json
+{
+  "related_origins": [
+    "https://keys.breez.technology",
+    "https://your-app.example.com"
+  ]
+}
+```
+
+To register your web origin, [contact us](mailto:contact@breez.technology?subject=Passkey%20configuration) to have it added to this file.
+
+#### Android: Asset Links
+
+**File**: `https://keys.breez.technology/.well-known/assetlinks.json`
+
+Establishes digital asset links between the domain and Android applications:
+
+```json
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.example.yourapp",
+      "sha256_cert_fingerprints": [
+        "B6:16:AD:FE:C5:C6:D3:4C:93:01:5B:4A:79:20:21:4E:62:43:AB:29:28:EE:34:9A:F2:46:55:4B:54:FC:42:DF"
+      ]
+    }
+  }
+]
+```
+
+Replace `com.example.yourapp` with your application package name and the fingerprint with your app's signing certificate SHA256 fingerprint. See the <a target="_blank" href="https://developers.google.com/digital-asset-links/v1/getting-started">Digital Asset Links</a> documentation and <a target="_blank" href="https://developer.android.com/identity/credential-manager/prerequisites">Credential Manager prerequisites</a> for details.
+
+To register your Android app, [contact us](mailto:contact@breez.technology?subject=Passkey%20configuration) with the details outlined to have it added to this file.
+
+#### iOS: Apple App Site Association
+
+**File**: `https://keys.breez.technology/.well-known/apple-app-site-association`
+
+Connects the domain to iOS applications for passkey sharing:
+
+```json
+{
+  "webcredentials": {
+    "apps": [
+      "TEAMID.com.example.yourapp"
+    ]
+  }
+}
+```
+
+Replace `TEAMID` with your Apple Developer Team ID and `com.example.yourapp` with your application bundle identifier.
+
+Your app must have the <a target="_blank" href="https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.associated-domains">Associated Domains</a> capability enabled. In Xcode, go to **Signing & Capabilities** → add **Associated Domains** → add the entry `webcredentials:keys.breez.technology`.
+
+<div class="warning">
+<h4>Expo Managed Workflow</h4>
+If you're using Expo, the Breez SDK plugin can configure this automatically. See the <a href="install_react_native.html#plugin-options">React Native/Expo installation guide</a> for details on the <code>enablePasskey</code> option.
+</div>
+
+To register your iOS app, [contact us](mailto:contact@breez.technology?subject=Passkey%20configuration) with the details outlined to have it added to this file.
+
+### Nostr relay configuration
+
+The SDK uses Nostr relays to store and discover wallet names. A Breez API key is required for authenticated access to the Breez-managed relay via <a target="_blank" href="https://github.com/nostr-protocol/nips/blob/master/42.md">NIP-42</a>. The SDK also implements <a target="_blank" href="https://github.com/nostr-protocol/nips/blob/master/65.md">NIP-65</a> to discover and publish to additional public relays for redundancy.
+
+## Implementing the PRF provider
+
+Your application must implement the PRF provider to interface with platform passkey APIs.
+
+{{#tabs passkey:implement-prf-provider}}
+
+### Platform considerations
+
+- **Web (browsers)**: Use the WebAuthn API with the `prf` extension. Browsers handle the salt transformation internally. Use discoverable credentials (`residentKey: 'required'`) with empty `allowCredentials` for assertion so the browser discovers the credential by RP ID.
+
+- **Android / iOS**: Use native passkey APIs with PRF support. Ensure the Associated Domains / Asset Links configuration is in place for `keys.breez.technology`.
+
+- **CLI / Desktop (CTAP2)**: Use the `hmac-secret` extension directly. Non-browser implementations must apply the WebAuthn salt transformation manually to produce the same PRF output as browsers:
+
+  ```
+  actualSalt = SHA-256("WebAuthn PRF" || 0x00 || developerSalt)
+  ```
+
+  This transformation is defined in the <a target="_blank" href="https://w3c.github.io/webauthn/#prf-extension">W3C WebAuthn PRF extension spec</a> and ensures that the same passkey + salt produces identical seeds across browser and native implementations.
+
+<h2 id="connecting-with-passkey">
+    <a class="header" href="#connecting-with-passkey">Connecting with a passkey</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/passkey/struct.Passkey.html#method.get_wallet">API docs</a>
+</h2>
+
+To connect with a passkey, call {{#name Passkey.get_wallet}} to derive a wallet, then pass its seed to {{#name connect}}. The wallet name defaults to `"Default"` when omitted.
+
+{{#tabs passkey:connect-with-passkey}}
+
+<h2 id="listing-wallet-names">
+    <a class="header" href="#listing-wallet-names">Listing wallet names</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/passkey/struct.Passkey.html#method.list_wallet_names">API docs</a>
+</h2>
+
+Discover wallet names associated to the passkey using Nostr.
+
+{{#tabs passkey:list-wallet-names}}
+
+<h2 id="storing-a-wallet-name">
+    <a class="header" href="#storing-a-wallet-name">Storing a wallet name</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/passkey/struct.Passkey.html#method.store_wallet_name">API docs</a>
+</h2>
+
+Publish a wallet name to Nostr so it can be discovered later.
+
+{{#tabs passkey:store-wallet-name}}
+
+## Best practices
+
+### Cache the user-selected wallet name
+
+Store the wallet name locally (e.g., `localStorage` on web, `SharedPreferences` on Android, `UserDefaults` on iOS) if selected by the user. This allows the app to skip the wallet name selection step on subsequent launches and go straight to passkey authentication.
+
+### Never store the derived mnemonic
+
+The mnemonic should always be re-derived from the passkey and wallet name on each session. The passkey authentication (biometric, PIN, etc.) is the security boundary — storing the mnemonic would bypass it. On app restart, check for a cached wallet name and prompt the user for passkey authentication to derive the seed.
+
+### Allow manual mnemonic backup
+
+Provide a way for users to reveal their derived 24-word mnemonic as an emergency backup. This should be user-initiated (e.g., behind a "Show recovery phrase" button) and derived on-demand via {{#name Passkey.get_wallet}} with the cached wallet name. This gives users a safety net if they lose access to their passkey.
+
+### Offer a mnemonic fallback
+
+Not all devices support the PRF extension. Check {{#name Passkey.is_available}} at startup and present the appropriate flow — seedless for capable devices, traditional mnemonic backup/restore for others.
+
+### Handle wallet name discovery failures
+
+When discovering wallet names, {{#name Passkey.list_wallet_names}} may return an empty list if relays are unreachable or the wallet name events have been pruned. Always allow manual wallet name entry as a fallback alongside the Nostr-discovered list.
+
+## Security considerations
+
+- **Passkey security**: The wallet's security depends on the passkey. Different passkeys produce different wallets.
+- **Wallet name visibility**: Wallet names are published publicly on Nostr. Security comes from the passkey secret, not the wallet name.
+- **PRF availability**: Check {{#name Passkey.is_available}} to gracefully handle devices without PRF support.
+- **Discoverable credentials**: Use resident keys so no credential IDs need to be stored by your application. The authenticator discovers the credential by RP ID.
+- **User verification**: All passkey operations should require user verification (`userVerification: 'required'`) to ensure biometric or PIN confirmation.
+
+## Passkey migration
+
+Passkey portability across platforms depends on Credential Provider (CXP) protocol support:
+
+- **iOS**: Supports CXP for exporting passkeys
+- **Android**: CXP support expected in future versions
+- **Third-party password managers**: Varying support for both CXP and PRF extensions. Neither iOS Password Manager nor Android's Google Password Manager currently support RP ID domain modification.
+
+For users who need to move between ecosystems, the manual mnemonic backup serves as a universal fallback.
+
+## Supported specs
+
+- [Seedless Restore](https://github.com/breez/seedless-restore) Passkey-based wallet derivation and discovery
+- [Nostr](https://github.com/nostr-protocol/nostr) Relay-based event protocol for wallet name storage
+- [NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md) Authentication of clients to relays
+- [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) Relay List Metadata

--- a/packages/flutter/lib/breez_sdk_spark.dart
+++ b/packages/flutter/lib/breez_sdk_spark.dart
@@ -8,4 +8,5 @@ export 'src/rust/logger.dart';
 export 'src/rust/models.dart';
 export 'src/rust/sdk_builder.dart';
 export 'src/rust/sdk.dart';
+export 'src/rust/passkey.dart';
 export 'src/config_extensions.dart';

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -201,10 +201,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-utility"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34a3b57207a7a1007832416c3e4862378c8451b4e8e093e436f48c2d3d2c151"
+dependencies = [
+ "futures-util",
+ "gloo-timers",
+ "tokio",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-wsocket"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7d8c7d34a225ba919dd9ba44d4b9106d20142da545e086be8ae21d1897e043"
+dependencies = [
+ "async-utility",
+ "futures",
+ "futures-util",
+ "js-sys",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-socks",
+ "tokio-tungstenite",
+ "url",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
+name = "atomic-destructor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef49f5882e4b6afaac09ad239a4f8c70a24b8f2b0897edb1f706008efd109cf4"
 
 [[package]]
 name = "atomic-polyfill"
@@ -489,6 +526,8 @@ dependencies = [
  "k256",
  "lnurl-models",
  "macros",
+ "nostr",
+ "nostr-sdk",
  "openssl",
  "platform-utils",
  "rusqlite",
@@ -514,6 +553,8 @@ dependencies = [
  "breez-sdk-spark",
  "extend",
  "flutter_rust_bridge",
+ "futures",
+ "tokio",
 ]
 
 [[package]]
@@ -583,6 +624,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +669,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -701,7 +767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -713,6 +779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -933,7 +1000,7 @@ dependencies = [
  "libsecp256k1",
  "lock_api",
  "once_cell",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
  "typenum",
  "wasm-bindgen",
@@ -958,7 +1025,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1066,7 +1133,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1092,7 +1159,7 @@ dependencies = [
  "jwt",
  "macros",
  "platform-utils",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_qs",
@@ -1192,7 +1259,7 @@ dependencies = [
  "hex",
  "itertools",
  "postcard",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "serdect",
  "thiserror 2.0.17",
@@ -1211,7 +1278,7 @@ dependencies = [
  "document-features",
  "frost-core-unofficial",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1224,7 +1291,7 @@ dependencies = [
  "frost-core-unofficial",
  "frost-rerandomized-unofficial",
  "k256",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
 ]
 
@@ -1383,6 +1450,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "graphql-introspection-query"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,7 +1526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1875,6 +1954,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,7 +2087,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -2130,6 +2221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+
+[[package]]
 name = "macros"
 version = "0.1.0"
 dependencies = [
@@ -2208,6 +2305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "negentropy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,6 +2318,70 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nostr"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62a97d745f1bd8d5e05a978632bbb87b0614567d5142906fe7c86fb2440faac6"
+dependencies = [
+ "base64 0.22.1",
+ "bech32",
+ "bip39",
+ "bitcoin_hashes",
+ "cbc",
+ "chacha20",
+ "chacha20poly1305",
+ "getrandom 0.2.16",
+ "instant",
+ "scrypt",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+ "url",
+]
+
+[[package]]
+name = "nostr-database"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
+dependencies = [
+ "lru",
+ "nostr",
+ "tokio",
+]
+
+[[package]]
+name = "nostr-relay-pool"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2f43b70d13dfc50508a13cd902e11f4625312b2ce0e4b7c4c2283fd04001bd"
+dependencies = [
+ "async-utility",
+ "async-wsocket",
+ "atomic-destructor",
+ "lru",
+ "negentropy",
+ "nostr",
+ "nostr-database",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "nostr-sdk"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599f8963d6a1522a13b1a2b0ea6e168acfc367706606f1d33fa595e91fa22db0"
+dependencies = [
+ "async-utility",
+ "nostr",
+ "nostr-database",
+ "nostr-relay-pool",
+ "tokio",
 ]
 
 [[package]]
@@ -2383,6 +2550,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,6 +2647,17 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tracing",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2618,8 +2817,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2629,7 +2838,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2639,6 +2858,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2910,6 +3138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,6 +3186,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,7 +3228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
- "rand",
+ "rand 0.8.5",
  "secp256k1-sys",
  "serde",
 ]
@@ -3132,6 +3381,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,7 +3424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3225,7 +3485,7 @@ dependencies = [
  "platform-utils",
  "prost",
  "prost-types",
- "rand",
+ "rand 0.8.5",
  "rustls 0.23.36",
  "serde",
  "serde_json",
@@ -3577,6 +3837,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3585,6 +3857,22 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3708,7 +3996,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -3830,6 +4118,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.17",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3876,7 +4183,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/packages/flutter/rust/Cargo.toml
+++ b/packages/flutter/rust/Cargo.toml
@@ -11,9 +11,16 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 async-trait = "0.1.88"
 # Replaced with release commit during publishing
-breez-sdk-spark = { path = "../../../crates/breez-sdk/core", features = ["openssl-vendored"] }
+breez-sdk-spark = { path = "../../../crates/breez-sdk/core", features = [
+    "openssl-vendored",
+    "passkey",
+] }
 extend = "1.2.0"
 flutter_rust_bridge = "=2.11.1"
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }
@@ -21,12 +28,16 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }
 # Support for 16KB page sizes on Android 15+ 64-bit architectures
 [target.aarch64-linux-android]
 rustflags = [
-    "-C", "link-arg=-Wl,--hash-style=both",
-    "-C", "link-arg=-Wl,-z,max-page-size=16384",
+    "-C",
+    "link-arg=-Wl,--hash-style=both",
+    "-C",
+    "link-arg=-Wl,-z,max-page-size=16384",
 ]
 
 [target.x86_64-linux-android]
 rustflags = [
-    "-C", "link-arg=-Wl,--hash-style=both",
-    "-C", "link-arg=-Wl,-z,max-page-size=16384",
+    "-C",
+    "link-arg=-Wl,--hash-style=both",
+    "-C",
+    "link-arg=-Wl,-z,max-page-size=16384",
 ]

--- a/packages/flutter/rust/src/errors.rs
+++ b/packages/flutter/rust/src/errors.rs
@@ -1,3 +1,4 @@
+pub use breez_sdk_spark::passkey::{PasskeyPrfError, PasskeyError};
 pub use breez_sdk_spark::{DepositClaimError, Fee, SdkError, StorageError};
 use flutter_rust_bridge::frb;
 
@@ -50,4 +51,27 @@ pub enum _StorageError {
     Implementation(String),
     InitializationError(String),
     Serialization(String),
+}
+
+#[frb(mirror(PasskeyPrfError))]
+pub enum _PasskeyPrfError {
+    PrfNotSupported,
+    UserCancelled,
+    CredentialNotFound,
+    AuthenticationFailed(String),
+    PrfEvaluationFailed(String),
+    Generic(String),
+}
+
+#[frb(mirror(PasskeyError))]
+pub enum _PasskeyError {
+    PrfError(PasskeyPrfError),
+    RelayConnectionFailed(String),
+    NostrWriteFailed(String),
+    NostrReadFailed(String),
+    KeyDerivationError(String),
+    InvalidPrfOutput(String),
+    MnemonicError(String),
+    InvalidSalt(String),
+    Generic(String),
 }

--- a/packages/flutter/rust/src/lib.rs
+++ b/packages/flutter/rust/src/lib.rs
@@ -6,5 +6,7 @@ pub mod logger;
 pub mod models;
 pub mod sdk;
 pub mod sdk_builder;
+pub mod passkey;
 
 pub use sdk::BreezSdk;
+pub use passkey::Passkey;

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
+
+pub use breez_sdk_spark::passkey::*;
 pub use breez_sdk_spark::sync_storage::*;
 pub use breez_sdk_spark::*;
 use flutter_rust_bridge::frb;
-use std::collections::HashMap;
 
 #[frb(mirror(BitcoinAddressDetails))]
 pub struct _BitcoinAddressDetails {
@@ -1181,4 +1183,16 @@ pub struct _UpdateContactRequest {
 pub struct _ListContactsRequest {
     pub offset: Option<u32>,
     pub limit: Option<u32>,
+}
+
+#[frb(mirror(NostrRelayConfig))]
+pub struct _NostrRelayConfig {
+    pub breez_api_key: Option<String>,
+    pub timeout_secs: Option<u32>,
+}
+
+#[frb(mirror(Wallet))]
+pub struct _Wallet {
+    pub seed: Seed,
+    pub name: String,
 }

--- a/packages/flutter/rust/src/passkey.rs
+++ b/packages/flutter/rust/src/passkey.rs
@@ -1,0 +1,179 @@
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+
+use breez_sdk_spark::passkey::{
+    NostrRelayConfig, PasskeyPrfError, PasskeyPrfProvider, PasskeyError,
+};
+use flutter_rust_bridge::{DartFnFuture, frb};
+use futures::FutureExt;
+
+/// Extract a human-readable message from a panic payload.
+fn panic_message(e: Box<dyn std::any::Any + Send>) -> String {
+    e.downcast_ref::<String>()
+        .cloned()
+        .or_else(|| e.downcast_ref::<&str>().map(|s| (*s).to_string()))
+        .unwrap_or_else(|| "Dart callback panicked".to_string())
+}
+
+/// Callback-based implementation of `PasskeyPrfProvider` for Flutter.
+///
+/// This struct wraps Dart callbacks to implement the PRF provider trait,
+/// allowing Flutter to provide the passkey PRF implementation.
+struct CallbackPrfProvider {
+    derive_prf_seed_fn: Arc<dyn Fn(String) -> DartFnFuture<Vec<u8>> + Send + Sync>,
+    is_prf_available_fn: Arc<dyn Fn() -> DartFnFuture<bool> + Send + Sync>,
+}
+
+#[async_trait::async_trait]
+impl PasskeyPrfProvider for CallbackPrfProvider {
+    async fn derive_prf_seed(&self, salt: String) -> Result<Vec<u8>, PasskeyPrfError> {
+        AssertUnwindSafe((self.derive_prf_seed_fn)(salt))
+            .catch_unwind()
+            .await
+            .map_err(|e| PasskeyPrfError::Generic(panic_message(e)))
+    }
+
+    async fn is_prf_available(&self) -> Result<bool, PasskeyPrfError> {
+        AssertUnwindSafe((self.is_prf_available_fn)())
+            .catch_unwind()
+            .await
+            .map_err(|e| PasskeyPrfError::Generic(panic_message(e)))
+    }
+}
+
+/// Flutter wrapper for passkey-based wallet operations.
+///
+/// Orchestrates wallet derivation and name management using
+/// passkey PRF callbacks and Nostr relays.
+#[derive(Clone)]
+#[frb(opaque)]
+pub struct Passkey {
+    pub(crate) inner: breez_sdk_spark::passkey::Passkey,
+}
+
+impl Passkey {
+    /// Create a new Passkey instance using Dart callbacks.
+    ///
+    /// # Arguments
+    /// * `derive_prf_seed` - Dart callback to derive a 32-byte seed from passkey PRF with a salt
+    /// * `is_prf_available` - Dart callback to check if PRF-capable passkey is available
+    /// * `relay_config` - Optional configuration for Nostr relay connections (uses default if None)
+    #[frb(sync)]
+    pub fn new(
+        derive_prf_seed: impl Fn(String) -> DartFnFuture<Vec<u8>> + Send + Sync + 'static,
+        is_prf_available: impl Fn() -> DartFnFuture<bool> + Send + Sync + 'static,
+        relay_config: Option<NostrRelayConfig>,
+    ) -> Self {
+        let provider = Arc::new(CallbackPrfProvider {
+            derive_prf_seed_fn: Arc::new(derive_prf_seed),
+            is_prf_available_fn: Arc::new(is_prf_available),
+        });
+
+        Self {
+            inner: breez_sdk_spark::passkey::Passkey::new(provider, relay_config),
+        }
+    }
+
+    /// Derive a wallet for a given wallet name.
+    ///
+    /// Uses the passkey PRF to derive a wallet from the wallet name.
+    /// This works for both creating a new wallet and restoring an existing one.
+    ///
+    /// # Arguments
+    /// * `wallet_name` - Optional wallet name string (defaults to "Default")
+    pub async fn get_wallet(
+        &self,
+        wallet_name: Option<String>,
+    ) -> Result<breez_sdk_spark::passkey::Wallet, PasskeyError> {
+        self.inner.get_wallet(wallet_name).await
+    }
+
+    /// List all wallet names published to Nostr for this passkey's identity.
+    ///
+    /// Requires 1 PRF call (for Nostr identity derivation).
+    pub async fn list_wallet_names(&self) -> Result<Vec<String>, PasskeyError> {
+        self.inner.list_wallet_names().await
+    }
+
+    /// Publish a wallet name to Nostr relays for this passkey's identity.
+    ///
+    /// Idempotent: if the wallet name already exists, it is not published again.
+    /// Requires 1 PRF call.
+    pub async fn store_wallet_name(&self, wallet_name: String) -> Result<(), PasskeyError> {
+        self.inner.store_wallet_name(wallet_name).await
+    }
+
+    /// Check if passkey PRF is available on this device.
+    pub async fn is_available(&self) -> Result<bool, PasskeyError> {
+        self.inner.is_available().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper to create a `DartFnFuture<T>` from a value.
+    fn ready<T: Send + 'static>(val: T) -> DartFnFuture<T> {
+        Box::pin(std::future::ready(val))
+    }
+
+    /// Helper to create a `DartFnFuture<T>` that panics with the given message.
+    fn panicking<T: Send + 'static>(msg: &'static str) -> DartFnFuture<T> {
+        Box::pin(async move { panic!("{msg}") })
+    }
+
+    #[tokio::test]
+    async fn test_derive_prf_seed_success() {
+        let expected = vec![42u8; 32];
+        let expected_clone = expected.clone();
+        let provider = CallbackPrfProvider {
+            derive_prf_seed_fn: Arc::new(move |_salt| ready(expected_clone.clone())),
+            is_prf_available_fn: Arc::new(|| ready(true)),
+        };
+
+        let result = provider.derive_prf_seed("test".to_string()).await;
+        assert_eq!(result.unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn test_derive_prf_seed_panic_caught() {
+        let provider = CallbackPrfProvider {
+            derive_prf_seed_fn: Arc::new(|_salt| panicking("Dart threw an exception")),
+            is_prf_available_fn: Arc::new(|| ready(true)),
+        };
+
+        let result = provider.derive_prf_seed("test".to_string()).await;
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, PasskeyPrfError::Generic(ref msg) if msg.contains("Dart threw an exception")),
+            "Expected Generic error with panic message, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_prf_available_success() {
+        let provider = CallbackPrfProvider {
+            derive_prf_seed_fn: Arc::new(|_salt| ready(vec![])),
+            is_prf_available_fn: Arc::new(|| ready(false)),
+        };
+
+        let result = provider.is_prf_available().await;
+        assert_eq!(result.unwrap(), false);
+    }
+
+    #[tokio::test]
+    async fn test_is_prf_available_panic_caught() {
+        let provider = CallbackPrfProvider {
+            derive_prf_seed_fn: Arc::new(|_salt| ready(vec![])),
+            is_prf_available_fn: Arc::new(|| panicking("device check failed")),
+        };
+
+        let result = provider.is_prf_available().await;
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, PasskeyPrfError::Generic(ref msg) if msg.contains("device check failed")),
+            "Expected Generic error with panic message, got: {err:?}"
+        );
+    }
+}

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -38,6 +38,22 @@ Then add the plugin to your `app.json` or `app.config.js`:
 }
 ```
 
+#### Plugin Options
+
+To enable [Passkey](https://sdk-doc-spark.breez.technology/guide/passkey.html) support, set `enablePasskey` to `true`. This adds `webcredentials:keys.breez.technology` to the iOS Associated Domains entitlement:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      ["@breeztech/breez-sdk-spark-react-native", {
+        "enablePasskey": true
+      }]
+    ]
+  }
+}
+```
+
 After adding the plugin, rebuild your app:
 
 ```sh

--- a/packages/react-native/plugin/src/index.ts
+++ b/packages/react-native/plugin/src/index.ts
@@ -14,13 +14,19 @@ export type BreezSdkPluginOptions = {
    * Set to true if you want to handle binary downloads manually
    */
   skipBinaryDownload?: boolean;
+  /**
+   * Add webcredentials:keys.breez.technology to the iOS Associated Domains
+   * entitlement, required for passkey-based seed derivation (default: false)
+   */
+  enablePasskey?: boolean;
 };
 
 const withBreezSdk: ConfigPlugin<BreezSdkPluginOptions | void> = (
   config,
   options
 ) => {
-  const { skipBinaryDownload = false } = options || {};
+  const { skipBinaryDownload = false, enablePasskey = false } =
+    options || {};
 
   return withPlugins(config, [
     // Download binary artifacts first
@@ -28,7 +34,7 @@ const withBreezSdk: ConfigPlugin<BreezSdkPluginOptions | void> = (
     // Configure Android
     withBreezSdkAndroid,
     // Configure iOS
-    withBreezSdkIOS,
+    [withBreezSdkIOS, { enablePasskey }] as const,
   ]);
 };
 

--- a/packages/react-native/plugin/src/withIOS.ts
+++ b/packages/react-native/plugin/src/withIOS.ts
@@ -1,11 +1,31 @@
-import { type ConfigPlugin } from '@expo/config-plugins';
+import { type ConfigPlugin, withEntitlementsPlist } from '@expo/config-plugins';
+
+type WithIOSOptions = {
+  enablePasskey: boolean;
+};
 
 /**
  * Configure iOS build settings for Breez SDK
  * The podspec already defines the minimum iOS version via min_ios_version_supported
  */
-export const withBreezSdkIOS: ConfigPlugin = (config) => {
-  // Currently no additional iOS configuration needed
-  // The podspec handles minimum version and framework linking
-  return config;
+export const withBreezSdkIOS: ConfigPlugin<WithIOSOptions> = (
+  config,
+  { enablePasskey }
+) => {
+  if (!enablePasskey) {
+    return config;
+  }
+
+  return withEntitlementsPlist(config, (config) => {
+    const domain = 'webcredentials:keys.breez.technology';
+    const domains: string[] =
+      (config.modResults['com.apple.developer.associated-domains'] as string[] | undefined) ?? [];
+
+    if (!domains.includes(domain)) {
+      domains.push(domain);
+    }
+
+    config.modResults['com.apple.developer.associated-domains'] = domains;
+    return config;
+  });
 };


### PR DESCRIPTION
Adds a gated `Passkey` utility with `PasskeyPrfProvider` trait interface to implement a platform interface with a WebAuthn passkey PRF extension. 

[Seedless Restore Spec](https://github.com/breez/seedless-restore)
[Glow Web implementation](https://github.com/breez/glow-web/pull/89)

TODO:
- [x] Add Breez NOSTR relay
- [x] NIP-42 Breez Authentication
- [x] NIP-65 Reply list sync (static list)
- [x] Add CLI PRF support
  - File-based PRF for testing
  - FIDO2/WebAuthn PRF for cross-CLI/browser testing
  - YubiKey Slot 2 / HMAC challenge-response
- [x] Docs

I think if we are to provide prewritten native plugin for android/iOS we should do so in a follow up PR

Closes #471 