### PR TITLE
fix: add username validation for lightning addresses

### DIFF
--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -105,6 +105,7 @@ where
         Extension(state): Extension<State<DB>>,
     ) -> Result<Json<CheckUsernameAvailableResponse>, (StatusCode, Json<Value>)> {
         let username = sanitize_username(&identifier);
+        validate_username(&username)?;
         let user = state
             .db
             .get_user_by_name(&sanitize_domain(&state, &host)?, &username)


### PR DESCRIPTION
Add validation to ensure usernames are non-empty and between 3-32 
characters after sanitization. Apply consistently across check and 
register methods to catch errors early.