### PR TITLE
Convert all Bitcoin transactions to v3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,21 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Dependencies
+
+The following system dependencies are required:
+
+```bash
+# Debian/Ubuntu
+apt-get install -y protobuf-compiler
+
+# macOS
+brew install protobuf
+
+# Arch Linux
+pacman -S protobuf
+```
+
 ## Build Commands
 
 ```bash

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -440,7 +440,7 @@ mod tests {
                 value,
                 parent_node_id: None,
                 node_tx: Transaction {
-                    version: Version::TWO,
+                    version: Version::non_standard(3),
                     lock_time: LockTime::ZERO,
                     input: vec![],
                     output: vec![],

--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -282,7 +282,7 @@ mod tests {
             value,
             parent_node_id: None,
             node_tx: Transaction {
-                version: Version::TWO,
+                version: Version::non_standard(3),
                 lock_time: LockTime::ZERO,
                 input: vec![],
                 output: vec![],

--- a/crates/spark/src/utils/transactions.rs
+++ b/crates/spark/src/utils/transactions.rs
@@ -417,7 +417,7 @@ pub(crate) fn create_static_deposit_refund_tx(
     refund_address: &Address,
 ) -> Transaction {
     Transaction {
-        version: Version::TWO,
+        version: Version::non_standard(3),
         lock_time: LockTime::ZERO,
         input: vec![TxIn {
             previous_output: deposit_outpoint,


### PR DESCRIPTION
Changed all Bitcoin transaction construction to use v3 instead of v2:

- Updated create_static_deposit_refund_tx to use Version::non_standard(3)
  in production code (crates/spark/src/utils/transactions.rs)
- Updated test helper create_test_leaves to use v3 transactions
  (crates/spark/src/tree/service.rs)
- Updated test helper create_test_tree_node to use v3 transactions
  (crates/spark/src/tree/store.rs)
- Added protobuf-compiler to dependencies in CLAUDE.md

All Spark protocol transactions now consistently use v3, which supports
ephemeral anchor outputs for CPFP fee bumping.