### PR TITLE
Cross-chain send: token → sats AMM conversion leg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=bc291392e232fe39741b988f484b540e4a827ec4#bc291392e232fe39741b988f484b540e4a827ec4"
+source = "git+https://github.com/breez/boltz-client?rev=50db30770c5422de131bad9fb5c45b4108a90340#50db30770c5422de131bad9fb5c45b4108a90340"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -1340,8 +1340,8 @@ dependencies = [
  "hex",
  "k256",
  "lightning-invoice 0.34.0",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=bc291392e232fe39741b988f484b540e4a827ec4)",
- "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=bc291392e232fe39741b988f484b540e4a827ec4)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=50db30770c5422de131bad9fb5c45b4108a90340)",
+ "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=50db30770c5422de131bad9fb5c45b4108a90340)",
  "serde",
  "serde_json",
  "sha2",
@@ -3983,7 +3983,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=bc291392e232fe39741b988f484b540e4a827ec4#bc291392e232fe39741b988f484b540e4a827ec4"
+source = "git+https://github.com/breez/boltz-client?rev=50db30770c5422de131bad9fb5c45b4108a90340#50db30770c5422de131bad9fb5c45b4108a90340"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -4659,12 +4659,12 @@ dependencies = [
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=bc291392e232fe39741b988f484b540e4a827ec4#bc291392e232fe39741b988f484b540e4a827ec4"
+source = "git+https://github.com/breez/boltz-client?rev=50db30770c5422de131bad9fb5c45b4108a90340#50db30770c5422de131bad9fb5c45b4108a90340"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bitreq 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=bc291392e232fe39741b988f484b540e4a827ec4)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=50db30770c5422de131bad9fb5c45b4108a90340)",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ bitcoin = { version = "0.32.6", features = ["serde"] }
 bitflags = "2.10.0"
 # bitreq = { version = "0.3.4" }
 bitreq = { git = "https://github.com/breez/corepc", branch = "yse-bitreq-rustls" }
-boltz-client = { git = "https://github.com/breez/boltz-client", rev = "bc291392e232fe39741b988f484b540e4a827ec4" }
+boltz-client = { git = "https://github.com/breez/boltz-client", rev = "50db30770c5422de131bad9fb5c45b4108a90340" }
 breez-sdk-common = { path = "crates/breez-sdk/common", default-features = false }
 breez-sdk-spark = { path = "crates/breez-sdk/core" }
 built = { version = "0.8.0", features = ["git2"] }

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -710,6 +710,7 @@ pub(crate) async fn execute_command(
                 estimated_out,
                 fee_amount,
                 ref fee_asset,
+                source_transfer_fee_sats,
                 ..
             } = prepare_response.payment_method
             {
@@ -724,6 +725,7 @@ pub(crate) async fn execute_command(
                     route.asset, route.chain,
                 );
                 println!("Fee: {fee_amount} {fee_denom}");
+                println!("Source transfer fee: {source_transfer_fee_sats} sats");
                 let line = rl
                     .readline_with_initial("Do you want to continue (y/n): ", ("y", ""))?
                     .to_lowercase();

--- a/crates/breez-sdk/core/src/cross_chain/boltz.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz.rs
@@ -107,10 +107,12 @@ impl BoltzService {
     /// Two-phase prepare for `FeesIncluded`: size the real invoice to
     /// `amount - ln_fee_probe_sats` so `invoice_sats + ln_fee_probe <= amount`.
     ///
-    /// Mirrors LNURL pay's `FeesIncluded` pattern at `lnurl.rs`. A throwaway swap
-    /// is created to probe the LN fee; it times out server-side (~24h). The
-    /// probe value is stored on the prepare as `source_transfer_fee_sats`
-    /// and enforced as a hard cap at send time.
+    /// Mirrors LNURL pay's `FeesIncluded` pattern at `lnurl.rs`. Phase 1 uses
+    /// boltz-client's lightweight probe-invoice API — random preimage, short
+    /// server-side expiry, no HD index burn / DB row / WS subscription — so
+    /// the probe doesn't pile up persistent state. The probe value is stored
+    /// on the prepare as `source_transfer_fee_sats` and enforced as a hard
+    /// cap at send time.
     async fn prepare_fees_included(
         &self,
         recipient_address: &str,
@@ -124,16 +126,16 @@ impl BoltzService {
             route.chain
         );
 
-        // Phase 1: throwaway invoice at `total_sats` to probe LN fee.
-        let (_throwaway_prepared, throwaway_created) = self
-            .create_swap(
+        // Phase 1: throwaway probe invoice at `total_sats` to probe LN fee.
+        let probe_invoice = self
+            .fetch_probe_invoice(
                 recipient_address,
                 chain.clone(),
                 total_sats,
                 max_slippage_bps,
             )
             .await?;
-        let ln_fee_probe_sats = self.fetch_ln_fee(&throwaway_created.invoice).await?;
+        let ln_fee_probe_sats = self.fetch_ln_fee(&probe_invoice).await?;
 
         if total_sats <= ln_fee_probe_sats {
             return Err(SdkError::InvalidInput(format!(
@@ -202,6 +204,39 @@ impl BoltzService {
             .map_err(|e| boltz_err_to_sdk(&e))?;
 
         Ok((prepared, created))
+    }
+
+    /// Fetch a throwaway hold invoice for LN-fee estimation only.
+    ///
+    /// Goes through `prepare_reverse_swap_from_sats` to get a fresh
+    /// `pair_hash` and validate the destination, then calls boltz-client's
+    /// `create_probe_invoice` — random preimage, short server-side expiry,
+    /// no HD index, no DB row, no WS subscription.
+    ///
+    /// The returned invoice MUST NOT be paid: the preimage is discarded,
+    /// so any payment cannot be claimed.
+    async fn fetch_probe_invoice(
+        &self,
+        recipient_address: &str,
+        chain: ChainId,
+        invoice_amount_sats: u64,
+        max_slippage_bps: Option<u32>,
+    ) -> Result<String, SdkError> {
+        let prepared: PreparedSwap = self
+            .client
+            .prepare_reverse_swap_from_sats(
+                recipient_address,
+                chain,
+                invoice_amount_sats,
+                max_slippage_bps,
+            )
+            .await
+            .map_err(|e| boltz_err_to_sdk(&e))?;
+
+        self.client
+            .create_probe_invoice(&prepared)
+            .await
+            .map_err(|e| boltz_err_to_sdk(&e))
     }
 
     async fn fetch_ln_fee(&self, invoice: &str) -> Result<u64, SdkError> {

--- a/crates/breez-sdk/core/src/cross_chain/boltz.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz.rs
@@ -17,8 +17,9 @@ use spark_wallet::SparkWallet;
 use tracing::{debug, error, info};
 
 use super::{
-    CrossChainPrepared, CrossChainProvider, CrossChainProviderContext, CrossChainRouteFilter,
-    CrossChainRoutePair, CrossChainSendResult, CrossChainService,
+    CrossChainFeeMode, CrossChainPrepared, CrossChainProvider, CrossChainProviderContext,
+    CrossChainRouteFilter, CrossChainRoutePair, CrossChainSendResult, CrossChainService,
+    SourceAsset,
 };
 use crate::{
     ConversionInfo, ConversionStatus, Network, PaymentMetadata, Storage, error::SdkError,
@@ -65,6 +66,196 @@ impl BoltzService {
             Network::Regtest => None,
         }
     }
+
+    /// One-shot prepare for `FeesExcluded`: `amount` is the provider invoice
+    /// target. The wallet pays `amount + ln_fee_sats` in total at send time.
+    async fn prepare_fees_excluded(
+        &self,
+        recipient_address: &str,
+        route: &CrossChainRoutePair,
+        chain: ChainId,
+        invoice_amount_sats: u64,
+        max_slippage_bps: Option<u32>,
+    ) -> Result<CrossChainPrepared, SdkError> {
+        debug!(
+            "Boltz: preparing reverse swap (FeesExcluded) to {recipient_address} on {}, amount {invoice_amount_sats} sats",
+            route.chain
+        );
+
+        let (prepared, created) = self
+            .create_swap(
+                recipient_address,
+                chain,
+                invoice_amount_sats,
+                max_slippage_bps,
+            )
+            .await?;
+
+        let ln_fee_sats = self.fetch_ln_fee(&created.invoice).await?;
+
+        Ok(Self::build_prepared(
+            route,
+            recipient_address,
+            &prepared,
+            created,
+            ln_fee_sats,
+            max_slippage_bps,
+            CrossChainFeeMode::FeesExcluded,
+        ))
+    }
+
+    /// Two-phase prepare for `FeesIncluded`: size the real invoice to
+    /// `amount - ln_fee_probe_sats` so `invoice_sats + ln_fee_probe <= amount`.
+    ///
+    /// Mirrors LNURL pay's `FeesIncluded` pattern at `lnurl.rs`. A throwaway swap
+    /// is created to probe the LN fee; it times out server-side (~24h). The
+    /// probe value is stored on the prepare as `source_transfer_fee_sats`
+    /// and enforced as a hard cap at send time.
+    async fn prepare_fees_included(
+        &self,
+        recipient_address: &str,
+        route: &CrossChainRoutePair,
+        chain: ChainId,
+        total_sats: u64,
+        max_slippage_bps: Option<u32>,
+    ) -> Result<CrossChainPrepared, SdkError> {
+        debug!(
+            "Boltz: preparing reverse swap (FeesIncluded) to {recipient_address} on {}, total {total_sats} sats",
+            route.chain
+        );
+
+        // Phase 1: throwaway invoice at `total_sats` to probe LN fee.
+        let (_throwaway_prepared, throwaway_created) = self
+            .create_swap(
+                recipient_address,
+                chain.clone(),
+                total_sats,
+                max_slippage_bps,
+            )
+            .await?;
+        let ln_fee_probe_sats = self.fetch_ln_fee(&throwaway_created.invoice).await?;
+
+        if total_sats <= ln_fee_probe_sats {
+            return Err(SdkError::InvalidInput(format!(
+                "Amount too small for cross-chain send: {total_sats} sats <= LN fee {ln_fee_probe_sats} sats."
+            )));
+        }
+
+        // Phase 2: real invoice sized to leave room for the probed fee.
+        let real_invoice_sats = total_sats.saturating_sub(ln_fee_probe_sats);
+        let (prepared, created) = self
+            .create_swap(
+                recipient_address,
+                chain,
+                real_invoice_sats,
+                max_slippage_bps,
+            )
+            .await?;
+        let ln_fee_final_sats = self.fetch_ln_fee(&created.invoice).await?;
+
+        // Mirrors LNURL's guard: if fee moved between queries, fail so caller retries.
+        if ln_fee_final_sats > ln_fee_probe_sats {
+            return Err(SdkError::Generic(
+                "Boltz LN fee increased between prepare queries. Please retry.".to_string(),
+            ));
+        }
+
+        // Store the probe (not the final) as the budget — matches LNURL's
+        // `fee_sats = first_fee` and keeps `invoice_sats + max_fee <= amount`.
+        Ok(Self::build_prepared(
+            route,
+            recipient_address,
+            &prepared,
+            created,
+            ln_fee_probe_sats,
+            max_slippage_bps,
+            CrossChainFeeMode::FeesIncluded,
+        ))
+    }
+
+    async fn create_swap(
+        &self,
+        recipient_address: &str,
+        chain: ChainId,
+        invoice_amount_sats: u64,
+        max_slippage_bps: Option<u32>,
+    ) -> Result<(PreparedSwap, boltz_client::models::CreatedSwap), SdkError> {
+        let prepared: PreparedSwap = self
+            .client
+            .prepare_reverse_swap_from_sats(
+                recipient_address,
+                chain,
+                invoice_amount_sats,
+                max_slippage_bps,
+            )
+            .await
+            .map_err(|e| boltz_err_to_sdk(&e))?;
+
+        // `create_reverse_swap` commits a HD key index, POSTs to Boltz to
+        // create the swap on the server, and writes a `BoltzSwap` row into
+        // the adapter cache KV. After this call Boltz is holding the swap
+        // state, so the only path back to a clean state is a timeout.
+        let created = self
+            .client
+            .create_reverse_swap(&prepared)
+            .await
+            .map_err(|e| boltz_err_to_sdk(&e))?;
+
+        Ok((prepared, created))
+    }
+
+    async fn fetch_ln_fee(&self, invoice: &str) -> Result<u64, SdkError> {
+        self.spark_wallet
+            .fetch_lightning_send_fee_estimate(invoice, None)
+            .await
+            .map_err(|e| {
+                SdkError::Generic(format!(
+                    "Failed to fetch lightning send fee estimate for Boltz invoice: {e}"
+                ))
+            })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_prepared(
+        route: &CrossChainRoutePair,
+        recipient_address: &str,
+        prepared: &PreparedSwap,
+        created: boltz_client::models::CreatedSwap,
+        ln_fee_sats: u64,
+        max_slippage_bps: Option<u32>,
+        fee_mode: CrossChainFeeMode,
+    ) -> CrossChainPrepared {
+        // `fee_amount` is the Boltz spread only (invoice sats - on-chain sats
+        // paid out). The LN routing budget is exposed separately as
+        // `source_transfer_fee_sats` — not double-counted here.
+        let boltz_spread_sats = created
+            .invoice_amount_sats
+            .saturating_sub(prepared.estimated_onchain_amount);
+        let fee_amount = u128::from(boltz_spread_sats);
+        let estimated_out = u128::from(prepared.usdt_amount);
+        let invoice_amount_sats = created.invoice_amount_sats;
+        let resolved_slippage = max_slippage_bps.unwrap_or(prepared.slippage_bps);
+
+        let provider_context = CrossChainProviderContext::Boltz {
+            swap_id: created.swap_id.clone(),
+            invoice: created.invoice,
+            max_slippage_bps: resolved_slippage,
+        };
+
+        CrossChainPrepared {
+            amount_in: u128::from(invoice_amount_sats),
+            estimated_out,
+            fee_amount,
+            fee_asset: None,
+            source_transfer_fee_sats: ln_fee_sats,
+            fee_mode,
+            expires_at: prepared.expires_at.to_string(),
+            pair: route.clone(),
+            recipient_address: recipient_address.to_string(),
+            token_identifier: None,
+            provider_context,
+        }
+    }
 }
 
 #[macros::async_trait]
@@ -102,6 +293,7 @@ impl CrossChainService for BoltzService {
         amount: u128,
         token_identifier: Option<String>,
         max_slippage_bps: Option<u32>,
+        fee_mode: CrossChainFeeMode,
     ) -> Result<CrossChainPrepared, SdkError> {
         // v1 Boltz is BTC-only. Tokens must be rejected before we commit any
         // state on Boltz's side.
@@ -111,7 +303,7 @@ impl CrossChainService for BoltzService {
             ));
         }
 
-        let invoice_amount_sats = u64::try_from(amount).map_err(|_| {
+        let total_sats = u64::try_from(amount).map_err(|_| {
             SdkError::InvalidInput(format!(
                 "Amount {amount} exceeds u64::MAX sats for Boltz reverse swap"
             ))
@@ -127,70 +319,28 @@ impl CrossChainService for BoltzService {
             )));
         }
 
-        debug!(
-            "Boltz: preparing reverse swap to {recipient_address} on {}, amount {invoice_amount_sats} sats",
-            route.chain
-        );
-
-        let prepared: PreparedSwap = self
-            .client
-            .prepare_reverse_swap_from_sats(
-                recipient_address,
-                chain,
-                invoice_amount_sats,
-                max_slippage_bps,
-            )
-            .await
-            .map_err(|e| boltz_err_to_sdk(&e))?;
-
-        // `create_reverse_swap` commits a HD key index, POSTs to Boltz to
-        // create the swap on the server, and writes a `BoltzSwap` row into
-        // the adapter cache KV. After this call Boltz is holding the swap
-        // state, so the only path back to a clean state is a timeout.
-        let created = self
-            .client
-            .create_reverse_swap(&prepared)
-            .await
-            .map_err(|e| boltz_err_to_sdk(&e))?;
-
-        let ln_fee_sats = self
-            .spark_wallet
-            .fetch_lightning_send_fee_estimate(&created.invoice, None)
-            .await
-            .map_err(|e| {
-                SdkError::Generic(format!(
-                    "Failed to fetch lightning send fee estimate for Boltz invoice: {e}"
-                ))
-            })?;
-
-        // Fee denominated in sats: Boltz spread (invoice sats - on-chain sats
-        // paid out) + lightning routing fee budget.
-        let boltz_spread_sats = created
-            .invoice_amount_sats
-            .saturating_sub(prepared.estimated_onchain_amount);
-        let fee_amount = u128::from(boltz_spread_sats).saturating_add(u128::from(ln_fee_sats));
-        let estimated_out = u128::from(prepared.usdt_amount);
-        let invoice_amount_sats = created.invoice_amount_sats;
-        let resolved_slippage = max_slippage_bps.unwrap_or(prepared.slippage_bps);
-
-        let provider_context = CrossChainProviderContext::Boltz {
-            swap_id: created.swap_id.clone(),
-            invoice: created.invoice,
-            ln_fee_sats,
-            max_slippage_bps: resolved_slippage,
-        };
-
-        Ok(CrossChainPrepared {
-            amount_in: u128::from(invoice_amount_sats),
-            estimated_out,
-            fee_amount,
-            fee_asset: None,
-            expires_at: prepared.expires_at.to_string(),
-            pair: route.clone(),
-            recipient_address: recipient_address.to_string(),
-            token_identifier: None,
-            provider_context,
-        })
+        match fee_mode {
+            CrossChainFeeMode::FeesExcluded => {
+                self.prepare_fees_excluded(
+                    recipient_address,
+                    route,
+                    chain,
+                    total_sats,
+                    max_slippage_bps,
+                )
+                .await
+            }
+            CrossChainFeeMode::FeesIncluded => {
+                self.prepare_fees_included(
+                    recipient_address,
+                    route,
+                    chain,
+                    total_sats,
+                    max_slippage_bps,
+                )
+                .await
+            }
+        }
     }
 
     #[allow(clippy::large_futures)]
@@ -198,7 +348,6 @@ impl CrossChainService for BoltzService {
         let CrossChainProviderContext::Boltz {
             swap_id,
             invoice,
-            ln_fee_sats,
             max_slippage_bps,
         } = &prepared.provider_context
         else {
@@ -210,6 +359,46 @@ impl CrossChainService for BoltzService {
         let invoice_amount_sats = u64::try_from(prepared.amount_in)
             .map_err(|e| SdkError::Generic(format!("Boltz invoice amount exceeds u64: {e}")))?;
 
+        let ln_fee_budget = prepared.source_transfer_fee_sats;
+
+        // Compute the LN payment amount based on fee_mode. For FeesIncluded,
+        // mirror LNURL's overpayment logic so the wallet actually consumes the
+        // user's budget when current_fee < ln_fee_probe.
+        let ln_amount_sats = match prepared.fee_mode {
+            CrossChainFeeMode::FeesExcluded => {
+                // Pay the invoice as-is; `max_fee_sat = ln_fee_budget` protects
+                // against fee drift (validated downstream).
+                None
+            }
+            CrossChainFeeMode::FeesIncluded => {
+                let current_fee = self
+                    .spark_wallet
+                    .fetch_lightning_send_fee_estimate(invoice, None)
+                    .await
+                    .map_err(|e| {
+                        SdkError::Generic(format!(
+                            "Failed to re-estimate Boltz LN fee at send: {e}"
+                        ))
+                    })?;
+
+                if current_fee > ln_fee_budget {
+                    return Err(SdkError::Generic(
+                        "Fee increased since prepare. Please retry.".to_string(),
+                    ));
+                }
+
+                let overpayment_uncapped = ln_fee_budget.saturating_sub(current_fee);
+                let max_allowed_overpayment = current_fee.max(1);
+                if overpayment_uncapped > max_allowed_overpayment {
+                    return Err(SdkError::Generic(format!(
+                        "Fee overpayment ({overpayment_uncapped} sats) exceeds allowed maximum ({max_allowed_overpayment} sats)"
+                    )));
+                }
+
+                Some(invoice_amount_sats.saturating_add(overpayment_uncapped))
+            }
+        };
+
         // Delegate the LN leg to the shared helper. It pays the hold
         // invoice, builds the Payment row, persists it, and spawns SSP-side
         // polling — the same path `send_bolt11_invoice` takes. On failure
@@ -219,8 +408,8 @@ impl CrossChainService for BoltzService {
             .lightning_sender
             .pay_and_persist_lightning_invoice(
                 invoice,
-                None,
-                *ln_fee_sats,
+                ln_amount_sats,
+                ln_fee_budget,
                 false,
                 prepared.amount_in,
                 None,
@@ -289,6 +478,7 @@ fn spec_to_route_pair(spec: &boltz_client::models::ChainSpec) -> CrossChainRoute
         contract_address: spec.token_address.clone(),
         decimals: 6,
         exact_out_eligible: false,
+        supported_sources: vec![SourceAsset::Bitcoin],
     }
 }
 

--- a/crates/breez-sdk/core/src/cross_chain/boltz.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz.rs
@@ -137,22 +137,37 @@ impl BoltzService {
             .await?;
         let ln_fee_probe_sats = self.fetch_ln_fee(&probe_invoice).await?;
 
-        if total_sats <= ln_fee_probe_sats {
-            return Err(SdkError::InvalidInput(format!(
-                "Amount too small for cross-chain send: {total_sats} sats <= LN fee {ln_fee_probe_sats} sats."
-            )));
-        }
+        let real_invoice_sats = fees_included_real_invoice_sats(total_sats, ln_fee_probe_sats)?;
 
         // Phase 2: real invoice sized to leave room for the probed fee.
-        let real_invoice_sats = total_sats.saturating_sub(ln_fee_probe_sats);
-        let (prepared, created) = self
-            .create_swap(
+        // Translate `AmountOutOfRange` here (rather than in `boltz_err_to_sdk`)
+        // so the message names the user's `total_sats` and the probed fee —
+        // the raw boltz error references `real_invoice_sats`, a number the
+        // caller never chose. The phase-2 prepare validates against the Boltz
+        // pair limits before `create_reverse_swap` is called, so a failure
+        // here commits no state.
+        let prepared = self
+            .client
+            .prepare_reverse_swap_from_sats(
                 recipient_address,
                 chain,
                 real_invoice_sats,
                 max_slippage_bps,
             )
-            .await?;
+            .await
+            .map_err(|e| match &e {
+                BoltzError::AmountOutOfRange { min, .. } => SdkError::InvalidInput(format!(
+                    "Amount {total_sats} sats too small for cross-chain send: \
+                    after subtracting LN fee ({ln_fee_probe_sats} sats), the remaining \
+                    invoice ({real_invoice_sats} sats) is below Boltz minimum ({min} sats)."
+                )),
+                _ => boltz_err_to_sdk(&e),
+            })?;
+        let created = self
+            .client
+            .create_reverse_swap(&prepared)
+            .await
+            .map_err(|e| boltz_err_to_sdk(&e))?;
         let ln_fee_final_sats = self.fetch_ln_fee(&created.invoice).await?;
 
         // Mirrors LNURL's guard: if fee moved between queries, fail so caller retries.
@@ -208,10 +223,12 @@ impl BoltzService {
 
     /// Fetch a throwaway hold invoice for LN-fee estimation only.
     ///
-    /// Goes through `prepare_reverse_swap_from_sats` to get a fresh
-    /// `pair_hash` and validate the destination, then calls boltz-client's
-    /// `create_probe_invoice` — random preimage, short server-side expiry,
-    /// no HD index, no DB row, no WS subscription.
+    /// Both calls in this path are stateless on our side:
+    /// - `prepare_reverse_swap_from_sats` is a pure quote (HTTP fetch only,
+    ///   no HD index burn, no DB row, no WS subscription).
+    /// - `create_probe_invoice` uses a random preimage, sets a short
+    ///   server-side expiry, and likewise does not increment the HD key
+    ///   index, persist to local storage, or open a WS subscription.
     ///
     /// The returned invoice MUST NOT be paid: the preimage is discarded,
     /// so any payment cannot be claimed.
@@ -501,6 +518,20 @@ fn boltz_err_to_sdk(err: &BoltzError) -> SdkError {
     SdkError::Generic(format!("Boltz: {err}"))
 }
 
+/// Phase-1 check for the `FeesIncluded` path: returns the size to use for the
+/// real invoice, or rejects if the probed LN fee already eats the budget.
+fn fees_included_real_invoice_sats(
+    total_sats: u64,
+    ln_fee_probe_sats: u64,
+) -> Result<u64, SdkError> {
+    if total_sats <= ln_fee_probe_sats {
+        return Err(SdkError::InvalidInput(format!(
+            "Amount too small for cross-chain send: {total_sats} sats <= LN fee {ln_fee_probe_sats} sats."
+        )));
+    }
+    Ok(total_sats.saturating_sub(ln_fee_probe_sats))
+}
+
 /// Build a [`CrossChainRoutePair`] from a Boltz [`ChainSpec`]. Surfaces
 /// `chain_id` for EVM chains as a decimal string; non-EVM transports
 /// (Solana, Tron) get `None`, matching the USDT0 deployments feed.
@@ -563,5 +594,33 @@ mod tests {
             pair.chain_id, None,
             "Non-EVM transports (Solana, Tron) expose no chain_id"
         );
+    }
+
+    #[test]
+    fn fees_included_real_invoice_sats_subtracts_probe_fee() {
+        let real = fees_included_real_invoice_sats(10_000, 250).expect("fits within budget");
+        assert_eq!(
+            real, 9_750,
+            "real invoice should leave room for the probed LN fee"
+        );
+    }
+
+    #[test]
+    fn fees_included_real_invoice_sats_rejects_when_fee_eats_budget() {
+        // Fee exactly equals total: no room for any invoice → reject.
+        let err = fees_included_real_invoice_sats(500, 500)
+            .expect_err("equal probe fee leaves zero invoice");
+        match err {
+            SdkError::InvalidInput(msg) => {
+                assert!(msg.contains("500"), "error should report the figures");
+                assert!(msg.contains("Amount too small"));
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+
+        // Fee exceeds total → also reject.
+        let err =
+            fees_included_real_invoice_sats(100, 250).expect_err("probe fee greater than total");
+        assert!(matches!(err, SdkError::InvalidInput(_)));
     }
 }

--- a/crates/breez-sdk/core/src/cross_chain/mod.rs
+++ b/crates/breez-sdk/core/src/cross_chain/mod.rs
@@ -25,6 +25,29 @@ pub enum CrossChainProvider {
     Boltz,
 }
 
+/// The source asset a cross-chain route accepts as input on the Spark side.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum SourceAsset {
+    /// Native BTC (sats).
+    Bitcoin,
+    /// A Spark token, identified by its bech32m `token_identifier` (e.g. `btkn1...`).
+    Token(String),
+}
+
+/// How the caller wants fees handled against the request `amount`.
+///
+/// - `FeesExcluded`: `amount` is the provider invoice/deposit target; the
+///   wallet pays `amount + source_transfer_fee_sats` in total.
+/// - `FeesIncluded`: `amount` is the wallet's total sats budget; the provider
+///   leg is sized so `amount_in + source_transfer_fee_sats <= amount`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum CrossChainFeeMode {
+    FeesExcluded,
+    FeesIncluded,
+}
+
 /// Filter for [`CrossChainService::get_routes`] and the public
 /// `get_cross_chain_routes()` API.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -61,6 +84,12 @@ pub struct CrossChainRoutePair {
     pub decimals: u8,
     /// Whether the route supports exact-out mode.
     pub exact_out_eligible: bool,
+    /// The source assets this route accepts on the Spark side.
+    ///
+    /// Boltz routes accept `[SourceAsset::Bitcoin]`. Orchestra routes accept
+    /// one or more of `Bitcoin` / `Token(...)` (a given destination endpoint
+    /// may be fronted by multiple source variants on Orchestra).
+    pub supported_sources: Vec<SourceAsset>,
 }
 
 /// Registry of cross-chain providers keyed by [`CrossChainProvider`].
@@ -109,9 +138,6 @@ pub enum CrossChainProviderContext {
         /// Hold invoice to pay. The invoice amount matches
         /// [`CrossChainPrepared::amount_in`].
         invoice: String,
-        /// Lightning routing fee budget in sats. Not recoverable from the
-        /// public `fee_amount`, which also folds in the Boltz spread.
-        ln_fee_sats: u64,
         /// Slippage tolerance applied to this swap, in basis points.
         max_slippage_bps: u32,
     },
@@ -131,6 +157,19 @@ pub(crate) struct CrossChainPrepared {
     pub fee_amount: u128,
     /// The asset the fee is denominated in. `None` means BTC (sats).
     pub fee_asset: Option<String>,
+    /// Sats cost to the wallet of moving `amount_in` from the wallet to the
+    /// provider. For Boltz: the Lightning routing fee budget for paying the
+    /// hold invoice (a budget, not a central estimate — enforced as a hard
+    /// cap at send time). For Orchestra: the Spark transfer fee (0 today;
+    /// non-zero in the future).
+    ///
+    /// Semantically distinct from `fee_amount` (provider's service fee /
+    /// spread) and from destination-chain costs (baked into `estimated_out`).
+    /// Denominated in sats — the field assumes a sats-denominated source leg.
+    pub source_transfer_fee_sats: u64,
+    /// Fee mode the prepare was called with. Needed at send time so the
+    /// provider knows whether to apply FeesIncluded-style overpayment.
+    pub fee_mode: CrossChainFeeMode,
     pub expires_at: String,
     pub pair: CrossChainRoutePair,
     pub recipient_address: String,
@@ -173,6 +212,7 @@ pub(crate) trait CrossChainService: Send + Sync {
         amount: u128,
         source_token_identifier: Option<String>,
         max_slippage_bps: Option<u32>,
+        fee_mode: CrossChainFeeMode,
     ) -> Result<CrossChainPrepared, SdkError>;
 
     /// Execute the send: transfer funds to the deposit address, submit to

--- a/crates/breez-sdk/core/src/cross_chain/orchestra.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra.rs
@@ -285,6 +285,46 @@ impl OrchestraService {
 
         Ok(())
     }
+
+    /// Resolves the Orchestra-side `source_asset` wire symbol (e.g. `"BTC"`,
+    /// `"USDB"`) for the given destination route + Spark source.
+    ///
+    /// Orchestra's `/quote` API identifies the source asset by
+    /// `(sourceChain, sourceAsset)` symbols rather than contract addresses,
+    /// so we look up the matching raw route and read its `source.asset`.
+    /// This doubles as validation that Orchestra actually offers a route for
+    /// the requested source-to-destination combination.
+    ///
+    /// `spark_routes()` is cache-backed (TTL'd) so this call is effectively
+    /// free in the hot path.
+    async fn resolve_source_asset(
+        &self,
+        dest: &CrossChainRoutePair,
+        token_identifier: Option<&str>,
+    ) -> Result<String, SdkError> {
+        let raw_routes =
+            self.client.spark_routes(true).await.map_err(|e| {
+                SdkError::Generic(format!("Failed to fetch cross-chain routes: {e}"))
+            })?;
+        let matched = raw_routes.iter().find(|r| {
+            let dest_matches = r.destination.chain == dest.chain
+                && r.destination.asset == dest.asset
+                && r.destination.contract_address == dest.contract_address;
+            let source_matches = match token_identifier {
+                None => r.source.asset.eq_ignore_ascii_case("BTC"),
+                Some(tid) => r.source.contract_address.as_deref() == Some(tid),
+            };
+            dest_matches && source_matches
+        });
+        matched.map(|r| r.source.asset.clone()).ok_or_else(|| {
+            SdkError::InvalidInput(format!(
+                "Orchestra does not offer a route for source {} → {}/{}",
+                token_identifier.unwrap_or("BTC"),
+                dest.chain,
+                dest.asset
+            ))
+        })
+    }
 }
 
 #[macros::async_trait]
@@ -381,43 +421,15 @@ impl CrossChainService for OrchestraService {
         max_slippage_bps: Option<u32>,
         fee_mode: CrossChainFeeMode,
     ) -> Result<CrossChainPrepared, SdkError> {
-        let dest_chain = &route.chain;
-        let dest_asset = &route.asset;
-        // Resolve the Orchestra-side source_asset string (e.g. "BTC", "USDB")
-        // from the cached spark_routes. Match the route with the correct
-        // destination triplet AND the desired source (contract_address when
-        // a token_identifier is requested, asset == "BTC" otherwise).
-        let raw_routes =
-            self.client.spark_routes(true).await.map_err(|e| {
-                SdkError::Generic(format!("Failed to fetch cross-chain routes: {e}"))
-            })?;
-        let matched = raw_routes.iter().find(|r| {
-            let dest_matches = r.destination.chain == *dest_chain
-                && r.destination.asset == *dest_asset
-                && r.destination.contract_address == route.contract_address;
-            let source_matches = match token_identifier.as_deref() {
-                None => r.source.asset.eq_ignore_ascii_case("BTC"),
-                Some(tid) => r.source.contract_address.as_deref() == Some(tid),
-            };
-            dest_matches && source_matches
-        });
-        let source_asset = match matched {
-            Some(r) => r.source.asset.clone(),
-            None => {
-                return Err(SdkError::InvalidInput(format!(
-                    "Orchestra does not offer a route for source {} → {}/{}",
-                    token_identifier.as_deref().unwrap_or("BTC"),
-                    dest_chain,
-                    dest_asset
-                )));
-            }
-        };
+        let source_asset = self
+            .resolve_source_asset(route, token_identifier.as_deref())
+            .await?;
 
         let request = QuoteRequest {
             source_chain: SPARK_SOURCE_CHAIN.to_string(),
             source_asset: source_asset.clone(),
-            destination_chain: dest_chain.clone(),
-            destination_asset: dest_asset.clone(),
+            destination_chain: route.chain.clone(),
+            destination_asset: route.asset.clone(),
             amount: amount.to_string(),
             recipient_address: recipient_address.to_string(),
             amount_mode: Some(AmountMode::ExactIn),

--- a/crates/breez-sdk/core/src/cross_chain/orchestra.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra.rs
@@ -6,7 +6,7 @@
 
 #![allow(dead_code)]
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use breez_sdk_common::input::CrossChainAddressFamily;
@@ -28,8 +28,9 @@ use crate::persist::{ConversionFilter, StorageListPaymentsRequest, StoragePaymen
 use crate::{ConversionInfo, ConversionStatus, PaymentDetails, Storage};
 
 use super::{
-    CrossChainPrepared, CrossChainProvider, CrossChainProviderContext, CrossChainRouteFilter,
-    CrossChainRoutePair, CrossChainSendResult, CrossChainService,
+    CrossChainFeeMode, CrossChainPrepared, CrossChainProvider, CrossChainProviderContext,
+    CrossChainRouteFilter, CrossChainRoutePair, CrossChainSendResult, CrossChainService,
+    SourceAsset,
 };
 
 /// The canonical Spark source chain string used by Orchestra.
@@ -319,9 +320,12 @@ impl CrossChainService for OrchestraService {
 
         // Multiple raw routes may exist for the same external chain (e.g.
         // BTC→USDT-on-tron and USDB→USDT-on-tron). Dedup by (chain, asset,
-        // contract_address) so the caller only sees one route per external endpoint.
-        let mut seen = HashSet::new();
-        let mut pairs: Vec<CrossChainRoutePair> = Vec::new();
+        // contract_address) so the caller only sees one route per external
+        // endpoint, but accumulate the Spark-side source variants into
+        // `supported_sources`.
+        type Key = (String, String, Option<String>);
+        let mut order: Vec<Key> = Vec::new();
+        let mut grouped: HashMap<Key, CrossChainRoutePair> = HashMap::new();
 
         for r in routes.iter().filter(|r| {
             let side = non_spark_side(r, is_send);
@@ -330,16 +334,41 @@ impl CrossChainService for OrchestraService {
                 && contract_filter.is_none_or(|filter_ca| ca.is_some_and(|c| c == filter_ca))
         }) {
             let side = non_spark_side(r, is_send);
-            let key = (
+            let key: Key = (
                 side.chain.clone(),
                 side.asset.clone(),
                 side.contract_address.clone(),
             );
-            if seen.insert(key) {
-                pairs.push(side_to_route_pair(side, r.exact_out_eligible));
+
+            // On send, the Spark side is `source`; on receive, it's `destination`.
+            let spark_side = if is_send { &r.source } else { &r.destination };
+            let source_variant = if spark_side.asset.eq_ignore_ascii_case("BTC") {
+                Some(SourceAsset::Bitcoin)
+            } else {
+                // Non-BTC Spark source without contract_address: defensive
+                // skip. Shouldn't happen per current Orchestra behavior.
+                spark_side
+                    .contract_address
+                    .as_ref()
+                    .map(|ca| SourceAsset::Token(ca.clone()))
+            };
+
+            let entry = grouped.entry(key.clone()).or_insert_with(|| {
+                order.push(key.clone());
+                side_to_route_pair(side, r.exact_out_eligible)
+            });
+
+            if let Some(variant) = source_variant
+                && !entry.supported_sources.contains(&variant)
+            {
+                entry.supported_sources.push(variant);
             }
         }
 
+        let pairs: Vec<CrossChainRoutePair> = order
+            .into_iter()
+            .filter_map(|k| grouped.remove(&k))
+            .collect();
         Ok(pairs)
     }
 
@@ -350,12 +379,38 @@ impl CrossChainService for OrchestraService {
         amount: u128,
         token_identifier: Option<String>,
         max_slippage_bps: Option<u32>,
+        fee_mode: CrossChainFeeMode,
     ) -> Result<CrossChainPrepared, SdkError> {
         let dest_chain = &route.chain;
         let dest_asset = &route.asset;
-        let source_asset = match token_identifier.as_deref() {
-            None => "BTC".to_string(),
-            Some(_) => "USDB".to_string(),
+        // Resolve the Orchestra-side source_asset string (e.g. "BTC", "USDB")
+        // from the cached spark_routes. Match the route with the correct
+        // destination triplet AND the desired source (contract_address when
+        // a token_identifier is requested, asset == "BTC" otherwise).
+        let raw_routes =
+            self.client.spark_routes(true).await.map_err(|e| {
+                SdkError::Generic(format!("Failed to fetch cross-chain routes: {e}"))
+            })?;
+        let matched = raw_routes.iter().find(|r| {
+            let dest_matches = r.destination.chain == *dest_chain
+                && r.destination.asset == *dest_asset
+                && r.destination.contract_address == route.contract_address;
+            let source_matches = match token_identifier.as_deref() {
+                None => r.source.asset.eq_ignore_ascii_case("BTC"),
+                Some(tid) => r.source.contract_address.as_deref() == Some(tid),
+            };
+            dest_matches && source_matches
+        });
+        let source_asset = match matched {
+            Some(r) => r.source.asset.clone(),
+            None => {
+                return Err(SdkError::InvalidInput(format!(
+                    "Orchestra does not offer a route for source {} → {}/{}",
+                    token_identifier.as_deref().unwrap_or("BTC"),
+                    dest_chain,
+                    dest_asset
+                )));
+            }
         };
 
         let request = QuoteRequest {
@@ -406,6 +461,11 @@ impl CrossChainService for OrchestraService {
             } else {
                 Some(quote.fee_asset)
             },
+            // Spark transfer fee is 0 today; the field is wired for a future
+            // non-zero case. Both FeesIncluded/FeesExcluded pass through
+            // identically since `amount_in = amount`.
+            source_transfer_fee_sats: 0,
+            fee_mode,
             expires_at: quote.expires_at,
             pair: route.clone(),
             recipient_address: recipient_address.to_string(),
@@ -532,6 +592,7 @@ fn side_to_route_pair(side: &RouteAsset, exact_out_eligible: bool) -> CrossChain
         contract_address: side.contract_address.clone(),
         decimals: side.decimals,
         exact_out_eligible,
+        supported_sources: Vec::new(),
     }
 }
 

--- a/crates/breez-sdk/core/src/cross_chain/orchestra.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra.rs
@@ -476,6 +476,9 @@ impl CrossChainService for OrchestraService {
             // Spark transfer fee is 0 today; the field is wired for a future
             // non-zero case. Both FeesIncluded/FeesExcluded pass through
             // identically since `amount_in = amount`.
+            // TODO: when source_transfer_fee_sats becomes non-zero, branch on
+            // fee_mode here like Boltz does — `FeesIncluded` will need to size
+            // `amount_in` so `amount_in + source_transfer_fee_sats <= amount`.
             source_transfer_fee_sats: 0,
             fee_mode,
             expires_at: quote.expires_at,

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -29,7 +29,8 @@ pub use chain::{
 pub use common::rest::{RestClient, RestResponse};
 pub use common::{fiat::*, models::*, sync_storage};
 pub use cross_chain::{
-    CrossChainProvider, CrossChainProviderContext, CrossChainRouteFilter, CrossChainRoutePair,
+    CrossChainFeeMode, CrossChainProvider, CrossChainProviderContext, CrossChainRouteFilter,
+    CrossChainRoutePair, SourceAsset,
 };
 pub use error::{DepositClaimError, SdkError, SignerError};
 pub use events::{EventEmitter, EventListener, OptimizationEvent, SdkEvent};

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1257,7 +1257,8 @@ pub struct PrepareLnurlPayResponse {
     /// When set, the payment will include a token conversion step before sending the payment
     pub conversion_estimate: Option<ConversionEstimate>,
     /// The fee policy actually applied. May differ from the request — e.g.,
-    /// AMM-conversion sends are always `FeesIncluded`.
+    /// LNURL sends with `token_identifier` set + conversion are always
+    /// `FeesIncluded` (explicit `FeesExcluded` is rejected).
     pub fee_policy: FeePolicy,
 }
 
@@ -1406,10 +1407,11 @@ pub struct PrepareSendPaymentRequest {
     pub conversion_options: Option<ConversionOptions>,
     /// How fees are handled. See [`FeePolicy`]. Defaults to `FeesExcluded`.
     ///
-    /// Ignored on AMM-conversion sends (whether the conversion was explicitly
-    /// requested or auto-injected by stable balance) — fees come out of the
-    /// converted sats. The prepare response's `fee_policy` reflects what was
-    /// actually applied.
+    /// Ignored on cross-chain AMM-conversion sends (whether the conversion was
+    /// explicitly requested or auto-injected by stable balance) — fees come
+    /// out of the converted sats. Bolt11 and Bitcoin AMM-conversion sends
+    /// still respect this field by sizing the conversion to cover fees. The
+    /// prepare response's `fee_policy` reflects what was actually applied.
     #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub fee_policy: Option<FeePolicy>,
 }
@@ -1429,7 +1431,7 @@ pub struct PrepareSendPaymentResponse {
     /// When set, the payment will include a conversion step before sending the payment
     pub conversion_estimate: Option<ConversionEstimate>,
     /// The fee policy actually applied. May differ from the request — e.g.,
-    /// AMM-conversion sends are always `FeesIncluded`.
+    /// cross-chain AMM-conversion sends are always `FeesIncluded`.
     pub fee_policy: FeePolicy,
 }
 

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1234,7 +1234,7 @@ pub struct PrepareLnurlPayRequest {
     /// If provided, the payment will include a token conversion step before sending the payment
     #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub conversion_options: Option<ConversionOptions>,
-    /// How fees should be handled. Defaults to `FeesExcluded` (fees added on top).
+    /// How fees are handled. See [`FeePolicy`]. Defaults to `FeesExcluded`.
     #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub fee_policy: Option<FeePolicy>,
 }
@@ -1256,7 +1256,8 @@ pub struct PrepareLnurlPayResponse {
     pub success_action: Option<SuccessAction>,
     /// When set, the payment will include a token conversion step before sending the payment
     pub conversion_estimate: Option<ConversionEstimate>,
-    /// How fees are handled for this payment.
+    /// The fee policy actually applied. May differ from the request — e.g.,
+    /// AMM-conversion sends are always `FeesIncluded`.
     pub fee_policy: FeePolicy,
 }
 
@@ -1343,15 +1344,23 @@ impl LnurlPayInfo {
 }
 
 /// Specifies how fees are handled in a payment.
+///
+/// "Fees" are the wallet's sender-paid fees (Lightning routing, on-chain,
+/// Spark transfer). They do not include provider spreads or destination-chain
+/// costs on cross-chain routes; those are reported separately via
+/// `estimated_out` on the prepare response and are not deterministic.
+/// `FeePolicy` only controls the wallet's spend accounting.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum FeePolicy {
-    /// Fees are added on top of the specified amount (default behavior).
-    /// The receiver gets the exact amount specified.
+    /// Fees are added on top of `amount`. Wallet's total spend is
+    /// `amount + fees`. For direct sat sends, the recipient receives exactly
+    /// `amount`. Default.
     #[default]
     FeesExcluded,
-    /// Fees are deducted from the specified amount.
-    /// The receiver gets the amount minus fees.
+    /// Fees are deducted from `amount`. Wallet's total spend is `amount`.
+    /// Use this to drain a balance — pass `amount = balance` and the wallet
+    /// spends exactly that.
     FeesIncluded,
 }
 
@@ -1395,7 +1404,12 @@ pub struct PrepareSendPaymentRequest {
     /// If provided, the payment will include a conversion step before sending the payment
     #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub conversion_options: Option<ConversionOptions>,
-    /// How fees should be handled. Defaults to `FeesExcluded` (fees added on top).
+    /// How fees are handled. See [`FeePolicy`]. Defaults to `FeesExcluded`.
+    ///
+    /// Ignored on AMM-conversion sends (whether the conversion was explicitly
+    /// requested or auto-injected by stable balance) — fees come out of the
+    /// converted sats. The prepare response's `fee_policy` reflects what was
+    /// actually applied.
     #[cfg_attr(feature = "uniffi", uniffi(default=None))]
     pub fee_policy: Option<FeePolicy>,
 }
@@ -1414,7 +1428,8 @@ pub struct PrepareSendPaymentResponse {
     pub token_identifier: Option<String>,
     /// When set, the payment will include a conversion step before sending the payment
     pub conversion_estimate: Option<ConversionEstimate>,
-    /// How fees are handled for this payment.
+    /// The fee policy actually applied. May differ from the request — e.g.,
+    /// AMM-conversion sends are always `FeesIncluded`.
     pub fee_policy: FeePolicy,
 }
 

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     BitcoinAddressDetails, BitcoinChainService, BitcoinNetwork, Bolt11InvoiceDetails,
     ExternalInputParser, FiatCurrency, LnurlPayRequestDetails, LnurlWithdrawRequestDetails, Rate,
     SdkError, SparkInvoiceDetails, SuccessAction, SuccessActionProcessed,
-    cross_chain::{CrossChainProviderContext, CrossChainRoutePair},
+    cross_chain::{CrossChainFeeMode, CrossChainProviderContext, CrossChainRoutePair},
     error::DepositClaimError,
 };
 
@@ -1142,7 +1142,16 @@ pub enum SendPaymentMethod {
         route: CrossChainRoutePair,
         /// Raw destination address (e.g. `0xabc...`).
         recipient_address: String,
-        /// Amount (in source base units) the user must transfer.
+        /// Amount routed to the provider (invoice target for Boltz, deposit
+        /// amount for Orchestra). Wallet total cost depends on `fee_mode`:
+        /// - `FeesExcluded`: `amount_in + source_transfer_fee_sats`
+        /// - `FeesIncluded`: the original `amount` on the request (exact
+        ///   when the send-time fee overpayment is not capped; slightly less
+        ///   otherwise).
+        ///
+        /// In `AmountIn` + conversion mode the user transfers tokens (per
+        /// `conversion_estimate.amount_in`) rather than sats on the wallet
+        /// side — `amount_in` still refers to the provider leg in sats.
         amount_in: u128,
         /// Estimated amount the recipient will receive in the destination
         /// asset's base units. Already nets out any destination-chain costs
@@ -1156,6 +1165,13 @@ pub enum SendPaymentMethod {
         fee_amount: u128,
         /// The asset the fee is denominated in (e.g. "USDC", "USDB"). `None` means BTC (sats).
         fee_asset: Option<String>,
+        /// Sats cost to the wallet of moving `amount_in` from the wallet to
+        /// the provider. Boltz: LN routing fee budget (a hard cap enforced
+        /// at send time). Orchestra: Spark transfer fee (0 today).
+        source_transfer_fee_sats: u64,
+        /// Fee mode that was used at prepare time, carried through so the
+        /// send stage applies consistent semantics.
+        fee_mode: CrossChainFeeMode,
         /// ISO8601 timestamp after which this quote is no longer valid.
         expires_at: String,
         /// Provider-internal state produced by `prepareSendPayment` and

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -605,23 +605,20 @@ impl BreezSdk {
 
         let is_conversion = effective_conversion_options.is_some();
 
-        // Boltz conversion + AmountIn + FeesExcluded is unfundable in the
-        // typical stable-balance case: the AMM consumes the token balance, so
-        // there's no separate sats reserve to cover LN routing fees. Reject
-        // the combination rather than supporting a partial set of cases.
-        if is_conversion && fee_policy == FeePolicy::FeesExcluded {
-            return Err(SdkError::InvalidInput(
-                "Token-conversion CrossChain sends require FeesIncluded fee policy.".to_string(),
-            ));
-        }
-
-        let fee_mode = if is_conversion {
-            CrossChainFeeMode::FeesIncluded
+        // On the conversion path, `fee_policy` has no coherent partition: the
+        // wallet's only sats budget comes from the AMM output, so fees can
+        // only come out of that budget. Force `FeesIncluded` regardless of
+        // what the caller passed — keeps the stable-balance illusion intact
+        // for callers that default to `FeesExcluded` for sat sends.
+        let effective_fee_policy = if is_conversion {
+            FeePolicy::FeesIncluded
         } else {
-            match fee_policy {
-                FeePolicy::FeesExcluded => CrossChainFeeMode::FeesExcluded,
-                FeePolicy::FeesIncluded => CrossChainFeeMode::FeesIncluded,
-            }
+            fee_policy
+        };
+
+        let fee_mode = match effective_fee_policy {
+            FeePolicy::FeesExcluded => CrossChainFeeMode::FeesExcluded,
+            FeePolicy::FeesIncluded => CrossChainFeeMode::FeesIncluded,
         };
 
         // Compute conversion estimate + provider-leg amount.
@@ -631,7 +628,7 @@ impl BreezSdk {
                     effective_conversion_options.as_ref(),
                     token_identifier.as_ref(),
                     amount,
-                    fee_policy,
+                    effective_fee_policy,
                 )
                 .await?;
             // Balance sufficiency: token balance must cover conversion input.
@@ -695,7 +692,7 @@ impl BreezSdk {
             amount: provider_amount,
             token_identifier: response_token_identifier,
             conversion_estimate,
-            fee_policy,
+            fee_policy: effective_fee_policy,
         })
     }
 

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -18,7 +18,7 @@ use crate::{
     GetPaymentResponse, InputType, OnchainConfirmationSpeed, PaymentStatus, SendOnchainFeeQuote,
     SendPaymentMethod, SendPaymentOptions, SparkHtlcOptions, SparkInvoiceDetails,
     WaitForPaymentIdentifier,
-    cross_chain::{CrossChainPrepared, CrossChainRoutePair},
+    cross_chain::{CrossChainFeeMode, CrossChainPrepared, CrossChainRoutePair, SourceAsset},
     error::SdkError,
     events::SdkEvent,
     models::{
@@ -160,7 +160,14 @@ impl BreezSdk {
             ))?;
 
             return self
-                .prepare_cross_chain_send(address, route, amount, token_identifier, fee_policy)
+                .prepare_cross_chain_send(
+                    address,
+                    route,
+                    amount,
+                    token_identifier,
+                    request.conversion_options.clone(),
+                    fee_policy,
+                )
                 .await;
         }
 
@@ -557,12 +564,14 @@ impl BreezSdk {
     }
 
     /// Prepare a cross-chain send using the given route.
+    #[allow(clippy::too_many_lines)]
     async fn prepare_cross_chain_send(
         &self,
         address: &str,
         route: &CrossChainRoutePair,
         amount: u128,
         token_identifier: Option<String>,
+        conversion_options: Option<ConversionOptions>,
         fee_policy: FeePolicy,
     ) -> Result<PrepareSendPaymentResponse, SdkError> {
         // Validate address is a recognized cross-chain address.
@@ -572,10 +581,102 @@ impl BreezSdk {
             ));
         }
 
+        crate::utils::send_payment_validation::validate_prepare_cross_chain_request_pre(
+            amount,
+            conversion_options.as_ref(),
+        )?;
+
+        // --- Source-selection decision tree ---
+        let effective_conversion_options = self
+            .resolve_cross_chain_source(
+                route,
+                token_identifier.as_ref(),
+                conversion_options.as_ref(),
+                amount,
+            )
+            .await?;
+
+        // Validate the effective source matches what the route accepts.
+        crate::utils::send_payment_validation::validate_prepare_cross_chain_request_post(
+            route,
+            token_identifier.as_ref(),
+            effective_conversion_options.as_ref(),
+        )?;
+
+        let is_conversion = effective_conversion_options.is_some();
+
+        // Boltz conversion + AmountIn + FeesExcluded is unfundable in the
+        // typical stable-balance case: the AMM consumes the token balance, so
+        // there's no separate sats reserve to cover LN routing fees. Reject
+        // the combination rather than supporting a partial set of cases.
+        if is_conversion && fee_policy == FeePolicy::FeesExcluded {
+            return Err(SdkError::InvalidInput(
+                "Token-conversion CrossChain sends require FeesIncluded fee policy.".to_string(),
+            ));
+        }
+
+        let fee_mode = if is_conversion {
+            CrossChainFeeMode::FeesIncluded
+        } else {
+            match fee_policy {
+                FeePolicy::FeesExcluded => CrossChainFeeMode::FeesExcluded,
+                FeePolicy::FeesIncluded => CrossChainFeeMode::FeesIncluded,
+            }
+        };
+
+        // Compute conversion estimate + provider-leg amount.
+        let (provider_amount, conversion_estimate, response_token_identifier) = if is_conversion {
+            let (estimated_sats, estimate) = self
+                .estimate_sats_from_token_conversion(
+                    effective_conversion_options.as_ref(),
+                    token_identifier.as_ref(),
+                    amount,
+                    fee_policy,
+                )
+                .await?;
+            // Balance sufficiency: token balance must cover conversion input.
+            if let Some(ref ce) = estimate
+                && let ConversionType::ToBitcoin {
+                    from_token_identifier,
+                } = &ce.options.conversion_type
+            {
+                let balances = self.spark_wallet.get_token_balances().await?;
+                let have = balances
+                    .get(from_token_identifier)
+                    .map_or(0u128, |b| b.balance);
+                if have < ce.amount_in {
+                    return Err(SdkError::InvalidInput(format!(
+                        "Insufficient {from_token_identifier} balance for conversion: have {have}, need {}.",
+                        ce.amount_in
+                    )));
+                }
+            }
+            // Response token_identifier is None on ToBitcoin conversion — send
+            // leg is denominated in sats.
+            (estimated_sats, estimate, None)
+        } else {
+            // No conversion: token_identifier on response mirrors the route's
+            // matched source.
+            (amount, None, token_identifier.clone())
+        };
+
         let service = self.cross_chain_providers.get(route.provider)?;
+        // When conversion is active, the provider source is always BTC (sats).
+        let provider_token_identifier = if is_conversion {
+            None
+        } else {
+            token_identifier.clone()
+        };
 
         let prepared = service
-            .prepare(address, route, amount, token_identifier.clone(), None)
+            .prepare(
+                address,
+                route,
+                provider_amount,
+                provider_token_identifier,
+                None,
+                fee_mode,
+            )
             .await?;
 
         Ok(PrepareSendPaymentResponse {
@@ -586,14 +687,87 @@ impl BreezSdk {
                 estimated_out: prepared.estimated_out,
                 fee_amount: prepared.fee_amount,
                 fee_asset: prepared.fee_asset,
+                source_transfer_fee_sats: prepared.source_transfer_fee_sats,
+                fee_mode: prepared.fee_mode,
                 expires_at: prepared.expires_at,
                 provider_context: prepared.provider_context,
             },
-            amount,
-            token_identifier,
-            conversion_estimate: None,
+            amount: provider_amount,
+            token_identifier: response_token_identifier,
+            conversion_estimate,
             fee_policy,
         })
+    }
+
+    /// Resolves the effective `conversion_options` for a cross-chain send.
+    ///
+    /// Decision tree: explicit caller intent wins; then direct send if the
+    /// route accepts the user's `token_identifier`; then auto-inject
+    /// `ToBitcoin` if the token is the stable-balance active token and the
+    /// route accepts sats; then defer to the stable-balance sats-side
+    /// auto-inject when no `token_identifier` was supplied — the inner
+    /// `stable_balance.get_conversion_options` checks `balance_sats >= amount`
+    /// to decide whether a top-up conversion is needed.
+    async fn resolve_cross_chain_source(
+        &self,
+        route: &CrossChainRoutePair,
+        token_identifier: Option<&String>,
+        conversion_options: Option<&ConversionOptions>,
+        amount: u128,
+    ) -> Result<Option<ConversionOptions>, SdkError> {
+        // 1) Explicit caller intent wins.
+        if let Some(opts) = conversion_options {
+            return Ok(Some(opts.clone()));
+        }
+
+        match token_identifier {
+            // 2) Caller specified a token.
+            Some(token_id) => {
+                let route_accepts_token = route
+                    .supported_sources
+                    .iter()
+                    .any(|s| matches!(s, SourceAsset::Token(t) if t == token_id));
+                if route_accepts_token {
+                    // Direct token send — no conversion needed.
+                    return Ok(None);
+                }
+
+                let route_accepts_bitcoin = route.supported_sources.contains(&SourceAsset::Bitcoin);
+                if !route_accepts_bitcoin {
+                    // Neither direct nor auto-inject; caller must handle.
+                    return Ok(None);
+                }
+
+                // Auto-inject ToBitcoin if and only if `token_id` is the
+                // stable-balance active token.
+                if let Some(sb) = &self.stable_balance
+                    && sb.get_active_token_identifier().await.as_deref() == Some(token_id)
+                {
+                    return Ok(Some(ConversionOptions {
+                        conversion_type: ConversionType::ToBitcoin {
+                            from_token_identifier: token_id.clone(),
+                        },
+                        max_slippage_bps: sb.config.max_slippage_bps,
+                        completion_timeout_secs: None,
+                    }));
+                }
+                Ok(None)
+            }
+            // 3) No token specified.
+            None => {
+                if route.supported_sources.contains(&SourceAsset::Bitcoin) {
+                    // Defer to stable_balance auto-inject: fires when the
+                    // sats balance is insufficient to cover `amount`.
+                    self.get_conversion_options_for_payment(None, None, amount)
+                        .await
+                } else {
+                    // Route only accepts tokens but user didn't specify one.
+                    // FromBitcoin + CrossChain is out of scope; nothing to
+                    // auto-inject. Leave as None; post-validation will error.
+                    Ok(None)
+                }
+            }
+        }
     }
 
     pub(super) async fn maybe_convert_token_send_payment(
@@ -846,14 +1020,57 @@ impl BreezSdk {
                     .await?;
                 Ok((response, purpose, uses_amount_in))
             }
-            SendPaymentMethod::CrossChainAddress { .. } => {
-                // Cross-chain sends bypass the AMM token converter entirely;
-                // they should never reach pre-send conversion.
-                Err(SdkError::InvalidInput(
-                    "Cross-chain sends do not support AMM conversions".to_string(),
-                ))
+            SendPaymentMethod::CrossChainAddress {
+                recipient_address, ..
+            } => {
+                let purpose = ConversionPurpose::OngoingPayment {
+                    payment_request: recipient_address.clone(),
+                };
+                let conversion_amount_override = match &conversion_amount {
+                    ConversionAmount::AmountIn(_) => Some(conversion_amount),
+                    ConversionAmount::MinAmountOut(_) => None,
+                };
+                let response = self
+                    .convert_token_for_crosschain(
+                        conversion_options,
+                        amount,
+                        &purpose,
+                        from_token_identifier.as_ref(),
+                        conversion_amount_override,
+                    )
+                    .await?;
+                Ok((response, purpose, uses_amount_in))
             }
         }
+    }
+
+    /// Runs the AMM token conversion for a cross-chain send.
+    ///
+    /// - **`AmountIn`**: converter's slippage floor is the prepare-time
+    ///   `estimate.amount_out`. Pass through.
+    /// - **`MinAmountOut`**: converter must deliver at least `response.amount`
+    ///   sats (the sats target the provider leg was sized for).
+    async fn convert_token_for_crosschain(
+        &self,
+        conversion_options: &ConversionOptions,
+        amount: u128,
+        conversion_purpose: &ConversionPurpose,
+        token_identifier: Option<&String>,
+        conversion_amount_override: Option<ConversionAmount>,
+    ) -> Result<TokenConversionResponse, SdkError> {
+        let conversion_amount =
+            conversion_amount_override.unwrap_or(ConversionAmount::MinAmountOut(amount));
+
+        self.token_converter
+            .convert(
+                conversion_options,
+                conversion_purpose,
+                token_identifier,
+                conversion_amount,
+                None,
+            )
+            .await
+            .map_err(Into::into)
     }
 
     /// Links conversion child payments to their parent to hide them from `list_payments`.
@@ -1086,6 +1303,8 @@ impl BreezSdk {
                 estimated_out,
                 fee_amount,
                 fee_asset,
+                source_transfer_fee_sats,
+                fee_mode,
                 expires_at,
                 provider_context,
             } => {
@@ -1096,6 +1315,8 @@ impl BreezSdk {
                     estimated_out: *estimated_out,
                     fee_amount: *fee_amount,
                     fee_asset: fee_asset.clone(),
+                    source_transfer_fee_sats: *source_transfer_fee_sats,
+                    fee_mode: *fee_mode,
                     expires_at: expires_at.clone(),
                     pair: route.clone(),
                     recipient_address: recipient_address.clone(),
@@ -1848,10 +2069,11 @@ impl BreezSdk {
 
         let input_str = match &request.payment_request {
             PaymentRequest::Input { input: s } => s.as_str(),
+            // `prepare_send_payment` intercepts `PaymentRequest::CrossChain`
+            // up front and dispatches to `prepare_cross_chain_send`, so the
+            // Bolt11 path is only ever entered with `PaymentRequest::Input`.
             PaymentRequest::CrossChain { .. } => {
-                return Err(SdkError::InvalidInput(
-                    "Token conversion is not supported for cross-chain sends".to_string(),
-                ));
+                unreachable!("CrossChain dispatched before bolt11 prepare path")
             }
         };
         let lightning_fee_sats = self

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -712,57 +712,26 @@ impl BreezSdk {
         conversion_options: Option<&ConversionOptions>,
         amount: u128,
     ) -> Result<Option<ConversionOptions>, SdkError> {
-        // 1) Explicit caller intent wins.
-        if let Some(opts) = conversion_options {
-            return Ok(Some(opts.clone()));
-        }
+        let active_stable_token = match &self.stable_balance {
+            Some(sb) => sb.get_active_token_identifier().await,
+            None => None,
+        };
+        let stable_max_slippage_bps = self
+            .stable_balance
+            .as_ref()
+            .and_then(|sb| sb.config.max_slippage_bps);
 
-        match token_identifier {
-            // 2) Caller specified a token.
-            Some(token_id) => {
-                let route_accepts_token = route
-                    .supported_sources
-                    .iter()
-                    .any(|s| matches!(s, SourceAsset::Token(t) if t == token_id));
-                if route_accepts_token {
-                    // Direct token send — no conversion needed.
-                    return Ok(None);
-                }
-
-                let route_accepts_bitcoin = route.supported_sources.contains(&SourceAsset::Bitcoin);
-                if !route_accepts_bitcoin {
-                    // Neither direct nor auto-inject; caller must handle.
-                    return Ok(None);
-                }
-
-                // Auto-inject ToBitcoin if and only if `token_id` is the
-                // stable-balance active token.
-                if let Some(sb) = &self.stable_balance
-                    && sb.get_active_token_identifier().await.as_deref() == Some(token_id)
-                {
-                    return Ok(Some(ConversionOptions {
-                        conversion_type: ConversionType::ToBitcoin {
-                            from_token_identifier: token_id.clone(),
-                        },
-                        max_slippage_bps: sb.config.max_slippage_bps,
-                        completion_timeout_secs: None,
-                    }));
-                }
-                Ok(None)
-            }
-            // 3) No token specified.
-            None => {
-                if route.supported_sources.contains(&SourceAsset::Bitcoin) {
-                    // Defer to stable_balance auto-inject: fires when the
-                    // sats balance is insufficient to cover `amount`.
-                    self.get_conversion_options_for_payment(None, None, amount)
-                        .await
-                } else {
-                    // Route only accepts tokens but user didn't specify one.
-                    // FromBitcoin + CrossChain is out of scope; nothing to
-                    // auto-inject. Leave as None; post-validation will error.
-                    Ok(None)
-                }
+        match resolve_cross_chain_source_pure(
+            route,
+            token_identifier,
+            conversion_options,
+            active_stable_token.as_ref(),
+            stable_max_slippage_bps,
+        ) {
+            CrossChainSourceResolution::UseAsIs(opts) => Ok(opts),
+            CrossChainSourceResolution::DeferToStableBalance => {
+                self.get_conversion_options_for_payment(None, None, amount)
+                    .await
             }
         }
     }
@@ -2069,8 +2038,12 @@ impl BreezSdk {
             // `prepare_send_payment` intercepts `PaymentRequest::CrossChain`
             // up front and dispatches to `prepare_cross_chain_send`, so the
             // Bolt11 path is only ever entered with `PaymentRequest::Input`.
+            // Defensive guard: error rather than panic if the dispatcher
+            // invariant is ever violated.
             PaymentRequest::CrossChain { .. } => {
-                unreachable!("CrossChain dispatched before bolt11 prepare path")
+                return Err(SdkError::Generic(
+                    "internal: CrossChain reached bolt11 prepare path".to_string(),
+                ));
             }
         };
         let lightning_fee_sats = self
@@ -2211,5 +2184,253 @@ impl BreezSdk {
             )
             .await
             .map_err(Into::into)
+    }
+}
+
+/// Result of the pure cross-chain source-selection decision tree.
+///
+/// `DeferToStableBalance` covers the no-token + sats-supported case where the
+/// caller must consult `stable_balance.get_conversion_options` (which itself
+/// depends on the runtime sats balance) to decide whether a top-up conversion
+/// is needed. Every other branch is fully resolved by static inputs.
+#[derive(Debug, Clone, PartialEq)]
+enum CrossChainSourceResolution {
+    UseAsIs(Option<ConversionOptions>),
+    DeferToStableBalance,
+}
+
+/// Pure decision logic for `BreezSdk::resolve_cross_chain_source`.
+///
+/// Inputs:
+/// - `active_stable_token` — `Some(id)` when stable-balance is configured AND
+///   has an active token; `None` otherwise.
+/// - `stable_max_slippage_bps` — slippage from `StableBalanceConfig` to put on
+///   the auto-injected `ToBitcoin` options when stable-balance fires.
+fn resolve_cross_chain_source_pure(
+    route: &CrossChainRoutePair,
+    token_identifier: Option<&String>,
+    conversion_options: Option<&ConversionOptions>,
+    active_stable_token: Option<&String>,
+    stable_max_slippage_bps: Option<u32>,
+) -> CrossChainSourceResolution {
+    // 1) Explicit caller intent wins.
+    if let Some(opts) = conversion_options {
+        return CrossChainSourceResolution::UseAsIs(Some(opts.clone()));
+    }
+
+    match token_identifier {
+        // 2) Caller specified a token.
+        Some(token_id) => {
+            let route_accepts_token = route
+                .supported_sources
+                .iter()
+                .any(|s| matches!(s, SourceAsset::Token(t) if t == token_id));
+            if route_accepts_token {
+                // Direct token send — no conversion needed.
+                return CrossChainSourceResolution::UseAsIs(None);
+            }
+
+            let route_accepts_bitcoin = route.supported_sources.contains(&SourceAsset::Bitcoin);
+            if !route_accepts_bitcoin {
+                // Neither direct nor auto-inject; caller must handle.
+                return CrossChainSourceResolution::UseAsIs(None);
+            }
+
+            // Auto-inject ToBitcoin if and only if `token_id` is the
+            // stable-balance active token.
+            if active_stable_token == Some(token_id) {
+                return CrossChainSourceResolution::UseAsIs(Some(ConversionOptions {
+                    conversion_type: ConversionType::ToBitcoin {
+                        from_token_identifier: token_id.clone(),
+                    },
+                    max_slippage_bps: stable_max_slippage_bps,
+                    completion_timeout_secs: None,
+                }));
+            }
+            CrossChainSourceResolution::UseAsIs(None)
+        }
+        // 3) No token specified.
+        None => {
+            if route.supported_sources.contains(&SourceAsset::Bitcoin) {
+                // Defer to stable_balance auto-inject: fires when the
+                // sats balance is insufficient to cover `amount`.
+                CrossChainSourceResolution::DeferToStableBalance
+            } else {
+                // Route only accepts tokens but user didn't specify one.
+                // FromBitcoin + CrossChain is out of scope; nothing to
+                // auto-inject. Leave as None; post-validation will error.
+                CrossChainSourceResolution::UseAsIs(None)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CrossChainProvider;
+
+    fn make_route(supported_sources: Vec<SourceAsset>) -> CrossChainRoutePair {
+        CrossChainRoutePair {
+            provider: CrossChainProvider::Orchestra,
+            chain: "tron".to_string(),
+            chain_id: None,
+            asset: "USDT".to_string(),
+            contract_address: None,
+            decimals: 6,
+            exact_out_eligible: false,
+            supported_sources,
+        }
+    }
+
+    fn explicit_options() -> ConversionOptions {
+        ConversionOptions {
+            conversion_type: ConversionType::ToBitcoin {
+                from_token_identifier: "USDC".to_string(),
+            },
+            max_slippage_bps: Some(123),
+            completion_timeout_secs: Some(42),
+        }
+    }
+
+    #[test]
+    fn explicit_conversion_options_win() {
+        // Even when the route would accept the token directly, explicit
+        // caller-supplied options short-circuit the decision tree.
+        let route = make_route(vec![SourceAsset::Token("USDB".to_string())]);
+        let opts = explicit_options();
+        let usdb = "USDB".to_string();
+
+        let result = resolve_cross_chain_source_pure(
+            &route,
+            Some(&usdb),
+            Some(&opts),
+            Some(&usdb),
+            Some(50),
+        );
+
+        assert_eq!(
+            result,
+            CrossChainSourceResolution::UseAsIs(Some(opts.clone())),
+            "explicit options should pass through unchanged"
+        );
+    }
+
+    #[test]
+    fn token_directly_supported_no_conversion() {
+        let route = make_route(vec![SourceAsset::Token("USDB".to_string())]);
+        let usdb = "USDB".to_string();
+
+        let result =
+            resolve_cross_chain_source_pure(&route, Some(&usdb), None, Some(&usdb), Some(50));
+
+        assert_eq!(
+            result,
+            CrossChainSourceResolution::UseAsIs(None),
+            "direct token send should not auto-inject conversion"
+        );
+    }
+
+    #[test]
+    fn token_unsupported_route_lacks_bitcoin_no_inject() {
+        // Route only supports a different token; no Bitcoin path exists, so
+        // we cannot auto-inject ToBitcoin. Leave as None — post-validation
+        // will reject.
+        let route = make_route(vec![SourceAsset::Token("USDB".to_string())]);
+        let user_token = "USDC".to_string();
+        let active_stable_token = "USDB".to_string();
+
+        let result = resolve_cross_chain_source_pure(
+            &route,
+            Some(&user_token),
+            None,
+            Some(&active_stable_token),
+            Some(50),
+        );
+
+        assert_eq!(result, CrossChainSourceResolution::UseAsIs(None));
+    }
+
+    #[test]
+    fn token_is_active_stable_balance_auto_injects_to_bitcoin() {
+        // Route accepts sats but not the user's token; the user's token IS
+        // the stable-balance active token, so auto-inject ToBitcoin.
+        let route = make_route(vec![SourceAsset::Bitcoin]);
+        let usdb = "USDB".to_string();
+
+        let result =
+            resolve_cross_chain_source_pure(&route, Some(&usdb), None, Some(&usdb), Some(75));
+
+        let expected_opts = ConversionOptions {
+            conversion_type: ConversionType::ToBitcoin {
+                from_token_identifier: "USDB".to_string(),
+            },
+            max_slippage_bps: Some(75),
+            completion_timeout_secs: None,
+        };
+        assert_eq!(
+            result,
+            CrossChainSourceResolution::UseAsIs(Some(expected_opts))
+        );
+    }
+
+    #[test]
+    fn token_is_not_active_stable_balance_no_inject() {
+        // Route accepts sats and a token, the user supplied a token, but the
+        // token is NOT the stable-balance active token — we leave the
+        // conversion options None. Post-validation will reject because the
+        // effective source (Token(USDC)) isn't in supported_sources.
+        let route = make_route(vec![SourceAsset::Bitcoin]);
+        let user_token = "USDC".to_string();
+        let active_stable_token = "USDB".to_string();
+
+        let result = resolve_cross_chain_source_pure(
+            &route,
+            Some(&user_token),
+            None,
+            Some(&active_stable_token),
+            Some(50),
+        );
+
+        assert_eq!(result, CrossChainSourceResolution::UseAsIs(None));
+    }
+
+    #[test]
+    fn token_specified_no_stable_balance_configured_no_inject() {
+        let route = make_route(vec![SourceAsset::Bitcoin]);
+        let usdb = "USDB".to_string();
+
+        let result = resolve_cross_chain_source_pure(&route, Some(&usdb), None, None, None);
+
+        assert_eq!(
+            result,
+            CrossChainSourceResolution::UseAsIs(None),
+            "without stable balance, no auto-inject is possible"
+        );
+    }
+
+    #[test]
+    fn no_token_route_accepts_sats_defers_to_stable_balance() {
+        let route = make_route(vec![SourceAsset::Bitcoin]);
+
+        let result = resolve_cross_chain_source_pure(&route, None, None, None, None);
+
+        assert_eq!(
+            result,
+            CrossChainSourceResolution::DeferToStableBalance,
+            "no-token + sats-route must defer so stable balance can decide"
+        );
+    }
+
+    #[test]
+    fn no_token_route_token_only_no_inject() {
+        // Route only accepts a token; caller didn't specify one and we
+        // cannot auto-inject FromBitcoin (out of scope). Post-validation
+        // will reject.
+        let route = make_route(vec![SourceAsset::Token("USDB".to_string())]);
+
+        let result = resolve_cross_chain_source_pure(&route, None, None, None, None);
+
+        assert_eq!(result, CrossChainSourceResolution::UseAsIs(None));
     }
 }

--- a/crates/breez-sdk/core/src/token_conversion/models.rs
+++ b/crates/breez-sdk/core/src/token_conversion/models.rs
@@ -376,7 +376,7 @@ pub(crate) struct TokenConversionResponse {
 /// Options for conversion when fulfilling a payment. When set, the SDK will
 /// perform a conversion before fulfilling the payment. If not set, the payment
 /// will only be fulfilled if the wallet has sufficient balance of the required asset.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct ConversionOptions {
     /// The type of conversion to perform when fulfilling the payment

--- a/crates/breez-sdk/core/src/utils/send_payment_validation.rs
+++ b/crates/breez-sdk/core/src/utils/send_payment_validation.rs
@@ -2,7 +2,10 @@ use bitcoin::address::NetworkUnchecked;
 
 use crate::{
     Bolt11InvoiceDetails, ConversionOptions, ConversionType, FeePolicy, InputType,
-    SparkInvoiceDetails, error::SdkError, models::PrepareSendPaymentRequest,
+    SparkInvoiceDetails,
+    cross_chain::{CrossChainRoutePair, SourceAsset},
+    error::SdkError,
+    models::PrepareSendPaymentRequest,
 };
 use platform_utils::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -274,6 +277,74 @@ fn validate_bitcoin_address_request(request: &PrepareSendPaymentRequest) -> Resu
         return Err(SdkError::InvalidInput(
             "Conversion must be to Bitcoin for Bitcoin addresses".to_string(),
         ));
+    }
+
+    Ok(())
+}
+
+/// Pre-decision-tree validation for cross-chain sends.
+///
+/// Runs at the top of `prepare_cross_chain_send` before route source
+/// resolution. Validates amount is positive and that `FromBitcoin` is not
+/// requested.
+pub(crate) fn validate_prepare_cross_chain_request_pre(
+    amount: u128,
+    conversion_options: Option<&ConversionOptions>,
+) -> Result<(), SdkError> {
+    if amount == 0 {
+        return Err(SdkError::InvalidInput(
+            "Amount must be greater than 0.".to_string(),
+        ));
+    }
+
+    if let Some(ConversionOptions {
+        conversion_type: ConversionType::FromBitcoin,
+        ..
+    }) = conversion_options
+    {
+        return Err(SdkError::InvalidInput(
+            "FromBitcoin conversion is not supported for cross-chain sends.".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Post-decision-tree validation: the effective source asset must be in the
+/// route's `supported_sources`.
+pub(crate) fn validate_prepare_cross_chain_request_post(
+    route: &CrossChainRoutePair,
+    token_identifier: Option<&String>,
+    effective_conversion_options: Option<&ConversionOptions>,
+) -> Result<(), SdkError> {
+    let effective_source = if effective_conversion_options.is_some() {
+        // Conversion runs before the provider leg → source is always sats.
+        SourceAsset::Bitcoin
+    } else {
+        match token_identifier {
+            Some(tid) => SourceAsset::Token(tid.clone()),
+            None => SourceAsset::Bitcoin,
+        }
+    };
+
+    if !route.supported_sources.contains(&effective_source) {
+        let supported_list = route
+            .supported_sources
+            .iter()
+            .map(|s| match s {
+                SourceAsset::Bitcoin => "sats".to_string(),
+                SourceAsset::Token(t) => t.clone(),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(SdkError::InvalidInput(match token_identifier {
+            Some(tid) => format!(
+                "Route does not accept source asset {tid}. Supported: {supported_list}. Provide a token_identifier matching one of the supported sources, or pick another route."
+            ),
+            None => format!(
+                "Route does not accept sats. Provide a token_identifier matching one of: {supported_list}."
+            ),
+        }));
     }
 
     Ok(())
@@ -1274,6 +1345,125 @@ mod tests {
             result.is_ok(),
             "Should succeed for FeesIncluded with ToBitcoin conversion (send-all-with-conversion)"
         );
+    }
+
+    // CrossChain validation tests
+    fn make_route(supported_sources: Vec<SourceAsset>) -> CrossChainRoutePair {
+        CrossChainRoutePair {
+            provider: crate::CrossChainProvider::Orchestra,
+            chain: "tron".to_string(),
+            chain_id: None,
+            asset: "USDT".to_string(),
+            contract_address: None,
+            decimals: 6,
+            exact_out_eligible: false,
+            supported_sources,
+        }
+    }
+
+    #[test_all]
+    fn test_validate_prepare_cross_chain_pre_zero_amount() {
+        let result = validate_prepare_cross_chain_request_pre(0, None);
+        assert!(result.is_err(), "Should fail for amount == 0");
+        if let Err(SdkError::InvalidInput(msg)) = result {
+            assert!(
+                msg.contains("greater than 0"),
+                "Error message should mention requirement"
+            );
+        } else {
+            panic!("Expected InvalidInput error");
+        }
+    }
+
+    #[test_all]
+    fn test_validate_prepare_cross_chain_pre_from_bitcoin_rejected() {
+        let options = ConversionOptions {
+            conversion_type: ConversionType::FromBitcoin,
+            max_slippage_bps: None,
+            completion_timeout_secs: None,
+        };
+        let result = validate_prepare_cross_chain_request_pre(1000, Some(&options));
+        assert!(result.is_err(), "Should fail for FromBitcoin");
+        if let Err(SdkError::InvalidInput(msg)) = result {
+            assert!(
+                msg.contains("FromBitcoin"),
+                "Error message should mention FromBitcoin"
+            );
+        } else {
+            panic!("Expected InvalidInput error");
+        }
+    }
+
+    #[test_all]
+    fn test_validate_prepare_cross_chain_pre_to_bitcoin_allowed() {
+        let options = ConversionOptions {
+            conversion_type: ConversionType::ToBitcoin {
+                from_token_identifier: "USDB".to_string(),
+            },
+            max_slippage_bps: None,
+            completion_timeout_secs: None,
+        };
+        let result = validate_prepare_cross_chain_request_pre(1000, Some(&options));
+        assert!(result.is_ok(), "ToBitcoin should be allowed");
+    }
+
+    #[test_all]
+    fn test_validate_prepare_cross_chain_post_direct_sats_ok() {
+        let route = make_route(vec![SourceAsset::Bitcoin]);
+        let result = validate_prepare_cross_chain_request_post(&route, None, None);
+        assert!(result.is_ok(), "Direct sats send should be accepted");
+    }
+
+    #[test_all]
+    fn test_validate_prepare_cross_chain_post_direct_token_ok() {
+        let route = make_route(vec![SourceAsset::Token("USDB".to_string())]);
+        let tid = "USDB".to_string();
+        let result = validate_prepare_cross_chain_request_post(&route, Some(&tid), None);
+        assert!(result.is_ok(), "Direct token send should be accepted");
+    }
+
+    #[test_all]
+    fn test_validate_prepare_cross_chain_post_token_mismatch_rejected() {
+        let route = make_route(vec![SourceAsset::Bitcoin]);
+        let tid = "USDC".to_string();
+        // No auto-inject fired → effective source is Token(USDC), route only
+        // accepts sats → reject.
+        let result = validate_prepare_cross_chain_request_post(&route, Some(&tid), None);
+        assert!(result.is_err(), "Source mismatch should be rejected");
+        if let Err(SdkError::InvalidInput(msg)) = result {
+            assert!(
+                msg.contains("USDC"),
+                "Error should mention the rejected token"
+            );
+        } else {
+            panic!("Expected InvalidInput error");
+        }
+    }
+
+    #[test_all]
+    fn test_validate_prepare_cross_chain_post_sats_unsupported_rejected() {
+        let route = make_route(vec![SourceAsset::Token("USDB".to_string())]);
+        let result = validate_prepare_cross_chain_request_post(&route, None, None);
+        assert!(
+            result.is_err(),
+            "Route without sats support should reject sats send"
+        );
+    }
+
+    #[test_all]
+    fn test_validate_prepare_cross_chain_post_conversion_forces_bitcoin() {
+        let route = make_route(vec![SourceAsset::Bitcoin]);
+        let tid = "USDB".to_string();
+        let options = ConversionOptions {
+            conversion_type: ConversionType::ToBitcoin {
+                from_token_identifier: tid.clone(),
+            },
+            max_slippage_bps: None,
+            completion_timeout_secs: None,
+        };
+        // Conversion is active → effective source is sats → route accepts sats.
+        let result = validate_prepare_cross_chain_request_post(&route, Some(&tid), Some(&options));
+        assert!(result.is_ok(), "Conversion path should pass");
     }
 
     // Dust limit tests

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -863,6 +863,18 @@ pub enum CrossChainRouteFilter {
     },
 }
 
+#[macros::extern_wasm_bindgen(breez_sdk_spark::SourceAsset)]
+pub enum SourceAsset {
+    Bitcoin,
+    Token(String),
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::CrossChainFeeMode)]
+pub enum CrossChainFeeMode {
+    FeesExcluded,
+    FeesIncluded,
+}
+
 #[macros::extern_wasm_bindgen(breez_sdk_spark::CrossChainRoutePair)]
 pub struct CrossChainRoutePair {
     pub provider: CrossChainProvider,
@@ -873,6 +885,7 @@ pub struct CrossChainRoutePair {
     pub contract_address: Option<String>,
     pub decimals: u8,
     pub exact_out_eligible: bool,
+    pub supported_sources: Vec<SourceAsset>,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::CrossChainProviderContext)]
@@ -884,7 +897,6 @@ pub enum CrossChainProviderContext {
     Boltz {
         swap_id: String,
         invoice: String,
-        ln_fee_sats: u64,
         max_slippage_bps: u32,
     },
 }
@@ -938,6 +950,8 @@ pub enum SendPaymentMethod {
         #[serde(with = "serde_u128_as_string")]
         fee_amount: u128,
         fee_asset: Option<String>,
+        source_transfer_fee_sats: u64,
+        fee_mode: CrossChainFeeMode,
         expires_at: String,
         provider_context: CrossChainProviderContext,
     },

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=bc291392e232fe39741b988f484b540e4a827ec4#bc291392e232fe39741b988f484b540e4a827ec4"
+source = "git+https://github.com/breez/boltz-client?rev=50db30770c5422de131bad9fb5c45b4108a90340#50db30770c5422de131bad9fb5c45b4108a90340"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -1129,8 +1129,8 @@ dependencies = [
  "hex",
  "k256",
  "lightning-invoice 0.34.0",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=bc291392e232fe39741b988f484b540e4a827ec4)",
- "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=bc291392e232fe39741b988f484b540e4a827ec4)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=50db30770c5422de131bad9fb5c45b4108a90340)",
+ "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=50db30770c5422de131bad9fb5c45b4108a90340)",
  "serde",
  "serde_json",
  "sha2",
@@ -3210,7 +3210,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=bc291392e232fe39741b988f484b540e4a827ec4#bc291392e232fe39741b988f484b540e4a827ec4"
+source = "git+https://github.com/breez/boltz-client?rev=50db30770c5422de131bad9fb5c45b4108a90340#50db30770c5422de131bad9fb5c45b4108a90340"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3619,12 +3619,12 @@ dependencies = [
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=bc291392e232fe39741b988f484b540e4a827ec4#bc291392e232fe39741b988f484b540e4a827ec4"
+source = "git+https://github.com/breez/boltz-client?rev=50db30770c5422de131bad9fb5c45b4108a90340#50db30770c5422de131bad9fb5c45b4108a90340"
 dependencies = [
  "async-trait",
  "base64",
  "bitreq 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=bc291392e232fe39741b988f484b540e4a827ec4)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=50db30770c5422de131bad9fb5c45b4108a90340)",
  "reqwest",
  "serde",
  "serde_json",

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -248,6 +248,18 @@ pub struct _CrossChainAddressDetails {
     pub amount: Option<u128>,
 }
 
+#[frb(mirror(SourceAsset))]
+pub enum _SourceAsset {
+    Bitcoin,
+    Token(String),
+}
+
+#[frb(mirror(CrossChainFeeMode))]
+pub enum _CrossChainFeeMode {
+    FeesExcluded,
+    FeesIncluded,
+}
+
 #[frb(mirror(CrossChainRoutePair))]
 pub struct _CrossChainRoutePair {
     pub provider: CrossChainProvider,
@@ -257,6 +269,7 @@ pub struct _CrossChainRoutePair {
     pub contract_address: Option<String>,
     pub decimals: u8,
     pub exact_out_eligible: bool,
+    pub supported_sources: Vec<SourceAsset>,
 }
 
 #[frb(mirror(CrossChainProviderContext))]
@@ -268,7 +281,6 @@ pub enum _CrossChainProviderContext {
     Boltz {
         swap_id: String,
         invoice: String,
-        ln_fee_sats: u64,
         max_slippage_bps: u32,
     },
 }
@@ -549,6 +561,8 @@ pub enum _SendPaymentMethod {
         estimated_out: u128,
         fee_amount: u128,
         fee_asset: Option<String>,
+        source_transfer_fee_sats: u64,
+        fee_mode: CrossChainFeeMode,
         expires_at: String,
         provider_context: CrossChainProviderContext,
     },


### PR DESCRIPTION
Extends the send-with-conversion pipeline (SparkAddress / SparkInvoice / Bolt11 / BitcoinAddress) to CrossChain. Primary motivation: USDB-only stable-balance wallets can now pay Boltz destinations (Boltz accepts sats only) by auto-converting through the Flashnet AMM.

## What changed

- **New types**: `SourceAsset { Bitcoin, Token(String) }`, `CrossChainFeeMode { FeesExcluded, FeesIncluded }`.
- **`CrossChainRoutePair`** gains `supported_sources: Vec<SourceAsset>` so the prepare layer can decide whether auto-conversion is needed without provider-specific knowledge.
- **`CrossChainPrepared` / `SendPaymentMethod::CrossChainAddress`** gain `source_transfer_fee_sats: u64` (LN routing budget for Boltz, Spark transfer fee for Orchestra) and `fee_mode`. Boltz's `ln_fee_sats` moved out of the provider context into this public field — the send path enforces it as a hard cap.
- **Orchestra**: `get_routes` dedups by destination endpoint but accumulates source variants into `supported_sources`. `prepare` resolves the Orchestra-side `source_asset` string via the cached `spark_routes` (replaces the `Some(_) → "USDB"` hardcode, supports any future Spark source).
- **Boltz**: `prepare` grows a two-phase `FeesIncluded` path (throwaway invoice probes LN fee → real invoice sized to `amount − probe`, with a guard if the probe drifts between calls). `send` mirrors LNURL's overpayment logic so the full `FeesIncluded` budget is consumed.
- **`prepare_cross_chain_send`**: runs a source-selection decision tree (explicit options → direct send if route accepts the token → auto-inject `ToBitcoin` when the token is the stable-balance active token → defer to stable-balance auto-inject for sats), validates `amount > 0` + token balance sufficiency, forces `FeesIncluded` on conversion paths, and rejects `FromBitcoin + CrossChain`.
- **`execute_pre_send_conversion`**: `CrossChainAddress` branch added via a new `convert_token_for_crosschain` helper; the previous `Err` arm is removed.
- **Validation**: pre/post helpers reject `amount = 0`, `FromBitcoin + CrossChain`, and effective-source-not-in-`supported_sources`.
- **CLI**: route picker prints `supported_sources=[…]`; cross-chain confirmation prompt prints `Source transfer fee` alongside `Fee`.
- **Bindings**: WASM and Flutter mirrors updated for the new types and fields.

## What's out of scope

- FromBitcoin + CrossChain (sats → non-stable token send).
- Non-USDB token source routed through USDB via AMM (USDC → USDB → Orchestra).
- Idempotency key support for CrossChain conversion paths (tracked separately; retry may re-run the AMM leg).