### PR TITLE
Run stale-reservation cleanup before the active-swap gate

### DIFF
--- a/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
@@ -36,6 +36,12 @@ const TOKEN_STORE_WRITE_LOCK_KEY = "8390042714201347154"; // 0x746F6B656E535452 
  */
 const SPENT_MARKER_CLEANUP_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
+/**
+ * Reservations whose created_at is older than this are considered stale and are
+ * dropped at the start of setTokensOutputs. Matches the tree store's timeout.
+ */
+const RESERVATION_TIMEOUT_SECS = 300; // 5 minutes
+
 class PostgresTokenStore {
   constructor(pool, logger = null) {
     this.pool = pool;
@@ -102,6 +108,13 @@ class PostgresTokenStore {
       const refreshTimestamp = new Date(refreshStartedAtMs);
 
       await this._withWriteTransaction(async (client) => {
+        // Drop expired reservations BEFORE evaluating has_active_swap, otherwise a stale
+        // Swap reservation (from a crashed client or a swap whose finalize/cancel never
+        // ran) keeps has_active_swap true forever, which makes setTokensOutputs
+        // early-return and never reach any subsequent reconciliation. The reservation
+        // pins itself in place and the local token-output set freezes.
+        await this._cleanupStaleReservations(client);
+
         // Skip if swap is active or completed during this refresh
         const swapCheckResult = await client.query(
           `SELECT
@@ -723,6 +736,19 @@ class PostgresTokenStore {
       const v = c === "x" ? r : (r & 0x3) | 0x8;
       return v.toString(16);
     });
+  }
+
+  /**
+   * Delete reservations that have exceeded the timeout.
+   * Called during setTokensOutputs to clean up stale reservations from crashed clients.
+   * The ON DELETE SET NULL foreign key constraint automatically releases the outputs.
+   */
+  async _cleanupStaleReservations(client) {
+    await client.query(
+      `DELETE FROM token_reservations
+       WHERE created_at < NOW() - make_interval(secs => $1)`,
+      [RESERVATION_TIMEOUT_SECS]
+    );
   }
 
   /**

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -189,6 +189,12 @@ class PostgresTreeStore {
       await this._withWriteTransaction(async (client) => {
         const refreshTimestamp = new Date(refreshStartedAtMs);
 
+        // Drop expired reservations BEFORE evaluating has_active_swap, otherwise a stale
+        // Swap reservation (from a crashed client or a swap whose finalize/cancel never
+        // ran) keeps has_active_swap true forever, which makes set_leaves early-return
+        // and never reach the cleanup again. The reservation pins itself in place.
+        await this._cleanupStaleReservations(client);
+
         // Check for active swap or swap completed during refresh
         const swapCheckResult = await client.query(`
           SELECT
@@ -211,14 +217,14 @@ class PostgresTreeStore {
         );
         const spentIds = new Set(spentResult.rows.map((r) => r.leaf_id));
 
-        // Delete non-reserved leaves added before refresh started
+        // Delete non-reserved leaves added before refresh started.
+        // Includes leaves released earlier in this transaction by _cleanupStaleReservations
+        // (FK ON DELETE SET NULL) — those rows kept their old added_at, so they are
+        // dropped here and re-fetched from the operator response in the upsert below.
         await client.query(
           "DELETE FROM tree_leaves WHERE reservation_id IS NULL AND added_at < $1",
           [refreshTimestamp]
         );
-
-        // Clean up stale reservations (after leaf delete)
-        await this._cleanupStaleReservations(client);
 
         // Upsert all leaves (filtering spent)
         await this._batchUpsertLeaves(client, leaves, false, spentIds);

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -38,6 +38,10 @@ const TOKEN_STORE_WRITE_LOCK_KEY: i64 = 0x746F_6B65_6E53_5452; // "toknSTR" as h
 /// Actual deletion only happens for markers older than this threshold.
 const SPENT_MARKER_CLEANUP_THRESHOLD_MS: i64 = 5 * 60 * 1000; // 5 minutes
 
+/// Reservations whose `created_at` is older than this are considered stale and are
+/// dropped at the start of `set_tokens_outputs`. Matches the tree store's timeout.
+const RESERVATION_TIMEOUT_SECS: f64 = 300.0; // 5 minutes
+
 /// `PostgreSQL`-backed token output store implementation.
 pub struct PostgresTokenStore {
     pool: Pool,
@@ -58,6 +62,13 @@ impl TokenOutputStore for PostgresTokenStore {
         let tx = client.transaction().await.map_err(map_err)?;
 
         Self::acquire_write_lock(&tx).await?;
+
+        // Drop expired reservations BEFORE evaluating has_active_swap, otherwise a stale
+        // Swap reservation (from a crashed client or a swap whose finalize/cancel never
+        // ran) keeps has_active_swap true forever, which makes set_tokens_outputs
+        // early-return and never reach any subsequent reconciliation. The reservation
+        // pins itself in place and the local token-output set freezes.
+        Self::cleanup_stale_reservations(&tx).await?;
 
         // Skip if swap is active or completed during this refresh
         let (has_active_swap, swap_completed_during_refresh): (bool, bool) = {
@@ -861,6 +872,28 @@ impl PostgresTokenStore {
         Ok(())
     }
 
+    /// Deletes reservations that have exceeded the timeout.
+    /// Called during `set_tokens_outputs` to clean up stale reservations from crashed clients.
+    /// The `ON DELETE SET NULL` foreign key constraint automatically releases the outputs.
+    async fn cleanup_stale_reservations(
+        tx: &tokio_postgres::Transaction<'_>,
+    ) -> Result<u64, TokenOutputServiceError> {
+        let result = tx
+            .execute(
+                r"DELETE FROM token_reservations
+                  WHERE created_at < NOW() - make_interval(secs => $1)",
+                &[&RESERVATION_TIMEOUT_SECS],
+            )
+            .await
+            .map_err(map_err)?;
+
+        if result > 0 {
+            trace!("Cleaned up {} stale token reservations", result);
+        }
+
+        Ok(result)
+    }
+
     /// Cleans up spent markers older than the cleanup threshold relative to refresh timestamp.
     async fn cleanup_spent_markers(
         tx: &tokio_postgres::Transaction<'_>,
@@ -1261,5 +1294,87 @@ mod tests {
     async fn test_insert_outputs_clears_spent_status() {
         let fixture = PostgresTokenStoreTestFixture::new().await;
         shared_tests::test_insert_outputs_clears_spent_status(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_stale_swap_reservation_does_not_block_set_tokens_outputs() {
+        // Regression test mirroring the tree store fix: a stale Swap reservation
+        // must be cleaned up before has_active_swap is evaluated, otherwise the
+        // reservation pins itself in place and the local token-output set freezes.
+        let fixture = PostgresTokenStoreTestFixture::new().await;
+        let token1 = shared_tests::create_token_outputs(1, vec![100, 200]);
+        fixture
+            .store
+            .set_tokens_outputs(
+                std::slice::from_ref(&token1),
+                shared_tests::future_refresh_start(),
+            )
+            .await
+            .unwrap();
+
+        let reservation = fixture
+            .store
+            .reserve_token_outputs(
+                "token-1",
+                ReservationTarget::MinTotalValue(100),
+                TokenReservationPurpose::Swap,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let stored = fixture
+            .store
+            .get_token_outputs(GetTokenOutputsFilter::Identifier("token-1"))
+            .await
+            .unwrap();
+        assert!(!stored.reserved_for_swap.is_empty());
+
+        // Backdate the swap reservation past the 5-minute timeout.
+        let client = fixture.store.pool.get().await.unwrap();
+        client
+            .execute(
+                "UPDATE token_reservations SET created_at = NOW() - INTERVAL '10 minutes' WHERE id = $1",
+                &[&reservation.id],
+            )
+            .await
+            .unwrap();
+
+        // set_tokens_outputs brings fresh data including a new output. Pre-fix:
+        // skipped on has_active_swap, the new output is dropped and the reservation
+        // lingers forever. Post-fix: cleanup runs first, the stale reservation is
+        // dropped, has_active_swap is false, set_tokens_outputs applies.
+        let token1_refresh = shared_tests::create_token_outputs(1, vec![100, 200, 300]);
+        fixture
+            .store
+            .set_tokens_outputs(
+                std::slice::from_ref(&token1_refresh),
+                shared_tests::future_refresh_start(),
+            )
+            .await
+            .unwrap();
+
+        let stored = fixture
+            .store
+            .get_token_outputs(GetTokenOutputsFilter::Identifier("token-1"))
+            .await
+            .unwrap();
+        assert!(
+            stored.reserved_for_swap.is_empty(),
+            "Stale swap reservation should be cleaned up"
+        );
+        assert_eq!(
+            stored.available.len(),
+            3,
+            "set_tokens_outputs should have proceeded and applied the operator's view (3 outputs)"
+        );
+        assert!(
+            stored
+                .available
+                .iter()
+                .any(|o| o.output.token_amount == 300),
+            "the 300-amount output from the refresh should be present"
+        );
     }
 }

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -161,6 +161,12 @@ impl TreeStore for PostgresTreeStore {
         // Acquire advisory lock to prevent deadlocks with concurrent operations
         Self::acquire_write_lock(&tx).await?;
 
+        // Drop expired reservations BEFORE evaluating has_active_swap, otherwise a stale
+        // Swap reservation (from a crashed client or a swap whose finalize/cancel never
+        // ran) keeps has_active_swap true forever, which makes set_leaves early-return
+        // and never reach the cleanup again. The reservation pins itself in place.
+        Self::cleanup_stale_reservations(&tx).await?;
+
         // Check if any swap reservation is currently active, or if a swap completed
         // after this refresh started (making the refresh data potentially inconsistent).
         let (has_active_swap, swap_completed_during_refresh): (bool, bool) = {
@@ -207,18 +213,15 @@ impl TreeStore for PostgresTreeStore {
 
         // Delete non-reserved leaves that were added BEFORE refresh started.
         // The advisory lock acquired at the start of this transaction prevents deadlocks.
+        // Includes leaves released earlier in this transaction by cleanup_stale_reservations
+        // (FK ON DELETE SET NULL) — those rows kept their old added_at, so they are
+        // dropped here and re-fetched from the operator response in the upsert below.
         tx.execute(
             "DELETE FROM tree_leaves WHERE reservation_id IS NULL AND added_at < $1",
             &[&refresh_timestamp],
         )
         .await
         .map_err(map_err)?;
-
-        // Clean up stale reservations from crashed clients.
-        // This MUST be done AFTER the leaf delete above, because DELETE on tree_reservations
-        // can affect tree_leaves through the ON DELETE SET NULL foreign key constraint,
-        // which interferes with the timestamp-based leaf deletion.
-        Self::cleanup_stale_reservations(&tx).await?;
 
         // Upsert all leaves. batch_upsert_leaves handles spent filtering via skip_ids,
         // and its ON CONFLICT clause preserves reservation_id (not in the UPDATE SET list).
@@ -1476,6 +1479,79 @@ mod tests {
             "Fresh reservation should NOT be cleaned up"
         );
         assert_eq!(all_leaves.available.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_stale_swap_reservation_does_not_block_set_leaves() {
+        // Regression test: a stale Swap reservation must be cleaned up before
+        // has_active_swap is evaluated, otherwise the reservation pins itself in
+        // place — set_leaves early-returns on has_active_swap, never reaches the
+        // cleanup, and the wallet's leaf set freezes at the snapshot when the swap
+        // started.
+        let fixture = PostgresTreeStoreTestFixture::new().await;
+        let leaves = vec![
+            create_test_tree_node("node1", 100),
+            create_test_tree_node("node2", 200),
+        ];
+        fixture.store.add_leaves(&leaves).await.unwrap();
+
+        let reservation = reserve_leaves(
+            &fixture.store,
+            Some(&TargetAmounts::new_amount_and_fee(100, None)),
+            true,
+            ReservationPurpose::Swap,
+        )
+        .await
+        .unwrap();
+
+        let all_leaves = fixture.store.get_leaves().await.unwrap();
+        assert_eq!(all_leaves.reserved_for_swap.len(), 1);
+        assert_eq!(all_leaves.available.len(), 1);
+
+        // Backdate the swap reservation past the 5-minute timeout.
+        let client = fixture.store.pool.get().await.unwrap();
+        client
+            .execute(
+                "UPDATE tree_reservations SET created_at = NOW() - INTERVAL '10 minutes' WHERE id = $1",
+                &[&reservation.id],
+            )
+            .await
+            .unwrap();
+
+        // set_leaves brings fresh data from the operator that includes both leaves
+        // plus a new one. Pre-fix: skipped on has_active_swap, the new leaf is lost
+        // and the reservation lingers forever. Post-fix: cleanup runs first, the
+        // stale reservation is dropped, has_active_swap is false, set_leaves applies.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let refresh_start = SystemTime::now();
+        let refresh_leaves = vec![
+            create_test_tree_node("node1", 100),
+            create_test_tree_node("node2", 200),
+            create_test_tree_node("node3", 300),
+        ];
+        fixture
+            .store
+            .set_leaves(&refresh_leaves, &[], refresh_start)
+            .await
+            .unwrap();
+
+        let all_leaves = fixture.store.get_leaves().await.unwrap();
+        assert!(
+            all_leaves.reserved_for_swap.is_empty(),
+            "Stale swap reservation should be cleaned up"
+        );
+        assert_eq!(
+            all_leaves.available.len(),
+            3,
+            "set_leaves should have proceeded and applied the operator's view (3 leaves)"
+        );
+        assert!(
+            all_leaves
+                .available
+                .iter()
+                .any(|l| l.id.to_string() == "node3"),
+            "node3 from the refresh should be present"
+        );
     }
 
     // ==================== Concurrency Stress Tests ====================


### PR DESCRIPTION
Postgres tree store skips set_leaves when an active Swap reservation exists, but the per-call cleanup of expired reservations runs only after that early-return. A swap reservation that crashed before finalize/cancel keeps has_active_swap true forever, blocks its own cleanup, and freezes the local leaf/output set. Operator-side balance updates are never applied.

Tree store: move cleanup_stale_reservations to before the swap-gate check (Rust + JS Postgres); drop the now-redundant second call.

Token store: introduce cleanup_stale_reservations (matching the tree store's RESERVATION_TIMEOUT_SECS = 300s) and call it in the same spot (Rust + JS Postgres). The schema already carries created_at on token_reservations, so no migration is needed.

Add Rust regression tests for both stores: a backdated Swap reservation must be cleaned up and the refresh must apply.