### PR TITLE
Sync: Reconcile pending payments older than 1 minute

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
+++ b/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
@@ -311,3 +311,145 @@ async fn test_02_htlc_refund(
     info!("=== Test test_02_htlc_refund PASSED ===");
     Ok(())
 }
+
+/// Test 3: Reconciliation detects a stale pending HTLC that failed on the server
+/// A payment stored as Pending at an older sync offset never transitions to Failed
+/// because the offset-based sync skips it on subsequent syncs.
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn test_03_reconcile_stale_pending_payment(
+    #[future] alice_sdk: Result<SdkInstance>,
+    #[future] bob_sdk: Result<SdkInstance>,
+) -> Result<()> {
+    info!("=== Starting test_03_reconcile_stale_pending_payment ===");
+
+    let mut alice = alice_sdk.await?;
+    let mut bob = bob_sdk.await?;
+
+    ensure_funded(&mut alice, 200).await?;
+
+    // Step 1: Alice sends a Spark HTLC with a 60-second expiry.
+    // 60 seconds is long enough such that the offset advances past it,
+    // yet short enough to fail well before the 120s test timeout.
+    let (_, payment_hash) = generate_preimage_hash_pair();
+
+    let bob_spark_address = bob
+        .sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::SparkAddress,
+        })
+        .await?
+        .payment_request;
+
+    let prepare = alice
+        .sdk
+        .prepare_send_payment(PrepareSendPaymentRequest {
+            payment_request: bob_spark_address,
+            amount: Some(5),
+            token_identifier: None,
+            conversion_options: None,
+            fee_policy: None,
+        })
+        .await?;
+
+    alice
+        .sdk
+        .send_payment(SendPaymentRequest {
+            prepare_response: prepare,
+            options: Some(SendPaymentOptions::SparkAddress {
+                htlc_options: Some(SparkHtlcOptions {
+                    payment_hash: payment_hash.clone(),
+                    expiry_duration_secs: 60,
+                }),
+            }),
+            idempotency_key: None,
+        })
+        .await?;
+
+    info!("Alice sent HTLC (75s expiry) — payment is Pending at position N");
+
+    // Step 2: Alice sends a regular (non-HTLC) Spark to advance the sync offset past the
+    // HTLC's position. Once the auto-sync processes both transfers, the stored
+    // offset will be N+1, making the HTLC invisible to subsequent offset-based syncs.
+    let bob_spark_address2 = bob
+        .sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::SparkAddress,
+        })
+        .await?
+        .payment_request;
+
+    let prepare2 = alice
+        .sdk
+        .prepare_send_payment(PrepareSendPaymentRequest {
+            payment_request: bob_spark_address2,
+            amount: Some(5),
+            token_identifier: None,
+            conversion_options: None,
+            fee_policy: None,
+        })
+        .await?;
+
+    alice
+        .sdk
+        .send_payment(SendPaymentRequest {
+            prepare_response: prepare2,
+            options: None,
+            idempotency_key: None,
+        })
+        .await?;
+
+    wait_for_payment_succeeded_event(&mut bob.events, PaymentType::Receive, 60).await?;
+
+    info!("Alice sent regular Spark (position N+1) — offset will advance past HTLC");
+
+    // Step 3: Explicit sync to commit the advanced offset. After this the HTLC is
+    // invisible to the offset-based sync (which starts from N+1 onwards).
+    alice.sdk.sync_wallet(SyncWalletRequest {}).await?;
+
+    let pending = alice
+        .sdk
+        .list_payments(ListPaymentsRequest {
+            status_filter: Some(vec![PaymentStatus::Pending]),
+            ..Default::default()
+        })
+        .await?
+        .payments;
+    assert!(
+        pending.iter().any(|p| p.payment_type == PaymentType::Send),
+        "HTLC should still be Pending locally after the offset advances past it"
+    );
+
+    // Step 4: Wait for the paymentFailed event emitted by reconciliation.
+    info!("Waiting for paymentFailed event from reconciliation (up to 120s)...");
+    let failed_payment =
+        wait_for_payment_failed_event(&mut alice.events, PaymentType::Send, 120).await?;
+
+    assert_eq!(failed_payment.status, PaymentStatus::Failed);
+    assert_eq!(failed_payment.amount, 5);
+
+    info!(
+        "Received paymentFailed event for payment {}",
+        failed_payment.id
+    );
+
+    // Step 5: Confirm local storage reflects the new status
+    let failed_payments = alice
+        .sdk
+        .list_payments(ListPaymentsRequest {
+            status_filter: Some(vec![PaymentStatus::Failed]),
+            ..Default::default()
+        })
+        .await?
+        .payments;
+
+    assert!(
+        failed_payments
+            .iter()
+            .any(|p| p.payment_type == PaymentType::Send && p.amount == 5),
+        "HTLC payment should be Failed in local storage"
+    );
+
+    info!("=== Test test_03_reconcile_stale_pending_payment PASSED ===");
+    Ok(())
+}

--- a/crates/breez-sdk/core/src/sync.rs
+++ b/crates/breez-sdk/core/src/sync.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 
 use spark_wallet::{
     ListTokenTransactionsRequest, ListTransfersRequest, Order, PagingFilter, SparkWallet,
@@ -171,19 +171,10 @@ impl SparkSyncService {
             }
         };
 
-        // Build a map of payment ID → status. Payment IDs for bitcoin/lightning payments are transfer UUIDs;
-        // token payment IDs use a different format. Parse each to filter for transfers only.
-        let (transfer_ids, pending_by_id): (Vec<TransferId>, HashMap<String, PaymentStatus>) =
-            pending_payments
-                .iter()
-                .fold((Vec::new(), HashMap::new()), |(mut ids, mut map), p| {
-                    if let Ok(transfer_id) = TransferId::from_str(&p.id) {
-                        ids.push(transfer_id);
-                        map.insert(p.id.clone(), p.status);
-                    }
-                    (ids, map)
-                });
-
+        let transfer_ids: Vec<TransferId> = pending_payments
+            .iter()
+            .filter_map(|p| TransferId::from_str(&p.id).ok())
+            .collect();
         if transfer_ids.is_empty() {
             return;
         }
@@ -216,16 +207,13 @@ impl SparkSyncService {
                 }
             };
 
-            // Only act if the status has changed from what we have stored
-            let maybe_existing_status = pending_by_id.get(&payment.id).copied();
-
-            if !maybe_existing_status.is_some_and(|s| s != payment.status) {
+            if payment.status == PaymentStatus::Pending {
                 continue;
             }
 
             info!(
-                "Reconciliation: payment {} status changed from {:?} to {:?}",
-                payment.id, maybe_existing_status, payment.status
+                "Reconciliation: payment {} status changed from Pending to {:?}",
+                payment.id, payment.status
             );
 
             if let Err(e) = self.storage.insert_payment(payment.clone()).await {

--- a/crates/breez-sdk/core/src/sync.rs
+++ b/crates/breez-sdk/core/src/sync.rs
@@ -1,13 +1,14 @@
-use std::sync::Arc;
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use spark_wallet::{
     ListTokenTransactionsRequest, ListTransfersRequest, Order, PagingFilter, SparkWallet,
+    TransferId,
 };
 use tracing::{error, info};
 
 use crate::{
     EventEmitter, Payment, PaymentDetails, PaymentStatus, SdkError, Storage,
-    persist::{CachedSyncInfo, ObjectCacheRepository},
+    persist::{CachedSyncInfo, ObjectCacheRepository, StorageListPaymentsRequest},
     utils::{payments::get_payment_and_emit_event, token::token_transaction_to_payments},
 };
 
@@ -141,7 +142,102 @@ impl SparkSyncService {
             next_filter = transfers_response.next;
         }
 
+        // Re-check all locally-stored pending payments to catch status transitions
+        // that occurred before our current offset window (e.g. pending → failed).
+        self.reconcile_pending_payments(initial_sync_complete).await;
+
         Ok(())
+    }
+
+    /// Re-fetches all locally-stored pending payments from the server and updates
+    /// any whose status has changed. This catches cases where a payment transitioned to
+    /// failed/completed before the current sync offset window began.
+    /// Skip payments younger than 1 minute to avoid unnecessary server load.
+    async fn reconcile_pending_payments(&self, initial_sync_complete: bool) {
+        let now = u64::from(breez_sdk_common::utils::now());
+        let pending_payments = match self
+            .storage
+            .list_payments(StorageListPaymentsRequest {
+                status_filter: Some(vec![PaymentStatus::Pending]),
+                to_timestamp: Some(now.saturating_sub(60)),
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(p) => p,
+            Err(e) => {
+                error!("Failed to list pending payments for reconciliation: {e:?}");
+                return;
+            }
+        };
+
+        // Build a map of payment ID → status. Payment IDs for bitcoin/lightning payments are transfer UUIDs;
+        // token payment IDs use a different format. Parse each to filter for transfers only.
+        let (transfer_ids, pending_by_id): (Vec<TransferId>, HashMap<String, PaymentStatus>) =
+            pending_payments
+                .iter()
+                .fold((Vec::new(), HashMap::new()), |(mut ids, mut map), p| {
+                    if let Ok(transfer_id) = TransferId::from_str(&p.id) {
+                        ids.push(transfer_id);
+                        map.insert(p.id.clone(), p.status);
+                    }
+                    (ids, map)
+                });
+
+        if transfer_ids.is_empty() {
+            return;
+        }
+
+        info!(
+            "Reconciling {} locally-pending bitcoin payments against server",
+            transfer_ids.len()
+        );
+        let transfers_response = match self
+            .spark_wallet
+            .list_transfers(ListTransfersRequest {
+                transfer_ids,
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                error!("Failed to fetch pending payments for reconciliation: {e:?}");
+                return;
+            }
+        };
+
+        for transfer in &transfers_response.items {
+            let payment = match Payment::try_from(transfer.clone()) {
+                Ok(p) => p,
+                Err(e) => {
+                    error!("Failed to convert transfer to payment during reconciliation: {e:?}");
+                    continue;
+                }
+            };
+
+            // Only act if the status has changed from what we have stored
+            let maybe_existing_status = pending_by_id.get(&payment.id).copied();
+
+            if !maybe_existing_status.is_some_and(|s| s != payment.status) {
+                continue;
+            }
+
+            info!(
+                "Reconciliation: payment {} status changed from {:?} to {:?}",
+                payment.id, maybe_existing_status, payment.status
+            );
+
+            if let Err(e) = self.storage.insert_payment(payment.clone()).await {
+                error!("Failed to update payment status during reconciliation: {e:?}");
+                continue;
+            }
+
+            if initial_sync_complete {
+                get_payment_and_emit_event(&self.storage, &self.event_emitter, payment.clone())
+                    .await;
+            }
+        }
     }
 
     async fn apply_payment_metadata(&self, payment: &Payment) -> Result<(), SdkError> {


### PR DESCRIPTION
Closes #777

This PR fixes a scenario in which the optimized sync process skips over payments which remain pending between syncs, causing them to fall behind the current tip and never be updated again.