### PR TITLE
add /health endpoint to lnurl server

### DIFF
--- a/crates/breez-sdk/lnurl/src/main.rs
+++ b/crates/breez-sdk/lnurl/src/main.rs
@@ -3,7 +3,7 @@ use anyhow::anyhow;
 use axum::{
     Extension, Router,
     extract::DefaultBodyLimit,
-    http::Method,
+    http::{Method, StatusCode},
     middleware,
     routing::{delete, get, post},
 };
@@ -351,6 +351,7 @@ where
             get(LnurlServer::<DB>::handle_invoice),
         )
         .route("/verify/{payment_hash}", get(LnurlServer::<DB>::verify))
+        .route("/health", get(|| async { StatusCode::OK }))
         .layer(Extension(state))
         .layer(
             CorsLayer::new()


### PR DESCRIPTION
Useful for deployment strategies where old containers don't get removed before /health returns success.