### PR TITLE
build: upgrade rusqlite to v0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2735,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3978,9 +3978,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags 2.10.0",
  "fallible-iterator 0.3.0",
@@ -3992,9 +3992,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55709bc01054c69e2f1cefdc886642b5e6376a8db3c86f761be0c423eebf178b"
+checksum = "923b42e802f7dc20a0a6b5e097ba7c83fe4289da07e49156fecf6af08aa9cd1c"
 dependencies = [
  "log",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,8 +99,8 @@ reqwest = { version = "0.12.23", default-features = false, features = ["json", "
 rstest = "0.26.1"
 rstest_reuse = "0.7.0"
 # We want to match the rusqlite version used by ldk-node and the rest of the ecosystem
-rusqlite = { version = "0.31.0", features = ["backup", "bundled"] }
-rusqlite_migration = { version = "1.2.0" }
+rusqlite = { version = "0.32.1", features = ["backup", "bundled"] }
+rusqlite_migration = { version = "1.3.1" }
 rustls = { version = "0.23.28", default-features = false, features = ["ring"] }
 rustyline = "16.0.0"
 serde = "1.0.219"

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -2068,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2833,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -2847,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55709bc01054c69e2f1cefdc886642b5e6376a8db3c86f761be0c423eebf178b"
+checksum = "923b42e802f7dc20a0a6b5e097ba7c83fe4289da07e49156fecf6af08aa9cd1c"
 dependencies = [
  "log",
  "rusqlite",


### PR DESCRIPTION
- Bumps `rusqlite` from 0.31.0 to 0.32.1
- Bumps `rusqlite_migration` from 1.2.0 to 1.3.1 (required for rusqlite 0.32 compatibility)

### Motivation

`rusqlite 0.31.0` pulls in `libsqlite3-sys 0.28.0`. Since `libsqlite3-sys` uses `links = "sqlite3"`, Cargo enforces exactly one version of this crate in the final binary. This makes it impossible to compile any project that combines the Spark SDK with crates depending on a newer `libsqlite3-sys`, notably `sqlx-sqlite 0.8.x `(used by `sea-orm`) which requires `libsqlite3-sys ^0.30.1`.

Upgrading to `rusqlite 0.32.1` aligns on `libsqlite3-sys ^0.30.1`, resolving the conflict and allowing the Spark SDK to coexist with the broader Rust database ecosystem.

`sqlx-sqlite` next release `0.9.x` will allow cohabiting with any version between `v0.30, <v0.37` (See here: https://github.com/launchbadge/sqlx/pull/4161) so we will be able to upgrade `rusqlite` further `v0.38` once released.
Further proof that current supported version`libsqlite3-sys 0.28.0` is way too old and not supported by the Rust ecosystem anymore.

No API changes, the rusqlite surface used by the SDK is stable across `0.31→0.32`.