### PR TITLE
chore: sync Python CLI with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
@@ -71,6 +71,8 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`, `issuer <subcommand>`
 
+**Contacts**: `contacts add`, `contacts update`, `contacts delete`, `contacts list`
+
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 
 Each command supports `--help` for detailed usage, e.g. `receive --help`.

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/contacts.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/contacts.py
@@ -1,0 +1,141 @@
+import argparse
+
+from breez_sdk_spark import (
+    AddContactRequest,
+    ListContactsRequest,
+    UpdateContactRequest,
+)
+
+from breez_cli.serialization import print_value
+
+# Contacts subcommand names (used for REPL completion)
+CONTACTS_COMMAND_NAMES = [
+    "contacts add",
+    "contacts update",
+    "contacts delete",
+    "contacts list",
+]
+
+
+def _parser(name, description=""):
+    return argparse.ArgumentParser(prog=f"contacts {name}", description=description)
+
+
+# --- add ---
+
+def _build_add_parser():
+    p = _parser("add", "Add a new contact")
+    p.add_argument("name", help="Name of the contact")
+    p.add_argument("payment_identifier", help="Lightning address (user@domain)")
+    return p
+
+async def _handle_add(sdk, args):
+    result = await sdk.add_contact(
+        request=AddContactRequest(
+            name=args.name,
+            payment_identifier=args.payment_identifier,
+        )
+    )
+    print_value(result)
+
+
+# --- update ---
+
+def _build_update_parser():
+    p = _parser("update", "Update an existing contact")
+    p.add_argument("id", help="ID of the contact to update")
+    p.add_argument("name", help="New name for the contact")
+    p.add_argument("payment_identifier", help="New Lightning address (user@domain)")
+    return p
+
+async def _handle_update(sdk, args):
+    result = await sdk.update_contact(
+        request=UpdateContactRequest(
+            id=args.id,
+            name=args.name,
+            payment_identifier=args.payment_identifier,
+        )
+    )
+    print_value(result)
+
+
+# --- delete ---
+
+def _build_delete_parser():
+    p = _parser("delete", "Delete a contact")
+    p.add_argument("id", help="ID of the contact to delete")
+    return p
+
+async def _handle_delete(sdk, args):
+    await sdk.delete_contact(id=args.id)
+    print("Contact deleted successfully")
+
+
+# --- list ---
+
+def _build_list_parser():
+    p = _parser("list", "List contacts")
+    p.add_argument("offset", nargs="?", type=int, default=None,
+                   help="Number of contacts to skip")
+    p.add_argument("limit", nargs="?", type=int, default=None,
+                   help="Maximum number of contacts to return")
+    return p
+
+async def _handle_list(sdk, args):
+    result = await sdk.list_contacts(
+        request=ListContactsRequest(
+            offset=args.offset,
+            limit=args.limit,
+        )
+    )
+    print_value(result)
+
+
+# ---------------------------------------------------------------------------
+# Registry and dispatch
+# ---------------------------------------------------------------------------
+
+def _build_contacts_registry():
+    return {
+        "add": (_build_add_parser(), _handle_add),
+        "update": (_build_update_parser(), _handle_update),
+        "delete": (_build_delete_parser(), _handle_delete),
+        "list": (_build_list_parser(), _handle_list),
+    }
+
+
+_REGISTRY = None
+
+def _get_registry():
+    global _REGISTRY
+    if _REGISTRY is None:
+        _REGISTRY = _build_contacts_registry()
+    return _REGISTRY
+
+
+async def dispatch_contacts_command(args, sdk):
+    """Dispatch a contacts subcommand given the args after 'contacts'."""
+    registry = _get_registry()
+
+    if not args or args[0] == "help":
+        print("\nContacts subcommands:\n")
+        for name, (parser, _) in sorted(registry.items()):
+            desc = parser.description or ""
+            print(f"  contacts {name:30s} {desc}")
+        print()
+        return
+
+    sub_name = args[0]
+    sub_args = args[1:]
+
+    if sub_name not in registry:
+        print(f"Unknown contacts subcommand: {sub_name}. Use 'contacts help' for available commands.")
+        return
+
+    parser, handler = registry[sub_name]
+    try:
+        parsed = parser.parse_args(sub_args)
+    except SystemExit:
+        return
+
+    await handler(sdk, parsed)

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
@@ -23,12 +23,8 @@ from breez_sdk_spark import (
     init_logging,
 )
 
-try:
-    from breez_sdk_spark import create_postgres_storage
-except ImportError:
-    create_postgres_storage = None
-
 from breez_cli.commands import COMMAND_NAMES, build_command_registry
+from breez_cli.contacts import CONTACTS_COMMAND_NAMES, dispatch_contacts_command
 from breez_cli.issuer import ISSUER_COMMAND_NAMES, dispatch_issuer_command
 from breez_cli.persistence import CliPersistence
 from breez_cli.serialization import serialize
@@ -89,13 +85,8 @@ async def main(data_dir, network, account_number, postgres_connection_string,
     builder = SdkBuilder(config=config, seed=seed)
 
     if postgres_connection_string:
-        if create_postgres_storage is None:
-            raise click.ClickException(
-                "--postgres-connection-string requires a newer version of breez-sdk-spark"
-            )
         pg_config = default_postgres_storage_config(connection_string=postgres_connection_string)
-        storage = await create_postgres_storage(config=pg_config)
-        await builder.with_storage(storage=storage)
+        await builder.with_postgres_storage(config=pg_config)
     else:
         await builder.with_default_storage(storage_dir=str(data_dir))
 
@@ -117,7 +108,7 @@ async def main(data_dir, network, account_number, postgres_connection_string,
 
 async def run_repl(sdk, token_issuer, network, persistence):
     history_file = persistence.history_file()
-    all_commands = sorted(set(COMMAND_NAMES + ISSUER_COMMAND_NAMES + ["exit", "quit", "help"]))
+    all_commands = sorted(set(COMMAND_NAMES + CONTACTS_COMMAND_NAMES + ISSUER_COMMAND_NAMES + ["exit", "quit", "help"]))
     session = PromptSession(
         history=FileHistory(history_file),
         auto_suggest=AutoSuggestFromHistory(),
@@ -155,7 +146,9 @@ async def run_repl(sdk, token_issuer, network, persistence):
             cmd_name = args[0]
             cmd_args = args[1:]
 
-            if cmd_name == "issuer":
+            if cmd_name == "contacts":
+                await dispatch_contacts_command(cmd_args, sdk)
+            elif cmd_name == "issuer":
                 await dispatch_issuer_command(cmd_args, token_issuer)
             elif cmd_name in registry:
                 parser, handler = registry[cmd_name]
@@ -191,7 +184,8 @@ def print_help(registry):
         parser, _ = registry[name]
         desc = parser.description or ""
         print(f"  {name:40s} {desc}")
-    print(f"\n  {'issuer <subcommand>':40s} Token issuer commands (use 'issuer help' for details)")
+    print(f"\n  {'contacts <subcommand>':40s} Contacts commands (use 'contacts help' for details)")
+    print(f"  {'issuer <subcommand>':40s} Token issuer commands (use 'issuer help' for details)")
     print(f"  {'exit / quit':40s} Exit the CLI")
     print(f"  {'help':40s} Show this help message")
     print()


### PR DESCRIPTION
Automated sync of Python CLI from Rust CLI changes.

**Source commit:** [`8d56504`](https://github.com/breez/spark-sdk/commit/8d56504e83c844f64970536014f3e0a0e49694cd)
**Claude log:** [View artifact](https://github.com/breez/spark-sdk/actions/runs/22692009532)

<details>
<summary>Sync findings</summary>

## Divergences
- Missing `contacts` subcommand group (Rust has `contacts.rs` with add/update/delete/list; Python had no contacts module)
- Python `main.py` used wrong postgres storage API: `create_postgres_storage()` + `with_storage()` instead of `builder.with_postgres_storage()`
- Python README missing contacts commands section

## Applied
- Created `contacts.py` with add/update/delete/list subcommands matching Rust `contacts.rs` (`contacts.py`)
- Fixed postgres storage initialization to use `builder.with_postgres_storage(config=pg_config)` matching Rust and Python snippets (`main.py`)
- Removed unused `create_postgres_storage` import and fallback guard (`main.py`)
- Added contacts dispatch, completion, and help entry in REPL (`main.py`)
- Added contacts commands section to README (`README.md`)

## Skipped
- (none)

</details>