### PR TITLE
fix: use workflow_run trigger for CLI sync workflows

### DIFF
--- a/.github/workflows/sync-cli-langs.yml
+++ b/.github/workflows/sync-cli-langs.yml
@@ -7,59 +7,21 @@ on:
       - 'crates/breez-sdk/cli/src/**'
       - 'crates/breez-sdk/cli/README.md'
   workflow_dispatch:
-    inputs:
-      languages-to-sync:
-        description: 'Array of languages to sync (remove what you do not want)'
-        required: true
-        type: string
-        default: '["python", "go", "dart"]'
-      base-sha:
-        description: 'Base commit SHA to diff against (leave empty to auto-detect from last sync commit)'
-        required: false
-        type: string
+
+# This workflow acts as a trigger for the per-language sync workflows.
+# They react to this workflow's completion via the workflow_run event,
+# which claude-code-action supports (unlike push).
+#
+# To sync a single language manually, dispatch its workflow directly
+# (e.g., "Sync Dart CLI from Rust CLI") instead of this umbrella.
 
 concurrency:
   group: sync-cli-langs-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:
-  sync-python:
-    name: Sync Python CLI
-    if: contains(fromJSON(inputs.languages-to-sync || '["python", "go", "dart"]'), 'python')
-    uses: ./.github/workflows/sync-python-cli.yml
-    with:
-      base_sha: ${{ github.event.before || inputs.base-sha || '' }}
-    secrets: inherit
-
-  sync-go:
-    name: Sync Go CLI
-    if: contains(fromJSON(inputs.languages-to-sync || '["python", "go", "dart"]'), 'go')
-    uses: ./.github/workflows/sync-go-cli.yml
-    with:
-      base_sha: ${{ github.event.before || inputs.base-sha || '' }}
-    secrets: inherit
-
-  sync-dart:
-    name: Sync Dart CLI
-    if: contains(fromJSON(inputs.languages-to-sync || '["python", "go", "dart"]'), 'dart')
-    uses: ./.github/workflows/sync-dart-cli.yml
-    with:
-      base_sha: ${{ github.event.before || inputs.base-sha || '' }}
-    secrets: inherit
-
-  summary:
-    name: Sync Summary
-    needs: [sync-python, sync-go, sync-dart]
-    if: always()
+  trigger:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 1
     steps:
-      - name: Report results
-        run: |
-          echo "## CLI Sync Results" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Language | Status |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|----------|--------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Python | ${{ needs.sync-python.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Go | ${{ needs.sync-go.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Dart | ${{ needs.sync-dart.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
+      - run: echo "Rust CLI changed — language syncs will start via workflow_run"

--- a/.github/workflows/sync-dart-cli.yml
+++ b/.github/workflows/sync-dart-cli.yml
@@ -9,12 +9,9 @@ on:
         description: 'Base commit SHA to diff against (leave empty to auto-detect from last sync commit)'
         required: false
         type: string
-  workflow_call:
-    inputs:
-      base_sha:
-        description: 'Base commit SHA for diffing (from umbrella workflow or github.event.before)'
-        required: false
-        type: string
+  workflow_run:
+    workflows: ["Sync CLI Languages"]
+    types: [completed]
 
 concurrency:
   group: sync-dart-cli-${{ github.sha }}
@@ -22,6 +19,9 @@ concurrency:
 
 jobs:
   sync-dart-cli:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -39,9 +39,9 @@ jobs:
         id: diff-info
         run: |
           # Determine diff base. Priority:
-          # 1. Explicit base_sha from umbrella workflow or workflow_dispatch input
+          # 1. Explicit base-sha from workflow_dispatch input
           # 2. Auto-detect: last commit that touched this language CLI (= last sync point)
-          DIFF_BASE="${{ inputs.base_sha || inputs.base-sha }}"
+          DIFF_BASE="${{ inputs.base-sha }}"
           if [ -z "$DIFF_BASE" ] || [ "$DIFF_BASE" = "0000000000000000000000000000000000000000" ]; then
             DIFF_BASE=$(git log -1 --format=%H -- 'crates/breez-sdk/bindings/examples/cli/langs/dart/')
             if [ -n "$DIFF_BASE" ]; then

--- a/.github/workflows/sync-go-cli.yml
+++ b/.github/workflows/sync-go-cli.yml
@@ -9,12 +9,9 @@ on:
         description: 'Base commit SHA to diff against (leave empty to auto-detect from last sync commit)'
         required: false
         type: string
-  workflow_call:
-    inputs:
-      base_sha:
-        description: 'Base commit SHA for diffing (from umbrella workflow or github.event.before)'
-        required: false
-        type: string
+  workflow_run:
+    workflows: ["Sync CLI Languages"]
+    types: [completed]
 
 concurrency:
   group: sync-go-cli-${{ github.sha }}
@@ -22,6 +19,9 @@ concurrency:
 
 jobs:
   sync-go-cli:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -39,9 +39,9 @@ jobs:
         id: diff-info
         run: |
           # Determine diff base. Priority:
-          # 1. Explicit base_sha from umbrella workflow or workflow_dispatch input
+          # 1. Explicit base-sha from workflow_dispatch input
           # 2. Auto-detect: last commit that touched this language CLI (= last sync point)
-          DIFF_BASE="${{ inputs.base_sha || inputs.base-sha }}"
+          DIFF_BASE="${{ inputs.base-sha }}"
           if [ -z "$DIFF_BASE" ] || [ "$DIFF_BASE" = "0000000000000000000000000000000000000000" ]; then
             DIFF_BASE=$(git log -1 --format=%H -- 'crates/breez-sdk/bindings/examples/cli/langs/go/')
             if [ -n "$DIFF_BASE" ]; then

--- a/.github/workflows/sync-python-cli.yml
+++ b/.github/workflows/sync-python-cli.yml
@@ -9,12 +9,9 @@ on:
         description: 'Base commit SHA to diff against (leave empty to auto-detect from last sync commit)'
         required: false
         type: string
-  workflow_call:
-    inputs:
-      base_sha:
-        description: 'Base commit SHA for diffing (from umbrella workflow or github.event.before)'
-        required: false
-        type: string
+  workflow_run:
+    workflows: ["Sync CLI Languages"]
+    types: [completed]
 
 concurrency:
   group: sync-python-cli-${{ github.sha }}
@@ -22,6 +19,9 @@ concurrency:
 
 jobs:
   sync-python-cli:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -39,9 +39,9 @@ jobs:
         id: diff-info
         run: |
           # Determine diff base. Priority:
-          # 1. Explicit base_sha from umbrella workflow or workflow_dispatch input
+          # 1. Explicit base-sha from workflow_dispatch input
           # 2. Auto-detect: last commit that touched this language CLI (= last sync point)
-          DIFF_BASE="${{ inputs.base_sha || inputs.base-sha }}"
+          DIFF_BASE="${{ inputs.base-sha }}"
           if [ -z "$DIFF_BASE" ] || [ "$DIFF_BASE" = "0000000000000000000000000000000000000000" ]; then
             DIFF_BASE=$(git log -1 --format=%H -- 'crates/breez-sdk/bindings/examples/cli/langs/python/')
             if [ -n "$DIFF_BASE" ]; then

--- a/crates/breez-sdk/bindings/examples/cli/sync-prompts/workflow-template.yml
+++ b/crates/breez-sdk/bindings/examples/cli/sync-prompts/workflow-template.yml
@@ -9,12 +9,9 @@ on:
         description: 'Base commit SHA to diff against (leave empty to auto-detect from last sync commit)'
         required: false
         type: string
-  workflow_call:
-    inputs:
-      base_sha:
-        description: 'Base commit SHA for diffing (from umbrella workflow or github.event.before)'
-        required: false
-        type: string
+  workflow_run:
+    workflows: ["Sync CLI Languages"]
+    types: [completed]
 
 concurrency:
   group: {{CONCURRENCY_GROUP}}-${{ github.sha }}
@@ -22,6 +19,9 @@ concurrency:
 
 jobs:
   {{JOB_NAME}}:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -39,9 +39,9 @@ jobs:
         id: diff-info
         run: |
           # Determine diff base. Priority:
-          # 1. Explicit base_sha from umbrella workflow or workflow_dispatch input
+          # 1. Explicit base-sha from workflow_dispatch input
           # 2. Auto-detect: last commit that touched this language CLI (= last sync point)
-          DIFF_BASE="${{ inputs.base_sha || inputs.base-sha }}"
+          DIFF_BASE="${{ inputs.base-sha }}"
           if [ -z "$DIFF_BASE" ] || [ "$DIFF_BASE" = "0000000000000000000000000000000000000000" ]; then
             DIFF_BASE=$(git log -1 --format=%H -- '{{TARGET_DIR}}')
             if [ -n "$DIFF_BASE" ]; then


### PR DESCRIPTION
## Summary
- `claude-code-action` does not support `push` events, causing "Unsupported event type: push" errors when the umbrella workflow called child workflows via `workflow_call` (which inherits the parent's event type)
- Switched to the `workflow_run` pattern (matching the official `ci-failure-auto-fix.yml` example): the umbrella becomes a lightweight trigger, and per-language sync workflows react to its completion
- Updated the workflow template and regenerated all per-language workflow files

## Test plan
- [ ] Merge to main with a CLI source change and verify the umbrella triggers, then each language sync workflow starts via `workflow_run`
- [ ] Manually dispatch an individual language sync workflow and verify it still works via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)