### PR TITLE
ci: add analysis checks for Dart and Go CLI examples

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,6 +177,43 @@ jobs:
       - name: Verify generated workflow files are up-to-date
         run: make sync-prompts-check
 
+  cli-examples:
+    name: CLI examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: 3.38.9
+
+      - name: Set up just
+        uses: extractions/setup-just@v3
+
+      - name: Generate Flutter bindings
+        working-directory: packages/flutter
+        run: just codegen
+
+      - name: Check Dart CLI
+        working-directory: crates/breez-sdk/bindings/examples/cli
+        run: make check-dart
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.19'
+
+      - name: Check Go CLI
+        working-directory: crates/breez-sdk/bindings/examples/cli
+        run: make check-go
+
   docs-rust:
     name: Docs (rust)
     runs-on: ubuntu-latest

--- a/crates/breez-sdk/bindings/examples/cli/Makefile
+++ b/crates/breez-sdk/bindings/examples/cli/Makefile
@@ -17,8 +17,12 @@ sync-prompts-generate: ## Regenerate workflow files from templates
 check-python: ## Syntax-check Python CLI source files
 	python3 -m py_compile $(PYTHON_SRC)/*.py
 
-check-go: ## Syntax-check Go CLI source files
+check-go: ## Check Go CLI (format + build + vet)
 	cd $(GO_SRC) && gofmt -e *.go > /dev/null
+	cd $(GO_SRC) && go build ./...
+	cd $(GO_SRC) && go vet ./...
 
-check-dart: ## Syntax-check Dart CLI source files
-	cd $(DART_SRC) && dart format --set-exit-if-changed lib/ bin/
+check-dart: ## Check Dart CLI (format + analyze)
+	cd $(DART_SRC) && dart pub get
+	cd $(DART_SRC) && dart format -l 110 --set-exit-if-changed lib/ bin/
+	cd $(DART_SRC) && dart analyze --fatal-infos lib/ bin/

--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/analysis_options.yaml
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/analysis_options.yaml
@@ -1,0 +1,8 @@
+include: package:lints/recommended.yaml
+
+formatter:
+  page_width: 110
+
+linter:
+  rules:
+    depend_on_referenced_packages: false

--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/bin/breez_cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/bin/breez_cli.dart
@@ -6,22 +6,9 @@ import 'package:breez_cli/cli.dart';
 Future<void> main(List<String> arguments) async {
   final parser =
       ArgParser()
-        ..addOption(
-          'data-dir',
-          abbr: 'd',
-          defaultsTo: './.data',
-          help: 'Path to the data directory',
-        )
-        ..addOption(
-          'network',
-          defaultsTo: 'regtest',
-          allowed: ['regtest', 'mainnet'],
-          help: 'Network to use',
-        )
-        ..addOption(
-          'account-number',
-          help: 'Account number for the Spark signer',
-        )
+        ..addOption('data-dir', abbr: 'd', defaultsTo: './.data', help: 'Path to the data directory')
+        ..addOption('network', defaultsTo: 'regtest', allowed: ['regtest', 'mainnet'], help: 'Network to use')
+        ..addOption('account-number', help: 'Account number for the Spark signer')
         ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage');
 
   final ArgResults results;
@@ -45,14 +32,9 @@ Future<void> main(List<String> arguments) async {
   final dataDir = results.option('data-dir')!;
   final network = results.option('network')!;
   final accountNumberStr = results.option('account-number');
-  final accountNumber =
-      accountNumberStr != null ? int.parse(accountNumberStr) : null;
+  final accountNumber = accountNumberStr != null ? int.parse(accountNumberStr) : null;
 
-  await runCli(
-    dataDir: dataDir,
-    network: network,
-    accountNumber: accountNumber,
-  );
+  await runCli(dataDir: dataDir, network: network, accountNumber: accountNumber);
 
   // Force exit — the native FFI library may keep background threads alive
   // after sdk.disconnect(), preventing the Dart VM from exiting cleanly.

--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/cli.dart
@@ -10,14 +10,8 @@ import 'persistence.dart';
 import 'readline.dart';
 import 'serialization.dart';
 
-Future<void> runCli({
-  required String dataDir,
-  required String network,
-  int? accountNumber,
-}) async {
-  await BreezSdkSparkLib.init(
-    externalLibrary: ExternalLibrary.open(_nativeLibPath()),
-  );
+Future<void> runCli({required String dataDir, required String network, int? accountNumber}) async {
+  await BreezSdkSparkLib.init(externalLibrary: ExternalLibrary.open(_nativeLibPath()));
 
   final dir = Directory(dataDir);
   if (!dir.existsSync()) {
@@ -85,17 +79,8 @@ Future<void> _runRepl(
   stdout.writeln("Type 'help' for available commands or 'exit' to quit");
 
   final registry = buildCommandRegistry();
-  final allCommands = [
-    ...commandNames,
-    ...issuerCommandNames,
-    'exit',
-    'quit',
-    'help',
-  ];
-  final rl = Readline(
-    completions: allCommands,
-    historyFile: persistence.historyFile,
-  );
+  final allCommands = [...commandNames, ...issuerCommandNames, 'exit', 'quit', 'help'];
+  final rl = Readline(completions: allCommands, historyFile: persistence.historyFile);
 
   while (true) {
     try {
@@ -126,9 +111,7 @@ Future<void> _runRepl(
         final entry = registry[cmdName]!;
         await entry.handler(sdk, tokenIssuer, cmdArgs);
       } else {
-        stdout.writeln(
-          "Unknown command: $cmdName. Type 'help' for available commands.",
-        );
+        stdout.writeln("Unknown command: $cmdName. Type 'help' for available commands.");
       }
     } on StdinException {
       stdout.writeln('');

--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/commands.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -40,12 +39,7 @@ const commandNames = [
   'get-spark-status',
 ];
 
-typedef CommandHandler =
-    Future<void> Function(
-      BreezSdk sdk,
-      TokenIssuer tokenIssuer,
-      List<String> args,
-    );
+typedef CommandHandler = Future<void> Function(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args);
 
 class CommandEntry {
   final String description;
@@ -57,89 +51,41 @@ class CommandEntry {
 Map<String, CommandEntry> buildCommandRegistry() {
   return {
     'get-info': CommandEntry('Get balance information', _handleGetInfo),
-    'get-payment': CommandEntry(
-      'Get the payment with the given ID',
-      _handleGetPayment,
-    ),
+    'get-payment': CommandEntry('Get the payment with the given ID', _handleGetPayment),
     'sync': CommandEntry('Sync wallet state', _handleSync),
     'list-payments': CommandEntry('List payments', _handleListPayments),
     'receive': CommandEntry('Receive a payment', _handleReceive),
     'pay': CommandEntry('Pay the given payment request', _handlePay),
     'lnurl-pay': CommandEntry('Pay using LNURL', _handleLnurlPay),
-    'lnurl-withdraw': CommandEntry(
-      'Withdraw using LNURL',
-      _handleLnurlWithdraw,
-    ),
+    'lnurl-withdraw': CommandEntry('Withdraw using LNURL', _handleLnurlWithdraw),
     'lnurl-auth': CommandEntry('Authenticate using LNURL', _handleLnurlAuth),
-    'claim-htlc-payment': CommandEntry(
-      'Claim an HTLC payment',
-      _handleClaimHtlcPayment,
-    ),
-    'claim-deposit': CommandEntry(
-      'Claim an on-chain deposit',
-      _handleClaimDeposit,
-    ),
-    'parse': CommandEntry(
-      'Parse an input (invoice, address, LNURL)',
-      _handleParse,
-    ),
-    'refund-deposit': CommandEntry(
-      'Refund an on-chain deposit',
-      _handleRefundDeposit,
-    ),
-    'list-unclaimed-deposits': CommandEntry(
-      'List unclaimed on-chain deposits',
-      _handleListUnclaimedDeposits,
-    ),
+    'claim-htlc-payment': CommandEntry('Claim an HTLC payment', _handleClaimHtlcPayment),
+    'claim-deposit': CommandEntry('Claim an on-chain deposit', _handleClaimDeposit),
+    'parse': CommandEntry('Parse an input (invoice, address, LNURL)', _handleParse),
+    'refund-deposit': CommandEntry('Refund an on-chain deposit', _handleRefundDeposit),
+    'list-unclaimed-deposits': CommandEntry('List unclaimed on-chain deposits', _handleListUnclaimedDeposits),
     'buy-bitcoin': CommandEntry('Buy Bitcoin via MoonPay', _handleBuyBitcoin),
     'check-lightning-address-available': CommandEntry(
       'Check if a lightning address username is available',
       _handleCheckLightningAddressAvailable,
     ),
-    'get-lightning-address': CommandEntry(
-      'Get registered lightning address',
-      _handleGetLightningAddress,
-    ),
+    'get-lightning-address': CommandEntry('Get registered lightning address', _handleGetLightningAddress),
     'register-lightning-address': CommandEntry(
       'Register a lightning address',
       _handleRegisterLightningAddress,
     ),
-    'delete-lightning-address': CommandEntry(
-      'Delete lightning address',
-      _handleDeleteLightningAddress,
-    ),
-    'list-fiat-currencies': CommandEntry(
-      'List fiat currencies',
-      _handleListFiatCurrencies,
-    ),
-    'list-fiat-rates': CommandEntry(
-      'List available fiat rates',
-      _handleListFiatRates,
-    ),
-    'recommended-fees': CommandEntry(
-      'Get recommended BTC fees',
-      _handleRecommendedFees,
-    ),
-    'get-tokens-metadata': CommandEntry(
-      'Get metadata for token(s)',
-      _handleGetTokensMetadata,
-    ),
+    'delete-lightning-address': CommandEntry('Delete lightning address', _handleDeleteLightningAddress),
+    'list-fiat-currencies': CommandEntry('List fiat currencies', _handleListFiatCurrencies),
+    'list-fiat-rates': CommandEntry('List available fiat rates', _handleListFiatRates),
+    'recommended-fees': CommandEntry('Get recommended BTC fees', _handleRecommendedFees),
+    'get-tokens-metadata': CommandEntry('Get metadata for token(s)', _handleGetTokensMetadata),
     'fetch-conversion-limits': CommandEntry(
       'Fetch conversion limits for a token',
       _handleFetchConversionLimits,
     ),
-    'get-user-settings': CommandEntry(
-      'Get user settings',
-      _handleGetUserSettings,
-    ),
-    'set-user-settings': CommandEntry(
-      'Update user settings',
-      _handleSetUserSettings,
-    ),
-    'get-spark-status': CommandEntry(
-      'Get Spark network service status',
-      _handleGetSparkStatus,
-    ),
+    'get-user-settings': CommandEntry('Get user settings', _handleGetUserSettings),
+    'set-user-settings': CommandEntry('Update user settings', _handleSetUserSettings),
+    'get-spark-status': CommandEntry('Get Spark network service status', _handleGetSparkStatus),
   };
 }
 
@@ -178,28 +124,18 @@ bool? _parseBool(String? value) {
 
 // --- get-info ---
 
-Future<void> _handleGetInfo(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleGetInfo(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final parser = _parser('get-info')..addOption('ensure-synced', abbr: 'e');
   final results = _parseArgs(parser, args, 'get-info [options]');
   if (results == null) return;
   final ensureSynced = _parseBool(results.option('ensure-synced'));
-  final result = await sdk.getInfo(
-    request: GetInfoRequest(ensureSynced: ensureSynced),
-  );
+  final result = await sdk.getInfo(request: GetInfoRequest(ensureSynced: ensureSynced));
   printValue(result);
 }
 
 // --- get-payment ---
 
-Future<void> _handleGetPayment(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleGetPayment(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final parser = _parser('get-payment');
   if (args.isEmpty || args.contains('help') || args.contains('--help')) {
     print('Usage: get-payment <payment_id>');
@@ -207,19 +143,13 @@ Future<void> _handleGetPayment(
   }
   parser.parse(args);
   final paymentId = args.last;
-  final result = await sdk.getPayment(
-    request: GetPaymentRequest(paymentId: paymentId),
-  );
+  final result = await sdk.getPayment(request: GetPaymentRequest(paymentId: paymentId));
   printValue(result);
 }
 
 // --- sync ---
 
-Future<void> _handleSync(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleSync(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final result = await sdk.syncWallet(request: SyncWalletRequest());
   printValue(result);
 }
@@ -276,11 +206,7 @@ TokenTransactionType? _parseTxType(String s) {
   }
 }
 
-Future<void> _handleListPayments(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleListPayments(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final parser =
       _parser('list-payments')
         ..addMultiOption('type-filter', abbr: 't')
@@ -300,21 +226,13 @@ Future<void> _handleListPayments(
   List<PaymentType>? typeFilter;
   final typeFilterValues = results.multiOption('type-filter');
   if (typeFilterValues.isNotEmpty) {
-    typeFilter =
-        typeFilterValues
-            .map(_parsePaymentType)
-            .whereType<PaymentType>()
-            .toList();
+    typeFilter = typeFilterValues.map(_parsePaymentType).whereType<PaymentType>().toList();
   }
 
   List<PaymentStatus>? statusFilter;
   final statusFilterValues = results.multiOption('status-filter');
   if (statusFilterValues.isNotEmpty) {
-    statusFilter =
-        statusFilterValues
-            .map(_parsePaymentStatus)
-            .whereType<PaymentStatus>()
-            .toList();
+    statusFilter = statusFilterValues.map(_parsePaymentStatus).whereType<PaymentStatus>().toList();
   }
 
   AssetFilter? assetFilter;
@@ -330,15 +248,9 @@ Future<void> _handleListPayments(
   final paymentDetailsFilter = <PaymentDetailsFilter>[];
   final htlcStatusValues = results.multiOption('spark-htlc-status-filter');
   if (htlcStatusValues.isNotEmpty) {
-    final statuses =
-        htlcStatusValues
-            .map(_parseHtlcStatus)
-            .whereType<SparkHtlcStatus>()
-            .toList();
+    final statuses = htlcStatusValues.map(_parseHtlcStatus).whereType<SparkHtlcStatus>().toList();
     if (statuses.isNotEmpty) {
-      paymentDetailsFilter.add(
-        PaymentDetailsFilter.spark(htlcStatus: statuses),
-      );
+      paymentDetailsFilter.add(PaymentDetailsFilter.spark(htlcStatus: statuses));
     }
   }
   final txHash = results.option('tx-hash');
@@ -363,10 +275,8 @@ Future<void> _handleListPayments(
       typeFilter: typeFilter,
       statusFilter: statusFilter,
       assetFilter: assetFilter,
-      paymentDetailsFilter:
-          paymentDetailsFilter.isNotEmpty ? paymentDetailsFilter : null,
-      fromTimestamp:
-          fromTimestampStr != null ? BigInt.parse(fromTimestampStr) : null,
+      paymentDetailsFilter: paymentDetailsFilter.isNotEmpty ? paymentDetailsFilter : null,
+      fromTimestamp: fromTimestampStr != null ? BigInt.parse(fromTimestampStr) : null,
       toTimestamp: toTimestampStr != null ? BigInt.parse(toTimestampStr) : null,
       sortAscending: _parseBool(results.option('sort-ascending')),
     ),
@@ -376,19 +286,10 @@ Future<void> _handleListPayments(
 
 // --- receive ---
 
-Future<void> _handleReceive(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleReceive(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final parser =
       _parser('receive')
-        ..addOption(
-          'method',
-          abbr: 'm',
-          mandatory: true,
-          help: 'sparkaddress, sparkinvoice, bitcoin, bolt11',
-        )
+        ..addOption('method', abbr: 'm', mandatory: true, help: 'sparkaddress, sparkinvoice, bitcoin, bolt11')
         ..addOption('description', abbr: 'd')
         ..addOption('amount', abbr: 'a')
         ..addOption('token-identifier', abbr: 't')
@@ -415,9 +316,7 @@ Future<void> _handleReceive(
     case 'sparkinvoice':
       BigInt? expiryTime;
       if (expirySecs != null) {
-        expiryTime = BigInt.from(
-          DateTime.now().millisecondsSinceEpoch ~/ 1000 + expirySecs,
-        );
+        expiryTime = BigInt.from(DateTime.now().millisecondsSinceEpoch ~/ 1000 + expirySecs);
       }
       paymentMethod = ReceivePaymentMethod.sparkInvoice(
         amount: amount,
@@ -453,14 +352,10 @@ Future<void> _handleReceive(
       return;
   }
 
-  final result = await sdk.receivePayment(
-    request: ReceivePaymentRequest(paymentMethod: paymentMethod),
-  );
+  final result = await sdk.receivePayment(request: ReceivePaymentRequest(paymentMethod: paymentMethod));
 
   if (result.fee > BigInt.zero) {
-    print(
-      'Prepared payment requires fee of ${result.fee} sats/token base units\n',
-    );
+    print('Prepared payment requires fee of ${result.fee} sats/token base units\n');
   }
 
   printValue(result);
@@ -468,19 +363,10 @@ Future<void> _handleReceive(
 
 // --- pay ---
 
-Future<void> _handlePay(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final parser =
       _parser('pay')
-        ..addOption(
-          'payment-request',
-          abbr: 'r',
-          mandatory: true,
-          help: 'Invoice, address, or LNURL to pay',
-        )
+        ..addOption('payment-request', abbr: 'r', mandatory: true, help: 'Invoice, address, or LNURL to pay')
         ..addOption('amount', abbr: 'a')
         ..addOption('token-identifier', abbr: 't')
         ..addOption('idempotency-key', abbr: 'i')
@@ -532,12 +418,8 @@ Future<void> _handlePay(
   if (prepareResponse.conversionEstimate != null) {
     final est = prepareResponse.conversionEstimate!;
     final units =
-        prepareResponse.paymentMethod is SendPaymentMethod_BitcoinAddress
-            ? 'sats'
-            : 'token base units';
-    print(
-      'Estimated conversion of ${est.amount} $units with a ${est.fee} $units fee',
-    );
+        prepareResponse.paymentMethod is SendPaymentMethod_BitcoinAddress ? 'sats' : 'token base units';
+    print('Estimated conversion of ${est.amount} $units with a ${est.fee} $units fee');
     final answer = prompt('Do you want to continue (y/n): ', defaultValue: 'y');
     if (answer.toLowerCase() != 'y') {
       print('Payment cancelled');
@@ -559,11 +441,7 @@ Future<void> _handlePay(
 
 // --- lnurl-pay ---
 
-Future<void> _handleLnurlPay(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleLnurlPay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final parser =
       _parser('lnurl-pay')
         ..addOption('comment', abbr: 'c')
@@ -572,11 +450,7 @@ Future<void> _handleLnurlPay(
         ..addOption('from-token')
         ..addOption('convert-max-slippage-bps', abbr: 's')
         ..addFlag('fees-included', defaultsTo: false);
-  final results = _parseArgs(
-    parser,
-    args,
-    'lnurl-pay <lnurl-or-address> [options]',
-  );
+  final results = _parseArgs(parser, args, 'lnurl-pay <lnurl-or-address> [options]');
   if (results == null) return;
 
   // The LNURL is the first positional argument (remaining args)
@@ -614,12 +488,10 @@ Future<void> _handleLnurlPay(
     return;
   }
 
-  final _k = BigInt.from(1000);
-  final minSendable = (payRequest.minSendable + _k - BigInt.one) ~/ _k;
-  final maxSendable = payRequest.maxSendable ~/ _k;
-  final amountStr = prompt(
-    'Amount to pay (min $minSendable sat, max $maxSendable sat): ',
-  );
+  final k = BigInt.from(1000);
+  final minSendable = (payRequest.minSendable + k - BigInt.one) ~/ k;
+  final maxSendable = payRequest.maxSendable ~/ k;
+  final amountStr = prompt('Amount to pay (min $minSendable sat, max $maxSendable sat): ');
   final amountSats = BigInt.parse(amountStr);
 
   final prepareResponse = await sdk.prepareLnurlPay(
@@ -635,9 +507,7 @@ Future<void> _handleLnurlPay(
 
   if (prepareResponse.conversionEstimate != null) {
     final est = prepareResponse.conversionEstimate!;
-    print(
-      'Estimated conversion of ${est.amount} token base units with a ${est.fee} token base units fee',
-    );
+    print('Estimated conversion of ${est.amount} token base units with a ${est.fee} token base units fee');
     final answer = prompt('Do you want to continue (y/n): ', defaultValue: 'y');
     if (answer.toLowerCase() != 'y') {
       print('Payment cancelled');
@@ -660,11 +530,7 @@ Future<void> _handleLnurlPay(
 
 // --- lnurl-withdraw ---
 
-Future<void> _handleLnurlWithdraw(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleLnurlWithdraw(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final parser = _parser('lnurl-withdraw')..addOption('timeout', abbr: 't');
   final results = _parseArgs(parser, args, 'lnurl-withdraw <lnurl> [options]');
   if (results == null) return;
@@ -685,13 +551,10 @@ Future<void> _handleLnurlWithdraw(
   }
 
   final withdrawRequest = parsed.field0;
-  final _k = BigInt.from(1000);
-  final minWithdrawable =
-      (withdrawRequest.minWithdrawable + _k - BigInt.one) ~/ _k;
-  final maxWithdrawable = withdrawRequest.maxWithdrawable ~/ _k;
-  final amountStr = prompt(
-    'Amount to withdraw (min $minWithdrawable sat, max $maxWithdrawable sat): ',
-  );
+  final k = BigInt.from(1000);
+  final minWithdrawable = (withdrawRequest.minWithdrawable + k - BigInt.one) ~/ k;
+  final maxWithdrawable = withdrawRequest.maxWithdrawable ~/ k;
+  final amountStr = prompt('Amount to withdraw (min $minWithdrawable sat, max $maxWithdrawable sat): ');
   final amountSats = BigInt.parse(amountStr);
 
   final result = await sdk.lnurlWithdraw(
@@ -706,11 +569,7 @@ Future<void> _handleLnurlWithdraw(
 
 // --- lnurl-auth ---
 
-Future<void> _handleLnurlAuth(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleLnurlAuth(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   if (args.isEmpty || args.first == 'help' || args.first == '--help') {
     print('Usage: lnurl-auth <lnurl>');
     return;
@@ -738,39 +597,25 @@ Future<void> _handleLnurlAuth(
 
 // --- claim-htlc-payment ---
 
-Future<void> _handleClaimHtlcPayment(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleClaimHtlcPayment(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   if (args.isEmpty || args.first == 'help' || args.first == '--help') {
     print('Usage: claim-htlc-payment <preimage>');
     return;
   }
   final preimage = args.first;
-  final result = await sdk.claimHtlcPayment(
-    request: ClaimHtlcPaymentRequest(preimage: preimage),
-  );
+  final result = await sdk.claimHtlcPayment(request: ClaimHtlcPaymentRequest(preimage: preimage));
   printValue(result.payment);
 }
 
 // --- claim-deposit ---
 
-Future<void> _handleClaimDeposit(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleClaimDeposit(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final parser =
       _parser('claim-deposit')
         ..addOption('fee-sat')
         ..addOption('sat-per-vbyte')
         ..addOption('recommended-fee-leeway');
-  final results = _parseArgs(
-    parser,
-    args,
-    'claim-deposit <txid> <vout> [options]',
-  );
+  final results = _parseArgs(parser, args, 'claim-deposit <txid> <vout> [options]');
   if (results == null) return;
 
   if (results.rest.length < 2) {
@@ -787,14 +632,10 @@ Future<void> _handleClaimDeposit(
   MaxFee? maxFee;
   if (leewayStr != null) {
     if (feeSatStr != null || satPerVbyteStr != null) {
-      print(
-        'Cannot specify fee_sat or sat_per_vbyte when using recommended fee',
-      );
+      print('Cannot specify fee_sat or sat_per_vbyte when using recommended fee');
       return;
     }
-    maxFee = MaxFee.networkRecommended(
-      leewaySatPerVbyte: BigInt.parse(leewayStr),
-    );
+    maxFee = MaxFee.networkRecommended(leewaySatPerVbyte: BigInt.parse(leewayStr));
   } else if (feeSatStr != null && satPerVbyteStr != null) {
     print('Cannot specify both fee_sat and sat_per_vbyte');
     return;
@@ -804,19 +645,13 @@ Future<void> _handleClaimDeposit(
     maxFee = MaxFee.rate(satPerVbyte: BigInt.parse(satPerVbyteStr));
   }
 
-  final result = await sdk.claimDeposit(
-    request: ClaimDepositRequest(txid: txid, vout: vout, maxFee: maxFee),
-  );
+  final result = await sdk.claimDeposit(request: ClaimDepositRequest(txid: txid, vout: vout, maxFee: maxFee));
   printValue(result);
 }
 
 // --- parse ---
 
-Future<void> _handleParse(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleParse(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   if (args.isEmpty || args.first == 'help' || args.first == '--help') {
     print('Usage: parse <input>');
     return;
@@ -828,26 +663,16 @@ Future<void> _handleParse(
 
 // --- refund-deposit ---
 
-Future<void> _handleRefundDeposit(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleRefundDeposit(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final parser =
       _parser('refund-deposit')
         ..addOption('fee-sat')
         ..addOption('sat-per-vbyte');
-  final results = _parseArgs(
-    parser,
-    args,
-    'refund-deposit <txid> <vout> <address> [options]',
-  );
+  final results = _parseArgs(parser, args, 'refund-deposit <txid> <vout> <address> [options]');
   if (results == null) return;
 
   if (results.rest.length < 3) {
-    print(
-      'Usage: refund-deposit <txid> <vout> <destination_address> [options]',
-    );
+    print('Usage: refund-deposit <txid> <vout> <destination_address> [options]');
     return;
   }
   final txid = results.rest[0];
@@ -873,36 +698,21 @@ Future<void> _handleRefundDeposit(
   }
 
   final result = await sdk.refundDeposit(
-    request: RefundDepositRequest(
-      txid: txid,
-      vout: vout,
-      destinationAddress: destinationAddress,
-      fee: fee,
-    ),
+    request: RefundDepositRequest(txid: txid, vout: vout, destinationAddress: destinationAddress, fee: fee),
   );
   printValue(result);
 }
 
 // --- list-unclaimed-deposits ---
 
-Future<void> _handleListUnclaimedDeposits(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
-  final result = await sdk.listUnclaimedDeposits(
-    request: ListUnclaimedDepositsRequest(),
-  );
+Future<void> _handleListUnclaimedDeposits(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
+  final result = await sdk.listUnclaimedDeposits(request: ListUnclaimedDepositsRequest());
   printValue(result);
 }
 
 // --- buy-bitcoin ---
 
-Future<void> _handleBuyBitcoin(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleBuyBitcoin(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final parser =
       _parser('buy-bitcoin')
         ..addOption('locked-amount-sat')
@@ -915,10 +725,7 @@ Future<void> _handleBuyBitcoin(
   final redirectUrl = results.option('redirect-url');
 
   final result = await sdk.buyBitcoin(
-    request: BuyBitcoinRequest(
-      lockedAmountSat: lockedAmount,
-      redirectUrl: redirectUrl,
-    ),
+    request: BuyBitcoinRequest(lockedAmountSat: lockedAmount, redirectUrl: redirectUrl),
   );
   print('Open this URL in a browser to complete the purchase:');
   print(result.url);
@@ -944,22 +751,14 @@ Future<void> _handleCheckLightningAddressAvailable(
 
 // --- get-lightning-address ---
 
-Future<void> _handleGetLightningAddress(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleGetLightningAddress(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final result = await sdk.getLightningAddress();
   printValue(result);
 }
 
 // --- register-lightning-address ---
 
-Future<void> _handleRegisterLightningAddress(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleRegisterLightningAddress(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   if (args.isEmpty || args.first == 'help' || args.first == '--help') {
     print('Usage: register-lightning-address <username> [description]');
     return;
@@ -967,91 +766,55 @@ Future<void> _handleRegisterLightningAddress(
   final username = args[0];
   final description = args.length > 1 ? args[1] : null;
   final result = await sdk.registerLightningAddress(
-    request: RegisterLightningAddressRequest(
-      username: username,
-      description: description,
-    ),
+    request: RegisterLightningAddressRequest(username: username, description: description),
   );
   printValue(result);
 }
 
 // --- delete-lightning-address ---
 
-Future<void> _handleDeleteLightningAddress(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleDeleteLightningAddress(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   await sdk.deleteLightningAddress();
   print('Lightning address deleted');
 }
 
 // --- list-fiat-currencies ---
 
-Future<void> _handleListFiatCurrencies(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleListFiatCurrencies(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final result = await sdk.listFiatCurrencies();
   printValue(result);
 }
 
 // --- list-fiat-rates ---
 
-Future<void> _handleListFiatRates(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleListFiatRates(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final result = await sdk.listFiatRates();
   printValue(result);
 }
 
 // --- recommended-fees ---
 
-Future<void> _handleRecommendedFees(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleRecommendedFees(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final result = await sdk.recommendedFees();
   printValue(result);
 }
 
 // --- get-tokens-metadata ---
 
-Future<void> _handleGetTokensMetadata(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleGetTokensMetadata(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   if (args.isEmpty || args.first == 'help' || args.first == '--help') {
-    print(
-      'Usage: get-tokens-metadata <token_identifier> [token_identifier...]',
-    );
+    print('Usage: get-tokens-metadata <token_identifier> [token_identifier...]');
     return;
   }
-  final result = await sdk.getTokensMetadata(
-    request: GetTokensMetadataRequest(tokenIdentifiers: args),
-  );
+  final result = await sdk.getTokensMetadata(request: GetTokensMetadataRequest(tokenIdentifiers: args));
   printValue(result);
 }
 
 // --- fetch-conversion-limits ---
 
-Future<void> _handleFetchConversionLimits(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
-  final parser = _parser('fetch-conversion-limits')
-    ..addFlag('from-bitcoin', abbr: 'f', defaultsTo: false);
-  final results = _parseArgs(
-    parser,
-    args,
-    'fetch-conversion-limits [-f] <token_identifier>',
-  );
+Future<void> _handleFetchConversionLimits(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
+  final parser = _parser('fetch-conversion-limits')..addFlag('from-bitcoin', abbr: 'f', defaultsTo: false);
+  final results = _parseArgs(parser, args, 'fetch-conversion-limits [-f] <token_identifier>');
   if (results == null) return;
 
   if (results.rest.isEmpty) {
@@ -1069,9 +832,7 @@ Future<void> _handleFetchConversionLimits(
     );
   } else {
     request = FetchConversionLimitsRequest(
-      conversionType: ConversionType.toBitcoin(
-        fromTokenIdentifier: tokenIdentifier,
-      ),
+      conversionType: ConversionType.toBitcoin(fromTokenIdentifier: tokenIdentifier),
       tokenIdentifier: null,
     );
   }
@@ -1082,40 +843,26 @@ Future<void> _handleFetchConversionLimits(
 
 // --- get-user-settings ---
 
-Future<void> _handleGetUserSettings(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleGetUserSettings(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final result = await sdk.getUserSettings();
   printValue(result);
 }
 
 // --- set-user-settings ---
 
-Future<void> _handleSetUserSettings(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleSetUserSettings(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final parser = _parser('set-user-settings')..addOption('private', abbr: 'p');
   final results = _parseArgs(parser, args, 'set-user-settings [options]');
   if (results == null) return;
   final privateMode = _parseBool(results.option('private'));
 
-  await sdk.updateUserSettings(
-    request: UpdateUserSettingsRequest(sparkPrivateModeEnabled: privateMode),
-  );
+  await sdk.updateUserSettings(request: UpdateUserSettingsRequest(sparkPrivateModeEnabled: privateMode));
   print('User settings updated');
 }
 
 // --- get-spark-status ---
 
-Future<void> _handleGetSparkStatus(
-  BreezSdk sdk,
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleGetSparkStatus(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final result = await getSparkStatus();
   printValue(result);
 }
@@ -1127,13 +874,9 @@ Future<void> _handleGetSparkStatus(
 SendPaymentOptions? _readPaymentOptions(SendPaymentMethod paymentMethod) {
   if (paymentMethod is SendPaymentMethod_BitcoinAddress) {
     final feeQuote = paymentMethod.feeQuote;
-    final fastFee =
-        feeQuote.speedFast.userFeeSat + feeQuote.speedFast.l1BroadcastFeeSat;
-    final mediumFee =
-        feeQuote.speedMedium.userFeeSat +
-        feeQuote.speedMedium.l1BroadcastFeeSat;
-    final slowFee =
-        feeQuote.speedSlow.userFeeSat + feeQuote.speedSlow.l1BroadcastFeeSat;
+    final fastFee = feeQuote.speedFast.userFeeSat + feeQuote.speedFast.l1BroadcastFeeSat;
+    final mediumFee = feeQuote.speedMedium.userFeeSat + feeQuote.speedMedium.l1BroadcastFeeSat;
+    final slowFee = feeQuote.speedSlow.userFeeSat + feeQuote.speedSlow.l1BroadcastFeeSat;
     print('Please choose payment fee:');
     print('1. Fast: $fastFee');
     print('2. Medium: $mediumFee');
@@ -1154,37 +897,24 @@ SendPaymentOptions? _readPaymentOptions(SendPaymentMethod paymentMethod) {
   if (paymentMethod is SendPaymentMethod_Bolt11Invoice) {
     if (paymentMethod.sparkTransferFeeSats != null) {
       print('Choose payment option:');
-      print(
-        '1. Spark transfer fee: ${paymentMethod.sparkTransferFeeSats} sats',
-      );
+      print('1. Spark transfer fee: ${paymentMethod.sparkTransferFeeSats} sats');
       print('2. Lightning fee: ${paymentMethod.lightningFeeSats} sats');
       final line = prompt('', defaultValue: '1');
       if (line == '1') {
-        return SendPaymentOptions.bolt11Invoice(
-          preferSpark: true,
-          completionTimeoutSecs: 0,
-        );
+        return SendPaymentOptions.bolt11Invoice(preferSpark: true, completionTimeoutSecs: 0);
       }
     }
-    return SendPaymentOptions.bolt11Invoice(
-      preferSpark: false,
-      completionTimeoutSecs: 0,
-    );
+    return SendPaymentOptions.bolt11Invoice(preferSpark: false, completionTimeoutSecs: 0);
   }
 
   if (paymentMethod is SendPaymentMethod_SparkAddress) {
     // HTLC options are only valid for Bitcoin payments, not token payments
     if (paymentMethod.tokenIdentifier != null) return null;
 
-    final answer = prompt(
-      'Do you want to create an HTLC transfer? (y/n)',
-      defaultValue: 'n',
-    );
+    final answer = prompt('Do you want to create an HTLC transfer? (y/n)', defaultValue: 'n');
     if (answer.toLowerCase() != 'y') return null;
 
-    var paymentHash = prompt(
-      'Please enter the HTLC payment hash (hex string) or leave empty to generate: ',
-    );
+    var paymentHash = prompt('Please enter the HTLC payment hash (hex string) or leave empty to generate: ');
     if (paymentHash.isEmpty) {
       final random = Random.secure();
       final preimageBytes = Uint8List(32);
@@ -1197,16 +927,11 @@ SendPaymentOptions? _readPaymentOptions(SendPaymentMethod paymentMethod) {
       print('Associated payment hash: $paymentHash');
     }
 
-    final expiryStr = prompt(
-      'Please enter the HTLC expiry duration in seconds: ',
-    );
+    final expiryStr = prompt('Please enter the HTLC expiry duration in seconds: ');
     final expiryDurationSecs = BigInt.parse(expiryStr);
 
     return SendPaymentOptions.sparkAddress(
-      htlcOptions: SparkHtlcOptions(
-        paymentHash: paymentHash,
-        expiryDurationSecs: expiryDurationSecs,
-      ),
+      htlcOptions: SparkHtlcOptions(paymentHash: paymentHash, expiryDurationSecs: expiryDurationSecs),
     );
   }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/issuer.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/issuer.dart
@@ -14,8 +14,7 @@ const issuerCommandNames = [
   'issuer unfreeze-token',
 ];
 
-typedef IssuerHandler =
-    Future<void> Function(TokenIssuer tokenIssuer, List<String> args);
+typedef IssuerHandler = Future<void> Function(TokenIssuer tokenIssuer, List<String> args);
 
 class _IssuerEntry {
   final String description;
@@ -27,48 +26,23 @@ Map<String, _IssuerEntry>? _registry;
 
 Map<String, _IssuerEntry> _getRegistry() {
   return _registry ??= {
-    'token-balance': _IssuerEntry(
-      'Get issuer token balance',
-      _handleTokenBalance,
-    ),
-    'token-metadata': _IssuerEntry(
-      'Get issuer token metadata',
-      _handleTokenMetadata,
-    ),
-    'create-token': _IssuerEntry(
-      'Create a new issuer token',
-      _handleCreateToken,
-    ),
-    'mint-token': _IssuerEntry(
-      'Mint supply of the issuer token',
-      _handleMintToken,
-    ),
-    'burn-token': _IssuerEntry(
-      'Burn supply of the issuer token',
-      _handleBurnToken,
-    ),
-    'freeze-token': _IssuerEntry(
-      'Freeze tokens at an address',
-      _handleFreezeToken,
-    ),
-    'unfreeze-token': _IssuerEntry(
-      'Unfreeze tokens at an address',
-      _handleUnfreezeToken,
-    ),
+    'token-balance': _IssuerEntry('Get issuer token balance', _handleTokenBalance),
+    'token-metadata': _IssuerEntry('Get issuer token metadata', _handleTokenMetadata),
+    'create-token': _IssuerEntry('Create a new issuer token', _handleCreateToken),
+    'mint-token': _IssuerEntry('Mint supply of the issuer token', _handleMintToken),
+    'burn-token': _IssuerEntry('Burn supply of the issuer token', _handleBurnToken),
+    'freeze-token': _IssuerEntry('Freeze tokens at an address', _handleFreezeToken),
+    'unfreeze-token': _IssuerEntry('Unfreeze tokens at an address', _handleUnfreezeToken),
   };
 }
 
 /// Dispatch an issuer subcommand given the args after 'issuer'.
-Future<void> dispatchIssuerCommand(
-  List<String> args,
-  TokenIssuer tokenIssuer,
-) async {
+Future<void> dispatchIssuerCommand(List<String> args, TokenIssuer tokenIssuer) async {
   final registry = _getRegistry();
 
   if (args.isEmpty || args[0] == 'help' || args[0] == '--help') {
     print('\nIssuer subcommands:\n');
-    for (final entry
-        in registry.entries.toList()..sort((a, b) => a.key.compareTo(b.key))) {
+    for (final entry in registry.entries.toList()..sort((a, b) => a.key.compareTo(b.key))) {
       print('  issuer ${entry.key.padRight(30)} ${entry.value.description}');
     }
     print('');
@@ -79,9 +53,7 @@ Future<void> dispatchIssuerCommand(
   final subArgs = args.sublist(1);
 
   if (!registry.containsKey(subName)) {
-    print(
-      "Unknown issuer subcommand: $subName. Use 'issuer help' for available commands.",
-    );
+    print("Unknown issuer subcommand: $subName. Use 'issuer help' for available commands.");
     return;
   }
 
@@ -90,45 +62,31 @@ Future<void> dispatchIssuerCommand(
 
 // --- token-balance ---
 
-Future<void> _handleTokenBalance(
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleTokenBalance(TokenIssuer tokenIssuer, List<String> args) async {
   final result = await tokenIssuer.getIssuerTokenBalance();
   printValue(result);
 }
 
 // --- token-metadata ---
 
-Future<void> _handleTokenMetadata(
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleTokenMetadata(TokenIssuer tokenIssuer, List<String> args) async {
   final result = await tokenIssuer.getIssuerTokenMetadata();
   printValue(result);
 }
 
 // --- create-token ---
 
-Future<void> _handleCreateToken(
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
-  final parser =
-      ArgParser()..addFlag('is-freezable', abbr: 'f', defaultsTo: false);
+Future<void> _handleCreateToken(TokenIssuer tokenIssuer, List<String> args) async {
+  final parser = ArgParser()..addFlag('is-freezable', abbr: 'f', defaultsTo: false);
   if (args.contains('help') || args.contains('--help')) {
-    print(
-      'Usage: issuer create-token <name> <ticker> <decimals> <max_supply> [-f]',
-    );
+    print('Usage: issuer create-token <name> <ticker> <decimals> <max_supply> [-f]');
     print(parser.usage);
     return;
   }
   final results = parser.parse(args);
 
   if (results.rest.length < 4) {
-    print(
-      'Usage: issuer create-token <name> <ticker> <decimals> <max_supply> [-f]',
-    );
+    print('Usage: issuer create-token <name> <ticker> <decimals> <max_supply> [-f]');
     return;
   }
   final name = results.rest[0];
@@ -151,68 +109,48 @@ Future<void> _handleCreateToken(
 
 // --- mint-token ---
 
-Future<void> _handleMintToken(
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleMintToken(TokenIssuer tokenIssuer, List<String> args) async {
   if (args.isEmpty || args.first == 'help' || args.first == '--help') {
     print('Usage: issuer mint-token <amount>');
     return;
   }
   final amount = BigInt.parse(args[0]);
-  final result = await tokenIssuer.mintIssuerToken(
-    request: MintIssuerTokenRequest(amount: amount),
-  );
+  final result = await tokenIssuer.mintIssuerToken(request: MintIssuerTokenRequest(amount: amount));
   printValue(result);
 }
 
 // --- burn-token ---
 
-Future<void> _handleBurnToken(
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleBurnToken(TokenIssuer tokenIssuer, List<String> args) async {
   if (args.isEmpty || args.first == 'help' || args.first == '--help') {
     print('Usage: issuer burn-token <amount>');
     return;
   }
   final amount = BigInt.parse(args[0]);
-  final result = await tokenIssuer.burnIssuerToken(
-    request: BurnIssuerTokenRequest(amount: amount),
-  );
+  final result = await tokenIssuer.burnIssuerToken(request: BurnIssuerTokenRequest(amount: amount));
   printValue(result);
 }
 
 // --- freeze-token ---
 
-Future<void> _handleFreezeToken(
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleFreezeToken(TokenIssuer tokenIssuer, List<String> args) async {
   if (args.isEmpty || args.first == 'help' || args.first == '--help') {
     print('Usage: issuer freeze-token <address>');
     return;
   }
   final address = args[0];
-  final result = await tokenIssuer.freezeIssuerToken(
-    request: FreezeIssuerTokenRequest(address: address),
-  );
+  final result = await tokenIssuer.freezeIssuerToken(request: FreezeIssuerTokenRequest(address: address));
   printValue(result);
 }
 
 // --- unfreeze-token ---
 
-Future<void> _handleUnfreezeToken(
-  TokenIssuer tokenIssuer,
-  List<String> args,
-) async {
+Future<void> _handleUnfreezeToken(TokenIssuer tokenIssuer, List<String> args) async {
   if (args.isEmpty || args.first == 'help' || args.first == '--help') {
     print('Usage: issuer unfreeze-token <address>');
     return;
   }
   final address = args[0];
-  final result = await tokenIssuer.unfreezeIssuerToken(
-    request: UnfreezeIssuerTokenRequest(address: address),
-  );
+  final result = await tokenIssuer.unfreezeIssuerToken(request: UnfreezeIssuerTokenRequest(address: address));
   printValue(result);
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/readline.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/readline.dart
@@ -150,24 +150,14 @@ class Readline {
                   } else if (_historyIndex > 0) {
                     _historyIndex--;
                   }
-                  _replaceBuffer(
-                    prompt,
-                    buf,
-                    cursor,
-                    _history[_historyIndex].codeUnits,
-                  );
+                  _replaceBuffer(prompt, buf, cursor, _history[_historyIndex].codeUnits);
                   cursor = buf.length;
                 }
               case 66: // Down arrow
                 if (_historyIndex >= 0) {
                   if (_historyIndex < _history.length - 1) {
                     _historyIndex++;
-                    _replaceBuffer(
-                      prompt,
-                      buf,
-                      cursor,
-                      _history[_historyIndex].codeUnits,
-                    );
+                    _replaceBuffer(prompt, buf, cursor, _history[_historyIndex].codeUnits);
                   } else {
                     _historyIndex = -1;
                     _replaceBuffer(prompt, buf, cursor, _savedLine.codeUnits);
@@ -234,8 +224,7 @@ class Readline {
     void Function(List<int> newBuf, int newCursor) update,
   ) {
     final text = String.fromCharCodes(buf);
-    final matches =
-        _completions.where((c) => c.startsWith(text)).toList()..sort();
+    final matches = _completions.where((c) => c.startsWith(text)).toList()..sort();
 
     if (matches.isEmpty) return;
 
@@ -291,10 +280,7 @@ class Readline {
     if (_historyFile == null) return;
     final file = File(_historyFile);
     // Keep last 500 entries.
-    final entries =
-        _history.length > 500
-            ? _history.sublist(_history.length - 500)
-            : _history;
+    final entries = _history.length > 500 ? _history.sublist(_history.length - 500) : _history;
     file.writeAsStringSync('${entries.join('\n')}\n');
   }
 
@@ -318,12 +304,7 @@ class Readline {
   }
 
   /// Replace buffer contents and redraw.
-  void _replaceBuffer(
-    String prompt,
-    List<int> buf,
-    int oldCursor,
-    List<int> newContent,
-  ) {
+  void _replaceBuffer(String prompt, List<int> buf, int oldCursor, List<int> newContent) {
     buf
       ..clear()
       ..addAll(newContent);

--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/serialization.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/serialization.dart
@@ -1,3 +1,7 @@
+// dart:mirrors is available at runtime (JIT via `dart run`) but not recognized
+// by `dart analyze` when Flutter packages are in the dependency tree.
+// ignore_for_file: uri_does_not_exist, undefined_function, undefined_class
+// ignore_for_file: type_test_with_undefined_name, undefined_identifier
 import 'dart:convert';
 import 'dart:mirrors';
 
@@ -36,9 +40,7 @@ Map<String, dynamic> _reflectFields(InstanceMirror mirror) {
       if (decl is VariableMirror && !decl.isStatic && !decl.isPrivate) {
         final name = MirrorSystem.getName(entry.key);
         if (!fields.containsKey(name)) {
-          fields[name] = objToSerializable(
-            mirror.getField(entry.key).reflectee,
-          );
+          fields[name] = objToSerializable(mirror.getField(entry.key).reflectee);
         }
       }
     }

--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/pubspec.yaml
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/pubspec.yaml
@@ -12,3 +12,6 @@ dependencies:
   crypto: ^3.0.0
   breez_sdk_spark_flutter:
     path: ../../../../../../../packages/flutter
+
+dev_dependencies:
+  lints: ^5.1.1

--- a/crates/breez-sdk/bindings/examples/cli/langs/go/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/go/commands.go
@@ -85,7 +85,7 @@ func BuildCommandRegistry() map[string]Command {
 
 // PrintHelp prints available commands.
 func PrintHelp(registry map[string]Command) {
-	fmt.Println("\nAvailable commands:\n")
+	fmt.Println("\nAvailable commands:")
 	names := make([]string, 0, len(registry))
 	for name := range registry {
 		names = append(names, name)

--- a/crates/breez-sdk/bindings/examples/cli/langs/go/issuer.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/go/issuer.go
@@ -74,7 +74,7 @@ func DispatchIssuerCommand(args []string, issuer *breez_sdk_spark.TokenIssuer, r
 	registry := BuildIssuerRegistry()
 
 	if len(args) == 0 || args[0] == "help" {
-		fmt.Println("\nIssuer subcommands:\n")
+		fmt.Println("\nIssuer subcommands:")
 		names := make([]string, 0, len(registry))
 		for name := range registry {
 			names = append(names, name)

--- a/packages/flutter/lib/src/config_extensions.dart
+++ b/packages/flutter/lib/src/config_extensions.dart
@@ -28,15 +28,11 @@ extension ConfigCopyWith on Config {
       syncIntervalSecs: syncIntervalSecs ?? this.syncIntervalSecs,
       maxDepositClaimFee: maxDepositClaimFee ?? this.maxDepositClaimFee,
       lnurlDomain: lnurlDomain ?? this.lnurlDomain,
-      preferSparkOverLightning:
-          preferSparkOverLightning ?? this.preferSparkOverLightning,
+      preferSparkOverLightning: preferSparkOverLightning ?? this.preferSparkOverLightning,
       externalInputParsers: externalInputParsers ?? this.externalInputParsers,
-      useDefaultExternalInputParsers:
-          useDefaultExternalInputParsers ?? this.useDefaultExternalInputParsers,
-      realTimeSyncServerUrl:
-          realTimeSyncServerUrl ?? this.realTimeSyncServerUrl,
-      privateEnabledDefault:
-          privateEnabledDefault ?? this.privateEnabledDefault,
+      useDefaultExternalInputParsers: useDefaultExternalInputParsers ?? this.useDefaultExternalInputParsers,
+      realTimeSyncServerUrl: realTimeSyncServerUrl ?? this.realTimeSyncServerUrl,
+      privateEnabledDefault: privateEnabledDefault ?? this.privateEnabledDefault,
       optimizationConfig: optimizationConfig ?? this.optimizationConfig,
       stableBalanceConfig: stableBalanceConfig ?? this.stableBalanceConfig,
       maxConcurrentClaims: maxConcurrentClaims ?? this.maxConcurrentClaims,


### PR DESCRIPTION
Add CI job that runs static analysis and format checks for Dart and Go CLI examples. Dart CLI uses 110 line length to match Flutter. SDK interface changes now break the build immediately instead of being discovered during the next CLI sync.