### PR TITLE
Reuse reqwest Client to enable connection pooling

### DIFF
--- a/crates/flashnet/src/api.rs
+++ b/crates/flashnet/src/api.rs
@@ -35,6 +35,7 @@ pub struct FlashnetClient {
     pub(crate) config: FlashnetConfig,
     pub(crate) cache_store: Arc<CacheStore>,
     pub(crate) spark_wallet: Arc<SparkWallet>,
+    pub(crate) http_client: reqwest::Client,
 }
 
 impl FlashnetClient {
@@ -47,6 +48,7 @@ impl FlashnetClient {
             config,
             cache_store,
             spark_wallet,
+            http_client: reqwest::Client::new(),
         }
     }
 

--- a/crates/flashnet/src/auth.rs
+++ b/crates/flashnet/src/auth.rs
@@ -155,7 +155,6 @@ impl FlashnetClient {
         S: serde::Serialize + Clone,
         D: serde::de::DeserializeOwned,
     {
-        let client = reqwest::Client::new();
         let query = match query {
             Some(q) => {
                 let qs_config =
@@ -168,7 +167,7 @@ impl FlashnetClient {
             None => String::new(),
         };
         let url = format!("{}/{}{}", self.config.base_url, endpoint, query);
-        let builder = client.get(&url).headers(headers);
+        let builder = self.http_client.get(&url).headers(headers);
 
         self.request_inner(builder).await
     }
@@ -183,9 +182,8 @@ impl FlashnetClient {
         S: serde::Serialize + Clone,
         D: serde::de::DeserializeOwned,
     {
-        let client = reqwest::Client::new();
         let url = format!("{}/{}", self.config.base_url, endpoint);
-        let builder = client.post(&url).headers(headers).json(&body);
+        let builder = self.http_client.post(&url).headers(headers).json(&body);
         self.request_inner(builder).await
     }
 


### PR DESCRIPTION
Creating a new reqwest::Client on every HTTP request prevents connection reuse and loses the benefits of connection pooling.

Changes:
- Add http_client field to FlashnetClient struct
- Initialize client once in constructor
- Remove client instantiation from get_request_inner and post_request_inner
- Reuse self.http_client instance for all HTTP requests