### PR TITLE
fix: use static addresses for deposit address generation

### DIFF
--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -299,7 +299,7 @@ impl BreezSdk {
         request: BuyBitcoinRequest,
     ) -> Result<BuyBitcoinResponse, SdkError> {
         let address =
-            get_or_create_deposit_address(&self.spark_wallet, self.storage.clone()).await?;
+            get_or_create_deposit_address(&self.spark_wallet, self.storage.clone(), true).await?;
 
         let url = self
             .buy_bitcoin_provider

--- a/crates/breez-sdk/core/src/sdk/helpers.rs
+++ b/crates/breez-sdk/core/src/sdk/helpers.rs
@@ -210,6 +210,7 @@ pub(crate) fn validate_breez_api_key(api_key: &str) -> Result<(), SdkError> {
 pub(crate) async fn get_or_create_deposit_address(
     spark_wallet: &SparkWallet,
     storage: Arc<dyn Storage>,
+    is_static: bool,
 ) -> Result<String, SdkError> {
     let object_repository = ObjectCacheRepository::new(storage);
 
@@ -225,7 +226,7 @@ pub(crate) async fn get_or_create_deposit_address(
     let address = match deposit_addresses.items.last() {
         Some(address) => address.to_string(),
         None => spark_wallet
-            .generate_deposit_address(false)
+            .generate_deposit_address(is_static)
             .await?
             .to_string(),
     };

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -87,7 +87,7 @@ impl BreezSdk {
             }
             ReceivePaymentMethod::BitcoinAddress => {
                 let address =
-                    get_or_create_deposit_address(&self.spark_wallet, self.storage.clone()).await?;
+                    get_or_create_deposit_address(&self.spark_wallet, self.storage.clone(), true).await?;
                 Ok(ReceivePaymentResponse {
                     payment_request: address,
                     fee: 0,


### PR DESCRIPTION
## Summary
Add `is_static: bool` param to `get_or_create_deposit_address` and pass it through to `generate_deposit_address`.

Use static addresses on:
- `receive_payment(BitcoinAddress)`
- `buy_bitcoin`

Fixes regression from #578 where `generate_deposit_address(true)` was changed to `false` when extracting the helper from `receive_payment`.

`is_static` is added for future uses where non-static address generation is preferred.

## Test plan
- [x] `make build` passes
- [ ] Verify static deposit address generation in regtest

🤖 Generated with [Claude Code](https://claude.com/claude-code)