### PR TITLE
Poll for balance restoration in HTLC refund test

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
+++ b/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
@@ -301,14 +301,11 @@ async fn test_02_htlc_refund(
         && details.status == SparkHtlcStatus::Returned
     ));
 
-    // Verify Alice's balance went back to the initial balance
-    let alice_balance_after_refund = alice
-        .sdk
-        .get_info(GetInfoRequest {
-            ensure_synced: Some(false),
-        })
-        .await?
-        .balance_sats;
+    // Verify Alice's balance went back to the initial balance.
+    // The HTLC refund leaf transfer may not have fully settled yet,
+    // so poll until the balance is restored.
+    let alice_balance_after_refund =
+        wait_for_balance(&alice.sdk, Some(alice_balance), None, 30).await?;
     assert_eq!(alice_balance_after_refund, alice_balance);
 
     info!("=== Test test_02_htlc_refund PASSED ===");


### PR DESCRIPTION
## Summary
Updated the HTLC refund test to poll for balance restoration instead of performing a single synchronous check, accounting for delayed settlement of HTLC refund leaf transfers.

## Key Changes
- Replaced single `get_info()` call with `wait_for_balance()` polling function
- Added a 30-second timeout for balance restoration to complete
- Updated comment to clarify that the refund may not settle immediately
- Improved test reliability by handling asynchronous balance updates

## Implementation Details
The HTLC refund leaf transfer may not settle instantaneously, causing the balance check to fail if performed immediately. By polling with `wait_for_balance()`, the test now waits for the expected balance to be restored within a reasonable timeframe, making the test more robust and less flaky.

https://claude.ai/code/session_01XZUEuWDAxNjajgyLaX5FxC