### PR TITLE
fix: receive Spark invoice u128 not supported

### DIFF
--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -228,6 +228,7 @@ pub struct SparkInvoiceDetails {
     pub invoice: String,
     pub identity_public_key: String,
     pub network: BitcoinNetwork,
+    #[tsify(type = "string")]
     #[serde(with = "serde_option_u128_as_string")]
     pub amount: Option<u128>,
     pub token_identifier: Option<String>,
@@ -646,6 +647,7 @@ pub struct TokenMetadata {
     // Serde doesn't support deserializing u128 types whenever they are used with flatten: https://github.com/serde-rs/json/issues/625
     // This occurs in the storage implementation when parsing `PaymentDetails` due to the use of flatten in LnurlRequestDetails
     // Serializing as string is a workaround to avoid the issue.
+    #[tsify(type = "string")]
     #[serde(with = "serde_u128_as_string")]
     pub max_supply: u128,
     pub is_freezable: bool,
@@ -661,6 +663,8 @@ pub struct SyncWalletResponse {}
 pub enum ReceivePaymentMethod {
     SparkAddress,
     SparkInvoice {
+        #[tsify(type = "string")]
+        #[serde(with = "serde_option_u128_as_string")]
         amount: Option<u128>,
         token_identifier: Option<String>,
         expiry_time: Option<u64>,
@@ -703,12 +707,14 @@ pub enum SendPaymentMethod {
     }, // should be replaced with the parsed invoice
     SparkAddress {
         address: String,
+        #[tsify(type = "string")]
         #[serde(with = "serde_u128_as_string")]
         fee: u128,
         token_identifier: Option<String>,
     },
     SparkInvoice {
         spark_invoice_details: SparkInvoiceDetails,
+        #[tsify(type = "string")]
         #[serde(with = "serde_u128_as_string")]
         fee: u128,
         token_identifier: Option<String>,
@@ -1116,6 +1122,7 @@ pub struct OptimizationProgress {
 pub struct TokenConversionInfo {
     pub pool_id: String,
     pub payment_id: Option<String>,
+    #[tsify(type = "string")]
     #[serde(default, with = "serde_option_u128_as_string")]
     pub fee: Option<u128>,
     pub refund_identifier: Option<String>,

--- a/docs/breez-sdk/snippets/wasm/receive_payment.ts
+++ b/docs/breez-sdk/snippets/wasm/receive_payment.ts
@@ -53,7 +53,7 @@ const exampleReceiveSparkAddress = async (sdk: BreezSdk) => {
 const exampleReceiveSparkInvoice = async (sdk: BreezSdk) => {
   // ANCHOR: receive-payment-spark-invoice
   const optionalDescription = '<invoice description>'
-  const optionalAmountSats = BigInt(5_000)
+  const optionalAmountSats = '5000'
   const optionalExpiryTimeSeconds = 1716691200
   const optionalSenderPublicKey = '<sender public key>'
 

--- a/docs/breez-sdk/snippets/wasm/tokens.ts
+++ b/docs/breez-sdk/snippets/wasm/tokens.ts
@@ -42,7 +42,7 @@ const exampleReceiveTokenPaymentSparkInvoice = async (sdk: BreezSdk) => {
   // ANCHOR: receive-token-payment-spark-invoice
   const tokenIdentifier = '<token identifier>'
   const optionalDescription = '<invoice description>'
-  const optionalAmount = BigInt(5_000)
+  const optionalAmount = '5000'
   const optionalExpiryTimeSeconds = 1716691200
   const optionalSenderPublicKey = '<sender public key>'
 

--- a/packages/wasm/examples/web/index.html
+++ b/packages/wasm/examples/web/index.html
@@ -67,6 +67,7 @@
               <option value="bolt11Invoice">BOLT11 Invoice</option>
               <option value="bitcoinAddress">Bitcoin Address</option>
               <option value="sparkAddress">Spark Address</option>
+              <option value="sparkInvoice">Spark Invoice (Token)</option>
             </select>
           </div>
           <div id="bolt11-fields">
@@ -77,6 +78,20 @@
             <div class="form-group">
               <label for="amount">Amount (sats, optional):</label>
               <input type="number" id="amount" placeholder="Amount in satoshis">
+            </div>
+          </div>
+          <div id="spark-invoice-fields" style="display: none;">
+            <div class="form-group">
+              <label for="spark-amount">Amount (optional):</label>
+              <input type="number" id="spark-amount" placeholder="Amount in sats or token units">
+            </div>
+            <div class="form-group">
+              <label for="token-identifier">Token Identifier (optional):</label>
+              <input type="text" id="token-identifier" placeholder="Leave empty for Bitcoin">
+            </div>
+            <div class="form-group">
+              <label for="spark-description">Description (optional):</label>
+              <input type="text" id="spark-description" placeholder="Invoice description">
             </div>
           </div>
           <div class="modal-actions">

--- a/packages/wasm/examples/web/src/main.js
+++ b/packages/wasm/examples/web/src/main.js
@@ -72,6 +72,10 @@ const elements = {
   description: document.getElementById("description"),
   amount: document.getElementById("amount"),
   bolt11Fields: document.getElementById("bolt11-fields"),
+  sparkInvoiceFields: document.getElementById("spark-invoice-fields"),
+  sparkAmount: document.getElementById("spark-amount"),
+  tokenIdentifier: document.getElementById("token-identifier"),
+  sparkDescription: document.getElementById("spark-description"),
   prepareReceiveBtn: document.getElementById("prepare-receive-btn"),
   cancelReceiveBtn: document.getElementById("cancel-receive-btn"),
   receiveResult: document.getElementById("receive-result"),
@@ -354,6 +358,18 @@ async function receive() {
         description: description,
         amountSats: amountSats,
       };
+    } else if (paymentMethodType === "sparkInvoice") {
+      const sparkAmountStr = elements.sparkAmount.value;
+      const tokenId = elements.tokenIdentifier.value.trim();
+      const sparkDesc = elements.sparkDescription.value.trim();
+
+      paymentMethod = {
+        type: "sparkInvoice",
+        amount: sparkAmountStr || undefined,
+        tokenIdentifier: tokenId || undefined,
+        description: sparkDesc || undefined,
+      };
+      console.log("Creating Spark Invoice with:", paymentMethod);
     } else {
       // For sparkAddress and bitcoinAddress, just pass the type
       paymentMethod = { type: paymentMethodType };
@@ -632,8 +648,9 @@ elements.lnurlPayBtn.addEventListener("click", () => {
 });
 
 elements.paymentMethod.addEventListener("change", () => {
-  elements.bolt11Fields.style.display =
-    elements.paymentMethod.value === "bolt11Invoice" ? "block" : "none";
+  const method = elements.paymentMethod.value;
+  elements.bolt11Fields.style.display = method === "bolt11Invoice" ? "block" : "none";
+  elements.sparkInvoiceFields.style.display = method === "sparkInvoice" ? "block" : "none";
 });
 
 elements.prepareReceiveBtn.addEventListener("click", receive);


### PR DESCRIPTION
This fixes a bug that prevented Spark invoices from being created on Wasm. It was caused by a `serde` limitation on u128 support. We already have #347 to find a better solution other than serializing as string. 

This also fixes the TypeScript types of all fields that use the string serialization workaround. 

Tested on the web example.
