### PR TITLE
fix(sync-ci): prevent Claude from dismissing real differences as language variations

### DIFF
--- a/.github/workflows/sync-dart-cli.yml
+++ b/.github/workflows/sync-dart-cli.yml
@@ -150,6 +150,8 @@ jobs:
             - **Command handlers**: logic, control flow, error handling
             - **Imports**: removed or renamed SDK symbols
 
+            **Critical: do NOT dismiss differences as "expected language variations."** Only pure syntax differences are expected (e.g., `.await` vs `await`, `snake_case` vs `camelCase`). If the Rust and Dart CLIs call different SDK functions, use different initialization patterns, pass different arguments, or have different control flow — that is a real divergence that must be reported and fixed. When in doubt, treat it as a real difference.
+
             Only after listing all differences should you decide which ones to fix. Implement what's feasible — if a feature can't be ported (missing bindings, no equivalent package, platform limitation), add the CLI flag but 'print a "not yet supported" message in the handler' and leave a comment explaining why.
 
             Also check the Dart SDK snippets at `docs/breez-sdk/snippets/` for the correct API calling conventions. The snippets are always up-to-date — if the Dart CLI uses an SDK function that doesn't appear in the snippets, it has likely been removed or renamed.

--- a/.github/workflows/sync-go-cli.yml
+++ b/.github/workflows/sync-go-cli.yml
@@ -150,6 +150,8 @@ jobs:
             - **Command handlers**: logic, control flow, error handling
             - **Imports**: removed or renamed SDK symbols
 
+            **Critical: do NOT dismiss differences as "expected language variations."** Only pure syntax differences are expected (e.g., `.await` vs `await`, `snake_case` vs `camelCase`). If the Rust and Go CLIs call different SDK functions, use different initialization patterns, pass different arguments, or have different control flow — that is a real divergence that must be reported and fixed. When in doubt, treat it as a real difference.
+
             Only after listing all differences should you decide which ones to fix. Implement what's feasible — if a feature can't be ported (missing bindings, no equivalent package, platform limitation), add the CLI flag but 'use `handleNotYetSupported` as the handler' and leave a comment explaining why.
 
             Also check the Go SDK snippets at `docs/breez-sdk/snippets/` for the correct API calling conventions. The snippets are always up-to-date — if the Go CLI uses an SDK function that doesn't appear in the snippets, it has likely been removed or renamed.

--- a/.github/workflows/sync-python-cli.yml
+++ b/.github/workflows/sync-python-cli.yml
@@ -150,6 +150,8 @@ jobs:
             - **Command handlers**: logic, control flow, error handling
             - **Imports**: removed or renamed SDK symbols
 
+            **Critical: do NOT dismiss differences as "expected language variations."** Only pure syntax differences are expected (e.g., `.await` vs `await`, `snake_case` vs `camelCase`). If the Rust and Python CLIs call different SDK functions, use different initialization patterns, pass different arguments, or have different control flow — that is a real divergence that must be reported and fixed. When in doubt, treat it as a real difference.
+
             Only after listing all differences should you decide which ones to fix. Implement what's feasible — if a feature can't be ported (missing bindings, no equivalent package, platform limitation), add the CLI flag but 'print a "not yet supported" message in the handler' and leave a comment explaining why.
 
             Also check the Python SDK snippets at `docs/breez-sdk/snippets/` for the correct API calling conventions. The snippets are always up-to-date — if the Python CLI uses an SDK function that doesn't appear in the snippets, it has likely been removed or renamed.

--- a/.github/workflows/sync-swift-cli.yml
+++ b/.github/workflows/sync-swift-cli.yml
@@ -150,6 +150,8 @@ jobs:
             - **Command handlers**: logic, control flow, error handling
             - **Imports**: removed or renamed SDK symbols
 
+            **Critical: do NOT dismiss differences as "expected language variations."** Only pure syntax differences are expected (e.g., `.await` vs `await`, `snake_case` vs `camelCase`). If the Rust and Swift CLIs call different SDK functions, use different initialization patterns, pass different arguments, or have different control flow — that is a real divergence that must be reported and fixed. When in doubt, treat it as a real difference.
+
             Only after listing all differences should you decide which ones to fix. Implement what's feasible — if a feature can't be ported (missing bindings, no equivalent package, platform limitation), add the CLI flag but 'print "Not yet supported" and return' and leave a comment explaining why.
 
             Also check the Swift SDK snippets at `docs/breez-sdk/snippets/` for the correct API calling conventions. The snippets are always up-to-date — if the Swift CLI uses an SDK function that doesn't appear in the snippets, it has likely been removed or renamed.

--- a/crates/breez-sdk/bindings/examples/cli/sync-prompts/prompt-template.md
+++ b/crates/breez-sdk/bindings/examples/cli/sync-prompts/prompt-template.md
@@ -15,6 +15,8 @@ The diff is a hint for what changed recently, but it may not reveal all differen
 - **Command handlers**: logic, control flow, error handling
 - **Imports**: removed or renamed SDK symbols
 
+**Critical: do NOT dismiss differences as "expected language variations."** Only pure syntax differences are expected (e.g., `.await` vs `await`, `snake_case` vs `camelCase`). If the Rust and {{LANG_NAME}} CLIs call different SDK functions, use different initialization patterns, pass different arguments, or have different control flow — that is a real divergence that must be reported and fixed. When in doubt, treat it as a real difference.
+
 Only after listing all differences should you decide which ones to fix. Implement what's feasible — if a feature can't be ported (missing bindings, no equivalent package, platform limitation), add the CLI flag but {{UNSUPPORTED_HANDLER}} and leave a comment explaining why.
 
 Also check the {{LANG_NAME}} SDK snippets at `docs/breez-sdk/snippets/` for the correct API calling conventions. The snippets are always up-to-date — if the {{LANG_NAME}} CLI uses an SDK function that doesn't appear in the snippets, it has likely been removed or renamed.


### PR DESCRIPTION
Full source comparison failed because Claude noticed the postgres storage pattern difference but dismissed it as an "expected language variation." 

Added explicit instruction that only pure syntax differences (await style, case conventions) are expected, different SDK functions, initialization patterns, or control flow are real divergences that must be fixed.