### PR TITLE
docs: mark llms-txt backends as optional

### DIFF
--- a/docs/breez-sdk/book.toml
+++ b/docs/breez-sdk/book.toml
@@ -28,6 +28,8 @@ api_key_form_uri = "https://breez.technology/request-api-key/#contact-us-form-sd
 
 # Basic llmstxt.org format output
 [output.llms-txt]
+optional = true
 
 # Detailed llmstxt.org format output with additional information
 [output.llms-txt-full]
+optional = true


### PR DESCRIPTION
## Summary
- Adds `optional = true` to both `[output.llms-txt]` and `[output.llms-txt-full]` in `book.toml`
- This allows `mdbook build` to succeed without `mdbook-llms-txt-tools` installed
- When the plugin **is** installed (`cargo install mdbook-llms-txt-tools`), it generates [llmstxt.org](https://llmstxt.org/) format output (`llms.txt` and `llms-full.txt`)

## Test plan
- [ ] `mdbook build` succeeds without `mdbook-llms-txt-tools` installed
- [ ] With `cargo install mdbook-llms-txt-tools`, `mdbook build` generates `book/llms-txt/llms.txt` and `book/llms-txt-full/llms-full.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)