### PR TITLE
bindings: Remove build dependencies

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build Python bindings
         working-directory: crates/breez-sdk/bindings
         run: |
-          cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library ../../../aarch64-unknown-linux-gnu/libbreez_sdk_spark_bindings.so --no-format --language python -o ffi/python
+          cargo run --features=uniffi-cli --bin uniffi-bindgen generate --library ../../../aarch64-unknown-linux-gnu/libbreez_sdk_spark_bindings.so --no-format --language python -o ffi/python
 
       - name: Archive Python language bindings
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build Swift bindings
         working-directory: crates/breez-sdk/bindings
         run: |
-          cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library ../../../aarch64-apple-ios/libbreez_sdk_spark_bindings.a --no-format --language swift -o ffi/swift
+          cargo run --features=uniffi-cli --bin uniffi-bindgen generate --library ../../../aarch64-apple-ios/libbreez_sdk_spark_bindings.a --no-format --language swift -o ffi/swift
           # WA pre 0.29.0: Fix redeclaration of protocol UniffiForeignFutureTask https://github.com/mozilla/uniffi-rs/pull/2341
           find ffi/swift -name "*.swift" -exec sed -i 's/protocol UniffiForeignFutureTask/fileprivate protocol UniffiForeignFutureTask/g' {} \;
 

--- a/crates/breez-sdk/bindings/Cargo.toml
+++ b/crates/breez-sdk/bindings/Cargo.toml
@@ -7,10 +7,12 @@ version.workspace = true
 default = ["postgres"]
 # PostgreSQL storage backend (disable for mobile builds to reduce binary size)
 postgres = ["breez-sdk-spark/postgres"]
+uniffi-cli = ["uniffi/bindgen-tests", "uniffi/cli"]
 
 [[bin]]
 name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
+required-features = ["uniffi-cli"]
 
 [lib]
 name = "breez_sdk_spark_bindings"
@@ -18,7 +20,7 @@ crate-type = ["staticlib", "cdylib", "lib"]
 
 [dependencies]
 breez-sdk-spark = { workspace = true, features = ["uniffi"] }
-uniffi = { workspace = true, features = ["bindgen-tests", "cli", "tokio"] }
+uniffi = { workspace = true, features = ["tokio"] }
 
 [build-dependencies]
 glob.workspace = true

--- a/crates/breez-sdk/bindings/Makefile
+++ b/crates/breez-sdk/bindings/Makefile
@@ -28,10 +28,10 @@ bindings-golang: build-release install-uniffi-bindgen-golang
 	uniffi-bindgen-go --library $(BIN_PATH) -o $(FFI_DIR)golang -c ./uniffi.toml
 
 bindings-python: build-release
-	cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library $(BIN_PATH) --no-format --language python -o $(FFI_DIR)python
+	cargo run --features=uniffi-cli --bin uniffi-bindgen generate --library $(BIN_PATH) --no-format --language python -o $(FFI_DIR)python
 
 bindings-swift: build-release
-	cargo run --features=uniffi/cli --bin uniffi-bindgen generate --library $(BIN_PATH) --no-format --language swift -o $(FFI_DIR)swift
+	cargo run --features=uniffi-cli --bin uniffi-bindgen generate --library $(BIN_PATH) --no-format --language swift -o $(FFI_DIR)swift
 
 build-release:
 	cargo build --release


### PR DESCRIPTION
The uniffi_bindgen, goblin, clap_builder, clap, cargo_metadata, textwrap and askama dependencies are being statically linked into the runtime library because of the uniffi dependency features "bindgen-tests" and "cli" in the bindings crate.

Removing them makes the most effect on the iOS static library, dropping ~20MB from each arch:
- Single archs: ~172MB -> ~152MB
- Universal: ~347MB -> ~303MB
