### PR TITLE
Add example app links to README and install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ Looking for a quick way to try the Breez SDK in the browser or as PWA? Check out
 
 > **Note:** The demo is for demonstration purposes only and not intended for production use.
 
+## **Example Apps**
+
+The repository includes full working CLI example apps for every supported language, demonstrating end-to-end SDK usage.
+
+| Language | CLI Example App |
+|----------|-----------------|
+| Rust | [crates/breez-sdk/cli](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/cli) |
+| JavaScript/TypeScript | [cli/langs/wasm](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/wasm), [glow-web](https://github.com/breez/glow-web) |
+| Swift | [cli/langs/swift](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/swift) |
+| Kotlin | [cli/langs/kotlin-multiplatform](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform) |
+| Flutter/Dart | [cli/langs/flutter](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/flutter) |
+| Python | [cli/langs/python](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/python) |
+| Go | [cli/langs/golang](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/golang) |
+| React Native | [cli/langs/react-native](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/react-native) |
+| C# | [cli/langs/csharp](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/csharp) |
+
 ## **Support**
 
 Have a question for the team? Join our [Telegram channel](https://t.me/breezsdk) or email us at [contact@breez.technology](mailto:contact@breez.technology)

--- a/docs/breez-sdk/src/guide/install_android_kotlin.md
+++ b/docs/breez-sdk/src/guide/install_android_kotlin.md
@@ -15,3 +15,7 @@ dependencies {
   implementation("breez_sdk_spark:bindings-android:{VERSION}")
 }
 ```
+
+## Example App
+
+For a full working example app, see the [Kotlin CLI example app](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform).

--- a/docs/breez-sdk/src/guide/install_csharp.md
+++ b/docs/breez-sdk/src/guide/install_csharp.md
@@ -23,3 +23,7 @@ Add the following to your `.csproj` file:
   <PackageReference Include="Breez.Sdk.Spark" Version="{VERSION}" />
 </ItemGroup>
 ```
+
+## Example App
+
+For a full working example app, see the [C# CLI example app](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/csharp).

--- a/docs/breez-sdk/src/guide/install_flutter.md
+++ b/docs/breez-sdk/src/guide/install_flutter.md
@@ -8,3 +8,7 @@ dependencies:
     git:
       url: https://github.com/breez/breez-sdk-spark-flutter
 ```
+
+## Example App
+
+For a full working example app, see the [Flutter CLI example app](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/flutter).

--- a/docs/breez-sdk/src/guide/install_go.md
+++ b/docs/breez-sdk/src/guide/install_go.md
@@ -87,3 +87,7 @@ Copy the binding library to the same directory as the executable file or include
 ```bash
 cp vendor/github.com/breez/breez-sdk-spark-go/breez_sdk_spark/lib/windows-amd64/*.dll build/windows/
 ```
+
+## Example App
+
+For a full working example app, see the [Go CLI example app](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/golang).

--- a/docs/breez-sdk/src/guide/install_ios_swift.md
+++ b/docs/breez-sdk/src/guide/install_ios_swift.md
@@ -22,3 +22,7 @@ Add the following to the dependencies array of your `Package.swift`:
 ``` swift
 .package(url: "https://github.com/breez/breez-sdk-spark-swift.git", from: "{VERSION}"),
 ```
+
+## Example App
+
+For a full working example app, see the [Swift CLI example app](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/swift).

--- a/docs/breez-sdk/src/guide/install_javascript.md
+++ b/docs/breez-sdk/src/guide/install_javascript.md
@@ -11,3 +11,9 @@ or
 ```console
 yarn add @breeztech/breez-sdk-spark
 ```
+
+## Example Apps
+
+For full working example apps, see:
+- [CLI example app](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/wasm)
+- [Glow Web App](https://github.com/breez/glow-web)

--- a/docs/breez-sdk/src/guide/install_kotlin_multiplatform.md
+++ b/docs/breez-sdk/src/guide/install_kotlin_multiplatform.md
@@ -99,3 +99,7 @@ Or via the command line:
 ```bash
 ./gradlew build -PbreezSdkSparkFrameworkPath=/path/to/framework/dir
 ```
+
+## Example App
+
+For a full working example app, see the [Kotlin Multiplatform CLI example app](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform).

--- a/docs/breez-sdk/src/guide/install_python.md
+++ b/docs/breez-sdk/src/guide/install_python.md
@@ -5,3 +5,7 @@ We recommend using our official Python package: [breez-sdk-spark](https://pypi.o
 ```console
 pip install breez-sdk-spark
 ```
+
+## Example App
+
+For a full working example app, see the [Python CLI example app](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/python).

--- a/docs/breez-sdk/src/guide/install_react_native.md
+++ b/docs/breez-sdk/src/guide/install_react_native.md
@@ -52,3 +52,7 @@ To enable [Passkey](passkey.md#ios-apple-app-site-association) support, set `ena
 This package contains native code and requires a custom development build. It will not work with Expo Go.
 
 </div>
+
+## Example App
+
+For a full working example app, see the [React Native CLI example app](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/bindings/examples/cli/langs/react-native).

--- a/docs/breez-sdk/src/guide/install_rust.md
+++ b/docs/breez-sdk/src/guide/install_rust.md
@@ -7,3 +7,7 @@ Check [breez/spark-sdk](https://github.com/breez/spark-sdk/releases) for the lat
 [dependencies]
 breez-sdk-spark = { git = "https://github.com/breez/spark-sdk", tag = "{VERSION}" }
 ```
+
+## Example App
+
+For a full working example app, see the [Rust CLI example app](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/cli).


### PR DESCRIPTION
## Summary
- Add an **Examples Apps** section to the README with a table linking to CLI example apps for all languages
- Add an **Example App(s)** section to each language install pages in the docs, linking to the respective CLI example app. Include `glow-web` for JavaScript/TypeScript.