### PR TITLE
fix: balance doesn't update immediately on receive (multi-instance)

### DIFF
--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -284,11 +284,9 @@ impl BreezSdk {
             && now.saturating_sub(last) < sync_interval_secs
         {
             debug!("sync_wallet_internal: Synced recently, skipping");
-            // Another instance sharing our storage synced recently, so shared
-            // caches are fresh — tell consumers so their UIs refresh. Without
-            // this, an instance that keeps skipping (e.g. a browser tab when
-            // another tab is the periodic-sync winner) would never emit a
-            // `Synced` event.
+            // When another instance shares our storage and keeps winning the sync
+            // race, we would otherwise never emit a Synced event. Emit it here so
+            // consumers are still notified that storage is up to date.
             self.event_emitter.emit(&SdkEvent::Synced).await;
             return Ok(());
         }

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -284,6 +284,12 @@ impl BreezSdk {
             && now.saturating_sub(last) < sync_interval_secs
         {
             debug!("sync_wallet_internal: Synced recently, skipping");
+            // Another instance sharing our storage synced recently, so shared
+            // caches are fresh — tell consumers so their UIs refresh. Without
+            // this, an instance that keeps skipping (e.g. a browser tab when
+            // another tab is the periodic-sync winner) would never emit a
+            // `Synced` event.
+            self.event_emitter.emit(&SdkEvent::Synced).await;
             return Ok(());
         }
 

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1813,17 +1813,10 @@ async fn claim_pending_transfers(
         .await;
 
     // Collect successful claims, log failures (best-effort).
-    // TransferAlreadyClaimed is treated as success - the leaves are already in the store.
     let mut successful_items = Vec::new();
 
     for (transfer, result) in claim_results {
-        let is_already_claimed = matches!(
-            &result,
-            Err(SparkWalletError::ServiceError(
-                ServiceError::TransferAlreadyClaimed
-            ))
-        );
-        if result.is_ok() || is_already_claimed {
+        if result.is_ok() {
             let mut completed = transfer;
             completed.status = TransferStatus::Completed;
             successful_items.push(completed);
@@ -2201,13 +2194,8 @@ impl BackgroundProcessor {
             ));
 
         trace!("Claiming transfer from event");
-        match claim_transfer(&transfer, &self.transfer_service, &self.tree_service).await {
-            Ok(_) => trace!("Claimed transfer from event"),
-            Err(SparkWalletError::ServiceError(ServiceError::TransferAlreadyClaimed)) => {
-                trace!("Transfer already claimed by another instance");
-            }
-            Err(e) => return Err(e),
-        }
+        claim_transfer(&transfer, &self.transfer_service, &self.tree_service).await?;
+        trace!("Claimed transfer from event");
 
         // Update transfer status before notifying listeners
         let mut claimed_transfer = transfer;

--- a/crates/spark/src/services/error.rs
+++ b/crates/spark/src/services/error.rs
@@ -68,8 +68,6 @@ pub enum ServiceError {
     ClaimTransferError(String),
     #[error("Signature verification failed: {0}")]
     SignatureVerificationFailed(String),
-    #[error("Transfer already claimed")]
-    TransferAlreadyClaimed,
 
     // Swap related errors
     #[error("invalid amount")]

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -77,6 +77,16 @@ enum SignRefundsOutcome {
     AlreadyClaimed(Box<Transfer>),
 }
 
+/// Outcome of calling `finalize_node_signatures`.
+///
+/// Same concurrent-claim fallback as [`SignRefundsOutcome`]: if the coordinator's
+/// finalize fails because another instance of this wallet already finalized the
+/// transfer, we return the completed transfer instead of an error.
+enum FinalizeOutcome {
+    Finalized(Vec<TreeNode>),
+    AlreadyClaimed(Box<Transfer>),
+}
+
 /// Configuration for claiming transfers
 pub struct ClaimTransferConfig {
     pub max_retries: u32,
@@ -826,13 +836,26 @@ impl TransferService {
         debug!("Claim transfer sign refunds successful.");
 
         // Finalize the node signatures with the coordinator
-        let finalized_nodes = self
-            .finalize_node_signatures(&node_signatures)
+        let finalized_nodes = match self
+            .finalize_node_signatures(&transfer.id, &node_signatures)
             .await
-            .map_err(|e| {
+        {
+            Ok(FinalizeOutcome::Finalized(nodes)) => nodes,
+            Ok(FinalizeOutcome::AlreadyClaimed(completed)) => {
+                // Another instance of this wallet finalized the transfer concurrently;
+                // return the coordinator's finalized leaves so the caller can update
+                // its local tree uniformly.
+                debug!(
+                    "Transfer {} already claimed by another instance at finalize step; using coordinator's finalized leaves",
+                    transfer.id
+                );
+                return Ok(completed.leaves.into_iter().map(|l| l.leaf).collect());
+            }
+            Err(e) => {
                 debug!("Failed to finalize node signatures: {}", e);
-                e
-            })?;
+                return Err(e);
+            }
+        };
         debug!("Finalize node signatures successful.");
         Ok(finalized_nodes)
     }
@@ -1143,12 +1166,19 @@ impl TransferService {
         Ok(SignRefundsOutcome::Signed(node_signatures))
     }
 
-    /// Finalizes node signatures with the coordinator
+    /// Finalizes node signatures with the coordinator.
+    ///
+    /// Returns [`FinalizeOutcome::Finalized`] with the new nodes on success. If the
+    /// coordinator rejects the request because another instance of this wallet has
+    /// already finalized the transfer, returns [`FinalizeOutcome::AlreadyClaimed`]
+    /// with the coordinator's completed transfer so the caller can uniformly update
+    /// its local tree.
     async fn finalize_node_signatures(
         &self,
+        transfer_id: &TransferId,
         node_signatures: &[operator_rpc::spark::NodeSignatures],
-    ) -> Result<Vec<TreeNode>, ServiceError> {
-        let response = self
+    ) -> Result<FinalizeOutcome, ServiceError> {
+        let result = self
             .operator_pool
             .get_coordinator()
             .client
@@ -1156,7 +1186,23 @@ impl TransferService {
                 intent: operator_rpc::common::SignatureIntent::Transfer as i32,
                 node_signatures: node_signatures.to_vec(),
             })
-            .await?;
+            .await;
+
+        let response = match result {
+            Ok(resp) => resp,
+            Err(e) => {
+                if let OperatorRpcError::Connection(_) = e
+                    && let Some(coordinator_transfer) = self.query_transfer(transfer_id).await?
+                    && coordinator_transfer.status == TransferStatus::Completed
+                {
+                    return Ok(FinalizeOutcome::AlreadyClaimed(Box::new(
+                        coordinator_transfer,
+                    )));
+                } else {
+                    return Err(e.into());
+                }
+            }
+        };
 
         let nodes = response
             .nodes
@@ -1164,7 +1210,7 @@ impl TransferService {
             .map(|node| node.try_into())
             .collect::<Result<Vec<TreeNode>, _>>()?;
 
-        Ok(nodes)
+        Ok(FinalizeOutcome::Finalized(nodes))
     }
 
     pub async fn verify_pending_transfer(

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -31,7 +31,7 @@ use k256::Scalar;
 use platform_utils::time::SystemTime;
 use platform_utils::tokio;
 use prost::Message as ProstMessage;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, warn};
 
 use crate::{
     signer::Signer,
@@ -64,27 +64,6 @@ pub struct LeafRefundSigningData {
     pub vout: u32,
     /// For coop exit signing: the connector transaction output to use as prev_out
     pub connector_prev_out: Option<bitcoin::TxOut>,
-}
-
-/// Outcome of calling `claim_transfer_sign_refunds`.
-///
-/// The coordinator may report — via a connection error followed by a successful
-/// `query_transfer` — that the transfer has already been claimed by another
-/// instance of this wallet. In that case there are no new signatures to finalize;
-/// we return the completed transfer so the caller can extract its leaves.
-enum SignRefundsOutcome {
-    Signed(Vec<operator_rpc::spark::NodeSignatures>),
-    AlreadyClaimed(Box<Transfer>),
-}
-
-/// Outcome of calling `finalize_node_signatures`.
-///
-/// Same concurrent-claim fallback as [`SignRefundsOutcome`]: if the coordinator's
-/// finalize fails because another instance of this wallet already finalized the
-/// transfer, we return the completed transfer instead of an error.
-enum FinalizeOutcome {
-    Finalized(Vec<TreeNode>),
-    AlreadyClaimed(Box<Transfer>),
 }
 
 /// Configuration for claiming transfers
@@ -695,10 +674,9 @@ impl TransferService {
 
     /// Claims a transfer with retry logic and automatic leaf preparation.
     ///
-    /// Returns the claimed leaves on success. If the coordinator reports the transfer
-    /// has already been claimed (another instance of this wallet won the race), the
-    /// finalized leaves from the coordinator are returned uniformly — the caller does
-    /// not need to distinguish this case.
+    /// Returns the claimed leaves on success. If a concurrent instance of this
+    /// wallet wins the race and finalizes the transfer, the coordinator's finalized
+    /// leaves are returned uniformly — callers do not need to distinguish this case.
     pub async fn claim_transfer(
         &self,
         transfer: &Transfer,
@@ -719,48 +697,59 @@ impl TransferService {
                 tokio::time::sleep(Duration::from_millis(delay_ms)).await;
             }
 
-            // Verify the pending transfer and get leaf key map
-            let leaf_key_map = match self.verify_pending_transfer(transfer).await {
-                Ok(map) => map,
-                Err(e) => {
-                    error!("Failed to verify pending transfer: {}", e);
-                    retry_count += 1;
-                    continue;
-                }
-            };
-
-            // Prepare leaves to claim
-            let leaves_to_claim = match self
-                .prepare_leaves_for_claiming(transfer, &leaf_key_map)
-                .await
-            {
-                Ok(leaves) => leaves,
+            match self.try_claim_transfer(transfer).await {
+                Ok(nodes) => return Ok(nodes),
                 Err(ServiceError::NoLeavesToClaim) => {
                     debug!("There are no leaves to claim for this transfer");
                     return Ok(Vec::new());
                 }
                 Err(e) => {
-                    error!("Failed to prepare leaves for claiming: {}", e);
+                    error!("Failed to claim transfer: {}", e);
+                    // A concurrent instance of this wallet may have finalized the
+                    // transfer — if so, use its leaves instead of retrying.
+                    if let Some(leaves) =
+                        self.finalized_leaves_if_already_claimed(&transfer.id).await
+                    {
+                        return Ok(leaves);
+                    }
                     retry_count += 1;
-                    continue;
                 }
-            };
-
-            // Actually claim the transfer
-            let result = match self
-                .claim_transfer_with_leaves(transfer, leaves_to_claim)
-                .await
-            {
-                Ok(res) => res,
-                Err(e) => {
-                    error!("Failed to claim transfer with leaves: {}", e);
-                    retry_count += 1;
-                    continue;
-                }
-            };
-
-            return Ok(result);
+            }
         }
+    }
+
+    /// Single claim attempt: verify, prepare leaves, and run the 3-step claim flow.
+    async fn try_claim_transfer(&self, transfer: &Transfer) -> Result<Vec<TreeNode>, ServiceError> {
+        let leaf_key_map = self.verify_pending_transfer(transfer).await?;
+        let leaves_to_claim = self
+            .prepare_leaves_for_claiming(transfer, &leaf_key_map)
+            .await?;
+        self.claim_transfer_with_leaves(transfer, leaves_to_claim)
+            .await
+    }
+
+    /// If the transfer is `Completed` on the coordinator, returns its finalized
+    /// leaves. Used after a failed claim attempt to detect that another instance
+    /// of this wallet already finalized the claim concurrently.
+    ///
+    /// A failed coordinator query is non-fatal here — it's logged and treated as
+    /// "not completed" so the caller falls through to its normal error handling.
+    async fn finalized_leaves_if_already_claimed(
+        &self,
+        transfer_id: &TransferId,
+    ) -> Option<Vec<TreeNode>> {
+        let completed = match self.query_transfer(transfer_id).await {
+            Ok(Some(t)) if t.status == TransferStatus::Completed => t,
+            Ok(_) => return None,
+            Err(e) => {
+                warn!("Failed to check if transfer {transfer_id} was claimed concurrently: {e:?}");
+                return None;
+            }
+        };
+        debug!(
+            "Transfer {transfer_id} already claimed by another instance; using coordinator's finalized leaves"
+        );
+        Some(completed.leaves.into_iter().map(|l| l.leaf).collect())
     }
 
     /// Prepares leaves for claiming by creating LeafKeyTweak structs
@@ -812,50 +801,11 @@ impl TransferService {
         };
 
         debug!("Claim transfer tweak keys successful.");
-        // Sign refunds and get node signatures
-        let node_signatures = match self
+        let node_signatures = self
             .claim_transfer_sign_refunds(transfer, &leaves_to_claim, proof_map.as_ref())
-            .await
-        {
-            Ok(SignRefundsOutcome::Signed(sigs)) => sigs,
-            Ok(SignRefundsOutcome::AlreadyClaimed(completed)) => {
-                // Another instance of this wallet claimed the transfer concurrently;
-                // return the coordinator's finalized leaves so the caller can update
-                // its local tree uniformly.
-                debug!(
-                    "Transfer {} already claimed by another instance; using coordinator's finalized leaves",
-                    transfer.id
-                );
-                return Ok(completed.leaves.into_iter().map(|l| l.leaf).collect());
-            }
-            Err(e) => {
-                debug!("Failed to claim transfer sign refunds: {}", e);
-                return Err(e);
-            }
-        };
+            .await?;
         debug!("Claim transfer sign refunds successful.");
-
-        // Finalize the node signatures with the coordinator
-        let finalized_nodes = match self
-            .finalize_node_signatures(&transfer.id, &node_signatures)
-            .await
-        {
-            Ok(FinalizeOutcome::Finalized(nodes)) => nodes,
-            Ok(FinalizeOutcome::AlreadyClaimed(completed)) => {
-                // Another instance of this wallet finalized the transfer concurrently;
-                // return the coordinator's finalized leaves so the caller can update
-                // its local tree uniformly.
-                debug!(
-                    "Transfer {} already claimed by another instance at finalize step; using coordinator's finalized leaves",
-                    transfer.id
-                );
-                return Ok(completed.leaves.into_iter().map(|l| l.leaf).collect());
-            }
-            Err(e) => {
-                debug!("Failed to finalize node signatures: {}", e);
-                return Err(e);
-            }
-        };
+        let finalized_nodes = self.finalize_node_signatures(&node_signatures).await?;
         debug!("Finalize node signatures successful.");
         Ok(finalized_nodes)
     }
@@ -1073,14 +1023,14 @@ impl TransferService {
         Ok((leaf_tweaks_map, *proof))
     }
 
-    /// Claims transfer by signing refunds with the coordinator
+    /// Claims transfer by signing refunds with the coordinator.
     async fn claim_transfer_sign_refunds(
         &self,
         transfer: &Transfer,
         leaf_keys: &[LeafKeyTweak],
         // TODO: do something with proofs? Currently not used in js implementation
         _proof_map: Option<&ProofMap>,
-    ) -> Result<SignRefundsOutcome, ServiceError> {
+    ) -> Result<Vec<operator_rpc::spark::NodeSignatures>, ServiceError> {
         // Prepare leaf data map with refund signing information
         let mut leaf_data_map = HashMap::new();
         for leaf_key in leaf_keys {
@@ -1120,7 +1070,7 @@ impl TransferService {
             prepare_refund_so_signing_jobs(self.network, leaf_keys, &mut leaf_data_map, true)?;
 
         // Call the coordinator to get signing results
-        let result = self
+        let response = self
             .operator_pool
             .get_coordinator()
             .client
@@ -1134,23 +1084,7 @@ impl TransferService {
                     .to_vec(),
                 signing_jobs,
             })
-            .await;
-
-        let response = match result {
-            Ok(resp) => resp,
-            Err(e) => {
-                if let OperatorRpcError::Connection(_) = e
-                    && let Some(coordinator_transfer) = self.query_transfer(&transfer.id).await?
-                    && coordinator_transfer.status == TransferStatus::Completed
-                {
-                    return Ok(SignRefundsOutcome::AlreadyClaimed(Box::new(
-                        coordinator_transfer,
-                    )));
-                } else {
-                    return Err(e.into());
-                }
-            }
-        };
+            .await?;
 
         // Sign the refunds using FROST
         let node_signatures = sign_aggregate_refunds(
@@ -1163,22 +1097,15 @@ impl TransferService {
         )
         .await?;
 
-        Ok(SignRefundsOutcome::Signed(node_signatures))
+        Ok(node_signatures)
     }
 
     /// Finalizes node signatures with the coordinator.
-    ///
-    /// Returns [`FinalizeOutcome::Finalized`] with the new nodes on success. If the
-    /// coordinator rejects the request because another instance of this wallet has
-    /// already finalized the transfer, returns [`FinalizeOutcome::AlreadyClaimed`]
-    /// with the coordinator's completed transfer so the caller can uniformly update
-    /// its local tree.
     async fn finalize_node_signatures(
         &self,
-        transfer_id: &TransferId,
         node_signatures: &[operator_rpc::spark::NodeSignatures],
-    ) -> Result<FinalizeOutcome, ServiceError> {
-        let result = self
+    ) -> Result<Vec<TreeNode>, ServiceError> {
+        let response = self
             .operator_pool
             .get_coordinator()
             .client
@@ -1186,23 +1113,7 @@ impl TransferService {
                 intent: operator_rpc::common::SignatureIntent::Transfer as i32,
                 node_signatures: node_signatures.to_vec(),
             })
-            .await;
-
-        let response = match result {
-            Ok(resp) => resp,
-            Err(e) => {
-                if let OperatorRpcError::Connection(_) = e
-                    && let Some(coordinator_transfer) = self.query_transfer(transfer_id).await?
-                    && coordinator_transfer.status == TransferStatus::Completed
-                {
-                    return Ok(FinalizeOutcome::AlreadyClaimed(Box::new(
-                        coordinator_transfer,
-                    )));
-                } else {
-                    return Err(e.into());
-                }
-            }
-        };
+            .await?;
 
         let nodes = response
             .nodes
@@ -1210,7 +1121,7 @@ impl TransferService {
             .map(|node| node.try_into())
             .collect::<Result<Vec<TreeNode>, _>>()?;
 
-        Ok(FinalizeOutcome::Finalized(nodes))
+        Ok(nodes)
     }
 
     pub async fn verify_pending_transfer(

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -66,6 +66,17 @@ pub struct LeafRefundSigningData {
     pub connector_prev_out: Option<bitcoin::TxOut>,
 }
 
+/// Outcome of calling `claim_transfer_sign_refunds`.
+///
+/// The coordinator may report — via a connection error followed by a successful
+/// `query_transfer` — that the transfer has already been claimed by another
+/// instance of this wallet. In that case there are no new signatures to finalize;
+/// we return the completed transfer so the caller can extract its leaves.
+enum SignRefundsOutcome {
+    Signed(Vec<operator_rpc::spark::NodeSignatures>),
+    AlreadyClaimed(Box<Transfer>),
+}
+
 /// Configuration for claiming transfers
 pub struct ClaimTransferConfig {
     pub max_retries: u32,
@@ -674,17 +685,10 @@ impl TransferService {
 
     /// Claims a transfer with retry logic and automatic leaf preparation.
     ///
-    /// Returns the claimed leaves on success.
-    ///
-    /// # Concurrent claims
-    ///
-    /// If the coordinator reports the transfer has already been claimed (another
-    /// instance of this wallet won the race), this method re-queries the transfer
-    /// from the coordinator. If it's now [`TransferStatus::Completed`], the finalized
-    /// leaves from that response are returned as if this call had performed the
-    /// claim — so the caller can update its local tree uniformly. Only if the transfer
-    /// can't be confirmed as completed does [`ServiceError::TransferAlreadyClaimed`]
-    /// propagate.
+    /// Returns the claimed leaves on success. If the coordinator reports the transfer
+    /// has already been claimed (another instance of this wallet won the race), the
+    /// finalized leaves from the coordinator are returned uniformly — the caller does
+    /// not need to distinguish this case.
     pub async fn claim_transfer(
         &self,
         transfer: &Transfer,
@@ -738,22 +742,6 @@ impl TransferService {
                 .await
             {
                 Ok(res) => res,
-                Err(ServiceError::TransferAlreadyClaimed) => {
-                    // Another instance of this wallet claimed the transfer concurrently.
-                    // Re-query the transfer from the coordinator; if it's now completed,
-                    // return its finalized leaves so the caller can update its local tree
-                    // instead of surfacing the error.
-                    debug!(
-                        "Transfer {} already claimed by another instance; fetching finalized transfer",
-                        transfer.id
-                    );
-                    match self.query_transfer(&transfer.id).await? {
-                        Some(updated) if updated.status == TransferStatus::Completed => {
-                            return Ok(updated.leaves.into_iter().map(|l| l.leaf).collect());
-                        }
-                        _ => return Err(ServiceError::TransferAlreadyClaimed),
-                    }
-                }
                 Err(e) => {
                     error!("Failed to claim transfer with leaves: {}", e);
                     retry_count += 1;
@@ -815,14 +803,26 @@ impl TransferService {
 
         debug!("Claim transfer tweak keys successful.");
         // Sign refunds and get node signatures
-        let node_signatures_result = self
+        let node_signatures = match self
             .claim_transfer_sign_refunds(transfer, &leaves_to_claim, proof_map.as_ref())
-            .await;
-
-        let node_signatures = node_signatures_result.map_err(|e| {
-            debug!("Failed to claim transfer sign refunds: {}", e);
-            e
-        })?;
+            .await
+        {
+            Ok(SignRefundsOutcome::Signed(sigs)) => sigs,
+            Ok(SignRefundsOutcome::AlreadyClaimed(completed)) => {
+                // Another instance of this wallet claimed the transfer concurrently;
+                // return the coordinator's finalized leaves so the caller can update
+                // its local tree uniformly.
+                debug!(
+                    "Transfer {} already claimed by another instance; using coordinator's finalized leaves",
+                    transfer.id
+                );
+                return Ok(completed.leaves.into_iter().map(|l| l.leaf).collect());
+            }
+            Err(e) => {
+                debug!("Failed to claim transfer sign refunds: {}", e);
+                return Err(e);
+            }
+        };
         debug!("Claim transfer sign refunds successful.");
 
         // Finalize the node signatures with the coordinator
@@ -1057,7 +1057,7 @@ impl TransferService {
         leaf_keys: &[LeafKeyTweak],
         // TODO: do something with proofs? Currently not used in js implementation
         _proof_map: Option<&ProofMap>,
-    ) -> Result<Vec<operator_rpc::spark::NodeSignatures>, ServiceError> {
+    ) -> Result<SignRefundsOutcome, ServiceError> {
         // Prepare leaf data map with refund signing information
         let mut leaf_data_map = HashMap::new();
         for leaf_key in leaf_keys {
@@ -1120,7 +1120,9 @@ impl TransferService {
                     && let Some(coordinator_transfer) = self.query_transfer(&transfer.id).await?
                     && coordinator_transfer.status == TransferStatus::Completed
                 {
-                    return Err(ServiceError::TransferAlreadyClaimed);
+                    return Ok(SignRefundsOutcome::AlreadyClaimed(Box::new(
+                        coordinator_transfer,
+                    )));
                 } else {
                     return Err(e.into());
                 }
@@ -1138,7 +1140,7 @@ impl TransferService {
         )
         .await?;
 
-        Ok(node_signatures)
+        Ok(SignRefundsOutcome::Signed(node_signatures))
     }
 
     /// Finalizes node signatures with the coordinator

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -672,7 +672,19 @@ impl TransferService {
         Ok(signable_message)
     }
 
-    /// Claims a transfer with retry logic and automatic leaf preparation
+    /// Claims a transfer with retry logic and automatic leaf preparation.
+    ///
+    /// Returns the claimed leaves on success.
+    ///
+    /// # Concurrent claims
+    ///
+    /// If the coordinator reports the transfer has already been claimed (another
+    /// instance of this wallet won the race), this method re-queries the transfer
+    /// from the coordinator. If it's now [`TransferStatus::Completed`], the finalized
+    /// leaves from that response are returned as if this call had performed the
+    /// claim — so the caller can update its local tree uniformly. Only if the transfer
+    /// can't be confirmed as completed does [`ServiceError::TransferAlreadyClaimed`]
+    /// propagate.
     pub async fn claim_transfer(
         &self,
         transfer: &Transfer,
@@ -727,8 +739,20 @@ impl TransferService {
             {
                 Ok(res) => res,
                 Err(ServiceError::TransferAlreadyClaimed) => {
-                    // Transfer was already claimed by another instance - don't retry.
-                    return Err(ServiceError::TransferAlreadyClaimed);
+                    // Another instance of this wallet claimed the transfer concurrently.
+                    // Re-query the transfer from the coordinator; if it's now completed,
+                    // return its finalized leaves so the caller can update its local tree
+                    // instead of surfacing the error.
+                    debug!(
+                        "Transfer {} already claimed by another instance; fetching finalized transfer",
+                        transfer.id
+                    );
+                    match self.query_transfer(&transfer.id).await? {
+                        Some(updated) if updated.status == TransferStatus::Completed => {
+                            return Ok(updated.leaves.into_iter().map(|l| l.leaf).collect());
+                        }
+                        _ => return Err(ServiceError::TransferAlreadyClaimed),
+                    }
                 }
                 Err(e) => {
                     error!("Failed to claim transfer with leaves: {}", e);

--- a/crates/spark/src/tree/leaf_optimizer.rs
+++ b/crates/spark/src/tree/leaf_optimizer.rs
@@ -296,13 +296,6 @@ impl LeafOptimizer {
                 Ok(())
             }
             Err(e) => {
-                info!(
-                    "Refreshing leaves on optimization failure (failure is likely caused by leaves having been spent by a concurrent instance)"
-                );
-                if let Err(e) = self.tree_service.refresh_leaves().await {
-                    error!("Failed to refresh leaves on optimization failure: {:?}", e);
-                }
-
                 self.emit_event(OptimizationEvent::Failed {
                     error: e.to_string(),
                 });
@@ -447,12 +440,14 @@ impl LeafOptimizer {
                     );
                 }
                 Err(e) => {
-                    if let Err(e) = self
+                    if let Err(cancel_err) = self
                         .tree_service
                         .cancel_reservation(swap_reservation.id)
                         .await
                     {
-                        error!("Failed to cancel reservation on optimization round failure: {e:?}");
+                        error!(
+                            "Failed to cancel reservation on optimization round failure: {cancel_err:?}"
+                        );
                     }
 
                     return Err(TreeServiceError::Generic(format!(


### PR DESCRIPTION
This fixes 3 issues that could cause balance to lag increasing after receiving a payment when multiple instances are running concurrently:
- Claim race caused the losing instance to only insert leaves into store on the next background full sync, causing a lag of up to sync period  -> fixed by querying for the transfer on TransferAlreadyClaimed error
- With the fix above, instances reliably race for optimizing leaves, causing balance to wobble due to the losing instance refreshing leaves immediately -> fixed by removing the refresh on optimization failure. There's no need to refresh leaves immediately. 
- On browser instances sharing an indexed db storage, the sync skip mechanism could cause an instance to never emit `Synced` even, which can cause the UI to never get updated -> fixed by emitting `Synced` when syncing is skipped 