### PR TITLE
create index on users pubkey column

### DIFF
--- a/crates/breez-sdk/lnurl/migrations/postgres/20260303_users_pubkey_index.sql
+++ b/crates/breez-sdk/lnurl/migrations/postgres/20260303_users_pubkey_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_users_pubkey ON users(pubkey);

--- a/crates/breez-sdk/lnurl/migrations/sqlite/20260303_users_pubkey_index.sql
+++ b/crates/breez-sdk/lnurl/migrations/sqlite/20260303_users_pubkey_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_users_pubkey ON users(pubkey);


### PR DESCRIPTION
Index Advisor Recommendations:
CREATE INDEX ON public.users USING btree (pubkey)

Cost Analysis:
- Startup Cost Before: 188.51
- Startup Cost After: 7
- Total Cost Before: 188.52
- Total Cost After: 7.01

SQL Query:
```sql
SELECT COUNT(*)
             FROM invoices i
             JOIN users u ON i.user_pubkey = u.pubkey
             WHERE i.user_pubkey = $1 AND i.invoice_expiry > $2 AND i.preimage IS NULL AND u.lnurl_private_mode_enabled = FALSE
```