### PR TITLE
ship dSYMs with breez_sdk_sparkFFI.xcframework

### DIFF
--- a/.github/workflows/build-bindings-darwin.yml
+++ b/.github/workflows/build-bindings-darwin.yml
@@ -52,19 +52,41 @@ jobs:
 
       - name: Build bindings
         working-directory: crates/breez-sdk/bindings
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: "full"
         run: cargo lipo --release --targets ${{ matrix.target }}
-      
+
+      - name: Generate dSYM and strip dylib
+        run: |
+          cd target/${{ matrix.target }}/release
+          cp libbreez_sdk_spark_bindings.dylib breez_sdk_sparkFFI
+          dsymutil breez_sdk_sparkFFI -o breez_sdk_sparkFFI.framework.dSYM
+          /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier com.apple.xcode.dsym.breez_sdk_sparkFFI" breez_sdk_sparkFFI.framework.dSYM/Contents/Info.plist
+          rm breez_sdk_sparkFFI
+          strip -S libbreez_sdk_spark_bindings.dylib
+
+      - name: Stage dSYM for upload
+        run: |
+          mkdir -p dsym-stage
+          cp -R target/${{ matrix.target }}/release/breez_sdk_sparkFFI.framework.dSYM dsym-stage/
+
       - name: Archive bindings
         uses: actions/upload-artifact@v4
         with:
           name: bindings-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/libbreez_sdk_spark_bindings.a
-      
+
       - name: Archive bindings
         uses: actions/upload-artifact@v4
         with:
           name: bindings-dynamic-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/libbreez_sdk_spark_bindings.dylib
+
+      - name: Archive dSYM
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-dsym-${{ matrix.target }}
+          path: dsym-stage
   
   merge:
     runs-on: macOS-latest
@@ -91,6 +113,16 @@ jobs:
         name: bindings-dynamic-x86_64-apple-darwin
         path: dynamic-x86_64-apple-darwin
 
+    - uses: actions/download-artifact@v4
+      with:
+        name: bindings-dsym-aarch64-apple-darwin
+        path: dsym-aarch64-apple-darwin
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: bindings-dsym-x86_64-apple-darwin
+        path: dsym-x86_64-apple-darwin
+
     - name: Build Darwin universal
       run: |
         mkdir -p darwin-universal
@@ -100,6 +132,17 @@ jobs:
       run: |
         mkdir -p dynamic-darwin-universal
         lipo -create -output dynamic-darwin-universal/libbreez_sdk_spark_bindings.dylib dynamic-aarch64-apple-darwin/libbreez_sdk_spark_bindings.dylib dynamic-x86_64-apple-darwin/libbreez_sdk_spark_bindings.dylib
+
+    - name: Build Darwin universal dSYM
+      run: |
+        DSYM_OUT=dsym-darwin-universal/breez_sdk_sparkFFI.framework.dSYM
+        mkdir -p "$DSYM_OUT/Contents/Resources/DWARF"
+        cp dsym-aarch64-apple-darwin/breez_sdk_sparkFFI.framework.dSYM/Contents/Info.plist \
+           "$DSYM_OUT/Contents/Info.plist"
+        lipo -create \
+          -output "$DSYM_OUT/Contents/Resources/DWARF/breez_sdk_sparkFFI" \
+          dsym-aarch64-apple-darwin/breez_sdk_sparkFFI.framework.dSYM/Contents/Resources/DWARF/breez_sdk_sparkFFI \
+          dsym-x86_64-apple-darwin/breez_sdk_sparkFFI.framework.dSYM/Contents/Resources/DWARF/breez_sdk_sparkFFI
 
     - name: Archive release
       uses: actions/upload-artifact@v4
@@ -112,6 +155,12 @@ jobs:
       with:
         name: bindings-dynamic-darwin-universal
         path: dynamic-darwin-universal/libbreez_sdk_spark_bindings.dylib
+
+    - name: Archive darwin-universal dSYM
+      uses: actions/upload-artifact@v4
+      with:
+        name: bindings-dsym-darwin-universal
+        path: dsym-darwin-universal
 
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
@@ -154,3 +203,27 @@ jobs:
         with:
           name: bindings-dynamic-${{ matrix.target }}
           path: ./*
+
+  build-dsym-dummies:
+    if: ${{ inputs.use-dummy-binaries }}
+    runs-on: ubuntu-latest
+    name: Build dSYM dummies ${{ matrix.target }}
+    strategy:
+      matrix:
+        target: [
+          aarch64-apple-darwin,
+          x86_64-apple-darwin,
+          darwin-universal
+        ]
+    steps:
+      - name: Build dummy darwin dSYM ${{ matrix.target }}
+        run: |
+          mkdir -p dsym-stage/breez_sdk_sparkFFI.framework.dSYM/Contents/Resources/DWARF
+          touch dsym-stage/breez_sdk_sparkFFI.framework.dSYM/Contents/Info.plist
+          touch dsym-stage/breez_sdk_sparkFFI.framework.dSYM/Contents/Resources/DWARF/breez_sdk_sparkFFI
+
+      - name: Upload dummy darwin dSYM ${{ matrix.target }} artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-dsym-${{ matrix.target }}
+          path: dsym-stage

--- a/.github/workflows/build-bindings-darwin.yml
+++ b/.github/workflows/build-bindings-darwin.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build bindings
         working-directory: crates/breez-sdk/bindings
         env:
-          CARGO_PROFILE_RELEASE_DEBUG: "full"
+          CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"
         run: cargo lipo --release --targets ${{ matrix.target }}
 
       - name: Generate dSYM and strip dylib

--- a/.github/workflows/build-bindings-darwin.yml
+++ b/.github/workflows/build-bindings-darwin.yml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Build bindings
         working-directory: crates/breez-sdk/bindings
-        env:
-          CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"
         run: cargo lipo --release --targets ${{ matrix.target }}
 
       - name: Generate dSYM and strip dylib

--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -60,8 +60,6 @@ jobs:
 
       - name: Build bindings
         working-directory: crates/breez-sdk/bindings
-        env:
-          CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Generate dSYM and strip dylib

--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build bindings
         working-directory: crates/breez-sdk/bindings
         env:
-          CARGO_PROFILE_RELEASE_DEBUG: "full"
+          CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Generate dSYM and strip dylib

--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -60,19 +60,47 @@ jobs:
 
       - name: Build bindings
         working-directory: crates/breez-sdk/bindings
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: "full"
         run: cargo build --release --target ${{ matrix.target }}
-      
+
+      - name: Generate dSYM and strip dylib
+        run: |
+          cd target/${{ matrix.target }}/release
+          # Copy the dylib under the intended framework binary name so the
+          # resulting .dSYM bundle and inner DWARF file match what Xcode
+          # looks for inside the XCFramework.
+          cp libbreez_sdk_spark_bindings.dylib breez_sdk_sparkFFI
+          dsymutil breez_sdk_sparkFFI -o breez_sdk_sparkFFI.framework.dSYM
+          /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier com.apple.xcode.dsym.breez_sdk_sparkFFI" breez_sdk_sparkFFI.framework.dSYM/Contents/Info.plist
+          rm breez_sdk_sparkFFI
+          # The DWARF is now in the .dSYM bundle; strip debug symbols from
+          # the dylib we will ship. LC_UUID is preserved so the stripped
+          # dylib still matches the .dSYM.
+          strip -S libbreez_sdk_spark_bindings.dylib
+
+      - name: Stage dSYM for upload
+        run: |
+          mkdir -p dsym-stage
+          cp -R target/${{ matrix.target }}/release/breez_sdk_sparkFFI.framework.dSYM dsym-stage/
+
       - name: Archive bindings
         uses: actions/upload-artifact@v4
         with:
           name: bindings-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/libbreez_sdk_spark_bindings.a
-      
+
       - name: Archive dylib bindings
         uses: actions/upload-artifact@v4
         with:
           name: bindings-dynamic-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/libbreez_sdk_spark_bindings.dylib
+
+      - name: Archive dSYM
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-dsym-${{ matrix.target }}
+          path: dsym-stage
 
   merge:
     runs-on: macOS-latest
@@ -109,6 +137,16 @@ jobs:
           name: bindings-dynamic-aarch64-apple-ios-sim
           path: dynamic-aarch64-apple-ios-sim
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: bindings-dsym-aarch64-apple-ios-sim
+          path: dsym-aarch64-apple-ios-sim
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: bindings-dsym-x86_64-apple-ios
+          path: dsym-x86_64-apple-ios
+
       - name: Build ios-universal
         run: |
           mkdir -p ios-universal
@@ -128,6 +166,19 @@ jobs:
         run: |
           mkdir -p dynamic-ios-universal-sim
           lipo -create -output dynamic-ios-universal-sim/libbreez_sdk_spark_bindings.dylib dynamic-aarch64-apple-ios-sim/libbreez_sdk_spark_bindings.dylib dynamic-x86_64-apple-ios/libbreez_sdk_spark_bindings.dylib
+
+      - name: Build ios-universal-sim dSYM
+        run: |
+          # Combine per-arch dSYMs by lipo'ing their inner DWARF Mach-O into
+          # a single universal DWARF file.
+          DSYM_OUT=dsym-ios-universal-sim/breez_sdk_sparkFFI.framework.dSYM
+          mkdir -p "$DSYM_OUT/Contents/Resources/DWARF"
+          cp dsym-aarch64-apple-ios-sim/breez_sdk_sparkFFI.framework.dSYM/Contents/Info.plist \
+             "$DSYM_OUT/Contents/Info.plist"
+          lipo -create \
+            -output "$DSYM_OUT/Contents/Resources/DWARF/breez_sdk_sparkFFI" \
+            dsym-aarch64-apple-ios-sim/breez_sdk_sparkFFI.framework.dSYM/Contents/Resources/DWARF/breez_sdk_sparkFFI \
+            dsym-x86_64-apple-ios/breez_sdk_sparkFFI.framework.dSYM/Contents/Resources/DWARF/breez_sdk_sparkFFI
 
       - name: Archive ios-universal
         uses: actions/upload-artifact@v4
@@ -152,6 +203,12 @@ jobs:
         with:
           name: bindings-dynamic-ios-universal-sim
           path: dynamic-ios-universal-sim/libbreez_sdk_spark_bindings.dylib
+
+      - name: Archive ios-universal-sim dSYM
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-dsym-ios-universal-sim
+          path: dsym-ios-universal-sim
 
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
@@ -200,3 +257,28 @@ jobs:
         with:
           name: bindings-${{ matrix.target }}
           path: ./*
+
+  build-dsym-dummies:
+    if: ${{ inputs.use-dummy-binaries }}
+    runs-on: ubuntu-latest
+    name: Build dSYM dummies ${{ matrix.target }}
+    strategy:
+      matrix:
+        target: [
+          aarch64-apple-ios,
+          x86_64-apple-ios,
+          aarch64-apple-ios-sim,
+          ios-universal-sim,
+        ]
+    steps:
+      - name: Build dummy ios dSYM ${{ matrix.target }}
+        run: |
+          mkdir -p dsym-stage/breez_sdk_sparkFFI.framework.dSYM/Contents/Resources/DWARF
+          touch dsym-stage/breez_sdk_sparkFFI.framework.dSYM/Contents/Info.plist
+          touch dsym-stage/breez_sdk_sparkFFI.framework.dSYM/Contents/Resources/DWARF/breez_sdk_sparkFFI
+
+      - name: Upload dummy ios dSYM ${{ matrix.target }} artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-dsym-${{ matrix.target }}
+          path: dsym-stage

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -105,6 +105,24 @@ jobs:
           name: bindings-dynamic-darwin-universal
           path: darwin-universal
 
+      - name: Download dSYM ios-arm64
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-dsym-aarch64-apple-ios
+          path: dsym-ios-arm64
+
+      - name: Download dSYM ios-arm64_x86_64-simulator
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-dsym-ios-universal-sim
+          path: dsym-ios-arm64_x86_64-simulator
+
+      - name: Download dSYM macos-arm64_x86_64
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-dsym-darwin-universal
+          path: dsym-macos-arm64_x86_64
+
       - name: Copy swift bindings
         run: |
           mkdir -p build/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark
@@ -118,6 +136,14 @@ jobs:
           install_name_tool -id @rpath/breez_sdk_sparkFFI.framework/breez_sdk_sparkFFI build/crates/breez-sdk/bindings/langs/swift/breez_sdk_sparkFFI.xcframework/ios-arm64/breez_sdk_sparkFFI.framework/breez_sdk_sparkFFI
           install_name_tool -id @rpath/breez_sdk_sparkFFI.framework/breez_sdk_sparkFFI build/crates/breez-sdk/bindings/langs/swift/breez_sdk_sparkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdk_sparkFFI.framework/breez_sdk_sparkFFI
           install_name_tool -id @rpath/breez_sdk_sparkFFI.framework/Versions/A/breez_sdk_sparkFFI build/crates/breez-sdk/bindings/langs/swift/breez_sdk_sparkFFI.xcframework/macos-arm64_x86_64/breez_sdk_sparkFFI.framework/Versions/A/breez_sdk_sparkFFI
+
+      - name: Embed dSYMs in xcframework
+        run: |
+          XCF=build/crates/breez-sdk/bindings/langs/swift/breez_sdk_sparkFFI.xcframework
+          for slice in ios-arm64 ios-arm64_x86_64-simulator macos-arm64_x86_64; do
+            mkdir -p "$XCF/$slice/dSYMs"
+            cp -R "dsym-$slice/breez_sdk_sparkFFI.framework.dSYM" "$XCF/$slice/dSYMs/"
+          done
 
       - name: Set plist versions
         working-directory: build/crates/breez-sdk/bindings/langs/swift/breez_sdk_sparkFFI.xcframework

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,94 @@
 [profile.release]
 lto = true
-opt-level = "z"   # Optimize for size.
-codegen-units = 1 # Reduce Parallel Code Generation Units to Increase Optimization
-panic = "abort"   # Abort on panic, as unwinding code does require extra binary size
+opt-level = "z"        # Optimize for size.
+codegen-units = 1      # Reduce Parallel Code Generation Units to Increase Optimization
+panic = "abort"        # Abort on panic, as unwinding code does require extra binary size
 rpath = true
+debug = "line-tables-only" # Emit line tables so dsymutil can build dSYMs with
+                           # matching UUIDs (required for Xcode archive validation
+                           # of the Apple XCFramework) and stack traces resolve
+                           # to file + line. Per-package overrides below strip
+                           # third-party dependencies down to no debug info.
+
+# Debug-info scoping for release builds.
+#
+# We ship Apple bindings through `breez_sdk_sparkFFI.xcframework`, which embeds
+# `.dSYM` bundles so Xcode archive validation passes. Full DWARF over our whole
+# dependency graph (rustls, tokio, ldk-node, secp256k1, bitcoin, ...) inflates
+# those dSYMs by an order of magnitude without meaningfully improving crash
+# reports for the code that actually matters.
+#
+# Strategy: emit `line-tables-only` DWARF for every first-party crate under
+# `crates/`, and no debug info at all for third-party dependencies. First-party
+# stack frames still resolve to file + line in crash reports; third-party frames
+# keep their symbol names from the Mach-O symbol table but lose source lines.
+# If a crash repeatedly surfaces inside a specific external crate, we can flip
+# that crate back to `line-tables-only` on demand.
+[profile.release.package."*"]
+debug = false
+
+[profile.release.package.breez-sdk-bindings]
+debug = "line-tables-only"
+
+[profile.release.package.breez-sdk-spark]
+debug = "line-tables-only"
+
+[profile.release.package.breez-sdk-common]
+debug = "line-tables-only"
+
+[profile.release.package.breez-sdk-spark-wasm]
+debug = "line-tables-only"
+
+[profile.release.package.breez-sdk-itest]
+debug = "line-tables-only"
+
+[profile.release.package.breez-sdk-bench]
+debug = "line-tables-only"
+
+[profile.release.package.spark]
+debug = "line-tables-only"
+
+[profile.release.package.spark-wallet]
+debug = "line-tables-only"
+
+[profile.release.package.spark-postgres]
+debug = "line-tables-only"
+
+[profile.release.package.spark-itest]
+debug = "line-tables-only"
+
+[profile.release.package.spark-cli]
+debug = "line-tables-only"
+
+[profile.release.package.lnurl]
+debug = "line-tables-only"
+
+[profile.release.package.lnurl-models]
+debug = "line-tables-only"
+
+[profile.release.package.flashnet]
+debug = "line-tables-only"
+
+[profile.release.package.platform-utils]
+debug = "line-tables-only"
+
+[profile.release.package.utils]
+debug = "line-tables-only"
+
+[profile.release.package.macros]
+debug = "line-tables-only"
+
+[profile.release.package.macro_test]
+debug = "line-tables-only"
+
+[profile.release.package.cli]
+debug = "line-tables-only"
+
+[profile.release.package.xtask]
+debug = "line-tables-only"
+
+[profile.release.package.nip65-publisher]
+debug = "line-tables-only"
 
 [workspace]
 resolver = "2"

--- a/crates/breez-sdk/bindings/langs/swift/breez_sdk_sparkFFI.xcframework/Info.plist
+++ b/crates/breez-sdk/bindings/langs/swift/breez_sdk_sparkFFI.xcframework/Info.plist
@@ -5,6 +5,8 @@
 	<key>AvailableLibraries</key>
 	<array>
 		<dict>
+			<key>DebugSymbolsPath</key>
+			<string>dSYMs</string>
 			<key>LibraryIdentifier</key>
 			<string>macos-arm64_x86_64</string>
 			<key>LibraryPath</key>
@@ -18,6 +20,8 @@
 			<string>macos</string>
 		</dict>
 		<dict>
+			<key>DebugSymbolsPath</key>
+			<string>dSYMs</string>
 			<key>LibraryIdentifier</key>
 			<string>ios-arm64_x86_64-simulator</string>
 			<key>LibraryPath</key>
@@ -33,6 +37,8 @@
 			<string>simulator</string>
 		</dict>
 		<dict>
+			<key>DebugSymbolsPath</key>
+			<string>dSYMs</string>
 			<key>LibraryIdentifier</key>
 			<string>ios-arm64</string>
 			<key>LibraryPath</key>


### PR DESCRIPTION
Xcode archive validation rejected apps linking the Swift package with
"The archive did not include a dSYM for the breez_sdk_sparkFFI.framework
with the UUIDs [...]" because the XCFramework was assembled by copying
raw dylibs into a committed framework skeleton with no debug symbols
anywhere in the bundle.

- Build the iOS/Darwin bindings with CARGO_PROFILE_RELEASE_DEBUG=full so
  the dylibs carry a debug map that dsymutil can consume.
- Run dsymutil per target and stage a breez_sdk_sparkFFI.framework.dSYM
  next to each dylib; strip -S the shipped dylib afterwards so LC_UUID
  is preserved but debug info is dropped from the binary.
- In the merge jobs, lipo the per-arch DWARF Mach-Os into a single
  universal dSYM for the ios-arm64_x86_64-simulator and
  macos-arm64_x86_64 slices.
- Download the three per-slice dSYM artifacts in publish-swift and
  embed them under <slice>/dSYMs/breez_sdk_sparkFFI.framework.dSYM, and
  advertise them via DebugSymbolsPath=dSYMs in the xcframework plist.