### PR TITLE
Add user agent support to rtsync and breez server clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.16",
  "hex",
+ "http 1.3.1",
  "lightning",
  "macros",
  "mockall",
@@ -690,6 +691,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tonic-web-wasm-client",
+ "tower-service",
  "tracing",
  "wasm-bindgen-test",
 ]

--- a/crates/breez-sdk/breez-itest/tests/distributed_lock.rs
+++ b/crates/breez-sdk/breez-itest/tests/distributed_lock.rs
@@ -111,7 +111,8 @@ async fn test_distributed_lock_acquire_and_release(
     // Same signer key = same user (two instances of the same wallet)
     let signer_key: [u8; 32] = [1u8; 32];
 
-    let sync_client: Arc<dyn SyncerClient> = Arc::new(BreezSyncerClient::new(grpc_url, None)?);
+    let sync_client: Arc<dyn SyncerClient> =
+        Arc::new(BreezSyncerClient::new(grpc_url, None, "breez-sdk-itest")?);
 
     let instance_a = create_signing_client(Arc::clone(&sync_client), &signer_key);
     let instance_b = create_signing_client(Arc::clone(&sync_client), &signer_key);
@@ -157,7 +158,8 @@ async fn test_distributed_lock_multiple_instances(
 
     let signer_key: [u8; 32] = [2u8; 32];
 
-    let sync_client: Arc<dyn SyncerClient> = Arc::new(BreezSyncerClient::new(grpc_url, None)?);
+    let sync_client: Arc<dyn SyncerClient> =
+        Arc::new(BreezSyncerClient::new(grpc_url, None, "breez-sdk-itest")?);
 
     let instance_a = create_signing_client(Arc::clone(&sync_client), &signer_key);
     let instance_b = create_signing_client(Arc::clone(&sync_client), &signer_key);
@@ -210,7 +212,8 @@ async fn test_distributed_lock_expiration(
 
     let signer_key: [u8; 32] = [3u8; 32];
 
-    let sync_client: Arc<dyn SyncerClient> = Arc::new(BreezSyncerClient::new(grpc_url, None)?);
+    let sync_client: Arc<dyn SyncerClient> =
+        Arc::new(BreezSyncerClient::new(grpc_url, None, "breez-sdk-itest")?);
 
     let instance_a = create_signing_client(Arc::clone(&sync_client), &signer_key);
     let instance_b = create_signing_client(Arc::clone(&sync_client), &signer_key);
@@ -246,7 +249,8 @@ async fn test_distributed_lock_release_idempotent(
 
     let signer_key: [u8; 32] = [4u8; 32];
 
-    let sync_client: Arc<dyn SyncerClient> = Arc::new(BreezSyncerClient::new(grpc_url, None)?);
+    let sync_client: Arc<dyn SyncerClient> =
+        Arc::new(BreezSyncerClient::new(grpc_url, None, "breez-sdk-itest")?);
 
     let instance_a = create_signing_client(Arc::clone(&sync_client), &signer_key);
 
@@ -277,7 +281,8 @@ async fn test_distributed_lock_different_users(
     let user_a_key: [u8; 32] = [5u8; 32];
     let user_b_key: [u8; 32] = [6u8; 32];
 
-    let sync_client: Arc<dyn SyncerClient> = Arc::new(BreezSyncerClient::new(grpc_url, None)?);
+    let sync_client: Arc<dyn SyncerClient> =
+        Arc::new(BreezSyncerClient::new(grpc_url, None, "breez-sdk-itest")?);
 
     let user_a = create_signing_client(Arc::clone(&sync_client), &user_a_key);
     let user_b = create_signing_client(Arc::clone(&sync_client), &user_b_key);
@@ -317,7 +322,8 @@ async fn test_distributed_lock_exclusive(
 
     let signer_key: [u8; 32] = [7u8; 32];
 
-    let sync_client: Arc<dyn SyncerClient> = Arc::new(BreezSyncerClient::new(grpc_url, None)?);
+    let sync_client: Arc<dyn SyncerClient> =
+        Arc::new(BreezSyncerClient::new(grpc_url, None, "breez-sdk-itest")?);
 
     let instance_a = create_signing_client(Arc::clone(&sync_client), &signer_key);
     let instance_b = create_signing_client(Arc::clone(&sync_client), &signer_key);

--- a/crates/breez-sdk/common/Cargo.toml
+++ b/crates/breez-sdk/common/Cargo.toml
@@ -57,9 +57,11 @@ tonic = { workspace = true, features = [
 # WASM dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 dnssec-prover = { workspace = true, features = ["validation"] }
+http.workspace = true
 reqwest.workspace = true
 tonic = { workspace = true, features = ["codegen", "prost"] }
 tonic-web-wasm-client.workspace = true
+tower-service.workspace = true
 
 # Wasm dev dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]

--- a/crates/breez-sdk/common/src/breez_server.rs
+++ b/crates/breez-sdk/common/src/breez_server.rs
@@ -30,9 +30,13 @@ pub struct BreezServer {
 }
 
 impl BreezServer {
-    pub fn new(server_url: &str, api_key: Option<String>) -> anyhow::Result<Self> {
+    pub fn new(
+        server_url: &str,
+        api_key: Option<String>,
+        user_agent: &str,
+    ) -> anyhow::Result<Self> {
         Ok(Self {
-            grpc_client: Mutex::new(GrpcClient::new(server_url)?),
+            grpc_client: Mutex::new(GrpcClient::new(server_url, user_agent)?),
             api_key,
         })
     }

--- a/crates/breez-sdk/common/src/grpc/transport.rs
+++ b/crates/breez-sdk/common/src/grpc/transport.rs
@@ -10,9 +10,9 @@ pub struct GrpcClient {
 }
 
 impl GrpcClient {
-    pub fn new(url: &str) -> Result<Self> {
+    pub fn new(url: &str, user_agent: &str) -> Result<Self> {
         Ok(Self {
-            inner: Self::create_endpoint(url)?.connect_lazy(),
+            inner: Self::create_endpoint(url, user_agent)?.connect_lazy(),
         })
     }
 
@@ -20,14 +20,15 @@ impl GrpcClient {
         self.inner
     }
 
-    fn create_endpoint(server_url: &str) -> Result<tonic::transport::Endpoint> {
+    fn create_endpoint(server_url: &str, user_agent: &str) -> Result<tonic::transport::Endpoint> {
         Ok(
             tonic::transport::Endpoint::from_shared(server_url.to_string())?
                 .tls_config(ClientTlsConfig::new().with_webpki_roots())?
                 .http2_keep_alive_interval(Duration::new(5, 0))
                 .tcp_keepalive(Some(Duration::from_secs(5)))
                 .keep_alive_timeout(Duration::from_secs(5))
-                .keep_alive_while_idle(true),
+                .keep_alive_while_idle(true)
+                .user_agent(user_agent)?,
         )
     }
 }

--- a/crates/breez-sdk/common/src/grpc/transport_wasm.rs
+++ b/crates/breez-sdk/common/src/grpc/transport_wasm.rs
@@ -21,8 +21,14 @@ impl Service<http::Request<tonic::body::BoxBody>> for Transport {
     }
 
     fn call(&mut self, mut req: http::Request<tonic::body::BoxBody>) -> Self::Future {
+        // Set both `User-Agent` and `X-User-Agent`. Chrome silently drops any
+        // script-set `User-Agent` on Fetch requests (crbug.com/571722), so we
+        // also send `X-User-Agent` to ensure the value reaches the server
+        // cross-browser. Firefox and Safari honor `User-Agent`.
         req.headers_mut()
             .insert("User-Agent", self.user_agent.clone());
+        req.headers_mut()
+            .insert("X-User-Agent", self.user_agent.clone());
         self.inner.call(req)
     }
 }

--- a/crates/breez-sdk/common/src/grpc/transport_wasm.rs
+++ b/crates/breez-sdk/common/src/grpc/transport_wasm.rs
@@ -1,6 +1,31 @@
-use anyhow::Result;
+use std::task::{Context, Poll};
 
-pub type Transport = tonic_web_wasm_client::Client;
+use anyhow::Result;
+use http::HeaderValue;
+use tower_service::Service;
+
+#[derive(Clone)]
+pub struct Transport {
+    inner: tonic_web_wasm_client::Client,
+    user_agent: HeaderValue,
+}
+
+impl Service<http::Request<tonic::body::BoxBody>> for Transport {
+    type Response = http::Response<tonic_web_wasm_client::ResponseBody>;
+    type Error = tonic_web_wasm_client::Error;
+    type Future =
+        <tonic_web_wasm_client::Client as Service<http::Request<tonic::body::BoxBody>>>::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<tonic::body::BoxBody>) -> Self::Future {
+        req.headers_mut()
+            .insert("User-Agent", self.user_agent.clone());
+        self.inner.call(req)
+    }
+}
 
 #[derive(Clone)]
 pub struct GrpcClient {
@@ -8,9 +33,13 @@ pub struct GrpcClient {
 }
 
 impl GrpcClient {
-    pub fn new(url: &str) -> Result<Self> {
+    pub fn new(url: &str, user_agent: &str) -> Result<Self> {
+        let user_agent = HeaderValue::from_str(user_agent)?;
         Ok(Self {
-            inner: tonic_web_wasm_client::Client::new(url.to_string()),
+            inner: Transport {
+                inner: tonic_web_wasm_client::Client::new(url.to_string()),
+                user_agent,
+            },
         })
     }
 

--- a/crates/breez-sdk/common/src/sync/client.rs
+++ b/crates/breez-sdk/common/src/sync/client.rs
@@ -32,7 +32,7 @@ pub struct BreezSyncerClient {
 
 impl BreezSyncerClient {
     #[allow(unused)]
-    pub fn new(server_url: &str, api_key: Option<&str>) -> anyhow::Result<Self> {
+    pub fn new(server_url: &str, api_key: Option<&str>, user_agent: &str) -> anyhow::Result<Self> {
         let api_key_metadata = match &api_key {
             Some(key) => Some(
                 format!("Bearer {key}")
@@ -43,7 +43,7 @@ impl BreezSyncerClient {
         };
 
         let client = ProtoSyncerClient::with_interceptor(
-            GrpcClient::new(server_url)?.into_inner(),
+            GrpcClient::new(server_url, user_agent)?.into_inner(),
             ApiKeyInterceptor { api_key_metadata },
         );
         Ok(Self { client })

--- a/crates/breez-sdk/core/src/realtime_sync/init.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/init.rs
@@ -12,6 +12,7 @@ use crate::{
 pub struct RealTimeSyncParams {
     pub server_url: String,
     pub api_key: Option<String>,
+    pub user_agent: String,
     pub signer: Arc<dyn breez_sdk_common::sync::SyncSigner>,
     pub storage: Arc<dyn Storage>,
     pub shutdown_receiver: tokio::sync::watch::Receiver<()>,
@@ -36,8 +37,12 @@ pub async fn init_and_start_real_time_sync(
     synced_storage.initial_setup();
     let storage: Arc<dyn Storage> = synced_storage.clone();
     let sync_client: Arc<dyn breez_sdk_common::sync::SyncerClient> = Arc::new(
-        BreezSyncerClient::new(&params.server_url, params.api_key.as_deref())
-            .map_err(|e| SdkError::Generic(e.to_string()))?,
+        BreezSyncerClient::new(
+            &params.server_url,
+            params.api_key.as_deref(),
+            &params.user_agent,
+        )
+        .map_err(|e| SdkError::Generic(e.to_string()))?,
     );
 
     let signing_client = SigningClient::new(

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -487,7 +487,7 @@ impl SdkBuilder {
             crate::built_info::PKG_NAME,
             crate::built_info::GIT_VERSION.unwrap_or(crate::built_info::PKG_VERSION),
         );
-        info!("Building SparkWallet with user agent: {}", user_agent);
+        info!("Building sdk with user agent: {}", user_agent);
 
         let breez_server = Arc::new(
             BreezServer::new(PRODUCTION_BREEZSERVER_URL, None, &user_agent)

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -482,8 +482,15 @@ impl SdkBuilder {
             }
         };
 
+        let user_agent = format!(
+            "{}/{}",
+            crate::built_info::PKG_NAME,
+            crate::built_info::GIT_VERSION.unwrap_or(crate::built_info::PKG_VERSION),
+        );
+        info!("Building SparkWallet with user agent: {}", user_agent);
+
         let breez_server = Arc::new(
-            BreezServer::new(PRODUCTION_BREEZSERVER_URL, None)
+            BreezServer::new(PRODUCTION_BREEZSERVER_URL, None, &user_agent)
                 .map_err(|e| SdkError::Generic(e.to_string()))?,
         );
 
@@ -496,12 +503,6 @@ impl SdkBuilder {
             Some(client) => client,
             None => Arc::new(DefaultHttpClient::default()),
         };
-        let user_agent = format!(
-            "{}/{}",
-            crate::built_info::PKG_NAME,
-            crate::built_info::GIT_VERSION.unwrap_or(crate::built_info::PKG_VERSION),
-        );
-        info!("Building SparkWallet with user agent: {}", user_agent);
         let mut spark_wallet_config = if let Some(env_config) = &self.config.spark_config {
             Self::build_spark_wallet_config(self.config.network.into(), env_config)?
         } else {
@@ -510,7 +511,7 @@ impl SdkBuilder {
         spark_wallet_config.operator_pool = spark_wallet_config
             .operator_pool
             .with_user_agent(Some(user_agent.clone()));
-        spark_wallet_config.service_provider_config.user_agent = Some(user_agent);
+        spark_wallet_config.service_provider_config.user_agent = Some(user_agent.clone());
         spark_wallet_config.leaf_auto_optimize_enabled =
             self.config.optimization_config.auto_enabled;
         spark_wallet_config.leaf_optimization_options.multiplicity =
@@ -585,6 +586,7 @@ impl SdkBuilder {
             init_and_start_real_time_sync(RealTimeSyncParams {
                 server_url: server_url.clone(),
                 api_key: self.config.api_key.clone(),
+                user_agent,
                 signer: rtsync_signer,
                 storage: Arc::clone(&storage),
                 shutdown_receiver: shutdown_sender.subscribe(),

--- a/crates/spark/src/operator/rpc/transport/grpc_client_wasm.rs
+++ b/crates/spark/src/operator/rpc/transport/grpc_client_wasm.rs
@@ -22,8 +22,14 @@ impl Service<http::Request<tonic::body::BoxBody>> for Transport {
     }
 
     fn call(&mut self, mut req: http::Request<tonic::body::BoxBody>) -> Self::Future {
+        // Set both `User-Agent` and `X-User-Agent`. Chrome silently drops any
+        // script-set `User-Agent` on Fetch requests (crbug.com/571722), so we
+        // also send `X-User-Agent` to ensure the value reaches the server
+        // cross-browser. Firefox and Safari honor `User-Agent`.
         req.headers_mut()
             .insert("User-Agent", self.user_agent.clone());
+        req.headers_mut()
+            .insert("X-User-Agent", self.user_agent.clone());
         self.inner.call(req)
     }
 }

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "dnssec-prover",
  "futures",
  "hex",
+ "http",
  "lightning",
  "macros",
  "platform-utils",
@@ -448,6 +449,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tonic-web-wasm-client",
+ "tower-service",
  "tracing",
 ]
 


### PR DESCRIPTION
## Summary
This PR adds support for custom User-Agent headers in gRPC client communications across both native and WebAssembly transports.

## Key Changes
- **Transport layer enhancements**:
  - Refactored `transport_wasm.rs` from a type alias to a proper `Transport` struct that wraps `tonic_web_wasm_client::Client` and implements `tower_service::Service`
  - Added User-Agent header injection in the WASM transport's `call` method
  - Updated `transport.rs` to accept and apply user agent configuration to the endpoint

- **Client API updates**:
  - Modified `GrpcClient::new()` to accept an optional `user_agent` parameter in both native and WASM implementations
  - Updated `BreezSyncerClient::new()` to accept and forward the user agent parameter to `GrpcClient`
  - Added `user_agent` field to `RealTimeSyncParams` struct

- **SDK integration**:
  - Updated `SdkBuilder` to pass the user agent to real-time sync initialization
  - Updated all test calls to `BreezSyncerClient::new()` to include the new user agent parameter

- **Dependencies**:
  - Added `http` and `tower-service` crate dependencies for WASM target to support the new Transport implementation

## Implementation Details
The WASM transport implementation uses a custom `Transport` struct that intercepts requests and injects the User-Agent header before delegating to the underlying `tonic_web_wasm_client::Client`. The native transport leverages tonic's built-in `user_agent()` endpoint configuration method. This approach maintains consistency across both platforms while respecting their respective capabilities.

https://claude.ai/code/session_01GR3QbjiAz5WvY2hKoaUrRB