### PR TITLE
Send all with stable balance

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -608,7 +608,7 @@ public static class Commands
         if (prepareResponse.conversionEstimate != null)
         {
             var est = prepareResponse.conversionEstimate;
-            Console.WriteLine($"Estimated conversion of {est.amount} with a {est.fee} fee");
+            Console.WriteLine($"Estimated conversion of {est.amountIn} → {est.amountOut} with a {est.fee} fee");
             var line = readline("Do you want to continue (y/n) [y]: ");
             if (line != null && line.Trim().ToLower() != "" && line.Trim().ToLower() != "y")
             {
@@ -688,10 +688,11 @@ public static class Commands
         bool? validateSuccessUrl = validateStr != null ? validateStr.ToLower() == "true" : null;
 
         var prepareResponse = await sdk.PrepareLnurlPay(request: new PrepareLnurlPayRequest(
-            amountSats: amountSats,
+            amount: amountSats,
             payRequest: payRequest,
             comment: comment,
             validateSuccessActionUrl: validateSuccessUrl,
+            tokenIdentifier: null,
             conversionOptions: conversionOptions,
             feePolicy: feePolicy
         ));
@@ -700,7 +701,7 @@ public static class Commands
         if (prepareResponse.conversionEstimate != null)
         {
             var est = prepareResponse.conversionEstimate;
-            Console.WriteLine($"Estimated conversion of {est.amount} token base units with a {est.fee} token base units fee");
+            Console.WriteLine($"Estimated conversion of {est.amountIn} token base units → {est.amountOut} sats with a {est.fee} token base units fee");
             var line = readline("Do you want to continue (y/n) [y]: ");
             if (line != null && line.Trim().ToLower() != "" && line.Trim().ToLower() != "y")
             {

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
@@ -5,35 +5,27 @@ import 'package:breez_cli/cli.dart';
 import 'package:breez_cli/passkey.dart';
 
 Future<void> main(List<String> arguments) async {
-  final parser =
-      ArgParser()
-        ..addOption('data-dir', abbr: 'd', defaultsTo: './.data', help: 'Path to the data directory')
-        ..addOption('network', defaultsTo: 'regtest', allowed: ['regtest', 'mainnet'], help: 'Network to use')
-        ..addOption('account-number', help: 'Account number for the Spark signer')
-        ..addOption(
-          'postgres-connection-string',
-          help: 'PostgreSQL connection string (uses SQLite by default)',
-        )
-        ..addOption('stable-balance-token-identifier', help: 'Stable balance token identifier')
-        ..addOption('stable-balance-threshold', help: 'Stable balance threshold in sats')
-        ..addOption(
-          'passkey',
-          help: 'Use passkey with PRF provider (file, yubikey, or fido2)',
-          valueHelp: 'PROVIDER',
-        )
-        ..addOption('label', help: 'Label for seed derivation (requires --passkey)')
-        ..addFlag(
-          'list-labels',
-          negatable: false,
-          help: 'List and select labels from Nostr (requires --passkey)',
-        )
-        ..addFlag(
-          'store-label',
-          negatable: false,
-          help: 'Publish label to Nostr (requires --passkey and --label)',
-        )
-        ..addOption('rpid', help: 'Relying party ID for FIDO2 provider (requires --passkey)')
-        ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage');
+  final parser = ArgParser()
+    ..addOption('data-dir', abbr: 'd', defaultsTo: './.data', help: 'Path to the data directory')
+    ..addOption('network', defaultsTo: 'regtest', allowed: ['regtest', 'mainnet'], help: 'Network to use')
+    ..addOption('account-number', help: 'Account number for the Spark signer')
+    ..addOption('postgres-connection-string', help: 'PostgreSQL connection string (uses SQLite by default)')
+    ..addOption('stable-balance-token-identifier', help: 'Stable balance token identifier')
+    ..addOption('stable-balance-threshold', help: 'Stable balance threshold in sats')
+    ..addOption(
+      'passkey',
+      help: 'Use passkey with PRF provider (file, yubikey, or fido2)',
+      valueHelp: 'PROVIDER',
+    )
+    ..addOption('label', help: 'Label for seed derivation (requires --passkey)')
+    ..addFlag('list-labels', negatable: false, help: 'List and select labels from Nostr (requires --passkey)')
+    ..addFlag(
+      'store-label',
+      negatable: false,
+      help: 'Publish label to Nostr (requires --passkey and --label)',
+    )
+    ..addOption('rpid', help: 'Relying party ID for FIDO2 provider (requires --passkey)')
+    ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage');
 
   final ArgResults results;
   try {
@@ -60,8 +52,9 @@ Future<void> main(List<String> arguments) async {
   final postgresConnectionString = results.option('postgres-connection-string');
   final stableBalanceTokenIdentifier = results.option('stable-balance-token-identifier');
   final stableBalanceThresholdStr = results.option('stable-balance-threshold');
-  final stableBalanceThreshold =
-      stableBalanceThresholdStr != null ? BigInt.parse(stableBalanceThresholdStr) : null;
+  final stableBalanceThreshold = stableBalanceThresholdStr != null
+      ? BigInt.parse(stableBalanceThresholdStr)
+      : null;
 
   final passkeyProvider = results.option('passkey');
   final label = results.option('label');

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
@@ -5,27 +5,35 @@ import 'package:breez_cli/cli.dart';
 import 'package:breez_cli/passkey.dart';
 
 Future<void> main(List<String> arguments) async {
-  final parser = ArgParser()
-    ..addOption('data-dir', abbr: 'd', defaultsTo: './.data', help: 'Path to the data directory')
-    ..addOption('network', defaultsTo: 'regtest', allowed: ['regtest', 'mainnet'], help: 'Network to use')
-    ..addOption('account-number', help: 'Account number for the Spark signer')
-    ..addOption('postgres-connection-string', help: 'PostgreSQL connection string (uses SQLite by default)')
-    ..addOption('stable-balance-token-identifier', help: 'Stable balance token identifier')
-    ..addOption('stable-balance-threshold', help: 'Stable balance threshold in sats')
-    ..addOption(
-      'passkey',
-      help: 'Use passkey with PRF provider (file, yubikey, or fido2)',
-      valueHelp: 'PROVIDER',
-    )
-    ..addOption('label', help: 'Label for seed derivation (requires --passkey)')
-    ..addFlag('list-labels', negatable: false, help: 'List and select labels from Nostr (requires --passkey)')
-    ..addFlag(
-      'store-label',
-      negatable: false,
-      help: 'Publish label to Nostr (requires --passkey and --label)',
-    )
-    ..addOption('rpid', help: 'Relying party ID for FIDO2 provider (requires --passkey)')
-    ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage');
+  final parser =
+      ArgParser()
+        ..addOption('data-dir', abbr: 'd', defaultsTo: './.data', help: 'Path to the data directory')
+        ..addOption('network', defaultsTo: 'regtest', allowed: ['regtest', 'mainnet'], help: 'Network to use')
+        ..addOption('account-number', help: 'Account number for the Spark signer')
+        ..addOption(
+          'postgres-connection-string',
+          help: 'PostgreSQL connection string (uses SQLite by default)',
+        )
+        ..addOption('stable-balance-token-identifier', help: 'Stable balance token identifier')
+        ..addOption('stable-balance-threshold', help: 'Stable balance threshold in sats')
+        ..addOption(
+          'passkey',
+          help: 'Use passkey with PRF provider (file, yubikey, or fido2)',
+          valueHelp: 'PROVIDER',
+        )
+        ..addOption('label', help: 'Label for seed derivation (requires --passkey)')
+        ..addFlag(
+          'list-labels',
+          negatable: false,
+          help: 'List and select labels from Nostr (requires --passkey)',
+        )
+        ..addFlag(
+          'store-label',
+          negatable: false,
+          help: 'Publish label to Nostr (requires --passkey and --label)',
+        )
+        ..addOption('rpid', help: 'Relying party ID for FIDO2 provider (requires --passkey)')
+        ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage');
 
   final ArgResults results;
   try {
@@ -52,9 +60,8 @@ Future<void> main(List<String> arguments) async {
   final postgresConnectionString = results.option('postgres-connection-string');
   final stableBalanceTokenIdentifier = results.option('stable-balance-token-identifier');
   final stableBalanceThresholdStr = results.option('stable-balance-threshold');
-  final stableBalanceThreshold = stableBalanceThresholdStr != null
-      ? BigInt.parse(stableBalanceThresholdStr)
-      : null;
+  final stableBalanceThreshold =
+      stableBalanceThresholdStr != null ? BigInt.parse(stableBalanceThresholdStr) : null;
 
   final passkeyProvider = results.option('passkey');
   final label = results.option('label');

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -207,19 +207,18 @@ TokenTransactionType? _parseTxType(String s) {
 }
 
 Future<void> _handleListPayments(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser =
-      _parser('list-payments')
-        ..addMultiOption('type-filter', abbr: 't')
-        ..addMultiOption('status-filter', abbr: 's')
-        ..addOption('asset-filter', abbr: 'a')
-        ..addMultiOption('spark-htlc-status-filter')
-        ..addOption('tx-hash')
-        ..addOption('tx-type')
-        ..addOption('from-timestamp')
-        ..addOption('to-timestamp')
-        ..addOption('limit', abbr: 'l', defaultsTo: '10')
-        ..addOption('offset', abbr: 'o', defaultsTo: '0')
-        ..addOption('sort-ascending');
+  final parser = _parser('list-payments')
+    ..addMultiOption('type-filter', abbr: 't')
+    ..addMultiOption('status-filter', abbr: 's')
+    ..addOption('asset-filter', abbr: 'a')
+    ..addMultiOption('spark-htlc-status-filter')
+    ..addOption('tx-hash')
+    ..addOption('tx-type')
+    ..addOption('from-timestamp')
+    ..addOption('to-timestamp')
+    ..addOption('limit', abbr: 'l', defaultsTo: '10')
+    ..addOption('offset', abbr: 'o', defaultsTo: '0')
+    ..addOption('sort-ascending');
   final results = _parseArgs(parser, args, 'list-payments [options]');
   if (results == null) return;
 
@@ -287,16 +286,15 @@ Future<void> _handleListPayments(BreezSdk sdk, TokenIssuer tokenIssuer, List<Str
 // --- receive ---
 
 Future<void> _handleReceive(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser =
-      _parser('receive')
-        ..addOption('method', abbr: 'm', mandatory: true, help: 'sparkaddress, sparkinvoice, bitcoin, bolt11')
-        ..addOption('description', abbr: 'd')
-        ..addOption('amount', abbr: 'a')
-        ..addOption('token-identifier', abbr: 't')
-        ..addOption('expiry-secs', abbr: 'e')
-        ..addOption('sender-public-key', abbr: 's')
-        ..addFlag('hodl', defaultsTo: false)
-        ..addFlag('new-address', defaultsTo: false, help: 'Get a new bitcoin deposit address');
+  final parser = _parser('receive')
+    ..addOption('method', abbr: 'm', mandatory: true, help: 'sparkaddress, sparkinvoice, bitcoin, bolt11')
+    ..addOption('description', abbr: 'd')
+    ..addOption('amount', abbr: 'a')
+    ..addOption('token-identifier', abbr: 't')
+    ..addOption('expiry-secs', abbr: 'e')
+    ..addOption('sender-public-key', abbr: 's')
+    ..addFlag('hodl', defaultsTo: false)
+    ..addFlag('new-address', defaultsTo: false, help: 'Get a new bitcoin deposit address');
   final results = _parseArgs(parser, args, 'receive -m <method> [options]');
   if (results == null) return;
 
@@ -366,16 +364,15 @@ Future<void> _handleReceive(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> 
 // --- pay ---
 
 Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser =
-      _parser('pay')
-        ..addOption('payment-request', abbr: 'r', mandatory: true, help: 'Invoice, address, or LNURL to pay')
-        ..addOption('amount', abbr: 'a')
-        ..addOption('token-identifier', abbr: 't')
-        ..addOption('idempotency-key', abbr: 'i')
-        ..addFlag('from-bitcoin', defaultsTo: false)
-        ..addOption('from-token')
-        ..addOption('convert-max-slippage-bps', abbr: 's')
-        ..addFlag('fees-included', defaultsTo: false);
+  final parser = _parser('pay')
+    ..addOption('payment-request', abbr: 'r', mandatory: true, help: 'Invoice, address, or LNURL to pay')
+    ..addOption('amount', abbr: 'a')
+    ..addOption('token-identifier', abbr: 't')
+    ..addOption('idempotency-key', abbr: 'i')
+    ..addFlag('from-bitcoin', defaultsTo: false)
+    ..addOption('from-token')
+    ..addOption('convert-max-slippage-bps', abbr: 's')
+    ..addFlag('fees-included', defaultsTo: false);
   final results = _parseArgs(parser, args, 'pay -r <request> [options]');
   if (results == null) return;
 
@@ -420,7 +417,9 @@ Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args
   if (prepareResponse.conversionEstimate != null) {
     final est = prepareResponse.conversionEstimate!;
     final units = est.options.conversionType is ConversionType_FromBitcoin ? 'sats' : 'token base units';
-    print('Estimated conversion of ${est.amount} $units with a ${est.fee} $units fee');
+    print(
+      'Estimated conversion of ${est.amountIn} $units → ${est.amountOut} $units with a ${est.fee} $units fee',
+    );
     final answer = prompt('Do you want to continue (y/n): ', defaultValue: 'y');
     if (answer.toLowerCase() != 'y') {
       print('Payment cancelled');
@@ -443,14 +442,13 @@ Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args
 // --- lnurl-pay ---
 
 Future<void> _handleLnurlPay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser =
-      _parser('lnurl-pay')
-        ..addOption('comment', abbr: 'c')
-        ..addOption('validate', abbr: 'v')
-        ..addOption('idempotency-key', abbr: 'i')
-        ..addOption('from-token')
-        ..addOption('convert-max-slippage-bps', abbr: 's')
-        ..addFlag('fees-included', defaultsTo: false);
+  final parser = _parser('lnurl-pay')
+    ..addOption('comment', abbr: 'c')
+    ..addOption('validate', abbr: 'v')
+    ..addOption('idempotency-key', abbr: 'i')
+    ..addOption('from-token')
+    ..addOption('convert-max-slippage-bps', abbr: 's')
+    ..addFlag('fees-included', defaultsTo: false);
   final results = _parseArgs(parser, args, 'lnurl-pay <lnurl-or-address> [options]');
   if (results == null) return;
 
@@ -497,7 +495,7 @@ Future<void> _handleLnurlPay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String>
 
   final prepareResponse = await sdk.prepareLnurlPay(
     request: PrepareLnurlPayRequest(
-      amountSats: amountSats,
+      amount: amountSats,
       comment: results.option('comment'),
       payRequest: payRequest,
       validateSuccessActionUrl: _parseBool(results.option('validate')),
@@ -508,7 +506,9 @@ Future<void> _handleLnurlPay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String>
 
   if (prepareResponse.conversionEstimate != null) {
     final est = prepareResponse.conversionEstimate!;
-    print('Estimated conversion of ${est.amount} token base units with a ${est.fee} token base units fee');
+    print(
+      'Estimated conversion of ${est.amountIn} token base units → ${est.amountOut} sats with a ${est.fee} token base units fee',
+    );
     final answer = prompt('Do you want to continue (y/n): ', defaultValue: 'y');
     if (answer.toLowerCase() != 'y') {
       print('Payment cancelled');
@@ -611,11 +611,10 @@ Future<void> _handleClaimHtlcPayment(BreezSdk sdk, TokenIssuer tokenIssuer, List
 // --- claim-deposit ---
 
 Future<void> _handleClaimDeposit(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser =
-      _parser('claim-deposit')
-        ..addOption('fee-sat')
-        ..addOption('sat-per-vbyte')
-        ..addOption('recommended-fee-leeway');
+  final parser = _parser('claim-deposit')
+    ..addOption('fee-sat')
+    ..addOption('sat-per-vbyte')
+    ..addOption('recommended-fee-leeway');
   final results = _parseArgs(parser, args, 'claim-deposit <txid> <vout> [options]');
   if (results == null) return;
 
@@ -646,7 +645,9 @@ Future<void> _handleClaimDeposit(BreezSdk sdk, TokenIssuer tokenIssuer, List<Str
     maxFee = MaxFee.rate(satPerVbyte: BigInt.parse(satPerVbyteStr));
   }
 
-  final result = await sdk.claimDeposit(request: ClaimDepositRequest(txid: txid, vout: vout, maxFee: maxFee));
+  final result = await sdk.claimDeposit(
+    request: ClaimDepositRequest(txid: txid, vout: vout, maxFee: maxFee),
+  );
   printValue(result);
 }
 
@@ -665,10 +666,9 @@ Future<void> _handleParse(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> ar
 // --- refund-deposit ---
 
 Future<void> _handleRefundDeposit(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser =
-      _parser('refund-deposit')
-        ..addOption('fee-sat')
-        ..addOption('sat-per-vbyte');
+  final parser = _parser('refund-deposit')
+    ..addOption('fee-sat')
+    ..addOption('sat-per-vbyte');
   final results = _parseArgs(parser, args, 'refund-deposit <txid> <vout> <address> [options]');
   if (results == null) return;
 
@@ -714,11 +714,10 @@ Future<void> _handleListUnclaimedDeposits(BreezSdk sdk, TokenIssuer tokenIssuer,
 // --- buy-bitcoin ---
 
 Future<void> _handleBuyBitcoin(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser =
-      _parser('buy-bitcoin')
-        ..addOption('provider', defaultsTo: 'moonpay', help: 'Provider: moonpay (default) or cashapp')
-        ..addOption('amount-sat', help: 'Amount in satoshis')
-        ..addOption('redirect-url', help: 'Redirect URL after purchase (MoonPay only)');
+  final parser = _parser('buy-bitcoin')
+    ..addOption('provider', defaultsTo: 'moonpay', help: 'Provider: moonpay (default) or cashapp')
+    ..addOption('amount-sat', help: 'Amount in satoshis')
+    ..addOption('redirect-url', help: 'Redirect URL after purchase (MoonPay only)');
   final results = _parseArgs(parser, args, 'buy-bitcoin [options]');
   if (results == null) return;
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -207,18 +207,19 @@ TokenTransactionType? _parseTxType(String s) {
 }
 
 Future<void> _handleListPayments(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser = _parser('list-payments')
-    ..addMultiOption('type-filter', abbr: 't')
-    ..addMultiOption('status-filter', abbr: 's')
-    ..addOption('asset-filter', abbr: 'a')
-    ..addMultiOption('spark-htlc-status-filter')
-    ..addOption('tx-hash')
-    ..addOption('tx-type')
-    ..addOption('from-timestamp')
-    ..addOption('to-timestamp')
-    ..addOption('limit', abbr: 'l', defaultsTo: '10')
-    ..addOption('offset', abbr: 'o', defaultsTo: '0')
-    ..addOption('sort-ascending');
+  final parser =
+      _parser('list-payments')
+        ..addMultiOption('type-filter', abbr: 't')
+        ..addMultiOption('status-filter', abbr: 's')
+        ..addOption('asset-filter', abbr: 'a')
+        ..addMultiOption('spark-htlc-status-filter')
+        ..addOption('tx-hash')
+        ..addOption('tx-type')
+        ..addOption('from-timestamp')
+        ..addOption('to-timestamp')
+        ..addOption('limit', abbr: 'l', defaultsTo: '10')
+        ..addOption('offset', abbr: 'o', defaultsTo: '0')
+        ..addOption('sort-ascending');
   final results = _parseArgs(parser, args, 'list-payments [options]');
   if (results == null) return;
 
@@ -286,15 +287,16 @@ Future<void> _handleListPayments(BreezSdk sdk, TokenIssuer tokenIssuer, List<Str
 // --- receive ---
 
 Future<void> _handleReceive(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser = _parser('receive')
-    ..addOption('method', abbr: 'm', mandatory: true, help: 'sparkaddress, sparkinvoice, bitcoin, bolt11')
-    ..addOption('description', abbr: 'd')
-    ..addOption('amount', abbr: 'a')
-    ..addOption('token-identifier', abbr: 't')
-    ..addOption('expiry-secs', abbr: 'e')
-    ..addOption('sender-public-key', abbr: 's')
-    ..addFlag('hodl', defaultsTo: false)
-    ..addFlag('new-address', defaultsTo: false, help: 'Get a new bitcoin deposit address');
+  final parser =
+      _parser('receive')
+        ..addOption('method', abbr: 'm', mandatory: true, help: 'sparkaddress, sparkinvoice, bitcoin, bolt11')
+        ..addOption('description', abbr: 'd')
+        ..addOption('amount', abbr: 'a')
+        ..addOption('token-identifier', abbr: 't')
+        ..addOption('expiry-secs', abbr: 'e')
+        ..addOption('sender-public-key', abbr: 's')
+        ..addFlag('hodl', defaultsTo: false)
+        ..addFlag('new-address', defaultsTo: false, help: 'Get a new bitcoin deposit address');
   final results = _parseArgs(parser, args, 'receive -m <method> [options]');
   if (results == null) return;
 
@@ -364,15 +366,16 @@ Future<void> _handleReceive(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> 
 // --- pay ---
 
 Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser = _parser('pay')
-    ..addOption('payment-request', abbr: 'r', mandatory: true, help: 'Invoice, address, or LNURL to pay')
-    ..addOption('amount', abbr: 'a')
-    ..addOption('token-identifier', abbr: 't')
-    ..addOption('idempotency-key', abbr: 'i')
-    ..addFlag('from-bitcoin', defaultsTo: false)
-    ..addOption('from-token')
-    ..addOption('convert-max-slippage-bps', abbr: 's')
-    ..addFlag('fees-included', defaultsTo: false);
+  final parser =
+      _parser('pay')
+        ..addOption('payment-request', abbr: 'r', mandatory: true, help: 'Invoice, address, or LNURL to pay')
+        ..addOption('amount', abbr: 'a')
+        ..addOption('token-identifier', abbr: 't')
+        ..addOption('idempotency-key', abbr: 'i')
+        ..addFlag('from-bitcoin', defaultsTo: false)
+        ..addOption('from-token')
+        ..addOption('convert-max-slippage-bps', abbr: 's')
+        ..addFlag('fees-included', defaultsTo: false);
   final results = _parseArgs(parser, args, 'pay -r <request> [options]');
   if (results == null) return;
 
@@ -442,13 +445,14 @@ Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args
 // --- lnurl-pay ---
 
 Future<void> _handleLnurlPay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser = _parser('lnurl-pay')
-    ..addOption('comment', abbr: 'c')
-    ..addOption('validate', abbr: 'v')
-    ..addOption('idempotency-key', abbr: 'i')
-    ..addOption('from-token')
-    ..addOption('convert-max-slippage-bps', abbr: 's')
-    ..addFlag('fees-included', defaultsTo: false);
+  final parser =
+      _parser('lnurl-pay')
+        ..addOption('comment', abbr: 'c')
+        ..addOption('validate', abbr: 'v')
+        ..addOption('idempotency-key', abbr: 'i')
+        ..addOption('from-token')
+        ..addOption('convert-max-slippage-bps', abbr: 's')
+        ..addFlag('fees-included', defaultsTo: false);
   final results = _parseArgs(parser, args, 'lnurl-pay <lnurl-or-address> [options]');
   if (results == null) return;
 
@@ -611,10 +615,11 @@ Future<void> _handleClaimHtlcPayment(BreezSdk sdk, TokenIssuer tokenIssuer, List
 // --- claim-deposit ---
 
 Future<void> _handleClaimDeposit(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser = _parser('claim-deposit')
-    ..addOption('fee-sat')
-    ..addOption('sat-per-vbyte')
-    ..addOption('recommended-fee-leeway');
+  final parser =
+      _parser('claim-deposit')
+        ..addOption('fee-sat')
+        ..addOption('sat-per-vbyte')
+        ..addOption('recommended-fee-leeway');
   final results = _parseArgs(parser, args, 'claim-deposit <txid> <vout> [options]');
   if (results == null) return;
 
@@ -645,9 +650,7 @@ Future<void> _handleClaimDeposit(BreezSdk sdk, TokenIssuer tokenIssuer, List<Str
     maxFee = MaxFee.rate(satPerVbyte: BigInt.parse(satPerVbyteStr));
   }
 
-  final result = await sdk.claimDeposit(
-    request: ClaimDepositRequest(txid: txid, vout: vout, maxFee: maxFee),
-  );
+  final result = await sdk.claimDeposit(request: ClaimDepositRequest(txid: txid, vout: vout, maxFee: maxFee));
   printValue(result);
 }
 
@@ -666,9 +669,10 @@ Future<void> _handleParse(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> ar
 // --- refund-deposit ---
 
 Future<void> _handleRefundDeposit(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser = _parser('refund-deposit')
-    ..addOption('fee-sat')
-    ..addOption('sat-per-vbyte');
+  final parser =
+      _parser('refund-deposit')
+        ..addOption('fee-sat')
+        ..addOption('sat-per-vbyte');
   final results = _parseArgs(parser, args, 'refund-deposit <txid> <vout> <address> [options]');
   if (results == null) return;
 
@@ -714,10 +718,11 @@ Future<void> _handleListUnclaimedDeposits(BreezSdk sdk, TokenIssuer tokenIssuer,
 // --- buy-bitcoin ---
 
 Future<void> _handleBuyBitcoin(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser = _parser('buy-bitcoin')
-    ..addOption('provider', defaultsTo: 'moonpay', help: 'Provider: moonpay (default) or cashapp')
-    ..addOption('amount-sat', help: 'Amount in satoshis')
-    ..addOption('redirect-url', help: 'Redirect URL after purchase (MoonPay only)');
+  final parser =
+      _parser('buy-bitcoin')
+        ..addOption('provider', defaultsTo: 'moonpay', help: 'Provider: moonpay (default) or cashapp')
+        ..addOption('amount-sat', help: 'Amount in satoshis')
+        ..addOption('redirect-url', help: 'Redirect URL after purchase (MoonPay only)');
   final results = _parseArgs(parser, args, 'buy-bitcoin [options]');
   if (results == null) return;
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/contacts.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/contacts.dart
@@ -95,9 +95,10 @@ Future<void> _handleDelete(BreezSdk sdk, List<String> args) async {
 // --- list ---
 
 Future<void> _handleList(BreezSdk sdk, List<String> args) async {
-  final parser = ArgParser()
-    ..addOption('offset')
-    ..addOption('limit');
+  final parser =
+      ArgParser()
+        ..addOption('offset')
+        ..addOption('limit');
   if (args.contains('help') || args.contains('--help')) {
     print('Usage: contacts list [options]');
     print(parser.usage);
@@ -108,8 +109,6 @@ Future<void> _handleList(BreezSdk sdk, List<String> args) async {
   final limitStr = results.option('limit');
   final offset = offsetStr != null ? int.parse(offsetStr) : null;
   final limit = limitStr != null ? int.parse(limitStr) : null;
-  final result = await sdk.listContacts(
-    request: ListContactsRequest(offset: offset, limit: limit),
-  );
+  final result = await sdk.listContacts(request: ListContactsRequest(offset: offset, limit: limit));
   printValue(result);
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/contacts.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/contacts.dart
@@ -95,10 +95,9 @@ Future<void> _handleDelete(BreezSdk sdk, List<String> args) async {
 // --- list ---
 
 Future<void> _handleList(BreezSdk sdk, List<String> args) async {
-  final parser =
-      ArgParser()
-        ..addOption('offset')
-        ..addOption('limit');
+  final parser = ArgParser()
+    ..addOption('offset')
+    ..addOption('limit');
   if (args.contains('help') || args.contains('--help')) {
     print('Usage: contacts list [options]');
     print(parser.usage);
@@ -109,6 +108,8 @@ Future<void> _handleList(BreezSdk sdk, List<String> args) async {
   final limitStr = results.option('limit');
   final offset = offsetStr != null ? int.parse(offsetStr) : null;
   final limit = limitStr != null ? int.parse(limitStr) : null;
-  final result = await sdk.listContacts(request: ListContactsRequest(offset: offset, limit: limit));
+  final result = await sdk.listContacts(
+    request: ListContactsRequest(offset: offset, limit: limit),
+  );
   printValue(result);
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -458,7 +458,7 @@ func handlePay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []stri
 		if _, ok := est.Options.ConversionType.(breez_sdk_spark.ConversionTypeFromBitcoin); ok {
 			units = "sats"
 		}
-		fmt.Printf("Estimated conversion of %v %s with a %v %s fee\n", est.Amount, units, est.Fee, units)
+		fmt.Printf("Estimated conversion of %v %s → %v %s with a %v %s fee\n", est.AmountIn, units, est.AmountOut, units, est.Fee, units)
 		line, err := readlineWithDefault(rl, "Do you want to continue (y/n): ", "y")
 		if err != nil {
 			return err
@@ -543,7 +543,7 @@ func handleLnurlPay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args [
 	}
 
 	prepareReq := breez_sdk_spark.PrepareLnurlPayRequest{
-		AmountSats: amountSats,
+		Amount: new(big.Int).SetUint64(amountSats),
 		PayRequest: payRequest,
 	}
 	if *comment != "" {
@@ -586,7 +586,7 @@ func handleLnurlPay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args [
 	// Show conversion estimate and confirm
 	if prepareResponse.ConversionEstimate != nil {
 		est := prepareResponse.ConversionEstimate
-		fmt.Printf("Estimated conversion of %v token base units with a %v token base units fee\n", est.Amount, est.Fee)
+		fmt.Printf("Estimated conversion of %v token base units → %v sats with a %v token base units fee\n", est.AmountIn, est.AmountOut, est.Fee)
 		line, err := readlineWithDefault(rl, "Do you want to continue (y/n): ", "y")
 		if err != nil {
 			return err

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -447,7 +447,7 @@ suspend fun handlePay(sdk: BreezSdk, reader: LineReader, args: List<String>) {
     // Show conversion estimate if applicable
     prepareResponse.conversionEstimate?.let { conversionEstimate ->
         val units = if (conversionEstimate.options.conversionType == ConversionType.FromBitcoin) "sats" else "token base units"
-        println("Estimated conversion of ${conversionEstimate.amount} $units with a ${conversionEstimate.fee} $units fee")
+        println("Estimated conversion of ${conversionEstimate.amountIn} $units → ${conversionEstimate.amountOut} $units with a ${conversionEstimate.fee} $units fee")
         val line = readlineWithDefault(reader, "Do you want to continue (y/n): ", "y").lowercase()
         if (line != "y") {
             println("Payment cancelled")
@@ -526,10 +526,11 @@ suspend fun handleLnurlPay(sdk: BreezSdk, reader: LineReader, args: List<String>
 
     val prepareResponse = sdk.prepareLnurlPay(
         PrepareLnurlPayRequest(
-            amountSats = amountSats,
+            amount = BigInteger.fromLong(amountSats.toLong()),
             payRequest = payRequest,
             comment = comment,
             validateSuccessActionUrl = validateSuccessUrl,
+            tokenIdentifier = null,
             conversionOptions = conversionOptions,
             feePolicy = feePolicy,
         )
@@ -537,7 +538,7 @@ suspend fun handleLnurlPay(sdk: BreezSdk, reader: LineReader, args: List<String>
 
     // Show conversion estimate if applicable
     prepareResponse.conversionEstimate?.let { conversionEstimate ->
-        println("Estimated conversion of ${conversionEstimate.amount} token base units with a ${conversionEstimate.fee} token base units fee")
+        println("Estimated conversion of ${conversionEstimate.amountIn} token base units → ${conversionEstimate.amountOut} sats with a ${conversionEstimate.fee} token base units fee")
         val line = readlineWithDefault(reader, "Do you want to continue (y/n): ", "y").lowercase()
         if (line != "y") {
             println("Payment cancelled")

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -464,7 +464,7 @@ func handlePay(_ sdk: BreezSdk, _ args: [String]) async throws {
         } else {
             units = "token base units"
         }
-        print("Estimated conversion of \(estimate.amount) \(units) with a \(estimate.fee) \(units) fee")
+        print("Estimated conversion of \(estimate.amountIn) \(units) → \(estimate.amountOut) \(units) with a \(estimate.fee) \(units) fee")
         let line = readlineWithDefault("Do you want to continue (y/n): ", defaultValue: "y")
         if line.trimmingCharacters(in: .whitespaces).lowercased() != "y" {
             print("Payment cancelled")
@@ -531,16 +531,17 @@ func handleLnurlPay(_ sdk: BreezSdk, _ args: [String]) async throws {
     }
 
     let prepareResponse = try await sdk.prepareLnurlPay(request: PrepareLnurlPayRequest(
-        amountSats: amountSats,
+        amount: BInt(amountSats),
         payRequest: payRequest,
         comment: comment,
         validateSuccessActionUrl: validateSuccessUrl,
+        tokenIdentifier: nil,
         conversionOptions: conversionOptions,
         feePolicy: feePolicy
     ))
 
     if let estimate = prepareResponse.conversionEstimate {
-        print("Estimated conversion of \(estimate.amount) token base units with a \(estimate.fee) token base units fee")
+        print("Estimated conversion of \(estimate.amountIn) token base units → \(estimate.amountOut) sats with a \(estimate.fee) token base units fee")
         let line = readlineWithDefault("Do you want to continue (y/n): ", defaultValue: "y")
         if line.trimmingCharacters(in: .whitespaces).lowercased() != "y" {
             print("Payment cancelled")

--- a/crates/breez-sdk/breez-itest/tests/lnurl.rs
+++ b/crates/breez-sdk/breez-itest/tests/lnurl.rs
@@ -329,10 +329,11 @@ async fn test_05_lnurl_payment_flow(
     let prepare_response = alice
         .sdk
         .prepare_lnurl_pay(PrepareLnurlPayRequest {
-            amount_sats: payment_amount_sats,
+            amount: payment_amount_sats as u128,
             pay_request: details.pay_request,
             comment: Some(payment_comment.to_string()),
             validate_success_action_url: None,
+            token_identifier: None,
             conversion_options: None,
             fee_policy: None,
         })
@@ -483,10 +484,11 @@ async fn test_07_lnurl_send_all_payment(
     let prepare_response = alice
         .sdk
         .prepare_lnurl_pay(PrepareLnurlPayRequest {
-            amount_sats: alice_balance,
+            amount: alice_balance.into(),
             pay_request: details.pay_request,
             comment: Some("FeesIncluded test from Alice".to_string()),
             validate_success_action_url: None,
+            token_identifier: None,
             conversion_options: None,
             fee_policy: Some(FeePolicy::FeesIncluded),
         })
@@ -632,10 +634,11 @@ async fn test_08_lnurl_send_all_with_fee_overpayment(
     ) -> Result<u64> {
         let prepare = sdk
             .prepare_lnurl_pay(PrepareLnurlPayRequest {
-                amount_sats: amount,
+                amount: amount.into(),
                 pay_request: pay_request.clone(),
                 comment: None,
                 validate_success_action_url: None,
+                token_identifier: None,
                 conversion_options: None,
                 fee_policy: None,
             })
@@ -786,10 +789,11 @@ async fn test_08_lnurl_send_all_with_fee_overpayment(
     let prepare_response = alice
         .sdk
         .prepare_lnurl_pay(PrepareLnurlPayRequest {
-            amount_sats: target_balance,
+            amount: target_balance.into(),
             pay_request: details.pay_request,
             comment: Some("FeesIncluded with overpayment test".to_string()),
             validate_success_action_url: None,
+            token_identifier: None,
             conversion_options: None,
             fee_policy: Some(FeePolicy::FeesIncluded),
         })
@@ -1062,10 +1066,11 @@ async fn test_11_lnurl_spark_address_payment(
     let prepare_response = alice
         .sdk
         .prepare_lnurl_pay(PrepareLnurlPayRequest {
-            amount_sats: payment_amount_sats,
+            amount: payment_amount_sats as u128,
             pay_request: details.pay_request,
             comment: Some(payment_comment.to_string()),
             validate_success_action_url: None,
+            token_identifier: None,
             conversion_options: None,
             fee_policy: None,
         })

--- a/crates/breez-sdk/breez-itest/tests/rtsync.rs
+++ b/crates/breez-sdk/breez-itest/tests/rtsync.rs
@@ -161,10 +161,11 @@ async fn test_01_rtsync_lnurl_info_sync(
     let prepare_response = alice1
         .sdk
         .prepare_lnurl_pay(PrepareLnurlPayRequest {
-            amount_sats: 10_000,
+            amount: 10_000,
             pay_request: details.pay_request,
             comment: Some(ln_address_comment.clone()),
             validate_success_action_url: None,
+            token_identifier: None,
             conversion_options: None,
             fee_policy: None,
         })

--- a/crates/breez-sdk/breez-itest/tests/token_conversion.rs
+++ b/crates/breez-sdk/breez-itest/tests/token_conversion.rs
@@ -85,7 +85,7 @@ async fn test_token_conversion_success(
         .expect("Conversion estimate should be present");
     info!(
         "Prepared token payment: amount={:?} (converting bitcoin amount={}, fee={})",
-        prepare_btc_to_token.amount, conversion_estimate.amount, conversion_estimate.fee
+        prepare_btc_to_token.amount, conversion_estimate.amount_out, conversion_estimate.fee
     );
 
     let send_btc_to_token = alice
@@ -252,7 +252,7 @@ async fn test_token_conversion_success(
         .expect("Conversion estimate should be present");
     info!(
         "Prepared bitcoin payment: amount={:?} (converting token amount={}, fee={})",
-        prepare_token_to_btc.amount, conversion_estimate.amount, conversion_estimate.fee
+        prepare_token_to_btc.amount, conversion_estimate.amount_out, conversion_estimate.fee
     );
 
     let send_token_to_btc = bob
@@ -490,7 +490,7 @@ async fn test_token_conversion_failure(
         .expect("Conversion estimate should be present");
     info!(
         "Prepared token payment: amount={:?} (converting bitcoin amount={}, fee={})",
-        prepare_low_slippage.amount, conversion_estimate.amount, conversion_estimate.fee
+        prepare_low_slippage.amount, conversion_estimate.amount_out, conversion_estimate.fee
     );
 
     // Send the payment - expect it to fail due to slippage

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -659,7 +659,7 @@ pub(crate) async fn execute_command(
                     };
                 println!(
                     "Estimated conversion of {} {} with a {} {} fee",
-                    conversion_estimate.amount, units, conversion_estimate.fee, units
+                    conversion_estimate.amount_out, units, conversion_estimate.fee, units
                 );
                 let line = rl
                     .readline_with_initial("Do you want to continue (y/n): ", ("y", ""))?
@@ -713,14 +713,15 @@ pub(crate) async fn execute_command(
                     let max_sendable = pay_request.max_sendable / 1000;
                     let prompt =
                         format!("Amount to pay (min {min_sendable} sat, max {max_sendable} sat): ");
-                    let amount_sats = rl.readline(&prompt)?.parse::<u64>()?;
+                    let amount = rl.readline(&prompt)?.parse::<u128>()?;
 
                     let prepare_response = sdk
                         .prepare_lnurl_pay(PrepareLnurlPayRequest {
-                            amount_sats,
+                            amount,
                             comment,
                             pay_request,
                             validate_success_action_url: validate_success_url,
+                            token_identifier: None,
                             conversion_options,
                             fee_policy,
                         })
@@ -729,7 +730,7 @@ pub(crate) async fn execute_command(
                     if let Some(conversion_estimate) = &prepare_response.conversion_estimate {
                         println!(
                             "Estimated conversion of {} token base units with a {} token base units fee",
-                            conversion_estimate.amount, conversion_estimate.fee
+                            conversion_estimate.amount_out, conversion_estimate.fee
                         );
                         let line = rl
                             .readline_with_initial("Do you want to continue (y/n): ", ("y", ""))?

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -188,6 +188,10 @@ pub enum Command {
         #[arg(short = 'i', long)]
         idempotency_key: Option<String>,
 
+        /// If provided, the amount can be provide in the token units.
+        #[arg(short = 't', long)]
+        token_identifier: Option<String>,
+
         // If provided, the payment will include a token conversion step, converting from the
         // specified token to Bitcoin to fulfill the payment.
         #[arg(long = "from-token")]
@@ -658,8 +662,8 @@ pub(crate) async fn execute_command(
                         "token base units"
                     };
                 println!(
-                    "Estimated conversion of {} {} with a {} {} fee",
-                    conversion_estimate.amount_out, units, conversion_estimate.fee, units
+                    "Estimated conversion of {} {} with a {} token base units fee",
+                    conversion_estimate.amount_out, units, conversion_estimate.fee
                 );
                 let line = rl
                     .readline_with_initial("Do you want to continue (y/n): ", ("y", ""))?
@@ -687,6 +691,7 @@ pub(crate) async fn execute_command(
             comment,
             validate_success_url,
             idempotency_key,
+            token_identifier,
             convert_from_token_identifier,
             convert_max_slippage_bps: max_slippage_bps,
             fees_included,
@@ -711,8 +716,13 @@ pub(crate) async fn execute_command(
                 | InputType::LnurlPay(pay_request) => {
                     let min_sendable = pay_request.min_sendable.div_ceil(1000);
                     let max_sendable = pay_request.max_sendable / 1000;
-                    let prompt =
-                        format!("Amount to pay (min {min_sendable} sat, max {max_sendable} sat): ");
+                    let prompt = if token_identifier.is_none() {
+                        format!("Amount to pay (min {min_sendable} sat, max {max_sendable} sat): ")
+                    } else {
+                        format!(
+                            "Amount to pay (min {min_sendable} sat, max {max_sendable} sat) in token units: "
+                        )
+                    };
                     let amount = rl.readline(&prompt)?.parse::<u128>()?;
 
                     let prepare_response = sdk
@@ -721,16 +731,23 @@ pub(crate) async fn execute_command(
                             comment,
                             pay_request,
                             validate_success_action_url: validate_success_url,
-                            token_identifier: None,
+                            token_identifier,
                             conversion_options,
                             fee_policy,
                         })
                         .await?;
 
                     if let Some(conversion_estimate) = &prepare_response.conversion_estimate {
+                        let units = if conversion_estimate.options.conversion_type
+                            == ConversionType::FromBitcoin
+                        {
+                            "token base units"
+                        } else {
+                            "sats"
+                        };
                         println!(
-                            "Estimated conversion of {} token base units with a {} token base units fee",
-                            conversion_estimate.amount_out, conversion_estimate.fee
+                            "Estimated conversion of {} {} with a {} token base units fee",
+                            conversion_estimate.amount_out, units, conversion_estimate.fee
                         );
                         let line = rl
                             .readline_with_initial("Do you want to continue (y/n): ", ("y", ""))?

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -188,7 +188,7 @@ pub enum Command {
         #[arg(short = 'i', long)]
         idempotency_key: Option<String>,
 
-        /// If provided, the amount can be provide in the token units.
+        /// If provided, the amount will be denominated in token base units.
         #[arg(short = 't', long)]
         token_identifier: Option<String>,
 
@@ -655,15 +655,19 @@ pub(crate) async fn execute_command(
             };
 
             if let Some(conversion_estimate) = &prepare_response.conversion_estimate {
-                let units =
+                let (in_units, out_units) =
                     if conversion_estimate.options.conversion_type == ConversionType::FromBitcoin {
-                        "sats"
+                        ("sats", "token base units")
                     } else {
-                        "token base units"
+                        ("token base units", "sats")
                     };
                 println!(
-                    "Estimated conversion of {} {} with a {} token base units fee",
-                    conversion_estimate.amount_out, units, conversion_estimate.fee
+                    "Estimated conversion from {} {} to {} {} with a {} token base units fee",
+                    conversion_estimate.amount_in,
+                    in_units,
+                    conversion_estimate.amount_out,
+                    out_units,
+                    conversion_estimate.fee
                 );
                 let line = rl
                     .readline_with_initial("Do you want to continue (y/n): ", ("y", ""))?
@@ -720,7 +724,7 @@ pub(crate) async fn execute_command(
                         format!("Amount to pay (min {min_sendable} sat, max {max_sendable} sat): ")
                     } else {
                         format!(
-                            "Amount to pay (min {min_sendable} sat, max {max_sendable} sat) in token units: "
+                            "Amount to pay (min {min_sendable} sat, max {max_sendable} sat) in token base units: "
                         )
                     };
                     let amount = rl.readline(&prompt)?.parse::<u128>()?;
@@ -738,16 +742,20 @@ pub(crate) async fn execute_command(
                         .await?;
 
                     if let Some(conversion_estimate) = &prepare_response.conversion_estimate {
-                        let units = if conversion_estimate.options.conversion_type
+                        let (in_units, out_units) = if conversion_estimate.options.conversion_type
                             == ConversionType::FromBitcoin
                         {
-                            "token base units"
+                            ("sats", "token base units")
                         } else {
-                            "sats"
+                            ("token base units", "sats")
                         };
                         println!(
-                            "Estimated conversion of {} {} with a {} token base units fee",
-                            conversion_estimate.amount_out, units, conversion_estimate.fee
+                            "Estimated conversion from {} {} to {} {} with a {} token base units fee",
+                            conversion_estimate.amount_in,
+                            in_units,
+                            conversion_estimate.amount_out,
+                            out_units,
+                            conversion_estimate.fee
                         );
                         let line = rl
                             .readline_with_initial("Do you want to continue (y/n): ", ("y", ""))?

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -690,7 +690,7 @@ pub struct StableBalanceConfig {
 
     /// Maximum slippage in basis points (1/100 of a percent).
     ///
-    /// Defaults to 50 bps (0.5%) if not set.
+    /// Defaults to 10 bps (0.1%) if not set.
     #[cfg_attr(feature = "uniffi", uniffi(default = None))]
     pub max_slippage_bps: Option<u32>,
 }
@@ -1157,13 +1157,18 @@ pub struct ReceivePaymentResponse {
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PrepareLnurlPayRequest {
-    /// The amount to send in satoshis.
-    pub amount_sats: u64,
+    /// The amount to send.
+    /// For regular sends, this is in satoshis.
+    /// For send-all with conversion (`ToBitcoin`), this is the token amount in base units.
+    pub amount: u128,
     pub pay_request: LnurlPayRequestDetails,
     #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub comment: Option<String>,
     #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub validate_success_action_url: Option<bool>,
+    /// The token identifier when sending a token amount with conversion.
+    #[cfg_attr(feature = "uniffi", uniffi(default=None))]
+    pub token_identifier: Option<String>,
     /// If provided, the payment will include a token conversion step before sending the payment
     #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub conversion_options: Option<ConversionOptions>,
@@ -1186,6 +1191,8 @@ pub struct PrepareLnurlPayResponse {
     pub success_action: Option<SuccessAction>,
     /// When set, the payment will include a token conversion step before sending the payment
     pub conversion_estimate: Option<ConversionEstimate>,
+    /// The token identifier for send-all-with-conversion flows
+    pub token_identifier: Option<String>,
     /// How fees are handled for this payment.
     pub fee_policy: FeePolicy,
 }

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1157,9 +1157,8 @@ pub struct ReceivePaymentResponse {
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PrepareLnurlPayRequest {
-    /// The amount to send.
-    /// For regular sends, this is in satoshis.
-    /// For send-all with conversion (`ToBitcoin`), this is the token amount in base units.
+    /// The amount to send. Denominated in satoshis, or in token base units
+    /// when `token_identifier` is set.
     pub amount: u128,
     pub pay_request: LnurlPayRequestDetails,
     #[cfg_attr(feature = "uniffi", uniffi(default=None))]
@@ -1180,7 +1179,10 @@ pub struct PrepareLnurlPayRequest {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PrepareLnurlPayResponse {
-    /// The amount to send in satoshis.
+    /// The amount for the payment, always denominated in sats, even when a
+    /// `token_identifier` and conversion are present.
+    /// When a conversion is present, the token input amount is available in
+    /// `conversion_estimate.amount_in`.
     pub amount_sats: u64,
     pub comment: Option<String>,
     pub pay_request: LnurlPayRequestDetails,
@@ -1191,8 +1193,6 @@ pub struct PrepareLnurlPayResponse {
     pub success_action: Option<SuccessAction>,
     /// When set, the payment will include a token conversion step before sending the payment
     pub conversion_estimate: Option<ConversionEstimate>,
-    /// The token identifier for send-all-with-conversion flows
-    pub token_identifier: Option<String>,
     /// How fees are handled for this payment.
     pub fee_policy: FeePolicy,
 }
@@ -1325,8 +1325,10 @@ pub struct PrepareSendPaymentRequest {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PrepareSendPaymentResponse {
     pub payment_method: SendPaymentMethod,
-    /// The amount for the payment.
-    /// Denominated in satoshis for Bitcoin payments, or token base units for token payments.
+    /// The amount to be sent, denominated in satoshis for Bitcoin payments
+    /// (including token-to-Bitcoin conversions), or token base units for token payments.
+    /// When a conversion is present, the input amount is in
+    /// `conversion_estimate.amount_in`.
     pub amount: u128,
     /// Optional token identifier for token payments.
     /// Absence indicates that the payment is a Bitcoin payment.

--- a/crates/breez-sdk/core/src/sdk/lnurl.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl.rs
@@ -57,8 +57,11 @@ impl BreezSdk {
 
         // FeesIncluded uses the double-query approach
         if fee_policy == FeePolicy::FeesIncluded {
+            let amount_sats: u64 = amount
+                .try_into()
+                .map_err(|_| SdkError::InvalidInput("Amount too large for LNURL".to_string()))?;
             return self
-                .prepare_lnurl_pay_fees_included(request, amount, conversion_estimate)
+                .prepare_lnurl_pay_fees_included(request, amount_sats, conversion_estimate)
                 .await;
         }
 
@@ -112,7 +115,6 @@ impl BreezSdk {
             fee_sats: lightning_fee_sats,
             success_action: success_data.success_action.map(From::from),
             conversion_estimate: prepare_response.conversion_estimate,
-            token_identifier: prepare_response.token_identifier,
             fee_policy,
         })
     }
@@ -181,7 +183,7 @@ impl BreezSdk {
             None
         };
 
-        // For send-all with conversion, pass through FeesIncluded so the conversion
+        // For FeesIncluded with conversion, pass through FeesIncluded so the conversion
         // flow queries actual balance post-conversion. Otherwise use FeesExcluded.
         let internal_fee_policy = if is_fees_included && has_conversion {
             FeePolicy::FeesIncluded
@@ -198,7 +200,10 @@ impl BreezSdk {
                         lightning_fee_sats: request.prepare_response.fee_sats,
                     },
                     amount: u128::from(receiver_amount_sats),
-                    token_identifier: request.prepare_response.token_identifier,
+                    // LNURL always sends sats — token_identifier is None on the
+                    // internal PrepareSendPaymentResponse even when a conversion
+                    // is present (the token info is in conversion_estimate).
+                    token_identifier: None,
                     conversion_estimate: request.prepare_response.conversion_estimate,
                     fee_policy: internal_fee_policy,
                 },
@@ -419,19 +424,14 @@ impl BreezSdk {
     pub(super) async fn prepare_lnurl_pay_fees_included(
         &self,
         request: PrepareLnurlPayRequest,
-        amount: u128,
+        amount_sats: u64,
         conversion_estimate: Option<crate::ConversionEstimate>,
     ) -> Result<PrepareLnurlPayResponse, SdkError> {
-        let amount_sats: u64 = amount
-            .try_into()
-            .map_err(|_| SdkError::InvalidInput("Amount too large".to_string()))?;
         if amount_sats == 0 {
             return Err(SdkError::InvalidInput(
                 "Amount must be greater than 0".to_string(),
             ));
         }
-
-        let token_identifier = request.token_identifier.clone();
 
         // 1. Validate amount is within LNURL limits
         let min_sendable_sats = request.pay_request.min_sendable.div_ceil(1000);
@@ -534,7 +534,6 @@ impl BreezSdk {
             fee_sats: first_fee,
             success_action: success_data.success_action.map(From::from),
             conversion_estimate,
-            token_identifier,
             fee_policy: FeePolicy::FeesIncluded,
         })
     }

--- a/crates/breez-sdk/core/src/sdk/lnurl.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl.rs
@@ -1,5 +1,5 @@
 use breez_sdk_common::lnurl::{self, error::LnurlError, pay::validate_lnurl_pay};
-use tracing::{info, trace};
+use tracing::info;
 
 use crate::{
     FeePolicy, InputType, LnurlAuthRequestDetails, LnurlCallbackStatus, LnurlPayInfo,
@@ -39,35 +39,18 @@ impl BreezSdk {
             .await?;
         let is_token_conversion = conversion_estimate.is_some();
 
-        // Apply a slippage buffer only on the AmountIn conversion path
-        // (token_identifier set, variable sat output) so the LNURL invoice is sized
-        // below the worst-case conversion output and is guaranteed payable. The
-        // MinAmountOut path (no token_identifier) needs no buffer because the
-        // converter is invoked with MinAmountOut(invoice + fees) at execution time
-        // and is guaranteed to deliver enough sats or fail. The actual sats sent at
-        // execution time come from `complete_conversion_and_send` using the real
-        // post-conversion balance and may overpay this invoice.
+        // When token_identifier is set, the amount is in token units and the
+        // conversion output (estimated_sats) is all we have to pay with — there
+        // are no separate sats to cover fees. Force FeesIncluded so fees are
+        // deducted from the conversion output. Reject explicit FeesExcluded.
         let (amount, fee_policy) = if is_token_conversion && request.token_identifier.is_some() {
-            let max_slippage_bps = u128::from(
-                request
-                    .conversion_options
-                    .as_ref()
-                    .and_then(|co| co.max_slippage_bps)
-                    .unwrap_or(crate::token_conversion::DEFAULT_CONVERSION_MAX_SLIPPAGE_BPS),
-            );
-            let slippage_buffer = estimated_sats
-                .saturating_mul(max_slippage_bps)
-                .saturating_div(10_000);
-            let amount_after_slippage = estimated_sats.saturating_sub(slippage_buffer);
-            trace!(
-                "prepare_lnurl: token_amount={}, estimated_sats={}, slippage_bps={}, slippage_buffer={}, amount_for_invoice={}",
-                request.amount,
-                estimated_sats,
-                max_slippage_bps,
-                slippage_buffer,
-                amount_after_slippage
-            );
-            (amount_after_slippage, FeePolicy::FeesIncluded)
+            if fee_policy == FeePolicy::FeesExcluded {
+                return Err(SdkError::InvalidInput(
+                    "Token conversion with token_identifier requires FeesIncluded fee policy"
+                        .to_string(),
+                ));
+            }
+            (estimated_sats, FeePolicy::FeesIncluded)
         } else {
             (estimated_sats, fee_policy)
         };
@@ -178,16 +161,11 @@ impl BreezSdk {
 
             // Protect against excessive fee overpayment.
             // Allow overpayment up to 100% of actual fee, with a minimum of 1 sat.
-            // With conversion, skip this check — the slippage buffer deducted at prepare
-            // time means the actual post-conversion balance may exceed the invoice amount,
-            // and we want to overpay the invoice to send everything.
-            if !has_conversion {
-                let max_allowed_overpayment = current_fee.max(1);
-                if overpayment > max_allowed_overpayment {
-                    return Err(SdkError::Generic(format!(
-                        "Fee overpayment ({overpayment} sats) exceeds allowed maximum ({max_allowed_overpayment} sats)"
-                    )));
-                }
+            let max_allowed_overpayment = current_fee.max(1);
+            if overpayment > max_allowed_overpayment {
+                return Err(SdkError::Generic(format!(
+                    "Fee overpayment ({overpayment} sats) exceeds allowed maximum ({max_allowed_overpayment} sats)"
+                )));
             }
 
             if overpayment > 0 {
@@ -205,7 +183,6 @@ impl BreezSdk {
 
         // For send-all with conversion, pass through FeesIncluded so the conversion
         // flow queries actual balance post-conversion. Otherwise use FeesExcluded.
-        let has_conversion = request.prepare_response.conversion_estimate.is_some();
         let internal_fee_policy = if is_fees_included && has_conversion {
             FeePolicy::FeesIncluded
         } else {

--- a/crates/breez-sdk/core/src/sdk/lnurl.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl.rs
@@ -1,5 +1,5 @@
 use breez_sdk_common::lnurl::{self, error::LnurlError, pay::validate_lnurl_pay};
-use tracing::info;
+use tracing::{info, trace};
 
 use crate::{
     FeePolicy, InputType, LnurlAuthRequestDetails, LnurlCallbackStatus, LnurlPayInfo,
@@ -20,25 +20,79 @@ use super::{BreezSdk, helpers::process_success_action};
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 #[allow(clippy::needless_pass_by_value)]
 impl BreezSdk {
+    #[allow(clippy::too_many_lines)]
     pub async fn prepare_lnurl_pay(
         &self,
         request: PrepareLnurlPayRequest,
     ) -> Result<PrepareLnurlPayResponse, SdkError> {
         let fee_policy = request.fee_policy.unwrap_or_default();
-        let amount_sats = request.amount_sats;
 
-        if fee_policy == FeePolicy::FeesIncluded && request.conversion_options.is_some() {
+        // Check if this is a send-all with conversion using the same stable balance check
+        let is_send_all_with_conversion = match &self.stable_balance {
+            Some(sb) => {
+                sb.is_send_all_with_conversion(
+                    request.token_identifier.as_ref(),
+                    Some(request.amount),
+                    request.conversion_options.as_ref(),
+                    fee_policy,
+                )
+                .await?
+            }
+            None => false,
+        };
+
+        // token_identifier with conversion is only valid for send-all
+        if request.token_identifier.is_some() && !is_send_all_with_conversion {
             return Err(SdkError::InvalidInput(
-                "FeesIncluded cannot be combined with token conversion".to_string(),
+                "Token identifier with conversion is only supported for send-all".to_string(),
             ));
         }
 
+        // For send-all with conversion, estimate total sats first.
+        // Deduct the max slippage so the LNURL invoice is smaller than the worst-case
+        // conversion output — the conversion will fail if slippage exceeds this guard,
+        // so we're guaranteed to have enough sats to pay the invoice.
+        let amount = if is_send_all_with_conversion {
+            let (total_sats, _) = self
+                .estimate_total_sats_with_conversion(
+                    request.conversion_options.as_ref(),
+                    request.token_identifier.as_ref(),
+                    request.amount,
+                )
+                .await?;
+            let max_slippage_bps = u128::from(
+                request
+                    .conversion_options
+                    .as_ref()
+                    .and_then(|co| co.max_slippage_bps)
+                    .unwrap_or(crate::token_conversion::DEFAULT_CONVERSION_MAX_SLIPPAGE_BPS),
+            );
+            let slippage_buffer = total_sats
+                .saturating_mul(max_slippage_bps)
+                .saturating_div(10_000);
+            let amount_after_slippage = total_sats.saturating_sub(slippage_buffer);
+            trace!(
+                "[SEND-ALL] prepare_lnurl: token_amount={}, estimated_total_sats={}, slippage_bps={}, slippage_buffer={}, amount_for_invoice={}",
+                request.amount,
+                total_sats,
+                max_slippage_bps,
+                slippage_buffer,
+                amount_after_slippage
+            );
+            amount_after_slippage
+        } else {
+            request.amount
+        };
+
         // FeesIncluded uses the double-query approach
         if fee_policy == FeePolicy::FeesIncluded {
-            return self
-                .prepare_lnurl_pay_fees_included(request, amount_sats)
-                .await;
+            return self.prepare_lnurl_pay_fees_included(request, amount).await;
         }
+
+        // Regular send (no FeesIncluded, no conversion)
+        let amount_sats: u64 = amount
+            .try_into()
+            .map_err(|_| SdkError::InvalidInput("Amount too large for LNURL".to_string()))?;
 
         let success_data = match validate_lnurl_pay(
             self.lnurl_client.as_ref(),
@@ -60,7 +114,7 @@ impl BreezSdk {
             .prepare_send_payment(crate::PrepareSendPaymentRequest {
                 payment_request: success_data.pr,
                 amount: Some(u128::from(amount_sats)),
-                token_identifier: None,
+                token_identifier: request.token_identifier.clone(),
                 conversion_options: request.conversion_options.clone(),
                 fee_policy: None,
             })
@@ -85,6 +139,7 @@ impl BreezSdk {
             fee_sats: lightning_fee_sats,
             success_action: success_data.success_action.map(From::from),
             conversion_estimate: prepare_response.conversion_estimate,
+            token_identifier: prepare_response.token_identifier,
             fee_policy,
         })
     }
@@ -108,6 +163,7 @@ impl BreezSdk {
         };
 
         // Calculate amount override for FeesIncluded operations
+        let has_conversion = request.prepare_response.conversion_estimate.is_some();
         let amount_override = if is_fees_included {
             // Re-estimate current fee for the invoice
             let current_fee = self
@@ -132,11 +188,16 @@ impl BreezSdk {
 
             // Protect against excessive fee overpayment.
             // Allow overpayment up to 100% of actual fee, with a minimum of 1 sat.
-            let max_allowed_overpayment = current_fee.max(1);
-            if overpayment > max_allowed_overpayment {
-                return Err(SdkError::Generic(format!(
-                    "Fee overpayment ({overpayment} sats) exceeds allowed maximum ({max_allowed_overpayment} sats)"
-                )));
+            // With conversion, skip this check — the slippage buffer deducted at prepare
+            // time means the actual post-conversion balance may exceed the invoice amount,
+            // and we want to overpay the invoice to send everything.
+            if !has_conversion {
+                let max_allowed_overpayment = current_fee.max(1);
+                if overpayment > max_allowed_overpayment {
+                    return Err(SdkError::Generic(format!(
+                        "Fee overpayment ({overpayment} sats) exceeds allowed maximum ({max_allowed_overpayment} sats)"
+                    )));
+                }
             }
 
             if overpayment > 0 {
@@ -152,6 +213,15 @@ impl BreezSdk {
             None
         };
 
+        // For send-all with conversion, pass through FeesIncluded so the conversion
+        // flow queries actual balance post-conversion. Otherwise use FeesExcluded.
+        let has_conversion = request.prepare_response.conversion_estimate.is_some();
+        let internal_fee_policy = if is_fees_included && has_conversion {
+            FeePolicy::FeesIncluded
+        } else {
+            FeePolicy::FeesExcluded
+        };
+
         let mut payment = Box::pin(self.maybe_convert_token_send_payment(
             SendPaymentRequest {
                 prepare_response: PrepareSendPaymentResponse {
@@ -161,9 +231,9 @@ impl BreezSdk {
                         lightning_fee_sats: request.prepare_response.fee_sats,
                     },
                     amount: u128::from(receiver_amount_sats),
-                    token_identifier: None,
+                    token_identifier: request.prepare_response.token_identifier,
                     conversion_estimate: request.prepare_response.conversion_estimate,
-                    fee_policy: FeePolicy::FeesExcluded, // Always FeesExcluded for internal handling
+                    fee_policy: internal_fee_policy,
                 },
                 options: None,
                 idempotency_key: request.idempotency_key,
@@ -378,16 +448,33 @@ impl BreezSdk {
     /// 3. Calculates actual send amount (amount - estimated fee)
     /// 4. Second query: gets invoice for actual amount
     /// 5. Returns the prepare response with the second invoice
+    #[allow(clippy::too_many_lines)]
     pub(super) async fn prepare_lnurl_pay_fees_included(
         &self,
         request: PrepareLnurlPayRequest,
-        amount_sats: u64,
+        amount: u128,
     ) -> Result<PrepareLnurlPayResponse, SdkError> {
+        let amount_sats: u64 = amount
+            .try_into()
+            .map_err(|_| SdkError::InvalidInput("Amount too large".to_string()))?;
         if amount_sats == 0 {
             return Err(SdkError::InvalidInput(
                 "Amount must be greater than 0".to_string(),
             ));
         }
+
+        // Compute conversion estimate if this is a send-all-with-conversion
+        let token_identifier = request.token_identifier.clone();
+        let conversion_estimate = if request.conversion_options.is_some() {
+            self.estimate_conversion(
+                request.conversion_options.as_ref(),
+                token_identifier.as_ref(),
+                crate::token_conversion::ConversionAmount::AmountIn(request.amount),
+            )
+            .await?
+        } else {
+            None
+        };
 
         // 1. Validate amount is within LNURL limits
         let min_sendable_sats = request.pay_request.min_sendable.div_ceil(1000);
@@ -489,7 +576,8 @@ impl BreezSdk {
             invoice_details,
             fee_sats: first_fee,
             success_action: success_data.success_action.map(From::from),
-            conversion_estimate: None,
+            conversion_estimate,
+            token_identifier,
             fee_policy: FeePolicy::FeesIncluded,
         })
     }

--- a/crates/breez-sdk/core/src/sdk/lnurl.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl.rs
@@ -138,7 +138,6 @@ impl BreezSdk {
         };
 
         // Calculate amount override for FeesIncluded operations
-        let has_conversion = request.prepare_response.conversion_estimate.is_some();
         let amount_override = if is_fees_included {
             // Re-estimate current fee for the invoice
             let current_fee = self
@@ -183,8 +182,10 @@ impl BreezSdk {
             None
         };
 
-        // For FeesIncluded with conversion, pass through FeesIncluded so the conversion
-        // flow queries actual balance post-conversion. Otherwise use FeesExcluded.
+        // For conversions, use FeesIncluded so the send path deducts fees from
+        // the post-conversion balance. For non-conversion FeesIncluded, the LNURL
+        // flow handles fees via invoice sizing and amount_override.
+        let has_conversion = request.prepare_response.conversion_estimate.is_some();
         let internal_fee_policy = if is_fees_included && has_conversion {
             FeePolicy::FeesIncluded
         } else {
@@ -199,7 +200,15 @@ impl BreezSdk {
                         spark_transfer_fee_sats: None,
                         lightning_fee_sats: request.prepare_response.fee_sats,
                     },
-                    amount: u128::from(receiver_amount_sats),
+                    // For conversions, use the prepare's total amount (before fee
+                    // deduction) so the sats_change logic in complete_conversion_and_send
+                    // correctly computes the post-conversion amount override.
+                    // For non-conversions, use the invoice amount.
+                    amount: if has_conversion {
+                        u128::from(request.prepare_response.amount_sats)
+                    } else {
+                        u128::from(receiver_amount_sats)
+                    },
                     // LNURL always sends sats — token_identifier is None on the
                     // internal PrepareSendPaymentResponse even when a conversion
                     // is present (the token info is in conversion_estimate).
@@ -211,7 +220,14 @@ impl BreezSdk {
                 idempotency_key: request.idempotency_key,
             },
             true,
-            amount_override,
+            // For conversions, don't pass amount_override — let
+            // complete_conversion_and_send compute it from sats_change.
+            // For non-conversions, use the LNURL-computed override.
+            if has_conversion {
+                None
+            } else {
+                amount_override
+            },
         ))
         .await?
         .payment;

--- a/crates/breez-sdk/core/src/sdk/lnurl.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl.rs
@@ -27,39 +27,27 @@ impl BreezSdk {
     ) -> Result<PrepareLnurlPayResponse, SdkError> {
         let fee_policy = request.fee_policy.unwrap_or_default();
 
-        // Check if this is a send-all with conversion using the same stable balance check
-        let is_send_all_with_conversion = match &self.stable_balance {
-            Some(sb) => {
-                sb.is_send_all_with_conversion(
-                    request.token_identifier.as_ref(),
-                    Some(request.amount),
-                    request.conversion_options.as_ref(),
-                    fee_policy,
-                )
-                .await?
-            }
-            None => false,
-        };
+        // For token conversions, the helper returns the raw estimated sats.
+        // For plain LNURL pay (no conversion) it returns request.amount unchanged.
+        let (estimated_sats, conversion_estimate) = self
+            .estimate_sats_from_token_conversion(
+                request.conversion_options.as_ref(),
+                request.token_identifier.as_ref(),
+                request.amount,
+                fee_policy,
+            )
+            .await?;
+        let is_token_conversion = conversion_estimate.is_some();
 
-        // token_identifier with conversion is only valid for send-all
-        if request.token_identifier.is_some() && !is_send_all_with_conversion {
-            return Err(SdkError::InvalidInput(
-                "Token identifier with conversion is only supported for send-all".to_string(),
-            ));
-        }
-
-        // For send-all with conversion, estimate total sats first.
-        // Deduct the max slippage so the LNURL invoice is smaller than the worst-case
-        // conversion output — the conversion will fail if slippage exceeds this guard,
-        // so we're guaranteed to have enough sats to pay the invoice.
-        let amount = if is_send_all_with_conversion {
-            let (total_sats, _) = self
-                .estimate_total_sats_with_conversion(
-                    request.conversion_options.as_ref(),
-                    request.token_identifier.as_ref(),
-                    request.amount,
-                )
-                .await?;
+        // Apply a slippage buffer only on the AmountIn conversion path
+        // (token_identifier set, variable sat output) so the LNURL invoice is sized
+        // below the worst-case conversion output and is guaranteed payable. The
+        // MinAmountOut path (no token_identifier) needs no buffer because the
+        // converter is invoked with MinAmountOut(invoice + fees) at execution time
+        // and is guaranteed to deliver enough sats or fail. The actual sats sent at
+        // execution time come from `complete_conversion_and_send` using the real
+        // post-conversion balance and may overpay this invoice.
+        let (amount, fee_policy) = if is_token_conversion && request.token_identifier.is_some() {
             let max_slippage_bps = u128::from(
                 request
                     .conversion_options
@@ -67,26 +55,28 @@ impl BreezSdk {
                     .and_then(|co| co.max_slippage_bps)
                     .unwrap_or(crate::token_conversion::DEFAULT_CONVERSION_MAX_SLIPPAGE_BPS),
             );
-            let slippage_buffer = total_sats
+            let slippage_buffer = estimated_sats
                 .saturating_mul(max_slippage_bps)
                 .saturating_div(10_000);
-            let amount_after_slippage = total_sats.saturating_sub(slippage_buffer);
+            let amount_after_slippage = estimated_sats.saturating_sub(slippage_buffer);
             trace!(
-                "[SEND-ALL] prepare_lnurl: token_amount={}, estimated_total_sats={}, slippage_bps={}, slippage_buffer={}, amount_for_invoice={}",
+                "prepare_lnurl: token_amount={}, estimated_sats={}, slippage_bps={}, slippage_buffer={}, amount_for_invoice={}",
                 request.amount,
-                total_sats,
+                estimated_sats,
                 max_slippage_bps,
                 slippage_buffer,
                 amount_after_slippage
             );
-            amount_after_slippage
+            (amount_after_slippage, FeePolicy::FeesIncluded)
         } else {
-            request.amount
+            (estimated_sats, fee_policy)
         };
 
         // FeesIncluded uses the double-query approach
         if fee_policy == FeePolicy::FeesIncluded {
-            return self.prepare_lnurl_pay_fees_included(request, amount).await;
+            return self
+                .prepare_lnurl_pay_fees_included(request, amount, conversion_estimate)
+                .await;
         }
 
         // Regular send (no FeesIncluded, no conversion)
@@ -453,6 +443,7 @@ impl BreezSdk {
         &self,
         request: PrepareLnurlPayRequest,
         amount: u128,
+        conversion_estimate: Option<crate::ConversionEstimate>,
     ) -> Result<PrepareLnurlPayResponse, SdkError> {
         let amount_sats: u64 = amount
             .try_into()
@@ -463,18 +454,7 @@ impl BreezSdk {
             ));
         }
 
-        // Compute conversion estimate if this is a send-all-with-conversion
         let token_identifier = request.token_identifier.clone();
-        let conversion_estimate = if request.conversion_options.is_some() {
-            self.estimate_conversion(
-                request.conversion_options.as_ref(),
-                token_identifier.as_ref(),
-                crate::token_conversion::ConversionAmount::AmountIn(request.amount),
-            )
-            .await?
-        } else {
-            None
-        };
 
         // 1. Validate amount is within LNURL limits
         let min_sendable_sats = request.pay_request.min_sendable.div_ceil(1000);

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -157,20 +157,42 @@ impl BreezSdk {
         let fee_policy = request.fee_policy.unwrap_or_default();
         let token_identifier = request.token_identifier.clone();
 
+        let is_send_all_with_conversion = match &self.stable_balance {
+            Some(sb) => {
+                sb.is_send_all_with_conversion(
+                    token_identifier.as_ref(),
+                    request.amount,
+                    request.conversion_options.as_ref(),
+                    fee_policy,
+                )
+                .await?
+            }
+            None => false,
+        };
+
         match &parsed_input {
             InputType::SparkAddress(spark_address_details) => {
                 let amount = request
                     .amount
                     .ok_or(SdkError::InvalidInput("Amount is required".to_string()))?;
 
-                let conversion_estimate = self
-                    .estimate_conversion(
+                let (amount, conversion_estimate) = if is_send_all_with_conversion {
+                    self.estimate_total_sats_with_conversion(
                         request.conversion_options.as_ref(),
                         token_identifier.as_ref(),
                         amount,
-                        fee_policy,
                     )
-                    .await?;
+                    .await?
+                } else {
+                    let estimate = self
+                        .estimate_conversion(
+                            request.conversion_options.as_ref(),
+                            token_identifier.as_ref(),
+                            ConversionAmount::MinAmountOut(amount),
+                        )
+                        .await?;
+                    (amount, estimate)
+                };
 
                 Ok(PrepareSendPaymentResponse {
                     payment_method: SendPaymentMethod::SparkAddress {
@@ -194,14 +216,23 @@ impl BreezSdk {
                     .or(request.amount)
                     .ok_or(SdkError::InvalidInput("Amount is required".to_string()))?;
 
-                let conversion_estimate = self
-                    .estimate_conversion(
+                let (amount, conversion_estimate) = if is_send_all_with_conversion {
+                    self.estimate_total_sats_with_conversion(
                         request.conversion_options.as_ref(),
                         effective_token_identifier.as_ref(),
                         amount,
-                        fee_policy,
                     )
-                    .await?;
+                    .await?
+                } else {
+                    let estimate = self
+                        .estimate_conversion(
+                            request.conversion_options.as_ref(),
+                            effective_token_identifier.as_ref(),
+                            ConversionAmount::MinAmountOut(amount),
+                        )
+                        .await?;
+                    (amount, estimate)
+                };
 
                 Ok(PrepareSendPaymentResponse {
                     payment_method: SendPaymentMethod::SparkInvoice {
@@ -225,6 +256,18 @@ impl BreezSdk {
                 } else {
                     None
                 };
+
+                if is_send_all_with_conversion {
+                    return self
+                        .prepare_bolt11_send_all_with_conversion(
+                            &request,
+                            detailed_bolt11_invoice,
+                            spark_transfer_fee_sats,
+                            token_identifier,
+                            fee_policy,
+                        )
+                        .await;
+                }
 
                 let amount = request
                     .amount
@@ -258,8 +301,9 @@ impl BreezSdk {
                     .estimate_conversion(
                         request.conversion_options.as_ref(),
                         token_identifier.as_ref(),
-                        amount.saturating_add(u128::from(lightning_fee_sats)),
-                        fee_policy,
+                        ConversionAmount::MinAmountOut(
+                            amount.saturating_add(u128::from(lightning_fee_sats)),
+                        ),
                     )
                     .await?;
 
@@ -276,6 +320,17 @@ impl BreezSdk {
                 })
             }
             InputType::BitcoinAddress(withdrawal_address) => {
+                if is_send_all_with_conversion {
+                    return self
+                        .prepare_bitcoin_send_all_with_conversion(
+                            &request,
+                            withdrawal_address,
+                            token_identifier,
+                            fee_policy,
+                        )
+                        .await;
+                }
+
                 let amount = request
                     .amount
                     .ok_or(SdkError::InvalidInput("Amount is required".to_string()))?;
@@ -291,12 +346,21 @@ impl BreezSdk {
                     )));
                 }
 
+                // When stable balance is active (has an active label), sats come
+                // from token conversion so they don't exist yet — pass None to
+                // skip leaf selection.
+                let stable_balance_active = match &self.stable_balance {
+                    Some(sb) => sb.get_active_label().await.is_some(),
+                    None => false,
+                };
+                let fee_quote_amount = if stable_balance_active {
+                    None
+                } else {
+                    Some(amount.try_into()?)
+                };
                 let fee_quote: SendOnchainFeeQuote = self
                     .spark_wallet
-                    .fetch_coop_exit_fee_quote(
-                        &withdrawal_address.address,
-                        Some(amount.try_into()?),
-                    )
+                    .fetch_coop_exit_fee_quote(&withdrawal_address.address, fee_quote_amount)
                     .await?
                     .into();
 
@@ -317,8 +381,9 @@ impl BreezSdk {
                     .estimate_conversion(
                         request.conversion_options.as_ref(),
                         token_identifier.as_ref(),
-                        amount.saturating_add(u128::from(fee_quote.speed_fast.total_fee_sat())),
-                        fee_policy,
+                        ConversionAmount::MinAmountOut(
+                            amount.saturating_add(u128::from(fee_quote.speed_fast.total_fee_sat())),
+                        ),
                     )
                     .await?;
 
@@ -524,15 +589,8 @@ impl BreezSdk {
             None => None,
         };
 
-        // FeesIncluded not supported with token conversion (validated earlier)
-        if request.prepare_response.fee_policy == FeePolicy::FeesIncluded {
-            return Err(SdkError::InvalidInput(
-                "FeesIncluded not supported with token conversion".to_string(),
-            ));
-        }
-
         // Step 1: Execute the token conversion
-        let (conversion_response, conversion_purpose) = self
+        let (conversion_response, conversion_purpose, is_send_all) = self
             .execute_pre_send_conversion(conversion_options, request)
             .await?;
 
@@ -546,6 +604,7 @@ impl BreezSdk {
             &conversion_response,
             &conversion_purpose,
             request,
+            is_send_all,
             suppress_payment_event,
         )
         .await
@@ -554,14 +613,58 @@ impl BreezSdk {
 
     /// Executes the token conversion for the given payment method.
     ///
-    /// Returns the conversion response and purpose (self-transfer vs ongoing payment).
+    /// Returns the conversion response, purpose (self-transfer vs ongoing payment),
+    /// and whether this is a send-all-with-conversion.
+    ///
+    /// For send-all-with-conversion, re-validates the token balance and uses `AmountIn`
+    /// to convert the full token amount. Otherwise, uses `MinAmountOut` with the payment amount.
+    #[allow(clippy::too_many_lines)]
     async fn execute_pre_send_conversion(
         &self,
         conversion_options: &ConversionOptions,
         request: &SendPaymentRequest,
-    ) -> Result<(TokenConversionResponse, ConversionPurpose), SdkError> {
+    ) -> Result<(TokenConversionResponse, ConversionPurpose, bool), SdkError> {
         let amount = request.prepare_response.amount;
         let token_identifier = request.prepare_response.token_identifier.clone();
+
+        // Re-validate send-all at send time — balance may have changed since prepare.
+        let is_send_all = match &self.stable_balance {
+            Some(sb) => {
+                sb.is_send_all_with_conversion(
+                    token_identifier.as_ref(),
+                    request
+                        .prepare_response
+                        .conversion_estimate
+                        .as_ref()
+                        .map(|e| e.amount_in),
+                    Some(conversion_options),
+                    request.prepare_response.fee_policy,
+                )
+                .await?
+            }
+            None => false,
+        };
+
+        let conversion_amount = if is_send_all {
+            let token_amount = request
+                .prepare_response
+                .conversion_estimate
+                .as_ref()
+                .map(|e| e.amount_in)
+                .ok_or(SdkError::InvalidInput(
+                    "Conversion estimate required for send-all with conversion".to_string(),
+                ))?;
+            tracing::trace!(
+                amount = amount,
+                token_amount = token_amount,
+                token_identifier = ?request.prepare_response.token_identifier,
+                fee_policy = ?request.prepare_response.fee_policy,
+                "[SEND-ALL] execute_pre_send_conversion: converting full token balance"
+            );
+            ConversionAmount::AmountIn(token_amount)
+        } else {
+            ConversionAmount::MinAmountOut(amount)
+        };
 
         match &request.prepare_response.payment_method {
             SendPaymentMethod::SparkAddress { address, .. } => {
@@ -583,11 +686,11 @@ impl BreezSdk {
                         conversion_options,
                         &purpose,
                         token_identifier.as_ref(),
-                        ConversionAmount::MinAmountOut(amount),
+                        conversion_amount,
                         None,
                     )
                     .await?;
-                Ok((response, purpose))
+                Ok((response, purpose, is_send_all))
             }
             SendPaymentMethod::SparkInvoice {
                 spark_invoice_details:
@@ -613,11 +716,11 @@ impl BreezSdk {
                         conversion_options,
                         &purpose,
                         token_identifier.as_ref(),
-                        ConversionAmount::MinAmountOut(amount),
+                        conversion_amount,
                         None,
                     )
                     .await?;
-                Ok((response, purpose))
+                Ok((response, purpose, is_send_all))
             }
             SendPaymentMethod::Bolt11Invoice {
                 spark_transfer_fee_sats,
@@ -628,6 +731,10 @@ impl BreezSdk {
                 let purpose = ConversionPurpose::OngoingPayment {
                     payment_request: invoice_details.invoice.bolt11.clone(),
                 };
+                let conversion_amount_override = match &conversion_amount {
+                    ConversionAmount::AmountIn(_) => Some(conversion_amount),
+                    ConversionAmount::MinAmountOut(_) => None,
+                };
                 let response = self
                     .convert_token_for_bolt11_invoice(
                         conversion_options,
@@ -637,13 +744,18 @@ impl BreezSdk {
                         &purpose,
                         amount,
                         token_identifier.as_ref(),
+                        conversion_amount_override,
                     )
                     .await?;
-                Ok((response, purpose))
+                Ok((response, purpose, is_send_all))
             }
             SendPaymentMethod::BitcoinAddress { address, fee_quote } => {
                 let purpose = ConversionPurpose::OngoingPayment {
                     payment_request: address.address.clone(),
+                };
+                let conversion_amount_override = match &conversion_amount {
+                    ConversionAmount::AmountIn(_) => Some(conversion_amount),
+                    ConversionAmount::MinAmountOut(_) => None,
                 };
                 let response = self
                     .convert_token_for_bitcoin_address(
@@ -653,9 +765,10 @@ impl BreezSdk {
                         &purpose,
                         amount,
                         token_identifier.as_ref(),
+                        conversion_amount_override,
                     )
                     .await?;
-                Ok((response, purpose))
+                Ok((response, purpose, is_send_all))
             }
         }
     }
@@ -687,12 +800,15 @@ impl BreezSdk {
     ///
     /// For self-transfers, returns immediately after conversion completes.
     /// For ongoing payments, sends the actual payment and links any remaining children.
+    /// For send-all, queries the actual sat balance post-conversion and uses it as the
+    /// send amount (with `FeesIncluded` to deduct fees).
     async fn complete_conversion_and_send(
         &self,
         conversion_options: &ConversionOptions,
         conversion_response: &TokenConversionResponse,
         conversion_purpose: &ConversionPurpose,
         request: &SendPaymentRequest,
+        is_send_all: bool,
         suppress_payment_event: &mut bool,
     ) -> Result<SendPaymentResponse, SdkError> {
         // Trigger a wallet state sync if converting from Bitcoin to token
@@ -726,8 +842,22 @@ impl BreezSdk {
             return Ok(SendPaymentResponse { payment });
         }
 
+        // For send-all, use actual sat balance post-conversion to handle slippage
+        let amount_override = if is_send_all {
+            let balance = self.spark_wallet.get_balance().await?;
+            tracing::trace!(
+                sat_balance_post_conversion = balance,
+                request_amount = request.prepare_response.amount,
+                fee_policy = ?request.prepare_response.fee_policy,
+                "[SEND-ALL] complete_conversion_and_send: post-conversion balance as amount_override"
+            );
+            Some(balance)
+        } else {
+            None
+        };
+
         // Now send the actual payment
-        let response = Box::pin(self.send_payment_internal(request, None)).await?;
+        let response = Box::pin(self.send_payment_internal(request, amount_override)).await?;
 
         // Link conversion children to the send payment (deferred linking)
         self.storage
@@ -779,9 +909,10 @@ impl BreezSdk {
                 Box::pin(self.send_spark_address(
                     address,
                     token_identifier,
-                    amount,
+                    amount_override.map_or(amount, u128::from),
                     request.options.as_ref(),
                     request.idempotency_key.clone(),
+                    request.prepare_response.conversion_estimate.as_ref(),
                 ))
                 .await
             }
@@ -789,8 +920,12 @@ impl BreezSdk {
                 spark_invoice_details,
                 ..
             } => {
-                self.send_spark_invoice(&spark_invoice_details.invoice, request, amount)
-                    .await
+                self.send_spark_invoice(
+                    &spark_invoice_details.invoice,
+                    request,
+                    amount_override.map_or(amount, u128::from),
+                )
+                .await
             }
             SendPaymentMethod::Bolt11Invoice {
                 invoice_details,
@@ -809,7 +944,8 @@ impl BreezSdk {
                 .await
             }
             SendPaymentMethod::BitcoinAddress { address, fee_quote } => {
-                self.send_bitcoin_address(address, fee_quote, request).await
+                self.send_bitcoin_address(address, fee_quote, request, amount_override)
+                    .await
             }
         }
     }
@@ -821,6 +957,7 @@ impl BreezSdk {
         amount: u128,
         options: Option<&SendPaymentOptions>,
         idempotency_key: Option<String>,
+        conversion_estimate: Option<&ConversionEstimate>,
     ) -> Result<SendPaymentResponse, SdkError> {
         let spark_address = address
             .parse::<SparkAddress>()
@@ -846,7 +983,21 @@ impl BreezSdk {
                 .await;
         }
 
-        let payment = if let Some(identifier) = token_identifier {
+        // For ToBitcoin conversions, token_identifier was used for the conversion step
+        // (already completed). The actual payment is a regular BTC transfer.
+        let is_to_bitcoin = matches!(
+            conversion_estimate,
+            Some(ConversionEstimate {
+                options: ConversionOptions {
+                    conversion_type: ConversionType::ToBitcoin { .. },
+                    ..
+                },
+                ..
+            })
+        );
+        let payment = if let Some(identifier) = token_identifier
+            && !is_to_bitcoin
+        {
             self.send_spark_token_address(identifier, amount, spark_address)
                 .await?
         } else {
@@ -1028,31 +1179,8 @@ impl BreezSdk {
         amount_override: Option<u64>,
         amount: u128,
     ) -> Result<SendPaymentResponse, SdkError> {
-        // Handle FeesIncluded for amountless Bolt11 invoices
-        let amount_to_send = if request.prepare_response.fee_policy == FeePolicy::FeesIncluded
-            && invoice_details.amount_msat.is_none()
-            && amount_override.is_none()
-        {
-            let amt = self
-                .calculate_fees_included_bolt11_amount(
-                    &invoice_details.invoice.bolt11,
-                    amount.try_into()?,
-                    lightning_fee_sats,
-                )
-                .await?;
-            Some(u128::from(amt))
-        } else {
-            match amount_override {
-                // Amount override provided
-                Some(amt) => Some(amt.into()),
-                None => match invoice_details.amount_msat {
-                    // We are not sending amount in case the invoice contains it.
-                    Some(_) => None,
-                    // We are sending amount for zero amount invoice
-                    None => Some(amount),
-                },
-            }
-        };
+        // Determine routing preference and actual fee before calculating the send amount,
+        // so FeesIncluded deducts the correct fee (Spark=0 vs Lightning).
         let (prefer_spark, completion_timeout_secs) = match request.options {
             Some(SendPaymentOptions::Bolt11Invoice {
                 prefer_spark,
@@ -1060,9 +1188,46 @@ impl BreezSdk {
             }) => (prefer_spark, completion_timeout_secs),
             _ => (self.config.prefer_spark_over_lightning, None),
         };
-        let fee_sats = match (prefer_spark, spark_transfer_fee_sats, lightning_fee_sats) {
-            (true, Some(fee), _) => fee,
-            _ => lightning_fee_sats,
+        let is_spark_route = prefer_spark && spark_transfer_fee_sats.is_some();
+        let fee_sats = if is_spark_route {
+            spark_transfer_fee_sats.unwrap_or(0)
+        } else {
+            lightning_fee_sats
+        };
+
+        // Handle FeesIncluded: deduct fees from the total balance.
+        // Applies to both amountless invoices and fixed-amount invoices with amount_override
+        // (send-all-with-conversion via LNURL — overpays the invoice to drain the wallet).
+        let is_fees_included = request.prepare_response.fee_policy == FeePolicy::FeesIncluded;
+        let amount_to_send = if is_fees_included
+            && (invoice_details.amount_msat.is_none() || amount_override.is_some())
+        {
+            let total_sats: u64 = match amount_override {
+                Some(sat_balance) => sat_balance,
+                None => amount.try_into()?,
+            };
+            // Spark route: deduct known fee directly (often 0).
+            // Lightning route: re-estimate fees via calculate_fees_included_bolt11_amount
+            // which handles fee changes between prepare and send.
+            let amt = if is_spark_route {
+                total_sats.saturating_sub(fee_sats)
+            } else {
+                self.calculate_fees_included_bolt11_amount(
+                    &invoice_details.invoice.bolt11,
+                    total_sats,
+                    fee_sats,
+                )
+                .await?
+            };
+            Some(u128::from(amt))
+        } else {
+            match amount_override {
+                Some(amt) => Some(amt.into()),
+                None => match invoice_details.amount_msat {
+                    Some(_) => None,
+                    None => Some(amount),
+                },
+            }
         };
         let transfer_id = request
             .idempotency_key
@@ -1134,6 +1299,7 @@ impl BreezSdk {
         address: &BitcoinAddressDetails,
         fee_quote: &SendOnchainFeeQuote,
         request: &SendPaymentRequest,
+        amount_override: Option<u64>,
     ) -> Result<SendPaymentResponse, SdkError> {
         // Extract confirmation speed from options
         let confirmation_speed = match &request.options {
@@ -1157,12 +1323,14 @@ impl BreezSdk {
             OnchainConfirmationSpeed::Slow => fee_quote.speed_slow.total_fee_sat(),
         };
 
-        // Compute amount - for FeesIncluded, receiver gets total minus fees
-        let amount_sats: u64 = if request.prepare_response.fee_policy == FeePolicy::FeesIncluded {
-            let total_sats: u64 = request.prepare_response.amount.try_into()?;
+        // Compute amount - for FeesIncluded, receiver gets total minus fees.
+        // amount_override (send-all post-conversion) is always FeesIncluded.
+        let total_sats: u64 =
+            amount_override.unwrap_or(request.prepare_response.amount.try_into()?);
+        let amount_sats = if request.prepare_response.fee_policy == FeePolicy::FeesIncluded {
             total_sats.saturating_sub(fee_sats)
         } else {
-            request.prepare_response.amount.try_into()?
+            total_sats
         };
 
         // Validate the output amount meets the dust limit for this address type
@@ -1332,26 +1500,32 @@ impl BreezSdk {
         conversion_purpose: &ConversionPurpose,
         amount: u128,
         token_identifier: Option<&String>,
+        conversion_amount_override: Option<ConversionAmount>,
     ) -> Result<TokenConversionResponse, SdkError> {
-        // Determine the fee to be used based on preference
-        let fee_sats = match request.options {
-            Some(SendPaymentOptions::Bolt11Invoice { prefer_spark, .. }) => {
-                match (prefer_spark, spark_transfer_fee_sats) {
-                    (true, Some(fee)) => fee,
-                    _ => lightning_fee_sats,
+        let conversion_amount = if let Some(ca) = conversion_amount_override {
+            ca
+        } else {
+            // Determine the fee to be used based on preference
+            let fee_sats = match request.options {
+                Some(SendPaymentOptions::Bolt11Invoice { prefer_spark, .. }) => {
+                    match (prefer_spark, spark_transfer_fee_sats) {
+                        (true, Some(fee)) => fee,
+                        _ => lightning_fee_sats,
+                    }
                 }
-            }
-            _ => lightning_fee_sats,
+                _ => lightning_fee_sats,
+            };
+            // The absolute minimum amount out is the lightning invoice amount plus fee
+            let min_amount_out = amount.saturating_add(u128::from(fee_sats));
+            ConversionAmount::MinAmountOut(min_amount_out)
         };
-        // The absolute minimum amount out is the lightning invoice amount plus fee
-        let min_amount_out = amount.saturating_add(u128::from(fee_sats));
 
         self.token_converter
             .convert(
                 conversion_options,
                 conversion_purpose,
                 token_identifier,
-                ConversionAmount::MinAmountOut(min_amount_out),
+                conversion_amount,
                 None,
             )
             .await
@@ -1380,31 +1554,173 @@ impl BreezSdk {
 
     /// Estimates a conversion for a payment, returning `None` when no conversion is needed.
     ///
-    /// Skips conversion for `FeesIncluded` fee policy (validated earlier).
-    /// Auto-populates conversion options from stable balance config when applicable.
-    async fn estimate_conversion(
+    /// For `AmountIn`: validates with the given options directly (caller knows what to convert).
+    /// For `MinAmountOut`: auto-populates conversion options from stable balance config when applicable.
+    pub(super) async fn estimate_conversion(
         &self,
         request_options: Option<&ConversionOptions>,
         token_identifier: Option<&String>,
-        amount: u128,
-        fee_policy: FeePolicy,
+        conversion_amount: ConversionAmount,
     ) -> Result<Option<ConversionEstimate>, SdkError> {
-        if fee_policy == FeePolicy::FeesIncluded {
-            return Ok(None);
+        match conversion_amount {
+            ConversionAmount::AmountIn(_) => self
+                .token_converter
+                .validate(request_options, token_identifier, conversion_amount)
+                .await
+                .map_err(Into::into),
+            ConversionAmount::MinAmountOut(amount) => {
+                let options = self
+                    .get_conversion_options_for_payment(request_options, token_identifier, amount)
+                    .await?;
+                self.token_converter
+                    .validate(options.as_ref(), token_identifier, conversion_amount)
+                    .await
+                    .map_err(Into::into)
+            }
         }
-        let options = self
-            .get_conversion_options_for_payment(request_options, token_identifier, amount)
-            .await?;
-        self.token_converter
-            .validate(
-                options.as_ref(),
-                token_identifier,
-                ConversionAmount::MinAmountOut(amount),
-            )
-            .await
-            .map_err(Into::into)
     }
 
+    /// Estimates the total sats available after converting the specified token amount.
+    ///
+    /// Converts the specified token amount to sats (using `AmountIn`), then adds
+    /// the existing sat balance to get the total available sats.
+    ///
+    /// Returns `(total_sats, conversion_estimate)`.
+    pub(super) async fn estimate_total_sats_with_conversion(
+        &self,
+        conversion_options: Option<&ConversionOptions>,
+        token_identifier: Option<&String>,
+        token_amount: u128,
+    ) -> Result<(u128, Option<ConversionEstimate>), SdkError> {
+        let conversion_estimate = self
+            .estimate_conversion(
+                conversion_options,
+                token_identifier,
+                ConversionAmount::AmountIn(token_amount),
+            )
+            .await?;
+
+        let estimated_sats_from_conversion =
+            conversion_estimate.as_ref().map_or(0, |e| e.amount_out);
+
+        let sat_balance = u128::from(self.spark_wallet.get_balance().await?);
+        let total_sats = estimated_sats_from_conversion.saturating_add(sat_balance);
+
+        Ok((total_sats, conversion_estimate))
+    }
+
+    /// Prepares a Bolt11 invoice payment for send-all with token conversion.
+    ///
+    /// Estimates the conversion, fetches lightning fees based on total sats,
+    /// and validates the receiver amount covers fees.
+    async fn prepare_bolt11_send_all_with_conversion(
+        &self,
+        request: &PrepareSendPaymentRequest,
+        invoice: &Bolt11InvoiceDetails,
+        spark_transfer_fee_sats: Option<u64>,
+        token_identifier: Option<String>,
+        fee_policy: FeePolicy,
+    ) -> Result<PrepareSendPaymentResponse, SdkError> {
+        let token_amount = request
+            .amount
+            .ok_or(SdkError::InvalidInput("Amount is required".to_string()))?;
+
+        let (total_sats, conversion_estimate) = self
+            .estimate_total_sats_with_conversion(
+                request.conversion_options.as_ref(),
+                token_identifier.as_ref(),
+                token_amount,
+            )
+            .await?;
+
+        let lightning_fee_sats = self
+            .spark_wallet
+            .fetch_lightning_send_fee_estimate(
+                &request.payment_request,
+                Some(total_sats.try_into()?),
+            )
+            .await?;
+
+        let total_u64: u64 = total_sats.try_into()?;
+        if total_u64 <= lightning_fee_sats {
+            return Err(SdkError::InvalidInput(
+                "Amount too small to cover fees".to_string(),
+            ));
+        }
+
+        Ok(PrepareSendPaymentResponse {
+            payment_method: SendPaymentMethod::Bolt11Invoice {
+                invoice_details: invoice.clone(),
+                spark_transfer_fee_sats,
+                lightning_fee_sats,
+            },
+            amount: total_sats,
+            token_identifier,
+            conversion_estimate,
+            fee_policy,
+        })
+    }
+
+    /// Prepares a Bitcoin address payment for send-all with token conversion.
+    ///
+    /// Estimates the conversion, fetches onchain fee quote based on total sats,
+    /// and validates the output after fees meets the dust limit.
+    async fn prepare_bitcoin_send_all_with_conversion(
+        &self,
+        request: &PrepareSendPaymentRequest,
+        withdrawal_address: &BitcoinAddressDetails,
+        token_identifier: Option<String>,
+        fee_policy: FeePolicy,
+    ) -> Result<PrepareSendPaymentResponse, SdkError> {
+        let token_amount = request
+            .amount
+            .ok_or(SdkError::InvalidInput("Amount is required".to_string()))?;
+
+        let (total_sats, conversion_estimate) = self
+            .estimate_total_sats_with_conversion(
+                request.conversion_options.as_ref(),
+                token_identifier.as_ref(),
+                token_amount,
+            )
+            .await?;
+
+        let dust_limit_sats = get_dust_limit_sats(&withdrawal_address.address)?;
+        let total_u64: u64 = total_sats.try_into()?;
+        if total_u64 < dust_limit_sats {
+            return Err(SdkError::InvalidInput(format!(
+                "Amount is below the minimum of {dust_limit_sats} sats required for this address"
+            )));
+        }
+
+        // Pass None for amount — the sats don't exist yet (still tokens),
+        // so leaf selection would fail. Get a generic fee estimate instead.
+        let fee_quote: SendOnchainFeeQuote = self
+            .spark_wallet
+            .fetch_coop_exit_fee_quote(&withdrawal_address.address, None)
+            .await?
+            .into();
+
+        let min_fee_sats = fee_quote.speed_slow.total_fee_sat();
+        let output_amount_sats = total_u64.saturating_sub(min_fee_sats);
+        if output_amount_sats < dust_limit_sats {
+            return Err(SdkError::InvalidInput(format!(
+                "Amount is below the minimum of {dust_limit_sats} sats required for this address after lowest fees of {min_fee_sats} sats"
+            )));
+        }
+
+        Ok(PrepareSendPaymentResponse {
+            payment_method: SendPaymentMethod::BitcoinAddress {
+                address: withdrawal_address.clone(),
+                fee_quote,
+            },
+            amount: total_sats,
+            token_identifier,
+            conversion_estimate,
+            fee_policy,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
     async fn convert_token_for_bitcoin_address(
         &self,
         conversion_options: &ConversionOptions,
@@ -1413,28 +1729,33 @@ impl BreezSdk {
         conversion_purpose: &ConversionPurpose,
         amount: u128,
         token_identifier: Option<&String>,
+        conversion_amount_override: Option<ConversionAmount>,
     ) -> Result<TokenConversionResponse, SdkError> {
-        // Derive fee_sats from request.options confirmation speed
-        let fee_sats = match &request.options {
-            Some(SendPaymentOptions::BitcoinAddress { confirmation_speed }) => {
-                match confirmation_speed {
-                    OnchainConfirmationSpeed::Slow => fee_quote.speed_slow.total_fee_sat(),
-                    OnchainConfirmationSpeed::Medium => fee_quote.speed_medium.total_fee_sat(),
-                    OnchainConfirmationSpeed::Fast => fee_quote.speed_fast.total_fee_sat(),
+        let conversion_amount = if let Some(ca) = conversion_amount_override {
+            ca
+        } else {
+            // Derive fee_sats from request.options confirmation speed
+            let fee_sats = match &request.options {
+                Some(SendPaymentOptions::BitcoinAddress { confirmation_speed }) => {
+                    match confirmation_speed {
+                        OnchainConfirmationSpeed::Slow => fee_quote.speed_slow.total_fee_sat(),
+                        OnchainConfirmationSpeed::Medium => fee_quote.speed_medium.total_fee_sat(),
+                        OnchainConfirmationSpeed::Fast => fee_quote.speed_fast.total_fee_sat(),
+                    }
                 }
-            }
-            _ => fee_quote.speed_fast.total_fee_sat(), // Default to fast
+                _ => fee_quote.speed_fast.total_fee_sat(), // Default to fast
+            };
+            // The absolute minimum amount out is the amount plus fee
+            let min_amount_out = amount.saturating_add(u128::from(fee_sats));
+            ConversionAmount::MinAmountOut(min_amount_out)
         };
-
-        // The absolute minimum amount out is the amount plus fee
-        let min_amount_out = amount.saturating_add(u128::from(fee_sats));
 
         self.token_converter
             .convert(
                 conversion_options,
                 conversion_purpose,
                 token_identifier,
-                ConversionAmount::MinAmountOut(min_amount_out),
+                conversion_amount,
                 None,
             )
             .await

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -172,14 +172,32 @@ impl BreezSdk {
                     )
                     .await?;
 
+                // For ToBitcoin conversions, the output is sats — clear token_identifier
+                // so it reflects the output denomination, not the input.
+                let is_to_bitcoin = matches!(
+                    conversion_estimate,
+                    Some(ConversionEstimate {
+                        options: ConversionOptions {
+                            conversion_type: ConversionType::ToBitcoin { .. },
+                            ..
+                        },
+                        ..
+                    })
+                );
+                let response_token_identifier = if is_to_bitcoin {
+                    None
+                } else {
+                    token_identifier.clone()
+                };
+
                 Ok(PrepareSendPaymentResponse {
                     payment_method: SendPaymentMethod::SparkAddress {
                         address: spark_address_details.address.clone(),
                         fee: 0,
-                        token_identifier: token_identifier.clone(),
+                        token_identifier: response_token_identifier.clone(),
                     },
                     amount,
-                    token_identifier,
+                    token_identifier: response_token_identifier,
                     conversion_estimate,
                     fee_policy,
                 })
@@ -203,14 +221,30 @@ impl BreezSdk {
                     )
                     .await?;
 
+                let is_to_bitcoin = matches!(
+                    conversion_estimate,
+                    Some(ConversionEstimate {
+                        options: ConversionOptions {
+                            conversion_type: ConversionType::ToBitcoin { .. },
+                            ..
+                        },
+                        ..
+                    })
+                );
+                let response_token_identifier = if is_to_bitcoin {
+                    None
+                } else {
+                    effective_token_identifier.clone()
+                };
+
                 Ok(PrepareSendPaymentResponse {
                     payment_method: SendPaymentMethod::SparkInvoice {
                         spark_invoice_details: spark_invoice_details.clone(),
                         fee: 0,
-                        token_identifier: effective_token_identifier.clone(),
+                        token_identifier: response_token_identifier.clone(),
                     },
                     amount,
-                    token_identifier: effective_token_identifier,
+                    token_identifier: response_token_identifier,
                     conversion_estimate,
                     fee_policy,
                 })
@@ -561,7 +595,7 @@ impl BreezSdk {
         };
 
         // Step 1: Execute the token conversion
-        let (conversion_response, conversion_purpose, is_send_all) = self
+        let (conversion_response, conversion_purpose, is_send_all, uses_amount_in) = self
             .execute_pre_send_conversion(conversion_options, request)
             .await?;
 
@@ -576,6 +610,7 @@ impl BreezSdk {
             &conversion_purpose,
             request,
             is_send_all,
+            uses_amount_in,
             suppress_payment_event,
         )
         .await
@@ -587,27 +622,37 @@ impl BreezSdk {
     /// Returns the conversion response, purpose (self-transfer vs ongoing payment),
     /// and whether this is a send-all-with-conversion.
     ///
-    /// Re-validates the token balance and chooses the conversion direction:
-    /// - `token_identifier` set → user specified a token amount; uses `AmountIn`
-    ///   from the prepared estimate (variable sat output).
-    /// - `token_identifier` not set → user specified a sat amount; uses
-    ///   `MinAmountOut(amount)`, which the per-payment-method paths expand to
-    ///   `MinAmountOut(amount + fees)` so the converter delivers enough to cover
-    ///   the send and its fees.
+    /// Re-evaluates whether this is still a send-all based on the current token
+    /// balance (which may have changed since prepare) and chooses the conversion direction:
+    /// - `ToBitcoin` conversion → uses `AmountIn` from the conversion estimate
+    ///   (variable sat output).
+    /// - Other conversions → uses `MinAmountOut(amount)`, which the per-payment-method
+    ///   paths expand to `MinAmountOut(amount + fees)` so the converter delivers enough
+    ///   to cover the send and its fees.
     #[allow(clippy::too_many_lines)]
     async fn execute_pre_send_conversion(
         &self,
         conversion_options: &ConversionOptions,
         request: &SendPaymentRequest,
-    ) -> Result<(TokenConversionResponse, ConversionPurpose, bool), SdkError> {
+    ) -> Result<(TokenConversionResponse, ConversionPurpose, bool, bool), SdkError> {
         let amount = request.prepare_response.amount;
-        let token_identifier = request.prepare_response.token_identifier.clone();
 
-        // Re-validate at send time — balance may have changed since prepare.
+        // Extract from_token_identifier from conversion options for ToBitcoin conversions.
+        // This replaces the previous reliance on prepare_response.token_identifier,
+        // which is now None for ToBitcoin (reflects output denomination).
+        let from_token_identifier = match &conversion_options.conversion_type {
+            ConversionType::ToBitcoin {
+                from_token_identifier,
+            } => Some(from_token_identifier.clone()),
+            ConversionType::FromBitcoin => None,
+        };
+
+        // Re-evaluate send-all at send time — if the token balance changed since
+        // prepare, is_send_all may become false (existing sats won't be swept).
         let (is_token_conversion, is_send_all) = self
             .is_token_conversion(
                 Some(conversion_options),
-                token_identifier.as_ref(),
+                from_token_identifier.as_ref(),
                 request
                     .prepare_response
                     .conversion_estimate
@@ -618,14 +663,17 @@ impl BreezSdk {
             .await?;
 
         // AmountIn vs MinAmountOut at convert time:
-        // - token_identifier set → user specified a token amount; use AmountIn
-        //   from the estimate (variable sat output, slippage-buffered at prepare
-        //   time).
-        // - token_identifier not set → user specified a sat amount; MinAmountOut
-        //   guarantees ≥ requested sats out (or the conversion fails). For
-        //   payment-method-specific paths (Bolt11, Bitcoin), `convert_token_for_*`
-        //   recomputes MinAmountOut(amount + fees) when no override is supplied.
-        let conversion_amount = if is_token_conversion && token_identifier.is_some() {
+        // Determine whether the prepare used AmountIn (user specified token amount,
+        // variable sat output) or MinAmountOut (user specified sats, guaranteed output).
+        // When AmountIn was used, the prepare's `amount` equals the estimate's
+        // `amount_out` (estimated sats). When MinAmountOut was used, `amount` is the
+        // user's requested sats and won't match `amount_out`.
+        let was_amount_in = request
+            .prepare_response
+            .conversion_estimate
+            .as_ref()
+            .is_some_and(|e| e.amount_out == amount);
+        let conversion_amount = if is_token_conversion && was_amount_in {
             let token_amount = request
                 .prepare_response
                 .conversion_estimate
@@ -638,6 +686,7 @@ impl BreezSdk {
         } else {
             ConversionAmount::MinAmountOut(amount)
         };
+        let uses_amount_in = matches!(conversion_amount, ConversionAmount::AmountIn(_));
 
         match &request.prepare_response.payment_method {
             SendPaymentMethod::SparkAddress { address, .. } => {
@@ -658,12 +707,12 @@ impl BreezSdk {
                     .convert(
                         conversion_options,
                         &purpose,
-                        token_identifier.as_ref(),
+                        from_token_identifier.as_ref(),
                         conversion_amount,
                         None,
                     )
                     .await?;
-                Ok((response, purpose, is_send_all))
+                Ok((response, purpose, is_send_all, uses_amount_in))
             }
             SendPaymentMethod::SparkInvoice {
                 spark_invoice_details:
@@ -688,12 +737,12 @@ impl BreezSdk {
                     .convert(
                         conversion_options,
                         &purpose,
-                        token_identifier.as_ref(),
+                        from_token_identifier.as_ref(),
                         conversion_amount,
                         None,
                     )
                     .await?;
-                Ok((response, purpose, is_send_all))
+                Ok((response, purpose, is_send_all, uses_amount_in))
             }
             SendPaymentMethod::Bolt11Invoice {
                 spark_transfer_fee_sats,
@@ -716,11 +765,11 @@ impl BreezSdk {
                         request,
                         &purpose,
                         amount,
-                        token_identifier.as_ref(),
+                        from_token_identifier.as_ref(),
                         conversion_amount_override,
                     )
                     .await?;
-                Ok((response, purpose, is_send_all))
+                Ok((response, purpose, is_send_all, uses_amount_in))
             }
             SendPaymentMethod::BitcoinAddress { address, fee_quote } => {
                 let purpose = ConversionPurpose::OngoingPayment {
@@ -737,11 +786,11 @@ impl BreezSdk {
                         request,
                         &purpose,
                         amount,
-                        token_identifier.as_ref(),
+                        from_token_identifier.as_ref(),
                         conversion_amount_override,
                     )
                     .await?;
-                Ok((response, purpose, is_send_all))
+                Ok((response, purpose, is_send_all, uses_amount_in))
             }
         }
     }
@@ -775,6 +824,7 @@ impl BreezSdk {
     /// For ongoing payments, sends the actual payment and links any remaining children.
     /// For send-all, queries the actual sat balance post-conversion and uses it as the
     /// send amount (with `FeesIncluded` to deduct fees).
+    #[allow(clippy::too_many_arguments)]
     async fn complete_conversion_and_send(
         &self,
         conversion_options: &ConversionOptions,
@@ -782,6 +832,7 @@ impl BreezSdk {
         conversion_purpose: &ConversionPurpose,
         request: &SendPaymentRequest,
         is_send_all: bool,
+        uses_amount_in: bool,
         suppress_payment_event: &mut bool,
     ) -> Result<SendPaymentResponse, SdkError> {
         // Trigger a wallet state sync if converting from Bitcoin to token
@@ -817,14 +868,13 @@ impl BreezSdk {
 
         // Determine the amount to use for the actual send.
         // - Send-all: drain the wallet — use the full post-conversion sat balance.
-        // - Non-send-all with `token_identifier` set: user specified a token
-        //   amount → send the actual sats produced by *this* conversion. This
-        //   honors "convert N tokens and send the result" regardless of slippage.
-        // - Non-send-all without `token_identifier`: user specified a sat amount
-        //   (e.g. LNURL with `--from-token` and a sat amount). The conversion was
-        //   sized as MinAmountOut(invoice + fee), so the converted sats cover the
-        //   invoice plus fee with possible slippage slack. Don't override — send
-        //   exactly the requested invoice amount and let the slack cover fees.
+        // - Non-send-all ToBitcoin: user specified a token amount → send the actual
+        //   sats produced by *this* conversion. This honors "convert N tokens and
+        //   send the result" regardless of slippage.
+        // - Other conversions (e.g. FromBitcoin, or sat-specified ToBitcoin via
+        //   stable balance): the conversion was sized as MinAmountOut(amount + fees),
+        //   so the converted output covers the send. Don't override — send exactly
+        //   the requested amount and let the slack cover fees.
         let amount_override = if is_send_all {
             let balance = self.spark_wallet.get_balance().await?;
             tracing::trace!(
@@ -834,7 +884,7 @@ impl BreezSdk {
                 "[SEND-ALL] complete_conversion_and_send: post-conversion balance as amount_override"
             );
             Some(balance)
-        } else if request.prepare_response.token_identifier.is_some() {
+        } else if uses_amount_in {
             let converted_sats: u64 = payment
                 .amount
                 .try_into()
@@ -911,7 +961,6 @@ impl BreezSdk {
                     amount_override.map_or(amount, u128::from),
                     request.options.as_ref(),
                     request.idempotency_key.clone(),
-                    request.prepare_response.conversion_estimate.as_ref(),
                 ))
                 .await
             }
@@ -956,7 +1005,6 @@ impl BreezSdk {
         amount: u128,
         options: Option<&SendPaymentOptions>,
         idempotency_key: Option<String>,
-        conversion_estimate: Option<&ConversionEstimate>,
     ) -> Result<SendPaymentResponse, SdkError> {
         let spark_address = address
             .parse::<SparkAddress>()
@@ -982,21 +1030,7 @@ impl BreezSdk {
                 .await;
         }
 
-        // For ToBitcoin conversions, token_identifier was used for the conversion step
-        // (already completed). The actual payment is a regular BTC transfer.
-        let is_to_bitcoin = matches!(
-            conversion_estimate,
-            Some(ConversionEstimate {
-                options: ConversionOptions {
-                    conversion_type: ConversionType::ToBitcoin { .. },
-                    ..
-                },
-                ..
-            })
-        );
-        let payment = if let Some(identifier) = token_identifier
-            && !is_to_bitcoin
-        {
+        let payment = if let Some(identifier) = token_identifier {
             self.send_spark_token_address(identifier, amount, spark_address)
                 .await?
         } else {
@@ -1794,7 +1828,8 @@ impl BreezSdk {
                 lightning_fee_sats,
             },
             amount: estimated_sats,
-            token_identifier: token_identifier.cloned(),
+            // ToBitcoin conversion outputs sats — token_identifier is None
+            token_identifier: None,
             conversion_estimate,
             fee_policy,
         }))
@@ -1858,7 +1893,8 @@ impl BreezSdk {
                 fee_quote,
             },
             amount: estimated_sats,
-            token_identifier: token_identifier.cloned(),
+            // ToBitcoin conversion outputs sats — token_identifier is None
+            token_identifier: None,
             conversion_estimate,
             fee_policy,
         }))

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -1603,6 +1603,8 @@ impl BreezSdk {
 
         // If the caller passed a token_identifier it must match conversion options.
         // If they omitted it, we can't compare against the balance, so is_send_all=false.
+        // Send-all also requires stable balance to be active with a matching active token,
+        // otherwise we shouldn't sweep the existing sat balance.
         let is_send_all = match token_identifier {
             Some(token_id) => {
                 if token_id != from_token_identifier {
@@ -1612,7 +1614,13 @@ impl BreezSdk {
                 }
                 let token_balances = self.spark_wallet.get_token_balances().await?;
                 let token_balance = token_balances.get(token_id).map_or(0, |tb| tb.balance);
-                amount == token_balance && fee_policy == FeePolicy::FeesIncluded
+                let has_active_stable_token = match &self.stable_balance {
+                    Some(sb) => sb.get_active_token_identifier().await.as_ref() == Some(token_id),
+                    None => false,
+                };
+                amount == token_balance
+                    && fee_policy == FeePolicy::FeesIncluded
+                    && has_active_stable_token
             }
             None => false,
         };
@@ -1766,9 +1774,16 @@ impl BreezSdk {
             .await?;
 
         let total_u64: u64 = estimated_sats.try_into()?;
-        if total_u64 <= lightning_fee_sats {
+        // For fixed-amount invoices, the converted sats must cover invoice amount + fees.
+        // For amountless invoices (send-all), just check fees are covered.
+        let min_required = if let Some(amount_msat) = invoice.amount_msat {
+            (amount_msat / 1000).saturating_add(lightning_fee_sats)
+        } else {
+            lightning_fee_sats
+        };
+        if total_u64 <= min_required {
             return Err(SdkError::InvalidInput(
-                "Amount too small to cover fees".to_string(),
+                "Token conversion amount too small to cover invoice amount and fees".to_string(),
             ));
         }
 

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -157,42 +157,20 @@ impl BreezSdk {
         let fee_policy = request.fee_policy.unwrap_or_default();
         let token_identifier = request.token_identifier.clone();
 
-        let is_send_all_with_conversion = match &self.stable_balance {
-            Some(sb) => {
-                sb.is_send_all_with_conversion(
-                    token_identifier.as_ref(),
-                    request.amount,
-                    request.conversion_options.as_ref(),
-                    fee_policy,
-                )
-                .await?
-            }
-            None => false,
-        };
-
         match &parsed_input {
             InputType::SparkAddress(spark_address_details) => {
                 let amount = request
                     .amount
                     .ok_or(SdkError::InvalidInput("Amount is required".to_string()))?;
 
-                let (amount, conversion_estimate) = if is_send_all_with_conversion {
-                    self.estimate_total_sats_with_conversion(
+                let (amount, conversion_estimate) = self
+                    .resolve_send_amount_with_conversion_estimate(
                         request.conversion_options.as_ref(),
-                        token_identifier.as_ref(),
+                        request.token_identifier.as_ref(),
                         amount,
+                        fee_policy,
                     )
-                    .await?
-                } else {
-                    let estimate = self
-                        .estimate_conversion(
-                            request.conversion_options.as_ref(),
-                            token_identifier.as_ref(),
-                            ConversionAmount::MinAmountOut(amount),
-                        )
-                        .await?;
-                    (amount, estimate)
-                };
+                    .await?;
 
                 Ok(PrepareSendPaymentResponse {
                     payment_method: SendPaymentMethod::SparkAddress {
@@ -216,23 +194,14 @@ impl BreezSdk {
                     .or(request.amount)
                     .ok_or(SdkError::InvalidInput("Amount is required".to_string()))?;
 
-                let (amount, conversion_estimate) = if is_send_all_with_conversion {
-                    self.estimate_total_sats_with_conversion(
+                let (amount, conversion_estimate) = self
+                    .resolve_send_amount_with_conversion_estimate(
                         request.conversion_options.as_ref(),
                         effective_token_identifier.as_ref(),
                         amount,
+                        fee_policy,
                     )
-                    .await?
-                } else {
-                    let estimate = self
-                        .estimate_conversion(
-                            request.conversion_options.as_ref(),
-                            effective_token_identifier.as_ref(),
-                            ConversionAmount::MinAmountOut(amount),
-                        )
-                        .await?;
-                    (amount, estimate)
-                };
+                    .await?;
 
                 Ok(PrepareSendPaymentResponse {
                     payment_method: SendPaymentMethod::SparkInvoice {
@@ -257,16 +226,17 @@ impl BreezSdk {
                     None
                 };
 
-                if is_send_all_with_conversion {
-                    return self
-                        .prepare_bolt11_send_all_with_conversion(
-                            &request,
-                            detailed_bolt11_invoice,
-                            spark_transfer_fee_sats,
-                            token_identifier,
-                            fee_policy,
-                        )
-                        .await;
+                if let Some(response) = self
+                    .maybe_prepare_bolt11_from_token_conversion(
+                        &request,
+                        detailed_bolt11_invoice,
+                        spark_transfer_fee_sats,
+                        token_identifier.as_ref(),
+                        fee_policy,
+                    )
+                    .await?
+                {
+                    return Ok(response);
                 }
 
                 let amount = request
@@ -320,15 +290,16 @@ impl BreezSdk {
                 })
             }
             InputType::BitcoinAddress(withdrawal_address) => {
-                if is_send_all_with_conversion {
-                    return self
-                        .prepare_bitcoin_send_all_with_conversion(
-                            &request,
-                            withdrawal_address,
-                            token_identifier,
-                            fee_policy,
-                        )
-                        .await;
+                if let Some(response) = self
+                    .maybe_prepare_bitcoin_from_token_conversion(
+                        &request,
+                        withdrawal_address,
+                        token_identifier.as_ref(),
+                        fee_policy,
+                    )
+                    .await?
+                {
+                    return Ok(response);
                 }
 
                 let amount = request
@@ -616,8 +587,13 @@ impl BreezSdk {
     /// Returns the conversion response, purpose (self-transfer vs ongoing payment),
     /// and whether this is a send-all-with-conversion.
     ///
-    /// For send-all-with-conversion, re-validates the token balance and uses `AmountIn`
-    /// to convert the full token amount. Otherwise, uses `MinAmountOut` with the payment amount.
+    /// Re-validates the token balance and chooses the conversion direction:
+    /// - `token_identifier` set → user specified a token amount; uses `AmountIn`
+    ///   from the prepared estimate (variable sat output).
+    /// - `token_identifier` not set → user specified a sat amount; uses
+    ///   `MinAmountOut(amount)`, which the per-payment-method paths expand to
+    ///   `MinAmountOut(amount + fees)` so the converter delivers enough to cover
+    ///   the send and its fees.
     #[allow(clippy::too_many_lines)]
     async fn execute_pre_send_conversion(
         &self,
@@ -627,40 +603,37 @@ impl BreezSdk {
         let amount = request.prepare_response.amount;
         let token_identifier = request.prepare_response.token_identifier.clone();
 
-        // Re-validate send-all at send time — balance may have changed since prepare.
-        let is_send_all = match &self.stable_balance {
-            Some(sb) => {
-                sb.is_send_all_with_conversion(
-                    token_identifier.as_ref(),
-                    request
-                        .prepare_response
-                        .conversion_estimate
-                        .as_ref()
-                        .map(|e| e.amount_in),
-                    Some(conversion_options),
-                    request.prepare_response.fee_policy,
-                )
-                .await?
-            }
-            None => false,
-        };
+        // Re-validate at send time — balance may have changed since prepare.
+        let (is_token_conversion, is_send_all) = self
+            .is_token_conversion(
+                Some(conversion_options),
+                token_identifier.as_ref(),
+                request
+                    .prepare_response
+                    .conversion_estimate
+                    .as_ref()
+                    .map(|e| e.amount_in),
+                request.prepare_response.fee_policy,
+            )
+            .await?;
 
-        let conversion_amount = if is_send_all {
+        // AmountIn vs MinAmountOut at convert time:
+        // - token_identifier set → user specified a token amount; use AmountIn
+        //   from the estimate (variable sat output, slippage-buffered at prepare
+        //   time).
+        // - token_identifier not set → user specified a sat amount; MinAmountOut
+        //   guarantees ≥ requested sats out (or the conversion fails). For
+        //   payment-method-specific paths (Bolt11, Bitcoin), `convert_token_for_*`
+        //   recomputes MinAmountOut(amount + fees) when no override is supplied.
+        let conversion_amount = if is_token_conversion && token_identifier.is_some() {
             let token_amount = request
                 .prepare_response
                 .conversion_estimate
                 .as_ref()
                 .map(|e| e.amount_in)
                 .ok_or(SdkError::InvalidInput(
-                    "Conversion estimate required for send-all with conversion".to_string(),
+                    "Conversion estimate required for token conversion".to_string(),
                 ))?;
-            tracing::trace!(
-                amount = amount,
-                token_amount = token_amount,
-                token_identifier = ?request.prepare_response.token_identifier,
-                fee_policy = ?request.prepare_response.fee_policy,
-                "[SEND-ALL] execute_pre_send_conversion: converting full token balance"
-            );
             ConversionAmount::AmountIn(token_amount)
         } else {
             ConversionAmount::MinAmountOut(amount)
@@ -842,7 +815,16 @@ impl BreezSdk {
             return Ok(SendPaymentResponse { payment });
         }
 
-        // For send-all, use actual sat balance post-conversion to handle slippage
+        // Determine the amount to use for the actual send.
+        // - Send-all: drain the wallet — use the full post-conversion sat balance.
+        // - Non-send-all with `token_identifier` set: user specified a token
+        //   amount → send the actual sats produced by *this* conversion. This
+        //   honors "convert N tokens and send the result" regardless of slippage.
+        // - Non-send-all without `token_identifier`: user specified a sat amount
+        //   (e.g. LNURL with `--from-token` and a sat amount). The conversion was
+        //   sized as MinAmountOut(invoice + fee), so the converted sats cover the
+        //   invoice plus fee with possible slippage slack. Don't override — send
+        //   exactly the requested invoice amount and let the slack cover fees.
         let amount_override = if is_send_all {
             let balance = self.spark_wallet.get_balance().await?;
             tracing::trace!(
@@ -852,7 +834,24 @@ impl BreezSdk {
                 "[SEND-ALL] complete_conversion_and_send: post-conversion balance as amount_override"
             );
             Some(balance)
+        } else if request.prepare_response.token_identifier.is_some() {
+            let converted_sats: u64 = payment
+                .amount
+                .try_into()
+                .map_err(|_| SdkError::Generic("Converted sats too large for u64".to_string()))?;
+            tracing::trace!(
+                converted_sats = converted_sats,
+                prepared_amount = request.prepare_response.amount,
+                fee_policy = ?request.prepare_response.fee_policy,
+                "complete_conversion_and_send: actual converted sats as amount_override (token-amount conversion)"
+            );
+            Some(converted_sats)
         } else {
+            tracing::trace!(
+                prepared_amount = request.prepare_response.amount,
+                fee_policy = ?request.prepare_response.fee_policy,
+                "complete_conversion_and_send: no override (sat-amount conversion, slack covers fee)"
+            );
             None
         };
 
@@ -1580,112 +1579,242 @@ impl BreezSdk {
         }
     }
 
-    /// Estimates the total sats available after converting the specified token amount.
-    ///
-    /// Converts the specified token amount to sats (using `AmountIn`), then adds
-    /// the existing sat balance to get the total available sats.
-    ///
-    /// Returns `(total_sats, conversion_estimate)`.
-    pub(super) async fn estimate_total_sats_with_conversion(
+    // Returns `(is_token_conversion, is_send_all)`.
+    pub(super) async fn is_token_conversion(
         &self,
         conversion_options: Option<&ConversionOptions>,
         token_identifier: Option<&String>,
-        token_amount: u128,
+        amount: Option<u128>,
+        fee_policy: FeePolicy,
+    ) -> Result<(bool, bool), SdkError> {
+        let (
+            Some(amount),
+            Some(ConversionOptions {
+                conversion_type:
+                    ConversionType::ToBitcoin {
+                        from_token_identifier,
+                    },
+                ..
+            }),
+        ) = (amount, conversion_options)
+        else {
+            return Ok((false, false));
+        };
+
+        // If the caller passed a token_identifier it must match conversion options.
+        // If they omitted it, we can't compare against the balance, so is_send_all=false.
+        let is_send_all = match token_identifier {
+            Some(token_id) => {
+                if token_id != from_token_identifier {
+                    return Err(SdkError::Generic(
+                        "Request token identifier must match conversion options".to_string(),
+                    ));
+                }
+                let token_balances = self.spark_wallet.get_token_balances().await?;
+                let token_balance = token_balances.get(token_id).map_or(0, |tb| tb.balance);
+                amount == token_balance && fee_policy == FeePolicy::FeesIncluded
+            }
+            None => false,
+        };
+
+        Ok((true, is_send_all))
+    }
+
+    /// Estimates the sats available for a send that may go through a token→BTC conversion.
+    ///
+    /// Branches on `token_identifier`:
+    /// - **Set** → `amount` is in token base units; uses `AmountIn(amount)` (variable
+    ///   sat output). For send-all, adds the existing sat balance to the conversion
+    ///   output.
+    /// - **Not set** → `amount` is already in sats; uses `MinAmountOut(amount)` so
+    ///   the converter is guaranteed to deliver at least `amount` sats or fail.
+    ///   `estimated_sats == amount` in this case.
+    ///
+    /// Returns `(estimated_sats, conversion_estimate)`. When the request is not a
+    /// token conversion, `estimated_sats == amount` and `conversion_estimate` is None,
+    /// so callers can use `conversion_estimate.is_some()` to detect the conversion path.
+    /// The returned `estimated_sats` is the *raw* expected conversion output — callers
+    /// that need a defensive lower bound (e.g. LNURL invoice sizing on the `AmountIn`
+    /// path) should apply their own slippage buffer.
+    pub(super) async fn estimate_sats_from_token_conversion(
+        &self,
+        conversion_options: Option<&ConversionOptions>,
+        token_identifier: Option<&String>,
+        amount: u128,
+        fee_policy: FeePolicy,
     ) -> Result<(u128, Option<ConversionEstimate>), SdkError> {
-        let conversion_estimate = self
+        let (is_token_conversion, is_send_all) = self
+            .is_token_conversion(
+                conversion_options,
+                token_identifier,
+                Some(amount),
+                fee_policy,
+            )
+            .await?;
+        if !is_token_conversion {
+            return Ok((amount, None));
+        }
+
+        // When token_identifier is provided, `amount` is in token units → AmountIn.
+        // When it's omitted, `amount` is in sats → MinAmountOut (we want at least
+        // that many sats out of the conversion).
+        let (conversion_amount, estimated_sats_from_conversion) = if token_identifier.is_some() {
+            let estimate = self
+                .estimate_conversion(
+                    conversion_options,
+                    token_identifier,
+                    ConversionAmount::AmountIn(amount),
+                )
+                .await?;
+            let sats = estimate.as_ref().map_or(0, |e| e.amount_out);
+            (estimate, sats)
+        } else {
+            let estimate = self
+                .estimate_conversion(
+                    conversion_options,
+                    token_identifier,
+                    ConversionAmount::MinAmountOut(amount),
+                )
+                .await?;
+            // For MinAmountOut, the requested sats is the amount we asked for.
+            (estimate, amount)
+        };
+
+        // For send-all, include existing sats balance — the actual send at execution
+        // time will use the full post-conversion balance.
+        let estimated_sats = if is_send_all {
+            let sat_balance = u128::from(self.spark_wallet.get_balance().await?);
+            estimated_sats_from_conversion.saturating_add(sat_balance)
+        } else {
+            estimated_sats_from_conversion
+        };
+
+        Ok((estimated_sats, conversion_amount))
+    }
+
+    /// Resolves the effective send amount and conversion estimate for a prepare flow
+    /// where the destination accepts sats directly (Spark address, Spark invoice).
+    ///
+    /// - **Token conversion** (`token_identifier` set + `ToBitcoin` options): substitutes
+    ///   `amount` with the post-conversion estimated sats, returns the `AmountIn` estimate.
+    /// - **Plain send with conversion options** (no `token_identifier`, sats `amount` +
+    ///   options): keeps `amount` as-is, attaches a `MinAmountOut` estimate for display.
+    /// - **Plain send (no options)**: passes through unchanged with `None` estimate.
+    async fn resolve_send_amount_with_conversion_estimate(
+        &self,
+        conversion_options: Option<&ConversionOptions>,
+        token_identifier: Option<&String>,
+        amount: u128,
+        fee_policy: FeePolicy,
+    ) -> Result<(u128, Option<ConversionEstimate>), SdkError> {
+        let (estimated_sats, conversion_estimate) = self
+            .estimate_sats_from_token_conversion(
+                conversion_options,
+                token_identifier,
+                amount,
+                fee_policy,
+            )
+            .await?;
+        if conversion_estimate.is_some() {
+            return Ok((estimated_sats, conversion_estimate));
+        }
+        let estimate = self
             .estimate_conversion(
                 conversion_options,
                 token_identifier,
-                ConversionAmount::AmountIn(token_amount),
+                ConversionAmount::MinAmountOut(amount),
             )
             .await?;
-
-        let estimated_sats_from_conversion =
-            conversion_estimate.as_ref().map_or(0, |e| e.amount_out);
-
-        let sat_balance = u128::from(self.spark_wallet.get_balance().await?);
-        let total_sats = estimated_sats_from_conversion.saturating_add(sat_balance);
-
-        Ok((total_sats, conversion_estimate))
+        Ok((amount, estimate))
     }
 
-    /// Prepares a Bolt11 invoice payment for send-all with token conversion.
+    /// Prepares a Bolt11 invoice payment for token-to-Bitcoin conversion (send-all
+    /// or non-send-all). Returns `Ok(None)` when the request is not a token conversion
+    /// so the caller can fall through to the regular bolt11 prepare path.
     ///
-    /// Estimates the conversion, fetches lightning fees based on total sats,
+    /// Estimates the conversion, fetches lightning fees based on the estimated sats,
     /// and validates the receiver amount covers fees.
-    async fn prepare_bolt11_send_all_with_conversion(
+    async fn maybe_prepare_bolt11_from_token_conversion(
         &self,
         request: &PrepareSendPaymentRequest,
         invoice: &Bolt11InvoiceDetails,
         spark_transfer_fee_sats: Option<u64>,
-        token_identifier: Option<String>,
+        token_identifier: Option<&String>,
         fee_policy: FeePolicy,
-    ) -> Result<PrepareSendPaymentResponse, SdkError> {
-        let token_amount = request
-            .amount
-            .ok_or(SdkError::InvalidInput("Amount is required".to_string()))?;
-
-        let (total_sats, conversion_estimate) = self
-            .estimate_total_sats_with_conversion(
+    ) -> Result<Option<PrepareSendPaymentResponse>, SdkError> {
+        let Some(token_amount) = request.amount else {
+            return Ok(None);
+        };
+        let (estimated_sats, conversion_estimate) = self
+            .estimate_sats_from_token_conversion(
                 request.conversion_options.as_ref(),
-                token_identifier.as_ref(),
+                token_identifier,
                 token_amount,
+                fee_policy,
             )
             .await?;
+        if conversion_estimate.is_none() {
+            return Ok(None);
+        }
 
         let lightning_fee_sats = self
             .spark_wallet
             .fetch_lightning_send_fee_estimate(
                 &request.payment_request,
-                Some(total_sats.try_into()?),
+                Some(estimated_sats.try_into()?),
             )
             .await?;
 
-        let total_u64: u64 = total_sats.try_into()?;
+        let total_u64: u64 = estimated_sats.try_into()?;
         if total_u64 <= lightning_fee_sats {
             return Err(SdkError::InvalidInput(
                 "Amount too small to cover fees".to_string(),
             ));
         }
 
-        Ok(PrepareSendPaymentResponse {
+        Ok(Some(PrepareSendPaymentResponse {
             payment_method: SendPaymentMethod::Bolt11Invoice {
                 invoice_details: invoice.clone(),
                 spark_transfer_fee_sats,
                 lightning_fee_sats,
             },
-            amount: total_sats,
-            token_identifier,
+            amount: estimated_sats,
+            token_identifier: token_identifier.cloned(),
             conversion_estimate,
             fee_policy,
-        })
+        }))
     }
 
-    /// Prepares a Bitcoin address payment for send-all with token conversion.
+    /// Prepares a Bitcoin address payment for token-to-Bitcoin conversion (send-all
+    /// or non-send-all). Returns `Ok(None)` when the request is not a token conversion
+    /// so the caller can fall through to the regular bitcoin address prepare path.
     ///
-    /// Estimates the conversion, fetches onchain fee quote based on total sats,
-    /// and validates the output after fees meets the dust limit.
-    async fn prepare_bitcoin_send_all_with_conversion(
+    /// Estimates the conversion, fetches onchain fee quote based on the estimated
+    /// sats, and validates the output after fees meets the dust limit.
+    async fn maybe_prepare_bitcoin_from_token_conversion(
         &self,
         request: &PrepareSendPaymentRequest,
         withdrawal_address: &BitcoinAddressDetails,
-        token_identifier: Option<String>,
+        token_identifier: Option<&String>,
         fee_policy: FeePolicy,
-    ) -> Result<PrepareSendPaymentResponse, SdkError> {
-        let token_amount = request
-            .amount
-            .ok_or(SdkError::InvalidInput("Amount is required".to_string()))?;
-
-        let (total_sats, conversion_estimate) = self
-            .estimate_total_sats_with_conversion(
+    ) -> Result<Option<PrepareSendPaymentResponse>, SdkError> {
+        let Some(token_amount) = request.amount else {
+            return Ok(None);
+        };
+        let (estimated_sats, conversion_estimate) = self
+            .estimate_sats_from_token_conversion(
                 request.conversion_options.as_ref(),
-                token_identifier.as_ref(),
+                token_identifier,
                 token_amount,
+                fee_policy,
             )
             .await?;
+        if conversion_estimate.is_none() {
+            return Ok(None);
+        }
 
         let dust_limit_sats = get_dust_limit_sats(&withdrawal_address.address)?;
-        let total_u64: u64 = total_sats.try_into()?;
+        let total_u64: u64 = estimated_sats.try_into()?;
         if total_u64 < dust_limit_sats {
             return Err(SdkError::InvalidInput(format!(
                 "Amount is below the minimum of {dust_limit_sats} sats required for this address"
@@ -1708,16 +1837,16 @@ impl BreezSdk {
             )));
         }
 
-        Ok(PrepareSendPaymentResponse {
+        Ok(Some(PrepareSendPaymentResponse {
             payment_method: SendPaymentMethod::BitcoinAddress {
                 address: withdrawal_address.clone(),
                 fee_quote,
             },
-            amount: total_sats,
-            token_identifier,
+            amount: estimated_sats,
+            token_identifier: token_identifier.cloned(),
             conversion_estimate,
             fee_policy,
-        })
+        }))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -561,6 +561,7 @@ impl BreezSdk {
             Box::pin(self.convert_token_send_payment_internal(
                 conversion_options,
                 &request,
+                amount_override,
                 &mut suppress_payment_event,
             ))
             .await
@@ -586,6 +587,7 @@ impl BreezSdk {
         &self,
         conversion_options: &ConversionOptions,
         request: &SendPaymentRequest,
+        caller_amount_override: Option<u64>,
         suppress_payment_event: &mut bool,
     ) -> Result<SendPaymentResponse, SdkError> {
         // Suppress auto-convert while this send-with-conversion is in flight
@@ -595,7 +597,7 @@ impl BreezSdk {
         };
 
         // Step 1: Execute the token conversion
-        let (conversion_response, conversion_purpose, is_send_all, uses_amount_in) = self
+        let (conversion_response, conversion_purpose, uses_amount_in) = self
             .execute_pre_send_conversion(conversion_options, request)
             .await?;
 
@@ -609,8 +611,8 @@ impl BreezSdk {
             &conversion_response,
             &conversion_purpose,
             request,
-            is_send_all,
             uses_amount_in,
+            caller_amount_override,
             suppress_payment_event,
         )
         .await
@@ -620,26 +622,22 @@ impl BreezSdk {
     /// Executes the token conversion for the given payment method.
     ///
     /// Returns the conversion response, purpose (self-transfer vs ongoing payment),
-    /// and whether this is a send-all-with-conversion.
+    /// and whether the conversion used `AmountIn` (needed by `complete_conversion_and_send`
+    /// to compute the amount override).
     ///
-    /// Re-evaluates whether this is still a send-all based on the current token
-    /// balance (which may have changed since prepare) and chooses the conversion direction:
-    /// - `ToBitcoin` conversion → uses `AmountIn` from the conversion estimate
-    ///   (variable sat output).
-    /// - Other conversions → uses `MinAmountOut(amount)`, which the per-payment-method
-    ///   paths expand to `MinAmountOut(amount + fees)` so the converter delivers enough
-    ///   to cover the send and its fees.
+    /// Chooses the conversion direction based on whether the prepare used `AmountIn`
+    /// (user specified token amount, `amount == estimate.amount_out`) or `MinAmountOut`
+    /// (user specified sats). For `MinAmountOut`, the per-payment-method paths expand to
+    /// `MinAmountOut(amount + fees)` so the converter delivers enough to cover the send.
     #[allow(clippy::too_many_lines)]
     async fn execute_pre_send_conversion(
         &self,
         conversion_options: &ConversionOptions,
         request: &SendPaymentRequest,
-    ) -> Result<(TokenConversionResponse, ConversionPurpose, bool, bool), SdkError> {
+    ) -> Result<(TokenConversionResponse, ConversionPurpose, bool), SdkError> {
         let amount = request.prepare_response.amount;
 
         // Extract from_token_identifier from conversion options for ToBitcoin conversions.
-        // This replaces the previous reliance on prepare_response.token_identifier,
-        // which is now None for ToBitcoin (reflects output denomination).
         let from_token_identifier = match &conversion_options.conversion_type {
             ConversionType::ToBitcoin {
                 from_token_identifier,
@@ -647,33 +645,19 @@ impl BreezSdk {
             ConversionType::FromBitcoin => None,
         };
 
-        // Re-evaluate send-all at send time — if the token balance changed since
-        // prepare, is_send_all may become false (existing sats won't be swept).
-        let (is_token_conversion, is_send_all) = self
-            .is_token_conversion(
-                Some(conversion_options),
-                from_token_identifier.as_ref(),
-                request
-                    .prepare_response
-                    .conversion_estimate
-                    .as_ref()
-                    .map(|e| e.amount_in),
-                request.prepare_response.fee_policy,
-            )
-            .await?;
-
         // AmountIn vs MinAmountOut at convert time:
-        // Determine whether the prepare used AmountIn (user specified token amount,
-        // variable sat output) or MinAmountOut (user specified sats, guaranteed output).
-        // When AmountIn was used, the prepare's `amount` equals the estimate's
-        // `amount_out` (estimated sats). When MinAmountOut was used, `amount` is the
-        // user's requested sats and won't match `amount_out`.
-        let was_amount_in = request
+        // For AmountIn (user specified token amount), the prepare's `amount` is
+        // derived from `estimate.amount_out` (+ optional sat balance), so
+        // `amount >= estimate.amount_out`.
+        // For MinAmountOut (user specified sats), the converter guarantees
+        // `estimate.amount_out >= amount`, so `amount <= estimate.amount_out`
+        // (strictly less when there's conversion slack).
+        let uses_amount_in = request
             .prepare_response
             .conversion_estimate
             .as_ref()
-            .is_some_and(|e| e.amount_out == amount);
-        let conversion_amount = if is_token_conversion && was_amount_in {
+            .is_some_and(|e| amount >= e.amount_out);
+        let conversion_amount = if uses_amount_in {
             let token_amount = request
                 .prepare_response
                 .conversion_estimate
@@ -686,7 +670,6 @@ impl BreezSdk {
         } else {
             ConversionAmount::MinAmountOut(amount)
         };
-        let uses_amount_in = matches!(conversion_amount, ConversionAmount::AmountIn(_));
 
         match &request.prepare_response.payment_method {
             SendPaymentMethod::SparkAddress { address, .. } => {
@@ -712,7 +695,7 @@ impl BreezSdk {
                         None,
                     )
                     .await?;
-                Ok((response, purpose, is_send_all, uses_amount_in))
+                Ok((response, purpose, uses_amount_in))
             }
             SendPaymentMethod::SparkInvoice {
                 spark_invoice_details:
@@ -742,7 +725,7 @@ impl BreezSdk {
                         None,
                     )
                     .await?;
-                Ok((response, purpose, is_send_all, uses_amount_in))
+                Ok((response, purpose, uses_amount_in))
             }
             SendPaymentMethod::Bolt11Invoice {
                 spark_transfer_fee_sats,
@@ -769,7 +752,7 @@ impl BreezSdk {
                         conversion_amount_override,
                     )
                     .await?;
-                Ok((response, purpose, is_send_all, uses_amount_in))
+                Ok((response, purpose, uses_amount_in))
             }
             SendPaymentMethod::BitcoinAddress { address, fee_quote } => {
                 let purpose = ConversionPurpose::OngoingPayment {
@@ -790,7 +773,7 @@ impl BreezSdk {
                         conversion_amount_override,
                     )
                     .await?;
-                Ok((response, purpose, is_send_all, uses_amount_in))
+                Ok((response, purpose, uses_amount_in))
             }
         }
     }
@@ -822,17 +805,20 @@ impl BreezSdk {
     ///
     /// For self-transfers, returns immediately after conversion completes.
     /// For ongoing payments, sends the actual payment and links any remaining children.
-    /// For send-all, queries the actual sat balance post-conversion and uses it as the
-    /// send amount (with `FeesIncluded` to deduct fees).
-    #[allow(clippy::too_many_arguments)]
+    /// For `AmountIn` conversions, computes `amount_override = converted_sats + sats_change`
+    /// where `sats_change` is the difference between the prepare amount and the estimated
+    /// conversion output (representing any existing sat balance included at prepare time).
+    /// If `caller_amount_override` is provided (e.g. from the LNURL flow which handles
+    /// its own fee logic), it takes precedence over the computed override.
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     async fn complete_conversion_and_send(
         &self,
         conversion_options: &ConversionOptions,
         conversion_response: &TokenConversionResponse,
         conversion_purpose: &ConversionPurpose,
         request: &SendPaymentRequest,
-        is_send_all: bool,
         uses_amount_in: bool,
+        caller_amount_override: Option<u64>,
         suppress_payment_event: &mut bool,
     ) -> Result<SendPaymentResponse, SdkError> {
         // Trigger a wallet state sync if converting from Bitcoin to token
@@ -867,40 +853,59 @@ impl BreezSdk {
         }
 
         // Determine the amount to use for the actual send.
-        // - Send-all: drain the wallet — use the full post-conversion sat balance.
-        // - Non-send-all ToBitcoin: user specified a token amount → send the actual
-        //   sats produced by *this* conversion. This honors "convert N tokens and
-        //   send the result" regardless of slippage.
-        // - Other conversions (e.g. FromBitcoin, or sat-specified ToBitcoin via
-        //   stable balance): the conversion was sized as MinAmountOut(amount + fees),
-        //   so the converted output covers the send. Don't override — send exactly
-        //   the requested amount and let the slack cover fees.
-        let amount_override = if is_send_all {
-            let balance = self.spark_wallet.get_balance().await?;
+        //
+        // If the caller provided an amount_override (e.g. LNURL flow with its own
+        // fee logic), use it directly.
+        //
+        // For AmountIn conversions (user specified token amount), the prepare's
+        // `amount` includes estimated conversion output + any existing sat balance
+        // (sats_change). At send time, use the actual converted sats + sats_change
+        // to honor the prepare estimate while accounting for slippage.
+        // This unifies send-all (sats_change > 0) and non-send-all (sats_change = 0).
+        //
+        // For MinAmountOut conversions (user specified sats, e.g. auto stable
+        // balance), the conversion guarantees ≥ requested sats, so no override is
+        // needed — send exactly the prepared amount.
+        let amount_override = if let Some(override_amount) = caller_amount_override {
             tracing::trace!(
-                sat_balance_post_conversion = balance,
-                request_amount = request.prepare_response.amount,
-                fee_policy = ?request.prepare_response.fee_policy,
-                "[SEND-ALL] complete_conversion_and_send: post-conversion balance as amount_override"
+                override_amount,
+                "complete_conversion_and_send: using caller-provided amount_override"
             );
-            Some(balance)
+            Some(override_amount)
         } else if uses_amount_in {
             let converted_sats: u64 = payment
                 .amount
                 .try_into()
                 .map_err(|_| SdkError::Generic("Converted sats too large for u64".to_string()))?;
+            let estimated_conversion_out: u64 = request
+                .prepare_response
+                .conversion_estimate
+                .as_ref()
+                .map_or(0, |e| e.amount_out)
+                .try_into()
+                .map_err(|_| SdkError::Generic("Estimated sats too large for u64".to_string()))?;
+            let sats_change = request
+                .prepare_response
+                .amount
+                .try_into()
+                .map(|amount: u64| amount.saturating_sub(estimated_conversion_out))
+                .unwrap_or(0);
+            let total = converted_sats.saturating_add(sats_change);
             tracing::trace!(
-                converted_sats = converted_sats,
+                converted_sats,
+                estimated_conversion_out,
+                sats_change,
+                total,
                 prepared_amount = request.prepare_response.amount,
                 fee_policy = ?request.prepare_response.fee_policy,
-                "complete_conversion_and_send: actual converted sats as amount_override (token-amount conversion)"
+                "complete_conversion_and_send: amount_override = converted_sats + sats_change"
             );
-            Some(converted_sats)
+            Some(total)
         } else {
             tracing::trace!(
                 prepared_amount = request.prepare_response.amount,
                 fee_policy = ?request.prepare_response.fee_policy,
-                "complete_conversion_and_send: no override (sat-amount conversion, slack covers fee)"
+                "complete_conversion_and_send: no override (MinAmountOut conversion)"
             );
             None
         };

--- a/crates/breez-sdk/core/src/stable_balance/conversions.rs
+++ b/crates/breez-sdk/core/src/stable_balance/conversions.rs
@@ -379,13 +379,13 @@ impl StableBalance {
         };
 
         // Would create token dust if projected balance is still below min conversion limit
-        let estimated_total = existing_tokens.saturating_add(est.amount);
+        let estimated_total = existing_tokens.saturating_add(est.amount_out);
         if estimated_total < to_btc_min {
             debug!(
                 "Auto-conversion skipped: {balance_sats} sats would produce \
                  {} tokens, total {estimated_total} still below ToBitcoin min {to_btc_min} \
                  (existing tokens: {existing_tokens})",
-                est.amount,
+                est.amount_out,
             );
             return true;
         }

--- a/crates/breez-sdk/core/src/stable_balance/mod.rs
+++ b/crates/breez-sdk/core/src/stable_balance/mod.rs
@@ -145,7 +145,8 @@ pub(crate) use self::queue::PendingConversion;
 
 use crate::events::{EventEmitter, EventMiddleware, SdkEvent};
 use crate::models::{
-    ConversionDetails, ConversionStatus, Payment, PaymentMethod, PaymentType, StableBalanceToken,
+    ConversionDetails, ConversionStatus, FeePolicy, Payment, PaymentMethod, PaymentType,
+    StableBalanceToken,
 };
 use crate::persist::{ObjectCacheRepository, PaymentMetadata, Storage};
 use crate::{
@@ -308,6 +309,60 @@ impl StableBalance {
             .await
             .as_ref()
             .map(|t| t.label.clone())
+    }
+
+    /// Checks whether the given request parameters constitute a send-all-with-conversion.
+    ///
+    /// Returns `true` when:
+    /// - Fee policy is `FeesIncluded`
+    /// - The active token matches the request's `token_identifier` and `from_token_identifier`
+    /// - The amount equals the full token balance
+    ///
+    /// Returns an error if the amount doesn't match the full token balance (partial send
+    /// masquerading as send-all).
+    pub(crate) async fn is_send_all_with_conversion(
+        &self,
+        token_identifier: Option<&String>,
+        amount: Option<u128>,
+        conversion_options: Option<&ConversionOptions>,
+        fee_policy: FeePolicy,
+    ) -> Result<bool, SdkError> {
+        if fee_policy != FeePolicy::FeesIncluded {
+            return Ok(false);
+        }
+
+        let (
+            Some(token_id),
+            Some(amount),
+            Some(ConversionOptions {
+                conversion_type:
+                    ConversionType::ToBitcoin {
+                        from_token_identifier,
+                    },
+                ..
+            }),
+        ) = (token_identifier, amount, conversion_options)
+        else {
+            return Ok(false);
+        };
+
+        let active_token_id = self.get_active_token_identifier().await;
+        if active_token_id.as_ref() != Some(token_id) || token_id != from_token_identifier {
+            return Ok(false);
+        }
+
+        let token_balances = self.spark_wallet.get_token_balances().await?;
+        let token_balance = token_balances
+            .get(from_token_identifier)
+            .map_or(0, |tb| tb.balance);
+
+        if amount != token_balance {
+            return Err(SdkError::InvalidInput(format!(
+                "Send-all amount ({amount}) must equal the full token balance ({token_balance})"
+            )));
+        }
+
+        Ok(true)
     }
 
     /// Acquires a payment guard that suppresses auto-convert while held.

--- a/crates/breez-sdk/core/src/stable_balance/mod.rs
+++ b/crates/breez-sdk/core/src/stable_balance/mod.rs
@@ -145,8 +145,7 @@ pub(crate) use self::queue::PendingConversion;
 
 use crate::events::{EventEmitter, EventMiddleware, SdkEvent};
 use crate::models::{
-    ConversionDetails, ConversionStatus, FeePolicy, Payment, PaymentMethod, PaymentType,
-    StableBalanceToken,
+    ConversionDetails, ConversionStatus, Payment, PaymentMethod, PaymentType, StableBalanceToken,
 };
 use crate::persist::{ObjectCacheRepository, PaymentMetadata, Storage};
 use crate::{
@@ -309,60 +308,6 @@ impl StableBalance {
             .await
             .as_ref()
             .map(|t| t.label.clone())
-    }
-
-    /// Checks whether the given request parameters constitute a send-all-with-conversion.
-    ///
-    /// Returns `true` when:
-    /// - Fee policy is `FeesIncluded`
-    /// - The active token matches the request's `token_identifier` and `from_token_identifier`
-    /// - The amount equals the full token balance
-    ///
-    /// Returns an error if the amount doesn't match the full token balance (partial send
-    /// masquerading as send-all).
-    pub(crate) async fn is_send_all_with_conversion(
-        &self,
-        token_identifier: Option<&String>,
-        amount: Option<u128>,
-        conversion_options: Option<&ConversionOptions>,
-        fee_policy: FeePolicy,
-    ) -> Result<bool, SdkError> {
-        if fee_policy != FeePolicy::FeesIncluded {
-            return Ok(false);
-        }
-
-        let (
-            Some(token_id),
-            Some(amount),
-            Some(ConversionOptions {
-                conversion_type:
-                    ConversionType::ToBitcoin {
-                        from_token_identifier,
-                    },
-                ..
-            }),
-        ) = (token_identifier, amount, conversion_options)
-        else {
-            return Ok(false);
-        };
-
-        let active_token_id = self.get_active_token_identifier().await;
-        if active_token_id.as_ref() != Some(token_id) || token_id != from_token_identifier {
-            return Ok(false);
-        }
-
-        let token_balances = self.spark_wallet.get_token_balances().await?;
-        let token_balance = token_balances
-            .get(from_token_identifier)
-            .map_or(0, |tb| tb.balance);
-
-        if amount != token_balance {
-            return Err(SdkError::InvalidInput(format!(
-                "Send-all amount ({amount}) must equal the full token balance ({token_balance})"
-            )));
-        }
-
-        Ok(true)
     }
 
     /// Acquires a payment guard that suppresses auto-convert while held.

--- a/crates/breez-sdk/core/src/token_conversion/flashnet.rs
+++ b/crates/breez-sdk/core/src/token_conversion/flashnet.rs
@@ -380,7 +380,8 @@ impl FlashnetTokenConverter {
 
         Ok(ConversionEstimate {
             options: conversion_options.clone(),
-            amount: amount_in,
+            amount_in,
+            amount_out: response.amount_out,
             fee: response.fee_paid_asset_in.unwrap_or(0),
             amount_adjustment,
         })
@@ -637,14 +638,18 @@ impl FlashnetTokenConverter {
                 "No conversion estimate available".to_string(),
             ))?;
 
-        match amount {
-            ConversionAmount::MinAmountOut(min_out) => {
-                Ok((estimate.amount, *min_out, estimate.amount_adjustment))
-            }
-            ConversionAmount::AmountIn(amount_in) => {
-                Ok((*amount_in, estimate.amount, estimate.amount_adjustment))
-            }
-        }
+        // For MinAmountOut, use the original requested minimum as min_amount_out
+        // (not the simulated output, which may be higher and cause unnecessary failures).
+        // For AmountIn, use the slippage-adjusted estimated output.
+        let min_amount_out = match amount {
+            ConversionAmount::MinAmountOut(min_out) => *min_out,
+            ConversionAmount::AmountIn(_) => estimate.amount_out,
+        };
+        Ok((
+            estimate.amount_in,
+            min_amount_out,
+            estimate.amount_adjustment,
+        ))
     }
 }
 
@@ -817,7 +822,8 @@ impl TokenConverter for FlashnetTokenConverter {
 
                 Ok(Some(ConversionEstimate {
                     options: options.clone(),
-                    amount: estimated_out,
+                    amount_in,
+                    amount_out: estimated_out,
                     fee: response.fee_paid_asset_in.unwrap_or(0),
                     amount_adjustment: None,
                 }))

--- a/crates/breez-sdk/core/src/token_conversion/mod.rs
+++ b/crates/breez-sdk/core/src/token_conversion/mod.rs
@@ -46,8 +46,7 @@ pub(crate) trait TokenConverter: Send + Sync {
     ///
     /// # Returns
     /// The estimated conversion including amount and fee, or None if options is None.
-    /// For `MinAmountOut`: `estimate.amount` is the required input amount.
-    /// For `AmountIn`: `estimate.amount` is the estimated output amount (slippage-adjusted).
+    /// `estimate.amount_in` is the input amount, `estimate.amount_out` is the estimated output.
     async fn validate(
         &self,
         options: Option<&ConversionOptions>,

--- a/crates/breez-sdk/core/src/token_conversion/models.rs
+++ b/crates/breez-sdk/core/src/token_conversion/models.rs
@@ -32,10 +32,15 @@ pub(crate) enum FeeSplit {
 pub struct ConversionEstimate {
     /// The conversion options used for the estimate
     pub options: ConversionOptions,
-    /// The estimated amount to be received from the conversion
-    /// Denominated in satoshis if converting from Bitcoin, otherwise in the token base units.
-    pub amount: u128,
-    /// The fee estimated for the conversion
+    /// The input amount for the conversion.
+    /// For `FromBitcoin`: the satoshis required to produce the desired token output.
+    /// For `ToBitcoin`: the token amount being converted.
+    pub amount_in: u128,
+    /// The estimated output amount from the conversion.
+    /// For `FromBitcoin`: the estimated token amount received.
+    /// For `ToBitcoin`: the estimated satoshis received.
+    pub amount_out: u128,
+    /// The fee estimated for the conversion.
     /// Denominated in satoshis if converting from Bitcoin, otherwise in the token base units.
     pub fee: u128,
     /// The reason the conversion amount was adjusted, if applicable.

--- a/crates/breez-sdk/core/src/utils/send_payment_validation.rs
+++ b/crates/breez-sdk/core/src/utils/send_payment_validation.rs
@@ -27,10 +27,20 @@ pub(crate) fn validate_prepare_send_payment_request(
     // Validate amount is > 0 if provided
     validate_amount(request.amount)?;
 
-    // Validate FeesIncluded is not combined with token conversion
-    if request.fee_policy == Some(FeePolicy::FeesIncluded) && request.conversion_options.is_some() {
+    // Validate FeesIncluded is not combined with FromBitcoin conversion.
+    // FeesIncluded + ToBitcoin is allowed (send-all-with-conversion from stable balance).
+    if request.fee_policy == Some(FeePolicy::FeesIncluded)
+        && request.conversion_options.is_some()
+        && !matches!(
+            &request.conversion_options,
+            Some(ConversionOptions {
+                conversion_type: ConversionType::ToBitcoin { .. },
+                ..
+            })
+        )
+    {
         return Err(SdkError::InvalidInput(
-            "FeesIncluded cannot be combined with token conversion".to_string(),
+            "FeesIncluded cannot be combined with FromBitcoin conversion".to_string(),
         ));
     }
 
@@ -166,23 +176,18 @@ fn validate_spark_address_request(request: &PrepareSendPaymentRequest) -> Result
     // Check if token identifier is provided
     let has_token_identifier = request.token_identifier.is_some();
 
-    // Validate conversion depending on whether token identifier is provided
-    if let Some(conversion_options) = &request.conversion_options {
-        match (has_token_identifier, &conversion_options.conversion_type) {
-            (true, ConversionType::ToBitcoin { .. }) => {
-                return Err(SdkError::InvalidInput(
-                    "Conversion must be from Bitcoin when a token identifier is provided"
-                        .to_string(),
-                ));
-            }
-            (false, ConversionType::FromBitcoin) => {
-                return Err(SdkError::InvalidInput(
-                    "Conversion must be to Bitcoin when no token identifier is provided"
-                        .to_string(),
-                ));
-            }
-            _ => {}
-        }
+    // Validate conversion depending on whether token identifier is provided.
+    // token_identifier + ToBitcoin is allowed (send-all-with-conversion from stable balance).
+    if let Some(conversion_options) = &request.conversion_options
+        && !has_token_identifier
+        && matches!(
+            conversion_options.conversion_type,
+            ConversionType::FromBitcoin
+        )
+    {
+        return Err(SdkError::InvalidInput(
+            "Conversion must be to Bitcoin when no token identifier is provided".to_string(),
+        ));
     }
 
     // Token identifier is optional for spark addresses
@@ -202,8 +207,17 @@ fn validate_bolt11_invoice_request(
         ));
     }
 
-    // Token identifier cannot be provided for Bolt11 invoices
-    if request.token_identifier.is_some() {
+    // Token identifier cannot be provided for Bolt11 invoices unless ToBitcoin conversion
+    // is present (send-all-with-conversion from stable balance).
+    if request.token_identifier.is_some()
+        && !matches!(
+            &request.conversion_options,
+            Some(ConversionOptions {
+                conversion_type: ConversionType::ToBitcoin { .. },
+                ..
+            })
+        )
+    {
         return Err(SdkError::InvalidInput(
             "Token identifier can't be provided for this payment request: non-spark address"
                 .to_string(),
@@ -227,8 +241,17 @@ fn validate_bolt11_invoice_request(
 
 /// Validates a Bitcoin address request.
 fn validate_bitcoin_address_request(request: &PrepareSendPaymentRequest) -> Result<(), SdkError> {
-    // Token identifier cannot be provided for Bitcoin addresses
-    if request.token_identifier.is_some() {
+    // Token identifier cannot be provided for Bitcoin addresses unless ToBitcoin conversion
+    // is present (send-all-with-conversion from stable balance).
+    if request.token_identifier.is_some()
+        && !matches!(
+            &request.conversion_options,
+            Some(ConversionOptions {
+                conversion_type: ConversionType::ToBitcoin { .. },
+                ..
+            })
+        )
+    {
         return Err(SdkError::InvalidInput(
             "Token identifier can't be provided for this payment request: non-spark address"
                 .to_string(),
@@ -841,6 +864,23 @@ mod tests {
 
     #[test_all]
     fn test_validate_token_spark_address_with_invalid_conversion() {
+        // FromBitcoin without token_identifier is invalid
+        let mut request = create_test_request();
+        request.amount = Some(1000);
+        request.conversion_options = Some(ConversionOptions {
+            conversion_type: ConversionType::FromBitcoin,
+            max_slippage_bps: None,
+            completion_timeout_secs: None,
+        });
+        let result = validate_spark_address_request(&request);
+        assert!(
+            result.is_err(),
+            "Should fail when FromBitcoin conversion is provided without token identifier"
+        );
+    }
+
+    #[test_all]
+    fn test_validate_token_spark_address_with_to_bitcoin_conversion_succeeds() {
         let mut request = create_token_amount_request(1000, "token123");
         request.conversion_options = Some(ConversionOptions {
             conversion_type: ConversionType::ToBitcoin {
@@ -851,8 +891,8 @@ mod tests {
         });
         let result = validate_spark_address_request(&request);
         assert!(
-            result.is_err(),
-            "Should fail when conversion to Bitcoin is provided"
+            result.is_ok(),
+            "Should succeed when ToBitcoin conversion is provided for token spark address"
         );
     }
 
@@ -1168,7 +1208,7 @@ mod tests {
     }
 
     #[test_all]
-    fn test_validate_fees_included_with_token_conversion_fails() {
+    fn test_validate_fees_included_with_from_bitcoin_conversion_fails() {
         use crate::PaymentRequestSource;
         let address_details = BitcoinAddressDetails {
             address: "bc1...".to_string(),
@@ -1177,6 +1217,40 @@ mod tests {
         };
 
         let mut request = create_fees_included_request(1000);
+        request.conversion_options = Some(ConversionOptions {
+            conversion_type: ConversionType::FromBitcoin,
+            max_slippage_bps: None,
+            completion_timeout_secs: None,
+        });
+
+        let input_type = InputType::BitcoinAddress(address_details);
+        let identity_key = "test_identity".to_string();
+        let result = validate_prepare_send_payment_request(&input_type, &request, &identity_key);
+        assert!(
+            result.is_err(),
+            "Should fail for FeesIncluded with FromBitcoin conversion"
+        );
+        if let Err(SdkError::InvalidInput(msg)) = result {
+            assert!(
+                msg.contains("FeesIncluded cannot be combined with FromBitcoin conversion"),
+                "Error message should mention FeesIncluded and FromBitcoin conversion"
+            );
+        } else {
+            panic!("Expected InvalidInput error");
+        }
+    }
+
+    #[test_all]
+    fn test_validate_fees_included_with_to_bitcoin_conversion_succeeds() {
+        use crate::PaymentRequestSource;
+        let address_details = BitcoinAddressDetails {
+            address: "bc1...".to_string(),
+            network: BitcoinNetwork::Regtest,
+            source: PaymentRequestSource::default(),
+        };
+
+        let mut request = create_fees_included_request(1000);
+        request.token_identifier = Some("token123".to_string());
         request.conversion_options = Some(ConversionOptions {
             conversion_type: ConversionType::ToBitcoin {
                 from_token_identifier: "token123".to_string(),
@@ -1189,17 +1263,9 @@ mod tests {
         let identity_key = "test_identity".to_string();
         let result = validate_prepare_send_payment_request(&input_type, &request, &identity_key);
         assert!(
-            result.is_err(),
-            "Should fail for FeesIncluded with token conversion"
+            result.is_ok(),
+            "Should succeed for FeesIncluded with ToBitcoin conversion (send-all-with-conversion)"
         );
-        if let Err(SdkError::InvalidInput(msg)) = result {
-            assert!(
-                msg.contains("FeesIncluded cannot be combined with token conversion"),
-                "Error message should mention FeesIncluded and token conversion"
-            );
-        } else {
-            panic!("Expected InvalidInput error");
-        }
     }
 
     // Dust limit tests

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -840,10 +840,11 @@ pub enum FeePolicy {
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::PrepareLnurlPayRequest)]
 pub struct PrepareLnurlPayRequest {
-    pub amount_sats: u64,
+    pub amount: u128,
     pub comment: Option<String>,
     pub pay_request: LnurlPayRequestDetails,
     pub validate_success_action_url: Option<bool>,
+    pub token_identifier: Option<String>,
     pub conversion_options: Option<ConversionOptions>,
     pub fee_policy: Option<FeePolicy>,
 }
@@ -857,6 +858,7 @@ pub struct PrepareLnurlPayResponse {
     pub invoice_details: Bolt11InvoiceDetails,
     pub success_action: Option<SuccessAction>,
     pub conversion_estimate: Option<ConversionEstimate>,
+    pub token_identifier: Option<String>,
     pub fee_policy: FeePolicy,
 }
 
@@ -1280,7 +1282,8 @@ pub struct OptimizationProgress {
 #[macros::extern_wasm_bindgen(breez_sdk_spark::ConversionEstimate)]
 pub struct ConversionEstimate {
     pub options: ConversionOptions,
-    pub amount: u128,
+    pub amount_in: u128,
+    pub amount_out: u128,
     pub fee: u128,
     pub amount_adjustment: Option<AmountAdjustmentReason>,
 }

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -858,7 +858,6 @@ pub struct PrepareLnurlPayResponse {
     pub invoice_details: Bolt11InvoiceDetails,
     pub success_action: Option<SuccessAction>,
     pub conversion_estimate: Option<ConversionEstimate>,
-    pub token_identifier: Option<String>,
     pub fee_policy: FeePolicy,
 }
 

--- a/docs/breez-sdk/snippets/csharp/LnurlPay.cs
+++ b/docs/breez-sdk/snippets/csharp/LnurlPay.cs
@@ -21,35 +21,19 @@ namespace BreezSdkSnippets
                 var optionalComment = "<comment>";
                 var payRequest = details.payRequest;
                 var optionalValidateSuccessActionUrl = true;
-                // Optionally set to use token funds to pay via token conversion
-                var optionalMaxSlippageBps = 50U;
-                var optionalCompletionTimeoutSecs = 30U;
-                var optionalConversionOptions = new ConversionOptions(
-                    conversionType: new ConversionType.ToBitcoin(
-                        fromTokenIdentifier: "<token identifier>"
-                    ),
-                    maxSlippageBps: optionalMaxSlippageBps,
-                    completionTimeoutSecs: optionalCompletionTimeoutSecs
-                );
 
                 var request = new PrepareLnurlPayRequest(
-                    amountSats: amountSats,
+                    amount: amountSats,
                     payRequest: payRequest,
                     comment: optionalComment,
                     validateSuccessActionUrl: optionalValidateSuccessActionUrl,
-                    conversionOptions: optionalConversionOptions,
+                    tokenIdentifier: null,
+                    conversionOptions: null,
                     feePolicy: null
                 );
                 var prepareResponse = await sdk.PrepareLnurlPay(request: request);
 
                 // If the fees are acceptable, continue to create the LNURL Pay
-                if (prepareResponse.conversionEstimate != null)
-                {
-                    Console.WriteLine("Estimated conversion amount: " +
-                        $"{prepareResponse.conversionEstimate.amount} token base units");
-                    Console.WriteLine("Estimated conversion fee: " +
-                        $"{prepareResponse.conversionEstimate.fee} token base units");
-                }
                 var feeSats = prepareResponse.feeSats;
                 Console.WriteLine($"Fees: {feeSats} sats");
             }
@@ -67,10 +51,11 @@ namespace BreezSdkSnippets
             var optionalValidateSuccessActionUrl = true;
 
             var request = new PrepareLnurlPayRequest(
-                amountSats: amountSats,
+                amount: amountSats,
                 payRequest: payRequest,
                 comment: optionalComment,
                 validateSuccessActionUrl: optionalValidateSuccessActionUrl,
+                tokenIdentifier: null,
                 conversionOptions: null,
                 feePolicy: FeePolicy.FeesIncluded
             );

--- a/docs/breez-sdk/snippets/csharp/SendPayment.cs
+++ b/docs/breez-sdk/snippets/csharp/SendPayment.cs
@@ -141,11 +141,6 @@ namespace BreezSdkSnippets
         async Task PrepareSendPaymentSendAll(BreezSdk sdk)
         {
             // ANCHOR: prepare-send-payment-send-all
-            // To send the entire token balance plus any remaining sats,
-            // provide the full token balance as the amount with ToBitcoin
-            // conversion options and FeesIncluded. The SDK converts all
-            // tokens to sats, combines with existing sat balance, and
-            // deducts fees — draining the wallet completely.
             var paymentRequest = "<payment request>";
             var tokenIdentifier = "<token identifier>";
 

--- a/docs/breez-sdk/snippets/csharp/SendPayment.cs
+++ b/docs/breez-sdk/snippets/csharp/SendPayment.cs
@@ -138,6 +138,54 @@ namespace BreezSdkSnippets
             // ANCHOR_END: prepare-send-payment-fees-included
         }
 
+        async Task PrepareSendPaymentSendAll(BreezSdk sdk)
+        {
+            // ANCHOR: prepare-send-payment-send-all
+            // To send the entire token balance plus any remaining sats,
+            // provide the full token balance as the amount with ToBitcoin
+            // conversion options and FeesIncluded. The SDK converts all
+            // tokens to sats, combines with existing sat balance, and
+            // deducts fees — draining the wallet completely.
+            var paymentRequest = "<payment request>";
+            var tokenIdentifier = "<token identifier>";
+
+            var info = await sdk.GetInfo(request: new GetInfoRequest(ensureSynced: false));
+            if (!info.tokenBalances.TryGetValue(tokenIdentifier, out var tokenBalance))
+            {
+                throw new Exception("Token balance not found");
+            }
+
+            var conversionOptions = new ConversionOptions(
+                conversionType: new ConversionType.ToBitcoin(
+                    fromTokenIdentifier: tokenIdentifier
+                ),
+                maxSlippageBps: null,
+                completionTimeoutSecs: null
+            );
+
+            var request = new PrepareSendPaymentRequest(
+                paymentRequest: paymentRequest,
+                amount: tokenBalance.balance,
+                tokenIdentifier: tokenIdentifier,
+                conversionOptions: conversionOptions,
+                feePolicy: FeePolicy.FeesIncluded
+            );
+            var prepareResponse = await sdk.PrepareSendPayment(request: request);
+
+            // The response amount is the estimated total sats available
+            // (converted sats + existing sat balance)
+            Console.WriteLine($"Total sats available: {prepareResponse.amount}");
+
+            if (prepareResponse.conversionEstimate != null)
+            {
+                Console.WriteLine("Converting " +
+                    $"{prepareResponse.conversionEstimate.amountIn} token units → ~{prepareResponse.conversionEstimate.amountOut} sats");
+                Console.WriteLine("Conversion fee: " +
+                    $"{prepareResponse.conversionEstimate.fee} token units");
+            }
+            // ANCHOR_END: prepare-send-payment-send-all
+        }
+
         async Task PrepareSendPaymentTokenConversion(BreezSdk sdk)
         {
             // ANCHOR: prepare-send-payment-with-conversion
@@ -165,10 +213,10 @@ namespace BreezSdkSnippets
             // If the fees are acceptable, continue to create the Send Payment
             if (prepareResponse.conversionEstimate != null)
             {
-                Console.WriteLine("Estimated conversion amount: " +
-                    $"{prepareResponse.conversionEstimate.amount} token base units");
+                Console.WriteLine("Estimated conversion: " +
+                    $"{prepareResponse.conversionEstimate.amountIn} token units → {prepareResponse.conversionEstimate.amountOut} sats");
                 Console.WriteLine("Estimated conversion fee: " +
-                    $"{prepareResponse.conversionEstimate.fee} token base units");
+                    $"{prepareResponse.conversionEstimate.fee} token units");
             }
             // ANCHOR_END: prepare-send-payment-with-conversion
         }

--- a/docs/breez-sdk/snippets/csharp/Tokens.cs
+++ b/docs/breez-sdk/snippets/csharp/Tokens.cs
@@ -191,10 +191,10 @@ namespace BreezSdkSnippets
             // If the fees are acceptable, continue to send the token payment
             if (prepareResponse.conversionEstimate != null)
             {
-                Console.WriteLine("Estimated conversion amount: " +
-                    $"{prepareResponse.conversionEstimate.amount} sats");
+                Console.WriteLine("Estimated conversion: " +
+                    $"{prepareResponse.conversionEstimate.amountIn} token units → {prepareResponse.conversionEstimate.amountOut} sats");
                 Console.WriteLine("Estimated conversion fee: " +
-                    $"{prepareResponse.conversionEstimate.fee} sats");
+                    $"{prepareResponse.conversionEstimate.fee} token units");
             }
             // ANCHOR_END: prepare-send-payment-with-conversion
         }

--- a/docs/breez-sdk/snippets/flutter/lib/lnurl_pay.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/lnurl_pay.dart
@@ -12,36 +12,20 @@ Future<void> prepareLnurlPay(BreezSdk sdk) async {
     BigInt amountSats = BigInt.from(5000);
     String optionalComment = "<comment>";
     bool optionalValidateSuccessActionUrl = true;
-    // Optionally set to use token funds to pay via token conversion
-    int optionalMaxSlippageBps = 50;
-    int optionalCompletionTimeoutSecs = 30;
-    final optionalConversionOptions = ConversionOptions(
-      conversionType: ConversionType.toBitcoin(
-        fromTokenIdentifier: "<token identifier>",
-      ),
-      maxSlippageBps: optionalMaxSlippageBps,
-      completionTimeoutSecs: optionalCompletionTimeoutSecs,
-    );
 
     PrepareLnurlPayRequest request = PrepareLnurlPayRequest(
-      amountSats: amountSats,
+      amount: amountSats,
       payRequest: inputType.field0.payRequest,
       comment: optionalComment,
       validateSuccessActionUrl: optionalValidateSuccessActionUrl,
-      conversionOptions: optionalConversionOptions,
+      tokenIdentifier: null,
+      conversionOptions: null,
       feePolicy: null,
     );
     PrepareLnurlPayResponse prepareResponse =
         await sdk.prepareLnurlPay(request: request);
 
     // If the fees are acceptable, continue to create the LNURL Pay
-    if (prepareResponse.conversionEstimate != null) {
-      print(
-          "Estimated conversion amount: ${prepareResponse.conversionEstimate!.amount} token base units");
-      print(
-          "Estimated conversion fee: ${prepareResponse.conversionEstimate!.fee} token base units");
-    }
-
     BigInt feeSats = prepareResponse.feeSats;
     print("Fees: $feeSats sats");
   }
@@ -71,10 +55,11 @@ Future<void> prepareLnurlPayFeesIncluded(BreezSdk sdk, LnurlPayRequestDetails pa
   BigInt amountSats = BigInt.from(5000);
 
   PrepareLnurlPayRequest request = PrepareLnurlPayRequest(
-    amountSats: amountSats,
+    amount: amountSats,
     payRequest: payRequest,
     comment: optionalComment,
     validateSuccessActionUrl: optionalValidateSuccessActionUrl,
+    tokenIdentifier: null,
     conversionOptions: null,
     feePolicy: FeePolicy.feesIncluded,
   );

--- a/docs/breez-sdk/snippets/flutter/lib/send_payment.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/send_payment.dart
@@ -135,9 +135,9 @@ Future<PrepareSendPaymentResponse> prepareSendPaymentTokenConversion(
   // If the fees are acceptable, continue to create the Send Payment
   if (response.conversionEstimate != null) {
     print(
-        "Estimated conversion amount: ${response.conversionEstimate!.amount} token base units");
+        "Estimated conversion: ${response.conversionEstimate!.amountIn} token units → ${response.conversionEstimate!.amountOut} sats");
     print(
-        "Estimated conversion fee: ${response.conversionEstimate!.fee} token base units");
+        "Estimated conversion fee: ${response.conversionEstimate!.fee} token units");
   }
   // ANCHOR_END: prepare-send-payment-with-conversion
   return response;
@@ -213,5 +213,50 @@ Future<PrepareSendPaymentResponse> prepareSendPaymentFeesIncluded(
   print("Amount: ${response.amount}");
   // The receiver gets amount - fees (fees are available in response.paymentMethod)
   // ANCHOR_END: prepare-send-payment-fees-included
+  return response;
+}
+
+Future<PrepareSendPaymentResponse> prepareSendPaymentSendAll(
+    BreezSdk sdk) async {
+  // ANCHOR: prepare-send-payment-send-all
+  // To send the entire token balance plus any remaining sats,
+  // provide the full token balance as the amount with ToBitcoin
+  // conversion options and FeesIncluded. The SDK converts all
+  // tokens to sats, combines with existing sat balance, and
+  // deducts fees — draining the wallet completely.
+  String paymentRequest = "<payment request>";
+  String tokenIdentifier = "<token identifier>";
+
+  final info = await sdk.getInfo(request: GetInfoRequest(ensureSynced: false));
+  final tokenBalance = info.tokenBalances[tokenIdentifier];
+  if (tokenBalance == null) {
+    throw Exception("Token balance not found");
+  }
+
+  final conversionOptions = ConversionOptions(
+    conversionType: ConversionType.toBitcoin(
+      fromTokenIdentifier: tokenIdentifier,
+    ),
+  );
+
+  final request = PrepareSendPaymentRequest(
+      paymentRequest: paymentRequest,
+      amount: tokenBalance.balance,
+      tokenIdentifier: tokenIdentifier,
+      conversionOptions: conversionOptions,
+      feePolicy: FeePolicy.feesIncluded);
+  final response = await sdk.prepareSendPayment(request: request);
+
+  // The response amount is the estimated total sats available
+  // (converted sats + existing sat balance)
+  print("Total sats available: ${response.amount}");
+
+  if (response.conversionEstimate != null) {
+    print(
+        "Converting ${response.conversionEstimate!.amountIn} token units → ~${response.conversionEstimate!.amountOut} sats");
+    print(
+        "Conversion fee: ${response.conversionEstimate!.fee} token units");
+  }
+  // ANCHOR_END: prepare-send-payment-send-all
   return response;
 }

--- a/docs/breez-sdk/snippets/flutter/lib/send_payment.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/send_payment.dart
@@ -219,11 +219,6 @@ Future<PrepareSendPaymentResponse> prepareSendPaymentFeesIncluded(
 Future<PrepareSendPaymentResponse> prepareSendPaymentSendAll(
     BreezSdk sdk) async {
   // ANCHOR: prepare-send-payment-send-all
-  // To send the entire token balance plus any remaining sats,
-  // provide the full token balance as the amount with ToBitcoin
-  // conversion options and FeesIncluded. The SDK converts all
-  // tokens to sats, combines with existing sat balance, and
-  // deducts fees — draining the wallet completely.
   String paymentRequest = "<payment request>";
   String tokenIdentifier = "<token identifier>";
 

--- a/docs/breez-sdk/snippets/flutter/lib/tokens.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/tokens.dart
@@ -174,9 +174,9 @@ Future<void> prepareSendPaymentTokenConversion(BreezSdk sdk) async {
   // If the fees are acceptable, continue to send the token payment
   if (prepareResponse.conversionEstimate != null) {
     print(
-        "Estimated conversion amount: ${prepareResponse.conversionEstimate!.amount} sats");
+        "Estimated conversion: ${prepareResponse.conversionEstimate!.amountIn} token units → ${prepareResponse.conversionEstimate!.amountOut} sats");
     print(
-        "Estimated conversion fee: ${prepareResponse.conversionEstimate!.fee} sats");
+        "Estimated conversion fee: ${prepareResponse.conversionEstimate!.fee} token units");
   }
   // ANCHOR_END: prepare-send-payment-with-conversion
 }

--- a/docs/breez-sdk/snippets/go/lnurl_pay.go
+++ b/docs/breez-sdk/snippets/go/lnurl_pay.go
@@ -3,6 +3,7 @@ package example
 import (
 	"errors"
 	"log"
+	"math/big"
 
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 )
@@ -27,26 +28,17 @@ func PrepareLnurlPay(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.PrepareLnu
 
 	switch inputType := input.(type) {
 	case breez_sdk_spark.InputTypeLightningAddress:
-		amountSats := uint64(5_000)
+		amountSats := new(big.Int).SetInt64(5_000)
 		optionalComment := "<comment>"
 		optionalValidateSuccessActionUrl := true
-		// Optionally set to use token funds to pay via token conversion
-		optionalMaxSlippageBps := uint32(50)
-		optionalCompletionTimeoutSecs := uint32(30)
-		optionalConversionOptions := breez_sdk_spark.ConversionOptions{
-			ConversionType: breez_sdk_spark.ConversionTypeToBitcoin{
-				FromTokenIdentifier: "<token identifier>",
-			},
-			MaxSlippageBps:        &optionalMaxSlippageBps,
-			CompletionTimeoutSecs: &optionalCompletionTimeoutSecs,
-		}
 
 		request := breez_sdk_spark.PrepareLnurlPayRequest{
-			AmountSats:               amountSats,
+			Amount:                   amountSats,
 			PayRequest:               inputType.Field0.PayRequest,
 			Comment:                  &optionalComment,
 			ValidateSuccessActionUrl: &optionalValidateSuccessActionUrl,
-			ConversionOptions:        &optionalConversionOptions,
+			TokenIdentifier:          nil,
+			ConversionOptions:        nil,
 			FeePolicy:                nil,
 		}
 
@@ -62,11 +54,6 @@ func PrepareLnurlPay(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.PrepareLnu
 		}
 
 		// If the fees are acceptable, continue to create the LNURL Pay
-		if prepareResponse.ConversionEstimate != nil {
-			log.Printf("Estimated conversion amount: %v token base units", prepareResponse.ConversionEstimate.Amount)
-			log.Printf("Estimated conversion fee: %v token base units", prepareResponse.ConversionEstimate.Fee)
-		}
-
 		feeSats := prepareResponse.FeeSats
 		log.Printf("Fees: %v sats", feeSats)
 		return &prepareResponse, nil
@@ -103,16 +90,17 @@ func PrepareLnurlPayFeesIncluded(sdk *breez_sdk_spark.BreezSdk, payRequest breez
 	// By default (FeePolicyFeesExcluded), fees are added on top of the amount.
 	// Use FeePolicyFeesIncluded to deduct fees from the amount instead.
 	// The receiver gets amount minus fees.
-	amountSats := uint64(5_000)
+	amountSats := new(big.Int).SetInt64(5_000)
 	optionalComment := "<comment>"
 	optionalValidateSuccessActionUrl := true
 	feePolicy := breez_sdk_spark.FeePolicyFeesIncluded
 
 	request := breez_sdk_spark.PrepareLnurlPayRequest{
-		AmountSats:               amountSats,
+		Amount:                   amountSats,
 		PayRequest:               payRequest,
 		Comment:                  &optionalComment,
 		ValidateSuccessActionUrl: &optionalValidateSuccessActionUrl,
+		TokenIdentifier:          nil,
 		ConversionOptions:        nil,
 		FeePolicy:                &feePolicy,
 	}

--- a/docs/breez-sdk/snippets/go/send_payment.go
+++ b/docs/breez-sdk/snippets/go/send_payment.go
@@ -312,11 +312,6 @@ func PrepareSendPaymentFeesIncluded(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_s
 
 func PrepareSendPaymentSendAll(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.PrepareSendPaymentResponse, error) {
 	// ANCHOR: prepare-send-payment-send-all
-	// To send the entire token balance plus any remaining sats,
-	// provide the full token balance as the amount with ToBitcoin
-	// conversion options and FeesIncluded. The SDK converts all
-	// tokens to sats, combines with existing sat balance, and
-	// deducts fees — draining the wallet completely.
 	paymentRequest := "<payment request>"
 	tokenIdentifier := "<token identifier>"
 

--- a/docs/breez-sdk/snippets/go/send_payment.go
+++ b/docs/breez-sdk/snippets/go/send_payment.go
@@ -187,8 +187,8 @@ func PrepareSendPaymentTokenConversion(sdk *breez_sdk_spark.BreezSdk) (*breez_sd
 
 	// If the fees are acceptable, continue to create the Send Payment
 	if response.ConversionEstimate != nil {
-		log.Printf("Estimated conversion amount: %v token base units", response.ConversionEstimate.Amount)
-		log.Printf("Estimated conversion fee: %v token base units", response.ConversionEstimate.Fee)
+		log.Printf("Estimated conversion: %v token units → %v sats", response.ConversionEstimate.AmountIn, response.ConversionEstimate.AmountOut)
+		log.Printf("Estimated conversion fee: %v token units", response.ConversionEstimate.Fee)
 	}
 	// ANCHOR_END: prepare-send-payment-with-conversion
 	return &response, nil
@@ -307,5 +307,65 @@ func PrepareSendPaymentFeesIncluded(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_s
 	log.Printf("Amount: %v", response.Amount)
 	// The receiver gets amount - fees (fees are available in response.PaymentMethod)
 	// ANCHOR_END: prepare-send-payment-fees-included
+	return &response, nil
+}
+
+func PrepareSendPaymentSendAll(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.PrepareSendPaymentResponse, error) {
+	// ANCHOR: prepare-send-payment-send-all
+	// To send the entire token balance plus any remaining sats,
+	// provide the full token balance as the amount with ToBitcoin
+	// conversion options and FeesIncluded. The SDK converts all
+	// tokens to sats, combines with existing sat balance, and
+	// deducts fees — draining the wallet completely.
+	paymentRequest := "<payment request>"
+	tokenIdentifier := "<token identifier>"
+
+	ensureSynced := false
+	info, err := sdk.GetInfo(breez_sdk_spark.GetInfoRequest{
+		EnsureSynced: &ensureSynced,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	tokenBalance, ok := info.TokenBalances[tokenIdentifier]
+	if !ok {
+		return nil, errors.New("token balance not found")
+	}
+
+	conversionOptions := breez_sdk_spark.ConversionOptions{
+		ConversionType: breez_sdk_spark.ConversionTypeToBitcoin{
+			FromTokenIdentifier: tokenIdentifier,
+		},
+	}
+	feePolicy := breez_sdk_spark.FeePolicyFeesIncluded
+
+	request := breez_sdk_spark.PrepareSendPaymentRequest{
+		PaymentRequest:    paymentRequest,
+		Amount:            &tokenBalance.Balance,
+		TokenIdentifier:   &tokenIdentifier,
+		ConversionOptions: &conversionOptions,
+		FeePolicy:         &feePolicy,
+	}
+	response, err := sdk.PrepareSendPayment(request)
+
+	if err != nil {
+		var sdkErr *breez_sdk_spark.SdkError
+		if errors.As(err, &sdkErr) {
+			// Handle SdkError - can inspect specific variants if needed
+			// e.g., switch on sdkErr variant for InsufficientFunds, NetworkError, etc.
+		}
+		return nil, err
+	}
+
+	// The response amount is the estimated total sats available
+	// (converted sats + existing sat balance)
+	log.Printf("Total sats available: %v", response.Amount)
+
+	if response.ConversionEstimate != nil {
+		log.Printf("Converting %v token units → ~%v sats", response.ConversionEstimate.AmountIn, response.ConversionEstimate.AmountOut)
+		log.Printf("Conversion fee: %v token units", response.ConversionEstimate.Fee)
+	}
+	// ANCHOR_END: prepare-send-payment-send-all
 	return &response, nil
 }

--- a/docs/breez-sdk/snippets/go/tokens.go
+++ b/docs/breez-sdk/snippets/go/tokens.go
@@ -251,8 +251,8 @@ func PrepareSendTokenPaymentTokenConversion(sdk *breez_sdk_spark.BreezSdk) error
 
 	// If the fees are acceptable, continue to send the token payment
 	if prepareResponse.ConversionEstimate != nil {
-		log.Printf("Estimated conversion amount: %v sats", prepareResponse.ConversionEstimate.Amount)
-		log.Printf("Estimated conversion fee: %v sats", prepareResponse.ConversionEstimate.Fee)
+		log.Printf("Estimated conversion: %v token units → %v sats", prepareResponse.ConversionEstimate.AmountIn, prepareResponse.ConversionEstimate.AmountOut)
+		log.Printf("Estimated conversion fee: %v token units", prepareResponse.ConversionEstimate.Fee)
 	}
 	// ANCHOR_END: prepare-send-payment-with-conversion
 	return nil

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/LnurlPay.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/LnurlPay.kt
@@ -1,6 +1,7 @@
 package com.example.kotlinmpplib
 
 import breez_sdk_spark.*
+import com.ionspin.kotlin.bignum.integer.BigInteger
 
 class LnurlPay {
     suspend fun prepareLnurlPay(sdk: BreezSdk) {
@@ -12,38 +13,24 @@ class LnurlPay {
         try {
             val inputType = sdk.parse(lnurlPayUrl)
             if (inputType is InputType.LightningAddress) {
-                val amountSats = 5_000.toULong()
+                val amountSats = BigInteger.fromLong(5_000L)
                 val optionalComment = "<comment>"
                 val payRequest = inputType.v1.payRequest
                 val optionalValidateSuccessActionUrl = true
-                // Optionally set to use token funds to pay via token conversion
-                val optionalMaxSlippageBps = 50u
-                val optionalCompletionTimeoutSecs = 30u
-                val optionalConversionOptions = ConversionOptions(
-                    conversionType = ConversionType.ToBitcoin(
-                        "<token identifier>"
-                    ),
-                    maxSlippageBps = optionalMaxSlippageBps,
-                    completionTimeoutSecs = optionalCompletionTimeoutSecs
-                )
 
                 val req = PrepareLnurlPayRequest(
-                    amountSats = amountSats,
+                    amount = amountSats,
                     payRequest = payRequest,
                     comment = optionalComment,
                     validateSuccessActionUrl = optionalValidateSuccessActionUrl,
-                    conversionOptions = optionalConversionOptions,
+                    tokenIdentifier = null,
+                    conversionOptions = null,
                     feePolicy = null,
                 )
                 val prepareResponse = sdk.prepareLnurlPay(req)
 
                 // If the fees are acceptable, continue to create the LNURL Pay
-                prepareResponse.conversionEstimate?.let { conversionEstimate ->
-                    // Log.v("Breez", "Estimated conversion amount: ${conversionEstimate.amount} token base units")
-                    // Log.v("Breez", "Estimated conversion fee: ${conversionEstimate.fee} token base units")
-                }
-
-                val feeSats = prepareResponse.feeSats;
+                val feeSats = prepareResponse.feeSats
                 // Log.v("Breez", "Fees: ${feeSats} sats")
             }
         } catch (e: Exception) {
@@ -70,13 +57,14 @@ class LnurlPay {
         // The receiver gets amount minus fees.
         val optionalComment = "<comment>"
         val optionalValidateSuccessActionUrl = true
-        val amountSats = 5_000.toULong()
+        val amountSats = BigInteger.fromLong(5_000L)
 
         val req = PrepareLnurlPayRequest(
-            amountSats = amountSats,
+            amount = amountSats,
             payRequest = payRequest,
             comment = optionalComment,
             validateSuccessActionUrl = optionalValidateSuccessActionUrl,
+            tokenIdentifier = null,
             conversionOptions = null,
             feePolicy = FeePolicy.FEES_INCLUDED,
         )

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
@@ -106,6 +106,52 @@ class SendPayment {
         // ANCHOR_END: prepare-send-payment-fees-included
     }
 
+    suspend fun prepareSendPaymentSendAll(sdk: BreezSdk) {
+        // ANCHOR: prepare-send-payment-send-all
+        // To send the entire token balance plus any remaining sats,
+        // provide the full token balance as the amount with ToBitcoin
+        // conversion options and FeesIncluded. The SDK converts all
+        // tokens to sats, combines with existing sat balance, and
+        // deducts fees — draining the wallet completely.
+        val paymentRequest = "<payment request>"
+        val tokenIdentifier = "<token identifier>"
+
+        try {
+            val info = sdk.getInfo(GetInfoRequest(false))
+            val tokenBalance = info.tokenBalances[tokenIdentifier]
+                ?: throw Exception("Token balance not found")
+
+            val conversionOptions = ConversionOptions(
+                conversionType = ConversionType.ToBitcoin(
+                    tokenIdentifier
+                ),
+                maxSlippageBps = null,
+                completionTimeoutSecs = null
+            )
+
+            val req = PrepareSendPaymentRequest(
+                paymentRequest,
+                amount = tokenBalance.balance,
+                tokenIdentifier = tokenIdentifier,
+                conversionOptions = conversionOptions,
+                feePolicy = FeePolicy.FEES_INCLUDED,
+            )
+            val prepareResponse = sdk.prepareSendPayment(req)
+
+            // The response amount is the estimated total sats available
+            // (converted sats + existing sat balance)
+            // Log.v("Breez", "Total sats available: ${prepareResponse.amount}")
+
+            prepareResponse.conversionEstimate?.let { conversionEstimate ->
+                // Log.v("Breez", "Converting ${conversionEstimate.amountIn} token units → ~${conversionEstimate.amountOut} sats")
+                // Log.v("Breez", "Conversion fee: ${conversionEstimate.fee} token units")
+            }
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: prepare-send-payment-send-all
+    }
+
     suspend fun prepareSendPaymentSparkAddress(sdk: BreezSdk) {
         // ANCHOR: prepare-send-payment-spark-address
         val paymentRequest = "<spark address>"
@@ -194,8 +240,8 @@ class SendPayment {
 
             // If the fees are acceptable, continue to create the Send Payment
             prepareResponse.conversionEstimate?.let { conversionEstimate ->
-                // Log.v("Breez", "Estimated conversion amount: ${conversionEstimate.amount} token base units")
-                // Log.v("Breez", "Estimated conversion fee: ${conversionEstimate.fee} token base units")
+                // Log.v("Breez", "Estimated conversion: ${conversionEstimate.amountIn} token units → ${conversionEstimate.amountOut} sats")
+                // Log.v("Breez", "Estimated conversion fee: ${conversionEstimate.fee} token units")
             }
         } catch (e: Exception) {
             // handle error

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
@@ -108,11 +108,6 @@ class SendPayment {
 
     suspend fun prepareSendPaymentSendAll(sdk: BreezSdk) {
         // ANCHOR: prepare-send-payment-send-all
-        // To send the entire token balance plus any remaining sats,
-        // provide the full token balance as the amount with ToBitcoin
-        // conversion options and FeesIncluded. The SDK converts all
-        // tokens to sats, combines with existing sat balance, and
-        // deducts fees — draining the wallet completely.
         val paymentRequest = "<payment request>"
         val tokenIdentifier = "<token identifier>"
 

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Tokens.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Tokens.kt
@@ -208,8 +208,8 @@ class Tokens {
 
             // If the fees are acceptable, continue to send the token payment
             prepareResponse.conversionEstimate?.let { conversionEstimate ->
-                println("Estimated conversion amount: ${conversionEstimate.amount} sats")
-                println("Estimated conversion fee: ${conversionEstimate.fee} sats")
+                println("Estimated conversion: ${conversionEstimate.amountIn} token units → ${conversionEstimate.amountOut} sats")
+                println("Estimated conversion fee: ${conversionEstimate.fee} token units")
             }
         } catch (e: Exception) {
             // handle error

--- a/docs/breez-sdk/snippets/python/src/lnurl_pay.py
+++ b/docs/breez-sdk/snippets/python/src/lnurl_pay.py
@@ -7,8 +7,6 @@ from breez_sdk_spark import (
     LnurlPayRequestDetails,
     PrepareLnurlPayRequest,
     PrepareLnurlPayResponse,
-    ConversionOptions,
-    ConversionType,
 )
 
 
@@ -28,37 +26,19 @@ async def prepare_pay(sdk: BreezSdk):
             optional_comment = "<comment>"
             pay_request = details.pay_request
             optional_validate_success_action_url = True
-            # Optionally set to use token funds to pay via token conversion
-            optional_max_slippage_bps = 50
-            optional_completion_timeout_secs = 30
-            optional_conversion_options = ConversionOptions(
-                conversion_type=ConversionType.TO_BITCOIN(
-                    from_token_identifier="<token identifier>"
-                ),
-                max_slippage_bps=optional_max_slippage_bps,
-                completion_timeout_secs=optional_completion_timeout_secs,
-            )
 
             request = PrepareLnurlPayRequest(
-                amount_sats=amount_sats,
+                amount=amount_sats,
                 pay_request=pay_request,
                 comment=optional_comment,
                 validate_success_action_url=optional_validate_success_action_url,
-                conversion_options=optional_conversion_options,
+                token_identifier=None,
+                conversion_options=None,
                 fee_policy=None,
             )
             prepare_response = await sdk.prepare_lnurl_pay(request=request)
 
             # If the fees are acceptable, continue to create the LNURL Pay
-            if prepare_response.conversion_estimate is not None:
-                conversion_estimate = prepare_response.conversion_estimate
-                logging.debug(
-                    f"Estimated conversion amount: {conversion_estimate.amount} token base units"
-                )
-                logging.debug(
-                    f"Estimated conversion fee: {conversion_estimate.fee} token base units"
-                )
-
             logging.debug(f"Fees: {prepare_response.fee_sats} sats")
             return prepare_response
     except Exception as error:
@@ -97,10 +77,11 @@ async def prepare_pay_fees_included(sdk: BreezSdk, pay_request: LnurlPayRequestD
     optional_validate_success_action_url = True
 
     request = PrepareLnurlPayRequest(
-        amount_sats=amount_sats,
+        amount=amount_sats,
         pay_request=pay_request,
         comment=optional_comment,
         validate_success_action_url=optional_validate_success_action_url,
+        token_identifier=None,
         conversion_options=None,
         fee_policy=FeePolicy.FEES_INCLUDED,
     )

--- a/docs/breez-sdk/snippets/python/src/send_payment.py
+++ b/docs/breez-sdk/snippets/python/src/send_payment.py
@@ -265,11 +265,6 @@ async def prepare_send_payment_fees_included(sdk: BreezSdk):
 
 async def prepare_send_payment_send_all(sdk: BreezSdk):
     # ANCHOR: prepare-send-payment-send-all
-    # To send the entire token balance plus any remaining sats,
-    # provide the full token balance as the amount with ToBitcoin
-    # conversion options and FeesIncluded. The SDK converts all
-    # tokens to sats, combines with existing sat balance, and
-    # deducts fees — draining the wallet completely.
     payment_request = "<payment request>"
     token_identifier = "<token identifier>"
     try:

--- a/docs/breez-sdk/snippets/python/src/send_payment.py
+++ b/docs/breez-sdk/snippets/python/src/send_payment.py
@@ -3,6 +3,7 @@ import logging
 from breez_sdk_spark import (
     BreezSdk,
     FeePolicy,
+    GetInfoRequest,
     OnchainConfirmationSpeed,
     PrepareSendPaymentRequest,
     PrepareSendPaymentResponse,
@@ -161,10 +162,11 @@ async def prepare_send_payment_token_conversion(sdk: BreezSdk):
         if prepare_response.conversion_estimate is not None:
             conversion_estimate = prepare_response.conversion_estimate
             logging.debug(
-                f"Estimated conversion amount: {conversion_estimate.amount} token base units"
+                f"Estimated conversion: {conversion_estimate.amount_in}"
+                f" token units → {conversion_estimate.amount_out} sats"
             )
             logging.debug(
-                f"Estimated conversion fee: {conversion_estimate.fee} token base units"
+                f"Estimated conversion fee: {conversion_estimate.fee} token units"
             )
     except Exception as error:
         logging.error(error)
@@ -259,3 +261,52 @@ async def prepare_send_payment_fees_included(sdk: BreezSdk):
         logging.error(error)
         raise
     # ANCHOR_END: prepare-send-payment-fees-included
+
+
+async def prepare_send_payment_send_all(sdk: BreezSdk):
+    # ANCHOR: prepare-send-payment-send-all
+    # To send the entire token balance plus any remaining sats,
+    # provide the full token balance as the amount with ToBitcoin
+    # conversion options and FeesIncluded. The SDK converts all
+    # tokens to sats, combines with existing sat balance, and
+    # deducts fees — draining the wallet completely.
+    payment_request = "<payment request>"
+    token_identifier = "<token identifier>"
+    try:
+        info = await sdk.get_info(request=GetInfoRequest(ensure_synced=False))
+        token_balance = info.token_balances.get(token_identifier)
+        if token_balance is None:
+            raise ValueError("Token balance not found")
+
+        conversion_options = ConversionOptions(
+            conversion_type=ConversionType.TO_BITCOIN(
+                from_token_identifier=token_identifier
+            ),
+        )
+
+        request = PrepareSendPaymentRequest(
+            payment_request=payment_request,
+            amount=token_balance.balance,
+            token_identifier=token_identifier,
+            conversion_options=conversion_options,
+            fee_policy=FeePolicy.FEES_INCLUDED,
+        )
+        prepare_response = await sdk.prepare_send_payment(request=request)
+
+        # The response amount is the estimated total sats available
+        # (converted sats + existing sat balance)
+        logging.debug(f"Total sats available: {prepare_response.amount}")
+
+        if prepare_response.conversion_estimate is not None:
+            conversion_estimate = prepare_response.conversion_estimate
+            logging.debug(
+                f"Converting {conversion_estimate.amount_in}"
+                f" token units → ~{conversion_estimate.amount_out} sats"
+            )
+            logging.debug(
+                f"Conversion fee: {conversion_estimate.fee} token units"
+            )
+    except Exception as error:
+        logging.error(error)
+        raise
+    # ANCHOR_END: prepare-send-payment-send-all

--- a/docs/breez-sdk/snippets/python/src/tokens.py
+++ b/docs/breez-sdk/snippets/python/src/tokens.py
@@ -195,10 +195,11 @@ async def prepare_send_payment_token_conversion(sdk: BreezSdk):
         if prepare_response.conversion_estimate is not None:
             conversion_estimate = prepare_response.conversion_estimate
             logging.debug(
-                f"Estimated conversion amount: {conversion_estimate.amount} sats"
+                f"Estimated conversion: {conversion_estimate.amount_in}"
+                f" token units → {conversion_estimate.amount_out} sats"
             )
             logging.debug(
-                f"Estimated conversion fee: {conversion_estimate.fee} sats"
+                f"Estimated conversion fee: {conversion_estimate.fee} token units"
             )
     except Exception as error:
         logging.error(error)

--- a/docs/breez-sdk/snippets/react-native/lnurl_pay.ts
+++ b/docs/breez-sdk/snippets/react-native/lnurl_pay.ts
@@ -3,8 +3,7 @@ import {
   InputType_Tags,
   type LnurlPayRequestDetails,
   FeePolicy,
-  type PrepareLnurlPayResponse,
-  ConversionType
+  type PrepareLnurlPayResponse
 } from '@breeztech/breez-sdk-spark-react-native'
 
 const examplePrepareLnurlPay = async (sdk: BreezSdk) => {
@@ -20,33 +19,18 @@ const examplePrepareLnurlPay = async (sdk: BreezSdk) => {
     const optionalComment = '<comment>'
     const payRequest = input.inner[0].payRequest
     const optionalValidateSuccessActionUrl = true
-    // Optionally set to use token funds to pay via token conversion
-    const optionalMaxSlippageBps = 50
-    const optionalCompletionTimeoutSecs = 30
-    const optionalConversionOptions = {
-      conversionType: new ConversionType.ToBitcoin({
-        fromTokenIdentifier: '<token identifier>'
-      }),
-      maxSlippageBps: optionalMaxSlippageBps,
-      completionTimeoutSecs: optionalCompletionTimeoutSecs
-    }
 
     const prepareResponse = await sdk.prepareLnurlPay({
-      amountSats,
+      amount: amountSats,
       payRequest,
       comment: optionalComment,
       validateSuccessActionUrl: optionalValidateSuccessActionUrl,
-      conversionOptions: optionalConversionOptions,
+      tokenIdentifier: undefined,
+      conversionOptions: undefined,
       feePolicy: undefined
     })
 
     // If the fees are acceptable, continue to create the LNURL Pay
-    if (prepareResponse.conversionEstimate !== undefined) {
-      const conversionEstimate = prepareResponse.conversionEstimate
-      console.debug(`Estimated conversion amount: ${conversionEstimate.amount} token base units`)
-      console.debug(`Estimated conversion fee: ${conversionEstimate.fee} token base units`)
-    }
-
     const feeSats = prepareResponse.feeSats
     console.log(`Fees: ${feeSats} sats`)
   }
@@ -74,10 +58,11 @@ const examplePrepareLnurlPayFeesIncluded = async (sdk: BreezSdk, payRequest: Lnu
   const amountSats = BigInt(5_000)
 
   const prepareResponse = await sdk.prepareLnurlPay({
-    amountSats,
+    amount: amountSats,
     payRequest,
     comment: optionalComment,
     validateSuccessActionUrl: optionalValidateSuccessActionUrl,
+    tokenIdentifier: undefined,
     conversionOptions: undefined,
     feePolicy: FeePolicy.FeesIncluded
   })

--- a/docs/breez-sdk/snippets/react-native/send_payment.ts
+++ b/docs/breez-sdk/snippets/react-native/send_payment.ts
@@ -130,8 +130,8 @@ const examplePrepareSendPaymentTokenConversion = async (sdk: BreezSdk) => {
   // If the fees are acceptable, continue to create the Send Payment
   if (prepareResponse.conversionEstimate !== undefined) {
     const conversionEstimate = prepareResponse.conversionEstimate
-    console.debug(`Estimated conversion amount: ${conversionEstimate.amount} token base units`)
-    console.debug(`Estimated conversion fee: ${conversionEstimate.fee} token base units`)
+    console.debug(`Estimated conversion: ${conversionEstimate.amountIn} token units → ${conversionEstimate.amountOut} sats`)
+    console.debug(`Estimated conversion fee: ${conversionEstimate.fee} token units`)
   }
   // ANCHOR_END: prepare-send-payment-with-conversion
 }
@@ -213,4 +213,48 @@ const examplePrepareSendPaymentFeesIncluded = async (sdk: BreezSdk) => {
   console.log(`Amount: ${prepareResponse.amount}`)
   // The receiver gets amount - fees (fees are available in prepareResponse.paymentMethod)
   // ANCHOR_END: prepare-send-payment-fees-included
+}
+
+const examplePrepareSendPaymentSendAll = async (sdk: BreezSdk) => {
+  // ANCHOR: prepare-send-payment-send-all
+  // To send the entire token balance plus any remaining sats,
+  // provide the full token balance as the amount with ToBitcoin
+  // conversion options and FeesIncluded. The SDK converts all
+  // tokens to sats, combines with existing sat balance, and
+  // deducts fees — draining the wallet completely.
+  const paymentRequest = '<payment request>'
+  const tokenIdentifier = '<token identifier>'
+
+  const info = await sdk.getInfo({ ensureSynced: false })
+  const tokenBalance = info.tokenBalances.get(tokenIdentifier)
+  if (tokenBalance === undefined) {
+    throw new Error('Token balance not found')
+  }
+
+  const conversionOptions = {
+    conversionType: new ConversionType.ToBitcoin({
+      fromTokenIdentifier: tokenIdentifier
+    }),
+    maxSlippageBps: undefined,
+    completionTimeoutSecs: undefined
+  }
+
+  const prepareResponse = await sdk.prepareSendPayment({
+    paymentRequest,
+    amount: tokenBalance.balance,
+    tokenIdentifier,
+    conversionOptions,
+    feePolicy: FeePolicy.FeesIncluded
+  })
+
+  // The response amount is the estimated total sats available
+  // (converted sats + existing sat balance)
+  console.log(`Total sats available: ${prepareResponse.amount}`)
+
+  if (prepareResponse.conversionEstimate !== undefined) {
+    const estimate = prepareResponse.conversionEstimate
+    console.log(`Converting ${estimate.amountIn} token units → ~${estimate.amountOut} sats`)
+    console.log(`Conversion fee: ${estimate.fee} token units`)
+  }
+  // ANCHOR_END: prepare-send-payment-send-all
 }

--- a/docs/breez-sdk/snippets/react-native/send_payment.ts
+++ b/docs/breez-sdk/snippets/react-native/send_payment.ts
@@ -217,11 +217,6 @@ const examplePrepareSendPaymentFeesIncluded = async (sdk: BreezSdk) => {
 
 const examplePrepareSendPaymentSendAll = async (sdk: BreezSdk) => {
   // ANCHOR: prepare-send-payment-send-all
-  // To send the entire token balance plus any remaining sats,
-  // provide the full token balance as the amount with ToBitcoin
-  // conversion options and FeesIncluded. The SDK converts all
-  // tokens to sats, combines with existing sat balance, and
-  // deducts fees — draining the wallet completely.
   const paymentRequest = '<payment request>'
   const tokenIdentifier = '<token identifier>'
 

--- a/docs/breez-sdk/snippets/react-native/tokens.ts
+++ b/docs/breez-sdk/snippets/react-native/tokens.ts
@@ -165,8 +165,8 @@ const examplePrepareSendPaymentTokenConversion = async (sdk: BreezSdk) => {
   // If the fees are acceptable, continue to send the token payment
   if (prepareResponse.conversionEstimate !== undefined) {
     const conversionEstimate = prepareResponse.conversionEstimate
-    console.debug(`Estimated conversion amount: ${conversionEstimate.amount} sats`)
-    console.debug(`Estimated conversion fee: ${conversionEstimate.fee} sats`)
+    console.debug(`Estimated conversion: ${conversionEstimate.amountIn} token units → ${conversionEstimate.amountOut} sats`)
+    console.debug(`Estimated conversion fee: ${conversionEstimate.fee} token units`)
   }
   // ANCHOR_END: prepare-send-payment-with-conversion
 }

--- a/docs/breez-sdk/snippets/rust/src/lnurl_pay.rs
+++ b/docs/breez-sdk/snippets/rust/src/lnurl_pay.rs
@@ -13,34 +13,20 @@ async fn prepare_pay(sdk: &BreezSdk) -> Result<()> {
         let amount_sats = 5_000;
         let optional_comment = Some("<comment>".to_string());
         let optional_validate_success_action_url = Some(true);
-        // Optionally set to use token funds to pay via token conversion
-        let optional_max_slippage_bps = Some(50);
-        let optional_completion_timeout_secs = Some(30);
-        let optional_conversion_options = Some(ConversionOptions {
-            conversion_type: ConversionType::ToBitcoin {
-                from_token_identifier: "<token identifier>".to_string(),
-            },
-            max_slippage_bps: optional_max_slippage_bps,
-            completion_timeout_secs: optional_completion_timeout_secs,
-        });
 
         let prepare_response = sdk
             .prepare_lnurl_pay(PrepareLnurlPayRequest {
-                amount_sats,
+                amount: amount_sats,
                 pay_request: details.pay_request,
                 comment: optional_comment,
                 validate_success_action_url: optional_validate_success_action_url,
-                conversion_options: optional_conversion_options,
+                token_identifier: None,
+                conversion_options: None,
                 fee_policy: None,
             })
             .await?;
 
         // If the fees are acceptable, continue to create the LNURL Pay
-        if let Some(conversion_estimate) = &prepare_response.conversion_estimate {
-            info!("Estimated conversion amount: {} token base units", conversion_estimate.amount);
-            info!("Estimated conversion fee: {} token base units", conversion_estimate.fee);
-        }
-
         let fee_sats = prepare_response.fee_sats;
         info!("Fees: {fee_sats} sats");
     }
@@ -73,10 +59,11 @@ async fn prepare_pay_fees_included(sdk: &BreezSdk, pay_request: LnurlPayRequestD
 
     let prepare_response = sdk
         .prepare_lnurl_pay(PrepareLnurlPayRequest {
-            amount_sats,
+            amount: amount_sats,
             pay_request,
             comment: optional_comment,
             validate_success_action_url: optional_validate_success_action_url,
+            token_identifier: None,
             conversion_options: None,
             fee_policy: Some(FeePolicy::FeesIncluded),
         })

--- a/docs/breez-sdk/snippets/rust/src/send_payment.rs
+++ b/docs/breez-sdk/snippets/rust/src/send_payment.rs
@@ -134,8 +134,8 @@ async fn prepare_send_payment_token_conversion(sdk: &BreezSdk) -> Result<()> {
 
     // If the fees are acceptable, continue to create the Send Payment
     if let Some(conversion_estimate) = &prepare_response.conversion_estimate {
-        info!("Estimated conversion amount: {} token base units", conversion_estimate.amount);
-        info!("Estimated conversion fee: {} token base units", conversion_estimate.fee);
+        info!("Estimated conversion: {} token units → {} sats", conversion_estimate.amount_in, conversion_estimate.amount_out);
+        info!("Estimated conversion fee: {} token units", conversion_estimate.fee);
     }
     // ANCHOR_END: prepare-send-payment-with-conversion
     Ok(())
@@ -229,5 +229,56 @@ async fn prepare_send_payment_fees_included(sdk: &BreezSdk) -> Result<()> {
     info!("Amount: {}", prepare_response.amount);
     // The receiver gets amount - fees (fees are available in prepare_response.payment_method)
     // ANCHOR_END: prepare-send-payment-fees-included
+    Ok(())
+}
+
+async fn prepare_send_payment_send_all(sdk: &BreezSdk) -> Result<()> {
+    // ANCHOR: prepare-send-payment-send-all
+    // To send the entire token balance plus any remaining sats,
+    // provide the full token balance as the amount with ToBitcoin
+    // conversion options and FeesIncluded. The SDK converts all
+    // tokens to sats, combines with existing sat balance, and
+    // deducts fees — draining the wallet completely.
+    let payment_request = "<payment request>".to_string();
+    let token_identifier = "<token identifier>".to_string();
+
+    let info = sdk
+        .get_info(GetInfoRequest {
+            ensure_synced: Some(false),
+        })
+        .await?;
+
+    let token_balance = info
+        .token_balances
+        .get(&token_identifier)
+        .ok_or_else(|| anyhow::anyhow!("Token balance not found"))?;
+
+    let conversion_options = Some(ConversionOptions {
+        conversion_type: ConversionType::ToBitcoin {
+            from_token_identifier: token_identifier.clone(),
+        },
+        max_slippage_bps: None,
+        completion_timeout_secs: None,
+    });
+
+    let prepare_response = sdk
+        .prepare_send_payment(PrepareSendPaymentRequest {
+            payment_request,
+            amount: Some(token_balance.balance),
+            token_identifier: Some(token_identifier),
+            conversion_options,
+            fee_policy: Some(FeePolicy::FeesIncluded),
+        })
+        .await?;
+
+    // The response amount is the estimated total sats available
+    // (converted sats + existing sat balance)
+    info!("Total sats available: {}", prepare_response.amount);
+
+    if let Some(conversion_estimate) = &prepare_response.conversion_estimate {
+        info!("Converting {} token units → ~{} sats", conversion_estimate.amount_in, conversion_estimate.amount_out);
+        info!("Conversion fee: {} token units", conversion_estimate.fee);
+    }
+    // ANCHOR_END: prepare-send-payment-send-all
     Ok(())
 }

--- a/docs/breez-sdk/snippets/rust/src/send_payment.rs
+++ b/docs/breez-sdk/snippets/rust/src/send_payment.rs
@@ -234,11 +234,6 @@ async fn prepare_send_payment_fees_included(sdk: &BreezSdk) -> Result<()> {
 
 async fn prepare_send_payment_send_all(sdk: &BreezSdk) -> Result<()> {
     // ANCHOR: prepare-send-payment-send-all
-    // To send the entire token balance plus any remaining sats,
-    // provide the full token balance as the amount with ToBitcoin
-    // conversion options and FeesIncluded. The SDK converts all
-    // tokens to sats, combines with existing sat balance, and
-    // deducts fees — draining the wallet completely.
     let payment_request = "<payment request>".to_string();
     let token_identifier = "<token identifier>".to_string();
 

--- a/docs/breez-sdk/snippets/rust/src/tokens.rs
+++ b/docs/breez-sdk/snippets/rust/src/tokens.rs
@@ -196,8 +196,8 @@ async fn prepare_send_payment_token_conversion(sdk: &BreezSdk) -> Result<()> {
 
     // If the fees are acceptable, continue to send the token payment
     if let Some(conversion_estimate) = &prepare_response.conversion_estimate {
-        info!("Estimated conversion amount: {} sats", conversion_estimate.amount);
-        info!("Estimated conversion fee: {} sats", conversion_estimate.fee);
+        info!("Estimated conversion: {} token units → {} sats", conversion_estimate.amount_in, conversion_estimate.amount_out);
+        info!("Estimated conversion fee: {} token units", conversion_estimate.fee);
     }
     // ANCHOR_END: prepare-send-payment-with-conversion
     Ok(())

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/LnurlPay.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/LnurlPay.swift
@@ -1,3 +1,4 @@
+import BigNumber
 import BreezSdkSpark
 import Foundation
 
@@ -10,37 +11,23 @@ func preparePay(sdk: BreezSdk) async throws {
 
     let inputType = try await sdk.parse(input: lnurlPayUrl)
     if case .lightningAddress(v1: let details) = inputType {
-        let amountSats: UInt64 = 5_000
+        let amountSats = BInt(5_000)
         let optionalComment = "<comment>"
         let payRequest = details.payRequest
         let optionalValidateSuccessActionUrl = true
-        // Optionally set to use token funds to pay via token conversion
-        let optionalMaxSlippageBps = UInt32(50)
-        let optionalCompletionTimeoutSecs = UInt32(30)
-        let conversionOptions = ConversionOptions(
-            conversionType: ConversionType.toBitcoin(
-                fromTokenIdentifier: "<token identifier>"
-            ),
-            maxSlippageBps: optionalMaxSlippageBps,
-            completionTimeoutSecs: optionalCompletionTimeoutSecs
-        )
 
         let request = PrepareLnurlPayRequest(
-            amountSats: amountSats,
+            amount: amountSats,
             payRequest: payRequest,
             comment: optionalComment,
             validateSuccessActionUrl: optionalValidateSuccessActionUrl,
-            conversionOptions: conversionOptions,
+            tokenIdentifier: nil,
+            conversionOptions: nil,
             feePolicy: nil
         )
         let prepareResponse = try await sdk.prepareLnurlPay(request: request)
 
         // If the fees are acceptable, continue to create the LNURL Pay
-        if let conversionEstimate = prepareResponse.conversionEstimate {
-            print("Estimated conversion amount: \(conversionEstimate.amount) token base units")
-            print("Estimated conversion fee: \(conversionEstimate.fee) token base units")
-        }
-
         let feeSats = prepareResponse.feeSats
         print("Fees: \(feeSats) sats")
     }
@@ -53,15 +40,16 @@ func prepareLnurlPayFeesIncluded(sdk: BreezSdk, payRequest: LnurlPayRequestDetai
     // By default (.feesExcluded), fees are added on top of the amount.
     // Use .feesIncluded to deduct fees from the amount instead.
     // The receiver gets amount minus fees.
-    let amountSats: UInt64 = 5_000
+    let amountSats = BInt(5_000)
     let optionalComment = "<comment>"
     let optionalValidateSuccessActionUrl = true
 
     let request = PrepareLnurlPayRequest(
-        amountSats: amountSats,
+        amount: amountSats,
         payRequest: payRequest,
         comment: optionalComment,
         validateSuccessActionUrl: optionalValidateSuccessActionUrl,
+        tokenIdentifier: nil,
         conversionOptions: nil,
         feePolicy: .feesIncluded
     )

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SendPayment.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SendPayment.swift
@@ -122,8 +122,8 @@ func prepareSendTokenPaymentTokenConversion(sdk: BreezSdk) async throws {
         ))
 
     if let conversionEstimate = prepareResponse.conversionEstimate {
-        print("Estimated conversion amount: \(conversionEstimate.amount) token base units")
-        print("Estimated conversion fee: \(conversionEstimate.fee) token base units")
+        print("Estimated conversion: \(conversionEstimate.amountIn) token units → \(conversionEstimate.amountOut) sats")
+        print("Estimated conversion fee: \(conversionEstimate.fee) token units")
     }
     // ANCHOR_END: prepare-send-payment-with-conversion
 }
@@ -198,4 +198,49 @@ func prepareSendPaymentFeesIncluded(sdk: BreezSdk) async throws {
     print("Amount: \(String(describing: prepareResponse.amount))")
     // The receiver gets amount - fees (fees are available in prepareResponse.paymentMethod)
     // ANCHOR_END: prepare-send-payment-fees-included
+}
+
+func prepareSendPaymentSendAll(sdk: BreezSdk) async throws {
+    // ANCHOR: prepare-send-payment-send-all
+    // To send the entire token balance plus any remaining sats,
+    // provide the full token balance as the amount with ToBitcoin
+    // conversion options and FeesIncluded. The SDK converts all
+    // tokens to sats, combines with existing sat balance, and
+    // deducts fees — draining the wallet completely.
+    let paymentRequest = "<payment request>"
+    let tokenIdentifier = "<token identifier>"
+
+    let info = try await sdk.getInfo(
+        request: GetInfoRequest(ensureSynced: false))
+
+    guard let tokenBalance = info.tokenBalances[tokenIdentifier] else {
+        throw SdkError.InvalidInput("Token balance not found")
+    }
+
+    let conversionOptions = ConversionOptions(
+        conversionType: ConversionType.toBitcoin(
+            fromTokenIdentifier: tokenIdentifier
+        ),
+        maxSlippageBps: nil,
+        completionTimeoutSecs: nil
+    )
+
+    let prepareResponse = try await sdk.prepareSendPayment(
+        request: PrepareSendPaymentRequest(
+            paymentRequest: paymentRequest,
+            amount: tokenBalance.balance,
+            tokenIdentifier: tokenIdentifier,
+            conversionOptions: conversionOptions,
+            feePolicy: .feesIncluded
+        ))
+
+    // The response amount is the estimated total sats available
+    // (converted sats + existing sat balance)
+    print("Total sats available: \(prepareResponse.amount)")
+
+    if let conversionEstimate = prepareResponse.conversionEstimate {
+        print("Converting \(conversionEstimate.amountIn) token units → ~\(conversionEstimate.amountOut) sats")
+        print("Conversion fee: \(conversionEstimate.fee) token units")
+    }
+    // ANCHOR_END: prepare-send-payment-send-all
 }

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SendPayment.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SendPayment.swift
@@ -202,11 +202,6 @@ func prepareSendPaymentFeesIncluded(sdk: BreezSdk) async throws {
 
 func prepareSendPaymentSendAll(sdk: BreezSdk) async throws {
     // ANCHOR: prepare-send-payment-send-all
-    // To send the entire token balance plus any remaining sats,
-    // provide the full token balance as the amount with ToBitcoin
-    // conversion options and FeesIncluded. The SDK converts all
-    // tokens to sats, combines with existing sat balance, and
-    // deducts fees — draining the wallet completely.
     let paymentRequest = "<payment request>"
     let tokenIdentifier = "<token identifier>"
 

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Tokens.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Tokens.swift
@@ -171,8 +171,8 @@ func prepareSendPaymentTokenConversion(sdk: BreezSdk) async throws {
 
     // If the fees are acceptable, continue to send the token payment
     if let conversionEstimate = prepareResponse.conversionEstimate {
-        print("Estimated conversion amount: \(conversionEstimate.amount) sats")
-        print("Estimated conversion fee: \(conversionEstimate.fee) sats")
+        print("Estimated conversion: \(conversionEstimate.amountIn) token units → \(conversionEstimate.amountOut) sats")
+        print("Estimated conversion fee: \(conversionEstimate.fee) token units")
     }
     // ANCHOR_END: prepare-send-payment-with-conversion
 }

--- a/docs/breez-sdk/snippets/wasm/lnurl_pay.ts
+++ b/docs/breez-sdk/snippets/wasm/lnurl_pay.ts
@@ -2,7 +2,6 @@ import type {
   BreezSdk,
   LnurlPayRequestDetails,
   PrepareLnurlPayResponse,
-  ConversionOptions,
   FeePolicy
 } from '@breeztech/breez-sdk-spark'
 
@@ -15,38 +14,22 @@ const examplePrepareLnurlPay = async (sdk: BreezSdk) => {
 
   const input = await sdk.parse(lnurlPayUrl)
   if (input.type === 'lightningAddress') {
-    const amountSats = 5_000
+    const amountSats = BigInt(5_000)
     const optionalComment = '<comment>'
     const payRequest = input.payRequest
     const optionalValidateSuccessActionUrl = true
-    // Optionally set to use token funds to pay via token conversion
-    const optionalMaxSlippageBps = 50
-    const optionalCompletionTimeoutSecs = 30
-    const optionalConversionOptions: ConversionOptions = {
-      conversionType: {
-        type: 'toBitcoin',
-        fromTokenIdentifier: '<token identifier>'
-      },
-      maxSlippageBps: optionalMaxSlippageBps,
-      completionTimeoutSecs: optionalCompletionTimeoutSecs
-    }
 
     const prepareResponse = await sdk.prepareLnurlPay({
-      amountSats,
+      amount: amountSats,
       payRequest,
       comment: optionalComment,
       validateSuccessActionUrl: optionalValidateSuccessActionUrl,
-      conversionOptions: optionalConversionOptions,
+      tokenIdentifier: undefined,
+      conversionOptions: undefined,
       feePolicy: undefined
     })
 
     // If the fees are acceptable, continue to create the LNURL Pay
-    if (prepareResponse.conversionEstimate !== undefined) {
-      const conversionEstimate = prepareResponse.conversionEstimate
-      console.debug(`Estimated conversion amount: ${conversionEstimate.amount} token base units`)
-      console.debug(`Estimated conversion fee: ${conversionEstimate.fee} token base units`)
-    }
-
     const feeSats = prepareResponse.feeSats
     console.log(`Fees: ${feeSats} sats`)
   }
@@ -60,14 +43,15 @@ const examplePrepareLnurlPayFeesIncluded = async (sdk: BreezSdk, payRequest: Lnu
   // The receiver gets amount minus fees.
   const optionalComment = '<comment>'
   const optionalValidateSuccessActionUrl = true
-  const amountSats = 5_000
+  const amountSats = BigInt(5_000)
   const feePolicy: FeePolicy = 'feesIncluded'
 
   const prepareResponse = await sdk.prepareLnurlPay({
-    amountSats,
+    amount: amountSats,
     payRequest,
     comment: optionalComment,
     validateSuccessActionUrl: optionalValidateSuccessActionUrl,
+    tokenIdentifier: undefined,
     conversionOptions: undefined,
     feePolicy
   })

--- a/docs/breez-sdk/snippets/wasm/send_payment.ts
+++ b/docs/breez-sdk/snippets/wasm/send_payment.ts
@@ -129,8 +129,8 @@ const examplePrepareSendPaymentTokenConversion = async (sdk: BreezSdk) => {
   // If the fees are acceptable, continue to create the Send Payment
   if (prepareResponse.conversionEstimate !== undefined) {
     const conversionEstimate = prepareResponse.conversionEstimate
-    console.debug(`Estimated conversion amount: ${conversionEstimate.amount} token base units`)
-    console.debug(`Estimated conversion fee: ${conversionEstimate.fee} token base units`)
+    console.debug(`Estimated conversion: ${conversionEstimate.amountIn} token units → ${conversionEstimate.amountOut} sats`)
+    console.debug(`Estimated conversion fee: ${conversionEstimate.fee} token units`)
   }
   // ANCHOR_END: prepare-send-payment-with-conversion
 }
@@ -214,4 +214,48 @@ const examplePrepareSendPaymentFeesIncluded = async (sdk: BreezSdk) => {
   console.log(`Amount: ${prepareResponse.amount}`)
   // The receiver gets amount - fees (fees are available in prepareResponse.paymentMethod)
   // ANCHOR_END: prepare-send-payment-fees-included
+}
+
+const examplePrepareSendPaymentSendAll = async (sdk: BreezSdk) => {
+  // ANCHOR: prepare-send-payment-send-all
+  // To send the entire token balance plus any remaining sats,
+  // provide the full token balance as the amount with ToBitcoin
+  // conversion options and FeesIncluded. The SDK converts all
+  // tokens to sats, combines with existing sat balance, and
+  // deducts fees — draining the wallet completely.
+  const paymentRequest = '<payment request>'
+  const tokenIdentifier = '<token identifier>'
+
+  const info = await sdk.getInfo({ ensureSynced: false })
+  const tokenBalance = info.tokenBalances.get(tokenIdentifier)
+  if (tokenBalance === undefined) {
+    throw new Error('Token balance not found')
+  }
+
+  const conversionOptions: ConversionOptions = {
+    conversionType: {
+      type: 'toBitcoin',
+      fromTokenIdentifier: tokenIdentifier
+    }
+  }
+  const feePolicy: FeePolicy = 'feesIncluded'
+
+  const prepareResponse = await sdk.prepareSendPayment({
+    paymentRequest,
+    amount: tokenBalance.balance,
+    tokenIdentifier,
+    conversionOptions,
+    feePolicy
+  })
+
+  // The response amount is the estimated total sats available
+  // (converted sats + existing sat balance)
+  console.log(`Total sats available: ${prepareResponse.amount}`)
+
+  if (prepareResponse.conversionEstimate !== undefined) {
+    const estimate = prepareResponse.conversionEstimate
+    console.log(`Converting ${estimate.amountIn} token units → ~${estimate.amountOut} sats`)
+    console.log(`Conversion fee: ${estimate.fee} token units`)
+  }
+  // ANCHOR_END: prepare-send-payment-send-all
 }

--- a/docs/breez-sdk/snippets/wasm/send_payment.ts
+++ b/docs/breez-sdk/snippets/wasm/send_payment.ts
@@ -218,11 +218,6 @@ const examplePrepareSendPaymentFeesIncluded = async (sdk: BreezSdk) => {
 
 const examplePrepareSendPaymentSendAll = async (sdk: BreezSdk) => {
   // ANCHOR: prepare-send-payment-send-all
-  // To send the entire token balance plus any remaining sats,
-  // provide the full token balance as the amount with ToBitcoin
-  // conversion options and FeesIncluded. The SDK converts all
-  // tokens to sats, combines with existing sat balance, and
-  // deducts fees — draining the wallet completely.
   const paymentRequest = '<payment request>'
   const tokenIdentifier = '<token identifier>'
 

--- a/docs/breez-sdk/snippets/wasm/tokens.ts
+++ b/docs/breez-sdk/snippets/wasm/tokens.ts
@@ -163,8 +163,8 @@ const examplePrepareSendPaymentTokenConversion = async (sdk: BreezSdk) => {
   // If the fees are acceptable, continue to send the token payment
   if (prepareResponse.conversionEstimate !== undefined) {
     const conversionEstimate = prepareResponse.conversionEstimate
-    console.log(`Estimated conversion amount: ${conversionEstimate.amount} sats`)
-    console.log(`Estimated conversion fee: ${conversionEstimate.fee} sats`)
+    console.log(`Estimated conversion: ${conversionEstimate.amountIn} token units → ${conversionEstimate.amountOut} sats`)
+    console.log(`Estimated conversion fee: ${conversionEstimate.fee} token units`)
   }
   // ANCHOR_END: prepare-send-payment-with-conversion
 }

--- a/docs/breez-sdk/src/guide/getting_started.md
+++ b/docs/breez-sdk/src/guide/getting_started.md
@@ -10,6 +10,8 @@ Integrating Breez SDK into your application takes just a few minutes. Follow the
 - **[Listening to events](/guide/events.md)**
 - **[Adding logging](/guide/logging.md)**
 - **[Spark status](/guide/spark_status.md)**
+- **[Stable balance](/guide/stable_balance.md)**
+- **[Passkey login](/guide/passkey.md)**
 
 ## API Key
 

--- a/docs/breez-sdk/src/guide/lnurl_pay.md
+++ b/docs/breez-sdk/src/guide/lnurl_pay.md
@@ -26,6 +26,10 @@ This is particularly useful when you want to spend your entire balance in a sing
 
 {{#tabs lnurl_pay:prepare-lnurl-pay-fees-included}}
 
+### Sending entire token balance
+
+When [stable balance](./stable_balance.md) is active, you can send your entire wallet balance via LNURL. See [Sending entire balance](./stable_balance.md#sending-entire-balance) for details.
+
 <h2 id="lnurl-payments">
     <a class="header" href="#lnurl-payments">LNURL Payments</a>
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.lnurl_pay">API docs</a>

--- a/docs/breez-sdk/src/guide/send_payment.md
+++ b/docs/breez-sdk/src/guide/send_payment.md
@@ -65,6 +65,10 @@ This is particularly useful when you want to spend your entire balance in a sing
 
 {{#tabs send_payment:prepare-send-payment-fees-included}}
 
+When [stable balance](./stable_balance.md) is active, you can send your entire wallet balance — both the token balance and any remaining sats — by combining {{#enum FeePolicy::FeesIncluded}} with {{#enum ConversionType::ToBitcoin}} conversion options. See [Sending entire balance](./stable_balance.md#sending-entire-balance) for details.
+
+{{#tabs send_payment:prepare-send-payment-send-all}}
+
 <h2 id="sending-payments">
     <a class="header" href="#sending-payments">Sending Payments</a>
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.send_payment">API docs</a>

--- a/docs/breez-sdk/src/guide/stable_balance.md
+++ b/docs/breez-sdk/src/guide/stable_balance.md
@@ -74,11 +74,11 @@ You can still explicitly specify `conversion options` in your request if you nee
 
 ## Sending entire balance
 
-When stable balance is active, you can send your entire wallet balance — both the token balance and any remaining sats — in a single payment. This is useful for draining a wallet completely.
+When stable balance is active, you can send your entire wallet balance — both the token balance and any remaining Bitcoin — in a single payment. This is useful for draining a wallet completely.
 
-To send all, provide the full token balance as the amount along with {{#enum FeePolicy::FeesIncluded}} and {{#enum ConversionType::ToBitcoin}} conversion options. The SDK converts all specified tokens to Bitcoin, combines the result with any existing sat balance, and deducts payment fees from the total.
+To send all, provide the full token balance as the amount along with {{#enum FeePolicy::FeesIncluded}} and {{#enum ConversionType::ToBitcoin}} conversion options. The SDK converts all specified tokens to Bitcoin, combines the result with any existing Bitcoin balance, and deducts payment fees from the total.
 
-The prepare response returns the estimated total sats available after conversion, and includes a {{#name conversion_estimate}} with the conversion details.
+The prepare response returns the estimated total Bitcoin available after conversion, and includes a {{#name conversion_estimate}} with the conversion details.
 
 The same approach works with {{#name prepare_lnurl_pay}} for [LNURL payments](./lnurl_pay.md).
 

--- a/docs/breez-sdk/src/guide/stable_balance.md
+++ b/docs/breez-sdk/src/guide/stable_balance.md
@@ -72,6 +72,25 @@ You can still explicitly specify `conversion options` in your request if you nee
 
 </div>
 
+## Sending entire balance
+
+When stable balance is active, you can send your entire wallet balance — both the token balance and any remaining sats — in a single payment. This is useful for draining a wallet completely.
+
+To send all, provide the full token balance as the amount along with {{#enum FeePolicy::FeesIncluded}} and {{#enum ConversionType::ToBitcoin}} conversion options. The SDK converts all specified tokens to Bitcoin, combines the result with any existing sat balance, and deducts payment fees from the total.
+
+The prepare response returns the estimated total sats available after conversion, and includes a {{#name conversion_estimate}} with the conversion details.
+
+The same approach works with {{#name prepare_lnurl_pay}} for [LNURL payments](./lnurl_pay.md).
+
+{{#tabs send_payment:prepare-send-payment-send-all}}
+
+<div class="warning">
+<h4>Developer note</h4>
+
+The actual sats received from conversion may differ slightly from the estimate due to price movement. The SDK handles this by querying the actual balance after conversion completes and sending the full available amount.
+
+</div>
+
 ## Conversion details
 
 Payments involving token conversions include a {{#name conversion_details}} field that describes the conversion that took place. This is useful for displaying conversion context in your UI.

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -371,7 +371,6 @@ pub struct _PrepareLnurlPayResponse {
     pub invoice_details: Bolt11InvoiceDetails,
     pub success_action: Option<SuccessAction>,
     pub conversion_estimate: Option<ConversionEstimate>,
-    pub token_identifier: Option<String>,
     pub fee_policy: FeePolicy,
 }
 

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -353,10 +353,11 @@ pub enum _FeePolicy {
 
 #[frb(mirror(PrepareLnurlPayRequest))]
 pub struct _PrepareLnurlPayRequest {
-    pub amount_sats: u64,
+    pub amount: u128,
     pub pay_request: LnurlPayRequestDetails,
     pub comment: Option<String>,
     pub validate_success_action_url: Option<bool>,
+    pub token_identifier: Option<String>,
     pub conversion_options: Option<ConversionOptions>,
     pub fee_policy: Option<FeePolicy>,
 }
@@ -370,6 +371,7 @@ pub struct _PrepareLnurlPayResponse {
     pub invoice_details: Bolt11InvoiceDetails,
     pub success_action: Option<SuccessAction>,
     pub conversion_estimate: Option<ConversionEstimate>,
+    pub token_identifier: Option<String>,
     pub fee_policy: FeePolicy,
 }
 
@@ -1129,7 +1131,8 @@ pub struct _OptimizationProgress {
 #[frb(mirror(ConversionEstimate))]
 pub struct _ConversionEstimate {
     pub options: ConversionOptions,
-    pub amount: u128,
+    pub amount_in: u128,
+    pub amount_out: u128,
     pub fee: u128,
     pub amount_adjustment: Option<AmountAdjustmentReason>,
 }


### PR DESCRIPTION
Send-all with stable balance works by combining token conversion with `FeesIncluded` fee policy. The user provides their full token balance as the amount, sets a `token_identifier`, and specifies `ConversionOptions` with `ToBitcoin` conversion type along with `FeePolicy::FeesIncluded`. During prepare, the SDK estimates the total sats available by converting all tokens to sats and adding any existing sat balance, then deducts fees. At send time, the SDK re-evaluates whether this is still a send-all based on current balance, if so converts the full token amount using `AmountIn` (rather than `MinAmountOut`), then queries the actual post-conversion sat balance and sends the entire balance minus fees - effectively draining the wallet completely

**Breaking change:**
- PrepareLnurlPayRequest
  - Replaces `amount_sats` with `amount`
  - Adds `token_identifier` 

Closes #770 