### PR TITLE
Lib: Add partner ID per gRPC request

### DIFF
--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -14,6 +14,7 @@ mod persist;
 mod realtime_sync;
 mod sdk;
 mod sdk_builder;
+mod session_manager;
 pub mod signer;
 mod stable_balance;
 mod sync;

--- a/crates/breez-sdk/core/src/sdk/init.rs
+++ b/crates/breez-sdk/core/src/sdk/init.rs
@@ -39,6 +39,7 @@ impl BreezSdk {
             token_converter: params.token_converter,
             stable_balance: params.stable_balance,
             buy_bitcoin_provider: params.buy_bitcoin_provider,
+            session_manager: params.session_manager,
         };
 
         sdk.start(initial_synced_sender);

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -19,6 +19,7 @@ use spark_wallet::SparkWallet;
 use std::sync::Arc;
 use tokio::sync::{Mutex, OnceCell, oneshot, watch};
 
+use crate::session_manager::BreezSessionManager;
 use crate::{
     BitcoinChainService, ExternalInputParser, InputType, Logger, Network, OptimizationConfig,
     error::SdkError, events::EventEmitter, lnurl::LnurlServerClient, logger, models::Config,
@@ -93,6 +94,7 @@ pub struct BreezSdk {
     pub(crate) token_converter: Arc<dyn TokenConverter>,
     pub(crate) stable_balance: Option<Arc<StableBalance>>,
     pub(crate) buy_bitcoin_provider: Arc<MoonpayProvider>,
+    pub(crate) session_manager: Arc<BreezSessionManager>,
 }
 
 pub(crate) struct BreezSdkParams {
@@ -110,6 +112,7 @@ pub(crate) struct BreezSdkParams {
     pub token_converter: Arc<dyn TokenConverter>,
     pub stable_balance: Option<Arc<StableBalance>>,
     pub sync_coordinator: SyncCoordinator,
+    pub session_manager: Arc<BreezSessionManager>,
 }
 
 pub async fn parse_input(

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -5,6 +5,10 @@ use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::{Instrument, debug, error, info, trace, warn};
 
+use crate::Network;
+use crate::session_manager::{
+    BreezSessionManager, KEY_BREEZ_JWT, calculate_expiry, is_jwt_expired, jwt_exp,
+};
 use crate::{
     DepositInfo, InputType, MaxFee, PaymentDetails, PaymentType,
     error::SdkError,
@@ -27,7 +31,33 @@ use super::{
     parse_input,
 };
 
+const JWT_REFRESH_RETRY_SECS: u64 = 10;
+
 impl BreezSdk {
+    async fn jwt_interval(&self, refresh_counter: u8) -> Duration {
+        let mut token = self.session_manager.token.read().await.clone();
+
+        if token.is_none() {
+            token = self
+                .storage
+                .get_cached_item(KEY_BREEZ_JWT.to_string())
+                .await
+                .ok()
+                .flatten();
+            if let Some(token) = &token
+                && !is_jwt_expired(token)
+            {
+                *self.session_manager.token.write().await = Some(token.clone());
+            }
+        }
+
+        Duration::from_secs(match (token, refresh_counter) {
+            (None, counter) if counter < 3 => 0,
+            (None, _) => JWT_REFRESH_RETRY_SECS,
+            (Some(token), _) => jwt_exp(&token).map_or(JWT_REFRESH_RETRY_SECS, calculate_expiry),
+        })
+    }
+
     pub(super) fn periodic_sync(&self, initial_synced_sender: watch::Sender<bool>) {
         let sdk = self.clone();
         let mut shutdown_receiver = sdk.shutdown_sender.subscribe();
@@ -35,6 +65,10 @@ impl BreezSdk {
         let sync_coordinator = sdk.sync_coordinator.clone();
         let mut sync_trigger_receiver = sdk.sync_coordinator.subscribe();
         let mut last_sync_time = SystemTime::now();
+        let (should_refresh_jwt, mut refresh_counter) = (
+            matches!(sdk.config.network, Network::Mainnet) && sdk.config.api_key.is_some(),
+            0,
+        );
 
         let sync_interval = u64::from(self.config.sync_interval_secs);
         let span = tracing::Span::current();
@@ -91,6 +125,28 @@ impl BreezSdk {
                             last_sync_time = SystemTime::now();
                         }
                     }
+
+                    () = tokio::time::sleep(sdk.jwt_interval(refresh_counter).await), if should_refresh_jwt => {
+                        refresh_counter = refresh_counter.saturating_add(1);
+                        let api_key = sdk.config.api_key.as_ref().unwrap();
+                        let token = match BreezSessionManager::new_jwt(api_key).await {
+                            Ok(token) => token,
+                            Err(err) => {
+                                warn!("Could not fetch new JWT: {err}");
+                                continue;
+                            }
+                        };
+                        *sdk.session_manager.token.write().await = Some(token.clone());
+                        if let Err(err) = sdk
+                            .storage
+                            .set_cached_item(KEY_BREEZ_JWT.to_string(), token)
+                            .await
+                        {
+                            warn!("Could not persist JWT: {err}");
+                        }
+                        refresh_counter = 0;
+                    }
+
                     // Ensure we sync at least the configured interval
                     () = tokio::time::sleep(Duration::from_secs(10)) => {
                         let now = SystemTime::now();

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -1,8 +1,6 @@
 use platform_utils::time::{Duration, Instant, SystemTime};
-use platform_utils::{DefaultHttpClient, HttpClient as _, tokio};
-use serde::Deserialize;
+use platform_utils::tokio;
 use spark_wallet::WalletEvent;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::{Instrument, debug, error, info, trace, warn};
@@ -13,7 +11,6 @@ use super::{
     parse_input,
 };
 use crate::Network;
-use crate::session_manager::{KEY_BREEZ_JWT, calculate_expiry, is_jwt_expired, jwt_exp};
 use crate::{
     DepositInfo, InputType, MaxFee, PaymentDetails, PaymentType,
     error::SdkError,
@@ -29,58 +26,8 @@ use crate::{
         utxo_fetcher::DetailedUtxo,
     },
 };
-use breez_sdk_common::breez_server::PRODUCTION_BREEZSERVER_URL;
-
-const JWT_REFRESH_RETRY_SECS: u64 = 10;
-
-#[derive(Deserialize)]
-struct JwtResponse {
-    token: String,
-}
 
 impl BreezSdk {
-    pub(crate) async fn new_jwt(api_key: &str) -> Result<String, SdkError> {
-        let client = DefaultHttpClient::new(None);
-        let mut headers = HashMap::new();
-        headers.insert("authorization".to_string(), format!("Bearer {api_key}"));
-        let res = client
-            .get(
-                format!("{PRODUCTION_BREEZSERVER_URL}/api/jwt"),
-                Some(headers),
-            )
-            .await
-            .map_err(|err| SdkError::Generic(format!("Could not retrieve JWT token: {err}")))?;
-
-        let JwtResponse { token } = serde_json::from_str(&res.body).map_err(|err| {
-            SdkError::Generic(format!("Could not parse JWT token response: {err}"))
-        })?;
-        Ok(token)
-    }
-
-    async fn jwt_interval(&self, refresh_counter: u8) -> Duration {
-        let mut token = self.session_manager.get_token().await;
-
-        if token.is_none() {
-            token = self
-                .storage
-                .get_cached_item(KEY_BREEZ_JWT.to_string())
-                .await
-                .ok()
-                .flatten();
-            if let Some(token) = &token
-                && !is_jwt_expired(token)
-            {
-                self.session_manager.set_token(token.clone()).await;
-            }
-        }
-
-        Duration::from_secs(match (token, refresh_counter) {
-            (None, counter) if counter < 3 => 0,
-            (None, _) => JWT_REFRESH_RETRY_SECS,
-            (Some(token), _) => jwt_exp(&token).map_or(JWT_REFRESH_RETRY_SECS, calculate_expiry),
-        })
-    }
-
     pub(super) fn periodic_sync(&self, initial_synced_sender: watch::Sender<bool>) {
         let sdk = self.clone();
         let mut shutdown_receiver = sdk.shutdown_sender.subscribe();
@@ -163,7 +110,7 @@ impl BreezSdk {
                         sdk.session_manager.set_token(token.clone()).await;
                         if let Err(err) = sdk
                             .storage
-                            .set_cached_item(KEY_BREEZ_JWT.to_string(), token)
+                            .set_cached_item(jwt::KEY_BREEZ_JWT.to_string(), token)
                             .await
                         {
                             warn!("Could not persist JWT: {err}");
@@ -710,5 +657,151 @@ impl BreezSdk {
             .trigger_sync_and_wait(super::SyncType::Full, true)
             .await?;
         Ok(SyncWalletResponse {})
+    }
+}
+
+mod jwt {
+    use std::collections::HashMap;
+
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    use breez_sdk_common::{breez_server::PRODUCTION_BREEZSERVER_URL, utils::now};
+    use platform_utils::{DefaultHttpClient, HttpClient as _, time::Duration};
+    use serde::Deserialize;
+
+    use crate::{BreezSdk, SdkError};
+
+    pub(super) const KEY_BREEZ_JWT: &str = "breez_jwt";
+    const JWT_REFRESH_RETRY_SECS: u64 = 10;
+    const JWT_EXPIRY_GRACE_PERIOD_SECS: u64 = 60 * 5; // Token expires 5 minutes in advance
+
+    #[derive(Deserialize)]
+    struct Jwt {
+        exp: u64,
+    }
+
+    #[derive(Deserialize)]
+    struct JwtServerResponse {
+        token: String,
+    }
+
+    pub(crate) fn calculate_expiry(exp: u64) -> u64 {
+        exp.saturating_sub(Into::<u64>::into(now()).saturating_add(JWT_EXPIRY_GRACE_PERIOD_SECS))
+    }
+
+    pub(crate) fn is_jwt_expired(token: &str) -> bool {
+        let Some(exp) = jwt_exp(token) else {
+            return true;
+        };
+        calculate_expiry(exp) == 0
+    }
+
+    pub(crate) fn jwt_exp(token: &str) -> Option<u64> {
+        let payload_b64 = token.split('.').nth(1)?;
+        let decoded = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
+        let payload = std::str::from_utf8(&decoded).ok()?;
+        let Jwt { exp } = serde_json::from_str(payload).ok()?;
+        Some(exp)
+    }
+
+    impl BreezSdk {
+        pub(super) async fn new_jwt(api_key: &str) -> Result<String, SdkError> {
+            let client = DefaultHttpClient::new(None);
+            let mut headers = HashMap::new();
+            headers.insert("authorization".to_string(), format!("Bearer {api_key}"));
+            let res = client
+                .get(
+                    format!("{PRODUCTION_BREEZSERVER_URL}/api/jwt"),
+                    Some(headers),
+                )
+                .await
+                .map_err(|err| SdkError::Generic(format!("Could not retrieve JWT token: {err}")))?;
+
+            let JwtServerResponse { token } = serde_json::from_str(&res.body).map_err(|err| {
+                SdkError::Generic(format!("Could not parse JWT token response: {err}"))
+            })?;
+            Ok(token)
+        }
+
+        pub(super) async fn jwt_interval(&self, refresh_counter: u8) -> Duration {
+            let mut token = self.session_manager.get_token().await;
+
+            if token.is_none() {
+                token = self
+                    .storage
+                    .get_cached_item(KEY_BREEZ_JWT.to_string())
+                    .await
+                    .ok()
+                    .flatten();
+                if let Some(token) = &token
+                    && !is_jwt_expired(token)
+                {
+                    self.session_manager.set_token(token.clone()).await;
+                }
+            }
+
+            Duration::from_secs(match (token, refresh_counter) {
+                (None, counter) if counter < 3 => 0,
+                (None, _) => JWT_REFRESH_RETRY_SECS,
+                (Some(token), _) => {
+                    jwt_exp(&token).map_or(JWT_REFRESH_RETRY_SECS, calculate_expiry)
+                }
+            })
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn make_jwt(exp: u64) -> String {
+            let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"HS256","typ":"JWT"}"#);
+            let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
+            format!("{header}.{payload}.fakesignature")
+        }
+
+        // --- jwt_exp ---
+
+        #[test]
+        fn test_jwt_exp_extracts_value() {
+            assert_eq!(jwt_exp(&make_jwt(9_999_999_999)), Some(9_999_999_999));
+        }
+
+        #[test]
+        fn test_jwt_exp_missing_exp_field() {
+            let payload = URL_SAFE_NO_PAD.encode(r#"{"sub":"user123"}"#);
+            assert_eq!(jwt_exp(&format!("h.{payload}.s")), None);
+        }
+
+        #[test]
+        fn test_jwt_exp_invalid_json() {
+            let payload = URL_SAFE_NO_PAD.encode("not json");
+            assert_eq!(jwt_exp(&format!("h.{payload}.s")), None);
+        }
+
+        // --- is_jwt_expired ---
+
+        #[test]
+        fn test_is_jwt_expired_far_past() {
+            assert!(is_jwt_expired(&make_jwt(0)));
+        }
+
+        #[test]
+        fn test_is_jwt_expired_far_future() {
+            assert!(!is_jwt_expired(&make_jwt(u64::MAX / 2)));
+        }
+
+        #[test]
+        fn test_is_jwt_expired_within_grace_period() {
+            // Will expire in 2 minutes, which is within the 3-minute grace window.
+            // Marked as expired
+            let token = make_jwt(u64::from(now()) + 120);
+            assert!(is_jwt_expired(&token));
+        }
+
+        #[test]
+        fn test_is_jwt_expired_malformed_token() {
+            assert!(is_jwt_expired("not.a.jwt"));
+            assert!(is_jwt_expired("onlyone"));
+        }
     }
 }

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -97,7 +97,7 @@ impl BreezSdk {
                         }
                     }
 
-                    () = tokio::time::sleep(sdk.jwt_interval(refresh_counter).await), if should_refresh_jwt => {
+                    () = sdk.jwt_interval(should_refresh_jwt, refresh_counter) => {
                         refresh_counter = refresh_counter.saturating_add(1);
                         let api_key = sdk.config.api_key.as_ref().unwrap();
 
@@ -738,15 +738,19 @@ mod jwt {
             }
         }
 
-        pub(super) async fn jwt_interval(&self, refresh_counter: u8) -> Duration {
+        pub(super) async fn jwt_interval(&self, should_refresh_jwt: bool, refresh_counter: u8) {
+            if !should_refresh_jwt {
+                std::future::pending::<()>().await;
+            }
             let token = self.session_manager.get_token().await;
-            Duration::from_secs(match (token, refresh_counter) {
+            let duration = Duration::from_secs(match (token, refresh_counter) {
                 (None, counter) if counter < 3 => 0,
                 (None, _) => JWT_REFRESH_RETRY_SECS,
                 (Some(token), _) => {
                     jwt_exp(&token).map_or(JWT_REFRESH_RETRY_SECS, calculate_expiry)
                 }
-            })
+            });
+            tokio::time::sleep(duration).await;
         }
     }
 

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -94,11 +94,7 @@ impl BreezSdk {
 
                     // Only executes on mainnet with API key
                     () = sdk.jwt_refresh_interval() => {
-                        let Some(api_key) = sdk.config.api_key.as_ref() else {
-                            warn!("Could not refresh JWT: no API key provided");
-                            return;
-                        };
-                        let token = match Self::new_jwt(api_key).await {
+                        let token = match sdk.new_jwt().await {
                             Ok(token) => token,
                             Err(err) => {
                                 warn!("Could not fetch new JWT: {err}");
@@ -702,7 +698,10 @@ mod jwt {
     }
 
     impl BreezSdk {
-        pub(super) async fn new_jwt(api_key: &str) -> Result<String, SdkError> {
+        pub(super) async fn new_jwt(&self) -> Result<String, SdkError> {
+            let Some(api_key) = &self.config.api_key else {
+                return Err(SdkError::Generic("Missing Breez API key".to_string()));
+            };
             let client = DefaultHttpClient::new(None);
             let mut headers = HashMap::new();
             headers.insert("authorization".to_string(), format!("Bearer {api_key}"));

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -46,6 +46,7 @@ impl BreezSdk {
             let balance_watcher =
                 BalanceWatcher::new(sdk.spark_wallet.clone(), sdk.storage.clone());
             let balance_watcher_id = sdk.add_event_listener(Box::new(balance_watcher)).await;
+            sdk.init_jwt().await;
             loop {
                 tokio::select! {
                     _ = shutdown_receiver.changed() => {
@@ -667,6 +668,7 @@ mod jwt {
     use breez_sdk_common::{breez_server::PRODUCTION_BREEZSERVER_URL, utils::now};
     use platform_utils::{DefaultHttpClient, HttpClient as _, time::Duration};
     use serde::Deserialize;
+    use tracing::warn;
 
     use crate::{BreezSdk, SdkError};
 
@@ -722,23 +724,22 @@ mod jwt {
             Ok(token)
         }
 
-        pub(super) async fn jwt_interval(&self, refresh_counter: u8) -> Duration {
-            let mut token = self.session_manager.get_token().await;
-
-            if token.is_none() {
-                token = self
-                    .storage
-                    .get_cached_item(KEY_BREEZ_JWT.to_string())
-                    .await
-                    .ok()
-                    .flatten();
-                if let Some(token) = &token
-                    && !is_jwt_expired(token)
-                {
-                    self.session_manager.set_token(token.clone()).await;
+        pub(super) async fn init_jwt(&self) {
+            match self
+                .storage
+                .get_cached_item(KEY_BREEZ_JWT.to_string())
+                .await
+            {
+                Ok(Some(stored_token)) if !is_jwt_expired(&stored_token) => {
+                    self.session_manager.set_token(stored_token).await;
                 }
+                Err(err) => warn!("Could not fetch stored JWT: {err}"),
+                _ => {}
             }
+        }
 
+        pub(super) async fn jwt_interval(&self, refresh_counter: u8) -> Duration {
+            let token = self.session_manager.get_token().await;
             Duration::from_secs(match (token, refresh_counter) {
                 (None, counter) if counter < 3 => 0,
                 (None, _) => JWT_REFRESH_RETRY_SECS,

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -35,7 +35,7 @@ const JWT_REFRESH_RETRY_SECS: u64 = 10;
 
 impl BreezSdk {
     async fn jwt_interval(&self, refresh_counter: u8) -> Duration {
-        let mut token = self.session_manager.token.read().await.clone();
+        let mut token = self.session_manager.get_token().await;
 
         if token.is_none() {
             token = self
@@ -47,7 +47,7 @@ impl BreezSdk {
             if let Some(token) = &token
                 && !is_jwt_expired(token)
             {
-                *self.session_manager.token.write().await = Some(token.clone());
+                self.session_manager.set_token(token.clone()).await;
             }
         }
 
@@ -136,7 +136,7 @@ impl BreezSdk {
                                 continue;
                             }
                         };
-                        *sdk.session_manager.token.write().await = Some(token.clone());
+                        sdk.session_manager.set_token(token.clone()).await;
                         if let Err(err) = sdk
                             .storage
                             .set_cached_item(KEY_BREEZ_JWT.to_string(), token)

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -10,7 +10,6 @@ use super::{
     helpers::{BalanceWatcher, update_balances},
     parse_input,
 };
-use crate::Network;
 use crate::{
     DepositInfo, InputType, MaxFee, PaymentDetails, PaymentType,
     error::SdkError,
@@ -35,10 +34,6 @@ impl BreezSdk {
         let sync_coordinator = sdk.sync_coordinator.clone();
         let mut sync_trigger_receiver = sdk.sync_coordinator.subscribe();
         let mut last_sync_time = SystemTime::now();
-        let (should_refresh_jwt, mut refresh_counter) = (
-            matches!(sdk.config.network, Network::Mainnet) && sdk.config.api_key.is_some(),
-            0,
-        );
 
         let sync_interval = u64::from(self.config.sync_interval_secs);
         let span = tracing::Span::current();
@@ -97,10 +92,12 @@ impl BreezSdk {
                         }
                     }
 
-                    () = sdk.jwt_interval(should_refresh_jwt, refresh_counter) => {
-                        refresh_counter = refresh_counter.saturating_add(1);
-                        let api_key = sdk.config.api_key.as_ref().unwrap();
-
+                    // Only executes on mainnet with API key
+                    () = sdk.jwt_refresh_interval() => {
+                        let Some(api_key) = sdk.config.api_key.as_ref() else {
+                            warn!("Could not refresh JWT: no API key provided");
+                            return;
+                        };
                         let token = match Self::new_jwt(api_key).await {
                             Ok(token) => token,
                             Err(err) => {
@@ -116,7 +113,6 @@ impl BreezSdk {
                         {
                             warn!("Could not persist JWT: {err}");
                         }
-                        refresh_counter = 0;
                     }
 
                     // Ensure we sync at least the configured interval
@@ -670,7 +666,7 @@ mod jwt {
     use serde::Deserialize;
     use tracing::warn;
 
-    use crate::{BreezSdk, SdkError};
+    use crate::{BreezSdk, Network, SdkError};
 
     pub(super) const KEY_BREEZ_JWT: &str = "breez_jwt";
     const JWT_REFRESH_RETRY_SECS: u64 = 10;
@@ -738,17 +734,16 @@ mod jwt {
             }
         }
 
-        pub(super) async fn jwt_interval(&self, should_refresh_jwt: bool, refresh_counter: u8) {
+        pub(super) async fn jwt_refresh_interval(&self) {
+            let should_refresh_jwt =
+                matches!(self.config.network, Network::Mainnet) && self.config.api_key.is_some();
             if !should_refresh_jwt {
                 std::future::pending::<()>().await;
             }
             let token = self.session_manager.get_token().await;
-            let duration = Duration::from_secs(match (token, refresh_counter) {
-                (None, counter) if counter < 3 => 0,
-                (None, _) => JWT_REFRESH_RETRY_SECS,
-                (Some(token), _) => {
-                    jwt_exp(&token).map_or(JWT_REFRESH_RETRY_SECS, calculate_expiry)
-                }
+            let duration = Duration::from_secs(match token {
+                None => JWT_REFRESH_RETRY_SECS,
+                Some(token) => jwt_exp(&token).map_or(JWT_REFRESH_RETRY_SECS, calculate_expiry),
             });
             tokio::time::sleep(duration).await;
         }

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -1,14 +1,19 @@
 use platform_utils::time::{Duration, Instant, SystemTime};
-use platform_utils::tokio;
+use platform_utils::{DefaultHttpClient, HttpClient as _, tokio};
+use serde::Deserialize;
 use spark_wallet::WalletEvent;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::{Instrument, debug, error, info, trace, warn};
 
-use crate::Network;
-use crate::session_manager::{
-    BreezSessionManager, KEY_BREEZ_JWT, calculate_expiry, is_jwt_expired, jwt_exp,
+use super::{
+    BreezSdk, CLAIM_TX_SIZE_VBYTES, SYNC_PAGING_LIMIT, SyncRequest, SyncType,
+    helpers::{BalanceWatcher, update_balances},
+    parse_input,
 };
+use crate::Network;
+use crate::session_manager::{KEY_BREEZ_JWT, calculate_expiry, is_jwt_expired, jwt_exp};
 use crate::{
     DepositInfo, InputType, MaxFee, PaymentDetails, PaymentType,
     error::SdkError,
@@ -24,16 +29,34 @@ use crate::{
         utxo_fetcher::DetailedUtxo,
     },
 };
-
-use super::{
-    BreezSdk, CLAIM_TX_SIZE_VBYTES, SYNC_PAGING_LIMIT, SyncRequest, SyncType,
-    helpers::{BalanceWatcher, update_balances},
-    parse_input,
-};
+use breez_sdk_common::breez_server::PRODUCTION_BREEZSERVER_URL;
 
 const JWT_REFRESH_RETRY_SECS: u64 = 10;
 
+#[derive(Deserialize)]
+struct JwtResponse {
+    token: String,
+}
+
 impl BreezSdk {
+    pub(crate) async fn new_jwt(api_key: &str) -> Result<String, SdkError> {
+        let client = DefaultHttpClient::new(None);
+        let mut headers = HashMap::new();
+        headers.insert("authorization".to_string(), format!("Bearer {api_key}"));
+        let res = client
+            .get(
+                format!("{PRODUCTION_BREEZSERVER_URL}/api/jwt"),
+                Some(headers),
+            )
+            .await
+            .map_err(|err| SdkError::Generic(format!("Could not retrieve JWT token: {err}")))?;
+
+        let JwtResponse { token } = serde_json::from_str(&res.body).map_err(|err| {
+            SdkError::Generic(format!("Could not parse JWT token response: {err}"))
+        })?;
+        Ok(token)
+    }
+
     async fn jwt_interval(&self, refresh_counter: u8) -> Duration {
         let mut token = self.session_manager.get_token().await;
 
@@ -129,7 +152,8 @@ impl BreezSdk {
                     () = tokio::time::sleep(sdk.jwt_interval(refresh_counter).await), if should_refresh_jwt => {
                         refresh_counter = refresh_counter.saturating_add(1);
                         let api_key = sdk.config.api_key.as_ref().unwrap();
-                        let token = match BreezSessionManager::new_jwt(api_key).await {
+
+                        let token = match Self::new_jwt(api_key).await {
                             Ok(token) => token,
                             Err(err) => {
                                 warn!("Could not fetch new JWT: {err}");

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -550,7 +550,7 @@ impl SdkBuilder {
         let mut wallet_builder =
             spark_wallet::WalletBuilder::new(spark_wallet_config, spark_signer)
                 .with_cancellation_token(shutdown_sender.subscribe())
-                .with_session_manager(session_manager);
+                .with_session_manager(session_manager.clone());
         if let Some(observer) = self.payment_observer {
             let observer: Arc<dyn spark_wallet::TransferObserver> =
                 Arc::new(SparkTransferObserver::new(observer));
@@ -668,6 +668,7 @@ impl SdkBuilder {
             token_converter,
             stable_balance,
             sync_coordinator,
+            session_manager,
         })?;
         debug!("Initialized and started breez sdk.");
 

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -12,7 +12,7 @@ use platform_utils::DefaultHttpClient;
 
 #[cfg(not(target_family = "wasm"))]
 use spark_wallet::Signer;
-use spark_wallet::{SparkWalletConfig, TokenOutputStore, TreeStore};
+use spark_wallet::{InMemorySessionManager, SparkWalletConfig, TokenOutputStore, TreeStore};
 use tokio::sync::watch;
 use tracing::{debug, info};
 
@@ -31,6 +31,7 @@ use crate::{
     persist::Storage,
     realtime_sync::{RealTimeSyncParams, init_and_start_real_time_sync},
     sdk::{BreezSdk, BreezSdkParams, SyncCoordinator},
+    session_manager::BreezSessionManager,
     signer::{
         breez::BreezSignerImpl, lnurl_auth::LnurlAuthSignerAdapter, rtsync::RTSyncSigner,
         spark::SparkSigner,
@@ -543,9 +544,13 @@ impl SdkBuilder {
                 Some(crate::persist::postgres::create_postgres_token_store(pool.clone()).await?);
         }
 
+        let session_manager = Arc::new(BreezSessionManager::new(Arc::new(
+            InMemorySessionManager::default(),
+        )));
         let mut wallet_builder =
             spark_wallet::WalletBuilder::new(spark_wallet_config, spark_signer)
-                .with_cancellation_token(shutdown_sender.subscribe());
+                .with_cancellation_token(shutdown_sender.subscribe())
+                .with_session_manager(session_manager);
         if let Some(observer) = self.payment_observer {
             let observer: Arc<dyn spark_wallet::TransferObserver> =
                 Arc::new(SparkTransferObserver::new(observer));

--- a/crates/breez-sdk/core/src/session_manager.rs
+++ b/crates/breez-sdk/core/src/session_manager.rs
@@ -1,15 +1,10 @@
 use std::sync::Arc;
 
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use bitcoin::secp256k1::PublicKey;
-use breez_sdk_common::utils::now;
 use platform_utils::tokio::sync::RwLock;
-use serde::Deserialize;
 use spark_wallet::{Session, SessionManager, SessionManagerError};
 
-pub(crate) const KEY_BREEZ_JWT: &str = "breez_jwt";
 const PARTNER_ID_HEADER: &str = "partner_id";
-const JWT_EXPIRY_GRACE_PERIOD_SECS: u64 = 60 * 5; // Token expires 5 minutes in advance
 
 pub(crate) struct BreezSessionManager {
     inner: Arc<dyn SessionManager>,
@@ -61,85 +56,5 @@ impl SessionManager for BreezSessionManager {
                 .insert(PARTNER_ID_HEADER.to_string(), token.clone());
         }
         self.inner.set_session(service_identity_key, session).await
-    }
-}
-
-#[derive(Deserialize)]
-struct Jwt {
-    exp: u64,
-}
-
-pub(crate) fn calculate_expiry(exp: u64) -> u64 {
-    exp.saturating_sub(Into::<u64>::into(now()).saturating_add(JWT_EXPIRY_GRACE_PERIOD_SECS))
-}
-
-pub(crate) fn is_jwt_expired(token: &str) -> bool {
-    let Some(exp) = jwt_exp(token) else {
-        return true;
-    };
-    calculate_expiry(exp) == 0
-}
-
-pub(crate) fn jwt_exp(token: &str) -> Option<u64> {
-    let payload_b64 = token.split('.').nth(1)?;
-    let decoded = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
-    let payload = std::str::from_utf8(&decoded).ok()?;
-    let Jwt { exp } = serde_json::from_str(payload).ok()?;
-    Some(exp)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn make_jwt(exp: u64) -> String {
-        let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"HS256","typ":"JWT"}"#);
-        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
-        format!("{header}.{payload}.fakesignature")
-    }
-
-    // --- jwt_exp ---
-
-    #[test]
-    fn test_jwt_exp_extracts_value() {
-        assert_eq!(jwt_exp(&make_jwt(9_999_999_999)), Some(9_999_999_999));
-    }
-
-    #[test]
-    fn test_jwt_exp_missing_exp_field() {
-        let payload = URL_SAFE_NO_PAD.encode(r#"{"sub":"user123"}"#);
-        assert_eq!(jwt_exp(&format!("h.{payload}.s")), None);
-    }
-
-    #[test]
-    fn test_jwt_exp_invalid_json() {
-        let payload = URL_SAFE_NO_PAD.encode("not json");
-        assert_eq!(jwt_exp(&format!("h.{payload}.s")), None);
-    }
-
-    // --- is_jwt_expired ---
-
-    #[test]
-    fn test_is_jwt_expired_far_past() {
-        assert!(is_jwt_expired(&make_jwt(0)));
-    }
-
-    #[test]
-    fn test_is_jwt_expired_far_future() {
-        assert!(!is_jwt_expired(&make_jwt(u64::MAX / 2)));
-    }
-
-    #[test]
-    fn test_is_jwt_expired_within_grace_period() {
-        // Will expire in 2 minutes, which is within the 3-minute grace window.
-        // Marked as expired
-        let token = make_jwt(u64::from(now()) + 120);
-        assert!(is_jwt_expired(&token));
-    }
-
-    #[test]
-    fn test_is_jwt_expired_malformed_token() {
-        assert!(is_jwt_expired("not.a.jwt"));
-        assert!(is_jwt_expired("onlyone"));
     }
 }

--- a/crates/breez-sdk/core/src/session_manager.rs
+++ b/crates/breez-sdk/core/src/session_manager.rs
@@ -40,8 +40,8 @@ impl SessionManager for BreezSessionManager {
         service_identity_key: &PublicKey,
     ) -> Result<Session, SessionManagerError> {
         let mut session = self.inner.get_session(service_identity_key).await?;
-        if !session.headers.contains_key(PARTNER_ID_HEADER)
-            && let Some(token) = self.token.read().await.as_ref()
+        if let Some(token) = self.token.read().await.as_ref()
+            && session.headers.get(PARTNER_ID_HEADER) != Some(token)
         {
             session
                 .headers

--- a/crates/breez-sdk/core/src/session_manager.rs
+++ b/crates/breez-sdk/core/src/session_manager.rs
@@ -16,7 +16,7 @@ const JWT_EXPIRY_GRACE_PERIOD_SECS: u64 = 60 * 5; // Token expires 5 minutes in 
 
 pub(crate) struct BreezSessionManager {
     inner: Arc<dyn SessionManager>,
-    pub(crate) token: RwLock<Option<String>>,
+    token: RwLock<Option<String>>,
 }
 
 #[derive(Deserialize)]
@@ -30,6 +30,14 @@ impl BreezSessionManager {
             inner,
             token: RwLock::new(None),
         }
+    }
+
+    pub(crate) async fn get_token(&self) -> Option<String> {
+        self.token.read().await.clone()
+    }
+
+    pub(crate) async fn set_token(&self, new_token: String) {
+        *self.token.write().await = Some(new_token);
     }
 
     pub(crate) async fn new_jwt(api_key: &str) -> Result<String, SessionManagerError> {

--- a/crates/breez-sdk/core/src/session_manager.rs
+++ b/crates/breez-sdk/core/src/session_manager.rs
@@ -53,8 +53,13 @@ impl SessionManager for BreezSessionManager {
     async fn set_session(
         &self,
         service_identity_key: &PublicKey,
-        session: Session,
+        mut session: Session,
     ) -> Result<(), SessionManagerError> {
+        if let Some(token) = self.token.read().await.as_ref() {
+            session
+                .headers
+                .insert(PARTNER_ID_HEADER.to_string(), token.clone());
+        }
         self.inner.set_session(service_identity_key, session).await
     }
 }

--- a/crates/breez-sdk/core/src/session_manager.rs
+++ b/crates/breez-sdk/core/src/session_manager.rs
@@ -1,0 +1,50 @@
+use std::{collections::HashMap, sync::Arc};
+
+use bitcoin::secp256k1::PublicKey;
+use spark_wallet::{Session, SessionManager, SessionManagerError};
+use tracing::warn;
+
+const PARTNER_ID_HEADER: &str = "partner_id";
+
+pub(crate) struct BreezSessionManager {
+    inner: Arc<dyn SessionManager>,
+}
+
+impl BreezSessionManager {
+    pub(crate) fn new(inner: Arc<dyn SessionManager>) -> Self {
+        Self { inner }
+    }
+
+    async fn get_or_set_partner_id(&self) -> Result<String, SessionManagerError> {
+        todo!();
+    }
+}
+
+#[macros::async_trait]
+impl SessionManager for BreezSessionManager {
+    async fn get_session(
+        &self,
+        service_identity_key: &PublicKey,
+    ) -> Result<Session, SessionManagerError> {
+        let mut session = self.inner.get_session(service_identity_key).await?;
+        let mut headers = HashMap::new();
+        match self.get_or_set_partner_id().await {
+            Ok(partner_id) => {
+                headers.insert(PARTNER_ID_HEADER.to_string(), partner_id);
+            }
+            Err(err) => {
+                warn!("Could not set partner_id: {err}");
+            }
+        }
+        session.set_headers(headers);
+        Ok(session)
+    }
+
+    async fn set_session(
+        &self,
+        service_identity_key: &PublicKey,
+        session: Session,
+    ) -> Result<(), SessionManagerError> {
+        self.inner.set_session(service_identity_key, session).await
+    }
+}

--- a/crates/breez-sdk/core/src/session_manager.rs
+++ b/crates/breez-sdk/core/src/session_manager.rs
@@ -1,14 +1,11 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use bitcoin::secp256k1::PublicKey;
 use breez_sdk_common::utils::now;
 use platform_utils::tokio::sync::RwLock;
-use platform_utils::{DefaultHttpClient, HttpClient};
 use serde::Deserialize;
 use spark_wallet::{Session, SessionManager, SessionManagerError};
-
-use breez_sdk_common::breez_server::PRODUCTION_BREEZSERVER_URL;
 
 pub(crate) const KEY_BREEZ_JWT: &str = "breez_jwt";
 const PARTNER_ID_HEADER: &str = "partner_id";
@@ -17,11 +14,6 @@ const JWT_EXPIRY_GRACE_PERIOD_SECS: u64 = 60 * 5; // Token expires 5 minutes in 
 pub(crate) struct BreezSessionManager {
     inner: Arc<dyn SessionManager>,
     token: RwLock<Option<String>>,
-}
-
-#[derive(Deserialize)]
-struct TokenResponse {
-    token: String,
 }
 
 impl BreezSessionManager {
@@ -38,26 +30,6 @@ impl BreezSessionManager {
 
     pub(crate) async fn set_token(&self, new_token: String) {
         *self.token.write().await = Some(new_token);
-    }
-
-    pub(crate) async fn new_jwt(api_key: &str) -> Result<String, SessionManagerError> {
-        let client = DefaultHttpClient::new(None);
-        let mut headers = HashMap::new();
-        headers.insert("authorization".to_string(), format!("Bearer {api_key}"));
-        let res = client
-            .get(
-                format!("{PRODUCTION_BREEZSERVER_URL}/api/jwt"),
-                Some(headers),
-            )
-            .await
-            .map_err(|err| {
-                SessionManagerError::Generic(format!("Could not retrieve JWT token: {err}"))
-            })?;
-
-        let TokenResponse { token } = serde_json::from_str(&res.body).map_err(|err| {
-            SessionManagerError::Generic(format!("Could not parse JWT token response: {err}"))
-        })?;
-        Ok(token)
     }
 }
 

--- a/crates/breez-sdk/core/src/session_manager.rs
+++ b/crates/breez-sdk/core/src/session_manager.rs
@@ -1,22 +1,55 @@
 use std::{collections::HashMap, sync::Arc};
 
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use bitcoin::secp256k1::PublicKey;
+use breez_sdk_common::utils::now;
+use platform_utils::tokio::sync::RwLock;
+use platform_utils::{DefaultHttpClient, HttpClient};
+use serde::Deserialize;
 use spark_wallet::{Session, SessionManager, SessionManagerError};
-use tracing::warn;
 
+use breez_sdk_common::breez_server::PRODUCTION_BREEZSERVER_URL;
+
+pub(crate) const KEY_BREEZ_JWT: &str = "breez_jwt";
 const PARTNER_ID_HEADER: &str = "partner_id";
+const JWT_EXPIRY_GRACE_PERIOD_SECS: u64 = 60 * 5; // Token expires 5 minutes in advance
 
 pub(crate) struct BreezSessionManager {
     inner: Arc<dyn SessionManager>,
+    pub(crate) token: RwLock<Option<String>>,
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    token: String,
 }
 
 impl BreezSessionManager {
     pub(crate) fn new(inner: Arc<dyn SessionManager>) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            token: RwLock::new(None),
+        }
     }
 
-    async fn get_or_set_partner_id(&self) -> Result<String, SessionManagerError> {
-        todo!();
+    pub(crate) async fn new_jwt(api_key: &str) -> Result<String, SessionManagerError> {
+        let client = DefaultHttpClient::new(None);
+        let mut headers = HashMap::new();
+        headers.insert("authorization".to_string(), format!("Bearer {api_key}"));
+        let res = client
+            .get(
+                format!("{PRODUCTION_BREEZSERVER_URL}/api/jwt"),
+                Some(headers),
+            )
+            .await
+            .map_err(|err| {
+                SessionManagerError::Generic(format!("Could not retrieve JWT token: {err}"))
+            })?;
+
+        let TokenResponse { token } = serde_json::from_str(&res.body).map_err(|err| {
+            SessionManagerError::Generic(format!("Could not parse JWT token response: {err}"))
+        })?;
+        Ok(token)
     }
 }
 
@@ -27,16 +60,13 @@ impl SessionManager for BreezSessionManager {
         service_identity_key: &PublicKey,
     ) -> Result<Session, SessionManagerError> {
         let mut session = self.inner.get_session(service_identity_key).await?;
-        let mut headers = HashMap::new();
-        match self.get_or_set_partner_id().await {
-            Ok(partner_id) => {
-                headers.insert(PARTNER_ID_HEADER.to_string(), partner_id);
-            }
-            Err(err) => {
-                warn!("Could not set partner_id: {err}");
-            }
+        if !session.headers.contains_key(PARTNER_ID_HEADER)
+            && let Some(token) = self.token.read().await.as_ref()
+        {
+            session
+                .headers
+                .insert(PARTNER_ID_HEADER.to_string(), token.clone());
         }
-        session.set_headers(headers);
         Ok(session)
     }
 
@@ -46,5 +76,85 @@ impl SessionManager for BreezSessionManager {
         session: Session,
     ) -> Result<(), SessionManagerError> {
         self.inner.set_session(service_identity_key, session).await
+    }
+}
+
+#[derive(Deserialize)]
+struct Jwt {
+    exp: u64,
+}
+
+pub(crate) fn calculate_expiry(exp: u64) -> u64 {
+    exp.saturating_sub(Into::<u64>::into(now()).saturating_add(JWT_EXPIRY_GRACE_PERIOD_SECS))
+}
+
+pub(crate) fn is_jwt_expired(token: &str) -> bool {
+    let Some(exp) = jwt_exp(token) else {
+        return true;
+    };
+    calculate_expiry(exp) == 0
+}
+
+pub(crate) fn jwt_exp(token: &str) -> Option<u64> {
+    let payload_b64 = token.split('.').nth(1)?;
+    let decoded = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
+    let payload = std::str::from_utf8(&decoded).ok()?;
+    let Jwt { exp } = serde_json::from_str(payload).ok()?;
+    Some(exp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_jwt(exp: u64) -> String {
+        let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"HS256","typ":"JWT"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
+        format!("{header}.{payload}.fakesignature")
+    }
+
+    // --- jwt_exp ---
+
+    #[test]
+    fn test_jwt_exp_extracts_value() {
+        assert_eq!(jwt_exp(&make_jwt(9_999_999_999)), Some(9_999_999_999));
+    }
+
+    #[test]
+    fn test_jwt_exp_missing_exp_field() {
+        let payload = URL_SAFE_NO_PAD.encode(r#"{"sub":"user123"}"#);
+        assert_eq!(jwt_exp(&format!("h.{payload}.s")), None);
+    }
+
+    #[test]
+    fn test_jwt_exp_invalid_json() {
+        let payload = URL_SAFE_NO_PAD.encode("not json");
+        assert_eq!(jwt_exp(&format!("h.{payload}.s")), None);
+    }
+
+    // --- is_jwt_expired ---
+
+    #[test]
+    fn test_is_jwt_expired_far_past() {
+        assert!(is_jwt_expired(&make_jwt(0)));
+    }
+
+    #[test]
+    fn test_is_jwt_expired_far_future() {
+        assert!(!is_jwt_expired(&make_jwt(u64::MAX / 2)));
+    }
+
+    #[test]
+    fn test_is_jwt_expired_within_grace_period() {
+        // Will expire in 2 minutes, which is within the 3-minute grace window.
+        // Marked as expired
+        let token = make_jwt(u64::from(now()) + 120);
+        assert!(is_jwt_expired(&token));
+    }
+
+    #[test]
+    fn test_is_jwt_expired_malformed_token() {
+        assert!(is_jwt_expired("not.a.jwt"));
+        assert!(is_jwt_expired("onlyone"));
     }
 }

--- a/crates/spark/src/operator/rpc/auth.rs
+++ b/crates/spark/src/operator/rpc/auth.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::OperatorRpcError;
@@ -91,6 +92,7 @@ impl OperatorAuth {
             expiration: verify_resp.expiration_timestamp.try_into().map_err(|_| {
                 OperatorRpcError::Authentication("Invalid expiration timestamp".to_string())
             })?,
+            headers: HashMap::new(),
         };
         Ok(session)
     }

--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -722,10 +722,21 @@ impl TryFrom<Session> for OperatorSessionInterceptor {
     type Error = OperatorRpcError;
 
     fn try_from(session: Session) -> std::result::Result<Self, Self::Error> {
+        let mut headers = Vec::new();
+        for (key, value) in session.headers {
+            let metadata_key = key
+                .parse::<tonic::metadata::MetadataKey<Ascii>>()
+                .map_err(|_| OperatorRpcError::Generic(format!("Invalid metadata key: {key}")))?;
+            let metadata_value = value.parse::<MetadataValue<Ascii>>().map_err(|_| {
+                OperatorRpcError::Generic(format!("Invalid metadata value for key: {key}"))
+            })?;
+            headers.push((metadata_key, metadata_value));
+        }
         Ok(OperatorSessionInterceptor {
             token: session.token.parse().map_err(|_| {
                 OperatorRpcError::Authentication("Invalid session token".to_string())
             })?,
+            headers,
         })
     }
 }
@@ -733,12 +744,16 @@ impl TryFrom<Session> for OperatorSessionInterceptor {
 #[derive(Clone, Debug)]
 struct OperatorSessionInterceptor {
     token: MetadataValue<Ascii>,
+    headers: Vec<(tonic::metadata::MetadataKey<Ascii>, MetadataValue<Ascii>)>,
 }
 
 impl Interceptor for OperatorSessionInterceptor {
     fn call(&mut self, mut req: Request<()>) -> std::result::Result<Request<()>, Status> {
         req.metadata_mut()
             .insert("authorization", self.token.clone());
+        for (key, value) in &self.headers {
+            req.metadata_mut().insert(key, value.clone());
+        }
         Ok(req)
     }
 }

--- a/crates/spark/src/session_manager.rs
+++ b/crates/spark/src/session_manager.rs
@@ -27,10 +27,6 @@ impl Session {
         };
         self.expiration > duration.as_secs()
     }
-
-    pub fn set_headers(&mut self, headers: HashMap<String, String>) {
-        self.headers = headers;
-    }
 }
 
 #[macros::async_trait]

--- a/crates/spark/src/session_manager.rs
+++ b/crates/spark/src/session_manager.rs
@@ -17,6 +17,7 @@ pub enum SessionManagerError {
 pub struct Session {
     pub token: String,
     pub expiration: u64,
+    pub headers: HashMap<String, String>,
 }
 
 impl Session {
@@ -25,6 +26,10 @@ impl Session {
             return false;
         };
         self.expiration > duration.as_secs()
+    }
+
+    pub fn set_headers(&mut self, headers: HashMap<String, String>) {
+        self.headers = headers;
     }
 }
 

--- a/crates/spark/src/ssp/graphql/client.rs
+++ b/crates/spark/src/ssp/graphql/client.rs
@@ -120,7 +120,7 @@ impl GraphQLClient {
     {
         let session = self.get_session().await?;
         let full_url = self.get_full_url();
-        let mut headers = HashMap::new();
+        let mut headers = session.headers.clone();
         self.add_auth_headers(&session, &mut headers)?;
 
         match self
@@ -137,7 +137,7 @@ impl GraphQLClient {
                     && status_code == 401
                 {
                     let session = self.get_session().await?;
-                    let mut headers = HashMap::new();
+                    let mut headers = session.headers.clone();
                     self.add_auth_headers(&session, &mut headers)?;
 
                     return self
@@ -210,6 +210,7 @@ impl GraphQLClient {
                 .map_err(|_| {
                     GraphQLError::Authentication("Invalid expiration timestamp".to_string())
                 })?,
+            headers: HashMap::new(),
         })
     }
 


### PR DESCRIPTION
This PR:
- Changes the `spark` crate to allow passing custom headers to `Session`
- Adds a wrapper around `SessionManager` in the SDK that allows for fetching of a partner_id JWT