### PR TITLE
Add get_emit_payment helper to consolidate payment event emission

### DIFF
--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -1,18 +1,14 @@
 use core::fmt;
 use std::{
     collections::BTreeMap,
-    sync::{
-        Arc, OnceLock,
-        atomic::{AtomicBool, AtomicU64, Ordering},
-    },
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
 use serde::Serialize;
 use tokio::sync::{Mutex, RwLock};
-use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::{DepositInfo, Payment, Storage, utils::payments::get_payment_with_conversion_details};
+use crate::{DepositInfo, Payment};
 
 /// Events emitted by the SDK
 #[allow(clippy::large_enum_variant)]
@@ -156,7 +152,6 @@ pub trait EventListener: Send + Sync {
 pub struct EventEmitter {
     has_real_time_sync: bool,
     rtsync_failed: AtomicBool,
-    storage: OnceLock<Arc<dyn Storage>>,
     listener_index: AtomicU64,
     listeners: RwLock<BTreeMap<String, Box<dyn EventListener>>>,
     synced_event_buffer: Mutex<Option<InternalSyncedEvent>>,
@@ -168,17 +163,10 @@ impl EventEmitter {
         Self {
             has_real_time_sync,
             rtsync_failed: AtomicBool::new(false),
-            storage: OnceLock::new(),
             listener_index: AtomicU64::new(0),
             listeners: RwLock::new(BTreeMap::new()),
             synced_event_buffer: Mutex::new(Some(InternalSyncedEvent::default())),
         }
-    }
-
-    /// Set the storage backend for payment event emission.
-    /// Must be called once after storage is fully initialized.
-    pub fn set_storage(&self, storage: Arc<dyn Storage>) {
-        let _ = self.storage.set(storage);
     }
 
     /// Add a listener to receive events
@@ -221,27 +209,6 @@ impl EventEmitter {
         for listener in listeners.values() {
             listener.on_event(event.clone()).await;
         }
-    }
-
-    /// Gets the payment from storage to include already stored metadata and conversion details.
-    /// Emit the appropriate event based on its status. Falls back to the provided
-    /// payment if the storage lookup fails.
-    pub(crate) async fn get_and_emit_payment(&self, payment: Payment) {
-        let payment = if let Some(storage) = self.storage.get() {
-            match get_payment_with_conversion_details(payment.id.clone(), Arc::clone(storage)).await
-            {
-                Ok(payment) => payment,
-                Err(e) => {
-                    warn!("Failed to fetch payment from storage: {e:?}");
-                    payment
-                }
-            }
-        } else {
-            warn!("Storage not set on EventEmitter, emitting payment as-is");
-            payment
-        };
-        info!("Emitting payment event: {payment:?}");
-        self.emit(&SdkEvent::from_payment(payment)).await;
     }
 
     pub async fn emit_synced(&self, synced: &InternalSyncedEvent) {

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -25,8 +25,8 @@ use crate::{
     token_conversion::{
         ConversionAmount, DEFAULT_CONVERSION_TIMEOUT_SECS, TokenConversionResponse,
     },
-    utils::payments::get_payment_with_conversion_details,
     utils::{
+        payments::{get_payment_and_emit_event, get_payment_with_conversion_details},
         send_payment_validation::validate_prepare_send_payment_request,
         token::map_and_persist_token_transaction,
     },
@@ -1226,7 +1226,7 @@ impl BreezSdk {
                                     error!("Failed to update payment in storage: {e:?}");
                                 }
                                 // Fetch the payment to include already stored metadata
-                                event_emitter.get_and_emit_payment(payment.clone()).await;
+                                get_payment_and_emit_event(&storage, &event_emitter, payment.clone()).await;
                                 sync_coordinator
                                     .trigger_sync_no_wait(SyncType::WalletState, true)
                                     .await;

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -14,7 +14,8 @@ use crate::{
     persist::{ObjectCacheRepository, UpdateDepositPayload},
     sync::SparkSyncService,
     utils::{
-        deposit_chain_syncer::DepositChainSyncer, run_with_shutdown, utxo_fetcher::DetailedUtxo,
+        deposit_chain_syncer::DepositChainSyncer, payments::get_payment_and_emit_event,
+        run_with_shutdown, utxo_fetcher::DetailedUtxo,
     },
 };
 
@@ -136,7 +137,7 @@ impl BreezSdk {
                     let _ = self.lnurl_preimage_trigger.send(());
 
                     // Fetch the payment to include already stored metadata
-                    self.event_emitter.get_and_emit_payment(payment).await;
+                    get_payment_and_emit_event(&self.storage, &self.event_emitter, payment).await;
                 }
                 self.sync_coordinator
                     .trigger_sync_no_wait(super::SyncType::WalletState, true)
@@ -154,7 +155,7 @@ impl BreezSdk {
                     self.sync_single_lnurl_metadata(&mut payment).await;
 
                     // Fetch the payment to include already stored metadata
-                    self.event_emitter.get_and_emit_payment(payment).await;
+                    get_payment_and_emit_event(&self.storage, &self.event_emitter, payment).await;
                 }
                 self.sync_coordinator
                     .trigger_sync_no_wait(super::SyncType::WalletState, true)

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -477,8 +477,6 @@ impl SdkBuilder {
                 (storage, None)
             };
 
-        event_emitter.set_storage(Arc::clone(&storage));
-
         // Create the MoonPay provider for buying Bitcoin
         let buy_bitcoin_provider: Arc<dyn BuyBitcoinProviderApi> =
             Arc::new(MoonpayProvider::new(breez_server.clone()));

--- a/crates/breez-sdk/core/src/sync.rs
+++ b/crates/breez-sdk/core/src/sync.rs
@@ -8,7 +8,7 @@ use tracing::{error, info};
 use crate::{
     EventEmitter, Payment, PaymentDetails, PaymentStatus, SdkError, Storage,
     persist::{CachedSyncInfo, ObjectCacheRepository},
-    utils::token::token_transaction_to_payments,
+    utils::{payments::get_payment_and_emit_event, token::token_transaction_to_payments},
 };
 
 const PAYMENT_SYNC_BATCH_SIZE: u64 = 50;
@@ -115,8 +115,7 @@ impl SparkSyncService {
 
                 if should_emit {
                     // Fetch the payment to include already stored metadata
-                    self.event_emitter
-                        .get_and_emit_payment(payment.clone())
+                    get_payment_and_emit_event(&self.storage, &self.event_emitter, payment.clone())
                         .await;
                 }
             }
@@ -350,8 +349,7 @@ impl SparkSyncService {
 
             if should_emit {
                 // Fetch the payment to include already stored metadata
-                self.event_emitter
-                    .get_and_emit_payment(payment.clone())
+                get_payment_and_emit_event(&self.storage, &self.event_emitter, payment.clone())
                     .await;
             }
         }

--- a/crates/breez-sdk/core/src/utils/payments.rs
+++ b/crates/breez-sdk/core/src/utils/payments.rs
@@ -1,8 +1,28 @@
 use std::sync::Arc;
 
-use tracing::warn;
+use tracing::{info, warn};
 
-use crate::{Payment, Storage, error::SdkError};
+use crate::{EventEmitter, Payment, Storage, error::SdkError, events::SdkEvent};
+
+/// Gets the payment from storage to include already stored metadata and conversion details.
+/// Emits the appropriate event based on its status. Falls back to the provided
+/// payment if the storage lookup fails.
+pub(crate) async fn get_payment_and_emit_event(
+    storage: &Arc<dyn Storage>,
+    event_emitter: &EventEmitter,
+    payment: Payment,
+) {
+    let payment =
+        match get_payment_with_conversion_details(payment.id.clone(), Arc::clone(storage)).await {
+            Ok(payment) => payment,
+            Err(e) => {
+                warn!("Failed to fetch payment from storage: {e:?}");
+                payment
+            }
+        };
+    info!("Emitting payment event: {payment:?}");
+    event_emitter.emit(&SdkEvent::from_payment(payment)).await;
+}
 
 /// Gets a payment from storage by ID to include already stored payment metadata
 /// and then enriches it with conversion details by looking up related payments.


### PR DESCRIPTION
Payment events were emitted without metadata or conversion details because each call site fetched from storage differently (or used the payment direct from a transfer). This particularly caused issues testing token conversions/stable balance where at the application level it usually reacts to events, but it was missing essential information. This PR:
- Moves `get_payment_with_conversion_details` to utils
- Adds `EventEmitter::get_emit_payment()` that re-fetches before emitting
- Replaces 6 duplicated fetch-then-emit call sites