### PR TITLE
add Unknown fallback for backend enum parsing

### DIFF
--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -415,6 +415,7 @@ pub enum TokenTransactionType {
     Transfer,
     Mint,
     Burn,
+    Unknown,
 }
 
 impl fmt::Display for TokenTransactionType {
@@ -423,19 +424,21 @@ impl fmt::Display for TokenTransactionType {
             TokenTransactionType::Transfer => write!(f, "transfer"),
             TokenTransactionType::Mint => write!(f, "mint"),
             TokenTransactionType::Burn => write!(f, "burn"),
+            TokenTransactionType::Unknown => write!(f, "unknown"),
         }
     }
 }
 
-impl FromStr for TokenTransactionType {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "transfer" => Ok(TokenTransactionType::Transfer),
-            "mint" => Ok(TokenTransactionType::Mint),
-            "burn" => Ok(TokenTransactionType::Burn),
-            _ => Err(format!("Invalid token transaction type '{s}'")),
+impl From<&str> for TokenTransactionType {
+    fn from(value: &str) -> Self {
+        match value.to_lowercase().as_str() {
+            "transfer" => Self::Transfer,
+            "mint" => Self::Mint,
+            "burn" => Self::Burn,
+            other => {
+                tracing::warn!("Unknown TokenTransactionType: {other}");
+                Self::Unknown
+            }
         }
     }
 }
@@ -471,6 +474,8 @@ pub enum SparkHtlcStatus {
     PreimageShared,
     /// The HTLC has been returned to the sender due to expiry
     Returned,
+
+    Unknown,
 }
 
 impl fmt::Display for SparkHtlcStatus {
@@ -479,19 +484,21 @@ impl fmt::Display for SparkHtlcStatus {
             SparkHtlcStatus::WaitingForPreimage => write!(f, "WaitingForPreimage"),
             SparkHtlcStatus::PreimageShared => write!(f, "PreimageShared"),
             SparkHtlcStatus::Returned => write!(f, "Returned"),
+            SparkHtlcStatus::Unknown => write!(f, "Unknown"),
         }
     }
 }
 
-impl FromStr for SparkHtlcStatus {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "WaitingForPreimage" => Ok(SparkHtlcStatus::WaitingForPreimage),
-            "PreimageShared" => Ok(SparkHtlcStatus::PreimageShared),
-            "Returned" => Ok(SparkHtlcStatus::Returned),
-            _ => Err("Invalid Spark HTLC status".to_string()),
+impl From<&str> for SparkHtlcStatus {
+    fn from(value: &str) -> Self {
+        match value {
+            "WaitingForPreimage" => Self::WaitingForPreimage,
+            "PreimageShared" => Self::PreimageShared,
+            "Returned" => Self::Returned,
+            other => {
+                tracing::warn!("Unrecognized SparkHtlcStatus: {other}");
+                Self::Unknown
+            }
         }
     }
 }

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -13,7 +13,7 @@ use tracing::warn;
 use crate::{
     AssetFilter, Contact, ConversionDetails, ConversionInfo, ConversionStatus, DepositInfo,
     ListContactsRequest, LnurlPayInfo, LnurlReceiveMetadata, LnurlWithdrawInfo, PaymentDetails,
-    PaymentMethod, SparkHtlcDetails, SparkHtlcStatus,
+    PaymentMethod, SparkHtlcDetails, SparkHtlcStatus, TokenTransactionType,
     error::DepositClaimError,
     persist::{
         Payment, PaymentMetadata, SetLnurlMetadataItem, Storage, StorageError,
@@ -1400,16 +1400,15 @@ fn map_payment(row: &Row) -> Result<Payment, StorageError> {
             let description: Option<String> = row.get(13);
             let preimage: Option<String> = row.get(14);
             let htlc_status_str: Option<String> = row.get(15);
-            let htlc_status: SparkHtlcStatus = htlc_status_str
-                .ok_or_else(|| {
-                    StorageError::Implementation(
-                        "htlc_status is required for Lightning payments".to_string(),
-                    )
-                })
-                .and_then(|s| {
-                    s.parse()
-                        .map_err(|e: String| StorageError::Serialization(e))
-                })?;
+            let htlc_status: SparkHtlcStatus = SparkHtlcStatus::from(
+                htlc_status_str
+                    .ok_or_else(|| {
+                        StorageError::Implementation(
+                            "htlc_status is required for Lightning payments".to_string(),
+                        )
+                    })?
+                    .as_str(),
+            );
             let htlc_expiry_time: i64 = row.get(16);
             let htlc_details = SparkHtlcDetails {
                 payment_hash,
@@ -1464,9 +1463,7 @@ fn map_payment(row: &Row) -> Result<Payment, StorageError> {
         }
         (_, _, _, _, Some(metadata)) => {
             let tx_type_str: String = row.get(22);
-            let tx_type = tx_type_str
-                .parse()
-                .map_err(|e: String| StorageError::Serialization(e))?;
+            let tx_type = TokenTransactionType::from(tx_type_str.as_str());
             let invoice_details_json: Option<serde_json::Value> = row.get(23);
             let invoice_details = from_json_opt(invoice_details_json)?;
             let conversion_info_json: Option<serde_json::Value> = row.get(19);
@@ -1513,17 +1510,11 @@ fn map_payment(row: &Row) -> Result<Payment, StorageError> {
         }),
         conversion_details: {
             let conversion_status_str: Option<String> = row.get(30);
-            conversion_status_str
-                .map(|s| {
-                    s.parse::<ConversionStatus>()
-                        .map(|status| ConversionDetails {
-                            status,
-                            from: None,
-                            to: None,
-                        })
-                        .map_err(StorageError::Serialization)
-                })
-                .transpose()?
+            conversion_status_str.map(|s| ConversionDetails {
+                status: ConversionStatus::from(s.as_str()),
+                from: None,
+                to: None,
+            })
         },
     })
 }

--- a/crates/breez-sdk/core/src/persist/sqlite.rs
+++ b/crates/breez-sdk/core/src/persist/sqlite.rs
@@ -1564,8 +1564,7 @@ impl FromSql for TokenTransactionType {
         match value {
             ValueRef::Text(i) => {
                 let s = std::str::from_utf8(i).map_err(|e| FromSqlError::Other(Box::new(e)))?;
-                let tx_type: TokenTransactionType =
-                    s.parse().map_err(|_: String| FromSqlError::InvalidType)?;
+                let tx_type = TokenTransactionType::from(s);
                 Ok(tx_type)
             }
             _ => Err(FromSqlError::InvalidType),
@@ -1584,8 +1583,7 @@ impl FromSql for SparkHtlcStatus {
         match value {
             ValueRef::Text(i) => {
                 let s = std::str::from_utf8(i).map_err(|e| FromSqlError::Other(Box::new(e)))?;
-                let status: SparkHtlcStatus =
-                    s.parse().map_err(|_: String| FromSqlError::InvalidType)?;
+                let status = SparkHtlcStatus::from(s);
                 Ok(status)
             }
             _ => Err(FromSqlError::InvalidType),
@@ -1604,8 +1602,7 @@ impl FromSql for ConversionStatus {
         match value {
             ValueRef::Text(i) => {
                 let s = std::str::from_utf8(i).map_err(|e| FromSqlError::Other(Box::new(e)))?;
-                let status: ConversionStatus =
-                    s.parse().map_err(|_: String| FromSqlError::InvalidType)?;
+                let status = ConversionStatus::from(s);
                 Ok(status)
             }
             _ => Err(FromSqlError::InvalidType),

--- a/crates/breez-sdk/core/src/token_conversion/models.rs
+++ b/crates/breez-sdk/core/src/token_conversion/models.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::str::FromStr;
 
 use flashnet::{BTC_ASSET_ADDRESS, Pool};
 use serde::{Deserialize, Serialize};
@@ -94,6 +93,8 @@ pub enum ConversionStatus {
     RefundNeeded,
     /// The conversion failed and a refund was made
     Refunded,
+
+    Unknown,
 }
 
 impl fmt::Display for ConversionStatus {
@@ -104,21 +105,23 @@ impl fmt::Display for ConversionStatus {
             ConversionStatus::Failed => write!(f, "failed"),
             ConversionStatus::RefundNeeded => write!(f, "refund_needed"),
             ConversionStatus::Refunded => write!(f, "refunded"),
+            ConversionStatus::Unknown => write!(f, "unknown"),
         }
     }
 }
 
-impl FromStr for ConversionStatus {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "pending" => Ok(ConversionStatus::Pending),
-            "completed" => Ok(ConversionStatus::Completed),
-            "failed" => Ok(ConversionStatus::Failed),
-            "refund_needed" => Ok(ConversionStatus::RefundNeeded),
-            "refunded" => Ok(ConversionStatus::Refunded),
-            _ => Err(format!("Invalid conversion status '{s}'")),
+impl From<&str> for ConversionStatus {
+    fn from(value: &str) -> Self {
+        match value {
+            "pending" => Self::Pending,
+            "completed" => Self::Completed,
+            "failed" => Self::Failed,
+            "refund_needed" => Self::RefundNeeded,
+            "refunded" => Self::Refunded,
+            other => {
+                tracing::warn!("Unrecognized ConversionStatus: {other}");
+                Self::Unknown
+            }
         }
     }
 }

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -509,6 +509,7 @@ pub enum TokenTransactionType {
     Transfer,
     Mint,
     Burn,
+    Unknown,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::SparkInvoicePaymentDetails)]
@@ -530,6 +531,7 @@ pub enum SparkHtlcStatus {
     WaitingForPreimage,
     PreimageShared,
     Returned,
+    Unknown,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::PaymentMethod)]
@@ -1305,6 +1307,7 @@ pub enum ConversionStatus {
     Failed,
     RefundNeeded,
     Refunded,
+    Unknown,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::ConversionInfo)]


### PR DESCRIPTION
fix: Added Unknown fallback for backend enum parsing

- Added Unknown variant to SparkHtlcStatus, TokenTransactionType and ConversionStatus
- Replaced FromStr with From<&str> for safe parsing
- Replaced .parse() usages with Enum::from(...)
- Updated FromSql implementations to avoid failures on unknown values
- Added tracing warnings for unrecognized values

This PR closes the issue #773.