### PR TITLE
LNURL server: sign webhooks

### DIFF
--- a/crates/breez-sdk/lnurl/migrations/postgres/20260416120000_webhook_signing.sql
+++ b/crates/breez-sdk/lnurl/migrations/postgres/20260416120000_webhook_signing.sql
@@ -1,0 +1,18 @@
+-- Per-domain signing secret for outgoing webhooks.
+ALTER TABLE domain_webhooks ADD COLUMN webhook_secret TEXT NOT NULL;
+
+-- Route webhook deliveries by domain instead of URL.
+-- The URL is resolved at send time from domain_webhooks and stored for audit.
+ALTER TABLE webhook_deliveries ADD COLUMN domain TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE webhook_deliveries ALTER COLUMN url DROP NOT NULL;
+
+-- Replace old (identifier, url) uniqueness with domain-based constraint.
+ALTER TABLE webhook_deliveries DROP CONSTRAINT webhook_deliveries_identifier_url_key;
+CREATE UNIQUE INDEX idx_webhook_deliveries_identifier_domain
+    ON webhook_deliveries (identifier, domain);
+
+-- Update the pending index to partition by domain instead of url.
+DROP INDEX IF EXISTS idx_webhook_deliveries_pending;
+CREATE INDEX idx_webhook_deliveries_pending
+    ON webhook_deliveries (domain, next_retry_at)
+    WHERE succeeded_at IS NULL;

--- a/crates/breez-sdk/lnurl/migrations/sqlite/20260416120000_webhook_signing.sql
+++ b/crates/breez-sdk/lnurl/migrations/sqlite/20260416120000_webhook_signing.sql
@@ -1,0 +1,27 @@
+-- Per-domain signing secret for outgoing webhooks.
+ALTER TABLE domain_webhooks ADD COLUMN webhook_secret TEXT NOT NULL;
+
+-- Recreate webhook_deliveries with domain column and correct constraints.
+-- No existing SQLite databases have webhook data, so a clean drop is safe.
+DROP TABLE webhook_deliveries;
+
+CREATE TABLE webhook_deliveries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    identifier TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    url TEXT,
+    payload TEXT NOT NULL,
+    created_at BIGINT NOT NULL,
+    succeeded_at BIGINT,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    next_retry_at BIGINT NOT NULL,
+    claimed_at BIGINT,
+    last_error_status_code INTEGER,
+    last_error_body TEXT,
+    UNIQUE (identifier, domain)
+);
+CREATE INDEX idx_webhook_deliveries_pending
+    ON webhook_deliveries (domain, next_retry_at)
+    WHERE succeeded_at IS NULL;
+CREATE INDEX idx_webhook_deliveries_created_at
+    ON webhook_deliveries (created_at);

--- a/crates/breez-sdk/lnurl/src/main.rs
+++ b/crates/breez-sdk/lnurl/src/main.rs
@@ -287,6 +287,10 @@ where
 
     let webhook_service = webhooks::WebhookService::new(repository.clone());
 
+    // Load webhook endpoint configs (domain → {url, secret}) and start
+    // a background refresher that keeps them in sync with the database.
+    let webhook_config_cache = webhooks::config::start(repository.clone()).await?;
+
     // Start background processors.
     zap::start_background_processor(
         repository.clone(),
@@ -298,6 +302,7 @@ where
         http_client,
         invoice_paid_rx,
         args.webhook_delivery_ttl_days,
+        webhook_config_cache,
     );
 
     // Get or create a shared webhook secret persisted in the database.

--- a/crates/breez-sdk/lnurl/src/postgresql/repository.rs
+++ b/crates/breez-sdk/lnurl/src/postgresql/repository.rs
@@ -2,7 +2,9 @@ use lnurl_models::ListMetadataMetadata;
 use sqlx::{PgPool, Row};
 
 use crate::repository::{Invoice, LnurlSenderComment, PendingZapReceipt, WebhookPayloadData};
-use crate::webhooks::repository::{NewWebhookDelivery, WebhookDelivery, WebhookRepositoryError};
+use crate::webhooks::repository::{
+    NewWebhookDelivery, WebhookConfig, WebhookDelivery, WebhookRepositoryError,
+};
 use crate::zap::Zap;
 use crate::{
     repository::LnurlRepositoryError,
@@ -575,9 +577,8 @@ impl crate::repository::LnurlRepository for LnurlRepository {
             "SELECT i.payment_hash, i.user_pubkey, i.invoice, i.preimage, i.amount_received_sat,
                     u.name, u.domain,
                     sc.sender_comment,
-                    dw.url
+                    i.domain
              FROM invoices i
-             JOIN domain_webhooks dw ON dw.domain = i.domain
              LEFT JOIN users u ON u.pubkey = i.user_pubkey AND u.domain = i.domain
              LEFT JOIN sender_comments sc ON sc.payment_hash = i.payment_hash
              WHERE i.payment_hash = ANY($1)
@@ -604,7 +605,7 @@ impl crate::repository::LnurlRepository for LnurlRepository {
                     amount_received_sat: row.try_get(4)?,
                     lightning_address,
                     sender_comment: row.try_get(7)?,
-                    webhook_url: row.try_get(8)?,
+                    domain: row.try_get(8)?,
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -623,17 +624,17 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
         }
         let now = now_millis();
         let identifiers: Vec<&str> = deliveries.iter().map(|d| d.identifier.as_str()).collect();
-        let urls: Vec<&str> = deliveries.iter().map(|d| d.url.as_str()).collect();
+        let domains: Vec<&str> = deliveries.iter().map(|d| d.domain.as_str()).collect();
         let payloads: Vec<&str> = deliveries.iter().map(|d| d.payload.as_str()).collect();
         let created_ats: Vec<i64> = vec![now; deliveries.len()];
 
         sqlx::query(
-            "INSERT INTO webhook_deliveries (identifier, url, payload, created_at, next_retry_at)
+            "INSERT INTO webhook_deliveries (identifier, domain, payload, created_at, next_retry_at)
              SELECT * FROM UNNEST($1::text[], $2::text[], $3::text[], $4::bigint[], $4::bigint[])
-             ON CONFLICT (identifier, url) DO NOTHING",
+             ON CONFLICT (identifier, domain) DO NOTHING",
         )
         .bind(&identifiers)
-        .bind(&urls)
+        .bind(&domains)
         .bind(&payloads)
         .bind(&created_ats)
         .execute(&self.pool)
@@ -652,16 +653,16 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
              WHERE id IN (
                  SELECT d.id
                  FROM (
-                     SELECT DISTINCT url
+                     SELECT DISTINCT domain
                      FROM webhook_deliveries
                      WHERE next_retry_at <= $1
                        AND succeeded_at IS NULL
                        AND COALESCE(claimed_at, 0) < $3
-                 ) urls
+                 ) domains
                  CROSS JOIN LATERAL (
                      SELECT id
                      FROM webhook_deliveries
-                     WHERE url = urls.url
+                     WHERE domain = domains.domain
                        AND next_retry_at <= $1
                        AND succeeded_at IS NULL
                        AND COALESCE(claimed_at, 0) < $3
@@ -670,7 +671,7 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
                      LIMIT 1
                  ) d
              )
-             RETURNING id, identifier, url, payload, created_at, retry_count, next_retry_at",
+             RETURNING id, identifier, domain, url, payload, created_at, retry_count, next_retry_at",
         )
         .bind(now)
         .bind(now)
@@ -683,11 +684,12 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
                 Ok::<_, sqlx::Error>(WebhookDelivery {
                     id: row.try_get(0)?,
                     identifier: row.try_get(1)?,
-                    url: row.try_get(2)?,
-                    payload: row.try_get(3)?,
-                    created_at: row.try_get(4)?,
-                    retry_count: row.try_get(5)?,
-                    next_retry_at: row.try_get(6)?,
+                    domain: row.try_get(2)?,
+                    url: row.try_get(3)?,
+                    payload: row.try_get(4)?,
+                    created_at: row.try_get(5)?,
+                    retry_count: row.try_get(6)?,
+                    next_retry_at: row.try_get(7)?,
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -698,10 +700,12 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
         &self,
         id: i64,
         succeeded_at: i64,
+        url: &str,
     ) -> Result<(), WebhookRepositoryError> {
-        sqlx::query("UPDATE webhook_deliveries SET succeeded_at = $2 WHERE id = $1")
+        sqlx::query("UPDATE webhook_deliveries SET succeeded_at = $2, url = $3 WHERE id = $1")
             .bind(id)
             .bind(succeeded_at)
+            .bind(url)
             .execute(&self.pool)
             .await?;
         Ok(())
@@ -714,11 +718,12 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
         next_retry_at: i64,
         status_code: Option<i32>,
         body: Option<&str>,
+        url: &str,
     ) -> Result<(), WebhookRepositoryError> {
         sqlx::query(
             "UPDATE webhook_deliveries
              SET retry_count = $2, next_retry_at = $3, claimed_at = NULL,
-                 last_error_status_code = $4, last_error_body = $5
+                 last_error_status_code = $4, last_error_body = $5, url = $6
              WHERE id = $1",
         )
         .bind(id)
@@ -726,6 +731,7 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
         .bind(next_retry_at)
         .bind(status_code)
         .bind(body)
+        .bind(url)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -751,5 +757,40 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
             .execute(&self.pool)
             .await?;
         Ok(result.rows_affected())
+    }
+
+    async fn delete_webhook_delivery(&self, id: i64) -> Result<(), WebhookRepositoryError> {
+        sqlx::query("DELETE FROM webhook_deliveries WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn park_webhook_delivery(&self, id: i64) -> Result<(), WebhookRepositoryError> {
+        sqlx::query(
+            "UPDATE webhook_deliveries SET next_retry_at = $2, claimed_at = NULL WHERE id = $1",
+        )
+        .bind(id)
+        .bind(i64::MAX)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn list_webhook_configs(&self) -> Result<Vec<WebhookConfig>, WebhookRepositoryError> {
+        let rows = sqlx::query("SELECT domain, url, webhook_secret FROM domain_webhooks")
+            .fetch_all(&self.pool)
+            .await?;
+        rows.into_iter()
+            .map(|row| {
+                Ok(WebhookConfig {
+                    domain: row.try_get(0)?,
+                    url: row.try_get(1)?,
+                    secret: row.try_get(2)?,
+                })
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()
+            .map_err(|e| WebhookRepositoryError::General(e.into()))
     }
 }

--- a/crates/breez-sdk/lnurl/src/repository.rs
+++ b/crates/breez-sdk/lnurl/src/repository.rs
@@ -152,7 +152,7 @@ pub trait LnurlRepository {
 
     /// Get data needed to build webhook payloads for the given payment hashes.
     /// Joins invoices, users, `sender_comments`, and `domain_webhooks`.
-    /// Only returns rows where the invoice has a domain with a configured webhook.
+    /// Returns rows for invoices that have a domain and a preimage.
     async fn get_webhook_payloads(
         &self,
         payment_hashes: &[String],
@@ -168,5 +168,5 @@ pub struct WebhookPayloadData {
     pub amount_received_sat: Option<i64>,
     pub lightning_address: Option<String>,
     pub sender_comment: Option<String>,
-    pub webhook_url: String,
+    pub domain: String,
 }

--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -1565,6 +1565,7 @@ mod tests {
             &self,
             _: i64,
             _: i64,
+            _: &str,
         ) -> Result<(), WebhookRepositoryError> {
             Ok(())
         }
@@ -1575,6 +1576,7 @@ mod tests {
             _: i64,
             _: Option<i32>,
             _: Option<&str>,
+            _: &str,
         ) -> Result<(), WebhookRepositoryError> {
             Ok(())
         }
@@ -1589,6 +1591,18 @@ mod tests {
             _: i64,
         ) -> Result<u64, WebhookRepositoryError> {
             Ok(0)
+        }
+        async fn delete_webhook_delivery(&self, _: i64) -> Result<(), WebhookRepositoryError> {
+            Ok(())
+        }
+        async fn park_webhook_delivery(&self, _: i64) -> Result<(), WebhookRepositoryError> {
+            Ok(())
+        }
+        async fn list_webhook_configs(
+            &self,
+        ) -> Result<Vec<crate::webhooks::repository::WebhookConfig>, WebhookRepositoryError>
+        {
+            Ok(vec![])
         }
     }
 

--- a/crates/breez-sdk/lnurl/src/sqlite/repository.rs
+++ b/crates/breez-sdk/lnurl/src/sqlite/repository.rs
@@ -2,7 +2,9 @@ use lnurl_models::ListMetadataMetadata;
 use sqlx::{Row, SqlitePool};
 
 use crate::repository::{Invoice, LnurlSenderComment, PendingZapReceipt, WebhookPayloadData};
-use crate::webhooks::repository::{NewWebhookDelivery, WebhookDelivery, WebhookRepositoryError};
+use crate::webhooks::repository::{
+    NewWebhookDelivery, WebhookConfig, WebhookDelivery, WebhookRepositoryError,
+};
 use crate::zap::Zap;
 use crate::{
     repository::LnurlRepositoryError,
@@ -586,9 +588,8 @@ impl crate::repository::LnurlRepository for LnurlRepository {
             "SELECT i.payment_hash, i.user_pubkey, i.invoice, i.preimage, i.amount_received_sat,
                     u.name, u.domain,
                     sc.sender_comment,
-                    dw.url
+                    i.domain
              FROM invoices i
-             JOIN domain_webhooks dw ON dw.domain = i.domain
              LEFT JOIN users u ON u.pubkey = i.user_pubkey AND u.domain = i.domain
              LEFT JOIN sender_comments sc ON sc.payment_hash = i.payment_hash
              WHERE i.payment_hash IN ({})
@@ -618,7 +619,7 @@ impl crate::repository::LnurlRepository for LnurlRepository {
                     amount_received_sat: row.try_get(4)?,
                     lightning_address,
                     sender_comment: row.try_get(7)?,
-                    webhook_url: row.try_get(8)?,
+                    domain: row.try_get(8)?,
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -643,12 +644,12 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
             .map_err(|e| WebhookRepositoryError::General(e.into()))?;
         for d in deliveries {
             sqlx::query(
-                "INSERT INTO webhook_deliveries (identifier, url, payload, created_at, next_retry_at)
+                "INSERT INTO webhook_deliveries (identifier, domain, payload, created_at, next_retry_at)
                  VALUES ($1, $2, $3, $4, $4)
-                 ON CONFLICT (identifier, url) DO NOTHING",
+                 ON CONFLICT (identifier, domain) DO NOTHING",
             )
             .bind(&d.identifier)
-            .bind(&d.url)
+            .bind(&d.domain)
             .bind(&d.payload)
             .bind(now)
             .execute(&mut *tx)
@@ -667,7 +668,7 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
         let stale_threshold = now.saturating_sub(300_000); // 5 minutes
         let rows = sqlx::query(
             "WITH candidates AS (
-                 SELECT id, ROW_NUMBER() OVER (PARTITION BY url ORDER BY next_retry_at ASC) AS rn
+                 SELECT id, ROW_NUMBER() OVER (PARTITION BY domain ORDER BY next_retry_at ASC) AS rn
                  FROM webhook_deliveries
                  WHERE next_retry_at <= $1
                    AND succeeded_at IS NULL
@@ -676,7 +677,7 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
              UPDATE webhook_deliveries
              SET claimed_at = $2
              WHERE id IN (SELECT id FROM candidates WHERE rn = 1)
-             RETURNING id, identifier, url, payload, created_at, retry_count, next_retry_at",
+             RETURNING id, identifier, domain, url, payload, created_at, retry_count, next_retry_at",
         )
         .bind(now)
         .bind(now)
@@ -689,11 +690,12 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
                 Ok::<_, sqlx::Error>(WebhookDelivery {
                     id: row.try_get(0)?,
                     identifier: row.try_get(1)?,
-                    url: row.try_get(2)?,
-                    payload: row.try_get(3)?,
-                    created_at: row.try_get(4)?,
-                    retry_count: row.try_get(5)?,
-                    next_retry_at: row.try_get(6)?,
+                    domain: row.try_get(2)?,
+                    url: row.try_get(3)?,
+                    payload: row.try_get(4)?,
+                    created_at: row.try_get(5)?,
+                    retry_count: row.try_get(6)?,
+                    next_retry_at: row.try_get(7)?,
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -704,10 +706,12 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
         &self,
         id: i64,
         succeeded_at: i64,
+        url: &str,
     ) -> Result<(), WebhookRepositoryError> {
-        sqlx::query("UPDATE webhook_deliveries SET succeeded_at = $2 WHERE id = $1")
+        sqlx::query("UPDATE webhook_deliveries SET succeeded_at = $2, url = $3 WHERE id = $1")
             .bind(id)
             .bind(succeeded_at)
+            .bind(url)
             .execute(&self.pool)
             .await?;
         Ok(())
@@ -720,11 +724,12 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
         next_retry_at: i64,
         status_code: Option<i32>,
         body: Option<&str>,
+        url: &str,
     ) -> Result<(), WebhookRepositoryError> {
         sqlx::query(
             "UPDATE webhook_deliveries
              SET retry_count = $2, next_retry_at = $3, claimed_at = NULL,
-                 last_error_status_code = $4, last_error_body = $5
+                 last_error_status_code = $4, last_error_body = $5, url = $6
              WHERE id = $1",
         )
         .bind(id)
@@ -732,6 +737,7 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
         .bind(next_retry_at)
         .bind(status_code)
         .bind(body)
+        .bind(url)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -763,5 +769,40 @@ impl crate::webhooks::WebhookRepository for LnurlRepository {
             .execute(&self.pool)
             .await?;
         Ok(result.rows_affected())
+    }
+
+    async fn delete_webhook_delivery(&self, id: i64) -> Result<(), WebhookRepositoryError> {
+        sqlx::query("DELETE FROM webhook_deliveries WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn park_webhook_delivery(&self, id: i64) -> Result<(), WebhookRepositoryError> {
+        sqlx::query(
+            "UPDATE webhook_deliveries SET next_retry_at = $2, claimed_at = NULL WHERE id = $1",
+        )
+        .bind(id)
+        .bind(i64::MAX)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn list_webhook_configs(&self) -> Result<Vec<WebhookConfig>, WebhookRepositoryError> {
+        let rows = sqlx::query("SELECT domain, url, webhook_secret FROM domain_webhooks")
+            .fetch_all(&self.pool)
+            .await?;
+        rows.into_iter()
+            .map(|row| {
+                Ok(WebhookConfig {
+                    domain: row.try_get(0)?,
+                    url: row.try_get(1)?,
+                    secret: row.try_get(2)?,
+                })
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()
+            .map_err(|e| WebhookRepositoryError::General(e.into()))
     }
 }

--- a/crates/breez-sdk/lnurl/src/webhook_notify.rs
+++ b/crates/breez-sdk/lnurl/src/webhook_notify.rs
@@ -62,7 +62,7 @@ where
 
         deliveries.push(NewWebhookDelivery {
             identifier: item.payment_hash,
-            url: item.webhook_url,
+            domain: item.domain,
             payload: json,
         });
     }
@@ -110,8 +110,6 @@ mod shared_tests {
     use crate::time::now_millis;
     use crate::webhooks::{WebhookRepository, WebhookService};
 
-    /// Assumes the domain webhook for "enqueue-test.example.com" is already
-    /// configured in the database before calling this function.
     pub async fn enqueue_webhooks_creates_delivery<DB>(db: &DB)
     where
         DB: LnurlRepository + WebhookRepository + Clone + Send + Sync + 'static,
@@ -122,7 +120,6 @@ mod shared_tests {
             super::test_helpers::generate_test_invoice(&preimage_bytes);
 
         let domain = "enqueue-test.example.com";
-        let webhook_url = "https://enqueue-test.example.com/hook";
 
         db.add_domain(domain).await.unwrap();
         db.upsert_user(&crate::user::User {
@@ -159,7 +156,7 @@ mod shared_tests {
         let deliveries = db.take_pending_webhook_deliveries().await.unwrap();
         assert_eq!(deliveries.len(), 1);
         assert_eq!(deliveries[0].identifier, payment_hash);
-        assert_eq!(deliveries[0].url, webhook_url);
+        assert_eq!(deliveries[0].domain, domain);
 
         let payload: serde_json::Value = serde_json::from_str(&deliveries[0].payload).unwrap();
         assert_eq!(payload["template"], "spark_payment_received");
@@ -205,8 +202,6 @@ mod shared_tests {
         );
     }
 
-    /// Assumes the domain webhook for "idempotent-test.example.com" is already
-    /// configured in the database before calling this function.
     pub async fn enqueue_webhooks_is_idempotent<DB>(db: &DB)
     where
         DB: LnurlRepository + WebhookRepository + Clone + Send + Sync + 'static,
@@ -263,53 +258,30 @@ mod shared_tests {
 mod sqlite_tests {
     use super::shared_tests;
 
-    async fn setup_test_db() -> (crate::sqlite::LnurlRepository, sqlx::SqlitePool) {
+    async fn setup_test_db() -> crate::sqlite::LnurlRepository {
         let pool = sqlx::sqlite::SqlitePoolOptions::new()
             .connect(":memory:")
             .await
             .unwrap();
         crate::sqlite::run_migrations(&pool).await.unwrap();
-        (crate::sqlite::LnurlRepository::new(pool.clone()), pool)
-    }
-
-    async fn insert_domain_webhook(pool: &sqlx::SqlitePool, domain: &str, url: &str) {
-        sqlx::query(
-            "INSERT INTO domain_webhooks (domain, url) VALUES ($1, $2) ON CONFLICT DO NOTHING",
-        )
-        .bind(domain)
-        .bind(url)
-        .execute(pool)
-        .await
-        .unwrap();
+        crate::sqlite::LnurlRepository::new(pool)
     }
 
     #[tokio::test]
     async fn enqueue_webhooks_creates_delivery() {
-        let (db, pool) = setup_test_db().await;
-        insert_domain_webhook(
-            &pool,
-            "enqueue-test.example.com",
-            "https://enqueue-test.example.com/hook",
-        )
-        .await;
+        let db = setup_test_db().await;
         shared_tests::enqueue_webhooks_creates_delivery(&db).await;
     }
 
     #[tokio::test]
     async fn enqueue_webhooks_skips_invoice_without_domain() {
-        let (db, _) = setup_test_db().await;
+        let db = setup_test_db().await;
         shared_tests::enqueue_webhooks_skips_invoice_without_domain(&db).await;
     }
 
     #[tokio::test]
     async fn enqueue_webhooks_is_idempotent() {
-        let (db, pool) = setup_test_db().await;
-        insert_domain_webhook(
-            &pool,
-            "idempotent-test.example.com",
-            "https://idempotent-test.example.com/hook",
-        )
-        .await;
+        let db = setup_test_db().await;
         shared_tests::enqueue_webhooks_is_idempotent(&db).await;
     }
 }
@@ -320,7 +292,7 @@ mod sqlite_tests {
 mod postgres_tests {
     use super::shared_tests;
 
-    async fn setup_test_db() -> Option<(crate::postgresql::LnurlRepository, sqlx::PgPool)> {
+    async fn setup_test_db() -> Option<crate::postgresql::LnurlRepository> {
         let url = std::env::var("LNURL_TEST_POSTGRES_URL").ok()?;
         let pool = sqlx::PgPool::connect(&url).await.ok()?;
         crate::postgresql::run_migrations(&pool).await.ok()?;
@@ -342,37 +314,20 @@ mod postgres_tests {
             .await
             .ok()?;
 
-        Some((crate::postgresql::LnurlRepository::new(pool.clone()), pool))
-    }
-
-    async fn insert_domain_webhook(pool: &sqlx::PgPool, domain: &str, url: &str) {
-        sqlx::query(
-            "INSERT INTO domain_webhooks (domain, url) VALUES ($1, $2) ON CONFLICT DO NOTHING",
-        )
-        .bind(domain)
-        .bind(url)
-        .execute(pool)
-        .await
-        .unwrap();
+        Some(crate::postgresql::LnurlRepository::new(pool))
     }
 
     #[tokio::test]
     async fn enqueue_webhooks_creates_delivery() {
-        let Some((db, pool)) = setup_test_db().await else {
+        let Some(db) = setup_test_db().await else {
             return;
         };
-        insert_domain_webhook(
-            &pool,
-            "enqueue-test.example.com",
-            "https://enqueue-test.example.com/hook",
-        )
-        .await;
         shared_tests::enqueue_webhooks_creates_delivery(&db).await;
     }
 
     #[tokio::test]
     async fn enqueue_webhooks_skips_invoice_without_domain() {
-        let Some((db, _)) = setup_test_db().await else {
+        let Some(db) = setup_test_db().await else {
             return;
         };
         shared_tests::enqueue_webhooks_skips_invoice_without_domain(&db).await;
@@ -380,15 +335,9 @@ mod postgres_tests {
 
     #[tokio::test]
     async fn enqueue_webhooks_is_idempotent() {
-        let Some((db, pool)) = setup_test_db().await else {
+        let Some(db) = setup_test_db().await else {
             return;
         };
-        insert_domain_webhook(
-            &pool,
-            "idempotent-test.example.com",
-            "https://idempotent-test.example.com/hook",
-        )
-        .await;
         shared_tests::enqueue_webhooks_is_idempotent(&db).await;
     }
 }

--- a/crates/breez-sdk/lnurl/src/webhooks/background.rs
+++ b/crates/breez-sdk/lnurl/src/webhooks/background.rs
@@ -4,15 +4,21 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, Semaphore};
 use tracing::{debug, error, warn};
 
+use bitcoin::hashes::{Hash, HashEngine, Hmac, HmacEngine, sha256};
+
+use super::config::WebhookConfigCache;
 use super::repository::{WebhookDelivery, WebhookRepository};
 use crate::time::now_millis;
+
+/// HTTP header used for the HMAC-SHA256 signature on outgoing webhooks.
+const SIGNATURE_HEADER: &str = "X-Breez-Signature";
 
 /// Retry configuration.
 const BASE_RETRY_DELAY_MS: i64 = 30_000; // 30 seconds
 const RETRY_MULTIPLIER: f64 = 1.5;
 
-/// Maximum number of concurrent in-flight webhook deliveries per URL.
-const MAX_CONCURRENT_PER_URL: usize = 20;
+/// Maximum number of concurrent in-flight webhook deliveries per domain.
+const MAX_CONCURRENT_PER_DOMAIN: usize = 20;
 
 /// Maximum length of error response body to store.
 const MAX_ERROR_BODY_LEN: usize = 512;
@@ -23,8 +29,8 @@ const WEBHOOK_TIMEOUT_SECS: u64 = 30;
 /// How often to run the webhook delivery cleanup (1 hour).
 const CLEANUP_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(60 * 60);
 
-/// Per-URL concurrency limiter for webhook delivery.
-pub(crate) type UrlSemaphores = Arc<Mutex<HashMap<String, Arc<Semaphore>>>>;
+/// Per-domain concurrency limiter for webhook delivery.
+pub(crate) type DomainSemaphores = Arc<Mutex<HashMap<String, Arc<Semaphore>>>>;
 
 /// Start all webhook-related background processors.
 pub fn start_background_processor<DB>(
@@ -32,6 +38,7 @@ pub fn start_background_processor<DB>(
     http_client: bitreq::Client,
     trigger_rx: tokio::sync::watch::Receiver<()>,
     webhook_delivery_ttl_days: u32,
+    config_cache: WebhookConfigCache,
 ) where
     DB: WebhookRepository + Clone + Send + Sync + 'static,
 {
@@ -39,6 +46,7 @@ pub fn start_background_processor<DB>(
         db.clone(),
         http_client,
         trigger_rx,
+        config_cache,
     ));
     tokio::spawn(webhook_cleanup_processor(db, webhook_delivery_ttl_days));
 }
@@ -54,15 +62,16 @@ async fn webhook_delivery_processor<DB>(
     db: DB,
     http_client: bitreq::Client,
     mut trigger_rx: tokio::sync::watch::Receiver<()>,
+    config_cache: WebhookConfigCache,
 ) where
     DB: WebhookRepository + Clone + Send + Sync + 'static,
 {
     debug!("Webhook delivery processor started");
 
-    let url_semaphores: UrlSemaphores = Arc::new(Mutex::new(HashMap::new()));
+    let domain_semaphores: DomainSemaphores = Arc::new(Mutex::new(HashMap::new()));
 
     // Process any pending items on startup
-    process_pending_webhook_deliveries(&db, &http_client, &url_semaphores).await;
+    process_pending_webhook_deliveries(&db, &http_client, &domain_semaphores, &config_cache).await;
 
     // Wait for triggers
     loop {
@@ -76,7 +85,8 @@ async fn webhook_delivery_processor<DB>(
             () = tokio::time::sleep(tokio::time::Duration::from_secs(60)) => {}
         }
 
-        process_pending_webhook_deliveries(&db, &http_client, &url_semaphores).await;
+        process_pending_webhook_deliveries(&db, &http_client, &domain_semaphores, &config_cache)
+            .await;
     }
 }
 
@@ -109,21 +119,22 @@ where
     }
 }
 
-/// Get or create the semaphore for a given URL.
-async fn get_semaphore(semaphores: &UrlSemaphores, url: &str) -> Arc<Semaphore> {
+/// Get or create the semaphore for a given domain.
+async fn get_semaphore(semaphores: &DomainSemaphores, domain: &str) -> Arc<Semaphore> {
     let mut map = semaphores.lock().await;
     Arc::clone(
-        map.entry(url.to_string())
-            .or_insert_with(|| Arc::new(Semaphore::new(MAX_CONCURRENT_PER_URL))),
+        map.entry(domain.to_string())
+            .or_insert_with(|| Arc::new(Semaphore::new(MAX_CONCURRENT_PER_DOMAIN))),
     )
 }
 
 /// Claim and deliver pending webhooks. The query returns at most one
-/// delivery per URL, so one slow domain cannot starve others.
+/// delivery per domain, so one slow domain cannot starve others.
 pub(crate) async fn process_pending_webhook_deliveries<DB>(
     db: &DB,
     http_client: &bitreq::Client,
-    url_semaphores: &UrlSemaphores,
+    domain_semaphores: &DomainSemaphores,
+    config_cache: &WebhookConfigCache,
 ) where
     DB: WebhookRepository + Clone + Send + Sync + 'static,
 {
@@ -144,13 +155,14 @@ pub(crate) async fn process_pending_webhook_deliveries<DB>(
     let mut unclaim_ids = Vec::new();
 
     for delivery in deliveries {
-        let sem = get_semaphore(url_semaphores, &delivery.url).await;
+        let sem = get_semaphore(domain_semaphores, &delivery.domain).await;
 
         if let Ok(permit) = sem.clone().try_acquire_owned() {
             let db = db.clone();
             let client = http_client.clone();
+            let config_cache = Arc::clone(config_cache);
             tokio::spawn(async move {
-                process_webhook_delivery(&db, &client, &delivery).await;
+                process_webhook_delivery(&db, &client, &delivery, &config_cache).await;
                 drop(permit);
             });
         } else {
@@ -171,15 +183,46 @@ async fn process_webhook_delivery<DB>(
     db: &DB,
     http_client: &bitreq::Client,
     delivery: &WebhookDelivery,
+    config_cache: &WebhookConfigCache,
 ) where
     DB: WebhookRepository + Clone + Send + Sync + 'static,
 {
+    let config = config_cache.read().await.get(&delivery.domain).cloned();
+
+    let Some(config) = config else {
+        // No webhook config for this domain.
+        if delivery.url.is_some() {
+            // Previously attempted — park the delivery so it's preserved for
+            // audit but never picked up again.
+            debug!(
+                "Webhook delivery {} for domain '{}': config removed, parking",
+                delivery.id, delivery.domain
+            );
+            if let Err(e) = db.park_webhook_delivery(delivery.id).await {
+                error!("Failed to park webhook delivery {}: {}", delivery.id, e);
+            }
+        } else {
+            // Never attempted — delete the delivery.
+            debug!(
+                "Webhook delivery {} for domain '{}': no config, deleting",
+                delivery.id, delivery.domain
+            );
+            if let Err(e) = db.delete_webhook_delivery(delivery.id).await {
+                error!("Failed to delete webhook delivery {}: {}", delivery.id, e);
+            }
+        }
+        return;
+    };
+
     let now = now_millis();
 
-    match send_webhook(http_client, &delivery.url, &delivery.payload).await {
+    match send_webhook(http_client, &config.url, &delivery.payload, &config.secret).await {
         Ok(()) => {
             debug!("Webhook delivery {} succeeded", delivery.id);
-            if let Err(e) = db.update_webhook_delivery_success(delivery.id, now).await {
+            if let Err(e) = db
+                .update_webhook_delivery_success(delivery.id, now, &config.url)
+                .await
+            {
                 error!(
                     "Failed to update webhook delivery success {}: {}",
                     delivery.id, e
@@ -202,6 +245,7 @@ async fn process_webhook_delivery<DB>(
                     next_retry_at,
                     status_code,
                     body.as_deref(),
+                    &config.url,
                 )
                 .await
             {
@@ -223,9 +267,16 @@ async fn send_webhook(
     http_client: &bitreq::Client,
     url: &str,
     payload_json: &str,
+    secret: &str,
 ) -> Result<(), WebhookError> {
+    let mut engine = HmacEngine::<sha256::Hash>::new(secret.as_bytes());
+    engine.input(payload_json.as_bytes());
+    let hmac: Hmac<sha256::Hash> = Hmac::from_engine(engine);
+    let signature_hex = hex::encode(hmac.to_byte_array());
+
     let req = bitreq::post(url)
         .with_header("Content-Type", "application/json")
+        .with_header(SIGNATURE_HEADER, &signature_hex)
         .with_body(payload_json)
         .with_timeout(WEBHOOK_TIMEOUT_SECS);
 
@@ -262,6 +313,7 @@ fn truncate_string(s: &str, max_len: usize) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
@@ -269,13 +321,16 @@ mod tests {
     use axum::Router;
     use axum::routing::post;
     use sqlx::{Row, SqlitePool};
-    use tokio::sync::Semaphore;
+    use tokio::sync::{RwLock, Semaphore};
 
     use super::*;
     use crate::webhooks::WebhookRepository;
-    use crate::webhooks::repository::NewWebhookDelivery;
+    use crate::webhooks::repository::{NewWebhookDelivery, WebhookConfig};
 
     // ── Test helpers ────────────────────────────────────────────────────
+
+    const TEST_DOMAIN: &str = "test.example.com";
+    const TEST_SECRET: &str = "test_webhook_secret";
 
     async fn setup_test_db() -> (crate::sqlite::LnurlRepository, SqlitePool) {
         let pool = sqlx::sqlite::SqlitePoolOptions::new()
@@ -287,13 +342,26 @@ mod tests {
         (db, pool)
     }
 
-    async fn insert_delivery(db: &impl WebhookRepository, identifier: &str, url: &str) {
+    async fn insert_delivery(db: &impl WebhookRepository, identifier: &str, domain: &str) {
         let delivery = NewWebhookDelivery {
             identifier: identifier.to_string(),
-            url: url.to_string(),
+            domain: domain.to_string(),
             payload: r#"{"event":"invoice.paid","id":"test123"}"#.to_string(),
         };
         db.insert_webhook_deliveries(&[delivery]).await.unwrap();
+    }
+
+    async fn insert_domain_webhook(pool: &SqlitePool, domain: &str, url: &str, secret: &str) {
+        sqlx::query(
+            "INSERT INTO domain_webhooks (domain, url, webhook_secret)
+             VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+        )
+        .bind(domain)
+        .bind(url)
+        .bind(secret)
+        .execute(pool)
+        .await
+        .unwrap();
     }
 
     async fn get_delivery_by_identifier(
@@ -301,7 +369,7 @@ mod tests {
         identifier: &str,
     ) -> sqlx::sqlite::SqliteRow {
         sqlx::query(
-            "SELECT id, identifier, url, payload, created_at, succeeded_at,
+            "SELECT id, identifier, domain, url, payload, created_at, succeeded_at,
                     retry_count, next_retry_at, claimed_at,
                     last_error_status_code, last_error_body
              FROM webhook_deliveries WHERE identifier = $1",
@@ -312,8 +380,25 @@ mod tests {
         .unwrap()
     }
 
-    fn new_semaphores() -> UrlSemaphores {
+    fn new_semaphores() -> DomainSemaphores {
         Arc::new(tokio::sync::Mutex::new(HashMap::new()))
+    }
+
+    fn config_cache_with(domain: &str, url: &str, secret: &str) -> WebhookConfigCache {
+        let mut map = HashMap::new();
+        map.insert(
+            domain.to_string(),
+            WebhookConfig {
+                domain: domain.to_string(),
+                url: url.to_string(),
+                secret: secret.to_string(),
+            },
+        );
+        Arc::new(RwLock::new(map))
+    }
+
+    fn empty_config_cache() -> WebhookConfigCache {
+        Arc::new(RwLock::new(HashMap::new()))
     }
 
     /// Start a mock HTTP server. Returns the base URL (e.g. `http://127.0.0.1:12345`).
@@ -336,20 +421,28 @@ mod tests {
         let base_url = start_mock_server(router).await;
         let url = format!("{base_url}/hook");
 
-        insert_delivery(&db, "success_1", &url).await;
+        insert_domain_webhook(&pool, TEST_DOMAIN, &url, TEST_SECRET).await;
+        insert_delivery(&db, "success_1", TEST_DOMAIN).await;
 
         let client = bitreq::Client::new(10);
         let semaphores = new_semaphores();
+        let config = config_cache_with(TEST_DOMAIN, &url, TEST_SECRET);
 
-        process_pending_webhook_deliveries(&db, &client, &semaphores).await;
+        process_pending_webhook_deliveries(&db, &client, &semaphores, &config).await;
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let row = get_delivery_by_identifier(&pool, "success_1").await;
         let succeeded_at: Option<i64> = row.try_get("succeeded_at").unwrap();
         let retry_count: i32 = row.try_get("retry_count").unwrap();
+        let stored_url: Option<String> = row.try_get("url").unwrap();
 
         assert!(succeeded_at.is_some(), "succeeded_at should be set");
         assert_eq!(retry_count, 0, "retry_count should be 0");
+        assert_eq!(
+            stored_url.as_deref(),
+            Some(url.as_str()),
+            "url should be stored"
+        );
     }
 
     #[tokio::test]
@@ -368,12 +461,14 @@ mod tests {
         let base_url = start_mock_server(router).await;
         let url = format!("{base_url}/hook");
 
-        insert_delivery(&db, "error_1", &url).await;
+        insert_domain_webhook(&pool, TEST_DOMAIN, &url, TEST_SECRET).await;
+        insert_delivery(&db, "error_1", TEST_DOMAIN).await;
 
         let client = bitreq::Client::new(10);
         let semaphores = new_semaphores();
+        let config = config_cache_with(TEST_DOMAIN, &url, TEST_SECRET);
 
-        process_pending_webhook_deliveries(&db, &client, &semaphores).await;
+        process_pending_webhook_deliveries(&db, &client, &semaphores, &config).await;
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let row = get_delivery_by_identifier(&pool, "error_1").await;
@@ -399,12 +494,14 @@ mod tests {
 
         // Port 1 — nothing is listening there.
         let url = "http://127.0.0.1:1/hook";
-        insert_delivery(&db, "conn_err_1", url).await;
+        insert_domain_webhook(&pool, TEST_DOMAIN, url, TEST_SECRET).await;
+        insert_delivery(&db, "conn_err_1", TEST_DOMAIN).await;
 
         let client = bitreq::Client::new(10);
         let semaphores = new_semaphores();
+        let config = config_cache_with(TEST_DOMAIN, url, TEST_SECRET);
 
-        process_pending_webhook_deliveries(&db, &client, &semaphores).await;
+        process_pending_webhook_deliveries(&db, &client, &semaphores, &config).await;
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         let row = get_delivery_by_identifier(&pool, "conn_err_1").await;
@@ -451,13 +548,15 @@ mod tests {
         let base_url = start_mock_server(router).await;
         let url = format!("{base_url}/hook");
 
-        insert_delivery(&db, "retry_1", &url).await;
+        insert_domain_webhook(&pool, TEST_DOMAIN, &url, TEST_SECRET).await;
+        insert_delivery(&db, "retry_1", TEST_DOMAIN).await;
 
         let client = bitreq::Client::new(10);
         let semaphores = new_semaphores();
+        let config = config_cache_with(TEST_DOMAIN, &url, TEST_SECRET);
 
         // First attempt — should fail.
-        process_pending_webhook_deliveries(&db, &client, &semaphores).await;
+        process_pending_webhook_deliveries(&db, &client, &semaphores, &config).await;
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let row = get_delivery_by_identifier(&pool, "retry_1").await;
@@ -478,7 +577,7 @@ mod tests {
         .unwrap();
 
         // Second attempt — should succeed.
-        process_pending_webhook_deliveries(&db, &client, &semaphores).await;
+        process_pending_webhook_deliveries(&db, &client, &semaphores, &config).await;
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let row = get_delivery_by_identifier(&pool, "retry_1").await;
@@ -507,12 +606,14 @@ mod tests {
         let base_url = start_mock_server(router).await;
         let url = format!("{base_url}/hook");
 
-        insert_delivery(&db, "truncate_1", &url).await;
+        insert_domain_webhook(&pool, TEST_DOMAIN, &url, TEST_SECRET).await;
+        insert_delivery(&db, "truncate_1", TEST_DOMAIN).await;
 
         let client = bitreq::Client::new(10);
         let semaphores = new_semaphores();
+        let config = config_cache_with(TEST_DOMAIN, &url, TEST_SECRET);
 
-        process_pending_webhook_deliveries(&db, &client, &semaphores).await;
+        process_pending_webhook_deliveries(&db, &client, &semaphores, &config).await;
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let row = get_delivery_by_identifier(&pool, "truncate_1").await;
@@ -551,6 +652,9 @@ mod tests {
     async fn slow_server_does_not_block_fast_server() {
         let (db, pool) = setup_test_db().await;
 
+        let slow_domain = "slow.example.com";
+        let fast_domain = "fast.example.com";
+
         // Slow server: sleeps 2 seconds before responding.
         let slow_router = Router::new().route(
             "/hook",
@@ -566,14 +670,34 @@ mod tests {
             Router::new().route("/hook", post(|| async { axum::http::StatusCode::OK }));
         let fast_url = format!("{}/hook", start_mock_server(fast_router).await);
 
-        insert_delivery(&db, "slow_1", &slow_url).await;
-        insert_delivery(&db, "fast_1", &fast_url).await;
+        insert_domain_webhook(&pool, slow_domain, &slow_url, TEST_SECRET).await;
+        insert_domain_webhook(&pool, fast_domain, &fast_url, TEST_SECRET).await;
+        insert_delivery(&db, "slow_1", slow_domain).await;
+        insert_delivery(&db, "fast_1", fast_domain).await;
 
         let client = bitreq::Client::new(10);
         let semaphores = new_semaphores();
+        let mut config_map = HashMap::new();
+        config_map.insert(
+            slow_domain.to_string(),
+            WebhookConfig {
+                domain: slow_domain.to_string(),
+                url: slow_url,
+                secret: TEST_SECRET.to_string(),
+            },
+        );
+        config_map.insert(
+            fast_domain.to_string(),
+            WebhookConfig {
+                domain: fast_domain.to_string(),
+                url: fast_url,
+                secret: TEST_SECRET.to_string(),
+            },
+        );
+        let config: WebhookConfigCache = Arc::new(RwLock::new(config_map));
 
         let result = tokio::time::timeout(Duration::from_secs(4), async {
-            process_pending_webhook_deliveries(&db, &client, &semaphores).await;
+            process_pending_webhook_deliveries(&db, &client, &semaphores, &config).await;
             // Wait enough for the slow server to finish.
             tokio::time::sleep(Duration::from_millis(2500)).await;
         })
@@ -597,28 +721,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn per_url_throttling_unclaims_excess() {
+    async fn per_domain_throttling_unclaims_excess() {
         let (db, pool) = setup_test_db().await;
 
-        // Use a real server so the URL is valid, but we expect the delivery never
-        // to be attempted because the semaphore has no available permits.
         let router = Router::new().route("/hook", post(|| async { axum::http::StatusCode::OK }));
         let base_url = start_mock_server(router).await;
         let url = format!("{base_url}/hook");
 
-        insert_delivery(&db, "throttle_1", &url).await;
+        insert_domain_webhook(&pool, TEST_DOMAIN, &url, TEST_SECRET).await;
+        insert_delivery(&db, "throttle_1", TEST_DOMAIN).await;
 
         let client = bitreq::Client::new(10);
+        let config = config_cache_with(TEST_DOMAIN, &url, TEST_SECRET);
 
-        // Pre-fill semaphores so this URL has 0 available permits.
+        // Pre-fill semaphores so this domain has 0 available permits.
         let semaphores = new_semaphores();
         {
-            let mut map = semaphores.lock().await;
-            // Create a semaphore with 0 permits — all slots "in use".
-            map.insert(url.clone(), Arc::new(Semaphore::new(0)));
+            let mut map: tokio::sync::MutexGuard<'_, HashMap<String, Arc<Semaphore>>> =
+                semaphores.lock().await;
+            map.insert(TEST_DOMAIN.to_string(), Arc::new(Semaphore::new(0)));
         }
 
-        process_pending_webhook_deliveries(&db, &client, &semaphores).await;
+        process_pending_webhook_deliveries(&db, &client, &semaphores, &config).await;
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let row = get_delivery_by_identifier(&pool, "throttle_1").await;
@@ -629,5 +753,111 @@ mod tests {
         assert!(claimed_at.is_none(), "delivery should have been unclaimed");
         assert_eq!(retry_count, 0, "retry_count should remain 0");
         assert!(succeeded_at.is_none(), "delivery should not have succeeded");
+    }
+
+    #[tokio::test]
+    async fn no_config_deletes_unattempted_delivery() {
+        let (db, pool) = setup_test_db().await;
+
+        insert_delivery(&db, "no_config_1", "unknown.example.com").await;
+
+        let client = bitreq::Client::new(10);
+        let semaphores = new_semaphores();
+        let config = empty_config_cache();
+
+        process_pending_webhook_deliveries(&db, &client, &semaphores, &config).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM webhook_deliveries WHERE identifier = $1")
+                .bind("no_config_1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count, 0, "unattempted delivery should be deleted");
+    }
+
+    #[tokio::test]
+    async fn no_config_parks_previously_attempted_delivery() {
+        let (db, pool) = setup_test_db().await;
+
+        // Insert a delivery that looks like it was previously attempted (url is set).
+        insert_delivery(&db, "parked_1", TEST_DOMAIN).await;
+        sqlx::query("UPDATE webhook_deliveries SET url = 'http://old.example.com/hook' WHERE identifier = $1")
+            .bind("parked_1")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let client = bitreq::Client::new(10);
+        let semaphores = new_semaphores();
+        let config = empty_config_cache();
+
+        process_pending_webhook_deliveries(&db, &client, &semaphores, &config).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let row = get_delivery_by_identifier(&pool, "parked_1").await;
+        let next_retry_at: i64 = row.try_get("next_retry_at").unwrap();
+        let succeeded_at: Option<i64> = row.try_get("succeeded_at").unwrap();
+
+        assert_eq!(next_retry_at, i64::MAX, "should be parked at i64::MAX");
+        assert!(succeeded_at.is_none(), "should not be marked as succeeded");
+    }
+
+    #[tokio::test]
+    async fn webhook_includes_signature_header() {
+        use axum::body::Bytes;
+        use axum::http::HeaderMap;
+
+        let (db, pool) = setup_test_db().await;
+
+        let received_sig = Arc::new(tokio::sync::Mutex::new(String::new()));
+        let received_body = Arc::new(tokio::sync::Mutex::new(String::new()));
+
+        let router = Router::new().route(
+            "/hook",
+            post({
+                let sig = Arc::clone(&received_sig);
+                let body = Arc::clone(&received_body);
+                move |headers: HeaderMap, raw_body: Bytes| {
+                    let sig = Arc::clone(&sig);
+                    let body = Arc::clone(&body);
+                    async move {
+                        if let Some(v) = headers.get("X-Breez-Signature") {
+                            *sig.lock().await = v.to_str().unwrap_or("").to_string();
+                        }
+                        *body.lock().await =
+                            String::from_utf8(raw_body.to_vec()).unwrap_or_default();
+                        axum::http::StatusCode::OK
+                    }
+                }
+            }),
+        );
+        let base_url = start_mock_server(router).await;
+        let url = format!("{base_url}/hook");
+
+        let secret = "my_secret_key";
+        insert_domain_webhook(&pool, TEST_DOMAIN, &url, secret).await;
+        insert_delivery(&db, "sig_1", TEST_DOMAIN).await;
+
+        let client = bitreq::Client::new(10);
+        let semaphores = new_semaphores();
+        let config = config_cache_with(TEST_DOMAIN, &url, secret);
+
+        process_pending_webhook_deliveries(&db, &client, &semaphores, &config).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let sig = received_sig.lock().await.clone();
+        let body = received_body.lock().await.clone();
+
+        assert!(!sig.is_empty(), "signature header should be present");
+        assert!(!body.is_empty(), "body should be present");
+
+        // Verify the signature manually.
+        let mut engine = HmacEngine::<sha256::Hash>::new(secret.as_bytes());
+        engine.input(body.as_bytes());
+        let expected: Hmac<sha256::Hash> = Hmac::from_engine(engine);
+        let expected_hex = hex::encode(expected.to_byte_array());
+        assert_eq!(sig, expected_hex, "signature should match HMAC-SHA256");
     }
 }

--- a/crates/breez-sdk/lnurl/src/webhooks/config.rs
+++ b/crates/breez-sdk/lnurl/src/webhooks/config.rs
@@ -1,0 +1,105 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::RwLock;
+use tracing::{debug, error, info};
+
+use super::repository::{WebhookConfig, WebhookRepository};
+
+const REFRESH_INTERVAL: Duration = Duration::from_secs(60);
+
+/// In-memory cache of webhook configurations keyed by domain.
+pub type WebhookConfigCache = Arc<RwLock<HashMap<String, WebhookConfig>>>;
+
+/// Load webhook configurations from the database and start a background task
+/// that periodically refreshes them.
+pub async fn start<DB>(db: DB) -> Result<WebhookConfigCache, anyhow::Error>
+where
+    DB: WebhookRepository + Clone + Send + Sync + 'static,
+{
+    let initial = load_configs(&db).await?;
+    let mut domains: Vec<&str> = initial.keys().map(String::as_str).collect();
+    domains.sort_unstable();
+    info!(
+        "loaded webhook configs for {} domain(s): {}",
+        domains.len(),
+        domains.join(", ")
+    );
+    let cache = Arc::new(RwLock::new(initial));
+
+    let cache_clone = Arc::clone(&cache);
+    tokio::spawn(async move {
+        debug!("Webhook config refresher started");
+        loop {
+            tokio::time::sleep(REFRESH_INTERVAL).await;
+            refresh_once(&db, &cache_clone).await;
+        }
+    });
+
+    Ok(cache)
+}
+
+async fn load_configs<DB>(db: &DB) -> Result<HashMap<String, WebhookConfig>, anyhow::Error>
+where
+    DB: WebhookRepository,
+{
+    let configs = db.list_webhook_configs().await?;
+    Ok(configs.into_iter().map(|c| (c.domain.clone(), c)).collect())
+}
+
+async fn refresh_once<DB>(db: &DB, cache: &RwLock<HashMap<String, WebhookConfig>>)
+where
+    DB: WebhookRepository,
+{
+    let latest = match load_configs(db).await {
+        Ok(m) => m,
+        Err(e) => {
+            error!("Failed to refresh webhook configs: {e}");
+            return;
+        }
+    };
+
+    {
+        let current = cache.read().await;
+        if configs_equal(&current, &latest) {
+            return;
+        }
+        log_changes(&current, &latest);
+    }
+
+    *cache.write().await = latest;
+}
+
+fn configs_equal(a: &HashMap<String, WebhookConfig>, b: &HashMap<String, WebhookConfig>) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().all(|(k, v)| {
+        b.get(k)
+            .is_some_and(|bv| bv.url == v.url && bv.secret == v.secret)
+    })
+}
+
+fn log_changes(current: &HashMap<String, WebhookConfig>, latest: &HashMap<String, WebhookConfig>) {
+    for domain in latest.keys() {
+        if !current.contains_key(domain) {
+            info!("webhook config added: {domain}");
+        }
+    }
+    for domain in current.keys() {
+        if !latest.contains_key(domain.as_str()) {
+            info!("webhook config removed: {domain}");
+        }
+    }
+    for (domain, new) in latest {
+        if let Some(old) = current.get(domain) {
+            if old.url != new.url {
+                info!("webhook config updated: {domain}: url changed");
+            }
+            if old.secret != new.secret {
+                info!("webhook config updated: {domain}: secret changed");
+            }
+        }
+    }
+}

--- a/crates/breez-sdk/lnurl/src/webhooks/mod.rs
+++ b/crates/breez-sdk/lnurl/src/webhooks/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod background;
+pub(crate) mod config;
 pub(crate) mod repository;
 pub(crate) mod service;
 

--- a/crates/breez-sdk/lnurl/src/webhooks/repository.rs
+++ b/crates/breez-sdk/lnurl/src/webhooks/repository.rs
@@ -13,7 +13,7 @@ impl From<sqlx::Error> for WebhookRepositoryError {
 #[derive(Debug, Clone)]
 pub struct NewWebhookDelivery {
     pub identifier: String,
-    pub url: String,
+    pub domain: String,
     pub payload: String,
 }
 
@@ -22,11 +22,20 @@ pub struct NewWebhookDelivery {
 pub struct WebhookDelivery {
     pub id: i64,
     pub identifier: String,
-    pub url: String,
+    pub domain: String,
+    pub url: Option<String>,
     pub payload: String,
     pub created_at: i64,
     pub retry_count: i32,
     pub next_retry_at: i64,
+}
+
+/// Webhook endpoint configuration loaded from `domain_webhooks`.
+#[derive(Debug, Clone)]
+pub struct WebhookConfig {
+    pub domain: String,
+    pub url: String,
+    pub secret: String,
 }
 
 #[async_trait::async_trait]
@@ -39,7 +48,7 @@ pub trait WebhookRepository {
 
     /// Claim pending webhook deliveries ready for processing
     /// (`next_retry_at` <= now, not yet succeeded, not recently claimed).
-    /// Returns at most one delivery per unique URL so that one slow domain
+    /// Returns at most one delivery per unique domain so that one slow domain
     /// cannot starve others.
     async fn take_pending_webhook_deliveries(
         &self,
@@ -50,6 +59,7 @@ pub trait WebhookRepository {
         &self,
         id: i64,
         succeeded_at: i64,
+        url: &str,
     ) -> Result<(), WebhookRepositoryError>;
 
     /// Record a webhook delivery failure and schedule the next retry.
@@ -60,6 +70,7 @@ pub trait WebhookRepository {
         next_retry_at: i64,
         status_code: Option<i32>,
         body: Option<&str>,
+        url: &str,
     ) -> Result<(), WebhookRepositoryError>;
 
     /// Release claimed webhook deliveries back to the queue so they can be
@@ -71,6 +82,16 @@ pub trait WebhookRepository {
         &self,
         before: i64,
     ) -> Result<u64, WebhookRepositoryError>;
+
+    /// Delete a single webhook delivery by ID.
+    async fn delete_webhook_delivery(&self, id: i64) -> Result<(), WebhookRepositoryError>;
+
+    /// Park a webhook delivery so it is never picked up again
+    /// (`next_retry_at = i64::MAX`). Preserves existing error fields for audit.
+    async fn park_webhook_delivery(&self, id: i64) -> Result<(), WebhookRepositoryError>;
+
+    /// Load all webhook endpoint configurations (domain, url, secret).
+    async fn list_webhook_configs(&self) -> Result<Vec<WebhookConfig>, WebhookRepositoryError>;
 }
 
 #[cfg(test)]
@@ -85,7 +106,7 @@ pub mod shared_tests {
         let now = now_millis();
         let delivery = NewWebhookDelivery {
             identifier: "success_test".to_string(),
-            url: "https://success.example.com/hook".to_string(),
+            domain: "success.example.com".to_string(),
             payload: r#"{"test":true}"#.to_string(),
         };
         db.insert_webhook_deliveries(&[delivery]).await.unwrap();
@@ -93,7 +114,7 @@ pub mod shared_tests {
         let claimed = db.take_pending_webhook_deliveries().await.unwrap();
         assert_eq!(claimed.len(), 1);
 
-        db.update_webhook_delivery_success(claimed[0].id, now)
+        db.update_webhook_delivery_success(claimed[0].id, now, "https://success.example.com/hook")
             .await
             .unwrap();
 
@@ -112,7 +133,7 @@ pub mod shared_tests {
         let now = now_millis();
         let delivery = NewWebhookDelivery {
             identifier: "failure_test".to_string(),
-            url: "https://failure.example.com/hook".to_string(),
+            domain: "failure.example.com".to_string(),
             payload: r#"{"test":true}"#.to_string(),
         };
         db.insert_webhook_deliveries(&[delivery]).await.unwrap();
@@ -121,9 +142,16 @@ pub mod shared_tests {
         assert_eq!(claimed.len(), 1);
 
         let future = now.saturating_add(999_999_999);
-        db.update_webhook_delivery_failure(claimed[0].id, 1, future, Some(500), Some("error"))
-            .await
-            .unwrap();
+        db.update_webhook_delivery_failure(
+            claimed[0].id,
+            1,
+            future,
+            Some(500),
+            Some("error"),
+            "https://failure.example.com/hook",
+        )
+        .await
+        .unwrap();
 
         // Should not be claimable yet (next_retry_at is far in the future)
         let claimed_again = db.take_pending_webhook_deliveries().await.unwrap();
@@ -139,7 +167,7 @@ pub mod shared_tests {
     {
         let delivery = NewWebhookDelivery {
             identifier: "cleanup_delivery".to_string(),
-            url: "https://cleanup.example.com/hook".to_string(),
+            domain: "cleanup.example.com".to_string(),
             payload: r#"{"test":true}"#.to_string(),
         };
         db.insert_webhook_deliveries(&[delivery]).await.unwrap();

--- a/docs/breez-sdk/src/guide/lnurl_webhooks.md
+++ b/docs/breez-sdk/src/guide/lnurl_webhooks.md
@@ -18,6 +18,44 @@ To start receiving webhooks, [send us](mailto:contact@breez.technology) your web
 
 Your endpoint should accept `POST` requests with a JSON body and respond with a `2xx` status code to acknowledge receipt.
 
+## Signature verification
+
+Every webhook request includes an `X-Breez-Signature` header containing a hex-encoded HMAC-SHA256 signature of the raw request body. You should verify this signature to ensure the request came from Breez and was not tampered with.
+
+The signing secret is provided to you during webhook setup. To verify:
+
+1. Compute the HMAC-SHA256 of the raw request body using your shared secret.
+2. Hex-encode the result.
+3. Compare it to the value in the `X-Breez-Signature` header.
+
+**Node.js example:**
+
+```javascript
+const crypto = require('crypto');
+
+function verifyWebhookSignature(secret, body, signatureHeader) {
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(body)
+    .digest('hex');
+  return crypto.timingSafeEqual(
+    Buffer.from(expected),
+    Buffer.from(signatureHeader),
+  );
+}
+```
+
+**Python example:**
+
+```python
+import hmac
+import hashlib
+
+def verify_webhook_signature(secret: str, body: bytes, signature_header: str) -> bool:
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+```
+
 ## Payload
 
 All payloads use a `{ "template": "...", "data": { ... } }` envelope. Currently the only template is `spark_payment_received`:
@@ -55,6 +93,7 @@ If your endpoint is unreachable or responds with a non-2xx status code, Breez wi
 
 ## Best practices
 
+- **Verify the signature.** Always verify the `X-Breez-Signature` header before processing the webhook. Reject requests with missing or invalid signatures.
 - **Return 2xx quickly.** Do your processing asynchronously after acknowledging the webhook. Slow responses will be treated as failures and retried.
 - **Deduplicate on `paymentHash`.** The same payment may be delivered more than once due to retries.
 - **Use `lightningAddress` or `userPubkey` to identify the user.** These fields tell you which user received the payment.


### PR DESCRIPTION
- Sign outgoing webhooks (X-Breez-Signature header)
- Route deliveries by domain instead of URL — there's only one webhook endpoint per domain, so storing the URL as routing key doesn't make sense. The URL is now resolved from domain_webhooks at send time. We still persist it on each attempt so we can see where it was sent for debugging
- domain_webhooks is now fully owned by the webhook domain. The LNURL side just enqueues a delivery for a domain and doesn't care about URLs or secrets
- Webhook configs are cached in memory and refreshed every 60s