### PR TITLE
fix: allow unsigned Spark invoices in address parsing

### DIFF
--- a/crates/spark/src/address/mod.rs
+++ b/crates/spark/src/address/mod.rs
@@ -477,22 +477,19 @@ impl FromStr for SparkAddress {
         let address = SparkAddress::new(identity_public_key, network, invoice_fields);
 
         if address.is_invoice() {
-            let hash = address.compute_invoice_hash()?;
-
-            let Some(sig) = signature else {
-                return Err(AddressError::Other("Invoice has no signature".to_string()));
-            };
-
-            let secp = Secp256k1::new();
-            if secp
-                .verify_schnorr(
-                    &sig,
-                    &Message::from_digest(hash.try_into().unwrap_or_default()),
-                    &address.identity_public_key.x_only_public_key().0,
-                )
-                .is_err()
-            {
-                return Err(AddressError::Other("Invalid invoice signature".to_string()));
+            if let Some(sig) = signature {
+                let hash = address.compute_invoice_hash()?;
+                let secp = Secp256k1::new();
+                if secp
+                    .verify_schnorr(
+                        &sig,
+                        &Message::from_digest(hash.try_into().unwrap_or_default()),
+                        &address.identity_public_key.x_only_public_key().0,
+                    )
+                    .is_err()
+                {
+                    return Err(AddressError::Other("Invalid invoice signature".to_string()));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Allow parsing Spark invoices without a signature, matching the behavior of Spark Signing Operators which treat signatures as optional
- When a signature is present, it is still verified as before
- This enables server-side invoice generation (e.g. on behalf of a customer) where the server has the customer's public key but not their signing key

## Context
The Spark SO `validateInvoiceFields` function ([source](https://github.com/lightsparkdev/spark/blob/main/spark/so/handler/tokens/internal_prepare_token_handler.go#L952-L956)) only verifies signatures when present:
```go
if decoded.SparkAddress.Signature != nil {
    err := common.VerifySparkAddressSignature(...)
}
```

The SDK should follow the same contract.

## Test plan
- [x] `cargo check -p spark` passes
- [x] `cargo test -p spark` — all tests pass
- [ ] Existing signed invoice flows still work (signature verified when present)
- [ ] Unsigned invoices can now be parsed and used as payment requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)