### PR TITLE
use greedy algorithm for leaf selection

### DIFF
--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -414,12 +414,23 @@ mod tests {
         // Check that reserved leaves were updated with new data
         let reservation = state.get_reservation(&reservation.id).await.unwrap();
         assert_eq!(reservation.len(), 2);
-        assert_eq!(reservation[0].value, 150);
+
+        // Find the leaves by their updated values (order may vary by selection algorithm)
+        let node1_leaf = reservation.iter().find(|l| l.value == 150);
+        let node2_leaf = reservation.iter().find(|l| l.value == 250);
+
+        assert!(
+            node1_leaf.is_some(),
+            "node1 with updated value 150 should exist"
+        );
+        assert!(
+            node2_leaf.is_some(),
+            "node2 with updated value 250 should exist"
+        );
         assert_eq!(
-            reservation[0].status,
+            node1_leaf.unwrap().status,
             crate::tree::TreeNodeStatus::TransferLocked
         );
-        assert_eq!(reservation[1].value, 250);
 
         // Check main pool
         let all_leaves = state.get_leaves().await.unwrap();


### PR DESCRIPTION
The existing algorithm for leaf selection uses dynamic programming to find a set of leaves matching the target value. In the worst case, however, the memory consumption for this was proportional to the target amount. So for example a target amount of 1M sat could use approximately 1M * ~32 bytes = 32MB of memory.

We replace the existing algorithm with a simple greedy selection algorithm. It simply takes the largest value first, and then the lower, etc. This will work most of the time, because leaves are generally powers of two. In the case non-power-of-two leaves exist, swaps will be performed more often than previously, but we think this is an edge case. The memory consumption was so large, that tradeoff is acceptable.

2 integration tests were added to check whether the algorithm wrks correctly even with non-power-of-two denominations. 1 of these integration tests is disabled, however. It waits for #580.