### PR TITLE
improve query performance

### DIFF
--- a/crates/breez-sdk/lnurl/migrations/postgres/20260303_metadata_query_indexes.sql
+++ b/crates/breez-sdk/lnurl/migrations/postgres/20260303_metadata_query_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_invoices_user_pubkey_updated_at ON invoices(user_pubkey, updated_at);
+CREATE INDEX idx_zaps_user_pubkey_updated_at ON zaps(user_pubkey, updated_at);
+CREATE INDEX idx_sender_comments_user_pubkey_updated_at ON sender_comments(user_pubkey, updated_at);

--- a/crates/breez-sdk/lnurl/migrations/sqlite/20260303_metadata_query_indexes.sql
+++ b/crates/breez-sdk/lnurl/migrations/sqlite/20260303_metadata_query_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_invoices_user_pubkey_updated_at ON invoices(user_pubkey, updated_at);
+CREATE INDEX idx_zaps_user_pubkey_updated_at ON zaps(user_pubkey, updated_at);
+CREATE INDEX idx_sender_comments_user_pubkey_updated_at ON sender_comments(user_pubkey, updated_at);

--- a/crates/breez-sdk/lnurl/src/postgresql/repository.rs
+++ b/crates/breez-sdk/lnurl/src/postgresql/repository.rs
@@ -227,16 +227,15 @@ impl crate::repository::LnurlRepository for LnurlRepository {
              ,      GREATEST(COALESCE(z.updated_at, 0), COALESCE(sc.updated_at, 0), COALESCE(i.updated_at, 0)) AS updated_at
              ,      i.preimage
              FROM (
-                 SELECT payment_hash FROM invoices WHERE user_pubkey = $1
+                 SELECT payment_hash FROM invoices WHERE user_pubkey = $1 AND updated_at > $4
                  UNION
-                 SELECT payment_hash FROM zaps WHERE user_pubkey = $1
+                 SELECT payment_hash FROM zaps WHERE user_pubkey = $1 AND updated_at > $4
                  UNION
-                 SELECT payment_hash FROM sender_comments WHERE user_pubkey = $1
+                 SELECT payment_hash FROM sender_comments WHERE user_pubkey = $1 AND updated_at > $4
              ) ph
              LEFT JOIN invoices i ON ph.payment_hash = i.payment_hash
              LEFT JOIN zaps z ON ph.payment_hash = z.payment_hash
              LEFT JOIN sender_comments sc ON ph.payment_hash = sc.payment_hash
-             WHERE GREATEST(COALESCE(z.updated_at, 0), COALESCE(sc.updated_at, 0), COALESCE(i.updated_at, 0)) > $4
              ORDER BY updated_at ASC
              OFFSET $2 LIMIT $3",
         )

--- a/crates/breez-sdk/lnurl/src/sqlite/repository.rs
+++ b/crates/breez-sdk/lnurl/src/sqlite/repository.rs
@@ -215,16 +215,15 @@ impl crate::repository::LnurlRepository for LnurlRepository {
              ,      MAX(COALESCE(z.updated_at, 0), COALESCE(sc.updated_at, 0), COALESCE(i.updated_at, 0)) AS updated_at
              ,      i.preimage
              FROM (
-                 SELECT payment_hash FROM invoices WHERE user_pubkey = $1
+                 SELECT payment_hash FROM invoices WHERE user_pubkey = $1 AND updated_at > $4
                  UNION
-                 SELECT payment_hash FROM zaps WHERE user_pubkey = $1
+                 SELECT payment_hash FROM zaps WHERE user_pubkey = $1 AND updated_at > $4
                  UNION
-                 SELECT payment_hash FROM sender_comments WHERE user_pubkey = $1
+                 SELECT payment_hash FROM sender_comments WHERE user_pubkey = $1 AND updated_at > $4
              ) ph
              LEFT JOIN invoices i ON ph.payment_hash = i.payment_hash
              LEFT JOIN zaps z ON ph.payment_hash = z.payment_hash
              LEFT JOIN sender_comments sc ON ph.payment_hash = sc.payment_hash
-             WHERE MAX(COALESCE(z.updated_at, 0), COALESCE(sc.updated_at, 0), COALESCE(i.updated_at, 0)) > $4
              ORDER BY updated_at ASC
              LIMIT $3 OFFSET $2",
         )


### PR DESCRIPTION
The LNURL server was logging slow query warnings:                                                                                  

```                                                                                                                                     
  WARN sqlx::query: slow statement: execution time exceeded alert threshold
    elapsed=3.674929167s slow_threshold=1s

    SELECT ph.payment_hash
    ,      sc.sender_comment
    ,      z.zap_request
    ,      z.zap_event
    ,      GREATEST(COALESCE(z.updated_at, 0), COALESCE(sc.updated_at, 0),
                    COALESCE(i.updated_at, 0)) AS updated_at
    ,      i.preimage
    FROM (
        SELECT payment_hash FROM invoices WHERE user_pubkey = $1
        UNION
        SELECT payment_hash FROM zaps WHERE user_pubkey = $1
        UNION
        SELECT payment_hash FROM sender_comments WHERE user_pubkey = $1
    ) ph
    LEFT JOIN invoices i ON ph.payment_hash = i.payment_hash
    LEFT JOIN zaps z ON ph.payment_hash = z.payment_hash
    LEFT JOIN sender_comments sc ON ph.payment_hash = sc.payment_hash
    WHERE GREATEST(COALESCE(z.updated_at, 0), COALESCE(sc.updated_at, 0),
                   COALESCE(i.updated_at, 0)) > $4
    ORDER BY updated_at ASC
    OFFSET $2 LIMIT $3
```

  This also caused connection pool exhaustion (acquired connection, but time to acquire exceeded slow threshold, 14.8s wait), since
  the slow query held connections for too long.

  Root cause

  The UNION subquery scanned all payment hashes for a user regardless of updated_at, then the WHERE GREATEST(...) filter was applied
  after 3 LEFT JOINs — processing the entire history just to filter it down.

  Fix

  1. Pushed updated_at > $4 filter into each UNION leg — the UNION now only collects recently-updated payment hashes, making the set
  proportional to the delta instead of full history. This also makes the WHERE GREATEST(...) clause redundant (if any table has
  updated_at > $4, the UNION includes it; the LEFT JOINs still fetch full data by PK).
  2. Added composite indexes (user_pubkey, updated_at) on invoices, zaps, and sender_comments — each UNION leg now does an efficient
  index range scan.