### PR TITLE
Fix double balance counting

### DIFF
--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -749,7 +749,24 @@ impl TransferService {
         debug!(
             "Transfer {transfer_id} already claimed by another instance; using coordinator's finalized leaves"
         );
-        Some(completed.leaves.into_iter().map(|l| l.leaf).collect())
+        let our_pubkey = self.signer.get_identity_public_key().await.ok()?;
+        let leaves: Vec<TreeNode> = completed
+            .leaves
+            .into_iter()
+            .map(|l| l.leaf)
+            .filter(|leaf| {
+                let is_ours = leaf.owner_identity_public_key == Some(our_pubkey);
+                if !is_ours {
+                    debug!(
+                        "Dropping leaf {} from already-claimed transfer {transfer_id} — \
+                         owner {:?} is no longer us",
+                        leaf.id, leaf.owner_identity_public_key
+                    );
+                }
+                is_ours
+            })
+            .collect();
+        Some(leaves)
     }
 
     /// Prepares leaves for claiming by creating LeafKeyTweak structs


### PR DESCRIPTION
Should fix the integration test failure in https://github.com/breez/spark-sdk/actions/runs/24928935206/job/73003456358?pr=830.

Here's a situation in an integration test fixed by this commit:

  1. Sync loop claims the deposit — claim_transfer succeeds, insert_leaves adds 8 leaves (9901 sats) to state.leaves
  2. Leaf optimizer reserves those 8 leaves for swap — they move from state.leaves to a Swap reservation. Balance stays 9901 (swap_reserved_balance counts them)
  3. swap_leaves() runs — calls initiate_swap_primary_transfer to our SO, signs adaptor sigs, calls request_swap to SSP. SSP creates the counter-transfer
  4. claim_transfer for the counter-swap — key tweaks succeed on all SOs, refund signing succeeds, then finalize_node_signatures fails ("transfer not found" — the SO replication race you identified). The retry path calls finalized_leaves_if_already_claimed, finds the transfer Completed, returns the 13 new leaves (8192 sats)
  5. Optimizer calls finalize_reservation — removes reservation, marks the 8 old leaves as spent in spent_leaf_ids, adds the 13 new leaves (8192 sats) to state.leaves. Balance = 8192
  6. Streaming event handler receives the deposit's UtxoSwap transfer — this is the SAME deposit from step 1, arriving via the event stream. It's NOT a CounterSwap so it's not skipped
  7. claim_transfer for the deposit — the deposit was already claimed in step 1. try_claim_transfer fails → finalized_leaves_if_already_claimed queries the coordinator → finds it Completed → returns the original 8 deposit leaves (9901 sats)
  8. insert_leaves → add_leaves — removes the 8 leaves from spent_leaf_ids, adds them back to state.leaves
  9. Balance = 8192 (new) + 9901 (old, un-spent) = 18093
  
  
 So `finalized_leaves_if_already_claimed` returned leaves from a transfer that were no longer ours. They were at the time of the transfer, but not anymore. But we would insert them in our db as available leaves anyway. This PR checks whether the leaves are ours. This doesn't entirely fix this race I reckon, because there is still time between returning the leaves and inserting them. But it should be much better.