### PR TITLE
get_lightning_address: wait for recovery

### DIFF
--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -393,22 +393,30 @@ impl ObjectCacheRepository {
         self.storage
             .set_cached_item(
                 LIGHTNING_ADDRESS_KEY.to_string(),
-                serde_json::to_string(value)?,
+                serde_json::to_string(&Some(value))?,
             )
             .await?;
         Ok(())
     }
 
+    /// Marks the lightning address as "recovered, no address registered" by storing `null`.
     pub(crate) async fn delete_lightning_address(&self) -> Result<(), StorageError> {
         self.storage
-            .delete_cached_item(LIGHTNING_ADDRESS_KEY.to_string())
+            .set_cached_item(
+                LIGHTNING_ADDRESS_KEY.to_string(),
+                serde_json::to_string(&None::<LightningAddressInfo>)?,
+            )
             .await?;
         Ok(())
     }
 
+    /// Returns:
+    /// - `Ok(None)` — key absent, never recovered
+    /// - `Ok(Some(None))` — recovered, no address registered
+    /// - `Ok(Some(Some(info)))` — recovered, has address
     pub(crate) async fn fetch_lightning_address(
         &self,
-    ) -> Result<Option<LightningAddressInfo>, StorageError> {
+    ) -> Result<Option<Option<LightningAddressInfo>>, StorageError> {
         let value = self
             .storage
             .get_cached_item(LIGHTNING_ADDRESS_KEY.to_string())

--- a/crates/breez-sdk/core/src/sdk/lightning_address.rs
+++ b/crates/breez-sdk/core/src/sdk/lightning_address.rs
@@ -27,7 +27,11 @@ impl BreezSdk {
 
     pub async fn get_lightning_address(&self) -> Result<Option<LightningAddressInfo>, SdkError> {
         let cache = ObjectCacheRepository::new(self.storage.clone());
-        Ok(cache.fetch_lightning_address().await?)
+        let cached = cache.fetch_lightning_address().await?;
+        if cached.is_none() && self.lnurl_server_client.is_some() {
+            return self.recover_lightning_address().await;
+        }
+        Ok(cached.flatten())
     }
 
     pub async fn register_lightning_address(
@@ -42,7 +46,7 @@ impl BreezSdk {
 
     pub async fn delete_lightning_address(&self) -> Result<(), SdkError> {
         let cache = ObjectCacheRepository::new(self.storage.clone());
-        let Some(address_info) = cache.fetch_lightning_address().await? else {
+        let Some(address_info) = cache.fetch_lightning_address().await?.flatten() else {
             return Ok(());
         };
 
@@ -130,5 +134,106 @@ impl BreezSdk {
         };
         cache.save_lightning_address(&address_info).await?;
         Ok(address_info)
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+mod tests {
+    use std::{path::PathBuf, sync::Arc};
+
+    use crate::{
+        LightningAddressInfo, LnurlInfo, persist::Storage, persist::sqlite::SqliteStorage,
+    };
+
+    use crate::persist::ObjectCacheRepository;
+
+    fn create_temp_dir(name: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!("breez-test-{}-{}", name, uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn create_temp_storage(name: &str) -> (Arc<SqliteStorage>, PathBuf) {
+        let dir = create_temp_dir(name);
+        let storage = SqliteStorage::new(&dir).expect("Failed to create storage");
+        (Arc::new(storage), dir)
+    }
+
+    fn sample_address_info() -> LightningAddressInfo {
+        LightningAddressInfo {
+            lightning_address: "test@example.com".to_string(),
+            username: "test".to_string(),
+            description: "Test address".to_string(),
+            lnurl: LnurlInfo::new("https://example.com/.well-known/lnurlp/test".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_returns_none_when_never_recovered() {
+        let (storage, _dir) = create_temp_storage("never_recovered");
+        let cache = ObjectCacheRepository::new(storage as Arc<_>);
+
+        // Key absent -> None (never recovered)
+        let result = cache.fetch_lightning_address().await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_returns_some_none_after_delete() {
+        let (storage, _dir) = create_temp_storage("after_delete");
+        let cache = ObjectCacheRepository::new(storage as Arc<_>);
+
+        // Save an address, then delete it
+        cache
+            .save_lightning_address(&sample_address_info())
+            .await
+            .unwrap();
+        cache.delete_lightning_address().await.unwrap();
+
+        // Key present, value null -> Some(None) (recovered, no address)
+        let result = cache.fetch_lightning_address().await.unwrap();
+        assert!(
+            matches!(result, Some(None)),
+            "Expected Some(None) after delete"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_returns_some_some_after_save() {
+        let (storage, _dir) = create_temp_storage("after_save");
+        let cache = ObjectCacheRepository::new(storage as Arc<_>);
+
+        cache
+            .save_lightning_address(&sample_address_info())
+            .await
+            .unwrap();
+
+        // Key present, value non-null -> Some(Some(info))
+        let result = cache.fetch_lightning_address().await.unwrap();
+        let info = result
+            .flatten()
+            .expect("Expected Some(Some(info)) after save");
+        assert_eq!(info.lightning_address, "test@example.com");
+    }
+
+    #[tokio::test]
+    async fn test_backward_compat_old_cached_json() {
+        let (storage, _dir) = create_temp_storage("backward_compat");
+
+        // Simulate old cache format: raw JSON object without Option wrapper
+        let old_value = serde_json::to_string(&sample_address_info()).unwrap();
+        storage
+            .set_cached_item("lightning_address".to_string(), old_value)
+            .await
+            .unwrap();
+
+        let cache = ObjectCacheRepository::new(storage as Arc<_>);
+        let result = cache.fetch_lightning_address().await.unwrap();
+        let info = result
+            .flatten()
+            .expect("Expected old cached JSON to deserialize as Some(info)");
+        assert_eq!(info.lightning_address, "test@example.com");
     }
 }


### PR DESCRIPTION
  - Sync the lightning address cache on startup so getLightningAddress returns the up-to-date address without requiring the caller to register first
  - If the background recovery hasn't run yet, getLightningAddress falls back to an inline network call
  - The cache now distinguishes "never recovered" (key absent) from "recovered, no address" (key present, value null), avoiding redundant network calls after a successful recovery that found no address