### PR TITLE
refactor: group free functions under BreezSdkSpark namespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,9 +53,9 @@ make clippy-fix         # Fix clippy issues
 
 ### Crate Structure
 
-- **crates/breez-sdk/core** - Main SDK library with public API (`BreezSdk`)
+- **crates/breez-sdk/core** - Main SDK library with public API (`BreezSdkSpark` namespace, `BreezSparkClient` client type)
 - **crates/breez-sdk/common** - Shared utilities, LNURL support, networking, sync protocol
-- **crates/breez-sdk/bindings** - UniFFI bindings for Go, Kotlin, Python, React Native, Swift
+- **crates/breez-sdk/bindings** - UniFFI bindings for Go, Kotlin, Python, React Native, Swift, C#
 - **crates/breez-sdk/wasm** - WebAssembly bindings for JavaScript/TypeScript
 - **crates/breez-sdk/cli** - Command-line interface for testing
 - **crates/spark** - Low-level Spark protocol (addresses, signing, operators, tokens)
@@ -69,10 +69,36 @@ make clippy-fix         # Fix clippy issues
 - `BitcoinChainService` trait - Blockchain provider interface
 - `EventEmitter` - Broadcasts `SdkEvent` (Synced, PaymentSucceeded, PaymentFailed, etc.)
 
+### Public API Namespace
+
+The SDK uses a `BreezSdkSpark` namespace struct to group all static/global entry points:
+
+```rust
+// Rust
+let config = BreezSdkSpark::default_config(Network::Mainnet);
+let client: BreezSparkClient = BreezSdkSpark::connect(request).await?;
+```
+
+All platforms expose the same `BreezSdkSpark.method()` pattern. The namespace is implemented differently per platform:
+
+| Platform | Mechanism |
+|----------|-----------|
+| Rust | `BreezSdkSpark` struct in `core/src/app.rs` |
+| WASM | `#[wasm_bindgen]` struct in `wasm/src/breez.rs` |
+| Flutter | `#[frb]` struct in `packages/flutter/rust/src/breez.rs` |
+| Kotlin | Hand-written `object` in `bindings/langs/kotlin-multiplatform/Breez.kt` |
+| Python | Hand-written class in `bindings/langs/python/src/breez_sdk_spark/breez.py` |
+| React Native | Hand-written TS class in `packages/react-native/src/Breez.ts` |
+| C# | `global_methods_class_name = "BreezSdkSpark"` in `bindings/uniffi.toml` |
+| Go | Package name `breez_sdk_spark` serves as namespace naturally |
+| Swift | Module name `BreezSdkSpark` serves as namespace naturally |
+
+> **Note:** Free functions (`default_config()`, `connect()`, etc.) are deprecated since 0.10.0. Use `BreezSdkSpark::` methods and `BreezSparkClient` instead.
+
 ### Data Flow
 
 ```
-BreezSdk (API) → SparkWallet (wallet ops) → Spark (protocol) → Operators (gRPC)
+BreezSparkClient (API) → SparkWallet (wallet ops) → Spark (protocol) → Operators (gRPC)
      ↓
 Storage → SyncedStorage → Breez Sync Service (multi-device)
 ```
@@ -86,6 +112,17 @@ When changing the SDK's public interface, update these files:
 3. **crates/breez-sdk/wasm/src/sdk.rs** - Update WASM interface
 4. **packages/flutter/rust/src/models.rs** - Update mirrored structs/enums
 5. **packages/flutter/rust/src/sdk.rs** - Update Flutter interface
+
+When adding new top-level static functions to `BreezSdkSpark`, also update:
+
+6. **crates/breez-sdk/core/src/app.rs** - Add method to `BreezSdkSpark` impl
+7. **crates/breez-sdk/wasm/src/breez.rs** - Add `#[wasm_bindgen]` static method
+8. **packages/flutter/rust/src/breez.rs** - Add `#[frb]` static method
+9. **crates/breez-sdk/bindings/langs/kotlin-multiplatform/Breez.kt** - Add to `object BreezSdkSpark`
+10. **crates/breez-sdk/bindings/langs/python/src/breez_sdk_spark/breez.py** - Add `@staticmethod`
+11. **packages/react-native/src/Breez.ts** - Add static method to `BreezSdkSpark` class
+
+Go, Swift, and C# auto-derive the namespace from package/module/config — no manual wrapper update needed.
 
 ## Documentation Inline Syntax
 
@@ -160,25 +197,25 @@ See working examples in `docs/breez-sdk/snippets/` - these are compiled/tested a
 **Minimal TypeScript example:**
 
 ```typescript
-import { connect, defaultConfig } from '@breeztech/breez-sdk-spark'
+import { BreezSdkSpark } from '@breeztech/breez-sdk-spark'
 
-const config = defaultConfig('mainnet')
+const config = BreezSdkSpark.defaultConfig('mainnet')
 config.apiKey = '<your api key>'
 
-const sdk = await connect({
+const client = await BreezSdkSpark.connect({
   config,
   seed: { type: 'mnemonic', mnemonic: '<12/24 words>', passphrase: undefined },
   storageDir: './.data'
 })
 
-const info = await sdk.getInfo({ ensureSynced: true })
+const info = await client.getInfo({ ensureSynced: true })
 // info.balanceSats, info.tokenBalances
 
 // To get addresses:
-// const lnAddress = await sdk.getLightningAddress()
-// const sparkAddr = await sdk.receivePayment({ paymentMethod: { type: 'sparkAddress' } })
+// const lnAddress = await client.getLightningAddress()
+// const sparkAddr = await client.receivePayment({ paymentMethod: { type: 'sparkAddress' } })
 
-await sdk.disconnect()
+await client.disconnect()
 ```
 
 **Minimal Rust example:**
@@ -186,33 +223,43 @@ await sdk.disconnect()
 ```rust
 use breez_sdk_spark::*;
 
-let mut config = default_config(Network::Mainnet);
+let mut config = BreezSdkSpark::default_config(Network::Mainnet);
 config.api_key = Some("<your api key>".to_string());
 
-let sdk = connect(ConnectRequest {
+let client: BreezSparkClient = BreezSdkSpark::connect(ConnectRequest {
     config,
     seed: Seed::Mnemonic { mnemonic: "<words>".into(), passphrase: None },
     storage_dir: "./.data".to_string(),
 }).await?;
 
-let info = sdk.get_info(GetInfoRequest { ensure_synced: Some(true) }).await?;
+let info = client.get_info(GetInfoRequest { ensure_synced: Some(true) }).await?;
 // info.balance_sats, info.token_balances
 
-sdk.disconnect().await?;
+client.disconnect().await?;
 ```
 
 ### Core API Methods
 
+**`BreezSdkSpark` namespace (static):**
+
 | Method | Description |
 |--------|-------------|
-| `connect(config, seed, storageDir)` | Initialize SDK |
+| `BreezSdkSpark.defaultConfig(network)` | Get default config for a network |
+| `BreezSdkSpark.connect(request)` | Connect and get a `BreezSparkClient` |
+| `BreezSdkSpark.parse(input)` | Parse any input (invoice, address, LNURL) |
+| `BreezSdkSpark.initLogging(...)` | Initialize SDK logging subsystem |
+| `BreezSdkSpark.getSparkStatus()` | Check Spark network status |
+
+**`BreezSparkClient` instance methods:**
+
+| Method | Description |
+|--------|-------------|
 | `disconnect()` | Clean shutdown |
 | `getInfo()` | Get balance (sats) and token balances |
 | `getLightningAddress()` | Get registered lightning address |
 | `receivePayment(paymentMethod)` | Generate invoice, BTC address, or Spark address |
 | `sendPayment(prepareResponse)` | Send payment (call prepareSendPayment first) |
 | `prepareSendPayment(destination)` | Prepare a payment, get fees |
-| `parse(input)` | Parse any input (invoice, address, LNURL) |
 | `listPayments(filter)` | Get transaction history |
 | `addEventListener(listener)` | Subscribe to events |
 | `buyBitcoin(request)` | Get MoonPay URL to buy Bitcoin |
@@ -255,13 +302,15 @@ Working code examples for all platforms are in `docs/breez-sdk/snippets/`:
 
 7. **Lightning address registration** - Call `registerLightningAddress()` to get a Lightning address; it's not automatic
 
+8. **Deprecated free functions** - `default_config()`, `connect()`, `parse_input()`, `init_logging()`, `get_spark_status()` are deprecated since 0.10.0. Use `BreezSdkSpark::method()` equivalents. `BreezSdk` is deprecated in favor of `BreezSparkClient`.
+
 ### Networks
 
 | Network | Config | Use Case |
 |---------|--------|----------|
-| `mainnet` | `defaultConfig('mainnet')` | Production |
-| `testnet` | `defaultConfig('testnet')` | Testing with testnet Bitcoin |
-| `regtest` | `defaultConfig('regtest')` | Development (no API key needed, use [Lightspark faucet](https://app.lightspark.com/regtest-faucet)) |
+| `mainnet` | `BreezSdkSpark.defaultConfig('mainnet')` | Production |
+| `testnet` | `BreezSdkSpark.defaultConfig('testnet')` | Testing with testnet Bitcoin |
+| `regtest` | `BreezSdkSpark.defaultConfig('regtest')` | Development (no API key needed, use [Lightspark faucet](https://app.lightspark.com/regtest-faucet)) |
 
 **Regtest** is recommended for development - free to use, no real value, supports Spark payments, deposits, withdrawals, and token issuance.
 
@@ -281,7 +330,7 @@ The SDK throws `SdkError` with these variants:
 
 ```typescript
 try {
-  await sdk.sendPayment({ prepareResponse })
+  await client.sendPayment({ prepareResponse })
 } catch (error) {
   if (error.message.includes('InsufficientFunds')) {
     // Handle insufficient balance
@@ -293,39 +342,39 @@ try {
 
 | Operation | Flow |
 |-----------|------|
-| **LNURL-Pay** | `parse(url)` → check `type === 'lnurlPay'` or `'lightningAddress'` → `prepareLnurlPay()` → `lnurlPay()` |
-| **LNURL-Withdraw** | `parse(url)` → check `type === 'lnurlWithdraw'` → `lnurlWithdraw({ amountSats, withdrawRequest })` |
-| **LNURL-Auth** | `parse(url)` → check `type === 'lnurlAuth'` → show domain to user → `lnurlAuth(requestData)` |
+| **LNURL-Pay** | `BreezSdkSpark.parse(url)` → check `type === 'lnurlPay'` or `'lightningAddress'` → `prepareLnurlPay()` → `lnurlPay()` |
+| **LNURL-Withdraw** | `BreezSdkSpark.parse(url)` → check `type === 'lnurlWithdraw'` → `lnurlWithdraw({ amountSats, withdrawRequest })` |
+| **LNURL-Auth** | `BreezSdkSpark.parse(url)` → check `type === 'lnurlAuth'` → show domain to user → `lnurlAuth(requestData)` |
 
 ### Token Operations
 
 **Receiving tokens:**
 ```typescript
 // Get token balances
-const info = await sdk.getInfo({ ensureSynced: true })
+const info = await client.getInfo({ ensureSynced: true })
 for (const [tokenId, balance] of Object.entries(info.tokenBalances)) {
   console.log(`${balance.tokenMetadata.ticker}: ${balance.balance}`)
 }
 
 // Receive via Spark invoice
-const response = await sdk.receivePayment({
+const response = await client.receivePayment({
   paymentMethod: { type: 'sparkInvoice', tokenIdentifier: '<token id>', amount: '1000' }
 })
 ```
 
 **Sending tokens:**
 ```typescript
-const prepareResponse = await sdk.prepareSendPayment({
+const prepareResponse = await client.prepareSendPayment({
   paymentRequest: '<spark address or invoice>',
   tokenIdentifier: '<token id>',
   amount: BigInt(1000)
 })
-await sdk.sendPayment({ prepareResponse })
+await client.sendPayment({ prepareResponse })
 ```
 
 **Issuing tokens (for token issuers):**
 ```typescript
-const issuer = sdk.getTokenIssuer()
+const issuer = client.getTokenIssuer()
 const metadata = await issuer.createIssuerToken({
   name: 'My Token', ticker: 'MTK', decimals: 6, isFreezable: false, maxSupply: BigInt(1_000_000)
 })

--- a/crates/breez-sdk/bindings/Makefile
+++ b/crates/breez-sdk/bindings/Makefile
@@ -71,6 +71,7 @@ package-android: build-android
 	rm $(FFI_DIR)kotlin/jniLibs/**/*spark.so
 	cp -r $(FFI_DIR)kotlin/jniLibs langs/android/lib/src/main
 	cp -r $(FFI_DIR)kotlin/main/kotlin/breez_sdk_spark langs/android/lib/src/main/kotlin/
+	cp langs/kotlin-multiplatform/Breez.kt langs/android/lib/src/main/kotlin/breez_sdk_spark/
 	cd langs/android && ./gradlew assemble
 	mkdir -p $(FFI_DIR)android
 	cp langs/android/lib/build/outputs/aar/lib-release.aar $(FFI_DIR)android
@@ -133,11 +134,15 @@ build-kotlin-multiplatform: build-kotlin-multiplatform-bindgen-only build-ndk-re
 # Package with dummy binaries (useful for testing)
 package-kotlin-multiplatform-dummy-binaries: build-kotlin-multiplatform-bindgen-only
 	cp -r $(FFI_DIR)kmp/* $(KMP_BASE)/
+	mkdir -p $(KMP_BASE)/commonMain/kotlin/breez_sdk_spark
+	cp langs/kotlin-multiplatform/Breez.kt $(KMP_BASE)/commonMain/kotlin/breez_sdk_spark/
 	cd langs/kotlin-multiplatform && ./gradlew :breez-sdk-spark-kmp:assemble
 
 # Full package with all binaries
 package-kotlin-multiplatform: build-kotlin-multiplatform
 	cp -r $(FFI_DIR)kmp/* $(KMP_BASE)/
+	mkdir -p $(KMP_BASE)/commonMain/kotlin/breez_sdk_spark
+	cp langs/kotlin-multiplatform/Breez.kt $(KMP_BASE)/commonMain/kotlin/breez_sdk_spark/
 	rm -f $(FFI_DIR)kotlin/jniLibs/**/*spark.so
 	cp -r $(FFI_DIR)kotlin/jniLibs/ $(KMP_BASE)/androidMain/jniLibs/
 	cd langs/kotlin-multiplatform && ./gradlew :breez-sdk-spark-kmp:assemble

--- a/crates/breez-sdk/bindings/langs/kotlin-multiplatform/Breez.kt
+++ b/crates/breez-sdk/bindings/langs/kotlin-multiplatform/Breez.kt
@@ -1,0 +1,48 @@
+package breez_sdk_spark
+
+/** Preferred name for the SDK client type. */
+typealias BreezSparkClient = BreezSdk
+
+/**
+ * Top-level namespace for the Breez SDK Spark.
+ *
+ * Groups all static/global SDK functions that don't require a wallet
+ * connection. Use `BreezSdkSpark.connect()` to obtain a [BreezSparkClient] instance.
+ */
+object BreezSdkSpark {
+    /** Returns a default SDK configuration for the given network. */
+    fun defaultConfig(network: Network): Config =
+        breez_sdk_spark.defaultConfig(network)
+
+    /** Initializes the SDK logging subsystem. */
+    fun initLogging(logDir: String? = null, appLogger: Logger? = null, logFilter: String? = null) =
+        breez_sdk_spark.initLogging(logDir, appLogger, logFilter)
+
+    /** Connects to the Spark network using the provided configuration and seed. */
+    suspend fun connect(request: ConnectRequest): BreezSparkClient =
+        breez_sdk_spark.connect(request)
+
+    /** Connects to the Spark network using an external signer. */
+    suspend fun connectWithSigner(request: ConnectWithSignerRequest): BreezSparkClient =
+        breez_sdk_spark.connectWithSigner(request)
+
+    /** Creates a default external signer from a mnemonic phrase. */
+    fun defaultExternalSigner(
+        mnemonic: String,
+        passphrase: String? = null,
+        network: Network,
+        keySetConfig: KeySetConfig? = null,
+    ): ExternalSigner =
+        breez_sdk_spark.defaultExternalSigner(mnemonic, passphrase, network, keySetConfig)
+
+    /** Parses a payment input string and returns the identified type. */
+    suspend fun parse(
+        input: String,
+        externalInputParsers: List<ExternalInputParser>? = null,
+    ): InputType =
+        breez_sdk_spark.parse(input, externalInputParsers)
+
+    /** Fetches the current status of Spark network services. */
+    suspend fun getSparkStatus(): SparkStatus =
+        breez_sdk_spark.getSparkStatus()
+}

--- a/crates/breez-sdk/bindings/langs/python/.gitignore
+++ b/crates/breez-sdk/bindings/langs/python/.gitignore
@@ -1,5 +1,6 @@
 src/breez_sdk_spark/*
 !src/breez_sdk_spark/__init__.py
+!src/breez_sdk_spark/breez.py
 *.egg-info
 build
 dist

--- a/crates/breez-sdk/bindings/langs/python/src/breez_sdk_spark/__init__.py
+++ b/crates/breez-sdk/bindings/langs/python/src/breez_sdk_spark/__init__.py
@@ -1,2 +1,3 @@
 from breez_sdk_spark.breez_sdk_spark_bindings import *
 from breez_sdk_spark.breez_sdk_spark import *
+from breez_sdk_spark.breez import BreezSdkSpark, BreezSparkClient

--- a/crates/breez-sdk/bindings/langs/python/src/breez_sdk_spark/breez.py
+++ b/crates/breez-sdk/bindings/langs/python/src/breez_sdk_spark/breez.py
@@ -1,0 +1,55 @@
+"""Top-level namespace for the Breez SDK Spark.
+
+Groups all static/global SDK functions that don't require a wallet
+connection. Use ``BreezSdkSpark.connect()`` to obtain a ``BreezSparkClient`` instance.
+"""
+
+from breez_sdk_spark.breez_sdk_spark import (
+    BreezSdk as BreezSparkClient,
+    connect as _connect,
+    connect_with_signer as _connect_with_signer,
+    default_config as _default_config,
+    default_external_signer as _default_external_signer,
+    get_spark_status as _get_spark_status,
+    init_logging as _init_logging,
+    parse as _parse,
+)
+
+
+class BreezSdkSpark:
+    """Top-level namespace for the Breez SDK Spark."""
+
+    @staticmethod
+    def default_config(network):
+        """Returns a default SDK configuration for the given network."""
+        return _default_config(network)
+
+    @staticmethod
+    def init_logging(log_dir=None, app_logger=None, log_filter=None):
+        """Initializes the SDK logging subsystem."""
+        return _init_logging(log_dir, app_logger, log_filter)
+
+    @staticmethod
+    async def connect(request):
+        """Connects to the Spark network using the provided configuration and seed."""
+        return await _connect(request)
+
+    @staticmethod
+    async def connect_with_signer(request):
+        """Connects to the Spark network using an external signer."""
+        return await _connect_with_signer(request)
+
+    @staticmethod
+    def default_external_signer(mnemonic, passphrase=None, network=None, key_set_config=None):
+        """Creates a default external signer from a mnemonic phrase."""
+        return _default_external_signer(mnemonic, passphrase, network, key_set_config)
+
+    @staticmethod
+    async def parse(input, external_input_parsers=None):
+        """Parses a payment input string and returns the identified type."""
+        return await _parse(input, external_input_parsers)
+
+    @staticmethod
+    async def get_spark_status():
+        """Fetches the current status of Spark network services."""
+        return await _get_spark_status()

--- a/crates/breez-sdk/bindings/uniffi.toml
+++ b/crates/breez-sdk/bindings/uniffi.toml
@@ -22,6 +22,7 @@ package_name = "breez_sdk_spark"
 cdylib_name = "breez_sdk_spark_bindings"
 namespace = "Breez.Sdk.Spark"
 access_modifier = "public"
+global_methods_class_name = "BreezSdkSpark"
 
 # https://github.com/NordSecurity/uniffi-bindgen-go/blob/main/docs/CONFIGURATION.md
 [bindings.go]

--- a/crates/breez-sdk/breez-bench/src/bin/bench.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/bench.rs
@@ -18,9 +18,9 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
 use breez_sdk_spark::{
-    BreezSdk, EventListener, GetInfoRequest, Network, PaymentType, PrepareSendPaymentRequest,
-    ReceivePaymentMethod, ReceivePaymentRequest, SdkBuilder, SdkEvent, Seed, SendPaymentRequest,
-    SyncWalletRequest, default_config,
+    BreezSdk, BreezSdkSpark, EventListener, GetInfoRequest, Network, PaymentType,
+    PrepareSendPaymentRequest, ReceivePaymentMethod, ReceivePaymentRequest, SdkBuilder, SdkEvent,
+    Seed, SendPaymentRequest, SyncWalletRequest,
 };
 use tokio::sync::mpsc;
 
@@ -631,7 +631,7 @@ async fn initialize_regtest_sdk_pair(
     let mut sender_seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut sender_seed);
 
-    let mut sender_config = default_config(Network::Regtest);
+    let mut sender_config = BreezSdkSpark::default_config(Network::Regtest);
     if let Some(multiplicity) = sender_multiplicity {
         sender_config.optimization_config.multiplicity = multiplicity;
     }
@@ -645,7 +645,7 @@ async fn initialize_regtest_sdk_pair(
     let mut receiver_seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut receiver_seed);
 
-    let mut receiver_config = default_config(Network::Regtest);
+    let mut receiver_config = BreezSdkSpark::default_config(Network::Regtest);
     receiver_config.optimization_config.multiplicity = receiver_multiplicity;
 
     let itest_receiver =
@@ -694,7 +694,7 @@ async fn initialize_mainnet_sdk(
     let breez_api_key = std::env::var_os("BREEZ_API_KEY")
         .map(|var| var.into_string().expect("Expected valid API key string"));
 
-    let mut config = default_config(Network::Mainnet);
+    let mut config = BreezSdkSpark::default_config(Network::Mainnet);
     config.api_key = breez_api_key;
     if let Some(multiplicity) = multiplicity {
         config.optimization_config.multiplicity = multiplicity;

--- a/crates/breez-sdk/breez-bench/src/bin/claim_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/claim_perf.rs
@@ -18,9 +18,9 @@ use tracing_subscriber::EnvFilter;
 
 use breez_sdk_itest::{RegtestFaucet, build_sdk_with_custom_config};
 use breez_sdk_spark::{
-    BreezSdk, GetInfoRequest, ListPaymentsRequest, Network, PaymentStatus, PaymentType,
-    PrepareSendPaymentRequest, ReceivePaymentMethod, ReceivePaymentRequest, SdkEvent,
-    SendPaymentRequest, SyncWalletRequest, default_config,
+    BreezSdk, BreezSdkSpark, GetInfoRequest, ListPaymentsRequest, Network, PaymentStatus,
+    PaymentType, PrepareSendPaymentRequest, ReceivePaymentMethod, ReceivePaymentRequest, SdkEvent,
+    SendPaymentRequest, SyncWalletRequest,
 };
 
 use breez_bench::events::{wait_for_claimed_event, wait_for_synced_event};
@@ -127,7 +127,7 @@ async fn run_single_claim_benchmark(
     let sender_dir = TempDir::new("claim-bench-sender")?;
     let mut sender_seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut sender_seed);
-    let mut sender_config = default_config(Network::Regtest);
+    let mut sender_config = BreezSdkSpark::default_config(Network::Regtest);
     sender_config.optimization_config.auto_enabled = false;
     let itest_sender = build_sdk_with_custom_config(
         sender_dir.path().to_string_lossy().to_string(),
@@ -142,7 +142,7 @@ async fn run_single_claim_benchmark(
 
     // 2. Create a temporary receiver just to get the Spark address, then disconnect it
     let receiver_dir = TempDir::new("claim-bench-receiver")?;
-    let mut temp_receiver_config = default_config(Network::Regtest);
+    let mut temp_receiver_config = BreezSdkSpark::default_config(Network::Regtest);
     temp_receiver_config.optimization_config.auto_enabled = false;
     let mut temp_receiver = build_sdk_with_custom_config(
         receiver_dir.path().to_string_lossy().to_string(),
@@ -248,7 +248,7 @@ async fn run_single_claim_benchmark(
         "Creating receiver with max_concurrent_claims={}...",
         concurrency
     );
-    let mut receiver_config = default_config(Network::Regtest);
+    let mut receiver_config = BreezSdkSpark::default_config(Network::Regtest);
     receiver_config.optimization_config.auto_enabled = false;
     receiver_config.max_concurrent_claims = concurrency;
 

--- a/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
@@ -17,8 +17,8 @@ use tracing_subscriber::EnvFilter;
 
 use breez_sdk_itest::{RegtestFaucet, build_sdk_with_custom_config};
 use breez_sdk_spark::{
-    BreezSdk, GetInfoRequest, Network, PrepareSendPaymentRequest, ReceivePaymentMethod,
-    ReceivePaymentRequest, SdkEvent, SendPaymentRequest, SyncWalletRequest, default_config,
+    BreezSdk, BreezSdkSpark, GetInfoRequest, Network, PrepareSendPaymentRequest,
+    ReceivePaymentMethod, ReceivePaymentRequest, SdkEvent, SendPaymentRequest, SyncWalletRequest,
 };
 
 use breez_bench::events::{wait_for_claimed_event, wait_for_synced_event};
@@ -560,7 +560,7 @@ async fn initialize_sdk_pair(
     let mut sender_seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut sender_seed);
 
-    let mut sender_config = default_config(Network::Regtest);
+    let mut sender_config = BreezSdkSpark::default_config(Network::Regtest);
     // Disable auto-optimization if requested, or if we're doing pre-optimization
     // (to avoid auto-opt triggering after funding)
     if no_auto_optimize || pre_optimize.is_some() {
@@ -579,7 +579,7 @@ async fn initialize_sdk_pair(
     let mut receiver_seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut receiver_seed);
 
-    let mut receiver_config = default_config(Network::Regtest);
+    let mut receiver_config = BreezSdkSpark::default_config(Network::Regtest);
     // Disable auto-optimization for receiver if requested
     receiver_config.optimization_config.auto_enabled = false;
     let itest_receiver =

--- a/crates/breez-sdk/breez-itest/src/fixtures/mod.rs
+++ b/crates/breez-sdk/breez-itest/src/fixtures/mod.rs
@@ -3,6 +3,7 @@ pub mod docker;
 pub mod lnurl;
 
 use anyhow::Result;
+#[allow(deprecated)] // default_config deprecated since 0.10.0
 use breez_sdk_spark::{MaxFee, Network, StableBalanceConfig, default_config};
 use rand::RngCore;
 use rstest::fixture;
@@ -48,6 +49,7 @@ pub async fn bob_no_fee_sdk() -> Result<SdkInstance> {
     let mut seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut seed);
 
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut cfg = default_config(Network::Regtest);
     cfg.max_deposit_claim_fee = None;
     build_sdk_with_custom_config(path, seed, cfg, Some(dir), true).await
@@ -60,6 +62,7 @@ pub async fn bob_strict_fee_sdk() -> Result<SdkInstance> {
     let mut seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut seed);
 
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut cfg = default_config(Network::Regtest);
     cfg.max_deposit_claim_fee = Some(MaxFee::Fixed { amount: 0 });
     build_sdk_with_custom_config(path, seed, cfg, Some(dir), true).await
@@ -99,6 +102,7 @@ pub async fn alice_sdk_stable_balance() -> Result<SdkInstance> {
     let mut seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut seed);
 
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut cfg = default_config(Network::Regtest);
     cfg.stable_balance_config = Some(StableBalanceConfig {
         token_identifier: "btknrt1ra8lrwpqgqfz7gcy3gfcucaw3fh62tp3d6qkjxafx0cnxm5gmd3q0xy27c"
@@ -118,6 +122,7 @@ pub async fn alice_sdk_stable_balance_with_reserve() -> Result<SdkInstance> {
     let mut seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut seed);
 
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut cfg = default_config(Network::Regtest);
     cfg.stable_balance_config = Some(StableBalanceConfig {
         token_identifier: "btknrt1ra8lrwpqgqfz7gcy3gfcucaw3fh62tp3d6qkjxafx0cnxm5gmd3q0xy27c"

--- a/crates/breez-sdk/breez-itest/src/helpers.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers.rs
@@ -36,6 +36,7 @@ pub async fn build_sdk_with_dir(
     seed_bytes: [u8; 32],
     temp_dir: Option<tempdir::TempDir>,
 ) -> Result<SdkInstance> {
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut config = default_config(Network::Regtest);
     config.api_key = None; // Regtest: no API key needed
     config.lnurl_domain = None; // Avoid lnurl server in tests
@@ -150,6 +151,7 @@ pub async fn build_sdk_from_mnemonic(
     passphrase: Option<String>,
     temp_dir: Option<tempdir::TempDir>,
 ) -> Result<SdkInstance> {
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut config = default_config(Network::Regtest);
     config.api_key = None; // Regtest: no API key needed
     config.lnurl_domain = None; // Avoid lnurl server in tests
@@ -199,6 +201,7 @@ pub async fn build_sdk_with_external_signer(
     mnemonic: String,
     temp_dir: Option<TempDir>,
 ) -> Result<SdkInstance> {
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut config = default_config(Network::Regtest);
     config.api_key = None;
     config.lnurl_domain = None;
@@ -207,6 +210,7 @@ pub async fn build_sdk_with_external_signer(
     config.real_time_sync_server_url = None;
 
     // Create default external signer from mnemonic
+    #[allow(deprecated)] // default_external_signer deprecated since 0.10.0
     let signer = breez_sdk_spark::default_external_signer(
         mnemonic,
         None, // no passphrase
@@ -219,6 +223,7 @@ pub async fn build_sdk_with_external_signer(
     )?;
 
     // Use connect_with_signer instead of connect
+    #[allow(deprecated)] // connect_with_signer deprecated since 0.10.0
     let sdk = connect_with_signer(ConnectWithSignerRequest {
         config,
         signer,
@@ -847,6 +852,7 @@ pub async fn build_sdk_with_postgres(
     ))
     .await?;
 
+    #[allow(deprecated)]
     let mut config = breez_sdk_spark::default_config(breez_sdk_spark::Network::Regtest);
     config.api_key = None;
     config.lnurl_domain = None;

--- a/crates/breez-sdk/breez-itest/tests/lnurl.rs
+++ b/crates/breez-sdk/breez-itest/tests/lnurl.rs
@@ -31,6 +31,7 @@ async fn alice_sdk() -> Result<SdkInstance> {
     let mut seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut seed);
 
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut config = default_config(Network::Regtest);
     config.api_key = None; // Regtest: no API key needed
     config.prefer_spark_over_lightning = true;
@@ -60,6 +61,7 @@ async fn bob_sdk(#[future] lnurl_fixture: LnurlFixture) -> Result<SdkInstance> {
     let mut seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut seed);
 
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut config = default_config(Network::Regtest);
     config.api_key = None; // Regtest: no API key needed
     config.lnurl_domain = Some(lnurl_domain.to_string());
@@ -408,6 +410,7 @@ async fn test_06_client_side_zap_receipt(
     let mut seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut seed);
 
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut config = default_config(Network::Regtest);
     config.api_key = None;
     config.lnurl_domain = Some(lnurl_domain.clone());

--- a/crates/breez-sdk/breez-itest/tests/lnurl_auth.rs
+++ b/crates/breez-sdk/breez-itest/tests/lnurl_auth.rs
@@ -119,6 +119,7 @@ async fn auth_sdk() -> Result<SdkInstance> {
     let mut seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut seed);
 
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut config = default_config(Network::Regtest);
     config.api_key = None; // Regtest: no API key needed
     config.prefer_spark_over_lightning = true;

--- a/crates/breez-sdk/breez-itest/tests/rtsync.rs
+++ b/crates/breez-sdk/breez-itest/tests/rtsync.rs
@@ -65,6 +65,7 @@ async fn bob_sdk(#[future] lnurl_fixture: LnurlFixture) -> Result<SdkInstance> {
     let mut seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut seed);
 
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut config = default_config(Network::Regtest);
     config.api_key = None; // Regtest: no API key needed
     config.lnurl_domain = Some(lnurl_domain.to_string());
@@ -90,6 +91,7 @@ async fn bob_sdk(#[future] lnurl_fixture: LnurlFixture) -> Result<SdkInstance> {
 async fn create_sdk_with_rtsync(name: &str, seed: [u8; 32], sync_url: &str) -> Result<SdkInstance> {
     let temp_dir = TempDir::new(&format!("breez-sdk-{name}"))?;
 
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut config = default_config(Network::Regtest);
     config.api_key = None; // Regtest: no API key needed
     config.prefer_spark_over_lightning = true;

--- a/crates/breez-sdk/breez-itest/tests/user_settings.rs
+++ b/crates/breez-sdk/breez-itest/tests/user_settings.rs
@@ -11,6 +11,7 @@ use tracing::info;
 
 #[fixture]
 fn persistent_sdk_private() -> ReinitializableSdkInstance {
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut cfg = default_config(Network::Regtest);
     cfg.private_enabled_default = true;
     ReinitializableSdkInstance::new(cfg, TempDir::new("breez-sdk-persistent-private").unwrap())
@@ -19,6 +20,7 @@ fn persistent_sdk_private() -> ReinitializableSdkInstance {
 
 #[fixture]
 fn persistent_sdk_non_private() -> ReinitializableSdkInstance {
+    #[allow(deprecated)] // default_config deprecated since 0.10.0
     let mut cfg = default_config(Network::Regtest);
     cfg.private_enabled_default = false;
     ReinitializableSdkInstance::new(

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -871,6 +871,7 @@ pub(crate) async fn execute_command(
             Ok(true)
         }
         Command::GetSparkStatus => {
+            #[allow(deprecated)]
             let res = breez_sdk_spark::get_spark_status().await?;
             print_value(&res)?;
             Ok(true)

--- a/crates/breez-sdk/cli/src/main.rs
+++ b/crates/breez-sdk/cli/src/main.rs
@@ -4,6 +4,7 @@ mod persist;
 use crate::command::CliHelper;
 use crate::persist::CliPersistence;
 use anyhow::{Result, anyhow};
+#[allow(deprecated)] // CLI uses deprecated free functions (default_config, init_logging)
 use breez_sdk_spark::{
     EventListener, Network, SdkBuilder, SdkEvent, Seed, StableBalanceConfig,
     create_postgres_storage, default_config, default_postgres_storage_config,
@@ -89,6 +90,7 @@ impl EventListener for CliEventListener {
     }
 }
 
+#[allow(deprecated)] // uses deprecated default_config and init_logging free functions
 async fn run_interactive_mode(
     data_dir: PathBuf,
     network: Network,

--- a/crates/breez-sdk/core/src/app.rs
+++ b/crates/breez-sdk/core/src/app.rs
@@ -1,0 +1,161 @@
+use crate::{
+    ExternalInputParser, InputType, Logger, Network, SparkStatus, error::SdkError, models::Config,
+};
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+use {
+    crate::{ConnectRequest, models::KeySetConfig, sdk::BreezSdk, sdk_builder::SdkBuilder},
+    std::sync::Arc,
+};
+
+/// Top-level namespace for the Breez SDK Spark.
+///
+/// `BreezSdkSpark` groups all static/global SDK functions that don't require a wallet
+/// connection. Use [`BreezSdkSpark::connect`] (non-WASM) or the existing [`connect`](crate::connect)
+/// free function to obtain a [`BreezSparkClient`](crate::BreezSparkClient) instance.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use breez_sdk_spark::{BreezSdkSpark, Network};
+///
+/// let config = BreezSdkSpark::default_config(Network::Mainnet);
+/// ```
+pub struct BreezSdkSpark;
+
+#[allow(deprecated)] // delegates to deprecated free functions (default_config, init_logging, etc.)
+impl BreezSdkSpark {
+    /// Returns a default SDK configuration for the given network.
+    ///
+    /// This is equivalent to the [`default_config`](crate::default_config) free function.
+    pub fn default_config(network: Network) -> Config {
+        crate::default_config(network)
+    }
+
+    /// Initializes the SDK logging subsystem.
+    ///
+    /// This is equivalent to the [`init_logging`](crate::init_logging) free function.
+    pub fn init_logging(
+        log_dir: Option<String>,
+        app_logger: Option<Box<dyn Logger>>,
+        log_filter: Option<String>,
+    ) -> Result<(), SdkError> {
+        crate::init_logging(log_dir, app_logger, log_filter)
+    }
+
+    /// Parses a payment input string and returns the identified type.
+    ///
+    /// Supports BOLT11 invoices, Lightning addresses, LNURL variants, Bitcoin
+    /// addresses, Spark addresses/invoices, BIP21 URIs, and more.
+    ///
+    /// This is equivalent to the [`parse`](crate::parse) free function.
+    pub async fn parse(
+        input: &str,
+        external_input_parsers: Option<Vec<ExternalInputParser>>,
+    ) -> Result<InputType, SdkError> {
+        crate::parse(input, external_input_parsers).await
+    }
+
+    /// Fetches the current status of Spark network services.
+    ///
+    /// This is equivalent to the [`get_spark_status`](crate::get_spark_status) free function.
+    pub async fn get_spark_status() -> Result<SparkStatus, SdkError> {
+        crate::get_spark_status().await
+    }
+}
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+#[allow(deprecated)] // delegates to deprecated free functions (connect, connect_with_signer, etc.)
+impl BreezSdkSpark {
+    /// Creates a default external signer from a mnemonic phrase.
+    ///
+    /// This is equivalent to the [`default_external_signer`](crate::default_external_signer) free function.
+    pub fn default_external_signer(
+        mnemonic: String,
+        passphrase: Option<String>,
+        network: Network,
+        key_set_config: Option<KeySetConfig>,
+    ) -> Result<Arc<dyn crate::signer::ExternalSigner>, SdkError> {
+        crate::default_external_signer(mnemonic, passphrase, network, key_set_config)
+    }
+
+    /// Creates an SDK builder for advanced configuration.
+    ///
+    /// Use this when you need to customize storage, chain services, or other
+    /// provider implementations.
+    pub fn builder(config: Config, seed: crate::Seed) -> SdkBuilder {
+        SdkBuilder::new(config, seed)
+    }
+
+    /// Connects to the Spark network using the provided configuration and seed.
+    ///
+    /// This is equivalent to the [`connect`](crate::connect) free function.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The connection request containing config, seed, and storage directory
+    ///
+    /// # Returns
+    ///
+    /// An initialized [`BreezSparkClient`](crate::BreezSparkClient) instance
+    pub async fn connect(request: ConnectRequest) -> Result<BreezSdk, SdkError> {
+        crate::connect(request).await
+    }
+
+    /// Connects to the Spark network using an external signer.
+    ///
+    /// This is equivalent to the [`connect_with_signer`](crate::connect_with_signer) free function.
+    pub async fn connect_with_signer(
+        request: crate::ConnectWithSignerRequest,
+    ) -> Result<BreezSdk, SdkError> {
+        crate::connect_with_signer(request).await
+    }
+}
+
+#[cfg(test)]
+#[allow(deprecated)] // tests call deprecated default_config to verify parity
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_breez_default_config_matches_free_function() {
+        let from_breez = BreezSdkSpark::default_config(Network::Mainnet);
+        let from_free = crate::default_config(Network::Mainnet);
+
+        assert!(
+            matches!(from_breez.network, Network::Mainnet),
+            "Expected Mainnet network"
+        );
+        assert_eq!(from_breez.api_key, from_free.api_key);
+        assert_eq!(from_breez.sync_interval_secs, from_free.sync_interval_secs);
+        assert_eq!(from_breez.lnurl_domain, from_free.lnurl_domain);
+        assert_eq!(
+            from_breez.prefer_spark_over_lightning,
+            from_free.prefer_spark_over_lightning
+        );
+        assert_eq!(
+            from_breez.private_enabled_default,
+            from_free.private_enabled_default
+        );
+    }
+
+    #[test]
+    fn test_breez_default_config_regtest() {
+        let config = BreezSdkSpark::default_config(Network::Regtest);
+
+        assert!(
+            matches!(config.network, Network::Regtest),
+            "Expected Regtest network"
+        );
+        assert!(config.lnurl_domain.is_none());
+    }
+
+    #[test]
+    fn test_breez_spark_client_type_alias_compiles() {
+        // Verify the type aliases are usable at compile time
+        fn _takes_spark_client(_sdk: &crate::BreezSparkClient) {}
+        fn _takes_breez_sdk(_sdk: &crate::BreezSdk) {}
+
+        // Both should accept the same type — this is a compile-time test
+    }
+}

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -1,3 +1,4 @@
+mod app;
 #[cfg(feature = "uniffi")]
 pub mod bindings;
 mod chain;
@@ -11,6 +12,7 @@ mod models;
 mod nostr;
 mod persist;
 mod realtime_sync;
+#[allow(deprecated)] // sdk module defines and re-exports deprecated free functions
 mod sdk;
 mod sdk_builder;
 pub mod signer;
@@ -19,6 +21,7 @@ mod sync;
 pub mod token_conversion;
 mod utils;
 
+pub use app::BreezSdkSpark;
 pub use chain::{
     BitcoinChainService, ChainServiceError, RecommendedFees, TxStatus, Utxo,
     rest_client::{ChainApiType, RestClientChainService},
@@ -33,7 +36,10 @@ pub use persist::{
     PaymentMetadata, SetLnurlMetadataItem, Storage, StorageError, UpdateDepositPayload,
     path::default_storage_path,
 };
-pub use sdk::{BreezSdk, default_config, get_spark_status, init_logging, parse_input};
+#[allow(deprecated)] // re-exporting deprecated free functions for backward compatibility
+pub use sdk::{
+    BreezSdk, BreezSparkClient, default_config, get_spark_status, init_logging, parse, parse_input,
+};
 pub use sdk_builder::SdkBuilder;
 pub use spark_wallet::KeySet;
 
@@ -46,11 +52,13 @@ pub use persist::postgres::{
 };
 
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+#[allow(deprecated)] // re-exporting deprecated connect/connect_with_signer free functions
 pub use {
     persist::sqlite::SqliteStorage,
     sdk::{connect, connect_with_signer},
 };
 
+#[allow(deprecated)] // re-exporting deprecated free function for backward compatibility
 pub use sdk::default_external_signer;
 
 #[cfg(feature = "test-utils")]

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -16,6 +16,7 @@ use crate::{
     utils::token::get_tokens_metadata_cached_or_query,
 };
 
+#[allow(deprecated)] // parse_input deprecated since 0.10.0; used by BreezSdk::parse()
 use super::{BreezSdk, helpers::get_or_create_deposit_address, parse_input};
 
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
@@ -66,6 +67,7 @@ impl BreezSdk {
         Ok(())
     }
 
+    #[allow(deprecated)] // delegates to deprecated parse_input free function
     pub async fn parse(&self, input: &str) -> Result<InputType, SdkError> {
         parse_input(input, Some(self.external_input_parsers.clone())).await
     }

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -96,6 +96,12 @@ pub struct BreezSdk {
     pub(crate) buy_bitcoin_provider: Arc<dyn BuyBitcoinProviderApi>,
 }
 
+/// Alias for [`BreezSdk`].
+///
+/// `BreezSparkClient` is the preferred name going forward. The original `BreezSdk`
+/// name is retained for backward compatibility.
+pub type BreezSparkClient = BreezSdk;
+
 pub(crate) struct BreezSdkParams {
     pub config: Config,
     pub storage: Arc<dyn Storage>,
@@ -112,6 +118,8 @@ pub(crate) struct BreezSdkParams {
     pub buy_bitcoin_provider: Arc<dyn BuyBitcoinProviderApi>,
 }
 
+#[deprecated(since = "0.10.0", note = "Use `BreezSdkSpark::parse()` instead")]
+#[allow(deprecated)]
 pub async fn parse_input(
     input: &str,
     external_input_parsers: Option<Vec<ExternalInputParser>>,
@@ -124,7 +132,22 @@ pub async fn parse_input(
     .into())
 }
 
+/// Parses a payment input string and returns the identified type.
+///
+/// Supports BOLT11 invoices, Lightning addresses, LNURL variants, Bitcoin
+/// addresses, Spark addresses/invoices, BIP21 URIs, and more.
+#[allow(deprecated)]
+#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+pub async fn parse(
+    input: &str,
+    external_input_parsers: Option<Vec<ExternalInputParser>>,
+) -> Result<InputType, SdkError> {
+    parse_input(input, external_input_parsers).await
+}
+
+#[allow(deprecated)]
 #[cfg_attr(feature = "uniffi", uniffi::export)]
+#[deprecated(since = "0.10.0", note = "Use `BreezSdkSpark::init_logging()` instead")]
 pub fn init_logging(
     log_dir: Option<String>,
     app_logger: Option<Box<dyn Logger>>,
@@ -143,7 +166,9 @@ pub fn init_logging(
 ///
 /// Result containing either the initialized `BreezSdk` or an `SdkError`
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+#[allow(deprecated)]
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+#[deprecated(since = "0.10.0", note = "Use `BreezSdkSpark::connect()` instead")]
 pub async fn connect(request: crate::ConnectRequest) -> Result<BreezSdk, SdkError> {
     let builder = super::sdk_builder::SdkBuilder::new(request.config, request.seed)
         .with_default_storage(request.storage_dir);
@@ -164,7 +189,12 @@ pub async fn connect(request: crate::ConnectRequest) -> Result<BreezSdk, SdkErro
 ///
 /// Result containing either the initialized `BreezSdk` or an `SdkError`
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+#[allow(deprecated)]
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+#[deprecated(
+    since = "0.10.0",
+    note = "Use `BreezSdkSpark::connect_with_signer()` instead"
+)]
 pub async fn connect_with_signer(
     request: crate::ConnectWithSignerRequest,
 ) -> Result<BreezSdk, SdkError> {
@@ -174,7 +204,12 @@ pub async fn connect_with_signer(
     Ok(sdk)
 }
 
+#[allow(deprecated)]
 #[cfg_attr(feature = "uniffi", uniffi::export)]
+#[deprecated(
+    since = "0.10.0",
+    note = "Use `BreezSdkSpark::default_config()` instead"
+)]
 pub fn default_config(network: Network) -> Config {
     let lnurl_domain = match network {
         Network::Mainnet => Some("breez.tips".to_string()),
@@ -215,7 +250,12 @@ pub fn default_config(network: Network) -> Config {
 /// # Returns
 ///
 /// Result containing the signer as `Arc<dyn ExternalSigner>`
+#[allow(deprecated)]
 #[cfg_attr(feature = "uniffi", uniffi::export)]
+#[deprecated(
+    since = "0.10.0",
+    note = "Use `BreezSdkSpark::default_external_signer()` instead"
+)]
 pub fn default_external_signer(
     mnemonic: String,
     passphrase: Option<String>,
@@ -241,7 +281,12 @@ pub fn default_external_signer(
 ///
 /// This function queries the Spark status API and returns the worst status
 /// across the Spark Operators and SSP services.
+#[allow(deprecated)]
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+#[deprecated(
+    since = "0.10.0",
+    note = "Use `BreezSdkSpark::get_spark_status()` instead"
+)]
 pub async fn get_spark_status() -> Result<crate::SparkStatus, SdkError> {
     use chrono::DateTime;
     use platform_utils::DefaultHttpClient;

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -18,6 +18,7 @@ use crate::{
     },
 };
 
+#[allow(deprecated)] // parse_input deprecated since 0.10.0; used by sync_single_lnurl_metadata
 use super::{
     BreezSdk, CLAIM_TX_SIZE_VBYTES, SYNC_PAGING_LIMIT, SyncRequest, SyncType,
     helpers::{BalanceWatcher, update_balances},
@@ -161,6 +162,7 @@ impl BreezSdk {
         }
     }
 
+    #[allow(deprecated)] // calls deprecated parse_input internally
     pub(super) async fn sync_single_lnurl_metadata(&self, payment: &mut Payment) {
         if payment.payment_type != PaymentType::Receive {
             return;

--- a/crates/breez-sdk/core/src/signer/default_external.rs
+++ b/crates/breez-sdk/core/src/signer/default_external.rs
@@ -9,6 +9,8 @@ use crate::signer::external_types::{
     RecoverableEcdsaSignatureBytes, SchnorrSignatureBytes, SecretBytes, string_to_derivation_path,
 };
 use crate::signer::{BreezSigner, ExternalSigner, breez::BreezSignerImpl};
+#[allow(deprecated)]
+// default_config deprecated since 0.10.0; used by DefaultExternalSigner::new
 use crate::{Network, SdkError, Seed, default_config, models::KeySetType};
 
 /// Default implementation of `ExternalSigner` that uses the internal `BreezSignerImpl`.
@@ -30,6 +32,7 @@ impl DefaultExternalSigner {
     /// * `use_address_index` - Whether to use address index in derivation
     /// * `account_number` - Optional account number for key derivation
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
+    #[allow(deprecated)] // calls deprecated default_config to build internal config
     pub fn new(
         mnemonic: String,
         passphrase: Option<String>,
@@ -355,6 +358,7 @@ impl ExternalSigner for DefaultExternalSigner {
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // tests use deprecated default_config free function
 mod tests {
     use super::*;
     use crate::models::KeySetType;

--- a/crates/breez-sdk/core/src/signer/nostr.rs
+++ b/crates/breez-sdk/core/src/signer/nostr.rs
@@ -82,6 +82,7 @@ impl NostrSigner {
 
 #[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]
+#[allow(deprecated)] // tests use deprecated default_config free function
 mod tests {
     use std::sync::Arc;
 

--- a/crates/breez-sdk/wasm/src/breez.rs
+++ b/crates/breez-sdk/wasm/src/breez.rs
@@ -1,0 +1,93 @@
+use wasm_bindgen::prelude::*;
+
+use crate::{error::WasmResult, logger::Logger, models::*, sdk::BreezSdk, sdk_builder::SdkBuilder};
+
+/// Top-level namespace for the Breez SDK Spark.
+///
+/// Groups all static/global SDK functions that don't require a wallet
+/// connection. Use `BreezSdkSpark.connect()` to obtain a `BreezSparkClient` instance.
+#[wasm_bindgen]
+pub struct BreezSdkSpark;
+
+#[wasm_bindgen]
+impl BreezSdkSpark {
+    /// Returns a default SDK configuration for the given network.
+    #[wasm_bindgen(js_name = "defaultConfig")]
+    pub fn default_config(network: Network) -> Config {
+        #[allow(deprecated)] // default_config deprecated since 0.10.0
+        breez_sdk_spark::default_config(network.into()).into()
+    }
+
+    /// Initializes the SDK logging subsystem.
+    ///
+    /// In WASM, logging uses the `tracing` framework with a JavaScript callback.
+    /// The `filter` parameter controls log verbosity (e.g. `"debug"`, `"info"`).
+    #[wasm_bindgen(js_name = "initLogging")]
+    pub async fn init_logging(logger: Logger, filter: Option<String>) -> WasmResult<()> {
+        crate::sdk::init_logging(logger, filter).await
+    }
+
+    /// Parses a payment input string and returns the identified type.
+    ///
+    /// Supports BOLT11 invoices, Lightning addresses, LNURL variants, Bitcoin
+    /// addresses, Spark addresses/invoices, BIP21 URIs, and more.
+    ///
+    /// Note: External input parsers are configured via `Config.externalInputParsers`
+    /// and passed during `connect()`. Ad-hoc parser overrides are not supported in WASM.
+    #[wasm_bindgen(js_name = "parse")]
+    pub async fn parse(input: &str) -> WasmResult<InputType> {
+        let result = breez_sdk_spark::parse(input, None).await?;
+        Ok(result.into())
+    }
+
+    /// Connects to the Spark network using the provided configuration and seed.
+    #[wasm_bindgen(js_name = "connect")]
+    pub async fn connect(request: ConnectRequest) -> WasmResult<BreezSdk> {
+        let builder = SdkBuilder::new(request.config, request.seed)
+            .with_default_storage(request.storage_dir)
+            .await?;
+        let sdk = builder.build().await?;
+        Ok(sdk)
+    }
+
+    /// Connects to the Spark network using an external signer.
+    #[wasm_bindgen(js_name = "connectWithSigner")]
+    pub async fn connect_with_signer(
+        config: Config,
+        signer: crate::signer::JsExternalSigner,
+        storage_dir: String,
+    ) -> WasmResult<BreezSdk> {
+        let builder = SdkBuilder::new_with_signer(config, signer)
+            .with_default_storage(storage_dir)
+            .await?;
+        let sdk = builder.build().await?;
+        Ok(sdk)
+    }
+
+    /// Creates a default external signer from a mnemonic phrase.
+    #[wasm_bindgen(js_name = "defaultExternalSigner")]
+    pub fn default_external_signer(
+        mnemonic: String,
+        passphrase: Option<String>,
+        network: Network,
+        key_set_config: Option<KeySetConfig>,
+    ) -> WasmResult<crate::signer::DefaultSigner> {
+        #[allow(deprecated)] // default_external_signer deprecated since 0.10.0
+        let signer = breez_sdk_spark::default_external_signer(
+            mnemonic,
+            passphrase,
+            network.into(),
+            key_set_config.map(|k| k.into()),
+        )?;
+
+        Ok(crate::signer::DefaultSigner::new(signer))
+    }
+
+    /// Fetches the current status of Spark network services.
+    #[wasm_bindgen(js_name = "getSparkStatus")]
+    pub async fn get_spark_status() -> WasmResult<SparkStatus> {
+        #[allow(deprecated)] // get_spark_status deprecated since 0.10.0
+        let status = breez_sdk_spark::get_spark_status().await?;
+        Ok(status.into())
+    }
+}

--- a/crates/breez-sdk/wasm/src/lib.rs
+++ b/crates/breez-sdk/wasm/src/lib.rs
@@ -1,3 +1,4 @@
+mod breez;
 mod error;
 mod event;
 mod issuer;

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -56,6 +56,7 @@ pub async fn connect_with_signer(
 }
 
 #[wasm_bindgen(js_name = "defaultConfig")]
+#[allow(deprecated)]
 pub fn default_config(network: Network) -> Config {
     breez_sdk_spark::default_config(network.into()).into()
 }
@@ -64,11 +65,13 @@ pub fn default_config(network: Network) -> Config {
 ///
 /// This creates a signer that can be used with `connectWithSigner` or `SdkBuilder.newWithSigner`.
 #[wasm_bindgen(js_name = "getSparkStatus")]
+#[allow(deprecated)]
 pub async fn get_spark_status() -> WasmResult<SparkStatus> {
     Ok(breez_sdk_spark::get_spark_status().await?.into())
 }
 
 #[wasm_bindgen(js_name = "defaultExternalSigner")]
+#[allow(deprecated)]
 pub fn default_external_signer(
     mnemonic: String,
     passphrase: Option<String>,

--- a/docs/breez-sdk/snippets/csharp/Config.cs
+++ b/docs/breez-sdk/snippets/csharp/Config.cs
@@ -8,7 +8,7 @@ namespace BreezSdkSnippets
         {
             // ANCHOR: max-deposit-claim-fee
             // Create the default config with API key
-            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            var config = BreezSdkSpark.DefaultConfig(Network.Mainnet) with
             {
                 apiKey = "<breez api key>"
             };
@@ -32,7 +32,7 @@ namespace BreezSdkSnippets
         {
             // ANCHOR: private-enabled-default
             // Disable Spark private mode by default
-            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            var config = BreezSdkSpark.DefaultConfig(Network.Mainnet) with
             {
                 privateEnabledDefault = false
             };
@@ -42,7 +42,7 @@ namespace BreezSdkSnippets
         void ConfigureOptimizationConfiguration()
         {
             // ANCHOR: optimization-configuration
-            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            var config = BreezSdkSpark.DefaultConfig(Network.Mainnet) with
             {
                 optimizationConfig = new OptimizationConfig(autoEnabled: true, multiplicity: 1)
             };
@@ -52,7 +52,7 @@ namespace BreezSdkSnippets
         void ConfigureStableBalance()
         {
             // ANCHOR: stable-balance-config
-            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            var config = BreezSdkSpark.DefaultConfig(Network.Mainnet) with
             {
                 // Enable stable balance with auto-conversion to a specific token
                 stableBalanceConfig = new StableBalanceConfig(

--- a/docs/breez-sdk/snippets/csharp/ExternalSigner.cs
+++ b/docs/breez-sdk/snippets/csharp/ExternalSigner.cs
@@ -19,7 +19,7 @@ namespace BreezSdkSnippets
                 accountNumber: accountNumber
             );
 
-            var signer = BreezSdkSparkMethods.DefaultExternalSigner(
+            var signer = BreezSdkSpark.DefaultExternalSigner(
                 mnemonic: mnemonic,
                 passphrase: null,
                 network: network,
@@ -34,13 +34,13 @@ namespace BreezSdkSnippets
         public static async Task<BreezSdk> ConnectWithSigner(ExternalSigner signer)
         {
             // Create the config
-            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            var config = BreezSdkSpark.DefaultConfig(Network.Mainnet) with
             {
                 apiKey = "<breez api key>"
             };
 
             // Connect using the external signer
-            var sdk = await BreezSdkSparkMethods.ConnectWithSigner(new ConnectWithSignerRequest(
+            var sdk = await BreezSdkSpark.ConnectWithSigner(new ConnectWithSignerRequest(
                 config: config,
                 signer: signer,
                 storageDir: "./.data"

--- a/docs/breez-sdk/snippets/csharp/GettingStarted.cs
+++ b/docs/breez-sdk/snippets/csharp/GettingStarted.cs
@@ -11,12 +11,12 @@ namespace BreezSdkSnippets
             var mnemonic = "<mnemonic words>";
             var seed = new Seed.Mnemonic(mnemonic: mnemonic, passphrase: null);
             // Create the default config
-            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            var config = BreezSdkSpark.DefaultConfig(Network.Mainnet) with
             {
                 apiKey = "<breez api key>"
             };
             // Connect to the SDK using the simplified connect method
-            var sdk = await BreezSdkSparkMethods.Connect(
+            var sdk = await BreezSdkSpark.Connect(
                 request: new ConnectRequest(
                     config: config,
                     seed: seed,
@@ -48,7 +48,7 @@ namespace BreezSdkSnippets
 
         void SetLogger(SdkLogger logger)
         {
-            BreezSdkSparkMethods.InitLogging(logDir: null, appLogger: logger, logFilter: null);
+            BreezSdkSpark.InitLogging(logDir: null, appLogger: logger, logFilter: null);
         }
         // ANCHOR_END: logging
 
@@ -118,7 +118,7 @@ namespace BreezSdkSnippets
         // ANCHOR: spark-status
         async Task GetSparkStatus()
         {
-            var sparkStatus = await BreezSdkSparkMethods.GetSparkStatus();
+            var sparkStatus = await BreezSdkSpark.GetSparkStatus();
 
             switch (sparkStatus.status)
             {

--- a/docs/breez-sdk/snippets/csharp/IssuingTokens.cs
+++ b/docs/breez-sdk/snippets/csharp/IssuingTokens.cs
@@ -36,7 +36,7 @@ namespace BreezSdkSnippets
 
             var mnemonic = "<mnemonic words>";
             var seed = new Seed.Mnemonic(mnemonic: mnemonic, passphrase: null);
-            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            var config = BreezSdkSpark.DefaultConfig(Network.Mainnet) with
             {
                 apiKey = "<breez api key>"
             };

--- a/docs/breez-sdk/snippets/csharp/LightningAddress.cs
+++ b/docs/breez-sdk/snippets/csharp/LightningAddress.cs
@@ -7,7 +7,7 @@ namespace BreezSdkSnippets
         void ConfigureLightningAddress()
         {
             // ANCHOR: config-lightning-address
-            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            var config = BreezSdkSpark.DefaultConfig(Network.Mainnet) with
             {
                 apiKey = "your-api-key",
                 lnurlDomain = "yourdomain.com"

--- a/docs/breez-sdk/snippets/csharp/ParsingInputs.cs
+++ b/docs/breez-sdk/snippets/csharp/ParsingInputs.cs
@@ -4,12 +4,12 @@ namespace BreezSdkSnippets
 {
     class ParsingInputs
     {
-        async Task ParseInput(BreezSdk sdk)
+        async Task ParseInput()
         {
             // ANCHOR: parse-inputs
             var inputStr = "an input to be parsed...";
 
-            var parsedInput = await sdk.Parse(input: inputStr);
+            var parsedInput = await BreezSdkSpark.Parse(input: inputStr, externalInputParsers: null);
             switch (parsedInput)
             {
                 case InputType.BitcoinAddress bitcoinAddress:
@@ -78,7 +78,7 @@ namespace BreezSdkSnippets
         {
             // ANCHOR: set-external-input-parsers
             // Create the default config
-            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            var config = BreezSdkSpark.DefaultConfig(Network.Mainnet) with
             {
                 apiKey = "<breez api key>",
                 externalInputParsers = new List<ExternalInputParser>

--- a/docs/breez-sdk/snippets/csharp/RefundingPayments.cs
+++ b/docs/breez-sdk/snippets/csharp/RefundingPayments.cs
@@ -102,7 +102,7 @@ namespace BreezSdkSnippets
         {
             // ANCHOR: set-max-fee-to-recommended-fees
             // Create the default config
-            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            var config = BreezSdkSpark.DefaultConfig(Network.Mainnet) with
             {
                 apiKey = "<breez api key>"
             };

--- a/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
+++ b/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
@@ -11,7 +11,7 @@ namespace BreezSdkSnippets
             var mnemonic = "<mnemonic words>";
             var seed = new Seed.Mnemonic(mnemonic: mnemonic, passphrase: null);
             // Create the default config
-            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            var config = BreezSdkSpark.DefaultConfig(Network.Mainnet) with
             {
                 apiKey = "<breez api key>"
             };
@@ -89,7 +89,7 @@ namespace BreezSdkSnippets
             var seed = new Seed.Mnemonic(mnemonic: mnemonic, passphrase: null);
 
             // Create the default config
-            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            var config = BreezSdkSpark.DefaultConfig(Network.Mainnet) with
             {
                 apiKey = "<breez api key>"
             };
@@ -97,7 +97,7 @@ namespace BreezSdkSnippets
             // Configure PostgreSQL storage
             // Connection string format: "host=localhost user=postgres password=secret dbname=spark"
             // Or URI format: "postgres://user:password@host:port/dbname?sslmode=require"
-            var postgresConfig = BreezSdkSparkMethods.DefaultPostgresStorageConfig(
+            var postgresConfig = BreezSdkSpark.DefaultPostgresStorageConfig(
                 connectionString: "host=localhost user=postgres dbname=spark"
             );
             // Optionally pool settings can be adjusted. Some examples:
@@ -108,7 +108,7 @@ namespace BreezSdkSnippets
             };
 
             // Create the storage and build the SDK
-            var storage = await BreezSdkSparkMethods.CreatePostgresStorage(config: postgresConfig);
+            var storage = await BreezSdkSpark.CreatePostgresStorage(config: postgresConfig);
             var builder = new SdkBuilder(config: config, seed: seed);
             await builder.WithStorage(storage);
             var sdk = await builder.Build();

--- a/docs/breez-sdk/snippets/flutter/lib/config.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/config.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 Future<void> configureMaxDepositClaimFee() async {
   // ANCHOR: max-deposit-claim-fee
   // Create the default config
-  var config = defaultConfig(network: Network.mainnet)
+  var config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
       .copyWith(apiKey: "<breez api key>");
 
   // Disable automatic claiming
@@ -31,7 +31,7 @@ Future<void> configureMaxDepositClaimFee() async {
 Future<void> configurePrivateEnabledDefault() async {
   // ANCHOR: private-enabled-default
   // Disable Spark private mode by default
-  var config = defaultConfig(network: Network.mainnet)
+  var config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
       .copyWith(privateEnabledDefault: false);
   // ANCHOR_END: private-enabled-default
   print(config);
@@ -39,7 +39,7 @@ Future<void> configurePrivateEnabledDefault() async {
 
 Future<void> configureOptimizationConfiguration() async {
   // ANCHOR: optimization-configuration
-  var config = defaultConfig(network: Network.mainnet).copyWith(
+  var config = BreezSdkSpark.defaultConfig(network: Network.mainnet).copyWith(
       optimizationConfig:
           OptimizationConfig(autoEnabled: true, multiplicity: 1));
   // ANCHOR_END: optimization-configuration
@@ -48,7 +48,7 @@ Future<void> configureOptimizationConfiguration() async {
 
 Future<void> configureStableBalance() async {
   // ANCHOR: stable-balance-config
-  var config = defaultConfig(network: Network.mainnet).copyWith(
+  var config = BreezSdkSpark.defaultConfig(network: Network.mainnet).copyWith(
       // Enable stable balance with auto-conversion to a specific token
       stableBalanceConfig: StableBalanceConfig(
           tokenIdentifier: "<token_identifier>",

--- a/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
@@ -14,13 +14,13 @@ Future<void> initSdk() async {
   final seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: null);
 
   // Create the default config
-  final config = defaultConfig(network: Network.mainnet)
+  final config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
       .copyWith(apiKey: "<breez api key>");
 
   final connectRequest =
       ConnectRequest(config: config, seed: seed, storageDir: "./.data");
 
-  final sdk = await connect(request: connectRequest);
+  final sdk = await BreezSdkSpark.connect(request: connectRequest);
   // ANCHOR_END: init-sdk
   print(sdk);
 }
@@ -39,7 +39,7 @@ Future<void> fetchBalance(BreezSdk sdk) async {
 
 // ANCHOR: spark-status
 Future<void> gettingStartedSparkStatus() async {
-  final sparkStatus = await getSparkStatus();
+  final sparkStatus = await BreezSdkSpark.getSparkStatus();
 
   switch (sparkStatus.status) {
     case ServiceStatus.operational:
@@ -63,7 +63,7 @@ Future<void> gettingStartedSparkStatus() async {
 }
 // ANCHOR_END: spark-status
 
-class BreezSdkSpark {
+class GettingStartedSnippets {
   // ANCHOR: logging
   StreamSubscription<LogEntry>? _logSubscription;
   Stream<LogEntry>? _logStream;
@@ -74,7 +74,7 @@ class BreezSdkSpark {
   // or singleton SDK service. It is recommended to use a single instance
   // of the SDK across your Flutter app.
   void initializeLogStream() {
-    _logStream ??= initLogging().asBroadcastStream();
+    _logStream ??= BreezSdkSpark.initLogging().asBroadcastStream();
   }
 
   final _logStreamController = StreamController<LogEntry>.broadcast();

--- a/docs/breez-sdk/snippets/flutter/lib/parsing_inputs.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/parsing_inputs.dart
@@ -1,11 +1,11 @@
 import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
 import 'helper.dart';
 
-Future<void> parseInput(BreezSdk sdk) async {
+Future<void> parseInput() async {
   // ANCHOR: parse-inputs
   String input = "an input to be parsed...";
 
-  InputType inputType = await sdk.parse(input: input);
+  InputType inputType = await BreezSdkSpark.parse(input: input);
   if (inputType is InputType_BitcoinAddress) {
     print("Input is Bitcoin address ${inputType.field0.address}");
   } else if (inputType is InputType_Bolt11Invoice) {
@@ -29,15 +29,15 @@ Future<void> parseInput(BreezSdk sdk) async {
     } else {
       print("  Amount: ${invoice.amount} sats");
     }
-    
+
     if (invoice.description != null) {
       print("  Description: ${invoice.description}");
     }
-    
+
     if (invoice.expiryTime != null) {
       print("  Expiry time: ${DateTime.fromMillisecondsSinceEpoch(invoice.expiryTime!.toInt() * 1000)}");
     }
-    
+
     if (invoice.senderPublicKey != null) {
       print("  Sender public key: ${invoice.senderPublicKey}");
     }
@@ -50,7 +50,7 @@ Future<void> parseInput(BreezSdk sdk) async {
 Future<void> setExternalInputParsers() async {
   // ANCHOR: set-external-input-parsers
   // Create the default config
-  Config config = defaultConfig(network: Network.mainnet)
+  Config config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
       .copyWith(apiKey: "<breez api key>");
 
   config = config.copyWith(

--- a/docs/breez-sdk/snippets/flutter/lib/sdk_building.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/sdk_building.dart
@@ -9,7 +9,7 @@ Future<void> initSdkAdvanced() async {
   final seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: null);
 
   // Create the default config
-  final config = defaultConfig(network: Network.mainnet)
+  final config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
       .copyWith(apiKey: "<breez api key>");
 
   // Build the SDK using the config, seed and default storage

--- a/docs/breez-sdk/snippets/go/parsing_inputs.go
+++ b/docs/breez-sdk/snippets/go/parsing_inputs.go
@@ -8,11 +8,11 @@ import (
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 )
 
-func ParseInput(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.InputType, error) {
+func ParseInput() (*breez_sdk_spark.InputType, error) {
 	// ANCHOR: parse-inputs
 	inputStr := "an input to be parsed..."
 
-	input, err := sdk.Parse(inputStr)
+	input, err := breez_sdk_spark.Parse(inputStr, nil)
 
 	if err != nil {
 		var sdkErr *breez_sdk_spark.SdkError

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
@@ -6,7 +6,7 @@ class Config {
     fun configureSdk() {
         // ANCHOR: max-deposit-claim-fee
         // Create the default config
-        val config = defaultConfig(Network.MAINNET)
+        val config = BreezSdkSpark.defaultConfig(Network.MAINNET)
         config.apiKey = "<breez api key>"
 
         // Disable automatic claiming
@@ -28,7 +28,7 @@ class Config {
     fun configurePrivateEnabledDefault() {
         // ANCHOR: private-enabled-default
         // Disable Spark private mode by default
-        val config = defaultConfig(Network.MAINNET)
+        val config = BreezSdkSpark.defaultConfig(Network.MAINNET)
         config.privateEnabledDefault = false
         // ANCHOR_END: private-enabled-default
         println("Config: $config")
@@ -36,7 +36,7 @@ class Config {
 
     fun configureOptimizationConfiguration() {
         // ANCHOR: optimization-configuration
-        val config = defaultConfig(Network.MAINNET)
+        val config = BreezSdkSpark.defaultConfig(Network.MAINNET)
         config.optimizationConfig = OptimizationConfig(autoEnabled = true, multiplicity = 1u)
         // ANCHOR_END: optimization-configuration
         println("Config: $config")
@@ -44,7 +44,7 @@ class Config {
 
     fun configureStableBalance() {
         // ANCHOR: stable-balance-config
-        val config = defaultConfig(Network.MAINNET)
+        val config = BreezSdkSpark.defaultConfig(Network.MAINNET)
 
         // Enable stable balance with auto-conversion to a specific token
         config.stableBalanceConfig = StableBalanceConfig(

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ExternalSigner.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ExternalSigner.kt
@@ -10,33 +10,33 @@ class ExternalSigner {
         val keySetType = KeySetType.DEFAULT
         val useAddressIndex = false
         val accountNumber = 0U
-        
+
         val keySetConfig = KeySetConfig(
             keySetType = keySetType,
             useAddressIndex = useAddressIndex,
             accountNumber = accountNumber
         )
-        
-        val signer = defaultExternalSigner(
+
+        val signer = BreezSdkSpark.defaultExternalSigner(
             mnemonic = mnemonic,
             passphrase = null,
             network = network,
             keySetConfig = keySetConfig
         )
-        
+
         return signer
     }
     // ANCHOR_END: default-external-signer
-    
+
     // ANCHOR: connect-with-signer
     suspend fun connectWithSigner(signer: breez_sdk_spark.ExternalSigner) {
         // Create the config
-        val config = defaultConfig(Network.MAINNET)
+        val config = BreezSdkSpark.defaultConfig(Network.MAINNET)
         config.apiKey = "<breez api key>"
-        
+
         try {
             // Connect using the external signer
-            val sdk = connectWithSigner(ConnectWithSignerRequest(
+            val sdk = BreezSdkSpark.connectWithSigner(ConnectWithSignerRequest(
                 config = config,
                 signer = signer,
                 storageDir = "./.data"

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
@@ -9,12 +9,12 @@ class GettingStarted {
         val seed = Seed.Mnemonic(mnemonic, null)
 
         // Create the default config
-        val config = defaultConfig(Network.MAINNET)
+        val config = BreezSdkSpark.defaultConfig(Network.MAINNET)
         config.apiKey = "<breez api key>"
 
         try {
             // Connect to the SDK using the simplified connect method
-            val sdk = connect(ConnectRequest(
+            val sdk = BreezSdkSpark.connect(ConnectRequest(
                 config = config,
                 seed = seed,
                 storageDir = "./.data"
@@ -48,7 +48,7 @@ class GettingStarted {
 
     fun setLogger(logger: SdkLogger) {
         try {
-            initLogging(null, logger, null)
+            BreezSdkSpark.initLogging(null, logger, null)
         } catch (e: Exception) {
             // handle error
         }
@@ -118,7 +118,7 @@ class GettingStarted {
     // ANCHOR: spark-status
     suspend fun gettingStartedSparkStatus() {
         try {
-            val sparkStatus = getSparkStatus()
+            val sparkStatus = BreezSdkSpark.getSparkStatus()
 
             when (sparkStatus.status) {
                 ServiceStatus.OPERATIONAL -> {

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ParsingInputs.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ParsingInputs.kt
@@ -3,12 +3,12 @@ package com.example.kotlinmpplib
 import breez_sdk_spark.*
 
 class ParsingInputs {
-    suspend fun parseInput(sdk: BreezSdk) {
+    suspend fun parseInput() {
         // ANCHOR: parse-inputs
         val input = "an input to be parsed..."
 
         try {
-            val inputType = sdk.parse(input)
+            val inputType = BreezSdkSpark.parse(input)
             when (inputType) {
                 is InputType.BitcoinAddress -> {
                     println("Input is Bitcoin address ${inputType.v1.address}")
@@ -68,7 +68,7 @@ class ParsingInputs {
     suspend fun setExternalInputParsers() {
         // ANCHOR: set-external-input-parsers
         // Create the default config
-        val config = defaultConfig(Network.MAINNET)
+        val config = BreezSdkSpark.defaultConfig(Network.MAINNET)
         config.apiKey = "<breez api key>"
 
         // Configure external parsers

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
@@ -9,7 +9,7 @@ class SdkBuilding {
         val seed = Seed.Mnemonic(mnemonic, null)
 
         // Create the default config
-        val config = defaultConfig(Network.MAINNET)
+        val config = BreezSdkSpark.defaultConfig(Network.MAINNET)
         config.apiKey = "<breez api key>"
 
         try {
@@ -29,7 +29,7 @@ class SdkBuilding {
         // ANCHOR_END: init-sdk-advanced
     }
 
-    suspend fun withRestChainService(builder: SdkBuilder) { 
+    suspend fun withRestChainService(builder: SdkBuilder) {
         // ANCHOR: with-rest-chain-service
         val url = "<your REST chain service URL>"
         val chainApiType = ChainApiType.MEMPOOL_SPACE
@@ -50,13 +50,13 @@ class SdkBuilding {
         val keySetType = KeySetType.DEFAULT
         val useAddressIndex = false
         val optionalAccountNumber = 21u
-        
+
         val keySetConfig = KeySetConfig(
             keySetType = keySetType,
             useAddressIndex = useAddressIndex,
             accountNumber = optionalAccountNumber
         )
-        
+
         builder.withKeySet(keySetConfig)
         // ANCHOR_END: with-key-set
     }
@@ -83,7 +83,7 @@ class SdkBuilding {
         val seed = Seed.Mnemonic(mnemonic, null)
 
         // Create the default config
-        val config = defaultConfig(Network.MAINNET)
+        val config = BreezSdkSpark.defaultConfig(Network.MAINNET)
         config.apiKey = "<breez api key>"
 
         // Configure PostgreSQL storage

--- a/docs/breez-sdk/snippets/python/src/config.py
+++ b/docs/breez-sdk/snippets/python/src/config.py
@@ -1,6 +1,6 @@
 import logging
 from breez_sdk_spark import (
-    default_config,
+    BreezSdkSpark,
     Network,
     MaxFee,
     OptimizationConfig,
@@ -11,7 +11,7 @@ from breez_sdk_spark import (
 async def configure_sdk():
     # ANCHOR: max-deposit-claim-fee
     # Create the default config
-    config = default_config(network=Network.MAINNET)
+    config = BreezSdkSpark.default_config(network=Network.MAINNET)
     config.api_key = "<breez api key>"
 
     # Disable automatic claiming
@@ -32,21 +32,21 @@ async def configure_sdk():
 async def configure_private_enabled_default():
     # ANCHOR: private-enabled-default
     # Disable Spark private mode by default
-    config = default_config(network=Network.MAINNET)
+    config = BreezSdkSpark.default_config(network=Network.MAINNET)
     config.private_enabled_default = False
     # ANCHOR_END: private-enabled-default
     logging.info(f"Config: {config}")
 
 async def configure_optimization_configuration():
     # ANCHOR: optimization-configuration
-    config = default_config(network=Network.MAINNET)
+    config = BreezSdkSpark.default_config(network=Network.MAINNET)
     config.optimization_config = OptimizationConfig(auto_enabled=True, multiplicity=1)
     # ANCHOR_END: optimization-configuration
     logging.info(f"Config: {config}")
 
 async def configure_stable_balance():
     # ANCHOR: stable-balance-config
-    config = default_config(network=Network.MAINNET)
+    config = BreezSdkSpark.default_config(network=Network.MAINNET)
 
     # Enable stable balance with auto-conversion to a specific token
     config.stable_balance_config = StableBalanceConfig(

--- a/docs/breez-sdk/snippets/python/src/external_signer.py
+++ b/docs/breez-sdk/snippets/python/src/external_signer.py
@@ -1,7 +1,5 @@
 from breez_sdk_spark import (
-    default_config,
-    default_external_signer,
-    connect_with_signer,
+    BreezSdkSpark,
     BreezSdk,
     ConnectWithSignerRequest,
     ExternalSigner,
@@ -24,7 +22,7 @@ def create_signer() -> ExternalSigner:
         account_number=account_number,
     )
 
-    signer = default_external_signer(
+    signer = BreezSdkSpark.default_external_signer(
         mnemonic=mnemonic,
         passphrase=None,
         network=network,
@@ -37,11 +35,11 @@ def create_signer() -> ExternalSigner:
 # ANCHOR: connect-with-signer
 async def example_connect_with_signer(signer: ExternalSigner) -> BreezSdk:
     # Create the config
-    config = default_config(Network.MAINNET)
+    config = BreezSdkSpark.default_config(Network.MAINNET)
     config.api_key = "<breez api key>"
 
     # Connect using the external signer
-    sdk = await connect_with_signer(ConnectWithSignerRequest(
+    sdk = await BreezSdkSpark.connect_with_signer(ConnectWithSignerRequest(
         config=config,
         signer=signer,
         storage_dir="./.data"

--- a/docs/breez-sdk/snippets/python/src/getting_started.py
+++ b/docs/breez-sdk/snippets/python/src/getting_started.py
@@ -1,13 +1,10 @@
 import logging
 from breez_sdk_spark import (
+    BreezSdkSpark,
     BreezSdk,
-    connect,
     ConnectRequest,
-    default_config,
     EventListener,
-    get_spark_status,
     GetInfoRequest,
-    init_logging,
     LogEntry,
     Logger,
     Network,
@@ -23,11 +20,11 @@ async def init_sdk():
     mnemonic = "<mnemonic words>"
     seed = Seed.MNEMONIC(mnemonic=mnemonic, passphrase=None)
     # Create the default config
-    config = default_config(network=Network.MAINNET)
+    config = BreezSdkSpark.default_config(network=Network.MAINNET)
     config.api_key = "<breez api key>"
     try:
         # Connect to the SDK using the simplified connect method
-        sdk = await connect(
+        sdk = await BreezSdkSpark.connect(
             request=ConnectRequest(config=config, seed=seed, storage_dir="./.data")
         )
         return sdk
@@ -59,7 +56,7 @@ class SdkLogger(Logger):
 
 def set_logger(logger: SdkLogger):
     try:
-        init_logging(log_dir=None, app_logger=logger, log_filter=None)
+        BreezSdkSpark.init_logging(log_dir=None, app_logger=logger, log_filter=None)
     except Exception as error:
         logging.error(error)
         raise
@@ -125,7 +122,7 @@ async def remove_event_listener(sdk: BreezSdk, listener_id: str):
 # ANCHOR: spark-status
 async def getting_started_spark_status():
     try:
-        spark_status = await get_spark_status()
+        spark_status = await BreezSdkSpark.get_spark_status()
 
         if spark_status.status == ServiceStatus.OPERATIONAL:
             logging.debug("Spark is fully operational")

--- a/docs/breez-sdk/snippets/python/src/parsing_inputs.py
+++ b/docs/breez-sdk/snippets/python/src/parsing_inputs.py
@@ -1,14 +1,14 @@
 # pylint: disable=too-many-branches
 import logging
-from breez_sdk_spark import BreezSdk, InputType, default_config, ExternalInputParser, Network
+from breez_sdk_spark import BreezSdkSpark, InputType, ExternalInputParser, Network
 
 
-async def parse_input(sdk: BreezSdk):
+async def parse_input():
     # ANCHOR: parse-inputs
     input_str = "an input to be parsed..."
 
     try:
-        parsed_input = await sdk.parse(input=input_str)
+        parsed_input = await BreezSdkSpark.parse(input=input_str)
         if isinstance(parsed_input, InputType.BITCOIN_ADDRESS):
             details = parsed_input[0]
             logging.debug(f"Input is Bitcoin address {details.address}")
@@ -59,7 +59,7 @@ async def parse_input(sdk: BreezSdk):
 async def set_external_input_parsers():
     # ANCHOR: set-external-input-parsers
     # Create the default config
-    config = default_config(network=Network.MAINNET)
+    config = BreezSdkSpark.default_config(network=Network.MAINNET)
     config.api_key = "<breez api key>"
 
     # Configure external parsers

--- a/docs/breez-sdk/snippets/python/src/sdk_building.py
+++ b/docs/breez-sdk/snippets/python/src/sdk_building.py
@@ -1,8 +1,8 @@
 import logging
 import typing
 from breez_sdk_spark import (
+    BreezSdkSpark,
     create_postgres_storage,
-    default_config,
     default_postgres_storage_config,
     Network,
     ProvisionalPayment,
@@ -22,7 +22,7 @@ async def init_sdk_advanced():
     mnemonic = "<mnemonic words>"
     seed = Seed.MNEMONIC(mnemonic=mnemonic, passphrase=None)
     # Create the default config
-    config = default_config(network=Network.MAINNET)
+    config = BreezSdkSpark.default_config(network=Network.MAINNET)
     config.api_key = "<breez api key>"
     try:
         # Build the SDK using the config, seed and default storage
@@ -94,7 +94,7 @@ async def init_sdk_postgres():
     seed = Seed.MNEMONIC(mnemonic=mnemonic, passphrase=None)
 
     # Create the default config
-    config = default_config(network=Network.MAINNET)
+    config = BreezSdkSpark.default_config(network=Network.MAINNET)
     config.api_key = "<breez api key>"
 
     # Configure PostgreSQL storage

--- a/docs/breez-sdk/snippets/react-native/config.ts
+++ b/docs/breez-sdk/snippets/react-native/config.ts
@@ -1,5 +1,5 @@
 import {
-  defaultConfig,
+  BreezSdkSpark,
   Network,
   MaxFee,
   OptimizationConfig,
@@ -9,7 +9,7 @@ import {
 const exampleConfigureSdk = () => {
   // ANCHOR: max-deposit-claim-fee
   // Create the default config
-  const config = defaultConfig(Network.Mainnet)
+  const config = BreezSdkSpark.defaultConfig(Network.Mainnet)
   config.apiKey = '<breez api key>'
 
   // Disable automatic claiming
@@ -31,7 +31,7 @@ const exampleConfigureSdk = () => {
 const exampleConfigurePrivateEnabledDefault = () => {
   // ANCHOR: private-enabled-default
   // Disable Spark private mode by default
-  const config = defaultConfig(Network.Mainnet)
+  const config = BreezSdkSpark.defaultConfig(Network.Mainnet)
   config.privateEnabledDefault = false
   // ANCHOR_END: private-enabled-default
   console.log('Config:', config)
@@ -39,7 +39,7 @@ const exampleConfigurePrivateEnabledDefault = () => {
 
 const exampleConfigureOptimizationConfiguration = () => {
   // ANCHOR: optimization-configuration
-  const config = defaultConfig(Network.Mainnet)
+  const config = BreezSdkSpark.defaultConfig(Network.Mainnet)
   config.optimizationConfig = { autoEnabled: true, multiplicity: 1 }
   // ANCHOR_END: optimization-configuration
   console.log('Config:', config)
@@ -47,7 +47,7 @@ const exampleConfigureOptimizationConfiguration = () => {
 
 const exampleConfigureStableBalance = () => {
   // ANCHOR: stable-balance-config
-  const config = defaultConfig(Network.Mainnet)
+  const config = BreezSdkSpark.defaultConfig(Network.Mainnet)
 
   // Enable stable balance with auto-conversion to a specific token
   config.stableBalanceConfig = {

--- a/docs/breez-sdk/snippets/react-native/external_signer.ts
+++ b/docs/breez-sdk/snippets/react-native/external_signer.ts
@@ -1,7 +1,5 @@
 import {
-  defaultExternalSigner,
-  connectWithSigner,
-  defaultConfig,
+  BreezSdkSpark,
   Network,
   KeySetType
 } from '@breeztech/breez-sdk-spark-react-native'
@@ -18,20 +16,20 @@ const createSigner = () => {
   }
 
   // Create the default signer from the SDK
-  const signer = defaultExternalSigner(mnemonic, undefined, Network.Mainnet, keySetConfig)
+  const signer = BreezSdkSpark.defaultExternalSigner(mnemonic, undefined, Network.Mainnet, keySetConfig)
 
   return signer
 }
 // ANCHOR_END: default-external-signer
 
 // ANCHOR: connect-with-signer
-const exampleConnectWithSigner = async (signer: ReturnType<typeof defaultExternalSigner>) => {
+const exampleConnectWithSigner = async (signer: ReturnType<typeof BreezSdkSpark.defaultExternalSigner>) => {
   // Create the config
-  const config = defaultConfig(Network.Mainnet)
+  const config = BreezSdkSpark.defaultConfig(Network.Mainnet)
   config.apiKey = '<breez api key>'
 
   // Connect using the external signer
-  const sdk = await connectWithSigner({
+  const sdk = await BreezSdkSpark.connectWithSigner({
     config,
     signer,
     storageDir: `${RNFS.DocumentDirectoryPath}/data`

--- a/docs/breez-sdk/snippets/react-native/getting_started.ts
+++ b/docs/breez-sdk/snippets/react-native/getting_started.ts
@@ -1,15 +1,12 @@
 import {
-  defaultConfig,
-  connect,
+  BreezSdkSpark,
   Network,
   SdkBuilder,
   type BreezSdk,
-  initLogging,
   type LogEntry,
   type SdkEvent,
   SdkEvent_Tags,
   Seed,
-  getSparkStatus,
   ServiceStatus
 } from '@breeztech/breez-sdk-spark-react-native'
 import RNFS from 'react-native-fs'
@@ -21,10 +18,10 @@ const exampleGettingStarted = async () => {
   const seed = new Seed.Mnemonic({ mnemonic, passphrase: undefined })
 
   // Create the default config
-  const config = defaultConfig(Network.Mainnet)
+  const config = BreezSdkSpark.defaultConfig(Network.Mainnet)
   config.apiKey = '<breez api key>'
 
-  const sdk = await connect({
+  const sdk = await BreezSdkSpark.connect({
     config,
     seed,
     storageDir: `${RNFS.DocumentDirectoryPath}/data`
@@ -53,7 +50,7 @@ const exampleLogging = async () => {
   }
 
   const logger = new JsLogger()
-  initLogging(undefined, logger, undefined)
+  BreezSdkSpark.initLogging(undefined, logger, undefined)
   // ANCHOR_END: logging
 }
 
@@ -102,7 +99,7 @@ const exampleRemoveEventListener = async (sdk: BreezSdk, listenerId: string) => 
 
 const exampleGetSparkStatus = async () => {
   // ANCHOR: spark-status
-  const sparkStatus = await getSparkStatus()
+  const sparkStatus = await BreezSdkSpark.getSparkStatus()
 
   switch (sparkStatus.status) {
     case ServiceStatus.Operational:

--- a/docs/breez-sdk/snippets/react-native/parsing_inputs.ts
+++ b/docs/breez-sdk/snippets/react-native/parsing_inputs.ts
@@ -1,15 +1,14 @@
 import {
-  defaultConfig,
+  BreezSdkSpark,
   Network,
-  type BreezSdk,
   InputType_Tags
 } from '@breeztech/breez-sdk-spark-react-native'
 
-const parseInputs = async (sdk: BreezSdk) => {
+const parseInputs = async () => {
   // ANCHOR: parse-inputs
   const inputStr = 'an input to be parsed...'
 
-  const input = await sdk.parse(inputStr)
+  const input = await BreezSdkSpark.parse(inputStr)
 
   if (input.tag === InputType_Tags.BitcoinAddress) {
     console.log(`Input is Bitcoin address ${input.inner[0].address}`)
@@ -62,7 +61,7 @@ const parseInputs = async (sdk: BreezSdk) => {
 const exampleSetExternalInputParsers = async () => {
   // ANCHOR: set-external-input-parsers
   // Create the default config
-  const config = defaultConfig(Network.Mainnet)
+  const config = BreezSdkSpark.defaultConfig(Network.Mainnet)
   config.apiKey = '<breez api key>'
 
   // Configure external parsers

--- a/docs/breez-sdk/snippets/react-native/sdk_building.ts
+++ b/docs/breez-sdk/snippets/react-native/sdk_building.ts
@@ -1,7 +1,7 @@
 import {
+  BreezSdkSpark,
   SdkBuilder,
   Seed,
-  defaultConfig,
   Network,
   ChainApiType,
   KeySetType,
@@ -18,7 +18,7 @@ const exampleGettingStartedAdvanced = async () => {
   const seed = new Seed.Mnemonic({ mnemonic, passphrase: undefined })
 
   // Create the default config
-  const config = defaultConfig(Network.Mainnet)
+  const config = BreezSdkSpark.defaultConfig(Network.Mainnet)
   config.apiKey = '<breez api key>'
 
   // Build the SDK using the config, seed and default storage

--- a/docs/breez-sdk/snippets/react-native/yarn.lock
+++ b/docs/breez-sdk/snippets/react-native/yarn.lock
@@ -2,34 +2,34 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.12.13", "@babel/code-frame@^7.24.7", "@babel/code-frame@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
-  integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
+"@babel/code-frame@^7.12.13", "@babel/code-frame@^7.24.7", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
+  integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.28.5"
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
-"@babel/compat-data@^7.27.2", "@babel/compat-data@^7.27.7":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.28.4.tgz#96fdf1af1b8859c8474ab39c295312bfb7c24b04"
-  integrity sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==
+"@babel/compat-data@^7.28.6":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.0.tgz#00d03e8c0ac24dd9be942c5370990cbe1f17d88d"
+  integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
 "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.24.7", "@babel/core@^7.25.2":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.28.4.tgz#12a550b8794452df4c8b084f95003bce1742d496"
-  integrity sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.0.tgz#5286ad785df7f79d656e88ce86e650d16ca5f322"
+  integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
   dependencies:
-    "@babel/code-frame" "^7.27.1"
-    "@babel/generator" "^7.28.3"
-    "@babel/helper-compilation-targets" "^7.27.2"
-    "@babel/helper-module-transforms" "^7.28.3"
-    "@babel/helpers" "^7.28.4"
-    "@babel/parser" "^7.28.4"
-    "@babel/template" "^7.27.2"
-    "@babel/traverse" "^7.28.4"
-    "@babel/types" "^7.28.4"
+    "@babel/code-frame" "^7.29.0"
+    "@babel/generator" "^7.29.0"
+    "@babel/helper-compilation-targets" "^7.28.6"
+    "@babel/helper-module-transforms" "^7.28.6"
+    "@babel/helpers" "^7.28.6"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/traverse" "^7.29.0"
+    "@babel/types" "^7.29.0"
     "@jridgewell/remapping" "^2.3.5"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
@@ -37,13 +37,13 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.25.0", "@babel/generator@^7.28.3":
-  version "7.28.3"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.28.3.tgz#9626c1741c650cbac39121694a0f2d7451b8ef3e"
-  integrity sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==
+"@babel/generator@^7.25.0", "@babel/generator@^7.29.0", "@babel/generator@^7.29.1":
+  version "7.29.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.1.tgz#d09876290111abbb00ef962a7b83a5307fba0d50"
+  integrity sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==
   dependencies:
-    "@babel/parser" "^7.28.3"
-    "@babel/types" "^7.28.2"
+    "@babel/parser" "^7.29.0"
+    "@babel/types" "^7.29.0"
     "@jridgewell/gen-mapping" "^0.3.12"
     "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
@@ -55,79 +55,79 @@
   dependencies:
     "@babel/types" "^7.27.3"
 
-"@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.27.2":
-  version "7.27.2"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz#46a0f6efab808d51d29ce96858dd10ce8732733d"
-  integrity sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==
+"@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz#32c4a3f41f12ed1532179b108a4d746e105c2b25"
+  integrity sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==
   dependencies:
-    "@babel/compat-data" "^7.27.2"
+    "@babel/compat-data" "^7.28.6"
     "@babel/helper-validator-option" "^7.27.1"
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
-"@babel/helper-create-class-features-plugin@^7.27.1":
-  version "7.28.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz#3e747434ea007910c320c4d39a6b46f20f371d46"
-  integrity sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==
+"@babel/helper-create-class-features-plugin@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz#611ff5482da9ef0db6291bcd24303400bca170fb"
+  integrity sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.27.3"
-    "@babel/helper-member-expression-to-functions" "^7.27.1"
+    "@babel/helper-member-expression-to-functions" "^7.28.5"
     "@babel/helper-optimise-call-expression" "^7.27.1"
-    "@babel/helper-replace-supers" "^7.27.1"
+    "@babel/helper-replace-supers" "^7.28.6"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
-    "@babel/traverse" "^7.28.3"
+    "@babel/traverse" "^7.28.6"
     semver "^6.3.1"
 
-"@babel/helper-create-regexp-features-plugin@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz#05b0882d97ba1d4d03519e4bce615d70afa18c53"
-  integrity sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==
+"@babel/helper-create-regexp-features-plugin@^7.27.1", "@babel/helper-create-regexp-features-plugin@^7.28.5":
+  version "7.28.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz#7c1ddd64b2065c7f78034b25b43346a7e19ed997"
+  integrity sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.27.1"
-    regexpu-core "^6.2.0"
+    "@babel/helper-annotate-as-pure" "^7.27.3"
+    regexpu-core "^6.3.1"
     semver "^6.3.1"
 
-"@babel/helper-define-polyfill-provider@^0.6.5":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz#742ccf1cb003c07b48859fc9fa2c1bbe40e5f753"
-  integrity sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==
+"@babel/helper-define-polyfill-provider@^0.6.5", "@babel/helper-define-polyfill-provider@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.6.tgz#714dfe33d8bd710f556df59953720f6eeb6c1a14"
+  integrity sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==
   dependencies:
-    "@babel/helper-compilation-targets" "^7.27.2"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    debug "^4.4.1"
+    "@babel/helper-compilation-targets" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
+    debug "^4.4.3"
     lodash.debounce "^4.0.8"
-    resolve "^1.22.10"
+    resolve "^1.22.11"
 
 "@babel/helper-globals@^7.28.0":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz#b9430df2aa4e17bc28665eadeae8aa1d985e6674"
   integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
 
-"@babel/helper-member-expression-to-functions@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz#ea1211276be93e798ce19037da6f06fbb994fa44"
-  integrity sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==
+"@babel/helper-member-expression-to-functions@^7.28.5":
+  version "7.28.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz#f3e07a10be37ed7a63461c63e6929575945a6150"
+  integrity sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==
   dependencies:
-    "@babel/traverse" "^7.27.1"
-    "@babel/types" "^7.27.1"
+    "@babel/traverse" "^7.28.5"
+    "@babel/types" "^7.28.5"
 
-"@babel/helper-module-imports@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz#7ef769a323e2655e126673bb6d2d6913bbead204"
-  integrity sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==
+"@babel/helper-module-imports@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz#60632cbd6ffb70b22823187201116762a03e2d5c"
+  integrity sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==
   dependencies:
-    "@babel/traverse" "^7.27.1"
-    "@babel/types" "^7.27.1"
+    "@babel/traverse" "^7.28.6"
+    "@babel/types" "^7.28.6"
 
-"@babel/helper-module-transforms@^7.27.1", "@babel/helper-module-transforms@^7.28.3":
-  version "7.28.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz#a2b37d3da3b2344fe085dab234426f2b9a2fa5f6"
-  integrity sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==
+"@babel/helper-module-transforms@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz#9312d9d9e56edc35aeb6e95c25d4106b50b9eb1e"
+  integrity sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==
   dependencies:
-    "@babel/helper-module-imports" "^7.27.1"
-    "@babel/helper-validator-identifier" "^7.27.1"
-    "@babel/traverse" "^7.28.3"
+    "@babel/helper-module-imports" "^7.28.6"
+    "@babel/helper-validator-identifier" "^7.28.5"
+    "@babel/traverse" "^7.28.6"
 
 "@babel/helper-optimise-call-expression@^7.27.1":
   version "7.27.1"
@@ -136,10 +136,10 @@
   dependencies:
     "@babel/types" "^7.27.1"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.8.0":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz#ddb2f876534ff8013e6c2b299bf4d39b3c51d44c"
-  integrity sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.28.6", "@babel/helper-plugin-utils@^7.8.0":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz#6f13ea251b68c8532e985fd532f28741a8af9ac8"
+  integrity sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==
 
 "@babel/helper-remap-async-to-generator@^7.27.1":
   version "7.27.1"
@@ -150,14 +150,14 @@
     "@babel/helper-wrap-function" "^7.27.1"
     "@babel/traverse" "^7.27.1"
 
-"@babel/helper-replace-supers@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz#b1ed2d634ce3bdb730e4b52de30f8cccfd692bc0"
-  integrity sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==
+"@babel/helper-replace-supers@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz#94aa9a1d7423a00aead3f204f78834ce7d53fe44"
+  integrity sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==
   dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.27.1"
+    "@babel/helper-member-expression-to-functions" "^7.28.5"
     "@babel/helper-optimise-call-expression" "^7.27.1"
-    "@babel/traverse" "^7.27.1"
+    "@babel/traverse" "^7.28.6"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.27.1":
   version "7.27.1"
@@ -172,10 +172,10 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
-"@babel/helper-validator-identifier@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
-  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
+"@babel/helper-validator-identifier@^7.28.5":
+  version "7.28.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
+  integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
 
 "@babel/helper-validator-option@^7.27.1":
   version "7.27.1"
@@ -183,28 +183,28 @@
   integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
 
 "@babel/helper-wrap-function@^7.27.1":
-  version "7.28.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz#fe4872092bc1438ffd0ce579e6f699609f9d0a7a"
-  integrity sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz#4e349ff9222dab69a93a019cc296cdd8442e279a"
+  integrity sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==
   dependencies:
-    "@babel/template" "^7.27.2"
-    "@babel/traverse" "^7.28.3"
-    "@babel/types" "^7.28.2"
+    "@babel/template" "^7.28.6"
+    "@babel/traverse" "^7.28.6"
+    "@babel/types" "^7.28.6"
 
-"@babel/helpers@^7.28.4":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.28.4.tgz#fe07274742e95bdf7cf1443593eeb8926ab63827"
-  integrity sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==
+"@babel/helpers@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.28.6.tgz#fca903a313ae675617936e8998b814c415cbf5d7"
+  integrity sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==
   dependencies:
-    "@babel/template" "^7.27.2"
-    "@babel/types" "^7.28.4"
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.28.6"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.24.7", "@babel/parser@^7.25.3", "@babel/parser@^7.27.2", "@babel/parser@^7.28.3", "@babel/parser@^7.28.4":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.4.tgz#da25d4643532890932cc03f7705fe19637e03fa8"
-  integrity sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.24.7", "@babel/parser@^7.25.3", "@babel/parser@^7.28.6", "@babel/parser@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.0.tgz#669ef345add7d057e92b7ed15f0bac07611831b6"
+  integrity sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==
   dependencies:
-    "@babel/types" "^7.28.4"
+    "@babel/types" "^7.29.0"
 
 "@babel/plugin-proposal-export-default-from@^7.24.7":
   version "7.27.1"
@@ -249,25 +249,25 @@
     "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-syntax-export-default-from@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.27.1.tgz#8efed172e79ab657c7fa4d599224798212fb7e18"
-  integrity sha512-eBC/3KSekshx19+N40MzjWqJd7KTEdOoLesAfa4IDFI8eRz5a47i5Oszus6zG/cwIXN63YhgLOMSSNJx49sENg==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.28.6.tgz#8e19047560a8a48b11f1f5b46881f445f8692830"
+  integrity sha512-Svlx1fjJFnNz0LZeUaybRukSxZI3KkpApUmIRzEdXC5k8ErTOz0OD0kNrICi5Vc3GlpP5ZCeRyRO+mfWTSz+iQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-syntax-flow@^7.12.1", "@babel/plugin-syntax-flow@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz#6c83cf0d7d635b716827284b7ecd5aead9237662"
-  integrity sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.28.6.tgz#447559a225e66c4cd477a3ffb1a74d8c1fe25a62"
+  integrity sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-syntax-import-attributes@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz#34c017d54496f9b11b61474e7ea3dfd5563ffe07"
-  integrity sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz#b71d5914665f60124e133696f17cd7669062c503"
+  integrity sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-syntax-import-meta@^7.10.4":
   version "7.10.4"
@@ -283,12 +283,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz#2f9beb5eff30fa507c5532d107daac7b888fa34c"
-  integrity sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==
+"@babel/plugin-syntax-jsx@^7.27.1", "@babel/plugin-syntax-jsx@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz#f8ca28bbd84883b5fea0e447c635b81ba73997ee"
+  integrity sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
   version "7.10.4"
@@ -346,12 +346,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-typescript@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz#5147d29066a793450f220c63fa3a9431b7e6dd18"
-  integrity sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==
+"@babel/plugin-syntax-typescript@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz#c7b2ddf1d0a811145b1de800d1abd146af92e3a2"
+  integrity sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-arrow-functions@^7.24.7":
   version "7.27.1"
@@ -361,65 +361,65 @@
     "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-transform-async-generator-functions@^7.25.4":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz#1276e6c7285ab2cd1eccb0bc7356b7a69ff842c2"
-  integrity sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz#63ed829820298f0bf143d5a4a68fb8c06ffd742f"
+  integrity sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
     "@babel/helper-remap-async-to-generator" "^7.27.1"
-    "@babel/traverse" "^7.28.0"
+    "@babel/traverse" "^7.29.0"
 
 "@babel/plugin-transform-async-to-generator@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz#9a93893b9379b39466c74474f55af03de78c66e7"
-  integrity sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz#bd97b42237b2d1bc90d74bcb486c39be5b4d7e77"
+  integrity sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==
   dependencies:
-    "@babel/helper-module-imports" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-module-imports" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
     "@babel/helper-remap-async-to-generator" "^7.27.1"
 
 "@babel/plugin-transform-block-scoping@^7.25.0":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.4.tgz#e19ac4ddb8b7858bac1fd5c1be98a994d9726410"
-  integrity sha512-1yxmvN0MJHOhPVmAsmoW5liWwoILobu/d/ShymZmj867bAdxGbehIrew1DuLpw2Ukv+qDSSPQdYW1dLNE7t11A==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz#e1ef5633448c24e76346125c2534eeb359699a99"
+  integrity sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-class-properties@^7.24.7", "@babel/plugin-transform-class-properties@^7.25.4":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz#dd40a6a370dfd49d32362ae206ddaf2bb082a925"
-  integrity sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz#d274a4478b6e782d9ea987fda09bdb6d28d66b72"
+  integrity sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-class-features-plugin" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-classes@^7.25.4":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.4.tgz#75d66175486788c56728a73424d67cbc7473495c"
-  integrity sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz#8f6fb79ba3703978e701ce2a97e373aae7dda4b7"
+  integrity sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.27.3"
-    "@babel/helper-compilation-targets" "^7.27.2"
+    "@babel/helper-compilation-targets" "^7.28.6"
     "@babel/helper-globals" "^7.28.0"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/helper-replace-supers" "^7.27.1"
-    "@babel/traverse" "^7.28.4"
+    "@babel/helper-plugin-utils" "^7.28.6"
+    "@babel/helper-replace-supers" "^7.28.6"
+    "@babel/traverse" "^7.28.6"
 
 "@babel/plugin-transform-computed-properties@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz#81662e78bf5e734a97982c2b7f0a793288ef3caa"
-  integrity sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz#936824fc71c26cb5c433485776d79c8e7b0202d2"
+  integrity sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/template" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
+    "@babel/template" "^7.28.6"
 
-"@babel/plugin-transform-destructuring@^7.24.8", "@babel/plugin-transform-destructuring@^7.28.0":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz#0f156588f69c596089b7d5b06f5af83d9aa7f97a"
-  integrity sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==
+"@babel/plugin-transform-destructuring@^7.24.8", "@babel/plugin-transform-destructuring@^7.28.5":
+  version "7.28.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz#b8402764df96179a2070bb7b501a1586cf8ad7a7"
+  integrity sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/traverse" "^7.28.0"
+    "@babel/traverse" "^7.28.5"
 
 "@babel/plugin-transform-flow-strip-types@^7.25.2", "@babel/plugin-transform-flow-strip-types@^7.27.1":
   version "7.27.1"
@@ -454,66 +454,66 @@
     "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-transform-logical-assignment-operators@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz#890cb20e0270e0e5bebe3f025b434841c32d5baa"
-  integrity sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz#53028a3d77e33c50ef30a8fce5ca17065936e605"
+  integrity sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-modules-commonjs@^7.24.7", "@babel/plugin-transform-modules-commonjs@^7.24.8", "@babel/plugin-transform-modules-commonjs@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz#8e44ed37c2787ecc23bdc367f49977476614e832"
-  integrity sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz#c0232e0dfe66a734cc4ad0d5e75fc3321b6fdef1"
+  integrity sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==
   dependencies:
-    "@babel/helper-module-transforms" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-module-transforms" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-named-capturing-groups-regex@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz#f32b8f7818d8fc0cc46ee20a8ef75f071af976e1"
-  integrity sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz#a26cd51e09c4718588fc4cce1c5d1c0152102d6a"
+  integrity sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-regexp-features-plugin" "^7.28.5"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-nullish-coalescing-operator@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz#4f9d3153bf6782d73dd42785a9d22d03197bc91d"
-  integrity sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz#9bc62096e90ab7a887f3ca9c469f6adec5679757"
+  integrity sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-numeric-separator@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz#614e0b15cc800e5997dadd9bd6ea524ed6c819c6"
-  integrity sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz#1310b0292762e7a4a335df5f580c3320ee7d9e9f"
+  integrity sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-object-rest-spread@^7.24.7":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.4.tgz#9ee1ceca80b3e6c4bac9247b2149e36958f7f98d"
-  integrity sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz#fdd4bc2d72480db6ca42aed5c051f148d7b067f7"
+  integrity sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==
   dependencies:
-    "@babel/helper-compilation-targets" "^7.27.2"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/plugin-transform-destructuring" "^7.28.0"
+    "@babel/helper-compilation-targets" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
+    "@babel/plugin-transform-destructuring" "^7.28.5"
     "@babel/plugin-transform-parameters" "^7.27.7"
-    "@babel/traverse" "^7.28.4"
+    "@babel/traverse" "^7.28.6"
 
 "@babel/plugin-transform-optional-catch-binding@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz#84c7341ebde35ccd36b137e9e45866825072a30c"
-  integrity sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz#75107be14c78385978201a49c86414a150a20b4c"
+  integrity sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-optional-chaining@^7.24.7", "@babel/plugin-transform-optional-chaining@^7.24.8":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz#874ce3c4f06b7780592e946026eb76a32830454f"
-  integrity sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz#926cf150bd421fc8362753e911b4a1b1ce4356cd"
+  integrity sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
 
 "@babel/plugin-transform-parameters@^7.24.7", "@babel/plugin-transform-parameters@^7.27.7":
@@ -524,21 +524,21 @@
     "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-transform-private-methods@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz#fdacbab1c5ed81ec70dfdbb8b213d65da148b6af"
-  integrity sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz#c76fbfef3b86c775db7f7c106fff544610bdb411"
+  integrity sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-class-features-plugin" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-private-property-in-object@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz#4dbbef283b5b2f01a21e81e299f76e35f900fb11"
-  integrity sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz#4fafef1e13129d79f1d75ac180c52aafefdb2811"
+  integrity sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.27.1"
-    "@babel/helper-create-class-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-annotate-as-pure" "^7.27.3"
+    "@babel/helper-create-class-features-plugin" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-react-display-name@^7.24.7":
   version "7.28.0"
@@ -562,30 +562,30 @@
     "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-transform-react-jsx@^7.25.2":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz#1023bc94b78b0a2d68c82b5e96aed573bcfb9db0"
-  integrity sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz#f51cb70a90b9529fbb71ee1f75ea27b7078eed62"
+  integrity sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.27.1"
-    "@babel/helper-module-imports" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/plugin-syntax-jsx" "^7.27.1"
-    "@babel/types" "^7.27.1"
+    "@babel/helper-annotate-as-pure" "^7.27.3"
+    "@babel/helper-module-imports" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
+    "@babel/plugin-syntax-jsx" "^7.28.6"
+    "@babel/types" "^7.28.6"
 
 "@babel/plugin-transform-regenerator@^7.24.7":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.4.tgz#9d3fa3bebb48ddd0091ce5729139cd99c67cea51"
-  integrity sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz#dec237cec1b93330876d6da9992c4abd42c9d18b"
+  integrity sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-runtime@^7.24.7":
-  version "7.28.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz#f5990a1b2d2bde950ed493915e0719841c8d0eaa"
-  integrity sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.0.tgz#a5fded13cc656700804bfd6e5ebd7fffd5266803"
+  integrity sha512-jlaRT5dJtMaMCV6fAuLbsQMSwz/QkvaHOHOSXRitGGwSpR1blCY4KUKoyP2tYO8vJcqYe8cEj96cqSztv3uF9w==
   dependencies:
-    "@babel/helper-module-imports" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-module-imports" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
     babel-plugin-polyfill-corejs2 "^0.4.14"
     babel-plugin-polyfill-corejs3 "^0.13.0"
     babel-plugin-polyfill-regenerator "^0.6.5"
@@ -599,11 +599,11 @@
     "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-transform-spread@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz#1a264d5fc12750918f50e3fe3e24e437178abb08"
-  integrity sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz#40a2b423f6db7b70f043ad027a58bcb44a9757b6"
+  integrity sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.28.6"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
 
 "@babel/plugin-transform-sticky-regex@^7.24.7":
@@ -613,16 +613,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-typescript@^7.25.2", "@babel/plugin-transform-typescript@^7.27.1":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz#796cbd249ab56c18168b49e3e1d341b72af04a6b"
-  integrity sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==
+"@babel/plugin-transform-typescript@^7.25.2", "@babel/plugin-transform-typescript@^7.28.5":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz#1e93d96da8adbefdfdade1d4956f73afa201a158"
+  integrity sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.27.3"
-    "@babel/helper-create-class-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-class-features-plugin" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
-    "@babel/plugin-syntax-typescript" "^7.27.1"
+    "@babel/plugin-syntax-typescript" "^7.28.6"
 
 "@babel/plugin-transform-unicode-regex@^7.24.7":
   version "7.27.1"
@@ -642,20 +642,20 @@
     "@babel/plugin-transform-flow-strip-types" "^7.27.1"
 
 "@babel/preset-typescript@^7.24.7":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz#190742a6428d282306648a55b0529b561484f912"
-  integrity sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==
+  version "7.28.5"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz#540359efa3028236958466342967522fd8f2a60c"
+  integrity sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
     "@babel/helper-validator-option" "^7.27.1"
     "@babel/plugin-syntax-jsx" "^7.27.1"
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
-    "@babel/plugin-transform-typescript" "^7.27.1"
+    "@babel/plugin-transform-typescript" "^7.28.5"
 
 "@babel/register@^7.24.6":
-  version "7.28.3"
-  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.28.3.tgz#abd8a3753480c799bdaf9c9092d6745d16e052c2"
-  integrity sha512-CieDOtd8u208eI49bYl4z1J22ySFw87IGwE+IswFEExH7e3rLgKb0WNQeumnacQ1+VoDJLYI5QFA3AJZuyZQfA==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.28.6.tgz#f54461dd32f6a418c1eb1f583c95ed0b7266ea4c"
+  integrity sha512-pgcbbEl/dWQYb6L6Yew6F94rdwygfuv+vJ/tXfwIOYAfPB6TNWpXUMEtEq3YuTeHRdvMIhvz13bkT9CNaS+wqA==
   dependencies:
     clone-deep "^4.0.1"
     find-cache-dir "^2.0.0"
@@ -664,52 +664,52 @@
     source-map-support "^0.5.16"
 
 "@babel/runtime@^7.25.0":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.4.tgz#a70226016fabe25c5783b2f22d3e1c9bc5ca3326"
-  integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
+  integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
-"@babel/template@^7.25.0", "@babel/template@^7.27.1", "@babel/template@^7.27.2", "@babel/template@^7.3.3":
-  version "7.27.2"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.2.tgz#fa78ceed3c4e7b63ebf6cb39e5852fca45f6809d"
-  integrity sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==
+"@babel/template@^7.25.0", "@babel/template@^7.28.6", "@babel/template@^7.3.3":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.28.6.tgz#0e7e56ecedb78aeef66ce7972b082fce76a23e57"
+  integrity sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==
   dependencies:
-    "@babel/code-frame" "^7.27.1"
-    "@babel/parser" "^7.27.2"
-    "@babel/types" "^7.27.1"
+    "@babel/code-frame" "^7.28.6"
+    "@babel/parser" "^7.28.6"
+    "@babel/types" "^7.28.6"
 
 "@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.4.tgz#8d456101b96ab175d487249f60680221692b958b"
-  integrity sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.0.tgz#f323d05001440253eead3c9c858adbe00b90310a"
+  integrity sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==
   dependencies:
-    "@babel/code-frame" "^7.27.1"
-    "@babel/generator" "^7.28.3"
+    "@babel/code-frame" "^7.29.0"
+    "@babel/generator" "^7.29.0"
     "@babel/helper-globals" "^7.28.0"
-    "@babel/parser" "^7.28.4"
-    "@babel/template" "^7.27.2"
-    "@babel/types" "^7.28.4"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.29.0"
     debug "^4.3.1"
 
-"@babel/traverse@^7.25.3", "@babel/traverse@^7.27.1", "@babel/traverse@^7.28.0", "@babel/traverse@^7.28.3", "@babel/traverse@^7.28.4":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.4.tgz#8d456101b96ab175d487249f60680221692b958b"
-  integrity sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==
+"@babel/traverse@^7.25.3", "@babel/traverse@^7.27.1", "@babel/traverse@^7.28.5", "@babel/traverse@^7.28.6", "@babel/traverse@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.0.tgz#f323d05001440253eead3c9c858adbe00b90310a"
+  integrity sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==
   dependencies:
-    "@babel/code-frame" "^7.27.1"
-    "@babel/generator" "^7.28.3"
+    "@babel/code-frame" "^7.29.0"
+    "@babel/generator" "^7.29.0"
     "@babel/helper-globals" "^7.28.0"
-    "@babel/parser" "^7.28.4"
-    "@babel/template" "^7.27.2"
-    "@babel/types" "^7.28.4"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.29.0"
     debug "^4.3.1"
 
-"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.25.2", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.28.4", "@babel/types@^7.3.3":
-  version "7.28.4"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.4.tgz#0a4e618f4c60a7cd6c11cb2d48060e4dbe38ac3a"
-  integrity sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==
+"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.25.2", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.28.5", "@babel/types@^7.28.6", "@babel/types@^7.29.0", "@babel/types@^7.3.3":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
+  integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
-    "@babel/helper-validator-identifier" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.28.5"
 
 "@breeztech/breez-sdk-spark-react-native@../../../../packages/react-native":
   version "0.1.4"
@@ -827,16 +827,16 @@
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
 "@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz#7308df158e064f0dd8b8fdb58aa14fa2a7f913b3"
-  integrity sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
+  integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
 "@eslint-community/regexpp@^4.11.0", "@eslint-community/regexpp@^4.5.1", "@eslint-community/regexpp@^4.6.1":
-  version "4.12.1"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.1.tgz#cfc6cffe39df390a3841cde2abccf92eaa7ae0e0"
-  integrity sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
+  integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
 
 "@eslint/eslintrc@^2.1.4":
   version "2.1.4"
@@ -1035,10 +1035,10 @@
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.78.0.tgz#e18165f05424bfd2240662ee1dcc4e13a3b9dab8"
   integrity sha512-PPHlTRuP9litTYkbFNkwveQFto3I94QRWPBBARU0cH/4ks4EkfCfb/Pdb3AHgtJi58QthSHKFvKTQnAWyHPs7w==
 
-"@react-native/assets-registry@0.81.4":
-  version "0.81.4"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.81.4.tgz#bfa477c8e9d54d6ef4ab6e81b886d5be13c09fbd"
-  integrity sha512-AMcDadefBIjD10BRqkWw+W/VdvXEomR6aEZ0fhQRAv7igrBzb4PTn4vHKYg+sUK0e3wa74kcMy2DLc/HtnGcMA==
+"@react-native/assets-registry@0.84.0":
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.84.0.tgz#ee7951ab96d8fe7889636733b4aeb7e5a6f0e7fd"
+  integrity sha512-YiU9h1IN0pvvZsHbd03MaD7mE2q+ySaKMlE9tWK+3iiwtbEaMQOsMUuSJ1er2LU6ERMWfhfvCYgWpKRGOMeN8A==
 
 "@react-native/babel-plugin-codegen@0.78.0":
   version "0.78.0"
@@ -1112,17 +1112,17 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/codegen@0.81.4":
-  version "0.81.4"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.81.4.tgz#eb884e2c3c6a46ccddbdfa6198705658e4a30c6c"
-  integrity sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw==
+"@react-native/codegen@0.84.0":
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.84.0.tgz#ce0ee426392c8d9f78d0a630daedc42e63003c2d"
+  integrity sha512-TcTAO58JigCw9onYTrbE2yK2js5YNgqbmnpYyq9oXz2mofbX7JcK53kIi7fhqyJhie8RkY+X85zSOTWNs6S3CA==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/parser" "^7.25.3"
-    glob "^7.1.1"
-    hermes-parser "0.29.1"
+    hermes-parser "0.32.0"
     invariant "^2.2.4"
     nullthrows "^1.1.1"
+    tinyglobby "^0.2.15"
     yargs "^17.6.2"
 
 "@react-native/community-cli-plugin@0.78.0":
@@ -1141,17 +1141,17 @@
     readline "^1.3.0"
     semver "^7.1.3"
 
-"@react-native/community-cli-plugin@0.81.4":
-  version "0.81.4"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.4.tgz#7bed570cec5277baa22a6eae0843abbd1345a290"
-  integrity sha512-8mpnvfcLcnVh+t1ok6V9eozWo8Ut+TZhz8ylJ6gF9d6q9EGDQX6s8jenan5Yv/pzN4vQEKI4ib2pTf/FELw+SA==
+"@react-native/community-cli-plugin@0.84.0":
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.84.0.tgz#76af8a47d6886b2176b12d81fafb9b0e21f21b1c"
+  integrity sha512-uYoLBHnAzod4E5dA5rPPQeny2A5RD0PiIJQ4r+2F7cvA+5bZ8+znxw4TdaSiEk8uhN+clffI4d2bl9V4+xEK+Q==
   dependencies:
-    "@react-native/dev-middleware" "0.81.4"
+    "@react-native/dev-middleware" "0.84.0"
     debug "^4.4.0"
     invariant "^2.2.4"
-    metro "^0.83.1"
-    metro-config "^0.83.1"
-    metro-core "^0.83.1"
+    metro "^0.83.3"
+    metro-config "^0.83.3"
+    metro-core "^0.83.3"
     semver "^7.1.3"
 
 "@react-native/debugger-frontend@0.78.0":
@@ -1159,10 +1159,19 @@
   resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.78.0.tgz#aedd183429cf29a4c59b63f357fc66ae411849db"
   integrity sha512-KQYD9QlxES/VdmXh9EEvtZCJK1KAemLlszQq4dpLU1stnue5N8dnCY6A7PpStMf5UtAMk7tiniQhaicw0uVHgQ==
 
-"@react-native/debugger-frontend@0.81.4":
-  version "0.81.4"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.81.4.tgz#da05018377a6d24ed694057c3445907ba81413ae"
-  integrity sha512-SU05w1wD0nKdQFcuNC9D6De0ITnINCi8MEnx9RsTD2e4wN83ukoC7FpXaPCYyP6+VjFt5tUKDPgP1O7iaNXCqg==
+"@react-native/debugger-frontend@0.84.0":
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.84.0.tgz#631a45e7df87e6ce366b8c8c844cd2b3985f763b"
+  integrity sha512-n7JKYVDCbA2aj8/5/OD1IK7nuiAYj5l/Z6yhGf7GG4EGaeQdthqdb0LZbseaRPyZK/7tLfdnLdqlqdTQC6/UTQ==
+
+"@react-native/debugger-shell@0.84.0":
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-shell/-/debugger-shell-0.84.0.tgz#78ba506c5e8998a1aced33864f91627849850fbf"
+  integrity sha512-5t/NvQLYk/d0kWlGOMNobkjfimqBc+/LYRmSOkgKm+pyOhxjygCLSnRjAUkeRALSZ8h6MKGTz1Wc4pbmJr7T0Q==
+  dependencies:
+    cross-spawn "^7.0.6"
+    debug "^4.4.0"
+    fb-dotslash "0.5.8"
 
 "@react-native/dev-middleware@0.78.0":
   version "0.78.0"
@@ -1182,13 +1191,14 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/dev-middleware@0.81.4":
-  version "0.81.4"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.81.4.tgz#61271dbbd4ff92d7f53462f19f3273bc28bb8bf0"
-  integrity sha512-hu1Wu5R28FT7nHXs2wWXvQ++7W7zq5GPY83llajgPlYKznyPLAY/7bArc5rAzNB7b0kwnlaoPQKlvD/VP9LZug==
+"@react-native/dev-middleware@0.84.0":
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.84.0.tgz#b92aa0de5495681d8b6af3d1a4d4e37785871acb"
+  integrity sha512-c0o7YW39AUI1FSLV/TFSszr87kQGmaePAQK0ygIRnwZ2fAGDnQ5Iu/tk3u9O5lVH6nTjfAwTKJ3El9YeEWDeEQ==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.81.4"
+    "@react-native/debugger-frontend" "0.84.0"
+    "@react-native/debugger-shell" "0.84.0"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -1197,27 +1207,27 @@
     nullthrows "^1.1.1"
     open "^7.0.3"
     serve-static "^1.16.2"
-    ws "^6.2.3"
+    ws "^7.5.10"
 
 "@react-native/gradle-plugin@0.78.0":
   version "0.78.0"
   resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.78.0.tgz#858d22b5ec456e12837b85c7721fde87268c4810"
   integrity sha512-WvwgfmVs1QfFl1FOL514kz2Fs5Nkg2BGgpE8V0ild8b/UT6jCD8qh2dTI5kL0xdT0d2Xd2BxfuFN0xCLkMC+SA==
 
-"@react-native/gradle-plugin@0.81.4":
-  version "0.81.4"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.81.4.tgz#249b7876df47a3ddefddffa71b1fd0193f7da376"
-  integrity sha512-T7fPcQvDDCSusZFVSg6H1oVDKb/NnVYLnsqkcHsAF2C2KGXyo3J7slH/tJAwNfj/7EOA2OgcWxfC1frgn9TQvw==
+"@react-native/gradle-plugin@0.84.0":
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.84.0.tgz#60796582901a2b1e003df87a10dbf0cf474b87e9"
+  integrity sha512-j8g/I4Z+SAdh2NXOVng4rmfYgPoeJBZwAKoGPpSe/wB/9XDLh9IRGUTg8dGS5BWUy2471xBUoGZPwHb6QMJmVw==
 
 "@react-native/js-polyfills@0.78.0":
   version "0.78.0"
   resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.78.0.tgz#44bb9f477dcce9003c21fa63dbba7d5ce4ab6d10"
   integrity sha512-YZ9XtS77s/df7548B6dszX89ReehnA7hiab/axc30j/Mgk7Wv2woOjBKnAA4+rZ0ITLtxNwyJIMaRAc9kGznXw==
 
-"@react-native/js-polyfills@0.81.4":
-  version "0.81.4"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.81.4.tgz#cbc3924cfb994ed00ef841a796f54be21520d3b0"
-  integrity sha512-sr42FaypKXJHMVHhgSbu2f/ZJfrLzgaoQ+HdpRvKEiEh2mhFf6XzZwecyLBvWqf2pMPZa+CpPfNPiejXjKEy8w==
+"@react-native/js-polyfills@0.84.0":
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.84.0.tgz#2e714527376e0883ea2d6504e268d8e35e63b0e9"
+  integrity sha512-xaxmzYWLgHH+2uAZQ0owEkDE58hOTWmuBKD/Gl+cDFD3mFfSK4lZpin/3hiXtE5LB4BwgqICsPN07zCAqx6Fpg==
 
 "@react-native/metro-babel-transformer@0.78.0":
   version "0.78.0"
@@ -1234,10 +1244,10 @@
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.78.0.tgz#23ac9562728119444a63f1d2b782225a36fc33c4"
   integrity sha512-FkeLvLLaMYlGsSntixTUvlNtc1OHij4TYRtymMNPWqBKFAMXJB/qe45VxXNzWP+jD0Ok6yXineQFtktKcHk9PA==
 
-"@react-native/normalize-colors@0.81.4":
-  version "0.81.4"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.81.4.tgz#a0384d5aaac825aeefa5e391947189f6cee4a641"
-  integrity sha512-9nRRHO1H+tcFqjb9gAM105Urtgcanbta2tuqCVY0NATHeFPDEAB7gPyiLxCHKMi1NbhP6TH0kxgSWXKZl1cyRg==
+"@react-native/normalize-colors@0.84.0":
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.84.0.tgz#c5ef828a4b3340c45e66b6d01a656a458611f885"
+  integrity sha512-7JgZyWtQ9Sz4qZvCTsURUtuv8/niEZ/iCorp7eExc3GgpBWNazPumieiUoWPdgRKofU0Bqpr2/dJevEn2hrlwA==
 
 "@react-native/virtualized-lists@0.78.0":
   version "0.78.0"
@@ -1247,10 +1257,10 @@
     invariant "^2.2.4"
     nullthrows "^1.1.1"
 
-"@react-native/virtualized-lists@0.81.4":
-  version "0.81.4"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.81.4.tgz#3c9c162fc96777c87ca07e8686f227343dbc8f13"
-  integrity sha512-hBM+rMyL6Wm1Q4f/WpqGsaCojKSNUBqAXLABNGoWm1vabZ7cSnARMxBvA/2vo3hLcoR4v7zDK8tkKm9+O0LjVA==
+"@react-native/virtualized-lists@0.84.0":
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.84.0.tgz#741cbf4e87f20941bb072437f7ce706f6225db74"
+  integrity sha512-ugwSj0Gb4MYrcm8uQrQw8qHPx5RKGDLuZRAP/AuwneFizHx8YCLBEFbOYRGWgxHBRtkJ70D1o+jpIx3CK3p5lw==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -1261,9 +1271,9 @@
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
 "@sinclair/typebox@^0.27.8":
-  version "0.27.8"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
-  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+  version "0.27.10"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.10.tgz#beefe675f1853f73676aecc915b2bd2ac98c4fc6"
+  integrity sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==
 
 "@sinonjs/commons@^3.0.0":
   version "3.0.1"
@@ -1356,11 +1366,11 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "24.5.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.5.1.tgz#dab6917c47113eb4502d27d06e89a407ec0eff95"
-  integrity sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.3.0.tgz#749b1bd4058e51b72e22bd41e9eab6ebd0180470"
+  integrity sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==
   dependencies:
-    undici-types "~7.12.0"
+    undici-types "~7.18.0"
 
 "@types/react-native@^0.73.0":
   version "0.73.0"
@@ -1385,9 +1395,9 @@
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
 
 "@types/yargs@^17.0.8":
-  version "17.0.33"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.33.tgz#8c32303da83eec050a84b3c7ae7b9f922d13e32d"
-  integrity sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==
+  version "17.0.35"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.35.tgz#07013e46aa4d7d7d50a49e15604c1c5340d4eb24"
+  integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -1497,15 +1507,23 @@ accepts@^1.3.7:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+accepts@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-2.0.0.tgz#bbcf4ba5075467f3f2131eab3cffc73c2f5d7895"
+  integrity sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==
+  dependencies:
+    mime-types "^3.0.0"
+    negotiator "^1.0.0"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn@^8.15.0, acorn@^8.9.0:
-  version "8.15.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
-  integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
+  integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
 
 agent-base@^7.1.2:
   version "7.1.4"
@@ -1513,9 +1531,9 @@ agent-base@^7.1.2:
   integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 ajv@^6.12.4:
-  version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.14.0.tgz#fd067713e228210636ebb08c60bd3765d6dbe73a"
+  integrity sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1724,12 +1742,12 @@ babel-plugin-jest-hoist@^29.6.3:
     "@types/babel__traverse" "^7.0.6"
 
 babel-plugin-polyfill-corejs2@^0.4.14:
-  version "0.4.14"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz#8101b82b769c568835611542488d463395c2ef8f"
-  integrity sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz#808fa349686eea4741807cfaaa2aa3aa57ce120a"
+  integrity sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==
   dependencies:
-    "@babel/compat-data" "^7.27.7"
-    "@babel/helper-define-polyfill-provider" "^0.6.5"
+    "@babel/compat-data" "^7.28.6"
+    "@babel/helper-define-polyfill-provider" "^0.6.6"
     semver "^6.3.1"
 
 babel-plugin-polyfill-corejs3@^0.13.0:
@@ -1741,11 +1759,11 @@ babel-plugin-polyfill-corejs3@^0.13.0:
     core-js-compat "^3.43.0"
 
 babel-plugin-polyfill-regenerator@^0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz#32752e38ab6f6767b92650347bf26a31b16ae8c5"
-  integrity sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.6.tgz#69f5dd263cab933c42fe5ea05e83443b374bd4bf"
+  integrity sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==
   dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.6.5"
+    "@babel/helper-define-polyfill-provider" "^0.6.6"
 
 babel-plugin-syntax-hermes-parser@0.25.1:
   version "0.25.1"
@@ -1754,12 +1772,12 @@ babel-plugin-syntax-hermes-parser@0.25.1:
   dependencies:
     hermes-parser "0.25.1"
 
-babel-plugin-syntax-hermes-parser@0.29.1:
-  version "0.29.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.29.1.tgz#09ca9ecb0330eba1ef939b6d3f1f55bb06a9dc33"
-  integrity sha512-2WFYnoWGdmih1I1J5eIqxATOeycOqRwYxAQBu3cUu/rhwInwHUg7k60AFNbuGjSDL8tje5GDrAnxzRLcu2pYcA==
+babel-plugin-syntax-hermes-parser@0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz#06f7452bf91adf6cafd7c98e7467404d4eb65cec"
+  integrity sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==
   dependencies:
-    hermes-parser "0.29.1"
+    hermes-parser "0.32.0"
 
 babel-plugin-transform-flow-enums@^0.0.2:
   version "0.0.2"
@@ -1812,10 +1830,10 @@ base64-js@^1.5.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-baseline-browser-mapping@^2.8.3:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.4.tgz#e553e12272c4965682743705efd8b4b4cf0d709b"
-  integrity sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==
+baseline-browser-mapping@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz#5b09935025bf8a80e29130251e337c6a7fc8cbb9"
+  integrity sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==
 
 brace-expansion@^1.1.7:
   version "1.1.12"
@@ -1839,16 +1857,16 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, browserslist@^4.25.3:
-  version "4.26.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.26.2.tgz#7db3b3577ec97f1140a52db4936654911078cef3"
-  integrity sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==
+browserslist@^4.24.0, browserslist@^4.28.1:
+  version "4.28.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.1.tgz#7f534594628c53c63101079e27e40de490456a95"
+  integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
   dependencies:
-    baseline-browser-mapping "^2.8.3"
-    caniuse-lite "^1.0.30001741"
-    electron-to-chromium "^1.5.218"
-    node-releases "^2.0.21"
-    update-browserslist-db "^1.1.3"
+    baseline-browser-mapping "^2.9.0"
+    caniuse-lite "^1.0.30001759"
+    electron-to-chromium "^1.5.263"
+    node-releases "^2.0.27"
+    update-browserslist-db "^1.2.0"
 
 bser@2.1.1:
   version "2.1.1"
@@ -1934,10 +1952,10 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001741:
-  version "1.0.30001743"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz#50ff91a991220a1ee2df5af00650dd5c308ea7cd"
-  integrity sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==
+caniuse-lite@^1.0.30001759:
+  version "1.0.30001770"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz#4dc47d3b263a50fbb243448034921e0a88591a84"
+  integrity sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==
 
 chalk@^4.0.0:
   version "4.1.2"
@@ -2045,11 +2063,11 @@ convert-source-map@^2.0.0:
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
 core-js-compat@^3.43.0:
-  version "3.45.1"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.45.1.tgz#424f3f4af30bf676fd1b67a579465104f64e9c7a"
-  integrity sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==
+  version "3.48.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.48.0.tgz#7efbe1fc1cbad44008190462217cc5558adaeaa6"
+  integrity sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==
   dependencies:
-    browserslist "^4.25.3"
+    browserslist "^4.28.1"
 
 cosmiconfig@^5.0.5:
   version "5.2.1"
@@ -2061,7 +2079,7 @@ cosmiconfig@^5.0.5:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cross-spawn@^7.0.2:
+cross-spawn@^7.0.2, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -2104,7 +2122,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.1:
+debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -2141,7 +2159,7 @@ define-properties@^1.1.3, define-properties@^1.2.1:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
-depd@2.0.0:
+depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
@@ -2186,10 +2204,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-electron-to-chromium@^1.5.218:
-  version "1.5.220"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.220.tgz#a9853fa5edcf51f4c7db369144377cf31d783b8f"
-  integrity sha512-TWXijEwR1ggr4BdAKrb1nMNqYLTx1/4aD1fkeZU+FVJGTKu53/T7UyHKXlqEX3Ub02csyHePbHmkvnrjcaYzMA==
+electron-to-chromium@^1.5.263:
+  version "1.5.302"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz#032a5802b31f7119269959c69fe2015d8dad5edb"
+  integrity sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -2220,10 +2238,10 @@ error-stack-parser@^2.0.6:
   dependencies:
     stackframe "^1.3.4"
 
-es-abstract@^1.17.5, es-abstract@^1.23.2, es-abstract@^1.23.3, es-abstract@^1.23.5, es-abstract@^1.23.6, es-abstract@^1.23.9, es-abstract@^1.24.0:
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.24.0.tgz#c44732d2beb0acc1ed60df840869e3106e7af328"
-  integrity sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==
+es-abstract@^1.17.5, es-abstract@^1.23.2, es-abstract@^1.23.3, es-abstract@^1.23.5, es-abstract@^1.23.6, es-abstract@^1.23.9, es-abstract@^1.24.0, es-abstract@^1.24.1:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.24.1.tgz#f0c131ed5ea1bb2411134a8dd94def09c46c7899"
+  integrity sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==
   dependencies:
     array-buffer-byte-length "^1.0.2"
     arraybuffer.prototype.slice "^1.0.4"
@@ -2291,25 +2309,25 @@ es-errors@^1.3.0:
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
 es-iterator-helpers@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz#d1dd0f58129054c0ad922e6a9a1e65eef435fe75"
-  integrity sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz#d979a9f686e2b0b72f88dbead7229924544720bc"
+  integrity sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==
   dependencies:
     call-bind "^1.0.8"
-    call-bound "^1.0.3"
+    call-bound "^1.0.4"
     define-properties "^1.2.1"
-    es-abstract "^1.23.6"
+    es-abstract "^1.24.1"
     es-errors "^1.3.0"
-    es-set-tostringtag "^2.0.3"
+    es-set-tostringtag "^2.1.0"
     function-bind "^1.1.2"
-    get-intrinsic "^1.2.6"
+    get-intrinsic "^1.3.0"
     globalthis "^1.0.4"
     gopd "^1.2.0"
     has-property-descriptors "^1.0.2"
     has-proto "^1.2.0"
     has-symbols "^1.1.0"
     internal-slot "^1.1.0"
-    iterator.prototype "^1.1.4"
+    iterator.prototype "^1.1.5"
     safe-array-concat "^1.1.3"
 
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
@@ -2319,7 +2337,7 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   dependencies:
     es-errors "^1.3.0"
 
-es-set-tostringtag@^2.0.3, es-set-tostringtag@^2.1.0:
+es-set-tostringtag@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
   integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
@@ -2581,9 +2599,9 @@ esprima@^4.0.0, esprima@~4.0.0:
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esquery@^1.4.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.6.0.tgz#91419234f804d852a82dceec3e16cdc22cf9dae7"
-  integrity sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.7.0.tgz#08d048f261f0ddedb5bae95f46809463d9c9496d"
+  integrity sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==
   dependencies:
     estraverse "^5.1.0"
 
@@ -2615,9 +2633,9 @@ event-target-shim@^5.0.0, event-target-shim@^5.0.1:
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 exponential-backoff@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.2.tgz#a8f26adb96bf78e8cd8ad1037928d5e5c0679d91"
-  integrity sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.3.tgz#51cf92c1c0493c766053f9d3abee4434c244d2f6"
+  integrity sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -2646,11 +2664,16 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fastq@^1.6.0:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.19.1.tgz#d50eaba803c8846a883c16492821ebcd2cda55f5"
-  integrity sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.20.1.tgz#ca750a10dc925bc8b18839fd203e3ef4b3ced675"
+  integrity sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==
   dependencies:
     reusify "^1.0.4"
+
+fb-dotslash@0.5.8:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/fb-dotslash/-/fb-dotslash-0.5.8.tgz#c5ef3dacd75e1ddb2197c367052464ddde0115f5"
+  integrity sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==
 
 fb-watchman@^2.0.0:
   version "2.0.2"
@@ -2658,6 +2681,11 @@ fb-watchman@^2.0.0:
   integrity sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==
   dependencies:
     bser "2.1.1"
+
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -2738,9 +2766,9 @@ flow-enums-runtime@^0.0.6:
   integrity sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==
 
 flow-parser@0.*:
-  version "0.283.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.283.0.tgz#708e03c36cb7e94fd5411a314733164682edf28d"
-  integrity sha512-PNpYZX8guJSDiHv7DQo+BLgiRNjbUQrag52b/8/znK+n0kGBbGtG9Smklb0VRdBdHg+UYKk9hSpWez3nXI5nEw==
+  version "0.302.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.302.0.tgz#9ef815410c6f6a513011f2df2fd9c56e068c338b"
+  integrity sha512-Y7AMBG/MTixQ/sTSCSGtXrYtqocpWbu6YbsScv0icWSmllxz8hIYaJUMK6WopAW1x/rMD0dhihcsWnXJlpYphg==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
@@ -2749,7 +2777,7 @@ for-each@^0.3.3, for-each@^0.3.5:
   dependencies:
     is-callable "^1.2.7"
 
-fresh@0.5.2:
+fresh@~0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
@@ -2785,6 +2813,11 @@ functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+generator-function@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/generator-function/-/generator-function-2.0.1.tgz#0e75dd410d1243687a0ba2e951b94eedb8f737a2"
+  integrity sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -2835,9 +2868,9 @@ get-symbol-description@^1.1.0:
     get-intrinsic "^1.2.6"
 
 get-tsconfig@^4.7.0, get-tsconfig@^4.7.2:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.10.1.tgz#d34c1c01f47d65a606c37aa7a177bc3e56ab4b2e"
-  integrity sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==
+  version "4.13.6"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.13.6.tgz#2fbfda558a98a691a798f123afd95915badce876"
+  integrity sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
@@ -2952,15 +2985,25 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hermes-compiler@250829098.0.7:
+  version "250829098.0.7"
+  resolved "https://registry.yarnpkg.com/hermes-compiler/-/hermes-compiler-250829098.0.7.tgz#5c320077d22bcbb8f13b3379c719986364a8cb61"
+  integrity sha512-8QOmg1VjAWv8poFVslJDY8qkvjTy/UiO3R/hyGoC0IAchLzBdS9/TmAvI9cN1F3yLTEjimAIQQtUslpBMPXVVg==
+
 hermes-estree@0.25.1:
   version "0.25.1"
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.25.1.tgz#6aeec17d1983b4eabf69721f3aa3eb705b17f480"
   integrity sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==
 
-hermes-estree@0.29.1:
-  version "0.29.1"
-  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.29.1.tgz#043c7db076e0e8ef8c5f6ed23828d1ba463ebcc5"
-  integrity sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==
+hermes-estree@0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.32.0.tgz#bb7da6613ab8e67e334a1854ea1e209f487d307b"
+  integrity sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==
+
+hermes-estree@0.33.3:
+  version "0.33.3"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.33.3.tgz#6d6b593d4b471119772c82bdb0212dfadabb6f17"
+  integrity sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==
 
 hermes-parser@0.25.1:
   version "0.25.1"
@@ -2969,23 +3012,30 @@ hermes-parser@0.25.1:
   dependencies:
     hermes-estree "0.25.1"
 
-hermes-parser@0.29.1:
-  version "0.29.1"
-  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.29.1.tgz#436b24bcd7bb1e71f92a04c396ccc0716c288d56"
-  integrity sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==
+hermes-parser@0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.32.0.tgz#7916984ef6fdce62e7415d354cf35392061cd303"
+  integrity sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==
   dependencies:
-    hermes-estree "0.29.1"
+    hermes-estree "0.32.0"
 
-http-errors@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
-  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
+hermes-parser@0.33.3:
+  version "0.33.3"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.33.3.tgz#da50ababb7a5ab636d339e7b2f6e3848e217e09d"
+  integrity sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==
   dependencies:
-    depd "2.0.0"
-    inherits "2.0.4"
-    setprototypeof "1.2.0"
-    statuses "2.0.1"
-    toidentifier "1.0.1"
+    hermes-estree "0.33.3"
+
+http-errors@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
+  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
+  dependencies:
+    depd "~2.0.0"
+    inherits "~2.0.4"
+    setprototypeof "~1.2.0"
+    statuses "~2.0.2"
+    toidentifier "~1.0.1"
 
 https-proxy-agent@^7.0.5:
   version "7.0.6"
@@ -3036,7 +3086,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@~2.0.3:
+inherits@2, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3109,7 +3159,7 @@ is-callable@^1.2.7:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
-is-core-module@^2.12.1, is-core-module@^2.13.0, is-core-module@^2.16.0, is-core-module@^2.16.1:
+is-core-module@^2.12.1, is-core-module@^2.13.0, is-core-module@^2.16.1:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
   integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
@@ -3161,12 +3211,13 @@ is-fullwidth-code-point@^3.0.0:
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-generator-function@^1.0.10:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.0.tgz#bf3eeda931201394f57b5dba2800f91a238309ca"
-  integrity sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.2.tgz#ae3b61e3d5ea4e4839b90bad22b02335051a17d5"
+  integrity sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==
   dependencies:
-    call-bound "^1.0.3"
-    get-proto "^1.0.0"
+    call-bound "^1.0.4"
+    generator-function "^2.0.0"
+    get-proto "^1.0.1"
     has-tostringtag "^1.0.2"
     safe-regex-test "^1.1.0"
 
@@ -3316,7 +3367,7 @@ istanbul-lib-instrument@^5.0.4:
     istanbul-lib-coverage "^3.2.0"
     semver "^6.3.0"
 
-iterator.prototype@^1.1.4:
+iterator.prototype@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/iterator.prototype/-/iterator.prototype-1.1.5.tgz#12c959a29de32de0aa3bbbb801f4d777066dae39"
   integrity sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==
@@ -3433,17 +3484,17 @@ jest-worker@^29.7.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
-  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
+  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
 js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
 
@@ -3476,15 +3527,10 @@ jscodeshift@^17.0.0:
     tmp "^0.2.3"
     write-file-atomic "^5.0.1"
 
-jsesc@^3.0.2:
+jsesc@^3.0.2, jsesc@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
-
-jsesc@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
-  integrity sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -3662,14 +3708,14 @@ metro-babel-transformer@0.81.5:
     hermes-parser "0.25.1"
     nullthrows "^1.1.1"
 
-metro-babel-transformer@0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.83.1.tgz#77e548b4b8f087fe30ffcd112826b371f83b597d"
-  integrity sha512-r3xAD3964E8dwDBaZNSO2aIIvWXjIK80uO2xo0/pi3WI8XWT9h5SCjtGWtMtE5PRWw+t20TN0q1WMRsjvhC1rQ==
+metro-babel-transformer@0.83.4:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.83.4.tgz#9a4068c1a4ba40c073ee7830b19ed87d3ed1557e"
+  integrity sha512-xfNtsYIigybqm9xVL3ygTYYNFyYTMf2lGg/Wt+znVGtwcjXoRPG80WlL5SS09ZjYVei3MoE920i7MNr7ukSULA==
   dependencies:
     "@babel/core" "^7.25.2"
     flow-enums-runtime "^0.0.6"
-    hermes-parser "0.29.1"
+    hermes-parser "0.33.3"
     nullthrows "^1.1.1"
 
 metro-cache-key@0.81.5:
@@ -3679,10 +3725,10 @@ metro-cache-key@0.81.5:
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-metro-cache-key@0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.83.1.tgz#18c59c7c6944cfa0856d57ff5ebbdc18dec12687"
-  integrity sha512-ZUs+GD5CNeDLxx5UUWmfg26IL+Dnbryd+TLqTlZnDEgehkIa11kUSvgF92OFfJhONeXzV4rZDRGNXoo6JT+8Gg==
+metro-cache-key@0.83.4:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.83.4.tgz#eb70beab737782bf36eb145a30c2e97e20de52e8"
+  integrity sha512-Y8E6mm1alkYIRzmfkOdrwXMzJ4HKANYiZE7J2d3iYTwmnLIQG+aoIpvla+bo6LRxH1Gm3qjEiOl+LbxvPCzIug==
   dependencies:
     flow-enums-runtime "^0.0.6"
 
@@ -3695,15 +3741,15 @@ metro-cache@0.81.5:
     flow-enums-runtime "^0.0.6"
     metro-core "0.81.5"
 
-metro-cache@0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.83.1.tgz#bc1319d44934d0935ec4eaf10d28b90ec6ce0aac"
-  integrity sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ==
+metro-cache@0.83.4:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.83.4.tgz#d9ff274c053e1ffcbf42b49882af9473ac5f35fb"
+  integrity sha512-Pm6CiksVms0cZNDDe/nFzYr1xpXzJLOSwvOjl4b3cYtXxEFllEjD6EeBgoQK5C8yk7U54PcuRaUAFSvJ+eCKbg==
   dependencies:
     exponential-backoff "^3.1.1"
     flow-enums-runtime "^0.0.6"
     https-proxy-agent "^7.0.5"
-    metro-core "0.83.1"
+    metro-core "0.83.4"
 
 metro-config@0.81.5, metro-config@^0.81.0:
   version "0.81.5"
@@ -3719,19 +3765,19 @@ metro-config@0.81.5, metro-config@^0.81.0:
     metro-core "0.81.5"
     metro-runtime "0.81.5"
 
-metro-config@0.83.1, metro-config@^0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.83.1.tgz#28db7ae553883802c30b1eb374817ad1e686e7b4"
-  integrity sha512-HJhpZx3wyOkux/jeF1o7akFJzZFdbn6Zf7UQqWrvp7gqFqNulQ8Mju09raBgPmmSxKDl4LbbNeigkX0/nKY1QA==
+metro-config@0.83.4, metro-config@^0.83.3:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.83.4.tgz#10c99df962cf3a1ab6ad86bcc697dfcac0a316af"
+  integrity sha512-ydOgMNI9aT8l2LOTOugt1FvC7getPKG9uJo9Vclg9/RWJxbwkBF/FMBm6w5gH8NwJokSmQrbNkojXPn7nm0kGw==
   dependencies:
     connect "^3.6.5"
-    cosmiconfig "^5.0.5"
     flow-enums-runtime "^0.0.6"
     jest-validate "^29.7.0"
-    metro "0.83.1"
-    metro-cache "0.83.1"
-    metro-core "0.83.1"
-    metro-runtime "0.83.1"
+    metro "0.83.4"
+    metro-cache "0.83.4"
+    metro-core "0.83.4"
+    metro-runtime "0.83.4"
+    yaml "^2.6.1"
 
 metro-core@0.81.5, metro-core@^0.81.0:
   version "0.81.5"
@@ -3742,14 +3788,14 @@ metro-core@0.81.5, metro-core@^0.81.0:
     lodash.throttle "^4.1.1"
     metro-resolver "0.81.5"
 
-metro-core@0.83.1, metro-core@^0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.83.1.tgz#fbedf8c6cfdcc58eaec7011718f1041ac9562cff"
-  integrity sha512-uVL1eAJcMFd2o2Q7dsbpg8COaxjZBBGaXqO2OHnivpCdfanraVL8dPmY6It9ZeqWLOihUKZ2yHW4b6soVCzH/Q==
+metro-core@0.83.4, metro-core@^0.83.3:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.83.4.tgz#06fd79d73935748317076aab24be0bb4cbaab801"
+  integrity sha512-EE+j/imryd3og/6Ly9usku9vcTLQr2o4IDax/izsr6b0HRqZK9k6f5SZkGkOPqnsACLq6csPCx+2JsgF9DkVbw==
   dependencies:
     flow-enums-runtime "^0.0.6"
     lodash.throttle "^4.1.1"
-    metro-resolver "0.83.1"
+    metro-resolver "0.83.4"
 
 metro-file-map@0.81.5:
   version "0.81.5"
@@ -3766,10 +3812,10 @@ metro-file-map@0.81.5:
     nullthrows "^1.1.1"
     walker "^1.0.7"
 
-metro-file-map@0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.83.1.tgz#9c9a295edd0eb234f23b44952786f0e95c3b2d8d"
-  integrity sha512-Yu429lnexKl44PttKw3nhqgmpBR+6UQ/tRaYcxPeEShtcza9DWakCn7cjqDTQZtWR2A8xSNv139izJMyQ4CG+w==
+metro-file-map@0.83.4:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.83.4.tgz#f694f2e4950e64daff922b80d87e98731daa756b"
+  integrity sha512-RSZLpGQhW9topefjJ9dp77Ff7BP88b17sb/YjxLHC1/H0lJVYYC9Cgqua21Vxe4RUJK2z64hw72g+ySLGTCawA==
   dependencies:
     debug "^4.4.0"
     fb-watchman "^2.0.0"
@@ -3789,10 +3835,10 @@ metro-minify-terser@0.81.5:
     flow-enums-runtime "^0.0.6"
     terser "^5.15.0"
 
-metro-minify-terser@0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.83.1.tgz#227f534876fb8eb089b64d7bff8cf77d1817c8f4"
-  integrity sha512-kmooOxXLvKVxkh80IVSYO4weBdJDhCpg5NSPkjzzAnPJP43u6+usGXobkTWxxrAlq900bhzqKek4pBsUchlX6A==
+metro-minify-terser@0.83.4:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.83.4.tgz#43dea24b72369e01a1831483e7b1bd49581a4cb9"
+  integrity sha512-KmZnpxfj0nPIRkbBNTc6xul5f5GPvWL5kQ1UkisB7qFkgh6+UiJG+L4ukJ2sK7St6+8Za/Cb68MUEYkUouIYcQ==
   dependencies:
     flow-enums-runtime "^0.0.6"
     terser "^5.15.0"
@@ -3804,10 +3850,10 @@ metro-resolver@0.81.5:
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-metro-resolver@0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.83.1.tgz#2e14c8b0762883f3568f41cde08f4a48893021ce"
-  integrity sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g==
+metro-resolver@0.83.4:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.83.4.tgz#20e9ebc45beeacc7fff657e3ad0404ad9bdffe55"
+  integrity sha512-drWdylyNqgdaJufz0GjU/ielv2hjcc6piegjjJwKn8l7A/72aLQpUpOHtP+GMR+kOqhSsD4MchhJ6PSANvlSEw==
   dependencies:
     flow-enums-runtime "^0.0.6"
 
@@ -3819,10 +3865,10 @@ metro-runtime@0.81.5, metro-runtime@^0.81.0:
     "@babel/runtime" "^7.25.0"
     flow-enums-runtime "^0.0.6"
 
-metro-runtime@0.83.1, metro-runtime@^0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.83.1.tgz#5835c57c20cb89db45c48abb4bdae0246529a21b"
-  integrity sha512-3Ag8ZS4IwafL/JUKlaeM6/CbkooY+WcVeqdNlBG0m4S0Qz0om3rdFdy1y6fYBpl6AwXJwWeMuXrvZdMuByTcRA==
+metro-runtime@0.83.4, metro-runtime@^0.83.3:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.83.4.tgz#44296e7ddee052cf1966f484f60fc6290a1cf5df"
+  integrity sha512-sWj9KN311yG22Zv0kVbAp9dorB9HtTThvQKsAn6PLxrVrz+1UBsLrQSxjE/s4PtzDi1HABC648jo4K9Euz/5jw==
   dependencies:
     "@babel/runtime" "^7.25.0"
     flow-enums-runtime "^0.0.6"
@@ -3843,19 +3889,18 @@ metro-source-map@0.81.5, metro-source-map@^0.81.0:
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-source-map@0.83.1, metro-source-map@^0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.83.1.tgz#afaeccad77f543eebfe22ecc1d94c0b58c721946"
-  integrity sha512-De7Vbeo96fFZ2cqmI0fWwVJbtHIwPZv++LYlWSwzTiCzxBDJORncN0LcT48Vi2UlQLzXJg+/CuTAcy7NBVh69A==
+metro-source-map@0.83.4, metro-source-map@^0.83.3:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.83.4.tgz#c39442f308708055df08545398f5d8d18b9bac7a"
+  integrity sha512-pPbmQwS0zgU+/0u5KPkuvlsQP0V+WYQ9qNshqupIL720QRH0vS3QR25IVVtbunofEDJchI11Q4QtIbmUyhpOBw==
   dependencies:
-    "@babel/traverse" "^7.25.3"
-    "@babel/traverse--for-generate-function-map" "npm:@babel/traverse@^7.25.3"
-    "@babel/types" "^7.25.2"
+    "@babel/traverse" "^7.29.0"
+    "@babel/types" "^7.29.0"
     flow-enums-runtime "^0.0.6"
     invariant "^2.2.4"
-    metro-symbolicate "0.83.1"
+    metro-symbolicate "0.83.4"
     nullthrows "^1.1.1"
-    ob1 "0.83.1"
+    ob1 "0.83.4"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
@@ -3871,14 +3916,14 @@ metro-symbolicate@0.81.5:
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.83.1.tgz#c03edc8e7c0e8b44821f2a807c0a8342aaeb77eb"
-  integrity sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg==
+metro-symbolicate@0.83.4:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.83.4.tgz#147dd0109c156351fa67a686377856075ed07b5a"
+  integrity sha512-clyWAXDgkDHPwvldl95pcLTrJIqUj9GbZayL8tfeUs69ilsIUBpVym2lRd/8l3/8PIHCInxL868NvD2Y7OqKXg==
   dependencies:
     flow-enums-runtime "^0.0.6"
     invariant "^2.2.4"
-    metro-source-map "0.83.1"
+    metro-source-map "0.83.4"
     nullthrows "^1.1.1"
     source-map "^0.5.6"
     vlq "^1.0.0"
@@ -3895,15 +3940,15 @@ metro-transform-plugins@0.81.5:
     flow-enums-runtime "^0.0.6"
     nullthrows "^1.1.1"
 
-metro-transform-plugins@0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.83.1.tgz#879b8ff34c3720d387889da60c03923394457988"
-  integrity sha512-1Y+I8oozXwhuS0qwC+ezaHXBf0jXW4oeYn4X39XWbZt9X2HfjodqY9bH9r6RUTsoiK7S4j8Ni2C91bUC+sktJQ==
+metro-transform-plugins@0.83.4:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.83.4.tgz#5a08d28f032c38400304141286616ce6ee5401da"
+  integrity sha512-c0ROVcyvdaGPUFIg2N5nEQF4xbsqB2p1PPPhVvK1d/Y7ZhBAFiwQ75so0SJok32q+I++lc/hq7IdPCp2frPGQg==
   dependencies:
     "@babel/core" "^7.25.2"
-    "@babel/generator" "^7.25.0"
-    "@babel/template" "^7.25.0"
-    "@babel/traverse" "^7.25.3"
+    "@babel/generator" "^7.29.1"
+    "@babel/template" "^7.28.6"
+    "@babel/traverse" "^7.29.0"
     flow-enums-runtime "^0.0.6"
     nullthrows "^1.1.1"
 
@@ -3926,23 +3971,23 @@ metro-transform-worker@0.81.5:
     metro-transform-plugins "0.81.5"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.83.1.tgz#47aa09f085fe4f859215506de886f1cb7deb300a"
-  integrity sha512-owCrhPyUxdLgXEEEAL2b14GWTPZ2zYuab1VQXcfEy0sJE71iciD7fuMcrngoufh7e7UHDZ56q4ktXg8wgiYA1Q==
+metro-transform-worker@0.83.4:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.83.4.tgz#c71c53687dcf274d668aa5c6a9d4d3c00a7f7203"
+  integrity sha512-6I81IZLeU/0ww7OBgCPALFl0OE0FQwvIuKCtuViSiKufmislF7kVr7IHH9GYtQuZcnualQ82gYeQ11KzZQTouw==
   dependencies:
     "@babel/core" "^7.25.2"
-    "@babel/generator" "^7.25.0"
-    "@babel/parser" "^7.25.3"
-    "@babel/types" "^7.25.2"
+    "@babel/generator" "^7.29.1"
+    "@babel/parser" "^7.29.0"
+    "@babel/types" "^7.29.0"
     flow-enums-runtime "^0.0.6"
-    metro "0.83.1"
-    metro-babel-transformer "0.83.1"
-    metro-cache "0.83.1"
-    metro-cache-key "0.83.1"
-    metro-minify-terser "0.83.1"
-    metro-source-map "0.83.1"
-    metro-transform-plugins "0.83.1"
+    metro "0.83.4"
+    metro-babel-transformer "0.83.4"
+    metro-cache "0.83.4"
+    metro-cache-key "0.83.4"
+    metro-minify-terser "0.83.4"
+    metro-source-map "0.83.4"
+    metro-transform-plugins "0.83.4"
     nullthrows "^1.1.1"
 
 metro@0.81.5, metro@^0.81.0:
@@ -3991,19 +4036,19 @@ metro@0.81.5, metro@^0.81.0:
     ws "^7.5.10"
     yargs "^17.6.2"
 
-metro@0.83.1, metro@^0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.83.1.tgz#9f9c138793288cbf9fb26aa84e0693df85607875"
-  integrity sha512-UGKepmTxoGD4HkQV8YWvpvwef7fUujNtTgG4Ygf7m/M0qjvb9VuDmAsEU+UdriRX7F61pnVK/opz89hjKlYTXA==
+metro@0.83.4, metro@^0.83.3:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.83.4.tgz#beddd541e8e6d227a670039548e39cae051069a2"
+  integrity sha512-eBkAtcob+YmvSLL+/rsFiK8dHNfDbQA2/pi0lnxg3E6LLtUpwDfdGJ9WBWXkj0PVeOhoWQyj9Rt7s/+6k/GXuA==
   dependencies:
-    "@babel/code-frame" "^7.24.7"
+    "@babel/code-frame" "^7.29.0"
     "@babel/core" "^7.25.2"
-    "@babel/generator" "^7.25.0"
-    "@babel/parser" "^7.25.3"
-    "@babel/template" "^7.25.0"
-    "@babel/traverse" "^7.25.3"
-    "@babel/types" "^7.25.2"
-    accepts "^1.3.7"
+    "@babel/generator" "^7.29.1"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/traverse" "^7.29.0"
+    "@babel/types" "^7.29.0"
+    accepts "^2.0.0"
     chalk "^4.0.0"
     ci-info "^2.0.0"
     connect "^3.6.5"
@@ -4011,25 +4056,25 @@ metro@0.83.1, metro@^0.83.1:
     error-stack-parser "^2.0.6"
     flow-enums-runtime "^0.0.6"
     graceful-fs "^4.2.4"
-    hermes-parser "0.29.1"
+    hermes-parser "0.33.3"
     image-size "^1.0.2"
     invariant "^2.2.4"
     jest-worker "^29.7.0"
     jsc-safe-url "^0.2.2"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.83.1"
-    metro-cache "0.83.1"
-    metro-cache-key "0.83.1"
-    metro-config "0.83.1"
-    metro-core "0.83.1"
-    metro-file-map "0.83.1"
-    metro-resolver "0.83.1"
-    metro-runtime "0.83.1"
-    metro-source-map "0.83.1"
-    metro-symbolicate "0.83.1"
-    metro-transform-plugins "0.83.1"
-    metro-transform-worker "0.83.1"
-    mime-types "^2.1.27"
+    metro-babel-transformer "0.83.4"
+    metro-cache "0.83.4"
+    metro-cache-key "0.83.4"
+    metro-config "0.83.4"
+    metro-core "0.83.4"
+    metro-file-map "0.83.4"
+    metro-resolver "0.83.4"
+    metro-runtime "0.83.4"
+    metro-source-map "0.83.4"
+    metro-symbolicate "0.83.4"
+    metro-transform-plugins "0.83.4"
+    metro-transform-worker "0.83.4"
+    mime-types "^3.0.1"
     nullthrows "^1.1.1"
     serialize-error "^2.1.0"
     source-map "^0.5.6"
@@ -4050,12 +4095,24 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
+mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
 mime-types@^2.1.27, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+mime-types@^3.0.0, mime-types@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.2.tgz#39002d4182575d5af036ffa118100f2524b2e2ab"
+  integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
+  dependencies:
+    mime-db "^1.54.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -4106,25 +4163,40 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
+negotiator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
+  integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
+
 neo-async@^2.5.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+node-exports-info@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/node-exports-info/-/node-exports-info-1.6.0.tgz#1aedafb01a966059c9a5e791a94a94d93f5c2a13"
+  integrity sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==
+  dependencies:
+    array.prototype.flatmap "^1.3.3"
+    es-errors "^1.3.0"
+    object.entries "^1.1.9"
+    semver "^6.3.1"
+
 node-forge@^1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
-  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.3.tgz#0ad80f6333b3a0045e827ac20b7f735f93716751"
+  integrity sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==
 
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
-node-releases@^2.0.21:
-  version "2.0.21"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.21.tgz#f59b018bc0048044be2d4c4c04e4c8b18160894c"
-  integrity sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==
+node-releases@^2.0.27:
+  version "2.0.27"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
+  integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
 
 normalize-path@^3.0.0:
   version "3.0.0"
@@ -4143,10 +4215,10 @@ ob1@0.81.5:
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-ob1@0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.83.1.tgz#32f5c9e3f8cc5a6ecb1cb344e87a6e39a93f848a"
-  integrity sha512-ngwqewtdUzFyycomdbdIhFLjePPSOt1awKMUXQ0L7iLHgWEPF3DsCerblzjzfAUHaXuvE9ccJymWQ/4PNNqvnQ==
+ob1@0.83.4:
+  version "0.83.4"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.83.4.tgz#f034e861376ca4294c5e75623389f07b48028aeb"
+  integrity sha512-9JiflaRKCkxKzH8uuZlax72cHzZ8iFLsNIORFOAKDgZUOfvfwYWOVS0ezGLzPp/yEhVktD+PTTImC0AAehSOBw==
   dependencies:
     flow-enums-runtime "^0.0.6"
 
@@ -4216,17 +4288,17 @@ object.values@^1.1.6, object.values@^1.2.1:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-on-finished@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
-  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
-  dependencies:
-    ee-first "1.1.1"
-
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   integrity sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==
+  dependencies:
+    ee-first "1.1.1"
+
+on-finished@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
   dependencies:
     ee-first "1.1.1"
 
@@ -4366,6 +4438,11 @@ picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+
 pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
@@ -4467,43 +4544,44 @@ react-native-fs@^2.20.0:
     utf8 "^3.0.0"
 
 react-native@*:
-  version "0.81.4"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.81.4.tgz#d5e9d0a71ed2e80a550a6c358f2ce3ddb6f5b119"
-  integrity sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ==
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.84.0.tgz#0758f856df367789be3dcc78640eec8a77dbcbbb"
+  integrity sha512-CcBfucLDHz8MAjQx9kFXasYtpcn8zP1YapUgGtAy0psRZTLShwF9yeh5+ErSgEK2gXV1CCSz7hqCZqx1eMyBLA==
   dependencies:
     "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.81.4"
-    "@react-native/codegen" "0.81.4"
-    "@react-native/community-cli-plugin" "0.81.4"
-    "@react-native/gradle-plugin" "0.81.4"
-    "@react-native/js-polyfills" "0.81.4"
-    "@react-native/normalize-colors" "0.81.4"
-    "@react-native/virtualized-lists" "0.81.4"
+    "@react-native/assets-registry" "0.84.0"
+    "@react-native/codegen" "0.84.0"
+    "@react-native/community-cli-plugin" "0.84.0"
+    "@react-native/gradle-plugin" "0.84.0"
+    "@react-native/js-polyfills" "0.84.0"
+    "@react-native/normalize-colors" "0.84.0"
+    "@react-native/virtualized-lists" "0.84.0"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"
     babel-jest "^29.7.0"
-    babel-plugin-syntax-hermes-parser "0.29.1"
+    babel-plugin-syntax-hermes-parser "0.32.0"
     base64-js "^1.5.1"
     commander "^12.0.0"
     flow-enums-runtime "^0.0.6"
-    glob "^7.1.1"
+    hermes-compiler "250829098.0.7"
     invariant "^2.2.4"
     jest-environment-node "^29.7.0"
     memoize-one "^5.0.0"
-    metro-runtime "^0.83.1"
-    metro-source-map "^0.83.1"
+    metro-runtime "^0.83.3"
+    metro-source-map "^0.83.3"
     nullthrows "^1.1.1"
     pretty-format "^29.7.0"
     promise "^8.3.0"
     react-devtools-core "^6.1.5"
     react-refresh "^0.14.0"
     regenerator-runtime "^0.13.2"
-    scheduler "0.26.0"
+    scheduler "0.27.0"
     semver "^7.1.3"
     stacktrace-parser "^0.1.10"
+    tinyglobby "^0.2.15"
     whatwg-fetch "^3.0.0"
-    ws "^6.2.3"
+    ws "^7.5.10"
     yargs "^17.6.2"
 
 react-native@0.78.0:
@@ -4617,15 +4695,15 @@ regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
     gopd "^1.2.0"
     set-function-name "^2.0.2"
 
-regexpu-core@^6.2.0:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-6.3.1.tgz#fb8b707d0efe18e9464d3ae76ae1e3c96c8467ae"
-  integrity sha512-DzcswPr252wEr7Qz8AyAVbfyBDKLoYp6eRA1We2Fa9qirRFSdtkP5sHr3yglDKy2BbA0fd2T+j/CUSKes3FeVQ==
+regexpu-core@^6.3.1:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-6.4.0.tgz#3580ce0c4faedef599eccb146612436b62a176e5"
+  integrity sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==
   dependencies:
     regenerate "^1.4.2"
     regenerate-unicode-properties "^10.2.2"
     regjsgen "^0.8.0"
-    regjsparser "^0.12.0"
+    regjsparser "^0.13.0"
     unicode-match-property-ecmascript "^2.0.0"
     unicode-match-property-value-ecmascript "^2.2.1"
 
@@ -4634,12 +4712,12 @@ regjsgen@^0.8.0:
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.8.0.tgz#df23ff26e0c5b300a6470cad160a9d090c3a37ab"
   integrity sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==
 
-regjsparser@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.12.0.tgz#0e846df6c6530586429377de56e0475583b088dc"
-  integrity sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==
+regjsparser@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.13.0.tgz#01f8351335cf7898d43686bc74d2dd71c847ecc0"
+  integrity sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==
   dependencies:
-    jsesc "~3.0.2"
+    jsesc "~3.1.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -4666,21 +4744,24 @@ resolve-pkg-maps@^1.0.0:
   resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
   integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
 
-resolve@^1.22.10, resolve@^1.22.2, resolve@^1.22.4:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
-  integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
+resolve@^1.22.11, resolve@^1.22.2, resolve@^1.22.4:
+  version "1.22.11"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.11.tgz#aad857ce1ffb8bfa9b0b1ac29f1156383f68c262"
+  integrity sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==
   dependencies:
-    is-core-module "^2.16.0"
+    is-core-module "^2.16.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^2.0.0-next.5:
-  version "2.0.0-next.5"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.5.tgz#6b0ec3107e671e52b68cd068ef327173b90dc03c"
-  integrity sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==
+  version "2.0.0-next.6"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.6.tgz#b3961812be69ace7b3bc35d5bf259434681294af"
+  integrity sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==
   dependencies:
-    is-core-module "^2.13.0"
+    es-errors "^1.3.0"
+    is-core-module "^2.16.1"
+    node-exports-info "^1.6.0"
+    object-keys "^1.1.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -4736,10 +4817,10 @@ scheduler@0.25.0:
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.25.0.tgz#336cd9768e8cceebf52d3c80e3dcf5de23e7e015"
   integrity sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==
 
-scheduler@0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.26.0.tgz#4ce8a8c2a2095f13ea11bf9a445be50c555d6337"
-  integrity sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==
+scheduler@0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
+  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 selfsigned@^2.4.1:
   version "2.4.1"
@@ -4760,28 +4841,28 @@ semver@^6.3.0, semver@^6.3.1:
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.0.0, semver@^7.1.3, semver@^7.5.3, semver@^7.5.4:
-  version "7.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
-  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
-send@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.19.0.tgz#bbc5a388c8ea6c048967049dbeac0e4a3f09d7f8"
-  integrity sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==
+send@~0.19.1:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.19.2.tgz#59bc0da1b4ea7ad42736fd642b1c4294e114ff29"
+  integrity sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==
   dependencies:
     debug "2.6.9"
     depd "2.0.0"
     destroy "1.2.0"
-    encodeurl "~1.0.2"
+    encodeurl "~2.0.0"
     escape-html "~1.0.3"
     etag "~1.8.1"
-    fresh "0.5.2"
-    http-errors "2.0.0"
+    fresh "~0.5.2"
+    http-errors "~2.0.1"
     mime "1.6.0"
     ms "2.1.3"
-    on-finished "2.4.1"
+    on-finished "~2.4.1"
     range-parser "~1.2.1"
-    statuses "2.0.1"
+    statuses "~2.0.2"
 
 serialize-error@^2.1.0:
   version "2.1.0"
@@ -4789,14 +4870,14 @@ serialize-error@^2.1.0:
   integrity sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==
 
 serve-static@^1.16.2:
-  version "1.16.2"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.2.tgz#b6a5343da47f6bdd2673848bf45754941e803296"
-  integrity sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==
+  version "1.16.3"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.3.tgz#a97b74d955778583f3862a4f0b841eb4d5d78cf9"
+  integrity sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==
   dependencies:
     encodeurl "~2.0.0"
     escape-html "~1.0.3"
     parseurl "~1.3.3"
-    send "0.19.0"
+    send "~0.19.1"
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -4829,7 +4910,7 @@ set-proto@^1.0.0:
     es-errors "^1.3.0"
     es-object-atoms "^1.0.0"
 
-setprototypeof@1.2.0:
+setprototypeof@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
@@ -4955,15 +5036,15 @@ stacktrace-parser@^0.1.10:
   dependencies:
     type-fest "^0.7.1"
 
-statuses@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
-  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
-
 statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+statuses@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
@@ -5078,9 +5159,9 @@ supports-preserve-symlinks-flag@^1.0.0:
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 terser@^5.15.0:
-  version "5.44.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.44.0.tgz#ebefb8e5b8579d93111bfdfc39d2cf63879f4a82"
-  integrity sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.46.0.tgz#1b81e560d584bbdd74a8ede87b4d9477b0ff9695"
+  integrity sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.15.0"
@@ -5111,6 +5192,14 @@ tiny-invariant@^1.3.3:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
 
+tinyglobby@^0.2.15:
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
+  integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+
 tmp@^0.2.3:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
@@ -5128,7 +5217,7 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-toidentifier@1.0.1:
+toidentifier@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
@@ -5232,9 +5321,9 @@ typed-array-length@^1.0.7:
     reflect.getprototypeof "^1.0.6"
 
 typescript@*:
-  version "5.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
-  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 unbox-primitive@^1.1.0:
   version "1.1.0"
@@ -5246,10 +5335,10 @@ unbox-primitive@^1.1.0:
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
 
-undici-types@~7.12.0:
-  version "7.12.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.12.0.tgz#15c5c7475c2a3ba30659529f5cdb4674b622fafb"
-  integrity sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"
@@ -5284,10 +5373,10 @@ unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
-update-browserslist-db@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz#348377dd245216f9e7060ff50b15a1b740b75420"
-  integrity sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==
+update-browserslist-db@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
+  integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.1"
@@ -5367,9 +5456,9 @@ which-collection@^1.0.2:
     is-weakset "^2.0.3"
 
 which-typed-array@^1.1.16, which-typed-array@^1.1.19:
-  version "1.1.19"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.19.tgz#df03842e870b6b88e117524a4b364b6fc689f956"
-  integrity sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==
+  version "1.1.20"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.20.tgz#3fdb7adfafe0ea69157b1509f3a1cd892bd1d122"
+  integrity sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==
   dependencies:
     available-typed-arrays "^1.0.7"
     call-bind "^1.0.8"
@@ -5442,6 +5531,11 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yaml@^2.6.1:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.2.tgz#5694f25eca0ce9c3e7a9d9e00ce0ddabbd9e35c5"
+  integrity sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==
 
 yargs-parser@^21.1.1:
   version "21.1.1"

--- a/docs/breez-sdk/snippets/rust/src/config.rs
+++ b/docs/breez-sdk/snippets/rust/src/config.rs
@@ -5,7 +5,7 @@ use log::info;
 pub(crate) fn configure_sdk() -> Result<()> {
     // ANCHOR: max-deposit-claim-fee
     // Create the default config
-    let mut config = default_config(Network::Mainnet);
+    let mut config = BreezSdkSpark::default_config(Network::Mainnet);
     config.api_key = Some("<breez api key>".to_string());
 
     // Disable automatic claiming
@@ -30,7 +30,7 @@ pub(crate) fn configure_sdk() -> Result<()> {
 pub(crate) fn configure_private_enabled_default() -> Result<()> {
     // ANCHOR: private-enabled-default
     // Disable Spark private mode by default
-    let mut config = default_config(Network::Mainnet);
+    let mut config = BreezSdkSpark::default_config(Network::Mainnet);
     config.private_enabled_default = false;
     // ANCHOR_END: private-enabled-default
     info!("Config: {:?}", config);
@@ -39,7 +39,7 @@ pub(crate) fn configure_private_enabled_default() -> Result<()> {
 
 pub(crate) fn configure_optimization_configuration() -> Result<()> {
     // ANCHOR: optimization-configuration
-    let mut config = default_config(Network::Mainnet);
+    let mut config = BreezSdkSpark::default_config(Network::Mainnet);
     config.optimization_config = OptimizationConfig {
         auto_enabled: true,
         multiplicity: 1,
@@ -51,7 +51,7 @@ pub(crate) fn configure_optimization_configuration() -> Result<()> {
 
 pub(crate) fn configure_stable_balance() -> Result<()> {
     // ANCHOR: stable-balance-config
-    let mut config = default_config(Network::Mainnet);
+    let mut config = BreezSdkSpark::default_config(Network::Mainnet);
 
     // Enable stable balance with auto-conversion to a specific token
     config.stable_balance_config = Some(StableBalanceConfig {

--- a/docs/breez-sdk/snippets/rust/src/external_signer.rs
+++ b/docs/breez-sdk/snippets/rust/src/external_signer.rs
@@ -6,8 +6,8 @@ use breez_sdk_spark::*;
 fn create_signer() -> Result<Arc<dyn ExternalSigner>, SdkError> {
     let mnemonic = "<mnemonic words>".to_string();
     let network = Network::Mainnet;
-    
-    let signer = default_external_signer(
+
+    let signer = BreezSdkSpark::default_external_signer(
         mnemonic,
         None, // passphrase
         network,
@@ -17,25 +17,25 @@ fn create_signer() -> Result<Arc<dyn ExternalSigner>, SdkError> {
             account_number: Some(0),
         }),
     )?;
-    
+
     Ok(signer)
 }
 // ANCHOR_END: default-external-signer
 
 // ANCHOR: connect-with-signer
-async fn connect_example(signer: Arc<dyn ExternalSigner>) -> Result<BreezSdk, SdkError> {
+async fn connect_example(signer: Arc<dyn ExternalSigner>) -> Result<BreezSparkClient, SdkError> {
     // Create the config
-    let mut config = default_config(Network::Mainnet);
+    let mut config = BreezSdkSpark::default_config(Network::Mainnet);
     config.api_key = Some("<breez api key>".to_string());
-    
+
     // Connect using the external signer
-    let sdk = connect_with_signer(ConnectWithSignerRequest {
-        config,
-        signer,
-        storage_dir: "./.data".to_string(),
-    })
-    .await?;
-    
+    let sdk = BreezSdkSpark::connect_with_signer(ConnectWithSignerRequest {
+            config,
+            signer,
+            storage_dir: "./.data".to_string(),
+        })
+        .await?;
+
     Ok(sdk)
 }
 // ANCHOR_END: connect-with-signer

--- a/docs/breez-sdk/snippets/rust/src/getting_started.rs
+++ b/docs/breez-sdk/snippets/rust/src/getting_started.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use breez_sdk_spark::*;
 use log::info;
 
-pub(crate) async fn init_sdk() -> Result<BreezSdk> {
+pub(crate) async fn init_sdk() -> Result<BreezSparkClient> {
     // ANCHOR: init-sdk
     // Construct the seed using mnemonic words or entropy bytes
     let mnemonic = "<mnemonic words>".to_string();
@@ -15,22 +15,22 @@ pub(crate) async fn init_sdk() -> Result<BreezSdk> {
     };
 
     // Create the default config
-    let mut config = default_config(Network::Mainnet);
+    let mut config = BreezSdkSpark::default_config(Network::Mainnet);
     config.api_key = Some("<breez api key>".to_string());
 
     // Connect to the SDK using the simplified connect method
-    let sdk = connect(ConnectRequest {
-        config,
-        seed,
-        storage_dir: "./.data".to_string(),
-    })
-    .await?;
+    let sdk = BreezSdkSpark::connect(ConnectRequest {
+            config,
+            seed,
+            storage_dir: "./.data".to_string(),
+        })
+        .await?;
 
     // ANCHOR_END: init-sdk
     Ok(sdk)
 }
 
-pub(crate) async fn getting_started_node_info(sdk: &BreezSdk) -> Result<()> {
+pub(crate) async fn getting_started_node_info(sdk: &BreezSparkClient) -> Result<()> {
     // ANCHOR: fetch-balance
     let info = sdk
         .get_info(GetInfoRequest {
@@ -51,7 +51,7 @@ pub(crate) fn getting_started_logging(data_dir: String) -> Result<()> {
     let data_dir_path = PathBuf::from(&data_dir);
     fs::create_dir_all(data_dir_path)?;
 
-    init_logging(Some(data_dir), None, None)?;
+    BreezSdkSpark::init_logging(Some(data_dir), None, None)?;
     // ANCHOR_END: logging
     Ok(())
 }
@@ -90,7 +90,7 @@ impl EventListener for SdkEventListener {
 }
 
 pub(crate) async fn add_event_listener(
-    sdk: &BreezSdk,
+    sdk: &BreezSparkClient,
     listener: Box<SdkEventListener>,
 ) -> Result<String> {
     let listener_id = sdk.add_event_listener(listener).await;
@@ -99,7 +99,7 @@ pub(crate) async fn add_event_listener(
 // ANCHOR_END: add-event-listener
 
 // ANCHOR: remove-event-listener
-pub(crate) async fn remove_event_listener(sdk: &BreezSdk, listener_id: &str) -> Result<()> {
+pub(crate) async fn remove_event_listener(sdk: &BreezSparkClient, listener_id: &str) -> Result<()> {
     sdk.remove_event_listener(listener_id).await;
     Ok(())
 }
@@ -107,7 +107,7 @@ pub(crate) async fn remove_event_listener(sdk: &BreezSdk, listener_id: &str) -> 
 
 // ANCHOR: spark-status
 pub(crate) async fn getting_started_spark_status() -> Result<()> {
-    let spark_status = get_spark_status().await?;
+    let spark_status = BreezSdkSpark::get_spark_status().await?;
 
     match spark_status.status {
         ServiceStatus::Operational => {
@@ -133,9 +133,8 @@ pub(crate) async fn getting_started_spark_status() -> Result<()> {
 // ANCHOR_END: spark-status
 
 // ANCHOR: disconnect
-pub(crate) async fn disconnect(sdk: &BreezSdk) -> Result<()> {
+pub(crate) async fn disconnect(sdk: &BreezSparkClient) -> Result<()> {
     sdk.disconnect().await?;
     Ok(())
 }
 // ANCHOR_END: disconnect
-

--- a/docs/breez-sdk/snippets/rust/src/main.rs
+++ b/docs/breez-sdk/snippets/rust/src/main.rs
@@ -1,3 +1,7 @@
+// Some snippets still show deprecated free functions (default_config, etc.)
+// as part of older documentation examples alongside the new BreezSdkSpark:: API.
+#![allow(deprecated)]
+
 mod buying_bitcoin;
 mod config;
 mod external_signer;

--- a/docs/breez-sdk/snippets/rust/src/parsing_inputs.rs
+++ b/docs/breez-sdk/snippets/rust/src/parsing_inputs.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use breez_sdk_spark::*;
 
-async fn parse_input(sdk: &BreezSdk) -> Result<()> {
+async fn parse_input() -> Result<()> {
     // ANCHOR: parse-inputs
     let input = "an input to be parsed...";
 
-    match sdk.parse(input).await? {
+    match BreezSdkSpark::parse(input, None).await? {
         InputType::BitcoinAddress(details) => {
             println!("Input is Bitcoin address {}", details.address);
         }
@@ -65,7 +65,7 @@ async fn parse_input(sdk: &BreezSdk) -> Result<()> {
 pub(crate) async fn set_external_input_parsers() -> Result<()> {
     // ANCHOR: set-external-input-parsers
     // Create the default config
-    let mut config = default_config(Network::Mainnet);
+    let mut config = BreezSdkSpark::default_config(Network::Mainnet);
     config.api_key = Some("<breez api key>".to_string());
 
     // Configure external parsers

--- a/docs/breez-sdk/snippets/rust/src/sdk_building.rs
+++ b/docs/breez-sdk/snippets/rust/src/sdk_building.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use breez_sdk_spark::*;
 use log::info;
 
-pub(crate) async fn init_sdk_advanced() -> Result<BreezSdk> {
+pub(crate) async fn init_sdk_advanced() -> Result<BreezSparkClient> {
     // ANCHOR: init-sdk-advanced
     // Construct the seed using mnemonic words or entropy bytes
     let mnemonic = "<mnemonic words>".to_string();
@@ -15,11 +15,11 @@ pub(crate) async fn init_sdk_advanced() -> Result<BreezSdk> {
     };
 
     // Create the default config
-    let mut config = default_config(Network::Mainnet);
+    let mut config = BreezSdkSpark::default_config(Network::Mainnet);
     config.api_key = Some("<breez api key>".to_string());
 
     // Build the SDK using the config, seed and default storage
-    let builder = SdkBuilder::new(config, seed).with_default_storage("./.data".to_string());
+    let builder = BreezSdkSpark::builder(config, seed).with_default_storage("./.data".to_string());
     // You can also pass your custom implementations:
     // let builder = builder.with_storage(<your storage implementation>)
     // let builder = builder.with_chain_service(<your chain service implementation>)
@@ -82,7 +82,7 @@ pub(crate) fn with_payment_observer(builder: SdkBuilder) -> SdkBuilder {
 }
 // ANCHOR_END: with-payment-observer
 
-pub(crate) async fn init_sdk_postgres() -> Result<BreezSdk> {
+pub(crate) async fn init_sdk_postgres() -> Result<BreezSparkClient> {
     // ANCHOR: init-sdk-postgres
     // Construct the seed using mnemonic words or entropy bytes
     let mnemonic = "<mnemonic words>".to_string();
@@ -92,7 +92,7 @@ pub(crate) async fn init_sdk_postgres() -> Result<BreezSdk> {
     };
 
     // Create the default config
-    let mut config = default_config(Network::Mainnet);
+    let mut config = BreezSdkSpark::default_config(Network::Mainnet);
     config.api_key = Some("<breez api key>".to_string());
 
     // Configure PostgreSQL storage
@@ -106,7 +106,7 @@ pub(crate) async fn init_sdk_postgres() -> Result<BreezSdk> {
 
     // Create the storage and build the SDK
     let storage = create_postgres_storage(postgres_config).await?;
-    let sdk = SdkBuilder::new(config, seed)
+    let sdk = BreezSdkSpark::builder(config, seed)
         .with_storage(storage)
         .build()
         .await?;

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Config.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Config.swift
@@ -3,7 +3,7 @@ import BreezSdkSpark
 func configureSdk() async throws {
     // ANCHOR: max-deposit-claim-fee
     // Create the default config
-    var config = defaultConfig(network: Network.mainnet)
+    var config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
     config.apiKey = "<breez api key>"
 
     // Disable automatic claiming
@@ -25,7 +25,7 @@ func configureSdk() async throws {
 func configurePrivateEnabledDefault() async throws {
     // ANCHOR: private-enabled-default
     // Disable Spark private mode by default
-    var config = defaultConfig(network: Network.mainnet)
+    var config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
     config.privateEnabledDefault = false
     // ANCHOR_END: private-enabled-default
     print("Config: \(config)")
@@ -33,7 +33,7 @@ func configurePrivateEnabledDefault() async throws {
 
 func configureOptimizationConfiguration() async throws {
     // ANCHOR: optimization-configuration
-    var config = defaultConfig(network: Network.mainnet)
+    var config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
     config.optimizationConfig = OptimizationConfig(autoEnabled: true, multiplicity: 1)
     // ANCHOR_END: optimization-configuration
     print("Config: \(config)")
@@ -41,7 +41,7 @@ func configureOptimizationConfiguration() async throws {
 
 func configureStableBalance() async throws {
     // ANCHOR: stable-balance-config
-    var config = defaultConfig(network: Network.mainnet)
+    var config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
 
     // Enable stable balance with auto-conversion to a specific token
     config.stableBalanceConfig = StableBalanceConfig(

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ExternalSigner.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ExternalSigner.swift
@@ -6,8 +6,8 @@ class ExternalSignerSnippets {
     func createSigner() throws -> ExternalSigner {
         let mnemonic = "<mnemonic words>"
         let network = Network.mainnet
-        
-        let signer = try defaultExternalSigner(
+
+        let signer = try BreezSdkSpark.defaultExternalSigner(
             mnemonic: mnemonic,
             passphrase: nil,
             network: network,
@@ -17,24 +17,24 @@ class ExternalSignerSnippets {
                 accountNumber: 0
             )
         )
-        
+
         return signer
     }
     // ANCHOR_END: default-external-signer
-    
+
     // ANCHOR: connect-with-signer
     func connectExample(signer: ExternalSigner) async throws -> BreezSdk {
         // Create the config
-        var config = defaultConfig(network: .mainnet)
+        var config = BreezSdkSpark.defaultConfig(network: .mainnet)
         config.apiKey = "<breez api key>"
-        
+
         // Connect using the external signer
         let sdk = try await BreezSdkSpark.connectWithSigner(request: ConnectWithSignerRequest(
             config: config,
             signer: signer,
             storageDir: "./.data"
         ))
-        
+
         return sdk
     }
     // ANCHOR_END: connect-with-signer

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
@@ -7,11 +7,11 @@ func initSdk() async throws -> BreezSdk {
     let seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: nil)
 
     // Create the default config
-    var config = defaultConfig(network: Network.mainnet)
+    var config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
     config.apiKey = "<breez api key>"
 
     // Connect to the SDK using the simplified connect method
-    let sdk = try await connect(
+    let sdk = try await BreezSdkSpark.connect(
         request: ConnectRequest(
             config: config,
             seed: seed,
@@ -44,7 +44,7 @@ class SdkLogger: Logger {
 }
 
 func logging() throws {
-    try initLogging(logDir: nil, appLogger: SdkLogger(), logFilter: nil)
+    try BreezSdkSpark.initLogging(logDir: nil, appLogger: SdkLogger(), logFilter: nil)
 }
 // ANCHOR_END: logging
 
@@ -95,7 +95,7 @@ func removeEventListener(sdk: BreezSdk, listenerId: String) async {
 
 // ANCHOR: spark-status
 func gettingStartedSparkStatus() async throws {
-    let sparkStatus = try await getSparkStatus()
+    let sparkStatus = try await BreezSdkSpark.getSparkStatus()
 
     switch sparkStatus.status {
     case .operational:

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ParsingInputs.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ParsingInputs.swift
@@ -1,12 +1,12 @@
 import BreezSdkSpark
 import Foundation
 
-func parseInput(sdk: BreezSdk) async throws {
+func parseInput() async throws {
     // ANCHOR: parse-inputs
     let input = "an input to be parsed..."
 
     do {
-        let inputType = try await sdk.parse(input: input)
+        let inputType = try await BreezSdkSpark.parse(input: input)
         switch inputType {
         case .bitcoinAddress(v1: let details):
             print("Input is Bitcoin address \(details.address)")
@@ -59,7 +59,7 @@ func parseInput(sdk: BreezSdk) async throws {
 func setExternalInputParsers() async {
     // ANCHOR: set-external-input-parsers
     // Create the default config
-    var config = defaultConfig(network: Network.mainnet)
+    var config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
     config.apiKey = "<breez api key>"
 
     // Configure external parsers

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
@@ -7,7 +7,7 @@ func initSdkAdvanced() async throws -> BreezSdk {
     let seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: nil)
 
     // Create the default config
-    var config = defaultConfig(network: Network.mainnet)
+    var config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
     config.apiKey = "<breez api key>"
 
     // Build the SDK using the config, seed and default storage
@@ -46,13 +46,13 @@ func withKeySet(builder: SdkBuilder) async {
     let keySetType = KeySetType.default
     let useAddressIndex = false
     let optionalAccountNumber = UInt32(21)
-    
+
     let config = KeySetConfig(
         keySetType: keySetType,
         useAddressIndex: useAddressIndex,
         accountNumber: optionalAccountNumber
     )
-    
+
     await builder.withKeySet(config: config)
     // ANCHOR_END: with-key-set
 }
@@ -79,7 +79,7 @@ func initSdkPostgres() async throws -> BreezSdk {
     let seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: nil)
 
     // Create the default config
-    var config = defaultConfig(network: Network.mainnet)
+    var config = BreezSdkSpark.defaultConfig(network: Network.mainnet)
     config.apiKey = "<breez api key>"
 
     // Configure PostgreSQL storage

--- a/docs/breez-sdk/snippets/wasm/config.ts
+++ b/docs/breez-sdk/snippets/wasm/config.ts
@@ -1,9 +1,9 @@
-import { defaultConfig } from '@breeztech/breez-sdk-spark'
+import { BreezSdkSpark } from '@breeztech/breez-sdk-spark'
 
 const exampleConfigureSdk = async () => {
   // ANCHOR: max-deposit-claim-fee
   // Create the default config
-  const config = defaultConfig('mainnet')
+  const config = BreezSdkSpark.defaultConfig('mainnet')
   config.apiKey = '<breez api key>'
 
   // Disable automatic claiming
@@ -25,7 +25,7 @@ const exampleConfigureSdk = async () => {
 const exampleConfigurePrivateEnabledDefault = async () => {
   // ANCHOR: private-enabled-default
   // Disable Spark private mode by default
-  const config = defaultConfig('mainnet')
+  const config = BreezSdkSpark.defaultConfig('mainnet')
   config.privateEnabledDefault = false
   // ANCHOR_END: private-enabled-default
   console.log('Config:', config)
@@ -33,7 +33,7 @@ const exampleConfigurePrivateEnabledDefault = async () => {
 
 const exampleConfigureOptimizationConfiguration = async () => {
   // ANCHOR: optimization-configuration
-  const config = defaultConfig('mainnet')
+  const config = BreezSdkSpark.defaultConfig('mainnet')
   config.optimizationConfig = { autoEnabled: true, multiplicity: 1 }
   // ANCHOR_END: optimization-configuration
   console.log('Config:', config)
@@ -41,7 +41,7 @@ const exampleConfigureOptimizationConfiguration = async () => {
 
 const exampleConfigureStableBalance = async () => {
   // ANCHOR: stable-balance-config
-  const config = defaultConfig('mainnet')
+  const config = BreezSdkSpark.defaultConfig('mainnet')
 
   // Enable stable balance with auto-conversion to a specific token
   config.stableBalanceConfig = {

--- a/docs/breez-sdk/snippets/wasm/external_signer.ts
+++ b/docs/breez-sdk/snippets/wasm/external_signer.ts
@@ -1,8 +1,4 @@
-import {
-  defaultExternalSigner,
-  connectWithSigner,
-  defaultConfig
-} from '@breeztech/breez-sdk-spark'
+import { BreezSdkSpark } from '@breeztech/breez-sdk-spark'
 import type { KeySetConfig } from '@breeztech/breez-sdk-spark'
 
 // ANCHOR: default-external-signer
@@ -15,20 +11,20 @@ const createSigner = () => {
   }
 
   // Create the default signer from the SDK
-  const signer = defaultExternalSigner(mnemonic, null, 'mainnet', keySetConfig)
+  const signer = BreezSdkSpark.defaultExternalSigner(mnemonic, null, 'mainnet', keySetConfig)
 
   return signer
 }
 // ANCHOR_END: default-external-signer
 
 // ANCHOR: connect-with-signer
-const exampleConnectWithSigner = async (signer: ReturnType<typeof defaultExternalSigner>) => {
+const exampleConnectWithSigner = async (signer: ReturnType<typeof BreezSdkSpark.defaultExternalSigner>) => {
   // Create the config
-  const config = defaultConfig('mainnet')
+  const config = BreezSdkSpark.defaultConfig('mainnet')
   config.apiKey = '<breez api key>'
 
   // Connect using the external signer
-  const sdk = await connectWithSigner(
+  const sdk = await BreezSdkSpark.connectWithSigner(
     config,
     signer,
     'breez_spark_db' // For WASM, this is the IndexedDB database name

--- a/docs/breez-sdk/snippets/wasm/getting_started.ts
+++ b/docs/breez-sdk/snippets/wasm/getting_started.ts
@@ -1,12 +1,9 @@
 import {
+  BreezSdkSpark,
   type BreezSdk,
-  connect,
-  defaultConfig,
-  getSparkStatus,
-  initLogging,
+  SdkBuilder,
   type LogEntry,
   type SdkEvent,
-  SdkBuilder,
   type Seed
 } from '@breeztech/breez-sdk-spark'
 
@@ -18,7 +15,7 @@ const exampleGettingStarted = async () => {
   // Call init when using the SDK in a web environment before calling any other SDK
   // methods. This is not needed when using the SDK in a Node.js/Deno environment.
   //
-  // import init, { BreezSdk, defaultConfig } from '@breeztech/breez-sdk-spark'
+  // import init, { BreezSdkSpark } from '@breeztech/breez-sdk-spark'
   await init()
 
   // Construct the seed using mnemonic words or entropy bytes
@@ -26,11 +23,11 @@ const exampleGettingStarted = async () => {
   const seed: Seed = { type: 'mnemonic', mnemonic, passphrase: undefined }
 
   // Create the default config
-  const config = defaultConfig('mainnet')
+  const config = BreezSdkSpark.defaultConfig('mainnet')
   config.apiKey = '<breez api key>'
 
   // Connect to the SDK using the simplified connect method
-  const sdk = await connect({
+  const sdk = await BreezSdkSpark.connect({
     config,
     seed,
     storageDir: './.data'
@@ -59,7 +56,7 @@ const exampleLogging = async () => {
   }
 
   const logger = new JsLogger()
-  await initLogging(logger)
+  await BreezSdkSpark.initLogging(logger)
   // ANCHOR_END: logging
 }
 
@@ -125,7 +122,7 @@ const exampleRemoveEventListener = async (sdk: BreezSdk, listenerId: string) => 
 
 const exampleGetSparkStatus = async () => {
   // ANCHOR: spark-status
-  const sparkStatus = await getSparkStatus()
+  const sparkStatus = await BreezSdkSpark.getSparkStatus()
 
   switch (sparkStatus.status) {
     case 'operational': {

--- a/docs/breez-sdk/snippets/wasm/parsing_inputs.ts
+++ b/docs/breez-sdk/snippets/wasm/parsing_inputs.ts
@@ -1,10 +1,10 @@
-import { defaultConfig, Seed, type BreezSdk } from '@breeztech/breez-sdk-spark'
+import { BreezSdkSpark, type Seed, type BreezSdk } from '@breeztech/breez-sdk-spark'
 
-const parseInputs = async (sdk: BreezSdk) => {
+const parseInputs = async () => {
   // ANCHOR: parse-inputs
   const input = 'an input to be parsed...'
 
-  const parsed = await sdk.parse(input)
+  const parsed = await BreezSdkSpark.parse(input)
 
   switch (parsed.type) {
     case 'bitcoinAddress':
@@ -68,7 +68,7 @@ const parseInputs = async (sdk: BreezSdk) => {
 const exampleSetExternalInputParsers = async () => {
   // ANCHOR: set-external-input-parsers
   // Create the default config
-  const config = defaultConfig('mainnet')
+  const config = BreezSdkSpark.defaultConfig('mainnet')
   config.apiKey = '<breez api key>'
 
   // Configure external parsers

--- a/docs/breez-sdk/snippets/wasm/sdk_building.ts
+++ b/docs/breez-sdk/snippets/wasm/sdk_building.ts
@@ -1,4 +1,4 @@
-import { SdkBuilder, defaultConfig } from '@breeztech/breez-sdk-spark'
+import { SdkBuilder, BreezSdkSpark } from '@breeztech/breez-sdk-spark'
 import type {
   ProvisionalPayment,
   Seed,
@@ -33,7 +33,7 @@ const exampleGettingStartedAdvanced = async () => {
   const seed: Seed = { type: 'mnemonic', mnemonic, passphrase: undefined }
 
   // Create the default config
-  const config = defaultConfig('mainnet')
+  const config = BreezSdkSpark.defaultConfig('mainnet')
   config.apiKey = '<breez api key>'
 
   // Build the SDK using the config, seed and default storage

--- a/docs/breez-sdk/src/SUMMARY.md
+++ b/docs/breez-sdk/src/SUMMARY.md
@@ -48,6 +48,7 @@
   - [Conditional Payments](guide/htlcs.md)
   - [Using an External Signer](guide/external_signer.md)
 - [Moving to production](guide/moving_to_production.md)
+- [Migration guide](guide/migration.md)
 
 ---
 

--- a/docs/breez-sdk/src/guide/config.md
+++ b/docs/breez-sdk/src/guide/config.md
@@ -35,7 +35,7 @@ The LNURL domain to be used for receiving LNURL and Lightning address payments. 
 
 ## Prefer Spark over Lightning
 
-An on-off switch that determines whether to prefer settlement using Spark when sending and receiving payments via Lightning invoices. 
+An on-off switch that determines whether to prefer settlement using Spark when sending and receiving payments via Lightning invoices.
 
 ## External input parsing
 

--- a/docs/breez-sdk/src/guide/external_signer.md
+++ b/docs/breez-sdk/src/guide/external_signer.md
@@ -8,7 +8,7 @@ The External Signer feature allows you to provide custom signing logic for the S
 
 ## Using the Default External Signer
 
-The SDK provides a convenient factory function {{#name default_external_signer}} that creates a signer from a mnemonic. This is the easiest way to get started:
+The SDK provides a convenient method {{#name default_external_signer}} that creates a signer from a mnemonic. This is the easiest way to get started:
 
 {{#tabs external_signer:default-external-signer}}
 

--- a/docs/breez-sdk/src/guide/initializing.md
+++ b/docs/breez-sdk/src/guide/initializing.md
@@ -1,6 +1,6 @@
 <h1 id="initializing">
     <a class="header" href="#initializing">Initializing the SDK</a>
-    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.connect">API docs</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdkSpark.html#method.connect">API docs</a>
 </h1>
 
 ## Basic Initialization
@@ -15,9 +15,9 @@ The easiest way to initialize the SDK is with the {{#name connect}} method. This
 For WASM Web, SDK storage is managed using IndexedDB.
 </div>
 
-The storage is used to persist the SDK’s state. If you run multiple SDK instances, each must have its own unique storage directory.
+The storage is used to persist the SDK's state. If you run multiple SDK instances, each must have its own unique storage directory.
 
-Once connected, you’re ready to start interacting with the SDK.
+Once connected, you're ready to start interacting with the SDK.
 
 {{#tabs getting_started:init-sdk}}
 
@@ -35,7 +35,7 @@ For advanced use cases where you need more control, you can configure the SDK us
 - [Storage](customizing.md#with-storage) and [Real-Time Storage](customizing.md#with-real-time-storage) to manage stored data
 - [Bitcoin Chain Service](customizing.md#with-chain-service) to provide network data
 - [LNURL Client](customizing.md#with-lnurl-client) to make REST requests
-- [Fiat Service](customizing.md#with-fiat-service) to provide Fiat currencies and exchange rates 
+- [Fiat Service](customizing.md#with-fiat-service) to provide Fiat currencies and exchange rates
 - Change the [Key Set](customizing.md#with-key-set) to alter the derivation path used
 - [Payment Observer](customizing.md#with-payment-observer) to be notified before payments occur
 
@@ -46,7 +46,7 @@ See [Customizing the SDK](customizing.md) for examples of this advanced initiali
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.disconnect">API docs</a>
 </h2>
 
-When you’re done using the SDK, call the disconnect method to release any resources in use.
+When you're done using the SDK, call the disconnect method to release any resources in use.
 
 This is particularly useful if you need to re-instantiate the SDK, such as when changing the mnemonic or updating configuration.
 

--- a/docs/breez-sdk/src/guide/logging.md
+++ b/docs/breez-sdk/src/guide/logging.md
@@ -1,6 +1,6 @@
 <h1 id="adding-logging">
     <a class="header" href="#adding-logging">Adding logging</a>
-    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/fn.init_logging.html">API docs</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdkSpark.html#method.init_logging">API docs</a>
 </h1>
 
 The SDK implements detailed logging via a streaming interface you can manage within your application. The log entries are split into several levels that you can filter and store as desired within your application, for example, by appending them to a log file.

--- a/docs/breez-sdk/src/guide/migration.md
+++ b/docs/breez-sdk/src/guide/migration.md
@@ -1,0 +1,207 @@
+# Migration Guide
+
+This guide covers breaking changes and deprecations across SDK versions, with migration steps for each platform.
+
+## 0.10.0: Namespace and Client Type
+
+Free functions have been replaced by methods on the `BreezSdkSpark` struct, and the client type has been renamed from `BreezSdk` to `BreezSparkClient`.
+
+### What Changed
+
+| Before (deprecated) | After |
+|---------------------|-------|
+| `defaultConfig(network)` | `BreezSdkSpark.defaultConfig(network)` |
+| `connect(request)` | `BreezSdkSpark.connect(request)` |
+| `parse(input)` | `BreezSdkSpark.parse(input)` |
+| `initLogging(...)` | `BreezSdkSpark.initLogging(...)` |
+| `connectWithSigner(request)` | `BreezSdkSpark.connectWithSigner(request)` |
+| `defaultExternalSigner(...)` | `BreezSdkSpark.defaultExternalSigner(...)` |
+| `getSparkStatus()` | `BreezSdkSpark.getSparkStatus()` |
+| `BreezSdk` (client type) | `BreezSparkClient` |
+
+Instance methods on the client (`getInfo`, `sendPayment`, `disconnect`, etc.) are **unchanged**.
+
+---
+
+<custom-tabs category="lang">
+<div slot="title">Rust</div>
+<section>
+
+#### Before
+```rust,ignore
+use breez_sdk_spark::*;
+
+let config = default_config(Network::Mainnet);
+let sdk: BreezSdk = connect(ConnectRequest { config, seed, storage_dir }).await?;
+
+init_logging(Some(data_dir), None, None)?;
+let status = get_spark_status().await?;
+```
+
+#### After
+```rust,ignore
+use breez_sdk_spark::*;
+
+let config = BreezSdkSpark::default_config(Network::Mainnet);
+let client: BreezSparkClient = BreezSdkSpark::connect(ConnectRequest { config, seed, storage_dir }).await?;
+
+BreezSdkSpark::init_logging(Some(data_dir), None, None)?;
+let status = BreezSdkSpark::get_spark_status().await?;
+```
+
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+No code changes required. Swift uses the module name `BreezSdkSpark` as the namespace automatically:
+
+```swift,ignore
+// Both forms work — the module prefix is implicit
+let config = defaultConfig(network: .mainnet)
+let config = BreezSdkSpark.defaultConfig(network: .mainnet)
+```
+
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+#### Before
+```kotlin,ignore
+import breez_sdk_spark.*
+
+val config = defaultConfig(Network.MAINNET)
+val sdk: BreezSdk = connect(ConnectRequest(config, seed, storageDir))
+```
+
+#### After
+```kotlin,ignore
+import breez_sdk_spark.BreezSdkSpark
+import breez_sdk_spark.BreezSparkClient
+
+val config = BreezSdkSpark.defaultConfig(Network.MAINNET)
+val client: BreezSparkClient = BreezSdkSpark.connect(ConnectRequest(config, seed, storageDir))
+```
+
+</section>
+
+<div slot="title">C#</div>
+<section>
+
+#### Before
+```csharp,ignore
+using Breez.Sdk.Spark;
+
+var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet);
+var sdk = await BreezSdkSparkMethods.Connect(new ConnectRequest(config, seed, storageDir));
+```
+
+#### After
+```csharp,ignore
+using Breez.Sdk.Spark;
+
+var config = BreezSdkSpark.DefaultConfig(Network.Mainnet);
+var client = await BreezSdkSpark.Connect(new ConnectRequest(config, seed, storageDir));
+```
+
+</section>
+
+<div slot="title">Javascript</div>
+<section>
+
+#### Before
+```typescript,ignore
+import { connect, defaultConfig } from '@breeztech/breez-sdk-spark'
+
+const config = defaultConfig('mainnet')
+const sdk = await connect({ config, seed, storageDir: './.data' })
+```
+
+#### After
+```typescript,ignore
+import { BreezSdkSpark } from '@breeztech/breez-sdk-spark'
+
+const config = BreezSdkSpark.defaultConfig('mainnet')
+const client = await BreezSdkSpark.connect({ config, seed, storageDir: './.data' })
+```
+
+</section>
+
+<div slot="title">React Native</div>
+<section>
+
+#### Before
+```typescript,ignore
+import { connect, defaultConfig } from '@breeztech/breez-sdk-spark-react-native'
+
+const config = defaultConfig('mainnet')
+const sdk = await connect({ config, seed, storageDir })
+```
+
+#### After
+```typescript,ignore
+import { BreezSdkSpark } from '@breeztech/breez-sdk-spark-react-native'
+
+const config = BreezSdkSpark.defaultConfig('mainnet')
+const client = await BreezSdkSpark.connect({ config, seed, storageDir })
+```
+
+</section>
+
+<div slot="title">Flutter</div>
+<section>
+
+#### Before
+```dart,ignore
+import 'package:breez_sdk_spark/breez_sdk_spark.dart';
+
+final config = defaultConfig(network: Network.mainnet);
+final sdk = await connect(request: ConnectRequest(config: config, seed: seed, storageDir: storageDir));
+```
+
+#### After
+```dart,ignore
+import 'package:breez_sdk_spark/breez_sdk_spark.dart';
+
+final config = BreezSdkSpark.defaultConfig(network: Network.mainnet);
+final client = await BreezSdkSpark.connect(request: ConnectRequest(config: config, seed: seed, storageDir: storageDir));
+```
+
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+#### Before
+```python,ignore
+from breez_sdk_spark import default_config, connect, Network
+
+config = default_config(Network.MAINNET)
+sdk = await connect(ConnectRequest(config, seed, storage_dir))
+```
+
+#### After
+```python,ignore
+from breez_sdk_spark import BreezSdkSpark, BreezSparkClient, Network
+
+config = BreezSdkSpark.default_config(Network.MAINNET)
+client: BreezSparkClient = await BreezSdkSpark.connect(ConnectRequest(config, seed, storage_dir))
+```
+
+</section>
+
+<div slot="title">Go</div>
+<section>
+
+No code changes required. Go uses the package name as the namespace automatically:
+
+```go,ignore
+// Both forms are identical — Go always uses the package prefix
+config := breez_sdk_spark.DefaultConfig(breez_sdk_spark.NetworkMainnet)
+client, err := breez_sdk_spark.Connect(breez_sdk_spark.ConnectRequest{...})
+```
+
+</section>
+
+</custom-tabs>

--- a/docs/breez-sdk/src/guide/spark_status.md
+++ b/docs/breez-sdk/src/guide/spark_status.md
@@ -1,9 +1,9 @@
 <h1 id="spark-status">
     <a class="header" href="#spark-status">Spark status</a>
-    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/fn.get_spark_status.html">API docs</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdkSpark.html#method.get_spark_status">API docs</a>
 </h1>
 
-The SDK provides a standalone function to check the current operational status of the Spark network. This function does not require an SDK instance and can be called at any time, for example before initializing the SDK.
+The SDK provides a method to check the current operational status of the Spark network. This method does not require an SDK instance and can be called at any time, for example before initializing the SDK.
 
 It returns the overall status of the Spark network, along with a timestamp of when the status was last updated.
 

--- a/packages/flutter/lib/breez_sdk_spark.dart
+++ b/packages/flutter/lib/breez_sdk_spark.dart
@@ -1,6 +1,7 @@
 library;
 
 export 'src/rust/frb_generated.dart' show BreezSdkSparkLib;
+export 'src/rust/breez.dart';
 export 'src/rust/errors.dart';
 export 'src/rust/events.dart';
 export 'src/rust/issuer.dart';

--- a/packages/flutter/rust/src/breez.rs
+++ b/packages/flutter/rust/src/breez.rs
@@ -1,0 +1,59 @@
+use std::sync::Arc;
+
+use breez_sdk_spark::*;
+use flutter_rust_bridge::frb;
+
+use crate::frb_generated::StreamSink;
+use crate::logger::BindingLogger;
+use crate::sdk::BreezSdk;
+
+/// Top-level namespace for the Breez SDK Spark.
+///
+/// Groups all static/global SDK functions that don't require a wallet
+/// connection. Use `BreezSdkSpark.connect()` to obtain a `BreezSparkClient` instance.
+#[frb(opaque)]
+pub struct BreezSdkSpark;
+
+#[allow(deprecated)] // delegates to deprecated free functions (default_config, connect, etc.)
+impl BreezSdkSpark {
+    /// Returns a default SDK configuration for the given network.
+    #[frb(sync)]
+    pub fn default_config(network: Network) -> Config {
+        breez_sdk_spark::default_config(network)
+    }
+
+    /// Connects to the Spark network using the provided configuration and seed.
+    pub async fn connect(request: ConnectRequest) -> Result<BreezSdk, SdkError> {
+        let sdk = breez_sdk_spark::connect(request).await?;
+        Ok(BreezSdk {
+            inner: Arc::new(sdk),
+        })
+    }
+
+    /// Initializes the SDK logging subsystem.
+    #[frb(sync)]
+    pub fn init_logging(
+        log_dir: Option<String>,
+        app_logger: StreamSink<LogEntry>,
+        log_filter: Option<String>,
+    ) -> Result<(), SdkError> {
+        let app_logger: Box<dyn Logger> = Box::new(BindingLogger { logger: app_logger });
+        breez_sdk_spark::init_logging(log_dir, Some(app_logger), log_filter)
+    }
+
+    /// Parses a payment input string and returns the identified type.
+    ///
+    /// Supports BOLT11 invoices, Lightning addresses, LNURL variants, Bitcoin
+    /// addresses, Spark addresses/invoices, BIP21 URIs, and more.
+    pub async fn parse(
+        input: String,
+        external_input_parsers: Option<Vec<ExternalInputParser>>,
+    ) -> Result<InputType, SdkError> {
+        breez_sdk_spark::parse(&input, external_input_parsers).await
+    }
+
+    /// Fetches the current status of Spark network services.
+    pub async fn get_spark_status() -> Result<SparkStatus, SdkError> {
+        breez_sdk_spark::get_spark_status().await
+    }
+}

--- a/packages/flutter/rust/src/lib.rs
+++ b/packages/flutter/rust/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod breez;
 pub mod errors;
 pub mod events;
 mod frb_generated;
@@ -7,4 +8,5 @@ pub mod models;
 pub mod sdk;
 pub mod sdk_builder;
 
+pub use breez::BreezSdkSpark;
 pub use sdk::BreezSdk;

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -7,10 +7,12 @@ use crate::events::BindingEventListener;
 use crate::frb_generated::StreamSink;
 use crate::logger::BindingLogger;
 
+#[allow(deprecated)]
 pub async fn get_spark_status() -> Result<SparkStatus, SdkError> {
     breez_sdk_spark::get_spark_status().await
 }
 
+#[allow(deprecated)]
 pub async fn connect(request: ConnectRequest) -> Result<BreezSdk, SdkError> {
     let sdk = breez_sdk_spark::connect(request).await?;
     Ok(BreezSdk {
@@ -19,11 +21,13 @@ pub async fn connect(request: ConnectRequest) -> Result<BreezSdk, SdkError> {
 }
 
 #[frb(sync)]
+#[allow(deprecated)]
 pub fn default_config(network: Network) -> Config {
     breez_sdk_spark::default_config(network)
 }
 
 #[frb(sync)]
+#[allow(deprecated)]
 pub fn init_logging(
     log_dir: Option<String>,
     app_logger: StreamSink<LogEntry>,

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -2,19 +2,19 @@
   "name": "@breeztech/breez-sdk-spark-react-native",
   "version": "0.1.4",
   "description": "React Native bindings for the Breez SDK - Nodeless (Spark Implementation)",
-  "source": "./src/index.tsx",
-  "main": "./lib/commonjs/index.js",
-  "module": "./lib/module/index.js",
+  "source": "./src/main.ts",
+  "main": "./lib/commonjs/main.js",
+  "module": "./lib/module/main.js",
   "exports": {
     "./app.plugin.js": "./app.plugin.js",
     ".": {
       "import": {
-        "types": "./lib/typescript/module/src/index.d.ts",
-        "default": "./lib/module/index.js"
+        "types": "./lib/typescript/module/src/main.d.ts",
+        "default": "./lib/module/main.js"
       },
       "require": {
-        "types": "./lib/typescript/commonjs/src/index.d.ts",
-        "default": "./lib/commonjs/index.js"
+        "types": "./lib/typescript/commonjs/src/main.d.ts",
+        "default": "./lib/commonjs/main.js"
       }
     }
   },

--- a/packages/react-native/src/Breez.ts
+++ b/packages/react-native/src/Breez.ts
@@ -1,0 +1,83 @@
+/**
+ * Top-level namespace for the Breez SDK Spark.
+ *
+ * Groups all static/global SDK functions that don't require a wallet
+ * connection. Use `BreezSdkSpark.connect()` to obtain a `BreezSparkClient` instance.
+ */
+import {
+  connect as _connect,
+  connectWithSigner as _connectWithSigner,
+  defaultConfig as _defaultConfig,
+  defaultExternalSigner as _defaultExternalSigner,
+  getSparkStatus as _getSparkStatus,
+  initLogging as _initLogging,
+  parse as _parse,
+} from './generated/breez_sdk_spark';
+
+import type {
+  BreezSdkInterface,
+  Config,
+  ConnectRequest,
+  ConnectWithSignerRequest,
+  ExternalInputParser,
+  ExternalSigner,
+  InputType,
+  KeySetConfig,
+  Logger,
+  Network,
+  SparkStatus,
+} from './generated/breez_sdk_spark';
+
+/** Preferred name for the SDK client type. */
+export type BreezSparkClient = BreezSdkInterface;
+
+export class BreezSdkSpark {
+  /** Returns a default SDK configuration for the given network. */
+  static defaultConfig(network: Network): Config {
+    return _defaultConfig(network);
+  }
+
+  /** Initializes the SDK logging subsystem. */
+  static initLogging(
+    logDir: string | undefined,
+    appLogger: Logger | undefined,
+    logFilter: string | undefined
+  ): void {
+    _initLogging(logDir, appLogger, logFilter);
+  }
+
+  /** Connects to the Spark network using the provided configuration and seed. */
+  static async connect(request: ConnectRequest): Promise<BreezSparkClient> {
+    return _connect(request);
+  }
+
+  /** Connects to the Spark network using an external signer. */
+  static async connectWithSigner(
+    request: ConnectWithSignerRequest
+  ): Promise<BreezSparkClient> {
+    return _connectWithSigner(request);
+  }
+
+  /** Creates a default external signer from a mnemonic phrase. */
+  static defaultExternalSigner(
+    mnemonic: string,
+    passphrase: string | undefined,
+    network: Network,
+    keySetConfig: KeySetConfig | undefined
+  ): ExternalSigner {
+    return _defaultExternalSigner(mnemonic, passphrase, network, keySetConfig);
+  }
+
+  /** Parses a payment input string and returns the identified type. */
+  static async parse(
+    input: string,
+    externalInputParsers?: ExternalInputParser[]
+  ): Promise<InputType> {
+    return _parse(input, externalInputParsers ?? null);
+  }
+
+  /** Fetches the current status of Spark network services. */
+  static async getSparkStatus(): Promise<SparkStatus> {
+    return _getSparkStatus();
+  }
+}

--- a/packages/react-native/src/main.ts
+++ b/packages/react-native/src/main.ts
@@ -1,0 +1,6 @@
+// Re-export everything from the generated entry point.
+export * from './index';
+export { default } from './index';
+
+// Export the BreezSdkSpark namespace and BreezSparkClient type alias.
+export { BreezSdkSpark, type BreezSparkClient } from './Breez';


### PR DESCRIPTION
### Background
The Breez SDK currently exposes its top-level API as a collection of free functions (`default_config`, `connect`, `parse`, `init_logging`, etc.) and a `BreezSdk` client type. As the SDK matures, this flat structure makes it harder to discover the API surface, creates ambiguity in multi-SDK codebases, and doesn't align well with idiomatic patterns across our target platforms (Rust, Go, Kotlin, Swift, Python, C#, React Native, WASM, Flutter).

This PR establishes a consistent `BreezSdk{Protocol}` namespace and `Breez{Protocol}Client` type convention across all Breez SDK implementations.

---

### What This PR Does

Introduces a `BreezSdkSpark` namespace struct that groups all static/global SDK functions under a single, discoverable entry point:
```rust
// Before
let config = default_config(...);
let sdk: BreezSdk = connect(config, ...)?;

// After
let config = BreezSdkSpark::default_config(...);
let client: BreezSparkClient = BreezSdkSpark::connect(config, ...)?;
```

Adds `BreezSparkClient` as a type alias for `BreezSdk`, enabling a gradual rename without breaking existing code.

Deprecates the existing free functions (since `0.10.0`) with guidance pointing consumers to the `BreezSdkSpark::` equivalents.

### Platform-Specific Namespace Strategy

Each language binding exposes `BreezSdkSpark` idiomatically:

| Platform | Approach | File |
|----------|----------|------|
| **Rust** | `BreezSdkSpark` struct with associated functions | `core/src/app.rs` |
| **WASM** | `#[wasm_bindgen]` struct with static methods | `wasm/src/breez.rs` |
| **Flutter** | `#[frb]` struct with static methods | `flutter/rust/src/breez.rs` |
| **Kotlin** | Hand-written `object BreezSdkSpark` delegating to free functions | `bindings/langs/kotlin-multiplatform/Breez.kt` |
| **Python** | Hand-written class with `@staticmethod` methods | `bindings/langs/python/src/breez_sdk_spark/breez.py` |
| **React Native** | Hand-written TypeScript class with static methods | `packages/react-native/src/Breez.ts` |
| **C#** | `global_methods_class_name = "BreezSdkSpark"` in uniffi.toml | `bindings/uniffi.toml` |
| **Go** | Package name `breez_sdk_spark` serves as namespace naturally | No wrapper needed |
| **Swift** | Module name `BreezSdkSpark` serves as namespace naturally | No wrapper needed |

### Structural Changes for Maintainers

- **`crates/breez-sdk/core/src/app.rs`** — New `BreezSdkSpark` struct with all namespace methods. Split into two impl blocks: one for all targets, one `#[cfg(not(wasm))]` for methods unavailable in WASM.

- **`crates/breez-sdk/core/src/sdk/mod.rs`** — Added `pub type BreezSparkClient = BreezSdk`. All 7 free function deprecation notices updated to `since = "0.10.0"` with `"Use BreezSdkSpark::"` guidance.

- **`crates/breez-sdk/bindings/uniffi.toml`** — Added `global_methods_class_name = "BreezSdkSpark"` under `[bindings.csharp]`

- **`crates/breez-sdk/bindings/Makefile`** — Added `cp` step for `Breez.kt` (Android + KMP targets). Changed C# cleanup pattern from `rm -f *.cs` to `rm -f breez_sdk_spark*.cs` to preserve `global_methods_class_name` output.

- **Hand-written wrapper files** — Kotlin (`Breez.kt`), Python (`breez.py`), React Native (`Breez.ts`) are thin delegation layers that are checked into git alongside `.gitignore` exceptions.

### Why This Approach
- **No breaking changes**. Existing integrations continue to compile and run. Deprecation warnings guide users toward the new API without forcing an immediate migration.
- **Improved discoverability**. Typing `BreezSdkSpark.` in an IDE immediately surfaces all available entry points.
- **Platform consistency.** All 9 platforms get the same `BreezSdkSpark.connect()` / `BreezSdkSpark.defaultConfig()` shape.

### What This Does Not Change
- **Runtime behavior is identical** — `BreezSdkSpark::default_config()` delegates directly to `default_config()` internally.
- **No public API is removed**. Deprecations are warnings only.
- Internal call sites use `#[allow(deprecated)]` to keep CI clean without hiding the signal from external consumers.

### TODO:
- [x] Evaluate namespace handling strategies in languages without native namespace support (e.g., C#, Go, Python)
- [X] Evaluate naming to not conflict with other Breez products (breez-sdk-liquid)
  - [ ] Apply `BreezSdkLiquid` / `BreezLiquidClient` naming convention to `breez-sdk-liquid`