### PR TITLE
docs: improve expiries documentation

### DIFF
--- a/crates/breez-sdk/common/src/input/models.rs
+++ b/crates/breez-sdk/common/src/input/models.rs
@@ -189,7 +189,7 @@ pub struct SparkInvoiceDetails {
     pub amount: Option<u128>,
     /// The token identifier of the token payment. Absence indicates a Bitcoin payment.
     pub token_identifier: Option<String>,
-    /// Optional expiry time. If not provided, the invoice will never expire.
+    /// Optional expiry time as a unix timestamp in seconds. If not provided, the invoice will never expire.
     pub expiry_time: Option<u64>,
     /// Optional description.
     pub description: Option<String>,

--- a/crates/breez-sdk/core/src/common/models.rs
+++ b/crates/breez-sdk/core/src/common/models.rs
@@ -391,7 +391,7 @@ pub struct SparkInvoiceDetails {
     pub amount: Option<u128>,
     /// The token identifier of the token payment. Absence indicates a Bitcoin payment.
     pub token_identifier: Option<String>,
-    /// Optional expiry time. If not provided, the invoice will never expire.
+    /// Optional expiry time as a unix timestamp in seconds. If not provided, the invoice will never expire.
     pub expiry_time: Option<u64>,
     /// Optional description.
     pub description: Option<String>,

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -310,7 +310,7 @@ pub struct SparkHtlcDetails {
     pub payment_hash: String,
     /// The preimage of the HTLC. Empty until receiver has released it.
     pub preimage: Option<String>,
-    /// The expiry time of the HTLC in seconds since the Unix epoch
+    /// The expiry time of the HTLC as a unix timestamp in seconds
     pub expiry_time: u64,
     /// The HTLC status
     pub status: SparkHtlcStatus,
@@ -669,7 +669,7 @@ pub enum ReceivePaymentMethod {
         /// The presence of this field indicates that the payment is for a token
         /// If empty, it is a Bitcoin payment
         token_identifier: Option<String>,
-        /// The expiry time of the invoice in seconds since the Unix epoch
+        /// The expiry time of the invoice as a unix timestamp in seconds
         expiry_time: Option<u64>,
         /// A description to embed in the invoice.
         description: Option<String>,
@@ -680,7 +680,7 @@ pub enum ReceivePaymentMethod {
     Bolt11Invoice {
         description: String,
         amount_sats: Option<u64>,
-        /// The expiry time of the invoice in seconds
+        /// The expiry of the invoice as a duration in seconds
         expiry_secs: Option<u32>,
     },
 }

--- a/docs/breez-sdk/snippets/csharp/ReceivePayment.cs
+++ b/docs/breez-sdk/snippets/csharp/ReceivePayment.cs
@@ -11,7 +11,7 @@ namespace BreezSdkSnippets
             var description = "<invoice description>";
             // Optionally set the invoice amount you wish the payer to send
             var optionalAmountSats = 5_000UL;
-            // Optionally set the expiry time in seconds
+            // Optionally set the expiry duration in seconds
             var optionalExpirySecs = 3600U;
             var paymentMethod = new ReceivePaymentMethod.Bolt11Invoice(
                 description: description,
@@ -63,6 +63,7 @@ namespace BreezSdkSnippets
             // ANCHOR: receive-payment-spark-invoice
             var optionalDescription = "<invoice description>";
             var optionalAmountSats = new BigInteger(5000);
+            // Optionally set the expiry UNIX timestamp in seconds
             var optionalExpiryTimeSeconds = 1716691200UL;
             var optionalSenderPublicKey = "<sender public key>";
 

--- a/docs/breez-sdk/snippets/csharp/Tokens.cs
+++ b/docs/breez-sdk/snippets/csharp/Tokens.cs
@@ -55,6 +55,7 @@ namespace BreezSdkSnippets
             var tokenIdentifier = "<token identifier>";
             var optionalDescription = "<invoice description>";
             var optionalAmount = new BigInteger(5000);
+            // Optionally set the expiry UNIX timestamp in seconds
             var optionalExpiryTimeSeconds = 1716691200UL;
             var optionalSenderPublicKey = "<sender public key>";
 

--- a/docs/breez-sdk/snippets/flutter/lib/receive_payment.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/receive_payment.dart
@@ -6,7 +6,7 @@ Future<ReceivePaymentResponse> receivePaymentLightning(
   String description = "<invoice description>";
   // Optionally set the invoice amount you wish the payer to send
   BigInt optionalAmountSats = BigInt.from(5000);
-  // Optionally set the expiry time in seconds
+  // Optionally set the expiry duration in seconds
   int optionalExpirySecs = 3600;
 
   // Create an invoice and set the amount you wish the payer to send
@@ -64,6 +64,7 @@ Future<ReceivePaymentResponse> receivePaymentSparkInvoice(BreezSdk sdk) async {
   // ANCHOR: receive-payment-spark-invoice
   String optionalDescription = "<invoice description>";
   BigInt optionalAmountSats = BigInt.from(5000);
+  // Optionally set the expiry UNIX timestamp in seconds
   BigInt optionalExpiryTimeSeconds = BigInt.from(1716691200);
   String optionalSenderPublicKey = "<sender public key>";
 

--- a/docs/breez-sdk/snippets/flutter/lib/tokens.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/tokens.dart
@@ -43,6 +43,7 @@ Future<ReceivePaymentResponse> receiveTokenPaymentSparkInvoice(BreezSdk sdk) asy
   String tokenIdentifier = '<token identifier>';
   String optionalDescription = "<invoice description>";
   BigInt optionalAmount = BigInt.from(5000);
+  // Optionally set the expiry UNIX timestamp in seconds
   BigInt optionalExpiryTimeSeconds = BigInt.from(1716691200);
   String optionalSenderPublicKey = "<sender public key>"; 
 

--- a/docs/breez-sdk/snippets/go/receive_payment.go
+++ b/docs/breez-sdk/snippets/go/receive_payment.go
@@ -12,7 +12,7 @@ func ReceiveLightningBolt11(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.Rec
 	description := "<invoice description>"
 	// Optionally set the invoice amount you wish the payer to send
 	optionalAmountSats := uint64(5_000)
-	// Optionally set the expiry time in seconds
+	// Optionally set the expiry duration in seconds
 	optionalExpirySecs := uint32(3600)
 
 	request := breez_sdk_spark.ReceivePaymentRequest{
@@ -81,6 +81,7 @@ func ReceiveSparkInvoice(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.Receiv
 	// ANCHOR: receive-payment-spark-invoice
 	optionalDescription := "<invoice description>"
 	optionalAmountSats := new(big.Int).SetInt64(5_000)
+	// Optionally set the expiry UNIX timestamp in seconds
 	optionalExpiryTimeSeconds := uint64(1716691200)
 	optionalSenderPublicKey := "<sender public key>"
 

--- a/docs/breez-sdk/snippets/go/tokens.go
+++ b/docs/breez-sdk/snippets/go/tokens.go
@@ -62,6 +62,7 @@ func ReceiveTokenPaymentSparkInvoice(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_
 	tokenIdentifier := "<token identifier>"
 	optionalDescription := "<invoice description>"
 	optionalAmount := new(big.Int).SetInt64(5_000)
+	// Optionally set the expiry UNIX timestamp in seconds
 	optionalExpiryTimeSeconds := uint64(1716691200)
 	optionalSenderPublicKey := "<sender public key>"
 

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
@@ -10,7 +10,7 @@ class ReceivePayment {
             val description = "<invoice description>"
             // Optionally set the invoice amount you wish the payer to send
             val optionalAmountSats = 5_000.toULong()
-            // Optionally set the expiry time in seconds
+            // Optionally set the expiry duration in seconds
             val optionalExpirySecs = 3600.toUInt()
 
             val request = ReceivePaymentRequest(
@@ -71,6 +71,7 @@ class ReceivePayment {
             val optionalAmountSats = BigInteger.fromLong(5_000L)
             // Android (BigInteger from java.math)
             // val optionalAmountSats = BigInteger.valueOf(5_000L)
+            // Optionally set the expiry UNIX timestamp in seconds
             val optionalExpiryTimeSeconds = 1716691200.toULong()
             val optionalSenderPublicKey = "<sender public key>"
 

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Tokens.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Tokens.kt
@@ -61,6 +61,7 @@ class Tokens {
             val optionalAmount = BigInteger.fromLong(5_000L)
             // Android (BigInteger from java.math)
             // val optionalAmount = BigInteger.valueOf(5_000L)
+            // Optionally set the expiry UNIX timestamp in seconds
             val optionalExpiryTimeSeconds = 1716691200.toULong()
             val optionalSenderPublicKey = "<sender public key>"
 

--- a/docs/breez-sdk/snippets/python/src/receive_payment.py
+++ b/docs/breez-sdk/snippets/python/src/receive_payment.py
@@ -13,7 +13,7 @@ async def receive_lightning(sdk: BreezSdk):
         description = "<invoice description>"
         # Optionally set the invoice amount you wish the payer to send
         optional_amount_sats = 5_000
-        # Optionally set the expiry time in seconds
+        # Optionally set the expiry duration in seconds
         optional_expiry_secs = 3600
         payment_method = ReceivePaymentMethod.BOLT11_INVOICE(
             description=description,
@@ -77,6 +77,7 @@ async def receive_spark_invoice(sdk: BreezSdk):
     try:
         optional_description = "<invoice description>"
         optional_amount_sats = 5_000
+        # Optionally set the expiry UNIX timestamp in seconds
         optional_expiry_time_seconds = 1716691200
         optional_sender_public_key = "<sender public key>"
 

--- a/docs/breez-sdk/snippets/python/src/tokens.py
+++ b/docs/breez-sdk/snippets/python/src/tokens.py
@@ -64,6 +64,7 @@ async def receive_token_payment_spark_invoice(sdk: BreezSdk):
         token_identifier = "<token identifier>"
         optional_description = "<invoice description>"
         optional_amount = 5_000
+        # Optionally set the expiry UNIX timestamp in seconds
         optional_expiry_time_seconds = 1716691200
         optional_sender_public_key = "<sender public key>"
 

--- a/docs/breez-sdk/snippets/react-native/receive_payment.ts
+++ b/docs/breez-sdk/snippets/react-native/receive_payment.ts
@@ -8,7 +8,7 @@ const exampleReceiveLightningPayment = async (sdk: BreezSdk) => {
   const description = '<invoice description>'
   // Optionally set the invoice amount you wish the payer to send
   const optionalAmountSats = BigInt(5_000)
-  // Optionally set the expiry time in seconds
+  // Optionally set the expiry duration in seconds
   const optionalExpirySecs = 3600
 
   const response = await sdk.receivePayment({
@@ -56,6 +56,7 @@ const exampleReceiveSparkInvoice = async (sdk: BreezSdk) => {
   // ANCHOR: receive-payment-spark-invoice
   const optionalDescription = '<invoice description>'
   const optionalAmountSats = BigInt(5_000)
+  // Optionally set the expiry UNIX timestamp in seconds
   const optionalExpiryTimeSeconds = BigInt(1716691200)
   const optionalSenderPublicKey = '<sender public key>'
 

--- a/docs/breez-sdk/snippets/react-native/tokens.ts
+++ b/docs/breez-sdk/snippets/react-native/tokens.ts
@@ -48,6 +48,7 @@ const exampleReceiveTokenPaymentSparkInvoice = async (sdk: BreezSdk) => {
   const tokenIdentifier = '<token identifier>'
   const optionalDescription = '<invoice description>'
   const optionalAmount = BigInt(5_000)
+  // Optionally set the expiry UNIX timestamp in seconds
   const optionalExpiryTimeSeconds = BigInt(1716691200)
   const optionalSenderPublicKey = '<sender public key>'
 

--- a/docs/breez-sdk/snippets/rust/src/receive_payment.rs
+++ b/docs/breez-sdk/snippets/rust/src/receive_payment.rs
@@ -7,6 +7,7 @@ async fn receive_lightning_bolt11(sdk: &BreezSdk) -> Result<()> {
     let description = "<invoice description>".to_string();
     // Optionally set the invoice amount you wish the payer to send
     let optional_amount_sats = Some(5_000);
+    // Optionally set the expiry duration in seconds
     let optional_expiry_secs = Some(3600_u32);
 
     let response = sdk
@@ -63,6 +64,7 @@ async fn receive_spark_invoice(sdk: &BreezSdk) -> Result<()> {
     // ANCHOR: receive-payment-spark-invoice
     let optional_description = "<invoice description>".to_string();
     let optional_amount_sats = Some(5_000);
+    // Optionally set the expiry UNIX timestamp in seconds
     let optional_expiry_time_seconds = Some(1716691200);
     let optional_sender_public_key = Some("<sender public key>".to_string());
 

--- a/docs/breez-sdk/snippets/rust/src/tokens.rs
+++ b/docs/breez-sdk/snippets/rust/src/tokens.rs
@@ -54,6 +54,7 @@ async fn receive_token_payment_spark_invoice(sdk: &BreezSdk) -> Result<()> {
     let token_identifier = Some("<token identifier>".to_string());
     let optional_description = Some("<invoice description>".to_string());
     let optional_amount = Some(5_000);
+    // Optionally set the expiry UNIX timestamp in seconds
     let optional_expiry_time_seconds = Some(1716691200);
     let optional_sender_public_key = Some("<sender public key>".to_string());
 

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ReceivePayment.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ReceivePayment.swift
@@ -6,7 +6,7 @@ func receiveLightning(sdk: BreezSdk) async throws -> ReceivePaymentResponse {
     let description = "<invoice description>"
     // Optionally set the invoice amount you wish the payer to send
     let optionalAmountSats: UInt64 = 5_000
-    // Optionally set the expiry time in seconds
+    // Optionally set the expiry duration in seconds
     let optionalExpirySecs: UInt32 = 3600
     let response =
         try await sdk
@@ -68,6 +68,7 @@ func receiveSparkInvoice(sdk: BreezSdk) async throws -> ReceivePaymentResponse {
     // ANCHOR: receive-payment-spark-invoice
     let optionalDescription = "<invoice description>"
     let optionalAmountSats = BInt(5_000)
+    // Optionally set the expiry UNIX timestamp in seconds
     let optionalExpiryTimeSeconds: UInt64 = 1_716_691_200
     let optionalSenderPublicKey = "<sender public key>"
 

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Tokens.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Tokens.swift
@@ -46,6 +46,7 @@ func receiveTokenPaymentSparkInvoice(sdk: BreezSdk) async throws -> ReceivePayme
     let tokenIdentifier = "<token identifier>"
     let optionalDescription = "<invoice description>"
     let optionalAmount = BInt(5_000)
+    // Optionally set the expiry UNIX timestamp in seconds
     let optionalExpiryTimeSeconds: UInt64 = 1_716_691_200
     let optionalSenderPublicKey = "<sender public key>"
 

--- a/docs/breez-sdk/snippets/wasm/receive_payment.ts
+++ b/docs/breez-sdk/snippets/wasm/receive_payment.ts
@@ -5,7 +5,7 @@ const exampleReceiveLightningPayment = async (sdk: BreezSdk) => {
   const description = '<invoice description>'
   // Optionally set the invoice amount you wish the payer to send
   const optionalAmountSats = 5_000
-  // Optionally set the expiry time in seconds
+  // Optionally set the expiry duration in seconds
   const optionalExpirySecs = 3600
 
   const response = await sdk.receivePayment({
@@ -54,6 +54,7 @@ const exampleReceiveSparkInvoice = async (sdk: BreezSdk) => {
   // ANCHOR: receive-payment-spark-invoice
   const optionalDescription = '<invoice description>'
   const optionalAmountSats = '5000'
+  // Optionally set the expiry UNIX timestamp in seconds
   const optionalExpiryTimeSeconds = 1716691200
   const optionalSenderPublicKey = '<sender public key>'
 

--- a/docs/breez-sdk/snippets/wasm/tokens.ts
+++ b/docs/breez-sdk/snippets/wasm/tokens.ts
@@ -43,6 +43,7 @@ const exampleReceiveTokenPaymentSparkInvoice = async (sdk: BreezSdk) => {
   const tokenIdentifier = '<token identifier>'
   const optionalDescription = '<invoice description>'
   const optionalAmount = '5000'
+  // Optionally set the expiry UNIX timestamp in seconds
   const optionalExpiryTimeSeconds = 1716691200
   const optionalSenderPublicKey = '<sender public key>'
 


### PR DESCRIPTION
This clarifies the distinction between timestamp and duration expiries in rustdocs and snippets.