### PR TITLE
fix: handle broadcast receiver lag to prevent event processing termination.

### DIFF
--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1855,23 +1855,39 @@ impl BackgroundProcessor {
     }
 
     async fn process_events(&self, mut event_stream: broadcast::Receiver<SparkEvent>) {
-        while let Ok(event) = event_stream.recv().await {
-            debug!("Received event: {event}");
-            trace!("Received event: {event:?}");
-            let result = match event.clone() {
-                SparkEvent::Transfer(transfer) => self.process_transfer_event(*transfer).await,
-                SparkEvent::Deposit(deposit) => self.process_deposit_event(*deposit).await,
-                SparkEvent::Connected => self.process_connected_event().await,
-                SparkEvent::Disconnected => self.process_disconnected_event().await,
-            };
-            debug!("Processed event: {event}");
+        use broadcast::error::RecvError;
 
-            if let Err(e) = result {
-                error!("Error processing event: {e:?}");
+        loop {
+            match event_stream.recv().await {
+                Ok(event) => {
+                    debug!("Received event: {event}");
+                    trace!("Received event: {event:?}");
+                    let result = match event.clone() {
+                        SparkEvent::Transfer(transfer) => {
+                            self.process_transfer_event(*transfer).await
+                        }
+                        SparkEvent::Deposit(deposit) => self.process_deposit_event(*deposit).await,
+                        SparkEvent::Connected => self.process_connected_event().await,
+                        SparkEvent::Disconnected => self.process_disconnected_event().await,
+                    };
+                    debug!("Processed event: {event}");
+
+                    if let Err(e) = result {
+                        error!("Error processing event: {e:?}");
+                    }
+                }
+
+                Err(RecvError::Lagged(skipped)) => {
+                    warn!("Event stream lagged, skipped {} messages", skipped);
+                    // Continue processing - THIS IS THE CRITICAL FIX
+                    continue;
+                }
+                Err(RecvError::Closed) => {
+                    info!("Event stream closed, stopping event processing");
+                    break;
+                }
             }
         }
-
-        info!("Event stream closed, stopping event processing");
     }
 
     async fn process_deposit_event(&self, deposit: TreeNode) -> Result<(), SparkWalletError> {


### PR DESCRIPTION
Previously, the event processing loop would silently exit when the broadcast
receiver lagged behind, causing permanent failure of the event system. Now
properly handles RecvError::Lagged by logging a warning and continuing to
process subsequent events.