### PR TITLE
Add retry logic with exponential backoff to faucet requests

### DIFF
--- a/crates/breez-sdk/breez-itest/src/faucet.rs
+++ b/crates/breez-sdk/breez-itest/src/faucet.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use platform_utils::{
@@ -7,7 +8,7 @@ use platform_utils::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Global semaphore to limit concurrent faucet requests.
 /// This enables test parallelization while preventing faucet rate limiting.
@@ -117,6 +118,8 @@ impl RegtestFaucet {
     /// # Returns
     /// The transaction hash of the funding transaction
     pub async fn fund_address(&self, address: &str, amount_sats: u64) -> Result<String> {
+        const MAX_RETRIES: u32 = 3;
+
         // Acquire semaphore permit to limit concurrent faucet requests
         let _permit = FAUCET_SEMAPHORE
             .acquire()
@@ -128,6 +131,30 @@ impl RegtestFaucet {
             amount_sats, address
         );
 
+        let mut last_error = None;
+
+        for attempt in 0..=MAX_RETRIES {
+            if attempt > 0 {
+                let backoff = Duration::from_secs(2u64.pow(attempt));
+                warn!(
+                    "Faucet request failed, retrying in {}s (attempt {}/{})",
+                    backoff.as_secs(),
+                    attempt + 1,
+                    MAX_RETRIES + 1,
+                );
+                tokio::time::sleep(backoff).await;
+            }
+
+            match self.try_fund_address(address, amount_sats).await {
+                Ok(txid) => return Ok(txid),
+                Err(e) => last_error = Some(e),
+            }
+        }
+
+        Err(last_error.unwrap())
+    }
+
+    async fn try_fund_address(&self, address: &str, amount_sats: u64) -> Result<String> {
         let request_body = GraphQLRequest {
             operation_name: "RequestRegtestFunds".to_string(),
             variables: FaucetVariables {

--- a/crates/spark-itest/src/faucet.rs
+++ b/crates/spark-itest/src/faucet.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use platform_utils::{
     ContentType, DefaultHttpClient, HttpClient, add_basic_auth_header, add_content_type_header,
 };
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Configuration for the regtest faucet
 #[derive(Debug, Clone)]
@@ -97,11 +98,37 @@ impl RegtestFaucet {
     /// # Returns
     /// The transaction hash of the funding transaction
     pub async fn fund_address(&self, address: &str, amount_sats: u64) -> Result<String> {
+        const MAX_RETRIES: u32 = 3;
+
         info!(
             "Requesting funds from faucet: {} sats to address {}",
             amount_sats, address
         );
 
+        let mut last_error = None;
+
+        for attempt in 0..=MAX_RETRIES {
+            if attempt > 0 {
+                let backoff = Duration::from_secs(2u64.pow(attempt));
+                warn!(
+                    "Faucet request failed, retrying in {}s (attempt {}/{})",
+                    backoff.as_secs(),
+                    attempt + 1,
+                    MAX_RETRIES + 1,
+                );
+                tokio::time::sleep(backoff).await;
+            }
+
+            match self.try_fund_address(address, amount_sats).await {
+                Ok(txid) => return Ok(txid),
+                Err(e) => last_error = Some(e),
+            }
+        }
+
+        Err(last_error.unwrap())
+    }
+
+    async fn try_fund_address(&self, address: &str, amount_sats: u64) -> Result<String> {
         let request_body = GraphQLRequest {
             operation_name: "RequestRegtestFunds".to_string(),
             variables: FaucetVariables {


### PR DESCRIPTION
## Summary
Add automatic retry logic with exponential backoff to faucet funding requests in both breez-sdk and spark-itest integration tests. This improves reliability when dealing with transient faucet failures.

## Key Changes
- Added `Duration` import for timeout handling
- Added `warn` to tracing imports for retry logging
- Implemented retry mechanism with up to 3 retries (4 total attempts)
- Exponential backoff strategy: 2^attempt seconds between retries (2s, 4s, 8s)
- Extracted core funding logic into new `try_fund_address()` private method
- Main `fund_address()` method now handles retry loop and returns last error if all attempts fail
- Added warning logs indicating retry attempts with backoff duration

## Implementation Details
- Retries use exponential backoff: `Duration::from_secs(2u64.pow(attempt))`
- Backoff only applied after first attempt (attempt > 0)
- Logs include attempt count and total retries for visibility
- Changes applied consistently to both `crates/breez-sdk/breez-itest/src/faucet.rs` and `crates/spark-itest/src/faucet.rs`