### PR TITLE
use clap value enums for cli

### DIFF
--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -16,7 +16,7 @@ use breez_sdk_spark::{
     SparkHtlcOptions, SparkHtlcStatus, SyncWalletRequest, TokenIssuer, TokenTransactionType,
     UpdateUserSettingsRequest,
 };
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use rand::RngCore;
 use rustyline::{
     Completer, Editor, Helper, Hinter, Validator, highlight::Highlighter, hint::HistoryHinter,
@@ -31,6 +31,15 @@ use crate::command::contacts::ContactCommand;
 use crate::command::issuer::IssuerCommand;
 use crate::command::stable_balance::StableBalanceCommand;
 use crate::command::webhooks::WebhookCommand;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum ReceivePaymentMethodArg {
+    SparkAddress,
+    SparkInvoice,
+    Bitcoin,
+    Bolt11,
+}
 
 #[derive(Clone, Parser)]
 pub enum Command {
@@ -100,8 +109,8 @@ pub enum Command {
 
     /// Receive
     Receive {
-        #[arg(short = 'm', long = "method")]
-        payment_method: String,
+        #[arg(short = 'm', long = "method", value_enum)]
+        payment_method: ReceivePaymentMethodArg,
 
         /// Optional description for the invoice
         #[clap(short = 'd', long = "description")]
@@ -547,9 +556,9 @@ pub(crate) async fn execute_command(
             hodl,
             new_address,
         } => {
-            let payment_method = match payment_method.as_str() {
-                "sparkaddress" => ReceivePaymentMethod::SparkAddress,
-                "sparkinvoice" => ReceivePaymentMethod::SparkInvoice {
+            let payment_method = match payment_method {
+                ReceivePaymentMethodArg::SparkAddress => ReceivePaymentMethod::SparkAddress,
+                ReceivePaymentMethodArg::SparkInvoice => ReceivePaymentMethod::SparkInvoice {
                     amount,
                     token_identifier,
                     expiry_time: expiry_secs
@@ -564,10 +573,10 @@ pub(crate) async fn execute_command(
                     description,
                     sender_public_key,
                 },
-                "bitcoin" => ReceivePaymentMethod::BitcoinAddress {
+                ReceivePaymentMethodArg::Bitcoin => ReceivePaymentMethod::BitcoinAddress {
                     new_address: Some(new_address),
                 },
-                "bolt11" => {
+                ReceivePaymentMethodArg::Bolt11 => {
                     let payment_hash = if hodl {
                         let mut preimage_bytes = [0u8; 32];
                         rand::thread_rng().fill_bytes(&mut preimage_bytes);
@@ -590,7 +599,6 @@ pub(crate) async fn execute_command(
                         payment_hash,
                     }
                 }
-                _ => return Err(anyhow::anyhow!("Invalid payment method")),
             };
 
             let receive_result = sdk

--- a/crates/breez-sdk/cli/src/command/webhooks.rs
+++ b/crates/breez-sdk/cli/src/command/webhooks.rs
@@ -1,9 +1,29 @@
 use breez_sdk_spark::{
     BreezSdk, RegisterWebhookRequest, UnregisterWebhookRequest, WebhookEventType,
 };
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
 
 use crate::command::print_value;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum WebhookEventTypeArg {
+    LightningReceive,
+    LightningSend,
+    CoopExit,
+    StaticDeposit,
+}
+
+impl From<WebhookEventTypeArg> for WebhookEventType {
+    fn from(value: WebhookEventTypeArg) -> Self {
+        match value {
+            WebhookEventTypeArg::LightningReceive => WebhookEventType::LightningReceiveFinished,
+            WebhookEventTypeArg::LightningSend => WebhookEventType::LightningSendFinished,
+            WebhookEventTypeArg::CoopExit => WebhookEventType::CoopExitFinished,
+            WebhookEventTypeArg::StaticDeposit => WebhookEventType::StaticDepositFinished,
+        }
+    }
+}
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum WebhookCommand {
@@ -13,9 +33,9 @@ pub enum WebhookCommand {
         url: String,
         /// Secret for HMAC-SHA256 signature verification
         secret: String,
-        /// Event types to subscribe to (lightning-receive, lightning-send, coop-exit, static-deposit)
-        #[arg(required = true, num_args = 1..)]
-        events: Vec<String>,
+        /// Event types to subscribe to
+        #[arg(required = true, num_args = 1.., value_enum)]
+        events: Vec<WebhookEventTypeArg>,
     },
     /// Unregister a webhook
     Unregister {
@@ -24,18 +44,6 @@ pub enum WebhookCommand {
     },
     /// List all registered webhooks
     List,
-}
-
-fn parse_event_type(s: &str) -> Result<WebhookEventType, anyhow::Error> {
-    match s {
-        "lightning-receive" => Ok(WebhookEventType::LightningReceiveFinished),
-        "lightning-send" => Ok(WebhookEventType::LightningSendFinished),
-        "coop-exit" => Ok(WebhookEventType::CoopExitFinished),
-        "static-deposit" => Ok(WebhookEventType::StaticDepositFinished),
-        _ => Err(anyhow::anyhow!(
-            "Unknown event type: {s}. Valid values: lightning-receive, lightning-send, coop-exit, static-deposit"
-        )),
-    }
 }
 
 pub async fn handle_command(
@@ -48,10 +56,7 @@ pub async fn handle_command(
             secret,
             events,
         } => {
-            let event_types = events
-                .iter()
-                .map(|e| parse_event_type(e))
-                .collect::<Result<Vec<_>, _>>()?;
+            let event_types = events.into_iter().map(Into::into).collect();
             let response = sdk
                 .register_webhook(RegisterWebhookRequest {
                     url,


### PR DESCRIPTION
Improves the usage of the sdk cli a little, because it shows the possible options for receive...
```
Usage: breez-cli receive [OPTIONS] --method <PAYMENT_METHOD>

Options:
  -m, --method <PAYMENT_METHOD>
          [possible values: sparkaddress, sparkinvoice, bitcoin, bolt11]
```

... and webhook events
```
Usage: breez-cli webhooks register <URL> <SECRET> <EVENTS>...

Arguments:
  <EVENTS>...  Event types to subscribe to [possible values: lightning-receive, lightning-send, coop-exit, static-deposit]
```