### PR TITLE
Fix race condition in lnurl receive metadata sync

### DIFF
--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -208,10 +208,13 @@ impl BreezSdk {
             return;
         }
 
-        // Let's check whether the lnurl receive metadata was already synced, then return early
+        // Let's check whether the lnurl receive metadata was already synced, then return early.
+        // Important: Only return early if metadata is actually present (Some), otherwise we need
+        // to trigger a sync. This prevents a race condition where the payment is in storage but
+        // metadata sync from TransferClaimStarting hasn't completed yet.
         if let Ok(db_payment) = self.storage.get_payment_by_id(payment.id.clone()).await
             && let Some(PaymentDetails::Lightning {
-                lnurl_receive_metadata: db_lnurl_receive_metadata,
+                lnurl_receive_metadata: db_lnurl_receive_metadata @ Some(_),
                 ..
             }) = db_payment.details
         {


### PR DESCRIPTION
Closes #531

## Summary
Fixed a race condition in the payment sync logic where metadata sync could be skipped if a payment existed in storage but its lnurl receive metadata hadn't been synced yet from the `TransferClaimStarting` event.

## Changes
- Updated the early return condition in `BreezSdk::sync()` to only skip metadata sync when metadata is actually present (`Some(_)`)
- Previously, the code would return early even when `db_lnurl_receive_metadata` was `None`, preventing necessary metadata synchronization
- Added clarifying comments explaining the race condition and the fix

## Implementation Details
The fix uses a pattern match guard (`@ Some(_)`) to ensure we only return early if metadata has already been synced. This prevents a scenario where:
1. A payment is stored in the database
2. But the metadata sync from `TransferClaimStarting` hasn't completed yet
3. The old code would skip the sync, leaving the payment with incomplete metadata

This ensures metadata synchronization is always triggered when needed, even if the payment record already exists in storage.

https://claude.ai/code/session_01U2ux8XLpbmEB3ogVXwsqbY