### PR TITLE
Concurrent heavy load fix

### DIFF
--- a/crates/breez-sdk/breez-bench/Cargo.toml
+++ b/crates/breez-sdk/breez-bench/Cargo.toml
@@ -19,6 +19,10 @@ path = "src/bin/parallel_perf.rs"
 name = "claim-perf"
 path = "src/bin/claim_perf.rs"
 
+[[bin]]
+name = "concurrent-perf"
+path = "src/bin/concurrent_perf.rs"
+
 [dependencies]
 # Reuse all test infrastructure from breez-itest
 breez-sdk-itest = { path = "../breez-itest" }

--- a/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
@@ -1,0 +1,820 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Result, bail};
+use clap::Parser;
+use rand::{Rng, RngCore, SeedableRng};
+use tempdir::TempDir;
+use tokio::sync::{Semaphore, mpsc};
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+
+use breez_sdk_itest::{RegtestFaucet, build_sdk_with_tree_store_config, drop_postgres_database};
+use breez_sdk_spark::{
+    BreezSdk, GetInfoRequest, Network, PrepareSendPaymentRequest, ReceivePaymentMethod,
+    ReceivePaymentRequest, SdkEvent, SendPaymentRequest, SyncWalletRequest, default_config,
+};
+
+use breez_bench::events::{wait_for_claimed_event, wait_for_synced_event};
+use breez_bench::stats::DurationStats;
+
+#[derive(Parser, Debug)]
+#[command(name = "concurrent-perf")]
+#[command(about = "Concurrency-bounded Spark transfer throughput tester")]
+struct Args {
+    #[arg(long, default_value = "100")]
+    total_payments: u32,
+
+    #[arg(long, default_value = "6")]
+    concurrency: u32,
+
+    #[arg(long, default_value = "100")]
+    min_amount: u64,
+
+    #[arg(long, default_value = "2000")]
+    max_amount: u64,
+
+    #[arg(long)]
+    seed: Option<u64>,
+
+    #[arg(long)]
+    no_auto_optimize: bool,
+
+    #[arg(long, value_name = "MULTIPLICITY")]
+    pre_optimize: Option<u8>,
+
+    #[arg(long)]
+    sender_postgres: Option<String>,
+
+    #[arg(long)]
+    receiver_postgres: Option<String>,
+
+    #[arg(long)]
+    clean_postgres: bool,
+
+    #[arg(long, default_value = "1.5")]
+    funding_buffer: f64,
+
+    #[arg(long, default_value = "120")]
+    bucket_secs: u64,
+
+    #[arg(long)]
+    label: Option<String>,
+
+    #[arg(long, default_value = "1")]
+    sender_instances: u32,
+}
+
+#[derive(Debug, Clone)]
+struct PaymentTask {
+    id: usize,
+    amount: u64,
+}
+
+#[derive(Debug)]
+struct PaymentResult {
+    id: usize,
+    amount: u64,
+    duration: Duration,
+    completed_at: Duration,
+    success: bool,
+    error: Option<String>,
+}
+
+struct BenchSdkInstance {
+    sdk: BreezSdk,
+    events: mpsc::Receiver<SdkEvent>,
+    #[allow(dead_code)]
+    temp_dir: Option<TempDir>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new(
+            "concurrent_perf=info,\
+             breez_sdk_spark=error,\
+             spark=error,\
+             spark_wallet=error,\
+             breez_sdk_common=error,\
+             breez_sdk_itest=error,\
+             warn",
+        )
+    });
+
+    tracing_subscriber::fmt()
+        .without_time()
+        .with_env_filter(filter)
+        .init();
+
+    if args.clean_postgres {
+        if let Some(conn_str) = &args.sender_postgres {
+            drop_postgres_database(conn_str).await?;
+        }
+        if let Some(conn_str) = &args.receiver_postgres {
+            drop_postgres_database(conn_str).await?;
+        }
+        if args.sender_postgres.is_none() && args.receiver_postgres.is_none() {
+            warn!(
+                "--clean-postgres specified but no --sender-postgres or --receiver-postgres provided, skipping cleanup"
+            );
+        }
+    }
+
+    if args.total_payments == 0 {
+        bail!("--total-payments must be > 0");
+    }
+    if args.concurrency == 0 {
+        bail!("--concurrency must be > 0");
+    }
+    if args.min_amount == 0 || args.max_amount < args.min_amount {
+        bail!("invalid amount range");
+    }
+
+    let seed = args.seed.unwrap_or_else(|| {
+        let s = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        info!("Using random seed: {}", s);
+        s
+    });
+
+    info!("Concurrent Spark Transfer Test");
+    info!("==============================");
+    info!("Total payments: {}", args.total_payments);
+    info!("Concurrency:    {}", args.concurrency);
+    info!(
+        "Amount range:   {} - {} sats",
+        args.min_amount, args.max_amount
+    );
+    info!("Seed:           {}", seed);
+    info!("");
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let amounts: Vec<u64> = (0..args.total_payments)
+        .map(|_| rng.gen_range(args.min_amount..=args.max_amount))
+        .collect();
+    let total_send: u64 = amounts.iter().sum();
+
+    let funding_amount = ((total_send as f64) * args.funding_buffer).ceil() as u64;
+    let funding_amount = funding_amount.max(10_000);
+    info!(
+        "Total to send: {} sats; funding sender with {} sats (buffer x{:.2})",
+        total_send, funding_amount, args.funding_buffer
+    );
+
+    info!("Initializing sender and receiver SDKs...");
+    let (mut sender, mut receiver, sender_seed) = initialize_sdk_pair(
+        args.no_auto_optimize,
+        args.pre_optimize,
+        args.sender_postgres.clone(),
+        args.receiver_postgres.clone(),
+    )
+    .await?;
+
+    info!("Waiting for sender sync...");
+    wait_for_synced_event(&mut sender.events, 120).await?;
+    info!("Waiting for receiver sync...");
+    wait_for_synced_event(&mut receiver.events, 120).await?;
+
+    info!("Funding sender with {} sats (need {} sats min)...", funding_amount, total_send);
+    fund_via_faucet(&mut sender, funding_amount, total_send).await?;
+
+    let optimizer_duration = if args.pre_optimize.is_some() {
+        Some(run_optimization(&sender.sdk, "Pre-optimization").await?)
+    } else {
+        None
+    };
+
+    let receiver_address = receiver
+        .sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::SparkAddress,
+        })
+        .await?
+        .payment_request;
+    info!("Receiver address: {}", receiver_address);
+
+    let mut sender_instances: Vec<BenchSdkInstance> = Vec::new();
+    sender_instances.push(sender);
+    if args.sender_instances > 1 {
+        if args.sender_postgres.is_none() {
+            bail!(
+                "--sender-instances > 1 requires --sender-postgres so the instances share a tree store"
+            );
+        }
+        info!(
+            "Spawning {} additional sender SDK instance(s) sharing the same wallet + postgres tree store",
+            args.sender_instances - 1
+        );
+        for i in 1..args.sender_instances {
+            let extra = build_extra_sender(
+                sender_seed,
+                args.no_auto_optimize,
+                args.pre_optimize,
+                args.sender_postgres.clone(),
+                i,
+            )
+            .await?;
+            sender_instances.push(extra);
+        }
+        for (i, inst) in sender_instances.iter_mut().enumerate() {
+            info!("Waiting for sender instance {} initial sync", i);
+            wait_for_synced_event(&mut inst.events, 120).await?;
+        }
+    }
+
+    let payments: Vec<PaymentTask> = amounts
+        .into_iter()
+        .enumerate()
+        .map(|(id, amount)| PaymentTask { id, amount })
+        .collect();
+
+    info!("");
+    info!(
+        "Running {} payments via {} sender instance(s), each with concurrency={} (total in-flight cap = {})",
+        payments.len(),
+        sender_instances.len(),
+        args.concurrency,
+        sender_instances.len() as u32 * args.concurrency,
+    );
+    info!("");
+
+    let sender_sdks: Vec<Arc<BreezSdk>> = sender_instances
+        .into_iter()
+        .map(|i| Arc::new(i.sdk))
+        .collect();
+    let (results, total_duration) = execute_payments(
+        sender_sdks.clone(),
+        receiver_address,
+        payments,
+        args.concurrency,
+    )
+    .await;
+
+    print_summary(
+        &results,
+        total_duration,
+        args.concurrency,
+        args.bucket_secs,
+        args.label.as_deref(),
+        optimizer_duration,
+        args.pre_optimize,
+    );
+
+    info!("Disconnecting SDKs...");
+    for (i, sdk) in sender_sdks.iter().enumerate() {
+        if let Err(e) = sdk.disconnect().await {
+            warn!("Failed to disconnect sender instance {}: {}", i, e);
+        }
+    }
+    if let Err(e) = receiver.sdk.disconnect().await {
+        warn!("Failed to disconnect receiver SDK: {}", e);
+    }
+    info!("Cleanup complete");
+
+    Ok(())
+}
+
+async fn execute_payments(
+    senders: Vec<Arc<BreezSdk>>,
+    receiver_address: String,
+    payments: Vec<PaymentTask>,
+    concurrency: u32,
+) -> (Vec<PaymentResult>, Duration) {
+    let per_instance_semaphores: Vec<Arc<Semaphore>> = senders
+        .iter()
+        .map(|_| Arc::new(Semaphore::new(concurrency as usize)))
+        .collect();
+    let mut handles = Vec::with_capacity(payments.len());
+    let total_start = Instant::now();
+
+    for (idx, payment) in payments.into_iter().enumerate() {
+        let instance = idx % senders.len();
+        let sender = senders[instance].clone();
+        let receiver_address = receiver_address.clone();
+        let semaphore = per_instance_semaphores[instance].clone();
+        let id = payment.id;
+        let amount = payment.amount;
+
+        let total_start_inner = total_start;
+        let handle = tokio::spawn(async move {
+            let permit = semaphore
+                .acquire_owned()
+                .await
+                .expect("semaphore should never close");
+
+            println!("[START] #{} (instance {}): {} sats", id, instance, amount);
+            let start = Instant::now();
+            let res = execute_single_payment(&sender, &receiver_address, amount).await;
+            let duration = start.elapsed();
+            let completed_at = total_start_inner.elapsed();
+            drop(permit);
+
+            let success = res.is_ok();
+            let error = res.err().map(|e| e.to_string());
+
+            if success {
+                println!(
+                    "[OK]   #{} (instance {}): {} sats in {:.2}s",
+                    id,
+                    instance,
+                    amount,
+                    duration.as_secs_f64()
+                );
+            } else {
+                println!(
+                    "[FAIL] #{} (instance {}): {}",
+                    id,
+                    instance,
+                    error.as_deref().unwrap_or("unknown error")
+                );
+            }
+
+            PaymentResult {
+                id,
+                amount,
+                duration,
+                completed_at,
+                success,
+                error,
+            }
+        });
+
+        handles.push(handle);
+    }
+
+    let mut results = Vec::with_capacity(handles.len());
+    for handle in handles {
+        match handle.await {
+            Ok(r) => results.push(r),
+            Err(e) => warn!("Task join error: {}", e),
+        }
+    }
+
+    let total_duration = total_start.elapsed();
+    println!();
+    println!(
+        "All payments completed in {:.2}s",
+        total_duration.as_secs_f64()
+    );
+
+    (results, total_duration)
+}
+
+async fn execute_single_payment(
+    sender: &BreezSdk,
+    receiver_address: &str,
+    amount: u64,
+) -> Result<()> {
+    let prepare = sender
+        .prepare_send_payment(PrepareSendPaymentRequest {
+            payment_request: receiver_address.to_string(),
+            amount: Some(amount as u128),
+            token_identifier: None,
+            conversion_options: None,
+            fee_policy: None,
+        })
+        .await?;
+
+    sender
+        .send_payment(SendPaymentRequest {
+            prepare_response: prepare,
+            options: None,
+            idempotency_key: None,
+        })
+        .await?;
+
+    Ok(())
+}
+
+fn print_summary(
+    results: &[PaymentResult],
+    total_duration: Duration,
+    concurrency: u32,
+    bucket_secs: u64,
+    label: Option<&str>,
+    optimizer_duration: Option<Duration>,
+    multiplicity: Option<u8>,
+) {
+    println!();
+    println!("============================================================");
+    if let Some(l) = label {
+        println!("SUMMARY [{}]", l);
+    } else {
+        println!("SUMMARY");
+    }
+    println!("============================================================");
+    if let (Some(d), Some(m)) = (optimizer_duration, multiplicity) {
+        println!(
+            "Pre-optimization (multiplicity={}): {:.2}s",
+            m,
+            d.as_secs_f64()
+        );
+    } else if let Some(d) = optimizer_duration {
+        println!("Pre-optimization: {:.2}s", d.as_secs_f64());
+    }
+
+    let total = results.len();
+    let successful: Vec<_> = results.iter().filter(|r| r.success).collect();
+    let failed: Vec<_> = results.iter().filter(|r| !r.success).collect();
+
+    println!("Total payments: {}", total);
+    println!("Concurrency:    {}", concurrency);
+    println!(
+        "Success: {}/{} ({:.1}%)",
+        successful.len(),
+        total,
+        if total > 0 {
+            (successful.len() as f64 / total as f64) * 100.0
+        } else {
+            0.0
+        }
+    );
+    println!(
+        "Failures: {}/{} ({:.1}%)",
+        failed.len(),
+        total,
+        if total > 0 {
+            (failed.len() as f64 / total as f64) * 100.0
+        } else {
+            0.0
+        }
+    );
+
+    let mins = total_duration.as_secs_f64() / 60.0;
+    let throughput = if mins > 0.0 { total as f64 / mins } else { 0.0 };
+    let success_throughput = if mins > 0.0 {
+        successful.len() as f64 / mins
+    } else {
+        0.0
+    };
+    println!(
+        "Wall-clock: {:.2}s; throughput: {:.1} payments/min ({:.1} successful/min)",
+        total_duration.as_secs_f64(),
+        throughput,
+        success_throughput
+    );
+
+    if !successful.is_empty() {
+        let durations: Vec<Duration> = successful.iter().map(|r| r.duration).collect();
+        if let Some(s) = DurationStats::from_durations(&durations) {
+            println!();
+            println!("Per-payment latency (n={} successful):", successful.len());
+            println!(
+                "  Min: {}   Max: {}   Mean: {}",
+                DurationStats::format_duration(s.min),
+                DurationStats::format_duration(s.max),
+                DurationStats::format_duration(s.mean),
+            );
+            println!(
+                "  p50: {}   p95: {}   p99: {}",
+                DurationStats::format_duration(s.p50),
+                DurationStats::format_duration(s.p95),
+                DurationStats::format_duration(s.p99),
+            );
+        }
+
+        let amounts: Vec<u64> = successful.iter().map(|r| r.amount).collect();
+        let total_sent: u64 = amounts.iter().sum();
+        let min = amounts.iter().copied().min().unwrap_or(0);
+        let max = amounts.iter().copied().max().unwrap_or(0);
+        let mean = if !amounts.is_empty() {
+            total_sent / amounts.len() as u64
+        } else {
+            0
+        };
+        println!();
+        println!(
+            "Amounts (successful): total {} sats, min {}, max {}, mean {}",
+            total_sent, min, max, mean
+        );
+    }
+
+    if !results.is_empty() && bucket_secs > 0 {
+        let bucket = Duration::from_secs(bucket_secs);
+        let total_buckets = ((total_duration.as_secs_f64() / bucket.as_secs_f64()).ceil() as usize)
+            .max(1);
+        let mut succ_buckets = vec![0usize; total_buckets];
+        let mut fail_buckets = vec![0usize; total_buckets];
+        for r in results {
+            let idx = ((r.completed_at.as_secs_f64() / bucket.as_secs_f64()) as usize)
+                .min(total_buckets - 1);
+            if r.success {
+                succ_buckets[idx] += 1;
+            } else {
+                fail_buckets[idx] += 1;
+            }
+        }
+
+        println!();
+        println!(
+            "Throughput histogram ({}s buckets, completion time):",
+            bucket_secs
+        );
+        println!(
+            "  {:<14} {:>5}  {:>5}  {:>10}  {}",
+            "window", "ok", "fail", "rate/min", "bar"
+        );
+        let max_count = succ_buckets
+            .iter()
+            .zip(fail_buckets.iter())
+            .map(|(s, f)| s + f)
+            .max()
+            .unwrap_or(0);
+        for i in 0..total_buckets {
+            let from = (i as u64) * bucket_secs;
+            let to = from + bucket_secs;
+            let s = succ_buckets[i];
+            let f = fail_buckets[i];
+            let total = s + f;
+            let rate = (total as f64) * 60.0 / bucket.as_secs_f64();
+            let bar_len = if max_count > 0 {
+                (total as f64 / max_count as f64 * 40.0).round() as usize
+            } else {
+                0
+            };
+            let bar = "#".repeat(bar_len);
+            println!(
+                "  [{:>4}-{:<4}s]  {:>5}  {:>5}  {:>10.1}  {}",
+                from, to, s, f, rate, bar
+            );
+        }
+    }
+
+    if !failed.is_empty() {
+        println!();
+        println!("Failed payments ({}):", failed.len());
+        for r in &failed {
+            println!(
+                "  #{} ({} sats): {}",
+                r.id,
+                r.amount,
+                r.error.as_deref().unwrap_or("unknown error")
+            );
+        }
+        let mut by_error: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        for r in &failed {
+            let key = r.error.clone().unwrap_or_else(|| "unknown".to_string());
+            *by_error.entry(key).or_insert(0) += 1;
+        }
+        println!();
+        println!("Failure breakdown:");
+        for (err, count) in &by_error {
+            println!("  [{}x] {}", count, err);
+        }
+    }
+
+    println!();
+}
+
+async fn initialize_sdk_pair(
+    no_auto_optimize: bool,
+    pre_optimize: Option<u8>,
+    sender_postgres: Option<String>,
+    receiver_postgres: Option<String>,
+) -> Result<(BenchSdkInstance, BenchSdkInstance, [u8; 32])> {
+    let sender_dir = TempDir::new("concurrent-perf-sender")?;
+    let sender_path = sender_dir.path().to_string_lossy().to_string();
+    let mut sender_seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut sender_seed);
+
+    let mut sender_config = default_config(Network::Regtest);
+    if no_auto_optimize || pre_optimize.is_some() {
+        sender_config.optimization_config.auto_enabled = false;
+    }
+    if let Some(multiplicity) = pre_optimize {
+        sender_config.optimization_config.multiplicity = multiplicity;
+    }
+    let itest_sender = build_sdk_with_tree_store_config(
+        sender_path,
+        sender_seed,
+        sender_config,
+        None,
+        true,
+        sender_postgres,
+    )
+    .await?;
+
+    let receiver_dir = TempDir::new("concurrent-perf-receiver")?;
+    let receiver_path = receiver_dir.path().to_string_lossy().to_string();
+    let mut receiver_seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut receiver_seed);
+
+    let mut receiver_config = default_config(Network::Regtest);
+    receiver_config.optimization_config.auto_enabled = false;
+    let itest_receiver = build_sdk_with_tree_store_config(
+        receiver_path,
+        receiver_seed,
+        receiver_config,
+        None,
+        true,
+        receiver_postgres,
+    )
+    .await?;
+
+    Ok((
+        BenchSdkInstance {
+            sdk: itest_sender.sdk,
+            events: itest_sender.events,
+            temp_dir: Some(sender_dir),
+        },
+        BenchSdkInstance {
+            sdk: itest_receiver.sdk,
+            events: itest_receiver.events,
+            temp_dir: Some(receiver_dir),
+        },
+        sender_seed,
+    ))
+}
+
+async fn build_extra_sender(
+    seed: [u8; 32],
+    no_auto_optimize: bool,
+    pre_optimize: Option<u8>,
+    sender_postgres: Option<String>,
+    instance_index: u32,
+) -> Result<BenchSdkInstance> {
+    let dir = TempDir::new(&format!("concurrent-perf-sender-{instance_index}"))?;
+    let path = dir.path().to_string_lossy().to_string();
+
+    let mut config = default_config(Network::Regtest);
+    if no_auto_optimize || pre_optimize.is_some() {
+        config.optimization_config.auto_enabled = false;
+    }
+    if let Some(multiplicity) = pre_optimize {
+        config.optimization_config.multiplicity = multiplicity;
+    }
+    let itest = build_sdk_with_tree_store_config(
+        path,
+        seed,
+        config,
+        None,
+        true,
+        sender_postgres,
+    )
+    .await?;
+
+    Ok(BenchSdkInstance {
+        sdk: itest.sdk,
+        events: itest.events,
+        temp_dir: Some(dir),
+    })
+}
+
+async fn run_optimization(sdk: &BreezSdk, label: &str) -> Result<Duration> {
+    info!("Starting {}...", label.to_lowercase());
+    sdk.start_leaf_optimization().await;
+
+    let start = Instant::now();
+    let timeout = Duration::from_secs(900);
+    let poll_interval = Duration::from_millis(500);
+
+    loop {
+        let progress = sdk.get_leaf_optimization_progress();
+        if !progress.is_running {
+            let elapsed = start.elapsed();
+            info!("{} complete in {:.2}s", label, elapsed.as_secs_f64());
+            return Ok(elapsed);
+        }
+        info!(
+            "Optimization progress: round {}/{}",
+            progress.current_round, progress.total_rounds
+        );
+        if start.elapsed() >= timeout {
+            bail!("Timeout waiting for optimization to complete");
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+async fn fund_via_faucet(
+    sdk_instance: &mut BenchSdkInstance,
+    target_amount: u64,
+    min_required: u64,
+) -> Result<()> {
+    const FAUCET_MAX_PER_CALL: u64 = 50_000;
+    const FAUCET_MIN_PER_CALL: u64 = 1_000;
+
+    sdk_instance.sdk.sync_wallet(SyncWalletRequest {}).await?;
+
+    let receive = sdk_instance
+        .sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::BitcoinAddress { new_address: None },
+        })
+        .await?;
+    let deposit_address = receive.payment_request;
+    info!("Deposit address: {}", deposit_address);
+
+    let faucet = RegtestFaucet::new()?;
+
+    let mut remaining = target_amount;
+    let mut chunk_idx = 0u32;
+    while remaining > 0 {
+        sdk_instance.sdk.sync_wallet(SyncWalletRequest {}).await?;
+        let info = sdk_instance
+            .sdk
+            .get_info(GetInfoRequest {
+                ensure_synced: Some(false),
+            })
+            .await?;
+        if info.balance_sats >= min_required {
+            info!(
+                "Funded {} sats (min required {}).",
+                info.balance_sats, min_required
+            );
+            return Ok(());
+        }
+
+        let mut chunk = remaining.min(FAUCET_MAX_PER_CALL);
+        if chunk < FAUCET_MIN_PER_CALL {
+            chunk = FAUCET_MIN_PER_CALL;
+        }
+        chunk_idx += 1;
+        info!(
+            "Funding chunk #{}: {} sats (balance: {}, min required: {})",
+            chunk_idx, chunk, info.balance_sats, min_required
+        );
+
+        let txid = faucet.fund_address(&deposit_address, chunk).await?;
+        info!("Faucet chunk #{} txid: {}", chunk_idx, txid);
+
+        wait_for_claimed_event(&mut sdk_instance.events, 240).await?;
+
+        sdk_instance.sdk.sync_wallet(SyncWalletRequest {}).await?;
+        let after = sdk_instance
+            .sdk
+            .get_info(GetInfoRequest {
+                ensure_synced: Some(false),
+            })
+            .await?;
+        info!(
+            "Balance after chunk #{}: {} sats",
+            chunk_idx, after.balance_sats
+        );
+
+        if after.balance_sats >= min_required {
+            info!(
+                "Funded {} sats (min required {}).",
+                after.balance_sats, min_required
+            );
+            return Ok(());
+        }
+        remaining = remaining.saturating_sub(chunk);
+    }
+
+    let start = Instant::now();
+    let timeout = Duration::from_secs(60);
+    loop {
+        sdk_instance.sdk.sync_wallet(SyncWalletRequest {}).await?;
+        let info = sdk_instance
+            .sdk
+            .get_info(GetInfoRequest {
+                ensure_synced: Some(false),
+            })
+            .await?;
+        if info.balance_sats >= min_required {
+            info!(
+                "Funded. Balance: {} sats (min required {})",
+                info.balance_sats, min_required
+            );
+            return Ok(());
+        }
+        if start.elapsed() >= timeout {
+            let needed = min_required.saturating_sub(info.balance_sats);
+            info!(
+                "Balance {} below min required {}; funding extra {} sats",
+                info.balance_sats, min_required, needed
+            );
+            let extra = needed
+                .max(FAUCET_MIN_PER_CALL)
+                .min(FAUCET_MAX_PER_CALL);
+            let txid = faucet.fund_address(&deposit_address, extra).await?;
+            info!("Top-up faucet txid: {}", txid);
+            wait_for_claimed_event(&mut sdk_instance.events, 240).await?;
+            sdk_instance.sdk.sync_wallet(SyncWalletRequest {}).await?;
+            let after = sdk_instance
+                .sdk
+                .get_info(GetInfoRequest {
+                    ensure_synced: Some(false),
+                })
+                .await?;
+            if after.balance_sats >= min_required {
+                info!("Funded after top-up: {} sats", after.balance_sats);
+                return Ok(());
+            }
+            bail!(
+                "Failed to reach min required balance {}: have {}",
+                min_required,
+                after.balance_sats
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}

--- a/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
@@ -181,7 +181,10 @@ async fn main() -> Result<()> {
     info!("Waiting for receiver sync...");
     wait_for_synced_event(&mut receiver.events, 120).await?;
 
-    info!("Funding sender with {} sats (need {} sats min)...", funding_amount, total_send);
+    info!(
+        "Funding sender with {} sats (need {} sats min)...",
+        funding_amount, total_send
+    );
     fund_via_faucet(&mut sender, funding_amount, total_send).await?;
 
     let optimizer_duration = if args.pre_optimize.is_some() {
@@ -497,8 +500,8 @@ fn print_summary(
 
     if !results.is_empty() && bucket_secs > 0 {
         let bucket = Duration::from_secs(bucket_secs);
-        let total_buckets = ((total_duration.as_secs_f64() / bucket.as_secs_f64()).ceil() as usize)
-            .max(1);
+        let total_buckets =
+            ((total_duration.as_secs_f64() / bucket.as_secs_f64()).ceil() as usize).max(1);
         let mut succ_buckets = vec![0usize; total_buckets];
         let mut fail_buckets = vec![0usize; total_buckets];
         for r in results {
@@ -517,8 +520,8 @@ fn print_summary(
             bucket_secs
         );
         println!(
-            "  {:<14} {:>5}  {:>5}  {:>10}  {}",
-            "window", "ok", "fail", "rate/min", "bar"
+            "  {:<14} {:>5}  {:>5}  {:>10}  bar",
+            "window", "ok", "fail", "rate/min"
         );
         let max_count = succ_buckets
             .iter()
@@ -650,15 +653,8 @@ async fn build_extra_sender(
     if let Some(multiplicity) = pre_optimize {
         config.optimization_config.multiplicity = multiplicity;
     }
-    let itest = build_sdk_with_tree_store_config(
-        path,
-        seed,
-        config,
-        None,
-        true,
-        sender_postgres,
-    )
-    .await?;
+    let itest =
+        build_sdk_with_tree_store_config(path, seed, config, None, true, sender_postgres).await?;
 
     Ok(BenchSdkInstance {
         sdk: itest.sdk,
@@ -792,9 +788,7 @@ async fn fund_via_faucet(
                 "Balance {} below min required {}; funding extra {} sats",
                 info.balance_sats, min_required, needed
             );
-            let extra = needed
-                .max(FAUCET_MIN_PER_CALL)
-                .min(FAUCET_MAX_PER_CALL);
+            let extra = needed.clamp(FAUCET_MIN_PER_CALL, FAUCET_MAX_PER_CALL);
             let txid = faucet.fund_address(&deposit_address, extra).await?;
             info!("Top-up faucet txid: {}", txid);
             wait_for_claimed_event(&mut sdk_instance.events, 240).await?;

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -205,7 +205,6 @@ class PostgresTreeStore {
         // Clean up old spent markers
         await this._cleanupSpentMarkers(client, refreshTimestamp);
 
-        // Get recent spent leaf IDs (spent_at >= refresh_timestamp)
         const spentResult = await client.query(
           "SELECT leaf_id FROM tree_spent_leaves WHERE spent_at >= $1",
           [refreshTimestamp]

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -280,31 +280,25 @@ class PostgresTreeStore {
           [id]
         );
 
-        if (res.rows.length === 0) {
-          return; // Already finalized or cancelled
+        let isSwap = false;
+        let reservedLeafIds = [];
+        if (res.rows.length > 0) {
+          isSwap = res.rows[0].purpose === "Swap";
+          const leafResult = await client.query(
+            "SELECT id FROM tree_leaves WHERE reservation_id = $1",
+            [id]
+          );
+          reservedLeafIds = leafResult.rows.map((r) => r.id);
+          await this._batchInsertSpentLeaves(client, reservedLeafIds);
+          await client.query(
+            "DELETE FROM tree_leaves WHERE reservation_id = $1",
+            [id]
+          );
+          await client.query(
+            "DELETE FROM tree_reservations WHERE id = $1",
+            [id]
+          );
         }
-
-        const isSwap = res.rows[0].purpose === "Swap";
-
-        // Get reserved leaf IDs
-        const leafResult = await client.query(
-          "SELECT id FROM tree_leaves WHERE reservation_id = $1",
-          [id]
-        );
-        const reservedLeafIds = leafResult.rows.map((r) => r.id);
-
-        // Mark as spent
-        await this._batchInsertSpentLeaves(client, reservedLeafIds);
-
-        // Delete reserved leaves and reservation
-        await client.query(
-          "DELETE FROM tree_leaves WHERE reservation_id = $1",
-          [id]
-        );
-        await client.query(
-          "DELETE FROM tree_reservations WHERE id = $1",
-          [id]
-        );
 
         // Add new leaves if provided
         if (newLeaves && newLeaves.length > 0) {

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -295,24 +295,21 @@ impl TreeStore for PostgresTreeStore {
             .await
             .map_err(map_err)?;
 
-        let Some(reservation_row) = reservation else {
-            // Already finalized or cancelled - match in-memory behavior by returning Ok
-            return Ok(());
-        };
-
-        let is_swap = reservation_row.get::<_, String>("purpose") == "Swap";
-
-        // Get reserved leaf IDs and mark as spent.
-        // The advisory lock prevents concurrent modifications.
-        let reserved_leaf_ids: Vec<String> = {
-            let rows = tx
+        let (is_swap, reserved_leaf_ids) = if let Some(row) = reservation {
+            let is_swap = row.get::<_, String>("purpose") == "Swap";
+            let leaf_ids: Vec<String> = tx
                 .query(
                     "SELECT id FROM tree_leaves WHERE reservation_id = $1",
                     &[id],
                 )
                 .await
-                .map_err(map_err)?;
-            rows.iter().map(|r| r.get(0)).collect()
+                .map_err(map_err)?
+                .iter()
+                .map(|r| r.get(0))
+                .collect();
+            (is_swap, leaf_ids)
+        } else {
+            (false, Vec::new())
         };
 
         // Batch insert spent leaf markers

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -17,7 +17,7 @@ use spark_wallet::{
     select_leaves_by_minimum_amount, select_leaves_by_target_amounts,
 };
 use tokio::sync::watch;
-use tracing::trace;
+use tracing::{info, trace};
 use uuid::Uuid;
 
 use crate::config::PostgresStorageConfig;
@@ -37,11 +37,6 @@ const TREE_STORE_WRITE_LOCK_KEY: i64 = 0x7472_6565_5354_4f52; // "treeTOR" as he
 /// and will be cleaned up during `set_leaves()` to release leaves locked by crashed clients.
 const RESERVATION_TIMEOUT_SECS: f64 = 300.0; // 5 minutes
 
-/// Threshold in milliseconds for cleaning up spent leaf markers.
-/// Spent markers are kept in the database for this duration to support multiple
-/// SDK instances sharing the same postgres database. During `set_leaves`, spent
-/// markers older than `refresh_timestamp` are ignored (treated as deleted).
-/// Actual deletion only happens for markers older than this threshold.
 const SPENT_MARKER_CLEANUP_THRESHOLD_MS: i64 = 5 * 60 * 1000; // 5 minutes
 
 /// `PostgreSQL`-backed tree store implementation.
@@ -62,17 +57,10 @@ impl TreeStore for PostgresTreeStore {
             return Ok(());
         }
 
-        tracing::trace!(
-            "PostgresTreeStore::add_leaves: adding {} leaves",
-            leaves.len()
-        );
         for leaf in leaves {
-            tracing::trace!(
-                "PostgresTreeStore::add_leaves: leaf {} owner={:?} value={} status={:?}",
-                leaf.id,
-                leaf.owner_identity_public_key,
-                leaf.value,
-                leaf.status
+            trace!(
+                "leaf_lifecycle add_leaves: leaf={} value={}",
+                leaf.id, leaf.value
             );
         }
 
@@ -191,24 +179,15 @@ impl TreeStore for PostgresTreeStore {
         };
 
         if has_active_swap || swap_completed_during_refresh {
-            trace!(
-                "Skipping set_leaves: active_swap={}, swap_completed_during_refresh={}",
-                has_active_swap, swap_completed_during_refresh
+            info!(
+                "leaf_lifecycle set_leaves: SKIP active_swap={} swap_completed_during_refresh={} refresh_timestamp={:?}",
+                has_active_swap, swap_completed_during_refresh, refresh_timestamp
             );
             return Ok(());
         }
 
-        // Clean up old spent markers (older than threshold).
-        // We don't immediately delete all spent markers because this postgres store
-        // may be shared by multiple SDK instances. Instead, we keep markers for a
-        // threshold period and ignore (treat as deleted) markers where spent_at < refresh_timestamp.
         Self::cleanup_spent_markers(&tx, refresh_timestamp).await?;
 
-        // Get recent spent leaf IDs (spent_at >= refresh_timestamp).
-        // Older spent markers are ignored - if the refresh started after the spend,
-        // operators had time to process it. A spent leaf won't appear in `leaves`
-        // (coordinator processed the spend), it may only appear in `missing_operators_leaves`
-        // if returned (e.g., HTLC refund).
         let spent_ids: HashSet<String> = {
             let rows = tx
                 .query(
@@ -219,6 +198,12 @@ impl TreeStore for PostgresTreeStore {
                 .map_err(map_err)?;
             rows.iter().map(|r| r.get(0)).collect()
         };
+        info!(
+            "leaf_lifecycle set_leaves: PROCEED refresh_timestamp={:?} active_spent_ids={} (ids={:?})",
+            refresh_timestamp,
+            spent_ids.len(),
+            spent_ids
+        );
 
         // Delete non-reserved leaves that were added BEFORE refresh started.
         // The advisory lock acquired at the start of this transaction prevents deadlocks.
@@ -264,13 +249,26 @@ impl TreeStore for PostgresTreeStore {
             return Ok(());
         }
 
-        // Delete the reservation (ON DELETE SET NULL will clear reservation_id on leaves)
+        let returned_leaf_ids: Vec<String> = tx
+            .query(
+                "SELECT id FROM tree_leaves WHERE reservation_id = $1",
+                &[id],
+            )
+            .await
+            .map_err(map_err)?
+            .iter()
+            .map(|r| r.get(0))
+            .collect();
+        info!(
+            "leaf_lifecycle cancel: reservation={} returning_leaves={:?}",
+            id, returned_leaf_ids
+        );
+
         tx.execute("DELETE FROM tree_reservations WHERE id = $1", &[id])
             .await
             .map_err(map_err)?;
 
         tx.commit().await.map_err(map_err)?;
-        trace!("Cancelled reservation: {id}");
         self.notify_balance_change();
         Ok(())
     }
@@ -312,10 +310,15 @@ impl TreeStore for PostgresTreeStore {
             (false, Vec::new())
         };
 
-        // Batch insert spent leaf markers
+        info!(
+            "leaf_lifecycle finalize: reservation={} is_swap={} marking_spent={:?} new_leaves={}",
+            id,
+            is_swap,
+            reserved_leaf_ids,
+            new_leaves.map_or(0, <[TreeNode]>::len)
+        );
         Self::batch_insert_spent_leaves(&tx, &reserved_leaf_ids).await?;
 
-        // Delete reserved leaves and reservation
         tx.execute("DELETE FROM tree_leaves WHERE reservation_id = $1", &[id])
             .await
             .map_err(map_err)?;
@@ -324,8 +327,13 @@ impl TreeStore for PostgresTreeStore {
             .await
             .map_err(map_err)?;
 
-        // Batch upsert new leaves if provided (with fresh timestamp for race condition fix)
         if let Some(leaves) = new_leaves {
+            for l in leaves {
+                trace!(
+                    "leaf_lifecycle finalize: adding new leaf={} value={} reservation={}",
+                    l.id, l.value, id
+                );
+            }
             Self::batch_upsert_leaves(&tx, leaves, false, None).await?;
         }
 
@@ -703,10 +711,19 @@ impl PostgresTreeStore {
         skip_ids: Option<&HashSet<String>>,
     ) -> Result<(), TreeServiceError> {
         let filtered: Vec<&TreeNode> = if let Some(skip) = skip_ids {
-            leaves
-                .iter()
-                .filter(|l| !skip.contains(&l.id.to_string()))
-                .collect()
+            let mut kept = Vec::new();
+            for l in leaves {
+                let id_str = l.id.to_string();
+                if skip.contains(&id_str) {
+                    trace!(
+                        "leaf_lifecycle batch_upsert: skipped leaf={} (in spent_ids) is_missing_from_operators={}",
+                        id_str, is_missing_from_operators
+                    );
+                } else {
+                    kept.push(l);
+                }
+            }
+            kept
         } else {
             leaves.iter().collect()
         };
@@ -913,8 +930,13 @@ impl PostgresTreeStore {
         .await
         .map_err(map_err)?;
 
-        // Set reservation_id on leaves
         let leaf_ids: Vec<String> = leaves.iter().map(|l| l.id.to_string()).collect();
+        for l in leaves {
+            trace!(
+                "leaf_lifecycle reserve: leaf={} value={} reservation={} purpose={:?}",
+                l.id, l.value, reservation_id, purpose
+            );
+        }
         Self::batch_set_reservation_id(tx, reservation_id, &leaf_ids).await?;
 
         Ok(())

--- a/crates/spark/src/tree/leaf_optimizer.rs
+++ b/crates/spark/src/tree/leaf_optimizer.rs
@@ -230,78 +230,112 @@ impl LeafOptimizer {
         &self,
         _guard: RunningGuard,
     ) -> Result<(), TreeServiceError> {
-        // Reset cancellation flag
+        const MAX_PLANNING_ITERATIONS: u32 = 8;
+
         let _ = self.cancel_tx.send(false);
 
-        let leaves = self.tree_service.list_leaves().await?.available;
-
-        if leaves.is_empty() {
+        let initial_leaves = self.tree_service.list_leaves().await?.available;
+        if initial_leaves.is_empty() {
             debug!("No leaves available for optimization");
             self.emit_event(OptimizationEvent::Skipped);
             return Ok(());
         }
-
-        if !self.should_optimize(&leaves) {
+        if !self.should_optimize(&initial_leaves) {
             debug!("Optimization not needed, skipping");
             self.emit_event(OptimizationEvent::Skipped);
             return Ok(());
         }
 
-        let swaps = calculate_optimization_swaps(
-            &leaves.iter().map(|l| l.value).collect::<Vec<u64>>(),
-            self.config.multiplicity,
-            self.config.max_leaves_per_swap,
-        );
+        let mut started_emitted = false;
+        let mut cumulative_rounds: u32 = 0;
+        let mut next_leaves = Some(initial_leaves);
 
-        if swaps.is_empty() {
-            debug!("No swaps needed for optimization");
-            self.emit_event(OptimizationEvent::Skipped);
-            return Ok(());
-        }
-
-        let total_rounds = swaps.len() as u32;
-
-        info!(
-            "Starting leaf optimization with {} rounds, {} input leaves, {} output leaves",
-            total_rounds,
-            swaps.iter().map(|s| s.leaves_to_give.len()).sum::<usize>(),
-            swaps
-                .iter()
-                .map(|s| s.leaves_to_receive.len())
-                .sum::<usize>()
-        );
-
-        // Update progress with rounds info (is_running already set by start())
-        {
-            let mut progress = self.progress.lock().unwrap();
-            progress.current_round = 0;
-            progress.total_rounds = total_rounds;
-        }
-
-        self.emit_event(OptimizationEvent::Started { total_rounds });
-        info!("Starting leaf optimization with {} rounds", total_rounds);
-
-        // Execute each swap round using the reserved leaves
-        let result = self.execute_optimization_rounds(swaps).await;
-
-        match result {
-            Ok(true) => {
-                info!("Leaf optimization completed successfully");
-                self.emit_event(OptimizationEvent::Completed);
-                Ok(())
-            }
-            Ok(false) => {
-                info!("Leaf optimization was cancelled");
+        for iteration in 1..=MAX_PLANNING_ITERATIONS {
+            if *self.cancel_rx.borrow() {
+                debug!("Optimization cancelled before iteration {iteration}");
                 self.emit_event(OptimizationEvent::Cancelled);
-                Ok(())
+                return Ok(());
             }
-            Err(e) => {
-                self.emit_event(OptimizationEvent::Failed {
-                    error: e.to_string(),
+
+            let leaves = match next_leaves.take() {
+                Some(l) => l,
+                None => self.tree_service.list_leaves().await?.available,
+            };
+            if leaves.is_empty() {
+                break;
+            }
+
+            let swaps = calculate_optimization_swaps(
+                &leaves.iter().map(|l| l.value).collect::<Vec<u64>>(),
+                self.config.multiplicity,
+                self.config.max_leaves_per_swap,
+            );
+
+            if swaps.is_empty() {
+                if iteration == 1 {
+                    debug!("No swaps needed for optimization");
+                    self.emit_event(OptimizationEvent::Skipped);
+                    return Ok(());
+                }
+                break;
+            }
+
+            let rounds_in_iter = swaps.len() as u32;
+            let total_rounds_estimate = cumulative_rounds + rounds_in_iter;
+
+            info!(
+                "Optimization iteration {iteration}: {} rounds, {} input leaves, {} output leaves",
+                rounds_in_iter,
+                swaps.iter().map(|s| s.leaves_to_give.len()).sum::<usize>(),
+                swaps
+                    .iter()
+                    .map(|s| s.leaves_to_receive.len())
+                    .sum::<usize>()
+            );
+
+            if !started_emitted {
+                self.emit_event(OptimizationEvent::Started {
+                    total_rounds: total_rounds_estimate,
                 });
-                Err(e)
+                started_emitted = true;
+            }
+
+            {
+                let mut progress = self.progress.lock().unwrap();
+                progress.current_round = cumulative_rounds;
+                progress.total_rounds = total_rounds_estimate;
+            }
+
+            match self
+                .execute_optimization_rounds(swaps, cumulative_rounds, total_rounds_estimate)
+                .await
+            {
+                Ok(true) => {
+                    cumulative_rounds += rounds_in_iter;
+                }
+                Ok(false) => {
+                    info!("Leaf optimization was cancelled");
+                    self.emit_event(OptimizationEvent::Cancelled);
+                    return Ok(());
+                }
+                Err(e) => {
+                    self.emit_event(OptimizationEvent::Failed {
+                        error: e.to_string(),
+                    });
+                    return Err(e);
+                }
             }
         }
+
+        if !started_emitted {
+            self.emit_event(OptimizationEvent::Skipped);
+        } else {
+            info!(
+                "Leaf optimization completed successfully ({cumulative_rounds} rounds executed)"
+            );
+            self.emit_event(OptimizationEvent::Completed);
+        }
+        Ok(())
     }
 
     /// Cancels the ongoing optimization and waits for it to fully stop.
@@ -343,11 +377,13 @@ impl LeafOptimizer {
     async fn execute_optimization_rounds(
         &self,
         swaps: Vec<SwapPlan>,
+        rounds_offset: u32,
+        cumulative_total_rounds: u32,
     ) -> Result<bool, TreeServiceError> {
-        let total_rounds = swaps.len() as u32;
+        let total_rounds = cumulative_total_rounds.max(rounds_offset + swaps.len() as u32);
 
         for (index, swap) in swaps.into_iter().enumerate() {
-            let round = (index + 1) as u32;
+            let round = rounds_offset + (index + 1) as u32;
 
             // Check for cancellation before each round
             if *self.cancel_rx.borrow() {

--- a/crates/spark/src/tree/leaf_optimizer.rs
+++ b/crates/spark/src/tree/leaf_optimizer.rs
@@ -330,9 +330,7 @@ impl LeafOptimizer {
         if !started_emitted {
             self.emit_event(OptimizationEvent::Skipped);
         } else {
-            info!(
-                "Leaf optimization completed successfully ({cumulative_rounds} rounds executed)"
-            );
+            info!("Leaf optimization completed successfully ({cumulative_rounds} rounds executed)");
             self.emit_event(OptimizationEvent::Completed);
         }
         Ok(())

--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -6,7 +6,7 @@ use platform_utils::time::SystemTime;
 
 use platform_utils::tokio;
 use platform_utils::tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot, watch};
-use tracing::{debug, trace, warn};
+use tracing::{info, trace, warn};
 use uuid::Uuid;
 
 use crate::tree::{
@@ -293,25 +293,26 @@ impl InMemoryTreeStore {
         leaves: &[TreeNode],
     ) -> Result<(), TreeServiceError> {
         let now = SystemTime::now();
-        trace!(
-            "process_add_leaves: Adding {} leaves at {:?}",
-            leaves.len(),
-            now
-        );
         for leaf in leaves {
-            // Remove from spent_leaf_ids if present - when we receive a leaf through
-            // add_leaves (e.g., from a claimed transfer), it's no longer "spent" from
-            // our perspective. This handles the case where the same leaf returns to us
-            // after we sent it to someone else.
-            if state.spent_leaf_ids.remove(&leaf.id).is_some() {
-                trace!(
-                    "Removed leaf {} from spent_leaf_ids (receiving it back)",
-                    leaf.id
-                );
+            let mut updated_in_reservation: Option<LeavesReservationId> = None;
+            for (res_id, entry) in &mut state.leaves_reservations {
+                if let Some(stored) = entry.leaves.iter_mut().find(|s| s.node.id == leaf.id) {
+                    stored.node = leaf.clone();
+                    updated_in_reservation = Some(res_id.clone());
+                    break;
+                }
             }
+            if let Some(res_id) = updated_in_reservation {
+                info!(
+                    "leaf_lifecycle add_leaves: leaf={} value={} updated in reservation={} (skipped re-insert)",
+                    leaf.id, leaf.value, res_id
+                );
+                continue;
+            }
+            let was_spent = state.spent_leaf_ids.remove(&leaf.id).is_some();
             trace!(
-                "Adding leaf {} with value {} at {:?}",
-                leaf.id, leaf.value, now
+                "leaf_lifecycle add_leaves: leaf={} value={} cleared_spent_marker={}",
+                leaf.id, leaf.value, was_spent
             );
             state.leaves.insert(
                 leaf.id.clone(),
@@ -370,7 +371,6 @@ impl InMemoryTreeStore {
         missing_operators_leaves: &[TreeNode],
         refresh_started_at: SystemTime,
     ) -> Result<(), TreeServiceError> {
-        // Skip if swap is active or completed during this refresh
         let has_active_swap = state
             .leaves_reservations
             .values()
@@ -379,32 +379,62 @@ impl InMemoryTreeStore {
             .last_swap_completed_at
             .is_some_and(|completed_at| completed_at >= refresh_started_at);
         if has_active_swap || swap_completed_during_refresh {
-            debug!(
-                "Skipping set_leaves: active_swap={has_active_swap}, \
-                 swap_completed_during_refresh={swap_completed_during_refresh}"
+            info!(
+                "leaf_lifecycle set_leaves: SKIP active_swap={has_active_swap} \
+                 swap_completed_during_refresh={swap_completed_during_refresh} \
+                 refresh_started_at={refresh_started_at:?} \
+                 last_swap_completed_at={:?}",
+                state.last_swap_completed_at
             );
             return Ok(());
         }
+        info!(
+            "leaf_lifecycle set_leaves: PROCEED refresh_started_at={refresh_started_at:?} \
+             last_swap_completed_at={:?} spent_ids_before_clean={}",
+            state.last_swap_completed_at,
+            state.spent_leaf_ids.len()
+        );
 
-        // Remove spent entries that operators have had time to process
+        let cleared_spent: Vec<(TreeNodeId, SystemTime)> = state
+            .spent_leaf_ids
+            .iter()
+            .filter(|(_, spent_at)| **spent_at < refresh_started_at)
+            .map(|(id, ts)| (id.clone(), *ts))
+            .collect();
+        for (id, spent_at) in &cleared_spent {
+            info!(
+                "leaf_lifecycle set_leaves: clearing spent marker for leaf={} spent_at={:?} refresh_started_at={:?}",
+                id, spent_at, refresh_started_at
+            );
+        }
         state
             .spent_leaf_ids
             .retain(|_, spent_at| *spent_at >= refresh_started_at);
 
-        // Save old pools before replacing (moved, not cloned)
         let old_leaves = std::mem::take(&mut state.leaves);
         let old_missing = std::mem::take(&mut state.missing_operators_leaves);
 
-        // Build new pools from refresh data, excluding spent leaves
         let now = SystemTime::now();
         for leaf in leaves {
             if !state.spent_leaf_ids.contains_key(&leaf.id) {
+                let was_present = old_leaves.contains_key(&leaf.id);
+                if !was_present {
+                    info!(
+                        "leaf_lifecycle set_leaves: re-adding leaf={} value={} (from refresh)",
+                        leaf.id, leaf.value
+                    );
+                }
                 state.leaves.insert(
                     leaf.id.clone(),
                     StoredLeaf {
                         node: leaf.clone(),
                         added_at: now,
                     },
+                );
+            } else {
+                trace!(
+                    "leaf_lifecycle set_leaves: skipped leaf={} (in spent_leaf_ids)",
+                    leaf.id
                 );
             }
         }
@@ -420,14 +450,16 @@ impl InMemoryTreeStore {
             }
         }
 
-        // Re-add leaves from old state that were added after the refresh started
-        // and aren't in the refresh data (they weren't available when refresh collected data).
         let mut preserved_count = 0u32;
         for (id, stored) in old_leaves {
             if stored.added_at >= refresh_started_at
                 && !state.leaves.contains_key(&id)
                 && !state.missing_operators_leaves.contains_key(&id)
             {
+                trace!(
+                    "leaf_lifecycle set_leaves: preserved old leaf={} value={} (added after refresh started)",
+                    id, stored.node.value
+                );
                 state.leaves.insert(id, stored);
                 preserved_count += 1;
             }
@@ -437,6 +469,10 @@ impl InMemoryTreeStore {
                 && !state.leaves.contains_key(&id)
                 && !state.missing_operators_leaves.contains_key(&id)
             {
+                trace!(
+                    "leaf_lifecycle set_leaves: preserved old missing leaf={} value={}",
+                    id, stored.node.value
+                );
                 state.missing_operators_leaves.insert(id, stored);
                 preserved_count += 1;
             }
@@ -556,9 +592,12 @@ impl InMemoryTreeStore {
     /// Cancel a reservation and return leaves to the pool.
     /// The permit is automatically released when the ReservationEntry is dropped.
     fn process_cancel_reservation(state: &mut LeavesState, id: &LeavesReservationId) {
-        // Return leaves to pool - permit and pending change are dropped with the entry
         if let Some(entry) = state.leaves_reservations.remove(id) {
             for stored in entry.leaves {
+                trace!(
+                    "leaf_lifecycle cancel: returning leaf={} value={} reservation={} purpose={:?}",
+                    stored.node.id, stored.node.value, id, entry.purpose
+                );
                 state.leaves.insert(stored.node.id.clone(), stored);
             }
             trace!("Canceled leaves reservation: {}", id);
@@ -572,17 +611,16 @@ impl InMemoryTreeStore {
         id: &LeavesReservationId,
         new_leaves: Option<&[TreeNode]>,
     ) {
-        // Remove reservation and record spent leaf IDs
         if let Some(entry) = state.leaves_reservations.remove(id) {
-            // Mark all leaves from this reservation as spent to prevent re-adding during refresh
             let now = SystemTime::now();
             for stored in &entry.leaves {
+                trace!(
+                    "leaf_lifecycle finalize: marking spent leaf={} reservation={} purpose={:?}",
+                    stored.node.id, id, entry.purpose
+                );
                 state.spent_leaf_ids.insert(stored.node.id.clone(), now);
             }
 
-            // If this was a swap reservation with new leaves, record completion time.
-            // This is used to detect if a refresh started before a swap finished,
-            // which would cause stale data to be applied.
             if entry.purpose == ReservationPurpose::Swap && new_leaves.is_some() {
                 state.last_swap_completed_at = Some(now);
             }
@@ -590,10 +628,13 @@ impl InMemoryTreeStore {
             warn!("Tried to finalize a non existing reservation");
         }
 
-        // Add new leaves (e.g., change from swap) with fresh timestamp
         if let Some(resulting_leaves) = new_leaves {
             let now = SystemTime::now();
             for leaf in resulting_leaves {
+                trace!(
+                    "leaf_lifecycle finalize: adding new leaf={} value={} reservation={}",
+                    leaf.id, leaf.value, id
+                );
                 state.leaves.insert(
                     leaf.id.clone(),
                     StoredLeaf {
@@ -626,9 +667,12 @@ impl InMemoryTreeStore {
         let purpose = old_entry.purpose;
         let permit = old_entry._permit;
 
-        // Add change leaves to the available pool with fresh timestamp
         let now = SystemTime::now();
         for leaf in change_leaves {
+            trace!(
+                "leaf_lifecycle update_reservation: adding change leaf={} value={} reservation={}",
+                leaf.id, leaf.value, reservation_id
+            );
             state.leaves.insert(
                 leaf.id.clone(),
                 StoredLeaf {
@@ -689,11 +733,16 @@ impl InMemoryTreeStore {
             }
         }
         let id = Uuid::now_v7().to_string();
-        // Remove leaves from pool and collect as StoredLeaves for the reservation
         let stored_leaves: Vec<StoredLeaf> = leaves
             .iter()
             .filter_map(|leaf| state.leaves.remove(&leaf.id))
             .collect();
+        for stored in &stored_leaves {
+            trace!(
+                "leaf_lifecycle reserve: leaf={} value={} reservation={} purpose={:?}",
+                stored.node.id, stored.node.value, id, purpose
+            );
+        }
         state.leaves_reservations.insert(
             id.clone(),
             ReservationEntry {


### PR DESCRIPTION
**First fix for postgres backend:**
In the Postgres backend, we have code that unreserves leaves after a certain timeout.
Under heavy load, payments may take longer to complete, which means leaf reservations can remain active for a longer period. These reservations were then being cleaned up by that code path.
The main purpose of this cleanup is recovery, for example when an instance crashes and does not get a chance to unreserve the leaves properly. Because of that, we can use a much longer timeout for this recovery flow.
Before this change, the cleanup logic could mistakenly mark those leaves as available while they were still being used. This allowed the next reservation to pick them up, which then resulted in a PermissionDenied error from the operator, since those leaves no longer belonged to the user.

**Second fix is for the leaf optimizer:**  
re-plan after each round until plan is empty calculate_optimization_swaps was called once against the initial leaves; when a single round's batch exceeded max_leaves_per_swap, a greedy binary-expansion fallback silently dropped the multiplicity goal for the tail and the optimizer reported Completed against a lopsided leaf set. Wrap planner+executor in a loop (capped at 8 iterations) that exits when no more swaps are returned, so greedy-tail leftovers are swapped down to plan denominations.

**Third fix for the add_leaves**
add_leaves for the in-memory store added leaves although they were reserved, caused duplicate leaves and stale leaves in the store. We matched the in-memory store behavior to the postgress store where in case the leaf exist as reserved we update it instead of adding. 

Also added a utility to test heavy load controlling the following parameters:
* concurrent instances
* total payments
* concurrent payments per instance

I have ran the following matrix:

## Performance verification

Ran the new `concurrent-perf` benchmark on the regtest postgres backend with
all sender SDK instances sharing a single wallet (same seed) and a single
postgres tree store. 1000 payments per run, payment amounts 1–50 sats,
pre-optimization multiplicity = 2 (mostly), 2 reps per cell.

### Axis 1 — sender instances × concurrency-per-instance (60 in flight, mult=2)

| Instances | Concurrency / instance | In-flight | Mean wall-clock | Throughput |
| --- | --- | --- | --- | --- |
| 3  | 20 | 60 | 238.5 s | 252 /min |
| 4  | 15 | 60 | 190.7 s | 315 /min |
| 5  | 12 | 60 | 173.6 s | 346 /min |
| 6  | 10 | 60 | 147.0 s | 409 /min |
| 10 |  6 | 60 | **123.8 s** | **488 /min** |
| 15 |  4 | 60 | 129.4 s | 466 /min |
| 20 |  3 | 60 | 164.5 s | 365 /min |

### Axis 2 — pre-optimization multiplicity (at 4 instances × c=15)

| Multiplicity | Pre-opt time | Payment-phase wall-clock | Total |
| --- | --- | --- | --- |
| 2  | 10.8 s |  186.6 s | **197.4 s** |
| 4  | 16.2 s |  192.2 s | 208.4 s |
| 8  | 35.6 s |  188.6 s | 224.2 s |
| 12 | 45.3 s |  191.5 s | 236.8 s |
| 15 | 56.6 s |  195.6 s | 252.2 s |
| 20 | 68.8 s |  186.7 s | 255.5 s |

(Same trend at 3×20: mult >2 only adds pre-opt cost, payment-phase wall-clock is flat.)

### Findings

- 1000/1000 success across every configuration. No `PermissionDenied`,
  no `Reservation not found`, no leaf-spending errors.
- Best wall-clock: **10 instances × c=6 with multiplicity=2 (~124 s for
  1000 payments, ~488 payments/min)**.
- The (instances, concurrency) split matters more than the absolute total
  in-flight number; spreading load across more instances at lower
  per-instance concurrency reduces operator-side per-instance queue depth.
  The knee is at 10–15 instances; beyond ~15 instances the per-instance
  overhead (own connection pool, signer, sync loop, event stream) starts
  dominating.
- With the optimizer iteration fix, multiplicity has effectively zero
  effect on payment-phase throughput because swap rate is already 0% at
  mult=2. Higher multiplicities only inflate the one-time pre-opt cost.