### PR TITLE
SDK: Add fallback address support for LN invoices

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -364,6 +364,7 @@ suspend fun handleReceive(sdk: BreezSdk, reader: LineReader, args: List<String>)
                 amountSats = amountSats,
                 expirySecs = expirySecs,
                 paymentHash = paymentHash,
+                fallback = null,
             )
         }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -394,7 +394,8 @@ func handleReceive(_ sdk: BreezSdk, _ args: [String]) async throws {
             description: description ?? "",
             amountSats: amountSats,
             expirySecs: expirySecs,
-            paymentHash: paymentHash
+            paymentHash: paymentHash,
+            fallback: nil
         )
 
     default:

--- a/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
@@ -251,7 +251,7 @@ async fn main() -> Result<()> {
                     amount_sats: Some(amount),
                     expiry_secs: Some(3600),
                     payment_hash: None,
-                    use_mrh: None,
+                    fallback: None,
                 },
             })
             .await?

--- a/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
@@ -251,6 +251,7 @@ async fn main() -> Result<()> {
                     amount_sats: Some(amount),
                     expiry_secs: Some(3600),
                     payment_hash: None,
+                    use_mrh: None,
                 },
             })
             .await?

--- a/crates/breez-sdk/breez-itest/tests/breez_sdk_tests.rs
+++ b/crates/breez-sdk/breez-itest/tests/breez_sdk_tests.rs
@@ -291,6 +291,7 @@ async fn test_03_lightning_invoice_payment(
                 amount_sats: invoice_amount_sats,
                 expiry_secs: None,
                 payment_hash: None,
+                fallback: None,
             },
         })
         .await?
@@ -555,7 +556,7 @@ async fn test_05_lightning_invoice_prefer_spark_fee_path(
                 amount_sats: Some(invoice_amount_sats),
                 expiry_secs: None,
                 payment_hash: None,
-                use_mrh: None,
+                fallback: Some(FallbackMethod::SparkAddress),
             },
         })
         .await?
@@ -652,7 +653,7 @@ async fn test_06_lightning_timeout_and_wait(
                 amount_sats: None,
                 expiry_secs: None,
                 payment_hash: None,
-                use_mrh: None,
+                fallback: None,
             },
         })
         .await?
@@ -897,7 +898,7 @@ async fn test_08_lightning_invoice_expiry_secs(
                 amount_sats: Some(invoice_amount_sats),
                 expiry_secs: Some(custom_expiry_secs),
                 payment_hash: None,
-                use_mrh: None,
+                fallback: None,
             },
         })
         .await?;
@@ -1053,7 +1054,7 @@ async fn test_09_bolt11_send_all_with_fee_overpayment(
                 amount_sats: None,
                 expiry_secs: None,
                 payment_hash: None,
-                use_mrh: None,
+                fallback: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/breez_sdk_tests.rs
+++ b/crates/breez-sdk/breez-itest/tests/breez_sdk_tests.rs
@@ -555,6 +555,7 @@ async fn test_05_lightning_invoice_prefer_spark_fee_path(
                 amount_sats: Some(invoice_amount_sats),
                 expiry_secs: None,
                 payment_hash: None,
+                use_mrh: None,
             },
         })
         .await?
@@ -651,6 +652,7 @@ async fn test_06_lightning_timeout_and_wait(
                 amount_sats: None,
                 expiry_secs: None,
                 payment_hash: None,
+                use_mrh: None,
             },
         })
         .await?
@@ -895,6 +897,7 @@ async fn test_08_lightning_invoice_expiry_secs(
                 amount_sats: Some(invoice_amount_sats),
                 expiry_secs: Some(custom_expiry_secs),
                 payment_hash: None,
+                use_mrh: None,
             },
         })
         .await?;
@@ -1050,6 +1053,7 @@ async fn test_09_bolt11_send_all_with_fee_overpayment(
                 amount_sats: None,
                 expiry_secs: None,
                 payment_hash: None,
+                use_mrh: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/idempotency_tests.rs
+++ b/crates/breez-sdk/breez-itest/tests/idempotency_tests.rs
@@ -213,6 +213,7 @@ async fn test_02_lightning_idempotency_key(
                 amount_sats: Some(5),
                 expiry_secs: None,
                 payment_hash: None,
+                use_mrh: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/idempotency_tests.rs
+++ b/crates/breez-sdk/breez-itest/tests/idempotency_tests.rs
@@ -213,7 +213,7 @@ async fn test_02_lightning_idempotency_key(
                 amount_sats: Some(5),
                 expiry_secs: None,
                 payment_hash: None,
-                use_mrh: None,
+                fallback: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/lightning_hodl.rs
+++ b/crates/breez-sdk/breez-itest/tests/lightning_hodl.rs
@@ -30,7 +30,7 @@ async fn test_01_lightning_hodl_success(
                 amount_sats: Some(10_000),
                 expiry_secs: None,
                 payment_hash: Some(payment_hash.clone()),
-                use_mrh: None,
+                fallback: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/lightning_hodl.rs
+++ b/crates/breez-sdk/breez-itest/tests/lightning_hodl.rs
@@ -30,6 +30,7 @@ async fn test_01_lightning_hodl_success(
                 amount_sats: Some(10_000),
                 expiry_secs: None,
                 payment_hash: Some(payment_hash.clone()),
+                use_mrh: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/recovery.rs
+++ b/crates/breez-sdk/breez-itest/tests/recovery.rs
@@ -391,6 +391,7 @@ async fn test_setup_recovery_wallet() -> Result<()> {
                 amount_sats: Some(1_000),
                 expiry_secs: None,
                 payment_hash: None,
+                use_mrh: None,
             },
         })
         .await?
@@ -431,6 +432,7 @@ async fn test_setup_recovery_wallet() -> Result<()> {
                 amount_sats: Some(800),
                 expiry_secs: None,
                 payment_hash: None,
+                use_mrh: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/recovery.rs
+++ b/crates/breez-sdk/breez-itest/tests/recovery.rs
@@ -391,7 +391,7 @@ async fn test_setup_recovery_wallet() -> Result<()> {
                 amount_sats: Some(1_000),
                 expiry_secs: None,
                 payment_hash: None,
-                use_mrh: None,
+                fallback: None,
             },
         })
         .await?
@@ -432,7 +432,7 @@ async fn test_setup_recovery_wallet() -> Result<()> {
                 amount_sats: Some(800),
                 expiry_secs: None,
                 payment_hash: None,
-                use_mrh: None,
+                fallback: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/token_conversion.rs
+++ b/crates/breez-sdk/breez-itest/tests/token_conversion.rs
@@ -222,6 +222,7 @@ async fn test_token_conversion_success(
                 amount_sats: Some(token_to_sats_success_amount),
                 expiry_secs: None,
                 payment_hash: None,
+                use_mrh: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/token_conversion.rs
+++ b/crates/breez-sdk/breez-itest/tests/token_conversion.rs
@@ -222,7 +222,7 @@ async fn test_token_conversion_success(
                 amount_sats: Some(token_to_sats_success_amount),
                 expiry_secs: None,
                 payment_hash: None,
-                use_mrh: None,
+                fallback: None,
             },
         })
         .await?

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -600,6 +600,7 @@ pub(crate) async fn execute_command(
                         amount_sats: amount.map(TryInto::try_into).transpose()?,
                         expiry_secs,
                         payment_hash,
+                        use_mrh: None,
                     }
                 }
             };

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -6,7 +6,7 @@ mod webhooks;
 use bitcoin::hashes::{Hash, sha256};
 use breez_sdk_spark::{
     AssetFilter, BreezSdk, BuyBitcoinRequest, CheckLightningAddressRequest, ClaimDepositRequest,
-    ClaimHtlcPaymentRequest, ConversionOptions, ConversionType, Fee, FeePolicy,
+    ClaimHtlcPaymentRequest, ConversionOptions, ConversionType, FallbackMethod, Fee, FeePolicy,
     FetchConversionLimitsRequest, GetInfoRequest, GetPaymentRequest, GetTokensMetadataRequest,
     InputType, LightningAddressDetails, ListPaymentsRequest, ListUnclaimedDepositsRequest,
     LnurlPayRequest, LnurlWithdrawRequest, MaxFee, OnchainConfirmationSpeed, PaymentDetailsFilter,
@@ -39,6 +39,22 @@ pub enum ReceivePaymentMethodArg {
     SparkInvoice,
     Bitcoin,
     Bolt11,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum ReceiveFallbackArg {
+    SparkAddress,
+    SparkInvoice,
+}
+
+impl From<ReceiveFallbackArg> for FallbackMethod {
+    fn from(val: ReceiveFallbackArg) -> Self {
+        match val {
+            ReceiveFallbackArg::SparkAddress => FallbackMethod::SparkAddress,
+            ReceiveFallbackArg::SparkInvoice => FallbackMethod::SparkInvoice,
+        }
+    }
 }
 
 #[derive(Clone, Parser)]
@@ -139,6 +155,10 @@ pub enum Command {
         /// Request a new bitcoin deposit address instead of reusing the current one.
         #[arg(long)]
         new_address: bool,
+
+        /// Request a new bitcoin deposit address instead of reusing the current one.
+        #[arg(long)]
+        fallback: Option<ReceiveFallbackArg>,
     },
 
     /// Pay the given payment request
@@ -558,6 +578,7 @@ pub(crate) async fn execute_command(
             sender_public_key,
             hodl,
             new_address,
+            fallback,
         } => {
             let payment_method = match payment_method {
                 ReceivePaymentMethodArg::SparkAddress => ReceivePaymentMethod::SparkAddress,
@@ -600,7 +621,7 @@ pub(crate) async fn execute_command(
                         amount_sats: amount.map(TryInto::try_into).transpose()?,
                         expiry_secs,
                         payment_hash,
-                        use_mrh: None,
+                        fallback: fallback.map(Into::into),
                     }
                 }
             };

--- a/crates/breez-sdk/common/src/input/models.rs
+++ b/crates/breez-sdk/common/src/input/models.rs
@@ -105,6 +105,7 @@ pub struct Bolt11InvoiceDetails {
     pub payment_secret: String,
     pub routing_hints: Vec<Bolt11RouteHint>,
     pub timestamp: u64,
+    pub fallback_addresses: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/breez-sdk/common/src/input/parser/mod.rs
+++ b/crates/breez-sdk/common/src/input/parser/mod.rs
@@ -4,7 +4,7 @@ use bitcoin::{Address, Denomination, address::NetworkUnchecked};
 use lightning::bolt11_invoice::Bolt11InvoiceDescriptionRef;
 use platform_utils::time::UNIX_EPOCH;
 use regex_lite::Regex;
-use spark_wallet::{SparkAddress, SparkAddressPaymentType};
+use spark_wallet::{SparkAddress, SparkAddressPaymentType, extract_bolt11_spark_address};
 use tracing::{debug, error, warn};
 
 use crate::{
@@ -758,6 +758,16 @@ fn parse_bolt11(input: &str, source: &PaymentRequestSource) -> Option<Bolt11Invo
         Err(_) => return None,
     };
 
+    // Check for spark addresses embedded in the fallback fields
+    let mut fallback_addresses: Vec<String> = bolt11
+        .fallback_addresses()
+        .into_iter()
+        .map(|a| a.to_string())
+        .collect();
+    if let Some((_, spark_address_str)) = extract_bolt11_spark_address(&bolt11) {
+        fallback_addresses.push(spark_address_str);
+    }
+
     Some(Bolt11InvoiceDetails {
         amount_msat: bolt11.amount_milli_satoshis(),
         description: match bolt11.description() {
@@ -798,6 +808,7 @@ fn parse_bolt11(input: &str, source: &PaymentRequestSource) -> Option<Bolt11Invo
             })
             .collect(),
         timestamp: bolt11.duration_since_epoch().as_secs(),
+        fallback_addresses,
     })
 }
 

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1088,6 +1088,10 @@ pub enum ReceivePaymentMethod {
         /// The payer's HTLC will be held until the preimage is provided via
         /// `claim_htlc_payment` or the HTLC expires.
         payment_hash: Option<String>,
+        /// Whether or not to use Magic Routing Hints (MRH). Defaults to false.
+        /// When MRH is enabled payers will be able to pay directly via Spark invoice
+        /// if their clients support it.
+        use_mrh: Option<bool>,
     },
 }
 

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1058,6 +1058,13 @@ pub struct SyncWalletResponse {}
 
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum FallbackMethod {
+    SparkInvoice,
+    SparkAddress,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum ReceivePaymentMethod {
     SparkAddress,
     SparkInvoice {
@@ -1088,10 +1095,10 @@ pub enum ReceivePaymentMethod {
         /// The payer's HTLC will be held until the preimage is provided via
         /// `claim_htlc_payment` or the HTLC expires.
         payment_hash: Option<String>,
-        /// Whether or not to use Magic Routing Hints (MRH). Defaults to false.
-        /// When MRH is enabled payers will be able to pay directly via Spark invoice
-        /// if their clients support it.
-        use_mrh: Option<bool>,
+        /// Whether or not to enable fallback payments. Defaults to false.
+        /// When fallback payments are enabled payers will be able to pay directly via Spark invoice
+        /// or Spark address if their clients support it.
+        fallback: Option<FallbackMethod>,
     },
 }
 

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -262,9 +262,9 @@ pub struct PaymentMetadata {
     pub conversion_info: Option<ConversionInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conversion_status: Option<ConversionStatus>,
-    /// The payment hash of the BOLT11 invoice this Spark payment was settled with via MRH.
+    /// The payment hash of the BOLT11 invoice this Spark payment was settled via fallback
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mrh_payment_hash: Option<String>,
+    pub fallback_payment_hash: Option<String>,
 }
 
 /// Trait for persistent storage
@@ -346,7 +346,7 @@ pub trait Storage: Send + Sync {
     /// The payment if found or None if not found
     async fn get_payment_by_payment_hash(
         &self,
-        payment_hash: &str,
+        payment_hash: String,
     ) -> Result<Option<Payment>, StorageError>;
 
     /// Gets payments that have any of the specified parent payment IDs.

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -262,6 +262,9 @@ pub struct PaymentMetadata {
     pub conversion_info: Option<ConversionInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conversion_status: Option<ConversionStatus>,
+    /// The payment hash of the BOLT11 invoice this Spark payment was settled with via MRH.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mrh_payment_hash: Option<String>,
 }
 
 /// Trait for persistent storage
@@ -332,6 +335,18 @@ pub trait Storage: Send + Sync {
     async fn get_payment_by_invoice(
         &self,
         invoice: String,
+    ) -> Result<Option<Payment>, StorageError>;
+
+    /// Gets a Lightning payment by its payment hash
+    /// # Arguments
+    ///
+    /// * `payment_hash` - The payment hash to look up
+    /// # Returns
+    ///
+    /// The payment if found or None if not found
+    async fn get_payment_by_payment_hash(
+        &self,
+        payment_hash: &str,
     ) -> Result<Option<Payment>, StorageError>;
 
     /// Gets payments that have any of the specified parent payment IDs.

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -724,7 +724,7 @@ impl Storage for PostgresStorage {
 
     async fn get_payment_by_payment_hash(
         &self,
-        payment_hash: &str,
+        payment_hash: String,
     ) -> Result<Option<Payment>, StorageError> {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         let query = format!("{SELECT_PAYMENT_SQL} WHERE l.payment_hash = $1");
@@ -1711,9 +1711,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mrh_payment_hash() {
+    async fn test_fallback_payment_hash() {
         let fixture = PostgresTestFixture::new().await;
-        crate::persist::tests::test_mrh_payment_hash(Box::new(fixture.storage)).await;
+        crate::persist::tests::test_fallback_payment_hash(Box::new(fixture.storage)).await;
     }
 
     #[tokio::test]

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -722,6 +722,20 @@ impl Storage for PostgresStorage {
         }
     }
 
+    async fn get_payment_by_payment_hash(
+        &self,
+        payment_hash: &str,
+    ) -> Result<Option<Payment>, StorageError> {
+        let client = self.pool.get().await.map_err(map_pool_error)?;
+        let query = format!("{SELECT_PAYMENT_SQL} WHERE l.payment_hash = $1");
+        let row = client.query_opt(&query, &[&payment_hash]).await?;
+
+        match row {
+            Some(r) => Ok(Some(map_payment(&r)?)),
+            None => Ok(None),
+        }
+    }
+
     #[allow(clippy::arithmetic_side_effects)]
     async fn get_payments_by_parent_ids(
         &self,
@@ -1694,6 +1708,18 @@ mod tests {
     async fn test_conversion_status_persistence() {
         let fixture = PostgresTestFixture::new().await;
         crate::persist::tests::test_conversion_status_persistence(Box::new(fixture.storage)).await;
+    }
+
+    #[tokio::test]
+    async fn test_mrh_payment_hash() {
+        let fixture = PostgresTestFixture::new().await;
+        crate::persist::tests::test_mrh_payment_hash(Box::new(fixture.storage)).await;
+    }
+
+    #[tokio::test]
+    async fn test_payment_by_payment_hash() {
+        let fixture = PostgresTestFixture::new().await;
+        crate::persist::tests::test_payment_by_payment_hash(Box::new(fixture.storage)).await;
     }
 
     /// Generates a self-signed CA certificate in PEM format for testing.

--- a/crates/breez-sdk/core/src/persist/sqlite.rs
+++ b/crates/breez-sdk/core/src/persist/sqlite.rs
@@ -769,6 +769,21 @@ impl Storage for SqliteStorage {
         }
     }
 
+    async fn get_payment_by_payment_hash(
+        &self,
+        payment_hash: &str,
+    ) -> Result<Option<Payment>, StorageError> {
+        let connection = self.get_connection()?;
+        let query = format!("{SELECT_PAYMENT_SQL} WHERE l.payment_hash = ?");
+        let mut stmt = connection.prepare(&query)?;
+        let payment = stmt.query_row(params![payment_hash], map_payment);
+        match payment {
+            Ok(payment) => Ok(Some(payment)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     async fn get_payments_by_parent_ids(
         &self,
         parent_payment_ids: Vec<String>,
@@ -2277,5 +2292,21 @@ mod tests {
         let storage = SqliteStorage::new(&temp_dir).unwrap();
 
         crate::persist::tests::test_conversion_status_persistence(Box::new(storage)).await;
+    }
+
+    #[tokio::test]
+    async fn test_mrh_payment_hash() {
+        let temp_dir = create_temp_dir("sqlite_mrh_payment_hash");
+        let storage = SqliteStorage::new(&temp_dir).unwrap();
+
+        crate::persist::tests::test_mrh_payment_hash(Box::new(storage)).await;
+    }
+
+    #[tokio::test]
+    async fn test_payment_by_payment_hash() {
+        let temp_dir = create_temp_dir("sqlite_payment_by_payment_hash");
+        let storage = SqliteStorage::new(&temp_dir).unwrap();
+
+        crate::persist::tests::test_payment_by_payment_hash(Box::new(storage)).await;
     }
 }

--- a/crates/breez-sdk/core/src/persist/sqlite.rs
+++ b/crates/breez-sdk/core/src/persist/sqlite.rs
@@ -771,7 +771,7 @@ impl Storage for SqliteStorage {
 
     async fn get_payment_by_payment_hash(
         &self,
-        payment_hash: &str,
+        payment_hash: String,
     ) -> Result<Option<Payment>, StorageError> {
         let connection = self.get_connection()?;
         let query = format!("{SELECT_PAYMENT_SQL} WHERE l.payment_hash = ?");
@@ -2295,11 +2295,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mrh_payment_hash() {
-        let temp_dir = create_temp_dir("sqlite_mrh_payment_hash");
+    async fn test_fallback_payment_hash() {
+        let temp_dir = create_temp_dir("sqlite_fallback_payment_hash");
         let storage = SqliteStorage::new(&temp_dir).unwrap();
 
-        crate::persist::tests::test_mrh_payment_hash(Box::new(storage)).await;
+        crate::persist::tests::test_fallback_payment_hash(Box::new(storage)).await;
     }
 
     #[tokio::test]

--- a/crates/breez-sdk/core/src/persist/tests.rs
+++ b/crates/breez-sdk/core/src/persist/tests.rs
@@ -3160,8 +3160,8 @@ pub async fn test_conversion_status_persistence(storage: Box<dyn Storage>) {
     );
 }
 
-/// Tests that the MRH payment hash can be stored and retrieved via the cache.
-pub async fn test_mrh_payment_hash(storage: Box<dyn Storage>) {
+/// Tests that the fallback payment hash can be stored and retrieved via the cache.
+pub async fn test_fallback_payment_hash(storage: Box<dyn Storage>) {
     let spark_invoice = "spark:testinvoice123";
     let payment_hash =
         "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899".to_string();
@@ -3170,16 +3170,16 @@ pub async fn test_mrh_payment_hash(storage: Box<dyn Storage>) {
     // Not found before insertion
     let result = cache.fetch_payment_metadata(spark_invoice).await.unwrap();
     assert!(
-        result.and_then(|r| r.mrh_payment_hash).is_none(),
+        result.and_then(|r| r.fallback_payment_hash).is_none(),
         "Expected None before insertion"
     );
 
-    // Store the MRH mapping
+    // Store the fallback mapping
     cache
         .save_payment_metadata(
             spark_invoice,
             &PaymentMetadata {
-                mrh_payment_hash: Some(payment_hash.clone()),
+                fallback_payment_hash: Some(payment_hash.clone()),
                 ..Default::default()
             },
         )
@@ -3189,7 +3189,7 @@ pub async fn test_mrh_payment_hash(storage: Box<dyn Storage>) {
     // Retrieve it back
     let result = cache.fetch_payment_metadata(spark_invoice).await.unwrap();
     assert_eq!(
-        result.and_then(|r| r.mrh_payment_hash).as_deref(),
+        result.and_then(|r| r.fallback_payment_hash).as_deref(),
         Some(payment_hash.as_str()),
         "Expected the stored payment hash"
     );
@@ -3197,7 +3197,8 @@ pub async fn test_mrh_payment_hash(storage: Box<dyn Storage>) {
 
 /// Tests that `get_payment_by_payment_hash` can look up a Lightning payment by its payment hash.
 pub async fn test_payment_by_payment_hash(storage: Box<dyn Storage>) {
-    let payment_hash = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+    let payment_hash =
+        "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210".to_string();
     let lightning_payment = Payment {
         id: "mrh_ln_payment_001".to_string(),
         payment_type: PaymentType::Receive,
@@ -3207,10 +3208,11 @@ pub async fn test_payment_by_payment_hash(storage: Box<dyn Storage>) {
         timestamp: 1_700_000_000,
         method: PaymentMethod::Lightning,
         details: Some(PaymentDetails::Lightning {
-            description: Some("MRH test payment".to_string()),
+            description: Some("Fallback test payment".to_string()),
             invoice: "lnbc500n1ptest".to_string(),
-            destination_pubkey: "03aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111aa".to_string(),
-            htlc_details: test_lightning_htlc(payment_hash),
+            destination_pubkey:
+                "03aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111aa".to_string(),
+            htlc_details: test_lightning_htlc(&payment_hash),
             lnurl_pay_info: None,
             lnurl_withdraw_info: None,
             lnurl_receive_metadata: None,
@@ -3220,7 +3222,7 @@ pub async fn test_payment_by_payment_hash(storage: Box<dyn Storage>) {
 
     // Not found before insertion
     let result = storage
-        .get_payment_by_payment_hash(payment_hash)
+        .get_payment_by_payment_hash(payment_hash.clone())
         .await
         .unwrap();
     assert!(result.is_none(), "Expected None before insertion");
@@ -3240,7 +3242,9 @@ pub async fn test_payment_by_payment_hash(storage: Box<dyn Storage>) {
 
     // Non-existent hash returns None
     let result = storage
-        .get_payment_by_payment_hash("0000000000000000000000000000000000000000000000000000000000000000")
+        .get_payment_by_payment_hash(
+            "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+        )
         .await
         .unwrap();
     assert!(result.is_none(), "Expected None for unknown payment hash");

--- a/crates/breez-sdk/core/src/persist/tests.rs
+++ b/crates/breez-sdk/core/src/persist/tests.rs
@@ -3159,3 +3159,89 @@ pub async fn test_conversion_status_persistence(storage: Box<dyn Storage>) {
         "conversion_status should be updated to Completed"
     );
 }
+
+/// Tests that the MRH payment hash can be stored and retrieved via the cache.
+pub async fn test_mrh_payment_hash(storage: Box<dyn Storage>) {
+    let spark_invoice = "spark:testinvoice123";
+    let payment_hash =
+        "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899".to_string();
+    let cache = ObjectCacheRepository::new(storage.into());
+
+    // Not found before insertion
+    let result = cache.fetch_payment_metadata(spark_invoice).await.unwrap();
+    assert!(
+        result.and_then(|r| r.mrh_payment_hash).is_none(),
+        "Expected None before insertion"
+    );
+
+    // Store the MRH mapping
+    cache
+        .save_payment_metadata(
+            spark_invoice,
+            &PaymentMetadata {
+                mrh_payment_hash: Some(payment_hash.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    // Retrieve it back
+    let result = cache.fetch_payment_metadata(spark_invoice).await.unwrap();
+    assert_eq!(
+        result.and_then(|r| r.mrh_payment_hash).as_deref(),
+        Some(payment_hash.as_str()),
+        "Expected the stored payment hash"
+    );
+}
+
+/// Tests that `get_payment_by_payment_hash` can look up a Lightning payment by its payment hash.
+pub async fn test_payment_by_payment_hash(storage: Box<dyn Storage>) {
+    let payment_hash = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+    let lightning_payment = Payment {
+        id: "mrh_ln_payment_001".to_string(),
+        payment_type: PaymentType::Receive,
+        status: PaymentStatus::Pending,
+        amount: 50_000,
+        fees: 0,
+        timestamp: 1_700_000_000,
+        method: PaymentMethod::Lightning,
+        details: Some(PaymentDetails::Lightning {
+            description: Some("MRH test payment".to_string()),
+            invoice: "lnbc500n1ptest".to_string(),
+            destination_pubkey: "03aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111aa".to_string(),
+            htlc_details: test_lightning_htlc(payment_hash),
+            lnurl_pay_info: None,
+            lnurl_withdraw_info: None,
+            lnurl_receive_metadata: None,
+        }),
+        conversion_details: None,
+    };
+
+    // Not found before insertion
+    let result = storage
+        .get_payment_by_payment_hash(payment_hash)
+        .await
+        .unwrap();
+    assert!(result.is_none(), "Expected None before insertion");
+
+    storage
+        .insert_payment(lightning_payment.clone())
+        .await
+        .unwrap();
+
+    // Found after insertion
+    let result = storage
+        .get_payment_by_payment_hash(payment_hash)
+        .await
+        .unwrap();
+    assert!(result.is_some(), "Expected payment to be found");
+    assert_eq!(result.unwrap().id, lightning_payment.id);
+
+    // Non-existent hash returns None
+    let result = storage
+        .get_payment_by_payment_hash("0000000000000000000000000000000000000000000000000000000000000000")
+        .await
+        .unwrap();
+    assert!(result.is_none(), "Expected None for unknown payment hash");
+}

--- a/crates/breez-sdk/core/src/realtime_sync/storage.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/storage.rs
@@ -515,7 +515,7 @@ impl Storage for SyncedStorage {
 
     async fn get_payment_by_payment_hash(
         &self,
-        payment_hash: &str,
+        payment_hash: String,
     ) -> Result<Option<Payment>, StorageError> {
         self.inner.get_payment_by_payment_hash(payment_hash).await
     }

--- a/crates/breez-sdk/core/src/realtime_sync/storage.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/storage.rs
@@ -513,6 +513,13 @@ impl Storage for SyncedStorage {
         self.inner.get_payment_by_invoice(invoice).await
     }
 
+    async fn get_payment_by_payment_hash(
+        &self,
+        payment_hash: &str,
+    ) -> Result<Option<Payment>, StorageError> {
+        self.inner.get_payment_by_payment_hash(payment_hash).await
+    }
+
     async fn get_payments_by_parent_ids(
         &self,
         parent_payment_ids: Vec<String>,

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -381,7 +381,7 @@ impl BreezSdk {
                         Some(amount_sats),
                         None,
                         None,
-                        false,
+                        None,
                     )
                     .await?;
                 CashAppProvider::build_url(&receive_response.payment_request)

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -381,6 +381,7 @@ impl BreezSdk {
                         Some(amount_sats),
                         None,
                         None,
+                        false,
                     )
                     .await?;
                 CashAppProvider::build_url(&receive_response.payment_request)

--- a/crates/breez-sdk/core/src/sdk/lnurl.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl.rs
@@ -344,6 +344,7 @@ impl BreezSdk {
                     amount_sats: Some(amount_sats),
                     expiry_secs: None,
                     payment_hash: None,
+                    use_mrh: None,
                 },
             })
             .await?

--- a/crates/breez-sdk/core/src/sdk/lnurl.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl.rs
@@ -344,7 +344,7 @@ impl BreezSdk {
                     amount_sats: Some(amount_sats),
                     expiry_secs: None,
                     payment_hash: None,
-                    use_mrh: None,
+                    fallback: None,
                 },
             })
             .await?

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -22,7 +22,7 @@ use crate::{
         ReceivePaymentRequest, ReceivePaymentResponse, SendPaymentRequest, SendPaymentResponse,
         conversion_steps_from_payments,
     },
-    persist::PaymentMetadata,
+    persist::{ObjectCacheRepository, PaymentMetadata},
     token_conversion::{
         ConversionAmount, DEFAULT_CONVERSION_TIMEOUT_SECS, TokenConversionResponse,
     },
@@ -102,9 +102,16 @@ impl BreezSdk {
                 amount_sats,
                 expiry_secs,
                 payment_hash,
+                use_mrh,
             } => {
-                self.receive_bolt11_invoice(description, amount_sats, expiry_secs, payment_hash)
-                    .await
+                self.receive_bolt11_invoice(
+                    description,
+                    amount_sats,
+                    expiry_secs,
+                    payment_hash,
+                    use_mrh.unwrap_or(false),
+                )
+                .await
             }
         }
     }
@@ -495,17 +502,36 @@ impl BreezSdk {
         amount_sats: Option<u64>,
         expiry_secs: Option<u32>,
         payment_hash: Option<String>,
+        use_mrh: bool,
     ) -> Result<ReceivePaymentResponse, SdkError> {
+        let spark_invoice = if use_mrh {
+            Some(
+                self.spark_wallet
+                    .create_spark_invoice(
+                        amount_sats.map(u128::from),
+                        None,
+                        expiry_secs.and_then(|secs| {
+                            SystemTime::now().checked_add(Duration::from_secs(u64::from(secs)))
+                        }),
+                        Some(description.clone()),
+                        None,
+                    )
+                    .await?,
+            )
+        } else {
+            None
+        };
         let invoice = if let Some(payment_hash_hex) = payment_hash {
             let hash = sha256::Hash::from_str(&payment_hash_hex)
                 .map_err(|e| SdkError::InvalidInput(format!("Invalid payment hash: {e}")))?;
             self.spark_wallet
                 .create_hodl_lightning_invoice(
                     amount_sats.unwrap_or_default(),
-                    Some(InvoiceDescription::Memo(description.clone())),
+                    Some(InvoiceDescription::Memo(description)),
                     hash,
                     None,
                     expiry_secs,
+                    spark_invoice.clone(),
                 )
                 .await?
                 .invoice
@@ -513,14 +539,35 @@ impl BreezSdk {
             self.spark_wallet
                 .create_lightning_invoice(
                     amount_sats.unwrap_or_default(),
-                    Some(InvoiceDescription::Memo(description.clone())),
+                    Some(InvoiceDescription::Memo(description)),
                     None,
                     expiry_secs,
                     self.config.prefer_spark_over_lightning,
+                    spark_invoice.clone(),
                 )
                 .await?
                 .invoice
         };
+        // Store the MRH mapping: spark invoice → payment hash
+        if let Some(si) = spark_invoice {
+            if let Some(details) = breez_sdk_common::input::parse_invoice(&invoice) {
+                let cache = ObjectCacheRepository::new(self.storage.clone());
+                if let Err(e) = cache
+                    .save_payment_metadata(
+                        &si,
+                        &PaymentMetadata {
+                            mrh_payment_hash: Some(details.payment_hash),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                {
+                    error!("Failed to store MRH payment hash mapping: {e:?}");
+                }
+            } else {
+                error!("Failed to parse BOLT11 invoice for MRH mapping");
+            }
+        }
         Ok(ReceivePaymentResponse {
             payment_request: invoice,
             fee: 0,

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -9,8 +9,8 @@ use tracing::{Instrument, error, info, warn};
 
 use crate::{
     BitcoinAddressDetails, Bolt11InvoiceDetails, ClaimHtlcPaymentRequest, ClaimHtlcPaymentResponse,
-    ConversionEstimate, ConversionOptions, ConversionPurpose, ConversionType, FeePolicy,
-    FetchConversionLimitsRequest, FetchConversionLimitsResponse, GetPaymentRequest,
+    ConversionEstimate, ConversionOptions, ConversionPurpose, ConversionType, FallbackMethod,
+    FeePolicy, FetchConversionLimitsRequest, FetchConversionLimitsResponse, GetPaymentRequest,
     GetPaymentResponse, InputType, OnchainConfirmationSpeed, PaymentStatus, SendOnchainFeeQuote,
     SendPaymentMethod, SendPaymentOptions, SparkHtlcOptions, SparkInvoiceDetails,
     WaitForPaymentIdentifier,
@@ -102,14 +102,14 @@ impl BreezSdk {
                 amount_sats,
                 expiry_secs,
                 payment_hash,
-                use_mrh,
+                fallback,
             } => {
                 self.receive_bolt11_invoice(
                     description,
                     amount_sats,
                     expiry_secs,
                     payment_hash,
-                    use_mrh.unwrap_or(false),
+                    fallback,
                 )
                 .await
             }
@@ -502,24 +502,27 @@ impl BreezSdk {
         amount_sats: Option<u64>,
         expiry_secs: Option<u32>,
         payment_hash: Option<String>,
-        use_mrh: bool,
+        fallback: Option<FallbackMethod>,
     ) -> Result<ReceivePaymentResponse, SdkError> {
-        let spark_invoice = if use_mrh {
-            Some(
-                self.spark_wallet
-                    .create_spark_invoice(
-                        amount_sats.map(u128::from),
-                        None,
-                        expiry_secs.and_then(|secs| {
-                            SystemTime::now().checked_add(Duration::from_secs(u64::from(secs)))
-                        }),
-                        Some(description.clone()),
-                        None,
-                    )
-                    .await?,
-            )
-        } else {
-            None
+        let (include_spark_address, spark_invoice) = match fallback {
+            Some(FallbackMethod::SparkInvoice) => (
+                false,
+                Some(
+                    self.spark_wallet
+                        .create_spark_invoice(
+                            amount_sats.map(u128::from),
+                            None,
+                            expiry_secs.and_then(|secs| {
+                                SystemTime::now().checked_add(Duration::from_secs(u64::from(secs)))
+                            }),
+                            Some(description.clone()),
+                            None,
+                        )
+                        .await?,
+                ),
+            ),
+            Some(FallbackMethod::SparkAddress) => (true, None),
+            None => (self.config.prefer_spark_over_lightning, None),
         };
         let invoice = if let Some(payment_hash_hex) = payment_hash {
             let hash = sha256::Hash::from_str(&payment_hash_hex)
@@ -531,6 +534,7 @@ impl BreezSdk {
                     hash,
                     None,
                     expiry_secs,
+                    include_spark_address,
                     spark_invoice.clone(),
                 )
                 .await?
@@ -542,30 +546,32 @@ impl BreezSdk {
                     Some(InvoiceDescription::Memo(description)),
                     None,
                     expiry_secs,
-                    self.config.prefer_spark_over_lightning,
+                    include_spark_address,
                     spark_invoice.clone(),
                 )
                 .await?
                 .invoice
         };
-        // Store the MRH mapping: spark invoice → payment hash
-        if let Some(si) = spark_invoice {
-            if let Some(details) = breez_sdk_common::input::parse_invoice(&invoice) {
+
+        if spark_invoice.is_some() || include_spark_address {
+            if let Some(details) = breez_sdk_common::input::parse_invoice(&invoice)
+                && let Some(fallback_address) = details.fallback_addresses.first()
+            {
                 let cache = ObjectCacheRepository::new(self.storage.clone());
                 if let Err(e) = cache
                     .save_payment_metadata(
-                        &si,
+                        fallback_address,
                         &PaymentMetadata {
-                            mrh_payment_hash: Some(details.payment_hash),
+                            fallback_payment_hash: Some(details.payment_hash),
                             ..Default::default()
                         },
                     )
                     .await
                 {
-                    error!("Failed to store MRH payment hash mapping: {e:?}");
+                    error!("Failed to store fallback payment hash mapping: {e:?}");
                 }
             } else {
-                error!("Failed to parse BOLT11 invoice for MRH mapping");
+                error!("Failed to parse BOLT11 invoice for fallback mapping");
             }
         }
         Ok(ReceivePaymentResponse {

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -1,6 +1,6 @@
 use platform_utils::time::{Duration, Instant, SystemTime};
 use platform_utils::tokio;
-use spark_wallet::WalletEvent;
+use spark_wallet::{SparkAddress, WalletEvent};
 use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::{Instrument, debug, error, info, trace, warn};
@@ -135,7 +135,7 @@ impl BreezSdk {
             }
             WalletEvent::TransferClaimed(transfer) => {
                 info!("Transfer claimed");
-                let spark_invoice = transfer.spark_invoice.clone();
+                let fallback_key = transfer.spark_invoice.clone();
                 // Drop any unclaimed-deposit record for this outpoint
                 // independently of payment ingestion below, so a
                 // Payment::try_from failure does not leave the record
@@ -149,10 +149,11 @@ impl BreezSdk {
                         error!("Failed to insert succeeded payment: {e:?}");
                     }
 
-                    // If this Spark transfer settles an MRH BOLT11 invoice, mark the associated
+                    // If this Spark transfer settles via fallback, mark the associated
                     // Lightning receive payment as complete.
-                    if let Some(si) = &spark_invoice {
-                        self.complete_mrh_lightning_payment(si).await;
+                    if let Some(fallback_key) = fallback_key {
+                        self.complete_lightning_payment_via_fallback(fallback_key)
+                            .await;
                     }
 
                     // Ensure potential lnurl metadata is synced before emitting the event.
@@ -290,15 +291,15 @@ impl BreezSdk {
         *lnurl_receive_metadata = db_lnurl_receive_metadata;
     }
 
-    /// When a Spark transfer settles an MRH BOLT11 invoice, find the pending Lightning
+    /// When a Spark transfer settles an invoice, find the pending Lightning
     /// receive payment by its payment hash and mark it as Completed.
-    async fn complete_mrh_lightning_payment(&self, spark_invoice: &str) {
+    async fn complete_lightning_payment_via_fallback(&self, fallback_key: String) {
         let cache = ObjectCacheRepository::new(self.storage.clone());
-        let payment_hash = match cache.fetch_payment_metadata(spark_invoice).await {
-            Ok(Some(metadata)) => metadata.mrh_payment_hash,
+        let payment_hash = match cache.fetch_payment_metadata(&fallback_key).await {
+            Ok(Some(metadata)) => metadata.fallback_payment_hash,
             Ok(None) => return,
             Err(e) => {
-                error!("Failed to fetch MRH payment metadata for {spark_invoice}: {e:?}");
+                error!("Failed to fetch fallback payment metadata for {fallback_key}: {e:?}");
                 return;
             }
         };
@@ -308,7 +309,7 @@ impl BreezSdk {
 
         let lightning_payment = match self
             .storage
-            .get_payment_by_payment_hash(&payment_hash)
+            .get_payment_by_payment_hash(payment_hash.clone())
             .await
         {
             Ok(Some(p)) => p,
@@ -339,7 +340,7 @@ impl BreezSdk {
         }
 
         if let Err(e) = self.storage.insert_payment(updated.clone()).await {
-            error!("Failed to mark MRH Lightning payment as complete: {e:?}");
+            error!("Failed to mark Lightning payment as complete: {e:?}");
             return;
         }
 

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -1,6 +1,6 @@
 use platform_utils::time::{Duration, Instant, SystemTime};
 use platform_utils::tokio;
-use spark_wallet::{SparkAddress, WalletEvent};
+use spark_wallet::WalletEvent;
 use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::{Instrument, debug, error, info, trace, warn};

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -11,7 +11,7 @@ use super::{
     parse_input,
 };
 use crate::{
-    DepositInfo, InputType, MaxFee, PaymentDetails, PaymentType,
+    DepositInfo, InputType, MaxFee, PaymentDetails, PaymentStatus, PaymentType, SparkHtlcStatus,
     error::SdkError,
     events::{InternalSyncedEvent, SdkEvent},
     lnurl::ListMetadataRequest,
@@ -135,6 +135,7 @@ impl BreezSdk {
             }
             WalletEvent::TransferClaimed(transfer) => {
                 info!("Transfer claimed");
+                let spark_invoice = transfer.spark_invoice.clone();
                 // Drop any unclaimed-deposit record for this outpoint
                 // independently of payment ingestion below, so a
                 // Payment::try_from failure does not leave the record
@@ -146,6 +147,12 @@ impl BreezSdk {
                     // Insert the payment into storage to make it immediately available for listing
                     if let Err(e) = self.storage.insert_payment(payment.clone()).await {
                         error!("Failed to insert succeeded payment: {e:?}");
+                    }
+
+                    // If this Spark transfer settles an MRH BOLT11 invoice, mark the associated
+                    // Lightning receive payment as complete.
+                    if let Some(si) = &spark_invoice {
+                        self.complete_mrh_lightning_payment(si).await;
                     }
 
                     // Ensure potential lnurl metadata is synced before emitting the event.
@@ -281,6 +288,62 @@ impl BreezSdk {
             return;
         };
         *lnurl_receive_metadata = db_lnurl_receive_metadata;
+    }
+
+    /// When a Spark transfer settles an MRH BOLT11 invoice, find the pending Lightning
+    /// receive payment by its payment hash and mark it as Completed.
+    async fn complete_mrh_lightning_payment(&self, spark_invoice: &str) {
+        let cache = ObjectCacheRepository::new(self.storage.clone());
+        let payment_hash = match cache.fetch_payment_metadata(spark_invoice).await {
+            Ok(Some(metadata)) => metadata.mrh_payment_hash,
+            Ok(None) => return,
+            Err(e) => {
+                error!("Failed to fetch MRH payment metadata for {spark_invoice}: {e:?}");
+                return;
+            }
+        };
+        let Some(payment_hash) = payment_hash else {
+            return;
+        };
+
+        let lightning_payment = match self
+            .storage
+            .get_payment_by_payment_hash(&payment_hash)
+            .await
+        {
+            Ok(Some(p)) => p,
+            Ok(None) => return,
+            Err(e) => {
+                error!("Failed to look up Lightning payment by payment hash {payment_hash}: {e:?}");
+                return;
+            }
+        };
+
+        // Only update pending Lightning receive payments
+        if lightning_payment.status == PaymentStatus::Completed
+            || lightning_payment.status == PaymentStatus::Failed
+        {
+            return;
+        }
+
+        let mut updated = lightning_payment;
+        updated.status = PaymentStatus::Completed;
+
+        // Set HTLC status to PreimageShared
+        if let Some(PaymentDetails::Lightning {
+            ref mut htlc_details,
+            ..
+        }) = updated.details
+        {
+            htlc_details.status = SparkHtlcStatus::PreimageShared;
+        }
+
+        if let Err(e) = self.storage.insert_payment(updated.clone()).await {
+            error!("Failed to mark MRH Lightning payment as complete: {e:?}");
+            return;
+        }
+
+        get_payment_and_emit_event(&self.storage, &self.event_emitter, updated).await;
     }
 
     #[allow(clippy::too_many_lines)]

--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -690,6 +690,7 @@ where
                 Some(pubkey),
                 params.expiry,
                 state.include_spark_address,
+                None,
             )
             .await
             .map_err(|e| {

--- a/crates/breez-sdk/wasm/js/node-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/node-storage/index.cjs
@@ -484,10 +484,36 @@ class SqliteStorage {
       return Promise.resolve(this._rowToPayment(row));
     } catch (error) {
       if (error instanceof StorageError) return Promise.reject(error);
-      const paymentId = id || "unknown";
       return Promise.reject(
         new StorageError(
           `Failed to get payment by invoice '${invoice}': ${error.message}`,
+          error
+        )
+      );
+    }
+  }
+
+  getPaymentByPaymentHash(paymentHash) {
+    try {
+      if (!paymentHash) {
+        return Promise.reject(
+          new StorageError("Payment hash cannot be null or undefined")
+        );
+      }
+
+      const stmt = this.db.prepare(`${SELECT_PAYMENT_SQL} WHERE l.payment_hash = ?`);
+      const row = stmt.get(paymentHash);
+
+      if (!row) {
+        return Promise.resolve(null);
+      }
+
+      return Promise.resolve(this._rowToPayment(row));
+    } catch (error) {
+      if (error instanceof StorageError) return Promise.reject(error);
+      return Promise.reject(
+        new StorageError(
+          `Failed to get payment by payment hash '${paymentHash}': ${error.message}`,
           error
         )
       );

--- a/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
@@ -505,6 +505,31 @@ class PostgresStorage {
     }
   }
 
+  async getPaymentByPaymentHash(paymentHash) {
+    try {
+      if (!paymentHash) {
+        throw new StorageError("Payment hash cannot be null or undefined");
+      }
+
+      const result = await this.pool.query(
+        `${SELECT_PAYMENT_SQL} WHERE l.payment_hash = $1`,
+        [paymentHash]
+      );
+
+      if (result.rows.length === 0) {
+        return null;
+      }
+
+      return this._rowToPayment(result.rows[0]);
+    } catch (error) {
+      if (error instanceof StorageError) throw error;
+      throw new StorageError(
+        `Failed to get payment by payment hash '${paymentHash}': ${error.message}`,
+        error
+      );
+    }
+  }
+
   async getPaymentsByParentIds(parentPaymentIds) {
     try {
       if (!parentPaymentIds || parentPaymentIds.length === 0) {

--- a/crates/breez-sdk/wasm/js/web-storage/index.js
+++ b/crates/breez-sdk/wasm/js/web-storage/index.js
@@ -959,6 +959,83 @@ class IndexedDBStorage {
     });
   }
 
+  async getPaymentByPaymentHash(paymentHash) {
+    if (!this.db) {
+      throw new StorageError("Database not initialized");
+    }
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction(
+        ["payments", "payment_metadata", "lnurl_receive_metadata"],
+        "readonly"
+      );
+      const paymentStore = transaction.objectStore("payments");
+      const metadataStore = transaction.objectStore("payment_metadata");
+      const lnurlReceiveMetadataStore = transaction.objectStore(
+        "lnurl_receive_metadata"
+      );
+
+      // Scan all payments to find one with matching payment hash
+      const cursorRequest = paymentStore.openCursor();
+      let found = false;
+
+      cursorRequest.onsuccess = (event) => {
+        if (found) return;
+        const cursor = event.target.result;
+        if (!cursor) {
+          if (!found) resolve(null);
+          return;
+        }
+
+        const payment = cursor.value;
+        let details;
+        try {
+          details = typeof payment.details === "string"
+            ? JSON.parse(payment.details)
+            : payment.details;
+        } catch (_) {
+          cursor.continue();
+          return;
+        }
+
+        if (
+          details &&
+          details.type === "lightning" &&
+          details.htlcDetails?.paymentHash === paymentHash
+        ) {
+          found = true;
+
+          const metadataRequest = metadataStore.get(payment.id);
+          metadataRequest.onsuccess = () => {
+            const metadata = metadataRequest.result;
+            const paymentWithMetadata = this._mergePaymentMetadata(
+              payment,
+              metadata
+            );
+            this._fetchLnurlReceiveMetadata(
+              paymentWithMetadata,
+              lnurlReceiveMetadataStore
+            )
+              .then(resolve)
+              .catch(() => resolve(paymentWithMetadata));
+          };
+          metadataRequest.onerror = () => resolve(payment);
+        } else {
+          cursor.continue();
+        }
+      };
+
+      cursorRequest.onerror = () => {
+        reject(
+          new StorageError(
+            `Failed to get payment by payment hash '${paymentHash}': ${cursorRequest.error?.message || "Unknown error"}`,
+            cursorRequest.error
+          )
+        );
+      };
+    });
+  }
+
   /**
    * Checks if any related payments exist (payments with a parentPaymentId).
    * Uses the parentPaymentId index for efficient lookup.

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -752,6 +752,12 @@ pub struct SyncWalletRequest {}
 #[macros::extern_wasm_bindgen(breez_sdk_spark::SyncWalletResponse)]
 pub struct SyncWalletResponse {}
 
+#[macros::extern_wasm_bindgen(breez_sdk_spark::FallbackMethod)]
+pub enum FallbackMethod {
+    SparkAddress,
+    SparkInvoice,
+}
+
 #[macros::extern_wasm_bindgen(breez_sdk_spark::ReceivePaymentMethod)]
 pub enum ReceivePaymentMethod {
     SparkAddress,
@@ -772,7 +778,7 @@ pub enum ReceivePaymentMethod {
         amount_sats: Option<u64>,
         expiry_secs: Option<u32>,
         payment_hash: Option<String>,
-        use_mrh: Option<bool>,
+        fallback: Option<FallbackMethod>,
     },
 }
 
@@ -1037,7 +1043,7 @@ pub struct PaymentMetadata {
     pub lnurl_description: Option<String>,
     pub conversion_info: Option<ConversionInfo>,
     pub conversion_status: Option<ConversionStatus>,
-    pub mrh_payment_hash: Option<String>,
+    pub fallback_payment_hash: Option<String>,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::SetLnurlMetadataItem)]

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -772,6 +772,7 @@ pub enum ReceivePaymentMethod {
         amount_sats: Option<u64>,
         expiry_secs: Option<u32>,
         payment_hash: Option<String>,
+        use_mrh: Option<bool>,
     },
 }
 
@@ -1036,6 +1037,7 @@ pub struct PaymentMetadata {
     pub lnurl_description: Option<String>,
     pub conversion_info: Option<ConversionInfo>,
     pub conversion_status: Option<ConversionStatus>,
+    pub mrh_payment_hash: Option<String>,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::SetLnurlMetadataItem)]

--- a/crates/breez-sdk/wasm/src/persist/mod.rs
+++ b/crates/breez-sdk/wasm/src/persist/mod.rs
@@ -186,6 +186,22 @@ impl breez_sdk_spark::Storage for WasmStorage {
         Ok(payment.map(|p| p.into()))
     }
 
+    async fn get_payment_by_payment_hash(
+        &self,
+        payment_hash: &str,
+    ) -> Result<Option<breez_sdk_spark::Payment>, StorageError> {
+        let promise = self
+            .storage
+            .get_payment_by_payment_hash(payment_hash.to_string())
+            .map_err(js_error_to_storage_error)?;
+        let future = JsFuture::from(promise);
+        let result = future.await.map_err(js_error_to_storage_error)?;
+
+        let payment: Option<Payment> = serde_wasm_bindgen::from_value(result)
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
+        Ok(payment.map(|p| p.into()))
+    }
+
     async fn add_deposit(
         &self,
         txid: String,
@@ -480,6 +496,7 @@ const STORAGE_INTERFACE: &'static str = r#"export interface Storage {
     insertPaymentMetadata: (paymentId: string, metadata: PaymentMetadata) => Promise<void>;
     getPaymentById: (id: string) => Promise<Payment>;
     getPaymentByInvoice: (invoice: string) => Promise<Payment>;
+    getPaymentByPaymentHash: (paymentHash: string) => Promise<Payment | null>;
     addDeposit: (txid: string, vout: number, amount_sats: number, isMature: boolean) => Promise<void>;
     deleteDeposit: (txid: string, vout: number) => Promise<void>;
     listDeposits: () => Promise<DepositInfo[]>;
@@ -536,6 +553,12 @@ extern "C" {
 
     #[wasm_bindgen(structural, method, js_name = getPaymentByInvoice, catch)]
     pub fn get_payment_by_invoice(this: &Storage, invoice: String) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(structural, method, js_name = getPaymentByPaymentHash, catch)]
+    pub fn get_payment_by_payment_hash(
+        this: &Storage,
+        payment_hash: String,
+    ) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, js_name = addDeposit, catch)]
     pub fn add_deposit(

--- a/crates/breez-sdk/wasm/src/persist/mod.rs
+++ b/crates/breez-sdk/wasm/src/persist/mod.rs
@@ -188,11 +188,11 @@ impl breez_sdk_spark::Storage for WasmStorage {
 
     async fn get_payment_by_payment_hash(
         &self,
-        payment_hash: &str,
+        payment_hash: String,
     ) -> Result<Option<breez_sdk_spark::Payment>, StorageError> {
         let promise = self
             .storage
-            .get_payment_by_payment_hash(payment_hash.to_string())
+            .get_payment_by_payment_hash(payment_hash)
             .map_err(js_error_to_storage_error)?;
         let future = JsFuture::from(promise);
         let result = future.await.map_err(js_error_to_storage_error)?;

--- a/crates/breez-sdk/wasm/src/persist/tests/node.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/node.rs
@@ -537,3 +537,15 @@ async fn test_migration_from_v20_to_v21() {
     assert_eq!(returned.len(), 1);
     assert_eq!(returned[0].id, "ln-failed");
 }
+
+#[wasm_bindgen_test]
+async fn test_mrh_payment_hash() {
+    let storage = create_test_storage("mrh_payment_hash").await;
+    breez_sdk_spark::storage_tests::test_mrh_payment_hash(Box::new(storage)).await;
+}
+
+#[wasm_bindgen_test]
+async fn test_payment_by_payment_hash() {
+    let storage = create_test_storage("payment_by_payment_hash").await;
+    breez_sdk_spark::storage_tests::test_payment_by_payment_hash(Box::new(storage)).await;
+}

--- a/crates/breez-sdk/wasm/src/persist/tests/node.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/node.rs
@@ -539,9 +539,9 @@ async fn test_migration_from_v20_to_v21() {
 }
 
 #[wasm_bindgen_test]
-async fn test_mrh_payment_hash() {
-    let storage = create_test_storage("mrh_payment_hash").await;
-    breez_sdk_spark::storage_tests::test_mrh_payment_hash(Box::new(storage)).await;
+async fn test_fallback_payment_hash() {
+    let storage = create_test_storage("fallback_payment_hash").await;
+    breez_sdk_spark::storage_tests::test_fallback_payment_hash(Box::new(storage)).await;
 }
 
 #[wasm_bindgen_test]

--- a/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
@@ -159,9 +159,9 @@ async fn test_sync_storage() {
 }
 
 #[wasm_bindgen_test]
-async fn test_mrh_payment_hash() {
-    let storage = create_test_storage("pg_mrh_payment_hash").await;
-    breez_sdk_spark::storage_tests::test_mrh_payment_hash(Box::new(storage)).await;
+async fn test_fallback_payment_hash() {
+    let storage = create_test_storage("pg_fallback_payment_hash").await;
+    breez_sdk_spark::storage_tests::test_fallback_payment_hash(Box::new(storage)).await;
 }
 
 #[wasm_bindgen_test]

--- a/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
@@ -157,3 +157,15 @@ async fn test_sync_storage() {
     let storage = create_test_storage("pg_sync_storage").await;
     breez_sdk_spark::storage_tests::test_sync_storage(Box::new(storage)).await;
 }
+
+#[wasm_bindgen_test]
+async fn test_mrh_payment_hash() {
+    let storage = create_test_storage("pg_mrh_payment_hash").await;
+    breez_sdk_spark::storage_tests::test_mrh_payment_hash(Box::new(storage)).await;
+}
+
+#[wasm_bindgen_test]
+async fn test_payment_by_payment_hash() {
+    let storage = create_test_storage("pg_payment_by_payment_hash").await;
+    breez_sdk_spark::storage_tests::test_payment_by_payment_hash(Box::new(storage)).await;
+}

--- a/crates/breez-sdk/wasm/src/persist/tests/web.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/web.rs
@@ -549,3 +549,15 @@ async fn test_migration_from_v10_to_v11() {
     assert_eq!(returned.len(), 1);
     assert_eq!(returned[0].id, "ln-failed");
 }
+
+#[wasm_bindgen_test]
+async fn test_mrh_payment_hash() {
+    let storage = create_test_storage("mrh_payment_hash").await;
+    breez_sdk_spark::storage_tests::test_mrh_payment_hash(Box::new(storage)).await;
+}
+
+#[wasm_bindgen_test]
+async fn test_payment_by_payment_hash() {
+    let storage = create_test_storage("payment_by_payment_hash").await;
+    breez_sdk_spark::storage_tests::test_payment_by_payment_hash(Box::new(storage)).await;
+}

--- a/crates/breez-sdk/wasm/src/persist/tests/web.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/web.rs
@@ -551,9 +551,9 @@ async fn test_migration_from_v10_to_v11() {
 }
 
 #[wasm_bindgen_test]
-async fn test_mrh_payment_hash() {
-    let storage = create_test_storage("mrh_payment_hash").await;
-    breez_sdk_spark::storage_tests::test_mrh_payment_hash(Box::new(storage)).await;
+async fn test_fallback_payment_hash() {
+    let storage = create_test_storage("fallback_payment_hash").await;
+    breez_sdk_spark::storage_tests::test_fallback_payment_hash(Box::new(storage)).await;
 }
 
 #[wasm_bindgen_test]

--- a/crates/internal/src/command/lightning.rs
+++ b/crates/internal/src/command/lightning.rs
@@ -11,6 +11,8 @@ pub enum LightningCommand {
         amount_sat: u64,
         description: Option<String>,
         expiry_secs: Option<u32>,
+        include_spark_address: Option<bool>,
+        spark_invoice: Option<String>,
     },
     /// Create a HODL lightning invoice (no preimage stored with operators).
     /// The preimage is generated locally and printed. Use `htlc claim` to settle later.
@@ -18,6 +20,8 @@ pub enum LightningCommand {
         amount_sat: u64,
         description: Option<String>,
         expiry_secs: Option<u32>,
+        include_spark_address: Option<bool>,
+        spark_invoice: Option<String>,
     },
     /// Fetch a lightning receive payment.
     FetchReceivePayment { id: String },
@@ -54,10 +58,19 @@ pub async fn handle_command(
             amount_sat,
             description,
             expiry_secs,
+            include_spark_address,
+            spark_invoice,
         } => {
             let desc = description.map(InvoiceDescription::Memo);
             let payment = wallet
-                .create_lightning_invoice(amount_sat, desc, None, expiry_secs, true)
+                .create_lightning_invoice(
+                    amount_sat,
+                    desc,
+                    None,
+                    expiry_secs,
+                    include_spark_address.unwrap_or(false),
+                    spark_invoice,
+                )
                 .await?;
             let qr = QrCode::with_error_correction_level(&payment.invoice, EcLevel::L)
                 .unwrap()
@@ -72,6 +85,8 @@ pub async fn handle_command(
             amount_sat,
             description,
             expiry_secs,
+            include_spark_address,
+            spark_invoice,
         } => {
             // Generate preimage locally
             let preimage_secret = bitcoin::secp256k1::SecretKey::new(&mut OsRng);
@@ -82,7 +97,15 @@ pub async fn handle_command(
 
             let desc = description.map(InvoiceDescription::Memo);
             let payment = wallet
-                .create_hodl_lightning_invoice(amount_sat, desc, payment_hash, None, expiry_secs)
+                .create_hodl_lightning_invoice(
+                    amount_sat,
+                    desc,
+                    payment_hash,
+                    None,
+                    expiry_secs,
+                    include_spark_address.unwrap_or(false),
+                    spark_invoice,
+                )
                 .await?;
 
             let qr = QrCode::with_error_correction_level(&payment.invoice, EcLevel::L)

--- a/crates/spark-wallet/src/lib.rs
+++ b/crates/spark-wallet/src/lib.rs
@@ -44,6 +44,7 @@ pub use spark::{
         TreeStore, select_leaves_by_minimum_amount, select_leaves_by_target_amounts,
     },
     utils::{
+        lightning::extract_bolt11_spark_address,
         paging::{Order, PagingFilter, PagingResult},
         transactions::is_ephemeral_anchor_output,
     },

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -520,6 +520,7 @@ impl SparkWallet {
         public_key: Option<PublicKey>,
         expiry_secs: Option<u32>,
         include_spark_address: bool,
+        spark_invoice: Option<String>,
     ) -> Result<LightningReceivePayment, SparkWalletError> {
         Ok(self
             .lightning_service
@@ -530,6 +531,7 @@ impl SparkWallet {
                 expiry_secs,
                 include_spark_address,
                 public_key,
+                spark_invoice,
             )
             .await?)
     }
@@ -543,6 +545,7 @@ impl SparkWallet {
         payment_hash: Hash,
         public_key: Option<PublicKey>,
         expiry_secs: Option<u32>,
+        spark_invoice: Option<String>,
     ) -> Result<LightningReceivePayment, SparkWalletError> {
         Ok(self
             .lightning_service
@@ -552,6 +555,7 @@ impl SparkWallet {
                 payment_hash,
                 expiry_secs,
                 public_key,
+                spark_invoice,
             )
             .await?)
     }

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -423,17 +423,31 @@ impl SparkWallet {
             .await?;
 
         // In case the invoice is for a spark address, we can just transfer the amount to the receiver.
-        if let Some(receiver_spark_address) = receiver_spark_address {
+        if let Some((receiver_address, receiver_address_str)) = receiver_spark_address {
             if !self.config.self_payment_allowed
-                && receiver_spark_address.identity_public_key == self.identity_public_key
+                && receiver_address.identity_public_key == self.identity_public_key
             {
                 return Err(SparkWalletError::SelfPaymentNotAllowed);
             }
 
+            let transfer = match receiver_address.is_invoice() {
+                true => {
+                    self.transfer_with_invoice(
+                        total_amount_sat,
+                        &receiver_address,
+                        transfer_id,
+                        Some(receiver_address_str),
+                    )
+                    .await?
+                }
+                false => {
+                    self.transfer(total_amount_sat, &receiver_address, transfer_id)
+                        .await?
+                }
+            };
+
             return Ok(PayLightningInvoiceResult {
-                transfer: self
-                    .transfer(total_amount_sat, &receiver_spark_address, transfer_id)
-                    .await?,
+                transfer,
                 lightning_payment: None,
             });
         }
@@ -538,6 +552,7 @@ impl SparkWallet {
 
     /// Creates a HODL Lightning invoice. The SSP will hold the HTLC until
     /// `claim_htlc` is called with the preimage matching the payment_hash.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_hodl_lightning_invoice(
         &self,
         amount_sat: u64,
@@ -545,6 +560,7 @@ impl SparkWallet {
         payment_hash: Hash,
         public_key: Option<PublicKey>,
         expiry_secs: Option<u32>,
+        include_spark_address: bool,
         spark_invoice: Option<String>,
     ) -> Result<LightningReceivePayment, SparkWalletError> {
         Ok(self
@@ -554,6 +570,7 @@ impl SparkWallet {
                 description,
                 payment_hash,
                 expiry_secs,
+                include_spark_address,
                 public_key,
                 spark_invoice,
             )

--- a/crates/spark/src/services/lightning.rs
+++ b/crates/spark/src/services/lightning.rs
@@ -9,6 +9,7 @@ use crate::ssp::{
     ServiceProvider,
 };
 use crate::utils::leaf_key_tweak::prepare_leaf_key_tweaks_to_send;
+use crate::utils::lightning::extract_bolt11_spark_address;
 use crate::utils::preimage_swap::{SwapNodesForPreimageRequest, swap_nodes_for_preimage};
 use crate::{signer::Signer, tree::TreeNode};
 use bitcoin::hashes::{Hash, sha256};
@@ -28,7 +29,6 @@ use super::models::LightningSendRequestStatus;
 
 const DEFAULT_RECEIVE_EXPIRY_SECS: u32 = 60 * 60 * 24 * 30; // 30 days
 const DEFAULT_SEND_EXPIRY_SECS: u64 = 60 * 60 * 24 * 16; // 16 days
-const RECEIVER_IDENTITY_PUBLIC_KEY_SHORT_CHANNEL_ID: u64 = 17592187092992000001;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum InvoiceDescription {
@@ -227,6 +227,7 @@ impl LightningService {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_lightning_invoice(
         &self,
         amount_sats: u64,
@@ -256,12 +257,14 @@ impl LightningService {
     ///
     /// Spark addresses are never included in HODL invoices because a direct Spark
     /// transfer would bypass the Lightning HTLC hold mechanism entirely.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_hodl_lightning_invoice(
         &self,
         amount_sats: u64,
         description: Option<InvoiceDescription>,
         payment_hash: sha256::Hash,
         expiry_secs: Option<u32>,
+        include_spark_address: bool,
         identity_pubkey: Option<PublicKey>,
         spark_invoice: Option<String>,
     ) -> Result<LightningReceivePayment, ServiceError> {
@@ -271,7 +274,7 @@ impl LightningService {
             None,
             Some(payment_hash),
             expiry_secs,
-            false,
+            include_spark_address,
             identity_pubkey,
             spark_invoice,
         )
@@ -346,7 +349,8 @@ impl LightningService {
 
         // check if the spark address in the invoice matches the identity pubkey only
         if include_spark_address {
-            let spark_address = self.extract_spark_address(&decoded_invoice);
+            let spark_address = extract_bolt11_spark_address(&decoded_invoice)
+                .map(|(spark_address, _)| spark_address);
             let Some(spark_address) = spark_address else {
                 return Err(ServiceError::SSPswapError(
                     "Invalid invoice. Spark address not found".to_string(),
@@ -530,7 +534,16 @@ impl LightningService {
         max_fee_sat: Option<u64>,
         amount_to_send: Option<u64>,
         prefer_spark: bool,
-    ) -> Result<(u64, Option<SparkAddress>), ServiceError> {
+    ) -> Result<
+        (
+            u64,
+            Option<(
+                /* address */ SparkAddress,
+                /* address_str */ String,
+            )>,
+        ),
+        ServiceError,
+    > {
         let decoded_invoice = Bolt11Invoice::from_str(invoice)
             .map_err(|err| ServiceError::InvoiceDecodingError(err.to_string()))?;
 
@@ -542,7 +555,8 @@ impl LightningService {
 
         // get the invoice amount in sats, then validate the amount
         let to_pay_sat = get_invoice_amount_sats(&decoded_invoice, amount_to_send)?;
-        if prefer_spark && let Some(receiver_address) = self.extract_spark_address(&decoded_invoice)
+        if prefer_spark
+            && let Some(receiver_address) = extract_bolt11_spark_address(&decoded_invoice)
         {
             return Ok((to_pay_sat, Some(receiver_address)));
         }
@@ -572,18 +586,7 @@ impl LightningService {
     ) -> Result<Option<SparkAddress>, ServiceError> {
         let decoded_invoice = Bolt11Invoice::from_str(invoice)
             .map_err(|err| ServiceError::InvoiceDecodingError(err.to_string()))?;
-        Ok(self.extract_spark_address(&decoded_invoice))
-    }
-
-    fn extract_spark_address(&self, decoded_invoice: &Bolt11Invoice) -> Option<SparkAddress> {
-        for route_hint in decoded_invoice.route_hints() {
-            for node in route_hint.0 {
-                if node.short_channel_id == RECEIVER_IDENTITY_PUBLIC_KEY_SHORT_CHANNEL_ID {
-                    return Some(SparkAddress::new(node.src_node_id, self.network, None));
-                }
-            }
-        }
-        None
+        Ok(extract_bolt11_spark_address(&decoded_invoice).map(|(spark_address, _)| spark_address))
     }
 
     pub async fn fetch_lightning_send_fee_estimate(

--- a/crates/spark/src/services/lightning.rs
+++ b/crates/spark/src/services/lightning.rs
@@ -235,6 +235,7 @@ impl LightningService {
         expiry_secs: Option<u32>,
         include_spark_address: bool,
         identity_pubkey: Option<PublicKey>,
+        spark_invoice: Option<String>,
     ) -> Result<LightningReceivePayment, ServiceError> {
         self.create_lightning_invoice_inner(
             amount_sats,
@@ -244,6 +245,7 @@ impl LightningService {
             expiry_secs,
             include_spark_address,
             identity_pubkey,
+            spark_invoice,
         )
         .await
     }
@@ -261,6 +263,7 @@ impl LightningService {
         payment_hash: sha256::Hash,
         expiry_secs: Option<u32>,
         identity_pubkey: Option<PublicKey>,
+        spark_invoice: Option<String>,
     ) -> Result<LightningReceivePayment, ServiceError> {
         self.create_lightning_invoice_inner(
             amount_sats,
@@ -270,6 +273,7 @@ impl LightningService {
             expiry_secs,
             false,
             identity_pubkey,
+            spark_invoice,
         )
         .await
     }
@@ -284,6 +288,7 @@ impl LightningService {
         expiry_secs: Option<u32>,
         include_spark_address: bool,
         identity_pubkey: Option<PublicKey>,
+        spark_invoice: Option<String>,
     ) -> Result<LightningReceivePayment, ServiceError> {
         // Validate expiry_secs does not exceed i32::MAX (server limitation)
         if let Some(expiry) = expiry_secs
@@ -333,7 +338,7 @@ impl LightningService {
                 expiry_secs: Some(expiry.into()),
                 memo,
                 include_spark_address,
-                spark_invoice: None,
+                spark_invoice,
             })
             .await?;
         let decoded_invoice = Bolt11Invoice::from_str(&invoice.invoice.encoded_invoice)

--- a/crates/spark/src/utils/lightning.rs
+++ b/crates/spark/src/utils/lightning.rs
@@ -1,0 +1,80 @@
+use bitcoin::bech32::Fe32IterExt as _;
+use lightning_invoice::{Bolt11Invoice, RawTaggedField};
+
+use crate::address::SparkAddress;
+
+const RECEIVER_IDENTITY_PUBLIC_KEY_SHORT_CHANNEL_ID: u64 = 17592187092992000001;
+
+pub fn extract_bolt11_spark_address(
+    decoded_invoice: &Bolt11Invoice,
+) -> Option<(
+    /* address */ SparkAddress,
+    /* address_str */ String,
+)> {
+    let Ok(network) = decoded_invoice.network().try_into() else {
+        return None;
+    };
+    // MRH (legacy) - kept for backwards compatibility
+    for route_hint in decoded_invoice.route_hints() {
+        for node in route_hint.0 {
+            if node.short_channel_id == RECEIVER_IDENTITY_PUBLIC_KEY_SHORT_CHANNEL_ID {
+                let address = SparkAddress::new(node.src_node_id, network, None);
+                let Ok(address_str) = address.to_address_string() else {
+                    return None;
+                };
+                return Some((address, address_str));
+            }
+        }
+    }
+    // Fallback address - extract from version 31
+    let raw_invoice = decoded_invoice.clone().into_signed_raw();
+    for field in &raw_invoice.data.tagged_fields {
+        if let RawTaggedField::UnknownSemantics(data) = field {
+            let field_version = data[3].to_u8();
+            if field_version == 31 {
+                let bytes: Vec<u8> = data[4..].iter().copied().fes_to_bytes().collect();
+                let Ok(spark_address_str) = String::from_utf8(bytes) else {
+                    return None;
+                };
+                return spark_address_str
+                    .parse::<SparkAddress>()
+                    .ok()
+                    .map(|addr| (addr, spark_address_str));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr as _;
+
+    use lightning_invoice::Bolt11Invoice;
+    use macros::test_all;
+
+    use crate::{address::SparkAddress, utils::lightning::extract_bolt11_spark_address};
+
+    #[test_all]
+    fn test_bolt11_fallback_invoice() {
+        let fallback_invoice = Bolt11Invoice::from_str("lnbcrt10u1p57ljcepp5tj54la7l3lw0wn47pmu7m4ynewd9pxzswxxrj37nvhjujhqfz9gqsp5q6ewua5nmkqced2xrkcj7hz2wyxlaya29n3e0vt79fkntf6cv2nsxq9z0rgqnp4qtlyk6hxw5h4hrdfdkd4nh2rv0mwyyqvdtakr3dv6m4vvsmfshvg6rzjqgp0s738klwqef7yr8yu54vv3wfuk4psv46x5laf6l6v5x4lwwahvqqqqrusum7gtyqqqqqqqqqqqqqq9qfv9lwdcxzuntwf6rzur8wdehjct3dsens7t509a8qvmg0p48j7r4d4n8y6rjx5enxwfhwfknq7pn89e85et4x4585a3s8p4hvve48pc8xan6vah8xum3va485ut3v4kn2wfnw3ek2wrhxu68gct4v35rsamkv9h8z6njx4e8zemw0p3kgmf4w9u857n3waknwwf5w9nnxutc0guxwut4v3uhqar4wfmrwdrvxpk8qer98pkn2errwfnxgatdx568wenj0pnrymrvddhxwue5w4mhq7tndpekcdt2xa3hjuntdcekudtpxgc8ydt3vsu8gcfedfekcem2x4eh5vpedenrwvr3dcm8vvr6wumxkufnvvcxkmphxemnvum4wdexgwt68p4qcqzpudq5wdcxzuntd9h8vmmfvdjs9qyyssqkxvng3kw2rze8h774a3gd2nfhx2378t532ryrftjj59s26a6wtr8gc5knn2nl6cm33vv99wnt5202mp2s9n87jy4tkhctyjgflc6ywqqcdwv3x").unwrap();
+        let expected_invoice = SparkAddress::from_str("sparkrt1pgssyaql38ytyzp3hxjyxumfrhr53397rm0x39rzeu5hzv08kv358psvzgnssqgjzqqem593tse8w74taudh8wvanqjr5rqgnxcdm5qxzzqwm794qg3qxz8gqudypturv74l0lpde8m5dcrfdum54wfrxf2llkngs4uwpyshsl5j7cyrkn3n5a20r5qd8ta9jslgj5sz09nf70qn6v0zw6kq3c0kl76w6susrd9z8j").unwrap();
+        assert_eq!(
+            extract_bolt11_spark_address(&fallback_invoice).map(|(spark_address, _)| spark_address),
+            Some(expected_invoice)
+        );
+    }
+
+    #[test_all]
+    fn test_bolt11_fallback_address() {
+        let fallback_invoice = Bolt11Invoice::from_str("lnbcrt10u1p57lj4upp5qxa002jtss48lwgqrzqwhsr5388gv09k4tllfy9hlv78akygcmzssp5hkpfxyy7xrd7qwwc043cfjma9u4z5vasxuyrgqrh6wrvyx6xkevqxq9z0rgqnp4qtlyk6hxw5h4hrdfdkd4nh2rv0mwyyqvdtakr3dv6m4vvsmfshvg6rzjqf6plzwgkgyrrwdygdekj8w8frztu8k7dz2x9nefwyc70vergwrqeapyqr6zgqqqq8hxk2qqae4jsqyugqcqzpudqswfhh2ar9dp5kuarn9qyyssqn9tv97k2a24a45vkt3zvckjt80ph2luwjje5c8ymtf7qr3m4nkaqrqzuc9gzvjufxvvhk2lvzfxerccvtclakmyq43hfyfuwzgkx7hspfh5vzf").unwrap();
+        let expected_address = SparkAddress::from_str(
+            "sparkrt1pgssyaql38ytyzp3hxjyxumfrhr53397rm0x39rzeu5hzv08kv358psvs7ph8y",
+        )
+        .unwrap();
+        assert_eq!(
+            extract_bolt11_spark_address(&fallback_invoice).map(|(spark_address, _)| spark_address),
+            Some(expected_address)
+        );
+    }
+}

--- a/crates/spark/src/utils/mod.rs
+++ b/crates/spark/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub mod byte_padding;
 pub(super) mod frost;
 pub mod htlc_transactions;
 pub(crate) mod leaf_key_tweak;
+pub mod lightning;
 pub mod paging;
 pub(crate) mod preimage_swap;
 pub(crate) mod refund;

--- a/docs/breez-sdk/snippets/csharp/Htlcs.cs
+++ b/docs/breez-sdk/snippets/csharp/Htlcs.cs
@@ -62,7 +62,8 @@ namespace BreezSdkSnippets
                         description: "HODL invoice",
                         amountSats: 50_000UL,
                         expirySecs: null,
-                        paymentHash: paymentHash
+                        paymentHash: paymentHash,
+                        fallback: null
                     )
                 )
             );

--- a/docs/breez-sdk/snippets/csharp/ReceivePayment.cs
+++ b/docs/breez-sdk/snippets/csharp/ReceivePayment.cs
@@ -17,7 +17,8 @@ namespace BreezSdkSnippets
                 description: description,
                 amountSats: optionalAmountSats,
                 expirySecs: optionalExpirySecs,
-                paymentHash: null
+                paymentHash: null,
+                fallback: null
             );
             var request = new ReceivePaymentRequest(paymentMethod: paymentMethod);
             var response = await sdk.ReceivePayment(request: request);

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Htlcs.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Htlcs.kt
@@ -74,7 +74,8 @@ class Htlcs {
                         description = "HODL invoice",
                         amountSats = 50_000u,
                         expirySecs = null,
-                        paymentHash = paymentHash
+                        paymentHash = paymentHash,
+                        fallback = null,
                     )
                 )
             )

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
@@ -14,7 +14,7 @@ class ReceivePayment {
             val optionalExpirySecs = 3600.toUInt()
 
             val request = ReceivePaymentRequest(
-                ReceivePaymentMethod.Bolt11Invoice(description, optionalAmountSats, optionalExpirySecs, null)
+                ReceivePaymentMethod.Bolt11Invoice(description, optionalAmountSats, optionalExpirySecs, null, null)
             )
             val response = sdk.receivePayment(request)
 

--- a/docs/breez-sdk/snippets/python/src/receive_payment.py
+++ b/docs/breez-sdk/snippets/python/src/receive_payment.py
@@ -20,6 +20,7 @@ async def receive_lightning(sdk: BreezSdk):
             amount_sats=optional_amount_sats,
             expiry_secs=optional_expiry_secs,
             payment_hash=None,
+            fallback=None,
         )
         request = ReceivePaymentRequest(payment_method=payment_method)
         response = await sdk.receive_payment(request=request)

--- a/docs/breez-sdk/snippets/react-native/htlcs.ts
+++ b/docs/breez-sdk/snippets/react-native/htlcs.ts
@@ -66,7 +66,8 @@ const exampleReceiveHodlInvoicePayment = async (sdk: BreezSdk) => {
       description: 'HODL invoice',
       amountSats: BigInt(50_000),
       expirySecs: undefined,
-      paymentHash
+      paymentHash,
+      fallback: undefined
     })
   })
 

--- a/docs/breez-sdk/snippets/react-native/receive_payment.ts
+++ b/docs/breez-sdk/snippets/react-native/receive_payment.ts
@@ -16,7 +16,8 @@ const exampleReceiveLightningPayment = async (sdk: BreezSdk) => {
       description,
       amountSats: optionalAmountSats,
       expirySecs: optionalExpirySecs,
-      paymentHash: undefined
+      paymentHash: undefined,
+      fallback: undefined
     })
   })
 

--- a/docs/breez-sdk/snippets/rust/src/htlcs.rs
+++ b/docs/breez-sdk/snippets/rust/src/htlcs.rs
@@ -59,6 +59,7 @@ async fn receive_hodl_invoice_payment(sdk: &BreezSdk) -> Result<()> {
                 amount_sats: Some(50_000),
                 expiry_secs: None,
                 payment_hash: Some(payment_hash),
+                use_mrh: None,
             },
         })
         .await?;

--- a/docs/breez-sdk/snippets/rust/src/htlcs.rs
+++ b/docs/breez-sdk/snippets/rust/src/htlcs.rs
@@ -59,7 +59,7 @@ async fn receive_hodl_invoice_payment(sdk: &BreezSdk) -> Result<()> {
                 amount_sats: Some(50_000),
                 expiry_secs: None,
                 payment_hash: Some(payment_hash),
-                use_mrh: None,
+                fallback: None,
             },
         })
         .await?;

--- a/docs/breez-sdk/snippets/rust/src/receive_payment.rs
+++ b/docs/breez-sdk/snippets/rust/src/receive_payment.rs
@@ -17,7 +17,7 @@ async fn receive_lightning_bolt11(sdk: &BreezSdk) -> Result<()> {
                 amount_sats: optional_amount_sats,
                 expiry_secs: optional_expiry_secs,
                 payment_hash: None,
-                use_mrh: None,
+                fallback: None,
             },
         })
         .await?;

--- a/docs/breez-sdk/snippets/rust/src/receive_payment.rs
+++ b/docs/breez-sdk/snippets/rust/src/receive_payment.rs
@@ -17,6 +17,7 @@ async fn receive_lightning_bolt11(sdk: &BreezSdk) -> Result<()> {
                 amount_sats: optional_amount_sats,
                 expiry_secs: optional_expiry_secs,
                 payment_hash: None,
+                use_mrh: None,
             },
         })
         .await?;

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ReceivePayment.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ReceivePayment.swift
@@ -16,7 +16,8 @@ func receiveLightning(sdk: BreezSdk) async throws -> ReceivePaymentResponse {
                     description: description,
                     amountSats: optionalAmountSats,
                     expirySecs: optionalExpirySecs,
-                    paymentHash: nil
+                    paymentHash: nil,
+                    fallback: nil
                 )
             ))
 

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -392,6 +392,12 @@ pub struct _PrepareSendPaymentResponse {
     pub fee_policy: FeePolicy,
 }
 
+#[frb(mirror(FallbackMethod))]
+pub enum _FallbackMethod {
+    SparkInvoice,
+    SparkAddress,
+}
+
 #[frb(mirror(ReceivePaymentMethod))]
 pub enum _ReceivePaymentMethod {
     SparkAddress,
@@ -410,6 +416,7 @@ pub enum _ReceivePaymentMethod {
         amount_sats: Option<u64>,
         expiry_secs: Option<u32>,
         payment_hash: Option<String>,
+        fallback: Option<FallbackMethod>,
     },
 }
 


### PR DESCRIPTION
This PR adds fallback (previously named MRH) support to BOLT11 invoices.
On the send side, it allows the SDK to detect either MRH (legacy) or fallback addresses/spark invoices embedded in a lightning invoice, allowing the SDK to pay directly via Spark.
On the receive side, it adds a `FallbackMethod` to the receive payment request, such that users may be able to manually request whether to fallback to an address or embed a Spark invoice. It also changes the sync logic so that we're able to pick up on transfers related to the invoice and settle both payments.

## TO-DOs
- [ ] Fix `spark_invoice` not being populated on `query_all_transfers` - currently we're forwarding all the necessary information to the SSP to know this is a fallback payment, yet the field is never populated. We should resolve this internally
- [ ] Add docs