### PR TITLE
bump SO protos

### DIFF
--- a/crates/spark/build.rs
+++ b/crates/spark/build.rs
@@ -11,6 +11,7 @@ fn main() {
         .compile_protos(
             &[
                 "protos/spark/common.proto",
+                "protos/spark/multisig.proto",
                 "protos/spark/spark.proto",
                 "protos/spark/spark_authn.proto",
                 "protos/spark/spark_token.proto",

--- a/crates/spark/protos/spark/multisig.proto
+++ b/crates/spark/protos/spark/multisig.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package multisig;
+
+import "validate/validate.proto";
+
+option go_package = "github.com/lightsparkdev/spark/proto/multisig";
+
+message MultisigConfig {
+    uint32 version = 1;
+    uint32 threshold = 2 [(validate.rules).uint32.gte = 1];
+    // Public keys sorted lexicographically. Order determines canonical hash.
+    repeated bytes public_keys = 3 [(validate.rules).repeated = {
+        min_items: 2,
+        items: { bytes: { len: 33 } }
+    }];
+}
+
+message KeyedSignature {
+    bytes public_key = 1 [(validate.rules).bytes.len = 33];
+    bytes signature = 2 [
+        (validate.rules).bytes.min_len = 64,
+        (validate.rules).bytes.max_len = 73
+    ];
+}
+
+message MultisigSignatureSet {
+    MultisigConfig multisig_config = 1 [(validate.rules).message.required = true];
+    repeated KeyedSignature signatures = 2;
+}
+
+message SigningAuthority {
+    oneof authority {
+        bytes public_key = 1 [(validate.rules).bytes.len = 33];
+        MultisigConfig multisig = 2;
+    }
+}

--- a/crates/spark/protos/spark/spark.proto
+++ b/crates/spark/protos/spark/spark.proto
@@ -93,6 +93,8 @@ service SparkService {
 
     rpc update_wallet_setting(UpdateWalletSettingRequest) returns (UpdateWalletSettingResponse) {}
     rpc query_wallet_setting(QueryWalletSettingRequest) returns (QueryWalletSettingResponse) {}
+
+    rpc query_spark_transaction_volumes(QuerySparkTransactionVolumesRequest) returns (QuerySparkTransactionVolumesResponse) {}
 }
 
 message SubscribeToEventsRequest {
@@ -106,17 +108,29 @@ message SubscribeToEventsResponse {
         DepositEvent deposit = 2;
         ConnectedEvent connected = 3;
         TransferEvent sender_transfer = 4;
+        HeartbeatEvent heartbeat = 5;
+        TokenTransactionEvent token_transaction = 6;
     }
+}
+
+message TokenTransactionEvent {
+    bytes token_transaction_hash = 1;
+    repeated bytes token_identifiers = 2;
+    repeated string spark_invoices = 3;
 }
 
 message ConnectedEvent { }
 
+message HeartbeatEvent { }
+
 message TransferEvent {
     Transfer transfer = 10;
+    string trace_id = 11;
 }
 
 message DepositEvent {
     TreeNode deposit = 10;
+    string trace_id = 11;
 }
 
 /**
@@ -602,6 +616,8 @@ message TreeNode {
     bytes direct_refund_tx = 17;
     // The refund transaction of the node, this transaction is to pay to the user.
     bytes direct_from_cpfp_refund_tx = 18;
+    // The status of the node as a typed enum.
+    TreeNodeStatus treenode_status = 19;
 }
 
 /**
@@ -1554,7 +1570,7 @@ message InitiateSwapPrimaryTransferResponse {
 }
 
 // Adaptor public key is derived from the secret `t` using formula:
-// ```ignored
+// ```text
 // T = t * G
 // ```
 message AdaptorPublicKeyPackage {
@@ -1575,6 +1591,8 @@ enum TreeNodeStatus {
     TREE_NODE_STATUS_AGGREGATE_LOCK = 8;
     TREE_NODE_STATUS_EXITED = 9;
     TREE_NODE_STATUS_RENEW_LOCKED = 10;
+    TREE_NODE_STATUS_UNAVAILABLE = 11;
+    TREE_NODE_STATUS_PARENT_EXITED = 12;
 }
 
 message WalletSetting {
@@ -1601,4 +1619,40 @@ message QueryWalletSettingRequest {
 
 message QueryWalletSettingResponse {
     WalletSetting wallet_setting = 1;
+}
+
+enum SparkTransactionType {
+    SPARK_TRANSACTION_TYPE_UNSPECIFIED = 0;
+    SPARK_TRANSACTION_TYPE_TRANSFER = 1;
+    SPARK_TRANSACTION_TYPE_LIGHTNING_SEND = 2;
+    SPARK_TRANSACTION_TYPE_LIGHTNING_RECEIVE = 3;
+    SPARK_TRANSACTION_TYPE_COOPERATIVE_EXIT = 4;
+    SPARK_TRANSACTION_TYPE_DEPOSIT = 5;
+}
+
+message QuerySparkTransactionVolumesRequest {
+    string start_date = 1 [(validate.rules).string = {len: 10, pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"}];
+    string end_date = 2 [(validate.rules).string = {len: 10, pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"}];
+    // If empty, results include all transaction types. Otherwise results are
+    // scoped to the listed types (e.g. [LIGHTNING_SEND, LIGHTNING_RECEIVE]).
+    repeated SparkTransactionType transaction_types = 3 [(validate.rules).repeated = {items: {enum: {defined_only: true, not_in: [0]}}}];
+    // If unset, results include all networks. When set, results are scoped to that
+    // single network. All defined networks (MAINNET, REGTEST, TESTNET, SIGNET) are allowed.
+    optional Network network = 4 [(validate.rules).enum = {defined_only: true, not_in: [0]}];
+}
+
+message SparkTransactionVolume {
+    SparkTransactionType transaction_type = 1;
+    int64 volume_sats = 2;
+    int64 transaction_count = 3;
+}
+
+message QuerySparkTransactionVolumesResponse {
+    string partner_id = 1;
+    string label = 2;
+    string start_date = 3;
+    string end_date = 4;
+    repeated SparkTransactionVolume transaction_types = 5;
+    int64 total_volume_sats = 6;
+    int64 total_transaction_count = 7;
 }

--- a/crates/spark/protos/spark/spark_token.proto
+++ b/crates/spark/protos/spark/spark_token.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package spark_token;
 
 import "google/protobuf/timestamp.proto";
+import "spark/multisig.proto";
 import "spark/spark.proto";
 import "validate/validate.proto";
 
@@ -27,7 +28,11 @@ service SparkTokenService {
     rpc query_token_outputs(QueryTokenOutputsRequest)
         returns (QueryTokenOutputsResponse) {}
 
-    rpc freeze_tokens(FreezeIssuerTokenRequest) returns (FreezeIssuerTokenResponse) {}
+    rpc freeze_tokens(FreezeTokensRequest) returns (FreezeTokensResponse) {}
+
+    // Replaces start_transaction and commit_transaction in single phase transaction flow.
+    rpc broadcast_transaction(BroadcastTransactionRequest)
+        returns (BroadcastTransactionResponse) {}
 }
 
 // This proto is constructed by the wallet to specify leaves it wants to spend
@@ -42,6 +47,9 @@ message TokenTransferInput {
 }
 
 message TokenMintInput {
+    // Deprecated: The SO now uses token_identifier to look up the issuer public key
+    // from the TokenCreate record. This field is still included in the transaction hash,
+    // so it must be set correctly, but will be removed in a future version bump.
     bytes issuer_public_key = 1 [(validate.rules).bytes.len = 33];
     optional bytes token_identifier = 2 [(validate.rules).bytes.len = 32];
 }
@@ -54,6 +62,9 @@ message TokenCreateInput {
     bytes max_supply = 5 [(validate.rules).bytes.len = 16]; // Decoded uint128
     bool is_freezable = 6;
     optional bytes creation_entity_public_key = 7 [(validate.rules).bytes.len = 33];
+
+    // If any of the fields below are provided, use protohash to generate the token_identifier
+    optional bytes extra_metadata = 8 [(validate.rules).bytes = {max_len: 1024}];
 }
 
 // This proto is constructed by the wallet to specify outputs it wants to create
@@ -70,7 +81,30 @@ message TokenOutput {
     optional bytes token_identifier = 8 [(validate.rules).bytes.len = 32];
     bytes token_amount     = 7
         [(validate.rules).bytes.len = 16];  // Decoded uint128
+    // SE Schnorr signature enabling offline L1 withdrawal.
+    // Only present in query responses; empty until SE signing is implemented.
+    optional bytes se_withdrawal_signature = 9;
+    optional TokenOutputStatus status = 10;
+}
 
+enum TokenOutputStatus {
+    TOKEN_OUTPUT_STATUS_UNSPECIFIED = 0;
+    TOKEN_OUTPUT_STATUS_AVAILABLE = 1;
+    TOKEN_OUTPUT_STATUS_PENDING_OUTBOUND = 2;
+}
+
+message PartialTokenOutput {
+    bytes owner_public_key = 1 [(validate.rules).bytes.len = 33];
+    uint64 withdraw_bond_sats = 2;
+    uint64 withdraw_relative_block_locktime = 3;
+    bytes token_identifier = 4 [(validate.rules).bytes.len = 32];
+    bytes token_amount = 5
+        [(validate.rules).bytes.len = 16];  // Decoded uint128
+}
+
+message FinalTokenOutput {
+    PartialTokenOutput partial_token_output = 1;
+    bytes revocation_commitment = 2 [(validate.rules).bytes.len = 33];
 }
 
 enum TokenTransactionType {
@@ -96,7 +130,7 @@ message TokenTransaction {
     }
     repeated TokenOutput token_outputs                 = 4;
     repeated bytes spark_operator_identity_public_keys = 5
-        [(validate.rules).repeated .items.bytes.len = 33];
+    [(validate.rules).repeated .items.bytes.len = 33];
     // Server-set expiry time. The server calculates this by adding the client's
     // requested validity_duration_seconds to the server's current time when
     // creating the final transaction.
@@ -108,6 +142,60 @@ message TokenTransaction {
     google.protobuf.Timestamp client_created_timestamp = 9;
     // The spark invoices this transaction fulfills.
     repeated InvoiceAttachment invoice_attachments = 10;
+    // Should NOT be set explicitly on V2 transactions (protected with validation).
+    // Provided here to enable cross-conversion between v3 token transaction protos during migration.
+    optional uint64 validity_duration_seconds = 11;
+    // Optional client-specified deadline for transaction execution.
+    // Carried through from PartialTokenTransaction.execute_before during conversion.
+    optional google.protobuf.Timestamp execute_before = 12;
+}
+
+message TokenTransactionMetadata {
+    repeated bytes spark_operator_identity_public_keys = 2
+    [(validate.rules).repeated .items.bytes.len = 33];
+    spark.Network network = 3 [(validate.rules).enum = { not_in: [ 0 ] }];
+    // The timestamp of when the client created the transaction. This is used to
+    // determine which transaction should win in a race condition. Earlier
+    // timestamps win over later ones.
+    google.protobuf.Timestamp client_created_timestamp = 4;
+    // How long the transaction should be valid for, in seconds.
+    // The server will set the actual expiry_time in the final transaction based
+    // on this duration. Must be within [1, 300] seconds.
+    uint64 validity_duration_seconds = 5
+        [(validate.rules).uint64 = { gte: 1, lte: 300 }];
+    // The spark invoices this transaction fulfills.
+    repeated InvoiceAttachment invoice_attachments = 6;
+}
+
+message PartialTokenTransaction {
+    uint32 version = 1;
+    TokenTransactionMetadata token_transaction_metadata = 2;
+    oneof token_inputs {
+        TokenMintInput mint_input = 3;
+        TokenTransferInput transfer_input = 4;
+        TokenCreateInput create_input = 5;
+    }
+    repeated PartialTokenOutput partial_token_outputs = 6;
+    // Optional client-specified deadline for transaction execution.
+    // If set, the server must reject the transaction if current time > execute_before.
+    // Must be after client_created_timestamp, within a configurable max window,
+    // and truncated to microsecond precision.
+    optional google.protobuf.Timestamp execute_before = 7;
+}
+
+message FinalTokenTransaction {
+    uint32 version = 1;
+    TokenTransactionMetadata token_transaction_metadata = 2;
+    oneof token_inputs {
+        TokenMintInput mint_input = 3;
+        TokenTransferInput transfer_input = 4;
+        TokenCreateInput create_input = 5;
+    }
+    repeated FinalTokenOutput final_token_outputs = 6;
+    // Optional client-specified deadline for transaction execution.
+    // Included in the final hash to prevent malleability — an attacker cannot
+    // change the deadline without invalidating operator signatures.
+    optional google.protobuf.Timestamp execute_before = 7;
 }
 
 message InvoiceAttachment {
@@ -115,14 +203,19 @@ message InvoiceAttachment {
 }
 
 message SignatureWithIndex {
-    // This is a Schnorr or ECDSA DER signature which can be between 64 and 73
-    // bytes.
-    bytes signature = 1 [
+    // Deprecated: use authority_signatures instead.
+    optional bytes signature = 1 [
+        (validate.rules).bytes.ignore_empty = true,
         (validate.rules).bytes.min_len = 64,
         (validate.rules).bytes.max_len = 73
     ];
     // The index of the TTXO associated with this signature.
     uint32 input_index = 2;
+    // Supports single-key or multisig signatures.
+    oneof authority_signatures {
+        multisig.KeyedSignature single_signature = 3;
+        multisig.MultisigSignatureSet multisig_signatures = 4;
+    }
 }
 
 // A group of signatures for the input TTXOs binding them to the final token
@@ -138,8 +231,8 @@ message StartTransactionRequest {
     TokenTransaction partial_token_transaction = 2;
     // Filled by signing the partial token transaction hash with the
     // owner/issuer private key. For mint transactions this will be one
-    // signature for the input issuer_public_key For transfer transactions this
-    // will be one for each output for the output owner_public_key
+    // signature for the input issuer_public_key. For transfer transactions this
+    // will be one signature for each input to be sepnt.
     repeated SignatureWithIndex partial_token_transaction_owner_signatures = 3;
     // How long the transaction should be valid for, in seconds.
     // The server will set the actual expiry_time in the final transaction based
@@ -175,7 +268,29 @@ message CommitProgress {
 message CommitTransactionResponse {
     CommitStatus commit_status = 1;
     CommitProgress commit_progress = 2;
+    // The raw token identifier is returned on create transactions
+    optional bytes token_identifier = 3 [(validate.rules).bytes.len = 32];
 }
+
+
+message BroadcastTransactionRequest {
+    bytes identity_public_key = 1 [(validate.rules).bytes.len = 33];
+    PartialTokenTransaction partial_token_transaction = 2;
+    // Filled by signing the partial token transaction hash with the
+    // owner/issuer private key. For mint transactions this will be one
+    // signature for the input issuer_public_key. For transfer transactions this
+    // will be one signature for each input to be spent.
+    repeated SignatureWithIndex token_transaction_owner_signatures = 3;
+}
+
+message BroadcastTransactionResponse {
+    FinalTokenTransaction final_token_transaction = 1;
+    CommitStatus commit_status = 2;
+    CommitProgress commit_progress = 3;
+    // The raw token identifier is returned on create transactions
+    optional bytes token_identifier = 4 [(validate.rules).bytes.len = 32];
+}
+
 
 message QueryTokenMetadataRequest {
     repeated bytes token_identifiers = 1 [(validate.rules).repeated .items.bytes.len = 32];
@@ -191,6 +306,7 @@ message TokenMetadata {
     bool is_freezable = 6;
     optional bytes creation_entity_public_key = 7 [(validate.rules).bytes.len = 33];
     bytes token_identifier = 8 [(validate.rules).bytes.len = 32];
+    optional bytes extra_metadata = 9 [(validate.rules).bytes = {max_len: 1024}];
 }
 
 message QueryTokenMetadataResponse {
@@ -202,7 +318,7 @@ message QueryTokenOutputsRequest {
     // Optionally provide issuer public keys or token identifiers. If both are not set return outputs for all tokens.
     repeated bytes issuer_public_keys = 2 [(validate.rules).repeated.items.bytes.len = 33];
     repeated bytes token_identifiers = 4 [(validate.rules).repeated.items.bytes.len = 32];
-    spark.Network network = 3; // defaults to mainnet when no network is provided.
+    spark.Network network = 3;
     // For pagination
     spark.PageRequest page_request = 5;
 }
@@ -229,7 +345,7 @@ message QueryTokenTransactionsRequest {
 }
 
 message QueryTokenTransactionsByTxHash {
-    repeated bytes token_transaction_hashes = 1 [(validate.rules).repeated = {min_items: 1, max_items: 100, items: {bytes: {len: 32}}}];
+    repeated bytes token_transaction_hashes = 1 [(validate.rules).repeated = {min_items: 1, items: {bytes: {len: 32}}}];
 }
 
 message QueryTokenTransactionsByFilters {
@@ -287,15 +403,15 @@ message TokenTransactionWithStatus {
     TokenTransactionConfirmationMetadata confirmation_metadata = 3;
     // In rare cases the above reconstructed token transaction may not match the original token transaction due to:
     // a) a pre-empted transfer transaction having its input TTXOs remapped to the newer transaction
-    // b) proto migrations or field deprecations resulting in missing/swapped fields (eg. token public key -> token identifier) 
+    // b) proto migrations or field deprecations resulting in missing/swapped fields (eg. token public key -> token identifier)
     // Include the original hash to ensure clients can reconcile this transaction with the original if needed.
     bytes token_transaction_hash = 4 [(validate.rules).bytes.len = 32];
 }
 
 
-message FreezeIssuerTokenPayload {
+message FreezeTokensPayload {
     uint32 version = 1;
-    bytes owner_public_key = 2 [(validate.rules).bytes.len = 33];
+    optional bytes owner_public_key = 2 [(validate.rules).bytes.len = 33];
     optional bytes token_public_key = 3 [(validate.rules).bytes.len = 33];
     optional bytes token_identifier = 4 [(validate.rules).bytes.len = 32];
     uint64 issuer_provided_timestamp = 5;
@@ -304,13 +420,27 @@ message FreezeIssuerTokenPayload {
     bool should_unfreeze = 7;
 }
 
-message FreezeIssuerTokenRequest {
-    FreezeIssuerTokenPayload freeze_tokens_payload = 1;
+message FreezeTokensRequest {
+    FreezeTokensPayload freeze_tokens_payload = 1;
     // This is a Schnorr or ECDSA DER signature which can be between 64 and 73 bytes.
     bytes issuer_signature = 2 [(validate.rules).bytes.min_len = 64, (validate.rules).bytes.max_len = 73];
 }
 
-message FreezeIssuerTokenResponse {
-    repeated string impacted_output_ids = 1 [(validate.rules).repeated.items.string.uuid = true];
+// Reference to a token output by its outpoint (transaction hash + vout).
+message TokenOutputRef {
+    bytes transaction_hash = 1 [(validate.rules).bytes.len = 32];
+    uint32 vout = 2;
+}
+
+// FreezeProgress tracks the coordinated freeze status across operators.
+message FreezeProgress {
+    repeated bytes applied_operator_public_keys = 1 [(validate.rules).repeated.items.bytes.len = 33];
+}
+
+message FreezeTokensResponse {
+    // Deprecated: Use impacted_token_outputs instead. UUIDs are SO-local and differ across SOs.
+    repeated string impacted_output_ids = 1 [deprecated = true, (validate.rules).repeated.items.string.uuid = true];
     bytes impacted_token_amount = 2;  // Decoded uint128
+    repeated TokenOutputRef impacted_token_outputs = 3;
+    FreezeProgress freeze_progress = 4;
 }

--- a/crates/spark/src/events/server_stream.rs
+++ b/crates/spark/src/events/server_stream.rs
@@ -147,6 +147,14 @@ pub async fn subscribe_server_events(
                     debug!("Received connected event");
                     SparkEvent::Connected
                 }
+                Event::Heartbeat(_) => {
+                    trace!("Received heartbeat event");
+                    continue;
+                }
+                Event::TokenTransaction(_) => {
+                    trace!("Received token transaction event");
+                    continue;
+                }
             };
 
             debug!("Emitting spark event: {spark_event}");

--- a/crates/spark/src/operator/rpc/mod.rs
+++ b/crates/spark/src/operator/rpc/mod.rs
@@ -27,3 +27,8 @@ pub mod spark_token {
     #![allow(clippy::all)]
     tonic::include_proto!("spark_token");
 }
+
+pub mod multisig {
+    #![allow(clippy::all)]
+    tonic::include_proto!("multisig");
+}

--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -417,8 +417,8 @@ impl SparkRpcClient {
 
     pub async fn freeze_tokens(
         &self,
-        req: spark_token::FreezeIssuerTokenRequest,
-    ) -> Result<spark_token::FreezeIssuerTokenResponse> {
+        req: spark_token::FreezeTokensRequest,
+    ) -> Result<spark_token::FreezeTokensResponse> {
         debug!("Calling freeze_tokens with request: {:?}", req);
         Ok(self
             .spark_token_service_client()

--- a/crates/spark/src/services/models.rs
+++ b/crates/spark/src/services/models.rs
@@ -1161,14 +1161,16 @@ pub struct FreezeIssuerTokenResponse {
     pub impacted_token_amount: u128,
 }
 
-impl TryFrom<operator_rpc::spark_token::FreezeIssuerTokenResponse> for FreezeIssuerTokenResponse {
+impl TryFrom<operator_rpc::spark_token::FreezeTokensResponse> for FreezeIssuerTokenResponse {
     type Error = ServiceError;
 
     fn try_from(
-        response: operator_rpc::spark_token::FreezeIssuerTokenResponse,
+        response: operator_rpc::spark_token::FreezeTokensResponse,
     ) -> Result<Self, Self::Error> {
+        #[allow(deprecated)]
+        let impacted_output_ids = response.impacted_output_ids;
         Ok(FreezeIssuerTokenResponse {
-            impacted_output_ids: response.impacted_output_ids,
+            impacted_output_ids,
             impacted_token_amount: u128::from_unpadded_be_bytes(
                 response.impacted_token_amount.as_slice(),
             )
@@ -1364,6 +1366,7 @@ mod tests {
                 updated_time: None,
             }),
             status: "AVAILABLE".to_string(),
+            treenode_status: 0,
             network: 0,
             created_time: None,
             updated_time: None,
@@ -1449,6 +1452,8 @@ mod tests {
                         bech32m_decode_token_id(token_identifier, Some(Network::Regtest)).unwrap(),
                     ),
                     token_amount: token_amount.to_be_bytes().to_vec(),
+                    se_withdrawal_signature: None,
+                    status: None,
                 }),
                 previous_transaction_hash: previous_transaction_hash.clone(),
                 previous_transaction_vout,

--- a/crates/spark/src/token/token_service.rs
+++ b/crates/spark/src/token/token_service.rs
@@ -409,9 +409,9 @@ impl TokenService {
 
         let mut requests = Vec::new();
         for operator in self.operator_pool.get_all_operators() {
-            let freeze_tokens_payload = rpc::spark_token::FreezeIssuerTokenPayload {
+            let freeze_tokens_payload = rpc::spark_token::FreezeTokensPayload {
                 version: 1,
-                owner_public_key: owner_public_key.clone(),
+                owner_public_key: Some(owner_public_key.clone()),
                 token_identifier: Some(token_identifier.clone()),
                 should_unfreeze,
                 issuer_provided_timestamp,
@@ -426,13 +426,12 @@ impl TokenService {
                 .serialize()
                 .to_vec();
 
-            let request =
-                operator
-                    .client
-                    .freeze_tokens(rpc::spark_token::FreezeIssuerTokenRequest {
-                        freeze_tokens_payload: Some(freeze_tokens_payload),
-                        issuer_signature,
-                    });
+            let request = operator
+                .client
+                .freeze_tokens(rpc::spark_token::FreezeTokensRequest {
+                    freeze_tokens_payload: Some(freeze_tokens_payload),
+                    issuer_signature,
+                });
             requests.push(request);
         }
         let responses = futures::future::try_join_all(requests).await?;
@@ -840,6 +839,8 @@ impl TokenService {
             ),
             token_inputs: Some(token_inputs),
             invoice_attachments,
+            validity_duration_seconds: None,
+            execute_before: None,
         })
     }
 
@@ -871,16 +872,18 @@ impl TokenService {
                 | rpc::spark_token::token_transaction::TokenInputs::MintInput(_),
             ) => {
                 owner_signatures.push(SignatureWithIndex {
-                    signature,
+                    signature: Some(signature),
                     input_index: 0,
+                    authority_signatures: None,
                 });
             }
             Some(rpc::spark_token::token_transaction::TokenInputs::TransferInput(input)) => {
                 // One signature per input
                 for i in 0..input.outputs_to_spend.len() {
                     owner_signatures.push(SignatureWithIndex {
-                        signature: signature.clone(),
+                        signature: Some(signature.clone()),
                         input_index: i as u32,
+                        authority_signatures: None,
                     });
                 }
             }
@@ -1170,16 +1173,18 @@ impl TokenService {
                     | rpc::spark_token::token_transaction::TokenInputs::MintInput(_),
                 ) => {
                     signatures.push(rpc::spark_token::SignatureWithIndex {
-                        signature,
+                        signature: Some(signature),
                         input_index: 0,
+                        authority_signatures: None,
                     });
                 }
                 Some(rpc::spark_token::token_transaction::TokenInputs::TransferInput(input)) => {
                     // One signature per input
                     for i in 0..input.outputs_to_spend.len() {
                         signatures.push(rpc::spark_token::SignatureWithIndex {
-                            signature: signature.clone(),
+                            signature: Some(signature.clone()),
                             input_index: i as u32,
+                            authority_signatures: None,
                         });
                     }
                 }
@@ -1605,7 +1610,7 @@ fn validate_create_token_params(
 }
 
 fn hash_freeze_tokens_payload(
-    payload: &rpc::spark_token::FreezeIssuerTokenPayload,
+    payload: &rpc::spark_token::FreezeTokensPayload,
 ) -> Result<Vec<u8>, ServiceError> {
     let mut all_hashes = Vec::new();
     let empty_bytes = vec![];
@@ -1615,7 +1620,8 @@ fn hash_freeze_tokens_payload(
         .to_vec();
     all_hashes.push(version_hash);
 
-    let owner_public_key_hash = sha256::Hash::hash(&payload.owner_public_key)
+    let owner_public_key = payload.owner_public_key.as_ref().unwrap_or(&empty_bytes);
+    let owner_public_key_hash = sha256::Hash::hash(owner_public_key)
         .to_byte_array()
         .to_vec();
     all_hashes.push(owner_public_key_hash);
@@ -1698,6 +1704,8 @@ mod tests {
                     .unwrap(),
             ),
             token_amount: 50_u128.to_be_bytes().to_vec(),
+            se_withdrawal_signature: None,
+            status: None,
         }, TokenOutput {
             id: Some("660e8400-e29b-41d4-a716-446655440002".to_string()),
             owner_public_key: hex::decode(
@@ -1723,6 +1731,8 @@ mod tests {
                     .unwrap(),
             ),
             token_amount: 100_u128.to_be_bytes().to_vec(),
+            se_withdrawal_signature: None,
+            status: None,
         }],
             spark_operator_identity_public_keys: vec![
                 hex::decode(
@@ -1766,6 +1776,8 @@ mod tests {
             }, rpc::spark_token::InvoiceAttachment {
                 spark_invoice: "sparkrt1pgss8cf4gru7ece2ryn8ym3vm3yz8leeend2589m7svq2mgv0xncfyx8zg7qsqgjzqqe5p0arydhhu5utuc4zzm732h35fs2yzsc3gs6v8hzpgnaaax0kgcn7r7gq53lnxq0gqnuscptu60nvu02yyszq05p5syke4wzv7gn76gt3r30c90qt8u5nfec4vl60nrxphjgzqm4hgze4xrxejmu2vqlj8sxp4mzux2dlq7fpq9akl0tufcpqd25tcpljc407uexx26".to_string(),
             }],
+            validity_duration_seconds: None,
+            execute_before: None,
         }
     }
 


### PR DESCRIPTION
Spark added a heartbeat to the SO event stream, causing us to log a warning every 5 seconds:

```
2026-04-24T07:29:06.372600Z  WARN spark::events::server_stream: 81: Received empty event, skipping
2026-04-24T07:29:11.373407Z  WARN spark::events::server_stream: 81: Received empty event, skipping
```

Bump the protos so we understand this event, and the log goes to trace level.