### PR TITLE
Fix real-time sync blocking Synced event on failure

### DIFF
--- a/crates/breez-sdk/common/src/sync/background.rs
+++ b/crates/breez-sdk/common/src/sync/background.rs
@@ -21,6 +21,7 @@ pub trait NewRecordHandler: Send + Sync {
         incoming_count: Option<u32>,
         outgoing_count: Option<u32>,
     ) -> anyhow::Result<()>;
+    async fn on_sync_failed(&self);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -157,7 +158,7 @@ impl SyncProcessor {
         let mut stream = match self.client.listen_changes().await {
             Ok(stream) => stream,
             Err(e) => {
-                error!("Failed to establish update subscription: {e}");
+                error!("Failed to establish real-time sync update subscription: {e}");
                 return;
             }
         };
@@ -212,6 +213,21 @@ impl SyncProcessor {
         mut shutdown_receiver: watch::Receiver<()>,
         mut pull_trigger: watch::Receiver<()>,
     ) {
+        // Initial remote pull to fetch the latest state from the sync server.
+        // This ensures we do an initial pull, regardless of whether the subscription
+        // delivers a notification.
+        match self.pull_sync_once().await {
+            Ok(count) => {
+                if let Err(e) = self.new_record_handler.on_sync_completed(count, None).await {
+                    error!("Failed to notify of initial real-time sync completion: {e:?}");
+                }
+            }
+            Err(e) => {
+                error!("Failed initial remote pull: {e}");
+                self.new_record_handler.on_sync_failed().await;
+            }
+        }
+
         let mut push_trigger = self.push_sync_trigger.resubscribe();
         let (backoff_trigger_tx, mut backoff_trigger_rx) = mpsc::channel::<Duration>(10);
 
@@ -230,6 +246,7 @@ impl SyncProcessor {
                         Ok(count) => (count, None),
                         Err(e) => {
                             error!("Failed to sync once: {}", e);
+                            self.new_record_handler.on_sync_failed().await;
                             (None, None)
                         }
                     }
@@ -279,6 +296,7 @@ impl SyncProcessor {
             Ok(count) => count,
             Err(e) => {
                 error!("Failed to pull sync once in backoff mode: {}", e);
+                self.new_record_handler.on_sync_failed().await;
                 self.schedule_backoff(
                     backoff_handle,
                     backoff_trigger_tx,
@@ -292,6 +310,7 @@ impl SyncProcessor {
             Ok(count) => count,
             Err(e) => {
                 error!("Failed to push sync once in backoff mode: {}", e);
+                self.new_record_handler.on_sync_failed().await;
                 self.schedule_backoff(
                     backoff_handle,
                     backoff_trigger_tx,
@@ -320,6 +339,7 @@ impl SyncProcessor {
                         Ok(count) => count,
                         Err(e) => {
                             error!("Failed to sync once: {}", e);
+                            self.new_record_handler.on_sync_failed().await;
                             self.schedule_backoff(
                                 backoff_handle,
                                 backoff_trigger_tx,
@@ -336,6 +356,7 @@ impl SyncProcessor {
                     Ok(count) => count,
                     Err(e) => {
                         error!("Failed to sync once: {}", e);
+                        self.new_record_handler.on_sync_failed().await;
                         self.schedule_backoff(
                             backoff_handle,
                             backoff_trigger_tx,
@@ -1206,10 +1227,15 @@ mod tests {
             .returning(|_| Err(anyhow!("pull failed")));
         mock_client.expect_set_record().times(0);
 
+        let mut mock_handler = MockNewRecordHandler::new();
+        mock_handler
+            .expect_on_sync_failed()
+            .times(1)
+            .returning(|| ());
         let sync_processor = SyncProcessor::new(
             create_signing_client(mock_client, MockSyncSigner::new()),
             broadcast::channel(10).1,
-            Arc::new(MockNewRecordHandler::new()),
+            Arc::new(mock_handler),
             Arc::new(mock_storage),
         );
 
@@ -1249,10 +1275,15 @@ mod tests {
             .returning(|_| Err(anyhow!("pull failed")));
         mock_client.expect_set_record().times(0);
 
+        let mut mock_handler = MockNewRecordHandler::new();
+        mock_handler
+            .expect_on_sync_failed()
+            .times(1)
+            .returning(|| ());
         let sync_processor = SyncProcessor::new(
             create_signing_client(mock_client, MockSyncSigner::new()),
             broadcast::channel(10).1,
-            Arc::new(MockNewRecordHandler::new()),
+            Arc::new(mock_handler),
             Arc::new(mock_storage),
         );
 
@@ -1518,6 +1549,19 @@ mod tests {
         // Setup
         let mut mock_storage = MockSyncStorage::new();
 
+        // For initial pull_sync_once
+        mock_storage
+            .expect_get_last_revision()
+            .times(1)
+            .returning(|| Ok(5));
+
+        // For initial pull + push_sync_batch (checks for pending incoming)
+        mock_storage
+            .expect_get_incoming_records()
+            .times(2)
+            .with(eq(u32::MAX))
+            .returning(|_| Ok(Vec::new()));
+
         // For push_sync_once
         mock_storage
             .expect_get_pending_outgoing_changes()
@@ -1543,20 +1587,21 @@ mod tests {
             .times(1)
             .returning(|_, _| Ok(()));
 
-        mock_storage
-            .expect_get_incoming_records()
-            .times(1)
-            .with(eq(u32::MAX))
-            .returning(|_| Ok(Vec::new()));
-
         let (tx, rx) = broadcast::channel::<RecordId>(10);
         let mut mock_handler = MockNewRecordHandler::new();
+        // Initial pull + push sync
         mock_handler
             .expect_on_sync_completed()
-            .times(1)
+            .times(2)
             .returning(|_, _| Ok(()));
         let mock_handler = Arc::new(mock_handler);
         let mut syncer_client = MockSyncerClient::new();
+        // Initial pull
+        syncer_client.expect_list_changes().times(1).returning(|_| {
+            Ok(crate::sync::proto::ListChangesReply {
+                changes: Vec::new(),
+            })
+        });
         syncer_client.expect_set_record().times(1).returning(|_| {
             Ok(SetRecordReply {
                 ..Default::default()
@@ -1601,29 +1646,32 @@ mod tests {
         // Setup
         let mut mock_storage = MockSyncStorage::new();
 
-        // For pull_sync_once
+        // For initial pull_sync_once + triggered pull_sync_once
         mock_storage
             .expect_get_last_revision()
-            .times(1)
+            .times(2)
             .returning(|| Ok(5));
 
         let mut mock_client = MockSyncerClient::new();
-        mock_client.expect_list_changes().times(1).returning(|_| {
+        // Initial pull + triggered pull
+        mock_client.expect_list_changes().times(2).returning(|_| {
             Ok(crate::sync::proto::ListChangesReply {
                 changes: Vec::new(),
             })
         });
 
+        // Initial pull + triggered pull
         mock_storage
             .expect_get_incoming_records()
-            .times(1)
+            .times(2)
             .returning(|_| Ok(Vec::new()));
 
         let (_tx, rx) = broadcast::channel::<RecordId>(10);
         let mut mock_handler = MockNewRecordHandler::new();
+        // Initial pull + triggered pull
         mock_handler
             .expect_on_sync_completed()
-            .times(1)
+            .times(2)
             .returning(|_, _| Ok(()));
         let mock_handler = Arc::new(mock_handler);
         let client = create_signing_client(mock_client, MockSyncSigner::new());

--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 use std::{
     collections::BTreeMap,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
 use serde::Serialize;
@@ -151,6 +151,7 @@ pub trait EventListener: Send + Sync {
 /// Event publisher that manages event listeners
 pub struct EventEmitter {
     has_real_time_sync: bool,
+    rtsync_failed: AtomicBool,
     listener_index: AtomicU64,
     listeners: RwLock<BTreeMap<String, Box<dyn EventListener>>>,
     synced_event_buffer: Mutex<Option<InternalSyncedEvent>>,
@@ -161,6 +162,7 @@ impl EventEmitter {
     pub fn new(has_real_time_sync: bool) -> Self {
         Self {
             has_real_time_sync,
+            rtsync_failed: AtomicBool::new(false),
             listener_index: AtomicU64::new(0),
             listeners: RwLock::new(BTreeMap::new()),
             synced_event_buffer: Mutex::new(Some(InternalSyncedEvent::default())),
@@ -222,7 +224,11 @@ impl EventEmitter {
 
             // The first synced event emitted should at least have the wallet synced.
             // Subsequent events might have only partial syncs.
-            if merged.wallet && (!self.has_real_time_sync || merged.storage_incoming.is_some()) {
+            if merged.wallet
+                && (!self.has_real_time_sync
+                    || merged.storage_incoming.is_some()
+                    || self.rtsync_failed.load(Ordering::Relaxed))
+            {
                 *mtx = None;
             } else {
                 *mtx = Some(merged);
@@ -243,6 +249,22 @@ impl EventEmitter {
 
         // Emit the merged event
         self.emit(&SdkEvent::Synced).await;
+    }
+
+    /// Notify that real-time sync has failed. If the first synced event is still
+    /// buffered and the wallet has already synced, release it immediately instead
+    /// of waiting for a remote pull that may never arrive.
+    pub async fn notify_rtsync_failed(&self) {
+        self.rtsync_failed.store(true, Ordering::Relaxed);
+
+        let mut mtx = self.synced_event_buffer.lock().await;
+        if let Some(buffered) = &*mtx
+            && buffered.wallet
+        {
+            *mtx = None;
+            drop(mtx);
+            self.emit(&SdkEvent::Synced).await;
+        }
     }
 }
 
@@ -443,6 +465,66 @@ mod tests {
                 deposits: false,
                 lnurl_metadata: false,
                 storage_incoming: Some(0),
+            })
+            .await;
+
+        assert!(received.load(Ordering::Relaxed));
+    }
+
+    #[async_test_all]
+    async fn test_rtsync_failed_emits_synced_on_wallet_alone() {
+        let emitter = EventEmitter::new(true);
+        let received = Arc::new(AtomicBool::new(false));
+
+        let listener = Box::new(TestListener {
+            received: received.clone(),
+        });
+
+        emitter.add_listener(listener).await;
+
+        // Wallet synced but rtsync hasn't failed yet — should NOT emit
+        emitter
+            .emit_synced(&InternalSyncedEvent {
+                wallet: true,
+                wallet_state: false,
+                deposits: false,
+                lnurl_metadata: false,
+                storage_incoming: None,
+            })
+            .await;
+
+        assert!(!received.load(Ordering::Relaxed));
+
+        // rtsync fails — should immediately release the buffered event
+        emitter.notify_rtsync_failed().await;
+
+        assert!(received.load(Ordering::Relaxed));
+    }
+
+    #[async_test_all]
+    async fn test_rtsync_failed_before_wallet_sync_emits_on_wallet() {
+        let emitter = EventEmitter::new(true);
+        let received = Arc::new(AtomicBool::new(false));
+
+        let listener = Box::new(TestListener {
+            received: received.clone(),
+        });
+
+        emitter.add_listener(listener).await;
+
+        // rtsync fails before wallet syncs — nothing to release yet
+        emitter.notify_rtsync_failed().await;
+
+        assert!(!received.load(Ordering::Relaxed));
+
+        // Wallet syncs — should emit immediately (rtsync already marked failed)
+        emitter
+            .emit_synced(&InternalSyncedEvent {
+                wallet: true,
+                wallet_state: false,
+                deposits: false,
+                lnurl_metadata: false,
+                storage_incoming: None,
             })
             .await;
 

--- a/crates/breez-sdk/core/src/realtime_sync/storage.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/storage.rs
@@ -92,6 +92,10 @@ impl NewRecordHandler for SyncedStorage {
             .await;
         Ok(())
     }
+
+    async fn on_sync_failed(&self) {
+        self.event_emitter.notify_rtsync_failed().await;
+    }
 }
 
 impl SyncedStorage {


### PR DESCRIPTION
 Summary                                            
                                                                                                                                                                                                                                                            
  - When real-time sync fails (connection error, pull/push failure), the initial `Synced` event was never emitted, leaving listeners waiting indefinitely
  - Add `on_sync_failed` callback to `NewRecordHandler` to notify the `EventEmitter` when real-time sync encounters errors
  - `EventEmitter` now releases the buffered `Synced` event on rtsync failure if the wallet has already synced, instead of waiting for a remote pull that may never arrive
  - Add an initial remote pull at the start of the sync loop to ensure fresh state regardless of subscription delivery