### PR TITLE
feat: add sync_lightning_address method for runtime updates

### DIFF
--- a/crates/breez-sdk/core/src/sdk/lightning_address.rs
+++ b/crates/breez-sdk/core/src/sdk/lightning_address.rs
@@ -34,6 +34,10 @@ impl BreezSdk {
         Ok(cached.flatten())
     }
 
+    pub async fn sync_lightning_address(&self) -> Result<Option<LightningAddressInfo>, SdkError> {
+        self.recover_lightning_address().await
+    }
+
     pub async fn register_lightning_address(
         &self,
         request: RegisterLightningAddressRequest,


### PR DESCRIPTION
Added a manual sync capability for lightning addresses that allows applications to force a server sync at runtime. This complements the existing get_lightning_address() which already auto-recovers on first use (when cache is empty).

->This provides manual sync capability but does not enable automatic/immediate cross-instance detection. 

Refers to the issue #648 .

