### PR TITLE
Split kotlin-multiplatform CI into three single-purpose pathways

### DIFF
--- a/.claude/commands/update-snippets.md
+++ b/.claude/commands/update-snippets.md
@@ -37,7 +37,7 @@ When updating multiple snippet files:
 
 ### Phase 3: Update All Other Languages (Parallel)
 
-**Spawn all 8 agents in a single message** for: `go`, `python`, `kotlin-mpp`, `swift`, `csharp`, `flutter`, `wasm`, `react-native`
+**Spawn all 8 agents in a single message** for: `go`, `python`, `kotlin-multiplatform`, `swift`, `csharp`, `flutter`, `wasm`, `react-native`
 
 Use this prompt template for each:
 
@@ -73,9 +73,9 @@ After all agents complete, run verifications. Can be parallel.
 
 Run non-Node languages in parallel:
 ```bash
-cargo xtask check-doc-snippets --package go --skip-build
+cargo xtask check-doc-snippets --package golang --skip-build
 cargo xtask check-doc-snippets --package python --skip-build
-cargo xtask check-doc-snippets --package kotlin-mpp --skip-build
+cargo xtask check-doc-snippets --package kotlin-multiplatform --skip-build
 cargo xtask check-doc-snippets --package swift --skip-build
 cargo xtask check-doc-snippets --package csharp --skip-build
 cargo xtask check-doc-snippets --package flutter --skip-build
@@ -127,9 +127,9 @@ command -v nvm && nvm use 22 || true
 ```bash
 # Individual language (fast with --skip-build):
 cargo xtask check-doc-snippets --package rust --skip-build
-cargo xtask check-doc-snippets --package go --skip-build
+cargo xtask check-doc-snippets --package golang --skip-build
 cargo xtask check-doc-snippets --package python --skip-build
-cargo xtask check-doc-snippets --package kotlin-mpp --skip-build
+cargo xtask check-doc-snippets --package kotlin-multiplatform --skip-build
 cargo xtask check-doc-snippets --package swift --skip-build
 cargo xtask check-doc-snippets --package csharp --skip-build
 cargo xtask check-doc-snippets --package flutter --skip-build

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -3,6 +3,20 @@ name: CLI static analysis
 on:
   workflow_call:
 
+# Version pins for the kmp-* matrix jobs. Bump these in lockstep with the
+# canonical source so the cache keys invalidate alongside the binary itself.
+env:
+  # cargo-ndk 4.x is required by the `--link-libcxx-shared` flag the
+  # bindings Makefile passes (see `build-ndk-release-target-%`); the flag
+  # was added in 4.0.
+  CARGO_NDK_VERSION: 4.1.2
+  # Mirror of the gobley branch pinned in
+  # `crates/breez-sdk/bindings/Makefile` (`install-uniffi-bindgen-gobley`).
+  GOBLEY_REF: v0.3.7-with-fixes
+  # Mirror of `kotlin_target_version` in
+  # `crates/breez-sdk/bindings/uniffi.kotlin-multiplatform.toml`.
+  KOTLIN_NATIVE_VERSION: 1.9.21
+
 jobs:
   check:
     name: ${{ matrix.lang }}
@@ -89,9 +103,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.konan
-          # Bump the suffix when the Kotlin version pinned in
-          # crates/breez-sdk/bindings/uniffi.kotlin-multiplatform.toml changes.
-          key: konan-1.9.21-${{ runner.os }}
+          key: konan-${{ env.KOTLIN_NATIVE_VERSION }}-${{ runner.os }}
 
       - name: Add Android Rust target
         if: matrix.android-ndk
@@ -102,20 +114,18 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/cargo-ndk
-          key: cargo-ndk-${{ runner.os }}
+          key: cargo-ndk-${{ env.CARGO_NDK_VERSION }}-${{ runner.os }}
 
       - name: Install cargo-ndk
         if: matrix.android-ndk
-        run: command -v cargo-ndk || cargo install cargo-ndk --locked
+        run: command -v cargo-ndk || cargo install cargo-ndk --version ${{ env.CARGO_NDK_VERSION }} --locked
 
       - name: Cache gobley-uniffi-bindgen
         if: matrix.gradle
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/gobley-uniffi-bindgen
-          # Bump the suffix when the gobley pin in
-          # crates/breez-sdk/bindings/Makefile changes.
-          key: gobley-uniffi-bindgen-v0.3.7-with-fixes-${{ runner.os }}
+          key: gobley-uniffi-bindgen-${{ env.GOBLEY_REF }}-${{ runner.os }}
 
       - name: Generate KMP bindings (host)
         if: matrix.lang == 'kotlin-multiplatform-ios'

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -20,6 +20,23 @@ jobs:
           - lang: kotlin-multiplatform
             runner: ubuntu-latest
             java-version: "17"
+          # SDK Android compile smoke-test — gobley Android source +
+          # cargo-ndk cross-compile + AGP AAR assembly.
+          - lang: kotlin-multiplatform-android
+            runner: ubuntu-latest
+            java-version: "17"
+            gradle: true
+            android-ndk: true
+            sdk-target: true
+          # SDK iOS Kotlin/Native compile smoke-test — gobley native source +
+          # `.def`/cinterop bindings + Kotlin/Native compiler for all 3 iOS
+          # targets.
+          - lang: kotlin-multiplatform-ios
+            runner: macos-latest
+            java-version: "17"
+            gradle: true
+            konan: true
+            sdk-target: true
           - lang: python
             runner: ubuntu-latest
           - lang: react-native
@@ -63,6 +80,64 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Setup Gradle
+        if: matrix.gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Cache Konan toolchain
+        if: matrix.konan
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          # Bump the suffix when the Kotlin version pinned in
+          # crates/breez-sdk/bindings/uniffi.kotlin-multiplatform.toml changes.
+          key: konan-1.9.21-${{ runner.os }}
+
+      - name: Add Android Rust target
+        if: matrix.android-ndk
+        run: rustup target add aarch64-linux-android
+
+      - name: Cache cargo-ndk
+        if: matrix.android-ndk
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-ndk
+          key: cargo-ndk-${{ runner.os }}
+
+      - name: Install cargo-ndk
+        if: matrix.android-ndk
+        run: command -v cargo-ndk || cargo install cargo-ndk --locked
+
+      - name: Cache gobley-uniffi-bindgen
+        if: matrix.gradle
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/gobley-uniffi-bindgen
+          # Bump the suffix when the gobley pin in
+          # crates/breez-sdk/bindings/Makefile changes.
+          key: gobley-uniffi-bindgen-v0.3.7-with-fixes-${{ runner.os }}
+
+      - name: Generate KMP bindings (host)
+        if: matrix.lang == 'kotlin-multiplatform-ios'
+        working-directory: crates/breez-sdk/bindings
+        run: make build-kotlin-multiplatform-bindgen-host
+
+      - name: Compile iOS Kotlin/Native targets
+        if: matrix.lang == 'kotlin-multiplatform-ios'
+        working-directory: crates/breez-sdk/bindings/langs/kotlin-multiplatform
+        run: ./gradlew :breez-sdk-spark-kmp:compileKotlinIosArm64 :breez-sdk-spark-kmp:compileKotlinIosX64 :breez-sdk-spark-kmp:compileKotlinIosSimulatorArm64
+
+      - name: Generate KMP bindings (Android arm64)
+        if: matrix.lang == 'kotlin-multiplatform-android'
+        working-directory: crates/breez-sdk/bindings
+        run: make build-kotlin-multiplatform-bindgen-android-arm64
+
+      - name: Assemble Android release AAR
+        if: matrix.lang == 'kotlin-multiplatform-android'
+        working-directory: crates/breez-sdk/bindings/langs/kotlin-multiplatform
+        run: ./gradlew :breez-sdk-spark-kmp:assembleRelease -PskipIosTargets
+
       - name: Check CLI
+        if: matrix.sdk-target != true
         working-directory: crates/breez-sdk/bindings/examples/cli
         run: make check-${{ matrix.lang }}

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -11,32 +11,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Rust is the source of truth, kept on top.
           - platform: rust
             runner: ubuntu-latest
-          - platform: wasm
+          # Other bindings alphabetically.
+          - platform: csharp
             runner: ubuntu-latest
-            node-version: "22"
+            dotnet-version: "8.0.x"
           - platform: flutter
             runner: ubuntu-latest
             flutter: true
-          - platform: go
+          - platform: golang
             runner: ubuntu-latest
+          - platform: kotlin-multiplatform
+            runner: ubuntu-latest
+            java-version: "17"
+            gradle: true
           - platform: python
             runner: ubuntu-latest
             python-version: "3.12"
-          - platform: kotlin-mpp
-            runner: macos-latest
-            java-version: "17"
-            cargo-ndk: true
-          - platform: swift
-            runner: macos-latest
           - platform: react-native
             runner: macos-latest
             node-version: "22"
             ios-targets: true
-          - platform: csharp
+          - platform: swift
+            runner: macos-latest
+          - platform: wasm
             runner: ubuntu-latest
-            dotnet-version: "8.0.x"
+            node-version: "22"
     steps:
       - uses: actions/checkout@v4
 
@@ -75,9 +77,18 @@ jobs:
           distribution: "zulu"
           java-version: ${{ matrix.java-version }}
 
-      - name: Install cargo-ndk
-        if: matrix.cargo-ndk
-        run: cargo install cargo-ndk
+      - name: Setup Gradle
+        if: matrix.gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Cache gobley-uniffi-bindgen
+        if: matrix.gradle
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/gobley-uniffi-bindgen
+          # Bump the suffix when the gobley pin in
+          # crates/breez-sdk/bindings/Makefile changes.
+          key: gobley-uniffi-bindgen-v0.3.7-with-fixes-${{ runner.os }}
 
       - name: Install Rust targets (iOS)
         if: matrix.ios-targets

--- a/crates/breez-sdk/bindings/Makefile
+++ b/crates/breez-sdk/bindings/Makefile
@@ -43,7 +43,7 @@ install-uniffi-bindgen-cs:
 	$(INSTALL_PREFIX) cargo install uniffi-bindgen-cs --git https://github.com/breez/uniffi-bindgen-cs --branch v0.29.4-with-fixes
 
 install-uniffi-bindgen-gobley:
-	$(INSTALL_PREFIX) cargo install gobley-uniffi-bindgen --git https://github.com/breez/gobley --branch v0.3.7-with-fixes
+	@command -v gobley-uniffi-bindgen >/dev/null 2>&1 || $(INSTALL_PREFIX) cargo install gobley-uniffi-bindgen --git https://github.com/breez/gobley --branch v0.3.7-with-fixes
 
 install-uniffi-bindgen-golang:
 	$(INSTALL_PREFIX) cargo install uniffi-bindgen-go --git https://github.com/breez/uniffi-bindgen-go --branch v0.29.5-with-fixes
@@ -124,6 +124,27 @@ build-kotlin-multiplatform-bindgen-only: install-uniffi-bindgen-gobley build-ndk
 		--crate-configs breez_sdk_spark_bindings=./uniffi.kotlin-multiplatform.toml \
 		--crate-configs breez_sdk_spark=../core/uniffi.kotlin-multiplatform.toml \
 		$(TARGET_DIR)aarch64-linux-android/release/$(BIN_NAME).so
+
+# Run bindgen using the host's release library, no Android NDK build required.
+# Used by the docs-snippets check to avoid cross-compiling for Android.
+build-kotlin-multiplatform-bindgen-host: install-uniffi-bindgen-gobley build-release
+	gobley-uniffi-bindgen --library -o $(FFI_DIR)kmp \
+		--crate-configs breez_sdk_spark_bindings=./uniffi.kotlin-multiplatform.toml \
+		--crate-configs breez_sdk_spark=../core/uniffi.kotlin-multiplatform.toml \
+		$(BIN_PATH)
+	cp -r $(FFI_DIR)kmp/* $(KMP_BASE)/
+
+# Build Android arm64 bindings (cross-compile + bindgen + jniLibs copy).
+# Used by the cli-ci `kotlin-multiplatform-android` job for the Android
+# Kotlin compile + AAR smoke check on PRs.
+build-kotlin-multiplatform-bindgen-android-arm64: install-uniffi-bindgen-gobley build-ndk-release-target-aarch64-linux-android
+	gobley-uniffi-bindgen --library -o $(FFI_DIR)kmp \
+		--crate-configs breez_sdk_spark_bindings=./uniffi.kotlin-multiplatform.toml \
+		--crate-configs breez_sdk_spark=../core/uniffi.kotlin-multiplatform.toml \
+		$(TARGET_DIR)aarch64-linux-android/release/$(BIN_NAME).so
+	cp -r $(FFI_DIR)kmp/* $(KMP_BASE)/
+	mkdir -p $(KMP_BASE)/androidMain/jniLibs/arm64-v8a
+	cp $(FFI_DIR)kotlin/jniLibs/arm64-v8a/$(BIN_NAME).so $(KMP_BASE)/androidMain/jniLibs/arm64-v8a/
 
 # Build all binaries + run bindgen
 build-kotlin-multiplatform: build-kotlin-multiplatform-bindgen-only build-ndk-release-target-armv7-linux-androideabi build-ndk-release-target-i686-linux-android build-ndk-release-target-x86_64-linux-android

--- a/crates/breez-sdk/bindings/langs/kotlin-multiplatform/breez-sdk-spark-kmp/build.gradle.kts
+++ b/crates/breez-sdk/bindings/langs/kotlin-multiplatform/breez-sdk-spark-kmp/build.gradle.kts
@@ -6,6 +6,12 @@ plugins {
 
 apply(plugin = "kotlinx-atomicfu")
 
+// Skip iOS Kotlin/Native targets when explicitly requested. Used by the
+// docs-snippets CI job, which only needs the JVM publication. The cli-ci
+// `kotlin-multiplatform-ios` job and the release pipeline still build
+// every iOS target.
+val skipIosTargets = project.hasProperty("skipIosTargets")
+
 kotlin {
     // Enable the default target hierarchy
     applyDefaultHierarchyTemplate()
@@ -26,19 +32,21 @@ kotlin {
         }
     }
 
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.compilations["main"].cinterops {
-            create("breezSdkSparkCInterop") {
-                defFile(project.file("src/nativeInterop/cinterop/breez_sdk_spark.def"))
-                includeDirs(project.file("src/nativeInterop/cinterop/headers/breez_sdk_spark"))
-            }
-            create("breezSdkSparkBindingsCInterop") {
-                defFile(project.file("src/nativeInterop/cinterop/breez_sdk_spark_bindings.def"))
-                includeDirs(project.file("src/nativeInterop/cinterop/headers/breez_sdk_spark_bindings"))
+    if (!skipIosTargets) {
+        listOf(
+            iosX64(),
+            iosArm64(),
+            iosSimulatorArm64()
+        ).forEach {
+            it.compilations["main"].cinterops {
+                create("breezSdkSparkCInterop") {
+                    defFile(project.file("src/nativeInterop/cinterop/breez_sdk_spark.def"))
+                    includeDirs(project.file("src/nativeInterop/cinterop/headers/breez_sdk_spark"))
+                }
+                create("breezSdkSparkBindingsCInterop") {
+                    defFile(project.file("src/nativeInterop/cinterop/breez_sdk_spark_bindings.def"))
+                    includeDirs(project.file("src/nativeInterop/cinterop/headers/breez_sdk_spark_bindings"))
+                }
             }
         }
     }

--- a/crates/xtask/src/docs.rs
+++ b/crates/xtask/src/docs.rs
@@ -11,7 +11,7 @@ pub enum DocSnippetsPackage {
     Wasm,
     Flutter,
     Go,
-    KotlinMPP,
+    KotlinMultiplatform,
     Python,
     ReactNative,
     Rust,
@@ -25,8 +25,8 @@ impl FromStr for DocSnippetsPackage {
         match s {
             "wasm" => Ok(DocSnippetsPackage::Wasm),
             "flutter" => Ok(DocSnippetsPackage::Flutter),
-            "go" => Ok(DocSnippetsPackage::Go),
-            "kotlin-mpp" => Ok(DocSnippetsPackage::KotlinMPP),
+            "golang" => Ok(DocSnippetsPackage::Go),
+            "kotlin-multiplatform" => Ok(DocSnippetsPackage::KotlinMultiplatform),
             "python" => Ok(DocSnippetsPackage::Python),
             "react-native" => Ok(DocSnippetsPackage::ReactNative),
             "rust" => Ok(DocSnippetsPackage::Rust),
@@ -51,8 +51,8 @@ pub fn check_doc_snippets_cmd(
         Some(DocSnippetsPackage::Go) => {
             check_doc_snippets_go_cmd(skip_binding_gen)?;
         }
-        Some(DocSnippetsPackage::KotlinMPP) => {
-            check_doc_snippets_kotlin_mpp_cmd(skip_binding_gen)?;
+        Some(DocSnippetsPackage::KotlinMultiplatform) => {
+            check_doc_snippets_kotlin_multiplatform_cmd(skip_binding_gen)?;
         }
         Some(DocSnippetsPackage::Python) => {
             check_doc_snippets_python_cmd(skip_binding_gen)?;
@@ -73,7 +73,7 @@ pub fn check_doc_snippets_cmd(
             check_doc_snippets_wasm_cmd(skip_binding_gen)?;
             check_doc_snippets_flutter_cmd(skip_binding_gen)?;
             check_doc_snippets_go_cmd(skip_binding_gen)?;
-            check_doc_snippets_kotlin_mpp_cmd(skip_binding_gen)?;
+            check_doc_snippets_kotlin_multiplatform_cmd(skip_binding_gen)?;
             check_doc_snippets_python_cmd(skip_binding_gen)?;
             check_doc_snippets_react_native_cmd(skip_binding_gen)?;
             check_doc_snippets_rust_cmd()?;
@@ -270,48 +270,59 @@ go 1.19
     Ok(())
 }
 
-fn check_doc_snippets_kotlin_mpp_cmd(skip_binding_gen: bool) -> Result<()> {
+fn check_doc_snippets_kotlin_multiplatform_cmd(skip_binding_gen: bool) -> Result<()> {
     let workspace_root = env::current_dir()?;
 
     if !skip_binding_gen {
-        println!("Building Kotlin MPP Bindings");
+        println!("Building Kotlin Multiplatform bindings (host + JVM publication)");
 
+        // Run gobley-uniffi-bindgen against the host's release library, then
+        // copy the generated Kotlin sources into the KMP module. Skipping the
+        // Android NDK build keeps this off the cargo-ndk + cross-compile path.
         let bindings_dir = workspace_root.join("crates/breez-sdk/bindings");
         let status = Command::new("make")
-            .arg("package-kotlin-multiplatform-dummy-binaries")
+            .arg("build-kotlin-multiplatform-bindgen-host")
             .current_dir(&bindings_dir)
             .status()?;
         if !status.success() {
             anyhow::bail!(
-                "Failed to run 'make package-kotlin-multiplatform-dummy-binaries' in {:?}",
+                "Failed to run 'make build-kotlin-multiplatform-bindgen-host' in {:?}",
                 bindings_dir
             );
         }
 
-        let kotlin_mpp_dir = bindings_dir.join("langs/kotlin-multiplatform");
+        // `-PskipIosTargets` excludes the iOS targets from the module
+        // configuration so publishing the JVM publication doesn't pull in
+        // Konan downloads + iOS cinterop + iOS native compiles. SDK iOS
+        // compile coverage is provided by the cli-ci `kotlin-multiplatform-ios`
+        // job.
+        let kotlin_multiplatform_dir = bindings_dir.join("langs/kotlin-multiplatform");
         let status = Command::new("./gradlew")
-            .arg("publishToMavenLocal")
+            .arg("publishKotlinMultiplatformPublicationToMavenLocal")
+            .arg("publishJvmPublicationToMavenLocal")
             .arg("-PlibraryVersion=0.0.0-local-docs")
-            .current_dir(&kotlin_mpp_dir)
+            .arg("-PskipIosTargets")
+            .current_dir(&kotlin_multiplatform_dir)
             .status()?;
         if !status.success() {
             anyhow::bail!(
-                "Failed to run 'gradlew publishToMavenLocal' in {:?}",
-                kotlin_mpp_dir
+                "Failed to publish JVM Kotlin Multiplatform publication in {:?}",
+                kotlin_multiplatform_dir
             );
         }
     }
 
-    println!("Checking doc snippets Kotlin MPP");
+    println!("Checking doc snippets Kotlin Multiplatform");
 
     let kotlin_snippets_dir = workspace_root.join("docs/breez-sdk/snippets/kotlin_mpp_lib");
     let status = Command::new("./gradlew")
         .arg("compileKotlinJvm")
+        .arg("-PskipIosTargets")
         .current_dir(&kotlin_snippets_dir)
         .status()?;
     if !status.success() {
         anyhow::bail!(
-            "Failed to run './gradlew compileKotlinJvm' in {:?}",
+            "Failed to compile Kotlin doc snippets in {:?}",
             kotlin_snippets_dir
         );
     }

--- a/docs/breez-sdk/snippets/SNIPPET_CONVENTIONS.md
+++ b/docs/breez-sdk/snippets/SNIPPET_CONVENTIONS.md
@@ -440,7 +440,7 @@ cargo xtask check-doc-snippets --package <language>
 cargo xtask check-doc-snippets --package <language> --skip-build
 ```
 
-Languages: `rust`, `go`, `python`, `kotlin-mpp`, `swift`, `csharp`, `flutter`, `wasm`, `react-native`
+Languages: `rust`, `golang`, `python`, `kotlin-multiplatform`, `swift`, `csharp`, `flutter`, `wasm`, `react-native`
 
 **Node.js Requirement:** WASM and React Native require Node >= 22.
 ```bash

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/build.gradle.kts
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     alias(libs.plugins.androidLibrary)
 }
 
+// Skip iOS targets when the breez SDK was published JVM-only (used by
+// docs CI together with `-PskipIosTargets` on the SDK build).
+val skipIosTargets = project.hasProperty("skipIosTargets")
+
 kotlin {
     androidTarget {
         compilations.all {
@@ -14,14 +18,16 @@ kotlin {
 
     jvm()
 
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "shared"
-            isStatic = true
+    if (!skipIosTargets) {
+        listOf(
+            iosX64(),
+            iosArm64(),
+            iosSimulatorArm64()
+        ).forEach {
+            it.binaries.framework {
+                baseName = "shared"
+                isStatic = true
+            }
         }
     }
 


### PR DESCRIPTION
The Docs / kotlin-mpp job takes ~30 minutes because it builds every Kotlin Multiplatform target (JVM, Android, three iOS targets) and uses uncached Gradle distributions, Konan toolchains, and `cargo install` builds for the binary tools, even though the doc-snippets check only needs the JVM publication.

This PR splits the work across three single-purpose jobs that run in parallel:

| Job | Runs on | What it covers |
|---|---|---|
| **Docs / kotlin-multiplatform** | `ubuntu-latest` | Snippet shape against the SDK's JVM publication |
| **CLI / kotlin-multiplatform-android** | `ubuntu-latest` | NDK cross-compile of Rust bindings + Android Kotlin compile + AAR assembly |
| **CLI / kotlin-multiplatform-ios** | `macos-latest` | All three iOS Kotlin/Native target compiles (`compileKotlinIos{Arm64,X64,SimulatorArm64}`) |

The `Docs / kotlin-multiplatform` job also gets an opt-in `-PskipIosTargets` Gradle flag and a new `build-kotlin-multiplatform-bindgen-host` Make target, replacing `package-kotlin-multiplatform-dummy-binaries`. 

The Android job uses a new `build-kotlin-multiplatform-bindgen-android-arm64` Make target that runs `cargo-ndk` for one arch + gobley + copies the `.so` into `androidMain/jniLibs/` for AAR assembly. 

**Caches added:** 
- Gradle (`gradle/actions/setup-gradle@v4`), 
- `~/.konan` (iOS job),
- `~/.cargo/bin/gobley-uniffi-bindgen` (all three jobs), 
- `~/.cargo/bin/cargo-ndk` (Android job).

**Also (incidental cleanup):** 
- `Docs / *` matrix is rust-first then alphabetical;
- `CLI / *` matrix groups `kotlin-multiplatform`/`-android`/`-ios` together;
-  the `go` doc-snippet platform is renamed to `golang` to match `cli-ci`.

## Coverage

Total per-PR coverage is preserved
- JVM, Android, and iOS Kotlin/Native are all compiled per PR; 
- multi-variant publish (POM/module-file generation for every variant) is exercised at release time via `publish-kotlin-multiplatform.yml`.

## Timings

| Job | Before | After (cold) | After (warm) |
|---|---|---|---|
| `Docs / kotlin-multiplatform` | bundled in ~28 min | 8m 45s | 6m 58s |
| `CLI / kotlin-multiplatform` | ~8 min | 7m 54s | 4m 46s |
| `CLI / kotlin-multiplatform-android` | - | 8m 52s | 5m 23s |
| `CLI / kotlin-multiplatform-ios` | - | 11m 20s | 6m 26s |
| **Critical-path wall time** | **~28 min** | **~11 min** | **~7 min** |

###### **cold** = first run after force-push with caches evicted; **warm** = subsequent run reading caches saved by the previous one. 

Cache hit confirmation on the warm run (other than Swatinem rust-cache, which hits everywhere):
- iOS: ✅ Konan, ✅ gobley
- Android: ✅ cargo-ndk, ✅ gobley
- Docs: ✅ gobley

The Gradle User Home cache misses on every job because `gradle/actions/setup-gradle@v4` is read-only on PR runs by default. Enabling write-through-on-internal-PRs would shave another ~1 min off Docs in particular; left as a follow-up.