### PR TITLE
improve sync time

### DIFF
--- a/crates/breez-sdk/breez-itest/src/fixtures/mod.rs
+++ b/crates/breez-sdk/breez-itest/src/fixtures/mod.rs
@@ -71,14 +71,13 @@ pub async fn bob_strict_fee_sdk() -> Result<SdkInstance> {
     build_sdk_with_custom_config(path, seed, cfg, Some(dir), true).await
 }
 
-/// Fixture: Alice's SDK with external signer  
+/// Fixture: Alice's SDK with external signer
 #[fixture]
 pub async fn alice_external_signer_sdk() -> Result<SdkInstance> {
     let alice_dir = TempDir::new("breez-sdk-alice-ext-signer")?;
     let path = alice_dir.path().to_string_lossy().to_string();
 
-    // Use deterministic test mnemonic for Alice
-    let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".to_string();
+    let mnemonic = random_mnemonic()?;
 
     info!("Initializing Alice's SDK with external signer at: {}", path);
     build_sdk_with_external_signer(path, mnemonic, Some(alice_dir)).await
@@ -90,11 +89,16 @@ pub async fn bob_external_signer_sdk() -> Result<SdkInstance> {
     let bob_dir = TempDir::new("breez-sdk-bob-ext-signer")?;
     let path = bob_dir.path().to_string_lossy().to_string();
 
-    // Use different deterministic test mnemonic for Bob
-    let mnemonic = "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong".to_string();
+    let mnemonic = random_mnemonic()?;
 
     info!("Initializing Bob's SDK with external signer at: {}", path);
     build_sdk_with_external_signer(path, mnemonic, Some(bob_dir)).await
+}
+
+fn random_mnemonic() -> Result<String> {
+    let mut entropy = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut entropy);
+    Ok(bip39::Mnemonic::from_entropy(&entropy)?.to_string())
 }
 
 /// Fixture: Alice's SDK with stable balance config

--- a/crates/spark-itest/src/fixtures/setup.rs
+++ b/crates/spark-itest/src/fixtures/setup.rs
@@ -97,13 +97,15 @@ impl TestFixtures {
 
 // Helper function to create a test signer
 pub fn create_test_signer_alice() -> DefaultSigner {
-    // Use deterministic seed for testing
-    let seed = [3u8; 32];
-    DefaultSigner::new(&seed, spark_wallet::Network::Regtest).unwrap()
+    create_random_test_signer()
 }
 
 pub fn create_test_signer_bob() -> DefaultSigner {
-    // Use deterministic seed for testing
-    let seed = [4u8; 32];
+    create_random_test_signer()
+}
+
+fn create_random_test_signer() -> DefaultSigner {
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill(&mut seed);
     DefaultSigner::new(&seed, spark_wallet::Network::Regtest).unwrap()
 }

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1869,19 +1869,23 @@ async fn create_transfers(
         .filter_map(|t| t.spark_id.clone().map(|spark_id| (spark_id, t.clone())))
         .collect();
 
-    let htlc_requests = htlc_service
-        .query_htlc(
-            QueryHtlcFilter {
-                transfer_ids: preimage_swap_transfer_ids,
-                match_role: PreimageRequestRole::ReceiverAndSender,
-                identity_public_key: our_public_key,
-                status: None,
-                payment_hashes: Vec::new(),
-            },
-            None,
-        )
-        .await?
-        .items;
+    let htlc_requests = if preimage_swap_transfer_ids.is_empty() {
+        Vec::new()
+    } else {
+        htlc_service
+            .query_htlc(
+                QueryHtlcFilter {
+                    transfer_ids: preimage_swap_transfer_ids,
+                    match_role: PreimageRequestRole::ReceiverAndSender,
+                    identity_public_key: our_public_key,
+                    status: None,
+                    payment_hashes: Vec::new(),
+                },
+                None,
+            )
+            .await?
+            .items
+    };
 
     let htlc_requests_map: HashMap<String, PreimageRequestWithTransfer> = htlc_requests
         .into_iter()


### PR DESCRIPTION
When there are no htlcs to be queried, `transfer_ids` was empty. That caused a query for all htlcs. In an integration test I added that accidentally used a fixed, already used seed, that made calls to query_htlc taking 7-9 seconds, because it was querying all htlcs. By not querying when we don't have to, we save that time.

Additionally, some integration tests that do payments use a non-random seed. So sync takes an awfully long time at some point. Using a random seed should speed things up because we start with a blank slate.