### PR TITLE
Expose query_spark_invoices via SDK public API

### DIFF
--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1841,3 +1841,93 @@ pub struct UnregisterWebhookRequest {
     /// The unique identifier of the webhook to unregister.
     pub webhook_id: String,
 }
+
+/// Request for querying the status of Spark invoices.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct QuerySparkInvoicesRequest {
+    /// The list of Spark invoices to query.
+    pub invoices: Vec<String>,
+}
+
+/// Result of querying a single Spark invoice.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct QuerySparkInvoiceResult {
+    /// The queried invoice string.
+    pub invoice: String,
+    /// The status of the invoice on the Spark operator.
+    pub status: SparkInvoiceStatus,
+    /// Details of the underlying transfer when the invoice has been finalized.
+    pub transfer_type: Option<SparkInvoiceTransferType>,
+}
+
+/// Status of a queried Spark invoice as reported by the Spark operator.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum SparkInvoiceStatus {
+    /// The operator has no record of this invoice.
+    NotFound,
+    /// The invoice has been created but not yet fulfilled.
+    Pending,
+    /// The invoice has been fulfilled.
+    Finalized,
+    /// The invoice was returned (cancelled or refunded).
+    Returned,
+}
+
+/// Details of the transfer that fulfilled a finalized Spark invoice.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum SparkInvoiceTransferType {
+    /// A sats transfer fulfilled the invoice. `transfer_id` is the Spark transfer identifier.
+    Transfer { transfer_id: String },
+    /// A token transfer fulfilled the invoice. `final_token_tx_hash` is the hex-encoded
+    /// final token transaction hash.
+    TokenTransfer { final_token_tx_hash: String },
+}
+
+/// Response from querying Spark invoices.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct QuerySparkInvoicesResponse {
+    pub results: Vec<QuerySparkInvoiceResult>,
+}
+
+impl From<spark_wallet::QuerySparkInvoiceResult> for QuerySparkInvoiceResult {
+    fn from(value: spark_wallet::QuerySparkInvoiceResult) -> Self {
+        Self {
+            invoice: value.invoice,
+            status: value.status.into(),
+            transfer_type: value.transfer_type.map(Into::into),
+        }
+    }
+}
+
+impl From<spark_wallet::SparkInvoiceStatus> for SparkInvoiceStatus {
+    fn from(value: spark_wallet::SparkInvoiceStatus) -> Self {
+        match value {
+            spark_wallet::SparkInvoiceStatus::NotFound => SparkInvoiceStatus::NotFound,
+            spark_wallet::SparkInvoiceStatus::Pending => SparkInvoiceStatus::Pending,
+            spark_wallet::SparkInvoiceStatus::Finalized => SparkInvoiceStatus::Finalized,
+            spark_wallet::SparkInvoiceStatus::Returned => SparkInvoiceStatus::Returned,
+        }
+    }
+}
+
+impl From<spark_wallet::SparkInvoiceTransferType> for SparkInvoiceTransferType {
+    fn from(value: spark_wallet::SparkInvoiceTransferType) -> Self {
+        match value {
+            spark_wallet::SparkInvoiceTransferType::Transfer { transfer_id } => {
+                SparkInvoiceTransferType::Transfer {
+                    transfer_id: transfer_id.to_string(),
+                }
+            }
+            spark_wallet::SparkInvoiceTransferType::TokenTransfer {
+                final_token_tx_hash,
+            } => SparkInvoiceTransferType::TokenTransfer {
+                final_token_tx_hash,
+            },
+        }
+    }
+}

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -11,9 +11,9 @@ use crate::{
     BitcoinAddressDetails, Bolt11InvoiceDetails, ClaimHtlcPaymentRequest, ClaimHtlcPaymentResponse,
     ConversionEstimate, ConversionOptions, ConversionPurpose, ConversionType, FeePolicy,
     FetchConversionLimitsRequest, FetchConversionLimitsResponse, GetPaymentRequest,
-    GetPaymentResponse, InputType, OnchainConfirmationSpeed, PaymentStatus, SendOnchainFeeQuote,
-    SendPaymentMethod, SendPaymentOptions, SparkHtlcOptions, SparkInvoiceDetails,
-    WaitForPaymentIdentifier,
+    GetPaymentResponse, InputType, OnchainConfirmationSpeed, PaymentStatus,
+    QuerySparkInvoicesRequest, QuerySparkInvoicesResponse, SendOnchainFeeQuote, SendPaymentMethod,
+    SendPaymentOptions, SparkHtlcOptions, SparkInvoiceDetails, WaitForPaymentIdentifier,
     error::SdkError,
     events::SdkEvent,
     models::{
@@ -484,6 +484,25 @@ impl BreezSdk {
             get_payment_with_conversion_details(request.payment_id, self.storage.clone()).await?;
 
         Ok(GetPaymentResponse { payment })
+    }
+
+    /// Queries the Spark operator for the status of one or more Spark invoices.
+    ///
+    /// Returns one result per input invoice, reporting whether it is `NotFound`,
+    /// `Pending`, `Finalized` (paid), or `Returned`, along with the underlying
+    /// transfer details once finalized.
+    pub async fn query_spark_invoices(
+        &self,
+        request: QuerySparkInvoicesRequest,
+    ) -> Result<QuerySparkInvoicesResponse, SdkError> {
+        let results = self
+            .spark_wallet
+            .query_spark_invoices(request.invoices)
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        Ok(QuerySparkInvoicesResponse { results })
     }
 }
 

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -1439,3 +1439,34 @@ pub struct RegisterWebhookResponse {
 pub struct UnregisterWebhookRequest {
     pub webhook_id: String,
 }
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::QuerySparkInvoicesRequest)]
+pub struct QuerySparkInvoicesRequest {
+    pub invoices: Vec<String>,
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::QuerySparkInvoicesResponse)]
+pub struct QuerySparkInvoicesResponse {
+    pub results: Vec<QuerySparkInvoiceResult>,
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::QuerySparkInvoiceResult)]
+pub struct QuerySparkInvoiceResult {
+    pub invoice: String,
+    pub status: SparkInvoiceStatus,
+    pub transfer_type: Option<SparkInvoiceTransferType>,
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::SparkInvoiceStatus)]
+pub enum SparkInvoiceStatus {
+    NotFound,
+    Pending,
+    Finalized,
+    Returned,
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::SparkInvoiceTransferType)]
+pub enum SparkInvoiceTransferType {
+    Transfer { transfer_id: String },
+    TokenTransfer { final_token_tx_hash: String },
+}

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -193,6 +193,14 @@ impl BreezSdk {
         Ok(self.sdk.get_payment(request.into()).await?.into())
     }
 
+    #[wasm_bindgen(js_name = "querySparkInvoices")]
+    pub async fn query_spark_invoices(
+        &self,
+        request: QuerySparkInvoicesRequest,
+    ) -> WasmResult<QuerySparkInvoicesResponse> {
+        Ok(self.sdk.query_spark_invoices(request.into()).await?.into())
+    }
+
     #[wasm_bindgen(js_name = "claimDeposit")]
     pub async fn claim_deposit(
         &self,

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1279,6 +1279,37 @@ pub struct _UnregisterWebhookRequest {
     pub webhook_id: String,
 }
 
+#[frb(mirror(QuerySparkInvoicesRequest))]
+pub struct _QuerySparkInvoicesRequest {
+    pub invoices: Vec<String>,
+}
+
+#[frb(mirror(QuerySparkInvoicesResponse))]
+pub struct _QuerySparkInvoicesResponse {
+    pub results: Vec<QuerySparkInvoiceResult>,
+}
+
+#[frb(mirror(QuerySparkInvoiceResult))]
+pub struct _QuerySparkInvoiceResult {
+    pub invoice: String,
+    pub status: SparkInvoiceStatus,
+    pub transfer_type: Option<SparkInvoiceTransferType>,
+}
+
+#[frb(mirror(SparkInvoiceStatus))]
+pub enum _SparkInvoiceStatus {
+    NotFound,
+    Pending,
+    Finalized,
+    Returned,
+}
+
+#[frb(mirror(SparkInvoiceTransferType))]
+pub enum _SparkInvoiceTransferType {
+    Transfer { transfer_id: String },
+    TokenTransfer { final_token_tx_hash: String },
+}
+
 #[frb(mirror(NostrRelayConfig))]
 pub struct _NostrRelayConfig {
     pub breez_api_key: Option<String>,

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -134,6 +134,13 @@ impl BreezSdk {
         self.inner.get_payment(request).await
     }
 
+    pub async fn query_spark_invoices(
+        &self,
+        request: QuerySparkInvoicesRequest,
+    ) -> Result<QuerySparkInvoicesResponse, SdkError> {
+        self.inner.query_spark_invoices(request).await
+    }
+
     pub async fn claim_deposit(
         &self,
         request: ClaimDepositRequest,


### PR DESCRIPTION
## Summary
- Wraps `SparkWallet::query_spark_invoices` in a new `BreezSdk::query_spark_invoices` method so language bindings can query the Spark operator for invoice status (`NotFound` / `Pending` / `Finalized` / `Returned`) and, when finalized, the underlying transfer details.
- Adds `QuerySparkInvoicesRequest/Response`, `QuerySparkInvoiceResult`, `SparkInvoiceStatus`, `SparkInvoiceTransferType` to the core models with `uniffi::Record`/`Enum` derives, and mirrors them in the WASM and Flutter interfaces per `CLAUDE.md`.
- Used for direct polling of Spark Invoices from the SO