### PR TITLE
Reduce advisory locks and optimize balance query

### DIFF
--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -283,7 +283,7 @@ impl EventEmitter {
             let t = Instant::now();
             listener.on_event(event.clone()).await;
             let dt = t.elapsed();
-            internal_total += dt;
+            internal_total = internal_total.saturating_add(dt);
             info!("emit({event_label}) internal listener {id}: {dt:?}");
         }
         drop(internal);
@@ -297,7 +297,7 @@ impl EventEmitter {
                 let t = Instant::now();
                 event = mw.process(e).await;
                 let dt = t.elapsed();
-                middleware_total += dt;
+                middleware_total = middleware_total.saturating_add(dt);
                 info!("emit({event_label}) middleware #{i}: {dt:?}");
             } else {
                 break;
@@ -314,7 +314,7 @@ impl EventEmitter {
                 let t = Instant::now();
                 listener.on_event(event.clone()).await;
                 let dt = t.elapsed();
-                external_total += dt;
+                external_total = external_total.saturating_add(dt);
                 info!("emit({event_label}) external listener {id}: {dt:?}");
             }
         }
@@ -322,9 +322,12 @@ impl EventEmitter {
         info!(
             "emit({event_label}) completed in {:?} (internal[{}]={:?}, middleware[{}]={:?}, external[{}]={:?})",
             start.elapsed(),
-            internal_count, internal_total,
-            middleware_count, middleware_total,
-            external_count, external_total
+            internal_count,
+            internal_total,
+            middleware_count,
+            middleware_total,
+            external_count,
+            external_total
         );
     }
 

--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -7,7 +7,7 @@ use std::{
 use platform_utils::time::Instant;
 use serde::Serialize;
 use tokio::sync::{Mutex, RwLock};
-use tracing::debug;
+use tracing::info;
 use uuid::Uuid;
 
 use crate::{DepositInfo, LightningAddressInfo, Payment};
@@ -271,20 +271,34 @@ impl EventEmitter {
     /// 3. External listeners see the processed event
     pub async fn emit(&self, event: &SdkEvent) {
         let start = Instant::now();
+        let event_label = format!("{event}");
+        let mut internal_total = std::time::Duration::ZERO;
+        let mut middleware_total = std::time::Duration::ZERO;
+        let mut external_total = std::time::Duration::ZERO;
 
         // Phase 1: Internal listeners see raw event
         let internal = self.internal_listeners.read().await;
-        for listener in internal.values() {
+        let internal_count = internal.len();
+        for (id, listener) in internal.iter() {
+            let t = Instant::now();
             listener.on_event(event.clone()).await;
+            let dt = t.elapsed();
+            internal_total += dt;
+            info!("emit({event_label}) internal listener {id}: {dt:?}");
         }
         drop(internal);
 
         // Phase 2: Middleware chain
         let mut event = Some(event.clone());
         let middleware = self.middleware.read().await;
-        for mw in middleware.iter() {
+        let middleware_count = middleware.len();
+        for (i, mw) in middleware.iter().enumerate() {
             if let Some(e) = event {
+                let t = Instant::now();
                 event = mw.process(e).await;
+                let dt = t.elapsed();
+                middleware_total += dt;
+                info!("emit({event_label}) middleware #{i}: {dt:?}");
             } else {
                 break;
             }
@@ -292,14 +306,26 @@ impl EventEmitter {
         drop(middleware);
 
         // Phase 3: External listeners see processed event
+        let mut external_count = 0;
         if let Some(ref event) = event {
             let listeners = self.external_listeners.read().await;
-            for listener in listeners.values() {
+            external_count = listeners.len();
+            for (id, listener) in listeners.iter() {
+                let t = Instant::now();
                 listener.on_event(event.clone()).await;
+                let dt = t.elapsed();
+                external_total += dt;
+                info!("emit({event_label}) external listener {id}: {dt:?}");
             }
         }
 
-        debug!("emit() completed in {:?}", start.elapsed());
+        info!(
+            "emit({event_label}) completed in {:?} (internal[{}]={:?}, middleware[{}]={:?}, external[{}]={:?})",
+            start.elapsed(),
+            internal_count, internal_total,
+            middleware_count, middleware_total,
+            external_count, external_total
+        );
     }
 
     pub async fn emit_synced(&self, synced: &InternalSyncedEvent) {

--- a/crates/breez-sdk/core/src/sdk/helpers.rs
+++ b/crates/breez-sdk/core/src/sdk/helpers.rs
@@ -4,6 +4,7 @@ use breez_sdk_common::lnurl::{
     error::LnurlError,
     pay::{AesSuccessActionDataResult, SuccessAction, SuccessActionProcessed},
 };
+use platform_utils::time::Instant;
 use spark_wallet::SparkWallet;
 use std::{str::FromStr, sync::Arc};
 use tokio::sync::mpsc;
@@ -85,25 +86,42 @@ pub(crate) async fn update_balances(
     spark_wallet: Arc<SparkWallet>,
     storage: Arc<dyn Storage>,
 ) -> Result<(), SdkError> {
+    let total_start = Instant::now();
+
+    let t = Instant::now();
     let balance_sats = spark_wallet.get_balance().await?;
-    let token_balances = spark_wallet
-        .get_token_balances()
-        .await?
+    let get_balance_dt = t.elapsed();
+
+    let t = Instant::now();
+    let token_balances_raw = spark_wallet.get_token_balances().await?;
+    let get_token_balances_dt = t.elapsed();
+    let token_balances_count = token_balances_raw.len();
+    let token_balances = token_balances_raw
         .into_iter()
         .map(|(k, v)| (k, v.into()))
         .collect();
+
     let object_repository = ObjectCacheRepository::new(storage.clone());
 
+    let t = Instant::now();
     object_repository
         .save_account_info(&CachedAccountInfo {
             balance_sats,
             token_balances,
         })
         .await?;
+    let save_dt = t.elapsed();
+
     let identity_public_key = spark_wallet.get_identity_public_key();
     info!(
-        "Balance updated successfully {} for identity {}",
-        balance_sats, identity_public_key
+        "Balance updated successfully {} for identity {} (total: {:?}, get_balance: {:?}, get_token_balances[{}]: {:?}, save_account_info: {:?})",
+        balance_sats,
+        identity_public_key,
+        total_start.elapsed(),
+        get_balance_dt,
+        token_balances_count,
+        get_token_balances_dt,
+        save_dt
     );
     Ok(())
 }

--- a/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
@@ -292,6 +292,58 @@ class PostgresTokenStore {
    * List all token outputs grouped by status.
    * @returns {Promise<Array<{metadata: Object, available: Array, reservedForPayment: Array, reservedForSwap: Array}>>}
    */
+  /**
+   * Returns the spendable per-token balances aggregated server-side.
+   * Each entry includes full token metadata + the available + swap-reserved sum.
+   * Tokens with zero spendable balance are filtered out by the HAVING clause.
+   * @returns {Promise<Array<{metadata: object, balance: string}>>}
+   */
+  async getTokenBalances() {
+    try {
+      const result = await this.pool.query(`
+        SELECT m.identifier, m.issuer_public_key, m.name, m.ticker, m.decimals,
+               m.max_supply, m.is_freezable, m.creation_entity_public_key,
+               COALESCE(SUM(
+                 CASE
+                   WHEN o.reservation_id IS NULL THEN o.token_amount::numeric
+                   WHEN r.purpose = 'Swap' THEN o.token_amount::numeric
+                   ELSE 0
+                 END
+               ), 0)::text AS balance
+        FROM token_metadata m
+        JOIN token_outputs o ON o.token_identifier = m.identifier
+        LEFT JOIN token_reservations r ON o.reservation_id = r.id
+        GROUP BY m.identifier, m.issuer_public_key, m.name, m.ticker,
+                 m.decimals, m.max_supply, m.is_freezable, m.creation_entity_public_key
+        HAVING COALESCE(SUM(
+                 CASE
+                   WHEN o.reservation_id IS NULL THEN o.token_amount::numeric
+                   WHEN r.purpose = 'Swap' THEN o.token_amount::numeric
+                   ELSE 0
+                 END
+               ), 0) > 0
+      `);
+      return result.rows.map((row) => ({
+        metadata: {
+          identifier: row.identifier,
+          issuerPublicKey: row.issuer_public_key,
+          name: row.name,
+          ticker: row.ticker,
+          decimals: row.decimals,
+          maxSupply: row.max_supply,
+          isFreezable: row.is_freezable,
+          creationEntityPublicKey: row.creation_entity_public_key,
+        },
+        balance: row.balance,
+      }));
+    } catch (error) {
+      throw new TokenStoreError(
+        `Failed to get token balances: ${error.message}`,
+        error
+      );
+    }
+  }
+
   async listTokensOutputs() {
     try {
       const result = await this.pool.query(

--- a/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
@@ -75,7 +75,9 @@ class PostgresTokenStore {
   }
 
   /**
-   * Run a function inside a transaction with the advisory lock.
+   * Run a function inside a transaction with the advisory lock. Reserved for
+   * operations whose correctness depends on serializing the available-output
+   * set (`reserveTokenOutputs`, `setTokensOutputs`).
    * @param {function(import('pg').PoolClient): Promise<T>} fn
    * @returns {Promise<T>}
    * @template T
@@ -85,6 +87,30 @@ class PostgresTokenStore {
     try {
       await client.query("BEGIN");
       await client.query(`SELECT pg_advisory_xact_lock(${TOKEN_STORE_WRITE_LOCK_KEY})`);
+      const result = await fn(client);
+      await client.query("COMMIT");
+      return result;
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Run a function inside a transaction without the advisory lock. Used by
+   * operations scoped to a single reservation_id (`cancelReservation`,
+   * `finalizeReservation`) where MVCC + row-level locks suffice and the global
+   * lock would only add contention.
+   * @param {function(import('pg').PoolClient): Promise<T>} fn
+   * @returns {Promise<T>}
+   * @template T
+   */
+  async _withTransaction(fn) {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
       const result = await fn(client);
       await client.query("COMMIT");
       return result;
@@ -614,7 +640,7 @@ class PostgresTokenStore {
    */
   async cancelReservation(id) {
     try {
-      await this._withWriteTransaction(async (client) => {
+      await this._withTransaction(async (client) => {
         // Clear reservation_id from outputs
         await client.query(
           "UPDATE token_outputs SET reservation_id = NULL WHERE reservation_id = $1",
@@ -642,7 +668,7 @@ class PostgresTokenStore {
    */
   async finalizeReservation(id) {
     try {
-      await this._withWriteTransaction(async (client) => {
+      await this._withTransaction(async (client) => {
         // Get reservation purpose
         const reservationResult = await client.query(
           "SELECT purpose FROM token_reservations WHERE id = $1",

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -154,6 +154,30 @@ class PostgresTreeStore {
    * Get all leaves categorized by status.
    * @returns {Promise<Object>} Leaves object with available, notAvailable, etc.
    */
+  /**
+   * Returns the wallet's spendable balance (available + missing-from-operators
+   * + swap-reserved). Aggregated server-side so we don't fetch every leaf.
+   * @returns {Promise<bigint>}
+   */
+  async getAvailableBalance() {
+    try {
+      const result = await this.pool.query(`
+        SELECT COALESCE(SUM((l.data->>'value')::bigint), 0)::bigint AS balance
+        FROM tree_leaves l
+        LEFT JOIN tree_reservations r ON l.reservation_id = r.id
+        WHERE
+          (l.reservation_id IS NULL AND l.status = 'Available')
+          OR r.purpose = 'Swap'
+      `);
+      return BigInt(result.rows[0].balance);
+    } catch (error) {
+      throw new TreeStoreError(
+        `Failed to get available balance: ${error.message}`,
+        error
+      );
+    }
+  }
+
   async getLeaves() {
     try {
       const result = await this.pool.query(`

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -73,7 +73,9 @@ class PostgresTreeStore {
   }
 
   /**
-   * Run a function inside a transaction with the advisory lock.
+   * Run a function inside a transaction with the advisory lock. Reserved for
+   * operations whose correctness depends on serializing the available-leaf set
+   * (`tryReserveLeaves`, `setLeaves`).
    * @param {function(import('pg').PoolClient): Promise<T>} fn
    * @returns {Promise<T>}
    * @template T
@@ -83,6 +85,31 @@ class PostgresTreeStore {
     try {
       await client.query("BEGIN");
       await client.query(`SELECT pg_advisory_xact_lock(${TREE_STORE_WRITE_LOCK_KEY})`);
+      const result = await fn(client);
+      await client.query("COMMIT");
+      return result;
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Run a function inside a transaction without the advisory lock. Used by
+   * operations scoped to a single reservation_id (`addLeaves`,
+   * `cancelReservation`, `finalizeReservation`, `updateReservation`) where
+   * MVCC + row-level locks suffice and the global lock would only add
+   * contention.
+   * @param {function(import('pg').PoolClient): Promise<T>} fn
+   * @returns {Promise<T>}
+   * @template T
+   */
+  async _withTransaction(fn) {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
       const result = await fn(client);
       await client.query("COMMIT");
       return result;
@@ -106,7 +133,7 @@ class PostgresTreeStore {
         return;
       }
 
-      await this._withWriteTransaction(async (client) => {
+      await this._withTransaction(async (client) => {
         // Remove these leaves from spent_leaves table
         const leafIds = leaves.map((l) => l.id);
         await this._batchRemoveSpentLeaves(client, leafIds);
@@ -254,7 +281,7 @@ class PostgresTreeStore {
    */
   async cancelReservation(id, leavesToKeep) {
     try {
-      await this._withWriteTransaction(async (client) => {
+      await this._withTransaction(async (client) => {
         const res = await client.query(
           "SELECT id FROM tree_reservations WHERE id = $1",
           [id]
@@ -294,7 +321,7 @@ class PostgresTreeStore {
    */
   async finalizeReservation(id, newLeaves) {
     try {
-      await this._withWriteTransaction(async (client) => {
+      await this._withTransaction(async (client) => {
         // Check if reservation exists and get purpose
         const res = await client.query(
           "SELECT id, purpose FROM tree_reservations WHERE id = $1",
@@ -457,7 +484,7 @@ class PostgresTreeStore {
    */
   async updateReservation(reservationId, reservedLeaves, changeLeaves) {
     try {
-      return await this._withWriteTransaction(async (client) => {
+      return await this._withTransaction(async (client) => {
         // Check if reservation exists
         const res = await client.query(
           "SELECT id FROM tree_reservations WHERE id = $1",

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -404,59 +404,98 @@ class PostgresTreeStore {
     try {
       return await this._withWriteTransaction(async (client) => {
         const targetAmount = targetAmounts ? this._totalSats(targetAmounts) : 0;
+        const maxTarget = this._maxTargetForPrefilter(targetAmounts);
 
-        // Get available leaves
-        const availableResult = await client.query(`
-          SELECT data
+        // True total available, computed server-side over ALL eligible leaves.
+        // Required for the WaitForPending decision below — must NOT be derived
+        // from the prefiltered set since the prefilter may exclude big leaves.
+        const totalResult = await client.query(`
+          SELECT COALESCE(SUM((data->>'value')::bigint), 0)::bigint AS total
           FROM tree_leaves
           WHERE status = 'Available'
             AND is_missing_from_operators = FALSE
             AND reservation_id IS NULL
         `);
+        const available = Number(totalResult.rows[0].total);
 
-        const availableLeaves = availableResult.rows.map((r) => r.data);
-        const available = availableLeaves.reduce((sum, l) => sum + l.value, 0);
+        // Slim projection: only (id, value) for leaves the selection might use.
+        // Includes all leaves with value <= maxTarget (covers exact-match + the
+        // small-leaf accumulators for the minimum-amount path) plus the single
+        // smallest leaf with value > maxTarget (covers the minimum-amount
+        // fallback case where one larger leaf is sufficient).
+        const slimResult = await client.query(`
+          SELECT id, (data->>'value')::bigint AS value
+          FROM tree_leaves
+          WHERE status = 'Available'
+            AND is_missing_from_operators = FALSE
+            AND reservation_id IS NULL
+            AND (
+              (data->>'value')::bigint <= $1
+              OR id = (
+                SELECT id FROM tree_leaves
+                WHERE status = 'Available'
+                  AND is_missing_from_operators = FALSE
+                  AND reservation_id IS NULL
+                  AND (data->>'value')::bigint > $1
+                ORDER BY (data->>'value')::bigint
+                LIMIT 1
+              )
+            )
+        `, [maxTarget]);
+
+        const slimLeaves = slimResult.rows.map((r) => ({
+          id: r.id,
+          value: Number(r.value),
+        }));
 
         // Calculate pending balance
         const pending = await this._calculatePendingBalance(client);
 
-        // Try exact selection first
-        const selected = this._selectLeavesByTargetAmounts(availableLeaves, targetAmounts);
+        // Try exact selection on slim leaves — selection only reads .id/.value
+        const selected = this._selectLeavesByTargetAmounts(slimLeaves, targetAmounts);
 
         if (selected !== null) {
           if (selected.length === 0) {
             throw new TreeStoreError("NonReservableLeaves");
           }
 
+          const fullLeaves = await this._fetchFullLeavesByIds(
+            client,
+            selected.map((l) => l.id)
+          );
           const reservationId = this._generateId();
-          await this._createReservation(client, reservationId, selected, purpose, 0);
+          await this._createReservation(client, reservationId, fullLeaves, purpose, 0);
 
           return {
             type: "success",
             reservation: {
               id: reservationId,
-              leaves: selected,
+              leaves: fullLeaves,
             },
           };
         }
 
         if (!exactOnly) {
-          // Try minimum amount selection
-          const minSelected = this._selectLeavesByMinimumAmount(availableLeaves, targetAmount);
+          // Try minimum amount selection on the slim set
+          const minSelected = this._selectLeavesByMinimumAmount(slimLeaves, targetAmount);
           if (minSelected !== null) {
-            const reservedAmount = minSelected.reduce((sum, l) => sum + l.value, 0);
+            const fullLeaves = await this._fetchFullLeavesByIds(
+              client,
+              minSelected.map((l) => l.id)
+            );
+            const reservedAmount = fullLeaves.reduce((sum, l) => sum + l.value, 0);
             const pendingChange = reservedAmount > targetAmount && targetAmount > 0
               ? reservedAmount - targetAmount
               : 0;
 
             const reservationId = this._generateId();
-            await this._createReservation(client, reservationId, minSelected, purpose, pendingChange);
+            await this._createReservation(client, reservationId, fullLeaves, purpose, pendingChange);
 
             return {
               type: "success",
               reservation: {
                 id: reservationId,
-                leaves: minSelected,
+                leaves: fullLeaves,
               },
             };
           }
@@ -481,6 +520,34 @@ class PostgresTreeStore {
         error
       );
     }
+  }
+
+  /**
+   * Largest single value the selection algorithm could possibly need.
+   * For an unbounded target we have to return all leaves (no prefilter).
+   */
+  _maxTargetForPrefilter(targetAmounts) {
+    if (!targetAmounts) return Number.MAX_SAFE_INTEGER;
+    if (targetAmounts.type === "amountAndFee") {
+      return Math.max(targetAmounts.amountSats, targetAmounts.feeSats || 0);
+    }
+    if (targetAmounts.type === "exactDenominations") {
+      return targetAmounts.denominations.reduce((m, v) => Math.max(m, v), 0);
+    }
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  /**
+   * Pull the full `data` JSON for the leaves the selection algorithm picked.
+   * Typically this is 1-3 rows even when the prefiltered set was thousands.
+   */
+  async _fetchFullLeavesByIds(client, ids) {
+    if (!ids || ids.length === 0) return [];
+    const result = await client.query(
+      "SELECT data FROM tree_leaves WHERE id = ANY($1)",
+      [ids]
+    );
+    return result.rows.map((r) => r.data);
   }
 
   /**

--- a/crates/breez-sdk/wasm/src/token_store/mod.rs
+++ b/crates/breez-sdk/wasm/src/token_store/mod.rs
@@ -1,5 +1,5 @@
 use macros::async_trait;
-use platform_utils::time::SystemTime;
+use platform_utils::time::{Instant, SystemTime};
 use serde::{Deserialize, Serialize};
 use spark_wallet::{
     GetTokenOutputsFilter, ReservationTarget, SelectionStrategy, TokenMetadata, TokenOutput,
@@ -7,6 +7,7 @@ use spark_wallet::{
     TokenOutputsPerStatus, TokenOutputsReservation, TokenOutputsReservationId,
     TokenReservationPurpose,
 };
+use tracing::info;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_futures::js_sys::Promise;
@@ -328,12 +329,26 @@ impl TokenOutputStore for WasmTokenStore {
             .token_store
             .list_tokens_outputs()
             .map_err(js_error_to_token_error)?;
+
+        let t = Instant::now();
         let result = JsFuture::from(promise)
             .await
             .map_err(js_error_to_token_error)?;
+        let js_dt = t.elapsed();
+
+        let t = Instant::now();
         let wasm_results: Vec<WasmTokenOutputsPerStatus> =
             serde_wasm_bindgen::from_value(result)
                 .map_err(|e| TokenOutputServiceError::Generic(e.to_string()))?;
+        let deser_dt = t.elapsed();
+
+        info!(
+            "WasmTokenStore::list_tokens_outputs: {} entries, js_promise: {:?}, deserialize: {:?}",
+            wasm_results.len(),
+            js_dt,
+            deser_dt
+        );
+
         wasm_results
             .into_iter()
             .map(TryInto::try_into)

--- a/crates/breez-sdk/wasm/src/token_store/mod.rs
+++ b/crates/breez-sdk/wasm/src/token_store/mod.rs
@@ -112,6 +112,13 @@ impl TryFrom<WasmTokenMetadata> for TokenMetadata {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct WasmTokenBalance {
+    metadata: WasmTokenMetadata,
+    balance: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct WasmTokenOutput {
     id: String,
     owner_public_key: String,
@@ -320,6 +327,42 @@ impl TokenOutputStore for WasmTokenStore {
             .await
             .map_err(js_error_to_token_error)?;
         Ok(())
+    }
+
+    async fn get_token_balances(
+        &self,
+    ) -> Result<Vec<(TokenMetadata, u128)>, TokenOutputServiceError> {
+        let promise = self
+            .token_store
+            .get_token_balances()
+            .map_err(js_error_to_token_error)?;
+
+        let t = Instant::now();
+        let result = JsFuture::from(promise)
+            .await
+            .map_err(js_error_to_token_error)?;
+        let js_dt = t.elapsed();
+
+        let t = Instant::now();
+        let wasm_balances: Vec<WasmTokenBalance> = serde_wasm_bindgen::from_value(result)
+            .map_err(|e| TokenOutputServiceError::Generic(e.to_string()))?;
+        let deser_dt = t.elapsed();
+
+        info!(
+            "WasmTokenStore::get_token_balances: {} entries, js_promise: {:?}, deserialize: {:?}",
+            wasm_balances.len(),
+            js_dt,
+            deser_dt
+        );
+
+        wasm_balances
+            .into_iter()
+            .map(|b| {
+                let metadata: TokenMetadata = b.metadata.try_into()?;
+                let balance: u128 = b.balance.parse().map_err(map_parse_err)?;
+                Ok((metadata, balance))
+            })
+            .collect()
     }
 
     async fn list_tokens_outputs(
@@ -567,6 +610,7 @@ type WasmReservationTarget =
 export interface TokenStore {
     setTokensOutputs: (tokenOutputs: WasmTokenOutputs[], refreshStartedAtMs: number) => Promise<void>;
     listTokensOutputs: () => Promise<WasmTokenOutputsPerStatus[]>;
+    getTokenBalances: () => Promise<WasmTokenBalance[]>;
     getTokenOutputs: (filter: WasmGetTokenOutputsFilter) => Promise<WasmTokenOutputsPerStatus>;
     insertTokenOutputs: (tokenOutputs: WasmTokenOutputs) => Promise<void>;
     reserveTokenOutputs: (
@@ -595,6 +639,9 @@ extern "C" {
 
     #[wasm_bindgen(structural, method, js_name = listTokensOutputs, catch)]
     pub fn list_tokens_outputs(this: &TokenStoreJs) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(structural, method, js_name = getTokenBalances, catch)]
+    pub fn get_token_balances(this: &TokenStoreJs) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, js_name = getTokenOutputs, catch)]
     pub fn get_token_outputs(this: &TokenStoreJs, filter: JsValue) -> Result<Promise, JsValue>;

--- a/crates/breez-sdk/wasm/src/tree_store/mod.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/mod.rs
@@ -192,6 +192,33 @@ impl TreeStore for WasmTreeStore {
         Ok(())
     }
 
+    async fn get_available_balance(&self) -> Result<u64, TreeServiceError> {
+        let promise = self
+            .tree_store
+            .get_available_balance()
+            .map_err(js_error_to_tree_error)?;
+
+        let t = Instant::now();
+        let result = JsFuture::from(promise)
+            .await
+            .map_err(js_error_to_tree_error)?;
+        let js_dt = t.elapsed();
+
+        let balance = if let Some(n) = result.as_f64() {
+            n as u64
+        } else if let Ok(big) = result.clone().dyn_into::<wasm_bindgen_futures::js_sys::BigInt>() {
+            u64::try_from(big)
+                .map_err(|e| TreeServiceError::Generic(format!("BigInt overflow: {e:?}")))?
+        } else {
+            return Err(TreeServiceError::Generic(
+                "getAvailableBalance returned non-numeric value".to_string(),
+            ));
+        };
+
+        info!("WasmTreeStore::get_available_balance: {balance}, js_promise: {js_dt:?}");
+        Ok(balance)
+    }
+
     async fn get_leaves(&self) -> Result<Leaves, TreeServiceError> {
         let promise = self
             .tree_store
@@ -397,6 +424,7 @@ type ReserveResult =
 export interface TreeStore {
     addLeaves: (leaves: TreeNode[]) => Promise<void>;
     getLeaves: () => Promise<Leaves>;
+    getAvailableBalance: () => Promise<bigint | number>;
     setLeaves: (leaves: TreeNode[], missingLeaves: TreeNode[], refreshStartedAtMs: number) => Promise<void>;
     cancelReservation: (id: string, leavesToKeep: TreeNode[]) => Promise<void>;
     finalizeReservation: (id: string, newLeaves: TreeNode[] | null) => Promise<void>;
@@ -415,6 +443,9 @@ extern "C" {
 
     #[wasm_bindgen(structural, method, js_name = getLeaves, catch)]
     pub fn get_leaves(this: &TreeStoreJs) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(structural, method, js_name = getAvailableBalance, catch)]
+    pub fn get_available_balance(this: &TreeStoreJs) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, js_name = setLeaves, catch)]
     pub fn set_leaves(

--- a/crates/breez-sdk/wasm/src/tree_store/mod.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/mod.rs
@@ -4,12 +4,14 @@ mod tests;
 use std::sync::Arc;
 
 use macros::async_trait;
+use platform_utils::time::Instant;
 use platform_utils::tokio::sync::watch;
 use serde::{Deserialize, Serialize};
 use spark_wallet::{
     Leaves, LeavesReservation, LeavesReservationId, ReservationPurpose, ReserveResult,
     TargetAmounts, TreeNode, TreeServiceError, TreeStore,
 };
+use tracing::info;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_futures::js_sys::Promise;
@@ -195,12 +197,29 @@ impl TreeStore for WasmTreeStore {
             .tree_store
             .get_leaves()
             .map_err(js_error_to_tree_error)?;
+
+        let t = Instant::now();
         let result = JsFuture::from(promise)
             .await
             .map_err(js_error_to_tree_error)?;
+        let js_dt = t.elapsed();
+
+        let t = Instant::now();
         let wasm_leaves: WasmLeaves = serde_wasm_bindgen::from_value(result)
             .map_err(|e| TreeServiceError::Generic(e.to_string()))?;
-        Ok(wasm_leaves.into())
+        let deser_dt = t.elapsed();
+
+        let leaves: Leaves = wasm_leaves.into();
+        let count = leaves.available.len()
+            + leaves.not_available.len()
+            + leaves.available_missing_from_operators.len()
+            + leaves.reserved_for_payment.len()
+            + leaves.reserved_for_swap.len();
+        info!(
+            "WasmTreeStore::get_leaves: {} leaves, js_promise: {:?}, deserialize: {:?}",
+            count, js_dt, deser_dt
+        );
+        Ok(leaves)
     }
 
     async fn set_leaves(

--- a/crates/breez-sdk/wasm/src/tree_store/mod.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/mod.rs
@@ -206,7 +206,10 @@ impl TreeStore for WasmTreeStore {
 
         let balance = if let Some(n) = result.as_f64() {
             n as u64
-        } else if let Ok(big) = result.clone().dyn_into::<wasm_bindgen_futures::js_sys::BigInt>() {
+        } else if let Ok(big) = result
+            .clone()
+            .dyn_into::<wasm_bindgen_futures::js_sys::BigInt>()
+        {
             u64::try_from(big)
                 .map_err(|e| TreeServiceError::Generic(format!("BigInt overflow: {e:?}")))?
         } else {
@@ -321,6 +324,7 @@ impl TreeStore for WasmTreeStore {
         exact_only: bool,
         purpose: ReservationPurpose,
     ) -> Result<ReserveResult, TreeServiceError> {
+        let total_start = Instant::now();
         let target_js = match target_amounts {
             Some(t) => {
                 let wasm_target: WasmTargetAmounts = t.into();
@@ -342,6 +346,18 @@ impl TreeStore for WasmTreeStore {
         if matches!(&reserve_result, ReserveResult::Success(_)) {
             self.notify_balance_change();
         }
+        let outcome = match &reserve_result {
+            ReserveResult::Success(r) => format!("success(leaves={})", r.leaves.len()),
+            ReserveResult::WaitForPending { .. } => "waitForPending".to_string(),
+            ReserveResult::InsufficientFunds => "insufficientFunds".to_string(),
+        };
+        info!(
+            "WasmTreeStore::try_reserve_leaves: {} (exact_only={}, purpose={:?}, took {:?})",
+            outcome,
+            exact_only,
+            purpose,
+            total_start.elapsed()
+        );
         Ok(reserve_result)
     }
 

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -264,6 +264,47 @@ impl TokenOutputStore for PostgresTokenStore {
         Ok(())
     }
 
+    async fn get_token_balances(
+        &self,
+    ) -> Result<Vec<(TokenMetadata, u128)>, TokenOutputServiceError> {
+        let client = self.pool.get().await.map_err(map_err)?;
+        let rows = client
+            .query(
+                r"SELECT m.identifier, m.issuer_public_key, m.name, m.ticker, m.decimals,
+                         m.max_supply, m.is_freezable, m.creation_entity_public_key,
+                         COALESCE(SUM(
+                            CASE
+                              WHEN o.reservation_id IS NULL THEN o.token_amount::numeric
+                              WHEN r.purpose = 'Swap' THEN o.token_amount::numeric
+                              ELSE 0
+                            END
+                         ), 0)::text AS balance
+                  FROM token_metadata m
+                  JOIN token_outputs o ON o.token_identifier = m.identifier
+                  LEFT JOIN token_reservations r ON o.reservation_id = r.id
+                  GROUP BY m.identifier, m.issuer_public_key, m.name, m.ticker,
+                           m.decimals, m.max_supply, m.is_freezable, m.creation_entity_public_key
+                  HAVING COALESCE(SUM(
+                            CASE
+                              WHEN o.reservation_id IS NULL THEN o.token_amount::numeric
+                              WHEN r.purpose = 'Swap' THEN o.token_amount::numeric
+                              ELSE 0
+                            END
+                         ), 0) > 0",
+                &[],
+            )
+            .await
+            .map_err(map_err)?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let metadata = Self::metadata_from_row(&row)?;
+            let balance_str: String = row.get("balance");
+            let balance: u128 = balance_str.parse().map_err(map_err)?;
+            out.push((metadata, balance));
+        }
+        Ok(out)
+    }
+
     async fn list_tokens_outputs(
         &self,
     ) -> Result<Vec<TokenOutputsPerStatus>, TokenOutputServiceError> {
@@ -591,8 +632,6 @@ impl TokenOutputStore for PostgresTokenStore {
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
 
-        Self::acquire_write_lock(&tx).await?;
-
         // Clear reservation_id from outputs (ON DELETE SET NULL would do this,
         // but we do it explicitly for clarity)
         tx.execute(
@@ -619,8 +658,6 @@ impl TokenOutputStore for PostgresTokenStore {
     ) -> Result<(), TokenOutputServiceError> {
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
-
-        Self::acquire_write_lock(&tx).await?;
 
         // Get reservation purpose and reserved output IDs
         let reservation_row = tx

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -67,9 +67,6 @@ impl TreeStore for PostgresTreeStore {
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
 
-        // Acquire advisory lock to prevent deadlocks with concurrent operations
-        Self::acquire_write_lock(&tx).await?;
-
         // Remove these leaves from spent_leaves table - when we receive a leaf through
         // add_leaves (e.g., from a claimed transfer), it's no longer "spent" from
         // our perspective. This handles the case where the same leaf returns to us
@@ -88,6 +85,26 @@ impl TreeStore for PostgresTreeStore {
         );
         self.notify_balance_change();
         Ok(())
+    }
+
+    async fn get_available_balance(&self) -> Result<u64, TreeServiceError> {
+        let client = self.pool.get().await.map_err(map_err)?;
+        let row = client
+            .query_one(
+                r"
+                SELECT COALESCE(SUM((l.data->>'value')::bigint), 0)::bigint AS balance
+                FROM tree_leaves l
+                LEFT JOIN tree_reservations r ON l.reservation_id = r.id
+                WHERE
+                    (l.reservation_id IS NULL AND l.status = 'Available')
+                    OR r.purpose = 'Swap'
+                ",
+                &[],
+            )
+            .await
+            .map_err(map_err)?;
+        let balance: i64 = row.get("balance");
+        Ok(u64::try_from(balance).unwrap_or(0))
     }
 
     async fn get_leaves(&self) -> Result<Leaves, TreeServiceError> {
@@ -242,8 +259,6 @@ impl TreeStore for PostgresTreeStore {
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
 
-        Self::acquire_write_lock(&tx).await?;
-
         let reservation = tx
             .query_opt("SELECT id FROM tree_reservations WHERE id = $1", &[id])
             .await
@@ -295,9 +310,6 @@ impl TreeStore for PostgresTreeStore {
     ) -> Result<(), TreeServiceError> {
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
-
-        // Acquire advisory lock to prevent deadlocks with concurrent operations
-        Self::acquire_write_lock(&tx).await?;
 
         // Check if reservation exists and get its purpose
         let reservation = tx
@@ -526,10 +538,6 @@ impl TreeStore for PostgresTreeStore {
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
 
-        // Acquire advisory lock to prevent deadlocks with concurrent operations
-        Self::acquire_write_lock(&tx).await?;
-
-        // Check if reservation exists (advisory lock provides serialization, no row locking needed)
         let reservation = tx
             .query_opt(
                 "SELECT id FROM tree_reservations WHERE id = $1",

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -4,15 +4,15 @@
 //! suitable for server-side or multi-instance deployments where
 //! in-memory storage is insufficient.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use platform_utils::time::SystemTime;
+use platform_utils::time::{Instant, SystemTime};
 
 use deadpool_postgres::Pool;
 use macros::async_trait;
 use spark_wallet::{
-    Leaves, LeavesReservation, LeavesReservationId, ReservationPurpose, ReserveResult,
+    LeafLike, Leaves, LeavesReservation, LeavesReservationId, ReservationPurpose, ReserveResult,
     TargetAmounts, TreeNode, TreeNodeStatus, TreeServiceError, TreeStore,
     select_leaves_by_minimum_amount, select_leaves_by_target_amounts,
 };
@@ -27,6 +27,24 @@ use crate::pool::create_pool;
 
 /// Name of the schema migrations table for `PostgresTreeStore`.
 const TREE_MIGRATIONS_TABLE: &str = "tree_schema_migrations";
+
+/// Lightweight `(id, value)` pair used by `try_reserve_leaves` to run the
+/// selection algorithm without pulling each leaf's full `data` JSON.
+#[derive(Clone)]
+struct SlimLeaf {
+    id: String,
+    value: u64,
+}
+
+impl LeafLike for SlimLeaf {
+    type Id = String;
+    fn leaf_id(&self) -> &Self::Id {
+        &self.id
+    }
+    fn leaf_value(&self) -> u64 {
+        self.value
+    }
+}
 
 /// Advisory lock key for serializing tree store write operations.
 /// This prevents deadlocks by ensuring only one write transaction runs at a time.
@@ -389,7 +407,9 @@ impl TreeStore for PostgresTreeStore {
         exact_only: bool,
         purpose: ReservationPurpose,
     ) -> Result<ReserveResult, TreeServiceError> {
+        let total_start = Instant::now();
         let target_amount = target_amounts.map_or(0, TargetAmounts::total_sats);
+        let max_target = Self::slim_max_target(target_amounts);
         let reservation_id = Uuid::now_v7().to_string();
 
         let mut client = self.pool.get().await.map_err(map_err)?;
@@ -398,11 +418,13 @@ impl TreeStore for PostgresTreeStore {
         // Acquire advisory lock to prevent deadlocks with concurrent operations
         Self::acquire_write_lock(&tx).await?;
 
-        // Get available leaves (advisory lock provides serialization, no row locking needed)
-        let rows = tx
-            .query(
+        // True total available across ALL eligible leaves — required for the
+        // WaitForPending decision. Must NOT be derived from the prefiltered
+        // slim set since the prefilter excludes big leaves.
+        let total_row = tx
+            .query_one(
                 r"
-                SELECT data
+                SELECT COALESCE(SUM((data->>'value')::bigint), 0)::bigint AS total
                 FROM tree_leaves
                 WHERE status = 'Available'
                   AND is_missing_from_operators = FALSE
@@ -412,48 +434,72 @@ impl TreeStore for PostgresTreeStore {
             )
             .await
             .map_err(map_err)?;
+        let available: u64 = u64::try_from(total_row.get::<_, i64>("total")).unwrap_or(0);
 
-        let available_leaves: Vec<TreeNode> = rows
+        // Slim projection of selection candidates: id + value only.
+        // Includes all leaves with value <= max_target (covers exact-match +
+        // minimum-amount accumulators) plus the smallest leaf with value >
+        // max_target (covers the minimum-amount fallback case where one larger
+        // leaf is sufficient).
+        let max_target_signed: i64 = i64::try_from(max_target).unwrap_or(i64::MAX);
+        let slim_rows = tx
+            .query(
+                r"
+                SELECT id, (data->>'value')::bigint AS value
+                FROM tree_leaves
+                WHERE status = 'Available'
+                  AND is_missing_from_operators = FALSE
+                  AND reservation_id IS NULL
+                  AND (
+                    (data->>'value')::bigint <= $1
+                    OR id = (
+                      SELECT id FROM tree_leaves
+                      WHERE status = 'Available'
+                        AND is_missing_from_operators = FALSE
+                        AND reservation_id IS NULL
+                        AND (data->>'value')::bigint > $1
+                      ORDER BY (data->>'value')::bigint
+                      LIMIT 1
+                    )
+                  )
+                ",
+                &[&max_target_signed],
+            )
+            .await
+            .map_err(map_err)?;
+
+        let slim: Vec<SlimLeaf> = slim_rows
             .iter()
-            .map(|r| Self::deserialize_node(r.get("data")))
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(|r| {
+                let value = u64::try_from(r.get::<_, i64>("value")).unwrap_or(0);
+                SlimLeaf {
+                    id: r.get("id"),
+                    value,
+                }
+            })
+            .collect();
 
-        tracing::trace!(
-            "PostgresTreeStore::try_reserve_leaves: found {} available leaves",
-            available_leaves.len()
-        );
-        for leaf in &available_leaves {
-            tracing::trace!(
-                "PostgresTreeStore::try_reserve_leaves: available leaf {} owner={:?} value={}",
-                leaf.id,
-                leaf.owner_identity_public_key,
-                leaf.value
-            );
-        }
-
-        let available: u64 = available_leaves.iter().map(|l| l.value).sum();
         // Calculate pending balance within the same transaction for consistency
         let pending = Self::calculate_pending_balance(&tx).await?;
 
-        // Try exact selection first
-        let selected = select_leaves_by_target_amounts(&available_leaves, target_amounts);
+        // Try exact selection on the slim set — uses the same generic
+        // `select_helper` algorithm as the in-memory store.
+        let selected_exact = select_leaves_by_target_amounts(&slim, target_amounts);
 
-        match selected {
+        let result = match selected_exact {
             Ok(target_leaves) => {
-                let selected_leaves = [
-                    target_leaves.amount_leaves,
-                    target_leaves.fee_leaves.unwrap_or_default(),
-                ]
-                .concat();
-
-                // Reject empty reservations (matches in-memory behavior)
-                if selected_leaves.is_empty() {
+                let selected_ids: Vec<String> = target_leaves
+                    .amount_leaves
+                    .iter()
+                    .chain(target_leaves.fee_leaves.iter().flatten())
+                    .map(|l| l.id.clone())
+                    .collect();
+                if selected_ids.is_empty() {
                     return Err(TreeServiceError::NonReservableLeaves);
                 }
-
+                let selected_leaves = Self::resolve_full_leaves(&tx, &selected_ids).await?;
                 self.create_reservation(&tx, &reservation_id, &selected_leaves, purpose, 0)
                     .await?;
-
                 tx.commit().await.map_err(map_err)?;
                 self.notify_balance_change();
                 Ok(ReserveResult::Success(LeavesReservation::new(
@@ -462,10 +508,9 @@ impl TreeStore for PostgresTreeStore {
                 )))
             }
             Err(_) if !exact_only => {
-                // Try minimum amount selection
-                if let Ok(Some(selected_leaves)) =
-                    select_leaves_by_minimum_amount(&available_leaves, target_amount)
-                {
+                if let Ok(Some(min_slim)) = select_leaves_by_minimum_amount(&slim, target_amount) {
+                    let min_ids: Vec<String> = min_slim.iter().map(|l| l.id.clone()).collect();
+                    let selected_leaves = Self::resolve_full_leaves(&tx, &min_ids).await?;
                     let reserved_amount: u64 = selected_leaves.iter().map(|l| l.value).sum();
                     let pending_change = if reserved_amount > target_amount && target_amount > 0 {
                         reserved_amount - target_amount
@@ -481,17 +526,13 @@ impl TreeStore for PostgresTreeStore {
                         pending_change,
                     )
                     .await?;
-
                     tx.commit().await.map_err(map_err)?;
                     self.notify_balance_change();
-                    return Ok(ReserveResult::Success(LeavesReservation::new(
+                    Ok(ReserveResult::Success(LeavesReservation::new(
                         selected_leaves,
                         reservation_id,
-                    )));
-                }
-
-                // No suitable leaves found
-                if available + pending >= target_amount {
+                    )))
+                } else if available + pending >= target_amount {
                     Ok(ReserveResult::WaitForPending {
                         needed: target_amount,
                         available,
@@ -512,7 +553,23 @@ impl TreeStore for PostgresTreeStore {
                     Ok(ReserveResult::InsufficientFunds)
                 }
             }
-        }
+        };
+
+        let outcome = match &result {
+            Ok(ReserveResult::Success(r)) => format!("success(leaves={})", r.leaves.len()),
+            Ok(ReserveResult::WaitForPending { .. }) => "waitForPending".to_string(),
+            Ok(ReserveResult::InsufficientFunds) => "insufficientFunds".to_string(),
+            Err(e) => format!("err({e:?})"),
+        };
+        info!(
+            "PostgresTreeStore::try_reserve_leaves: {} (slim_candidates={}, max_target={}, exact_only={}, took {:?})",
+            outcome,
+            slim.len(),
+            max_target,
+            exact_only,
+            total_start.elapsed()
+        );
+        result
     }
 
     async fn now(&self) -> Result<SystemTime, TreeServiceError> {
@@ -864,6 +921,56 @@ impl PostgresTreeStore {
         }
 
         Ok(())
+    }
+
+    /// Largest single leaf value the selection algorithm could possibly need.
+    /// Used to bound the slim projection in `try_reserve_leaves`. For an
+    /// unbounded request we have to keep all leaves available.
+    fn slim_max_target(target_amounts: Option<&TargetAmounts>) -> u64 {
+        match target_amounts {
+            Some(TargetAmounts::AmountAndFee {
+                amount_sats,
+                fee_sats,
+            }) => std::cmp::max(*amount_sats, fee_sats.unwrap_or(0)),
+            Some(TargetAmounts::ExactDenominations { denominations }) => {
+                denominations.iter().copied().max().unwrap_or(0)
+            }
+            None => u64::MAX,
+        }
+    }
+
+    /// Pull the full `TreeNode` JSON only for the leaves the slim selection
+    /// picked, preserving the algorithm's selection order. Typically 1-3 rows
+    /// even when the slim candidate set was thousands.
+    async fn resolve_full_leaves(
+        tx: &tokio_postgres::Transaction<'_>,
+        ids: &[String],
+    ) -> Result<Vec<TreeNode>, TreeServiceError> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let rows = tx
+            .query(
+                "SELECT id, data FROM tree_leaves WHERE id = ANY($1)",
+                &[&ids],
+            )
+            .await
+            .map_err(map_err)?;
+        let mut by_id: HashMap<String, TreeNode> = HashMap::with_capacity(rows.len());
+        for r in &rows {
+            let id: String = r.get("id");
+            let node = Self::deserialize_node(r.get("data"))?;
+            by_id.insert(id, node);
+        }
+        let ordered: Vec<TreeNode> = ids.iter().filter_map(|id| by_id.remove(id)).collect();
+        if ordered.len() != ids.len() {
+            return Err(TreeServiceError::Generic(format!(
+                "Could not resolve full data for all selected leaves (wanted {}, got {})",
+                ids.len(),
+                ordered.len()
+            )));
+        }
+        Ok(ordered)
     }
 
     /// Acquires an exclusive advisory lock for write operations.

--- a/crates/spark-wallet/src/lib.rs
+++ b/crates/spark-wallet/src/lib.rs
@@ -38,10 +38,11 @@ pub use spark::{
     },
     tree::{
         DEFAULT_MAX_CONCURRENT_RESERVATIONS, DEFAULT_RESERVATION_TIMEOUT, InMemoryTreeStore,
-        LeafOptimizationOptions, Leaves, LeavesReservation, LeavesReservationId, OptimizationEvent,
-        OptimizationProgress, ReservationPurpose, ReserveResult, SelectLeavesOptions,
-        SigningKeyshare, TargetAmounts, TreeNode, TreeNodeId, TreeNodeStatus, TreeServiceError,
-        TreeStore, select_leaves_by_minimum_amount, select_leaves_by_target_amounts,
+        LeafLike, LeafOptimizationOptions, Leaves, LeavesReservation, LeavesReservationId,
+        OptimizationEvent, OptimizationProgress, ReservationPurpose, ReserveResult,
+        SelectLeavesOptions, SigningKeyshare, TargetAmounts, TreeNode, TreeNodeId, TreeNodeStatus,
+        TreeServiceError, TreeStore, select_leaves_by_minimum_amount,
+        select_leaves_by_target_amounts,
     },
     utils::{
         paging::{Order, PagingFilter, PagingResult},

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -183,6 +183,15 @@ pub struct SparkWallet {
     operator_pool: Arc<OperatorPool>,
     htlc_service: Arc<HtlcService>,
     leaf_optimizer: Arc<LeafOptimizer>,
+    /// One-shot, single-flight guard for `select_leaves_with_retry`'s call to
+    /// `refresh_leaves`. The cell's `get_or_init` blocks concurrent callers
+    /// during the in-flight refresh and short-circuits with a single atomic
+    /// load afterwards, so a startup payment burst triggers at most one
+    /// refresh and steady-state callers pay no synchronization cost. The
+    /// closure swallows refresh errors after logging, since "once per
+    /// lifetime" is what we want here regardless of outcome — subsequent
+    /// staleness is handled by the periodic + post-payment sync.
+    select_leaves_refresh: Arc<tokio::sync::OnceCell<()>>,
 }
 
 impl SparkWallet {
@@ -388,6 +397,7 @@ impl SparkWallet {
             operator_pool,
             htlc_service,
             leaf_optimizer,
+            select_leaves_refresh: Arc::new(tokio::sync::OnceCell::new()),
         })
     }
 }
@@ -1663,8 +1673,28 @@ impl SparkWallet {
                 }
             }
 
-            info!("Failed to select leaves, refreshing leaves and retrying");
-            self.tree_service.refresh_leaves().await?;
+            // Refresh leaves at most once per wallet instance from this code
+            // path. The first failure may be the startup race (payment fires
+            // before initial sync populates the cache); subsequent failures
+            // are almost always genuine in-process contention or true
+            // insufficient funds, both of which a fresh refresh wouldn't
+            // resolve. The periodic + post-payment sync keeps the cache
+            // fresh in steady state, so re-refreshing on every retry just
+            // hammers the operators.
+            //
+            // `OnceCell::get_or_init` provides single-flight: a startup
+            // payment spike sees the first caller drive the refresh while
+            // the rest suspend on the cell. Once it completes, all later
+            // callers short-circuit with a single atomic load — no spurious
+            // InsufficientFunds bouncing during the very first refresh.
+            self.select_leaves_refresh
+                .get_or_init(|| async {
+                    info!("First select-leaves failure: refreshing leaves once");
+                    if let Err(e) = self.tree_service.refresh_leaves().await {
+                        warn!("Initial refresh_leaves failed (will rely on periodic sync): {e:?}");
+                    }
+                })
+                .await;
 
             // Check if we have enough funds after refresh
             if let Some(target_amounts) = target_amounts {

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1284,17 +1284,17 @@ impl SparkWallet {
     pub async fn get_token_balances(
         &self,
     ) -> Result<HashMap<String, TokenBalance>, SparkWalletError> {
-        let token_outputs = self.token_output_service.list_tokens_outputs().await?;
+        let token_balances = self.token_output_service.get_token_balances().await?;
 
-        let balances = token_outputs
+        let balances = token_balances
             .into_iter()
-            .map(|token_outputs| {
-                let balance = token_outputs.balance();
+            .map(|(token_metadata, balance)| {
+                let identifier = token_metadata.identifier.clone();
                 (
-                    token_outputs.metadata.identifier.clone(),
+                    identifier,
                     TokenBalance {
                         balance,
-                        token_metadata: token_outputs.metadata,
+                        token_metadata,
                     },
                 )
             })

--- a/crates/spark/src/token/mod.rs
+++ b/crates/spark/src/token/mod.rs
@@ -173,6 +173,23 @@ pub trait TokenOutputStore: Send + Sync {
         &self,
     ) -> Result<Vec<TokenOutputsPerStatus>, TokenOutputServiceError>;
 
+    /// Returns just the spendable per-token balances paired with their metadata.
+    /// Default impl falls through to `list_tokens_outputs`; storage backends that
+    /// can compute the aggregate server-side should override.
+    async fn get_token_balances(
+        &self,
+    ) -> Result<Vec<(TokenMetadata, u128)>, TokenOutputServiceError> {
+        Ok(self
+            .list_tokens_outputs()
+            .await?
+            .into_iter()
+            .map(|t| {
+                let balance = t.balance();
+                (t.metadata, balance)
+            })
+            .collect())
+    }
+
     async fn get_token_outputs(
         &self,
         filter: GetTokenOutputsFilter<'_>,
@@ -215,6 +232,10 @@ pub trait TokenOutputService: Send + Sync {
     async fn list_tokens_outputs(
         &self,
     ) -> Result<Vec<TokenOutputsPerStatus>, TokenOutputServiceError>;
+
+    async fn get_token_balances(
+        &self,
+    ) -> Result<Vec<(TokenMetadata, u128)>, TokenOutputServiceError>;
 
     async fn refresh_tokens_outputs(&self) -> Result<(), TokenOutputServiceError>;
 

--- a/crates/spark/src/token/service.rs
+++ b/crates/spark/src/token/service.rs
@@ -35,6 +35,12 @@ impl TokenOutputService for SynchronousTokenOutputService {
         self.state.list_tokens_outputs().await
     }
 
+    async fn get_token_balances(
+        &self,
+    ) -> Result<Vec<(TokenMetadata, u128)>, TokenOutputServiceError> {
+        self.state.get_token_balances().await
+    }
+
     async fn refresh_tokens_outputs(&self) -> Result<(), TokenOutputServiceError> {
         // Capture the start time before any network calls from the store's clock.
         // This uses the DB server time for database-backed stores to avoid clock skew.

--- a/crates/spark/src/tree/mod.rs
+++ b/crates/spark/src/tree/mod.rs
@@ -496,6 +496,16 @@ pub trait TreeStore: Send + Sync {
     /// ```
     async fn get_leaves(&self) -> Result<Leaves, TreeServiceError>;
 
+    /// Returns the wallet's spendable balance: the sum of leaf values that
+    /// would be included in `Leaves::balance()` (available + missing-operators
+    /// + swap-reserved). Default impl falls through to `get_leaves`; storage
+    /// backends that can compute this server-side should override to skip the
+    /// per-leaf fetch + deserialization round-trip.
+    async fn get_available_balance(&self) -> Result<u64, TreeServiceError> {
+        let leaves = self.get_leaves().await?;
+        Ok(leaves.balance())
+    }
+
     /// Replaces all leaves in the store with the provided set.
     ///
     /// This method performs a complete replacement of the stored leaves,

--- a/crates/spark/src/tree/mod.rs
+++ b/crates/spark/src/tree/mod.rs
@@ -400,17 +400,37 @@ impl TargetAmounts {
     }
 }
 
-pub struct TargetLeaves {
-    pub amount_leaves: Vec<TreeNode>,
-    pub fee_leaves: Option<Vec<TreeNode>>,
+pub struct TargetLeaves<L = TreeNode> {
+    pub amount_leaves: Vec<L>,
+    pub fee_leaves: Option<Vec<L>>,
 }
 
-impl TargetLeaves {
-    pub fn new(amount_leaves: Vec<TreeNode>, fee_leaves: Option<Vec<TreeNode>>) -> Self {
+impl<L> TargetLeaves<L> {
+    pub fn new(amount_leaves: Vec<L>, fee_leaves: Option<Vec<L>>) -> Self {
         Self {
             amount_leaves,
             fee_leaves,
         }
+    }
+}
+
+/// Minimal "leaf-shaped" interface used by the selection algorithms in
+/// [`select_helper`]. Implementing this for a slim `(id, value)` projection
+/// lets storage backends (e.g. `PostgresTreeStore`) run the same selection
+/// without first deserializing every leaf's full `data` JSON.
+pub trait LeafLike: Clone {
+    type Id: Eq;
+    fn leaf_id(&self) -> &Self::Id;
+    fn leaf_value(&self) -> u64;
+}
+
+impl LeafLike for TreeNode {
+    type Id = TreeNodeId;
+    fn leaf_id(&self) -> &Self::Id {
+        &self.id
+    }
+    fn leaf_value(&self) -> u64 {
+        self.value
     }
 }
 

--- a/crates/spark/src/tree/select_helper.rs
+++ b/crates/spark/src/tree/select_helper.rs
@@ -1,13 +1,13 @@
 use tracing::{error, trace};
 
 use crate::tree::{
-    LeavesReservation, TargetAmounts, TargetLeaves, TreeNode, TreeService, TreeServiceError,
+    LeafLike, LeavesReservation, TargetAmounts, TargetLeaves, TreeService, TreeServiceError,
 };
 
-pub fn select_leaves_by_target_amounts(
-    leaves: &[TreeNode],
+pub fn select_leaves_by_target_amounts<L: LeafLike>(
+    leaves: &[L],
     target_amounts: Option<&TargetAmounts>,
-) -> Result<TargetLeaves, TreeServiceError> {
+) -> Result<TargetLeaves<L>, TreeServiceError> {
     let mut remaining_leaves = leaves.to_vec();
 
     // If no target amounts are specified, return all remaining leaves
@@ -31,7 +31,7 @@ pub fn select_leaves_by_target_amounts(
                     remaining_leaves.retain(|leaf| {
                         !amount_leaves
                             .iter()
-                            .any(|amount_leaf| amount_leaf.id == leaf.id)
+                            .any(|amount_leaf| amount_leaf.leaf_id() == leaf.leaf_id())
                     });
                     // Select leaves that match the fee_sats from the remaining leaves
                     Some(
@@ -55,15 +55,15 @@ pub fn select_leaves_by_target_amounts(
 
 /// Selects leaves from the tree that sum up to exactly the target amount.
 /// If such a combination of leaves does not exist, it returns `None`.
-pub fn select_leaves_by_exact_amount(
-    leaves: &[TreeNode],
+pub fn select_leaves_by_exact_amount<L: LeafLike>(
+    leaves: &[L],
     target_amount_sat: u64,
-) -> Result<Option<Vec<TreeNode>>, TreeServiceError> {
+) -> Result<Option<Vec<L>>, TreeServiceError> {
     if target_amount_sat == 0 {
         return Err(TreeServiceError::InvalidAmount);
     }
 
-    if leaves.iter().map(|leaf| leaf.value).sum::<u64>() < target_amount_sat {
+    if leaves.iter().map(LeafLike::leaf_value).sum::<u64>() < target_amount_sat {
         return Err(TreeServiceError::InsufficientFunds);
     }
 
@@ -80,39 +80,40 @@ pub fn select_leaves_by_exact_amount(
     Ok(None)
 }
 
-pub fn select_leaves_by_exact_denominations(
-    leaves: &[TreeNode],
+pub fn select_leaves_by_exact_denominations<L: LeafLike>(
+    leaves: &[L],
     denominations: &[u64],
-) -> Result<Vec<TreeNode>, TreeServiceError> {
+) -> Result<Vec<L>, TreeServiceError> {
     let mut remaining_leaves = leaves.to_vec();
     let mut selected_leaves = Vec::new();
 
     for denomination in denominations {
-        let leaf = find_exact_single_match(&remaining_leaves, *denomination)
+        let idx = remaining_leaves
+            .iter()
+            .position(|l| l.leaf_value() == *denomination)
             .ok_or(TreeServiceError::UnselectableAmount)?;
-        selected_leaves.push(leaf.clone());
-        remaining_leaves.retain(|remaining_leaf| remaining_leaf.id != leaf.id);
+        selected_leaves.push(remaining_leaves.swap_remove(idx));
     }
 
     Ok(selected_leaves)
 }
 
 /// Selects leaves from the tree that sum up to at least the target amount.
-pub fn select_leaves_by_minimum_amount(
-    leaves: &[TreeNode],
+pub fn select_leaves_by_minimum_amount<L: LeafLike>(
+    leaves: &[L],
     target_amount_sat: u64,
-) -> Result<Option<Vec<TreeNode>>, TreeServiceError> {
+) -> Result<Option<Vec<L>>, TreeServiceError> {
     if target_amount_sat == 0 {
         return Err(TreeServiceError::InvalidAmount);
     }
-    if leaves.iter().map(|leaf| leaf.value).sum::<u64>() < target_amount_sat {
+    if leaves.iter().map(LeafLike::leaf_value).sum::<u64>() < target_amount_sat {
         return Err(TreeServiceError::InsufficientFunds);
     }
 
     let mut result = Vec::new();
     let mut sum = 0;
     for leaf in leaves {
-        sum += leaf.value;
+        sum += leaf.leaf_value();
         result.push(leaf.clone());
         if sum >= target_amount_sat {
             break;
@@ -126,13 +127,13 @@ pub fn select_leaves_by_minimum_amount(
     Ok(Some(result))
 }
 
-pub(crate) fn find_exact_single_match(
-    leaves: &[TreeNode],
+pub(crate) fn find_exact_single_match<L: LeafLike>(
+    leaves: &[L],
     target_amount_sat: u64,
-) -> Option<TreeNode> {
+) -> Option<L> {
     leaves
         .iter()
-        .find(|leaf| leaf.value == target_amount_sat)
+        .find(|leaf| leaf.leaf_value() == target_amount_sat)
         .cloned()
 }
 
@@ -144,18 +145,18 @@ fn is_power_of_two(value: u64) -> bool {
 /// Greedy algorithm to find exact match.
 /// Sorts leaves by value in descending order and takes the largest leaf that fits
 /// the remaining amount until the target is reached or no valid leaf can be found.
-fn greedy_exact_match(leaves: &[TreeNode], target_amount_sat: u64) -> Option<Vec<TreeNode>> {
+fn greedy_exact_match<L: LeafLike>(leaves: &[L], target_amount_sat: u64) -> Option<Vec<L>> {
     let mut sorted_leaves = leaves.to_vec();
-    sorted_leaves.sort_by_key(|b| std::cmp::Reverse(b.value));
+    sorted_leaves.sort_by_key(|b| std::cmp::Reverse(b.leaf_value()));
 
     let mut result = Vec::new();
     let mut remaining = target_amount_sat;
 
     for leaf in &sorted_leaves {
-        if leaf.value > remaining {
+        if leaf.leaf_value() > remaining {
             continue;
         }
-        remaining -= leaf.value;
+        remaining -= leaf.leaf_value();
         result.push(leaf.clone());
         if remaining == 0 {
             return Some(result);
@@ -165,10 +166,10 @@ fn greedy_exact_match(leaves: &[TreeNode], target_amount_sat: u64) -> Option<Vec
     None // Couldn't reach exact target
 }
 
-pub(crate) fn find_exact_multiple_match(
-    leaves: &[TreeNode],
+pub(crate) fn find_exact_multiple_match<L: LeafLike>(
+    leaves: &[L],
     target_amount_sat: u64,
-) -> Option<Vec<TreeNode>> {
+) -> Option<Vec<L>> {
     if target_amount_sat == 0 {
         return Some(Vec::new());
     }
@@ -182,9 +183,9 @@ pub(crate) fn find_exact_multiple_match(
     }
 
     // Pass 2: Try with only power-of-two leaves (if there were non-power-of-two leaves)
-    let power_of_two_leaves: Vec<_> = leaves
+    let power_of_two_leaves: Vec<L> = leaves
         .iter()
-        .filter(|l| is_power_of_two(l.value))
+        .filter(|l| is_power_of_two(l.leaf_value()))
         .cloned()
         .collect();
 

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -179,15 +179,21 @@ impl TreeService for SynchronousTreeService {
         let (coordinator_leaves_res, operator_results) = tokio::join!(coord_fut, join_all(op_futs));
         let coordinator_leaves = coordinator_leaves_res?;
 
-        // Propagate any operator query error to preserve original behavior and
-        // collect successful operator leaves for later comparison
-        let mut operator_leaves_vec: Vec<Vec<TreeNode>> = Vec::new();
+        // Tolerate single-operator failures by treating their leaves as
+        // missing-from-operator instead of aborting the whole refresh. The
+        // multi-operator safety guarantee is preserved: a leaf an operator
+        // didn't acknowledge is flagged `is_missing_from_operators=true` and
+        // excluded from spending until that operator confirms it on a later
+        // refresh. Aborting on every operator hiccup used to trigger refresh
+        // storms that overloaded the (already flaky) operator further.
+        let mut successful_operators: Vec<(usize, Vec<TreeNode>)> = Vec::new();
+        let mut failed_operator_ids: Vec<usize> = Vec::new();
         for (id, res) in operator_results {
             match res {
-                Ok(leaves) => operator_leaves_vec.push(leaves),
+                Ok(leaves) => successful_operators.push((id, leaves)),
                 Err(e) => {
-                    error!("Failed to query operator {id}: {e:?}");
-                    return Err(e);
+                    error!("Failed to query operator {id}, treating its leaves as missing: {e:?}");
+                    failed_operator_ids.push(id);
                 }
             }
         }
@@ -195,10 +201,22 @@ impl TreeService for SynchronousTreeService {
         let mut missing_operator_leaves_map: HashMap<TreeNodeId, TreeNode> = HashMap::new();
         let mut ignored_leaves_map: HashMap<TreeNodeId, TreeNode> = HashMap::new();
 
-        // For each operator's leaves, compare against coordinator in the same way as before
-        for (operator_id, operator_leaves) in
-            operators.into_iter().zip(operator_leaves_vec.into_iter())
-        {
+        // For each failed operator, conservatively treat every coordinator
+        // leaf as missing from that operator's view — we have no positive
+        // evidence either way, so flag them as untrusted until the operator
+        // recovers.
+        for failed_id in &failed_operator_ids {
+            for leaf in &coordinator_leaves {
+                warn!(
+                    "Treating leaf {} as missing from operator {} (operator query failed)",
+                    leaf.id, failed_id
+                );
+                missing_operator_leaves_map.insert(leaf.id.clone(), leaf.clone());
+            }
+        }
+
+        // For each successful operator, compare against coordinator in the same way as before
+        for (operator_id, operator_leaves) in &successful_operators {
             for leaf in &coordinator_leaves {
                 match operator_leaves.iter().find(|l| l.id == leaf.id) {
                     Some(operator_leaf) => {
@@ -211,7 +229,7 @@ impl TreeService for SynchronousTreeService {
                         {
                             warn!(
                                 "Ignoring leaf due to mismatch between coordinator and operator {}. Coordinator: {:?}, Operator: {:?}",
-                                operator_id.0, leaf, operator_leaf
+                                operator_id, leaf, operator_leaf
                             );
                             missing_operator_leaves_map.insert(leaf.id.clone(), leaf.clone());
                         }
@@ -219,7 +237,7 @@ impl TreeService for SynchronousTreeService {
                     None => {
                         warn!(
                             "Ignoring leaf due to missing from operator {}: {:?}",
-                            operator_id.0, leaf.id
+                            operator_id, leaf.id
                         );
                         missing_operator_leaves_map.insert(leaf.id.clone(), leaf.clone());
                     }

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -290,8 +290,7 @@ impl TreeService for SynchronousTreeService {
     }
 
     async fn get_available_balance(&self) -> Result<u64, TreeServiceError> {
-        let leaves = self.state.get_leaves().await?;
-        Ok(leaves.balance())
+        self.state.get_available_balance().await
     }
 }
 


### PR DESCRIPTION
Advisory locks are only needed to reserve leaves not to finalize/cancel reservations as these will not ever race with the reservation itself so this PR fixes the over conservative approach and leave it only there.
Also balance calculation now runs directly on the store level and doesn't require fetching all leaves which maybe a lot in a production environment. 