### PR TITLE
Fix Python event listener deadlock by auto-setting asyncio event loop

### DIFF
--- a/crates/breez-sdk/bindings/langs/python/src/breez_sdk_spark/__init__.py
+++ b/crates/breez-sdk/bindings/langs/python/src/breez_sdk_spark/__init__.py
@@ -2,6 +2,7 @@ from breez_sdk_spark.breez_sdk_spark_bindings import *
 from breez_sdk_spark.breez_sdk_spark import *
 
 import asyncio
+import functools
 from breez_sdk_spark.breez_sdk_spark import (
     connect as _original_connect,
     connect_with_signer as _original_connect_with_signer,
@@ -14,11 +15,13 @@ def _ensure_event_loop():
     uniffi_set_event_loop(asyncio.get_running_loop())
 
 
+@functools.wraps(_original_connect)
 async def connect(*args, **kwargs):
     _ensure_event_loop()
     return await _original_connect(*args, **kwargs)
 
 
+@functools.wraps(_original_connect_with_signer)
 async def connect_with_signer(*args, **kwargs):
     _ensure_event_loop()
     return await _original_connect_with_signer(*args, **kwargs)


### PR DESCRIPTION
## Summary                                                                                                                         
          
  - Auto-call `uniffi_set_event_loop(asyncio.get_running_loop())` before returning a `BreezSdk` instance from `connect()`, `connect_with_signer()`, and `SdkBuilder.build()`                                                                                  
  - Fixes #662: Python `EventListener.on_event` callbacks deadlock when called from Rust's TOKIO1 thread because it has no Python asyncio event loop

## Context

UniFFI 0.28.3 exports `EventListener.on_event` as an async callback interface. When the SDK emits events from the TOKIO1 background thread (e.g., `TransferClaimed` during sync), UniFFI calls `asyncio.run_coroutine_threadsafe()` which needs a registered event loop. Without one, `asyncio.get_running_loop()` raises `RuntimeError: no running event loop`, the callback never completes, and the Rust `.await` hangs forever — deadlocking `periodic_sync` and all subsequent `sync_wallet()`/`get_info(ensure_synced=True)` calls.

UniFFI provides [uniffi_set_event_loop](https://mozilla.github.io/uniffi-rs/latest/futures.html#python-uniffi_set_event_loop) for this, but users had to call it manually. Since all SDK entry points are `async`, a running event loop is always available — so the SDK can set it automatically.

Verified with glow-cloud. 

