### PR TITLE
ssp client: retry on 5xx responses

### DIFF
--- a/crates/spark-itest/src/fixtures/setup.rs
+++ b/crates/spark-itest/src/fixtures/setup.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use rand::Rng;
 use spark_wallet::{
     DefaultSigner, LeafOptimizationOptions, Network, OperatorConfig, OperatorPoolConfig, PublicKey,
-    ServiceProviderConfig, SparkWalletConfig, TokenOutputsOptimizationOptions,
+    RetryConfig, ServiceProviderConfig, SparkWalletConfig, TokenOutputsOptimizationOptions,
 };
 use tracing::info;
 
@@ -81,6 +81,7 @@ impl TestFixtures {
                 schema_endpoint: None,
                 identity_public_key: PublicKey::from_slice(&[2; 33])?,
                 user_agent: Some("spark-wallet-itest/0.1.0".to_string()),
+                retry_config: RetryConfig::default(),
             },
             tokens_config: SparkWalletConfig::default_tokens_config(),
             leaf_optimization_options: LeafOptimizationOptions::default(),

--- a/crates/spark-wallet/src/config.rs
+++ b/crates/spark-wallet/src/config.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use spark::{
     Network,
     operator::{OperatorConfig, OperatorPoolConfig},
-    ssp::ServiceProviderConfig,
+    ssp::{RetryConfig, ServiceProviderConfig},
     token::TokensConfig,
     tree::LeafOptimizationOptions,
 };
@@ -138,6 +138,7 @@ impl SparkWalletConfig {
                 SparkWalletError::ValidationError("Invalid identity public key".to_string())
             })?,
             user_agent: None,
+            retry_config: RetryConfig::default(),
         })
     }
 

--- a/crates/spark/src/ssp/graphql/client.rs
+++ b/crates/spark/src/ssp/graphql/client.rs
@@ -1,12 +1,16 @@
 use base64::Engine;
 use bitcoin::secp256k1::PublicKey;
 use graphql_client::{GraphQLQuery, Response};
+use rand::Rng;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::{debug, error};
+use std::time::Duration;
+use tracing::{debug, error, warn};
 
+use platform_utils::tokio;
 use platform_utils::{ContentType, HttpClient, add_content_type_header, create_http_client};
+use tokio::time::sleep;
 
 use crate::default_user_agent;
 use crate::session_manager::{Session, SessionManager};
@@ -25,7 +29,7 @@ use crate::ssp::graphql::{
 };
 use crate::ssp::{
     ClaimStaticDepositInput, CoopExitFeeQuote, RequestCoopExitInput, RequestLightningReceiveInput,
-    RequestLightningSendInput, RequestSwapInput, SspTransfer,
+    RequestLightningSendInput, RequestSwapInput, RetryConfig, SspTransfer,
 };
 
 /// GraphQL client for interacting with the Spark server
@@ -36,6 +40,7 @@ pub struct GraphQLClient {
     signer: Arc<dyn Signer>,
     session_manager: Arc<dyn SessionManager>,
     ssp_identity_public_key: PublicKey,
+    retry_config: RetryConfig,
 }
 
 impl GraphQLClient {
@@ -57,6 +62,7 @@ impl GraphQLClient {
             signer,
             session_manager,
             ssp_identity_public_key: config.ssp_identity_public_key,
+            retry_config: config.retry_config,
         }
     }
 
@@ -89,7 +95,7 @@ impl GraphQLClient {
         let status_code = response.status;
         let text = &response.body;
         tracing::trace!("Response: {text:?}");
-        if (400..500).contains(&status_code) {
+        if !response.is_success() {
             return Err(GraphQLError::Network {
                 reason: text.clone(),
                 code: Some(status_code),
@@ -110,7 +116,11 @@ impl GraphQLClient {
         ))
     }
 
-    /// Execute a raw GraphQL query
+    /// Execute a raw GraphQL query.
+    ///
+    /// Retries once on a 401 (after re-authenticating) and up to
+    /// `retry_config.max_retries` times on transient 5xx responses with
+    /// exponential backoff and jitter.
     pub async fn post_query<Q: GraphQLQuery, T>(
         &self,
         variables: T,
@@ -118,34 +128,59 @@ impl GraphQLClient {
     where
         T: Serialize + Clone + Into<Q::Variables>,
     {
-        let session = self.get_session().await?;
         let full_url = self.get_full_url();
-        let mut headers = HashMap::new();
-        self.add_auth_headers(&session, &mut headers)?;
+        let mut auth_retried = false;
+        let mut server_attempt: u32 = 0;
 
-        match self
-            .post_query_inner::<Q, T>(&full_url, &headers, variables.clone())
-            .await
-        {
-            Ok(response) => Ok(response),
-            Err(e) => {
-                tracing::debug!("Received error: {}", e.to_string());
-                if let GraphQLError::Network {
-                    code: Some(status_code),
-                    ..
-                } = e.clone()
-                    && status_code == 401
-                {
-                    let session = self.get_session().await?;
-                    let mut headers = HashMap::new();
-                    self.add_auth_headers(&session, &mut headers)?;
+        loop {
+            let session = self.get_session().await?;
+            let mut headers = HashMap::new();
+            self.add_auth_headers(&session, &mut headers)?;
 
-                    return self
-                        .post_query_inner::<Q, T>(&full_url, &headers, variables)
-                        .await;
-                }
-                Err(e)
+            let err = match self
+                .post_query_inner::<Q, T>(&full_url, &headers, variables.clone())
+                .await
+            {
+                Ok(response) => return Ok(response),
+                Err(e) => e,
+            };
+
+            tracing::debug!("Received error: {}", err);
+
+            let GraphQLError::Network {
+                code: Some(status_code),
+                ..
+            } = &err
+            else {
+                return Err(err);
+            };
+
+            if *status_code == 401 && !auth_retried {
+                auth_retried = true;
+                continue;
             }
+
+            if (500..600).contains(status_code) && server_attempt < self.retry_config.max_retries {
+                let base = self
+                    .retry_config
+                    .base_delay_ms
+                    .saturating_mul(1u64 << server_attempt)
+                    .min(self.retry_config.max_delay_ms);
+                let jitter = rand::thread_rng().gen_range(0..=base / 2);
+                let delay_ms = base.saturating_add(jitter);
+                warn!(
+                    "Received {} from SSP, retrying in {}ms (attempt {}/{})",
+                    status_code,
+                    delay_ms,
+                    server_attempt + 1,
+                    self.retry_config.max_retries
+                );
+                sleep(Duration::from_millis(delay_ms)).await;
+                server_attempt += 1;
+                continue;
+            }
+
+            return Err(err);
         }
     }
 
@@ -571,5 +606,246 @@ impl GraphQLClient {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use macros::async_test_all;
+    use platform_utils::HttpError;
+
+    use super::*;
+    use crate::session_manager::InMemorySessionManager;
+    use crate::signer::create_test_signer;
+
+    /// Empty-list response for the `WalletWebhooks` query — used as a stand-in
+    /// for "any successful GraphQL response" in the retry tests.
+    const VALID_WEBHOOKS_RESPONSE: &str = r#"{"data":{"wallet_webhooks":{"webhooks":[]}}}"#;
+
+    #[derive(Default)]
+    struct MockHttpInner {
+        responses: Mutex<VecDeque<(u16, String)>>,
+        post_calls: AtomicUsize,
+    }
+
+    #[derive(Clone, Default)]
+    struct MockHttpClient(Arc<MockHttpInner>);
+
+    impl MockHttpClient {
+        fn with_responses(responses: Vec<(u16, &str)>) -> Self {
+            Self(Arc::new(MockHttpInner {
+                responses: Mutex::new(
+                    responses
+                        .into_iter()
+                        .map(|(s, b)| (s, b.to_string()))
+                        .collect(),
+                ),
+                post_calls: AtomicUsize::new(0),
+            }))
+        }
+
+        fn post_calls(&self) -> usize {
+            self.0.post_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[macros::async_trait]
+    impl HttpClient for MockHttpClient {
+        async fn get(
+            &self,
+            _url: String,
+            _headers: Option<HashMap<String, String>>,
+        ) -> Result<platform_utils::HttpResponse, HttpError> {
+            unimplemented!("get not used in these tests")
+        }
+
+        async fn post(
+            &self,
+            _url: String,
+            _headers: Option<HashMap<String, String>>,
+            _body: Option<String>,
+        ) -> Result<platform_utils::HttpResponse, HttpError> {
+            self.0.post_calls.fetch_add(1, Ordering::SeqCst);
+            let (status, body) = self
+                .0
+                .responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| HttpError::Other("mock: no more scripted responses".to_string()))?;
+            Ok(platform_utils::HttpResponse { status, body })
+        }
+
+        async fn delete(
+            &self,
+            _url: String,
+            _headers: Option<HashMap<String, String>>,
+            _body: Option<String>,
+        ) -> Result<platform_utils::HttpResponse, HttpError> {
+            unimplemented!("delete not used in these tests")
+        }
+    }
+
+    fn dummy_pubkey() -> PublicKey {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[7u8; 32]).expect("valid secret key");
+        PublicKey::from_secret_key(&secp, &sk)
+    }
+
+    /// Build a `GraphQLClient` wired up with the mock HTTP client and a
+    /// pre-populated valid session so `post_query` never triggers an
+    /// `authenticate()` round-trip.
+    async fn build_test_client(http: MockHttpClient, retry_config: RetryConfig) -> GraphQLClient {
+        let ssp_pk = dummy_pubkey();
+        let session_manager = Arc::new(InMemorySessionManager::default());
+        session_manager
+            .set_session(
+                &ssp_pk,
+                Session {
+                    token: "test-token".to_string(),
+                    expiration: u64::MAX,
+                    headers: HashMap::new(),
+                },
+            )
+            .await
+            .expect("set session");
+
+        GraphQLClient {
+            client: Box::new(http),
+            base_url: "http://test.invalid".to_string(),
+            schema_endpoint: "graphql".to_string(),
+            signer: Arc::new(create_test_signer()),
+            session_manager,
+            ssp_identity_public_key: ssp_pk,
+            retry_config,
+        }
+    }
+
+    /// Fast retry config that keeps tests snappy.
+    fn fast_retry(max_retries: u32) -> RetryConfig {
+        RetryConfig {
+            max_retries,
+            base_delay_ms: 1,
+            max_delay_ms: 5,
+        }
+    }
+
+    #[async_test_all]
+    async fn post_query_succeeds_after_5xx_retries() {
+        let http = MockHttpClient::with_responses(vec![
+            (503, "<html>Bad Gateway</html>"),
+            (502, ""),
+            (200, VALID_WEBHOOKS_RESPONSE),
+        ]);
+        let handle = http.clone();
+        let client = build_test_client(http, fast_retry(2)).await;
+
+        let result = client.list_wallet_webhooks().await;
+        assert!(result.is_ok(), "expected success, got {result:?}");
+        assert_eq!(handle.post_calls(), 3);
+    }
+
+    #[async_test_all]
+    async fn post_query_exhausts_5xx_retries() {
+        let max_retries = 2;
+        let attempts = (max_retries as usize) + 1;
+        let http = MockHttpClient::with_responses(
+            std::iter::repeat_n((500, "internal error"), attempts).collect(),
+        );
+        let handle = http.clone();
+        let client = build_test_client(http, fast_retry(max_retries)).await;
+
+        let err = client.list_wallet_webhooks().await.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                GraphQLError::Network {
+                    code: Some(500),
+                    ..
+                }
+            ),
+            "expected Network 500 after exhausting retries, got {err:?}"
+        );
+        assert_eq!(handle.post_calls(), attempts);
+    }
+
+    #[async_test_all]
+    async fn post_query_does_not_retry_on_4xx() {
+        let http = MockHttpClient::with_responses(vec![(400, "bad request")]);
+        let handle = http.clone();
+        let client = build_test_client(http, fast_retry(2)).await;
+
+        let err = client.list_wallet_webhooks().await.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                GraphQLError::Network {
+                    code: Some(400),
+                    ..
+                }
+            ),
+            "expected Network 400, got {err:?}"
+        );
+        assert_eq!(handle.post_calls(), 1);
+    }
+
+    #[async_test_all]
+    async fn post_query_retries_once_on_401() {
+        let http = MockHttpClient::with_responses(vec![
+            (401, "unauthorized"),
+            (200, VALID_WEBHOOKS_RESPONSE),
+        ]);
+        let handle = http.clone();
+        let client = build_test_client(http, fast_retry(2)).await;
+
+        let result = client.list_wallet_webhooks().await;
+        assert!(result.is_ok(), "expected success, got {result:?}");
+        assert_eq!(handle.post_calls(), 2);
+    }
+
+    #[async_test_all]
+    async fn post_query_does_not_retry_401_twice() {
+        let http =
+            MockHttpClient::with_responses(vec![(401, "unauthorized"), (401, "unauthorized")]);
+        let handle = http.clone();
+        let client = build_test_client(http, fast_retry(2)).await;
+
+        let err = client.list_wallet_webhooks().await.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                GraphQLError::Network {
+                    code: Some(401),
+                    ..
+                }
+            ),
+            "expected Network 401, got {err:?}"
+        );
+        assert_eq!(handle.post_calls(), 2);
+    }
+
+    #[async_test_all]
+    async fn post_query_respects_max_retries_zero() {
+        let http = MockHttpClient::with_responses(vec![(500, "boom")]);
+        let handle = http.clone();
+        let client = build_test_client(http, fast_retry(0)).await;
+
+        let err = client.list_wallet_webhooks().await.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                GraphQLError::Network {
+                    code: Some(500),
+                    ..
+                }
+            ),
+            "expected Network 500 with no retries, got {err:?}"
+        );
+        assert_eq!(handle.post_calls(), 1);
     }
 }

--- a/crates/spark/src/ssp/graphql/models.rs
+++ b/crates/spark/src/ssp/graphql/models.rs
@@ -90,6 +90,7 @@ pub(crate) struct GraphQLClientConfig {
 
     pub ssp_identity_public_key: PublicKey,
     pub user_agent: Option<String>,
+    pub retry_config: crate::ssp::RetryConfig,
 }
 
 /// Bitcoin network enum

--- a/crates/spark/src/ssp/mod.rs
+++ b/crates/spark/src/ssp/mod.rs
@@ -23,6 +23,33 @@ pub struct ServiceProviderConfig {
     #[serde_as(as = "DisplayFromStr")]
     pub identity_public_key: PublicKey,
     pub user_agent: Option<String>,
+    /// Retry policy for transient 5xx responses from the SSP.
+    #[serde(default)]
+    pub retry_config: RetryConfig,
+}
+
+/// Retry policy for transient 5xx responses from the SSP GraphQL endpoint.
+///
+/// The first retry waits `base_delay_ms` (plus up to 50% jitter), and each
+/// subsequent retry doubles the base delay, capped at `max_delay_ms`.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+pub struct RetryConfig {
+    /// Maximum number of retry attempts after the initial request fails with a 5xx.
+    pub max_retries: u32,
+    /// Initial backoff delay in milliseconds; doubled on each subsequent attempt.
+    pub base_delay_ms: u64,
+    /// Upper bound on the exponential backoff delay in milliseconds (excluding jitter).
+    pub max_delay_ms: u64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 2,
+            base_delay_ms: 50,
+            max_delay_ms: 500,
+        }
+    }
 }
 
 impl From<ServiceProviderConfig> for GraphQLClientConfig {
@@ -32,6 +59,7 @@ impl From<ServiceProviderConfig> for GraphQLClientConfig {
             schema_endpoint: opts.schema_endpoint,
             ssp_identity_public_key: opts.identity_public_key,
             user_agent: opts.user_agent,
+            retry_config: opts.retry_config,
         }
     }
 }


### PR DESCRIPTION
In #829 CI [failed](https://github.com/breez/spark-sdk/actions/runs/24909842211/job/72948579576?pr=829) with an integration test error. I'm assuming the response is something like a 502 error. 

```
Error: SparkSdkError: Service error: service provider error: serialization error: Json error: expected value at line 1 column 1
```

This PR adds retry to the graphql client for the SSP. So if 502 is returned, we retry once with a delay of 50ms. The retry is configurable. 