### PR TITLE
chore: sync Swift CLI with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
@@ -52,6 +52,10 @@ make clean            Remove build artifacts
 |--------|---------|-------------|
 | `-d`, `--data-dir` | `./.data` | Path to the data directory |
 | `--network` | `regtest` | Network to use (`regtest` or `mainnet`) |
+| `--account-number` | - | Account number for the Spark signer |
+| `--postgres-connection-string` | - | PostgreSQL connection string (uses SQLite by default) |
+| `--stable-balance-token-identifier` | - | Stable balance token identifier |
+| `--stable-balance-threshold` | - | Stable balance threshold in sats |
 
 ## Environment Variables
 
@@ -73,15 +77,11 @@ The CLI supports:
 
 **Lightning address**: `get-lightning-address`, `register-lightning-address`, `delete-lightning-address`, `check-lightning-address-available`
 
-**Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`
+**Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`, `issuer <subcommand>`
 
-**Fiat**: `list-fiat-currencies`, `list-fiat-rates`
+**Contacts**: `contacts add`, `contacts update`, `contacts delete`, `contacts list`
 
-**Settings**: `get-user-settings`, `set-user-settings`, `recommended-fees`, `get-spark-status`
-
-**Token issuer**: `issuer create-token`, `issuer mint-token`, `issuer burn-token`, `issuer token-balance`, `issuer token-metadata`, `issuer freeze-token`, `issuer unfreeze-token`
-
-**Input parsing**: `parse`
+**Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`, `recommended-fees`
 
 ## Development
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -135,6 +135,7 @@ func printHelp(_ registry: [String: CommandEntry]) {
         print("  \(name.padding(toLength: 40, withPad: " ", startingAt: 0))\(cmd.description)")
     }
     print("\n  \("issuer <subcommand>".padding(toLength: 40, withPad: " ", startingAt: 0))Token issuer commands (use 'issuer help' for details)")
+    print("  \("contacts <subcommand>".padding(toLength: 40, withPad: " ", startingAt: 0))Contacts commands (use 'contacts help' for details)")
     print("  \("exit / quit".padding(toLength: 40, withPad: " ", startingAt: 0))Exit the CLI")
     print("  \("help".padding(toLength: 40, withPad: " ", startingAt: 0))Show this help message")
     print()
@@ -257,11 +258,86 @@ func handleListPayments(_ sdk: BreezSdk, _ args: [String]) async throws {
     let fp = FlagParser(args)
     let limit = fp.get("l", "limit").flatMap { UInt32($0) } ?? 10
     let offset = fp.get("o", "offset").flatMap { UInt32($0) } ?? 0
+
+    let typeFilter: [PaymentType]? = fp.get("t", "type-filter").map { raw in
+        raw.split(separator: ",").compactMap { parsePaymentType(String($0)) }
+    }
+    let statusFilter: [PaymentStatus]? = fp.get("s", "status-filter").map { raw in
+        raw.split(separator: ",").compactMap { parsePaymentStatus(String($0)) }
+    }
+    let assetFilter: AssetFilter? = fp.get("a", "asset-filter").flatMap { parseAssetFilter($0) }
+    let fromTimestamp = fp.get("from-timestamp").flatMap { UInt64($0) }
+    let toTimestamp = fp.get("to-timestamp").flatMap { UInt64($0) }
+    let sortAscending: Bool? = fp.get("sort-ascending").map { $0 == "true" }
+
+    var paymentDetailsFilter: [PaymentDetailsFilter] = []
+    if let htlcStatusRaw = fp.get("spark-htlc-status-filter") {
+        let statuses = htlcStatusRaw.split(separator: ",").compactMap { parseSparkHtlcStatus(String($0)) }
+        paymentDetailsFilter.append(.spark(htlcStatus: statuses, conversionRefundNeeded: nil))
+    }
+    if let txHash = fp.get("tx-hash") {
+        paymentDetailsFilter.append(.token(conversionRefundNeeded: nil, txHash: txHash, txType: nil))
+    }
+    if let txTypeRaw = fp.get("tx-type"), let txType = parseTokenTransactionType(txTypeRaw) {
+        paymentDetailsFilter.append(.token(conversionRefundNeeded: nil, txHash: nil, txType: txType))
+    }
+
     let result = try await sdk.listPayments(request: ListPaymentsRequest(
+        typeFilter: typeFilter,
+        statusFilter: statusFilter,
+        assetFilter: assetFilter,
+        paymentDetailsFilter: paymentDetailsFilter.isEmpty ? nil : paymentDetailsFilter,
+        fromTimestamp: fromTimestamp,
+        toTimestamp: toTimestamp,
         offset: offset,
-        limit: limit
+        limit: limit,
+        sortAscending: sortAscending
     ))
     printValue(result)
+}
+
+// MARK: - Filter parsing helpers
+
+private func parsePaymentType(_ raw: String) -> PaymentType? {
+    switch raw.lowercased() {
+    case "send": return .send
+    case "receive": return .receive
+    default: return nil
+    }
+}
+
+private func parsePaymentStatus(_ raw: String) -> PaymentStatus? {
+    switch raw.lowercased() {
+    case "pending": return .pending
+    case "completed": return .completed
+    case "failed": return .failed
+    default: return nil
+    }
+}
+
+private func parseAssetFilter(_ raw: String) -> AssetFilter? {
+    if raw.lowercased() == "bitcoin" {
+        return .bitcoin
+    }
+    return .token(tokenIdentifier: raw)
+}
+
+private func parseSparkHtlcStatus(_ raw: String) -> SparkHtlcStatus? {
+    switch raw.lowercased().replacingOccurrences(of: "_", with: "") {
+    case "waitingforpreimage": return .waitingForPreimage
+    case "preimageshared": return .preimageShared
+    case "returned": return .returned
+    default: return nil
+    }
+}
+
+private func parseTokenTransactionType(_ raw: String) -> TokenTransactionType? {
+    switch raw.lowercased() {
+    case "transfer": return .transfer
+    case "mint": return .mint
+    case "burn": return .burn
+    default: return nil
+    }
 }
 
 // --- receive ---
@@ -559,7 +635,7 @@ func handleClaimHtlcPayment(_ sdk: BreezSdk, _ args: [String]) async throws {
     let result = try await sdk.claimHtlcPayment(request: ClaimHtlcPaymentRequest(
         preimage: args[0]
     ))
-    printValue(result)
+    printValue(result.payment)
 }
 
 // --- claim-deposit ---
@@ -663,7 +739,7 @@ func handleListUnclaimedDeposits(_ sdk: BreezSdk, _ args: [String]) async throws
 
 func handleBuyBitcoin(_ sdk: BreezSdk, _ args: [String]) async throws {
     let fp = FlagParser(args)
-    let lockedAmount = fp.get("amount").flatMap { UInt64($0) }
+    let lockedAmount = fp.get("locked-amount-sat").flatMap { UInt64($0) }
     let redirectUrl = fp.get("redirect-url")
 
     let result = try await sdk.buyBitcoin(request: BuyBitcoinRequest(

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Contacts.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Contacts.swift
@@ -1,0 +1,117 @@
+import Foundation
+import BreezSdkSpark
+
+// MARK: - Contacts command names (for REPL completion)
+
+let contactsCommandNames: [String] = [
+    "contacts add",
+    "contacts update",
+    "contacts delete",
+    "contacts list",
+]
+
+// MARK: - Dispatch
+
+func dispatchContactsCommand(_ args: [String], sdk: BreezSdk) async {
+    if args.isEmpty || args[0] == "help" {
+        printContactsHelp()
+        return
+    }
+
+    let subName = args[0]
+    let subArgs = Array(args.dropFirst())
+
+    do {
+        switch subName {
+        case "add":
+            try await handleContactAdd(sdk, subArgs)
+        case "update":
+            try await handleContactUpdate(sdk, subArgs)
+        case "delete":
+            try await handleContactDelete(sdk, subArgs)
+        case "list":
+            try await handleContactList(sdk, subArgs)
+        default:
+            print("Unknown contacts subcommand: \(subName). Use 'contacts help' for available commands.")
+        }
+    } catch {
+        print("Error: \(error)")
+    }
+}
+
+// MARK: - Help
+
+private func printContactsHelp() {
+    print("\nContacts subcommands:")
+    print("  contacts \("add".padding(toLength: 30, withPad: " ", startingAt: 0))Add a new contact")
+    print("  contacts \("update".padding(toLength: 30, withPad: " ", startingAt: 0))Update an existing contact")
+    print("  contacts \("delete".padding(toLength: 30, withPad: " ", startingAt: 0))Delete a contact")
+    print("  contacts \("list".padding(toLength: 30, withPad: " ", startingAt: 0))List contacts")
+    print()
+}
+
+// MARK: - Handlers
+
+// --- add ---
+
+private func handleContactAdd(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let fp = FlagParser(args)
+    guard fp.positional.count >= 2 else {
+        print("Usage: contacts add <name> <payment_identifier>")
+        return
+    }
+
+    let result = try await sdk.addContact(
+        request: AddContactRequest(
+            name: fp.positional[0],
+            paymentIdentifier: fp.positional[1]
+        ))
+    printValue(result)
+}
+
+// --- update ---
+
+private func handleContactUpdate(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let fp = FlagParser(args)
+    guard fp.positional.count >= 3 else {
+        print("Usage: contacts update <id> <name> <payment_identifier>")
+        return
+    }
+
+    let result = try await sdk.updateContact(
+        request: UpdateContactRequest(
+            id: fp.positional[0],
+            name: fp.positional[1],
+            paymentIdentifier: fp.positional[2]
+        ))
+    printValue(result)
+}
+
+// --- delete ---
+
+private func handleContactDelete(_ sdk: BreezSdk, _ args: [String]) async throws {
+    guard !args.isEmpty else {
+        print("Usage: contacts delete <id>")
+        return
+    }
+
+    try await sdk.deleteContact(id: args[0])
+    print("Contact deleted successfully")
+}
+
+// --- list ---
+
+private func handleContactList(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let fp = FlagParser(args)
+    let offset = fp.get("offset").flatMap { UInt32($0) }
+        ?? fp.positional.first.flatMap { UInt32($0) }
+    let limit = fp.get("limit").flatMap { UInt32($0) }
+        ?? (fp.positional.count > 1 ? UInt32(fp.positional[1]) : nil)
+
+    let result = try await sdk.listContacts(
+        request: ListContactsRequest(
+            offset: offset,
+            limit: limit
+        ))
+    printValue(result)
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
@@ -7,6 +7,10 @@ import CEditLine
 struct CliOptions {
     var dataDir: String = "./.data"
     var network: String = "regtest"
+    var accountNumber: UInt32?
+    var postgresConnectionString: String?
+    var stableBalanceTokenIdentifier: String?
+    var stableBalanceThreshold: UInt64?
 }
 
 func parseCliFlags() -> CliOptions {
@@ -21,6 +25,18 @@ func parseCliFlags() -> CliOptions {
         case "--network":
             i += 1
             if i < args.count { opts.network = args[i] }
+        case "--account-number":
+            i += 1
+            if i < args.count { opts.accountNumber = UInt32(args[i]) }
+        case "--postgres-connection-string":
+            i += 1
+            if i < args.count { opts.postgresConnectionString = args[i] }
+        case "--stable-balance-token-identifier":
+            i += 1
+            if i < args.count { opts.stableBalanceTokenIdentifier = args[i] }
+        case "--stable-balance-threshold":
+            i += 1
+            if i < args.count { opts.stableBalanceThreshold = UInt64(args[i]) }
         default:
             break
         }
@@ -167,11 +183,30 @@ var config = defaultConfig(network: network)
 if let apiKey = ProcessInfo.processInfo.environment["BREEZ_API_KEY"], !apiKey.isEmpty {
     config.apiKey = apiKey
 }
+if let tokenIdentifier = opts.stableBalanceTokenIdentifier {
+    config.stableBalanceConfig = StableBalanceConfig(
+        tokenIdentifier: tokenIdentifier,
+        thresholdSats: opts.stableBalanceThreshold,
+        maxSlippageBps: nil,
+        reservedSats: nil
+    )
+}
 
 // Build SDK
 let seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: nil)
 let builder = SdkBuilder(config: config, seed: seed)
-await builder.withDefaultStorage(storageDir: resolvedDir)
+if let connectionString = opts.postgresConnectionString {
+    await builder.withPostgresStorage(config: defaultPostgresStorageConfig(connectionString: connectionString))
+} else {
+    await builder.withDefaultStorage(storageDir: resolvedDir)
+}
+if let accountNumber = opts.accountNumber {
+    await builder.withKeySet(config: KeySetConfig(
+        keySetType: .default,
+        useAddressIndex: false,
+        accountNumber: accountNumber
+    ))
+}
 
 let sdk = try await builder.build()
 
@@ -185,7 +220,7 @@ let tokenIssuer = sdk.getTokenIssuer()
 let registry = buildCommandRegistry()
 
 // Set up tab completion
-allCompletionCommands = commandNames + issuerCommandNames + ["help", "exit", "quit"]
+allCompletionCommands = commandNames + issuerCommandNames + contactsCommandNames + ["help", "exit", "quit"]
 rl_attempted_completion_function = attemptedCompletion
 
 // Load history
@@ -229,6 +264,8 @@ replLoop: while true {
 
     if cmdName == "issuer" {
         await dispatchIssuerCommand(cmdArgs, tokenIssuer: tokenIssuer)
+    } else if cmdName == "contacts" {
+        await dispatchContactsCommand(cmdArgs, sdk: sdk)
     } else if let cmd = registry[cmdName] {
         do {
             try await cmd.run(sdk, cmdArgs)


### PR DESCRIPTION
Automated sync of Swift CLI from Rust CLI changes.

**Source commit:** [`8d56504`](https://github.com/breez/spark-sdk/commit/8d56504e83c844f64970536014f3e0a0e49694cd)
**Claude log:** [View artifact](https://github.com/breez/spark-sdk/actions/runs/22692201449)

<details>
<summary>Sync findings</summary>

## Divergences
- Missing `--account-number` CLI flag in Swift CLI (present in Rust)
- Missing `--postgres-connection-string` CLI flag and `withPostgresStorage` builder call in Swift CLI
- Missing `--stable-balance-token-identifier` and `--stable-balance-threshold` CLI flags and `StableBalanceConfig` usage in Swift CLI
- Missing `withKeySet` builder call when `--account-number` is provided in Swift CLI
- Missing `contacts` command subgroup (add, update, delete, list) in Swift CLI
- `list-payments` missing filter flags: `--type-filter`, `--status-filter`, `--asset-filter`, `--spark-htlc-status-filter`, `--tx-hash`, `--tx-type`, `--from-timestamp`, `--to-timestamp`, `--sort-ascending`
- `claim-htlc-payment` printed entire response instead of `result.payment` (Rust prints `res.payment`)
- `buy-bitcoin` used `--amount` flag instead of `--locked-amount-sat` (Rust uses `--locked-amount-sat`)
- `contacts` command group help entry missing from REPL help output
- Tab completion missing `contacts` command names
- README missing CLI options for `--account-number`, `--postgres-connection-string`, `--stable-balance-*`
- README missing `contacts` command group documentation

## Applied
- Added `--account-number`, `--postgres-connection-string`, `--stable-balance-token-identifier`, `--stable-balance-threshold` CLI flags to `main.swift`
- Added `withPostgresStorage` builder call when postgres connection string is provided in `main.swift`
- Added `withKeySet` builder call when account number is provided in `main.swift`
- Added `StableBalanceConfig` to config when stable balance token identifier is provided in `main.swift`
- Created `Contacts.swift` with dispatch function, command registry, and handlers for add/update/delete/list
- Added contacts command dispatch to REPL loop in `main.swift`
- Added contacts command names to tab completion in `main.swift`
- Added all missing `list-payments` filter flags with parsing helpers in `Commands.swift`
- Fixed `claim-htlc-payment` to print `result.payment` instead of full response in `Commands.swift`
- Fixed `buy-bitcoin` to use `--locked-amount-sat` flag instead of `--amount` in `Commands.swift`
- Added contacts help entry to REPL help output in `Commands.swift`
- Updated README with new CLI options and contacts command group

## Skipped
- Swift CLI has friendlier output for `check-lightning-address-available` (prints "available"/"NOT available" messages) — kept as UX improvement, suggest adding to Rust CLI
- Swift CLI has friendlier output for `delete-lightning-address` (prints "Lightning address deleted") — kept as UX improvement
- Swift CLI has friendlier output for `set-user-settings` (prints "User settings updated") — kept as UX improvement
- Swift CLI has friendlier output for `get-lightning-address` when nil (prints "No lightning address registered") — kept as UX improvement

</details>