### PR TITLE
Parallelize breez-itest tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,7 @@ jobs:
     env:
       FAUCET_USERNAME: ${{ secrets.FAUCET_USERNAME }}
       FAUCET_PASSWORD: ${{ secrets.FAUCET_PASSWORD }}
+      FAUCET_CONCURRENCY: "2"  # Max concurrent faucet requests (rate limiting)
       RECOVERY_TEST_MNEMONIC: ${{ secrets.RECOVERY_TEST_MNEMONIC }}
       RECOVERY_TEST_EXPECTED_PAYMENTS: ${{ secrets.RECOVERY_TEST_EXPECTED_PAYMENTS }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ itest:
 	cargo xtask itest
 
 breez-itest:
-	cargo xtask test --package breez-sdk-itest -- --test-threads=1
+	cargo xtask test --package breez-sdk-itest -- --test-threads=8
 
 claude-check:
 	make fmt-check clippy-check cargo-test


### PR DESCRIPTION
Add faucet rate limiting via semaphore to enable parallel test execution while respecting faucet API constraints. This addresses the first part of issue #548, bringing execution time in CI from ~50 to ~30 minutes.

Changes:
- Add global semaphore (FAUCET_CONCURRENCY env var, default: 2) to limit concurrent faucet requests in crates/breez-sdk/breez-itest/src/faucet.rs
- Update Makefile to run tests with 8 threads instead of 1
- Add FAUCET_CONCURRENCY env var to CI workflow

Tests that don't use the faucet (message_signing, user_settings, tokens, lnurl_auth) can now run fully in parallel. Tests that use the faucet can run in parallel but are rate-limited by the semaphore, preventing API rate limiting issues.