### PR TITLE
lnurl is not in the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,6 @@ debug = "line-tables-only"
 [profile.release.package.spark-cli]
 debug = "line-tables-only"
 
-[profile.release.package.lnurl]
-debug = "line-tables-only"
-
 [profile.release.package.lnurl-models]
 debug = "line-tables-only"
 


### PR DESCRIPTION
Remove the lnurl release profile change in the workspace. It triggered a warning:

```
warning: profile package spec `lnurl` in profile `release` did not match any packages

help: a package with a similar name exists: `url`
```