### PR TITLE
Fix Spark integration tests

### DIFF
--- a/crates/spark-itest/docker/migrations.dockerfile
+++ b/crates/spark-itest/docker/migrations.dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=39ecc67c0541b3c94a365e195722c30a9129600c
+ARG VERSION=e8ceff40979d27c1c19e31899901b7b47bd591bc
 ARG REPOSITORY=https://github.com/buildonspark/spark.git
 
 FROM debian:bookworm-20250721-slim AS downloader

--- a/crates/spark-itest/docker/spark-so.dockerfile
+++ b/crates/spark-itest/docker/spark-so.dockerfile
@@ -1,6 +1,6 @@
 # $USER name to be used in the `final` image
 ARG USER=so
-ARG VERSION=39ecc67c0541b3c94a365e195722c30a9129600c
+ARG VERSION=e8ceff40979d27c1c19e31899901b7b47bd591bc
 ARG REPOSITORY=https://github.com/buildonspark/spark.git
 
 FROM debian:bookworm-20250721-slim AS downloader

--- a/crates/spark/src/services/coop_exit.rs
+++ b/crates/spark/src/services/coop_exit.rs
@@ -398,7 +398,7 @@ impl CoopExitService {
                     cpfp_sequence: refund_tx_constructor.cpfp_sequence,
                     direct_sequence: refund_tx_constructor.direct_sequence,
                     node_tx: &refund_tx_constructor.node.node_tx,
-                    direct_tx: refund_tx_constructor.node.direct_tx.as_ref(),
+                    direct_tx: refund_tx_constructor.node.direct_refund_tx(),
                     connector_outpoint: OutPoint {
                         txid: connector_txid,
                         vout: refund_tx_constructor.vout,

--- a/crates/spark/src/tree/mod.rs
+++ b/crates/spark/src/tree/mod.rs
@@ -205,6 +205,16 @@ impl TreeNode {
         let sequence_num = self.node_sequence().to_consensus_u32() as u16;
         sequence_num == 0
     }
+
+    pub fn direct_refund_tx(&self) -> Option<&Transaction> {
+        // Zero-timelock nodes must not have a direct refund tx (SO enforces this).
+        // During renew_zero_timelock, the direct refund tx is intentionally omitted,
+        // so we must also omit it during transfers to avoid server rejection.
+        match self.is_zero_timelock() {
+            true => None,
+            false => self.direct_tx.as_ref(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -116,7 +116,7 @@ pub async fn sign_refunds(
 
     for (i, leaf) in leaves.iter().enumerate() {
         let node_tx = &leaf.node.node_tx;
-        let direct_tx = leaf.node.direct_tx.as_ref();
+        let direct_tx = leaf.node.direct_refund_tx();
 
         let old_sequence = leaf
             .node
@@ -491,7 +491,7 @@ pub fn prepare_refund_so_signing_jobs(
             } = refund_tx_constructor;
             create_refund_txs(
                 &node.node_tx,
-                node.direct_tx.as_ref(),
+                node.direct_refund_tx(),
                 cpfp_sequence,
                 direct_sequence,
                 receiving_pubkey,


### PR DESCRIPTION
Bumps spark git ref in Dockerfile to `39ecc67c0541b3c94a365e195722c30a9129600c`, which updated to frost 3.0