### PR TITLE
core: use `BreezSdk` as facade and forward to `SdkServices`

### DIFF
--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -16,46 +16,93 @@ use crate::{
     utils::token::get_tokens_metadata_cached_or_query,
 };
 
-use super::{BreezSdk, helpers::get_or_create_deposit_address, parse_input};
+use super::{
+    BreezSdk, SdkServices, helpers::get_or_create_deposit_address,
+    lightning_address::LightningAddressService, parse_input,
+};
 
-#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
-#[allow(clippy::needless_pass_by_value)]
-impl BreezSdk {
+/// Trait defining the core API methods of the SDK.
+#[macros::async_trait]
+pub(crate) trait ApiService {
     /// Registers a listener to receive SDK events
-    ///
-    /// # Arguments
-    ///
-    /// * `listener` - An implementation of the `EventListener` trait
-    ///
-    /// # Returns
-    ///
-    /// A unique identifier for the listener, which can be used to remove it later
-    pub async fn add_event_listener(&self, listener: Box<dyn EventListener>) -> String {
+    async fn add_event_listener(&self, listener: Box<dyn EventListener>) -> String;
+
+    /// Removes a previously registered event listener
+    async fn remove_event_listener(&self, id: &str) -> bool;
+
+    /// Stops the SDK's background tasks
+    async fn disconnect(&self) -> Result<(), SdkError>;
+
+    /// Parses an input string into an `InputType`
+    async fn parse(&self, input: &str) -> Result<InputType, SdkError>;
+
+    /// Returns the balance of the wallet in satoshis
+    async fn get_info(&self, request: GetInfoRequest) -> Result<GetInfoResponse, SdkError>;
+
+    /// List fiat currencies for which there is a known exchange rate
+    async fn list_fiat_currencies(&self) -> Result<ListFiatCurrenciesResponse, SdkError>;
+
+    /// List the latest rates of fiat currencies
+    async fn list_fiat_rates(&self) -> Result<ListFiatRatesResponse, SdkError>;
+
+    /// Get the recommended BTC fees
+    async fn recommended_fees(&self) -> Result<RecommendedFees, SdkError>;
+
+    /// Returns the metadata for the given token identifiers
+    async fn get_tokens_metadata(
+        &self,
+        request: GetTokensMetadataRequest,
+    ) -> Result<GetTokensMetadataResponse, SdkError>;
+
+    /// Signs a message with the wallet's identity key
+    async fn sign_message(
+        &self,
+        request: SignMessageRequest,
+    ) -> Result<SignMessageResponse, SdkError>;
+
+    /// Verifies a message signature against the provided public key
+    async fn check_message(
+        &self,
+        request: CheckMessageRequest,
+    ) -> Result<CheckMessageResponse, SdkError>;
+
+    /// Returns the user settings for the wallet
+    async fn get_user_settings(&self) -> Result<UserSettings, SdkError>;
+
+    /// Updates the user settings for the wallet
+    async fn update_user_settings(
+        &self,
+        request: UpdateUserSettingsRequest,
+    ) -> Result<(), SdkError>;
+
+    /// Returns an instance of the `TokenIssuer` for managing token issuance
+    fn get_token_issuer(&self) -> TokenIssuer;
+
+    /// Starts leaf optimization in the background
+    fn start_leaf_optimization(&self);
+
+    /// Cancels the ongoing leaf optimization
+    async fn cancel_leaf_optimization(&self) -> Result<(), SdkError>;
+
+    /// Returns the current optimization progress snapshot
+    fn get_leaf_optimization_progress(&self) -> OptimizationProgress;
+
+    /// Initiates a Bitcoin purchase flow via an external provider
+    async fn buy_bitcoin(&self, request: BuyBitcoinRequest)
+    -> Result<BuyBitcoinResponse, SdkError>;
+}
+
+#[macros::async_trait]
+impl ApiService for SdkServices {
+    async fn add_event_listener(&self, listener: Box<dyn EventListener>) -> String {
         self.event_emitter.add_listener(listener).await
     }
 
-    /// Removes a previously registered event listener
-    ///
-    /// # Arguments
-    ///
-    /// * `id` - The listener ID returned from `add_event_listener`
-    ///
-    /// # Returns
-    ///
-    /// `true` if the listener was found and removed, `false` otherwise
-    pub async fn remove_event_listener(&self, id: &str) -> bool {
+    async fn remove_event_listener(&self, id: &str) -> bool {
         self.event_emitter.remove_listener(id).await
     }
 
-    /// Stops the SDK's background tasks
-    ///
-    /// This method stops the background tasks started by the `start()` method.
-    /// It should be called before your application terminates to ensure proper cleanup.
-    ///
-    /// # Returns
-    ///
-    /// Result containing either success or an `SdkError` if the background task couldn't be stopped
-    pub async fn disconnect(&self) -> Result<(), SdkError> {
+    async fn disconnect(&self) -> Result<(), SdkError> {
         info!("Disconnecting Breez SDK");
         self.shutdown_sender
             .send(())
@@ -66,13 +113,12 @@ impl BreezSdk {
         Ok(())
     }
 
-    pub async fn parse(&self, input: &str) -> Result<InputType, SdkError> {
+    async fn parse(&self, input: &str) -> Result<InputType, SdkError> {
         parse_input(input, Some(self.external_input_parsers.clone())).await
     }
 
-    /// Returns the balance of the wallet in satoshis
     #[allow(unused_variables)]
-    pub async fn get_info(&self, request: GetInfoRequest) -> Result<GetInfoResponse, SdkError> {
+    async fn get_info(&self, request: GetInfoRequest) -> Result<GetInfoResponse, SdkError> {
         if request.ensure_synced.unwrap_or_default() {
             self.initial_synced_watcher
                 .clone()
@@ -94,9 +140,7 @@ impl BreezSdk {
         })
     }
 
-    /// List fiat currencies for which there is a known exchange rate,
-    /// sorted by the canonical name of the currency.
-    pub async fn list_fiat_currencies(&self) -> Result<ListFiatCurrenciesResponse, SdkError> {
+    async fn list_fiat_currencies(&self) -> Result<ListFiatCurrenciesResponse, SdkError> {
         let currencies = self
             .fiat_service
             .fetch_fiat_currencies()
@@ -107,8 +151,7 @@ impl BreezSdk {
         Ok(ListFiatCurrenciesResponse { currencies })
     }
 
-    /// List the latest rates of fiat currencies, sorted by name.
-    pub async fn list_fiat_rates(&self) -> Result<ListFiatRatesResponse, SdkError> {
+    async fn list_fiat_rates(&self) -> Result<ListFiatRatesResponse, SdkError> {
         let rates = self
             .fiat_service
             .fetch_fiat_rates()
@@ -119,18 +162,11 @@ impl BreezSdk {
         Ok(ListFiatRatesResponse { rates })
     }
 
-    /// Get the recommended BTC fees based on the configured chain service.
-    pub async fn recommended_fees(&self) -> Result<RecommendedFees, SdkError> {
+    async fn recommended_fees(&self) -> Result<RecommendedFees, SdkError> {
         Ok(self.chain_service.recommended_fees().await?)
     }
 
-    /// Returns the metadata for the given token identifiers.
-    ///
-    /// Results are not guaranteed to be in the same order as the input token identifiers.
-    ///
-    /// If the metadata is not found locally in cache, it will be queried from
-    /// the Spark network and then cached.
-    pub async fn get_tokens_metadata(
+    async fn get_tokens_metadata(
         &self,
         request: GetTokensMetadataRequest,
     ) -> Result<GetTokensMetadataResponse, SdkError> {
@@ -149,10 +185,7 @@ impl BreezSdk {
         })
     }
 
-    /// Signs a message with the wallet's identity key. The message is SHA256
-    /// hashed before signing. The returned signature will be hex encoded in
-    /// DER format by default, or compact format if specified.
-    pub async fn sign_message(
+    async fn sign_message(
         &self,
         request: SignMessageRequest,
     ) -> Result<SignMessageResponse, SdkError> {
@@ -172,10 +205,7 @@ impl BreezSdk {
         })
     }
 
-    /// Verifies a message signature against the provided public key. The message
-    /// is SHA256 hashed before verification. The signature can be hex encoded
-    /// in either DER or compact format.
-    pub async fn check_message(
+    async fn check_message(
         &self,
         request: CheckMessageRequest,
     ) -> Result<CheckMessageResponse, SdkError> {
@@ -197,10 +227,7 @@ impl BreezSdk {
         Ok(CheckMessageResponse { is_valid })
     }
 
-    /// Returns the user settings for the wallet.
-    ///
-    /// Some settings are fetched from the Spark network so network requests are performed.
-    pub async fn get_user_settings(&self) -> Result<UserSettings, SdkError> {
+    async fn get_user_settings(&self) -> Result<UserSettings, SdkError> {
         // Ensure spark private mode is initialized to avoid race conditions with the initialization task.
         self.ensure_spark_private_mode_initialized().await?;
 
@@ -213,10 +240,7 @@ impl BreezSdk {
         })
     }
 
-    /// Updates the user settings for the wallet.
-    ///
-    /// Some settings are updated on the Spark network so network requests may be performed.
-    pub async fn update_user_settings(
+    async fn update_user_settings(
         &self,
         request: UpdateUserSettingsRequest,
     ) -> Result<(), SdkError> {
@@ -249,9 +273,249 @@ impl BreezSdk {
         Ok(())
     }
 
+    fn get_token_issuer(&self) -> TokenIssuer {
+        TokenIssuer::new(self.spark_wallet.clone(), self.storage.clone())
+    }
+
+    fn start_leaf_optimization(&self) {
+        self.spark_wallet.start_leaf_optimization();
+    }
+
+    async fn cancel_leaf_optimization(&self) -> Result<(), SdkError> {
+        self.spark_wallet.cancel_leaf_optimization().await?;
+        Ok(())
+    }
+
+    fn get_leaf_optimization_progress(&self) -> OptimizationProgress {
+        self.spark_wallet.get_leaf_optimization_progress().into()
+    }
+
+    async fn buy_bitcoin(
+        &self,
+        request: BuyBitcoinRequest,
+    ) -> Result<BuyBitcoinResponse, SdkError> {
+        let address =
+            get_or_create_deposit_address(&self.spark_wallet, self.storage.clone(), true).await?;
+
+        let url = self
+            .buy_bitcoin_provider
+            .buy_bitcoin(address, request.locked_amount_sat, request.redirect_url)
+            .await
+            .map_err(|e| SdkError::Generic(format!("Failed to create buy bitcoin URL: {e}")))?;
+
+        Ok(BuyBitcoinResponse { url })
+    }
+}
+
+#[macros::async_trait]
+impl ApiService for BreezSdk {
+    async fn add_event_listener(&self, listener: Box<dyn EventListener>) -> String {
+        self.services.add_event_listener(listener).await
+    }
+
+    async fn remove_event_listener(&self, id: &str) -> bool {
+        self.services.remove_event_listener(id).await
+    }
+
+    async fn disconnect(&self) -> Result<(), SdkError> {
+        self.services.disconnect().await
+    }
+
+    async fn parse(&self, input: &str) -> Result<InputType, SdkError> {
+        self.services.parse(input).await
+    }
+
+    async fn get_info(&self, request: GetInfoRequest) -> Result<GetInfoResponse, SdkError> {
+        self.services.get_info(request).await
+    }
+
+    async fn list_fiat_currencies(&self) -> Result<ListFiatCurrenciesResponse, SdkError> {
+        self.services.list_fiat_currencies().await
+    }
+
+    async fn list_fiat_rates(&self) -> Result<ListFiatRatesResponse, SdkError> {
+        self.services.list_fiat_rates().await
+    }
+
+    async fn recommended_fees(&self) -> Result<RecommendedFees, SdkError> {
+        self.services.recommended_fees().await
+    }
+
+    async fn get_tokens_metadata(
+        &self,
+        request: GetTokensMetadataRequest,
+    ) -> Result<GetTokensMetadataResponse, SdkError> {
+        self.services.get_tokens_metadata(request).await
+    }
+
+    async fn sign_message(
+        &self,
+        request: SignMessageRequest,
+    ) -> Result<SignMessageResponse, SdkError> {
+        self.services.sign_message(request).await
+    }
+
+    async fn check_message(
+        &self,
+        request: CheckMessageRequest,
+    ) -> Result<CheckMessageResponse, SdkError> {
+        self.services.check_message(request).await
+    }
+
+    async fn get_user_settings(&self) -> Result<UserSettings, SdkError> {
+        self.services.get_user_settings().await
+    }
+
+    async fn update_user_settings(
+        &self,
+        request: UpdateUserSettingsRequest,
+    ) -> Result<(), SdkError> {
+        self.services.update_user_settings(request).await
+    }
+
+    fn get_token_issuer(&self) -> TokenIssuer {
+        self.services.get_token_issuer()
+    }
+
+    fn start_leaf_optimization(&self) {
+        self.services.start_leaf_optimization();
+    }
+
+    async fn cancel_leaf_optimization(&self) -> Result<(), SdkError> {
+        self.services.cancel_leaf_optimization().await
+    }
+
+    fn get_leaf_optimization_progress(&self) -> OptimizationProgress {
+        self.services.get_leaf_optimization_progress()
+    }
+
+    async fn buy_bitcoin(
+        &self,
+        request: BuyBitcoinRequest,
+    ) -> Result<BuyBitcoinResponse, SdkError> {
+        self.services.buy_bitcoin(request).await
+    }
+}
+
+#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+#[allow(clippy::needless_pass_by_value)]
+impl BreezSdk {
+    /// Registers a listener to receive SDK events
+    ///
+    /// # Arguments
+    ///
+    /// * `listener` - An implementation of the `EventListener` trait
+    ///
+    /// # Returns
+    ///
+    /// A unique identifier for the listener, which can be used to remove it later
+    pub async fn add_event_listener(&self, listener: Box<dyn EventListener>) -> String {
+        ApiService::add_event_listener(self, listener).await
+    }
+
+    /// Removes a previously registered event listener
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The listener ID returned from `add_event_listener`
+    ///
+    /// # Returns
+    ///
+    /// `true` if the listener was found and removed, `false` otherwise
+    pub async fn remove_event_listener(&self, id: &str) -> bool {
+        ApiService::remove_event_listener(self, id).await
+    }
+
+    /// Stops the SDK's background tasks
+    ///
+    /// This method stops the background tasks started by the `start()` method.
+    /// It should be called before your application terminates to ensure proper cleanup.
+    ///
+    /// # Returns
+    ///
+    /// Result containing either success or an `SdkError` if the background task couldn't be stopped
+    pub async fn disconnect(&self) -> Result<(), SdkError> {
+        ApiService::disconnect(self).await
+    }
+
+    pub async fn parse(&self, input: &str) -> Result<InputType, SdkError> {
+        ApiService::parse(self, input).await
+    }
+
+    /// Returns the balance of the wallet in satoshis
+    pub async fn get_info(&self, request: GetInfoRequest) -> Result<GetInfoResponse, SdkError> {
+        ApiService::get_info(self, request).await
+    }
+
+    /// List fiat currencies for which there is a known exchange rate,
+    /// sorted by the canonical name of the currency.
+    pub async fn list_fiat_currencies(&self) -> Result<ListFiatCurrenciesResponse, SdkError> {
+        ApiService::list_fiat_currencies(self).await
+    }
+
+    /// List the latest rates of fiat currencies, sorted by name.
+    pub async fn list_fiat_rates(&self) -> Result<ListFiatRatesResponse, SdkError> {
+        ApiService::list_fiat_rates(self).await
+    }
+
+    /// Get the recommended BTC fees based on the configured chain service.
+    pub async fn recommended_fees(&self) -> Result<RecommendedFees, SdkError> {
+        ApiService::recommended_fees(self).await
+    }
+
+    /// Returns the metadata for the given token identifiers.
+    ///
+    /// Results are not guaranteed to be in the same order as the input token identifiers.
+    ///
+    /// If the metadata is not found locally in cache, it will be queried from
+    /// the Spark network and then cached.
+    pub async fn get_tokens_metadata(
+        &self,
+        request: GetTokensMetadataRequest,
+    ) -> Result<GetTokensMetadataResponse, SdkError> {
+        ApiService::get_tokens_metadata(self, request).await
+    }
+
+    /// Signs a message with the wallet's identity key. The message is SHA256
+    /// hashed before signing. The returned signature will be hex encoded in
+    /// DER format by default, or compact format if specified.
+    pub async fn sign_message(
+        &self,
+        request: SignMessageRequest,
+    ) -> Result<SignMessageResponse, SdkError> {
+        ApiService::sign_message(self, request).await
+    }
+
+    /// Verifies a message signature against the provided public key. The message
+    /// is SHA256 hashed before verification. The signature can be hex encoded
+    /// in either DER or compact format.
+    pub async fn check_message(
+        &self,
+        request: CheckMessageRequest,
+    ) -> Result<CheckMessageResponse, SdkError> {
+        ApiService::check_message(self, request).await
+    }
+
+    /// Returns the user settings for the wallet.
+    ///
+    /// Some settings are fetched from the Spark network so network requests are performed.
+    pub async fn get_user_settings(&self) -> Result<UserSettings, SdkError> {
+        ApiService::get_user_settings(self).await
+    }
+
+    /// Updates the user settings for the wallet.
+    ///
+    /// Some settings are updated on the Spark network so network requests may be performed.
+    pub async fn update_user_settings(
+        &self,
+        request: UpdateUserSettingsRequest,
+    ) -> Result<(), SdkError> {
+        ApiService::update_user_settings(self, request).await
+    }
+
     /// Returns an instance of the [`TokenIssuer`] for managing token issuance.
     pub fn get_token_issuer(&self) -> TokenIssuer {
-        TokenIssuer::new(self.spark_wallet.clone(), self.storage.clone())
+        ApiService::get_token_issuer(self)
     }
 
     /// Starts leaf optimization in the background.
@@ -260,7 +524,7 @@ impl BreezSdk {
     /// immediately. Progress is reported via events.
     /// If optimization is already running, no new task will be started.
     pub fn start_leaf_optimization(&self) {
-        self.spark_wallet.start_leaf_optimization();
+        ApiService::start_leaf_optimization(self);
     }
 
     /// Cancels the ongoing leaf optimization.
@@ -272,13 +536,12 @@ impl BreezSdk {
     ///
     /// If no optimization is running, this method returns immediately.
     pub async fn cancel_leaf_optimization(&self) -> Result<(), SdkError> {
-        self.spark_wallet.cancel_leaf_optimization().await?;
-        Ok(())
+        ApiService::cancel_leaf_optimization(self).await
     }
 
     /// Returns the current optimization progress snapshot.
     pub fn get_leaf_optimization_progress(&self) -> OptimizationProgress {
-        self.spark_wallet.get_leaf_optimization_progress().into()
+        ApiService::get_leaf_optimization_progress(self)
     }
 
     /// Initiates a Bitcoin purchase flow via an external provider (`MoonPay`).
@@ -298,15 +561,6 @@ impl BreezSdk {
         &self,
         request: BuyBitcoinRequest,
     ) -> Result<BuyBitcoinResponse, SdkError> {
-        let address =
-            get_or_create_deposit_address(&self.spark_wallet, self.storage.clone(), true).await?;
-
-        let url = self
-            .buy_bitcoin_provider
-            .buy_bitcoin(address, request.locked_amount_sat, request.redirect_url)
-            .await
-            .map_err(|e| SdkError::Generic(format!("Failed to create buy bitcoin URL: {e}")))?;
-
-        Ok(BuyBitcoinResponse { url })
+        ApiService::buy_bitcoin(self, request).await
     }
 }

--- a/crates/breez-sdk/core/src/sdk/deposits.rs
+++ b/crates/breez-sdk/core/src/sdk/deposits.rs
@@ -7,12 +7,33 @@ use crate::{
     persist::UpdateDepositPayload, utils::utxo_fetcher::CachedUtxoFetcher,
 };
 
-use super::{BreezSdk, SyncType};
+use super::{BreezSdk, SdkServices, SyncType};
 
-#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
-#[allow(clippy::needless_pass_by_value)]
-impl BreezSdk {
-    pub async fn claim_deposit(
+/// Trait defining deposit-related operations.
+#[macros::async_trait]
+pub(crate) trait DepositsService {
+    /// Claims a deposit from a specific UTXO
+    async fn claim_deposit(
+        &self,
+        request: ClaimDepositRequest,
+    ) -> Result<ClaimDepositResponse, SdkError>;
+
+    /// Refunds a deposit to a specified address
+    async fn refund_deposit(
+        &self,
+        request: RefundDepositRequest,
+    ) -> Result<RefundDepositResponse, SdkError>;
+
+    /// Lists all unclaimed deposits
+    async fn list_unclaimed_deposits(
+        &self,
+        request: ListUnclaimedDepositsRequest,
+    ) -> Result<ListUnclaimedDepositsResponse, SdkError>;
+}
+
+#[macros::async_trait]
+impl DepositsService for SdkServices {
+    async fn claim_deposit(
         &self,
         request: ClaimDepositRequest,
     ) -> Result<ClaimDepositResponse, SdkError> {
@@ -53,7 +74,7 @@ impl BreezSdk {
         }
     }
 
-    pub async fn refund_deposit(
+    async fn refund_deposit(
         &self,
         request: RefundDepositRequest,
     ) -> Result<RefundDepositResponse, SdkError> {
@@ -93,11 +114,60 @@ impl BreezSdk {
     }
 
     #[allow(unused_variables)]
-    pub async fn list_unclaimed_deposits(
+    async fn list_unclaimed_deposits(
         &self,
         request: ListUnclaimedDepositsRequest,
     ) -> Result<ListUnclaimedDepositsResponse, SdkError> {
         let deposits = self.storage.list_deposits().await?;
         Ok(ListUnclaimedDepositsResponse { deposits })
+    }
+}
+
+#[macros::async_trait]
+impl DepositsService for BreezSdk {
+    async fn claim_deposit(
+        &self,
+        request: ClaimDepositRequest,
+    ) -> Result<ClaimDepositResponse, SdkError> {
+        self.services.claim_deposit(request).await
+    }
+
+    async fn refund_deposit(
+        &self,
+        request: RefundDepositRequest,
+    ) -> Result<RefundDepositResponse, SdkError> {
+        self.services.refund_deposit(request).await
+    }
+
+    async fn list_unclaimed_deposits(
+        &self,
+        request: ListUnclaimedDepositsRequest,
+    ) -> Result<ListUnclaimedDepositsResponse, SdkError> {
+        self.services.list_unclaimed_deposits(request).await
+    }
+}
+
+#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+#[allow(clippy::needless_pass_by_value)]
+impl BreezSdk {
+    pub async fn claim_deposit(
+        &self,
+        request: ClaimDepositRequest,
+    ) -> Result<ClaimDepositResponse, SdkError> {
+        DepositsService::claim_deposit(self, request).await
+    }
+
+    pub async fn refund_deposit(
+        &self,
+        request: RefundDepositRequest,
+    ) -> Result<RefundDepositResponse, SdkError> {
+        DepositsService::refund_deposit(self, request).await
+    }
+
+    pub async fn list_unclaimed_deposits(
+        &self,
+        request: ListUnclaimedDepositsRequest,
+    ) -> Result<ListUnclaimedDepositsResponse, SdkError> {
+        DepositsService::list_unclaimed_deposits(self, request).await
     }
 }

--- a/crates/breez-sdk/core/src/sdk/init.rs
+++ b/crates/breez-sdk/core/src/sdk/init.rs
@@ -15,11 +15,14 @@ use crate::{
     },
 };
 
-use super::{BreezSdk, BreezSdkParams, SyncCoordinator, helpers::validate_breez_api_key};
+use super::{
+    BreezSdk, BreezSdkParams, SdkServices, SyncCoordinator, api::ApiService,
+    helpers::validate_breez_api_key, lightning_address::LightningAddressService,
+};
 
-impl BreezSdk {
-    /// Creates a new instance of the `BreezSdk`
-    pub(crate) fn init_and_start(params: BreezSdkParams) -> Result<Self, SdkError> {
+impl SdkServices {
+    /// Creates a new instance of the `SdkServices`
+    pub(crate) fn init_and_start(params: BreezSdkParams) -> Result<Arc<Self>, SdkError> {
         // In Regtest we allow running without a Breez API key to facilitate local
         // integration tests. For non-regtest networks, a valid API key is required.
         if !matches!(params.config.network, Network::Regtest) {
@@ -62,7 +65,7 @@ impl BreezSdk {
         });
         let sync_coordinator = SyncCoordinator::new();
 
-        let sdk = Self {
+        let services = Arc::new(Self {
             config: params.config,
             spark_wallet: params.spark_wallet,
             storage: params.storage,
@@ -81,10 +84,10 @@ impl BreezSdk {
             token_converter,
             stable_balance,
             buy_bitcoin_provider: params.buy_bitcoin_provider,
-        };
+        });
 
-        sdk.start(initial_synced_sender);
-        Ok(sdk)
+        services.start(initial_synced_sender);
+        Ok(services)
     }
 
     /// Starts the SDK's background tasks
@@ -94,19 +97,19 @@ impl BreezSdk {
     /// 2. `periodic_sync`: syncs the wallet with the Spark network
     /// 3. `try_recover_lightning_address`: recovers the lightning address on startup
     /// 4. `spawn_lnurl_preimage_publisher`: publishes lnurl preimages for completed payments
-    pub(super) fn start(&self, initial_synced_sender: watch::Sender<bool>) {
+    pub(super) fn start(self: &Arc<Self>, initial_synced_sender: watch::Sender<bool>) {
         self.spawn_spark_private_mode_initialization();
         self.periodic_sync(initial_synced_sender);
         self.try_recover_lightning_address();
         self.spawn_lnurl_preimage_publisher();
     }
 
-    fn spawn_spark_private_mode_initialization(&self) {
-        let sdk = self.clone();
+    fn spawn_spark_private_mode_initialization(self: &Arc<Self>) {
+        let services = Arc::clone(self);
         let span = tracing::Span::current();
         tokio::spawn(
             async move {
-                if let Err(e) = sdk.ensure_spark_private_mode_initialized().await {
+                if let Err(e) = services.ensure_spark_private_mode_initialized().await {
                     error!("Failed to initialize spark private mode: {e:?}");
                 }
             }
@@ -115,15 +118,15 @@ impl BreezSdk {
     }
 
     /// Refreshes the user's lightning address on the server on startup.
-    fn try_recover_lightning_address(&self) {
-        let sdk = self.clone();
+    fn try_recover_lightning_address(self: &Arc<Self>) {
+        let services = Arc::clone(self);
         let span = tracing::Span::current();
         tokio::spawn(async move {
-            if sdk.config.lnurl_domain.is_none() {
+            if services.config.lnurl_domain.is_none() {
                 return;
             }
 
-            match sdk.recover_lightning_address().await {
+            match services.recover_lightning_address().await {
                 Ok(None) => info!("no lightning address to recover on startup"),
                 Ok(Some(value)) => info!(
                     "recovered lightning address on startup: address: {}, lnurl url: {}, lnurl bech32: {}",
@@ -172,5 +175,13 @@ impl BreezSdk {
             .await?;
         info!("Spark private mode initialized: enabled");
         Ok(())
+    }
+}
+
+impl BreezSdk {
+    /// Creates a new instance of the `BreezSdk`
+    pub(crate) fn init_and_start(params: BreezSdkParams) -> Result<Self, SdkError> {
+        let services = SdkServices::init_and_start(params)?;
+        Ok(Self { services })
     }
 }

--- a/crates/breez-sdk/core/src/sdk/lightning_address.rs
+++ b/crates/breez-sdk/core/src/sdk/lightning_address.rs
@@ -5,12 +5,42 @@ use crate::{
     error::SdkError, persist::ObjectCacheRepository,
 };
 
-use super::BreezSdk;
+use super::{BreezSdk, SdkServices};
 
-#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
-#[allow(clippy::needless_pass_by_value)]
-impl BreezSdk {
-    pub async fn check_lightning_address_available(
+/// Trait defining lightning address operations.
+#[macros::async_trait]
+pub(crate) trait LightningAddressService {
+    /// Checks if a lightning address username is available
+    async fn check_lightning_address_available(
+        &self,
+        req: CheckLightningAddressRequest,
+    ) -> Result<bool, SdkError>;
+
+    /// Gets the current lightning address info, if any
+    async fn get_lightning_address(&self) -> Result<Option<LightningAddressInfo>, SdkError>;
+
+    /// Registers a new lightning address
+    async fn register_lightning_address(
+        &self,
+        request: RegisterLightningAddressRequest,
+    ) -> Result<LightningAddressInfo, SdkError>;
+
+    /// Deletes the lightning address
+    async fn delete_lightning_address(&self) -> Result<(), SdkError>;
+
+    /// Recovers a lightning address from the server (internal use)
+    async fn recover_lightning_address(&self) -> Result<Option<LightningAddressInfo>, SdkError>;
+
+    /// Registers a lightning address (internal use, skips spark private mode check)
+    async fn register_lightning_address_internal(
+        &self,
+        request: RegisterLightningAddressRequest,
+    ) -> Result<LightningAddressInfo, SdkError>;
+}
+
+#[macros::async_trait]
+impl LightningAddressService for SdkServices {
+    async fn check_lightning_address_available(
         &self,
         req: CheckLightningAddressRequest,
     ) -> Result<bool, SdkError> {
@@ -25,7 +55,7 @@ impl BreezSdk {
         Ok(available)
     }
 
-    pub async fn get_lightning_address(&self) -> Result<Option<LightningAddressInfo>, SdkError> {
+    async fn get_lightning_address(&self) -> Result<Option<LightningAddressInfo>, SdkError> {
         let cache = ObjectCacheRepository::new(self.storage.clone());
         let cached = cache.fetch_lightning_address().await?;
         if cached.is_none() && self.lnurl_server_client.is_some() {
@@ -34,7 +64,7 @@ impl BreezSdk {
         Ok(cached.flatten())
     }
 
-    pub async fn register_lightning_address(
+    async fn register_lightning_address(
         &self,
         request: RegisterLightningAddressRequest,
     ) -> Result<LightningAddressInfo, SdkError> {
@@ -44,7 +74,7 @@ impl BreezSdk {
         self.register_lightning_address_internal(request).await
     }
 
-    pub async fn delete_lightning_address(&self) -> Result<(), SdkError> {
+    async fn delete_lightning_address(&self) -> Result<(), SdkError> {
         let cache = ObjectCacheRepository::new(self.storage.clone());
         let Some(address_info) = cache.fetch_lightning_address().await?.flatten() else {
             return Ok(());
@@ -64,14 +94,8 @@ impl BreezSdk {
         cache.delete_lightning_address().await?;
         Ok(())
     }
-}
 
-// Private lightning address methods
-impl BreezSdk {
-    /// Attempts to recover a lightning address from the lnurl server.
-    pub(super) async fn recover_lightning_address(
-        &self,
-    ) -> Result<Option<LightningAddressInfo>, SdkError> {
+    async fn recover_lightning_address(&self) -> Result<Option<LightningAddressInfo>, SdkError> {
         let cache = ObjectCacheRepository::new(self.storage.clone());
 
         let Some(client) = &self.lnurl_server_client else {
@@ -93,7 +117,7 @@ impl BreezSdk {
         Ok(result)
     }
 
-    pub(super) async fn register_lightning_address_internal(
+    async fn register_lightning_address_internal(
         &self,
         request: RegisterLightningAddressRequest,
     ) -> Result<LightningAddressInfo, SdkError> {
@@ -126,6 +150,70 @@ impl BreezSdk {
         };
         cache.save_lightning_address(&address_info).await?;
         Ok(address_info)
+    }
+}
+
+#[macros::async_trait]
+impl LightningAddressService for BreezSdk {
+    async fn check_lightning_address_available(
+        &self,
+        req: CheckLightningAddressRequest,
+    ) -> Result<bool, SdkError> {
+        self.services.check_lightning_address_available(req).await
+    }
+
+    async fn get_lightning_address(&self) -> Result<Option<LightningAddressInfo>, SdkError> {
+        self.services.get_lightning_address().await
+    }
+
+    async fn register_lightning_address(
+        &self,
+        request: RegisterLightningAddressRequest,
+    ) -> Result<LightningAddressInfo, SdkError> {
+        self.services.register_lightning_address(request).await
+    }
+
+    async fn delete_lightning_address(&self) -> Result<(), SdkError> {
+        self.services.delete_lightning_address().await
+    }
+
+    async fn recover_lightning_address(&self) -> Result<Option<LightningAddressInfo>, SdkError> {
+        self.services.recover_lightning_address().await
+    }
+
+    async fn register_lightning_address_internal(
+        &self,
+        request: RegisterLightningAddressRequest,
+    ) -> Result<LightningAddressInfo, SdkError> {
+        self.services
+            .register_lightning_address_internal(request)
+            .await
+    }
+}
+
+#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+#[allow(clippy::needless_pass_by_value)]
+impl BreezSdk {
+    pub async fn check_lightning_address_available(
+        &self,
+        req: CheckLightningAddressRequest,
+    ) -> Result<bool, SdkError> {
+        LightningAddressService::check_lightning_address_available(self, req).await
+    }
+
+    pub async fn get_lightning_address(&self) -> Result<Option<LightningAddressInfo>, SdkError> {
+        LightningAddressService::get_lightning_address(self).await
+    }
+
+    pub async fn register_lightning_address(
+        &self,
+        request: RegisterLightningAddressRequest,
+    ) -> Result<LightningAddressInfo, SdkError> {
+        LightningAddressService::register_lightning_address(self, request).await
+    }
+
+    pub async fn delete_lightning_address(&self) -> Result<(), SdkError> {
+        LightningAddressService::delete_lightning_address(self).await
     }
 }
 

--- a/crates/breez-sdk/core/src/sdk/lnurl.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl.rs
@@ -5,8 +5,9 @@ use tracing::{Instrument, debug, error, info};
 use crate::{
     FeePolicy, InputType, LnurlAuthRequestDetails, LnurlCallbackStatus, LnurlPayInfo,
     LnurlPayRequest, LnurlPayResponse, LnurlWithdrawInfo, LnurlWithdrawRequest,
-    LnurlWithdrawResponse, PaymentDetails, PaymentStatus, PaymentType, PrepareLnurlPayRequest,
-    PrepareLnurlPayResponse, SendPaymentMethod, SetLnurlMetadataItem, WaitForPaymentIdentifier,
+    LnurlWithdrawResponse, Payment, PaymentDetails, PaymentStatus, PaymentType,
+    PrepareLnurlPayRequest, PrepareLnurlPayResponse, SendPaymentMethod, SetLnurlMetadataItem,
+    WaitForPaymentIdentifier,
     error::SdkError,
     events::SdkEvent,
     models::{
@@ -19,12 +20,35 @@ use crate::{
 };
 use breez_sdk_common::lnurl::withdraw::execute_lnurl_withdraw;
 
-use super::{BreezSdk, helpers::process_success_action};
+use super::{
+    BreezSdk, SdkServices, api::ApiService, helpers::process_success_action,
+    payments::PaymentsService,
+};
 
-#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
-#[allow(clippy::needless_pass_by_value)]
-impl BreezSdk {
-    pub async fn prepare_lnurl_pay(
+/// Trait for LNURL operations
+#[macros::async_trait]
+pub(crate) trait LnurlService {
+    async fn prepare_lnurl_pay(
+        &self,
+        request: PrepareLnurlPayRequest,
+    ) -> Result<PrepareLnurlPayResponse, SdkError>;
+
+    async fn lnurl_pay(&self, request: LnurlPayRequest) -> Result<LnurlPayResponse, SdkError>;
+
+    async fn lnurl_withdraw(
+        &self,
+        request: LnurlWithdrawRequest,
+    ) -> Result<LnurlWithdrawResponse, SdkError>;
+
+    async fn lnurl_auth(
+        &self,
+        request_data: LnurlAuthRequestDetails,
+    ) -> Result<LnurlCallbackStatus, SdkError>;
+}
+
+#[macros::async_trait]
+impl LnurlService for SdkServices {
+    async fn prepare_lnurl_pay(
         &self,
         request: PrepareLnurlPayRequest,
     ) -> Result<PrepareLnurlPayResponse, SdkError> {
@@ -94,7 +118,7 @@ impl BreezSdk {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub async fn lnurl_pay(&self, request: LnurlPayRequest) -> Result<LnurlPayResponse, SdkError> {
+    async fn lnurl_pay(&self, request: LnurlPayRequest) -> Result<LnurlPayResponse, SdkError> {
         self.ensure_spark_private_mode_initialized().await?;
 
         let is_fees_included = request.prepare_response.fee_policy == FeePolicy::FeesIncluded;
@@ -231,32 +255,7 @@ impl BreezSdk {
         })
     }
 
-    /// Performs an LNURL withdraw operation for the amount of satoshis to
-    /// withdraw and the LNURL withdraw request details. The LNURL withdraw request
-    /// details can be obtained from calling [`BreezSdk::parse`].
-    ///
-    /// The method generates a Lightning invoice for the withdraw amount, stores
-    /// the LNURL withdraw metadata, and performs the LNURL withdraw using  the generated
-    /// invoice.
-    ///
-    /// If the `completion_timeout_secs` parameter is provided and greater than 0, the
-    /// method will wait for the payment to be completed within that period. If the
-    /// withdraw is completed within the timeout, the `payment` field in the response
-    /// will be set with the payment details. If the `completion_timeout_secs`
-    /// parameter is not provided or set to 0, the method will not wait for the payment
-    /// to be completed. If the withdraw is not completed within the
-    /// timeout, the `payment` field will be empty.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The LNURL withdraw request
-    ///
-    /// # Returns
-    ///
-    /// Result containing either:
-    /// * `LnurlWithdrawResponse` - The payment details if the withdraw request was successful
-    /// * `SdkError` - If there was an error during the withdraw process
-    pub async fn lnurl_withdraw(
+    async fn lnurl_withdraw(
         &self,
         request: LnurlWithdrawRequest,
     ) -> Result<LnurlWithdrawResponse, SdkError> {
@@ -339,12 +338,7 @@ impl BreezSdk {
         })
     }
 
-    /// Performs LNURL-auth with the service.
-    ///
-    /// This method implements the LNURL-auth protocol as specified in LUD-04 and LUD-05.
-    /// It derives a domain-specific linking key, signs the challenge, and sends the
-    /// authentication request to the service.
-    pub async fn lnurl_auth(
+    async fn lnurl_auth(
         &self,
         request_data: LnurlAuthRequestDetails,
     ) -> Result<LnurlCallbackStatus, SdkError> {
@@ -364,8 +358,95 @@ impl BreezSdk {
     }
 }
 
-// Private LNURL methods
+#[macros::async_trait]
+impl LnurlService for BreezSdk {
+    async fn prepare_lnurl_pay(
+        &self,
+        request: PrepareLnurlPayRequest,
+    ) -> Result<PrepareLnurlPayResponse, SdkError> {
+        self.services.prepare_lnurl_pay(request).await
+    }
+
+    async fn lnurl_pay(&self, request: LnurlPayRequest) -> Result<LnurlPayResponse, SdkError> {
+        self.services.lnurl_pay(request).await
+    }
+
+    async fn lnurl_withdraw(
+        &self,
+        request: LnurlWithdrawRequest,
+    ) -> Result<LnurlWithdrawResponse, SdkError> {
+        self.services.lnurl_withdraw(request).await
+    }
+
+    async fn lnurl_auth(
+        &self,
+        request_data: LnurlAuthRequestDetails,
+    ) -> Result<LnurlCallbackStatus, SdkError> {
+        self.services.lnurl_auth(request_data).await
+    }
+}
+
+#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+#[allow(clippy::needless_pass_by_value)]
 impl BreezSdk {
+    pub async fn prepare_lnurl_pay(
+        &self,
+        request: PrepareLnurlPayRequest,
+    ) -> Result<PrepareLnurlPayResponse, SdkError> {
+        LnurlService::prepare_lnurl_pay(self, request).await
+    }
+
+    pub async fn lnurl_pay(&self, request: LnurlPayRequest) -> Result<LnurlPayResponse, SdkError> {
+        LnurlService::lnurl_pay(self, request).await
+    }
+
+    /// Performs an LNURL withdraw operation for the amount of satoshis to
+    /// withdraw and the LNURL withdraw request details. The LNURL withdraw request
+    /// details can be obtained from calling [`BreezSdk::parse`].
+    ///
+    /// The method generates a Lightning invoice for the withdraw amount, stores
+    /// the LNURL withdraw metadata, and performs the LNURL withdraw using  the generated
+    /// invoice.
+    ///
+    /// If the `completion_timeout_secs` parameter is provided and greater than 0, the
+    /// method will wait for the payment to be completed within that period. If the
+    /// withdraw is completed within the timeout, the `payment` field in the response
+    /// will be set with the payment details. If the `completion_timeout_secs`
+    /// parameter is not provided or set to 0, the method will not wait for the payment
+    /// to be completed. If the withdraw is not completed within the
+    /// timeout, the `payment` field will be empty.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The LNURL withdraw request
+    ///
+    /// # Returns
+    ///
+    /// Result containing either:
+    /// * `LnurlWithdrawResponse` - The payment details if the withdraw request was successful
+    /// * `SdkError` - If there was an error during the withdraw process
+    pub async fn lnurl_withdraw(
+        &self,
+        request: LnurlWithdrawRequest,
+    ) -> Result<LnurlWithdrawResponse, SdkError> {
+        LnurlService::lnurl_withdraw(self, request).await
+    }
+
+    /// Performs LNURL-auth with the service.
+    ///
+    /// This method implements the LNURL-auth protocol as specified in LUD-04 and LUD-05.
+    /// It derives a domain-specific linking key, signs the challenge, and sends the
+    /// authentication request to the service.
+    pub async fn lnurl_auth(
+        &self,
+        request_data: LnurlAuthRequestDetails,
+    ) -> Result<LnurlCallbackStatus, SdkError> {
+        LnurlService::lnurl_auth(self, request_data).await
+    }
+}
+
+// Private LNURL methods on SdkServices
+impl SdkServices {
     /// Prepares an LNURL pay `FeesIncluded` operation using a double-query approach.
     ///
     /// This method:
@@ -498,14 +579,19 @@ impl BreezSdk {
             return;
         }
 
-        let sdk = self.clone();
-        let mut shutdown_receiver = sdk.shutdown_sender.subscribe();
-        let mut trigger_receiver = sdk.lnurl_preimage_trigger.clone().subscribe();
+        let storage = self.storage.clone();
+        let lnurl_server_client = self.lnurl_server_client.clone();
+        let config_support_lnurl_verify = self.config.support_lnurl_verify;
+        let mut shutdown_receiver = self.shutdown_sender.subscribe();
+        let mut trigger_receiver = self.lnurl_preimage_trigger.clone().subscribe();
         let span = tracing::Span::current();
 
         tokio::spawn(
             async move {
-                if let Err(e) = Self::process_pending_lnurl_preimages(&sdk).await {
+                if let Err(e) =
+                    Self::process_pending_lnurl_preimages_static(&storage, lnurl_server_client.as_ref())
+                        .await
+                {
                     error!("Failed to process pending LNURL preimages on startup: {e:?}");
                 }
 
@@ -516,9 +602,10 @@ impl BreezSdk {
                             return;
                         }
                         _ = trigger_receiver.recv() => {
-                            if let Err(e) = Self::process_pending_lnurl_preimages(&sdk).await {
-                                error!("Failed to process pending LNURL preimages: {e:?}");
-                            }
+                            if config_support_lnurl_verify
+                                && let Err(e) = Self::process_pending_lnurl_preimages_static(&storage, lnurl_server_client.as_ref()).await {
+                                    error!("Failed to process pending LNURL preimages: {e:?}");
+                                }
                         }
                     }
                 }
@@ -527,16 +614,18 @@ impl BreezSdk {
         );
     }
 
-    async fn process_pending_lnurl_preimages(&self) -> Result<(), SdkError> {
-        let Some(lnurl_server_client) = self.lnurl_server_client.clone() else {
+    async fn process_pending_lnurl_preimages_static(
+        storage: &std::sync::Arc<dyn crate::persist::Storage>,
+        lnurl_server_client: Option<&std::sync::Arc<dyn crate::lnurl::LnurlServerClient>>,
+    ) -> Result<(), SdkError> {
+        let Some(lnurl_server_client) = lnurl_server_client else {
             return Ok(());
         };
 
-        let limit = 100;
+        let limit: u32 = 100;
         loop {
             // Query only payments that need their preimage sent to the server
-            let pending = self
-                .storage
+            let pending: Vec<Payment> = storage
                 .list_payments(StorageListPaymentsRequest {
                     type_filter: Some(vec![PaymentType::Receive]),
                     status_filter: Some(vec![PaymentStatus::Completed]),
@@ -571,7 +660,9 @@ impl BreezSdk {
                 };
 
                 // Notify the LNURL server about the paid invoice
-                if let Err(e) = lnurl_server_client.notify_invoice_paid(&preimage).await {
+                let notify_result: Result<(), crate::lnurl::LnurlServerError> =
+                    lnurl_server_client.notify_invoice_paid(&preimage).await;
+                if let Err(e) = notify_result {
                     error!(
                         "Failed to notify invoice paid for payment_hash {}: {}",
                         htlc_details.payment_hash, e
@@ -585,8 +676,7 @@ impl BreezSdk {
                 );
 
                 // Update the LNURL metadata to mark the preimage as sent
-                if let Err(e) = self
-                    .storage
+                if let Err(e) = storage
                     .set_lnurl_metadata(vec![SetLnurlMetadataItem {
                         payment_hash: htlc_details.payment_hash.clone(),
                         sender_comment: metadata.sender_comment,

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -69,11 +69,10 @@ impl SyncRequest {
     }
 }
 
-/// `BreezSDK` is a wrapper around `SparkSDK` that provides a more structured API
-/// with request/response objects and comprehensive error handling.
+/// Internal services struct that holds all SDK components.
+/// This is crate-scoped and contains the actual implementation.
 #[derive(Clone)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
-pub struct BreezSdk {
+pub(crate) struct SdkServices {
     pub(crate) config: Config,
     pub(crate) spark_wallet: Arc<SparkWallet>,
     pub(crate) storage: Arc<dyn Storage>,
@@ -93,6 +92,16 @@ pub struct BreezSdk {
     pub(crate) token_converter: Arc<dyn TokenConverter>,
     pub(crate) stable_balance: Option<Arc<StableBalance>>,
     pub(crate) buy_bitcoin_provider: Arc<dyn BuyBitcoinProviderApi>,
+}
+
+/// `BreezSDK` is a wrapper around `SparkSDK` that provides a more structured API
+/// with request/response objects and comprehensive error handling.
+///
+/// This is a facade that delegates all operations to the internal `SdkServices`.
+#[derive(Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct BreezSdk {
+    pub(crate) services: Arc<SdkServices>,
 }
 
 pub(crate) struct BreezSdkParams {

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -36,14 +36,51 @@ use tokio_with_wasm::alias as tokio;
 use web_time::SystemTime;
 
 use super::{
-    BreezSdk, SyncType,
+    BreezSdk, SdkServices, SyncType,
+    api::ApiService,
     helpers::{InternalEventListener, get_or_create_deposit_address, is_payment_match},
 };
 
-#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
-#[allow(clippy::needless_pass_by_value)]
-impl BreezSdk {
-    pub async fn receive_payment(
+/// Trait for payment operations
+#[macros::async_trait]
+pub(crate) trait PaymentsService {
+    async fn receive_payment(
+        &self,
+        request: ReceivePaymentRequest,
+    ) -> Result<ReceivePaymentResponse, SdkError>;
+
+    async fn claim_htlc_payment(
+        &self,
+        request: ClaimHtlcPaymentRequest,
+    ) -> Result<ClaimHtlcPaymentResponse, SdkError>;
+
+    async fn prepare_send_payment(
+        &self,
+        request: PrepareSendPaymentRequest,
+    ) -> Result<PrepareSendPaymentResponse, SdkError>;
+
+    async fn send_payment(
+        &self,
+        request: SendPaymentRequest,
+    ) -> Result<SendPaymentResponse, SdkError>;
+
+    async fn fetch_conversion_limits(
+        &self,
+        request: FetchConversionLimitsRequest,
+    ) -> Result<FetchConversionLimitsResponse, SdkError>;
+
+    async fn list_payments(
+        &self,
+        request: ListPaymentsRequest,
+    ) -> Result<ListPaymentsResponse, SdkError>;
+
+    async fn get_payment(&self, request: GetPaymentRequest)
+    -> Result<GetPaymentResponse, SdkError>;
+}
+
+#[macros::async_trait]
+impl PaymentsService for SdkServices {
+    async fn receive_payment(
         &self,
         request: ReceivePaymentRequest,
     ) -> Result<ReceivePaymentResponse, SdkError> {
@@ -108,7 +145,7 @@ impl BreezSdk {
         }
     }
 
-    pub async fn claim_htlc_payment(
+    async fn claim_htlc_payment(
         &self,
         request: ClaimHtlcPaymentRequest,
     ) -> Result<ClaimHtlcPaymentResponse, SdkError> {
@@ -141,7 +178,7 @@ impl BreezSdk {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub async fn prepare_send_payment(
+    async fn prepare_send_payment(
         &self,
         request: PrepareSendPaymentRequest,
     ) -> Result<PrepareSendPaymentResponse, SdkError> {
@@ -362,7 +399,7 @@ impl BreezSdk {
         }
     }
 
-    pub async fn send_payment(
+    async fn send_payment(
         &self,
         request: SendPaymentRequest,
     ) -> Result<SendPaymentResponse, SdkError> {
@@ -370,7 +407,7 @@ impl BreezSdk {
         Box::pin(self.maybe_convert_token_send_payment(request, false, None)).await
     }
 
-    pub async fn fetch_conversion_limits(
+    async fn fetch_conversion_limits(
         &self,
         request: FetchConversionLimitsRequest,
     ) -> Result<FetchConversionLimitsResponse, SdkError> {
@@ -380,20 +417,7 @@ impl BreezSdk {
             .map_err(Into::into)
     }
 
-    /// Lists payments from the storage with pagination
-    ///
-    /// This method provides direct access to the payment history stored in the database.
-    /// It returns payments in reverse chronological order (newest first).
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - Contains pagination parameters (offset and limit)
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(ListPaymentsResponse)` - Contains the list of payments if successful
-    /// * `Err(SdkError)` - If there was an error accessing the storage
-    pub async fn list_payments(
+    async fn list_payments(
         &self,
         request: ListPaymentsRequest,
     ) -> Result<ListPaymentsResponse, SdkError> {
@@ -423,7 +447,7 @@ impl BreezSdk {
         Ok(ListPaymentsResponse { payments })
     }
 
-    pub async fn get_payment(
+    async fn get_payment(
         &self,
         request: GetPaymentRequest,
     ) -> Result<GetPaymentResponse, SdkError> {
@@ -448,8 +472,114 @@ impl BreezSdk {
     }
 }
 
-// Private payment methods
+#[macros::async_trait]
+impl PaymentsService for BreezSdk {
+    async fn receive_payment(
+        &self,
+        request: ReceivePaymentRequest,
+    ) -> Result<ReceivePaymentResponse, SdkError> {
+        self.services.receive_payment(request).await
+    }
+
+    async fn claim_htlc_payment(
+        &self,
+        request: ClaimHtlcPaymentRequest,
+    ) -> Result<ClaimHtlcPaymentResponse, SdkError> {
+        self.services.claim_htlc_payment(request).await
+    }
+
+    async fn prepare_send_payment(
+        &self,
+        request: PrepareSendPaymentRequest,
+    ) -> Result<PrepareSendPaymentResponse, SdkError> {
+        self.services.prepare_send_payment(request).await
+    }
+
+    async fn send_payment(
+        &self,
+        request: SendPaymentRequest,
+    ) -> Result<SendPaymentResponse, SdkError> {
+        self.services.send_payment(request).await
+    }
+
+    async fn fetch_conversion_limits(
+        &self,
+        request: FetchConversionLimitsRequest,
+    ) -> Result<FetchConversionLimitsResponse, SdkError> {
+        self.services.fetch_conversion_limits(request).await
+    }
+
+    async fn list_payments(
+        &self,
+        request: ListPaymentsRequest,
+    ) -> Result<ListPaymentsResponse, SdkError> {
+        self.services.list_payments(request).await
+    }
+
+    async fn get_payment(
+        &self,
+        request: GetPaymentRequest,
+    ) -> Result<GetPaymentResponse, SdkError> {
+        self.services.get_payment(request).await
+    }
+}
+
+// Public API
+#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+#[allow(clippy::needless_pass_by_value)]
 impl BreezSdk {
+    pub async fn receive_payment(
+        &self,
+        request: ReceivePaymentRequest,
+    ) -> Result<ReceivePaymentResponse, SdkError> {
+        PaymentsService::receive_payment(self, request).await
+    }
+
+    pub async fn claim_htlc_payment(
+        &self,
+        request: ClaimHtlcPaymentRequest,
+    ) -> Result<ClaimHtlcPaymentResponse, SdkError> {
+        PaymentsService::claim_htlc_payment(self, request).await
+    }
+
+    pub async fn prepare_send_payment(
+        &self,
+        request: PrepareSendPaymentRequest,
+    ) -> Result<PrepareSendPaymentResponse, SdkError> {
+        PaymentsService::prepare_send_payment(self, request).await
+    }
+
+    pub async fn send_payment(
+        &self,
+        request: SendPaymentRequest,
+    ) -> Result<SendPaymentResponse, SdkError> {
+        PaymentsService::send_payment(self, request).await
+    }
+
+    pub async fn fetch_conversion_limits(
+        &self,
+        request: FetchConversionLimitsRequest,
+    ) -> Result<FetchConversionLimitsResponse, SdkError> {
+        PaymentsService::fetch_conversion_limits(self, request).await
+    }
+
+    pub async fn list_payments(
+        &self,
+        request: ListPaymentsRequest,
+    ) -> Result<ListPaymentsResponse, SdkError> {
+        PaymentsService::list_payments(self, request).await
+    }
+
+    pub async fn get_payment(
+        &self,
+        request: GetPaymentRequest,
+    ) -> Result<GetPaymentResponse, SdkError> {
+        PaymentsService::get_payment(self, request).await
+    }
+}
+
+// Private payment methods on SdkServices
+impl SdkServices {
     async fn receive_bolt11_invoice(
         &self,
         description: String,

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -19,30 +19,40 @@ use crate::{
 };
 
 use super::{
-    BreezSdk, CLAIM_TX_SIZE_VBYTES, SYNC_PAGING_LIMIT, SyncRequest, SyncType,
+    BreezSdk, CLAIM_TX_SIZE_VBYTES, SYNC_PAGING_LIMIT, SdkServices, SyncRequest, SyncType,
+    api::ApiService,
     helpers::{BalanceWatcher, update_balances},
     parse_input,
 };
 
-impl BreezSdk {
-    pub(super) fn periodic_sync(&self, initial_synced_sender: watch::Sender<bool>) {
-        let sdk = self.clone();
-        let mut shutdown_receiver = sdk.shutdown_sender.subscribe();
-        let mut subscription = sdk.spark_wallet.subscribe_events();
-        let sync_coordinator = sdk.sync_coordinator.clone();
-        let mut sync_trigger_receiver = sdk.sync_coordinator.subscribe();
+/// Trait defining sync operations.
+#[macros::async_trait]
+pub(crate) trait SyncService {
+    /// Synchronizes the wallet with the Spark network
+    async fn sync_wallet(&self, request: SyncWalletRequest)
+    -> Result<SyncWalletResponse, SdkError>;
+}
+
+// Internal sync methods for SdkServices
+impl SdkServices {
+    pub(super) fn periodic_sync(self: &Arc<Self>, initial_synced_sender: watch::Sender<bool>) {
+        let services = Arc::clone(self);
+        let mut shutdown_receiver = services.shutdown_sender.subscribe();
+        let mut subscription = services.spark_wallet.subscribe_events();
+        let sync_coordinator = services.sync_coordinator.clone();
+        let mut sync_trigger_receiver = services.sync_coordinator.subscribe();
         let mut last_sync_time = SystemTime::now();
 
-        let sync_interval = u64::from(self.config.sync_interval_secs);
+        let sync_interval = u64::from(services.config.sync_interval_secs);
         let span = tracing::Span::current();
         tokio::spawn(async move {
             let balance_watcher =
-                BalanceWatcher::new(sdk.spark_wallet.clone(), sdk.storage.clone());
-            let balance_watcher_id = sdk.add_event_listener(Box::new(balance_watcher)).await;
+                BalanceWatcher::new(services.spark_wallet.clone(), services.storage.clone());
+            let balance_watcher_id = services.add_event_listener(Box::new(balance_watcher)).await;
             loop {
                 tokio::select! {
                     _ = shutdown_receiver.changed() => {
-                        if !sdk.remove_event_listener(&balance_watcher_id).await {
+                        if !services.remove_event_listener(&balance_watcher_id).await {
                             error!("Failed to remove balance watcher listener");
                         }
                         info!("Deposit tracking loop shutdown signal received");
@@ -53,7 +63,7 @@ impl BreezSdk {
                             Ok(event) => {
                                 info!("Received event: {event}");
                                 trace!("Received event: {:?}", event);
-                                sdk.handle_wallet_event(event).await;
+                                services.handle_wallet_event(event).await;
                             }
                             Err(e) => {
                                 error!("Failed to receive event: {e:?}");
@@ -65,10 +75,10 @@ impl BreezSdk {
                             continue;
                         };
                         info!("Sync trigger changed: {:?}", &sync_request);
-                        let cloned_sdk = sdk.clone();
+                        let cloned_services = Arc::clone(&services);
                         let initial_synced_sender = initial_synced_sender.clone();
                         if let Some(true) = Box::pin(run_with_shutdown(shutdown_receiver.clone(), "Sync trigger changed", async move {
-                            if let Err(e) = cloned_sdk.sync_wallet_internal(&sync_request).await {
+                            if let Err(e) = cloned_services.sync_wallet_internal(&sync_request).await {
                                 error!("Failed to sync wallet: {e:?}");
                                 let () = sync_request.reply(Some(e)).await;
                                 return false;
@@ -114,7 +124,7 @@ impl BreezSdk {
             WalletEvent::Synced => {
                 info!("Synced");
                 self.sync_coordinator
-                    .trigger_sync_no_wait(super::SyncType::Full, true)
+                    .trigger_sync_no_wait(SyncType::Full, true)
                     .await;
             }
             WalletEvent::TransferClaimed(transfer) => {
@@ -140,7 +150,7 @@ impl BreezSdk {
                         .await;
                 }
                 self.sync_coordinator
-                    .trigger_sync_no_wait(super::SyncType::WalletState, true)
+                    .trigger_sync_no_wait(SyncType::WalletState, true)
                     .await;
             }
             WalletEvent::TransferClaimStarting(transfer) => {
@@ -159,7 +169,7 @@ impl BreezSdk {
                         .await;
                 }
                 self.sync_coordinator
-                    .trigger_sync_no_wait(super::SyncType::WalletState, true)
+                    .trigger_sync_no_wait(SyncType::WalletState, true)
                     .await;
             }
             WalletEvent::Optimization(event) => {
@@ -586,19 +596,40 @@ impl BreezSdk {
     }
 }
 
+// Trait implementation for SdkServices
+#[macros::async_trait]
+impl SyncService for SdkServices {
+    async fn sync_wallet(
+        &self,
+        _request: SyncWalletRequest,
+    ) -> Result<SyncWalletResponse, SdkError> {
+        // Use the coordinator to coalesce duplicate sync requests
+        self.sync_coordinator
+            .trigger_sync_and_wait(SyncType::Full, true)
+            .await?;
+        Ok(SyncWalletResponse {})
+    }
+}
+
+// Trait implementation for BreezSdk - delegates to SdkServices
+#[macros::async_trait]
+impl SyncService for BreezSdk {
+    async fn sync_wallet(
+        &self,
+        request: SyncWalletRequest,
+    ) -> Result<SyncWalletResponse, SdkError> {
+        self.services.sync_wallet(request).await
+    }
+}
+
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 #[allow(clippy::needless_pass_by_value)]
 impl BreezSdk {
     /// Synchronizes the wallet with the Spark network
-    #[allow(unused_variables)]
     pub async fn sync_wallet(
         &self,
         request: SyncWalletRequest,
     ) -> Result<SyncWalletResponse, SdkError> {
-        // Use the coordinator to coalesce duplicate sync requests
-        self.sync_coordinator
-            .trigger_sync_and_wait(super::SyncType::Full, true)
-            .await?;
-        Ok(SyncWalletResponse {})
+        SyncService::sync_wallet(self, request).await
     }
 }


### PR DESCRIPTION
This PR abstracts all public methods under sdk/ into separate trait implementations, and implements them for both `SdkServices` (inner SDK object, real implementation) and `BreezSdk` (facade).

This is a necessary change in order for the plugins architecture to work as expected.