### PR TITLE
fix: missing connector tx on coop exit

### DIFF
--- a/crates/spark-itest/docker/migrations.dockerfile
+++ b/crates/spark-itest/docker/migrations.dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=a9f1e408bbc77a6f0bf3e94bf5d69d8704513087
+ARG VERSION=635525705aac777b4cb33e04ae899a6e5a8cae7f
 ARG REPOSITORY=https://github.com/buildonspark/spark.git
 
 FROM debian:bookworm-20250721-slim AS downloader

--- a/crates/spark-itest/docker/spark-so.dockerfile
+++ b/crates/spark-itest/docker/spark-so.dockerfile
@@ -1,6 +1,6 @@
 # $USER name to be used in the `final` image
 ARG USER=so
-ARG VERSION=a9f1e408bbc77a6f0bf3e94bf5d69d8704513087
+ARG VERSION=635525705aac777b4cb33e04ae899a6e5a8cae7f
 ARG REPOSITORY=https://github.com/buildonspark/spark.git
 
 FROM debian:bookworm-20250721-slim AS downloader

--- a/crates/spark-itest/tests/local_wallet_tests.rs
+++ b/crates/spark-itest/tests/local_wallet_tests.rs
@@ -69,7 +69,7 @@ async fn test_claim_confirmed_deposit(#[future] wallets: WalletsFixture) -> Resu
     fixture
         .fixtures
         .spark_so
-        .wait_for_log("Deposit confirmed before tree creation or tree already available")
+        .wait_for_log("tree not found in available or creating status")
         .await?;
     info!("SO confirmed deposit is ready to claim");
 

--- a/crates/spark/protos/spark/spark.proto
+++ b/crates/spark/protos/spark/spark.proto
@@ -14,7 +14,12 @@ service SparkService {
     // Generates a new static deposit address of the user or returns the existing one for the specified network.
     rpc generate_static_deposit_address(GenerateStaticDepositAddressRequest) returns (GenerateStaticDepositAddressResponse) {}
 
+    // Archives the current default static deposit address and generates a new one for the user.
+    rpc rotate_static_deposit_address(RotateStaticDepositAddressRequest) returns (RotateStaticDepositAddressResponse) {}
+
     rpc start_deposit_tree_creation(StartDepositTreeCreationRequest) returns (StartDepositTreeCreationResponse) {}
+    // Creates a deposit tree with the commitments from get_signing_commitments, after they are signed. Fails if the tree already exists.
+    rpc finalize_deposit_tree_creation(FinalizeDepositTreeCreationRequest) returns (FinalizeDepositTreeCreationResponse) {}
     rpc finalize_transfer_with_transfer_package(FinalizeTransferWithTransferPackageRequest) returns (FinalizeTransferResponse) {}
 
 
@@ -28,6 +33,8 @@ service SparkService {
     rpc get_signing_commitments(GetSigningCommitmentsRequest) returns (GetSigningCommitmentsResponse) {}
 
     rpc provide_preimage(ProvidePreimageRequest) returns (ProvidePreimageResponse) {}
+    // Used to check if a user has provided the preimage for a HODL invoice in lightning receive flow.
+    rpc query_preimage(QueryPreimageRequest) returns (QueryPreimageResponse) {}
     rpc query_htlc(QueryHtlcRequest) returns (QueryHtlcResponse) {}
 
 
@@ -118,7 +125,8 @@ enum Network {
 }
 
 message PageRequest {
-    int32 page_size = 1;
+    int32 unsafe_page_size = 1 [(validate.rules).int32 = { gte: 0, lte: 1000 }];
+    uint32 page_size = 4 [(validate.rules).uint32 = { gte: 0, lte: 1000 }];
     string cursor = 2;
     Direction direction = 3;
 }
@@ -209,6 +217,29 @@ message GenerateStaticDepositAddressRequest {
  */
 message GenerateStaticDepositAddressResponse {
     Address deposit_address = 1;
+}
+
+/**
+ * Request to rotate a static deposit address.
+ * This archives the current default address and generates a new one.
+ * Old address still can be used to receive deposits.
+ */
+message RotateStaticDepositAddressRequest {
+    // The signing public key of the user to aggregate with SO keys and produce the
+    // final pubkey used to generate P2TR address.
+    bytes signing_public_key = 1 [(validate.rules).bytes.len = 33];
+    // The network of the bitcoin network.
+    Network network = 2 [(validate.rules).enum = {not_in: [0]}];
+}
+
+/**
+ * Response to the request to rotate a static deposit address.
+ */
+message RotateStaticDepositAddressResponse {
+    // The newly generated default deposit address.
+    Address new_deposit_address = 1;
+    // The archived (previous default) deposit address.
+    Address archived_deposit_address = 2;
 }
 
 /**
@@ -397,9 +428,9 @@ message NodeSignatureShares {
     // The verifying key of the node.
     bytes verifying_key = 4;
     // The signing result of the node's transaction. This transaction is to pay to self.
-    SigningResult direct_node_tx_signing_result = 5;
+    SigningResult direct_node_tx_signing_result = 5 [deprecated = true];
     // The signing result of the node's direct refund transaction. This transaction is to broadcast for the SO.
-    SigningResult direct_refund_tx_signing_result = 6;
+    SigningResult direct_refund_tx_signing_result = 6 [deprecated = true];
     // The signing result of the node's direct from cpfp refund transaction. This transaction is to broadcast for the SO.
     SigningResult direct_from_cpfp_refund_tx_signing_result = 7;
 }
@@ -466,9 +497,9 @@ message StartDepositTreeCreationRequest {
     // The signing job for the root node's refund transaction.
     SigningJob refund_tx_signing_job = 4;
     // The direct signing job for the root node's transaction.
-    SigningJob direct_root_tx_signing_job = 5;
+    SigningJob direct_root_tx_signing_job = 5 [deprecated = true];
     // The signing job for the root node's direct refund transaction.
-    SigningJob direct_refund_tx_signing_job = 6;
+    SigningJob direct_refund_tx_signing_job = 6 [deprecated = true];
     // The signing job for the root node's direct from cpfp refund transaction.
     SigningJob direct_from_cpfp_refund_tx_signing_job = 7;
 }
@@ -481,6 +512,30 @@ message StartDepositTreeCreationResponse {
     string tree_id = 1;
     // The signature shares for the root node.
     NodeSignatureShares root_node_signature_shares = 2;
+}
+
+/**
+ * FinalizeDepositTreeCreationRequest is the request to finalize the tree creation for a tree root node.
+ */
+message FinalizeDepositTreeCreationRequest {
+    // The identity public key of the user
+    bytes identity_public_key = 1  [(validate.rules).bytes.len = 33];
+
+    // The on-chain utxo
+    UTXO on_chain_utxo = 2;
+
+    // User-signed transactions (with user signature shares, aggregated by server)
+    UserSignedTxSigningJob root_tx_signing_job = 3;
+    UserSignedTxSigningJob refund_tx_signing_job = 4;
+    UserSignedTxSigningJob direct_from_cpfp_refund_tx_signing_job = 5;
+}
+
+/**
+ * FinalizeDepositTreeCreationResponse is the response to the request to finalize the tree creation for a tree root node.
+ */
+message FinalizeDepositTreeCreationResponse {
+    // the root node of the created tree
+    TreeNode root_node = 1;
 }
 
 // This proto is constructed by the wallet to specify leaves it wants to spend as
@@ -868,6 +923,13 @@ message TransferFilter {
     Network network = 4; // defaults to mainnet when no network is provided.
     repeated TransferStatus statuses = 80;
     Order order = 5;
+
+    oneof time_filter {
+        // Filter transfers created strictly after this timestamp (exclusive)
+        google.protobuf.Timestamp created_after = 6;
+        // Filter transfers created strictly before this timestamp (exclusive)
+        google.protobuf.Timestamp created_before = 7;
+    }
 }
 
 message QueryTransfersResponse {
@@ -915,6 +977,9 @@ message GetSigningCommitmentsRequest {
     repeated string node_ids = 1;
     // The number of signing commitments to get per node ID.
     uint32 count = 2;
+    // Alternative to passing the node IDs: the number of node IDs for which to get signing commitments.
+    // Either `node_ids` or `node_id_count` should be passed, but not both.
+    uint32 node_id_count = 3;
 }
 
 message GetSigningCommitmentsResponse {
@@ -980,6 +1045,7 @@ message CooperativeExitRequest {
     StartTransferRequest transfer = 1;
     string exit_id = 2;
     bytes exit_txid = 3;
+    bytes connector_tx = 4;
 }
 
 message CooperativeExitResponse {
@@ -1181,6 +1247,14 @@ message ProvidePreimageResponse {
     Transfer transfer = 1;
 }
 
+message QueryPreimageRequest {
+    bytes payment_hash = 1 [(validate.rules).bytes.len = 32];
+}
+
+message QueryPreimageResponse {
+    optional bytes preimage = 1;
+}
+
 message TreeNodeIds {
     repeated string node_ids = 1;
 }
@@ -1295,6 +1369,12 @@ enum UtxoSwapRequestType {
   Refund = 2;
 }
 
+// Which hash variant to use in cryptographic operations.
+enum HashVariant {
+  HASH_VARIANT_UNSPECIFIED = 0;  // Legacy
+  HASH_VARIANT_V2 = 1;           // Structured hashing
+}
+
 message InitiateStaticDepositUtxoRefundRequest {
     UTXO on_chain_utxo = 1;
     // A package that is used for signing L1 Bitcoin transactions using FROST.
@@ -1316,6 +1396,8 @@ message InitiateStaticDepositUtxoRefundRequest {
     // The concatenated payload is then hashed with SHA-256, and the resulting hash
     // is signed using ECDSA with the user's identity private key to produce this signature.
     bytes user_signature = 4;
+    // Optional: which hash variant was used to create user_signature.
+    HashVariant hash_variant = 5;
 }
 
 message InitiateStaticDepositUtxoRefundResponse {

--- a/crates/spark/src/bitcoin/error.rs
+++ b/crates/spark/src/bitcoin/error.rs
@@ -7,4 +7,6 @@ pub enum BitcoinError {
     KeyCombinationError(String),
     #[error("taproot error: {0}")]
     Taproot(#[from] TaprootError),
+    #[error("invalid transaction: {0}")]
+    InvalidTransaction(String),
 }

--- a/crates/spark/src/services/coop_exit.rs
+++ b/crates/spark/src/services/coop_exit.rs
@@ -214,6 +214,7 @@ impl CoopExitService {
                 connector_txid,
                 coop_exit_input,
                 unwrapped_transfer_id,
+                raw_connector_transaction_bytes.clone(),
             )
             .await;
         let coop_exit_refund_signatures = match (&transfer_id, res) {
@@ -244,12 +245,19 @@ impl CoopExitService {
         connector_txid: Txid,
         exit_txid: Txid,
         transfer_id: TransferId,
+        connector_tx: Vec<u8>,
     ) -> Result<CoopExitRefundSignatures, ServiceError> {
         debug!(
             "Getting connector refund signatures for connector_txid: {connector_txid}, exit_txid: {exit_txid}",
         );
         let coop_exit_refund_signatures = self
-            .sign_coop_exit_refunds(&leaf_key_tweaks, connector_txid, exit_txid, transfer_id)
+            .sign_coop_exit_refunds(
+                &leaf_key_tweaks,
+                connector_txid,
+                exit_txid,
+                transfer_id,
+                connector_tx,
+            )
             .await?;
 
         trace!("Delivering transfer package for cooperative exit refund signatures");
@@ -274,6 +282,7 @@ impl CoopExitService {
         connector_txid: Txid,
         exit_txid: Txid,
         transfer_id: TransferId,
+        connector_tx: Vec<u8>,
     ) -> Result<CoopExitRefundSignatures, ServiceError> {
         debug!(
             "Signing cooperative exit refunds for connector_txid: {connector_txid}, exit_txid: {exit_txid}",
@@ -283,6 +292,21 @@ impl CoopExitService {
         let mut leaf_data_map =
             prepare_leaf_refund_signing_data(&self.signer, leaf_key_tweaks, receiving_public_key)
                 .await?;
+
+        // Parse connector tx to get outputs for signing
+        let connector_tx_parsed: Transaction = bitcoin::consensus::deserialize(&connector_tx)
+            .map_err(|_| {
+                ServiceError::Generic("Failed to deserialize connector transaction".to_string())
+            })?;
+
+        // Update leaf_data_map with connector prev_out for coop exit signing
+        for (i, leaf_key) in leaf_key_tweaks.iter().enumerate() {
+            if let Some(leaf_data) = leaf_data_map.get_mut(&leaf_key.node.id)
+                && i < connector_tx_parsed.output.len()
+            {
+                leaf_data.connector_prev_out = Some(connector_tx_parsed.output[i].clone());
+            }
+        }
 
         // Prepare refund signing jobs for the coordinator
         trace!("Preparing refund signing jobs for cooperative exit");
@@ -330,6 +354,7 @@ impl CoopExitService {
                     }),
                     exit_id: uuid::Uuid::now_v7().to_string(),
                     exit_txid: exit_txid.as_byte_array().to_vec(),
+                    connector_tx,
                 })
                 .await?;
         let transfer = response

--- a/crates/spark/src/services/timelock_manager.rs
+++ b/crates/spark/src/services/timelock_manager.rs
@@ -271,6 +271,7 @@ impl TimelockManager {
             .get_signing_commitments(GetSigningCommitmentsRequest {
                 node_ids: vec![node.id.to_string()],
                 count: signing_jobs.len() as u32,
+                node_id_count: 0,
             })
             .await?
             .signing_commitments
@@ -439,6 +440,7 @@ impl TimelockManager {
             .get_signing_commitments(GetSigningCommitmentsRequest {
                 node_ids: vec![node.id.to_string()],
                 count: signing_jobs.len() as u32,
+                node_id_count: 0,
             })
             .await?
             .signing_commitments
@@ -581,6 +583,7 @@ impl TimelockManager {
             .get_signing_commitments(GetSigningCommitmentsRequest {
                 node_ids: vec![node.id.to_string()],
                 count: signing_jobs.len() as u32,
+                node_id_count: 0,
             })
             .await?
             .signing_commitments

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -57,6 +57,8 @@ pub struct LeafRefundSigningData {
     pub direct_signing_nonce_commitment: FrostSigningCommitmentsWithNonces,
     pub direct_from_cpfp_signing_nonce_commitment: FrostSigningCommitmentsWithNonces,
     pub vout: u32,
+    /// For coop exit signing: the connector transaction output to use as prev_out
+    pub connector_prev_out: Option<bitcoin::TxOut>,
 }
 
 /// Configuration for claiming transfers
@@ -441,6 +443,7 @@ impl TransferService {
                     .map(|l| l.node.id.to_string())
                     .collect(),
                 count: 3,
+                node_id_count: 0,
             })
             .await?
             .signing_commitments
@@ -1066,6 +1069,7 @@ impl TransferService {
                     direct_signing_nonce_commitment,
                     direct_from_cpfp_signing_nonce_commitment,
                     vout: leaf_key.node.vout,
+                    connector_prev_out: None,
                 },
             );
         }

--- a/crates/spark/src/utils/preimage_swap.rs
+++ b/crates/spark/src/utils/preimage_swap.rs
@@ -63,7 +63,11 @@ pub(crate) async fn swap_nodes_for_preimage(
     let signing_commitments = operator_pool
         .get_coordinator()
         .client
-        .get_signing_commitments(GetSigningCommitmentsRequest { node_ids, count: 3 })
+        .get_signing_commitments(GetSigningCommitmentsRequest {
+            node_ids,
+            count: 3,
+            node_id_count: 0,
+        })
         .await?
         .signing_commitments
         .iter()

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -18,7 +18,12 @@ use crate::utils::htlc_transactions::{
     CreateLightningHtlcRefundTxsParams, create_lightning_htlc_refund_txs,
 };
 use crate::utils::transactions::{RefundTransactions, create_refund_txs};
-use crate::{Network, bitcoin::sighash_from_tx, core::next_sequence, services::LeafKeyTweak};
+use crate::{
+    Network,
+    bitcoin::{sighash_from_multi_input_tx, sighash_from_tx},
+    core::next_sequence,
+    services::LeafKeyTweak,
+};
 
 #[derive(Clone, Debug, Default)]
 pub struct RefundSignatures {
@@ -79,6 +84,7 @@ pub async fn prepare_leaf_refund_signing_data(
                 direct_signing_nonce_commitment,
                 direct_from_cpfp_signing_nonce_commitment,
                 vout: leaf_key.node.vout,
+                connector_prev_out: None,
             },
         );
     }
@@ -317,10 +323,34 @@ pub async fn sign_aggregate_refunds(
                 "Missing refund tx signing result".to_string(),
             ))?;
 
+        // For coop exit (multi-input refunds), build all_prev_outs with both node and connector outputs
+        let all_prev_outs = leaf_data
+            .connector_prev_out
+            .as_ref()
+            .map(|connector_out| vec![tx.output[0].clone(), connector_out.clone()]);
+
+        tracing::debug!(
+            "sign_aggregate_refunds: leaf={}, connector_prev_out={}, refund_tx_inputs={}, node_tx_out0_value={}, connector_out_value={:?}",
+            leaf_id,
+            leaf_data.connector_prev_out.is_some(),
+            refund_tx.input.len(),
+            tx.output[0].value,
+            leaf_data.connector_prev_out.as_ref().map(|c| c.value)
+        );
+
+        // Compute sighash for refund tx
+        // For multi-input transactions (coop exit), use all_prev_outs for BIP 341 sighash
+        let refund_sighash =
+            if let Some(prev_outs) = all_prev_outs.as_ref().filter(|_| refund_tx.input.len() > 1) {
+                sighash_from_multi_input_tx(refund_tx, 0, prev_outs)
+            } else {
+                sighash_from_tx(refund_tx, 0, &tx.output[0])
+            }
+            .map_err(|e| ServiceError::Generic(e.to_string()))?;
+
         let refund_tx_signature = sign_aggregate_frost(SignAggregateFrostParams {
             signer,
-            tx: refund_tx,
-            prev_out: &tx.output[0],
+            sighash: &refund_sighash,
             signing_public_key: &leaf_data.signing_public_key,
             aggregating_public_key: &leaf_data.signing_public_key,
             signing_private_key: &leaf_data.signing_private_key,
@@ -345,10 +375,28 @@ pub async fn sign_aggregate_refunds(
                     .ok_or(ServiceError::ValidationError(
                         "Missing direct refund tx signing result".to_string(),
                     ))?;
+
+                // Build all_prev_outs for direct refund (direct_tx + connector)
+                // BIP 341 Taproot sighash requires ALL inputs' prevouts
+                let direct_all_prev_outs = leaf_data
+                    .connector_prev_out
+                    .as_ref()
+                    .map(|connector_out| vec![direct_tx.output[0].clone(), connector_out.clone()]);
+
+                // Compute sighash for direct refund tx
+                let direct_refund_sighash = if let Some(prev_outs) = direct_all_prev_outs
+                    .as_ref()
+                    .filter(|_| direct_refund_tx.input.len() > 1)
+                {
+                    sighash_from_multi_input_tx(direct_refund_tx, 0, prev_outs)
+                } else {
+                    sighash_from_tx(direct_refund_tx, 0, &direct_tx.output[0])
+                }
+                .map_err(|e| ServiceError::Generic(e.to_string()))?;
+
                 let signature = sign_aggregate_frost(SignAggregateFrostParams {
                     signer,
-                    tx: direct_refund_tx,
-                    prev_out: &direct_tx.output[0],
+                    sighash: &direct_refund_sighash,
                     signing_public_key: &leaf_data.signing_public_key,
                     aggregating_public_key: &leaf_data.signing_public_key,
                     signing_private_key: &leaf_data.signing_private_key,
@@ -371,10 +419,22 @@ pub async fn sign_aggregate_refunds(
                     .ok_or(ServiceError::ValidationError(
                         "Missing direct from CPFP refund tx signing result".to_string(),
                     ))?;
+
+                // Compute sighash for direct from CPFP refund tx
+                // Reuse all_prev_outs from CPFP refund (same inputs: node_tx + connector)
+                let direct_from_cpfp_sighash = if let Some(prev_outs) = all_prev_outs
+                    .as_ref()
+                    .filter(|_| direct_from_cpfp_refund_tx.input.len() > 1)
+                {
+                    sighash_from_multi_input_tx(direct_from_cpfp_refund_tx, 0, prev_outs)
+                } else {
+                    sighash_from_tx(direct_from_cpfp_refund_tx, 0, &tx.output[0])
+                }
+                .map_err(|e| ServiceError::Generic(e.to_string()))?;
+
                 let signature = sign_aggregate_frost(SignAggregateFrostParams {
                     signer,
-                    tx: direct_from_cpfp_refund_tx,
-                    prev_out: &tx.output[0],
+                    sighash: &direct_from_cpfp_sighash,
                     signing_public_key: &leaf_data.signing_public_key,
                     aggregating_public_key: &leaf_data.signing_public_key,
                     signing_private_key: &leaf_data.signing_private_key,


### PR DESCRIPTION
Closes #587 

Updates the main proto file to latest, allowing us to set `connector_tx` which the SO has started to enforce. It also brings some other small changes that this PR also adapts to.

Updates also the local SO images for itests