### PR TITLE
token-conversions: Fix V3 pool selection

### DIFF
--- a/crates/breez-sdk/core/src/token_conversion/models.rs
+++ b/crates/breez-sdk/core/src/token_conversion/models.rs
@@ -3,10 +3,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::SdkError;
 
-/// Default maximum slippage for conversions in basis points (0.5%)
-pub const DEFAULT_CONVERSION_MAX_SLIPPAGE_BPS: u32 = 50;
+/// Default maximum slippage for conversions in basis points (0.1%)
+pub const DEFAULT_CONVERSION_MAX_SLIPPAGE_BPS: u32 = 10;
 /// Default timeout for conversion operations in seconds
 pub const DEFAULT_CONVERSION_TIMEOUT_SECS: u32 = 30;
+/// Default integrator pubkey used when executing conversions
+pub const DEFAULT_INTEGRATOR_PUBKEY: &str =
+    "037e26d9d62e0b3df2d3e66805f61de2a33914465297abf76817296a92ac3f2379";
+/// Default integrator fee BPS used when simulating/executing conversions
+pub const DEFAULT_INTEGRATOR_FEE_BPS: u32 = 5;
 
 /// Response from estimating a conversion, used when preparing a payment that requires conversion
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -87,7 +92,7 @@ pub struct ConversionOptions {
     /// The type of conversion to perform when fulfilling the payment
     pub conversion_type: ConversionType,
     /// The optional maximum slippage in basis points (1/100 of a percent) allowed when
-    /// a conversion is needed to fulfill the payment. Defaults to 50 bps (0.5%) if not set.
+    /// a conversion is needed to fulfill the payment. Defaults to 10 bps (0.1%) if not set.
     /// The conversion will fail if the actual amount received is less than
     /// `estimated_amount * (1 - max_slippage_bps / 10_000)`.
     #[cfg_attr(feature = "uniffi", uniffi(default = None))]

--- a/crates/flashnet/src/config.rs
+++ b/crates/flashnet/src/config.rs
@@ -1,21 +1,31 @@
 use spark::Network;
+use spark_wallet::PublicKey;
 
 #[derive(Clone, Debug)]
 pub struct FlashnetConfig {
     pub base_url: String,
     pub network: Network,
+    pub integrator_config: Option<IntegratorConfig>,
+}
+
+#[derive(Clone, Debug)]
+pub struct IntegratorConfig {
+    pub pubkey: PublicKey,
+    pub fee_bps: u32,
 }
 
 impl FlashnetConfig {
-    pub fn default_config(network: Network) -> Self {
+    pub fn default_config(network: Network, integrator_config: Option<IntegratorConfig>) -> Self {
         match network {
             Network::Mainnet => Self {
                 base_url: "https://api.flashnet.xyz".to_string(),
                 network,
+                integrator_config,
             },
             Network::Regtest | Network::Testnet | Network::Signet => Self {
                 base_url: "https://api.amm.makebitcoingreatagain.dev".to_string(),
                 network,
+                integrator_config,
             },
         }
     }

--- a/crates/flashnet/src/lib.rs
+++ b/crates/flashnet/src/lib.rs
@@ -9,7 +9,7 @@ mod utils;
 
 pub use api::{BTC_ASSET_ADDRESS, FlashnetClient};
 pub use cache::CacheStore;
-pub use config::FlashnetConfig;
+pub use config::*;
 pub use error::FlashnetError;
 pub use models::*;
 pub use pool_selection::select_best_pool;


### PR DESCRIPTION
This PR:
- Fixes `calculate_amount_in` fn to use price-based calculation for V3 concentrated pools instead of constant product formula
- Corrects inverted price formulas when using price-based calculation
- Removes the bit-masking (multiples of 64) requirement for V3 pools
- Reduces the default max slippage bps to 10 bps, as USDB V3 pools have virtually no slippage
- Auto-populates integrator config 