### PR TITLE
Bindings: KMP: Add macos native bindings

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -51,6 +51,15 @@ jobs:
             gradle: true
             konan: true
             sdk-target: true
+          # SDK macOS Kotlin/Native compile smoke-test — gobley native source +
+          # `.def`/cinterop bindings + Kotlin/Native compiler for macosArm64
+          # and macosX64 targets.
+          - lang: kotlin-multiplatform-macos
+            runner: macos-latest
+            java-version: "17"
+            gradle: true
+            konan: true
+            sdk-target: true
           - lang: python
             runner: ubuntu-latest
           - lang: react-native
@@ -128,7 +137,7 @@ jobs:
           key: gobley-uniffi-bindgen-${{ env.GOBLEY_REF }}-${{ runner.os }}
 
       - name: Generate KMP bindings (host)
-        if: matrix.lang == 'kotlin-multiplatform-ios'
+        if: matrix.lang == 'kotlin-multiplatform-ios' || matrix.lang == 'kotlin-multiplatform-macos'
         working-directory: crates/breez-sdk/bindings
         run: make build-kotlin-multiplatform-bindgen-host
 
@@ -136,6 +145,11 @@ jobs:
         if: matrix.lang == 'kotlin-multiplatform-ios'
         working-directory: crates/breez-sdk/bindings/langs/kotlin-multiplatform
         run: ./gradlew :breez-sdk-spark-kmp:compileKotlinIosArm64 :breez-sdk-spark-kmp:compileKotlinIosX64 :breez-sdk-spark-kmp:compileKotlinIosSimulatorArm64
+
+      - name: Compile macOS Kotlin/Native targets
+        if: matrix.lang == 'kotlin-multiplatform-macos'
+        working-directory: crates/breez-sdk/bindings/langs/kotlin-multiplatform
+        run: ./gradlew :breez-sdk-spark-kmp:compileKotlinMacosArm64 :breez-sdk-spark-kmp:compileKotlinMacosX64
 
       - name: Generate KMP bindings (Android arm64)
         if: matrix.lang == 'kotlin-multiplatform-android'

--- a/.github/workflows/publish-kotlin-multiplatform.yml
+++ b/.github/workflows/publish-kotlin-multiplatform.yml
@@ -78,6 +78,12 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
+      - name: Cache Konan toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-1.9.21-${{ runner.os }}
+
       - name: Download Android JNI libs
         uses: actions/download-artifact@v4
         with:

--- a/crates/breez-sdk/bindings/langs/kotlin-multiplatform/breez-sdk-spark-kmp-plugin/src/main/kotlin/technology/breez/spark/BreezSdkSparkPlugin.kt
+++ b/crates/breez-sdk/bindings/langs/kotlin-multiplatform/breez-sdk-spark-kmp-plugin/src/main/kotlin/technology/breez/spark/BreezSdkSparkPlugin.kt
@@ -56,11 +56,15 @@ class BreezSdkSparkPlugin : Plugin<Project> {
             }
 
             if (searchPaths.isEmpty()) {
-                // xcframework slice based on target platform
+                // xcframework slice based on target platform.
                 // The simulator slice is a universal binary (arm64 + x86_64), so both
                 // iosSimulatorArm64 and iosX64 targets are covered by the same slice.
-                val slice = if (platformName == "iphonesimulator")
-                    "ios-arm64_x86_64-simulator" else "ios-arm64"
+                // The macOS slice is also a universal binary (arm64 + x86_64).
+                val slice = when (platformName) {
+                    "iphonesimulator" -> "ios-arm64_x86_64-simulator"
+                    "macosx" -> "macos-arm64_x86_64"
+                    else -> "ios-arm64"
+                }
 
                 // SPM artifacts path
                 val derivedDataRoot = buildDir.substringBefore("/Build/")

--- a/crates/breez-sdk/bindings/langs/kotlin-multiplatform/breez-sdk-spark-kmp/build.gradle.kts
+++ b/crates/breez-sdk/bindings/langs/kotlin-multiplatform/breez-sdk-spark-kmp/build.gradle.kts
@@ -6,10 +6,11 @@ plugins {
 
 apply(plugin = "kotlinx-atomicfu")
 
-// Skip iOS Kotlin/Native targets when explicitly requested. Used by the
-// docs-snippets CI job, which only needs the JVM publication. The cli-ci
-// `kotlin-multiplatform-ios` job and the release pipeline still build
-// every iOS target.
+// Skip Apple Kotlin/Native targets (iOS + macOS) when explicitly requested.
+// Used by the docs-snippets CI job, which only needs the JVM publication, and
+// by the Android AAR smoke-test which runs on Ubuntu without a Konan macOS
+// toolchain. The cli-ci `kotlin-multiplatform-ios`, `kotlin-multiplatform-macos`
+// jobs and the release pipeline still build every Apple target.
 val skipIosTargets = project.hasProperty("skipIosTargets")
 
 kotlin {
@@ -36,7 +37,9 @@ kotlin {
         listOf(
             iosX64(),
             iosArm64(),
-            iosSimulatorArm64()
+            iosSimulatorArm64(),
+            macosArm64(),
+            macosX64(),
         ).forEach {
             it.compilations["main"].cinterops {
                 create("breezSdkSparkCInterop") {

--- a/docs/breez-sdk/src/guide/install_kotlin_multiplatform.md
+++ b/docs/breez-sdk/src/guide/install_kotlin_multiplatform.md
@@ -36,13 +36,6 @@ kotlin {
 
 Install the native binary framework via [Swift Package Manager](#swift-package-manager). The Gradle plugin automatically configures the framework search path from Xcode's build environment.
 
-<div class="warning">
-<h4>Developer note</h4>
-
-`breez-sdk-spark-kmp` Gradle dependency and the Swift package **MUST** have the same version. A version mismatch between the two will cause linking or runtime errors.
-
-</div>
-
 Add the Gradle plugin to your module's `build.gradle.kts` and update the iOS framework binaries to use a dynamic framework:
 
 ```gradle
@@ -64,9 +57,38 @@ kotlin {
 }
 ```
 
-#### Swift Package Manager
+### macOS
 
-##### Installation via Xcode
+Similarly to [iOS](#ios):
+
+```gradle
+plugins {
+    id("technology.breez.spark.kmp") version "{VERSION}"
+}
+
+kotlin {
+    listOf(
+        macosArm64(),
+        macosX64(),
+    ).forEach {
+        it.binaries.framework {
+            baseName = "shared"
+            isStatic = false
+        }
+    }
+}
+```
+
+### Swift Package Manager
+
+<div class="warning">
+<h4>Developer note</h4>
+
+`breez-sdk-spark-kmp` Gradle dependency and the Swift package **MUST** have the same version. A version mismatch between the two will cause linking or runtime errors.
+
+</div>
+
+#### Installation via Xcode
 
 Via `File > Add Packages...`, add
 
@@ -76,7 +98,7 @@ https://github.com/breez/breez-sdk-spark-swift.git
 
 as a package dependency in Xcode.
 
-##### Installation via Swift Package Manifest
+#### Installation via Swift Package Manifest
 
 Add the following to the dependencies array of your `Package.swift`:
 


### PR DESCRIPTION
This PR:
- Adds macOS x86/arm64 targets to the KMP bindings
- Improves kmp publish workflow by adding build cache
- Adds docs for setup (very similar to iOS)

Tested on macOS Sequoia 15.7 arm64