### PR TITLE
perf: use JVM-only compilation for kotlin-mpp doc snippet checks

### DIFF
--- a/crates/xtask/src/docs.rs
+++ b/crates/xtask/src/docs.rs
@@ -306,12 +306,12 @@ fn check_doc_snippets_kotlin_mpp_cmd(skip_binding_gen: bool) -> Result<()> {
 
     let kotlin_snippets_dir = workspace_root.join("docs/breez-sdk/snippets/kotlin_mpp_lib");
     let status = Command::new("./gradlew")
-        .arg("build")
+        .arg("compileKotlinJvm")
         .current_dir(&kotlin_snippets_dir)
         .status()?;
     if !status.success() {
         anyhow::bail!(
-            "Failed to run './gradlew build' in {:?}",
+            "Failed to run './gradlew compileKotlinJvm' in {:?}",
             kotlin_snippets_dir
         );
     }


### PR DESCRIPTION
All doc snippets are in `commonMain` with no platform-specific sources. Replacing `./gradlew build` with `./gradlew compileKotlinJvm` skips iOS native (LLVM) and Android compilation in the snippets project, saving ~8-10 min per CI run.

### Changelist
- Change Gradle task from `build` to `compileKotlinJvm` in `crates/xtask/src/docs.rs`

### Test plan
- [x] `Docs / kotlin-mpp` CI check passes
- [x] `Docs / kotlin-mpp` completes significantly faster (~10 min vs ~20 min)