### PR TITLE
Core: Remove JWT from SSP requests

### DIFF
--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -692,6 +692,10 @@ mod jwt {
     }
 
     impl BreezSdk {
+        fn enable_jwt(&self) -> bool {
+            matches!(self.config.network, Network::Mainnet) && self.config.api_key.is_some()
+        }
+
         pub(super) async fn set_and_save_jwt(&self, token: String) {
             self.session_manager.set_token(token.clone()).await;
             if let Err(err) = self
@@ -722,6 +726,9 @@ mod jwt {
         }
 
         pub(super) async fn init_jwt(&self) {
+            if !self.enable_jwt() {
+                return;
+            }
             let token = match self
                 .storage
                 .get_cached_item(KEY_BREEZ_JWT.to_string())
@@ -737,10 +744,8 @@ mod jwt {
         }
 
         pub(super) async fn jwt_refresh_interval(&self) {
-            let should_refresh_jwt =
-                matches!(self.config.network, Network::Mainnet) && self.config.api_key.is_some();
-            if !should_refresh_jwt {
-                std::future::pending::<()>().await;
+            if !self.enable_jwt() {
+                return std::future::pending::<()>().await;
             }
             let token = self.session_manager.get_token().await;
             let duration = Duration::from_secs(match token {

--- a/crates/spark/src/ssp/graphql/client.rs
+++ b/crates/spark/src/ssp/graphql/client.rs
@@ -120,7 +120,7 @@ impl GraphQLClient {
     {
         let session = self.get_session().await?;
         let full_url = self.get_full_url();
-        let mut headers = session.headers.clone();
+        let mut headers = HashMap::new();
         self.add_auth_headers(&session, &mut headers)?;
 
         match self
@@ -137,7 +137,7 @@ impl GraphQLClient {
                     && status_code == 401
                 {
                     let session = self.get_session().await?;
-                    let mut headers = session.headers.clone();
+                    let mut headers = HashMap::new();
                     self.add_auth_headers(&session, &mut headers)?;
 
                     return self


### PR DESCRIPTION
Following the offline dicussions, JWT usage on the SSP is not planned, so we remove it in order not to affect WASM builds (some calls fail with CORS errors)