### PR TITLE
Robust cancel reservation: verify operator state before releasing leaves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ fly.toml
 # Wasm package
 packages/wasm/breeztech-breez-sdk-spark-v0.1.0.tgz
 .claude/settings.local.json
+crates/breez-sdk/breez-bench/js/node_modules/

--- a/crates/breez-sdk/breez-bench/js/README.md
+++ b/crates/breez-sdk/breez-bench/js/README.md
@@ -1,0 +1,73 @@
+# Concurrent Spark transfer benchmark — Node.js wasm
+
+Counterpart to the Rust `concurrent-perf` bench (`crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs`). Measures send-payment throughput for `@breeztech/breez-sdk-spark/nodejs` against a real regtest network using the public Lightspark faucet.
+
+## Setup
+
+Requires Node.js with native module support for `better-sqlite3`. Tested on Node 22.
+
+```sh
+cd crates/breez-sdk/breez-bench/js
+nvm use 22   # or any node >=18
+npm install
+```
+
+The package depends on `../../../../packages/wasm` (the local wasm package). Rebuild the wasm package via `cargo xtask package wasm::node` if you change SDK source.
+
+## Required env
+
+- `FAUCET_USERNAME`, `FAUCET_PASSWORD` — Lightspark regtest faucet credentials.
+- `BREEZ_API_KEY` — optional (regtest doesn't require one).
+
+## Backends
+
+The bench supports SQLite (default, single instance) and Postgres (single or multi-instance).
+
+For Postgres, point `--sender-postgres` and `--receiver-postgres` at running databases. A local docker postgres works:
+
+```sh
+docker run -d --name spark-perf-pg -e POSTGRES_PASSWORD=postgres -p 5544:5432 postgres:16
+docker exec spark-perf-pg psql -U postgres -c 'CREATE DATABASE bench_sender_node;'
+docker exec spark-perf-pg psql -U postgres -c 'CREATE DATABASE bench_receiver_node;'
+```
+
+Multi-instance senders (`--sender-instances N` where N > 1) require `--sender-postgres` so all instances share one tree store.
+
+## Run
+
+SQLite, single instance:
+
+```sh
+FAUCET_USERNAME=… FAUCET_PASSWORD=… node concurrent_perf.js \
+    --total-payments 50 --concurrency 6
+```
+
+Postgres, multi-instance shared wallet:
+
+```sh
+FAUCET_USERNAME=… FAUCET_PASSWORD=… node concurrent_perf.js \
+    --total-payments 1000 --concurrency 6 --sender-instances 3 \
+    --sender-postgres   "postgres://postgres:postgres@localhost:5544/bench_sender_node" \
+    --receiver-postgres "postgres://postgres:postgres@localhost:5544/bench_receiver_node"
+```
+
+## Common flags
+
+| flag | default | meaning |
+|------|---------|---------|
+| `--total-payments N` | 100 | how many spark transfers to run |
+| `--concurrency N` | 6 | per-instance in-flight cap |
+| `--sender-instances N` | 1 | number of SDK instances sharing the sender wallet (requires `--sender-postgres` if > 1) |
+| `--min-amount`, `--max-amount` | 100, 2000 | per-payment sat range (random) |
+| `--funding-buffer` | 1.5 | faucet over-fund factor |
+| `--no-auto-optimize` | (off) | disable the leaf optimizer |
+| `--multiplicity N` | (default) | optimizer multiplicity |
+| `--keep-data` | (off) | keep sender/receiver data dirs after run |
+| `--sender-data-dir`, `--receiver-data-dir` | (tmp) | reuse a wallet across runs |
+| `--label TEXT` | none | echoed in the summary header |
+
+## Output
+
+Per-payment progress (`[OK]` / `[FAIL]`), then a summary block with throughput, latency percentiles, failure breakdown, and a 60-second-bucket histogram so degradation over time is visible.
+
+The SDK log is written to `<sender-data-dir>/sdk.log` (and the receiver's equivalent). Use `--keep-data` to preserve them after the run for analysis.

--- a/crates/breez-sdk/breez-bench/js/README.md
+++ b/crates/breez-sdk/breez-bench/js/README.md
@@ -8,7 +8,7 @@ Requires Node.js with native module support for `better-sqlite3`. Tested on Node
 
 ```sh
 cd crates/breez-sdk/breez-bench/js
-nvm use 22   # or any node >=18
+nvm use 22   # or any node >=22
 npm install
 ```
 

--- a/crates/breez-sdk/breez-bench/js/bigint_json.js
+++ b/crates/breez-sdk/breez-bench/js/bigint_json.js
@@ -1,0 +1,9 @@
+'use strict'
+
+// Allow JSON.stringify to handle BigInt values produced by the SDK.
+if (typeof BigInt !== 'undefined' && !BigInt.prototype.toJSON) {
+  // eslint-disable-next-line no-extend-native
+  BigInt.prototype.toJSON = function () {
+    return this.toString()
+  }
+}

--- a/crates/breez-sdk/breez-bench/js/concurrent_perf.js
+++ b/crates/breez-sdk/breez-bench/js/concurrent_perf.js
@@ -1,0 +1,461 @@
+'use strict'
+
+require('./bigint_json')
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const bip39 = require('bip39')
+
+const {
+  SdkBuilder,
+  defaultConfig,
+  defaultPostgresStorageConfig,
+  initLogging,
+} = require('@breeztech/breez-sdk-spark/nodejs')
+
+const { fundAddress } = require('./faucet.js')
+
+function parseArgs() {
+  const args = process.argv.slice(2)
+  const opts = {
+    totalPayments: 100,
+    concurrency: 6,
+    minAmount: 100,
+    maxAmount: 2000,
+    fundingBuffer: 1.5,
+    network: 'regtest',
+    label: null,
+    senderMnemonic: null,
+    receiverMnemonic: null,
+    senderDataDir: null,
+    receiverDataDir: null,
+    cleanData: true,
+    bucketSecs: 60,
+    apiKey: process.env.BREEZ_API_KEY,
+    autoOptimize: true,
+    multiplicity: null,
+    senderPostgres: null,
+    receiverPostgres: null,
+    senderInstances: 1,
+  }
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    switch (a) {
+      case '--total-payments': opts.totalPayments = parseInt(args[++i], 10); break
+      case '--concurrency': opts.concurrency = parseInt(args[++i], 10); break
+      case '--min-amount': opts.minAmount = parseInt(args[++i], 10); break
+      case '--max-amount': opts.maxAmount = parseInt(args[++i], 10); break
+      case '--funding-buffer': opts.fundingBuffer = parseFloat(args[++i]); break
+      case '--network': opts.network = args[++i]; break
+      case '--label': opts.label = args[++i]; break
+      case '--sender-mnemonic': opts.senderMnemonic = args[++i]; break
+      case '--receiver-mnemonic': opts.receiverMnemonic = args[++i]; break
+      case '--sender-data-dir': opts.senderDataDir = args[++i]; break
+      case '--receiver-data-dir': opts.receiverDataDir = args[++i]; break
+      case '--keep-data': opts.cleanData = false; break
+      case '--bucket-secs': opts.bucketSecs = parseInt(args[++i], 10); break
+      case '--api-key': opts.apiKey = args[++i]; break
+      case '--no-auto-optimize': opts.autoOptimize = false; break
+      case '--multiplicity': opts.multiplicity = parseInt(args[++i], 10); break
+      case '--sender-postgres': opts.senderPostgres = args[++i]; break
+      case '--receiver-postgres': opts.receiverPostgres = args[++i]; break
+      case '--sender-instances': opts.senderInstances = parseInt(args[++i], 10); break
+      case '-h':
+      case '--help': {
+        printHelp()
+        process.exit(0)
+      }
+      default:
+        console.error(`Unknown arg: ${a}`)
+        printHelp()
+        process.exit(1)
+    }
+  }
+  return opts
+}
+
+function printHelp() {
+  console.log('Concurrent payment benchmark for Breez SDK Spark on Node.js (wasm)')
+  console.log('')
+  console.log('Options:')
+  console.log('  --total-payments N          (default: 100)')
+  console.log('  --concurrency N             (default: 6)')
+  console.log('  --min-amount SATS           (default: 100)')
+  console.log('  --max-amount SATS           (default: 2000)')
+  console.log('  --funding-buffer F          (default: 1.5)')
+  console.log('  --network regtest|mainnet   (default: regtest)')
+  console.log('  --label NAME                Optional label for the run')
+  console.log('  --sender-mnemonic WORDS     Reuse a sender wallet (default: random)')
+  console.log('  --receiver-mnemonic WORDS   Reuse a receiver wallet (default: random)')
+  console.log('  --sender-data-dir PATH      Override sender data dir')
+  console.log('  --receiver-data-dir PATH    Override receiver data dir')
+  console.log('  --keep-data                 Do not remove data dirs at the end')
+  console.log('  --bucket-secs N             Throughput histogram bucket size (default: 60)')
+  console.log('')
+  console.log('Required env: FAUCET_USERNAME, FAUCET_PASSWORD')
+  console.log('Optional env: FAUCET_URL, BREEZ_API_KEY')
+}
+
+function tmpDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+}
+
+function rmrf(p) {
+  if (!p) return
+  try { fs.rmSync(p, { recursive: true, force: true }) } catch (_e) {}
+}
+
+function pickAmount(rng, min, max) {
+  return Math.floor(rng() * (max - min + 1)) + min
+}
+
+function mulberry32(seed) {
+  let s = seed >>> 0
+  return function () {
+    s = (s + 0x6D2B79F5) >>> 0
+    let t = s
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+class EventCollector {
+  constructor() {
+    this.events = []
+    this.waiters = []
+    this.onEvent = (ev) => {
+      this.events.push(ev)
+      const remaining = []
+      for (const w of this.waiters) {
+        if (w.predicate(ev)) {
+          w.resolve(ev)
+        } else {
+          remaining.push(w)
+        }
+      }
+      this.waiters = remaining
+    }
+  }
+
+  waitFor(predicate, timeoutMs) {
+    const matched = this.events.find(predicate)
+    if (matched) return Promise.resolve(matched)
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.waiters = this.waiters.filter((w) => w.timer !== timer)
+        reject(new Error(`Timeout waiting for event after ${timeoutMs}ms`))
+      }, timeoutMs)
+      this.waiters.push({ predicate, resolve: (ev) => { clearTimeout(timer); resolve(ev) }, timer })
+    })
+  }
+}
+
+class FileLogger {
+  constructor(filePath) {
+    this.stream = fs.createWriteStream(filePath, { flags: 'a' })
+    this.log = (entry) => {
+      try {
+        this.stream.write(`[${new Date().toISOString()} ${entry.level}]: ${entry.line}\n`)
+      } catch (_e) {}
+    }
+  }
+}
+
+async function buildSdk(opts, role, mnemonic, dataDir, postgres) {
+  const config = defaultConfig(opts.network)
+  if (opts.apiKey) config.apiKey = opts.apiKey
+  if (config.optimizationConfig) {
+    config.optimizationConfig.autoEnabled = opts.autoOptimize
+    if (opts.multiplicity != null) {
+      config.optimizationConfig.multiplicity = opts.multiplicity
+    }
+  }
+
+  const seed = { type: 'mnemonic', mnemonic, passphrase: undefined }
+  let builder = SdkBuilder.new(config, seed)
+  if (postgres) {
+    builder = builder.withPostgresBackend(defaultPostgresStorageConfig(postgres))
+  } else {
+    builder = await builder.withDefaultStorage(dataDir)
+  }
+  const sdk = await builder.build()
+
+  const collector = new EventCollector()
+  await sdk.addEventListener(collector)
+  return { sdk, events: collector, role }
+}
+
+const FAUCET_MAX_PER_CALL = 50000n
+const FAUCET_MIN_PER_CALL = 1000n
+
+async function fundAndWait(sender, amountSats, neededSats) {
+  const recv = await sender.sdk.receivePayment({ paymentMethod: { type: 'bitcoinAddress' } })
+  const address = recv.paymentRequest
+  console.log(`[fund] Sender deposit address: ${address}`)
+
+  let chunkIdx = 0
+  for (;;) {
+    await sender.sdk.syncWallet({})
+    const info = await sender.sdk.getInfo({})
+    const balance = BigInt(info.balanceSats)
+    if (balance >= BigInt(neededSats)) {
+      console.log(`[fund] Sender balance: ${balance} sats (target: ${neededSats})`)
+      return
+    }
+    const remaining = BigInt(amountSats) - balance
+    if (remaining <= 0n) {
+      console.log(`[fund] Reached target funding: ${balance} sats`)
+      return
+    }
+    let chunk = remaining < FAUCET_MAX_PER_CALL ? remaining : FAUCET_MAX_PER_CALL
+    if (chunk < FAUCET_MIN_PER_CALL) chunk = FAUCET_MIN_PER_CALL
+    chunkIdx++
+    console.log(`[fund] Chunk #${chunkIdx}: requesting ${chunk} sats (balance ${balance}/${neededSats})`)
+    const txid = await fundAddress(address, Number(chunk))
+    console.log(`[fund] Chunk #${chunkIdx} faucet txid: ${txid}`)
+    try {
+      await sender.events.waitFor((ev) => ev.type === 'claimedDeposits', 240_000)
+    } catch (_e) {
+      // fall through; balance check below decides
+    }
+  }
+}
+
+async function runOne(sender, receiverAddress, amount) {
+  const prep = await sender.sdk.prepareSendPayment({
+    paymentRequest: receiverAddress,
+    amount: BigInt(amount),
+  })
+  await sender.sdk.sendPayment({ prepareResponse: prep })
+}
+
+async function executePayments(senders, receiverAddress, payments, concurrency) {
+  const results = new Array(payments.length)
+  const total = payments.length
+  const numInstances = senders.length
+  let nextIdx = 0
+  let completed = 0
+
+  const totalStart = Date.now()
+
+  async function worker(instance, workerId) {
+    const sender = senders[instance]
+    for (;;) {
+      const i = nextIdx++
+      if (i >= total) return
+      const { id, amount } = payments[i]
+      const start = Date.now()
+      console.log(`[START] #${id} (inst ${instance} worker ${workerId}): ${amount} sats`)
+      let success = false
+      let error = null
+      try {
+        await runOne(sender, receiverAddress, amount)
+        success = true
+      } catch (e) {
+        error = e && e.message ? e.message : String(e)
+      }
+      const duration = Date.now() - start
+      const completedAt = Date.now() - totalStart
+      results[i] = { id, amount, durationMs: duration, completedAtMs: completedAt, success, error, instance }
+      completed++
+      if (success) {
+        console.log(`[OK]    #${id} (inst ${instance} worker ${workerId}): ${amount} sats in ${(duration / 1000).toFixed(2)}s   (${completed}/${total})`)
+      } else {
+        console.log(`[FAIL]  #${id} (inst ${instance} worker ${workerId}): ${error}   (${completed}/${total})`)
+      }
+    }
+  }
+
+  const workers = []
+  for (let inst = 0; inst < numInstances; inst++) {
+    for (let w = 0; w < concurrency; w++) {
+      workers.push(worker(inst, w))
+    }
+  }
+  await Promise.all(workers)
+
+  return { results, totalDurationMs: Date.now() - totalStart }
+}
+
+function summarize(results, totalDurationMs, concurrency, bucketSecs, label) {
+  const successful = results.filter((r) => r.success)
+  const failed = results.filter((r) => !r.success)
+  const succN = successful.length
+
+  console.log('')
+  console.log('============================================================')
+  console.log(`SUMMARY${label ? ` [${label}]` : ''}`)
+  console.log('============================================================')
+  console.log(`Total payments:       ${results.length}`)
+  console.log(`Successful:           ${succN}`)
+  console.log(`Failed:               ${failed.length}`)
+  console.log(`Concurrency:          ${concurrency}`)
+  console.log(`Wall-clock:           ${(totalDurationMs / 1000).toFixed(2)}s`)
+  if (succN > 0) {
+    const minutes = totalDurationMs / 60000
+    console.log(`Throughput:           ${(succN / minutes).toFixed(1)} payments/min`)
+    const durations = successful.map((r) => r.durationMs).sort((a, b) => a - b)
+    const sum = durations.reduce((a, b) => a + b, 0)
+    const mean = sum / durations.length
+    const p50 = durations[Math.floor(durations.length * 0.5)]
+    const p90 = durations[Math.floor(durations.length * 0.9)]
+    const p99 = durations[Math.floor(durations.length * 0.99)]
+    console.log(`Per-payment latency: mean ${(mean / 1000).toFixed(2)}s, p50 ${(p50 / 1000).toFixed(2)}s, p90 ${(p90 / 1000).toFixed(2)}s, p99 ${(p99 / 1000).toFixed(2)}s`)
+  }
+
+  if (failed.length > 0) {
+    console.log('')
+    console.log('Failures:')
+    const counts = new Map()
+    for (const r of failed) {
+      const key = (r.error || '').slice(0, 200)
+      counts.set(key, (counts.get(key) || 0) + 1)
+    }
+    for (const [k, v] of counts) {
+      console.log(`  ${v}x  ${k}`)
+    }
+  }
+
+  if (results.length > 0 && bucketSecs > 0) {
+    const bucketMs = bucketSecs * 1000
+    const totalBuckets = Math.max(1, Math.ceil(totalDurationMs / bucketMs))
+    const succBuckets = new Array(totalBuckets).fill(0)
+    const failBuckets = new Array(totalBuckets).fill(0)
+    for (const r of results) {
+      const b = Math.min(totalBuckets - 1, Math.floor(r.completedAtMs / bucketMs))
+      if (r.success) succBuckets[b]++
+      else failBuckets[b]++
+    }
+    const maxCount = Math.max(...succBuckets.map((s, i) => s + failBuckets[i]))
+    if (maxCount > 0) {
+      console.log('')
+      console.log(`Throughput histogram (${bucketSecs}s buckets):`)
+      console.log(`  ${'window'.padEnd(14)} ${'ok'.padStart(5)}  ${'fail'.padStart(5)}  ${'rate/min'.padStart(10)}  bar`)
+      for (let i = 0; i < totalBuckets; i++) {
+        const startSec = i * bucketSecs
+        const endSec = Math.min(totalDurationMs / 1000, (i + 1) * bucketSecs)
+        const succ = succBuckets[i]
+        const fail = failBuckets[i]
+        const rate = (succ * 60) / Math.max(1, endSec - startSec)
+        const bar = '#'.repeat(Math.round(((succ + fail) / maxCount) * 40))
+        console.log(`  ${`${startSec}-${endSec.toFixed(0)}s`.padEnd(14)} ${String(succ).padStart(5)}  ${String(fail).padStart(5)}  ${rate.toFixed(1).padStart(10)}  ${bar}`)
+      }
+    }
+  }
+}
+
+async function main() {
+  const opts = parseArgs()
+
+  if (!opts.totalPayments || opts.totalPayments <= 0) throw new Error('--total-payments must be > 0')
+  if (!opts.concurrency || opts.concurrency <= 0) throw new Error('--concurrency must be > 0')
+  if (opts.maxAmount < opts.minAmount) throw new Error('--max-amount must be >= --min-amount')
+
+  const senderMnemonic = opts.senderMnemonic || bip39.generateMnemonic()
+  const receiverMnemonic = opts.receiverMnemonic || bip39.generateMnemonic()
+  const senderDataDir = opts.senderDataDir || tmpDir('breez-bench-sender-')
+  const receiverDataDir = opts.receiverDataDir || tmpDir('breez-bench-receiver-')
+  fs.mkdirSync(senderDataDir, { recursive: true })
+  fs.mkdirSync(receiverDataDir, { recursive: true })
+
+  const senderLog = path.join(senderDataDir, 'sdk.log')
+  const receiverLog = path.join(receiverDataDir, 'sdk.log')
+
+  if (opts.senderInstances > 1 && !opts.senderPostgres) {
+    throw new Error('--sender-instances > 1 requires --sender-postgres so they share a tree store')
+  }
+
+  console.log('Concurrent Spark Transfer Test (Node.js / wasm)')
+  console.log('==============================================')
+  console.log(`Total payments:    ${opts.totalPayments}`)
+  console.log(`Concurrency:       ${opts.concurrency} (per instance)`)
+  console.log(`Sender instances:  ${opts.senderInstances}`)
+  console.log(`Amount range:      ${opts.minAmount} - ${opts.maxAmount} sats`)
+  console.log(`Network:           ${opts.network}`)
+  console.log(`Sender backend:    ${opts.senderPostgres ? 'postgres' : 'sqlite'}`)
+  console.log(`Receiver backend:  ${opts.receiverPostgres ? 'postgres' : 'sqlite'}`)
+  console.log(`Sender data dir:   ${senderDataDir}`)
+  console.log(`Receiver data dir: ${receiverDataDir}`)
+  console.log(`Sender log:        ${senderLog}`)
+  console.log(`Receiver log:      ${receiverLog}`)
+  console.log('')
+
+  try {
+    await initLogging(new FileLogger(senderLog))
+  } catch (_e) {}
+
+  const seed = (Date.now() & 0xFFFFFFFF) >>> 0
+  const rng = mulberry32(seed)
+  const amounts = []
+  for (let i = 0; i < opts.totalPayments; i++) {
+    amounts.push(pickAmount(rng, opts.minAmount, opts.maxAmount))
+  }
+  const totalSend = amounts.reduce((a, b) => a + b, 0)
+  const fundingAmount = Math.max(10_000, Math.ceil(totalSend * opts.fundingBuffer))
+  console.log(`Total to send:     ${totalSend} sats`)
+  console.log(`Funding amount:    ${fundingAmount} sats (buffer x${opts.fundingBuffer})`)
+
+  console.log('')
+  console.log('Initializing sender SDK (instance 0)...')
+  const senders = []
+  const firstSender = await buildSdk(opts, 'sender', senderMnemonic, senderDataDir, opts.senderPostgres)
+  senders.push(firstSender)
+  console.log('Initializing receiver SDK...')
+  const receiver = await buildSdk(opts, 'receiver', receiverMnemonic, receiverDataDir, opts.receiverPostgres)
+
+  console.log('Waiting for initial sync (sender 0)...')
+  await firstSender.events.waitFor((ev) => ev.type === 'synced', 120_000).catch(() => {})
+  console.log('Waiting for initial sync (receiver)...')
+  await receiver.events.waitFor((ev) => ev.type === 'synced', 120_000).catch(() => {})
+
+  console.log('')
+  await fundAndWait(firstSender, fundingAmount, totalSend)
+
+  for (let i = 1; i < opts.senderInstances; i++) {
+    const dataDir = `${senderDataDir}-inst-${i}`
+    fs.mkdirSync(dataDir, { recursive: true })
+    console.log(`Initializing sender SDK (instance ${i})...`)
+    const inst = await buildSdk(opts, 'sender', senderMnemonic, dataDir, opts.senderPostgres)
+    senders.push(inst)
+    await inst.events.waitFor((ev) => ev.type === 'synced', 120_000).catch(() => {})
+  }
+
+  const recv = await receiver.sdk.receivePayment({ paymentMethod: { type: 'sparkAddress' } })
+  const receiverAddress = recv.paymentRequest
+  console.log(`Receiver Spark address: ${receiverAddress}`)
+
+  const payments = amounts.map((amount, id) => ({ id, amount }))
+
+  console.log('')
+  console.log(
+    `Running ${payments.length} payments via ${senders.length} sender instance(s), each with concurrency=${opts.concurrency} (total in-flight cap = ${senders.length * opts.concurrency})...`
+  )
+  console.log('')
+
+  const { results, totalDurationMs } = await executePayments(senders, receiverAddress, payments, opts.concurrency)
+
+  summarize(results, totalDurationMs, opts.concurrency, opts.bucketSecs, opts.label)
+
+  console.log('')
+  console.log('Disconnecting SDKs...')
+  for (let i = 0; i < senders.length; i++) {
+    try { await senders[i].sdk.disconnect() } catch (_e) {}
+  }
+  try { await receiver.sdk.disconnect() } catch (_e) {}
+
+  if (opts.cleanData) {
+    rmrf(senderDataDir)
+    rmrf(receiverDataDir)
+    for (let i = 1; i < opts.senderInstances; i++) {
+      rmrf(`${senderDataDir}-inst-${i}`)
+    }
+  }
+  console.log('Done.')
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err)
+  process.exit(1)
+})

--- a/crates/breez-sdk/breez-bench/js/faucet.js
+++ b/crates/breez-sdk/breez-bench/js/faucet.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const FAUCET_URL = process.env.FAUCET_URL || 'https://api.lightspark.com/graphql/spark/rc'
+const FAUCET_USERNAME = process.env.FAUCET_USERNAME
+const FAUCET_PASSWORD = process.env.FAUCET_PASSWORD
+
+const QUERY = 'mutation RequestRegtestFunds($address: String!, $amount_sats: Long!) { request_regtest_funds(input: {address: $address, amount_sats: $amount_sats}) { transaction_hash}}'
+
+async function fundAddress(address, amountSats) {
+  if (!FAUCET_USERNAME || !FAUCET_PASSWORD) {
+    throw new Error('FAUCET_USERNAME and FAUCET_PASSWORD env vars are required')
+  }
+
+  const body = JSON.stringify({
+    operationName: 'RequestRegtestFunds',
+    variables: { amount_sats: amountSats, address },
+    query: QUERY,
+  })
+
+  const auth = Buffer.from(`${FAUCET_USERNAME}:${FAUCET_PASSWORD}`).toString('base64')
+
+  const maxRetries = 3
+  let lastErr = null
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (attempt > 0) {
+      const backoffMs = 2 ** attempt * 1000
+      await new Promise((r) => setTimeout(r, backoffMs))
+    }
+    try {
+      const res = await fetch(FAUCET_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${auth}`,
+        },
+        body,
+      })
+      const json = await res.json()
+      if (json.errors && json.errors.length > 0) {
+        throw new Error(`Faucet GraphQL error: ${JSON.stringify(json.errors)}`)
+      }
+      const txid = json.data && json.data.request_regtest_funds && json.data.request_regtest_funds.transaction_hash
+      if (!txid) {
+        throw new Error(`Unexpected faucet response: ${JSON.stringify(json)}`)
+      }
+      return txid
+    } catch (e) {
+      lastErr = e
+    }
+  }
+  throw lastErr
+}
+
+module.exports = { fundAddress }

--- a/crates/breez-sdk/breez-bench/js/package-lock.json
+++ b/crates/breez-sdk/breez-bench/js/package-lock.json
@@ -1,0 +1,650 @@
+{
+  "name": "breez-bench-nodejs",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "breez-bench-nodejs",
+      "version": "0.1.0",
+      "dependencies": {
+        "@breeztech/breez-sdk-spark": "file:../../../../packages/wasm",
+        "better-sqlite3": "^11.10.0",
+        "bip39": "^3.1.0",
+        "pg": "^8.20.0"
+      }
+    },
+    "../../../../packages/wasm": {
+      "name": "@breeztech/breez-sdk-spark",
+      "version": "0.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "optionalDependencies": {
+        "better-sqlite3": "^12.2.0",
+        "pg": "^8.18.0"
+      }
+    },
+    "node_modules/@breeztech/breez-sdk-spark": {
+      "resolved": "../../../../packages/wasm",
+      "link": true
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/crates/breez-sdk/breez-bench/js/package.json
+++ b/crates/breez-sdk/breez-bench/js/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "breez-bench-nodejs",
+  "version": "0.1.0",
+  "description": "Concurrent payment benchmark for Breez SDK Spark on Node.js (wasm)",
+  "private": true,
+  "main": "concurrent_perf.js",
+  "scripts": {
+    "start": "node concurrent_perf.js"
+  },
+  "dependencies": {
+    "@breeztech/breez-sdk-spark": "file:../../../../packages/wasm",
+    "better-sqlite3": "^11.10.0",
+    "bip39": "^3.1.0",
+    "pg": "^8.20.0"
+  }
+}

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -234,27 +234,43 @@ class PostgresTreeStore {
   }
 
   /**
-   * Cancel a reservation, releasing reserved leaves.
+   * Cancel a reservation. All leaves currently attached to the reservation are
+   * deleted from the store. The reservation row is dropped. The supplied
+   * `leavesToKeep` are inserted into the available pool.
+   *
+   * Callers pass the original reservation leaves to preserve the legacy
+   * "release everything back to the pool" behavior. Callers that have
+   * verified leaf state with the operator pass only the leaves confirmed
+   * safe to make available (e.g. dropping operator-locked leaves).
+   *
    * @param {string} id - Reservation ID
+   * @param {Array} leavesToKeep - Leaves to insert as available
    */
-  async cancelReservation(id) {
+  async cancelReservation(id, leavesToKeep) {
     try {
       await this._withWriteTransaction(async (client) => {
-        // Check if reservation exists
         const res = await client.query(
           "SELECT id FROM tree_reservations WHERE id = $1",
           [id]
         );
 
         if (res.rows.length === 0) {
-          return; // Already cancelled or finalized
+          return;
         }
 
-        // Delete reservation (ON DELETE SET NULL releases leaves)
+        await client.query(
+          "DELETE FROM tree_leaves WHERE reservation_id = $1",
+          [id]
+        );
+
         await client.query(
           "DELETE FROM tree_reservations WHERE id = $1",
           [id]
         );
+
+        if (leavesToKeep && leavesToKeep.length > 0) {
+          await this._batchUpsertLeaves(client, leavesToKeep, false, null);
+        }
       });
     } catch (error) {
       if (error instanceof TreeStoreError) throw error;

--- a/crates/breez-sdk/wasm/src/tree_store/mod.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/mod.rs
@@ -230,10 +230,16 @@ impl TreeStore for WasmTreeStore {
         Ok(())
     }
 
-    async fn cancel_reservation(&self, id: &LeavesReservationId) -> Result<(), TreeServiceError> {
+    async fn cancel_reservation(
+        &self,
+        id: &LeavesReservationId,
+        leaves_to_keep: &[TreeNode],
+    ) -> Result<(), TreeServiceError> {
+        let leaves_js = serde_wasm_bindgen::to_value(leaves_to_keep)
+            .map_err(|e| TreeServiceError::Generic(e.to_string()))?;
         let promise = self
             .tree_store
-            .cancel_reservation(id.clone())
+            .cancel_reservation(id.clone(), leaves_js)
             .map_err(js_error_to_tree_error)?;
         JsFuture::from(promise)
             .await
@@ -373,7 +379,7 @@ export interface TreeStore {
     addLeaves: (leaves: TreeNode[]) => Promise<void>;
     getLeaves: () => Promise<Leaves>;
     setLeaves: (leaves: TreeNode[], missingLeaves: TreeNode[], refreshStartedAtMs: number) => Promise<void>;
-    cancelReservation: (id: string) => Promise<void>;
+    cancelReservation: (id: string, leavesToKeep: TreeNode[]) => Promise<void>;
     finalizeReservation: (id: string, newLeaves: TreeNode[] | null) => Promise<void>;
     tryReserveLeaves: (targetAmounts: TargetAmounts | null, exactOnly: boolean, purpose: string) => Promise<ReserveResult>;
     now: () => Promise<number>;
@@ -400,7 +406,11 @@ extern "C" {
     ) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, js_name = cancelReservation, catch)]
-    pub fn cancel_reservation(this: &TreeStoreJs, id: String) -> Result<Promise, JsValue>;
+    pub fn cancel_reservation(
+        this: &TreeStoreJs,
+        id: String,
+        leaves_to_keep: JsValue,
+    ) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, js_name = finalizeReservation, catch)]
     pub fn finalize_reservation(

--- a/crates/breez-sdk/wasm/src/tree_store/tests.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests.rs
@@ -90,6 +90,19 @@ async fn test_cancel_reservation() {
 }
 
 #[wasm_bindgen_test]
+async fn test_cancel_reservation_drops_unkept_leaves() {
+    let store = create_test_tree_store("pg_tree_cancel_drop_some").await;
+    breez_sdk_spark::tree_store_tests::test_cancel_reservation_drops_unkept_leaves(&store).await;
+}
+
+#[wasm_bindgen_test]
+async fn test_cancel_reservation_drops_all_when_keep_empty() {
+    let store = create_test_tree_store("pg_tree_cancel_drop_all").await;
+    breez_sdk_spark::tree_store_tests::test_cancel_reservation_drops_all_when_keep_empty(&store)
+        .await;
+}
+
+#[wasm_bindgen_test]
 async fn test_cancel_reservation_nonexistent() {
     let store = create_test_tree_store("pg_tree_cancel_nonexist").await;
     breez_sdk_spark::tree_store_tests::test_cancel_reservation_nonexistent(&store).await;

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -17,7 +17,7 @@ use spark_wallet::{
     select_leaves_by_minimum_amount, select_leaves_by_target_amounts,
 };
 use tokio::sync::watch;
-use tracing::{info, trace};
+use tracing::{debug, info, trace};
 use uuid::Uuid;
 
 use crate::config::PostgresStorageConfig;
@@ -231,25 +231,26 @@ impl TreeStore for PostgresTreeStore {
         Ok(())
     }
 
-    async fn cancel_reservation(&self, id: &LeavesReservationId) -> Result<(), TreeServiceError> {
+    async fn cancel_reservation(
+        &self,
+        id: &LeavesReservationId,
+        leaves_to_keep: &[TreeNode],
+    ) -> Result<(), TreeServiceError> {
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
 
-        // Acquire advisory lock to prevent deadlocks with concurrent operations
         Self::acquire_write_lock(&tx).await?;
 
-        // Check if reservation exists (advisory lock provides serialization, no row locking needed)
         let reservation = tx
             .query_opt("SELECT id FROM tree_reservations WHERE id = $1", &[id])
             .await
             .map_err(map_err)?;
 
         if reservation.is_none() {
-            // Already cancelled or finalized
             return Ok(());
         }
 
-        let returned_leaf_ids: Vec<String> = tx
+        let prior_leaf_ids: Vec<String> = tx
             .query(
                 "SELECT id FROM tree_leaves WHERE reservation_id = $1",
                 &[id],
@@ -259,14 +260,25 @@ impl TreeStore for PostgresTreeStore {
             .iter()
             .map(|r| r.get(0))
             .collect();
+        let keep_ids: Vec<String> = leaves_to_keep.iter().map(|l| l.id.to_string()).collect();
+        let dropped_ids: Vec<&String> = prior_leaf_ids
+            .iter()
+            .filter(|id| !keep_ids.contains(id))
+            .collect();
         info!(
-            "leaf_lifecycle cancel: reservation={} returning_leaves={:?}",
-            id, returned_leaf_ids
+            "leaf_lifecycle cancel: reservation={} prior_leaves={:?} keeping={:?} dropping={:?}",
+            id, prior_leaf_ids, keep_ids, dropped_ids
         );
+
+        tx.execute("DELETE FROM tree_leaves WHERE reservation_id = $1", &[id])
+            .await
+            .map_err(map_err)?;
 
         tx.execute("DELETE FROM tree_reservations WHERE id = $1", &[id])
             .await
             .map_err(map_err)?;
+
+        Self::batch_upsert_leaves(&tx, leaves_to_keep, false, None).await?;
 
         tx.commit().await.map_err(map_err)?;
         self.notify_balance_change();
@@ -931,12 +943,10 @@ impl PostgresTreeStore {
         .map_err(map_err)?;
 
         let leaf_ids: Vec<String> = leaves.iter().map(|l| l.id.to_string()).collect();
-        for l in leaves {
-            trace!(
-                "leaf_lifecycle reserve: leaf={} value={} reservation={} purpose={:?}",
-                l.id, l.value, reservation_id, purpose
-            );
-        }
+        debug!(
+            "leaf_lifecycle reserve: reservation={} purpose={:?} leaf_ids={:?}",
+            reservation_id, purpose, leaf_ids
+        );
         Self::batch_set_reservation_id(tx, reservation_id, &leaf_ids).await?;
 
         Ok(())
@@ -1068,6 +1078,18 @@ mod tests {
     async fn test_cancel_reservation() {
         let fixture = PostgresTreeStoreTestFixture::new().await;
         shared_tests::test_cancel_reservation(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_cancel_reservation_drops_unkept_leaves() {
+        let fixture = PostgresTreeStoreTestFixture::new().await;
+        shared_tests::test_cancel_reservation_drops_unkept_leaves(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_cancel_reservation_drops_all_when_keep_empty() {
+        let fixture = PostgresTreeStoreTestFixture::new().await;
+        shared_tests::test_cancel_reservation_drops_all_when_keep_empty(&fixture.store).await;
     }
 
     #[tokio::test]
@@ -1553,7 +1575,9 @@ mod tests {
                         .await?;
 
                     if let ReserveResult::Success(reservation) = result {
-                        store_clone.cancel_reservation(&reservation.id).await?;
+                        store_clone
+                            .cancel_reservation(&reservation.id, &reservation.leaves)
+                            .await?;
                     }
                     tracing::debug!("Task {i} cycle {cycle} complete");
                 }
@@ -1627,7 +1651,9 @@ mod tests {
 
                 match result {
                     Ok(ReserveResult::Success(reservation)) => {
-                        store_clone.cancel_reservation(&reservation.id).await?;
+                        store_clone
+                            .cancel_reservation(&reservation.id, &reservation.leaves)
+                            .await?;
                         Ok((100 + i, "reserve success"))
                     }
                     Ok(_) => Ok((100 + i, "no leaves available")),

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -582,9 +582,9 @@ impl SparkWallet {
         // Fetches fee quote for the coop exit then cancels the reservation.
         let fee_quote_res = self
             .coop_exit_service
-            .fetch_coop_exit_fee_quote(reservation.leaves, withdrawal_address)
+            .fetch_coop_exit_fee_quote(reservation.leaves.clone(), withdrawal_address)
             .await;
-        self.tree_service.cancel_reservation(reservation.id).await?;
+        self.tree_service.cancel_reservation(reservation).await?;
 
         Ok(fee_quote_res?)
     }

--- a/crates/spark/src/services/swap.rs
+++ b/crates/spark/src/services/swap.rs
@@ -3,6 +3,7 @@ use std::{str::FromStr, sync::Arc, time::Duration};
 use bitcoin::consensus::serialize;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use platform_utils::time::SystemTime;
+use platform_utils::tokio;
 use rand::rngs::OsRng;
 use tracing::{debug, warn};
 
@@ -18,12 +19,20 @@ use crate::{
     },
     services::{LeafKeyTweak, ServiceError, SigningResult, Transfer, TransferId, TransferService},
     signer::{SecretSource, Signer},
-    ssp::{RequestSwapInput, ServiceProvider, UserLeafInput},
+    ssp::{RequestSwapInput, ServiceProvider, ServiceProviderError, UserLeafInput},
     tree::{TreeNode, TreeNodeId},
     utils::{frost::sign_aggregate_frost, refund::RefundSignatures},
 };
 
 const SWAP_EXPIRY_DURATION: Duration = Duration::from_secs(2 * 60);
+
+const SSP_REQUEST_SWAP_MAX_ATTEMPTS: u32 = 5;
+const SSP_REQUEST_SWAP_BASE_DELAY_MS: u64 = 100;
+const SSP_REQUEST_SWAP_MAX_DELAY_MS: u64 = 3000;
+
+fn is_retryable_ssp_error(error: &ServiceProviderError) -> bool {
+    matches!(error, ServiceProviderError::Network { .. })
+}
 
 pub struct Swap {
     network: Network,
@@ -142,8 +151,13 @@ impl Swap {
             transfer_package.direct_from_cpfp_leaves_to_send.clear();
         }
 
-        // Call initiate_swap_primary_transfer with the transfer_package and adaptor public keys
-        let response = self
+        let leaf_ids_for_log: Vec<String> = leaves.iter().map(|l| l.id.to_string()).collect();
+        debug!(
+            "leaf_lifecycle swap_rpc_initiate: transfer_id={} leaf_ids={:?}",
+            transfer_id, leaf_ids_for_log
+        );
+
+        let rpc_result = self
             .operator_pool
             .get_coordinator()
             .client
@@ -156,7 +170,24 @@ impl Swap {
                     direct_from_cpfp_adaptor_public_key: Vec::new(),
                 }),
             })
-            .await?;
+            .await;
+
+        let response = match rpc_result {
+            Ok(r) => {
+                debug!(
+                    "leaf_lifecycle swap_rpc_success: transfer_id={} leaf_ids={:?}",
+                    transfer_id, leaf_ids_for_log
+                );
+                r
+            }
+            Err(e) => {
+                warn!(
+                    "leaf_lifecycle swap_rpc_error: transfer_id={} leaf_ids={:?} error={:?}",
+                    transfer_id, leaf_ids_for_log, e
+                );
+                return Err(e.into());
+            }
+        };
 
         let _transfer = response.transfer.ok_or(ServiceError::Generic(
             "response missing transfer".to_string(),
@@ -243,20 +274,53 @@ impl Swap {
             });
         }
 
-        // Call request_swap to SSP (swap v3)
-        let swap_response = self
-            .ssp_client
-            .request_swap(RequestSwapInput {
-                adaptor_pubkey: hex::encode(cpfp_adaptor_public_key.serialize()),
-                total_amount_sats: leaf_sum,
-                target_amount_sats: maybe_target_amounts
-                    .clone()
-                    .unwrap_or_else(|| vec![target_sum]),
-                fee_sats: 0, // TODO: Request fee estimate from SSP
-                user_leaves,
-                user_outbound_transfer_external_id: transfer_id.to_string(),
-            })
-            .await?;
+        let request_swap_input = RequestSwapInput {
+            adaptor_pubkey: hex::encode(cpfp_adaptor_public_key.serialize()),
+            total_amount_sats: leaf_sum,
+            target_amount_sats: maybe_target_amounts
+                .clone()
+                .unwrap_or_else(|| vec![target_sum]),
+            fee_sats: 0, // TODO: Request fee estimate from SSP
+            user_leaves,
+            user_outbound_transfer_external_id: transfer_id.to_string(),
+        };
+
+        let swap_response = {
+            let mut attempt: u32 = 1;
+            loop {
+                match self
+                    .ssp_client
+                    .request_swap(request_swap_input.clone())
+                    .await
+                {
+                    Ok(r) => break r,
+                    Err(e)
+                        if attempt < SSP_REQUEST_SWAP_MAX_ATTEMPTS
+                            && is_retryable_ssp_error(&e) =>
+                    {
+                        let delay_ms = (SSP_REQUEST_SWAP_BASE_DELAY_MS * 2u64.pow(attempt - 1))
+                            .min(SSP_REQUEST_SWAP_MAX_DELAY_MS);
+                        warn!(
+                            "leaf_lifecycle swap_ssp_retry: transfer_id={} attempt={}/{} delay_ms={} error={:?}",
+                            transfer_id, attempt, SSP_REQUEST_SWAP_MAX_ATTEMPTS, delay_ms, e
+                        );
+                        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                        attempt += 1;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "leaf_lifecycle swap_ssp_error_after_initiate: transfer_id={} leaf_ids={:?} attempt={}/{} error={:?}",
+                            transfer_id,
+                            leaf_ids_for_log,
+                            attempt,
+                            SSP_REQUEST_SWAP_MAX_ATTEMPTS,
+                            e
+                        );
+                        return Err(e.into());
+                    }
+                }
+            }
+        };
 
         // TODO: Validate the amounts in swap_response match the leaf sum, and the target amounts are met.
         let inbound_transfer_id = swap_response

--- a/crates/spark/src/tree/leaf_optimizer.rs
+++ b/crates/spark/src/tree/leaf_optimizer.rs
@@ -474,10 +474,17 @@ impl LeafOptimizer {
                     );
                 }
                 Err(e) => {
-                    if let Err(cancel_err) = self
-                        .tree_service
-                        .cancel_reservation(swap_reservation.id)
-                        .await
+                    let reserved_leaf_ids: Vec<String> = swap_reservation
+                        .leaves
+                        .iter()
+                        .map(|l| l.id.to_string())
+                        .collect();
+                    warn!(
+                        "leaf_lifecycle swap_failed_in_optimize: reservation={} round={} leaf_ids={:?} error={:?}",
+                        swap_reservation.id, round, reserved_leaf_ids, e
+                    );
+                    if let Err(cancel_err) =
+                        self.tree_service.cancel_reservation(swap_reservation).await
                     {
                         error!(
                             "Failed to cancel reservation on optimization round failure: {cancel_err:?}"

--- a/crates/spark/src/tree/mod.rs
+++ b/crates/spark/src/tree/mod.rs
@@ -549,43 +549,21 @@ pub trait TreeStore: Send + Sync {
         refresh_started_at: platform_utils::time::SystemTime,
     ) -> Result<(), TreeServiceError>;
 
-    /// Cancels a leaf reservation and returns the leaves to the available pool.
+    /// Cancels a leaf reservation, replacing its leaves with the given keep-list.
     ///
-    /// This method releases a previously created reservation, making the reserved
-    /// leaves available again for future reservations. This is typically used
-    /// when a transaction fails or is cancelled.
+    /// All leaves currently attached to this reservation are removed from the store.
+    /// The reservation row is dropped. The supplied `leaves_to_keep` are then upserted
+    /// into the available pool with no reservation.
     ///
-    /// # Parameters
-    ///
-    /// * `id` - The unique reservation ID to cancel
-    ///
-    /// # Returns
-    ///
-    /// * `Result<(), TreeServiceError>` - Ok if the reservation was successfully
-    ///   cancelled, or an error if the operation fails
-    ///
-    /// # Errors
-    ///
-    /// Returns a `TreeServiceError` if:
-    /// * The reservation ID does not exist
-    /// * The reservation has already been finalized
-    /// * Storage operation fails
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use spark::tree::{TreeStore, TargetAmounts, TreeServiceError, ReservationPurpose, ReserveResult};
-    ///
-    /// # async fn example(store: &dyn TreeStore) -> Result<(), TreeServiceError> {
-    /// let target = TargetAmounts::new_amount_and_fee(25_000, None);
-    /// if let ReserveResult::Success(reservation) = store.try_reserve_leaves(Some(&target), false, ReservationPurpose::Payment).await? {
-    ///     // Later, if the transaction is cancelled
-    ///     store.cancel_reservation(&reservation.id).await?;
-    /// }
-    /// # Ok(())
-    /// # }
-    /// ```
-    async fn cancel_reservation(&self, id: &LeavesReservationId) -> Result<(), TreeServiceError>;
+    /// To preserve today's "release everything back to the pool" behavior, callers
+    /// pass the original reservation leaves as `leaves_to_keep`. To drop part of the
+    /// set (e.g. operator-locked leaves the caller has just verified), callers pass
+    /// only the leaves they have confirmed are safe to make available.
+    async fn cancel_reservation(
+        &self,
+        id: &LeavesReservationId,
+        leaves_to_keep: &[TreeNode],
+    ) -> Result<(), TreeServiceError>;
 
     /// Finalizes a leaf reservation, marking the leaves as consumed and optionally adding new leaves to the main pool.
     ///
@@ -904,7 +882,10 @@ pub trait TreeService: Send + Sync {
     /// # Ok(())
     /// # }
     /// ```
-    async fn cancel_reservation(&self, id: LeavesReservationId) -> Result<(), TreeServiceError>;
+    async fn cancel_reservation(
+        &self,
+        reservation: LeavesReservation,
+    ) -> Result<(), TreeServiceError>;
 
     /// Finalizes a leaf reservation, marking the reserved leaves as consumed and optionally adding new leaves to the main pool.
     ///

--- a/crates/spark/src/tree/mod.rs
+++ b/crates/spark/src/tree/mod.rs
@@ -857,13 +857,11 @@ pub trait TreeService: Send + Sync {
     ///
     /// # Parameters
     ///
-    /// * `id` - The unique reservation ID returned from [`select_leaves`]
+    /// * `reservation` - The reservation to cancel, including its current leaves
     ///
     /// # Errors
     ///
     /// Returns a `TreeServiceError` if:
-    /// * The reservation ID does not exist
-    /// * The reservation has already been finalized
     /// * Storage operation fails
     ///
     /// # Examples
@@ -877,7 +875,7 @@ pub trait TreeService: Send + Sync {
     /// let reservation = tree_service.select_leaves(Some(&target), ReservationPurpose::Payment, SelectLeavesOptions::default()).await?;
     ///
     /// // Later, if the transaction fails, cancel the reservation
-    /// tree_service.cancel_reservation(reservation.id).await;
+    /// tree_service.cancel_reservation(reservation).await;
     /// println!("Reservation cancelled, leaves returned to pool");
     /// # Ok(())
     /// # }

--- a/crates/spark/src/tree/select_helper.rs
+++ b/crates/spark/src/tree/select_helper.rs
@@ -215,7 +215,7 @@ where
             Ok(r)
         }
         Err(e) => {
-            if let Err(e) = tree_service.cancel_reservation(leaves.id.clone()).await {
+            if let Err(e) = tree_service.cancel_reservation(leaves.clone()).await {
                 error!("Failed to cancel reservation: {e:?}");
             }
             Err(e)

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use bitcoin::secp256k1::PublicKey;
 use platform_utils::tokio;
-use tracing::{error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::tree::{Leaves, ReservationPurpose, ReserveResult, SelectLeavesOptions, TreeNodeStatus};
 use crate::{
@@ -14,7 +14,7 @@ use crate::{
         OperatorPool,
         rpc::{
             SparkRpcClient,
-            spark::{QueryNodesRequest, query_nodes_request::Source},
+            spark::{QueryNodesRequest, TreeNodeIds, query_nodes_request::Source},
         },
     },
     services::{ServiceError, Swap, TimelockManager},
@@ -44,8 +44,14 @@ impl TreeService for SynchronousTreeService {
         self.state.get_leaves().await
     }
 
-    async fn cancel_reservation(&self, id: LeavesReservationId) -> Result<(), TreeServiceError> {
-        self.state.cancel_reservation(&id).await
+    async fn cancel_reservation(
+        &self,
+        reservation: LeavesReservation,
+    ) -> Result<(), TreeServiceError> {
+        let leaves_to_keep = self.verify_leaves_against_coordinator(&reservation).await;
+        self.state
+            .cancel_reservation(&reservation.id, &leaves_to_keep)
+            .await
     }
 
     async fn finalize_reservation(
@@ -381,8 +387,18 @@ impl SynchronousTreeService {
         let new_leaves = match swap_result {
             Ok(leaves) => leaves,
             Err(e) => {
-                // Swap failed - cancel the reservation to release the permit
-                if let Err(cancel_err) = self.state.cancel_reservation(&reservation.id).await {
+                let reserved_leaf_ids: Vec<String> = reservation
+                    .leaves
+                    .iter()
+                    .map(|l| l.id.to_string())
+                    .collect();
+                warn!(
+                    "leaf_lifecycle swap_failed_in_select: reservation={} leaf_ids={:?} error={:?}",
+                    reservation.id, reserved_leaf_ids, e
+                );
+                if let Err(cancel_err) =
+                    <Self as TreeService>::cancel_reservation(self, reservation).await
+                {
                     error!("Failed to cancel reservation after swap error: {cancel_err:?}");
                 }
                 return Err(e);
@@ -445,6 +461,98 @@ impl SynchronousTreeService {
                 Err(e)
             }
         }
+    }
+
+    async fn verify_leaves_against_coordinator(
+        &self,
+        reservation: &LeavesReservation,
+    ) -> Vec<TreeNode> {
+        if reservation.leaves.is_empty() {
+            return Vec::new();
+        }
+
+        let node_ids: Vec<String> = reservation
+            .leaves
+            .iter()
+            .map(|l| l.id.to_string())
+            .collect();
+        let coordinator_client = self.operator_pool.get_coordinator().client.clone();
+
+        const MAX_ATTEMPTS: u32 = 3;
+        const BASE_DELAY_MS: u64 = 100;
+        const MAX_DELAY_MS: u64 = 1000;
+
+        let mut last_err: Option<TreeServiceError> = None;
+        for attempt in 1..=MAX_ATTEMPTS {
+            let source = Source::NodeIds(TreeNodeIds {
+                node_ids: node_ids.clone(),
+            });
+            match self
+                .query_nodes(&coordinator_client, false, Some(source))
+                .await
+            {
+                Ok(nodes) => {
+                    let by_id: HashMap<TreeNodeId, TreeNode> =
+                        nodes.into_iter().map(|n| (n.id.clone(), n)).collect();
+                    let mut keep: Vec<TreeNode> = Vec::new();
+                    let mut dropped: Vec<(TreeNodeId, String)> = Vec::new();
+                    for original in &reservation.leaves {
+                        match by_id.get(&original.id) {
+                            Some(fresh) => {
+                                let owned = fresh
+                                    .owner_identity_public_key
+                                    .map(|owner| owner == self.identity_pubkey)
+                                    .unwrap_or(false);
+                                if !owned {
+                                    dropped.push((original.id.clone(), "not_owned".to_string()));
+                                } else if fresh.status != TreeNodeStatus::Available {
+                                    dropped.push((
+                                        original.id.clone(),
+                                        format!("status:{:?}", fresh.status),
+                                    ));
+                                } else {
+                                    keep.push(fresh.clone());
+                                }
+                            }
+                            None => dropped
+                                .push((original.id.clone(), "missing_from_response".to_string())),
+                        }
+                    }
+                    if dropped.is_empty() {
+                        debug!(
+                            "leaf_lifecycle cancel_verified_available: reservation={} kept={}",
+                            reservation.id,
+                            keep.len()
+                        );
+                    } else {
+                        warn!(
+                            "leaf_lifecycle cancel_verify_dropped: reservation={} kept={} dropped={:?}",
+                            reservation.id,
+                            keep.len(),
+                            dropped
+                        );
+                    }
+                    return keep;
+                }
+                Err(e) => {
+                    warn!(
+                        "leaf_lifecycle cancel_verify_query_attempt: reservation={} attempt={}/{} error={:?}",
+                        reservation.id, attempt, MAX_ATTEMPTS, e
+                    );
+                    last_err = Some(e);
+                    if attempt < MAX_ATTEMPTS {
+                        let delay_ms = (BASE_DELAY_MS * 2u64.pow(attempt - 1)).min(MAX_DELAY_MS);
+                        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                    }
+                }
+            }
+        }
+
+        warn!(
+            "leaf_lifecycle cancel_verify_dropped_all: reservation={} reason=query_failed error={:?}",
+            reservation.id, last_err
+        );
+        Vec::new()
     }
 
     async fn query_nodes_inner(
@@ -520,15 +628,16 @@ impl SynchronousTreeService {
         &self,
         reservation: LeavesReservation,
     ) -> Result<LeavesReservation, TreeServiceError> {
+        let id = reservation.id.clone();
+        let cancel_input = reservation.clone();
         let new_leaves = self
             .check_renew_nodes(reservation.leaves, async |e| {
-                // Cancel the reservation if the timelock check fails
-                if let Err(e) = self.state.cancel_reservation(&reservation.id).await {
-                    error!("Failed to cancel reservation: {e:?}");
+                if let Err(err) =
+                    <Self as TreeService>::cancel_reservation(self, cancel_input).await
+                {
+                    error!("Failed to cancel reservation: {err:?}");
                     return;
                 }
-                // If this is a partial check timelock error, the extend node timelock failed
-                // but we can still update the leaves that were refreshed
                 if let ServiceError::PartialCheckTimelockError(ref nodes) = e
                     && let Err(e) = self.state.add_leaves(nodes).await
                 {
@@ -537,7 +646,7 @@ impl SynchronousTreeService {
             })
             .await?;
 
-        Ok(LeavesReservation::new(new_leaves, reservation.id))
+        Ok(LeavesReservation::new(new_leaves, id))
     }
 
     /// Performs a swap operation and returns the new leaves.

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -396,9 +396,7 @@ impl SynchronousTreeService {
                     "leaf_lifecycle swap_failed_in_select: reservation={} leaf_ids={:?} error={:?}",
                     reservation.id, reserved_leaf_ids, e
                 );
-                if let Err(cancel_err) =
-                    <Self as TreeService>::cancel_reservation(self, reservation).await
-                {
+                if let Err(cancel_err) = self.cancel_reservation(reservation).await {
                     error!("Failed to cancel reservation after swap error: {cancel_err:?}");
                 }
                 return Err(e);
@@ -632,9 +630,7 @@ impl SynchronousTreeService {
         let cancel_input = reservation.clone();
         let new_leaves = self
             .check_renew_nodes(reservation.leaves, async |e| {
-                if let Err(err) =
-                    <Self as TreeService>::cancel_reservation(self, cancel_input).await
-                {
+                if let Err(err) = self.cancel_reservation(cancel_input).await {
                     error!("Failed to cancel reservation: {err:?}");
                     return;
                 }

--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -99,6 +99,7 @@ enum StoreCommand {
     },
     CancelReservation {
         id: LeavesReservationId,
+        leaves_to_keep: Vec<TreeNode>,
         response_tx: oneshot::Sender<Result<(), TreeServiceError>>,
     },
     FinalizeReservation {
@@ -236,9 +237,12 @@ impl InMemoryTreeStore {
                     );
                     let _ = response_tx.send(result);
                 }
-                StoreCommand::CancelReservation { id, response_tx } => {
-                    // Permit is automatically released when ReservationEntry is dropped
-                    Self::process_cancel_reservation(&mut state, &id);
+                StoreCommand::CancelReservation {
+                    id,
+                    leaves_to_keep,
+                    response_tx,
+                } => {
+                    Self::process_cancel_reservation(&mut state, &id, &leaves_to_keep);
                     let _ = response_tx.send(Ok(()));
                 }
                 StoreCommand::FinalizeReservation {
@@ -589,18 +593,40 @@ impl InMemoryTreeStore {
         }
     }
 
-    /// Cancel a reservation and return leaves to the pool.
-    /// The permit is automatically released when the ReservationEntry is dropped.
-    fn process_cancel_reservation(state: &mut LeavesState, id: &LeavesReservationId) {
-        if let Some(entry) = state.leaves_reservations.remove(id) {
-            for stored in entry.leaves {
-                trace!(
-                    "leaf_lifecycle cancel: returning leaf={} value={} reservation={} purpose={:?}",
-                    stored.node.id, stored.node.value, id, entry.purpose
-                );
-                state.leaves.insert(stored.node.id.clone(), stored);
-            }
-            trace!("Canceled leaves reservation: {}", id);
+    /// Cancel a reservation. The reservation entry and all of its currently-held leaves
+    /// are removed; the supplied `leaves_to_keep` are inserted into the available pool
+    /// with a fresh `added_at`. To release the original leaves unchanged, callers pass
+    /// them as `leaves_to_keep`.
+    fn process_cancel_reservation(
+        state: &mut LeavesState,
+        id: &LeavesReservationId,
+        leaves_to_keep: &[TreeNode],
+    ) {
+        let removed = state.leaves_reservations.remove(id);
+        let purpose = removed.as_ref().map(|e| e.purpose);
+        let prior_ids: Vec<TreeNodeId> = removed
+            .as_ref()
+            .map(|e| e.leaves.iter().map(|s| s.node.id.clone()).collect())
+            .unwrap_or_default();
+        let keep_ids: Vec<&TreeNodeId> = leaves_to_keep.iter().map(|l| &l.id).collect();
+        let dropped_ids: Vec<&TreeNodeId> = prior_ids
+            .iter()
+            .filter(|pid| !keep_ids.contains(pid))
+            .collect();
+        trace!(
+            "leaf_lifecycle cancel: reservation={} purpose={:?} prior_leaves={:?} keeping={:?} dropping={:?}",
+            id, purpose, prior_ids, keep_ids, dropped_ids
+        );
+
+        let now = SystemTime::now();
+        for leaf in leaves_to_keep {
+            state.leaves.insert(
+                leaf.id.clone(),
+                StoredLeaf {
+                    node: leaf.clone(),
+                    added_at: now,
+                },
+            );
         }
     }
 
@@ -811,10 +837,16 @@ impl TreeStore for InMemoryTreeStore {
         .await
     }
 
-    async fn cancel_reservation(&self, id: &LeavesReservationId) -> Result<(), TreeServiceError> {
+    async fn cancel_reservation(
+        &self,
+        id: &LeavesReservationId,
+        leaves_to_keep: &[TreeNode],
+    ) -> Result<(), TreeServiceError> {
         let id = id.clone();
+        let leaves_to_keep = leaves_to_keep.to_vec();
         self.send_command(|tx| StoreCommand::CancelReservation {
             id,
+            leaves_to_keep,
             response_tx: tx,
         })
         .await
@@ -950,6 +982,17 @@ mod tests {
     #[async_test_all]
     async fn test_cancel_reservation() {
         shared_tests::test_cancel_reservation(&InMemoryTreeStore::new()).await;
+    }
+
+    #[async_test_all]
+    async fn test_cancel_reservation_drops_unkept_leaves() {
+        shared_tests::test_cancel_reservation_drops_unkept_leaves(&InMemoryTreeStore::new()).await;
+    }
+
+    #[async_test_all]
+    async fn test_cancel_reservation_drops_all_when_keep_empty() {
+        shared_tests::test_cancel_reservation_drops_all_when_keep_empty(&InMemoryTreeStore::new())
+            .await;
     }
 
     #[async_test_all]

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -287,10 +287,11 @@ pub async fn test_cancel_reservation(store: &dyn TreeStore) {
     .await
     .unwrap();
 
-    // Cancel the reservation
-    store.cancel_reservation(&reservation.id).await.unwrap();
+    store
+        .cancel_reservation(&reservation.id, &reservation.leaves)
+        .await
+        .unwrap();
 
-    // Check that leaf was returned to main pool
     let all = get_all(store).await;
     assert!(all.reserved_for_payment.is_empty());
     assert_eq!(all.available.len(), 2);
@@ -298,11 +299,70 @@ pub async fn test_cancel_reservation(store: &dyn TreeStore) {
     assert!(all.available.iter().any(|l| l.id == leaves[1].id));
 }
 
+pub async fn test_cancel_reservation_drops_unkept_leaves(store: &dyn TreeStore) {
+    let leaves = vec![
+        create_test_tree_node("node1", 100),
+        create_test_tree_node("node2", 200),
+    ];
+    store.add_leaves(&leaves).await.unwrap();
+
+    let reservation = reserve_leaves(
+        store,
+        Some(&TargetAmounts::new_amount_and_fee(300, None)),
+        true,
+        ReservationPurpose::Payment,
+    )
+    .await
+    .unwrap();
+    assert_eq!(reservation.leaves.len(), 2);
+
+    let keep: Vec<_> = reservation
+        .leaves
+        .iter()
+        .filter(|l| l.id == leaves[0].id)
+        .cloned()
+        .collect();
+    store
+        .cancel_reservation(&reservation.id, &keep)
+        .await
+        .unwrap();
+
+    let all = get_all(store).await;
+    assert!(all.reserved_for_payment.is_empty());
+    assert_eq!(all.available.len(), 1);
+    assert_eq!(all.available[0].id, leaves[0].id);
+}
+
+pub async fn test_cancel_reservation_drops_all_when_keep_empty(store: &dyn TreeStore) {
+    let leaves = vec![
+        create_test_tree_node("node1", 100),
+        create_test_tree_node("node2", 200),
+    ];
+    store.add_leaves(&leaves).await.unwrap();
+
+    let reservation = reserve_leaves(
+        store,
+        Some(&TargetAmounts::new_amount_and_fee(300, None)),
+        true,
+        ReservationPurpose::Payment,
+    )
+    .await
+    .unwrap();
+
+    store
+        .cancel_reservation(&reservation.id, &[])
+        .await
+        .unwrap();
+
+    let all = get_all(store).await;
+    assert!(all.reserved_for_payment.is_empty());
+    assert!(all.available.is_empty());
+}
+
 pub async fn test_cancel_reservation_nonexistent(store: &dyn TreeStore) {
     let fake_id = "fake-reservation-id".to_string();
 
-    // Should not panic or cause issues
-    store.cancel_reservation(&fake_id).await.unwrap();
+    store.cancel_reservation(&fake_id, &[]).await.unwrap();
     assert_available_count(store, 0).await;
 }
 
@@ -376,8 +436,10 @@ pub async fn test_multiple_reservations(store: &dyn TreeStore) {
     assert_eq!(all.available.len(), 1);
     assert_eq!(all.available[0].id, leaves[2].id);
 
-    // Cancel one reservation
-    store.cancel_reservation(&reservation1.id).await.unwrap();
+    store
+        .cancel_reservation(&reservation1.id, &reservation1.leaves)
+        .await
+        .unwrap();
     assert_eq!(get_all(store).await.available.len(), 2);
 
     // Finalize the other
@@ -400,7 +462,7 @@ pub async fn test_reservation_ids_are_unique(store: &dyn TreeStore) {
     )
     .await
     .unwrap();
-    store.cancel_reservation(&r1.id).await.unwrap();
+    store.cancel_reservation(&r1.id, &r1.leaves).await.unwrap();
     let r2 = reserve_leaves(
         store,
         Some(&TargetAmounts::new_amount_and_fee(100, None)),
@@ -631,13 +693,15 @@ pub async fn test_pending_cleared_on_cancel(store: &dyn TreeStore) {
         .await
         .unwrap();
 
-    let reservation_id = match r1 {
-        ReserveResult::Success(r) => r.id,
+    let (reservation_id, prior_leaves) = match r1 {
+        ReserveResult::Success(r) => (r.id, r.leaves),
         _ => panic!("Expected Success"),
     };
 
-    // Cancel the reservation - pending should be cleared
-    store.cancel_reservation(&reservation_id).await.unwrap();
+    store
+        .cancel_reservation(&reservation_id, &prior_leaves)
+        .await
+        .unwrap();
 
     // Try to reserve 300 - should succeed since 1000 sat leaf is back
     let r2 = store
@@ -768,13 +832,15 @@ pub async fn test_notification_on_pending_balance_change(store: &dyn TreeStore) 
         platform_utils::tokio::time::timeout(std::time::Duration::from_millis(100), rx.changed())
             .await;
 
-    let reservation_id = match r1 {
-        ReserveResult::Success(r) => r.id,
+    let (reservation_id, prior_leaves) = match r1 {
+        ReserveResult::Success(r) => (r.id, r.leaves),
         _ => panic!("Expected Success"),
     };
 
-    // Cancel the reservation - pending changes from 900 to 0
-    store.cancel_reservation(&reservation_id).await.unwrap();
+    store
+        .cancel_reservation(&reservation_id, &prior_leaves)
+        .await
+        .unwrap();
 
     // Should get notification because pending balance changed
     let notification_result =


### PR DESCRIPTION
Two layers of defense against orphaned leaves where the operator-side state diverges from the wallet's local view after an ambiguous RPC failure.

**Phase 1 - SSP request_swap retry**
After `initiate_swap_primary_transfer` succeeds, an SSP `request_swap` failure used to leave the operator holding the leaves while the SDK cancelled the local reservation. Wrap the SSP call in a bounded retry (5 attempts, 100→3000 ms exp backoff) on Network errors. Idempotency key is the existing `user_outbound_transfer_external_id`

**Phase 2 — cancel-time leaf verification**
`TreeService::cancel_reservation` now queries the coordinator before releasing any leaves. Leaves the coordinator reports as not-Available, not owned by the wallet's identity key, or missing from the response are deleted from the local store rather than returned to the available pool. Pessimistic on coordinator-query failure (drop everything) as it is better missing leaves than risking in stale leaves as available. Next refresh will sync if needed.

Added NodeJS bench framework to verify using sqlite and postgres. 