### PR TITLE
point frost packages to lightspark repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
  "built",
  "chrono",
  "flashnet",
- "frost-secp256k1-tr-unofficial",
+ "frost-secp256k1-tr",
  "hex",
  "k256",
  "lnurl-models",
@@ -1664,10 +1664,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
-name = "frost-core-unofficial"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579bf9770b82531690aa948a39dcd77f098f86389d5b45b76252257420ff263d"
+name = "frost-core"
+version = "2.1.0"
+source = "git+https://github.com/lightsparkdev/frost?rev=9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180#9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180"
 dependencies = [
  "byteorder",
  "const-crc32-nostd",
@@ -1687,27 +1686,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "frost-rerandomized-unofficial"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3736da210f3df297cd1c2b58cf2934510f8f39d9ff6248bae8f1f6457fde98"
+name = "frost-rerandomized"
+version = "2.1.0"
+source = "git+https://github.com/lightsparkdev/frost?rev=9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180#9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180"
 dependencies = [
  "derive-getters",
  "document-features",
- "frost-core-unofficial",
+ "frost-core",
  "hex",
  "rand_core 0.6.4",
 ]
 
 [[package]]
-name = "frost-secp256k1-tr-unofficial"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5279a0a375d505f5ec711521284d183ab6fea98edfdf798d65434b16c59a251"
+name = "frost-secp256k1-tr"
+version = "2.1.0"
+source = "git+https://github.com/lightsparkdev/frost?rev=9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180#9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180"
 dependencies = [
  "document-features",
- "frost-core-unofficial",
- "frost-rerandomized-unofficial",
+ "frost-core",
+ "frost-rerandomized",
  "k256",
  "rand_core 0.6.4",
  "sha2",
@@ -4673,8 +4670,8 @@ dependencies = [
  "built",
  "bytes",
  "chrono",
- "frost-core-unofficial",
- "frost-secp256k1-tr-unofficial",
+ "frost-core",
+ "frost-secp256k1-tr",
  "futures",
  "graphql_client",
  "hex",
@@ -4789,7 +4786,7 @@ name = "spark-wallet"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "frost-secp256k1-tr-unofficial",
+ "frost-secp256k1-tr",
  "futures",
  "hex",
  "platform-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,10 +153,9 @@ hkdf = "0.12"
 sha2 = "0.10"
 figment = "0.10.19"
 flashnet = { path = "crates/flashnet", default-features = false }
-# frost-core = "2.1.0"
-frost-core = { package = "frost-core-unofficial", version = "2.2.0" }
-# frost-secp256k1-tr = "2.1.0"
-frost-secp256k1-tr = { package = "frost-secp256k1-tr-unofficial", version = "2.2.0" }
+# nested-signing branch
+frost-core = { git = "https://github.com/lightsparkdev/frost", rev = "9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180" }
+frost-secp256k1-tr = { git = "https://github.com/lightsparkdev/frost", rev = "9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180" }
 futures = { version = "0.3", default-features = false }
 glob = "0.3.1"
 graphql_client = { version = "0.14.0" }

--- a/crates/breez-sdk/lnurl/Cargo.lock
+++ b/crates/breez-sdk/lnurl/Cargo.lock
@@ -1216,10 +1216,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "frost-core-unofficial"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579bf9770b82531690aa948a39dcd77f098f86389d5b45b76252257420ff263d"
+name = "frost-core"
+version = "2.1.0"
+source = "git+https://github.com/lightsparkdev/frost?rev=9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180#9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180"
 dependencies = [
  "byteorder",
  "const-crc32-nostd",
@@ -1239,27 +1238,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "frost-rerandomized-unofficial"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3736da210f3df297cd1c2b58cf2934510f8f39d9ff6248bae8f1f6457fde98"
+name = "frost-rerandomized"
+version = "2.1.0"
+source = "git+https://github.com/lightsparkdev/frost?rev=9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180#9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180"
 dependencies = [
  "derive-getters",
  "document-features",
- "frost-core-unofficial",
+ "frost-core",
  "hex",
  "rand_core 0.6.4",
 ]
 
 [[package]]
-name = "frost-secp256k1-tr-unofficial"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5279a0a375d505f5ec711521284d183ab6fea98edfdf798d65434b16c59a251"
+name = "frost-secp256k1-tr"
+version = "2.1.0"
+source = "git+https://github.com/lightsparkdev/frost?rev=9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180#9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180"
 dependencies = [
  "document-features",
- "frost-core-unofficial",
- "frost-rerandomized-unofficial",
+ "frost-core",
+ "frost-rerandomized",
  "k256",
  "rand_core 0.6.4",
  "sha2",
@@ -3507,8 +3504,8 @@ dependencies = [
  "built",
  "bytes",
  "chrono",
- "frost-core-unofficial",
- "frost-secp256k1-tr-unofficial",
+ "frost-core",
+ "frost-secp256k1-tr",
  "futures",
  "graphql_client",
  "hex",
@@ -3543,7 +3540,7 @@ name = "spark-wallet"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "frost-secp256k1-tr-unofficial",
+ "frost-secp256k1-tr",
  "futures",
  "hex",
  "platform-utils",

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
  "built",
  "chrono",
  "flashnet",
- "frost-secp256k1-tr-unofficial",
+ "frost-secp256k1-tr",
  "hex",
  "k256",
  "lnurl-models",
@@ -1125,10 +1125,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "frost-core-unofficial"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579bf9770b82531690aa948a39dcd77f098f86389d5b45b76252257420ff263d"
+name = "frost-core"
+version = "2.1.0"
+source = "git+https://github.com/lightsparkdev/frost?rev=9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180#9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180"
 dependencies = [
  "byteorder",
  "const-crc32-nostd",
@@ -1148,27 +1147,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "frost-rerandomized-unofficial"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3736da210f3df297cd1c2b58cf2934510f8f39d9ff6248bae8f1f6457fde98"
+name = "frost-rerandomized"
+version = "2.1.0"
+source = "git+https://github.com/lightsparkdev/frost?rev=9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180#9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180"
 dependencies = [
  "derive-getters",
  "document-features",
- "frost-core-unofficial",
+ "frost-core",
  "hex",
  "rand_core 0.6.4",
 ]
 
 [[package]]
-name = "frost-secp256k1-tr-unofficial"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5279a0a375d505f5ec711521284d183ab6fea98edfdf798d65434b16c59a251"
+name = "frost-secp256k1-tr"
+version = "2.1.0"
+source = "git+https://github.com/lightsparkdev/frost?rev=9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180#9aaf1b6b9fa3c2c3c2c7c70da83061deda1a9180"
 dependencies = [
  "document-features",
- "frost-core-unofficial",
- "frost-rerandomized-unofficial",
+ "frost-core",
+ "frost-rerandomized",
  "k256",
  "rand_core 0.6.4",
  "sha2",
@@ -3164,8 +3161,8 @@ dependencies = [
  "built",
  "bytes",
  "chrono",
- "frost-core-unofficial",
- "frost-secp256k1-tr-unofficial",
+ "frost-core",
+ "frost-secp256k1-tr",
  "futures",
  "graphql_client",
  "hex",
@@ -3200,7 +3197,7 @@ name = "spark-wallet"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "frost-secp256k1-tr-unofficial",
+ "frost-secp256k1-tr",
  "futures",
  "hex",
  "platform-utils",


### PR DESCRIPTION
The unofficial frost crates were yanked.

Use the same frost crates as [spark library](https://github.com/buildonspark/spark/blob/4101f4ce9be44ad67ebfeea7474da28a8adfca2a/signer/Cargo.toml#L20-L21)