### PR TITLE
Clearer expiry names

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/breez_sdk_tests.rs
+++ b/crates/breez-sdk/breez-itest/tests/breez_sdk_tests.rs
@@ -288,7 +288,7 @@ async fn test_03_lightning_invoice_payment(
             payment_method: ReceivePaymentMethod::Bolt11Invoice {
                 description: format!("Test payment ({})", test_type),
                 amount_sats: invoice_amount_sats,
-                expiry_secs: None,
+                expiry_duration_secs: None,
             },
         })
         .await?
@@ -550,7 +550,7 @@ async fn test_05_lightning_invoice_prefer_spark_fee_path(
             payment_method: ReceivePaymentMethod::Bolt11Invoice {
                 description: "Prefer spark test".to_string(),
                 amount_sats: Some(invoice_amount_sats),
-                expiry_secs: None,
+                expiry_duration_secs: None,
             },
         })
         .await?
@@ -644,7 +644,7 @@ async fn test_06_lightning_timeout_and_wait(
             payment_method: ReceivePaymentMethod::Bolt11Invoice {
                 description: "Timeout test".to_string(),
                 amount_sats: None,
-                expiry_secs: None,
+                expiry_duration_secs: None,
             },
         })
         .await?
@@ -724,7 +724,7 @@ async fn test_07_spark_invoice(
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
-    let expiry_time = current_time + 120;
+    let expires_at = current_time + 120;
 
     // Get Alice's identity public key from her Spark address to use as sender public key in the invoice
     let alice_spark_address = alice
@@ -748,7 +748,7 @@ async fn test_07_spark_invoice(
             payment_method: ReceivePaymentMethod::SparkInvoice {
                 amount: Some(5),
                 token_identifier: None,
-                expiry_time: Some(expiry_time),
+                expires_at: Some(expires_at),
                 description: Some("Test invoice".to_string()),
                 sender_public_key: Some(alice_identity_public_key),
             },
@@ -835,14 +835,14 @@ async fn test_07_spark_invoice(
     Ok(())
 }
 
-/// Test 8: Lightning invoice with custom expiry_secs
+/// Test 8: Lightning invoice with custom expiry_duration_secs
 #[rstest]
 #[test_log::test(tokio::test)]
-async fn test_08_lightning_invoice_expiry_secs(
+async fn test_08_lightning_invoice_expiry_duration_secs(
     #[future] alice_sdk: Result<SdkInstance>,
     #[future] bob_sdk: Result<SdkInstance>,
 ) -> Result<()> {
-    info!("=== Starting test_08_lightning_invoice_expiry_secs ===");
+    info!("=== Starting test_08_lightning_invoice_expiry_duration_secs ===");
 
     let mut alice = alice_sdk.await?;
     let mut bob = bob_sdk.await?;
@@ -874,8 +874,8 @@ async fn test_08_lightning_invoice_expiry_secs(
 
     info!("Bob initial balance: {} sats", bob_initial_balance);
 
-    // Test with custom expiry_secs (1 hour = 3600 seconds)
-    let custom_expiry_secs: u32 = 3600 - 1;
+    // Test with custom expiry_duration_secs (1 hour = 3600 seconds)
+    let custom_expiry_duration_secs: u32 = 3600 - 1;
     let invoice_amount_sats = 5_000u64;
 
     // Bob creates a Lightning invoice with custom expiry
@@ -885,7 +885,7 @@ async fn test_08_lightning_invoice_expiry_secs(
             payment_method: ReceivePaymentMethod::Bolt11Invoice {
                 description: "Test invoice with custom expiry".to_string(),
                 amount_sats: Some(invoice_amount_sats),
-                expiry_secs: Some(custom_expiry_secs),
+                expiry_duration_secs: Some(custom_expiry_duration_secs),
             },
         })
         .await?;
@@ -893,7 +893,7 @@ async fn test_08_lightning_invoice_expiry_secs(
     let bob_invoice = receive_response.payment_request;
     info!(
         "Bob's Lightning invoice with {} secs expiry: {}",
-        custom_expiry_secs, bob_invoice
+        custom_expiry_duration_secs, bob_invoice
     );
 
     // Parse the invoice to verify expiry is set
@@ -906,8 +906,8 @@ async fn test_08_lightning_invoice_expiry_secs(
 
         // Verify the expiry matches what we requested
         assert_eq!(
-            invoice_details.expiry, custom_expiry_secs as u64,
-            "Invoice expiry should match requested expiry_secs"
+            invoice_details.expiry, custom_expiry_duration_secs as u64,
+            "Invoice expiry should match requested expiry_duration_secs"
         );
 
         // Verify the amount is correct (in millisats)
@@ -1002,6 +1002,6 @@ async fn test_08_lightning_invoice_expiry_secs(
         "Bob's balance should increase"
     );
 
-    info!("=== Test test_08_lightning_invoice_expiry_secs PASSED ===");
+    info!("=== Test test_08_lightning_invoice_expiry_duration_secs PASSED ===");
     Ok(())
 }

--- a/crates/breez-sdk/breez-itest/tests/idempotency_tests.rs
+++ b/crates/breez-sdk/breez-itest/tests/idempotency_tests.rs
@@ -210,7 +210,7 @@ async fn test_02_lightning_idempotency_key(
             payment_method: ReceivePaymentMethod::Bolt11Invoice {
                 description: "idempotency test".to_string(),
                 amount_sats: Some(5),
-                expiry_secs: None,
+                expiry_duration_secs: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/recovery.rs
+++ b/crates/breez-sdk/breez-itest/tests/recovery.rs
@@ -382,7 +382,7 @@ async fn test_setup_recovery_wallet() -> Result<()> {
             payment_method: ReceivePaymentMethod::Bolt11Invoice {
                 description: "Recovery test lightning payment".to_string(),
                 amount_sats: Some(1_000),
-                expiry_secs: None,
+                expiry_duration_secs: None,
             },
         })
         .await?
@@ -420,7 +420,7 @@ async fn test_setup_recovery_wallet() -> Result<()> {
             payment_method: ReceivePaymentMethod::Bolt11Invoice {
                 description: "Recovery test lightning receive".to_string(),
                 amount_sats: Some(800),
-                expiry_secs: None,
+                expiry_duration_secs: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/token_conversion.rs
+++ b/crates/breez-sdk/breez-itest/tests/token_conversion.rs
@@ -177,7 +177,7 @@ async fn test_token_conversion_success(
             payment_method: ReceivePaymentMethod::Bolt11Invoice {
                 description: "Token to Bitcoin test".to_string(),
                 amount_sats: Some(token_to_sats_success_amount),
-                expiry_secs: None,
+                expiry_duration_secs: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/tokens.rs
+++ b/crates/breez-sdk/breez-itest/tests/tokens.rs
@@ -282,7 +282,7 @@ async fn test_02_token_invoice(
             payment_method: ReceivePaymentMethod::SparkInvoice {
                 amount: Some(20),
                 token_identifier: Some(token_metadata.identifier.clone()),
-                expiry_time: None,
+                expires_at: None,
                 description: Some("test invoice".to_string()),
                 sender_public_key: None,
             },
@@ -761,7 +761,7 @@ async fn test_05_invoice_expiry(
     );
 
     // Bob creates an invoice that expires in 5 seconds
-    let expiry_time = Some(
+    let expires_at = Some(
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
             .as_secs()
@@ -774,7 +774,7 @@ async fn test_05_invoice_expiry(
             payment_method: ReceivePaymentMethod::SparkInvoice {
                 amount: Some(30),
                 token_identifier: Some(token_metadata.identifier.clone()),
-                expiry_time,
+                expires_at,
                 description: Some("expiring invoice".to_string()),
                 sender_public_key: None,
             },

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -446,7 +446,7 @@ pub(crate) async fn execute_command(
                 "sparkinvoice" => ReceivePaymentMethod::SparkInvoice {
                     amount,
                     token_identifier,
-                    expiry_time: expiry_secs
+                    expires_at: expiry_secs
                         .map(|secs| {
                             SystemTime::now()
                                 .duration_since(UNIX_EPOCH)?
@@ -462,7 +462,7 @@ pub(crate) async fn execute_command(
                 "bolt11" => ReceivePaymentMethod::Bolt11Invoice {
                     description: description.unwrap_or_default(),
                     amount_sats: amount.map(TryInto::try_into).transpose()?,
-                    expiry_secs,
+                    expiry_duration_secs: expiry_secs,
                 },
                 _ => return Err(anyhow::anyhow!("Invalid payment method")),
             };

--- a/crates/breez-sdk/common/src/input/models.rs
+++ b/crates/breez-sdk/common/src/input/models.rs
@@ -189,8 +189,8 @@ pub struct SparkInvoiceDetails {
     pub amount: Option<u128>,
     /// The token identifier of the token payment. Absence indicates a Bitcoin payment.
     pub token_identifier: Option<String>,
-    /// Optional expiry time. If not provided, the invoice will never expire.
-    pub expiry_time: Option<u64>,
+    /// Optional expiry time as a unix timestamp in seconds. If not provided, the invoice will never expire.
+    pub expires_at: Option<u64>,
     /// Optional description.
     pub description: Option<String>,
     /// If set, the invoice may only be fulfilled by a payer with this public key.

--- a/crates/breez-sdk/common/src/input/parser.rs
+++ b/crates/breez-sdk/common/src/input/parser.rs
@@ -651,14 +651,14 @@ pub fn parse_spark_address(input: &str, source: &PaymentRequestSource) -> Option
                 SparkAddressPaymentType::SatsPayment(_) => None,
             };
 
-            let Ok(expiry_time_duration) = invoice_fields
+            let Ok(expires_at_duration) = invoice_fields
                 .expiry_time
                 .map(|e| e.duration_since(UNIX_EPOCH))
                 .transpose()
             else {
                 return None;
             };
-            let expiry_time = expiry_time_duration.map(|e| e.as_secs());
+            let expires_at = expires_at_duration.map(|e| e.as_secs());
 
             return Some(InputType::SparkInvoice(SparkInvoiceDetails {
                 invoice: input.to_string(),
@@ -666,7 +666,7 @@ pub fn parse_spark_address(input: &str, source: &PaymentRequestSource) -> Option
                 network,
                 amount,
                 token_identifier,
-                expiry_time,
+                expires_at,
                 description: invoice_fields.memo,
                 sender_public_key: invoice_fields.sender_public_key.map(|e| e.to_string()),
             }));

--- a/crates/breez-sdk/core/src/common/models.rs
+++ b/crates/breez-sdk/core/src/common/models.rs
@@ -391,8 +391,8 @@ pub struct SparkInvoiceDetails {
     pub amount: Option<u128>,
     /// The token identifier of the token payment. Absence indicates a Bitcoin payment.
     pub token_identifier: Option<String>,
-    /// Optional expiry time. If not provided, the invoice will never expire.
-    pub expiry_time: Option<u64>,
+    /// Optional expiry time as a unix timestamp in seconds. If not provided, the invoice will never expire.
+    pub expires_at: Option<u64>,
     /// Optional description.
     pub description: Option<String>,
     /// If set, the invoice may only be fulfilled by a payer with this public key.

--- a/crates/breez-sdk/core/src/models/adaptors.rs
+++ b/crates/breez-sdk/core/src/models/adaptors.rs
@@ -397,7 +397,7 @@ impl TryFrom<PreimageRequest> for SparkHtlcDetails {
         Ok(Self {
             payment_hash: value.payment_hash.to_string(),
             preimage: value.preimage.map(|p| p.encode_hex()),
-            expiry_time: value
+            expires_at: value
                 .expiry_time
                 .duration_since(UNIX_EPOCH)
                 .map_err(|e| SdkError::Generic(format!("Invalid expiry time: {e}")))?

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -310,8 +310,8 @@ pub struct SparkHtlcDetails {
     pub payment_hash: String,
     /// The preimage of the HTLC. Empty until receiver has released it.
     pub preimage: Option<String>,
-    /// The expiry time of the HTLC in seconds since the Unix epoch
-    pub expiry_time: u64,
+    /// The expiry time of the HTLC as a unix timestamp in seconds
+    pub expires_at: u64,
     /// The HTLC status
     pub status: SparkHtlcStatus,
 }
@@ -669,8 +669,8 @@ pub enum ReceivePaymentMethod {
         /// The presence of this field indicates that the payment is for a token
         /// If empty, it is a Bitcoin payment
         token_identifier: Option<String>,
-        /// The expiry time of the invoice in seconds since the Unix epoch
-        expiry_time: Option<u64>,
+        /// The expiry time of the invoice as a unix timestamp in seconds
+        expires_at: Option<u64>,
         /// A description to embed in the invoice.
         description: Option<String>,
         /// If set, the invoice may only be fulfilled by a payer with this public key
@@ -680,8 +680,8 @@ pub enum ReceivePaymentMethod {
     Bolt11Invoice {
         description: String,
         amount_sats: Option<u64>,
-        /// The expiry time of the invoice in seconds
-        expiry_secs: Option<u32>,
+        /// The expiry of the invoice as a duration in seconds
+        expiry_duration_secs: Option<u32>,
     },
 }
 

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -846,7 +846,7 @@ pub mod tests {
                 htlc_details: Some(SparkHtlcDetails {
                     payment_hash: "payment_hash123".to_string(),
                     preimage: Some("preimage123".to_string()),
-                    expiry_time: 15_000,
+                    expires_at: 15_000,
                     status: SparkHtlcStatus::PreimageShared,
                 }),
                 token_conversion_info: None,
@@ -2045,7 +2045,7 @@ pub mod tests {
                 htlc_details: Some(SparkHtlcDetails {
                     payment_hash: "hash1".to_string(),
                     preimage: None,
-                    expiry_time: 2000,
+                    expires_at: 2000,
                     status: SparkHtlcStatus::WaitingForPreimage,
                 }),
                 token_conversion_info: None,
@@ -2065,7 +2065,7 @@ pub mod tests {
                 htlc_details: Some(SparkHtlcDetails {
                     payment_hash: "hash2".to_string(),
                     preimage: Some("preimage123".to_string()),
-                    expiry_time: 3000,
+                    expires_at: 3000,
                     status: SparkHtlcStatus::PreimageShared,
                 }),
                 token_conversion_info: None,
@@ -2085,7 +2085,7 @@ pub mod tests {
                 htlc_details: Some(SparkHtlcDetails {
                     payment_hash: "hash3".to_string(),
                     preimage: None,
-                    expiry_time: 4000,
+                    expires_at: 4000,
                     status: SparkHtlcStatus::Returned,
                 }),
                 token_conversion_info: None,
@@ -2760,7 +2760,7 @@ pub mod tests {
                 htlc_details: Some(SparkHtlcDetails {
                     payment_hash: "hash_123".to_string(),
                     preimage: None,
-                    expiry_time: 1_234_567_990,
+                    expires_at: 1_234_567_990,
                     status: SparkHtlcStatus::WaitingForPreimage,
                 }),
                 token_conversion_info: None,
@@ -2794,7 +2794,7 @@ pub mod tests {
             htlc_details: Some(SparkHtlcDetails {
                 payment_hash: "hash_123".to_string(),
                 preimage: Some("preimage_123".to_string()),
-                expiry_time: 1_234_567_990,
+                expires_at: 1_234_567_990,
                 status: SparkHtlcStatus::PreimageShared,
             }),
             token_conversion_info: None,

--- a/crates/breez-sdk/core/src/sdk.rs
+++ b/crates/breez-sdk/core/src/sdk.rs
@@ -1348,7 +1348,7 @@ impl BreezSdk {
             ReceivePaymentMethod::SparkInvoice {
                 amount,
                 token_identifier,
-                expiry_time,
+                expires_at,
                 description,
                 sender_public_key,
             } => {
@@ -1357,7 +1357,7 @@ impl BreezSdk {
                     .create_spark_invoice(
                         amount,
                         token_identifier.clone(),
-                        expiry_time
+                        expires_at
                             .map(|time| {
                                 SystemTime::UNIX_EPOCH
                                     .checked_add(Duration::from_secs(time))
@@ -1418,7 +1418,7 @@ impl BreezSdk {
             ReceivePaymentMethod::Bolt11Invoice {
                 description,
                 amount_sats,
-                expiry_secs,
+                expiry_duration_secs,
             } => Ok(ReceivePaymentResponse {
                 payment_request: self
                     .spark_wallet
@@ -1426,7 +1426,7 @@ impl BreezSdk {
                         amount_sats.unwrap_or_default(),
                         Some(InvoiceDescription::Memo(description.clone())),
                         None,
-                        expiry_secs,
+                        expiry_duration_secs,
                         self.config.prefer_spark_over_lightning,
                     )
                     .await?
@@ -1643,7 +1643,7 @@ impl BreezSdk {
                 payment_method: ReceivePaymentMethod::Bolt11Invoice {
                     description: withdraw_request.default_description.clone(),
                     amount_sats: Some(amount_sats),
-                    expiry_secs: None,
+                    expiry_duration_secs: None,
                 },
             })
             .await?

--- a/crates/breez-sdk/core/src/utils/send_payment_validation.rs
+++ b/crates/breez-sdk/core/src/utils/send_payment_validation.rs
@@ -71,11 +71,11 @@ fn validate_spark_invoice_request(
     }
 
     // Validate expiry time
-    if let Some(expiry_time) = spark_invoice_details.expiry_time {
+    if let Some(expires_at) = spark_invoice_details.expires_at {
         let current_time = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_err(|_| SdkError::Generic("Failed to get current time".to_string()))?;
-        if current_time > Duration::from_secs(expiry_time) {
+        if current_time > Duration::from_secs(expires_at) {
             return Err(SdkError::InvalidInput("Invoice has expired".to_string()));
         }
     }
@@ -218,7 +218,7 @@ mod tests {
             network: BitcoinNetwork::Regtest,
             amount: None,
             token_identifier: None,
-            expiry_time: None,
+            expires_at: None,
             description: None,
             sender_public_key: None,
         }
@@ -319,7 +319,7 @@ mod tests {
             .unwrap()
             .as_secs()
             .saturating_sub(1);
-        invoice.expiry_time = Some(expired_time);
+        invoice.expires_at = Some(expired_time);
 
         let request = create_test_request();
         let identity_key = "test_identity".to_string();
@@ -337,14 +337,14 @@ mod tests {
 
     #[allow(clippy::arithmetic_side_effects)]
     #[test_all]
-    fn test_validate_spark_invoice_valid_expiry_time() {
+    fn test_validate_spark_invoice_valid_expires_at() {
         let mut invoice = create_test_invoice();
         let future_time = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs()
             + 3600;
-        invoice.expiry_time = Some(future_time);
+        invoice.expires_at = Some(future_time);
 
         let request = create_test_request();
         let identity_key = "test_identity".to_string();
@@ -449,7 +449,7 @@ mod tests {
             .unwrap()
             .as_secs()
             + 3600;
-        invoice.expiry_time = Some(future_time);
+        invoice.expires_at = Some(future_time);
 
         let mut request = create_test_request();
         request.token_identifier = Some("token123".to_string());

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -232,7 +232,7 @@ pub struct SparkInvoiceDetails {
     #[serde(with = "serde_option_u128_as_string")]
     pub amount: Option<u128>,
     pub token_identifier: Option<String>,
-    pub expiry_time: Option<u64>,
+    pub expires_at: Option<u64>,
     pub description: Option<String>,
     pub sender_public_key: Option<String>,
 }
@@ -476,7 +476,7 @@ pub struct SparkInvoicePaymentDetails {
 pub struct SparkHtlcDetails {
     pub payment_hash: String,
     pub preimage: Option<String>,
-    pub expiry_time: u64,
+    pub expires_at: u64,
     pub status: SparkHtlcStatus,
 }
 
@@ -667,7 +667,7 @@ pub enum ReceivePaymentMethod {
         #[serde(with = "serde_option_u128_as_string")]
         amount: Option<u128>,
         token_identifier: Option<String>,
-        expiry_time: Option<u64>,
+        expires_at: Option<u64>,
         description: Option<String>,
         sender_public_key: Option<String>,
     },
@@ -675,7 +675,7 @@ pub enum ReceivePaymentMethod {
     Bolt11Invoice {
         description: String,
         amount_sats: Option<u64>,
-        expiry_secs: Option<u32>,
+        expiry_duration_secs: Option<u32>,
     },
 }
 

--- a/docs/breez-sdk/snippets/csharp/ParsingInputs.cs
+++ b/docs/breez-sdk/snippets/csharp/ParsingInputs.cs
@@ -58,9 +58,9 @@ namespace BreezSdkSnippets
                         Console.WriteLine($"  Description: {invoice.description}");
                     }
 
-                    if (invoice.expiryTime.HasValue)
+                    if (invoice.expiresAt.HasValue)
                     {
-                        Console.WriteLine($"  Expiry time: {invoice.expiryTime}");
+                        Console.WriteLine($"  Expires at: {invoice.expiresAt}");
                     }
 
                     if (invoice.senderPublicKey != null)

--- a/docs/breez-sdk/snippets/csharp/ReceivePayment.cs
+++ b/docs/breez-sdk/snippets/csharp/ReceivePayment.cs
@@ -11,12 +11,12 @@ namespace BreezSdkSnippets
             var description = "<invoice description>";
             // Optionally set the invoice amount you wish the payer to send
             var optionalAmountSats = 5_000UL;
-            // Optionally set the expiry time in seconds
-            var optionalExpirySecs = 3600U;
+            // Optionally set the expiry duration in seconds
+            var optionalExpiryDurationSecs = 3600U;
             var paymentMethod = new ReceivePaymentMethod.Bolt11Invoice(
                 description: description,
                 amountSats: optionalAmountSats,
-                expirySecs: optionalExpirySecs
+                expiryDurationSecs: optionalExpiryDurationSecs
             );
             var request = new ReceivePaymentRequest(paymentMethod: paymentMethod);
             var response = await sdk.ReceivePayment(request: request);
@@ -63,14 +63,14 @@ namespace BreezSdkSnippets
             // ANCHOR: receive-payment-spark-invoice
             var optionalDescription = "<invoice description>";
             var optionalAmountSats = new BigInteger(5000);
-            var optionalExpiryTimeSeconds = 1716691200UL;
+            var optionalExpiresAt = 1716691200UL;
             var optionalSenderPublicKey = "<sender public key>";
 
             var request = new ReceivePaymentRequest(
                 paymentMethod: new ReceivePaymentMethod.SparkInvoice(
                     description: optionalDescription,
                     amount: optionalAmountSats,
-                    expiryTime: optionalExpiryTimeSeconds,
+                    expiresAt: optionalExpiresAt,
                     senderPublicKey: optionalSenderPublicKey,
                     tokenIdentifier: null
                 )

--- a/docs/breez-sdk/snippets/csharp/Tokens.cs
+++ b/docs/breez-sdk/snippets/csharp/Tokens.cs
@@ -55,7 +55,7 @@ namespace BreezSdkSnippets
             var tokenIdentifier = "<token identifier>";
             var optionalDescription = "<invoice description>";
             var optionalAmount = new BigInteger(5000);
-            var optionalExpiryTimeSeconds = 1716691200UL;
+            var optionalExpiresAt = 1716691200UL;
             var optionalSenderPublicKey = "<sender public key>";
 
             var request = new ReceivePaymentRequest(
@@ -63,7 +63,7 @@ namespace BreezSdkSnippets
                     tokenIdentifier: tokenIdentifier,
                     description: optionalDescription,
                     amount: optionalAmount,
-                    expiryTime: optionalExpiryTimeSeconds,
+                    expiresAt: optionalExpiresAt,
                     senderPublicKey: optionalSenderPublicKey
                 )
             );

--- a/docs/breez-sdk/snippets/flutter/lib/parsing_inputs.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/parsing_inputs.dart
@@ -34,8 +34,8 @@ Future<void> parseInput(BreezSdk sdk) async {
       print("  Description: ${invoice.description}");
     }
     
-    if (invoice.expiryTime != null) {
-      print("  Expiry time: ${DateTime.fromMillisecondsSinceEpoch(invoice.expiryTime!.toInt() * 1000)}");
+    if (invoice.expiresAt != null) {
+      print("  Expires at: ${DateTime.fromMillisecondsSinceEpoch(invoice.expiresAt!.toInt() * 1000)}");
     }
     
     if (invoice.senderPublicKey != null) {

--- a/docs/breez-sdk/snippets/flutter/lib/receive_payment.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/receive_payment.dart
@@ -6,15 +6,15 @@ Future<ReceivePaymentResponse> receivePaymentLightning(
   String description = "<invoice description>";
   // Optionally set the invoice amount you wish the payer to send
   BigInt optionalAmountSats = BigInt.from(5000);
-  // Optionally set the expiry time in seconds
-  int optionalExpirySecs = 3600;
+  // Optionally set the expiry duration in seconds
+  int optionalExpiryDurationSecs = 3600;
 
   // Create an invoice and set the amount you wish the payer to send
   ReceivePaymentRequest request = ReceivePaymentRequest(
       paymentMethod: ReceivePaymentMethod.bolt11Invoice(
           description: description,
           amountSats: optionalAmountSats,
-          expirySecs: optionalExpirySecs));
+          expiryDurationSecs: optionalExpiryDurationSecs));
   ReceivePaymentResponse response = await sdk.receivePayment(
     request: request,
   );
@@ -64,14 +64,14 @@ Future<ReceivePaymentResponse> receivePaymentSparkInvoice(BreezSdk sdk) async {
   // ANCHOR: receive-payment-spark-invoice
   String optionalDescription = "<invoice description>";
   BigInt optionalAmountSats = BigInt.from(5000);
-  BigInt optionalExpiryTimeSeconds = BigInt.from(1716691200);
+  BigInt optionalExpiresAt = BigInt.from(1716691200);
   String optionalSenderPublicKey = "<sender public key>";
 
   ReceivePaymentRequest request =
       ReceivePaymentRequest(paymentMethod: ReceivePaymentMethod.sparkInvoice(
         description: optionalDescription,
         amount: optionalAmountSats,
-        expiryTime: optionalExpiryTimeSeconds,
+        expiresAt: optionalExpiresAt,
         senderPublicKey: optionalSenderPublicKey,
       ));
   ReceivePaymentResponse response = await sdk.receivePayment(

--- a/docs/breez-sdk/snippets/flutter/lib/tokens.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/tokens.dart
@@ -43,15 +43,15 @@ Future<ReceivePaymentResponse> receiveTokenPaymentSparkInvoice(BreezSdk sdk) asy
   String tokenIdentifier = '<token identifier>';
   String optionalDescription = "<invoice description>";
   BigInt optionalAmount = BigInt.from(5000);
-  BigInt optionalExpiryTimeSeconds = BigInt.from(1716691200);
-  String optionalSenderPublicKey = "<sender public key>"; 
+  BigInt optionalExpiresAt = BigInt.from(1716691200);
+  String optionalSenderPublicKey = "<sender public key>";
 
   ReceivePaymentRequest request =
       ReceivePaymentRequest(paymentMethod: ReceivePaymentMethod.sparkInvoice(
         tokenIdentifier: tokenIdentifier,
         description: optionalDescription,
         amount: optionalAmount,
-        expiryTime: optionalExpiryTimeSeconds,
+        expiresAt: optionalExpiresAt,
         senderPublicKey: optionalSenderPublicKey,
       ));
   ReceivePaymentResponse response = await sdk.receivePayment(

--- a/docs/breez-sdk/snippets/go/parsing_inputs.go
+++ b/docs/breez-sdk/snippets/go/parsing_inputs.go
@@ -52,8 +52,8 @@ func ParseInput(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.InputType, erro
 			log.Printf("  Description: %s", *invoice.Description)
 		}
 
-		if invoice.ExpiryTime != nil {
-			log.Printf("  Expiry time: %d", *invoice.ExpiryTime)
+		if invoice.ExpiresAt != nil {
+			log.Printf("  Expires at: %d", *invoice.ExpiresAt)
 		}
 
 		if invoice.SenderPublicKey != nil {

--- a/docs/breez-sdk/snippets/go/receive_payment.go
+++ b/docs/breez-sdk/snippets/go/receive_payment.go
@@ -12,14 +12,14 @@ func ReceiveLightningBolt11(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.Rec
 	description := "<invoice description>"
 	// Optionally set the invoice amount you wish the payer to send
 	optionalAmountSats := uint64(5_000)
-	// Optionally set the expiry time in seconds
-	optionalExpirySecs := uint32(3600)
+	// Optionally set the expiry duration in seconds
+	optionalExpiryDurationSecs := uint32(3600)
 
 	request := breez_sdk_spark.ReceivePaymentRequest{
 		PaymentMethod: breez_sdk_spark.ReceivePaymentMethodBolt11Invoice{
-			Description: description,
-			AmountSats:  &optionalAmountSats,
-			ExpirySecs:  &optionalExpirySecs,
+			Description:        description,
+			AmountSats:         &optionalAmountSats,
+			ExpiryDurationSecs: &optionalExpiryDurationSecs,
 		},
 	}
 
@@ -81,14 +81,14 @@ func ReceiveSparkInvoice(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.Receiv
 	// ANCHOR: receive-payment-spark-invoice
 	optionalDescription := "<invoice description>"
 	optionalAmountSats := new(big.Int).SetInt64(5_000)
-	optionalExpiryTimeSeconds := uint64(1716691200)
+	optionalExpiresAt := uint64(1716691200)
 	optionalSenderPublicKey := "<sender public key>"
 
 	request := breez_sdk_spark.ReceivePaymentRequest{
 		PaymentMethod: breez_sdk_spark.ReceivePaymentMethodSparkInvoice{
 			Description:     &optionalDescription,
 			Amount:          &optionalAmountSats,
-			ExpiryTime:      &optionalExpiryTimeSeconds,
+			ExpiresAt:       &optionalExpiresAt,
 			SenderPublicKey: &optionalSenderPublicKey,
 		},
 	}

--- a/docs/breez-sdk/snippets/go/tokens.go
+++ b/docs/breez-sdk/snippets/go/tokens.go
@@ -62,7 +62,7 @@ func ReceiveTokenPaymentSparkInvoice(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_
 	tokenIdentifier := "<token identifier>"
 	optionalDescription := "<invoice description>"
 	optionalAmount := new(big.Int).SetInt64(5_000)
-	optionalExpiryTimeSeconds := uint64(1716691200)
+	optionalExpiresAt := uint64(1716691200)
 	optionalSenderPublicKey := "<sender public key>"
 
 	request := breez_sdk_spark.ReceivePaymentRequest{
@@ -70,7 +70,7 @@ func ReceiveTokenPaymentSparkInvoice(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_
 			TokenIdentifier: &tokenIdentifier,
 			Description:     &optionalDescription,
 			Amount:          &optionalAmount,
-			ExpiryTime:      &optionalExpiryTimeSeconds,
+			ExpiresAt:       &optionalExpiresAt,
 			SenderPublicKey: &optionalSenderPublicKey,
 		},
 	}

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ParsingInputs.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ParsingInputs.kt
@@ -47,8 +47,8 @@ class ParsingInputs {
                         println("  Description: ${invoice.description}")
                     }
 
-                    if (invoice.expiryTime != null) {
-                        println("  Expiry time: ${invoice.expiryTime}")
+                    if (invoice.expiresAt != null) {
+                        println("  Expires at: ${invoice.expiresAt}")
                     }
 
                     if (invoice.senderPublicKey != null) {

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
@@ -10,11 +10,11 @@ class ReceivePayment {
             val description = "<invoice description>"
             // Optionally set the invoice amount you wish the payer to send
             val optionalAmountSats = 5_000.toULong()
-            // Optionally set the expiry time in seconds
-            val optionalExpirySecs = 3600.toUInt()
+            // Optionally set the expiry duration in seconds
+            val optionalExpiryDurationSecs = 3600.toUInt()
 
             val request = ReceivePaymentRequest(
-                ReceivePaymentMethod.Bolt11Invoice(description, optionalAmountSats, optionalExpirySecs)
+                ReceivePaymentMethod.Bolt11Invoice(description, optionalAmountSats, optionalExpiryDurationSecs)
             )
             val response = sdk.receivePayment(request)
 
@@ -71,7 +71,7 @@ class ReceivePayment {
             val optionalAmountSats = BigInteger.fromLong(5_000L)
             // Android (BigInteger from java.math)
             // val optionalAmountSats = BigInteger.valueOf(5_000L)
-            val optionalExpiryTimeSeconds = 1716691200.toULong()
+            val optionalExpiresAt = 1716691200.toULong()
             val optionalSenderPublicKey = "<sender public key>"
 
             val request = ReceivePaymentRequest(
@@ -79,7 +79,7 @@ class ReceivePayment {
                     tokenIdentifier = null,
                     description = optionalDescription,
                     amount = optionalAmountSats,
-                    expiryTime = optionalExpiryTimeSeconds,
+                    expiresAt = optionalExpiresAt,
                     senderPublicKey = optionalSenderPublicKey
                 )
             )

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Tokens.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Tokens.kt
@@ -61,7 +61,7 @@ class Tokens {
             val optionalAmount = BigInteger.fromLong(5_000L)
             // Android (BigInteger from java.math)
             // val optionalAmount = BigInteger.valueOf(5_000L)
-            val optionalExpiryTimeSeconds = 1716691200.toULong()
+            val optionalExpiresAt = 1716691200.toULong()
             val optionalSenderPublicKey = "<sender public key>"
 
             val request = ReceivePaymentRequest(
@@ -69,7 +69,7 @@ class Tokens {
                     tokenIdentifier = tokenIdentifier,
                     description = optionalDescription,
                     amount = optionalAmount,
-                    expiryTime = optionalExpiryTimeSeconds,
+                    expiresAt = optionalExpiresAt,
                     senderPublicKey = optionalSenderPublicKey
                 )
             )

--- a/docs/breez-sdk/snippets/python/src/parsing_inputs.py
+++ b/docs/breez-sdk/snippets/python/src/parsing_inputs.py
@@ -45,8 +45,8 @@ async def parse_input(sdk: BreezSdk):
             if invoice.description:
                 logging.debug(f"  Description: {invoice.description}")
 
-            if invoice.expiry_time:
-                logging.debug(f"  Expiry time: {invoice.expiry_time}")
+            if invoice.expires_at:
+                logging.debug(f"  Expires at: {invoice.expires_at}")
 
             if invoice.sender_public_key:
                 logging.debug(f"  Sender public key: {invoice.sender_public_key}")

--- a/docs/breez-sdk/snippets/python/src/receive_payment.py
+++ b/docs/breez-sdk/snippets/python/src/receive_payment.py
@@ -13,12 +13,12 @@ async def receive_lightning(sdk: BreezSdk):
         description = "<invoice description>"
         # Optionally set the invoice amount you wish the payer to send
         optional_amount_sats = 5_000
-        # Optionally set the expiry time in seconds
-        optional_expiry_secs = 3600
+        # Optionally set the expiry duration in seconds
+        optional_expiry_duration_secs = 3600
         payment_method = ReceivePaymentMethod.BOLT11_INVOICE(
             description=description,
             amount_sats=optional_amount_sats,
-            expiry_secs=optional_expiry_secs,
+            expiry_duration_secs=optional_expiry_duration_secs,
         )
         request = ReceivePaymentRequest(payment_method=payment_method)
         response = await sdk.receive_payment(request=request)
@@ -77,14 +77,14 @@ async def receive_spark_invoice(sdk: BreezSdk):
     try:
         optional_description = "<invoice description>"
         optional_amount_sats = 5_000
-        optional_expiry_time_seconds = 1716691200
+        optional_expires_at = 1716691200
         optional_sender_public_key = "<sender public key>"
 
         request = ReceivePaymentRequest(
             payment_method=ReceivePaymentMethod.SPARK_INVOICE(
                 description=optional_description,
                 amount=optional_amount_sats,
-                expiry_time=optional_expiry_time_seconds,
+                expires_at=optional_expires_at,
                 sender_public_key=optional_sender_public_key,
                 token_identifier=None,
             )

--- a/docs/breez-sdk/snippets/python/src/tokens.py
+++ b/docs/breez-sdk/snippets/python/src/tokens.py
@@ -64,7 +64,7 @@ async def receive_token_payment_spark_invoice(sdk: BreezSdk):
         token_identifier = "<token identifier>"
         optional_description = "<invoice description>"
         optional_amount = 5_000
-        optional_expiry_time_seconds = 1716691200
+        optional_expires_at = 1716691200
         optional_sender_public_key = "<sender public key>"
 
         request = ReceivePaymentRequest(
@@ -72,7 +72,7 @@ async def receive_token_payment_spark_invoice(sdk: BreezSdk):
                 token_identifier=token_identifier,
                 description=optional_description,
                 amount=optional_amount,
-                expiry_time=optional_expiry_time_seconds,
+                expires_at=optional_expires_at,
                 sender_public_key=optional_sender_public_key,
             )
         )

--- a/docs/breez-sdk/snippets/react-native/parsing_inputs.ts
+++ b/docs/breez-sdk/snippets/react-native/parsing_inputs.ts
@@ -46,8 +46,8 @@ const parseInputs = async (sdk: BreezSdk) => {
       console.log(`  Description: ${invoice.description}`)
     }
 
-    if (invoice.expiryTime != null) {
-      console.log(`  Expiry time: ${new Date(Number(invoice.expiryTime) * 1000).toISOString()}`)
+    if (invoice.expiresAt != null) {
+      console.log(`  Expires at: ${new Date(Number(invoice.expiresAt) * 1000).toISOString()}`)
     }
 
     if (invoice.senderPublicKey != null) {

--- a/docs/breez-sdk/snippets/react-native/receive_payment.ts
+++ b/docs/breez-sdk/snippets/react-native/receive_payment.ts
@@ -8,14 +8,14 @@ const exampleReceiveLightningPayment = async (sdk: BreezSdk) => {
   const description = '<invoice description>'
   // Optionally set the invoice amount you wish the payer to send
   const optionalAmountSats = BigInt(5_000)
-  // Optionally set the expiry time in seconds
-  const optionalExpirySecs = 3600
+  // Optionally set the expiry duration in seconds
+  const optionalExpiryDurationSecs = 3600
 
   const response = await sdk.receivePayment({
     paymentMethod: new ReceivePaymentMethod.Bolt11Invoice({
       description,
       amountSats: optionalAmountSats,
-      expirySecs: optionalExpirySecs
+      expiryDurationSecs: optionalExpiryDurationSecs
     })
   })
 
@@ -56,14 +56,14 @@ const exampleReceiveSparkInvoice = async (sdk: BreezSdk) => {
   // ANCHOR: receive-payment-spark-invoice
   const optionalDescription = '<invoice description>'
   const optionalAmountSats = BigInt(5_000)
-  const optionalExpiryTimeSeconds = BigInt(1716691200)
+  const optionalExpiresAt = BigInt(1716691200)
   const optionalSenderPublicKey = '<sender public key>'
 
   const response = await sdk.receivePayment({
     paymentMethod: new ReceivePaymentMethod.SparkInvoice({
       description: optionalDescription,
       amount: optionalAmountSats,
-      expiryTime: optionalExpiryTimeSeconds,
+      expiresAt: optionalExpiresAt,
       senderPublicKey: optionalSenderPublicKey,
       tokenIdentifier: undefined
     })

--- a/docs/breez-sdk/snippets/react-native/tokens.ts
+++ b/docs/breez-sdk/snippets/react-native/tokens.ts
@@ -48,7 +48,7 @@ const exampleReceiveTokenPaymentSparkInvoice = async (sdk: BreezSdk) => {
   const tokenIdentifier = '<token identifier>'
   const optionalDescription = '<invoice description>'
   const optionalAmount = BigInt(5_000)
-  const optionalExpiryTimeSeconds = BigInt(1716691200)
+  const optionalExpiresAt = BigInt(1716691200)
   const optionalSenderPublicKey = '<sender public key>'
 
   const response = await sdk.receivePayment({
@@ -56,7 +56,7 @@ const exampleReceiveTokenPaymentSparkInvoice = async (sdk: BreezSdk) => {
       tokenIdentifier,
       description: optionalDescription,
       amount: optionalAmount,
-      expiryTime: optionalExpiryTimeSeconds,
+      expiresAt: optionalExpiresAt,
       senderPublicKey: optionalSenderPublicKey
     })
   })

--- a/docs/breez-sdk/snippets/rust/src/parsing_inputs.rs
+++ b/docs/breez-sdk/snippets/rust/src/parsing_inputs.rs
@@ -47,8 +47,8 @@ async fn parse_input(sdk: &BreezSdk) -> Result<()> {
                 println!("  Description: {}", description);
             }
 
-            if let Some(expiry_time) = invoice.expiry_time {
-                println!("  Expiry time: {}", expiry_time);
+            if let Some(expires_at) = invoice.expires_at {
+                println!("  Expires at: {}", expires_at);
             }
 
             if let Some(sender_public_key) = &invoice.sender_public_key {

--- a/docs/breez-sdk/snippets/rust/src/receive_payment.rs
+++ b/docs/breez-sdk/snippets/rust/src/receive_payment.rs
@@ -7,14 +7,14 @@ async fn receive_lightning_bolt11(sdk: &BreezSdk) -> Result<()> {
     let description = "<invoice description>".to_string();
     // Optionally set the invoice amount you wish the payer to send
     let optional_amount_sats = Some(5_000);
-    let optional_expiry_secs = Some(3600_u32);
+    let optional_expiry_duration_secs = Some(3600_u32);
 
     let response = sdk
         .receive_payment(ReceivePaymentRequest {
             payment_method: ReceivePaymentMethod::Bolt11Invoice {
                 description,
                 amount_sats: optional_amount_sats,
-                expiry_secs: optional_expiry_secs,
+                expiry_duration_secs: optional_expiry_duration_secs,
             },
         })
         .await?;
@@ -63,7 +63,7 @@ async fn receive_spark_invoice(sdk: &BreezSdk) -> Result<()> {
     // ANCHOR: receive-payment-spark-invoice
     let optional_description = "<invoice description>".to_string();
     let optional_amount_sats = Some(5_000);
-    let optional_expiry_time_seconds = Some(1716691200);
+    let optional_expires_at = Some(1716691200);
     let optional_sender_public_key = Some("<sender public key>".to_string());
 
     let response = sdk
@@ -72,7 +72,7 @@ async fn receive_spark_invoice(sdk: &BreezSdk) -> Result<()> {
                 token_identifier: None,
                 description: Some(optional_description),
                 amount: optional_amount_sats,
-                expiry_time: optional_expiry_time_seconds,
+                expires_at: optional_expires_at,
                 sender_public_key: optional_sender_public_key,
             },
         })

--- a/docs/breez-sdk/snippets/rust/src/tokens.rs
+++ b/docs/breez-sdk/snippets/rust/src/tokens.rs
@@ -54,7 +54,7 @@ async fn receive_token_payment_spark_invoice(sdk: &BreezSdk) -> Result<()> {
     let token_identifier = Some("<token identifier>".to_string());
     let optional_description = Some("<invoice description>".to_string());
     let optional_amount = Some(5_000);
-    let optional_expiry_time_seconds = Some(1716691200);
+    let optional_expires_at = Some(1716691200);
     let optional_sender_public_key = Some("<sender public key>".to_string());
 
     let response = sdk
@@ -63,7 +63,7 @@ async fn receive_token_payment_spark_invoice(sdk: &BreezSdk) -> Result<()> {
                 token_identifier,
                 description: optional_description,
                 amount: optional_amount,
-                expiry_time: optional_expiry_time_seconds,
+                expires_at: optional_expires_at,
                 sender_public_key: optional_sender_public_key,
             },
         })

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ParsingInputs.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ParsingInputs.swift
@@ -39,8 +39,8 @@ func parseInput(sdk: BreezSdk) async throws {
                 print("  Description: \(description)")
             }
 
-            if let expiryTime = invoice.expiryTime {
-                print("  Expiry time: \(Date(timeIntervalSince1970: TimeInterval(expiryTime)))")
+            if let expiresAt = invoice.expiresAt {
+                print("  Expires at: \(Date(timeIntervalSince1970: TimeInterval(expiresAt)))")
             }
 
             if let senderPublicKey = invoice.senderPublicKey {

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ReceivePayment.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ReceivePayment.swift
@@ -6,8 +6,8 @@ func receiveLightning(sdk: BreezSdk) async throws -> ReceivePaymentResponse {
     let description = "<invoice description>"
     // Optionally set the invoice amount you wish the payer to send
     let optionalAmountSats: UInt64 = 5_000
-    // Optionally set the expiry time in seconds
-    let optionalExpirySecs: UInt32 = 3600
+    // Optionally set the expiry duration in seconds
+    let optionalExpiryDurationSecs: UInt32 = 3600
     let response =
         try await sdk
         .receivePayment(
@@ -15,7 +15,7 @@ func receiveLightning(sdk: BreezSdk) async throws -> ReceivePaymentResponse {
                 paymentMethod: ReceivePaymentMethod.bolt11Invoice(
                     description: description,
                     amountSats: optionalAmountSats,
-                    expirySecs: optionalExpirySecs
+                    expiryDurationSecs: optionalExpiryDurationSecs
                 )
             ))
 
@@ -68,7 +68,7 @@ func receiveSparkInvoice(sdk: BreezSdk) async throws -> ReceivePaymentResponse {
     // ANCHOR: receive-payment-spark-invoice
     let optionalDescription = "<invoice description>"
     let optionalAmountSats = BInt(5_000)
-    let optionalExpiryTimeSeconds: UInt64 = 1_716_691_200
+    let optionalExpiresAt: UInt64 = 1_716_691_200
     let optionalSenderPublicKey = "<sender public key>"
 
     let response =
@@ -78,7 +78,7 @@ func receiveSparkInvoice(sdk: BreezSdk) async throws -> ReceivePaymentResponse {
                 paymentMethod: ReceivePaymentMethod.sparkInvoice(
                     amount: optionalAmountSats,
                     tokenIdentifier: nil,
-                    expiryTime: optionalExpiryTimeSeconds,
+                    expiresAt: optionalExpiresAt,
                     description: optionalDescription,
                     senderPublicKey: optionalSenderPublicKey
                 )

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Tokens.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Tokens.swift
@@ -46,7 +46,7 @@ func receiveTokenPaymentSparkInvoice(sdk: BreezSdk) async throws -> ReceivePayme
     let tokenIdentifier = "<token identifier>"
     let optionalDescription = "<invoice description>"
     let optionalAmount = BInt(5_000)
-    let optionalExpiryTimeSeconds: UInt64 = 1_716_691_200
+    let optionalExpiresAt: UInt64 = 1_716_691_200
     let optionalSenderPublicKey = "<sender public key>"
 
     let response =
@@ -56,7 +56,7 @@ func receiveTokenPaymentSparkInvoice(sdk: BreezSdk) async throws -> ReceivePayme
                 paymentMethod: ReceivePaymentMethod.sparkInvoice(
                     amount: optionalAmount,
                     tokenIdentifier: tokenIdentifier,
-                    expiryTime: optionalExpiryTimeSeconds,
+                    expiresAt: optionalExpiresAt,
                     description: optionalDescription,
                     senderPublicKey: optionalSenderPublicKey
                 )

--- a/docs/breez-sdk/snippets/wasm/parsing_inputs.ts
+++ b/docs/breez-sdk/snippets/wasm/parsing_inputs.ts
@@ -49,8 +49,8 @@ const parseInputs = async (sdk: BreezSdk) => {
         console.log(`  Description: ${parsed.description}`)
       }
 
-      if (parsed.expiryTime != null) {
-        console.log(`  Expiry time: ${new Date(Number(parsed.expiryTime) * 1000).toISOString()}`)
+      if (parsed.expiresAt != null) {
+        console.log(`  Expires at: ${new Date(Number(parsed.expiresAt) * 1000).toISOString()}`)
       }
 
       if (parsed.senderPublicKey != null) {

--- a/docs/breez-sdk/snippets/wasm/receive_payment.ts
+++ b/docs/breez-sdk/snippets/wasm/receive_payment.ts
@@ -5,15 +5,15 @@ const exampleReceiveLightningPayment = async (sdk: BreezSdk) => {
   const description = '<invoice description>'
   // Optionally set the invoice amount you wish the payer to send
   const optionalAmountSats = 5_000
-  // Optionally set the expiry time in seconds
-  const optionalExpirySecs = 3600
+  // Optionally set the expiry duration in seconds
+  const optionalExpiryDurationSecs = 3600
 
   const response = await sdk.receivePayment({
     paymentMethod: {
       type: 'bolt11Invoice',
       description,
       amountSats: optionalAmountSats,
-      expirySecs: optionalExpirySecs
+      expiryDurationSecs: optionalExpiryDurationSecs
     }
   })
 
@@ -54,7 +54,7 @@ const exampleReceiveSparkInvoice = async (sdk: BreezSdk) => {
   // ANCHOR: receive-payment-spark-invoice
   const optionalDescription = '<invoice description>'
   const optionalAmountSats = '5000'
-  const optionalExpiryTimeSeconds = 1716691200
+  const optionalExpiresAt = 1716691200
   const optionalSenderPublicKey = '<sender public key>'
 
   const response = await sdk.receivePayment({
@@ -62,7 +62,7 @@ const exampleReceiveSparkInvoice = async (sdk: BreezSdk) => {
       type: 'sparkInvoice',
       description: optionalDescription,
       amount: optionalAmountSats,
-      expiryTime: optionalExpiryTimeSeconds,
+      expiresAt: optionalExpiresAt,
       senderPublicKey: optionalSenderPublicKey
     }
   })

--- a/docs/breez-sdk/snippets/wasm/tokens.ts
+++ b/docs/breez-sdk/snippets/wasm/tokens.ts
@@ -43,7 +43,7 @@ const exampleReceiveTokenPaymentSparkInvoice = async (sdk: BreezSdk) => {
   const tokenIdentifier = '<token identifier>'
   const optionalDescription = '<invoice description>'
   const optionalAmount = '5000'
-  const optionalExpiryTimeSeconds = 1716691200
+  const optionalExpiresAt = 1716691200
   const optionalSenderPublicKey = '<sender public key>'
 
   const response = await sdk.receivePayment({
@@ -52,7 +52,7 @@ const exampleReceiveTokenPaymentSparkInvoice = async (sdk: BreezSdk) => {
       tokenIdentifier,
       description: optionalDescription,
       amount: optionalAmount,
-      expiryTime: optionalExpiryTimeSeconds,
+      expiresAt: optionalExpiresAt,
       senderPublicKey: optionalSenderPublicKey
     }
   })

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -318,7 +318,7 @@ pub enum _ReceivePaymentMethod {
     SparkInvoice {
         amount: Option<u128>,
         token_identifier: Option<String>,
-        expiry_time: Option<u64>,
+        expires_at: Option<u64>,
         description: Option<String>,
         sender_public_key: Option<String>,
     },
@@ -326,7 +326,7 @@ pub enum _ReceivePaymentMethod {
     Bolt11Invoice {
         description: String,
         amount_sats: Option<u64>,
-        expiry_secs: Option<u32>,
+        expiry_duration_secs: Option<u32>,
     },
 }
 
@@ -547,7 +547,7 @@ pub struct _SparkInvoicePaymentDetails {
 pub struct _SparkHtlcDetails {
     pub payment_hash: String,
     pub preimage: Option<String>,
-    pub expiry_time: u64,
+    pub expires_at: u64,
     pub status: SparkHtlcStatus,
 }
 
@@ -727,7 +727,7 @@ pub struct _SparkInvoiceDetails {
     pub network: BitcoinNetwork,
     pub amount: Option<u128>,
     pub token_identifier: Option<String>,
-    pub expiry_time: Option<u64>,
+    pub expires_at: Option<u64>,
     pub description: Option<String>,
     pub sender_public_key: Option<String>,
 }


### PR DESCRIPTION
Closes #545 by clarifying the distinction between absolute timestamps and relative durations in `ReceivePaymentMethod `

- `expiry_time` → `expires_at` (SparkInvoice/SparkHtlcDetails): UNIX timestamp in seconds indicating when the invoice expires
- `expiry_secs` → `expiry_duration_secs` (Bolt11Invoice): Duration in seconds until the invoice expires

This is a breaking change.