### PR TITLE
Require amount when buying BTC via Cash App

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -941,8 +941,14 @@ public static class Commands
             case "cashapp":
             case "cash_app":
             case "cash-app":
+                var cashAppAmount = ParseOptionalUlong(amountSatStr);
+                if (cashAppAmount is null)
+                {
+                    Console.WriteLine("--amount-sat is required when --provider is cashapp");
+                    return;
+                }
                 request = new BuyBitcoinRequest.CashApp(
-                    amountSats: ParseOptionalUlong(amountSatStr)
+                    amountSats: cashAppAmount.Value
                 );
                 break;
             default:

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -734,6 +734,10 @@ Future<void> _handleBuyBitcoin(BreezSdk sdk, TokenIssuer tokenIssuer, List<Strin
   BuyBitcoinRequest request;
   switch (provider) {
     case 'cashapp' || 'cash_app' || 'cash-app':
+      if (amount == null) {
+        print('--amount-sat is required when --provider is cashapp');
+        return;
+      }
       request = BuyBitcoinRequest_CashApp(amountSats: amount);
     default:
       request = BuyBitcoinRequest_Moonpay(lockedAmountSat: amount, redirectUrl: redirectUrl);

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -533,9 +533,12 @@ pub(crate) async fn execute_command(
             redirect_url,
         } => {
             let request = match provider.to_lowercase().as_str() {
-                "cashapp" | "cash_app" | "cash-app" => BuyBitcoinRequest::CashApp {
-                    amount_sats: amount_sat,
-                },
+                "cashapp" | "cash_app" | "cash-app" => {
+                    let amount_sats = amount_sat.ok_or_else(|| {
+                        anyhow::anyhow!("--amount-sat is required when --provider is cashapp")
+                    })?;
+                    BuyBitcoinRequest::CashApp { amount_sats }
+                }
                 _ => BuyBitcoinRequest::Moonpay {
                     locked_amount_sat: amount_sat,
                     redirect_url,

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -957,11 +957,16 @@ pub enum BuyBitcoinRequest {
         redirect_url: Option<String>,
     },
     /// `CashApp`: Pay via the Lightning Network.
-    /// Generates a bolt11 invoice and returns a `cash.app` deep link.
-    /// Only available on mainnet.
+    /// Generates a bolt11 invoice for the given amount and returns a
+    /// `cash.app` deep link. Only available on mainnet.
+    ///
+    /// The amount is required. With an amountless invoice, Cash App only
+    /// lets the payer fund from their existing Cash App BTC balance. With
+    /// a fixed-amount invoice, Cash App opens up funding via fiat balance
+    /// and debit card.
     CashApp {
-        /// Amount in satoshis for the Lightning invoice.
-        amount_sats: Option<u64>,
+        /// Amount in satoshis for the Lightning invoice. Must be non-zero.
+        amount_sats: u64,
     },
 }
 

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -370,10 +370,15 @@ impl BreezSdk {
                         "CashApp is only available on mainnet".to_string(),
                     ));
                 }
+                if amount_sats == 0 {
+                    return Err(SdkError::Generic(
+                        "CashApp requires a non-zero amount".to_string(),
+                    ));
+                }
                 let receive_response = self
                     .receive_bolt11_invoice(
                         "Buy Bitcoin via CashApp".to_string(),
-                        amount_sats,
+                        Some(amount_sats),
                         None,
                         None,
                     )

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -1369,7 +1369,7 @@ pub enum BuyBitcoinRequest {
         redirect_url: Option<String>,
     },
     CashApp {
-        amount_sats: Option<u64>,
+        amount_sats: u64,
     },
 }
 

--- a/docs/breez-sdk/snippets/csharp/BuyingBitcoin.cs
+++ b/docs/breez-sdk/snippets/csharp/BuyingBitcoin.cs
@@ -26,8 +26,11 @@ namespace BreezSdkSnippets
         async Task BuyBitcoinViaCashapp(BreezSdk sdk)
         {
             // ANCHOR: buy-bitcoin-cashapp
+            // Cash App requires the amount to be specified up front.
+            var amountSats = (ulong)50_000;
+
             var request = new BuyBitcoinRequest.CashApp(
-                amountSats: null
+                amountSats: amountSats
             );
 
             var response = await sdk.BuyBitcoin(request: request);

--- a/docs/breez-sdk/snippets/flutter/lib/buying_bitcoin.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/buying_bitcoin.dart
@@ -19,8 +19,10 @@ Future<void> buyBitcoin(BreezSdk sdk) async {
 
 Future<void> buyBitcoinViaCashapp(BreezSdk sdk) async {
   // ANCHOR: buy-bitcoin-cashapp
-  final request = BuyBitcoinRequest_CashApp(
-      amountSats: null);
+  // Cash App requires the amount to be specified up front.
+  final amountSats = BigInt.from(50000);
+
+  final request = BuyBitcoinRequest_CashApp(amountSats: amountSats);
 
   final response = await sdk.buyBitcoin(request: request);
   print("Open this URL in Cash App to complete the purchase:");

--- a/docs/breez-sdk/snippets/go/buying_bitcoin.go
+++ b/docs/breez-sdk/snippets/go/buying_bitcoin.go
@@ -29,8 +29,11 @@ func BuyBitcoin(sdk *breez_sdk_spark.BreezSdk) error {
 
 func BuyBitcoinViaCashapp(sdk *breez_sdk_spark.BreezSdk) error {
 	// ANCHOR: buy-bitcoin-cashapp
+	// Cash App requires the amount to be specified up front.
+	amountSats := uint64(50_000)
+
 	request := breez_sdk_spark.BuyBitcoinRequestCashApp{
-		AmountSats: nil,
+		AmountSats: amountSats,
 	}
 
 	response, err := sdk.BuyBitcoin(request)

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/BuyingBitcoin.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/BuyingBitcoin.kt
@@ -23,7 +23,10 @@ class BuyingBitcoin {
 
     suspend fun buyBitcoinViaCashapp(sdk: BreezSdk) {
         // ANCHOR: buy-bitcoin-cashapp
-        val request = BuyBitcoinRequest.CashApp(amountSats = null)
+        // Cash App requires the amount to be specified up front.
+        val amountSats: ULong = 50_000u
+
+        val request = BuyBitcoinRequest.CashApp(amountSats = amountSats)
 
         val response = sdk.buyBitcoin(request)
         // Log.v("Breez", "Open this URL in Cash App to complete the purchase:")

--- a/docs/breez-sdk/snippets/python/src/buying_bitcoin.py
+++ b/docs/breez-sdk/snippets/python/src/buying_bitcoin.py
@@ -30,9 +30,12 @@ async def buy_bitcoin(sdk: BreezSdk):
 
 async def buy_bitcoin_via_cashapp(sdk: BreezSdk):
     # ANCHOR: buy-bitcoin-cashapp
+    # Cash App requires the amount to be specified up front.
+    amount_sats = 50_000
+
     try:
         request = BuyBitcoinRequest.CASH_APP(
-            amount_sats=None,
+            amount_sats=amount_sats,
         )
 
         response = await sdk.buy_bitcoin(request=request)

--- a/docs/breez-sdk/snippets/react-native/buying_bitcoin.ts
+++ b/docs/breez-sdk/snippets/react-native/buying_bitcoin.ts
@@ -23,8 +23,11 @@ const buyBitcoin = async (sdk: BreezSdk) => {
 
 const buyBitcoinViaCashapp = async (sdk: BreezSdk) => {
   // ANCHOR: buy-bitcoin-cashapp
+  // Cash App requires the amount to be specified up front.
+  const amountSats = BigInt(50_000)
+
   const request = new BuyBitcoinRequest.CashApp({
-    amountSats: undefined
+    amountSats
   })
 
   const response = await sdk.buyBitcoin(request)

--- a/docs/breez-sdk/snippets/rust/src/buying_bitcoin.rs
+++ b/docs/breez-sdk/snippets/rust/src/buying_bitcoin.rs
@@ -23,9 +23,10 @@ async fn buy_bitcoin(sdk: &BreezSdk) -> Result<()> {
 
 async fn buy_bitcoin_via_cashapp(sdk: &BreezSdk) -> Result<()> {
     // ANCHOR: buy-bitcoin-cashapp
-    let request = BuyBitcoinRequest::CashApp {
-        amount_sats: None,
-    };
+    // Cash App requires the amount to be specified up front.
+    let amount_sats = 50_000;
+
+    let request = BuyBitcoinRequest::CashApp { amount_sats };
 
     let response = sdk.buy_bitcoin(request).await?;
     info!("Open this URL in Cash App to complete the purchase:");

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/BuyingBitcoin.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/BuyingBitcoin.swift
@@ -20,7 +20,10 @@ func buyBitcoin(sdk: BreezSdk) async throws {
 
 func buyBitcoinViaCashapp(sdk: BreezSdk) async throws {
     // ANCHOR: buy-bitcoin-cashapp
-    let request = BuyBitcoinRequest.cashApp(amountSats: nil)
+    // Cash App requires the amount to be specified up front.
+    let amountSats: UInt64 = 50_000
+
+    let request = BuyBitcoinRequest.cashApp(amountSats: amountSats)
 
     let response = try await sdk.buyBitcoin(request: request)
     print("Open this URL in Cash App to complete the purchase:")

--- a/docs/breez-sdk/snippets/wasm/buying_bitcoin.ts
+++ b/docs/breez-sdk/snippets/wasm/buying_bitcoin.ts
@@ -21,9 +21,12 @@ const buyBitcoin = async (sdk: BreezSdk) => {
 
 const buyBitcoinViaCashapp = async (sdk: BreezSdk) => {
   // ANCHOR: buy-bitcoin-cashapp
+  // Cash App requires the amount to be specified up front.
+  const amountSats = 50_000
+
   const response = await sdk.buyBitcoin({
     type: 'cashApp',
-    amountSats: undefined
+    amountSats
   })
   console.log('Open this URL in Cash App to complete the purchase:')
   console.log(response.url)

--- a/docs/breez-sdk/src/guide/buy_bitcoin.md
+++ b/docs/breez-sdk/src/guide/buy_bitcoin.md
@@ -23,11 +23,14 @@ MoonPay supports Apple Pay and Google Pay, but these payment methods will not wo
 
 ## CashApp
 
-CashApp uses **Lightning (bolt11 invoices)** to receive purchased funds. The SDK generates a Lightning invoice and returns a CashApp deep link (`cash.app/launch/lightning/...`) that opens the CashApp for the user to complete payment.
+CashApp uses **Lightning (bolt11 invoices)** to receive purchased funds. The caller specifies the amount in satoshis; the SDK generates a bolt11 invoice for that amount and returns a CashApp deep link (`cash.app/launch/lightning/...`) that opens CashApp so the user can complete payment.
 
 <div class="warning">
-<h4>Developer note</h4>
-CashApp is only available on <strong>mainnet</strong>. Attempting to use CashApp on testnet or regtest will return an error.
+<h4>Developer notes</h4>
+<ul>
+<li>CashApp is only available on <strong>mainnet</strong>. Using CashApp on testnet or regtest returns an error.</li>
+<li>The amount is <strong>required</strong>. With an amountless invoice, Cash App only lets the payer fund from their existing Cash App BTC balance. When the invoice carries an amount, Cash App opens up funding via fiat balance and debit card.</li>
+</ul>
 </div>
 
 To initiate a Bitcoin purchase via CashApp:
@@ -36,38 +39,40 @@ To initiate a Bitcoin purchase via CashApp:
 
 The returned URL is a CashApp universal link (`https://cash.app/launch/lightning/<bolt11>`). On devices with CashApp installed it opens the app directly; otherwise it falls back to the CashApp website.
 
-<div class="warning">
-<h4>Developer note</h4>
+### Recommended UX
 
-The URL is obtained <strong>after an async SDK call</strong>, which means <code>window.open()</code> will be blocked by popup blockers on most mobile browsers and PWAs.
+1. Collect a non-zero amount before calling {{#name buy_bitcoin}}.
+2. On mobile, redirect to the returned URL. On desktop, render it as a QR code and dismiss when {{#enum SdkEvent::PaymentSucceeded}} fires for the invoice.
 
-**Recommended approach: pre-open a blank tab before the async call:**
+### Popup blockers on the web
+
+On web, `window.open()` called after `await sdk.buyBitcoin(...)` is typically blocked by mobile browsers and PWAs because it falls outside the original user gesture. Pre-open a blank tab synchronously inside the click handler, then navigate it once the URL is ready:
 
 ```javascript
-// 1. Open blank tab synchronously during the user gesture (click handler)
+// Open a placeholder tab during the user gesture so the browser
+// allows it; we navigate it once the SDK returns.
 const newTab = window.open('', '_blank');
 
-// 2. Async SDK call
-const response = await sdk.buyBitcoin({ provider: 'cashApp' });
+// Generate the Cash App invoice for the chosen amount.
+const response = await sdk.buyBitcoin({ type: 'cashApp', amountSats: 50_000 });
 
-// 3. Navigate the pre-opened tab (or fall back to same-tab)
+// Send the user to Cash App. If the placeholder was blocked, redirect
+// the current tab. The OS opens Cash App via the universal link.
 if (newTab) {
   newTab.location.href = response.url;
 } else {
-  // Mobile/PWA: popup was blocked, navigate in same tab
   window.location.href = response.url;
 }
 ```
 
-**Platform-specific guidance:**
+### Platform-specific guidance
 
 | Platform | Behavior | Recommendation |
 |----------|----------|----------------|
-| **Desktop browsers** | Pre-opened tab works reliably | Use the pattern above |
-| **Mobile browsers** | `window.open` may be blocked after async | Falls back to `location.href` automatically |
-| **PWA (standalone)** | `window.open` is almost always blocked | Same-tab redirect via `location.href`; opens system browser |
-| **iOS (native)** | Use `SFSafariViewController` or `UIApplication.open()` | Universal link triggers CashApp if installed |
-| **Android (native)** | Use <a href="https://developer.chrome.com/docs/android/custom-tabs" target="_blank">Chrome Custom Tabs</a> or `Intent` | Universal link triggers CashApp if installed |
+| **Desktop browsers** | Pre-opened tab works reliably; most desktops won't have CashApp installed | Render the CashApp URL as a QR for the user to scan on their phone |
+| **Mobile browsers** | `window.open` may be blocked after async | Pre-open a tab (see above); falls back to `location.href` automatically |
+| **PWA (standalone)** | `window.open` is almost always blocked | Same-tab redirect via `location.href`; opens system browser, which hands off to CashApp |
+| **iOS (native)** | Universal link triggers CashApp if installed | Open via `UIApplication.open()` or `SFSafariViewController` |
+| **Android (native)** | Universal link triggers CashApp if installed | Open via `Intent` or <a href="https://developer.chrome.com/docs/android/custom-tabs" target="_blank">Chrome Custom Tabs</a> |
 
 **CashApp availability:** US and UK only (excluding New York State for Bitcoin/Lightning features). CashApp handles region restrictions on their end, so no client-side gating is needed.
-</div>

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1194,7 +1194,7 @@ pub enum _BuyBitcoinRequest {
         redirect_url: Option<String>,
     },
     CashApp {
-        amount_sats: Option<u64>,
+        amount_sats: u64,
     },
 }
 


### PR DESCRIPTION
This PR makes the amount mandatory when buying BTC via Cash App.

We removed amountless invoice support on Cash App because the scope of the `buy_bitcoin` API is on-ramping. With an amountless invoice, Cash App only lets the payer fund from their existing Cash App BTC balance, which isn't on-ramping. When the invoice carries an amount, Cash App opens up funding via fiat balance and debit card.