### PR TITLE
claude: add update snippets command

### DIFF
--- a/.claude/commands/update-snippets.md
+++ b/.claude/commands/update-snippets.md
@@ -1,0 +1,158 @@
+---
+description: Update documentation snippets across all 9 languages
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task, TodoWrite
+---
+
+# Update Documentation Snippets
+
+Update code snippets in `docs/breez-sdk/snippets/` across all supported languages.
+
+## Arguments
+
+The user should provide:
+1. **Snippet file name(s)** - one or more (e.g., `send_payment`, `receive_payment`)
+2. **Change description** (what to add/modify)
+
+### Multiple Files
+
+When updating multiple snippet files:
+- Process **one file completely** (all 9 languages) before moving to next file
+- This prevents partial updates scattered across files if something fails
+- Create a todo list with files as top-level items, languages nested conceptually
+
+## Workflow
+
+### Phase 1: Setup
+
+1. Read `docs/breez-sdk/snippets/SNIPPET_CONVENTIONS.md` for patterns
+2. Create a todo list with all 9 languages
+
+### Phase 2: Update Rust (Canonical Reference)
+
+1. Read the Rust snippet file
+2. Make the requested changes following conventions
+3. Verify: `cargo xtask check-doc-snippets --package rust --skip-build`
+4. If verification fails, fix and re-verify
+5. Mark Rust as complete
+
+### Phase 3: Update All Other Languages (Parallel)
+
+**Spawn all 8 agents in a single message** for: `go`, `python`, `kotlin-mpp`, `swift`, `csharp`, `flutter`, `wasm`, `react-native`
+
+Use this prompt template for each:
+
+```
+You are updating the {LANGUAGE} snippet to match Rust.
+
+## Reference (Rust - canonical)
+{RUST_SNIPPET_CONTENT}
+
+## Conventions
+Read: docs/breez-sdk/snippets/SNIPPET_CONVENTIONS.md
+Focus on the {LANGUAGE} patterns for: imports, function signatures, enum discrimination, logging, error handling.
+
+## Your Task
+1. Read the current {LANGUAGE} snippet at: {LANGUAGE_FILE_PATH}
+2. Compare with Rust reference - identify what changed
+3. Apply equivalent changes following {LANGUAGE}-specific conventions
+4. Ensure ANCHOR names match Rust exactly (kebab-case)
+5. Ensure comments/descriptions match semantically
+6. Use the Edit tool to make changes (or Write if new file)
+
+Do NOT run verification - the main agent will handle that.
+```
+
+### Phase 4: Verify All Languages
+
+After all agents complete, run verifications. Can be parallel:
+
+```bash
+# Run all verifications (parallel in background or sequential):
+cargo xtask check-doc-snippets --package go --skip-build &
+cargo xtask check-doc-snippets --package python --skip-build &
+cargo xtask check-doc-snippets --package kotlin-mpp --skip-build &
+cargo xtask check-doc-snippets --package swift --skip-build &
+cargo xtask check-doc-snippets --package csharp --skip-build &
+cargo xtask check-doc-snippets --package flutter --skip-build &
+cargo xtask check-doc-snippets --package wasm --skip-build &
+cargo xtask check-doc-snippets --package react-native --skip-build &
+wait
+```
+
+If any verification fails:
+1. Fix the specific language
+2. Re-verify just that language
+3. Continue until all pass
+
+### Phase 5: Summary
+
+Report:
+- Languages updated successfully
+- Any issues encountered
+- Verification status for each language
+
+## File Paths
+
+| Language | Path Pattern |
+|----------|-------------|
+| Rust | `docs/breez-sdk/snippets/rust/src/{file}.rs` |
+| Go | `docs/breez-sdk/snippets/go/{file}.go` |
+| Python | `docs/breez-sdk/snippets/python/src/{file}.py` |
+| Kotlin | `docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/{File}.kt` |
+| Swift | `docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/{File}.swift` |
+| C# | `docs/breez-sdk/snippets/csharp/{File}.cs` |
+| Flutter | `docs/breez-sdk/snippets/flutter/lib/{file}.dart` |
+| WASM | `docs/breez-sdk/snippets/wasm/{file}.ts` |
+| React Native | `docs/breez-sdk/snippets/react-native/{file}.ts` |
+
+Note: Some languages use PascalCase filenames (Kotlin, Swift, C#).
+
+## Verification Commands
+
+**Node.js Requirement:** WASM and React Native require Node >= 22. Before verifying those:
+```bash
+# Check and set Node version if nvm is available:
+node --version || true
+command -v nvm && nvm use 22 || true
+```
+
+```bash
+# Individual language (fast with --skip-build):
+cargo xtask check-doc-snippets --package rust --skip-build
+cargo xtask check-doc-snippets --package go --skip-build
+cargo xtask check-doc-snippets --package python --skip-build
+cargo xtask check-doc-snippets --package kotlin-mpp --skip-build
+cargo xtask check-doc-snippets --package swift --skip-build
+cargo xtask check-doc-snippets --package csharp --skip-build
+cargo xtask check-doc-snippets --package flutter --skip-build
+cargo xtask check-doc-snippets --package wasm --skip-build
+cargo xtask check-doc-snippets --package react-native --skip-build
+
+# First run after SDK interface changes (rebuilds bindings):
+cargo xtask check-doc-snippets --package {language}
+```
+
+## Change Types
+
+### Modifying Existing Snippets
+- Read current snippet, apply changes, verify
+- Sub-agent receives both Rust reference AND current language snippet for context
+
+### Adding New Functions
+- Add to Rust first with proper ANCHOR markers
+- Sub-agents translate the new function following conventions
+- Ensure ANCHOR name is kebab-case and identical across all languages
+
+### Adding New Snippet Files
+- Create Rust file first with all functions and ANCHORs
+- Create each language file following the import/structure patterns in conventions
+- May need to update build files (Cargo.toml, go.mod, etc.) - verify will catch this
+
+## Important Notes
+
+- **ANCHOR names must be identical** across all languages
+- **Comments should match semantically** (same meaning, language-appropriate syntax)
+- **Rust first, then parallel** - Rust must complete before spawning other agents
+- **Single message for parallel agents** - spawn all 8 in one tool call block
+- **Verify after all agents complete** - not interleaved with agent spawning
+- If `--skip-build` fails with missing types, run without it once to rebuild bindings

--- a/docs/breez-sdk/snippets/SNIPPET_CONVENTIONS.md
+++ b/docs/breez-sdk/snippets/SNIPPET_CONVENTIONS.md
@@ -1,0 +1,351 @@
+# Snippet Conventions
+
+This document defines conventions for documentation snippets across all 9 supported languages. **Rust is the canonical reference** - all changes should be made to Rust first, then propagated to other languages.
+
+## Languages
+
+| Language | Directory | Extension | Naming |
+|----------|-----------|-----------|--------|
+| Rust | `rust/src/` | `.rs` | `snake_case` |
+| Go | `go/` | `.go` | `PascalCase` |
+| Python | `python/src/` | `.py` | `snake_case` |
+| Kotlin | `kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/` | `.kt` | `camelCase` |
+| Swift | `swift/BreezSdkSnippets/Sources/` | `.swift` | `camelCase` |
+| C# | `csharp/` | `.cs` | `PascalCase` |
+| Flutter | `flutter/lib/` | `.dart` | `camelCase` |
+| WASM | `wasm/` | `.ts` | `camelCase` |
+| React Native | `react-native/` | `.ts` | `camelCase` |
+
+## ANCHOR Markers
+
+All languages use identical ANCHOR syntax (even Python):
+
+```
+// ANCHOR: anchor-name
+[code]
+// ANCHOR_END: anchor-name
+```
+
+Rules:
+- Anchor names: **kebab-case**, identical across all languages
+- Opening: `// ANCHOR: name` (colon after ANCHOR)
+- Closing: `// ANCHOR_END: name` (underscore, no colon)
+- Python uses `//` for anchors (not `#`) for tooling compatibility
+
+## Function Signatures
+
+### Rust
+```rust
+async fn function_name(sdk: &BreezSdk) -> Result<()> {
+```
+
+### Go
+```go
+func FunctionName(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.ResponseType, error) {
+```
+
+### Python
+```python
+async def function_name(sdk: BreezSdk):
+```
+
+### Kotlin
+```kotlin
+suspend fun functionName(sdk: BreezSdk) {
+```
+
+### Swift
+```swift
+func functionName(sdk: BreezSdk) async throws {
+```
+
+### C#
+```csharp
+async Task FunctionName(BreezSdk sdk) {
+```
+
+### Flutter
+```dart
+Future<ResponseType> functionName(BreezSdk sdk) async {
+```
+
+### WASM / React Native
+```typescript
+const exampleFunctionName = async (sdk: BreezSdk) => {
+```
+
+## Import Patterns
+
+### Rust
+```rust
+use anyhow::Result;
+use breez_sdk_spark::*;
+use log::info;
+```
+
+### Go
+```go
+import (
+    "log"
+    "math/big"
+
+    "github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
+)
+```
+
+### Python
+```python
+import logging
+from breez_sdk_spark import (
+    BreezSdk,
+    SpecificType,
+)
+```
+
+### Kotlin
+```kotlin
+import com.example.BreezSdk
+import com.example.SpecificType
+```
+
+### Swift
+```swift
+import BreezSdkSpark
+```
+
+### C#
+```csharp
+using BreezSdkSpark;
+```
+
+### Flutter
+```dart
+import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
+```
+
+### WASM
+```typescript
+import { type BreezSdk, SpecificType } from '@breeztech/breez-sdk-spark'
+```
+
+### React Native
+```typescript
+import { type BreezSdk, SpecificType, SpecificType_Tags } from '@breeztech/breez-sdk-spark-react-native'
+```
+
+## Enum/Type Discrimination
+
+### Rust - if let / match
+```rust
+if let PaymentMethod::Bolt11Invoice { fee_sats, .. } = response.payment_method {
+    info!("Fee: {fee_sats} sats");
+}
+```
+
+### Go - type switch
+```go
+switch method := response.PaymentMethod.(type) {
+case breez_sdk_spark.PaymentMethodBolt11Invoice:
+    log.Printf("Fee: %v sats", method.FeeSats)
+}
+```
+
+### Python - isinstance
+```python
+if isinstance(response.payment_method, PaymentMethod.BOLT11_INVOICE):
+    logging.debug(f"Fee: {response.payment_method.fee_sats} sats")
+```
+
+### Kotlin - is
+```kotlin
+if (response.paymentMethod is PaymentMethod.Bolt11Invoice) {
+    val feeSats = (response.paymentMethod as PaymentMethod.Bolt11Invoice).feeSats
+}
+```
+
+### Swift - if case let
+```swift
+if case let .bolt11Invoice(feeSats, _) = response.paymentMethod {
+    print("Fee: \(feeSats) sats")
+}
+```
+
+### C# - pattern matching
+```csharp
+if (response.paymentMethod is PaymentMethod.Bolt11Invoice bolt11) {
+    Console.WriteLine($"Fee: {bolt11.feeSats} sats");
+}
+```
+
+### Flutter - is
+```dart
+if (response.paymentMethod is PaymentMethod_Bolt11Invoice) {
+    final feeSats = (response.paymentMethod as PaymentMethod_Bolt11Invoice).feeSats;
+    print("Fee: $feeSats sats");
+}
+```
+
+### WASM - type discriminant
+```typescript
+if (response.paymentMethod.type === 'bolt11Invoice') {
+    console.log(`Fee: ${response.paymentMethod.feeSats} sats`)
+}
+```
+
+### React Native - tag discriminant
+```typescript
+if (response.paymentMethod?.tag === PaymentMethod_Tags.Bolt11Invoice) {
+    console.log(`Fee: ${response.paymentMethod.inner.feeSats} sats`)
+}
+```
+
+## Logging
+
+| Language | Pattern |
+|----------|---------|
+| Rust | `info!("Message: {variable}");` |
+| Go | `log.Printf("Message: %v", variable)` |
+| Python | `logging.debug(f"Message: {variable}")` |
+| Kotlin | `// Log.v("Breez", "Message: $variable")` (commented) |
+| Swift | `print("Message: \(variable)")` |
+| C# | `Console.WriteLine($"Message: {variable}");` |
+| Flutter | `print("Message: $variable");` |
+| WASM | `console.log(\`Message: ${variable}\`)` |
+| React Native | `console.log(\`Message: ${variable}\`)` |
+
+## Error Handling
+
+### Rust
+```rust
+let response = sdk.method().await?;
+```
+
+### Go
+```go
+response, err := sdk.Method(request)
+if sdkErr := err.(*breez_sdk_spark.SdkError); sdkErr != nil {
+    return nil, err
+}
+```
+
+### Python
+```python
+try:
+    response = await sdk.method(request=request)
+except Exception as error:
+    logging.error(error)
+    raise
+```
+
+### Kotlin
+```kotlin
+try {
+    val response = sdk.method(request)
+} catch (e: Exception) {
+    // handle error
+}
+```
+
+### Swift
+```swift
+do {
+    let response = try await sdk.method(request: request)
+} catch {
+    // handle error
+}
+```
+
+### C# / Flutter / WASM / React Native
+No explicit try-catch in most snippets (implicit async error propagation).
+
+## Optional Values
+
+Use `optional` prefix consistently:
+- Rust/Python: `optional_amount_sats`
+- Others: `optionalAmountSats`
+
+## Request Construction
+
+### Rust
+```rust
+let request = RequestType {
+    field: value,
+    optional_field: Some(value),
+};
+```
+
+### Go
+```go
+request := breez_sdk_spark.RequestType{
+    Field: value,
+    OptionalField: &optionalValue,
+}
+```
+
+### Python
+```python
+request = RequestType(
+    field=value,
+    optional_field=optional_value,
+)
+```
+
+### Kotlin
+```kotlin
+val request = RequestType(field, optionalField)
+```
+
+### Swift
+```swift
+let request = RequestType(field: value, optionalField: optionalValue)
+```
+
+### C#
+```csharp
+var request = new RequestType(
+    field: value,
+    optionalField: optionalValue
+);
+```
+
+### Flutter
+```dart
+final request = RequestType(
+    field: value,
+    optionalField: optionalValue);
+```
+
+### WASM
+```typescript
+const response = await sdk.method({
+    field: value,
+    optionalField: optionalValue
+})
+```
+
+### React Native
+```typescript
+const response = await sdk.method({
+    field: value,
+    optionalField: optionalValue
+})
+```
+
+## Verification
+
+Run after each language change:
+```bash
+# First time after SDK interface change:
+cargo xtask check-doc-snippets --package <language>
+
+# Subsequent runs (faster):
+cargo xtask check-doc-snippets --package <language> --skip-build
+```
+
+Languages: `rust`, `go`, `python`, `kotlin-mpp`, `swift`, `csharp`, `flutter`, `wasm`, `react-native`
+
+**Node.js Requirement:** WASM and React Native require Node >= 22.
+```bash
+# Set Node version if nvm is available:
+command -v nvm && nvm use 22 || true
+```


### PR DESCRIPTION
This adds a new claude code command for updating doc snippets. Advantages:
- Achieves uniformity across snippets
- Handles verification of snippets and iterates until all are looking good
- Efficient (generation and verification done in parallel)

Basic Syntax

```
  /update-snippets <file_name(s)> "<change description>"
```

  Examples

  Modify an existing function:
```
  /update-snippets send_payment "Add token_identifier parameter to prepare_send_payment_lightning_bolt11"
```

  Add a new function to existing file:
```
  /update-snippets receive_payment "Add a new function receive_payment_lnurl for LNURL-withdraw"
```

  Update multiple files:
```
  /update-snippets send_payment receive_payment "Update fee field names from fee_sats to total_fee_sats"
```

  Create a new snippet file:
```
  /update-snippets token_management "New file with functions: list_tokens, get_token_balance, transfer_token"
```