### PR TITLE
Fix LnurlInfo migration issue

### DIFF
--- a/crates/breez-sdk/core/src/persist/postgres.rs
+++ b/crates/breez-sdk/core/src/persist/postgres.rs
@@ -728,6 +728,10 @@ impl PostgresStorage {
                 // This ensures clients get the new preimage field from the server
                 "DELETE FROM settings WHERE key = 'lnurl_metadata_updated_after'",
             ],
+            // Migration 9: Clear cached lightning address - schema changed from string to LnurlInfo struct
+            &[
+                "DELETE FROM settings WHERE key = 'lightning_address'",
+            ],
         ]
     }
 }

--- a/crates/breez-sdk/core/src/persist/sqlite.rs
+++ b/crates/breez-sdk/core/src/persist/sqlite.rs
@@ -309,6 +309,8 @@ impl SqliteStorage {
             // Clear the lnurl_metadata_updated_after setting to force re-sync
             // This ensures clients get the new preimage field from the server
             "DELETE FROM settings WHERE key = 'lnurl_metadata_updated_after';",
+            // Clear cached lightning address - schema changed from string to LnurlInfo struct
+            "DELETE FROM settings WHERE key = 'lightning_address';",
         ]
     }
 }

--- a/crates/breez-sdk/wasm/js/node-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/node-storage/migrations.cjs
@@ -374,6 +374,10 @@ class MigrationManager {
            WHERE key = 'sync_offset' AND json_valid(value)`,
         ]
       },
+      {
+        name: "Clear cached lightning address for LnurlInfo schema change",
+        sql: `DELETE FROM settings WHERE key = 'lightning_address'`
+      },
     ];
   }
 }

--- a/crates/breez-sdk/wasm/js/web-storage/index.js
+++ b/crates/breez-sdk/wasm/js/web-storage/index.js
@@ -408,7 +408,16 @@ class MigrationManager {
             };
           }
         },
-      }
+      },
+      {
+        name: "Clear cached lightning address for LnurlInfo schema change",
+        upgrade: (db, transaction) => {
+          if (db.objectStoreNames.contains("settings")) {
+            const settings = transaction.objectStore("settings");
+            settings.delete("lightning_address");
+          }
+        }
+      },
     ];
   }
 }
@@ -432,7 +441,7 @@ class IndexedDBStorage {
     this.db = null;
     this.migrationManager = null;
     this.logger = logger;
-    this.dbVersion = 12; // Current schema version
+    this.dbVersion = 13; // Current schema version
   }
 
   /**


### PR DESCRIPTION
Fixes migration issue where LightningAddressInfo's `lnurl` changed from String to `LnurlInfo`struct
- Adds database migrations to clear cached `lightning_address` setting across all storage implementations (SQLite, PostgreSQL, IndexedDB, Node.js SQLite)
- On cache miss, SDK re-fetches from server and stores in new format