### PR TITLE
chore: sync Dart CLI with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/README.md
@@ -43,10 +43,13 @@ make run-mainnet
 ## CLI Options
 
 ```
--d, --data-dir          Path to the data directory (default: ./.data)
-    --network           Network to use: regtest, mainnet (default: regtest)
-    --account-number    Account number for the Spark signer
--h, --help              Show usage
+-d, --data-dir                          Path to the data directory (default: ./.data)
+    --network                           Network to use: regtest, mainnet (default: regtest)
+    --account-number                    Account number for the Spark signer
+    --postgres-connection-string        PostgreSQL connection string (not yet supported, uses SQLite)
+    --stable-balance-token-identifier   Stable balance token identifier
+    --stable-balance-threshold          Stable balance threshold in sats
+-h, --help                              Show usage
 ```
 
 ## Commands
@@ -81,6 +84,7 @@ Once the CLI is running, type `help` to see all available commands:
 - `set-user-settings` — Update user settings
 - `get-spark-status` — Get Spark network status
 - `issuer <subcommand>` — Token issuer commands
+- `contacts <subcommand>` — Contacts commands (add, update, delete, list)
 
 ## Dart/FRB-Specific Notes
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/bin/breez_cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/bin/breez_cli.dart
@@ -9,6 +9,12 @@ Future<void> main(List<String> arguments) async {
         ..addOption('data-dir', abbr: 'd', defaultsTo: './.data', help: 'Path to the data directory')
         ..addOption('network', defaultsTo: 'regtest', allowed: ['regtest', 'mainnet'], help: 'Network to use')
         ..addOption('account-number', help: 'Account number for the Spark signer')
+        ..addOption(
+          'postgres-connection-string',
+          help: 'PostgreSQL connection string (uses SQLite by default)',
+        )
+        ..addOption('stable-balance-token-identifier', help: 'Stable balance token identifier')
+        ..addOption('stable-balance-threshold', help: 'Stable balance threshold in sats')
         ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage');
 
   final ArgResults results;
@@ -33,8 +39,20 @@ Future<void> main(List<String> arguments) async {
   final network = results.option('network')!;
   final accountNumberStr = results.option('account-number');
   final accountNumber = accountNumberStr != null ? int.parse(accountNumberStr) : null;
+  final postgresConnectionString = results.option('postgres-connection-string');
+  final stableBalanceTokenIdentifier = results.option('stable-balance-token-identifier');
+  final stableBalanceThresholdStr = results.option('stable-balance-threshold');
+  final stableBalanceThreshold =
+      stableBalanceThresholdStr != null ? BigInt.parse(stableBalanceThresholdStr) : null;
 
-  await runCli(dataDir: dataDir, network: network, accountNumber: accountNumber);
+  await runCli(
+    dataDir: dataDir,
+    network: network,
+    accountNumber: accountNumber,
+    postgresConnectionString: postgresConnectionString,
+    stableBalanceTokenIdentifier: stableBalanceTokenIdentifier,
+    stableBalanceThreshold: stableBalanceThreshold,
+  );
 
   // Force exit — the native FFI library may keep background threads alive
   // after sdk.disconnect(), preventing the Dart VM from exiting cleanly.

--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/cli.dart
@@ -5,12 +5,20 @@ import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 import 'commands.dart';
+import 'contacts.dart';
 import 'issuer.dart';
 import 'persistence.dart';
 import 'readline.dart';
 import 'serialization.dart';
 
-Future<void> runCli({required String dataDir, required String network, int? accountNumber}) async {
+Future<void> runCli({
+  required String dataDir,
+  required String network,
+  int? accountNumber,
+  String? postgresConnectionString,
+  String? stableBalanceTokenIdentifier,
+  BigInt? stableBalanceThreshold,
+}) async {
   await BreezSdkSparkLib.init(externalLibrary: ExternalLibrary.open(_nativeLibPath()));
 
   final dir = Directory(dataDir);
@@ -28,8 +36,27 @@ Future<void> runCli({required String dataDir, required String network, int? acco
     config = config.copyWith(apiKey: apiKey);
   }
 
+  if (stableBalanceTokenIdentifier != null) {
+    config = config.copyWith(
+      stableBalanceConfig: StableBalanceConfig(
+        tokenIdentifier: stableBalanceTokenIdentifier,
+        thresholdSats: stableBalanceThreshold,
+        maxSlippageBps: null,
+        reservedSats: null,
+      ),
+    );
+  }
+
   final seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: null);
   var builder = SdkBuilder(config: config, seed: seed);
+
+  if (postgresConnectionString != null) {
+    // PostgreSQL storage is not yet available in the Flutter/Dart SDK bindings.
+    stderr.writeln(
+      'Warning: --postgres-connection-string is not yet supported in the Dart CLI. '
+      'Using default SQLite storage instead.',
+    );
+  }
   builder = builder.withDefaultStorage(storageDir: dataDir);
 
   if (accountNumber != null) {
@@ -79,7 +106,14 @@ Future<void> _runRepl(
   stdout.writeln("Type 'help' for available commands or 'exit' to quit");
 
   final registry = buildCommandRegistry();
-  final allCommands = [...commandNames, ...issuerCommandNames, 'exit', 'quit', 'help'];
+  final allCommands = [
+    ...commandNames,
+    ...issuerCommandNames,
+    ...contactsCommandNames,
+    'exit',
+    'quit',
+    'help',
+  ];
   final rl = Readline(completions: allCommands, historyFile: persistence.historyFile);
 
   while (true) {
@@ -107,6 +141,8 @@ Future<void> _runRepl(
 
       if (cmdName == 'issuer') {
         await dispatchIssuerCommand(cmdArgs, tokenIssuer);
+      } else if (cmdName == 'contacts') {
+        await dispatchContactsCommand(cmdArgs, sdk);
       } else if (registry.containsKey(cmdName)) {
         final entry = registry[cmdName]!;
         await entry.handler(sdk, tokenIssuer, cmdArgs);
@@ -140,6 +176,9 @@ void _printHelp(Map<String, CommandEntry> registry) {
   }
   stdout.writeln(
     '  ${'issuer <subcommand>'.padRight(40)} Token issuer commands (use \'issuer help\' for details)',
+  );
+  stdout.writeln(
+    '  ${'contacts <subcommand>'.padRight(40)} Contacts commands (use \'contacts help\' for details)',
   );
   stdout.writeln('  ${'exit / quit'.padRight(40)} Exit the CLI');
   stdout.writeln('  ${'help'.padRight(40)} Show this help message');

--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/commands.dart
@@ -417,8 +417,7 @@ Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args
 
   if (prepareResponse.conversionEstimate != null) {
     final est = prepareResponse.conversionEstimate!;
-    final units =
-        prepareResponse.paymentMethod is SendPaymentMethod_BitcoinAddress ? 'sats' : 'token base units';
+    final units = est.options.conversionType is ConversionType_FromBitcoin ? 'sats' : 'token base units';
     print('Estimated conversion of ${est.amount} $units with a ${est.fee} $units fee');
     final answer = prompt('Do you want to continue (y/n): ', defaultValue: 'y');
     if (answer.toLowerCase() != 'y') {

--- a/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/contacts.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/dart/lib/contacts.dart
@@ -1,0 +1,110 @@
+import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
+
+import 'serialization.dart';
+
+/// Contacts subcommand names (used for tab completion).
+const contactsCommandNames = ['contacts add', 'contacts update', 'contacts delete', 'contacts list'];
+
+typedef ContactsHandler = Future<void> Function(BreezSdk sdk, List<String> args);
+
+class _ContactsEntry {
+  final String description;
+  final ContactsHandler handler;
+  const _ContactsEntry(this.description, this.handler);
+}
+
+Map<String, _ContactsEntry>? _registry;
+
+Map<String, _ContactsEntry> _getRegistry() {
+  return _registry ??= {
+    'add': _ContactsEntry('Add a new contact', _handleAdd),
+    'update': _ContactsEntry('Update an existing contact', _handleUpdate),
+    'delete': _ContactsEntry('Delete a contact', _handleDelete),
+    'list': _ContactsEntry('List contacts', _handleList),
+  };
+}
+
+/// Dispatch a contacts subcommand given the args after 'contacts'.
+Future<void> dispatchContactsCommand(List<String> args, BreezSdk sdk) async {
+  final registry = _getRegistry();
+
+  if (args.isEmpty || args[0] == 'help' || args[0] == '--help') {
+    print('\nContacts subcommands:\n');
+    for (final entry in registry.entries.toList()..sort((a, b) => a.key.compareTo(b.key))) {
+      print('  contacts ${entry.key.padRight(30)} ${entry.value.description}');
+    }
+    print('');
+    return;
+  }
+
+  final subName = args[0];
+  final subArgs = args.sublist(1);
+
+  if (!registry.containsKey(subName)) {
+    print("Unknown contacts subcommand: $subName. Use 'contacts help' for available commands.");
+    return;
+  }
+
+  await registry[subName]!.handler(sdk, subArgs);
+}
+
+// --- add ---
+
+Future<void> _handleAdd(BreezSdk sdk, List<String> args) async {
+  if (args.length < 2 || args.first == 'help' || args.first == '--help') {
+    print('Usage: contacts add <name> <payment_identifier>');
+    return;
+  }
+  final name = args[0];
+  final paymentIdentifier = args[1];
+  final result = await sdk.addContact(
+    request: AddContactRequest(name: name, paymentIdentifier: paymentIdentifier),
+  );
+  printValue(result);
+}
+
+// --- update ---
+
+Future<void> _handleUpdate(BreezSdk sdk, List<String> args) async {
+  if (args.length < 3 || args.first == 'help' || args.first == '--help') {
+    print('Usage: contacts update <id> <name> <payment_identifier>');
+    return;
+  }
+  final id = args[0];
+  final name = args[1];
+  final paymentIdentifier = args[2];
+  final result = await sdk.updateContact(
+    request: UpdateContactRequest(id: id, name: name, paymentIdentifier: paymentIdentifier),
+  );
+  printValue(result);
+}
+
+// --- delete ---
+
+Future<void> _handleDelete(BreezSdk sdk, List<String> args) async {
+  if (args.isEmpty || args.first == 'help' || args.first == '--help') {
+    print('Usage: contacts delete <id>');
+    return;
+  }
+  final id = args[0];
+  await sdk.deleteContact(id: id);
+  print('Contact deleted successfully');
+}
+
+// --- list ---
+
+Future<void> _handleList(BreezSdk sdk, List<String> args) async {
+  int? offset;
+  int? limit;
+  if (args.isNotEmpty && args.first != 'help' && args.first != '--help') {
+    offset = int.tryParse(args[0]);
+    if (args.length > 1) {
+      limit = int.tryParse(args[1]);
+    }
+  } else if (args.isNotEmpty) {
+    print('Usage: contacts list [offset] [limit]');
+    return;
+  }
+  final result = await sdk.listContacts(request: ListContactsRequest(offset: offset, limit: limit));
+  printValue(result);
+}


### PR DESCRIPTION
Automated sync of Dart CLI from Rust CLI changes.

**Source commit:** [`8d56504`](https://github.com/breez/spark-sdk/commit/8d56504e83c844f64970536014f3e0a0e49694cd)
**Claude log:** [View artifact](https://github.com/breez/spark-sdk/actions/runs/22692201449)

<details>
<summary>Sync findings</summary>

## Divergences
- Missing `contacts` command group (Rust has `contacts.rs` with add, update, delete, list subcommands; Dart had none)
- Missing `--postgres-connection-string` CLI flag (Rust CLI supports PostgreSQL storage via this flag; Dart CLI did not have it)
- Missing `--stable-balance-token-identifier` and `--stable-balance-threshold` CLI flags (Rust CLI sets `StableBalanceConfig`; Dart CLI did not)
- Pay command conversion estimate units check used wrong logic: Dart checked `paymentMethod is SendPaymentMethod_BitcoinAddress` instead of `conversionEstimate.options.conversionType is ConversionType_FromBitcoin` as Rust does
- Missing contacts commands in README documentation

## Applied
- Created `lib/contacts.dart` with add, update, delete, list handlers matching Rust `contacts.rs`
- Added contacts dispatch in `cli.dart` REPL loop and help output
- Added `contactsCommandNames` to tab completion list in `cli.dart`
- Added `--postgres-connection-string` CLI flag to `bin/breez_cli.dart` and `cli.dart` (prints "not yet supported" warning, falls back to SQLite)
- Added `--stable-balance-token-identifier` and `--stable-balance-threshold` CLI flags to `bin/breez_cli.dart` and `cli.dart`, setting `StableBalanceConfig` on config
- Fixed pay command conversion estimate units check in `commands.dart` to use `est.options.conversionType is ConversionType_FromBitcoin` matching Rust logic
- Updated `README.md` with contacts commands and new CLI options

## Skipped
- PostgreSQL storage not implemented (Flutter/Dart SDK bindings do not expose `withPostgresStorage` or `defaultPostgresStorageConfig`; flag added with warning message)

</details>