### PR TITLE
spark-wallet: Stop background tasks on SDK disconnect

### DIFF
--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -368,8 +368,11 @@ impl SdkBuilder {
         spark_wallet_config.leaf_optimization_options.multiplicity =
             self.config.optimization_config.multiplicity;
 
+        let shutdown_sender = watch::channel::<()>(()).0;
+
         let mut wallet_builder =
-            spark_wallet::WalletBuilder::new(spark_wallet_config, spark_signer);
+            spark_wallet::WalletBuilder::new(spark_wallet_config, spark_signer)
+                .with_cancellation_token(shutdown_sender.subscribe());
         if let Some(observer) = self.payment_observer {
             let observer: Arc<dyn spark_wallet::TransferObserver> =
                 Arc::new(SparkTransferObserver::new(observer));
@@ -392,7 +395,6 @@ impl SdkBuilder {
                 None => None,
             },
         };
-        let shutdown_sender = watch::channel::<()>(()).0;
 
         let event_emitter = Arc::new(EventEmitter::new(
             self.config.real_time_sync_server_url.is_some(),

--- a/crates/breez-sdk/lnurl/src/main.rs
+++ b/crates/breez-sdk/lnurl/src/main.rs
@@ -192,6 +192,7 @@ where
             Arc::clone(&connection_manager),
             None,
             true,
+            None,
         )
         .await?,
     );

--- a/crates/spark-wallet/src/wallet_builder.rs
+++ b/crates/spark-wallet/src/wallet_builder.rs
@@ -8,13 +8,14 @@ use spark::{
     token::{InMemoryTokenOutputStore, TokenOutputStore},
     tree::{InMemoryTreeStore, TreeStore},
 };
+use tokio::sync::watch;
 
 use crate::{SparkWallet, SparkWalletConfig, SparkWalletError};
 
-#[derive(Clone)]
 pub struct WalletBuilder {
     config: SparkWalletConfig,
     signer: Arc<dyn Signer>,
+    cancellation_token: Option<watch::Receiver<()>>,
     session_manager: Option<Arc<dyn SessionManager>>,
     tree_store: Option<Arc<dyn TreeStore>>,
     token_output_store: Option<Arc<dyn TokenOutputStore>>,
@@ -28,6 +29,7 @@ impl WalletBuilder {
         WalletBuilder {
             config,
             signer,
+            cancellation_token: None,
             session_manager: None,
             tree_store: None,
             token_output_store: None,
@@ -37,16 +39,27 @@ impl WalletBuilder {
         }
     }
 
+    /// Sets an external cancellation token for stopping background tasks.
+    /// If not set, an internal token will be created that stops tasks when the wallet is dropped.
+    #[must_use]
+    pub fn with_cancellation_token(mut self, cancellation_token: watch::Receiver<()>) -> Self {
+        self.cancellation_token = Some(cancellation_token);
+        self
+    }
+
+    #[must_use]
     pub fn with_session_manager(mut self, session_manager: Arc<dyn SessionManager>) -> Self {
         self.session_manager = Some(session_manager);
         self
     }
 
+    #[must_use]
     pub fn with_tree_store(mut self, tree_store: Arc<dyn TreeStore>) -> Self {
         self.tree_store = Some(tree_store);
         self
     }
 
+    #[must_use]
     pub fn with_token_output_store(
         mut self,
         token_output_store: Arc<dyn TokenOutputStore>,
@@ -55,6 +68,7 @@ impl WalletBuilder {
         self
     }
 
+    #[must_use]
     pub fn with_connection_manager(
         mut self,
         connection_manager: Arc<dyn ConnectionManager>,
@@ -63,11 +77,13 @@ impl WalletBuilder {
         self
     }
 
+    #[must_use]
     pub fn with_transfer_observer(mut self, transfer_observer: Arc<dyn TransferObserver>) -> Self {
         self.transfer_observer = Some(transfer_observer);
         self
     }
 
+    #[must_use]
     pub fn with_background_processing(mut self, with_background_processing: bool) -> Self {
         self.with_background_processing = with_background_processing;
         self
@@ -87,6 +103,7 @@ impl WalletBuilder {
                 .unwrap_or(Arc::new(DefaultConnectionManager::new())),
             self.transfer_observer,
             self.with_background_processing,
+            self.cancellation_token,
         )
         .await
     }


### PR DESCRIPTION
The BackgroundProcessor in SparkWallet (running token output optimization and event subscription) continued running after disconnect() was called. This occurred because the wallet created its own internal cancellation channel that only triggered on drop, while BreezSdk::disconnect() signaled a separate channel the wallet didn't observe. The Arc references held by background tasks prevented the wallet from being dropped.

The fix adds WalletBuilder::with_cancellation_token() to pass the SDK's shutdown signal to the wallet. When provided, background tasks observe this external token; otherwise, the original drop-based behavior is preserved for standalone usage.

This was observed using Wasm where the backgrounds tasks kept running after `sdk.disconnect(); sdk = null`. This might also happen in the UniFFI bindings until garbage collection occurs.