### PR TITLE
Fix missing direct_from_cpfp refund tx signing for leaves without direct_tx

### DIFF
--- a/crates/spark-itest/docker/migrations.dockerfile
+++ b/crates/spark-itest/docker/migrations.dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=635525705aac777b4cb33e04ae899a6e5a8cae7f
+ARG VERSION=b5c31cf977147712c3f663b4e3efe83400924da1
 ARG REPOSITORY=https://github.com/buildonspark/spark.git
 
 FROM debian:bookworm-20250721-slim AS downloader

--- a/crates/spark-itest/docker/spark-so.dockerfile
+++ b/crates/spark-itest/docker/spark-so.dockerfile
@@ -1,6 +1,6 @@
 # $USER name to be used in the `final` image
 ARG USER=so
-ARG VERSION=635525705aac777b4cb33e04ae899a6e5a8cae7f
+ARG VERSION=b5c31cf977147712c3f663b4e3efe83400924da1
 ARG REPOSITORY=https://github.com/buildonspark/spark.git
 
 FROM debian:bookworm-20250721-slim AS downloader

--- a/crates/spark-itest/src/helpers.rs
+++ b/crates/spark-itest/src/helpers.rs
@@ -70,7 +70,8 @@ where
 /// # Returns
 /// A tuple of (SparkWallet, event listener)
 pub async fn create_regtest_wallet() -> Result<(SparkWallet, Receiver<WalletEvent>)> {
-    let config = SparkWalletConfig::default_config(Network::Regtest);
+    let mut config = SparkWalletConfig::default_config(Network::Regtest);
+    config.leaf_auto_optimize_enabled = false;
 
     let mut seed = [0u8; 32];
     rand::thread_rng().fill(&mut seed);

--- a/crates/spark-itest/tests/deployed_deposit_tests.rs
+++ b/crates/spark-itest/tests/deployed_deposit_tests.rs
@@ -6,7 +6,7 @@ use spark_itest::{
     helpers::{create_regtest_wallet, wait_for_event},
     mempool::MempoolClient,
 };
-use spark_wallet::WalletEvent;
+use spark_wallet::{ExitSpeed, WalletEvent};
 use tracing::info;
 
 /// Test non-static deposit using deployed regtest with faucet funding.
@@ -85,6 +85,129 @@ async fn test_non_static_deposit_with_faucet() -> Result<()> {
         "Balance should increase by deposit amount"
     );
 
+    // Transfer deposited funds to a second wallet
+    let (bob, mut bob_listener) = create_regtest_wallet().await?;
+    let bob_address = bob.get_spark_address()?;
+    info!("Bob's Spark address: {:?}", bob_address);
+
+    let _transfer = wallet.transfer(deposit_amount, &bob_address, None).await?;
+    info!("Transfer initiated from Alice to Bob");
+
+    // Wait for TransferClaimed event on Bob
+    wait_for_event(
+        &mut bob_listener,
+        180,
+        "TransferClaimed",
+        |event| match &event {
+            WalletEvent::TransferClaimed(_) => Ok(Some(event)),
+            _ => Ok(None),
+        },
+    )
+    .await?;
+    info!("TransferClaimed received by Bob");
+
+    // Verify balances
+    let alice_balance = wallet.get_balance().await?;
+    let bob_balance = bob.get_balance().await?;
+    info!(
+        "Alice balance: {} sats, Bob balance: {} sats",
+        alice_balance, bob_balance
+    );
+
+    assert_eq!(
+        alice_balance, 0,
+        "Alice should have zero balance after transfer"
+    );
+    assert_eq!(
+        bob_balance, deposit_amount,
+        "Bob should have received the full deposit amount"
+    );
+
     info!("=== Test test_non_static_deposit_with_faucet PASSED ===");
+    Ok(())
+}
+
+/// Test non-static deposit followed by cooperative withdrawal to an on-chain address.
+///
+/// This test exercises the `create_connector_refund_txs` path with `direct_from_cpfp_tx`,
+/// which must be created regardless of whether a `direct_tx` exists.
+///
+/// Steps:
+/// 1. Alice deposits via faucet (non-static deposit)
+/// 2. Alice withdraws (coop exit) to Bob's non-static deposit address
+/// 3. Verifies Alice's balance is zero after withdrawal
+#[rstest]
+#[tokio::test]
+#[test_log::test]
+async fn test_non_static_deposit_then_coop_withdraw() -> Result<()> {
+    info!("=== Starting test_non_static_deposit_then_coop_withdraw ===");
+
+    let faucet = RegtestFaucet::new()?;
+    let mempool = MempoolClient::new()?;
+
+    // Create Alice's wallet and deposit funds
+    let (alice, mut alice_listener) = create_regtest_wallet().await?;
+
+    let deposit_address = alice.generate_deposit_address(false).await?;
+    info!("Alice deposit address: {}", deposit_address);
+
+    let deposit_amount = 50_000u64;
+    let txid = faucet
+        .fund_address(&deposit_address.to_string(), deposit_amount)
+        .await?;
+    info!("Faucet funded address, txid: {}", txid);
+
+    let tx = mempool.get_transaction(&txid).await?;
+    let vout = tx
+        .output
+        .iter()
+        .enumerate()
+        .find(|(_, output)| {
+            Address::from_script(&output.script_pubkey, bitcoin::Network::Regtest)
+                .is_ok_and(|addr| addr == deposit_address)
+        })
+        .map(|(i, _)| i as u32)
+        .expect("Could not find deposit address in transaction outputs");
+
+    let leaves = alice.claim_deposit(tx, vout).await?;
+    info!("Claimed deposit, got {} leaves", leaves.len());
+
+    wait_for_event(&mut alice_listener, 180, "DepositConfirmed", |e| match e {
+        WalletEvent::DepositConfirmed(_) => Ok(Some(e)),
+        _ => Ok(None),
+    })
+    .await?;
+    info!("Deposit confirmed");
+
+    let alice_balance = alice.get_balance().await?;
+    assert_eq!(alice_balance, deposit_amount);
+
+    // Create Bob's wallet and generate an on-chain deposit address for withdrawal target
+    let (bob, _bob_listener) = create_regtest_wallet().await?;
+    let bob_deposit_address = bob.generate_deposit_address(false).await?;
+    info!("Bob on-chain deposit address: {}", bob_deposit_address);
+
+    // Coop withdraw all of Alice's funds to Bob's on-chain address
+    let withdrawal_address = bob_deposit_address.to_string();
+    let fee_quote = alice
+        .fetch_coop_exit_fee_quote(&withdrawal_address, None)
+        .await?;
+    let fee_sats = fee_quote.fee_sats(&ExitSpeed::Slow);
+    info!("Coop exit fee quote: {} sats (slow)", fee_sats);
+
+    let _transfer = alice
+        .withdraw(&withdrawal_address, None, ExitSpeed::Slow, fee_quote, None)
+        .await?;
+    info!("Withdrawal initiated");
+
+    // Verify Alice's balance is zero
+    let alice_balance = alice.get_balance().await?;
+    info!("Alice balance after withdrawal: {} sats", alice_balance);
+    assert_eq!(
+        alice_balance, 0,
+        "Alice should have zero balance after withdrawal"
+    );
+
+    info!("=== Test test_non_static_deposit_then_coop_withdraw PASSED ===");
     Ok(())
 }

--- a/crates/spark/src/utils/transactions.rs
+++ b/crates/spark/src/utils/transactions.rs
@@ -313,8 +313,8 @@ pub(crate) fn create_initial_timelock_refund_txs(
 /// The function generates three possible transactions:
 /// 1. A CPFP transaction that spends from both the CPFP outpoint and connector outpoint
 /// 2. An optional direct transaction that spends from both the direct outpoint and connector outpoint (if provided)
-/// 3. An optional alternative direct transaction that spends from both the CPFP outpoint and connector outpoint,
-///    but using the direct sequence number (if direct_outpoint is provided)
+/// 3. An alternative direct transaction that spends from both the CPFP outpoint and connector outpoint,
+///    but using the direct sequence number (always present)
 ///
 /// All transactions pay to a P2TR (Pay-to-Taproot) address derived from the provided public key.
 ///
@@ -334,8 +334,8 @@ pub(crate) fn create_initial_timelock_refund_txs(
 /// A `RefundTransactions` struct containing:
 /// - `cpfp_tx`: Always present, spends both CPFP and connector outpoints
 /// - `direct_tx`: Only present if `direct_tx` is provided, spends direct and connector outpoints
-/// - `direct_from_cpfp_tx`: Alternative transaction that spends CPFP and connector outpoints with
-///   the direct sequence number (only present if `direct_tx` is provided)
+/// - `direct_from_cpfp_tx`: Always present, alternative transaction that spends CPFP and connector
+///   outpoints with the direct sequence number
 pub(crate) fn create_connector_refund_txs(
     params: ConnectorRefundTxsParams<'_>,
 ) -> RefundTransactions {
@@ -388,7 +388,7 @@ pub(crate) fn create_connector_refund_txs(
         tx
     });
 
-    let direct_from_cpfp_tx = params.direct_tx.map(|_| {
+    let direct_from_cpfp_tx = {
         let mut tx = create_spark_tx(
             cpfp_outpoint,
             params.direct_sequence,
@@ -401,8 +401,8 @@ pub(crate) fn create_connector_refund_txs(
             previous_output: params.connector_outpoint,
             ..Default::default()
         });
-        tx
-    });
+        Some(tx)
+    };
 
     RefundTransactions {
         cpfp_tx,


### PR DESCRIPTION
Closes #580 

The direct_from_cpfp_refund_tx spends from the CPFP (node_tx) output, not from direct_tx, so it must be signed regardless of whether direct_tx exists. Previously, both sign_refunds and
  sign_aggregate_refunds nested the direct_from_cpfp_refund_tx signing inside the direct_tx check, causing it to be skipped for leaves that have a CPFP refund but no direct transaction.

  This fix moves the direct_from_cpfp_refund_tx signing into its own independent block in both functions.

  Changes:
  - crates/spark/src/utils/refund.rs — Decouple direct_from_cpfp_refund_tx signing from direct_tx presence in both sign_refunds and sign_aggregate_refunds
  - crates/spark-itest/tests/local_wallet_tests.rs — Extend test_claim_confirmed_deposit to transfer the full deposited balance to Bob, exercising the refund signing path
  - crates/spark-itest/tests/deployed_deposit_tests.rs — Extend test_non_static_deposit_with_faucet with a transfer to verify deposited funds are spendable
  - Bump SO docker image version to latest