### PR TITLE
Simplify spark-cli usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,15 +283,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,12 +775,6 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "bytemuck"
-version = "1.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "byteorder"
@@ -1576,20 +1561,6 @@ checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "figment"
-version = "0.10.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
-dependencies = [
- "atomic",
- "pear",
- "serde",
- "serde_yaml",
- "uncased",
- "version_check",
 ]
 
 [[package]]
@@ -2558,12 +2529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inlinable_string"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3342,29 +3307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pear"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
-dependencies = [
- "inlinable_string",
- "pear_codegen",
- "yansi",
-]
-
-[[package]]
-name = "pear_codegen"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
-dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn 2.0.105",
-]
-
-[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,19 +3562,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.105",
- "version_check",
- "yansi",
 ]
 
 [[package]]
@@ -4597,19 +4526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.10.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4788,7 +4704,6 @@ dependencies = [
  "bitcoin",
  "clap",
  "dotenvy",
- "figment",
  "hex",
  "qrcode-rs",
  "rand 0.8.5",
@@ -4799,6 +4714,7 @@ dependencies = [
  "shellwords",
  "spark-wallet",
  "tokio",
+ "tracing",
  "tracing-subscriber",
 ]
 
@@ -5744,15 +5660,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
-name = "uncased"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5938,12 +5845,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -6603,12 +6504,6 @@ dependencies = [
  "serde_json",
  "xshell",
 ]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/crates/internal/Cargo.toml
+++ b/crates/internal/Cargo.toml
@@ -8,7 +8,6 @@ bip39.workspace = true
 bitcoin.workspace = true
 clap = { workspace = true, features = ["derive"] }
 dotenvy = "0.15.7"
-figment = { workspace = true, features = ["env", "yaml"] }
 hex.workspace = true
 qrcode-rs = { version = "0.1", default-features = false }
 rand.workspace = true
@@ -19,4 +18,5 @@ serde_json.workspace = true
 shellwords = "1.1.0"
 spark-wallet.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/internal/README.md
+++ b/crates/internal/README.md
@@ -1,0 +1,156 @@
+# Spark CLI
+
+A command-line tool for interacting with Spark wallets, including performing unilateral exits.
+
+## Prerequisites
+
+### Install Rust
+
+If you don't have Rust installed, install it via rustup:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source ~/.cargo/env
+```
+
+Verify installation:
+```bash
+rustc --version
+cargo --version
+```
+
+## Running the CLI
+
+Clone the repository and run:
+
+```bash
+git clone https://github.com/breez/spark-sdk.git
+cd spark-sdk
+cargo run -p spark-cli
+```
+
+### Command-Line Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--network` | Network: `mainnet` or `regtest` | `mainnet` |
+| `-d`, `--data-dir` | Data directory path | `.spark` |
+
+Example with options:
+```bash
+cargo run -p spark-cli -- --network regtest -d ~/.spark-regtest
+```
+
+## Entering Your Mnemonic
+
+When the CLI starts, you'll be prompted to enter your wallet's recovery phrase:
+
+```
+Enter your BIP-39 mnemonic phrase: word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12
+
+Enter passphrase (or press Enter for none):
+```
+
+- Enter your 12 or 24 word mnemonic phrase
+- If you used a passphrase when creating your wallet, enter it; otherwise press Enter
+
+## Unilateral Exit
+
+A unilateral exit allows you to withdraw your funds on-chain without cooperation from the Spark operators. Use this as a last resort if operators are unresponsive.
+
+### Step 1: Check Your Leaves
+
+First, list your wallet's leaves to see what can be exited:
+
+```
+spark-cli [mainnet]> leaves list --compact
+```
+
+This shows your leaf IDs and their values.
+
+### Step 2: Prepare a UTXO for Fees
+
+You need a Bitcoin UTXO from a separate Bitcoin wallet to pay for transaction fees. This cannot come from your Spark wallet - it must be an on-chain UTXO you control in another wallet (e.g., Sparrow, Electrum, Bitcoin Core).
+
+The UTXO format is:
+```
+txid:vout:value_sats:pubkey_hex
+```
+
+- `txid` - Transaction ID of the UTXO
+- `vout` - Output index (usually 0)
+- `value_sats` - Value in satoshis
+- `pubkey_hex` - Public key of the external wallet that owns this UTXO (hex format)
+
+Example:
+```
+abc123...def:0:50000:02abc123...
+```
+
+### Step 3: Execute Unilateral Exit
+
+Run the unilateral exit command:
+
+```
+spark-cli [mainnet]> withdraw unilateral-exit <fee_rate> --leaf <leaf_id> --utxo <utxo>
+```
+
+Parameters:
+- `<fee_rate>` - Fee rate in sats/vbyte (e.g., `10`)
+- `--leaf <leaf_id>` - The leaf ID to exit (from step 1)
+- `--utxo <utxo>` - Your fee-paying UTXO (from step 2)
+
+Example:
+```
+spark-cli [mainnet]> withdraw unilateral-exit 10 --leaf abc123 --utxo def456:0:50000:02abc...
+```
+
+### Step 4: Broadcast Transactions
+
+The CLI will output transaction data and PSBTs in order:
+
+1. **Node TX(s)** - Parent node transactions (if any)
+2. **Leaf TX** - The leaf node transaction
+3. **Refund TX** - The transaction that pays your funds to your address
+
+For each transaction, you need to:
+1. Sign the PSBT with your key (or use `-s` flag for auto-signing)
+2. Broadcast the TX and signed PSBT together
+3. Wait for confirmation before broadcasting the next
+
+**Important about the Refund TX:** The refund transaction has a CSV (CheckSequenceVerify) relative timelock. The CLI will display the timelock value, e.g., "CSV Timelock: 144 blocks after Leaf TX confirms". You must wait for this many blocks after the Leaf TX confirms before you can broadcast the Refund TX.
+
+## Advanced: Auto-signing PSBTs
+
+If you're comfortable providing your private key, the CLI can sign the PSBTs for you. Add the `-s` flag with your hex-encoded private key:
+
+```
+spark-cli [mainnet]> withdraw unilateral-exit 10 --leaf abc123 --utxo def456:0:50000:02abc... -s <private_key_hex>
+```
+
+**Warning:** Only use this on a secure, private machine. Never share your private key.
+
+Without the signing key, you'll need to sign the PSBTs manually using your external Bitcoin wallet before broadcasting.
+
+## Other Useful Commands
+
+```
+spark-cli [mainnet]> balance          # Check your balance
+spark-cli [mainnet]> info             # Wallet information
+spark-cli [mainnet]> help             # List all commands
+```
+
+## Troubleshooting
+
+### "Invalid mnemonic"
+- Ensure words are separated by single spaces
+- Check for typos in mnemonic words
+- Verify you're using a valid BIP-39 word list
+
+### Connection errors
+- Check your internet connection
+- Verify the network setting matches your wallet
+
+### Exit command fails
+- Ensure you have a valid UTXO for fees
+- Check that the leaf ID exists and has funds

--- a/crates/internal/src/command/htlc.rs
+++ b/crates/internal/src/command/htlc.rs
@@ -4,8 +4,6 @@ use clap::Subcommand;
 use rand::RngCore;
 use spark_wallet::{PagingFilter, Preimage, SparkAddress, SparkWallet};
 
-use crate::config::Config;
-
 #[derive(Clone, Debug, Subcommand)]
 pub enum HtlcCommand {
     /// List HTLCs.
@@ -38,7 +36,6 @@ pub enum HtlcCommand {
 }
 
 pub async fn handle_command(
-    _config: &Config,
     wallet: &SparkWallet,
     command: HtlcCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/internal/src/command/invoices.rs
+++ b/crates/internal/src/command/invoices.rs
@@ -6,8 +6,6 @@ use std::{
 use clap::Subcommand;
 use spark_wallet::{PublicKey, SparkWallet};
 
-use crate::config::Config;
-
 #[derive(Clone, Debug, Subcommand)]
 #[allow(clippy::large_enum_variant)]
 pub enum InvoicesCommand {
@@ -49,7 +47,6 @@ pub enum InvoicesCommand {
 }
 
 pub async fn handle_command(
-    _config: &Config,
     wallet: &SparkWallet,
     command: InvoicesCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/internal/src/command/lightning.rs
+++ b/crates/internal/src/command/lightning.rs
@@ -2,8 +2,6 @@ use clap::Subcommand;
 use qrcode_rs::{EcLevel, QrCode, render::unicode};
 use spark_wallet::{InvoiceDescription, SparkWallet};
 
-use crate::config::Config;
-
 #[derive(Clone, Debug, Subcommand)]
 pub enum LightningCommand {
     /// Create a lightning invoice.
@@ -39,7 +37,6 @@ pub enum LightningCommand {
 }
 
 pub async fn handle_command(
-    _config: &Config,
     wallet: &SparkWallet,
     command: LightningCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/internal/src/command/tokens.rs
+++ b/crates/internal/src/command/tokens.rs
@@ -5,8 +5,6 @@ use spark_wallet::{
     ListTokenTransactionsRequest, PagingFilter, SparkAddress, SparkWallet, TransferTokenOutput,
 };
 
-use crate::config::Config;
-
 /// A transfer output that can be parsed from a string in the format "token_id:amount:receiver_address"
 #[derive(Debug, Clone)]
 pub struct TransferTokenOutputArg {
@@ -76,7 +74,6 @@ pub enum TokensCommand {
 }
 
 pub async fn handle_command(
-    _config: &Config,
     wallet: &SparkWallet,
     command: TokensCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/internal/src/command/transfer.rs
+++ b/crates/internal/src/command/transfer.rs
@@ -1,8 +1,6 @@
 use clap::Subcommand;
 use spark_wallet::{ListTransfersRequest, PagingFilter, SparkAddress, SparkWallet};
 
-use crate::config::Config;
-
 #[derive(Clone, Debug, Subcommand)]
 #[allow(clippy::large_enum_variant)]
 pub enum TransferCommand {
@@ -39,7 +37,6 @@ pub enum TransferCommand {
 }
 
 pub async fn handle_command(
-    _config: &Config,
     wallet: &SparkWallet,
     command: TransferCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/internal/src/command/wallet_settings.rs
+++ b/crates/internal/src/command/wallet_settings.rs
@@ -1,8 +1,6 @@
 use clap::Subcommand;
 use spark_wallet::SparkWallet;
 
-use crate::config::Config;
-
 #[derive(Debug, Subcommand)]
 pub enum WalletSettingsCommand {
     /// Query the wallet settings.
@@ -16,7 +14,6 @@ pub enum WalletSettingsCommand {
 }
 
 pub async fn handle_command(
-    _config: &Config,
     wallet: &SparkWallet,
     command: WalletSettingsCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/internal/src/config.rs
+++ b/crates/internal/src/config.rs
@@ -1,66 +1,38 @@
-use std::path::PathBuf;
+use spark_wallet::Network;
 
-use bip39::Mnemonic;
-use serde::{Deserialize, Serialize};
-use spark_wallet::SparkWalletConfig;
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Config {
-    pub mempool_url: String,
-    pub mempool_username: String,
-    pub mempool_password: String,
-    pub log_filter: String,
-    pub log_path: PathBuf,
-    pub mnemonic: Mnemonic,
-    pub passphrase: String,
-    pub spark_config: SparkWalletConfig,
+#[derive(Clone, Debug)]
+pub struct MempoolConfig {
+    pub url: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
 }
 
-pub const DEFAULT_CONFIG: &str = r#"
-mempool_url: "https://regtest-mempool.us-west-2.sparkinfra.net/api"
-mempool_username: "spark-sdk"
-mempool_password: "mCMk1JqlBNtetUNy"
-log_filter: "spark_wallet=debug,spark=debug,info"
-log_path: "spark.log"
-passphrase: ""
-spark_config:
-  network: "regtest"
-  split_secret_threshold: 2
-  operator_pool:
-    coordinator_index: 0
-    operators:
-      - 
-        id: 0
-        identifier: 0000000000000000000000000000000000000000000000000000000000000001
-        address: https://0.spark.lightspark.com/
-        identity_public_key: 03dfbdff4b6332c220f8fa2ba8ed496c698ceada563fa01b67d9983bfc5c95e763
-      -
-        id: 1
-        identifier: 0000000000000000000000000000000000000000000000000000000000000002
-        address: https://spark-operator.breez.technology/
-        identity_public_key: 03e625e9768651c9be268e287245cc33f96a68ce9141b0b4769205db027ee8ed77
-      -
-        id: 2
-        identifier: 0000000000000000000000000000000000000000000000000000000000000003
-        address: https://2.spark.flashnet.xyz/
-        identity_public_key: 022eda13465a59205413086130a65dc0ed1b8f8e51937043161f8be0c369b1a410
-  reconnect_interval_seconds: 1
-  service_provider_config:
-    base_url: "https://api.lightspark.com"
-    schema_endpoint: "graphql/spark/rc"
-    identity_public_key: "022bf283544b16c0622daecb79422007d167eca6ce9f0c98c0c49833b1f7170bfe"
-  tokens_config:
-    expected_withdraw_bond_sats: 10000
-    expected_withdraw_relative_block_locktime: 1000
-    transaction_validity_duration_seconds: 180
-  leaf_optimization_options:
-    multiplicity: 1
-    max_leaves_per_swap: 64
-  leaf_auto_optimize_enabled: true
-  token_outputs_optimization_options:
-    min_outputs_threshold: 50
-    auto_optimize_interval:
-      secs: 120
-      nanos: 0
-  self_payment_allowed: false
-"#;
+impl MempoolConfig {
+    pub fn default_for_network(network: Network) -> Self {
+        match network {
+            Network::Mainnet => Self {
+                url: "https://mempool.space/api".to_string(),
+                username: None,
+                password: None,
+            },
+            _ => Self {
+                url: "https://regtest-mempool.us-west-2.sparkinfra.net/api".to_string(),
+                username: Some("spark-sdk".to_string()),
+                password: Some("mCMk1JqlBNtetUNy".to_string()),
+            },
+        }
+    }
+
+    pub fn from_env(network: Network) -> Self {
+        let default = Self::default_for_network(network);
+        Self {
+            url: std::env::var("SPARK_MEMPOOL_URL").unwrap_or(default.url),
+            username: std::env::var("SPARK_MEMPOOL_USERNAME")
+                .ok()
+                .or(default.username),
+            password: std::env::var("SPARK_MEMPOOL_PASSWORD")
+                .ok()
+                .or(default.password),
+        }
+    }
+}

--- a/crates/internal/src/main.rs
+++ b/crates/internal/src/main.rs
@@ -2,37 +2,36 @@ mod command;
 mod config;
 
 use std::borrow::Cow::{self, Owned};
-use std::fs::{OpenOptions, canonicalize};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use bip39::Mnemonic;
 use bitcoin::hashes::Hash;
 use clap::Parser;
-use figment::{
-    Figment,
-    providers::{Env, Format, Yaml},
-};
 use rustyline::error::ReadlineError;
 use rustyline::highlight::Highlighter;
 use rustyline::hint::HistoryHinter;
 use rustyline::{Completer, Editor, Helper, Hinter, Validator};
-use spark_wallet::{DefaultSigner, Network};
+use spark_wallet::{DefaultSigner, Network, SparkWalletConfig};
+use tracing::{info, warn};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::command::Command;
-use crate::config::{Config, DEFAULT_CONFIG};
-
-const HISTORY_FILE_NAME: &str = "history.txt";
+use crate::config::MempoolConfig;
 
 #[derive(Clone, Debug, Parser)]
+#[command(name = "spark-cli")]
+#[command(about = "CLI for interacting with Spark wallets")]
 struct Args {
-    /// Config path, relative to the working directory.
-    #[arg(long, default_value = "spark.conf")]
-    pub config: PathBuf,
+    /// Network to use (mainnet, regtest)
+    #[arg(long, default_value = "mainnet")]
+    pub network: String,
 
-    /// Working directory
-    #[arg(long, default_value = ".spark")]
-    pub working_directory: PathBuf,
+    /// Path to the data directory
+    #[arg(short, long, default_value = ".spark")]
+    pub data_dir: PathBuf,
 }
 
 #[derive(Helper, Completer, Hinter, Validator)]
@@ -50,35 +49,63 @@ impl Highlighter for CliHelper {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
-    std::fs::create_dir_all(&args.working_directory)?;
-    std::env::set_current_dir(&args.working_directory)?;
 
-    let config_file = canonicalize(&args.config).ok();
-    let mut figment = Figment::new().merge(Yaml::string(DEFAULT_CONFIG));
-    if let Some(config_file) = &config_file {
-        figment = figment.merge(Yaml::file(config_file));
-    } else {
-        std::fs::write(&args.config, DEFAULT_CONFIG)?;
-    }
-
-    let _ = dotenvy::dotenv();
-    let config: Config = figment.merge(Env::prefixed("SPARK_")).extract()?;
-    let seed = config.mnemonic.to_seed(config.passphrase.clone());
-
-    let log_path = match config.log_path.to_str() {
-        Some("spark.log") => {
-            let seed_hash = bitcoin::hashes::sha256::Hash::hash(&seed);
-            let log_file_name = format!("spark.{}.log", hex::encode(&seed_hash[0..4]));
-            PathBuf::from(log_file_name)
+    // Parse network (only mainnet or regtest allowed)
+    let network = match args.network.to_lowercase().as_str() {
+        "mainnet" => Network::Mainnet,
+        "regtest" => Network::Regtest,
+        _ => {
+            eprintln!(
+                "Invalid network '{}'. Use 'mainnet' or 'regtest'.",
+                args.network
+            );
+            std::process::exit(1);
         }
-        _ => config.log_path.clone(),
     };
+
+    // Load .env if present (from current directory before changing)
+    let _ = dotenvy::dotenv();
+
+    // Prompt for mnemonic
+    print!("Enter your BIP-39 mnemonic phrase: ");
+    std::io::stdout().flush()?;
+    let mut mnemonic_input = String::new();
+    std::io::stdin().read_line(&mut mnemonic_input)?;
+    let mnemonic: Mnemonic = mnemonic_input
+        .trim()
+        .parse()
+        .map_err(|e| format!("Invalid mnemonic: {e}"))?;
+
+    // Prompt for passphrase
+    print!("Enter passphrase (or press Enter for none): ");
+    std::io::stdout().flush()?;
+    let mut passphrase = String::new();
+    std::io::stdin().read_line(&mut passphrase)?;
+    let passphrase = passphrase.trim().to_string();
+
+    let seed = mnemonic.to_seed(&passphrase);
+
+    // Create wallet directory: <data-dir>/<network>/<seed_hash>/
+    let seed_hash = bitcoin::hashes::sha256::Hash::hash(&seed);
+    let seed_hash_hex = hex::encode(&seed_hash[0..4]);
+    let network_str = match network {
+        Network::Mainnet => "mainnet",
+        Network::Regtest => "regtest",
+        _ => unreachable!(),
+    };
+    let wallet_dir = args.data_dir.join(network_str).join(&seed_hash_hex);
+    std::fs::create_dir_all(&wallet_dir)?;
+    std::env::set_current_dir(&wallet_dir)?;
+
+    // Setup logging
+    let log_filter = std::env::var("SPARK_LOG_FILTER")
+        .unwrap_or_else(|_| "spark_wallet=info,spark=info,info".to_string());
     let log_file = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(log_path.clone())?;
+        .open("spark.log")?;
     tracing_subscriber::registry()
-        .with(EnvFilter::new(&config.log_filter))
+        .with(EnvFilter::new(&log_filter))
         .with(
             tracing_subscriber::fmt::layer()
                 .with_ansi(false)
@@ -87,11 +114,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
-    let network = config.spark_config.network;
+    // Use default config for the network
+    let spark_config = SparkWalletConfig::default_config(network);
+    let mempool_config = MempoolConfig::from_env(network);
+
+    // Connect to wallet
     let signer = DefaultSigner::new(&seed, network)?;
-    let wallet = Arc::new(
-        spark_wallet::SparkWallet::connect(config.spark_config.clone(), Arc::new(signer)).await?,
-    );
+    let wallet =
+        Arc::new(spark_wallet::SparkWallet::connect(spark_config, Arc::new(signer)).await?);
+
+    // Spawn event listener
     let clone = Arc::clone(&wallet);
     tokio::spawn(async move {
         let mut receiver = clone.subscribe_events();
@@ -99,32 +131,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tokio::select! {
                 Ok(event) = receiver.recv() => {
                     match event {
-                        spark_wallet::WalletEvent::DepositConfirmed(tree_node_id) => println!("Deposit confirmed: {tree_node_id}"),
-                        spark_wallet::WalletEvent::StreamConnected => println!("Connected to Spark server."),
-                        spark_wallet::WalletEvent::StreamDisconnected => println!("Disconnected from Spark server."),
-                        spark_wallet::WalletEvent::Synced => println!("Synced"),
-                        spark_wallet::WalletEvent::TransferClaimed(transfer) => println!("Transfer claimed: {}", transfer.id),
-                        spark_wallet::WalletEvent::TransferClaimStarting(transfer) => println!("Transfer claim starting: {}", transfer.id),
-                        spark_wallet::WalletEvent::Optimization(event) => println!("Optimization event: {:?}", event),
+                        spark_wallet::WalletEvent::DepositConfirmed(tree_node_id) => info!("Deposit confirmed: {tree_node_id}"),
+                        spark_wallet::WalletEvent::StreamConnected => info!("Connected to Spark server."),
+                        spark_wallet::WalletEvent::StreamDisconnected => warn!("Disconnected from Spark server."),
+                        spark_wallet::WalletEvent::Synced => info!("Synced"),
+                        spark_wallet::WalletEvent::TransferClaimed(transfer) => info!("Transfer claimed: {}", transfer.id),
+                        spark_wallet::WalletEvent::TransferClaimStarting(transfer) => info!("Transfer claim starting: {}", transfer.id),
+                        spark_wallet::WalletEvent::Optimization(event) => info!("Optimization event: {:?}", event),
                     }
                 }
-                else => eprintln!("Event stream closed."),
+                else => warn!("Event stream closed."),
             }
         }
     });
+
+    // Setup readline
     let rl = &mut Editor::new()?;
     rl.set_helper(Some(CliHelper {
         hinter: HistoryHinter {},
     }));
-    let _ = rl.load_history(HISTORY_FILE_NAME);
+    let _ = rl.load_history("history.txt");
 
     let cli_prompt = match network {
         Network::Mainnet => "spark-cli [mainnet]> ",
-        Network::Testnet => "spark-cli [testnet]> ",
         Network::Regtest => "spark-cli [regtest]> ",
-        Network::Signet => "spark-cli [signet]> ",
+        _ => unreachable!(),
     };
 
+    // REPL loop
     loop {
         let line_res = rl.readline(cli_prompt);
         match line_res {
@@ -141,8 +175,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     eprintln!("Error: {e}");
                     continue;
                 }
-                if let Err(e) =
-                    command::handle_command(rl, &config, &wallet, command_res.unwrap()).await
+                if let Err(e) = command::handle_command(
+                    rl,
+                    network,
+                    &mempool_config,
+                    &wallet,
+                    command_res.unwrap(),
+                )
+                .await
                 {
                     eprintln!("Error: {e}");
                 }
@@ -153,6 +193,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    rl.save_history(HISTORY_FILE_NAME).unwrap();
+    rl.save_history("history.txt").unwrap();
     Ok(())
 }

--- a/regtest/request-funds.sh
+++ b/regtest/request-funds.sh
@@ -51,7 +51,7 @@ else
 fi
 
 # URL for the GraphQL endpoint
-URL="https://api.loadtest.dev.sparkinfra.net/graphql/spark/rc"
+URL="https://api.lightspark.com/graphql/spark/rc"
 
 # GraphQL query
 QUERY='mutation RequestRegtestFunds($address: String!, $amount_sats: Long!) {


### PR DESCRIPTION
Updates the spark-cli to simplify usage and to support mainnet out-of-the-box
- Limit networks to mainnet (default) and regtest only
- Use `SparkWalletConfig::default_config(network)` instead of YAML config files
- Interactive mnemonic/passphrase prompts on startup
- Organize wallet data in `<data-dir>/<network>/<seed_hash>/` directories
- Fix unilateral exit TX labeling: Node TX(s) → Leaf TX → Refund TX
- Display timelock for Refund TX
- Add leaves list --compact flag
- Add end-user README with unilateral exit instructions
- Fix regtest/generate-private-key.sh public key derivation