### PR TITLE
Fix static deposit claim: retry transfer lookup and clean up stale records

### DIFF
--- a/crates/breez-sdk/core/src/sdk/deposits.rs
+++ b/crates/breez-sdk/core/src/sdk/deposits.rs
@@ -4,7 +4,7 @@ use tracing::error;
 use crate::{
     ClaimDepositRequest, ClaimDepositResponse, ListUnclaimedDepositsRequest,
     ListUnclaimedDepositsResponse, RefundDepositRequest, RefundDepositResponse, error::SdkError,
-    persist::UpdateDepositPayload, utils::utxo_fetcher::CachedUtxoFetcher,
+    models::Payment, persist::UpdateDepositPayload, utils::utxo_fetcher::CachedUtxoFetcher,
 };
 
 use super::{BreezSdk, SyncType};
@@ -26,16 +26,22 @@ impl BreezSdk {
             .max_fee
             .or(self.config.max_deposit_claim_fee.clone());
         match self.claim_utxo(&detailed_utxo, max_fee).await {
-            Ok(transfer) => {
+            Ok(transfer_id) => {
+                let transfer = self
+                    .spark_wallet
+                    .query_static_deposit_claim_transfer(transfer_id)
+                    .await?;
+                let payment: Payment = transfer.try_into()?;
+                // Insert the payment before returning so callers that
+                // immediately list payments see the claim.
+                self.storage.insert_payment(payment.clone()).await?;
                 self.storage
                     .delete_deposit(detailed_utxo.txid.to_string(), detailed_utxo.vout)
                     .await?;
                 self.sync_coordinator
                     .trigger_sync_no_wait(SyncType::WalletState, true)
                     .await;
-                Ok(ClaimDepositResponse {
-                    payment: transfer.try_into()?,
-                })
+                Ok(ClaimDepositResponse { payment })
             }
             Err(e) => {
                 error!("Failed to claim deposit: {e:?}");

--- a/crates/breez-sdk/core/src/sdk/deposits.rs
+++ b/crates/breez-sdk/core/src/sdk/deposits.rs
@@ -1,5 +1,9 @@
+use std::{str::FromStr, time::Duration};
+
 use bitcoin::{consensus::serialize, hex::DisplayHex};
-use tracing::error;
+use platform_utils::tokio;
+use spark_wallet::{ListTransfersRequest, TransferId, WalletTransfer};
+use tracing::{error, trace};
 
 use crate::{
     ClaimDepositRequest, ClaimDepositResponse, ListUnclaimedDepositsRequest,
@@ -8,6 +12,11 @@ use crate::{
 };
 
 use super::{BreezSdk, SyncType};
+
+// Retry parameters for looking up the transfer created by a static deposit
+// claim while it propagates across Spark operators.
+const CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS: u32 = 3;
+const CLAIM_TRANSFER_LOOKUP_BASE_DELAY_MS: u64 = 500;
 
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 #[allow(clippy::needless_pass_by_value)]
@@ -27,10 +36,7 @@ impl BreezSdk {
             .or(self.config.max_deposit_claim_fee.clone());
         match self.claim_utxo(&detailed_utxo, max_fee).await {
             Ok(transfer_id) => {
-                let transfer = self
-                    .spark_wallet
-                    .query_static_deposit_claim_transfer(transfer_id)
-                    .await?;
+                let transfer = self.lookup_claim_transfer_with_retry(transfer_id).await?;
                 let payment: Payment = transfer.try_into()?;
                 // Insert the payment before returning so callers that
                 // immediately list payments see the claim.
@@ -104,5 +110,54 @@ impl BreezSdk {
     ) -> Result<ListUnclaimedDepositsResponse, SdkError> {
         let deposits = self.storage.list_deposits().await?;
         Ok(ListUnclaimedDepositsResponse { deposits })
+    }
+}
+
+impl BreezSdk {
+    /// Looks up the transfer produced by a static deposit claim, retrying
+    /// while the Spark operators have not yet indexed it. The SSP commits
+    /// the claim synchronously, but there is a brief window before the
+    /// transfer becomes queryable from the operators; transient query
+    /// errors are also retried. Returns the last error if every attempt
+    /// fails.
+    async fn lookup_claim_transfer_with_retry(
+        &self,
+        transfer_id: String,
+    ) -> Result<WalletTransfer, SdkError> {
+        let parsed_id = TransferId::from_str(&transfer_id).map_err(SdkError::Generic)?;
+        let mut last_error: Option<SdkError> = None;
+
+        for attempt in 0..CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS {
+            if attempt > 0 {
+                let delay_ms = CLAIM_TRANSFER_LOOKUP_BASE_DELAY_MS
+                    .saturating_mul(2u64.saturating_pow(attempt.saturating_sub(1)));
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                trace!(
+                    "Retrying claim transfer lookup (attempt {}/{}) for transfer {transfer_id}",
+                    attempt.saturating_add(1),
+                    CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS
+                );
+            }
+
+            match self
+                .spark_wallet
+                .list_transfers(ListTransfersRequest {
+                    transfer_ids: vec![parsed_id.clone()],
+                    paging: None,
+                })
+                .await
+            {
+                Ok(mut resp) => {
+                    if let Some(transfer) = resp.items.pop() {
+                        return Ok(transfer);
+                    }
+                    last_error = None;
+                }
+                Err(e) => last_error = Some(e.into()),
+            }
+        }
+
+        Err(last_error
+            .unwrap_or_else(|| SdkError::Generic("transfer not found after claim".to_string())))
     }
 }

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -135,10 +135,22 @@ impl BreezSdk {
             }
             WalletEvent::TransferClaimed(transfer) => {
                 info!("Transfer claimed");
+                // Extract the claimed deposit outpoint (if any) before the
+                // transfer is moved into Payment::try_from. The outpoint is
+                // used below to clean up stale unclaimed-deposit records.
+                let claimed_deposit_outpoint = claim_static_deposit_outpoint(&transfer);
                 if let Ok(mut payment) = Payment::try_from(transfer) {
                     // Insert the payment into storage to make it immediately available for listing
                     if let Err(e) = self.storage.insert_payment(payment.clone()).await {
                         error!("Failed to insert succeeded payment: {e:?}");
+                    }
+
+                    // If this was a static-deposit claim, remove the stale
+                    // unclaimed-deposit record for that specific outpoint.
+                    // It may have been left behind by the synchronous claim
+                    // path failing while the event path succeeded.
+                    if let Some((tx_id, vout)) = &claimed_deposit_outpoint {
+                        self.cleanup_claimed_deposit(tx_id, *vout).await;
                     }
 
                     // Ensure potential lnurl metadata is synced before emitting the event.
@@ -181,6 +193,16 @@ impl BreezSdk {
             WalletEvent::Optimization(event) => {
                 info!("Optimization event: {:?}", event);
             }
+        }
+    }
+
+    /// Removes the unclaimed-deposit storage record for `(tx_id, vout)`.
+    /// Called after a deposit transfer has been claimed via the event-driven
+    /// path so that a `claim_error` persisted by a previously-failed
+    /// synchronous claim attempt does not linger.
+    async fn cleanup_claimed_deposit(&self, tx_id: &str, vout: u32) {
+        if let Err(e) = self.storage.delete_deposit(tx_id.to_string(), vout).await {
+            error!("Failed to delete claimed deposit {tx_id}:{vout} from storage: {e:?}");
         }
     }
 
@@ -629,6 +651,18 @@ impl BreezSdk {
             detailed_utxo.txid, detailed_utxo.vout, transfer.total_value_sat,
         );
         Ok(transfer)
+    }
+}
+
+/// Returns the `(txid, vout)` of the on-chain UTXO claimed by this transfer,
+/// if it was produced by a static-deposit claim.
+fn claim_static_deposit_outpoint(transfer: &spark_wallet::WalletTransfer) -> Option<(String, u32)> {
+    match transfer.user_request.as_ref()? {
+        spark_wallet::SspUserRequest::ClaimStaticDeposit(info) => {
+            let vout = u32::try_from(info.output_index).ok()?;
+            Some((info.transaction_id.clone(), vout))
+        }
+        _ => None,
     }
 }
 

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -135,22 +135,17 @@ impl BreezSdk {
             }
             WalletEvent::TransferClaimed(transfer) => {
                 info!("Transfer claimed");
-                // Extract the claimed deposit outpoint (if any) before the
-                // transfer is moved into Payment::try_from. The outpoint is
-                // used below to clean up stale unclaimed-deposit records.
-                let claimed_deposit_outpoint = claim_static_deposit_outpoint(&transfer);
+                // Drop any unclaimed-deposit record for this outpoint
+                // independently of payment ingestion below, so a
+                // Payment::try_from failure does not leave the record
+                // lingering.
+                if let Some((tx_id, vout)) = claim_static_deposit_outpoint(&transfer) {
+                    self.cleanup_claimed_deposit(&tx_id, vout).await;
+                }
                 if let Ok(mut payment) = Payment::try_from(transfer) {
                     // Insert the payment into storage to make it immediately available for listing
                     if let Err(e) = self.storage.insert_payment(payment.clone()).await {
                         error!("Failed to insert succeeded payment: {e:?}");
-                    }
-
-                    // If this was a static-deposit claim, remove the stale
-                    // unclaimed-deposit record for that specific outpoint.
-                    // It may have been left behind by the synchronous claim
-                    // path failing while the event path succeeded.
-                    if let Some((tx_id, vout)) = &claimed_deposit_outpoint {
-                        self.cleanup_claimed_deposit(tx_id, *vout).await;
                     }
 
                     // Ensure potential lnurl metadata is synced before emitting the event.
@@ -196,10 +191,8 @@ impl BreezSdk {
         }
     }
 
-    /// Removes the unclaimed-deposit storage record for `(tx_id, vout)`.
-    /// Called after a deposit transfer has been claimed via the event-driven
-    /// path so that a `claim_error` persisted by a previously-failed
-    /// synchronous claim attempt does not linger.
+    /// Removes the unclaimed-deposit storage record for `(tx_id, vout)`,
+    /// logging on failure rather than propagating the error.
     async fn cleanup_claimed_deposit(&self, tx_id: &str, vout: u32) {
         if let Err(e) = self.storage.delete_deposit(tx_id.to_string(), vout).await {
             error!("Failed to delete claimed deposit {tx_id}:{vout} from storage: {e:?}");
@@ -596,11 +589,13 @@ impl BreezSdk {
         Ok(())
     }
 
+    /// Submits a static deposit claim for `detailed_utxo` and returns the
+    /// resulting transfer id.
     pub(super) async fn claim_utxo(
         &self,
         detailed_utxo: &DetailedUtxo,
         max_claim_fee: Option<MaxFee>,
-    ) -> Result<spark_wallet::WalletTransfer, SdkError> {
+    ) -> Result<String, SdkError> {
         info!(
             "Fetching static deposit claim quote for deposit tx {}:{} and amount: {}",
             detailed_utxo.txid, detailed_utxo.vout, detailed_utxo.value
@@ -645,12 +640,13 @@ impl BreezSdk {
             "Claiming static deposit for utxo {}:{}",
             detailed_utxo.txid, detailed_utxo.vout
         );
-        let transfer = self.spark_wallet.claim_static_deposit(quote).await?;
+        let credit_amount_sats = quote.credit_amount_sats;
+        let transfer_id = self.spark_wallet.claim_static_deposit(quote).await?;
         info!(
-            "Claimed static deposit transfer for utxo {}:{}, value {}",
-            detailed_utxo.txid, detailed_utxo.vout, transfer.total_value_sat,
+            "Claimed static deposit for utxo {}:{} (deposit value {}, credit {}), transfer {transfer_id}",
+            detailed_utxo.txid, detailed_utxo.vout, detailed_utxo.value, credit_amount_sats,
         );
-        Ok(transfer)
+        Ok(transfer_id)
     }
 }
 

--- a/crates/internal/src/command/deposit.rs
+++ b/crates/internal/src/command/deposit.rs
@@ -105,10 +105,7 @@ pub async fn handle_command(
                     .fetch_static_deposit_claim_quote(tx.clone(), output_index)
                     .await?;
                 let transfer_id = wallet.claim_static_deposit(quote).await?;
-                let transfer = wallet
-                    .query_static_deposit_claim_transfer(transfer_id)
-                    .await?;
-                println!("{}", serde_json::to_string_pretty(&transfer)?);
+                println!("Claim submitted, transfer id: {transfer_id}");
             } else if let Some(output_index) = output_index {
                 let leaves = wallet.claim_deposit(tx, output_index).await?;
                 println!("{}", serde_json::to_string_pretty(&leaves)?);

--- a/crates/internal/src/command/deposit.rs
+++ b/crates/internal/src/command/deposit.rs
@@ -104,7 +104,10 @@ pub async fn handle_command(
                 let quote = wallet
                     .fetch_static_deposit_claim_quote(tx.clone(), output_index)
                     .await?;
-                let transfer = wallet.claim_static_deposit(quote).await?;
+                let transfer_id = wallet.claim_static_deposit(quote).await?;
+                let transfer = wallet
+                    .query_static_deposit_claim_transfer(transfer_id)
+                    .await?;
                 println!("{}", serde_json::to_string_pretty(&transfer)?);
             } else if let Some(output_index) = output_index {
                 let leaves = wallet.claim_deposit(tx, output_index).await?;

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -660,8 +660,7 @@ impl SparkWallet {
     }
 
     /// Submits a static deposit claim and returns the resulting transfer id.
-    /// Use [`Self::query_static_deposit_claim_transfer`] to fetch the full
-    /// transfer when needed.
+    /// The transfer can then be fetched with [`Self::list_transfers`].
     pub async fn claim_static_deposit(
         &self,
         quote: StaticDepositQuote,
@@ -671,26 +670,6 @@ impl SparkWallet {
         self.maybe_start_optimization().await;
 
         Ok(transfer_id)
-    }
-
-    /// Looks up the transfer produced by a static deposit claim, retrying
-    /// while the operator pool has not yet indexed it.
-    pub async fn query_static_deposit_claim_transfer(
-        &self,
-        transfer_id: String,
-    ) -> Result<WalletTransfer, SparkWalletError> {
-        let transfer = self
-            .deposit_service
-            .query_static_deposit_claim_transfer(transfer_id)
-            .await?;
-
-        Ok(WalletTransfer::from_transfer(
-            transfer,
-            None,
-            None,
-            self.identity_public_key,
-            self.config.service_provider_config.identity_public_key,
-        ))
     }
 
     pub async fn refund_static_deposit(

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -659,13 +659,30 @@ impl SparkWallet {
         Ok(deposit_nodes.into_iter().map(WalletLeaf::from).collect())
     }
 
+    /// Submits a static deposit claim and returns the resulting transfer id.
+    /// Use [`Self::query_static_deposit_claim_transfer`] to fetch the full
+    /// transfer when needed.
     pub async fn claim_static_deposit(
         &self,
         quote: StaticDepositQuote,
-    ) -> Result<WalletTransfer, SparkWalletError> {
-        let transfer = self.deposit_service.claim_static_deposit(quote).await?;
+    ) -> Result<String, SparkWalletError> {
+        let transfer_id = self.deposit_service.claim_static_deposit(quote).await?;
 
         self.maybe_start_optimization().await;
+
+        Ok(transfer_id)
+    }
+
+    /// Looks up the transfer produced by a static deposit claim, retrying
+    /// while the operator pool has not yet indexed it.
+    pub async fn query_static_deposit_claim_transfer(
+        &self,
+        transfer_id: String,
+    ) -> Result<WalletTransfer, SparkWalletError> {
+        let transfer = self
+            .deposit_service
+            .query_static_deposit_claim_transfer(transfer_id)
+            .await?;
 
         Ok(WalletTransfer::from_transfer(
             transfer,

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
+use std::{collections::HashSet, str::FromStr, sync::Arc};
 
 use bitcoin::{
     Address, Amount, OutPoint, Transaction, TxOut, Txid, Witness,
@@ -8,7 +8,6 @@ use bitcoin::{
     params::Params,
     secp256k1::{Message, PublicKey, ecdsa::Signature, schnorr},
 };
-use platform_utils::tokio;
 use serde::Serialize;
 use tracing::{error, trace};
 
@@ -17,12 +16,9 @@ use crate::{
     bitcoin::{BitcoinService, sighash_from_tx},
     operator::{
         OperatorPool,
-        rpc::{
-            self as operator_rpc,
-            spark::{HashVariant, TransferFilter, transfer_filter::Participant},
-        },
+        rpc::{self as operator_rpc, spark::HashVariant},
     },
-    services::{Transfer, Utxo},
+    services::Utxo,
     signer::{SecretSource, Signer},
     ssp::{ClaimStaticDepositInput, ClaimStaticDepositRequestType, ServiceProvider},
     tree::{TreeNode, TreeNodeId, TreeNodeStatus},
@@ -40,12 +36,6 @@ use crate::{
 use super::ServiceError;
 
 const CLAIM_STATIC_DEPOSIT_ACTION: &str = "claim_static_deposit";
-
-// Retry parameters for looking up the transfer created by a static deposit
-// claim while it propagates from the SSP to the receiver-side operator pool.
-const CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS: u32 = 3;
-const CLAIM_TRANSFER_LOOKUP_BASE_DELAY_MS: u64 = 500;
-const CLAIM_TRANSFER_LOOKUP_MAX_DELAY_MS: u64 = 2_000;
 
 // Conservative minimum fee threshold for refund transactions
 // Based on 194 vbyte estimate for 1-in/1-out tx at 1 sat/vB minimum relay fee.
@@ -271,8 +261,8 @@ impl DepositService {
     }
 
     /// Submits a static deposit claim to the SSP and returns the resulting
-    /// transfer id. Use [`Self::query_static_deposit_claim_transfer`] to
-    /// fetch the full transfer.
+    /// transfer id. The transfer can then be looked up by id via the
+    /// transfer service / `SparkWallet::list_transfers`.
     pub async fn claim_static_deposit(
         &self,
         quote: StaticDepositQuote,
@@ -323,64 +313,6 @@ impl DepositService {
             .await?;
 
         Ok(resp.transfer_id)
-    }
-
-    /// Looks up the transfer produced by a static deposit claim. Retries
-    /// while the operator pool has not yet indexed the transfer or the
-    /// query fails transiently; returns the last error if every attempt
-    /// fails.
-    pub async fn query_static_deposit_claim_transfer(
-        &self,
-        transfer_id: String,
-    ) -> Result<Transfer, ServiceError> {
-        let identity_public_key = self
-            .signer
-            .get_identity_public_key()
-            .await?
-            .serialize()
-            .to_vec();
-
-        let mut last_error: Option<ServiceError> = None;
-
-        for attempt in 0..CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS {
-            if attempt > 0 {
-                let delay_ms = CLAIM_TRANSFER_LOOKUP_BASE_DELAY_MS
-                    .saturating_mul(2u64.saturating_pow(attempt - 1))
-                    .min(CLAIM_TRANSFER_LOOKUP_MAX_DELAY_MS);
-                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-                trace!(
-                    "Retrying claim transfer lookup (attempt {}/{}) for transfer {transfer_id}",
-                    attempt + 1,
-                    CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS
-                );
-            }
-
-            match self
-                .operator_pool
-                .get_coordinator()
-                .client
-                .query_all_transfers(TransferFilter {
-                    participant: Some(Participant::ReceiverIdentityPublicKey(
-                        identity_public_key.clone(),
-                    )),
-                    transfer_ids: vec![transfer_id.clone()],
-                    network: self.network.to_proto_network() as i32,
-                    ..Default::default()
-                })
-                .await
-            {
-                Ok(resp) => {
-                    if let Some(transfer) = resp.transfers.into_iter().next() {
-                        return transfer.try_into();
-                    }
-                    last_error = None;
-                }
-                Err(e) => last_error = Some(e.into()),
-            }
-        }
-
-        Err(last_error
-            .unwrap_or_else(|| ServiceError::Generic("transfer not found after claim".to_string())))
     }
 
     pub async fn refund_static_deposit(

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -44,9 +44,9 @@ const CLAIM_STATIC_DEPOSIT_ACTION: &str = "claim_static_deposit";
 // Retry parameters for looking up the transfer created by a static deposit
 // claim. The SSP creates the transfer synchronously, but it can take a brief
 // window before it becomes visible to the receiver via the operator pool.
-const CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS: u32 = 5;
+const CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS: u32 = 3;
 const CLAIM_TRANSFER_LOOKUP_BASE_DELAY_MS: u64 = 500;
-const CLAIM_TRANSFER_LOOKUP_MAX_DELAY_MS: u64 = 5_000;
+const CLAIM_TRANSFER_LOOKUP_MAX_DELAY_MS: u64 = 2_000;
 
 // Conservative minimum fee threshold for refund transactions
 // Based on 194 vbyte estimate for 1-in/1-out tx at 1 sat/vB minimum relay fee.

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -42,8 +42,7 @@ use super::ServiceError;
 const CLAIM_STATIC_DEPOSIT_ACTION: &str = "claim_static_deposit";
 
 // Retry parameters for looking up the transfer created by a static deposit
-// claim. The SSP creates the transfer synchronously, but it can take a brief
-// window before it becomes visible to the receiver via the operator pool.
+// claim while it propagates from the SSP to the receiver-side operator pool.
 const CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS: u32 = 3;
 const CLAIM_TRANSFER_LOOKUP_BASE_DELAY_MS: u64 = 500;
 const CLAIM_TRANSFER_LOOKUP_MAX_DELAY_MS: u64 = 2_000;
@@ -271,10 +270,13 @@ impl DepositService {
         .await
     }
 
+    /// Submits a static deposit claim to the SSP and returns the resulting
+    /// transfer id. Use [`Self::query_static_deposit_claim_transfer`] to
+    /// fetch the full transfer.
     pub async fn claim_static_deposit(
         &self,
         quote: StaticDepositQuote,
-    ) -> Result<Transfer, ServiceError> {
+    ) -> Result<String, ServiceError> {
         trace!("Claiming static deposit with quote: {quote:?}");
         let StaticDepositQuote {
             txid,
@@ -320,30 +322,17 @@ impl DepositService {
             })
             .await?;
 
-        // Fetch the transfer from the operator pool coordinator, retrying
-        // while the receiver side has not yet indexed it.
-        let transfer = self
-            .query_claim_transfer_with_retry(resp.transfer_id)
-            .await?;
-
-        transfer.try_into()
+        Ok(resp.transfer_id)
     }
 
-    /// Look up the transfer created by a static deposit claim, retrying
-    /// while the operator pool has not yet indexed it or the query itself
-    /// fails transiently.
-    ///
-    /// The SSP creates the transfer synchronously, but it can take a brief
-    /// window before it becomes visible to the receiver, during which
-    /// `query_all_transfers` returns an empty list. The query can also fail
-    /// transiently (network, gRPC). Since the SSP has already committed the
-    /// claim by the time we get here, both cases are retried rather than
-    /// surfacing a spurious error. If every attempt fails, the last error
-    /// is returned.
-    async fn query_claim_transfer_with_retry(
+    /// Looks up the transfer produced by a static deposit claim. Retries
+    /// while the operator pool has not yet indexed the transfer or the
+    /// query fails transiently; returns the last error if every attempt
+    /// fails.
+    pub async fn query_static_deposit_claim_transfer(
         &self,
         transfer_id: String,
-    ) -> Result<operator_rpc::spark::Transfer, ServiceError> {
+    ) -> Result<Transfer, ServiceError> {
         let identity_public_key = self
             .signer
             .get_identity_public_key()
@@ -355,7 +344,8 @@ impl DepositService {
 
         for attempt in 0..CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS {
             if attempt > 0 {
-                let delay_ms = (CLAIM_TRANSFER_LOOKUP_BASE_DELAY_MS * 2u64.pow(attempt - 1))
+                let delay_ms = CLAIM_TRANSFER_LOOKUP_BASE_DELAY_MS
+                    .saturating_mul(2u64.saturating_pow(attempt - 1))
                     .min(CLAIM_TRANSFER_LOOKUP_MAX_DELAY_MS);
                 tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                 trace!(
@@ -381,7 +371,7 @@ impl DepositService {
             {
                 Ok(resp) => {
                     if let Some(transfer) = resp.transfers.into_iter().next() {
-                        return Ok(transfer);
+                        return transfer.try_into();
                     }
                     last_error = None;
                 }

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, str::FromStr, sync::Arc};
+use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
 
 use bitcoin::{
     Address, Amount, OutPoint, Transaction, TxOut, Txid, Witness,
@@ -8,6 +8,7 @@ use bitcoin::{
     params::Params,
     secp256k1::{Message, PublicKey, ecdsa::Signature, schnorr},
 };
+use platform_utils::tokio;
 use serde::Serialize;
 use tracing::{error, trace};
 
@@ -39,6 +40,13 @@ use crate::{
 use super::ServiceError;
 
 const CLAIM_STATIC_DEPOSIT_ACTION: &str = "claim_static_deposit";
+
+// Retry parameters for looking up the transfer created by a static deposit
+// claim. The SSP creates the transfer synchronously, but it can take a brief
+// window before it becomes visible to the receiver via the operator pool.
+const CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS: u32 = 5;
+const CLAIM_TRANSFER_LOOKUP_BASE_DELAY_MS: u64 = 500;
+const CLAIM_TRANSFER_LOOKUP_MAX_DELAY_MS: u64 = 5_000;
 
 // Conservative minimum fee threshold for refund transactions
 // Based on 194 vbyte estimate for 1-in/1-out tx at 1 sat/vB minimum relay fee.
@@ -312,31 +320,77 @@ impl DepositService {
             })
             .await?;
 
-        // Fetch the transfer from the operator pool coordinator
-        let transfers: operator_rpc::spark::QueryTransfersResponse = self
-            .operator_pool
-            .get_coordinator()
-            .client
-            .query_all_transfers(TransferFilter {
-                participant: Some(Participant::ReceiverIdentityPublicKey(
-                    self.signer
-                        .get_identity_public_key()
-                        .await?
-                        .serialize()
-                        .to_vec(),
-                )),
-                transfer_ids: vec![resp.transfer_id],
-                network: self.network.to_proto_network() as i32,
-                ..Default::default()
-            })
+        // Fetch the transfer from the operator pool coordinator, retrying
+        // while the receiver side has not yet indexed it.
+        let transfer = self
+            .query_claim_transfer_with_retry(resp.transfer_id)
             .await?;
-        let transfer = transfers
-            .transfers
-            .into_iter()
-            .nth(0)
-            .ok_or(ServiceError::Generic("transfer not found".to_string()))?;
 
         transfer.try_into()
+    }
+
+    /// Look up the transfer created by a static deposit claim, retrying
+    /// while the operator pool has not yet indexed it or the query itself
+    /// fails transiently.
+    ///
+    /// The SSP creates the transfer synchronously, but it can take a brief
+    /// window before it becomes visible to the receiver, during which
+    /// `query_all_transfers` returns an empty list. The query can also fail
+    /// transiently (network, gRPC). Since the SSP has already committed the
+    /// claim by the time we get here, both cases are retried rather than
+    /// surfacing a spurious error. If every attempt fails, the last error
+    /// is returned.
+    async fn query_claim_transfer_with_retry(
+        &self,
+        transfer_id: String,
+    ) -> Result<operator_rpc::spark::Transfer, ServiceError> {
+        let identity_public_key = self
+            .signer
+            .get_identity_public_key()
+            .await?
+            .serialize()
+            .to_vec();
+
+        let mut last_error: Option<ServiceError> = None;
+
+        for attempt in 0..CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS {
+            if attempt > 0 {
+                let delay_ms = (CLAIM_TRANSFER_LOOKUP_BASE_DELAY_MS * 2u64.pow(attempt - 1))
+                    .min(CLAIM_TRANSFER_LOOKUP_MAX_DELAY_MS);
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                trace!(
+                    "Retrying claim transfer lookup (attempt {}/{}) for transfer {transfer_id}",
+                    attempt + 1,
+                    CLAIM_TRANSFER_LOOKUP_MAX_ATTEMPTS
+                );
+            }
+
+            match self
+                .operator_pool
+                .get_coordinator()
+                .client
+                .query_all_transfers(TransferFilter {
+                    participant: Some(Participant::ReceiverIdentityPublicKey(
+                        identity_public_key.clone(),
+                    )),
+                    transfer_ids: vec![transfer_id.clone()],
+                    network: self.network.to_proto_network() as i32,
+                    ..Default::default()
+                })
+                .await
+            {
+                Ok(resp) => {
+                    if let Some(transfer) = resp.transfers.into_iter().next() {
+                        return Ok(transfer);
+                    }
+                    last_error = None;
+                }
+                Err(e) => last_error = Some(e.into()),
+            }
+        }
+
+        Err(last_error
+            .unwrap_or_else(|| ServiceError::Generic("transfer not found after claim".to_string())))
     }
 
     pub async fn refund_static_deposit(


### PR DESCRIPTION
Fixes two issues in the static deposit claim flow:

- **Transfer lookup race**: after the SSP commits a claim, the receiver side can briefly fail to see the transfer via `query_all_transfers`, causing a spurious `"transfer not found"` error. Now retried with exponential backoff (up to 5 attempts, 500ms–5s).
- **Stale unclaimed-deposit record**: when the sync claim path fails but the event-driven path later succeeds, the deposit record with a `claim_error` lingered in storage until the next background claim iteration. On `TransferClaimed`, if the transfer originated from a `ClaimStaticDeposit` request, the corresponding `(txid, vout)` record is now deleted.