### PR TITLE
Fix async overrides in Python snippets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5647,8 +5647,7 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 [[package]]
 name = "uniffi"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb08c58c7ed7033150132febe696bef553f891b1ede57424b40d87a89e3c170"
+source = "git+https://github.com/breez/uniffi-rs?branch=fix-python-async-protocol#aeb4aeff5fda878973cd673c95225f8301286ff1"
 dependencies = [
  "anyhow",
  "camino",
@@ -5663,8 +5662,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cade167af943e189a55020eda2c314681e223f1e42aca7c4e52614c2b627698f"
+source = "git+https://github.com/breez/uniffi-rs?branch=fix-python-async-protocol#aeb4aeff5fda878973cd673c95225f8301286ff1"
 dependencies = [
  "anyhow",
  "askama",
@@ -5687,8 +5685,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7cf32576e08104b7dc2a6a5d815f37616e66c6866c2a639fe16e6d2286b75b"
+source = "git+https://github.com/breez/uniffi-rs?branch=fix-python-async-protocol#aeb4aeff5fda878973cd673c95225f8301286ff1"
 dependencies = [
  "anyhow",
  "camino",
@@ -5698,8 +5695,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
+source = "git+https://github.com/breez/uniffi-rs?branch=fix-python-async-protocol#aeb4aeff5fda878973cd673c95225f8301286ff1"
 dependencies = [
  "quote",
  "syn 2.0.105",
@@ -5708,8 +5704,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7687007d2546c454d8ae609b105daceb88175477dac280707ad6d95bcd6f1f"
+source = "git+https://github.com/breez/uniffi-rs?branch=fix-python-async-protocol#aeb4aeff5fda878973cd673c95225f8301286ff1"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -5723,8 +5718,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c65a5b12ec544ef136693af8759fb9d11aefce740fb76916721e876639033b"
+source = "git+https://github.com/breez/uniffi-rs?branch=fix-python-async-protocol#aeb4aeff5fda878973cd673c95225f8301286ff1"
 dependencies = [
  "bincode",
  "camino",
@@ -5741,8 +5735,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a74ed96c26882dac1ca9b93ca23c827e284bacbd7ec23c6f0b0372f747d59e4"
+source = "git+https://github.com/breez/uniffi-rs?branch=fix-python-async-protocol#aeb4aeff5fda878973cd673c95225f8301286ff1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5753,8 +5746,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6f984f0781f892cc864a62c3a5c60361b1ccbd68e538e6c9fbced5d82268ac"
+source = "git+https://github.com/breez/uniffi-rs?branch=fix-python-async-protocol#aeb4aeff5fda878973cd673c95225f8301286ff1"
 dependencies = [
  "anyhow",
  "camino",
@@ -5766,8 +5758,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037820a4cfc4422db1eaa82f291a3863c92c7d1789dc513489c36223f9b4cdfc"
+source = "git+https://github.com/breez/uniffi-rs?branch=fix-python-async-protocol#aeb4aeff5fda878973cd673c95225f8301286ff1"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -6087,8 +6078,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+source = "git+https://github.com/breez/uniffi-rs?branch=fix-python-async-protocol#aeb4aeff5fda878973cd673c95225f8301286ff1"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,10 @@ tower-service = "0.3.3"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 tsify-next = {version = "0.5.5", default-features = false}
-uniffi = "0.28.3"
+# Fork of uniffi 0.28.3 that fixes Python Protocol generation for async callback
+# methods (plain `def` instead of `async def`). Fixed upstream in 0.30.0.
+# Switch back to upstream once we upgrade to uniffi >= 0.30.
+uniffi = { git = "https://github.com/breez/uniffi-rs", branch = "fix-python-async-protocol" }
 url = "2.5"
 uuid = { version = "1.17.0", features = ["v7", "v4"] }
 wasm-bindgen = "0.2.100"

--- a/docs/breez-sdk/snippets/python/src/getting_started.py
+++ b/docs/breez-sdk/snippets/python/src/getting_started.py
@@ -70,7 +70,7 @@ def set_logger(logger: SdkLogger):
 
 # ANCHOR: add-event-listener
 class SdkListener(EventListener):
-    def on_event(self, event: SdkEvent):
+    async def on_event(self, event: SdkEvent):
         if isinstance(event, SdkEvent.SYNCED):
             # Data has been synchronized with the network. When this event is received,
             # it is recommended to refresh the payment list and wallet balance.

--- a/docs/breez-sdk/snippets/python/src/sdk_building.py
+++ b/docs/breez-sdk/snippets/python/src/sdk_building.py
@@ -75,7 +75,7 @@ async def with_key_set(builder: SdkBuilder):
 
 # ANCHOR: with-payment-observer
 class ExamplePaymentObserver(PaymentObserver):
-    def before_send(self, payments: typing.List[ProvisionalPayment]):
+    async def before_send(self, payments: typing.List[ProvisionalPayment]):
         for payment in payments:
             logging.debug(f"About to send payment {payment.payment_id} of amount {payment.amount}")
 


### PR DESCRIPTION
## Summary                                                                                                                 
                                                       
  - Fix callback interface methods (`EventListener.on_event`, `PaymentObserver.before_send`) to use `async def`
  - Change to [UniFFI 0.28.3 fork](https://github.com/breez/uniffi-rs/commit/aeb4aeff5fda878973cd673c95225f8301286ff1) that uses correct async modifier in generated python. We can go back upstream when we are able to upgrade to 0.30 or higher                                                      
                                                                                                                         