### PR TITLE
Core: Add `Unrecoverable` error at startup for storage init

### DIFF
--- a/crates/breez-sdk/core/src/common/sync_storage.rs
+++ b/crates/breez-sdk/core/src/common/sync_storage.rs
@@ -16,7 +16,9 @@ impl SyncStorageWrapper {
 
 fn storage_to_sync_error(value: StorageError) -> breez_sdk_common::sync::storage::SyncStorageError {
     match value {
-        StorageError::Connection(msg) | StorageError::Implementation(msg) => {
+        StorageError::Connection(msg)
+        | StorageError::Implementation(msg)
+        | StorageError::MigrationError(msg) => {
             breez_sdk_common::sync::storage::SyncStorageError::Implementation(msg)
         }
         StorageError::InitializationError(msg) => {

--- a/crates/breez-sdk/core/src/error.rs
+++ b/crates/breez-sdk/core/src/error.rs
@@ -34,8 +34,8 @@ pub enum SdkError {
     NetworkError(String),
 
     /// Storage error
-    #[error("Storage error: {0}")]
-    StorageError(String),
+    #[error("Storage error: {message}")]
+    StorageError { recoverable: bool, message: String },
 
     #[error("Chain service error: {0}")]
     ChainServiceError(String),
@@ -117,7 +117,10 @@ impl From<crate::token_conversion::ConversionError> for SdkError {
                 SdkError::Generic("Duplicate transfer: conversion already handled".to_string())
             }
             ConversionError::Sdk(e) => e,
-            ConversionError::Storage(e) => SdkError::StorageError(e.to_string()),
+            ConversionError::Storage(e) => SdkError::StorageError {
+                recoverable: true,
+                message: e.to_string(),
+            },
             ConversionError::Wallet(e) => SdkError::SparkError(e.to_string()),
         }
     }
@@ -127,7 +130,18 @@ impl From<persist::StorageError> for SdkError {
     fn from(e: persist::StorageError) -> Self {
         match e {
             persist::StorageError::NotFound => SdkError::InvalidInput("Not found".to_string()),
-            _ => SdkError::StorageError(e.to_string()),
+            // Migration failures indicate corrupted storage that cannot be recovered by retrying.
+            // The app must clear its local data (storage directory) and call `connect` again.
+            persist::StorageError::MigrationError(err) => SdkError::StorageError {
+                recoverable: false,
+                message: format!(
+                    "Unrecoverable storage error, delete the storage directory and try again: {err}"
+                ),
+            },
+            _ => SdkError::StorageError {
+                recoverable: true,
+                message: e.to_string(),
+            },
         }
     }
 }

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -101,6 +101,9 @@ pub enum StorageError {
     #[error("Failed to initialize database: {0}")]
     InitializationError(String),
 
+    #[error("Failed to migrate database: {0}")]
+    MigrationError(String),
+
     #[error("Failed to serialize/deserialize data: {0}")]
     Serialization(String),
 

--- a/crates/breez-sdk/core/src/persist/sqlite.rs
+++ b/crates/breez-sdk/core/src/persist/sqlite.rs
@@ -356,7 +356,7 @@ impl From<rusqlite::Error> for StorageError {
 
 impl From<rusqlite_migration::Error> for StorageError {
     fn from(value: rusqlite_migration::Error) -> Self {
-        StorageError::Implementation(value.to_string())
+        StorageError::MigrationError(value.to_string())
     }
 }
 

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -635,8 +635,7 @@ impl SdkBuilder {
                         pool.clone(),
                         identity,
                     )
-                    .await
-                    .map_err(|e| SdkError::Generic(e.to_string()))?,
+                    .await?,
                 ));
             }
 
@@ -649,8 +648,7 @@ impl SdkBuilder {
             {
                 s = Some(Arc::new(
                     crate::persist::mysql::MysqlStorage::new_with_pool(pool.clone(), identity)
-                        .await
-                        .map_err(|e| SdkError::Generic(e.to_string()))?,
+                        .await?,
                 ));
             }
 

--- a/docs/breez-sdk/snippets/csharp/GettingStarted.cs
+++ b/docs/breez-sdk/snippets/csharp/GettingStarted.cs
@@ -159,5 +159,38 @@ namespace BreezSdkSnippets
             await sdk.Disconnect();
         }
         // ANCHOR_END: disconnect
+
+        // ANCHOR: corrupt-storage-error
+        async Task<BreezSdk> ConnectWithRecovery()
+        {
+            var storageDir = "./.data";
+
+            ConnectRequest MakeRequest()
+            {
+                var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+                {
+                    apiKey = "<breez api key>"
+                };
+                return new ConnectRequest(
+                    config: config,
+                    seed: new Seed.Mnemonic(mnemonic: "<mnemonic words>", passphrase: null),
+                    storageDir: storageDir
+                );
+            }
+
+            try
+            {
+                return await BreezSdkSparkMethods.Connect(MakeRequest());
+            }
+            catch (SdkException.StorageError e) when (!e.Recoverable)
+            {
+                // The SDK storage is corrupted and cannot be recovered by retrying.
+                // Clear the storage directory and reconnect with fresh storage.
+                if (Directory.Exists(storageDir))
+                    Directory.Delete(storageDir, recursive: true);
+                return await BreezSdkSparkMethods.Connect(MakeRequest());
+            }
+        }
+        // ANCHOR_END: corrupt-storage-error
     }
 }

--- a/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
@@ -1,5 +1,6 @@
-import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
+import 'dart:io';
 import 'dart:async';
+import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
 
 Future<void> initSdk() async {
   // ANCHOR: init-sdk
@@ -169,4 +170,31 @@ class BreezSdkSpark {
     await sdk.disconnect();
   }
   // ANCHOR_END: disconnect
+
+  // ANCHOR: corrupt-storage-error
+  Future<BreezSdk> connectWithRecovery() async {
+    final storageDir = './.data';
+
+    ConnectRequest makeRequest() {
+      final config = defaultConfig(network: Network.mainnet)
+          .copyWith(apiKey: '<breez api key>');
+      return ConnectRequest(
+        config: config,
+        seed: Seed.mnemonic(mnemonic: '<mnemonic words>', passphrase: null),
+        storageDir: storageDir,
+      );
+    }
+
+    try {
+      return await connect(request: makeRequest());
+    } on SdkError_StorageError catch (e) {
+      if (e.recoverable) rethrow;
+      // The SDK storage is corrupted and cannot be recovered by retrying.
+      // Clear the storage directory and reconnect with fresh storage.
+      final dir = Directory(storageDir);
+      if (await dir.exists()) await dir.delete(recursive: true);
+      return await connect(request: makeRequest());
+    }
+  }
+  // ANCHOR_END: corrupt-storage-error
 }

--- a/docs/breez-sdk/snippets/go/getting_started.go
+++ b/docs/breez-sdk/snippets/go/getting_started.go
@@ -3,6 +3,7 @@ package example
 import (
 	"errors"
 	"log"
+	"os"
 
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 )
@@ -163,3 +164,34 @@ func Disconnect(sdk *breez_sdk_spark.BreezSdk) {
 }
 
 // ANCHOR_END: disconnect
+
+// ANCHOR: corrupt-storage-error
+func ConnectWithRecovery() (*breez_sdk_spark.BreezSdk, error) {
+	storageDir := "./.data"
+
+	makeRequest := func() breez_sdk_spark.ConnectRequest {
+		apiKey := "<breez api key>"
+		config := breez_sdk_spark.DefaultConfig(breez_sdk_spark.NetworkMainnet)
+		config.ApiKey = &apiKey
+		return breez_sdk_spark.ConnectRequest{
+			Config:     config,
+			Seed:       breez_sdk_spark.SeedMnemonic{Mnemonic: "<mnemonic words>", Passphrase: nil},
+			StorageDir: storageDir,
+		}
+	}
+
+	sdk, err := breez_sdk_spark.Connect(makeRequest())
+	if err != nil {
+		var storageErr *breez_sdk_spark.SdkErrorStorageError
+		if errors.As(err, &storageErr) && !storageErr.Recoverable {
+			// The SDK storage is corrupted and cannot be recovered by retrying.
+			// Clear the storage directory and reconnect with fresh storage.
+			os.RemoveAll(storageDir)
+			return breez_sdk_spark.Connect(makeRequest())
+		}
+		return nil, err
+	}
+	return sdk, nil
+}
+
+// ANCHOR_END: corrupt-storage-error

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
@@ -162,4 +162,38 @@ class GettingStarted {
         }
     }
     // ANCHOR_END: disconnect
+
+    // ANCHOR: corrupt-storage-error
+    suspend fun connectWithRecovery(): BreezSdk? {
+        val storageDir = "./.data"
+
+        fun makeRequest(): ConnectRequest {
+            val config = defaultConfig(Network.MAINNET)
+            config.apiKey = "<breez api key>"
+            return ConnectRequest(
+                config = config,
+                seed = Seed.Mnemonic("<mnemonic words>", null),
+                storageDir = storageDir
+            )
+        }
+
+        return try {
+            connect(makeRequest())
+        } catch (e: SdkException.StorageError) {
+            if (e.recoverable) throw e
+            // The SDK storage is corrupted and cannot be recovered by retrying.
+            // Clear the storage directory and reconnect with fresh storage.
+            java.io.File(storageDir).deleteRecursively()
+            try {
+                connect(makeRequest())
+            } catch (e: Exception) {
+                // handle error
+                null
+            }
+        } catch (e: Exception) {
+            // handle error
+            null
+        }
+    }
+    // ANCHOR_END: corrupt-storage-error
 }

--- a/docs/breez-sdk/snippets/python/src/getting_started.py
+++ b/docs/breez-sdk/snippets/python/src/getting_started.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 from breez_sdk_spark import (
     BreezSdk,
     connect,
@@ -11,6 +12,7 @@ from breez_sdk_spark import (
     LogEntry,
     Logger,
     Network,
+    SdkError,
     SdkEvent,
     Seed,
     ServiceStatus,
@@ -163,3 +165,27 @@ async def disconnect(sdk: BreezSdk):
 
 
 # ANCHOR_END: disconnect
+
+
+# ANCHOR: corrupt-storage-error
+async def connect_with_recovery() -> BreezSdk:
+    storage_dir = "./.data"
+
+    def make_request():
+        config = default_config(Network.MAINNET)
+        config.api_key = "<breez api key>"
+        return ConnectRequest(
+            config=config,
+            seed=Seed.MNEMONIC(mnemonic="<mnemonic words>", passphrase=None),
+            storage_dir=storage_dir,
+        )
+
+    try:
+        return await connect(request=make_request())
+    except Exception as error:
+        if isinstance(error, SdkError.StorageError) and not error.recoverable:
+            # The SDK storage is corrupted and cannot be recovered by retrying.
+            # Clear the storage directory and reconnect with fresh storage.
+            shutil.rmtree(storage_dir, ignore_errors=True)
+            return await connect(request=make_request())
+# ANCHOR_END: corrupt-storage-error

--- a/docs/breez-sdk/snippets/react-native/getting_started.ts
+++ b/docs/breez-sdk/snippets/react-native/getting_started.ts
@@ -137,3 +137,33 @@ const exampleDisconnect = async (sdk: BreezSdk) => {
   await sdk.disconnect()
   // ANCHOR_END: disconnect
 }
+
+const exampleConnectWithRecovery = async () => {
+  // ANCHOR: corrupt-storage-error
+  const storageDir = `${RNFS.DocumentDirectoryPath}/data`
+
+  const connectRequest = {
+    config: (() => {
+      const config = defaultConfig(Network.Mainnet)
+      config.apiKey = '<breez api key>'
+      return config
+    })(),
+    seed: new Seed.Mnemonic({ mnemonic: '<mnemonic words>', passphrase: undefined }),
+    storageDir
+  }
+
+  let sdk
+  try {
+    sdk = await connect(connectRequest)
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Unrecoverable storage error')) {
+      // The SDK storage is corrupted and cannot be recovered by retrying.
+      // Clear the storage directory and reconnect with fresh storage.
+      await RNFS.unlink(storageDir).catch(() => {})
+      sdk = await connect(connectRequest)
+    } else {
+      throw error
+    }
+  }
+  // ANCHOR_END: corrupt-storage-error
+}

--- a/docs/breez-sdk/snippets/rust/src/getting_started.rs
+++ b/docs/breez-sdk/snippets/rust/src/getting_started.rs
@@ -147,3 +147,34 @@ pub(crate) async fn disconnect(sdk: &BreezSdk) -> Result<()> {
 }
 // ANCHOR_END: disconnect
 
+// ANCHOR: corrupt-storage-error
+pub(crate) async fn connect_with_recovery() -> Result<BreezSdk> {
+    let storage_dir = "./.data".to_string();
+
+    let make_request = || {
+        let mut config = default_config(Network::Mainnet);
+        config.api_key = Some("<breez api key>".to_string());
+        ConnectRequest {
+            config,
+            seed: Seed::Mnemonic {
+                mnemonic: "<mnemonic words>".to_string(),
+                passphrase: None,
+            },
+            storage_dir: storage_dir.clone(),
+        }
+    };
+
+    let sdk = match connect(make_request()).await {
+        Ok(sdk) => sdk,
+        Err(SdkError::StorageError { recoverable: false, .. }) => {
+            // The SDK storage is corrupted and cannot be recovered by retrying.
+            // Clear the storage directory and reconnect with fresh storage.
+            std::fs::remove_dir_all(&storage_dir).ok();
+            connect(make_request()).await?
+        }
+        Err(e) => return Err(e.into()),
+    };
+    Ok(sdk)
+}
+// ANCHOR_END: corrupt-storage-error
+

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
@@ -1,3 +1,4 @@
+import Foundation
 import BreezSdkSpark
 
 func initSdk() async throws -> BreezSdk {
@@ -125,3 +126,31 @@ func disconnect(sdk: BreezSdk) async throws {
     try await sdk.disconnect()
 }
 // ANCHOR_END: disconnect
+
+// ANCHOR: corrupt-storage-error
+func connectWithRecovery() async throws -> BreezSdk {
+    let storageDir = "./.data"
+
+    let makeRequest = {
+        var config = defaultConfig(network: Network.mainnet)
+        config.apiKey = "<breez api key>"
+        return ConnectRequest(
+            config: config,
+            seed: .mnemonic(mnemonic: "<mnemonic words>", passphrase: nil),
+            storageDir: storageDir
+        )
+    }
+
+    do {
+        return try await connect(request: makeRequest())
+    } catch {
+        if case SdkError.storageError(let recoverable, _) = error, !recoverable {
+            // The SDK storage is corrupted and cannot be recovered by retrying.
+            // Clear the storage directory and reconnect with fresh storage.
+            try? FileManager.default.removeItem(atPath: storageDir)
+            return try await connect(request: makeRequest())
+        }
+        throw error
+    }
+}
+// ANCHOR_END: corrupt-storage-error

--- a/docs/breez-sdk/snippets/wasm/getting_started.ts
+++ b/docs/breez-sdk/snippets/wasm/getting_started.ts
@@ -174,3 +174,34 @@ const exampleDisconnect = async (sdk: BreezSdk) => {
   await sdk.disconnect()
   // ANCHOR_END: disconnect
 }
+
+const exampleConnectWithRecovery = async () => {
+  // ANCHOR: corrupt-storage-error
+  const storageDir = './.data'
+
+  const seed: Seed = { type: 'mnemonic', mnemonic: '<mnemonic words>', passphrase: undefined }
+  const connectRequest = {
+    config: (() => {
+      const config = defaultConfig('mainnet')
+      config.apiKey = '<breez api key>'
+      return config
+    })(),
+    seed,
+    storageDir
+  }
+
+  let sdk: BreezSdk
+  try {
+    sdk = await connect(connectRequest)
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Unrecoverable storage error')) {
+      // The SDK storage is corrupted and cannot be recovered by retrying.
+      // Clear the storage directory and reconnect with fresh storage.
+      // (Platform-specific: delete the storageDir directory or clear IndexedDB)
+      sdk = await connect(connectRequest)
+    } else {
+      throw error
+    }
+  }
+  // ANCHOR_END: corrupt-storage-error
+}

--- a/docs/breez-sdk/src/guide/initializing.md
+++ b/docs/breez-sdk/src/guide/initializing.md
@@ -34,6 +34,19 @@ Instead of managing mnemonics directly, you can use passkeys to derive wallet se
 
 See [Connecting with a Passkey](passkey.md) for the full setup guide including PRF provider implementation, platform configuration, and label management.
 
+## Handling Initialization Failures
+
+Some initialization failures indicate that the local SDK storage is corrupted and retrying without action will not help. When {{#name connect}} returns a `StorageError` with `recoverable` set to false, the app must clear the SDK storage directory and retry.
+
+<div class="warning">
+<h4>Important</h4>
+
+Clearing the storage directory removes locally cached state. The wallet funds are safe — they are secured by the Spark protocol and can be recovered from the seed. However, local payment history and settings will be lost until the next sync.
+
+</div>
+
+{{#tabs getting_started:corrupt-storage-error}}
+
 ## Advanced Initialization
 
 For advanced use cases where you need more control, you can configure the SDK using the Builder pattern. With the SDK Builder you can define:

--- a/packages/flutter/rust/src/errors.rs
+++ b/packages/flutter/rust/src/errors.rs
@@ -1,7 +1,5 @@
-pub use breez_sdk_spark::passkey::{PasskeyPrfError, PasskeyError};
-pub use breez_sdk_spark::{
-    DepositClaimError, Fee, SdkError, SessionManagerError, StorageError,
-};
+pub use breez_sdk_spark::passkey::{PasskeyError, PasskeyPrfError};
+pub use breez_sdk_spark::{DepositClaimError, Fee, SdkError, SessionManagerError, StorageError};
 use flutter_rust_bridge::frb;
 
 #[frb(mirror(DepositClaimError))]
@@ -29,7 +27,7 @@ pub enum _SdkError {
     InvalidUuid(String),
     InvalidInput(String),
     NetworkError(String),
-    StorageError(String),
+    StorageError { recoverable: bool, message: String },
     ChainServiceError(String),
     MaxDepositClaimFeeExceeded {
         tx: String,
@@ -52,6 +50,7 @@ pub enum _StorageError {
     Connection(String),
     Implementation(String),
     InitializationError(String),
+    MigrationError(String),
     Serialization(String),
 }
 


### PR DESCRIPTION
Closes #815
This PR adds a `CorruptStorage` error variant to `SdkError`, making **migration** errors from `connect` more actionable for the user so they can know when to reset their storage. An example of how to catch the error and reset the storage has also been provided in the docs