### PR TITLE
fix: upload Claude execution log as artifact for debugging

### DIFF
--- a/.github/workflows/sync-dart-cli.yml
+++ b/.github/workflows/sync-dart-cli.yml
@@ -282,6 +282,15 @@ jobs:
           path: sync-dart.patch
           retention-days: 7
 
+      - name: Upload Claude log
+        if: always() && inputs.approve-run == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-dart-claude-log
+          path: /home/runner/work/_temp/claude-execution-output.json
+          retention-days: 7
+          if-no-files-found: ignore
+
       # ── Summary ─────────────────────────────────────────────────────
       - name: Summary
         if: always()

--- a/.github/workflows/sync-go-cli.yml
+++ b/.github/workflows/sync-go-cli.yml
@@ -261,6 +261,15 @@ jobs:
           path: sync-go.patch
           retention-days: 7
 
+      - name: Upload Claude log
+        if: always() && inputs.approve-run == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-go-claude-log
+          path: /home/runner/work/_temp/claude-execution-output.json
+          retention-days: 7
+          if-no-files-found: ignore
+
       # ── Summary ─────────────────────────────────────────────────────
       - name: Summary
         if: always()

--- a/.github/workflows/sync-python-cli.yml
+++ b/.github/workflows/sync-python-cli.yml
@@ -255,6 +255,15 @@ jobs:
           path: sync-python.patch
           retention-days: 7
 
+      - name: Upload Claude log
+        if: always() && inputs.approve-run == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-python-claude-log
+          path: /home/runner/work/_temp/claude-execution-output.json
+          retention-days: 7
+          if-no-files-found: ignore
+
       # ── Summary ─────────────────────────────────────────────────────
       - name: Summary
         if: always()

--- a/.github/workflows/sync-swift-cli.yml
+++ b/.github/workflows/sync-swift-cli.yml
@@ -276,6 +276,15 @@ jobs:
           path: sync-swift.patch
           retention-days: 7
 
+      - name: Upload Claude log
+        if: always() && inputs.approve-run == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-swift-claude-log
+          path: /home/runner/work/_temp/claude-execution-output.json
+          retention-days: 7
+          if-no-files-found: ignore
+
       # ── Summary ─────────────────────────────────────────────────────
       - name: Summary
         if: always()

--- a/crates/breez-sdk/bindings/examples/cli/sync-prompts/workflow-template.yml
+++ b/crates/breez-sdk/bindings/examples/cli/sync-prompts/workflow-template.yml
@@ -134,6 +134,15 @@ jobs:
           path: sync-{{LANG_ID}}.patch
           retention-days: 7
 
+      - name: Upload Claude log
+        if: always() && inputs.approve-run == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-{{LANG_ID}}-claude-log
+          path: /home/runner/work/_temp/claude-execution-output.json
+          retention-days: 7
+          if-no-files-found: ignore
+
       # ── Summary ─────────────────────────────────────────────────────
       - name: Summary
         if: always()


### PR DESCRIPTION
Uploads `claude-execution-output.json` as an artifact after each sync run so we can inspect Claude's reasoning when it produces unexpected results (e.g., empty patches).