### PR TITLE
Downgrade event stream reconnect log to debug

### DIFF
--- a/crates/spark/src/events/server_stream.rs
+++ b/crates/spark/src/events/server_stream.rs
@@ -72,7 +72,7 @@ pub async fn subscribe_server_events(
                     break;
                 }
                 Err(e) => {
-                    error!("Error receiving event, reconnecting: {}", e);
+                    debug!("Error receiving event, reconnecting: {}", e);
                     break;
                 }
             };


### PR DESCRIPTION
## Summary
- Downgrade log level from `error!` to `debug!` when the server event stream drops and triggers a reconnect
- The stream drops every ~10 minutes due to server-side max connection age, which is expected behavior
- Actual reconnect failures remain logged at error level