### PR TITLE
fix(parser): validate BIP-353 domain DNS labels correctly.

### DIFF
--- a/crates/breez-sdk/common/src/input/parser/mod.rs
+++ b/crates/breez-sdk/common/src/input/parser/mod.rs
@@ -136,7 +136,15 @@ where
 
         // Validate both parts are within the DNS label size limit.
         // See <https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4>
-        if local_part.len() > 63 || domain.len() > 63 {
+        if local_part.len() > 63 {
+            return Ok(None);
+        }
+
+        // Domain can contain multiple labels - validate each one
+        if domain
+            .split('.')
+            .any(|label| label.is_empty() || label.len() > 63)
+        {
             return Ok(None);
         }
 


### PR DESCRIPTION
RFC 1035 limits DNS labels to 63 characters, not entire domain names.

This change validates each domain label individually and rejects
empty labels, fixing incorrect rejection of valid BIP-353 addresses.