### PR TITLE
SSR Support for WASM Package

### DIFF
--- a/.github/workflows/build-bindings-wasm.yml
+++ b/.github/workflows/build-bindings-wasm.yml
@@ -60,3 +60,4 @@ jobs:
             packages/wasm/deno
             packages/wasm/nodejs
             packages/wasm/web
+            packages/wasm/ssr

--- a/crates/xtask/src/package.rs
+++ b/crates/xtask/src/package.rs
@@ -202,32 +202,32 @@ fn package_wasm_target(
     Ok(())
 }
 
-/// Parsed exports from a wasm-bindgen generated JS file.
+/// Parsed exports from a wasm-bindgen generated `.d.ts` file.
 struct WasmExports {
     functions: Vec<String>,
     classes: Vec<String>,
-    reexports: Vec<String>,
 }
 
-/// Parse exported symbols from a wasm-bindgen generated ESM `.js` file.
+/// Parse exported symbols from a wasm-bindgen generated `.d.ts` file.
 ///
-/// Recognises three line-level patterns produced by wasm-bindgen:
+/// This file is identical across web and nodejs targets (except `initSync`
+/// which only appears in the web target). Both targets generate
+/// `breez_sdk_spark_wasm.d.ts` with the same `export function` and
+/// `export class` patterns, so a single parser covers both use cases.
+///
+/// Recognises two line-level patterns:
 ///   `export function NAME(`
 ///   `export class NAME `
-///   `export { NAME };`
-///
-/// `export default` is intentionally skipped (the SSR shim provides its own).
-fn parse_wasm_exports(js_path: &Path) -> Result<WasmExports> {
-    let content = fs::read_to_string(js_path)
-        .with_context(|| format!("Failed to read {}", js_path.display()))?;
+fn parse_wasm_exports(dts_path: &Path) -> Result<WasmExports> {
+    let content = fs::read_to_string(dts_path)
+        .with_context(|| format!("Failed to read {}", dts_path.display()))?;
 
     let mut functions = Vec::new();
     let mut classes = Vec::new();
-    let mut reexports = Vec::new();
 
     for line in content.lines() {
         if let Some(rest) = line.strip_prefix("export function ") {
-            // "connect(request) {" → "connect"
+            // "connect(request: ConnectRequest): Promise<BreezSdk>;" → "connect"
             if let Some(name) = rest
                 .split(|c: char| !c.is_alphanumeric() && c != '_')
                 .next()
@@ -242,15 +242,6 @@ fn parse_wasm_exports(js_path: &Path) -> Result<WasmExports> {
             {
                 classes.push(name.to_string());
             }
-        } else if let Some(rest) = line.strip_prefix("export { ") {
-            // "initSync };" → "initSync"
-            if let Some(name) = rest
-                .split(|c: char| !c.is_alphanumeric() && c != '_')
-                .next()
-                && !name.is_empty()
-            {
-                reexports.push(name.to_string());
-            }
         }
     }
 
@@ -258,66 +249,19 @@ fn parse_wasm_exports(js_path: &Path) -> Result<WasmExports> {
         !functions.is_empty() && !classes.is_empty(),
         "Failed to parse WASM exports from {} — found {} functions, {} classes. \
          wasm-bindgen output format may have changed.",
-        js_path.display(),
+        dts_path.display(),
         functions.len(),
         classes.len()
     );
 
     println!(
-        "Parsed {} functions, {} classes, {} re-exports from {}",
+        "Parsed {} functions, {} classes from {}",
         functions.len(),
         classes.len(),
-        reexports.len(),
-        js_path.display()
+        dts_path.display()
     );
 
-    Ok(WasmExports {
-        functions,
-        classes,
-        reexports,
-    })
-}
-
-/// Parse exported symbols from a wasm-bindgen generated CJS `.js` file (Node.js target).
-///
-/// Recognises the pattern: `module.exports.NAME = ...`
-/// Skips internal wasm-bindgen symbols (`__wbindgen_*`, `__wbg_*`, `__wasm`).
-fn parse_nodejs_exports(js_path: &Path) -> Result<Vec<String>> {
-    let content = fs::read_to_string(js_path)
-        .with_context(|| format!("Failed to read {}", js_path.display()))?;
-
-    let mut exports = Vec::new();
-
-    for line in content.lines() {
-        if let Some(rest) = line.strip_prefix("module.exports.") {
-            // "connect = function(request) {" → "connect"
-            if let Some(name) = rest
-                .split(|c: char| !c.is_alphanumeric() && c != '_')
-                .next()
-                && !name.is_empty()
-                && !name.starts_with("__wbindgen")
-                && !name.starts_with("__wbg")
-                && !name.starts_with("__wasm")
-            {
-                exports.push(name.to_string());
-            }
-        }
-    }
-
-    anyhow::ensure!(
-        !exports.is_empty(),
-        "Failed to parse Node.js exports from {} — found 0 public exports. \
-         wasm-bindgen output format may have changed.",
-        js_path.display()
-    );
-
-    println!(
-        "Parsed {} public exports from {}",
-        exports.len(),
-        js_path.display()
-    );
-
-    Ok(exports)
+    Ok(WasmExports { functions, classes })
 }
 
 /// Generate the SSR-safe entry point at `pkg_dir/ssr/`.
@@ -327,8 +271,8 @@ fn parse_nodejs_exports(js_path: &Path) -> Result<Vec<String>> {
 /// until `init()` is called on the client, at which point they delegate to the
 /// real web module loaded via dynamic `import()`.
 fn create_ssr_entry_point(pkg_dir: &Path) -> Result<()> {
-    let web_js = pkg_dir.join("web/breez_sdk_spark_wasm.js");
-    let exports = parse_wasm_exports(&web_js)?;
+    let dts = pkg_dir.join("web/breez_sdk_spark_wasm.d.ts");
+    let exports = parse_wasm_exports(&dts)?;
 
     let ssr_dir = pkg_dir.join("ssr");
     fs::create_dir_all(&ssr_dir)?;
@@ -386,16 +330,6 @@ export default async function init(wasmInput) {
         ));
     }
 
-    // Re-export stubs (treated as functions)
-    for name in &exports.reexports {
-        js.push_str(&format!(
-            "export function {name}(...args) {{\n  \
-             if (!_module) _notInitialized('{name}');\n  \
-             return _module.{name}(...args);\n\
-             }}\n\n"
-        ));
-    }
-
     fs::write(ssr_dir.join("index.js"), &js).with_context(|| "Failed to write ssr/index.js")?;
 
     // --- ssr/index.d.ts ---
@@ -410,7 +344,7 @@ export default function init(wasmInput?: any): Promise<void>;
 
     println!(
         "Created SSR entry point with {} stubs",
-        exports.functions.len() + exports.classes.len() + exports.reexports.len()
+        exports.functions.len() + exports.classes.len()
     );
     Ok(())
 }
@@ -419,28 +353,32 @@ export default function init(wasmInput?: any): Promise<void>;
 /// `import { connect } from '@breeztech/breez-sdk-spark'` works in ESM
 /// contexts (e.g. Vite SSR) where the `"node"` export condition is active.
 fn create_nodejs_esm_wrapper(pkg_dir: &Path) -> Result<()> {
-    let node_js = pkg_dir.join("nodejs/breez_sdk_spark_wasm.js");
-    let exports = parse_nodejs_exports(&node_js)?;
+    let dts = pkg_dir.join("nodejs/breez_sdk_spark_wasm.d.ts");
+    let exports = parse_wasm_exports(&dts)?;
 
     let mut mjs = String::new();
     mjs.push_str(
         "// ESM wrapper for the CJS Node.js entry — re-exports named bindings\n\
          // so that `import { connect } from '@breeztech/breez-sdk-spark'` works\n\
-         // in ESM contexts (Vite SSR).\n\
+         // in ESM contexts.\n\
          import pkg from './index.js';\n\n\
          export const {\n",
     );
 
-    for name in &exports {
+    for name in &exports.functions {
+        mjs.push_str(&format!("  {name},\n"));
+    }
+    for name in &exports.classes {
         mjs.push_str(&format!("  {name},\n"));
     }
 
     mjs.push_str("} = pkg;\n\nexport default pkg;\n");
 
+    let count = exports.functions.len() + exports.classes.len();
     fs::write(pkg_dir.join("nodejs/index.mjs"), &mjs)
         .with_context(|| "Failed to write nodejs/index.mjs")?;
 
-    println!("Created Node.js ESM wrapper with {} exports", exports.len());
+    println!("Created Node.js ESM wrapper with {count} exports");
     Ok(())
 }
 

--- a/crates/xtask/src/package.rs
+++ b/crates/xtask/src/package.rs
@@ -109,7 +109,9 @@ fn package_wasm_cmd(wasm_package: WasmPackages) -> Result<()> {
             package_wasm_target(&wasm_crate_dir, &pkg_dir, "bundler", &clang_env)?;
             package_wasm_target(&wasm_crate_dir, &pkg_dir, "deno", &clang_env)?;
             package_wasm_target(&wasm_crate_dir, &pkg_dir, "nodejs", &clang_env)?;
+            create_nodejs_esm_wrapper(&pkg_dir)?;
             package_wasm_target(&wasm_crate_dir, &pkg_dir, "web", &clang_env)?;
+            create_ssr_entry_point(&pkg_dir)?;
         }
         WasmPackages::Bundle => {
             println!("Packaging Bundle WASM target");
@@ -122,10 +124,12 @@ fn package_wasm_cmd(wasm_package: WasmPackages) -> Result<()> {
         WasmPackages::Node => {
             println!("Packaging Node.js WASM target");
             package_wasm_target(&wasm_crate_dir, &pkg_dir, "nodejs", &clang_env)?;
+            create_nodejs_esm_wrapper(&pkg_dir)?;
         }
         WasmPackages::Web => {
             println!("Packaging Web WASM target");
             package_wasm_target(&wasm_crate_dir, &pkg_dir, "web", &clang_env)?;
+            create_ssr_entry_point(&pkg_dir)?;
         }
     }
 
@@ -195,6 +199,248 @@ fn package_wasm_target(
     }
 
     println!("Successfully built WASM target: {}", target);
+    Ok(())
+}
+
+/// Parsed exports from a wasm-bindgen generated JS file.
+struct WasmExports {
+    functions: Vec<String>,
+    classes: Vec<String>,
+    reexports: Vec<String>,
+}
+
+/// Parse exported symbols from a wasm-bindgen generated ESM `.js` file.
+///
+/// Recognises three line-level patterns produced by wasm-bindgen:
+///   `export function NAME(`
+///   `export class NAME `
+///   `export { NAME };`
+///
+/// `export default` is intentionally skipped (the SSR shim provides its own).
+fn parse_wasm_exports(js_path: &Path) -> Result<WasmExports> {
+    let content = fs::read_to_string(js_path)
+        .with_context(|| format!("Failed to read {}", js_path.display()))?;
+
+    let mut functions = Vec::new();
+    let mut classes = Vec::new();
+    let mut reexports = Vec::new();
+
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("export function ") {
+            // "connect(request) {" → "connect"
+            if let Some(name) = rest
+                .split(|c: char| !c.is_alphanumeric() && c != '_')
+                .next()
+                && !name.is_empty()
+            {
+                functions.push(name.to_string());
+            }
+        } else if let Some(rest) = line.strip_prefix("export class ") {
+            // "BreezSdk {" → "BreezSdk"
+            if let Some(name) = rest.split_whitespace().next()
+                && !name.is_empty()
+            {
+                classes.push(name.to_string());
+            }
+        } else if let Some(rest) = line.strip_prefix("export { ") {
+            // "initSync };" → "initSync"
+            if let Some(name) = rest
+                .split(|c: char| !c.is_alphanumeric() && c != '_')
+                .next()
+                && !name.is_empty()
+            {
+                reexports.push(name.to_string());
+            }
+        }
+    }
+
+    anyhow::ensure!(
+        !functions.is_empty() && !classes.is_empty(),
+        "Failed to parse WASM exports from {} — found {} functions, {} classes. \
+         wasm-bindgen output format may have changed.",
+        js_path.display(),
+        functions.len(),
+        classes.len()
+    );
+
+    println!(
+        "Parsed {} functions, {} classes, {} re-exports from {}",
+        functions.len(),
+        classes.len(),
+        reexports.len(),
+        js_path.display()
+    );
+
+    Ok(WasmExports {
+        functions,
+        classes,
+        reexports,
+    })
+}
+
+/// Parse exported symbols from a wasm-bindgen generated CJS `.js` file (Node.js target).
+///
+/// Recognises the pattern: `module.exports.NAME = ...`
+/// Skips internal wasm-bindgen symbols (`__wbindgen_*`, `__wbg_*`, `__wasm`).
+fn parse_nodejs_exports(js_path: &Path) -> Result<Vec<String>> {
+    let content = fs::read_to_string(js_path)
+        .with_context(|| format!("Failed to read {}", js_path.display()))?;
+
+    let mut exports = Vec::new();
+
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("module.exports.") {
+            // "connect = function(request) {" → "connect"
+            if let Some(name) = rest
+                .split(|c: char| !c.is_alphanumeric() && c != '_')
+                .next()
+                && !name.is_empty()
+                && !name.starts_with("__wbindgen")
+                && !name.starts_with("__wbg")
+                && !name.starts_with("__wasm")
+            {
+                exports.push(name.to_string());
+            }
+        }
+    }
+
+    anyhow::ensure!(
+        !exports.is_empty(),
+        "Failed to parse Node.js exports from {} — found 0 public exports. \
+         wasm-bindgen output format may have changed.",
+        js_path.display()
+    );
+
+    println!(
+        "Parsed {} public exports from {}",
+        exports.len(),
+        js_path.display()
+    );
+
+    Ok(exports)
+}
+
+/// Generate the SSR-safe entry point at `pkg_dir/ssr/`.
+///
+/// This creates a lightweight ESM module that is safe to import during
+/// server-side rendering. All exported functions/classes are stubs that throw
+/// until `init()` is called on the client, at which point they delegate to the
+/// real web module loaded via dynamic `import()`.
+fn create_ssr_entry_point(pkg_dir: &Path) -> Result<()> {
+    let web_js = pkg_dir.join("web/breez_sdk_spark_wasm.js");
+    let exports = parse_wasm_exports(&web_js)?;
+
+    let ssr_dir = pkg_dir.join("ssr");
+    fs::create_dir_all(&ssr_dir)?;
+
+    // --- ssr/index.js ---
+    let mut js = String::new();
+    js.push_str(
+        r#"// SSR-safe entry point for Breez SDK
+// Safe to import during server-side rendering — no WASM, no browser APIs, no Node.js APIs.
+// Call init() on the client before using any SDK functions.
+
+let _module = null;
+let _initPromise = null;
+
+function _notInitialized(name) {
+  throw new Error(
+    `@breeztech/breez-sdk-spark: "${name}" called before init(). ` +
+    `Call "await init()" on the client before using SDK functions.`
+  );
+}
+
+export default async function init(wasmInput) {
+  if (_module) return;
+  if (_initPromise) return _initPromise;
+  _initPromise = (async () => {
+    const mod = await import('../web/index.js');
+    await mod.default(wasmInput);
+    _module = mod;
+  })();
+  return _initPromise;
+}
+
+"#,
+    );
+
+    // Function stubs
+    for name in &exports.functions {
+        js.push_str(&format!(
+            "export function {name}(...args) {{\n  \
+             if (!_module) _notInitialized('{name}');\n  \
+             return _module.{name}(...args);\n\
+             }}\n\n"
+        ));
+    }
+
+    // Class stubs — after init(), delegate to the real class via `return new`
+    for name in &exports.classes {
+        js.push_str(&format!(
+            "export class {name} {{\n  \
+             constructor(...args) {{\n    \
+             if (!_module) _notInitialized('new {name}');\n    \
+             return new _module.{name}(...args);\n  \
+             }}\n\
+             }}\n\n"
+        ));
+    }
+
+    // Re-export stubs (treated as functions)
+    for name in &exports.reexports {
+        js.push_str(&format!(
+            "export function {name}(...args) {{\n  \
+             if (!_module) _notInitialized('{name}');\n  \
+             return _module.{name}(...args);\n\
+             }}\n\n"
+        ));
+    }
+
+    fs::write(ssr_dir.join("index.js"), &js).with_context(|| "Failed to write ssr/index.js")?;
+
+    // --- ssr/index.d.ts ---
+    let dts = r#"export * from "../web/breez_sdk_spark_wasm.js";
+export default function init(wasmInput?: any): Promise<void>;
+"#;
+    fs::write(ssr_dir.join("index.d.ts"), dts).with_context(|| "Failed to write ssr/index.d.ts")?;
+
+    // --- ssr/.gitignore ---
+    fs::write(ssr_dir.join(".gitignore"), "*\n")
+        .with_context(|| "Failed to write ssr/.gitignore")?;
+
+    println!(
+        "Created SSR entry point with {} stubs",
+        exports.functions.len() + exports.classes.len() + exports.reexports.len()
+    );
+    Ok(())
+}
+
+/// Generate an ESM wrapper at `pkg_dir/nodejs/index.mjs` so that
+/// `import { connect } from '@breeztech/breez-sdk-spark'` works in ESM
+/// contexts (e.g. Vite SSR) where the `"node"` export condition is active.
+fn create_nodejs_esm_wrapper(pkg_dir: &Path) -> Result<()> {
+    let node_js = pkg_dir.join("nodejs/breez_sdk_spark_wasm.js");
+    let exports = parse_nodejs_exports(&node_js)?;
+
+    let mut mjs = String::new();
+    mjs.push_str(
+        "// ESM wrapper for the CJS Node.js entry — re-exports named bindings\n\
+         // so that `import { connect } from '@breeztech/breez-sdk-spark'` works\n\
+         // in ESM contexts (Vite SSR).\n\
+         import pkg from './index.js';\n\n\
+         export const {\n",
+    );
+
+    for name in &exports {
+        mjs.push_str(&format!("  {name},\n"));
+    }
+
+    mjs.push_str("} = pkg;\n\nexport default pkg;\n");
+
+    fs::write(pkg_dir.join("nodejs/index.mjs"), &mjs)
+        .with_context(|| "Failed to write nodejs/index.mjs")?;
+
+    println!("Created Node.js ESM wrapper with {} exports", exports.len());
     Ok(())
 }
 
@@ -577,6 +823,7 @@ fn update_nodejs_package_json(out_path: &Path) -> Result<()> {
                 "postgres-token-store/".to_string(),
             ));
             files_array.push(serde_json::Value::String("index.js".to_string()));
+            files_array.push(serde_json::Value::String("index.mjs".to_string()));
         }
     } else {
         package_json["files"] = serde_json::json!([
@@ -587,7 +834,8 @@ fn update_nodejs_package_json(out_path: &Path) -> Result<()> {
             "postgres-storage/",
             "postgres-tree-store/",
             "postgres-token-store/",
-            "index.js"
+            "index.js",
+            "index.mjs"
         ]);
     }
 

--- a/docs/breez-sdk/snippets/wasm/getting_started.ts
+++ b/docs/breez-sdk/snippets/wasm/getting_started.ts
@@ -15,10 +15,15 @@ const init = async () => {}
 
 const exampleGettingStarted = async () => {
   // ANCHOR: init-sdk
-  // Call init when using the SDK in a web environment before calling any other SDK
-  // methods. This is not needed when using the SDK in a Node.js/Deno environment.
+  // Call init to load the WASM module before calling any other SDK methods.
+  // This is not needed when using the SDK via require() in Node.js.
   //
-  // import init, { BreezSdk, defaultConfig } from '@breeztech/breez-sdk-spark'
+  // For SSR frameworks (Next.js, SvelteKit, Nuxt), use the /ssr subpath:
+  //   import init, { connect } from '@breeztech/breez-sdk-spark/ssr'
+  // The /ssr import is safe during server-side rendering. Call init() on the
+  // client only (e.g., inside useEffect or onMount).
+  //
+  // import init from '@breeztech/breez-sdk-spark'
   await init()
 
   // Construct the seed using a mnemonic, entropy or passkey

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -28,94 +28,93 @@ Head over to the Breez SDK - Spark [documentation](https://sdk-doc-spark.breez.t
 
 ### Web
 
-When developing a browser application you should import `@breeztech/breez-sdk-spark` (or the explicit `@breeztech/breez-sdk-spark/web` submodule).
+When developing a browser application, import from `@breeztech/breez-sdk-spark` (or the explicit `@breeztech/breez-sdk-spark/web` subpath).
 
-It's important to first initialise the WebAssembly module by using `await init()` before making any other calls to the module.
+Call `await init()` to load the WebAssembly module before using any other SDK methods.
 
 ```js
 import init, {
-  initLogging,
   defaultConfig,
-  SdkBuilder,
+  connect,
 } from "@breeztech/breez-sdk-spark/web";
 
-// Initialise the WebAssembly module
 await init();
+
+const config = defaultConfig("mainnet");
+config.apiKey = "<your api key>";
+
+const sdk = await connect({
+  config,
+  seed: { type: "mnemonic", mnemonic: "<words>", passphrase: undefined },
+  storageDir: "./.data",
+});
+```
+
+### SSR Frameworks (Next.js, SvelteKit, Nuxt, Remix)
+
+Use the `@breeztech/breez-sdk-spark/ssr` subpath in SSR applications. It can be imported during server-side rendering without errors — no WASM is loaded, no browser or Node.js APIs are touched. Call `init()` on the client to load the WASM module before using SDK functions.
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import init, { connect, defaultConfig } from "@breeztech/breez-sdk-spark/ssr";
+
+export default function Wallet() {
+  const [sdk, setSdk] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      await init(); // Loads WASM — client-side only
+      const config = defaultConfig("mainnet");
+      config.apiKey = "<your api key>";
+      const s = await connect({
+        config,
+        seed: { type: "mnemonic", mnemonic: "<words>", passphrase: undefined },
+        storageDir: "./.data",
+      });
+      setSdk(s);
+    })();
+  }, []);
+
+  return <div>{sdk ? "Connected" : "Loading..."}</div>;
+}
 ```
 
 ### Node.js
 
 > **Note**: This package requires Node.js v22 or higher.
 
-When developing a node.js application you should require `@breeztech/breez-sdk-spark` (or the explicit `@breeztech/breez-sdk-spark/node` submodule).
+When developing a Node.js application, use `require("@breeztech/breez-sdk-spark")` (or the explicit `@breeztech/breez-sdk-spark/nodejs` subpath). No `init()` call is needed — the WASM module loads automatically.
 
 ```js
 const {
-  initLogging,
   defaultConfig,
-  SdkBuilder,
-} = require("@breeztech/breez-sdk-spark/nodejs");
-const { Command } = require("commander");
-require("dotenv").config();
+  connect,
+} = require("@breeztech/breez-sdk-spark");
 
-class JsLogger {
-  log = (logEntry) => {
-    console.log(
-      `[${new Date().toISOString()} ${logEntry.level}]: ${logEntry.line}`
-    );
-  };
-}
+const config = defaultConfig("mainnet");
+config.apiKey = process.env.BREEZ_API_KEY;
 
-const fileLogger = new JsLogger();
-
-class JsEventListener {
-  onEvent = (event) => {
-    fileLogger.log({
-      level: "INFO",
-      line: `Received event: ${JSON.stringify(event)}`,
-    });
-  };
-}
-
-const eventListener = new JsEventListener();
-const program = new Command();
-
-const initSdk = async () => {
-  // Set the logger to trace
-  await initLogging(fileLogger);
-
-  // Get the mnemonic
-  const mnemonic = process.env.MNEMONIC;
-
-  // Connect using the config
-  let config = defaultConfig("regtest");
-  config.apiKey = process.env.BREEZ_API_KEY;
-  console.log(`defaultConfig: ${JSON.stringify(config)}`);
-
-  let sdkBuilder = SdkBuilder.new(config, {
-    type: "mnemonic",
-    mnemonic: mnemonic,
-  });
-  sdkBuilder = await sdkBuilder.withDefaultStorage("./.data");
-
-  const sdk = await sdkBuilder.build();
-
-  await sdk.addEventListener(eventListener);
-  return sdk;
-};
-
-program
-  .name("breez-sdk-spark-wasm-cli")
-  .description("CLI for Breez SDK Spark - Wasm");
-
-program.command("get-info").action(async () => {
-  const sdk = await initSdk();
-  const res = await sdk.getInfo({});
-  console.log(`getInfo: ${JSON.stringify(res)}`);
+const sdk = await connect({
+  config,
+  seed: { type: "mnemonic", mnemonic: process.env.MNEMONIC, passphrase: undefined },
+  storageDir: "./.data",
 });
 
-program.parse();
+const info = await sdk.getInfo({});
+console.log(`Balance: ${info.balanceSats} sats`);
 ```
+
+### Subpath Exports
+
+| Subpath | Environment | Module Format |
+|---------|-------------|---------------|
+| `@breeztech/breez-sdk-spark` | Node.js / Browser (default) | CJS / ESM |
+| `@breeztech/breez-sdk-spark/web` | Browser | ESM |
+| `@breeztech/breez-sdk-spark/nodejs` | Node.js | CJS |
+| `@breeztech/breez-sdk-spark/bundler` | Bundler (Webpack, Vite) | ESM |
+| `@breeztech/breez-sdk-spark/deno` | Deno | ESM |
+| `@breeztech/breez-sdk-spark/ssr` | SSR (explicit) | ESM |
 
 ## Pricing
 

--- a/packages/wasm/examples/ssr/.gitignore
+++ b/packages/wasm/examples/ssr/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/packages/wasm/examples/ssr/README.md
+++ b/packages/wasm/examples/ssr/README.md
@@ -1,0 +1,26 @@
+# Breez SDK — SSR Example
+
+Demonstrates that `@breeztech/breez-sdk-spark` can be imported during
+server-side rendering without errors.
+
+## What this tests
+
+1. **Server**: `entry-server.js` imports `connect`, `defaultConfig`, and
+   `BreezSdk` from the SDK. These resolve to the SSR stubs — no WASM is
+   loaded, no browser or Node.js APIs are touched.
+
+2. **Client**: `entry-client.js` calls `init()` to load the WASM module,
+   then calls `defaultConfig()` to prove the SDK works after initialization.
+
+## Running
+
+```bash
+npm install
+npm run dev
+# Open http://localhost:3000
+```
+
+If SSR works correctly you will see:
+- "SSR succeeded" in the server-rendered section
+- "WASM loaded successfully" after the client hydrates
+- The regtest config JSON printed below

--- a/packages/wasm/examples/ssr/index.html
+++ b/packages/wasm/examples/ssr/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Breez SDK SSR Demo</title>
+    <style>
+      body { font-family: system-ui, sans-serif; max-width: 640px; margin: 2rem auto; padding: 0 1rem; }
+      #status { padding: 1rem; border-radius: 8px; margin: 1rem 0; }
+      .ok  { background: #d4edda; color: #155724; }
+      .err { background: #f8d7da; color: #721c24; }
+      pre  { background: #f5f5f5; padding: 1rem; border-radius: 4px; overflow-x: auto; }
+    </style>
+  </head>
+  <body>
+    <h1>Breez SDK — SSR Demo</h1>
+    <p>This page is <strong>server-side rendered</strong> by Vite SSR.
+       The SDK import resolves during SSR without errors.
+       WASM is only loaded on the client via <code>init()</code>.</p>
+    <div id="status">Loading...</div>
+    <h2>Server-rendered content</h2>
+    <div id="ssr-content"><!--ssr-outlet--></div>
+    <h2>Client-side SDK</h2>
+    <pre id="client-info">Initializing...</pre>
+    <!--app-script-->
+  </body>
+</html>

--- a/packages/wasm/examples/ssr/package.json
+++ b/packages/wasm/examples/ssr/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "breez-sdk-spark-ssr-demo",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "node server.js",
+    "build": "vite build && vite build --ssr src/entry-server.js --outDir dist/server"
+  },
+  "dependencies": {
+    "@breeztech/breez-sdk-spark": "file:../../"
+  },
+  "devDependencies": {
+    "express": "^5.1.0",
+    "vite": "^7.1.2"
+  }
+}

--- a/packages/wasm/examples/ssr/server.js
+++ b/packages/wasm/examples/ssr/server.js
@@ -1,0 +1,55 @@
+// Minimal Vite SSR dev server.
+// Based on https://vite.dev/guide/ssr
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import express from 'express'
+import { createServer as createViteServer } from 'vite'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+async function start() {
+  const app = express()
+
+  const vite = await createViteServer({
+    server: { middlewareMode: true },
+    appType: 'custom',
+    optimizeDeps: {
+      exclude: ['@breeztech/breez-sdk-spark'],
+    },
+  })
+
+  app.use(vite.middlewares)
+
+  app.use('{*path}', async (req, res, next) => {
+    try {
+      const url = req.originalUrl
+
+      // Read and transform index.html
+      let template = fs.readFileSync(path.resolve(__dirname, 'index.html'), 'utf-8')
+      template = await vite.transformIndexHtml(url, template)
+
+      // Load the server entry — this is the SSR test:
+      // the SDK import must not crash in Node.js.
+      const { render } = await vite.ssrLoadModule('/src/entry-server.js')
+      const ssrHtml = render()
+
+      // Inject SSR content and client script
+      const html = template
+        .replace('<!--ssr-outlet-->', ssrHtml)
+        .replace('<!--app-script-->', '<script type="module" src="/src/entry-client.js"></script>')
+
+      res.status(200).set({ 'Content-Type': 'text/html' }).end(html)
+    } catch (e) {
+      vite.ssrFixStacktrace(e)
+      next(e)
+    }
+  })
+
+  const port = 3000
+  app.listen(port, () => {
+    console.log(`SSR demo running at http://localhost:${port}`)
+  })
+}
+
+start()

--- a/packages/wasm/examples/ssr/src/entry-client.js
+++ b/packages/wasm/examples/ssr/src/entry-client.js
@@ -1,0 +1,26 @@
+// This module runs on the CLIENT after hydration.
+// It loads the WASM module and exercises the SDK.
+import init, { defaultConfig } from '@breeztech/breez-sdk-spark/ssr'
+
+const statusEl = document.getElementById('status')
+const infoEl = document.getElementById('client-info')
+
+async function main() {
+  try {
+    // Load WASM — this is the only step that requires a browser environment.
+    await init()
+
+    statusEl.textContent = 'WASM loaded successfully'
+    statusEl.className = 'ok'
+
+    // Call a real SDK function to prove it works after init().
+    const config = defaultConfig('regtest')
+    infoEl.textContent = JSON.stringify(config, null, 2)
+  } catch (err) {
+    statusEl.textContent = `Error: ${err.message}`
+    statusEl.className = 'err'
+    infoEl.textContent = err.stack
+  }
+}
+
+main()

--- a/packages/wasm/examples/ssr/src/entry-server.js
+++ b/packages/wasm/examples/ssr/src/entry-server.js
@@ -1,0 +1,12 @@
+// This module runs on the SERVER during SSR.
+// The SDK import must not crash here — no WASM, no browser APIs.
+import { connect, defaultConfig, BreezSdk } from '@breeztech/breez-sdk-spark/ssr'
+
+export function render() {
+  // Prove that the imports resolved without error on the server.
+  // We can reference the symbols — we just can't call them yet.
+  const exportedNames = [connect, defaultConfig, BreezSdk]
+    .map((sym) => sym.name || sym.constructor?.name || 'unknown')
+
+  return `<pre>SSR succeeded — imported ${exportedNames.length} SDK symbols on the server:\n${exportedNames.join(', ')}</pre>`
+}

--- a/packages/wasm/examples/ssr/vite.config.js
+++ b/packages/wasm/examples/ssr/vite.config.js
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: {
+    fs: {
+      allow: ['..', '../..'],
+    },
+  },
+  optimizeDeps: {
+    exclude: ['@breeztech/breez-sdk-spark'],
+  },
+  ssr: {
+    // Force Vite to bundle the SDK into the SSR output (not externalize it).
+    // This simulates what Next.js/Turbopack does and is the strictest test
+    // of the SSR shim — the stubs must be side-effect-free and import-safe.
+    noExternal: ['@breeztech/breez-sdk-spark'],
+  },
+  build: {
+    target: 'esnext',
+  },
+})

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -14,6 +14,7 @@
       "deno",
       "nodejs",
       "web",
+      "ssr",
       "!examples"
     ],
     "exports": {
@@ -21,8 +22,12 @@
       "./deno": "./deno/breez_sdk_spark_wasm.js",
       "./nodejs": "./nodejs/index.js",
       "./web": "./web/index.js",
+      "./ssr": "./ssr/index.js",
       ".": {
-        "node": "./nodejs/index.js",
+        "node": {
+          "import": "./nodejs/index.mjs",
+          "require": "./nodejs/index.js"
+        },
         "deno": "./deno/breez_sdk_spark_wasm.js",
         "default": "./web/index.js"
       }


### PR DESCRIPTION
This PR:
- Adds a Node.js ESM wrapper in the `/nodejs` subpackage
- Generates an SSR subpackage at `/ssr`, stubbing the real web module for node.js server-side rendering
- Updates docs, README and adds SSR example
