### PR TITLE
fix: allow github-actions bot to trigger CLI sync workflows

### DIFF
--- a/.github/workflows/sync-dart-cli.yml
+++ b/.github/workflows/sync-dart-cli.yml
@@ -113,6 +113,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'github-actions[bot]'
           claude_args: >-
             --allowed-tools
             Read,Write,Edit,Glob,Grep,

--- a/.github/workflows/sync-go-cli.yml
+++ b/.github/workflows/sync-go-cli.yml
@@ -113,6 +113,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'github-actions[bot]'
           claude_args: >-
             --allowed-tools
             Read,Write,Edit,Glob,Grep,

--- a/.github/workflows/sync-python-cli.yml
+++ b/.github/workflows/sync-python-cli.yml
@@ -113,6 +113,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'github-actions[bot]'
           claude_args: >-
             --allowed-tools
             Read,Write,Edit,Glob,Grep,

--- a/.github/workflows/sync-swift-cli.yml
+++ b/.github/workflows/sync-swift-cli.yml
@@ -113,6 +113,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'github-actions[bot]'
           claude_args: >-
             --allowed-tools
             Read,Write,Edit,Glob,Grep,

--- a/crates/breez-sdk/bindings/examples/cli/sync-prompts/workflow-template.yml
+++ b/crates/breez-sdk/bindings/examples/cli/sync-prompts/workflow-template.yml
@@ -113,6 +113,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'github-actions[bot]'
           claude_args: >-
             --allowed-tools
             {{ALLOWED_TOOLS}}


### PR DESCRIPTION
The parent workflow (sync-cli-langs.yml) dispatches child sync workflows via `gh workflow run`, which runs as `github-actions[bot]`. `claude-code-action` blocks non-human actors by default — adds `allowed_bots` to fix this.