### PR TITLE
Allow unsigned Spark invoices in address parsing

### DIFF
--- a/crates/spark/src/address/mod.rs
+++ b/crates/spark/src/address/mod.rs
@@ -476,13 +476,10 @@ impl FromStr for SparkAddress {
 
         let address = SparkAddress::new(identity_public_key, network, invoice_fields);
 
-        if address.is_invoice() {
+        if address.is_invoice()
+            && let Some(sig) = signature
+        {
             let hash = address.compute_invoice_hash()?;
-
-            let Some(sig) = signature else {
-                return Err(AddressError::Other("Invoice has no signature".to_string()));
-            };
-
             let secp = Secp256k1::new();
             if secp
                 .verify_schnorr(


### PR DESCRIPTION
## Summary
- Allow parsing Spark invoices without a signature, matching the behavior of Spark Signing Operators which treat signatures as optional
- When a signature is present, it is still verified as before
- This enables server-side invoice generation (e.g. on behalf of a customer) where the server has the customer's public key but not their signing key

## Context
The Spark SO `validateInvoiceFields` function only verifies signatures when present:
```go
if decoded.SparkAddress.Signature != nil {
    err := common.VerifySparkAddressSignature(...)
}
```

The SDK should follow the same contract. Without this fix, `prepare_send_payment` rejects unsigned invoices with `InvalidInput: 'invalid input'`.