### PR TITLE
spark: Fix static deposit refund

### DIFF
--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -310,9 +310,6 @@ impl DepositService {
             0, // temporary value for calculating the vsize. We set the real value bellow.
             &refund_address,
         );
-        let mut witness = Witness::new();
-        witness.push([0; 64]);
-        refund_tx.input[0].witness = witness;
 
         let fee_sats = fee.to_sats(refund_tx.vsize() as u64);
         if fee_sats < MIN_REFUND_FEE_SATS {


### PR DESCRIPTION
Seems this has been broken for about 4 weeks after the SO started validating static deposit refund txs. Before the fix we are getting this error because it contains a filled witness


> Error: SparkSdkError: Service error: service connection error: Connection error: status: Internal, message: "unexpected refund transaction structure: expected 0300000001a35a8936c9efcc9a1204172379efbde2750e77219a2916adb3e73308db51a5220000000000ffffffff01e06000000000000017a9140c80f7cb2e3c79862c67f636c72c490580de7ac48700000000, got 03000000000101a35a8936c9efcc9a1204172379efbde2750e77219a2916adb3e73308db51a5220000000000ffffffff01e06000000000000017a9140c80f7cb2e3c79862c67f636c72c490580de7ac48701400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", details: [], metadata: MetadataMap { headers: {"server": "awselb/2.0", "date": "Mon, 09 Feb 2026 11:54:01 GMT", "content-type": "application/grpc", "content-length": "0"} }
