### PR TITLE
feat: add pubkey-based bech32 variant to LnurlInfo

### DIFF
--- a/crates/breez-sdk/core/src/sdk/lightning_address.rs
+++ b/crates/breez-sdk/core/src/sdk/lightning_address.rs
@@ -78,7 +78,13 @@ impl BreezSdk {
         let resp = client.recover_lightning_address().await?;
 
         let result = if let Some(resp) = resp {
-            let address_info = resp.into();
+            let pubkey_hex = self.spark_wallet.get_identity_public_key().to_string();
+            let address_info = LightningAddressInfo {
+                description: resp.description,
+                lightning_address: resp.lightning_address,
+                lnurl: LnurlInfo::with_pubkey(resp.lnurl, client.domain(), &pubkey_hex),
+                username: resp.username,
+            };
             cache.save_lightning_address(&address_info).await?;
             Some(address_info)
         } else {
@@ -122,10 +128,11 @@ impl BreezSdk {
         };
 
         let response = client.register_lightning_address(&params).await?;
+        let pubkey_hex = self.spark_wallet.get_identity_public_key().to_string();
         let address_info = LightningAddressInfo {
             lightning_address: response.lightning_address,
             description,
-            lnurl: LnurlInfo::new(response.lnurl),
+            lnurl: LnurlInfo::with_pubkey(response.lnurl, client.domain(), &pubkey_hex),
             username,
         };
         cache.save_lightning_address(&address_info).await?;

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -978,6 +978,7 @@ pub struct RegisterLightningAddressRequest {
 pub struct LnurlInfo {
     pub url: String,
     pub bech32: String,
+    pub bech32_pubkey: Option<String>,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::LightningAddressInfo)]

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -847,6 +847,7 @@ pub struct _RegisterLightningAddressRequest {
 pub struct _LnurlInfo {
     pub url: String,
     pub bech32: String,
+    pub bech32_pubkey: Option<String>,
 }
 
 #[frb(mirror(LightningAddressInfo))]


### PR DESCRIPTION
## Summary
- Adds `bech32_pubkey` field to `LnurlInfo` — bech32-encoded LNURL using the pubkey-based path (`/lnurlp/{pubkey}`)
- Computed client-side from domain + identity pubkey in both register and recover flows

## Test plan
- [x] Verify `bech32_pubkey` is populated after register and recover
- [x] Verify `bech32_pubkey` decodes to a valid callback URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)