### PR TITLE
docs: update passkey documentation

### DIFF
--- a/crates/xtask/src/docs.rs
+++ b/crates/xtask/src/docs.rs
@@ -305,6 +305,8 @@ fn check_doc_snippets_kotlin_mpp_cmd(skip_binding_gen: bool) -> Result<()> {
     println!("Checking doc snippets Kotlin MPP");
 
     let kotlin_snippets_dir = workspace_root.join("docs/breez-sdk/snippets/kotlin_mpp_lib");
+
+    // Compile JVM target (commonMain sources)
     let status = Command::new("./gradlew")
         .arg("compileKotlinJvm")
         .current_dir(&kotlin_snippets_dir)
@@ -312,6 +314,19 @@ fn check_doc_snippets_kotlin_mpp_cmd(skip_binding_gen: bool) -> Result<()> {
     if !status.success() {
         anyhow::bail!(
             "Failed to run './gradlew compileKotlinJvm' in {:?}",
+            kotlin_snippets_dir
+        );
+    }
+
+    // Compile Android target (androidMain sources, including passkey snippets
+    // that use CredentialManagerPrfProvider which requires android.app.Activity)
+    let status = Command::new("./gradlew")
+        .arg("compileReleaseKotlinAndroid")
+        .current_dir(&kotlin_snippets_dir)
+        .status()?;
+    if !status.success() {
+        anyhow::bail!(
+            "Failed to run './gradlew compileReleaseKotlinAndroid' in {:?}",
             kotlin_snippets_dir
         );
     }

--- a/docs/breez-sdk/snippets-processor/src/main.rs
+++ b/docs/breez-sdk/snippets-processor/src/main.rs
@@ -183,7 +183,7 @@ impl SnippetsProcessor {
         vec![
             ("Rust", "rust", format!("snippets/rust/src/{}.rs", file_base)),
             ("Swift", "swift", format!("snippets/swift/BreezSdkSnippets/Sources/{}.swift", capitalize_first(file_base))),
-            ("Kotlin", "kotlin", format!("snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/{}.kt", capitalize_first(file_base))),
+            ("Kotlin", "kotlin", format!("snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/{}.kt", capitalize_first(file_base))),
             ("C#", "csharp", format!("snippets/csharp/{}.cs", capitalize_first(file_base))),
             ("Javascript", "typescript", format!("snippets/wasm/{}.ts", file_base)),
             ("React Native", "typescript", format!("snippets/react-native/{}.ts", file_base)),

--- a/docs/breez-sdk/snippets/csharp/Passkey.cs
+++ b/docs/breez-sdk/snippets/csharp/Passkey.cs
@@ -21,6 +21,25 @@ namespace BreezSdkSnippets
     }
     // ANCHOR_END: implement-prf-provider
 
+    class CheckAvailabilitySnippet
+    {
+        async Task CheckAvailability()
+        {
+            // ANCHOR: check-availability
+            var prfProvider = new CustomPasskeyPrfProvider();
+
+            if (await prfProvider.IsPrfAvailable())
+            {
+                // Show passkey as primary option
+            }
+            else
+            {
+                // Fall back to mnemonic flow
+            }
+            // ANCHOR_END: check-availability
+        }
+    }
+
     class PasskeySnippets
     {
         async Task<BreezSdk> ConnectWithPasskey()

--- a/docs/breez-sdk/snippets/csharp/Passkey.cs
+++ b/docs/breez-sdk/snippets/csharp/Passkey.cs
@@ -3,8 +3,8 @@ using Breez.Sdk.Spark;
 namespace BreezSdkSnippets
 {
     // ANCHOR: implement-prf-provider
-    // In practice, implement using platform-specific passkey APIs.
-    class ExamplePasskeyPrfProvider : PasskeyPrfProvider
+    // Implement using platform-specific passkey APIs if the SDK does not ship a built-in provider for your target.
+    class CustomPasskeyPrfProvider : PasskeyPrfProvider
     {
         public async Task<byte[]> DerivePrfSeed(string salt)
         {
@@ -26,7 +26,7 @@ namespace BreezSdkSnippets
         async Task<BreezSdk> ConnectWithPasskey()
         {
             // ANCHOR: connect-with-passkey
-            var prfProvider = new ExamplePasskeyPrfProvider();
+            var prfProvider = new CustomPasskeyPrfProvider();
             var passkey = new Passkey(prfProvider, null);
 
             // Derive the wallet from the passkey (pass null for the default wallet)
@@ -45,7 +45,7 @@ namespace BreezSdkSnippets
         async Task<string[]> ListLabels()
         {
             // ANCHOR: list-labels
-            var prfProvider = new ExamplePasskeyPrfProvider();
+            var prfProvider = new CustomPasskeyPrfProvider();
             var relayConfig = new NostrRelayConfig(
                 breezApiKey: "<breez api key>"
             );
@@ -65,7 +65,7 @@ namespace BreezSdkSnippets
         async Task StoreLabel()
         {
             // ANCHOR: store-label
-            var prfProvider = new ExamplePasskeyPrfProvider();
+            var prfProvider = new CustomPasskeyPrfProvider();
             var relayConfig = new NostrRelayConfig(
                 breezApiKey: "<breez api key>"
             );

--- a/docs/breez-sdk/snippets/flutter/lib/passkey.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/passkey.dart
@@ -2,14 +2,14 @@ import 'dart:typed_data';
 import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
 
 // ANCHOR: implement-prf-provider
-// Implement these functions using platform passkey APIs.
-Future<Uint8List> derivePrfSeed(String salt) async {
+// Use the built-in PasskeyPrfProvider, or implement the callbacks for custom logic.
+Future<Uint8List> exampleDerivePrfSeed(String salt) async {
   // Call platform passkey API with PRF extension
   // Returns 32-byte PRF output
   throw UnimplementedError('Implement using platform passkey APIs');
 }
 
-Future<bool> isPrfAvailable() async {
+Future<bool> exampleIsPrfAvailable() async {
   // Check if PRF-capable passkey exists
   throw UnimplementedError('Check platform passkey availability');
 }
@@ -17,9 +17,11 @@ Future<bool> isPrfAvailable() async {
 
 Future<BreezSdk> connectWithPasskey() async {
   // ANCHOR: connect-with-passkey
+  // Use the built-in platform PRF provider (or pass custom callbacks)
+  final prfProvider = PasskeyPrfProvider();
   final passkey = Passkey(
-    derivePrfSeed: derivePrfSeed,
-    isPrfAvailable: isPrfAvailable,
+    derivePrfSeed: prfProvider.derivePrfSeed,
+    isPrfAvailable: prfProvider.isPrfAvailable,
   );
 
   // Derive the wallet from the passkey (pass null for the default wallet)
@@ -35,12 +37,13 @@ Future<BreezSdk> connectWithPasskey() async {
 
 Future<List<String>> listLabels() async {
   // ANCHOR: list-labels
+  final prfProvider = PasskeyPrfProvider();
   final relayConfig = NostrRelayConfig(
     breezApiKey: '<breez api key>',
   );
   final passkey = Passkey(
-    derivePrfSeed: derivePrfSeed,
-    isPrfAvailable: isPrfAvailable,
+    derivePrfSeed: prfProvider.derivePrfSeed,
+    isPrfAvailable: prfProvider.isPrfAvailable,
     relayConfig: relayConfig,
   );
 
@@ -56,12 +59,13 @@ Future<List<String>> listLabels() async {
 
 Future<void> storeLabel() async {
   // ANCHOR: store-label
+  final prfProvider = PasskeyPrfProvider();
   final relayConfig = NostrRelayConfig(
     breezApiKey: '<breez api key>',
   );
   final passkey = Passkey(
-    derivePrfSeed: derivePrfSeed,
-    isPrfAvailable: isPrfAvailable,
+    derivePrfSeed: prfProvider.derivePrfSeed,
+    isPrfAvailable: prfProvider.isPrfAvailable,
     relayConfig: relayConfig,
   );
 

--- a/docs/breez-sdk/snippets/flutter/lib/passkey.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/passkey.dart
@@ -15,6 +15,17 @@ Future<bool> isPrfAvailable() async {
 }
 // ANCHOR_END: implement-prf-provider
 
+Future<void> checkAvailability() async {
+  // ANCHOR: check-availability
+  final prfProvider = PasskeyPrfProvider();
+  if (await prfProvider.isPrfAvailable()) {
+    // Show passkey as primary option
+  } else {
+    // Fall back to mnemonic flow
+  }
+  // ANCHOR_END: check-availability
+}
+
 Future<BreezSdk> connectWithPasskey() async {
   // ANCHOR: connect-with-passkey
   // Use the built-in platform PRF provider (or pass custom callbacks)

--- a/docs/breez-sdk/snippets/flutter/lib/passkey.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/passkey.dart
@@ -2,14 +2,14 @@ import 'dart:typed_data';
 import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
 
 // ANCHOR: implement-prf-provider
-// Use the built-in PasskeyPrfProvider, or implement the callbacks for custom logic.
-Future<Uint8List> exampleDerivePrfSeed(String salt) async {
+// Implement custom callbacks if the built-in PasskeyPrfProvider doesn't fit your needs.
+Future<Uint8List> derivePrfSeed(String salt) async {
   // Call platform passkey API with PRF extension
   // Returns 32-byte PRF output
   throw UnimplementedError('Implement using platform passkey APIs');
 }
 
-Future<bool> exampleIsPrfAvailable() async {
+Future<bool> isPrfAvailable() async {
   // Check if PRF-capable passkey exists
   throw UnimplementedError('Check platform passkey availability');
 }

--- a/docs/breez-sdk/snippets/go/passkey.go
+++ b/docs/breez-sdk/snippets/go/passkey.go
@@ -7,16 +7,16 @@ import (
 )
 
 // ANCHOR: implement-prf-provider
-// In practice, implement using platform-specific passkey APIs.
-type ExamplePasskeyPrfProvider struct{}
+// Implement using platform-specific passkey APIs if the SDK does not ship a built-in provider for your target.
+type CustomPasskeyPrfProvider struct{}
 
-func (p *ExamplePasskeyPrfProvider) DerivePrfSeed(salt string) ([]byte, error) {
+func (p *CustomPasskeyPrfProvider) DerivePrfSeed(salt string) ([]byte, error) {
 	// Call platform passkey API with PRF extension
 	// Returns 32-byte PRF output
 	panic("Implement using WebAuthn or native passkey APIs")
 }
 
-func (p *ExamplePasskeyPrfProvider) IsPrfAvailable() (bool, error) {
+func (p *CustomPasskeyPrfProvider) IsPrfAvailable() (bool, error) {
 	// Check if PRF-capable passkey exists
 	panic("Check platform passkey availability")
 }
@@ -25,7 +25,7 @@ func (p *ExamplePasskeyPrfProvider) IsPrfAvailable() (bool, error) {
 
 func ConnectWithPasskey() (*breez_sdk_spark.BreezSdk, error) {
 	// ANCHOR: connect-with-passkey
-	prfProvider := &ExamplePasskeyPrfProvider{}
+	prfProvider := &CustomPasskeyPrfProvider{}
 	passkey := breez_sdk_spark.NewPasskey(prfProvider, nil)
 
 	// Derive the wallet from the passkey (pass nil for the default wallet)
@@ -50,7 +50,7 @@ func ConnectWithPasskey() (*breez_sdk_spark.BreezSdk, error) {
 
 func ListLabels() ([]string, error) {
 	// ANCHOR: list-labels
-	prfProvider := &ExamplePasskeyPrfProvider{}
+	prfProvider := &CustomPasskeyPrfProvider{}
 	breezApiKey := "<breez api key>"
 	relayConfig := &breez_sdk_spark.NostrRelayConfig{
 		BreezApiKey: &breezApiKey,
@@ -72,7 +72,7 @@ func ListLabels() ([]string, error) {
 
 func StoreLabel() error {
 	// ANCHOR: store-label
-	prfProvider := &ExamplePasskeyPrfProvider{}
+	prfProvider := &CustomPasskeyPrfProvider{}
 	breezApiKey := "<breez api key>"
 	relayConfig := &breez_sdk_spark.NostrRelayConfig{
 		BreezApiKey: &breezApiKey,

--- a/docs/breez-sdk/snippets/go/passkey.go
+++ b/docs/breez-sdk/snippets/go/passkey.go
@@ -23,6 +23,19 @@ func (p *CustomPasskeyPrfProvider) IsPrfAvailable() (bool, error) {
 
 // ANCHOR_END: implement-prf-provider
 
+func CheckAvailability() {
+	// ANCHOR: check-availability
+	prfProvider := &CustomPasskeyPrfProvider{}
+
+	available, err := prfProvider.IsPrfAvailable()
+	if err == nil && available {
+		// Show passkey as primary option
+	} else {
+		// Fall back to mnemonic flow
+	}
+	// ANCHOR_END: check-availability
+}
+
 func ConnectWithPasskey() (*breez_sdk_spark.BreezSdk, error) {
 	// ANCHOR: connect-with-passkey
 	prfProvider := &CustomPasskeyPrfProvider{}

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/build.gradle.kts
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
         }
         androidMain.dependencies {
             implementation("androidx.core:core-ktx:1.15.0")
+            implementation("androidx.credentials:credentials:1.3.0")
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
@@ -20,7 +20,7 @@ class CustomPasskeyPrfProvider : PasskeyPrfProvider {
 }
 // ANCHOR_END: implement-prf-provider
 
-class CheckAvailabilitySnippet(private val activity: Activity) {
+class PasskeySnippets(private val activity: Activity) {
     suspend fun checkAvailability() {
         // ANCHOR: check-availability
         val prfProvider = CredentialManagerPrfProvider(
@@ -33,9 +33,7 @@ class CheckAvailabilitySnippet(private val activity: Activity) {
         }
         // ANCHOR_END: check-availability
     }
-}
 
-class PasskeySnippets(private val activity: Activity) {
     suspend fun connectWithPasskey(): BreezSdk {
         // ANCHOR: connect-with-passkey
         val prfProvider = CredentialManagerPrfProvider(

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Passkey.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Passkey.kt
@@ -1,10 +1,12 @@
 package com.example.kotlinmpplib
 
+import android.app.Activity
 import breez_sdk_spark.*
+import technology.breez.spark.passkey.CredentialManagerPrfProvider
 
 // ANCHOR: implement-prf-provider
-// In practice, implement PRF provider using platform passkey APIs
-class ExamplePasskeyPrfProvider : PasskeyPrfProvider {
+// Implement the interface for custom logic if the built-in CredentialManagerPrfProvider doesn't fit your needs.
+class CustomPasskeyPrfProvider : PasskeyPrfProvider {
     override suspend fun derivePrfSeed(salt: String): ByteArray {
         // Call platform passkey API with PRF extension
         // Returns 32-byte PRF output
@@ -18,10 +20,12 @@ class ExamplePasskeyPrfProvider : PasskeyPrfProvider {
 }
 // ANCHOR_END: implement-prf-provider
 
-class PasskeySnippets {
+class PasskeySnippets(private val activity: Activity) {
     suspend fun connectWithPasskey(): BreezSdk {
         // ANCHOR: connect-with-passkey
-        val prfProvider = ExamplePasskeyPrfProvider()
+        val prfProvider = CredentialManagerPrfProvider(
+            activityProvider = { activity }, // provide the current Activity
+        )
         val passkey = Passkey(prfProvider, null)
 
         // Derive the wallet from the passkey (pass null for the default wallet)
@@ -35,7 +39,9 @@ class PasskeySnippets {
 
     suspend fun listLabels(): List<String> {
         // ANCHOR: list-labels
-        val prfProvider = ExamplePasskeyPrfProvider()
+        val prfProvider = CredentialManagerPrfProvider(
+            activityProvider = { activity }, // provide the current Activity
+        )
         val relayConfig = NostrRelayConfig(breezApiKey = "<breez api key>")
         val passkey = Passkey(prfProvider, relayConfig)
 
@@ -51,7 +57,9 @@ class PasskeySnippets {
 
     suspend fun storeLabel() {
         // ANCHOR: store-label
-        val prfProvider = ExamplePasskeyPrfProvider()
+        val prfProvider = CredentialManagerPrfProvider(
+            activityProvider = { activity }, // provide the current Activity
+        )
         val relayConfig = NostrRelayConfig(breezApiKey = "<breez api key>")
         val passkey = Passkey(prfProvider, relayConfig)
 

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Passkey.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Passkey.kt
@@ -20,6 +20,21 @@ class CustomPasskeyPrfProvider : PasskeyPrfProvider {
 }
 // ANCHOR_END: implement-prf-provider
 
+class CheckAvailabilitySnippet(private val activity: Activity) {
+    suspend fun checkAvailability() {
+        // ANCHOR: check-availability
+        val prfProvider = CredentialManagerPrfProvider(
+            activityProvider = { activity }, // provide the current Activity
+        )
+        if (prfProvider.isPrfAvailable()) {
+            // Show passkey as primary option
+        } else {
+            // Fall back to mnemonic flow
+        }
+        // ANCHOR_END: check-availability
+    }
+}
+
 class PasskeySnippets(private val activity: Activity) {
     suspend fun connectWithPasskey(): BreezSdk {
         // ANCHOR: connect-with-passkey

--- a/docs/breez-sdk/snippets/python/src/passkey.py
+++ b/docs/breez-sdk/snippets/python/src/passkey.py
@@ -24,6 +24,17 @@ class CustomPasskeyPrfProvider(PasskeyPrfProvider):
 # ANCHOR_END: implement-prf-provider
 
 
+async def check_availability():
+    # ANCHOR: check-availability
+    prf_provider = CustomPasskeyPrfProvider()
+
+    if await prf_provider.is_prf_available():
+        pass  # Show passkey as primary option
+    else:
+        pass  # Fall back to mnemonic flow
+    # ANCHOR_END: check-availability
+
+
 async def connect_with_passkey():
     # ANCHOR: connect-with-passkey
     prf_provider = CustomPasskeyPrfProvider()

--- a/docs/breez-sdk/snippets/python/src/passkey.py
+++ b/docs/breez-sdk/snippets/python/src/passkey.py
@@ -11,8 +11,8 @@ from breez_sdk_spark import (
 
 
 # ANCHOR: implement-prf-provider
-# In practice, implement using platform-specific passkey APIs.
-class ExamplePasskeyPrfProvider(PasskeyPrfProvider):
+# Implement using platform-specific passkey APIs if the SDK does not ship a built-in provider for your target.
+class CustomPasskeyPrfProvider(PasskeyPrfProvider):
     async def derive_prf_seed(self, salt: str):
         # Call platform passkey API with PRF extension
         # Returns 32-byte PRF output
@@ -26,7 +26,7 @@ class ExamplePasskeyPrfProvider(PasskeyPrfProvider):
 
 async def connect_with_passkey():
     # ANCHOR: connect-with-passkey
-    prf_provider = ExamplePasskeyPrfProvider()
+    prf_provider = CustomPasskeyPrfProvider()
     passkey = Passkey(prf_provider, None)
 
     # Derive the wallet from the passkey (pass None for the default wallet)
@@ -40,7 +40,7 @@ async def connect_with_passkey():
 
 async def list_labels() -> list[str]:
     # ANCHOR: list-labels
-    prf_provider = ExamplePasskeyPrfProvider()
+    prf_provider = CustomPasskeyPrfProvider()
     relay_config = NostrRelayConfig(breez_api_key="<breez api key>")
     passkey = Passkey(prf_provider, relay_config)
 
@@ -55,7 +55,7 @@ async def list_labels() -> list[str]:
 
 async def store_label():
     # ANCHOR: store-label
-    prf_provider = ExamplePasskeyPrfProvider()
+    prf_provider = CustomPasskeyPrfProvider()
     relay_config = NostrRelayConfig(breez_api_key="<breez api key>")
     passkey = Passkey(prf_provider, relay_config)
 

--- a/docs/breez-sdk/snippets/python/src/passkey.py
+++ b/docs/breez-sdk/snippets/python/src/passkey.py
@@ -11,7 +11,8 @@ from breez_sdk_spark import (
 
 
 # ANCHOR: implement-prf-provider
-# Implement using platform-specific passkey APIs if the SDK does not ship a built-in provider for your target.
+# Implement using platform-specific passkey APIs if the SDK does not
+# ship a built-in provider for your target.
 class CustomPasskeyPrfProvider(PasskeyPrfProvider):
     async def derive_prf_seed(self, salt: str):
         # Call platform passkey API with PRF extension

--- a/docs/breez-sdk/snippets/react-native/passkey.ts
+++ b/docs/breez-sdk/snippets/react-native/passkey.ts
@@ -8,8 +8,8 @@ import {
 } from '@breeztech/breez-sdk-spark-react-native'
 
 // ANCHOR: implement-prf-provider
-// Use the built-in PasskeyPrfProvider, or implement the interface for custom logic.
-class ExamplePasskeyPrfProvider {
+// Implement the interface for custom logic if the built-in PasskeyPrfProvider doesn't fit your needs.
+class CustomPasskeyPrfProvider {
   derivePrfSeed = async (salt: string): Promise<ArrayBuffer> => {
     // Call platform passkey API with PRF extension
     // Returns 32-byte PRF output
@@ -23,7 +23,7 @@ class ExamplePasskeyPrfProvider {
 }
 // ANCHOR_END: implement-prf-provider
 
-const exampleConnectWithPasskey = async () => {
+const connectWithPasskey = async () => {
   // ANCHOR: connect-with-passkey
   // Use the built-in platform PRF provider (or pass a custom implementation)
   const prfProvider = new PasskeyPrfProvider()
@@ -38,7 +38,7 @@ const exampleConnectWithPasskey = async () => {
   return sdk
 }
 
-const exampleListLabels = async (): Promise<string[]> => {
+const listLabels = async (): Promise<string[]> => {
   // ANCHOR: list-labels
   const prfProvider = new PasskeyPrfProvider()
   const relayConfig: NostrRelayConfig = {
@@ -57,7 +57,7 @@ const exampleListLabels = async (): Promise<string[]> => {
   return labels
 }
 
-const exampleStoreLabel = async () => {
+const storeLabel = async () => {
   // ANCHOR: store-label
   const prfProvider = new PasskeyPrfProvider()
   const relayConfig: NostrRelayConfig = {

--- a/docs/breez-sdk/snippets/react-native/passkey.ts
+++ b/docs/breez-sdk/snippets/react-native/passkey.ts
@@ -1,13 +1,14 @@
 import type { NostrRelayConfig } from '@breeztech/breez-sdk-spark-react-native'
 import {
   Passkey,
+  PasskeyPrfProvider,
   connect,
   defaultConfig,
   Network
 } from '@breeztech/breez-sdk-spark-react-native'
 
 // ANCHOR: implement-prf-provider
-// In practice, implement PRF provider using platform passkey APIs
+// Use the built-in PasskeyPrfProvider, or implement the interface for custom logic.
 class ExamplePasskeyPrfProvider {
   derivePrfSeed = async (salt: string): Promise<ArrayBuffer> => {
     // Call platform passkey API with PRF extension
@@ -24,7 +25,8 @@ class ExamplePasskeyPrfProvider {
 
 const exampleConnectWithPasskey = async () => {
   // ANCHOR: connect-with-passkey
-  const prfProvider = new ExamplePasskeyPrfProvider()
+  // Use the built-in platform PRF provider (or pass a custom implementation)
+  const prfProvider = new PasskeyPrfProvider()
   const passkey = new Passkey(prfProvider, undefined)
 
   // Construct the wallet using the passkey (pass undefined for the default wallet)
@@ -38,7 +40,7 @@ const exampleConnectWithPasskey = async () => {
 
 const exampleListLabels = async (): Promise<string[]> => {
   // ANCHOR: list-labels
-  const prfProvider = new ExamplePasskeyPrfProvider()
+  const prfProvider = new PasskeyPrfProvider()
   const relayConfig: NostrRelayConfig = {
     breezApiKey: '<breez api key>',
     timeoutSecs: undefined
@@ -57,7 +59,7 @@ const exampleListLabels = async (): Promise<string[]> => {
 
 const exampleStoreLabel = async () => {
   // ANCHOR: store-label
-  const prfProvider = new ExamplePasskeyPrfProvider()
+  const prfProvider = new PasskeyPrfProvider()
   const relayConfig: NostrRelayConfig = {
     breezApiKey: '<breez api key>',
     timeoutSecs: undefined

--- a/docs/breez-sdk/snippets/react-native/passkey.ts
+++ b/docs/breez-sdk/snippets/react-native/passkey.ts
@@ -38,7 +38,7 @@ const connectWithPasskey = async () => {
   // ANCHOR: connect-with-passkey
   // Use the built-in platform PRF provider (or pass a custom implementation)
   const prfProvider = new PasskeyPrfProvider()
-  const passkey = new Passkey(prfProvider, undefined)
+  const passkey = new Passkey(prfProvider as any, undefined)
 
   // Construct the wallet using the passkey (pass undefined for the default wallet)
   const wallet = await passkey.getWallet('personal')
@@ -56,7 +56,7 @@ const listLabels = async (): Promise<string[]> => {
     breezApiKey: '<breez api key>',
     timeoutSecs: undefined
   }
-  const passkey = new Passkey(prfProvider, relayConfig)
+  const passkey = new Passkey(prfProvider as any, relayConfig)
 
   // Query Nostr for labels associated with this passkey
   const labels = await passkey.listLabels()
@@ -75,7 +75,7 @@ const storeLabel = async () => {
     breezApiKey: '<breez api key>',
     timeoutSecs: undefined
   }
-  const passkey = new Passkey(prfProvider, relayConfig)
+  const passkey = new Passkey(prfProvider as any, relayConfig)
 
   // Publish the label to Nostr for later discovery
   await passkey.storeLabel('personal')

--- a/docs/breez-sdk/snippets/react-native/passkey.ts
+++ b/docs/breez-sdk/snippets/react-native/passkey.ts
@@ -23,6 +23,17 @@ class CustomPasskeyPrfProvider {
 }
 // ANCHOR_END: implement-prf-provider
 
+const checkAvailability = async () => {
+  // ANCHOR: check-availability
+  const prfProvider = new PasskeyPrfProvider()
+  if (await prfProvider.isPrfAvailable()) {
+    // Show passkey as primary option
+  } else {
+    // Fall back to mnemonic flow
+  }
+  // ANCHOR_END: check-availability
+}
+
 const connectWithPasskey = async () => {
   // ANCHOR: connect-with-passkey
   // Use the built-in platform PRF provider (or pass a custom implementation)

--- a/docs/breez-sdk/snippets/rust/Cargo.lock
+++ b/docs/breez-sdk/snippets/rust/Cargo.lock
@@ -74,10 +74,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "async-stream"
@@ -135,7 +180,7 @@ dependencies = [
  "futures-util",
  "js-sys",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-socks",
  "tokio-tungstenite",
  "url",
@@ -235,6 +280,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -325,14 +376,15 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 [[package]]
 name = "bitreq"
 version = "0.3.4"
-source = "git+https://github.com/breez/corepc?branch=yse-bitreq-rustls#d052f8f0efd05459dd4ae157a2d68d2044ac824c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08221cf31c5f00fb6fc8fa697cea54176b06801a518bd9d3482aa27099827a3a"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
  "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "webpki-roots 0.25.4",
 ]
 
@@ -361,7 +413,7 @@ dependencies = [
  "aes",
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bech32",
  "bitcoin",
  "bitreq",
@@ -373,12 +425,13 @@ dependencies = [
  "macros",
  "platform-utils",
  "prost",
- "regex-lite",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
  "spark",
  "spark-wallet",
+ "strum",
  "thiserror 2.0.17",
  "tokio",
  "tonic",
@@ -393,13 +446,16 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bip39",
  "bitcoin",
  "bitflags",
  "breez-sdk-common",
  "built",
  "chrono",
+ "deadpool",
+ "deadpool-postgres",
+ "ecies",
  "flashnet",
  "frost-secp256k1-tr-unofficial",
  "hex",
@@ -411,17 +467,19 @@ dependencies = [
  "platform-utils",
  "rusqlite",
  "rusqlite_migration",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
- "spark-postgres",
  "spark-wallet",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-postgres",
+ "tokio-postgres-rustls",
  "tracing",
  "tracing-subscriber",
- "utils",
  "uuid",
- "x509-cert",
+ "webpki-roots 1.0.5",
+ "x509-parser",
 ]
 
 [[package]]
@@ -613,6 +671,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +803,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "der_derive"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +846,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -825,11 +912,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "ecies"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd378cd438dcec2698ce6fd6cdbb323c671552d8be5af853690dc8320bc676d"
+dependencies = [
+ "aes-gcm",
+ "getrandom 0.2.16",
+ "hkdf",
+ "libsecp256k1",
+ "lock_api",
+ "once_cell",
+ "rand_core 0.6.4",
+ "sha2",
+ "typenum",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -846,7 +951,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -876,6 +981,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum_to_enum"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a98f748df7c1570c9c6bfbd3b422adeee429fd778538c66b79cccbb051b0d02"
+dependencies = [
+ "enum_to_enum_derive",
+]
+
+[[package]]
+name = "enum_to_enum_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51953530e29a0e9abfb23af10748b0328cabf3d0d0e1ffd34b61144c0e0440b1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -950,16 +1075,16 @@ checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 name = "flashnet"
 version = "0.1.0"
 dependencies = [
- "base64",
  "bitcoin",
  "getrandom 0.2.16",
  "hex",
+ "jwt",
  "macros",
  "platform-utils",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "serde_urlencoded",
+ "serde_qs",
  "serde_with",
  "spark",
  "spark-wallet",
@@ -1382,7 +1507,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1462,10 +1587,10 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -1488,7 +1613,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1737,6 +1862,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+dependencies = [
+ "base64 0.13.1",
+ "crypto-common",
+ "digest 0.10.7",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +1928,51 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
+dependencies = [
+ "arrayref",
+ "base64 0.22.1",
+ "digest 0.9.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -1927,7 +2112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1941,6 +2126,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1966,12 +2157,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nostr"
 version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62a97d745f1bd8d5e05a978632bbb87b0614567d5142906fe7c86fb2440faac6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bech32",
  "bip39",
  "bitcoin_hashes",
@@ -2039,10 +2240,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2064,10 +2284,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -2121,7 +2354,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -2213,7 +2446,7 @@ name = "platform-utils"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bitreq",
  "macros",
  "reqwest",
@@ -2250,6 +2483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+
+[[package]]
 name = "possiblyrandom"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,7 +2516,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
@@ -2525,12 +2764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2542,7 +2775,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2630,6 +2863,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,9 +2886,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "log",
  "once_cell",
@@ -2781,6 +3034,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,6 +3151,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "1.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c21dc864770a74dc4d61d6454bf3b5eb7bc7014d0cead189aa909472a70c9c"
+dependencies = [
+ "itoa",
+ "percent-encoding",
+ "ryu",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2905,7 +3181,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2948,7 +3224,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2965,7 +3241,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3002,7 +3278,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3049,11 +3325,13 @@ name = "spark"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bitcoin",
  "built",
  "bytes",
  "chrono",
+ "ecies",
+ "enum_to_enum",
  "frost-core-unofficial",
  "frost-secp256k1-tr-unofficial",
  "futures",
@@ -3069,7 +3347,7 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.8.5",
- "rustls",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
  "serde_with",
@@ -3081,31 +3359,7 @@ dependencies = [
  "tower-service",
  "tracing",
  "unicode-normalization",
- "utils",
  "uuid",
-]
-
-[[package]]
-name = "spark-postgres"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "chrono",
- "deadpool",
- "deadpool-postgres",
- "macros",
- "platform-utils",
- "rustls",
- "serde",
- "serde_json",
- "spark-wallet",
- "thiserror 2.0.17",
- "tokio",
- "tokio-postgres",
- "tokio-postgres-rustls",
- "tracing",
- "uuid",
- "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -3167,6 +3421,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "subtle"
@@ -3456,11 +3731,21 @@ checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
 dependencies = [
  "const-oid",
  "ring",
- "rustls",
+ "rustls 0.23.36",
  "tokio",
  "tokio-postgres",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "x509-cert",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
 ]
 
 [[package]]
@@ -3469,7 +3754,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.36",
  "tokio",
 ]
 
@@ -3504,10 +3789,10 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tungstenite",
  "webpki-roots 0.26.11",
 ]
@@ -3558,7 +3843,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -3574,7 +3859,7 @@ dependencies = [
  "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -3603,7 +3888,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8957be1a1c7aa12d4c9d67882060dd57aed816bbc553fa60949312e839f4a8ea"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "futures-util",
@@ -3766,7 +4051,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.17",
@@ -3846,19 +4131,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "utils"
-version = "0.1.0"
-dependencies = [
- "aes-gcm",
- "getrandom 0.2.16",
- "hkdf",
- "rand 0.8.5",
- "secp256k1",
- "sha2",
- "thiserror 2.0.17",
-]
 
 [[package]]
 name = "uuid"
@@ -4318,6 +4590,23 @@ dependencies = [
  "der",
  "spki",
  "tls_codec",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]

--- a/docs/breez-sdk/snippets/rust/src/passkey.rs
+++ b/docs/breez-sdk/snippets/rust/src/passkey.rs
@@ -6,11 +6,11 @@ use breez_sdk_spark::{connect, default_config, ConnectRequest, Network};
 use std::sync::Arc;
 
 // ANCHOR: implement-prf-provider
-/// In practice, implement using platform-specific passkey APIs.
-struct ExamplePasskeyPrfProvider;
+/// Implement using platform-specific passkey APIs if the SDK does not ship a built-in provider for your target.
+struct CustomPasskeyPrfProvider;
 
 #[async_trait::async_trait]
-impl PasskeyPrfProvider for ExamplePasskeyPrfProvider {
+impl PasskeyPrfProvider for CustomPasskeyPrfProvider {
     async fn derive_prf_seed(&self, _salt: String) -> Result<Vec<u8>, PasskeyPrfError> {
         // Call platform passkey API with PRF extension
         // Returns 32-byte PRF output
@@ -26,7 +26,7 @@ impl PasskeyPrfProvider for ExamplePasskeyPrfProvider {
 
 async fn connect_with_passkey() -> Result<breez_sdk_spark::BreezSdk> {
     // ANCHOR: connect-with-passkey
-    let prf_provider = Arc::new(ExamplePasskeyPrfProvider);
+    let prf_provider = Arc::new(CustomPasskeyPrfProvider);
     let passkey = Passkey::new(prf_provider, None);
 
     // Derive the wallet from the passkey (pass None for the default wallet)
@@ -45,7 +45,7 @@ async fn connect_with_passkey() -> Result<breez_sdk_spark::BreezSdk> {
 
 async fn list_labels() -> Result<Vec<String>> {
     // ANCHOR: list-labels
-    let prf_provider = Arc::new(ExamplePasskeyPrfProvider);
+    let prf_provider = Arc::new(CustomPasskeyPrfProvider);
     let relay_config = NostrRelayConfig {
         breez_api_key: Some("<breez api key>".to_string()),
         ..NostrRelayConfig::default()
@@ -64,7 +64,7 @@ async fn list_labels() -> Result<Vec<String>> {
 
 async fn store_label() -> Result<()> {
     // ANCHOR: store-label
-    let prf_provider = Arc::new(ExamplePasskeyPrfProvider);
+    let prf_provider = Arc::new(CustomPasskeyPrfProvider);
     let relay_config = NostrRelayConfig {
         breez_api_key: Some("<breez api key>".to_string()),
         ..NostrRelayConfig::default()

--- a/docs/breez-sdk/snippets/rust/src/passkey.rs
+++ b/docs/breez-sdk/snippets/rust/src/passkey.rs
@@ -24,6 +24,19 @@ impl PasskeyPrfProvider for CustomPasskeyPrfProvider {
 }
 // ANCHOR_END: implement-prf-provider
 
+async fn check_availability() -> Result<()> {
+    // ANCHOR: check-availability
+    let prf_provider = Arc::new(CustomPasskeyPrfProvider);
+
+    if prf_provider.is_prf_available().await? {
+        // Show passkey as primary option
+    } else {
+        // Fall back to mnemonic flow
+    }
+    // ANCHOR_END: check-availability
+    Ok(())
+}
+
 async fn connect_with_passkey() -> Result<breez_sdk_spark::BreezSdk> {
     // ANCHOR: connect-with-passkey
     let prf_provider = Arc::new(CustomPasskeyPrfProvider);

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
@@ -2,7 +2,7 @@ import BreezSdkSpark
 import Foundation
 
 // ANCHOR: implement-prf-provider
-// In practice, implement using platform-specific passkey APIs.
+// Use the built-in PlatformPasskeyPrfProvider, or implement the interface for custom logic.
 class ExamplePasskeyPrfProvider: PasskeyPrfProvider {
     func derivePrfSeed(salt: String) async throws -> Data {
         // Call platform passkey API with PRF extension
@@ -19,7 +19,8 @@ class ExamplePasskeyPrfProvider: PasskeyPrfProvider {
 
 func connectWithPasskey() async throws -> BreezSdk {
     // ANCHOR: connect-with-passkey
-    let prfProvider = ExamplePasskeyPrfProvider()
+    // Use the built-in platform PRF provider (or pass a custom implementation)
+    let prfProvider = PlatformPasskeyPrfProvider()
     let passkey = Passkey(prfProvider: prfProvider, relayConfig: nil)
 
     // Derive the wallet from the passkey (pass nil for the default wallet)
@@ -38,7 +39,7 @@ func connectWithPasskey() async throws -> BreezSdk {
 
 func listLabels() async throws -> [String] {
     // ANCHOR: list-labels
-    let prfProvider = ExamplePasskeyPrfProvider()
+    let prfProvider = PlatformPasskeyPrfProvider()
     let relayConfig = NostrRelayConfig(breezApiKey: "<breez api key>")
     let passkey = Passkey(prfProvider: prfProvider, relayConfig: relayConfig)
 
@@ -54,7 +55,7 @@ func listLabels() async throws -> [String] {
 
 func storeLabel() async throws {
     // ANCHOR: store-label
-    let prfProvider = ExamplePasskeyPrfProvider()
+    let prfProvider = PlatformPasskeyPrfProvider()
     let relayConfig = NostrRelayConfig(breezApiKey: "<breez api key>")
     let passkey = Passkey(prfProvider: prfProvider, relayConfig: relayConfig)
 

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
@@ -2,8 +2,8 @@ import BreezSdkSpark
 import Foundation
 
 // ANCHOR: implement-prf-provider
-// Use the built-in PlatformPasskeyPrfProvider, or implement the interface for custom logic.
-class ExamplePasskeyPrfProvider: PasskeyPrfProvider {
+// Implement the interface for custom logic if the built-in PlatformPasskeyPrfProvider doesn't fit your needs.
+class CustomPasskeyPrfProvider: PasskeyPrfProvider {
     func derivePrfSeed(salt: String) async throws -> Data {
         // Call platform passkey API with PRF extension
         // Returns 32-byte PRF output

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
@@ -17,6 +17,17 @@ class CustomPasskeyPrfProvider: PasskeyPrfProvider {
 }
 // ANCHOR_END: implement-prf-provider
 
+func checkAvailability() async throws {
+    // ANCHOR: check-availability
+    let prfProvider = PlatformPasskeyPrfProvider()
+    if try await prfProvider.isPrfAvailable() {
+        // Show passkey as primary option
+    } else {
+        // Fall back to mnemonic flow
+    }
+    // ANCHOR_END: check-availability
+}
+
 func connectWithPasskey() async throws -> BreezSdk {
     // ANCHOR: connect-with-passkey
     // Use the built-in platform PRF provider (or pass a custom implementation)

--- a/docs/breez-sdk/snippets/wasm/passkey-prf-provider.d.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey-prf-provider.d.ts
@@ -1,0 +1,15 @@
+// Type declarations for the passkey-prf-provider subpath export.
+// The actual implementation ships at @breeztech/breez-sdk-spark/passkey-prf-provider.
+declare module '@breeztech/breez-sdk-spark/passkey-prf-provider' {
+  export class WebAuthnPrfProvider {
+    constructor (options?: {
+      rpId?: string
+      rpName?: string
+      userName?: string
+      userDisplayName?: string
+    })
+    derivePrfSeed (salt: string): Promise<Uint8Array>
+    isPrfAvailable (): Promise<boolean>
+    createPasskey (): Promise<void>
+  }
+}

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -17,6 +17,17 @@ class CustomPasskeyPrfProvider {
 }
 // ANCHOR_END: implement-prf-provider
 
+const checkAvailability = async () => {
+  // ANCHOR: check-availability
+  const prfProvider = new WebAuthnPrfProvider()
+  if (await prfProvider.isPrfAvailable()) {
+    // Show passkey as primary option
+  } else {
+    // Fall back to mnemonic flow
+  }
+  // ANCHOR_END: check-availability
+}
+
 const connectWithPasskey = async () => {
   // ANCHOR: connect-with-passkey
   // Use the built-in WebAuthn PRF provider (or pass a custom implementation)

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -2,8 +2,8 @@ import type { NostrRelayConfig } from '@breeztech/breez-sdk-spark'
 import { Passkey, WebAuthnPrfProvider, connect, defaultConfig } from '@breeztech/breez-sdk-spark'
 
 // ANCHOR: implement-prf-provider
-// Use the built-in WebAuthnPrfProvider for browsers, or implement the interface for custom logic.
-class ExamplePasskeyPrfProvider {
+// Implement the interface for custom logic if the built-in WebAuthnPrfProvider doesn't fit your needs.
+class CustomPasskeyPrfProvider {
   derivePrfSeed = async (salt: string): Promise<Uint8Array> => {
     // Call platform passkey API with PRF extension
     // Returns 32-byte PRF output
@@ -17,7 +17,7 @@ class ExamplePasskeyPrfProvider {
 }
 // ANCHOR_END: implement-prf-provider
 
-const exampleConnectWithPasskey = async () => {
+const connectWithPasskey = async () => {
   // ANCHOR: connect-with-passkey
   // Use the built-in WebAuthn PRF provider (or pass a custom implementation)
   const prfProvider = new WebAuthnPrfProvider()
@@ -32,7 +32,7 @@ const exampleConnectWithPasskey = async () => {
   return sdk
 }
 
-const exampleListLabels = async (): Promise<string[]> => {
+const listLabels = async (): Promise<string[]> => {
   // ANCHOR: list-labels
   const prfProvider = new WebAuthnPrfProvider()
   const relayConfig: NostrRelayConfig = {
@@ -50,7 +50,7 @@ const exampleListLabels = async (): Promise<string[]> => {
   return labels
 }
 
-const exampleStoreLabel = async () => {
+const storeLabel = async () => {
   // ANCHOR: store-label
   const prfProvider = new WebAuthnPrfProvider()
   const relayConfig: NostrRelayConfig = {

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -1,8 +1,8 @@
 import type { NostrRelayConfig } from '@breeztech/breez-sdk-spark'
-import { Passkey, connect, defaultConfig } from '@breeztech/breez-sdk-spark'
+import { Passkey, WebAuthnPrfProvider, connect, defaultConfig } from '@breeztech/breez-sdk-spark'
 
 // ANCHOR: implement-prf-provider
-// In practice, implement PRF provider using WebAuthn API
+// Use the built-in WebAuthnPrfProvider for browsers, or implement the interface for custom logic.
 class ExamplePasskeyPrfProvider {
   derivePrfSeed = async (salt: string): Promise<Uint8Array> => {
     // Call platform passkey API with PRF extension
@@ -19,7 +19,8 @@ class ExamplePasskeyPrfProvider {
 
 const exampleConnectWithPasskey = async () => {
   // ANCHOR: connect-with-passkey
-  const prfProvider = new ExamplePasskeyPrfProvider()
+  // Use the built-in WebAuthn PRF provider (or pass a custom implementation)
+  const prfProvider = new WebAuthnPrfProvider()
   const passkey = new Passkey(prfProvider, undefined)
 
   // Construct the wallet using the passkey (pass undefined for the default wallet)
@@ -33,7 +34,7 @@ const exampleConnectWithPasskey = async () => {
 
 const exampleListLabels = async (): Promise<string[]> => {
   // ANCHOR: list-labels
-  const prfProvider = new ExamplePasskeyPrfProvider()
+  const prfProvider = new WebAuthnPrfProvider()
   const relayConfig: NostrRelayConfig = {
     breezApiKey: '<breez api key>'
   }
@@ -51,7 +52,7 @@ const exampleListLabels = async (): Promise<string[]> => {
 
 const exampleStoreLabel = async () => {
   // ANCHOR: store-label
-  const prfProvider = new ExamplePasskeyPrfProvider()
+  const prfProvider = new WebAuthnPrfProvider()
   const relayConfig: NostrRelayConfig = {
     breezApiKey: '<breez api key>'
   }

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -1,5 +1,6 @@
 import type { NostrRelayConfig } from '@breeztech/breez-sdk-spark'
-import { Passkey, WebAuthnPrfProvider, connect, defaultConfig } from '@breeztech/breez-sdk-spark'
+import { Passkey, connect, defaultConfig } from '@breeztech/breez-sdk-spark'
+import { WebAuthnPrfProvider } from '@breeztech/breez-sdk-spark/passkey-prf-provider'
 
 // ANCHOR: implement-prf-provider
 // Implement the interface for custom logic if the built-in WebAuthnPrfProvider doesn't fit your needs.

--- a/docs/breez-sdk/src/SUMMARY.md
+++ b/docs/breez-sdk/src/SUMMARY.md
@@ -62,3 +62,4 @@
 - [Sending payments](guide/uxguide_send.md)
 - [Displaying payments](guide/uxguide_display.md)
 - [Seed & key management](guide/uxguide_seed.md)
+- [Passkey login](guide/uxguide_passkey.md)

--- a/docs/breez-sdk/src/guide/passkey.md
+++ b/docs/breez-sdk/src/guide/passkey.md
@@ -27,7 +27,13 @@ Declares which web origins can use the centralized RP ID for WebAuthn operations
 }
 ```
 
-To register your web origin, [contact us](mailto:contact@breez.technology?subject=Passkey%20configuration) to have it added to this file.
+**Default RP domain**: [Contact us](mailto:contact@breez.technology?subject=Passkey%20configuration) to register your web origin. Breez manages the configuration files for registered apps.
+
+**Custom RP domain**: Host this file on your own domain at `/.well-known/webauthn`.
+
+**Requirements**:
+- Chrome 116+, Safari 18+, Edge 116+
+- HTTPS (localhost is exempt during development)
 
 #### Android: Asset Links
 
@@ -53,15 +59,29 @@ Establishes digital asset links between the domain and Android applications:
 ]
 ```
 
-Replace `com.example.yourapp` with your application package name and the fingerprint with your app's signing certificate SHA256 fingerprint. See the <a target="_blank" href="https://developers.google.com/digital-asset-links/v1/getting-started">Digital Asset Links</a> documentation and <a target="_blank" href="https://developer.android.com/identity/credential-manager/prerequisites">Credential Manager prerequisites</a> for details.
+**Default RP domain**: [Contact us](mailto:contact@breez.technology?subject=Passkey%20configuration) to register your Android app. Breez manages the configuration files for registered apps.
 
-To register your Android app, [contact us](mailto:contact@breez.technology?subject=Passkey%20configuration) with the details outlined to have it added to this file.
+**Custom RP domain**: Host this file on your own domain at `/.well-known/assetlinks.json`. Replace `com.example.yourapp` with your application package name and the fingerprint with your app's signing certificate SHA256 fingerprint. See the <a target="_blank" href="https://developers.google.com/digital-asset-links/v1/getting-started">Digital Asset Links</a> documentation and <a target="_blank" href="https://developer.android.com/identity/credential-manager/prerequisites">Credential Manager prerequisites</a> for details.
 
-#### iOS: Apple App Site Association
+**Requirements**:
+- Android 9+ (API 28) with Google Play Services, or Android 14+ (API 34) with any compatible credential provider
+- `compileSdkVersion` must be at least 34 (required by the `androidx.credentials` library, not the device)
+
+<div class="warning">
+<h4>Android emulators</h4>
+Most Android emulator images ship with Google Play Services as the only available credential provider, and many don't have a passkey-capable provider at all. Physical devices are recommended for passkey testing.
+</div>
+
+<div class="warning">
+<h4>Credential provider requirement</h4>
+On Android 9-13, passkeys are provided via Google Play Services and require Google Password Manager to be present and up to date. Android 14+ adds native passkey support and can integrate with any installed credential provider. However, at least one credential provider must be installed for passkeys to function (e.g., Google Password Manager, Bitwarden, 1Password etc.).
+</div>
+
+#### iOS / macOS: Apple App Site Association
 
 **File**: `https://keys.breez.technology/.well-known/apple-app-site-association`
 
-Connects the domain to iOS applications for passkey sharing:
+Connects the domain to iOS and macOS applications for passkey sharing:
 
 ```json
 {
@@ -73,8 +93,6 @@ Connects the domain to iOS applications for passkey sharing:
 }
 ```
 
-Replace `TEAMID` with your Apple Developer Team ID and `com.example.yourapp` with your application bundle identifier.
-
 Your app must have the <a target="_blank" href="https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.associated-domains">Associated Domains</a> capability enabled. In Xcode, go to **Signing & Capabilities** → add **Associated Domains** → add the entry `webcredentials:keys.breez.technology`.
 
 <div class="warning">
@@ -82,7 +100,17 @@ Your app must have the <a target="_blank" href="https://developer.apple.com/docu
 If you're using Expo, the Breez SDK plugin can configure this automatically. See the <a href="install_react_native.html#plugin-options">React Native/Expo installation guide</a> for details on the <code>enablePasskey</code> option.
 </div>
 
-To register your iOS app, [contact us](mailto:contact@breez.technology?subject=Passkey%20configuration) with the details outlined to have it added to this file.
+**Default RP domain**: [Contact us](mailto:contact@breez.technology?subject=Passkey%20configuration) to register your iOS app. Breez manages the configuration files for registered apps.
+
+**Custom RP domain**: Host this file on your own domain at `/.well-known/apple-app-site-association`. Replace `TEAMID` with your Apple Developer Team ID and `com.example.yourapp` with your bundle identifier.
+
+**Requirements**:
+- iOS 18.0+, macOS 15.0+
+
+<div class="warning">
+<h4>Associated Domains entitlement must be enabled</h4>
+Without the Associated Domains entitlement, passkey operations will fail with a configuration error even though {{#name is_prf_available}} returns `true` (the OS-level check can't verify entitlements at runtime).
+</div>
 
 ### Nostr relay configuration
 
@@ -93,18 +121,46 @@ The SDK uses Nostr relays to store and discover labels. Configure relay access b
 
 The SDK also implements <a target="_blank" href="https://github.com/nostr-protocol/nips/blob/master/65.md">NIP-65</a> to discover and publish to additional public relays for redundancy. See the [Listing labels](#listing-labels) and [Storing a label](#storing-a-label) code examples below for usage.
 
-## Implementing the PRF provider
+## PRF providers
 
-Your application must implement the PRF provider to interface with platform passkey APIs.
+A PRF provider handles passkey credential registration, assertion, and PRF evaluation against the platform's authenticator. The SDK uses the seed it returns to deterministically derive wallet keys.
+
+### Built-in providers
+
+The SDK ships with PRF providers for the major platforms:
+
+| Platform | Provider |
+|----------|----------|
+| Web (browsers) | `WebAuthnPrfProvider` |
+| iOS / macOS | `PlatformPasskeyPrfProvider` |
+| React Native | `PasskeyPrfProvider` |
+| Flutter | `PasskeyPrfProvider` |
+
+Android (Kotlin), Kotlin Multiplatform, and other platforms not listed above need to implement their own provider; see [Custom providers](#custom-providers) below.
+
+**Constructor options** (all built-in providers):
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| {{#name rp_id}} | `keys.breez.technology` | Relying Party ID. **Changing this breaks existing credentials.** |
+| {{#name rp_name}} | `Breez SDK` | RP display name (registration only, does not affect existing credentials) |
+| {{#name user_name}} | {{#name rp_name}} | User name stored with the credential (registration only) |
+| {{#name user_display_name}} | {{#name user_name}} | Primary label shown in passkey picker (registration only) |
+
+Apps that share an RP ID, whether the default `keys.breez.technology` or a custom domain, recognize the same user's passkey without per-app enrollment. Users don't need to manually enroll a passkey before using a built-in provider; it auto-registers a new credential on first use if one doesn't already exist for the RP ID.
+
+Use a built-in provider with `Passkey` as shown in the [Connecting with a passkey](#connecting-with-passkey) snippets below.
+
+### Custom providers
+
+If the built-in providers don't fit your needs, implement the `PasskeyPrfProvider` interface directly using platform-native APIs.
 
 {{#tabs passkey:implement-prf-provider}}
 
-### Platform considerations
+#### Platform considerations
 
 - **Web (browsers)**: Use the WebAuthn API with the `prf` extension. Browsers handle the salt transformation internally. Use discoverable credentials (`residentKey: 'required'`) with empty `allowCredentials` for assertion so the browser discovers the credential by RP ID.
-
 - **Android / iOS**: Use native passkey APIs with PRF support. Ensure the Associated Domains / Asset Links configuration is in place for `keys.breez.technology`.
-
 - **CLI / Desktop (CTAP2)**: Use the `hmac-secret` extension directly. Non-browser implementations must apply the WebAuthn salt transformation manually to produce the same PRF output as browsers:
 
   ```
@@ -112,6 +168,18 @@ Your application must implement the PRF provider to interface with platform pass
   ```
 
   This transformation is defined in the <a target="_blank" href="https://w3c.github.io/webauthn/#prf-extension">W3C WebAuthn PRF extension spec</a> and ensures that the same passkey + salt produces identical seeds across browser and native implementations.
+
+## Checking passkey availability
+
+Use {{#name is_prf_available}} to gate passkey UI elements. This returns `false` on unsupported platforms (e.g., Android < 9, iOS < 18), allowing you to fall back to mnemonic-based onboarding gracefully:
+
+```
+if (await prfProvider.isPrfAvailable()) {
+  // Show passkey as primary option
+} else {
+  // Show mnemonic flow only
+}
+```
 
 <h2 id="connecting-with-passkey">
     <a class="header" href="#connecting-with-passkey">Connecting with a passkey</a>
@@ -139,28 +207,6 @@ Discover labels associated to the passkey using Nostr.
 Publish a label to Nostr so it can be discovered later.
 
 {{#tabs passkey:store-label}}
-
-## Best practices
-
-### Cache the user-selected label
-
-Store the label locally (e.g., `localStorage` on web, `SharedPreferences` on Android, `UserDefaults` on iOS) if selected by the user. This allows the app to skip the label selection step on subsequent launches and go straight to passkey authentication.
-
-### Never store the derived mnemonic
-
-The mnemonic should always be re-derived from the passkey and label on each session. The passkey authentication (biometric, PIN, etc.) is the security boundary — storing the mnemonic would bypass it. On app restart, check for a cached label and prompt the user for passkey authentication to derive the seed.
-
-### Allow manual mnemonic backup
-
-Provide a way for users to reveal their derived 12-word mnemonic as an emergency backup. This should be user-initiated (e.g., behind a "Show recovery phrase" button) and derived on-demand via {{#name Passkey.get_wallet}} with the cached label. This gives users a safety net if they lose access to their passkey.
-
-### Offer a mnemonic fallback
-
-Not all devices support the PRF extension. Check {{#name Passkey.is_available}} at startup and present the appropriate flow — seedless for capable devices, traditional mnemonic backup/restore for others.
-
-### Handle label discovery failures
-
-When discovering labels, {{#name Passkey.list_labels}} may return an empty list if relays are unreachable or the label events have been pruned. Always allow manual label entry as a fallback alongside the Nostr-discovered list.
 
 ## Supported specs
 

--- a/docs/breez-sdk/src/guide/passkey.md
+++ b/docs/breez-sdk/src/guide/passkey.md
@@ -174,13 +174,7 @@ If a built-in provider does not satisfy your requirements (e.g., you need a hard
 
 Use {{#name is_prf_available}} to gate passkey UI elements. This returns `false` on unsupported platforms (e.g., Android < 9, iOS < 18), allowing you to fall back to mnemonic-based onboarding gracefully:
 
-```
-if (await prfProvider.isPrfAvailable()) {
-  // Show passkey as primary option
-} else {
-  // Show mnemonic flow only
-}
-```
+{{#tabs passkey:check-availability}}
 
 <h2 id="connecting-with-passkey">
     <a class="header" href="#connecting-with-passkey">Connecting with a passkey</a>

--- a/docs/breez-sdk/src/guide/passkey.md
+++ b/docs/breez-sdk/src/guide/passkey.md
@@ -133,16 +133,17 @@ The SDK ships with PRF providers for the major platforms:
 |----------|----------|
 | Web (browsers) | `WebAuthnPrfProvider` |
 | iOS / macOS | `PlatformPasskeyPrfProvider` |
+| Android / Kotlin Multiplatform | `CredentialManagerPrfProvider` |
 | React Native | `PasskeyPrfProvider` |
 | Flutter | `PasskeyPrfProvider` |
 
-Android (Kotlin), Kotlin Multiplatform, and other platforms not listed above need to implement their own provider; see [Custom providers](#custom-providers) below.
+Built-in providers are not currently available for C#, Go, and Python.
 
 **Constructor options** (all built-in providers):
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| {{#name rp_id}} | `keys.breez.technology` | Relying Party ID. **Changing this breaks existing credentials.** |
+| {{#name rp_id}} | `keys.breez.technology` | Relying Party ID. Changing this means existing passkeys produce a different seed; see [migration considerations](https://github.com/breez/passkey-login/blob/main/SDK%20implementation.md#passkey-migration-considerations). |
 | {{#name rp_name}} | `Breez SDK` | RP display name (registration only, does not affect existing credentials) |
 | {{#name user_name}} | {{#name rp_name}} | User name stored with the credential (registration only) |
 | {{#name user_display_name}} | {{#name user_name}} | Primary label shown in passkey picker (registration only) |
@@ -153,7 +154,7 @@ Use a built-in provider with `Passkey` as shown in the [Connecting with a passke
 
 ### Custom providers
 
-If the built-in providers don't fit your needs, implement the `PasskeyPrfProvider` interface directly using platform-native APIs.
+If a built-in provider does not satisfy your requirements (e.g., you need a hardware security key, a FIDO2/CTAP2 transport, or a custom authenticator), implement the `PasskeyPrfProvider` interface directly using platform-native APIs.
 
 {{#tabs passkey:implement-prf-provider}}
 

--- a/docs/breez-sdk/src/guide/uxguide_passkey.md
+++ b/docs/breez-sdk/src/guide/uxguide_passkey.md
@@ -1,0 +1,32 @@
+## Passkey login
+
+### UX principles
+
+- **Be transparent about the trust model.** Users should know up front that the passkey is the wallet, not just a convenience layer.
+- **Make passkey login a choice on supported devices, not a forced default.** Users who prefer mnemonic onboarding should be able to opt out without friction.
+
+### Example onboarding flow
+
+The steps below describe one possible shape for a passkey onboarding flow that supports multiple labels per user. Adapt to your app's structure; apps that use a single hardcoded label can skip the label picker steps.
+
+1. **Detect existing passkey**: Call {{#name Passkey.list_labels}}. This triggers one passkey authentication prompt.
+   - **Labels found** → show a label picker (returning user).
+   - **No labels but passkey exists** → show a label picker with a sensible default pre-filled.
+   - **User cancelled / credential not found** → treat as "no existing passkey detected" and offer to create one.
+2. **Warn new users**: Before registering a new passkey, show a screen explaining that the passkey is how the wallet is accessed and that deleting it without a backup may permanently lose access. Require explicit acknowledgment.
+3. **Create passkey**: Call {{#name create_passkey}} to register the credential. Keeping this separate from derivation lets the user review before the OS prompts for credential creation.
+4. **Store label**: Call {{#name Passkey.store_label}} to publish the chosen label to Nostr so it can be discovered on other devices or after reinstall.
+5. **Derive and connect**: Call {{#name Passkey.get_wallet}} with the chosen label and pass the returned seed directly to {{#name connect}}. Reusing the seed across both calls avoids a second passkey prompt.
+
+Each step should own its own error handling. A failure partway through should retry only the failed step, not the entire flow.
+
+### Guidelines
+
+1. **Gate passkey UI on availability.** Check {{#name is_prf_available}} at startup and fall back to mnemonic onboarding on unsupported devices (Android < 9, iOS < 18, browsers without WebAuthn PRF).
+2. **Reuse the derived seed within an action.** Calling {{#name Passkey.get_wallet}} and then {{#name connect}} derives the seed twice and prompts the user twice. Pass the seed returned from `get_wallet` directly into `connect` instead of re-deriving.
+3. **Cache the user-selected label across sessions.** Store the chosen label locally (e.g., `localStorage` on web, `SharedPreferences` on Android, `UserDefaults` on iOS, `FlutterSecureStorage` on Flutter). On subsequent launches, skip the label picker and go straight to passkey authentication.
+4. **Never persist the derived mnemonic.** Re-derive from the passkey and label on each session. Persisting the mnemonic would bypass the OS authentication prompt.
+5. **Allow manual mnemonic backup.** Offer a user-initiated "Show recovery phrase" path that derives the mnemonic on demand via {{#name Passkey.get_wallet}}. This gives users a recovery option if they lose access to their passkey.
+6. **Handle cancellation by returning to the originating screen.** When {{#enum PasskeyPrfError::UserCancelled}} is raised, return the user to the screen where they triggered the action and let them re-initiate. Don't auto-retry, since automatic retry creates a prompt loop.
+7. **Treat "no credential" as an opportunity, not an error.** `noCredential` / `credentialNotFound` errors mean no passkey exists for the RP ID yet. Offer registration rather than showing an error.
+8. **Fall back to manual label entry.** When {{#name Passkey.list_labels}} returns an empty list (e.g., relays unreachable, events pruned), let the user type the label manually instead of blocking the flow.


### PR DESCRIPTION
Documents the built-in PRF providers added in #781.

Incorporates learnings from integrating passkey login in glow-flutter, glow-web, and the RN CLI example app.

## Summary
- Document built-in PRF providers and platform-specific setup
- Add recommended onboarding flow and best practices
- Document Android 9+ / 14+ distinction and credential provider requirements
- Update code snippets across all languages