### PR TITLE
Multi-tenant storage and tree/token stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,6 +5014,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "spark-postgres",
  "spark-wallet",
  "testcontainers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5004,6 +5004,7 @@ name = "spark-postgres"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bitcoin",
  "chrono",
  "deadpool",
  "deadpool-postgres",
@@ -5014,7 +5015,6 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "spark-postgres",
  "spark-wallet",
  "testcontainers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4983,7 +4983,9 @@ name = "spark-mysql"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bitcoin",
  "chrono",
+ "hex",
  "macros",
  "mysql_async",
  "platform-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5007,6 +5007,7 @@ dependencies = [
  "chrono",
  "deadpool",
  "deadpool-postgres",
+ "hex",
  "macros",
  "platform-utils",
  "rcgen",

--- a/crates/breez-sdk/core/src/persist/mysql/base.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/base.rs
@@ -111,7 +111,7 @@ pub(crate) fn create_pool(config: &MysqlStorageConfig) -> Result<mysql_async::Po
 pub(super) async fn run_migrations(
     pool: &mysql_async::Pool,
     migrations_table: &str,
-    migrations: &[&[Migration]],
+    migrations: &[Vec<Migration>],
 ) -> Result<(), StorageError> {
     spark_mysql::run_migrations(pool, migrations_table, migrations)
         .await
@@ -123,8 +123,9 @@ pub(super) async fn run_migrations(
 /// Creates a `MysqlTreeStore` instance for use with the SDK, using an existing pool.
 pub(crate) async fn create_mysql_tree_store(
     pool: mysql_async::Pool,
+    identity: &[u8],
 ) -> Result<Arc<dyn TreeStore>, StorageError> {
-    spark_mysql::create_mysql_tree_store_from_pool(pool)
+    spark_mysql::create_mysql_tree_store_from_pool(pool, identity)
         .await
         .map_err(StorageError::from)
 }
@@ -132,8 +133,9 @@ pub(crate) async fn create_mysql_tree_store(
 /// Creates a `MysqlTokenStore` instance for use with the SDK, using an existing pool.
 pub(crate) async fn create_mysql_token_store(
     pool: mysql_async::Pool,
+    identity: &[u8],
 ) -> Result<Arc<dyn TokenOutputStore>, StorageError> {
-    spark_mysql::create_mysql_token_store_from_pool(pool)
+    spark_mysql::create_mysql_token_store_from_pool(pool, identity)
         .await
         .map_err(StorageError::from)
 }

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -33,33 +33,51 @@ use super::base::{MysqlStorageConfig, create_pool};
 const MIGRATIONS_TABLE: &str = "schema_migrations";
 
 /// `MySQL`-based storage implementation using `mysql_async`'s connection pool.
+///
+/// Each instance is scoped to a single tenant identity (a 33-byte secp256k1
+/// compressed public key). All reads and writes are filtered by `user_id` so
+/// that multiple instances with distinct identities can share one `MySQL` DB
+/// without seeing each other's data.
 pub(crate) struct MysqlStorage {
     pool: Pool,
+    /// Tenant identity: 33-byte compressed secp256k1 pubkey. Stored as raw
+    /// bytes for direct binding to VARBINARY columns.
+    identity: Vec<u8>,
 }
 
 impl MysqlStorage {
     #[cfg(test)]
-    pub async fn new(config: MysqlStorageConfig) -> Result<Self, StorageError> {
+    pub async fn new(config: MysqlStorageConfig, identity: &[u8]) -> Result<Self, StorageError> {
         let pool = create_pool(&config)?;
-        Self::new_with_pool(pool).await
+        Self::new_with_pool(pool, identity).await
     }
 
-    pub async fn new_with_pool(pool: Pool) -> Result<Self, StorageError> {
-        let storage = Self { pool };
+    /// Creates a new `MysqlStorage` using an existing connection pool. Each
+    /// `MysqlStorage` is scoped to a single tenant `identity`.
+    pub async fn new_with_pool(pool: Pool, identity: &[u8]) -> Result<Self, StorageError> {
+        let storage = Self {
+            pool,
+            identity: identity.to_vec(),
+        };
         storage.migrate().await?;
         Ok(storage)
     }
 
     async fn migrate(&self) -> Result<(), StorageError> {
-        run_migrations(&self.pool, MIGRATIONS_TABLE, &Self::migrations()).await
+        run_migrations(
+            &self.pool,
+            MIGRATIONS_TABLE,
+            &Self::migrations(&self.identity),
+        )
+        .await
     }
 
     #[allow(clippy::too_many_lines)]
-    pub(crate) fn migrations() -> Vec<&'static [Migration]> {
+    pub(crate) fn migrations(identity: &[u8]) -> Vec<Vec<Migration>> {
         vec![
             // Migration 1: Core tables
-            &[
-                Migration::Sql(
+            vec![
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS payments (
                         id VARCHAR(255) NOT NULL PRIMARY KEY,
                         payment_type VARCHAR(64) NOT NULL,
@@ -73,13 +91,13 @@ impl MysqlStorage {
                         spark TINYINT(1) NULL
                     )",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS settings (
                         `key` VARCHAR(255) NOT NULL PRIMARY KEY,
                         value LONGTEXT NOT NULL
                     )",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS unclaimed_deposits (
                         txid VARCHAR(255) NOT NULL,
                         vout INT NOT NULL,
@@ -90,7 +108,7 @@ impl MysqlStorage {
                         PRIMARY KEY (txid, vout)
                     )",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS payment_metadata (
                         payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
                         parent_payment_id VARCHAR(255) NULL,
@@ -100,7 +118,7 @@ impl MysqlStorage {
                         conversion_info JSON NULL
                     )",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS payment_details_lightning (
                         payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
                         invoice LONGTEXT NOT NULL,
@@ -110,7 +128,7 @@ impl MysqlStorage {
                         preimage VARCHAR(255) NULL
                     )",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS payment_details_token (
                         payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
                         metadata JSON NOT NULL,
@@ -118,14 +136,14 @@ impl MysqlStorage {
                         invoice_details JSON NULL
                     )",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS payment_details_spark (
                         payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
                         invoice_details JSON NULL,
                         htlc_details JSON NULL
                     )",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS lnurl_receive_metadata (
                         payment_hash VARCHAR(255) NOT NULL PRIMARY KEY,
                         nostr_zap_request LONGTEXT NULL,
@@ -135,19 +153,19 @@ impl MysqlStorage {
                 ),
             ],
             // Migration 2: Sync tables
-            &[
-                Migration::Sql(
+            vec![
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS sync_revision (
                         id INT NOT NULL PRIMARY KEY DEFAULT 1,
                         revision BIGINT NOT NULL DEFAULT 0,
                         CHECK (id = 1)
                     )",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "INSERT INTO sync_revision (id, revision) VALUES (1, 0)
                      ON DUPLICATE KEY UPDATE id = id",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS sync_outgoing (
                         record_type VARCHAR(255) NOT NULL,
                         data_id VARCHAR(255) NOT NULL,
@@ -162,7 +180,7 @@ impl MysqlStorage {
                     table: "sync_outgoing",
                     columns: "(record_type, data_id)",
                 },
-                Migration::Sql(
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS sync_state (
                         record_type VARCHAR(255) NOT NULL,
                         data_id VARCHAR(255) NOT NULL,
@@ -173,7 +191,7 @@ impl MysqlStorage {
                         PRIMARY KEY(record_type, data_id)
                     )",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS sync_incoming (
                         record_type VARCHAR(255) NOT NULL,
                         data_id VARCHAR(255) NOT NULL,
@@ -191,7 +209,7 @@ impl MysqlStorage {
                 },
             ],
             // Migration 3: Indexes
-            &[
+            vec![
                 Migration::CreateIndex {
                     name: "idx_payments_timestamp",
                     table: "payments",
@@ -219,21 +237,21 @@ impl MysqlStorage {
                 },
             ],
             // Migration 4: Add tx_type to token payments
-            &[Migration::AddColumn {
+            vec![Migration::AddColumn {
                 table: "payment_details_token",
                 column: "tx_type",
                 definition: "VARCHAR(64) NOT NULL DEFAULT 'transfer'",
             }],
             // Migration 5: Clear sync tables to force re-sync
-            &[
-                Migration::Sql("DELETE FROM sync_outgoing"),
-                Migration::Sql("DELETE FROM sync_incoming"),
-                Migration::Sql("DELETE FROM sync_state"),
-                Migration::Sql("UPDATE sync_revision SET revision = 0"),
-                Migration::Sql("DELETE FROM settings WHERE `key` = 'sync_initial_complete'"),
+            vec![
+                Migration::sql("DELETE FROM sync_outgoing"),
+                Migration::sql("DELETE FROM sync_incoming"),
+                Migration::sql("DELETE FROM sync_state"),
+                Migration::sql("UPDATE sync_revision SET revision = 0"),
+                Migration::sql("DELETE FROM settings WHERE `key` = 'sync_initial_complete'"),
             ],
             // Migration 6: Add htlc_status and htlc_expiry_time to lightning payments
-            &[
+            vec![
                 Migration::AddColumn {
                     table: "payment_details_lightning",
                     column: "htlc_status",
@@ -246,8 +264,8 @@ impl MysqlStorage {
                 },
             ],
             // Migration 7: Backfill htlc_status for existing Lightning payments
-            &[
-                Migration::Sql(
+            vec![
+                Migration::sql(
                     "UPDATE payment_details_lightning
                      SET htlc_status = CASE
                              WHEN (SELECT status FROM payments WHERE id = payment_id) = 'completed' THEN 'PreimageShared'
@@ -255,33 +273,33 @@ impl MysqlStorage {
                              ELSE 'Returned'
                          END",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "UPDATE settings
                      SET value = JSON_SET(value, '$.offset', 0)
                      WHERE `key` = 'sync_offset' AND value IS NOT NULL",
                 ),
             ],
             // Migration 8: lnurl_receive_metadata preimage column (added then later dropped)
-            &[
+            vec![
                 Migration::AddColumn {
                     table: "lnurl_receive_metadata",
                     column: "preimage",
                     definition: "VARCHAR(255) NULL",
                 },
-                Migration::Sql("DELETE FROM settings WHERE `key` = 'lnurl_metadata_updated_after'"),
+                Migration::sql("DELETE FROM settings WHERE `key` = 'lnurl_metadata_updated_after'"),
             ],
             // Migration 9: Clear cached lightning address (schema changed)
-            &[Migration::Sql(
+            vec![Migration::sql(
                 "DELETE FROM settings WHERE `key` = 'lightning_address'",
             )],
             // Migration 10: Index on payment_hash for JOIN with lnurl_receive_metadata
-            &[Migration::CreateIndex {
+            vec![Migration::CreateIndex {
                 name: "idx_payment_details_lightning_payment_hash",
                 table: "payment_details_lightning",
                 columns: "(payment_hash)",
             }],
             // Migration 11: Contacts table
-            &[Migration::Sql(
+            vec![Migration::sql(
                 "CREATE TABLE IF NOT EXISTS contacts (
                         id VARCHAR(255) NOT NULL PRIMARY KEY,
                         name VARCHAR(255) NOT NULL,
@@ -291,28 +309,207 @@ impl MysqlStorage {
                     )",
             )],
             // Migration 12: Drop preimage column from lnurl_receive_metadata
-            &[Migration::DropColumn {
+            vec![Migration::DropColumn {
                 table: "lnurl_receive_metadata",
                 column: "preimage",
             }],
             // Migration 13: Clear cached lightning address again (format changed)
-            &[Migration::Sql(
+            vec![Migration::sql(
                 "DELETE FROM settings WHERE `key` = 'lightning_address'",
             )],
             // Migration 14: Add is_mature to unclaimed_deposits
-            &[Migration::AddColumn {
+            vec![Migration::AddColumn {
                 table: "unclaimed_deposits",
                 column: "is_mature",
                 definition: "TINYINT(1) NOT NULL DEFAULT 1",
             }],
             // Migration 15: Add conversion_status to payment_metadata
-            &[Migration::AddColumn {
+            vec![Migration::AddColumn {
                 table: "payment_metadata",
                 column: "conversion_status",
                 definition: "VARCHAR(64) NULL",
             }],
+            // Migration 16: Multi-tenant scoping. Adds `user_id VARBINARY(33)`
+            // to every per-user table, backfills it to the current tenant's
+            // identity (so existing single-tenant deployments remain readable),
+            // sets NOT NULL, and rewrites primary keys / indexes to lead with
+            // `user_id`. The literal hex of `identity` is inlined into the SQL
+            // backfill: identity bytes come from a typed secp256k1 pubkey so
+            // the character set is restricted to `[0-9a-f]{66}` — no
+            // SQL-injection surface even though the value is concatenated
+            // rather than parameter-bound.
+            multi_tenant_migration(identity),
         ]
     }
+}
+
+/// Builds the multi-tenant scoping migration. The `identity` is a 33-byte
+/// compressed secp256k1 pubkey; it's hex-encoded and inlined as an `UNHEX(...)`
+/// literal so each statement is parameter-free SQL.
+#[allow(clippy::too_many_lines)]
+fn multi_tenant_migration(identity: &[u8]) -> Vec<Migration> {
+    let id_hex = hex::encode(identity);
+    // Inline the identity as `UNHEX('...')` — `MySQL` accepts a hex string
+    // literal in a binary context, but `UNHEX` is more explicit and works
+    // anywhere a `VARBINARY` is expected.
+    let id_lit = format!("UNHEX('{id_hex}')");
+
+    let mut stmts: Vec<Migration> = Vec::new();
+
+    let scope_table = |table: &'static str, pk_cols: &str, stmts: &mut Vec<Migration>| {
+        stmts.push(Migration::AddColumn {
+            // We backfill in a follow-up UPDATE because `MySQL` cannot run
+            // `ADD COLUMN ... NOT NULL` without a default for non-empty tables
+            // unless we provide a default. The column is added nullable, then
+            // populated, then made NOT NULL.
+            table,
+            column: "user_id",
+            definition: "VARBINARY(33) NULL",
+        });
+        stmts.push(Migration::Sql(format!(
+            "UPDATE `{table}` SET user_id = {id_lit} WHERE user_id IS NULL"
+        )));
+        stmts.push(Migration::Sql(format!(
+            "ALTER TABLE `{table}` MODIFY COLUMN user_id VARBINARY(33) NOT NULL"
+        )));
+        stmts.push(Migration::Sql(format!(
+            "ALTER TABLE `{table}` DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, {pk_cols})"
+        )));
+    };
+
+    scope_table("payments", "id", &mut stmts);
+    stmts.push(Migration::DropIndex {
+        name: "idx_payments_timestamp",
+        table: "payments",
+    });
+    stmts.push(Migration::DropIndex {
+        name: "idx_payments_payment_type",
+        table: "payments",
+    });
+    stmts.push(Migration::DropIndex {
+        name: "idx_payments_status",
+        table: "payments",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_payments_user_timestamp",
+        table: "payments",
+        columns: "(user_id, timestamp)",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_payments_user_payment_type",
+        table: "payments",
+        columns: "(user_id, payment_type)",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_payments_user_status",
+        table: "payments",
+        columns: "(user_id, status)",
+    });
+
+    scope_table("payment_metadata", "payment_id", &mut stmts);
+    stmts.push(Migration::DropIndex {
+        name: "idx_payment_metadata_parent",
+        table: "payment_metadata",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_payment_metadata_user_parent",
+        table: "payment_metadata",
+        columns: "(user_id, parent_payment_id)",
+    });
+
+    scope_table("payment_details_lightning", "payment_id", &mut stmts);
+    stmts.push(Migration::DropIndex {
+        name: "idx_payment_details_lightning_invoice",
+        table: "payment_details_lightning",
+    });
+    stmts.push(Migration::DropIndex {
+        name: "idx_payment_details_lightning_payment_hash",
+        table: "payment_details_lightning",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_payment_details_lightning_user_invoice",
+        table: "payment_details_lightning",
+        columns: "(user_id, invoice(255))",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_payment_details_lightning_user_payment_hash",
+        table: "payment_details_lightning",
+        columns: "(user_id, payment_hash)",
+    });
+
+    scope_table("payment_details_token", "payment_id", &mut stmts);
+    scope_table("payment_details_spark", "payment_id", &mut stmts);
+    scope_table("lnurl_receive_metadata", "payment_hash", &mut stmts);
+    scope_table("unclaimed_deposits", "txid, vout", &mut stmts);
+    scope_table("contacts", "id", &mut stmts);
+    scope_table("settings", "`key`", &mut stmts);
+
+    // sync_revision was a single-row table (PK id=1, CHECK id=1). Drop the
+    // PK and the id column, then re-key by user_id. (`MySQL` 8 auto-drops
+    // the dependent CHECK constraint when its sole referenced column goes.)
+    stmts.push(Migration::DropPrimaryKey {
+        table: "sync_revision",
+    });
+    stmts.push(Migration::DropColumn {
+        table: "sync_revision",
+        column: "id",
+    });
+    stmts.push(Migration::AddColumn {
+        table: "sync_revision",
+        column: "user_id",
+        definition: "VARBINARY(33) NULL",
+    });
+    stmts.push(Migration::Sql(format!(
+        "UPDATE sync_revision SET user_id = {id_lit} WHERE user_id IS NULL"
+    )));
+    stmts.push(Migration::sql(
+        "ALTER TABLE sync_revision MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+    ));
+    stmts.push(Migration::sql(
+        "ALTER TABLE sync_revision ADD PRIMARY KEY (user_id)",
+    ));
+
+    // sync_outgoing has no PK, only an index — just add user_id and rewrite
+    // the index.
+    stmts.push(Migration::AddColumn {
+        table: "sync_outgoing",
+        column: "user_id",
+        definition: "VARBINARY(33) NULL",
+    });
+    stmts.push(Migration::Sql(format!(
+        "UPDATE sync_outgoing SET user_id = {id_lit} WHERE user_id IS NULL"
+    )));
+    stmts.push(Migration::sql(
+        "ALTER TABLE sync_outgoing MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+    ));
+    stmts.push(Migration::DropIndex {
+        name: "idx_sync_outgoing_data_id_record_type",
+        table: "sync_outgoing",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_sync_outgoing_user_record_type_data_id",
+        table: "sync_outgoing",
+        columns: "(user_id, record_type, data_id)",
+    });
+
+    scope_table("sync_state", "record_type, data_id", &mut stmts);
+
+    scope_table(
+        "sync_incoming",
+        "record_type, data_id, revision",
+        &mut stmts,
+    );
+    stmts.push(Migration::DropIndex {
+        name: "idx_sync_incoming_revision",
+        table: "sync_incoming",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_sync_incoming_user_revision",
+        table: "sync_incoming",
+        columns: "(user_id, revision)",
+    });
+
+    stmts
 }
 
 /// Converts an optional serializable value to a JSON string for `JSON` column storage.
@@ -344,8 +541,10 @@ impl Storage for MysqlStorage {
     ) -> Result<Vec<Payment>, StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
 
-        let mut where_clauses: Vec<String> = Vec::new();
-        let mut params: Vec<Value> = Vec::new();
+        // Tenant scoping is always the first WHERE clause; subsequent dynamic
+        // filters add more clauses and parameters.
+        let mut where_clauses: Vec<String> = vec!["p.user_id = ?".to_string()];
+        let mut params: Vec<Value> = vec![Value::from(self.identity.clone())];
 
         if let Some(ref type_filter) = request.type_filter
             && !type_filter.is_empty()
@@ -474,11 +673,8 @@ impl Storage for MysqlStorage {
 
         where_clauses.push("pm.parent_payment_id IS NULL".to_string());
 
-        let where_sql = if where_clauses.is_empty() {
-            String::new()
-        } else {
-            format!("WHERE {}", where_clauses.join(" AND "))
-        };
+        // Build the WHERE clause (always non-empty: tenant scoping is the first clause).
+        let where_sql = format!("WHERE {}", where_clauses.join(" AND "));
 
         let order_direction = if request.sort_ascending.unwrap_or(false) {
             "ASC"
@@ -525,8 +721,8 @@ impl Storage for MysqlStorage {
             };
 
         tx.exec_drop(
-            "INSERT INTO payments (id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "INSERT INTO payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                  ON DUPLICATE KEY UPDATE
                     payment_type = VALUES(payment_type),
                     status = VALUES(status),
@@ -538,6 +734,7 @@ impl Storage for MysqlStorage {
                     deposit_tx_id = VALUES(deposit_tx_id),
                     spark = VALUES(spark)",
             (
+                self.identity.clone(),
                 &payment.id,
                 payment.payment_type.to_string(),
                 payment.status.to_string(),
@@ -563,12 +760,12 @@ impl Storage for MysqlStorage {
                     let invoice_json = to_json_string_opt(invoice_details.as_ref())?;
                     let htlc_json = to_json_string_opt(htlc_details.as_ref())?;
                     tx.exec_drop(
-                        "INSERT INTO payment_details_spark (payment_id, invoice_details, htlc_details)
-                             VALUES (?, ?, ?)
+                        "INSERT INTO payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
+                             VALUES (?, ?, ?, ?)
                              ON DUPLICATE KEY UPDATE
                                 invoice_details = COALESCE(VALUES(invoice_details), invoice_details),
                                 htlc_details = COALESCE(VALUES(htlc_details), htlc_details)",
-                        (&payment.id, invoice_json, htlc_json),
+                        (self.identity.clone(), &payment.id, invoice_json, htlc_json),
                     )
                     .await
                     .map_err(map_db_error)?;
@@ -585,14 +782,15 @@ impl Storage for MysqlStorage {
                     .map_err(|e| StorageError::Serialization(e.to_string()))?;
                 let invoice_json = to_json_string_opt(invoice_details.as_ref())?;
                 tx.exec_drop(
-                    "INSERT INTO payment_details_token (payment_id, metadata, tx_hash, tx_type, invoice_details)
-                         VALUES (?, ?, ?, ?, ?)
+                    "INSERT INTO payment_details_token (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
+                         VALUES (?, ?, ?, ?, ?, ?)
                          ON DUPLICATE KEY UPDATE
                             metadata = VALUES(metadata),
                             tx_hash = VALUES(tx_hash),
                             tx_type = VALUES(tx_type),
                             invoice_details = COALESCE(VALUES(invoice_details), invoice_details)",
                     (
+                        self.identity.clone(),
                         &payment.id,
                         metadata_json,
                         tx_hash,
@@ -615,8 +813,8 @@ impl Storage for MysqlStorage {
                 let htlc_status = htlc_details.status.to_string();
                 let htlc_expiry_time = i64::try_from(htlc_details.expiry_time)?;
                 tx.exec_drop(
-                    "INSERT INTO payment_details_lightning (payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
-                         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    "INSERT INTO payment_details_lightning (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                          ON DUPLICATE KEY UPDATE
                             invoice = VALUES(invoice),
                             payment_hash = VALUES(payment_hash),
@@ -626,6 +824,7 @@ impl Storage for MysqlStorage {
                             htlc_status = COALESCE(VALUES(htlc_status), htlc_status),
                             htlc_expiry_time = COALESCE(VALUES(htlc_expiry_time), htlc_expiry_time)",
                     (
+                        self.identity.clone(),
                         &payment.id,
                         invoice,
                         payment_hash,
@@ -662,8 +861,8 @@ impl Storage for MysqlStorage {
             .map(std::string::ToString::to_string);
 
         conn.exec_drop(
-            "INSERT INTO payment_metadata (payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
-             VALUES (?, ?, ?, ?, ?, ?, ?)
+            "INSERT INTO payment_metadata (user_id, payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE
                 parent_payment_id = COALESCE(VALUES(parent_payment_id), parent_payment_id),
                 lnurl_pay_info = COALESCE(VALUES(lnurl_pay_info), lnurl_pay_info),
@@ -672,6 +871,7 @@ impl Storage for MysqlStorage {
                 conversion_info = COALESCE(VALUES(conversion_info), conversion_info),
                 conversion_status = COALESCE(VALUES(conversion_status), conversion_status)",
             (
+                self.identity.clone(),
                 payment_id,
                 metadata.parent_payment_id,
                 lnurl_pay_info_json,
@@ -691,9 +891,9 @@ impl Storage for MysqlStorage {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
 
         conn.exec_drop(
-            "INSERT INTO settings (`key`, value) VALUES (?, ?)
+            "INSERT INTO settings (user_id, `key`, value) VALUES (?, ?, ?)
              ON DUPLICATE KEY UPDATE value = VALUES(value)",
-            (key, value),
+            (self.identity.clone(), key, value),
         )
         .await
         .map_err(map_db_error)?;
@@ -705,7 +905,10 @@ impl Storage for MysqlStorage {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
 
         let row: Option<String> = conn
-            .exec_first("SELECT value FROM settings WHERE `key` = ?", (key,))
+            .exec_first(
+                "SELECT value FROM settings WHERE user_id = ? AND `key` = ?",
+                (self.identity.clone(), key),
+            )
             .await
             .map_err(map_db_error)?;
 
@@ -715,17 +918,23 @@ impl Storage for MysqlStorage {
     async fn delete_cached_item(&self, key: String) -> Result<(), StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
 
-        conn.exec_drop("DELETE FROM settings WHERE `key` = ?", (key,))
-            .await
-            .map_err(map_db_error)?;
+        conn.exec_drop(
+            "DELETE FROM settings WHERE user_id = ? AND `key` = ?",
+            (self.identity.clone(), key),
+        )
+        .await
+        .map_err(map_db_error)?;
 
         Ok(())
     }
 
     async fn get_payment_by_id(&self, id: String) -> Result<Payment, StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
-        let query = format!("{SELECT_PAYMENT_SQL} WHERE p.id = ?");
-        let row: Option<Row> = conn.exec_first(&query, (id,)).await.map_err(map_db_error)?;
+        let query = format!("{SELECT_PAYMENT_SQL} WHERE p.user_id = ? AND p.id = ?");
+        let row: Option<Row> = conn
+            .exec_first(&query, (self.identity.clone(), id))
+            .await
+            .map_err(map_db_error)?;
         let row = row.ok_or(StorageError::NotFound)?;
         map_payment(&row)
     }
@@ -735,9 +944,9 @@ impl Storage for MysqlStorage {
         invoice: String,
     ) -> Result<Option<Payment>, StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
-        let query = format!("{SELECT_PAYMENT_SQL} WHERE l.invoice = ?");
+        let query = format!("{SELECT_PAYMENT_SQL} WHERE p.user_id = ? AND l.invoice = ?");
         let row: Option<Row> = conn
-            .exec_first(&query, (invoice,))
+            .exec_first(&query, (self.identity.clone(), invoice))
             .await
             .map_err(map_db_error)?;
 
@@ -759,8 +968,9 @@ impl Storage for MysqlStorage {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
 
         let has_related: bool = conn
-            .query_first::<i64, _>(
-                "SELECT EXISTS(SELECT 1 FROM payment_metadata WHERE parent_payment_id IS NOT NULL LIMIT 1)",
+            .exec_first::<i64, _, _>(
+                "SELECT EXISTS(SELECT 1 FROM payment_metadata WHERE user_id = ? AND parent_payment_id IS NOT NULL LIMIT 1)",
+                (self.identity.clone(),),
             )
             .await
             .map_err(map_db_error)?
@@ -772,14 +982,11 @@ impl Storage for MysqlStorage {
 
         let placeholders = build_placeholders(parent_payment_ids.len());
         let query = format!(
-            "{SELECT_PAYMENT_SQL} WHERE pm.parent_payment_id IN ({placeholders}) ORDER BY p.timestamp ASC"
+            "{SELECT_PAYMENT_SQL} WHERE p.user_id = ? AND pm.parent_payment_id IN ({placeholders}) ORDER BY p.timestamp ASC"
         );
 
-        let params: Vec<Value> = parent_payment_ids
-            .iter()
-            .cloned()
-            .map(Value::from)
-            .collect();
+        let mut params: Vec<Value> = vec![Value::from(self.identity.clone())];
+        params.extend(parent_payment_ids.iter().cloned().map(Value::from));
 
         let rows: Vec<Row> = conn
             .exec(&query, Params::Positional(params))
@@ -807,10 +1014,11 @@ impl Storage for MysqlStorage {
     ) -> Result<(), StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
         conn.exec_drop(
-            "INSERT INTO unclaimed_deposits (txid, vout, amount_sats, is_mature)
-             VALUES (?, ?, ?, ?)
+            "INSERT INTO unclaimed_deposits (user_id, txid, vout, amount_sats, is_mature)
+             VALUES (?, ?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE is_mature = VALUES(is_mature), amount_sats = VALUES(amount_sats)",
             (
+                self.identity.clone(),
                 txid,
                 i32::try_from(vout)?,
                 i64::try_from(amount_sats)?,
@@ -825,8 +1033,8 @@ impl Storage for MysqlStorage {
     async fn delete_deposit(&self, txid: String, vout: u32) -> Result<(), StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
         conn.exec_drop(
-            "DELETE FROM unclaimed_deposits WHERE txid = ? AND vout = ?",
-            (txid, i32::try_from(vout)?),
+            "DELETE FROM unclaimed_deposits WHERE user_id = ? AND txid = ? AND vout = ?",
+            (self.identity.clone(), txid, i32::try_from(vout)?),
         )
         .await
         .map_err(map_db_error)?;
@@ -836,8 +1044,9 @@ impl Storage for MysqlStorage {
     async fn list_deposits(&self) -> Result<Vec<DepositInfo>, StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
         let rows: Vec<Row> = conn
-            .query(
-                "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM unclaimed_deposits",
+            .exec(
+                "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM unclaimed_deposits WHERE user_id = ?",
+                (self.identity.clone(),),
             )
             .await
             .map_err(map_db_error)?;
@@ -880,8 +1089,8 @@ impl Storage for MysqlStorage {
                 let error_json = serde_json::to_string(&error)
                     .map_err(|e| StorageError::Serialization(e.to_string()))?;
                 conn.exec_drop(
-                    "UPDATE unclaimed_deposits SET claim_error = ?, refund_tx = NULL, refund_tx_id = NULL WHERE txid = ? AND vout = ?",
-                    (error_json, txid, i32::try_from(vout)?),
+                    "UPDATE unclaimed_deposits SET claim_error = ?, refund_tx = NULL, refund_tx_id = NULL WHERE user_id = ? AND txid = ? AND vout = ?",
+                    (error_json, self.identity.clone(), txid, i32::try_from(vout)?),
                 )
                 .await
                 .map_err(map_db_error)?;
@@ -891,8 +1100,8 @@ impl Storage for MysqlStorage {
                 refund_tx,
             } => {
                 conn.exec_drop(
-                    "UPDATE unclaimed_deposits SET refund_tx = ?, refund_tx_id = ?, claim_error = NULL WHERE txid = ? AND vout = ?",
-                    (refund_tx, refund_txid, txid, i32::try_from(vout)?),
+                    "UPDATE unclaimed_deposits SET refund_tx = ?, refund_tx_id = ?, claim_error = NULL WHERE user_id = ? AND txid = ? AND vout = ?",
+                    (refund_tx, refund_txid, self.identity.clone(), txid, i32::try_from(vout)?),
                 )
                 .await
                 .map_err(map_db_error)?;
@@ -908,13 +1117,13 @@ impl Storage for MysqlStorage {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
         for m in metadata {
             conn.exec_drop(
-                "INSERT INTO lnurl_receive_metadata (payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
-                 VALUES (?, ?, ?, ?)
+                "INSERT INTO lnurl_receive_metadata (user_id, payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
+                 VALUES (?, ?, ?, ?, ?)
                  ON DUPLICATE KEY UPDATE
                     nostr_zap_request = VALUES(nostr_zap_request),
                     nostr_zap_receipt = VALUES(nostr_zap_receipt),
                     sender_comment = VALUES(sender_comment)",
-                (m.payment_hash, m.nostr_zap_request, m.nostr_zap_receipt, m.sender_comment),
+                (self.identity.clone(), m.payment_hash, m.nostr_zap_request, m.nostr_zap_receipt, m.sender_comment),
             )
             .await
             .map_err(map_db_error)?;
@@ -933,8 +1142,8 @@ impl Storage for MysqlStorage {
         let rows: Vec<(String, String, String, i64, i64)> = conn
             .exec(
                 "SELECT id, name, payment_identifier, created_at, updated_at
-                 FROM contacts ORDER BY name ASC LIMIT ? OFFSET ?",
-                (limit, offset),
+                 FROM contacts WHERE user_id = ? ORDER BY name ASC LIMIT ? OFFSET ?",
+                (self.identity.clone(), limit, offset),
             )
             .await
             .map_err(map_db_error)?;
@@ -957,8 +1166,8 @@ impl Storage for MysqlStorage {
         let row: Option<(String, String, String, i64, i64)> = conn
             .exec_first(
                 "SELECT id, name, payment_identifier, created_at, updated_at
-                 FROM contacts WHERE id = ?",
-                (id,),
+                 FROM contacts WHERE user_id = ? AND id = ?",
+                (self.identity.clone(), id),
             )
             .await
             .map_err(map_db_error)?;
@@ -976,13 +1185,14 @@ impl Storage for MysqlStorage {
     async fn insert_contact(&self, contact: Contact) -> Result<(), StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
         conn.exec_drop(
-            "INSERT INTO contacts (id, name, payment_identifier, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?)
+            "INSERT INTO contacts (user_id, id, name, payment_identifier, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE
                name = VALUES(name),
                payment_identifier = VALUES(payment_identifier),
                updated_at = VALUES(updated_at)",
             (
+                self.identity.clone(),
                 contact.id,
                 contact.name,
                 contact.payment_identifier,
@@ -997,9 +1207,12 @@ impl Storage for MysqlStorage {
 
     async fn delete_contact(&self, id: String) -> Result<(), StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
-        conn.exec_drop("DELETE FROM contacts WHERE id = ?", (id,))
-            .await
-            .map_err(map_db_error)?;
+        conn.exec_drop(
+            "DELETE FROM contacts WHERE user_id = ? AND id = ?",
+            (self.identity.clone(), id),
+        )
+        .await
+        .map_err(map_db_error)?;
         Ok(())
     }
 
@@ -1014,8 +1227,12 @@ impl Storage for MysqlStorage {
             .await
             .map_err(map_db_error)?;
 
+        // The local queue revision is per-tenant — two tenants don't share a queue.
         let local_revision: i64 = tx
-            .query_first("SELECT COALESCE(MAX(revision), 0) + 1 FROM sync_outgoing")
+            .exec_first(
+                "SELECT COALESCE(MAX(revision), 0) + 1 FROM sync_outgoing WHERE user_id = ?",
+                (self.identity.clone(),),
+            )
             .await
             .map_err(map_db_error)?
             .unwrap_or(1);
@@ -1025,9 +1242,10 @@ impl Storage for MysqlStorage {
         let commit_time = chrono::Utc::now().timestamp();
 
         tx.exec_drop(
-            "INSERT INTO sync_outgoing (record_type, data_id, schema_version, commit_time, updated_fields_json, revision)
-                 VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO sync_outgoing (user_id, record_type, data_id, schema_version, commit_time, updated_fields_json, revision)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
+                self.identity.clone(),
                 record.id.r#type,
                 record.id.data_id,
                 record.schema_version,
@@ -1057,8 +1275,9 @@ impl Storage for MysqlStorage {
 
         let mut result = tx
             .exec_iter(
-                "DELETE FROM sync_outgoing WHERE record_type = ? AND data_id = ? AND revision = ?",
+                "DELETE FROM sync_outgoing WHERE user_id = ? AND record_type = ? AND data_id = ? AND revision = ?",
                 (
+                    self.identity.clone(),
                     record.id.r#type.clone(),
                     record.id.data_id.clone(),
                     i64::try_from(local_revision)?,
@@ -1082,14 +1301,15 @@ impl Storage for MysqlStorage {
         let commit_time = chrono::Utc::now().timestamp();
 
         tx.exec_drop(
-            "INSERT INTO sync_state (record_type, data_id, schema_version, commit_time, data, revision)
-                 VALUES (?, ?, ?, ?, ?, ?)
+            "INSERT INTO sync_state (user_id, record_type, data_id, schema_version, commit_time, data, revision)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)
                  ON DUPLICATE KEY UPDATE
                     schema_version = VALUES(schema_version),
                     commit_time = VALUES(commit_time),
                     data = VALUES(data),
                     revision = VALUES(revision)",
             (
+                self.identity.clone(),
                 record.id.r#type,
                 record.id.data_id,
                 record.schema_version,
@@ -1101,9 +1321,13 @@ impl Storage for MysqlStorage {
         .await
         .map_err(map_db_error)?;
 
+        // Upsert this tenant's revision row. Migration 16 created a row at
+        // backfill, but a fresh tenant joining a shared DB after the migration
+        // won't have one yet.
         tx.exec_drop(
-            "UPDATE sync_revision SET revision = GREATEST(revision, ?)",
-            (i64::try_from(record.revision)?,),
+            "INSERT INTO sync_revision (user_id, revision) VALUES (?, ?)
+             ON DUPLICATE KEY UPDATE revision = GREATEST(revision, VALUES(revision))",
+            (self.identity.clone(), i64::try_from(record.revision)?),
         )
         .await
         .map_err(map_db_error)?;
@@ -1124,10 +1348,11 @@ impl Storage for MysqlStorage {
                 "SELECT o.record_type, o.data_id, o.schema_version, o.commit_time, o.updated_fields_json, o.revision,
                         e.schema_version AS existing_schema_version, e.commit_time AS existing_commit_time, e.data AS existing_data, e.revision AS existing_revision
                  FROM sync_outgoing o
-                 LEFT JOIN sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id
+                 LEFT JOIN sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id AND o.user_id = e.user_id
+                 WHERE o.user_id = ?
                  ORDER BY o.revision ASC
                  LIMIT ?",
-                (i64::from(limit),),
+                (self.identity.clone(), i64::from(limit)),
             )
             .await
             .map_err(map_db_error)?;
@@ -1163,8 +1388,12 @@ impl Storage for MysqlStorage {
     async fn get_last_revision(&self) -> Result<u64, StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
 
+        // A tenant that hasn't synced anything yet may have no row; treat as 0.
         let revision: i64 = conn
-            .query_first("SELECT revision FROM sync_revision")
+            .exec_first(
+                "SELECT revision FROM sync_revision WHERE user_id = ?",
+                (self.identity.clone(),),
+            )
             .await
             .map_err(map_db_error)?
             .unwrap_or(0);
@@ -1184,13 +1413,14 @@ impl Storage for MysqlStorage {
             let data_json = serde_json::to_string(&record.data)
                 .map_err(|e| StorageError::Serialization(e.to_string()))?;
             conn.exec_drop(
-                "INSERT INTO sync_incoming (record_type, data_id, schema_version, commit_time, data, revision)
-                 VALUES (?, ?, ?, ?, ?, ?)
+                "INSERT INTO sync_incoming (user_id, record_type, data_id, schema_version, commit_time, data, revision)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)
                  ON DUPLICATE KEY UPDATE
                     schema_version = VALUES(schema_version),
                     commit_time = VALUES(commit_time),
                     data = VALUES(data)",
                 (
+                    self.identity.clone(),
                     record.id.r#type,
                     record.id.data_id,
                     record.schema_version,
@@ -1210,8 +1440,9 @@ impl Storage for MysqlStorage {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
 
         conn.exec_drop(
-            "DELETE FROM sync_incoming WHERE record_type = ? AND data_id = ? AND revision = ?",
+            "DELETE FROM sync_incoming WHERE user_id = ? AND record_type = ? AND data_id = ? AND revision = ?",
             (
+                self.identity.clone(),
                 record.id.r#type,
                 record.id.data_id,
                 i64::try_from(record.revision)?,
@@ -1231,10 +1462,11 @@ impl Storage for MysqlStorage {
                 "SELECT i.record_type, i.data_id, i.schema_version, i.data, i.revision,
                         e.schema_version AS existing_schema_version, e.commit_time AS existing_commit_time, e.data AS existing_data, e.revision AS existing_revision
                  FROM sync_incoming i
-                 LEFT JOIN sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id
+                 LEFT JOIN sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id AND i.user_id = e.user_id
+                 WHERE i.user_id = ?
                  ORDER BY i.revision ASC
                  LIMIT ?",
-                (i64::from(limit),),
+                (self.identity.clone(), i64::from(limit)),
             )
             .await
             .map_err(map_db_error)?;
@@ -1274,13 +1506,15 @@ impl Storage for MysqlStorage {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
 
         let row: Option<Row> = conn
-            .query_first(
+            .exec_first(
                 "SELECT o.record_type, o.data_id, o.schema_version, o.commit_time, o.updated_fields_json, o.revision,
                         e.schema_version AS existing_schema_version, e.commit_time AS existing_commit_time, e.data AS existing_data, e.revision AS existing_revision
                  FROM sync_outgoing o
-                 LEFT JOIN sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id
+                 LEFT JOIN sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id AND o.user_id = e.user_id
+                 WHERE o.user_id = ?
                  ORDER BY o.revision DESC
                  LIMIT 1",
+                (self.identity.clone(),),
             )
             .await
             .map_err(map_db_error)?;
@@ -1325,14 +1559,15 @@ impl Storage for MysqlStorage {
         let commit_time = chrono::Utc::now().timestamp();
 
         tx.exec_drop(
-            "INSERT INTO sync_state (record_type, data_id, schema_version, commit_time, data, revision)
-                 VALUES (?, ?, ?, ?, ?, ?)
+            "INSERT INTO sync_state (user_id, record_type, data_id, schema_version, commit_time, data, revision)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)
                  ON DUPLICATE KEY UPDATE
                     schema_version = VALUES(schema_version),
                     commit_time = VALUES(commit_time),
                     data = VALUES(data),
                     revision = VALUES(revision)",
             (
+                self.identity.clone(),
                 record.id.r#type,
                 record.id.data_id,
                 record.schema_version,
@@ -1345,8 +1580,9 @@ impl Storage for MysqlStorage {
         .map_err(map_db_error)?;
 
         tx.exec_drop(
-            "UPDATE sync_revision SET revision = GREATEST(revision, ?)",
-            (i64::try_from(record.revision)?,),
+            "INSERT INTO sync_revision (user_id, revision) VALUES (?, ?)
+             ON DUPLICATE KEY UPDATE revision = GREATEST(revision, VALUES(revision))",
+            (self.identity.clone(), i64::try_from(record.revision)?),
         )
         .await
         .map_err(map_db_error)?;
@@ -1393,11 +1629,11 @@ const SELECT_PAYMENT_SQL: &str = "
            pm.conversion_status,
            pm.parent_payment_id
       FROM payments p
-      LEFT JOIN payment_details_lightning l ON p.id = l.payment_id
-      LEFT JOIN payment_details_token t ON p.id = t.payment_id
-      LEFT JOIN payment_details_spark s ON p.id = s.payment_id
-      LEFT JOIN payment_metadata pm ON p.id = pm.payment_id
-      LEFT JOIN lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash";
+      LEFT JOIN payment_details_lightning l ON p.id = l.payment_id AND p.user_id = l.user_id
+      LEFT JOIN payment_details_token t ON p.id = t.payment_id AND p.user_id = t.user_id
+      LEFT JOIN payment_details_spark s ON p.id = s.payment_id AND p.user_id = s.user_id
+      LEFT JOIN payment_metadata pm ON p.id = pm.payment_id AND p.user_id = pm.user_id
+      LEFT JOIN lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash AND l.user_id = lrm.user_id";
 
 #[allow(clippy::too_many_lines)]
 fn map_payment(row: &Row) -> Result<Payment, StorageError> {
@@ -1599,6 +1835,14 @@ mod tests {
     use testcontainers::{ContainerAsync, runners::AsyncRunner};
     use testcontainers_modules::mysql::Mysql;
 
+    /// A fixed 33-byte test identity used by single-tenant test fixtures.
+    /// Two-tenant isolation tests use a different identity for the second tenant.
+    pub(super) const TEST_IDENTITY_A: [u8; 33] = [
+        0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+        0x1e, 0x1f, 0x20,
+    ];
+
     struct MysqlTestFixture {
         storage: MysqlStorage,
         #[allow(dead_code)]
@@ -1619,9 +1863,12 @@ mod tests {
 
             let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
 
-            let storage = MysqlStorage::new(MysqlStorageConfig::with_defaults(connection_string))
-                .await
-                .expect("Failed to create MysqlStorage");
+            let storage = MysqlStorage::new(
+                MysqlStorageConfig::with_defaults(connection_string),
+                &TEST_IDENTITY_A,
+            )
+            .await
+            .expect("Failed to create MysqlStorage");
 
             Self { storage, container }
         }
@@ -1748,5 +1995,326 @@ mod tests {
     async fn test_conversion_status_persistence() {
         let fixture = MysqlTestFixture::new().await;
         crate::persist::tests::test_conversion_status_persistence(Box::new(fixture.storage)).await;
+    }
+
+    /// A second 33-byte test identity (must differ from `TEST_IDENTITY_A`).
+    const TEST_IDENTITY_B: [u8; 33] = [
+        0x03, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae,
+        0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd,
+        0xbe, 0xbf, 0xc0,
+    ];
+
+    /// Two `MysqlStorage` instances with distinct identities sharing one
+    /// connection pool / DB. The container must be kept alive for the test.
+    struct TwoTenantFixture {
+        a: MysqlStorage,
+        b: MysqlStorage,
+        #[allow(dead_code)]
+        container: ContainerAsync<Mysql>,
+    }
+
+    impl TwoTenantFixture {
+        async fn new() -> Self {
+            let container = Mysql::default()
+                .start()
+                .await
+                .expect("Failed to start MySQL container");
+
+            let host_port = container
+                .get_host_port_ipv4(3306)
+                .await
+                .expect("Failed to get host port");
+
+            let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
+
+            let config = MysqlStorageConfig::with_defaults(connection_string);
+            let pool = create_pool(&config).expect("Failed to create pool");
+
+            let a = MysqlStorage::new_with_pool(pool.clone(), &TEST_IDENTITY_A)
+                .await
+                .expect("Failed to create tenant A");
+            let b = MysqlStorage::new_with_pool(pool, &TEST_IDENTITY_B)
+                .await
+                .expect("Failed to create tenant B");
+
+            Self { a, b, container }
+        }
+    }
+
+    /// End-to-end isolation: every Storage method must keep tenants A and B
+    /// from observing each other's data. The test exercises each per-user
+    /// table — `payments`, `payment_metadata`, `lnurl_receive_metadata`,
+    /// `contacts`, `unclaimed_deposits`, `settings`, and the sync mirror
+    /// tables — and asserts that writes by A are invisible to B (and vice
+    /// versa). It is the regression net for "forgot the WHERE clause" bugs
+    /// in any future query.
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    async fn test_two_tenant_isolation() {
+        use crate::models::{Contact, ListContactsRequest};
+        use crate::persist::{Payment, StorageListPaymentsRequest};
+        use crate::sync_storage::{Record, RecordId, UnversionedRecordChange};
+        use crate::{
+            PaymentDetails, PaymentMethod, PaymentStatus, PaymentType, SetLnurlMetadataItem,
+            SparkHtlcDetails, SparkHtlcStatus, Storage,
+        };
+        use std::collections::HashMap;
+
+        let fx = TwoTenantFixture::new().await;
+
+        // --- payments (incl. lightning details) ---
+        let pmt_a = Payment {
+            id: "pmt_shared_id".to_string(),
+            payment_type: PaymentType::Send,
+            status: PaymentStatus::Completed,
+            amount: 1_000,
+            fees: 10,
+            timestamp: 100,
+            method: PaymentMethod::Lightning,
+            details: Some(PaymentDetails::Lightning {
+                invoice: "lnbc_a".to_string(),
+                destination_pubkey: "pkA".to_string(),
+                description: None,
+                htlc_details: SparkHtlcDetails {
+                    payment_hash: "shared_payment_hash".to_string(),
+                    preimage: Some("preimage_a".to_string()),
+                    expiry_time: 0,
+                    status: SparkHtlcStatus::PreimageShared,
+                },
+                lnurl_pay_info: None,
+                lnurl_withdraw_info: None,
+                lnurl_receive_metadata: None,
+            }),
+            conversion_details: None,
+        };
+        let mut pmt_b = pmt_a.clone();
+        if let Some(PaymentDetails::Lightning {
+            invoice,
+            destination_pubkey,
+            ..
+        }) = &mut pmt_b.details
+        {
+            *invoice = "lnbc_b".to_string();
+            *destination_pubkey = "pkB".to_string();
+        }
+
+        fx.a.insert_payment(pmt_a.clone()).await.unwrap();
+        fx.b.insert_payment(pmt_b.clone()).await.unwrap();
+
+        let list_a =
+            fx.a.list_payments(StorageListPaymentsRequest::default())
+                .await
+                .unwrap();
+        let list_b =
+            fx.b.list_payments(StorageListPaymentsRequest::default())
+                .await
+                .unwrap();
+        assert_eq!(list_a.len(), 1, "tenant A should see exactly 1 payment");
+        assert_eq!(list_b.len(), 1, "tenant B should see exactly 1 payment");
+        if let Some(PaymentDetails::Lightning { invoice, .. }) = &list_a[0].details {
+            assert_eq!(invoice, "lnbc_a");
+        } else {
+            panic!("expected lightning payment for A");
+        }
+        if let Some(PaymentDetails::Lightning { invoice, .. }) = &list_b[0].details {
+            assert_eq!(invoice, "lnbc_b");
+        } else {
+            panic!("expected lightning payment for B");
+        }
+
+        let by_id_a =
+            fx.a.get_payment_by_id("pmt_shared_id".to_string())
+                .await
+                .unwrap();
+        let by_id_b =
+            fx.b.get_payment_by_id("pmt_shared_id".to_string())
+                .await
+                .unwrap();
+        match (&by_id_a.details, &by_id_b.details) {
+            (
+                Some(PaymentDetails::Lightning { invoice: ia, .. }),
+                Some(PaymentDetails::Lightning { invoice: ib, .. }),
+            ) => assert!(ia != ib, "tenants must not see each other's invoice"),
+            _ => panic!("expected lightning details for both"),
+        }
+
+        assert!(
+            fx.a.get_payment_by_invoice("lnbc_b".to_string())
+                .await
+                .unwrap()
+                .is_none(),
+            "tenant A must not find tenant B's invoice"
+        );
+        assert!(
+            fx.b.get_payment_by_invoice("lnbc_a".to_string())
+                .await
+                .unwrap()
+                .is_none(),
+            "tenant B must not find tenant A's invoice"
+        );
+
+        // --- contacts ---
+        let now = 0u64;
+        fx.a.insert_contact(Contact {
+            id: "shared_contact_id".to_string(),
+            name: "Alice".to_string(),
+            payment_identifier: "alice@a".to_string(),
+            created_at: now,
+            updated_at: now,
+        })
+        .await
+        .unwrap();
+        let b_contacts =
+            fx.b.list_contacts(ListContactsRequest::default())
+                .await
+                .unwrap();
+        assert!(
+            b_contacts.is_empty(),
+            "tenant B must not see tenant A's contact"
+        );
+        assert!(
+            fx.b.get_contact("shared_contact_id".to_string())
+                .await
+                .is_err(),
+            "tenant B must not retrieve tenant A's contact by id"
+        );
+
+        // --- unclaimed deposits ---
+        fx.a.add_deposit("shared_txid".to_string(), 0, 5_000, true)
+            .await
+            .unwrap();
+        let b_deposits = fx.b.list_deposits().await.unwrap();
+        assert!(
+            b_deposits.is_empty(),
+            "tenant B must not see tenant A's deposit"
+        );
+
+        // --- settings (cached items) ---
+        fx.a.set_cached_item("k".to_string(), "value_a".to_string())
+            .await
+            .unwrap();
+        fx.b.set_cached_item("k".to_string(), "value_b".to_string())
+            .await
+            .unwrap();
+        assert_eq!(
+            fx.a.get_cached_item("k".to_string()).await.unwrap(),
+            Some("value_a".to_string())
+        );
+        assert_eq!(
+            fx.b.get_cached_item("k".to_string()).await.unwrap(),
+            Some("value_b".to_string())
+        );
+        fx.b.delete_cached_item("k".to_string()).await.unwrap();
+        assert_eq!(
+            fx.a.get_cached_item("k".to_string()).await.unwrap(),
+            Some("value_a".to_string())
+        );
+        assert_eq!(fx.b.get_cached_item("k".to_string()).await.unwrap(), None);
+
+        // --- lnurl receive metadata ---
+        fx.a.set_lnurl_metadata(vec![SetLnurlMetadataItem {
+            payment_hash: "shared_payment_hash".to_string(),
+            nostr_zap_request: Some("zap_a".to_string()),
+            nostr_zap_receipt: None,
+            sender_comment: None,
+        }])
+        .await
+        .unwrap();
+        fx.b.set_lnurl_metadata(vec![SetLnurlMetadataItem {
+            payment_hash: "shared_payment_hash".to_string(),
+            nostr_zap_request: Some("zap_b".to_string()),
+            nostr_zap_receipt: None,
+            sender_comment: None,
+        }])
+        .await
+        .unwrap();
+        let by_id_a =
+            fx.a.get_payment_by_id("pmt_shared_id".to_string())
+                .await
+                .unwrap();
+        let by_id_b =
+            fx.b.get_payment_by_id("pmt_shared_id".to_string())
+                .await
+                .unwrap();
+        if let (
+            Some(PaymentDetails::Lightning {
+                lnurl_receive_metadata: Some(ma),
+                ..
+            }),
+            Some(PaymentDetails::Lightning {
+                lnurl_receive_metadata: Some(mb),
+                ..
+            }),
+        ) = (&by_id_a.details, &by_id_b.details)
+        {
+            assert_eq!(ma.nostr_zap_request.as_deref(), Some("zap_a"));
+            assert_eq!(mb.nostr_zap_request.as_deref(), Some("zap_b"));
+        } else {
+            panic!("expected lnurl metadata to be visible to each tenant");
+        }
+
+        // --- sync state (sync_outgoing, sync_state, sync_revision) ---
+        let rec_id = RecordId::new("contact".to_string(), "rec_shared".to_string());
+        let updated_a: HashMap<String, String> = HashMap::new();
+        fx.a.add_outgoing_change(UnversionedRecordChange {
+            id: rec_id.clone(),
+            schema_version: "1".to_string(),
+            updated_fields: updated_a,
+        })
+        .await
+        .unwrap();
+        let b_pending = fx.b.get_pending_outgoing_changes(100).await.unwrap();
+        assert!(
+            b_pending.is_empty(),
+            "tenant B must not see tenant A's pending outgoing"
+        );
+        assert_eq!(fx.b.get_last_revision().await.unwrap(), 0);
+
+        let rec = Record {
+            id: rec_id.clone(),
+            schema_version: "1".to_string(),
+            data: HashMap::new(),
+            revision: 7,
+        };
+        let a_pending = fx.a.get_pending_outgoing_changes(100).await.unwrap();
+        let a_local_rev = a_pending[0].change.local_revision;
+        fx.a.complete_outgoing_sync(rec.clone(), a_local_rev)
+            .await
+            .unwrap();
+        assert_eq!(fx.a.get_last_revision().await.unwrap(), 7);
+        assert_eq!(
+            fx.b.get_last_revision().await.unwrap(),
+            0,
+            "tenant B's revision must remain isolated from tenant A's bumps"
+        );
+
+        let rec_b = Record {
+            id: rec_id.clone(),
+            schema_version: "1".to_string(),
+            data: HashMap::new(),
+            revision: 11,
+        };
+        fx.a.insert_incoming_records(vec![rec_b.clone()])
+            .await
+            .unwrap();
+        let b_incoming = fx.b.get_incoming_records(100).await.unwrap();
+        assert!(
+            b_incoming.is_empty(),
+            "tenant B must not see tenant A's incoming records"
+        );
+        fx.b.delete_incoming_record(rec_b.clone()).await.unwrap();
+        let a_incoming = fx.a.get_incoming_records(100).await.unwrap();
+        assert_eq!(
+            a_incoming.len(),
+            1,
+            "tenant A's incoming must survive B's delete on the same key"
+        );
+
+        let list_b_final =
+            fx.b.list_payments(StorageListPaymentsRequest::default())
+                .await
+                .unwrap();
+        assert_eq!(list_b_final.len(), 1);
+        assert_eq!(list_b_final[0].id, "pmt_shared_id");
     }
 }

--- a/crates/breez-sdk/core/src/persist/postgres/base.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/base.rs
@@ -203,8 +203,9 @@ pub(crate) async fn create_postgres_tree_store(
 /// Creates a `PostgresTokenStore` instance for use with the SDK, using an existing pool.
 pub(crate) async fn create_postgres_token_store(
     pool: deadpool_postgres::Pool,
+    identity: &[u8],
 ) -> Result<Arc<dyn TokenOutputStore>, StorageError> {
-    spark_postgres::create_postgres_token_store_from_pool(pool)
+    spark_postgres::create_postgres_token_store_from_pool(pool, identity)
         .await
         .map_err(StorageError::from)
 }

--- a/crates/breez-sdk/core/src/persist/postgres/base.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/base.rs
@@ -181,7 +181,7 @@ pub(crate) fn create_pool(
 pub(super) async fn run_migrations(
     pool: &deadpool_postgres::Pool,
     migrations_table: &str,
-    migrations: &[&[&str]],
+    migrations: &[Vec<String>],
 ) -> Result<(), StorageError> {
     spark_postgres::run_migrations(pool, migrations_table, migrations)
         .await

--- a/crates/breez-sdk/core/src/persist/postgres/base.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/base.rs
@@ -193,8 +193,9 @@ pub(super) async fn run_migrations(
 /// Creates a `PostgresTreeStore` instance for use with the SDK, using an existing pool.
 pub(crate) async fn create_postgres_tree_store(
     pool: deadpool_postgres::Pool,
+    identity: &[u8],
 ) -> Result<Arc<dyn TreeStore>, StorageError> {
-    spark_postgres::create_postgres_tree_store_from_pool(pool)
+    spark_postgres::create_postgres_tree_store_from_pool(pool, identity)
         .await
         .map_err(StorageError::from)
 }

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -34,9 +34,17 @@ use super::base::{map_db_error, map_pool_error, run_migrations};
 /// Name of the schema migrations table for `PostgresStorage`.
 const MIGRATIONS_TABLE: &str = "schema_migrations";
 
-/// PostgreSQL-based storage implementation using connection pooling
+/// PostgreSQL-based storage implementation using connection pooling.
+///
+/// Each instance is scoped to a single tenant identity (a 33-byte secp256k1
+/// compressed public key). All reads and writes are filtered by `user_id` so
+/// that multiple instances with distinct identities can share one Postgres DB
+/// without seeing each other's data.
 pub(crate) struct PostgresStorage {
     pool: Pool,
+    /// Tenant identity: 33-byte compressed secp256k1 pubkey. Stored as raw
+    /// bytes for direct binding to BYTEA columns.
+    identity: Vec<u8>,
 }
 
 impl PostgresStorage {
@@ -45,6 +53,7 @@ impl PostgresStorage {
     /// # Arguments
     ///
     /// * `config` - Configuration for the `PostgreSQL` connection pool
+    /// * `identity` - 33-byte compressed secp256k1 public key uniquely identifying this tenant
     ///
     /// # Connection String Formats
     ///
@@ -63,29 +72,38 @@ impl PostgresStorage {
     ///
     /// A new `PostgresStorage` instance or an error
     #[cfg(test)]
-    pub async fn new(config: PostgresStorageConfig) -> Result<Self, StorageError> {
+    pub async fn new(config: PostgresStorageConfig, identity: &[u8]) -> Result<Self, StorageError> {
         let pool = create_pool(&config)?;
-        Self::new_with_pool(pool).await
+        Self::new_with_pool(pool, identity).await
     }
 
     /// Creates a new `PostgresStorage` using an existing connection pool.
     ///
     /// This allows sharing a single pool across multiple store implementations.
-    pub async fn new_with_pool(pool: Pool) -> Result<Self, StorageError> {
-        let storage = Self { pool };
+    /// Each `PostgresStorage` is scoped to a single tenant `identity`.
+    pub async fn new_with_pool(pool: Pool, identity: &[u8]) -> Result<Self, StorageError> {
+        let storage = Self {
+            pool,
+            identity: identity.to_vec(),
+        };
         storage.migrate().await?;
         Ok(storage)
     }
 
     async fn migrate(&self) -> Result<(), StorageError> {
-        run_migrations(&self.pool, MIGRATIONS_TABLE, &Self::migrations()).await
+        run_migrations(
+            &self.pool,
+            MIGRATIONS_TABLE,
+            &Self::migrations(&self.identity),
+        )
+        .await
     }
 
     #[allow(clippy::too_many_lines)]
-    pub(crate) fn migrations() -> Vec<&'static [&'static str]> {
+    pub(crate) fn migrations(identity: &[u8]) -> Vec<Vec<String>> {
         vec![
             // Migration 1: Core tables
-            &[
+            vec![
                 "CREATE TABLE IF NOT EXISTS payments (
                     id TEXT PRIMARY KEY,
                     payment_type TEXT NOT NULL,
@@ -97,11 +115,11 @@ impl PostgresStorage {
                     withdraw_tx_id TEXT,
                     deposit_tx_id TEXT,
                     spark BOOLEAN
-                )",
+                )".to_string(),
                 "CREATE TABLE IF NOT EXISTS settings (
                     key TEXT PRIMARY KEY,
                     value TEXT NOT NULL
-                )",
+                )".to_string(),
                 "CREATE TABLE IF NOT EXISTS unclaimed_deposits (
                     txid TEXT NOT NULL,
                     vout INTEGER NOT NULL,
@@ -110,7 +128,7 @@ impl PostgresStorage {
                     refund_tx TEXT,
                     refund_tx_id TEXT,
                     PRIMARY KEY (txid, vout)
-                )",
+                )".to_string(),
                 "CREATE TABLE IF NOT EXISTS payment_metadata (
                     payment_id TEXT PRIMARY KEY,
                     parent_payment_id TEXT,
@@ -118,7 +136,7 @@ impl PostgresStorage {
                     lnurl_withdraw_info JSONB,
                     lnurl_description TEXT,
                     conversion_info JSONB
-                )",
+                )".to_string(),
                 "CREATE TABLE IF NOT EXISTS payment_details_lightning (
                     payment_id TEXT PRIMARY KEY,
                     invoice TEXT NOT NULL,
@@ -126,27 +144,27 @@ impl PostgresStorage {
                     destination_pubkey TEXT NOT NULL,
                     description TEXT,
                     preimage TEXT
-                )",
+                )".to_string(),
                 "CREATE TABLE IF NOT EXISTS payment_details_token (
                     payment_id TEXT PRIMARY KEY,
                     metadata JSONB NOT NULL,
                     tx_hash TEXT NOT NULL,
                     invoice_details JSONB
-                )",
+                )".to_string(),
                 "CREATE TABLE IF NOT EXISTS payment_details_spark (
                     payment_id TEXT PRIMARY KEY,
                     invoice_details JSONB,
                     htlc_details JSONB
-                )",
+                )".to_string(),
                 "CREATE TABLE IF NOT EXISTS lnurl_receive_metadata (
                     payment_hash TEXT PRIMARY KEY,
                     nostr_zap_request TEXT,
                     nostr_zap_receipt TEXT,
                     sender_comment TEXT
-                )",
+                )".to_string(),
             ],
             // Migration 2: Sync tables
-            &[
+            vec![
                 // sync_revision: tracks the last committed revision (from server-acknowledged
                 // or server-received records). Does NOT include pending outgoing queue ids.
                 // sync_outgoing.revision stores a local queue id for ordering/de-duplication only.
@@ -154,8 +172,8 @@ impl PostgresStorage {
                     id INTEGER PRIMARY KEY DEFAULT 1,
                     revision BIGINT NOT NULL DEFAULT 0,
                     CHECK (id = 1)
-                )",
-                "INSERT INTO sync_revision (id, revision) VALUES (1, 0) ON CONFLICT (id) DO NOTHING",
+                )".to_string(),
+                "INSERT INTO sync_revision (id, revision) VALUES (1, 0) ON CONFLICT (id) DO NOTHING".to_string(),
                 "CREATE TABLE IF NOT EXISTS sync_outgoing (
                     record_type TEXT NOT NULL,
                     data_id TEXT NOT NULL,
@@ -163,8 +181,8 @@ impl PostgresStorage {
                     commit_time BIGINT NOT NULL,
                     updated_fields_json JSONB NOT NULL,
                     revision BIGINT NOT NULL
-                )",
-                "CREATE INDEX IF NOT EXISTS idx_sync_outgoing_data_id_record_type ON sync_outgoing(record_type, data_id)",
+                )".to_string(),
+                "CREATE INDEX IF NOT EXISTS idx_sync_outgoing_data_id_record_type ON sync_outgoing(record_type, data_id)".to_string(),
                 "CREATE TABLE IF NOT EXISTS sync_state (
                     record_type TEXT NOT NULL,
                     data_id TEXT NOT NULL,
@@ -173,7 +191,7 @@ impl PostgresStorage {
                     data JSONB NOT NULL,
                     revision BIGINT NOT NULL,
                     PRIMARY KEY(record_type, data_id)
-                )",
+                )".to_string(),
                 "CREATE TABLE IF NOT EXISTS sync_incoming (
                     record_type TEXT NOT NULL,
                     data_id TEXT NOT NULL,
@@ -182,82 +200,196 @@ impl PostgresStorage {
                     data JSONB NOT NULL,
                     revision BIGINT NOT NULL,
                     PRIMARY KEY(record_type, data_id, revision)
-                )",
-                "CREATE INDEX IF NOT EXISTS idx_sync_incoming_revision ON sync_incoming(revision)",
+                )".to_string(),
+                "CREATE INDEX IF NOT EXISTS idx_sync_incoming_revision ON sync_incoming(revision)".to_string(),
             ],
             // Migration 3: Indexes
-            &[
-                "CREATE INDEX IF NOT EXISTS idx_payments_timestamp ON payments(timestamp)",
-                "CREATE INDEX IF NOT EXISTS idx_payments_payment_type ON payments(payment_type)",
-                "CREATE INDEX IF NOT EXISTS idx_payments_status ON payments(status)",
-                "CREATE INDEX IF NOT EXISTS idx_payment_details_lightning_invoice ON payment_details_lightning(invoice)",
-                "CREATE INDEX IF NOT EXISTS idx_payment_metadata_parent ON payment_metadata(parent_payment_id)",
+            vec![
+                "CREATE INDEX IF NOT EXISTS idx_payments_timestamp ON payments(timestamp)".to_string(),
+                "CREATE INDEX IF NOT EXISTS idx_payments_payment_type ON payments(payment_type)".to_string(),
+                "CREATE INDEX IF NOT EXISTS idx_payments_status ON payments(status)".to_string(),
+                "CREATE INDEX IF NOT EXISTS idx_payment_details_lightning_invoice ON payment_details_lightning(invoice)".to_string(),
+                "CREATE INDEX IF NOT EXISTS idx_payment_metadata_parent ON payment_metadata(parent_payment_id)".to_string(),
             ],
             // Migration 4: Add tx_type to token payments
-            &[
-                "ALTER TABLE payment_details_token ADD COLUMN tx_type TEXT NOT NULL DEFAULT 'transfer'",
+            vec![
+                "ALTER TABLE payment_details_token ADD COLUMN tx_type TEXT NOT NULL DEFAULT 'transfer'".to_string(),
             ],
             // Migration 5: Clear sync tables to force re-sync
-            &[
-                "DELETE FROM sync_outgoing",
-                "DELETE FROM sync_incoming",
-                "DELETE FROM sync_state",
-                "UPDATE sync_revision SET revision = 0",
-                "DELETE FROM settings WHERE key = 'sync_initial_complete'",
+            vec![
+                "DELETE FROM sync_outgoing".to_string(),
+                "DELETE FROM sync_incoming".to_string(),
+                "DELETE FROM sync_state".to_string(),
+                "UPDATE sync_revision SET revision = 0".to_string(),
+                "DELETE FROM settings WHERE key = 'sync_initial_complete'".to_string(),
             ],
             // Migration 6: Add htlc_status and htlc_expiry_time to lightning payments
-            &[
-                "ALTER TABLE payment_details_lightning ADD COLUMN htlc_status TEXT NOT NULL DEFAULT 'WaitingForPreimage'",
-                "ALTER TABLE payment_details_lightning ADD COLUMN htlc_expiry_time BIGINT NOT NULL DEFAULT 0",
+            vec![
+                "ALTER TABLE payment_details_lightning ADD COLUMN htlc_status TEXT NOT NULL DEFAULT 'WaitingForPreimage'".to_string(),
+                "ALTER TABLE payment_details_lightning ADD COLUMN htlc_expiry_time BIGINT NOT NULL DEFAULT 0".to_string(),
             ],
             // Migration 7: Backfill htlc_status for existing Lightning payments
-            &[
+            vec![
                 "UPDATE payment_details_lightning
                  SET htlc_status = CASE
                          WHEN (SELECT status FROM payments WHERE id = payment_id) = 'completed' THEN 'PreimageShared'
                          WHEN (SELECT status FROM payments WHERE id = payment_id) = 'pending' THEN 'WaitingForPreimage'
                          ELSE 'Returned'
-                     END",
+                     END".to_string(),
                 "UPDATE settings
                  SET value = jsonb_set(value::jsonb, '{offset}', '0')::text
-                 WHERE key = 'sync_offset' AND value IS NOT NULL",
+                 WHERE key = 'sync_offset' AND value IS NOT NULL".to_string(),
             ],
             // Migration 8: Add preimage column for LUD-21 and NIP-57 support
-            &[
-                "ALTER TABLE lnurl_receive_metadata ADD COLUMN IF NOT EXISTS preimage TEXT",
+            vec![
+                "ALTER TABLE lnurl_receive_metadata ADD COLUMN IF NOT EXISTS preimage TEXT".to_string(),
                 // Clear the lnurl_metadata_updated_after setting to force re-sync
                 // This ensures clients get the new preimage field from the server
-                "DELETE FROM settings WHERE key = 'lnurl_metadata_updated_after'",
+                "DELETE FROM settings WHERE key = 'lnurl_metadata_updated_after'".to_string(),
             ],
             // Migration 9: Clear cached lightning address - schema changed from string to LnurlInfo struct
-            &[
-                "DELETE FROM settings WHERE key = 'lightning_address'",
+            vec![
+                "DELETE FROM settings WHERE key = 'lightning_address'".to_string(),
             ],
             // Migration 10: Add index on payment_hash for JOIN with lnurl_receive_metadata
-            &[
-                "CREATE INDEX IF NOT EXISTS idx_payment_details_lightning_payment_hash ON payment_details_lightning(payment_hash)",
+            vec![
+                "CREATE INDEX IF NOT EXISTS idx_payment_details_lightning_payment_hash ON payment_details_lightning(payment_hash)".to_string(),
             ],
             // Migration 11: Contacts table
-            &["CREATE TABLE IF NOT EXISTS contacts (
+            vec!["CREATE TABLE IF NOT EXISTS contacts (
                     id TEXT PRIMARY KEY,
                     name TEXT NOT NULL,
                     payment_identifier TEXT NOT NULL,
                     created_at BIGINT NOT NULL,
                     updated_at BIGINT NOT NULL
-                )"],
+                )".to_string()],
             // Migration 12: Drop preimage column from lnurl_receive_metadata - no longer needed
             // since the server handles preimage tracking via webhooks.
-            &["ALTER TABLE lnurl_receive_metadata DROP COLUMN IF EXISTS preimage"],
+            vec!["ALTER TABLE lnurl_receive_metadata DROP COLUMN IF EXISTS preimage".to_string()],
             // Migration 13: Clear cached lightning address - format changed to CachedLightningAddress wrapper
-            &["DELETE FROM settings WHERE key = 'lightning_address'"],
+            vec!["DELETE FROM settings WHERE key = 'lightning_address'".to_string()],
             // Migration 14: Add is_mature to unclaimed_deposits
-            &[
-                "ALTER TABLE unclaimed_deposits ADD COLUMN is_mature BOOLEAN NOT NULL DEFAULT TRUE",
+            vec![
+                "ALTER TABLE unclaimed_deposits ADD COLUMN is_mature BOOLEAN NOT NULL DEFAULT TRUE".to_string(),
             ],
             // Migration 15: Add conversion_status to payment_metadata
-            &["ALTER TABLE payment_metadata ADD COLUMN IF NOT EXISTS conversion_status TEXT"],
+            vec!["ALTER TABLE payment_metadata ADD COLUMN IF NOT EXISTS conversion_status TEXT".to_string()],
+            // Migration 16: Multi-tenant scoping. Adds a `user_id BYTEA` column to every
+            // per-user table, backfills it to the current tenant's identity (so existing
+            // single-tenant deployments remain readable), sets NOT NULL, and rewrites
+            // primary keys / indexes to lead with `user_id`. The literal hex of `identity`
+            // is inlined into the SQL: identity bytes come from a typed secp256k1 pubkey
+            // so the character set is restricted to `[0-9a-f]{66}` — no SQL-injection
+            // surface even though the value is concatenated rather than parameter-bound.
+            // (Migrations are run as untyped batch_execute, so parameter binding is not
+            // available without restructuring the runner.)
+            multi_tenant_migration(identity),
         ]
     }
+}
+
+/// Builds the multi-tenant scoping migration. The `identity` is a 33-byte
+/// compressed secp256k1 pubkey; it's hex-encoded and inlined as a BYTEA literal
+/// so it can be parameter-free SQL (the migration runner uses `batch_execute`).
+fn multi_tenant_migration(identity: &[u8]) -> Vec<String> {
+    let id_hex = hex::encode(identity);
+    let id_lit = format!("'\\x{id_hex}'::bytea");
+
+    let scope_table = |table: &str, pk_cols: &str| -> Vec<String> {
+        vec![
+            format!("ALTER TABLE {table} ADD COLUMN user_id BYTEA"),
+            format!("UPDATE {table} SET user_id = {id_lit}"),
+            format!(
+                "ALTER TABLE {table} \
+                 ALTER COLUMN user_id SET NOT NULL, \
+                 DROP CONSTRAINT IF EXISTS {table}_pkey, \
+                 ADD PRIMARY KEY (user_id, {pk_cols})"
+            ),
+        ]
+    };
+
+    let mut stmts = Vec::new();
+
+    stmts.extend(scope_table("payments", "id"));
+    // Per-user index rewrite for payments
+    stmts.push("DROP INDEX IF EXISTS idx_payments_timestamp".to_string());
+    stmts.push("DROP INDEX IF EXISTS idx_payments_payment_type".to_string());
+    stmts.push("DROP INDEX IF EXISTS idx_payments_status".to_string());
+    stmts.push(
+        "CREATE INDEX idx_payments_user_timestamp ON payments(user_id, timestamp)".to_string(),
+    );
+    stmts.push(
+        "CREATE INDEX idx_payments_user_payment_type ON payments(user_id, payment_type)"
+            .to_string(),
+    );
+    stmts.push("CREATE INDEX idx_payments_user_status ON payments(user_id, status)".to_string());
+
+    stmts.extend(scope_table("payment_metadata", "payment_id"));
+    stmts.push("DROP INDEX IF EXISTS idx_payment_metadata_parent".to_string());
+    stmts.push(
+        "CREATE INDEX idx_payment_metadata_user_parent \
+         ON payment_metadata(user_id, parent_payment_id)"
+            .to_string(),
+    );
+
+    stmts.extend(scope_table("payment_details_lightning", "payment_id"));
+    stmts.push("DROP INDEX IF EXISTS idx_payment_details_lightning_invoice".to_string());
+    stmts.push("DROP INDEX IF EXISTS idx_payment_details_lightning_payment_hash".to_string());
+    stmts.push(
+        "CREATE INDEX idx_payment_details_lightning_user_invoice \
+         ON payment_details_lightning(user_id, invoice)"
+            .to_string(),
+    );
+    stmts.push(
+        "CREATE INDEX idx_payment_details_lightning_user_payment_hash \
+         ON payment_details_lightning(user_id, payment_hash)"
+            .to_string(),
+    );
+
+    stmts.extend(scope_table("payment_details_token", "payment_id"));
+    stmts.extend(scope_table("payment_details_spark", "payment_id"));
+    stmts.extend(scope_table("lnurl_receive_metadata", "payment_hash"));
+    stmts.extend(scope_table("unclaimed_deposits", "txid, vout"));
+    stmts.extend(scope_table("contacts", "id"));
+    stmts.extend(scope_table("settings", "key"));
+
+    // sync_revision was a single-row table (PK id=1, CHECK id=1). Drop the id column
+    // (CASCADE clears the PK and the CHECK), then re-key by user_id so every tenant
+    // has its own revision counter.
+    stmts.push("ALTER TABLE sync_revision DROP COLUMN id CASCADE".to_string());
+    stmts.push("ALTER TABLE sync_revision ADD COLUMN user_id BYTEA".to_string());
+    stmts.push(format!("UPDATE sync_revision SET user_id = {id_lit}"));
+    stmts.push(
+        "ALTER TABLE sync_revision \
+         ALTER COLUMN user_id SET NOT NULL, \
+         ADD PRIMARY KEY (user_id)"
+            .to_string(),
+    );
+
+    // sync_outgoing has no PK, only an index — just add user_id and rewrite the index.
+    stmts.push("ALTER TABLE sync_outgoing ADD COLUMN user_id BYTEA".to_string());
+    stmts.push(format!("UPDATE sync_outgoing SET user_id = {id_lit}"));
+    stmts.push("ALTER TABLE sync_outgoing ALTER COLUMN user_id SET NOT NULL".to_string());
+    stmts.push("DROP INDEX IF EXISTS idx_sync_outgoing_data_id_record_type".to_string());
+    stmts.push(
+        "CREATE INDEX idx_sync_outgoing_user_record_type_data_id \
+         ON sync_outgoing(user_id, record_type, data_id)"
+            .to_string(),
+    );
+
+    stmts.extend(scope_table("sync_state", "record_type, data_id"));
+
+    stmts.extend(scope_table(
+        "sync_incoming",
+        "record_type, data_id, revision",
+    ));
+    stmts.push("DROP INDEX IF EXISTS idx_sync_incoming_revision".to_string());
+    stmts.push(
+        "CREATE INDEX idx_sync_incoming_user_revision ON sync_incoming(user_id, revision)"
+            .to_string(),
+    );
+
+    stmts
 }
 
 /// Converts an optional serializable value to an optional `serde_json::Value` for JSONB storage.
@@ -289,10 +421,11 @@ impl Storage for PostgresStorage {
     ) -> Result<Vec<Payment>, StorageError> {
         let client = self.pool.get().await.map_err(map_pool_error)?;
 
-        // Build WHERE clauses based on filters
-        let mut where_clauses = Vec::new();
-        let mut params: Vec<Box<dyn ToSql + Sync + Send>> = Vec::new();
-        let mut param_idx = 1;
+        // Build WHERE clauses based on filters. Tenant scoping is always $1; subsequent
+        // dynamic filters use $2 onward.
+        let mut where_clauses = vec!["p.user_id = $1".to_string()];
+        let mut params: Vec<Box<dyn ToSql + Sync + Send>> = vec![Box::new(self.identity.clone())];
+        let mut param_idx = 2;
 
         // Filter by payment type
         if let Some(ref type_filter) = request.type_filter
@@ -460,12 +593,8 @@ impl Storage for PostgresStorage {
         // Exclude child payments
         where_clauses.push("pm.parent_payment_id IS NULL".to_string());
 
-        // Build the WHERE clause
-        let where_sql = if where_clauses.is_empty() {
-            String::new()
-        } else {
-            format!("WHERE {}", where_clauses.join(" AND "))
-        };
+        // Build the WHERE clause (always non-empty: tenant scoping is the first clause)
+        let where_sql = format!("WHERE {}", where_clauses.join(" AND "));
 
         // Determine sort order
         let order_direction = if request.sort_ascending.unwrap_or(false) {
@@ -519,9 +648,9 @@ impl Storage for PostgresStorage {
 
         // Insert or update main payment record (including detail columns atomically)
         tx.execute(
-            "INSERT INTO payments (id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-                 ON CONFLICT(id) DO UPDATE SET
+            "INSERT INTO payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                 ON CONFLICT(user_id, id) DO UPDATE SET
                     payment_type = EXCLUDED.payment_type,
                     status = EXCLUDED.status,
                     amount = EXCLUDED.amount,
@@ -532,6 +661,7 @@ impl Storage for PostgresStorage {
                     deposit_tx_id = EXCLUDED.deposit_tx_id,
                     spark = EXCLUDED.spark",
             &[
+                &self.identity,
                 &payment.id,
                 &payment.payment_type.to_string(),
                 &payment.status.to_string(),
@@ -556,12 +686,12 @@ impl Storage for PostgresStorage {
                     let invoice_json = to_json_opt(invoice_details.as_ref())?;
                     let htlc_json = to_json_opt(htlc_details.as_ref())?;
                     tx.execute(
-                        "INSERT INTO payment_details_spark (payment_id, invoice_details, htlc_details)
-                             VALUES ($1, $2, $3)
-                             ON CONFLICT(payment_id) DO UPDATE SET
+                        "INSERT INTO payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
+                             VALUES ($1, $2, $3, $4)
+                             ON CONFLICT(user_id, payment_id) DO UPDATE SET
                                 invoice_details = COALESCE(EXCLUDED.invoice_details, payment_details_spark.invoice_details),
                                 htlc_details = COALESCE(EXCLUDED.htlc_details, payment_details_spark.htlc_details)",
-                        &[&payment.id, &invoice_json, &htlc_json],
+                        &[&self.identity, &payment.id, &invoice_json, &htlc_json],
                     )
                     .await?;
                 }
@@ -577,14 +707,14 @@ impl Storage for PostgresStorage {
                     .map_err(|e| StorageError::Serialization(e.to_string()))?;
                 let invoice_json = to_json_opt(invoice_details.as_ref())?;
                 tx.execute(
-                    "INSERT INTO payment_details_token (payment_id, metadata, tx_hash, tx_type, invoice_details)
-                         VALUES ($1, $2, $3, $4, $5)
-                         ON CONFLICT(payment_id) DO UPDATE SET
+                    "INSERT INTO payment_details_token (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
+                         VALUES ($1, $2, $3, $4, $5, $6)
+                         ON CONFLICT(user_id, payment_id) DO UPDATE SET
                             metadata = EXCLUDED.metadata,
                             tx_hash = EXCLUDED.tx_hash,
                             tx_type = EXCLUDED.tx_type,
                             invoice_details = COALESCE(EXCLUDED.invoice_details, payment_details_token.invoice_details)",
-                    &[&payment.id, &metadata_json, &tx_hash, &tx_type.to_string(), &invoice_json],
+                    &[&self.identity, &payment.id, &metadata_json, &tx_hash, &tx_type.to_string(), &invoice_json],
                 )
                 .await?;
             }
@@ -600,9 +730,9 @@ impl Storage for PostgresStorage {
                 let htlc_status = htlc_details.status.to_string();
                 let htlc_expiry_time = i64::try_from(htlc_details.expiry_time)?;
                 tx.execute(
-                    "INSERT INTO payment_details_lightning (payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
-                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-                         ON CONFLICT(payment_id) DO UPDATE SET
+                    "INSERT INTO payment_details_lightning (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
+                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                         ON CONFLICT(user_id, payment_id) DO UPDATE SET
                             invoice = EXCLUDED.invoice,
                             payment_hash = EXCLUDED.payment_hash,
                             destination_pubkey = EXCLUDED.destination_pubkey,
@@ -610,7 +740,7 @@ impl Storage for PostgresStorage {
                             preimage = COALESCE(EXCLUDED.preimage, payment_details_lightning.preimage),
                             htlc_status = COALESCE(EXCLUDED.htlc_status, payment_details_lightning.htlc_status),
                             htlc_expiry_time = COALESCE(EXCLUDED.htlc_expiry_time, payment_details_lightning.htlc_expiry_time)",
-                    &[&payment.id, &invoice, payment_hash, &destination_pubkey, &description, preimage, &htlc_status, &htlc_expiry_time],
+                    &[&self.identity, &payment.id, &invoice, payment_hash, &destination_pubkey, &description, preimage, &htlc_status, &htlc_expiry_time],
                 )
                 .await?;
             }
@@ -640,9 +770,9 @@ impl Storage for PostgresStorage {
 
         client
             .execute(
-                "INSERT INTO payment_metadata (payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7)
-                 ON CONFLICT(payment_id) DO UPDATE SET
+                "INSERT INTO payment_metadata (user_id, payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                 ON CONFLICT(user_id, payment_id) DO UPDATE SET
                     parent_payment_id = COALESCE(EXCLUDED.parent_payment_id, payment_metadata.parent_payment_id),
                     lnurl_pay_info = COALESCE(EXCLUDED.lnurl_pay_info, payment_metadata.lnurl_pay_info),
                     lnurl_withdraw_info = COALESCE(EXCLUDED.lnurl_withdraw_info, payment_metadata.lnurl_withdraw_info),
@@ -650,6 +780,7 @@ impl Storage for PostgresStorage {
                     conversion_info = COALESCE(EXCLUDED.conversion_info, payment_metadata.conversion_info),
                     conversion_status = COALESCE(EXCLUDED.conversion_status, payment_metadata.conversion_status)",
                 &[
+                    &self.identity,
                     &payment_id,
                     &metadata.parent_payment_id,
                     &lnurl_pay_info_json,
@@ -669,9 +800,9 @@ impl Storage for PostgresStorage {
 
         client
             .execute(
-                "INSERT INTO settings (key, value) VALUES ($1, $2)
-                 ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value",
-                &[&key, &value],
+                "INSERT INTO settings (user_id, key, value) VALUES ($1, $2, $3)
+                 ON CONFLICT(user_id, key) DO UPDATE SET value = EXCLUDED.value",
+                &[&self.identity, &key, &value],
             )
             .await?;
 
@@ -682,7 +813,10 @@ impl Storage for PostgresStorage {
         let client = self.pool.get().await.map_err(map_pool_error)?;
 
         let row = client
-            .query_opt("SELECT value FROM settings WHERE key = $1", &[&key])
+            .query_opt(
+                "SELECT value FROM settings WHERE user_id = $1 AND key = $2",
+                &[&self.identity, &key],
+            )
             .await?;
 
         Ok(row.map(|r| r.get(0)))
@@ -692,7 +826,10 @@ impl Storage for PostgresStorage {
         let client = self.pool.get().await.map_err(map_pool_error)?;
 
         client
-            .execute("DELETE FROM settings WHERE key = $1", &[&key])
+            .execute(
+                "DELETE FROM settings WHERE user_id = $1 AND key = $2",
+                &[&self.identity, &key],
+            )
             .await?;
 
         Ok(())
@@ -700,9 +837,9 @@ impl Storage for PostgresStorage {
 
     async fn get_payment_by_id(&self, id: String) -> Result<Payment, StorageError> {
         let client = self.pool.get().await.map_err(map_pool_error)?;
-        let query = format!("{SELECT_PAYMENT_SQL} WHERE p.id = $1");
+        let query = format!("{SELECT_PAYMENT_SQL} WHERE p.user_id = $1 AND p.id = $2");
         let row = client
-            .query_one(&query, &[&id])
+            .query_one(&query, &[&self.identity, &id])
             .await
             .map_err(map_db_error)?;
         map_payment(&row)
@@ -713,8 +850,10 @@ impl Storage for PostgresStorage {
         invoice: String,
     ) -> Result<Option<Payment>, StorageError> {
         let client = self.pool.get().await.map_err(map_pool_error)?;
-        let query = format!("{SELECT_PAYMENT_SQL} WHERE l.invoice = $1");
-        let row = client.query_opt(&query, &[&invoice]).await?;
+        let query = format!("{SELECT_PAYMENT_SQL} WHERE p.user_id = $1 AND l.invoice = $2");
+        let row = client
+            .query_opt(&query, &[&self.identity, &invoice])
+            .await?;
 
         match row {
             Some(r) => Ok(Some(map_payment(&r)?)),
@@ -733,11 +872,11 @@ impl Storage for PostgresStorage {
 
         let client = self.pool.get().await.map_err(map_pool_error)?;
 
-        // Early exit if no related payments exist
+        // Early exit if no related payments exist for this tenant
         let has_related: bool = client
             .query_one(
-                "SELECT EXISTS(SELECT 1 FROM payment_metadata WHERE parent_payment_id IS NOT NULL LIMIT 1)",
-                &[],
+                "SELECT EXISTS(SELECT 1 FROM payment_metadata WHERE user_id = $1 AND parent_payment_id IS NOT NULL LIMIT 1)",
+                &[&self.identity],
             )
             .await
             .is_ok_and(|row| row.get(0));
@@ -746,22 +885,25 @@ impl Storage for PostgresStorage {
             return Ok(HashMap::new());
         }
 
-        // Build the IN clause with placeholders
+        // Build the IN clause with placeholders. $1 is reserved for user_id; parent ids
+        // start at $2.
         let placeholders: Vec<String> = parent_payment_ids
             .iter()
             .enumerate()
-            .map(|(i, _)| format!("${}", i + 1))
+            .map(|(i, _)| format!("${}", i + 2))
             .collect();
         let in_clause = placeholders.join(", ");
 
         let query = format!(
-            "{SELECT_PAYMENT_SQL} WHERE pm.parent_payment_id IN ({in_clause}) ORDER BY p.timestamp ASC"
+            "{SELECT_PAYMENT_SQL} WHERE p.user_id = $1 AND pm.parent_payment_id IN ({in_clause}) ORDER BY p.timestamp ASC"
         );
 
-        let params: Vec<&(dyn ToSql + Sync)> = parent_payment_ids
-            .iter()
-            .map(|id| id as &(dyn ToSql + Sync))
-            .collect();
+        let mut params: Vec<&(dyn ToSql + Sync)> = vec![&self.identity];
+        params.extend(
+            parent_payment_ids
+                .iter()
+                .map(|id| id as &(dyn ToSql + Sync)),
+        );
 
         let rows = client.query(&query, &params).await?;
 
@@ -785,10 +927,11 @@ impl Storage for PostgresStorage {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         client
             .execute(
-                "INSERT INTO unclaimed_deposits (txid, vout, amount_sats, is_mature)
-                 VALUES ($1, $2, $3, $4)
-                 ON CONFLICT(txid, vout) DO UPDATE SET is_mature = EXCLUDED.is_mature, amount_sats = EXCLUDED.amount_sats",
+                "INSERT INTO unclaimed_deposits (user_id, txid, vout, amount_sats, is_mature)
+                 VALUES ($1, $2, $3, $4, $5)
+                 ON CONFLICT(user_id, txid, vout) DO UPDATE SET is_mature = EXCLUDED.is_mature, amount_sats = EXCLUDED.amount_sats",
                 &[
+                    &self.identity,
                     &txid,
                     &i32::try_from(vout)?,
                     &i64::try_from(amount_sats)?,
@@ -803,8 +946,8 @@ impl Storage for PostgresStorage {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         client
             .execute(
-                "DELETE FROM unclaimed_deposits WHERE txid = $1 AND vout = $2",
-                &[&txid, &i32::try_from(vout)?],
+                "DELETE FROM unclaimed_deposits WHERE user_id = $1 AND txid = $2 AND vout = $3",
+                &[&self.identity, &txid, &i32::try_from(vout)?],
             )
             .await?;
         Ok(())
@@ -814,8 +957,8 @@ impl Storage for PostgresStorage {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         let rows = client
             .query(
-                "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM unclaimed_deposits",
-                &[],
+                "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM unclaimed_deposits WHERE user_id = $1",
+                &[&self.identity],
             )
             .await?;
 
@@ -854,8 +997,8 @@ impl Storage for PostgresStorage {
                     .map_err(|e| StorageError::Serialization(e.to_string()))?;
                 client
                     .execute(
-                        "UPDATE unclaimed_deposits SET claim_error = $1, refund_tx = NULL, refund_tx_id = NULL WHERE txid = $2 AND vout = $3",
-                        &[&error_json, &txid, &i32::try_from(vout)?],
+                        "UPDATE unclaimed_deposits SET claim_error = $1, refund_tx = NULL, refund_tx_id = NULL WHERE user_id = $2 AND txid = $3 AND vout = $4",
+                        &[&error_json, &self.identity, &txid, &i32::try_from(vout)?],
                     )
                     .await?;
             }
@@ -865,8 +1008,8 @@ impl Storage for PostgresStorage {
             } => {
                 client
                     .execute(
-                        "UPDATE unclaimed_deposits SET refund_tx = $1, refund_tx_id = $2, claim_error = NULL WHERE txid = $3 AND vout = $4",
-                        &[&refund_tx, &refund_txid, &txid, &i32::try_from(vout)?],
+                        "UPDATE unclaimed_deposits SET refund_tx = $1, refund_tx_id = $2, claim_error = NULL WHERE user_id = $3 AND txid = $4 AND vout = $5",
+                        &[&refund_tx, &refund_txid, &self.identity, &txid, &i32::try_from(vout)?],
                     )
                     .await?;
             }
@@ -882,13 +1025,13 @@ impl Storage for PostgresStorage {
         for m in metadata {
             client
                 .execute(
-                    "INSERT INTO lnurl_receive_metadata (payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
-                     VALUES ($1, $2, $3, $4)
-                     ON CONFLICT(payment_hash) DO UPDATE SET
+                    "INSERT INTO lnurl_receive_metadata (user_id, payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
+                     VALUES ($1, $2, $3, $4, $5)
+                     ON CONFLICT(user_id, payment_hash) DO UPDATE SET
                         nostr_zap_request = EXCLUDED.nostr_zap_request,
                         nostr_zap_receipt = EXCLUDED.nostr_zap_receipt,
                         sender_comment = EXCLUDED.sender_comment",
-                    &[&m.payment_hash, &m.nostr_zap_request, &m.nostr_zap_receipt, &m.sender_comment],
+                    &[&self.identity, &m.payment_hash, &m.nostr_zap_request, &m.nostr_zap_receipt, &m.sender_comment],
                 )
                 .await?;
         }
@@ -906,8 +1049,8 @@ impl Storage for PostgresStorage {
         let rows = client
             .query(
                 "SELECT id, name, payment_identifier, created_at, updated_at
-                 FROM contacts ORDER BY name ASC LIMIT $1 OFFSET $2",
-                &[&limit, &offset],
+                 FROM contacts WHERE user_id = $1 ORDER BY name ASC LIMIT $2 OFFSET $3",
+                &[&self.identity, &limit, &offset],
             )
             .await?;
 
@@ -929,8 +1072,8 @@ impl Storage for PostgresStorage {
         let row = client
             .query_opt(
                 "SELECT id, name, payment_identifier, created_at, updated_at
-                 FROM contacts WHERE id = $1",
-                &[&id],
+                 FROM contacts WHERE user_id = $1 AND id = $2",
+                &[&self.identity, &id],
             )
             .await?
             .ok_or(StorageError::NotFound)?;
@@ -947,13 +1090,14 @@ impl Storage for PostgresStorage {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         let result = client
             .execute(
-                "INSERT INTO contacts (id, name, payment_identifier, created_at, updated_at)
-                 VALUES ($1, $2, $3, $4, $5)
-                 ON CONFLICT (id) DO UPDATE SET
+                "INSERT INTO contacts (user_id, id, name, payment_identifier, created_at, updated_at)
+                 VALUES ($1, $2, $3, $4, $5, $6)
+                 ON CONFLICT (user_id, id) DO UPDATE SET
                    name = EXCLUDED.name,
                    payment_identifier = EXCLUDED.payment_identifier,
                    updated_at = EXCLUDED.updated_at",
                 &[
+                    &self.identity,
                     &contact.id,
                     &contact.name,
                     &contact.payment_identifier,
@@ -972,7 +1116,10 @@ impl Storage for PostgresStorage {
     async fn delete_contact(&self, id: String) -> Result<(), StorageError> {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         client
-            .execute("DELETE FROM contacts WHERE id = $1", &[&id])
+            .execute(
+                "DELETE FROM contacts WHERE user_id = $1 AND id = $2",
+                &[&self.identity, &id],
+            )
             .await?;
         Ok(())
     }
@@ -989,10 +1136,11 @@ impl Storage for PostgresStorage {
             .map_err(|e| StorageError::Connection(e.to_string()))?;
 
         // This revision is a local queue id for pending rows, not a server revision.
+        // Scoped per-tenant so two tenants don't share a queue.
         let local_revision: i64 = tx
             .query_one(
-                "SELECT COALESCE(MAX(revision), 0) + 1 FROM sync_outgoing",
-                &[],
+                "SELECT COALESCE(MAX(revision), 0) + 1 FROM sync_outgoing WHERE user_id = $1",
+                &[&self.identity],
             )
             .await
             .map_err(|e| StorageError::Connection(e.to_string()))?
@@ -1003,9 +1151,10 @@ impl Storage for PostgresStorage {
         let commit_time = chrono::Utc::now().timestamp();
 
         tx.execute(
-            "INSERT INTO sync_outgoing (record_type, data_id, schema_version, commit_time, updated_fields_json, revision)
-                 VALUES ($1, $2, $3, $4, $5, $6)",
+            "INSERT INTO sync_outgoing (user_id, record_type, data_id, schema_version, commit_time, updated_fields_json, revision)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)",
             &[
+                &self.identity,
                 &record.id.r#type,
                 &record.id.data_id,
                 &record.schema_version,
@@ -1039,8 +1188,9 @@ impl Storage for PostgresStorage {
 
         let rows_deleted = tx
             .execute(
-                "DELETE FROM sync_outgoing WHERE record_type = $1 AND data_id = $2 AND revision = $3",
+                "DELETE FROM sync_outgoing WHERE user_id = $1 AND record_type = $2 AND data_id = $3 AND revision = $4",
                 &[
+                    &self.identity,
                     &record.id.r#type,
                     &record.id.data_id,
                     &i64::try_from(local_revision)?,
@@ -1062,14 +1212,15 @@ impl Storage for PostgresStorage {
         let commit_time = chrono::Utc::now().timestamp();
 
         tx.execute(
-            "INSERT INTO sync_state (record_type, data_id, schema_version, commit_time, data, revision)
-                 VALUES ($1, $2, $3, $4, $5, $6)
-                 ON CONFLICT(record_type, data_id) DO UPDATE SET
+            "INSERT INTO sync_state (user_id, record_type, data_id, schema_version, commit_time, data, revision)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)
+                 ON CONFLICT(user_id, record_type, data_id) DO UPDATE SET
                     schema_version = EXCLUDED.schema_version,
                     commit_time = EXCLUDED.commit_time,
                     data = EXCLUDED.data,
                     revision = EXCLUDED.revision",
             &[
+                &self.identity,
                 &record.id.r#type,
                 &record.id.data_id,
                 &record.schema_version,
@@ -1081,9 +1232,12 @@ impl Storage for PostgresStorage {
         .await
         .map_err(|e| StorageError::Connection(e.to_string()))?;
 
+        // Upsert this tenant's revision row. The migration creates a row at backfill, but
+        // a fresh tenant joining a shared DB after migration won't have one yet.
         tx.execute(
-            "UPDATE sync_revision SET revision = GREATEST(revision, $1)",
-            &[&i64::try_from(record.revision)?],
+            "INSERT INTO sync_revision (user_id, revision) VALUES ($1, $2) \
+             ON CONFLICT (user_id) DO UPDATE SET revision = GREATEST(sync_revision.revision, EXCLUDED.revision)",
+            &[&self.identity, &i64::try_from(record.revision)?],
         )
         .await
         .map_err(|e| StorageError::Connection(e.to_string()))?;
@@ -1106,10 +1260,11 @@ impl Storage for PostgresStorage {
                 "SELECT o.record_type, o.data_id, o.schema_version, o.commit_time, o.updated_fields_json, o.revision,
                         e.schema_version AS existing_schema_version, e.commit_time AS existing_commit_time, e.data AS existing_data, e.revision AS existing_revision
                  FROM sync_outgoing o
-                 LEFT JOIN sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id
+                 LEFT JOIN sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id AND o.user_id = e.user_id
+                 WHERE o.user_id = $1
                  ORDER BY o.revision ASC
-                 LIMIT $1",
-                &[&i64::from(limit)],
+                 LIMIT $2",
+                &[&self.identity, &i64::from(limit)],
             )
             .await
             .map_err(|e| StorageError::Connection(e.to_string()))?;
@@ -1143,11 +1298,15 @@ impl Storage for PostgresStorage {
     async fn get_last_revision(&self) -> Result<u64, StorageError> {
         let client = self.pool.get().await.map_err(map_pool_error)?;
 
+        // A tenant that hasn't synced anything yet may not have a row. Treat missing as 0.
         let revision: i64 = client
-            .query_one("SELECT revision FROM sync_revision", &[])
+            .query_opt(
+                "SELECT revision FROM sync_revision WHERE user_id = $1",
+                &[&self.identity],
+            )
             .await
             .map_err(|e| StorageError::Connection(e.to_string()))?
-            .get(0);
+            .map_or(0, |row| row.get(0));
 
         Ok(u64::try_from(revision)?)
     }
@@ -1165,13 +1324,14 @@ impl Storage for PostgresStorage {
                 .map_err(|e| StorageError::Serialization(e.to_string()))?;
             client
                 .execute(
-                    "INSERT INTO sync_incoming (record_type, data_id, schema_version, commit_time, data, revision)
-                     VALUES ($1, $2, $3, $4, $5, $6)
-                     ON CONFLICT(record_type, data_id, revision) DO UPDATE SET
+                    "INSERT INTO sync_incoming (user_id, record_type, data_id, schema_version, commit_time, data, revision)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7)
+                     ON CONFLICT(user_id, record_type, data_id, revision) DO UPDATE SET
                         schema_version = EXCLUDED.schema_version,
                         commit_time = EXCLUDED.commit_time,
                         data = EXCLUDED.data",
                     &[
+                        &self.identity,
                         &record.id.r#type,
                         &record.id.data_id,
                         &record.schema_version,
@@ -1192,8 +1352,9 @@ impl Storage for PostgresStorage {
 
         client
             .execute(
-                "DELETE FROM sync_incoming WHERE record_type = $1 AND data_id = $2 AND revision = $3",
+                "DELETE FROM sync_incoming WHERE user_id = $1 AND record_type = $2 AND data_id = $3 AND revision = $4",
                 &[
+                    &self.identity,
                     &record.id.r#type,
                     &record.id.data_id,
                     &i64::try_from(record.revision)?,
@@ -1213,10 +1374,11 @@ impl Storage for PostgresStorage {
                 "SELECT i.record_type, i.data_id, i.schema_version, i.data, i.revision,
                         e.schema_version AS existing_schema_version, e.commit_time AS existing_commit_time, e.data AS existing_data, e.revision AS existing_revision
                  FROM sync_incoming i
-                 LEFT JOIN sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id
+                 LEFT JOIN sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id AND i.user_id = e.user_id
+                 WHERE i.user_id = $1
                  ORDER BY i.revision ASC
-                 LIMIT $1",
-                &[&i64::from(limit)],
+                 LIMIT $2",
+                &[&self.identity, &i64::from(limit)],
             )
             .await
             .map_err(|e| StorageError::Connection(e.to_string()))?;
@@ -1259,10 +1421,11 @@ impl Storage for PostgresStorage {
                 "SELECT o.record_type, o.data_id, o.schema_version, o.commit_time, o.updated_fields_json, o.revision,
                         e.schema_version AS existing_schema_version, e.commit_time AS existing_commit_time, e.data AS existing_data, e.revision AS existing_revision
                  FROM sync_outgoing o
-                 LEFT JOIN sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id
+                 LEFT JOIN sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id AND o.user_id = e.user_id
+                 WHERE o.user_id = $1
                  ORDER BY o.revision DESC
                  LIMIT 1",
-                &[],
+                &[&self.identity],
             )
             .await
             .map_err(|e| StorageError::Connection(e.to_string()))?;
@@ -1305,14 +1468,15 @@ impl Storage for PostgresStorage {
         let commit_time = chrono::Utc::now().timestamp();
 
         tx.execute(
-            "INSERT INTO sync_state (record_type, data_id, schema_version, commit_time, data, revision)
-                 VALUES ($1, $2, $3, $4, $5, $6)
-                 ON CONFLICT(record_type, data_id) DO UPDATE SET
+            "INSERT INTO sync_state (user_id, record_type, data_id, schema_version, commit_time, data, revision)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)
+                 ON CONFLICT(user_id, record_type, data_id) DO UPDATE SET
                     schema_version = EXCLUDED.schema_version,
                     commit_time = EXCLUDED.commit_time,
                     data = EXCLUDED.data,
                     revision = EXCLUDED.revision",
             &[
+                &self.identity,
                 &record.id.r#type,
                 &record.id.data_id,
                 &record.schema_version,
@@ -1324,9 +1488,11 @@ impl Storage for PostgresStorage {
         .await
         .map_err(|e| StorageError::Connection(e.to_string()))?;
 
+        // Upsert this tenant's revision row.
         tx.execute(
-            "UPDATE sync_revision SET revision = GREATEST(revision, $1)",
-            &[&i64::try_from(record.revision)?],
+            "INSERT INTO sync_revision (user_id, revision) VALUES ($1, $2) \
+             ON CONFLICT (user_id) DO UPDATE SET revision = GREATEST(sync_revision.revision, EXCLUDED.revision)",
+            &[&self.identity, &i64::try_from(record.revision)?],
         )
         .await
         .map_err(|e| StorageError::Connection(e.to_string()))?;
@@ -1375,11 +1541,11 @@ const SELECT_PAYMENT_SQL: &str = "
            pm.conversion_status,
            pm.parent_payment_id
       FROM payments p
-      LEFT JOIN payment_details_lightning l ON p.id = l.payment_id
-      LEFT JOIN payment_details_token t ON p.id = t.payment_id
-      LEFT JOIN payment_details_spark s ON p.id = s.payment_id
-      LEFT JOIN payment_metadata pm ON p.id = pm.payment_id
-      LEFT JOIN lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash";
+      LEFT JOIN payment_details_lightning l ON p.id = l.payment_id AND p.user_id = l.user_id
+      LEFT JOIN payment_details_token t ON p.id = t.payment_id AND p.user_id = t.user_id
+      LEFT JOIN payment_details_spark s ON p.id = s.payment_id AND p.user_id = s.user_id
+      LEFT JOIN payment_metadata pm ON p.id = pm.payment_id AND p.user_id = pm.user_id
+      LEFT JOIN lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash AND l.user_id = lrm.user_id";
 
 #[allow(clippy::too_many_lines)]
 fn map_payment(row: &Row) -> Result<Payment, StorageError> {
@@ -1545,6 +1711,14 @@ mod tests {
         container: ContainerAsync<Postgres>,
     }
 
+    /// A fixed 33-byte test identity used by single-tenant test fixtures.
+    /// Two-tenant isolation tests use a different identity for the second tenant.
+    pub(super) const TEST_IDENTITY_A: [u8; 33] = [
+        0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+        0x1e, 0x1f, 0x20,
+    ];
+
     impl PostgresTestFixture {
         async fn new() -> Self {
             // Start a PostgreSQL container using testcontainers
@@ -1564,10 +1738,12 @@ mod tests {
                 "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
             );
 
-            let storage =
-                PostgresStorage::new(PostgresStorageConfig::with_defaults(connection_string))
-                    .await
-                    .expect("Failed to create PostgresStorage");
+            let storage = PostgresStorage::new(
+                PostgresStorageConfig::with_defaults(connection_string),
+                &TEST_IDENTITY_A,
+            )
+            .await
+            .expect("Failed to create PostgresStorage");
 
             Self { storage, container }
         }
@@ -1696,6 +1872,342 @@ mod tests {
         crate::persist::tests::test_conversion_status_persistence(Box::new(fixture.storage)).await;
     }
 
+    /// A second 33-byte test identity (must differ from `TEST_IDENTITY_A`).
+    const TEST_IDENTITY_B: [u8; 33] = [
+        0x03, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae,
+        0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd,
+        0xbe, 0xbf, 0xc0,
+    ];
+
+    /// Two `PostgresStorage` instances with distinct identities sharing one
+    /// connection pool / DB. The container must be kept alive for the test.
+    struct TwoTenantFixture {
+        a: PostgresStorage,
+        b: PostgresStorage,
+        #[allow(dead_code)]
+        container: ContainerAsync<Postgres>,
+    }
+
+    impl TwoTenantFixture {
+        async fn new() -> Self {
+            let container = Postgres::default()
+                .start()
+                .await
+                .expect("Failed to start PostgreSQL container");
+
+            let host_port = container
+                .get_host_port_ipv4(5432)
+                .await
+                .expect("Failed to get host port");
+
+            let connection_string = format!(
+                "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
+            );
+
+            let config = PostgresStorageConfig::with_defaults(connection_string);
+            let pool = create_pool(&config).expect("Failed to create pool");
+
+            let a = PostgresStorage::new_with_pool(pool.clone(), &TEST_IDENTITY_A)
+                .await
+                .expect("Failed to create tenant A");
+            let b = PostgresStorage::new_with_pool(pool, &TEST_IDENTITY_B)
+                .await
+                .expect("Failed to create tenant B");
+
+            Self { a, b, container }
+        }
+    }
+
+    /// End-to-end isolation: every Storage method must keep tenants A and B
+    /// from observing each other's data. The test exercises each per-user
+    /// table — `payments`, `payment_metadata`, `lnurl_receive_metadata`,
+    /// `contacts`, `unclaimed_deposits`, `settings`, and the sync mirror
+    /// tables — and asserts that writes by A are invisible to B (and vice
+    /// versa). It is the regression net for "forgot the WHERE clause" bugs
+    /// in any future query.
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    async fn test_two_tenant_isolation() {
+        use crate::models::{Contact, ListContactsRequest};
+        use crate::persist::{Payment, StorageListPaymentsRequest};
+        use crate::sync_storage::{Record, RecordId, UnversionedRecordChange};
+        use crate::{
+            PaymentDetails, PaymentMethod, PaymentStatus, PaymentType, SetLnurlMetadataItem,
+            SparkHtlcDetails, SparkHtlcStatus, Storage,
+        };
+        use std::collections::HashMap;
+
+        let fx = TwoTenantFixture::new().await;
+
+        // --- payments (incl. lightning details) ---
+        let pmt_a = Payment {
+            id: "pmt_shared_id".to_string(),
+            payment_type: PaymentType::Send,
+            status: PaymentStatus::Completed,
+            amount: 1_000,
+            fees: 10,
+            timestamp: 100,
+            method: PaymentMethod::Lightning,
+            details: Some(PaymentDetails::Lightning {
+                invoice: "lnbc_a".to_string(),
+                destination_pubkey: "pkA".to_string(),
+                description: None,
+                htlc_details: SparkHtlcDetails {
+                    payment_hash: "shared_payment_hash".to_string(),
+                    preimage: Some("preimage_a".to_string()),
+                    expiry_time: 0,
+                    status: SparkHtlcStatus::PreimageShared,
+                },
+                lnurl_pay_info: None,
+                lnurl_withdraw_info: None,
+                lnurl_receive_metadata: None,
+            }),
+            conversion_details: None,
+        };
+        let mut pmt_b = pmt_a.clone();
+        if let Some(PaymentDetails::Lightning {
+            invoice,
+            destination_pubkey,
+            ..
+        }) = &mut pmt_b.details
+        {
+            *invoice = "lnbc_b".to_string();
+            *destination_pubkey = "pkB".to_string();
+        }
+
+        fx.a.insert_payment(pmt_a.clone()).await.unwrap();
+        fx.b.insert_payment(pmt_b.clone()).await.unwrap();
+
+        // Each tenant's list contains only its own row.
+        let list_a =
+            fx.a.list_payments(StorageListPaymentsRequest::default())
+                .await
+                .unwrap();
+        let list_b =
+            fx.b.list_payments(StorageListPaymentsRequest::default())
+                .await
+                .unwrap();
+        assert_eq!(list_a.len(), 1, "tenant A should see exactly 1 payment");
+        assert_eq!(list_b.len(), 1, "tenant B should see exactly 1 payment");
+        if let Some(PaymentDetails::Lightning { invoice, .. }) = &list_a[0].details {
+            assert_eq!(invoice, "lnbc_a");
+        } else {
+            panic!("expected lightning payment for A");
+        }
+        if let Some(PaymentDetails::Lightning { invoice, .. }) = &list_b[0].details {
+            assert_eq!(invoice, "lnbc_b");
+        } else {
+            panic!("expected lightning payment for B");
+        }
+
+        // get_payment_by_id is per-tenant: same id, different details, no leakage.
+        let by_id_a =
+            fx.a.get_payment_by_id("pmt_shared_id".to_string())
+                .await
+                .unwrap();
+        let by_id_b =
+            fx.b.get_payment_by_id("pmt_shared_id".to_string())
+                .await
+                .unwrap();
+        match (&by_id_a.details, &by_id_b.details) {
+            (
+                Some(PaymentDetails::Lightning { invoice: ia, .. }),
+                Some(PaymentDetails::Lightning { invoice: ib, .. }),
+            ) => assert!(ia != ib, "tenants must not see each other's invoice"),
+            _ => panic!("expected lightning details for both"),
+        }
+
+        // get_payment_by_invoice is also per-tenant.
+        assert!(
+            fx.a.get_payment_by_invoice("lnbc_b".to_string())
+                .await
+                .unwrap()
+                .is_none(),
+            "tenant A must not find tenant B's invoice"
+        );
+        assert!(
+            fx.b.get_payment_by_invoice("lnbc_a".to_string())
+                .await
+                .unwrap()
+                .is_none(),
+            "tenant B must not find tenant A's invoice"
+        );
+
+        // --- contacts ---
+        let now = 0u64;
+        fx.a.insert_contact(Contact {
+            id: "shared_contact_id".to_string(),
+            name: "Alice".to_string(),
+            payment_identifier: "alice@a".to_string(),
+            created_at: now,
+            updated_at: now,
+        })
+        .await
+        .unwrap();
+        let b_contacts =
+            fx.b.list_contacts(ListContactsRequest::default())
+                .await
+                .unwrap();
+        assert!(
+            b_contacts.is_empty(),
+            "tenant B must not see tenant A's contact"
+        );
+        // get_contact for the shared id should return NotFound for B.
+        assert!(
+            fx.b.get_contact("shared_contact_id".to_string())
+                .await
+                .is_err(),
+            "tenant B must not retrieve tenant A's contact by id"
+        );
+
+        // --- unclaimed deposits ---
+        fx.a.add_deposit("shared_txid".to_string(), 0, 5_000, true)
+            .await
+            .unwrap();
+        let b_deposits = fx.b.list_deposits().await.unwrap();
+        assert!(
+            b_deposits.is_empty(),
+            "tenant B must not see tenant A's deposit"
+        );
+
+        // --- settings (cached items) ---
+        fx.a.set_cached_item("k".to_string(), "value_a".to_string())
+            .await
+            .unwrap();
+        fx.b.set_cached_item("k".to_string(), "value_b".to_string())
+            .await
+            .unwrap();
+        assert_eq!(
+            fx.a.get_cached_item("k".to_string()).await.unwrap(),
+            Some("value_a".to_string())
+        );
+        assert_eq!(
+            fx.b.get_cached_item("k".to_string()).await.unwrap(),
+            Some("value_b".to_string())
+        );
+        // Deleting in B must not affect A.
+        fx.b.delete_cached_item("k".to_string()).await.unwrap();
+        assert_eq!(
+            fx.a.get_cached_item("k".to_string()).await.unwrap(),
+            Some("value_a".to_string())
+        );
+        assert_eq!(fx.b.get_cached_item("k".to_string()).await.unwrap(), None);
+
+        // --- lnurl receive metadata ---
+        fx.a.set_lnurl_metadata(vec![SetLnurlMetadataItem {
+            payment_hash: "shared_payment_hash".to_string(),
+            nostr_zap_request: Some("zap_a".to_string()),
+            nostr_zap_receipt: None,
+            sender_comment: None,
+        }])
+        .await
+        .unwrap();
+        fx.b.set_lnurl_metadata(vec![SetLnurlMetadataItem {
+            payment_hash: "shared_payment_hash".to_string(),
+            nostr_zap_request: Some("zap_b".to_string()),
+            nostr_zap_receipt: None,
+            sender_comment: None,
+        }])
+        .await
+        .unwrap();
+        // Each tenant's get_payment_by_id surfaces its own lnurl metadata via
+        // the SELECT_PAYMENT_SQL JOIN — confirms the lrm join is user-scoped.
+        let by_id_a =
+            fx.a.get_payment_by_id("pmt_shared_id".to_string())
+                .await
+                .unwrap();
+        let by_id_b =
+            fx.b.get_payment_by_id("pmt_shared_id".to_string())
+                .await
+                .unwrap();
+        if let (
+            Some(PaymentDetails::Lightning {
+                lnurl_receive_metadata: Some(ma),
+                ..
+            }),
+            Some(PaymentDetails::Lightning {
+                lnurl_receive_metadata: Some(mb),
+                ..
+            }),
+        ) = (&by_id_a.details, &by_id_b.details)
+        {
+            assert_eq!(ma.nostr_zap_request.as_deref(), Some("zap_a"));
+            assert_eq!(mb.nostr_zap_request.as_deref(), Some("zap_b"));
+        } else {
+            panic!("expected lnurl metadata to be visible to each tenant");
+        }
+
+        // --- sync state (sync_outgoing, sync_state, sync_revision) ---
+        let rec_id = RecordId::new("contact".to_string(), "rec_shared".to_string());
+        let updated_a: HashMap<String, String> = HashMap::new();
+        fx.a.add_outgoing_change(UnversionedRecordChange {
+            id: rec_id.clone(),
+            schema_version: "1".to_string(),
+            updated_fields: updated_a,
+        })
+        .await
+        .unwrap();
+        // B's pending queue must be empty.
+        let b_pending = fx.b.get_pending_outgoing_changes(100).await.unwrap();
+        assert!(
+            b_pending.is_empty(),
+            "tenant B must not see tenant A's pending outgoing"
+        );
+        // B's revision must be 0 even after A's queue is populated.
+        assert_eq!(fx.b.get_last_revision().await.unwrap(), 0);
+
+        // A completes the change with revision 7; B's revision remains untouched.
+        let rec = Record {
+            id: rec_id.clone(),
+            schema_version: "1".to_string(),
+            data: HashMap::new(),
+            revision: 7,
+        };
+        let a_pending = fx.a.get_pending_outgoing_changes(100).await.unwrap();
+        let a_local_rev = a_pending[0].change.local_revision;
+        fx.a.complete_outgoing_sync(rec.clone(), a_local_rev)
+            .await
+            .unwrap();
+        assert_eq!(fx.a.get_last_revision().await.unwrap(), 7);
+        assert_eq!(
+            fx.b.get_last_revision().await.unwrap(),
+            0,
+            "tenant B's revision must remain isolated from tenant A's bumps"
+        );
+
+        // Incoming records: insert via A; B must not see them, and B's deletes
+        // of an identical key must not affect A's.
+        let rec_b = Record {
+            id: rec_id.clone(),
+            schema_version: "1".to_string(),
+            data: HashMap::new(),
+            revision: 11,
+        };
+        fx.a.insert_incoming_records(vec![rec_b.clone()])
+            .await
+            .unwrap();
+        let b_incoming = fx.b.get_incoming_records(100).await.unwrap();
+        assert!(
+            b_incoming.is_empty(),
+            "tenant B must not see tenant A's incoming records"
+        );
+        fx.b.delete_incoming_record(rec_b.clone()).await.unwrap(); // no-op for B
+        let a_incoming = fx.a.get_incoming_records(100).await.unwrap();
+        assert_eq!(
+            a_incoming.len(),
+            1,
+            "tenant A's incoming must survive B's delete on the same key"
+        );
+
+        // --- final cross-check: tenant B's full payment list still has only its row ---
+        let list_b_final =
+            fx.b.list_payments(StorageListPaymentsRequest::default())
+                .await
+                .unwrap();
+        assert_eq!(list_b_final.len(), 1);
+        assert_eq!(list_b_final[0].id, "pmt_shared_id");
+    }
+
     /// Generates a self-signed CA certificate in PEM format for testing.
     fn generate_test_ca_pem(common_name: &str) -> String {
         let mut params = rcgen::CertificateParams::new(vec![]).expect("valid params");
@@ -1755,11 +2267,11 @@ mod tests {
                 .unwrap();
 
             // Apply migrations 1-6 (index 0-5)
-            let migrations = PostgresStorage::migrations();
+            let migrations = PostgresStorage::migrations(&TEST_IDENTITY_A);
             for (i, migration) in migrations.iter().take(6).enumerate() {
                 let version = i32::try_from(i + 1).unwrap();
-                for statement in *migration {
-                    client.execute(*statement, &[]).await.unwrap();
+                for statement in migration {
+                    client.execute(statement.as_str(), &[]).await.unwrap();
                 }
                 client
                     .execute(
@@ -1867,9 +2379,12 @@ mod tests {
         }
 
         // Step 3: Open with PostgresStorage (triggers migration 7 - the backfill)
-        let storage = PostgresStorage::new(PostgresStorageConfig::with_defaults(connection_string))
-            .await
-            .expect("Failed to create PostgresStorage");
+        let storage = PostgresStorage::new(
+            PostgresStorageConfig::with_defaults(connection_string),
+            &TEST_IDENTITY_A,
+        )
+        .await
+        .expect("Failed to create PostgresStorage");
 
         // Step 4: Verify Completed → PreimageShared
         let completed = storage

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -505,10 +505,17 @@ impl SdkBuilder {
             if s.is_none()
                 && let Some(ref pool) = postgres_pool
             {
+                let identity_pub_key = spark_signer
+                    .get_identity_public_key()
+                    .await
+                    .map_err(|e| SdkError::Generic(e.to_string()))?;
                 s = Some(Arc::new(
-                    crate::persist::postgres::PostgresStorage::new_with_pool(pool.clone())
-                        .await
-                        .map_err(|e| SdkError::Generic(e.to_string()))?,
+                    crate::persist::postgres::PostgresStorage::new_with_pool(
+                        pool.clone(),
+                        &identity_pub_key.serialize(),
+                    )
+                    .await
+                    .map_err(|e| SdkError::Generic(e.to_string()))?,
                 ));
             }
 

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -469,13 +469,19 @@ impl SdkBuilder {
             None
         };
 
-        // Create a shared MySQL pool if mysql backend is configured.
+        // Create a shared MySQL pool if mysql backend is configured, bundled
+        // with the tenant identity used to scope every read/write so storage,
+        // tree store, and token store share the same scope.
         #[cfg(feature = "mysql")]
-        let mysql_pool = if let Some(ref mysql_config) = self.mysql_backend_config {
-            Some(
-                crate::persist::mysql::create_pool(mysql_config)
-                    .map_err(|e| SdkError::Generic(e.to_string()))?,
-            )
+        let mysql_backend = if let Some(ref mysql_config) = self.mysql_backend_config {
+            let pool = crate::persist::mysql::create_pool(mysql_config)
+                .map_err(|e| SdkError::Generic(e.to_string()))?;
+            let identity = spark_signer
+                .get_identity_public_key()
+                .await
+                .map_err(|e| SdkError::Generic(e.to_string()))?
+                .serialize();
+            Some((pool, identity))
         } else {
             None
         };
@@ -525,10 +531,10 @@ impl SdkBuilder {
                 not(all(target_family = "wasm", target_os = "unknown"))
             ))]
             if s.is_none()
-                && let Some(ref pool) = mysql_pool
+                && let Some((ref pool, ref identity)) = mysql_backend
             {
                 s = Some(Arc::new(
-                    crate::persist::mysql::MysqlStorage::new_with_pool(pool.clone())
+                    crate::persist::mysql::MysqlStorage::new_with_pool(pool.clone(), identity)
                         .await
                         .map_err(|e| SdkError::Generic(e.to_string()))?,
                 ));
@@ -591,9 +597,10 @@ impl SdkBuilder {
 
         #[cfg(feature = "mysql")]
         if tree_store.is_none()
-            && let Some(ref pool) = mysql_pool
+            && let Some((ref pool, ref identity)) = mysql_backend
         {
-            tree_store = Some(crate::persist::mysql::create_mysql_tree_store(pool.clone()).await?);
+            tree_store =
+                Some(crate::persist::mysql::create_mysql_tree_store(pool.clone(), identity).await?);
         }
 
         // Create token output store if configured
@@ -612,10 +619,11 @@ impl SdkBuilder {
 
         #[cfg(feature = "mysql")]
         if token_output_store.is_none()
-            && let Some(ref pool) = mysql_pool
+            && let Some((ref pool, ref identity)) = mysql_backend
         {
-            token_output_store =
-                Some(crate::persist::mysql::create_mysql_token_store(pool.clone()).await?);
+            token_output_store = Some(
+                crate::persist::mysql::create_mysql_token_store(pool.clone(), identity).await?,
+            );
         }
 
         let session_manager = Arc::new(BreezSessionManager::new(Arc::new(

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -602,10 +602,12 @@ impl SdkBuilder {
 
         #[cfg(feature = "postgres")]
         if token_output_store.is_none()
-            && let Some((ref pool, _)) = postgres_backend
+            && let Some((ref pool, ref identity)) = postgres_backend
         {
-            token_output_store =
-                Some(crate::persist::postgres::create_postgres_token_store(pool.clone()).await?);
+            token_output_store = Some(
+                crate::persist::postgres::create_postgres_token_store(pool.clone(), identity)
+                    .await?,
+            );
         }
 
         #[cfg(feature = "mysql")]

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -452,14 +452,19 @@ impl SdkBuilder {
             _ => {}
         }
 
-        // Create a shared PostgreSQL pool if postgres backend is configured.
-        // This single pool is reused for storage, tree store, and token store.
+        // Create a shared PostgreSQL pool if postgres backend is configured,
+        // bundled with the tenant identity used to scope every read/write so
+        // storage, tree store, and token store share the same scope.
         #[cfg(feature = "postgres")]
-        let postgres_pool = if let Some(ref postgres_config) = self.postgres_backend_config {
-            Some(
-                crate::persist::postgres::create_pool(postgres_config)
-                    .map_err(|e| SdkError::Generic(e.to_string()))?,
-            )
+        let postgres_backend = if let Some(ref postgres_config) = self.postgres_backend_config {
+            let pool = crate::persist::postgres::create_pool(postgres_config)
+                .map_err(|e| SdkError::Generic(e.to_string()))?;
+            let identity = spark_signer
+                .get_identity_public_key()
+                .await
+                .map_err(|e| SdkError::Generic(e.to_string()))?
+                .serialize();
+            Some((pool, identity))
         } else {
             None
         };
@@ -503,16 +508,12 @@ impl SdkBuilder {
                 not(all(target_family = "wasm", target_os = "unknown"))
             ))]
             if s.is_none()
-                && let Some(ref pool) = postgres_pool
+                && let Some((ref pool, ref identity)) = postgres_backend
             {
-                let identity_pub_key = spark_signer
-                    .get_identity_public_key()
-                    .await
-                    .map_err(|e| SdkError::Generic(e.to_string()))?;
                 s = Some(Arc::new(
                     crate::persist::postgres::PostgresStorage::new_with_pool(
                         pool.clone(),
-                        &identity_pub_key.serialize(),
+                        identity,
                     )
                     .await
                     .map_err(|e| SdkError::Generic(e.to_string()))?,
@@ -580,10 +581,12 @@ impl SdkBuilder {
 
         #[cfg(feature = "postgres")]
         if tree_store.is_none()
-            && let Some(ref pool) = postgres_pool
+            && let Some((ref pool, ref identity)) = postgres_backend
         {
-            tree_store =
-                Some(crate::persist::postgres::create_postgres_tree_store(pool.clone()).await?);
+            tree_store = Some(
+                crate::persist::postgres::create_postgres_tree_store(pool.clone(), identity)
+                    .await?,
+            );
         }
 
         #[cfg(feature = "mysql")]
@@ -599,7 +602,7 @@ impl SdkBuilder {
 
         #[cfg(feature = "postgres")]
         if token_output_store.is_none()
-            && let Some(ref pool) = postgres_pool
+            && let Some((ref pool, _)) = postgres_backend
         {
             token_output_store =
                 Some(crate::persist::postgres::create_postgres_token_store(pool.clone()).await?);

--- a/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
@@ -76,11 +76,11 @@ const SELECT_PAYMENT_SQL = `
            lrm.payment_hash AS lnurl_payment_hash,
            pm.parent_payment_id
       FROM payments p
-      LEFT JOIN payment_details_lightning l ON p.id = l.payment_id
-      LEFT JOIN payment_details_token t ON p.id = t.payment_id
-      LEFT JOIN payment_details_spark s ON p.id = s.payment_id
-      LEFT JOIN payment_metadata pm ON p.id = pm.payment_id
-      LEFT JOIN lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash`;
+      LEFT JOIN payment_details_lightning l ON p.id = l.payment_id AND p.user_id = l.user_id
+      LEFT JOIN payment_details_token t ON p.id = t.payment_id AND p.user_id = t.user_id
+      LEFT JOIN payment_details_spark s ON p.id = s.payment_id AND p.user_id = s.user_id
+      LEFT JOIN payment_metadata pm ON p.id = pm.payment_id AND p.user_id = pm.user_id
+      LEFT JOIN lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash AND l.user_id = lrm.user_id`;
 
 /**
  * mysql2 may return JSON columns as either parsed objects or raw strings
@@ -100,8 +100,19 @@ function toBool(value) {
 }
 
 class MysqlStorage {
-  constructor(pool, logger = null) {
+  /**
+   * @param {import('mysql2/promise').Pool} pool - Connection pool (may be shared with other tenants).
+   * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+   *   uniquely identifying this tenant. All reads and writes are scoped to it
+   *   so that multiple instances with distinct identities can share one DB.
+   * @param {object} [logger]
+   */
+  constructor(pool, identity, logger = null) {
+    if (!identity) {
+      throw new StorageError("MysqlStorage requires a tenant identity");
+    }
     this.pool = pool;
+    this.identity = Buffer.from(identity);
     this.logger = logger;
   }
 
@@ -109,7 +120,7 @@ class MysqlStorage {
   async initialize() {
     try {
       const migrationManager = new MysqlMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool);
+      await migrationManager.migrate(this.pool, this.identity);
       return this;
     } catch (error) {
       throw new StorageError(
@@ -153,8 +164,8 @@ class MysqlStorage {
   async getCachedItem(key) {
     try {
       const [rows] = await this.pool.query(
-        "SELECT value FROM settings WHERE `key` = ?",
-        [key]
+        "SELECT value FROM settings WHERE user_id = ? AND `key` = ?",
+        [this.identity, key]
       );
       return rows.length > 0 ? rows[0].value : null;
     } catch (error) {
@@ -168,9 +179,9 @@ class MysqlStorage {
   async setCachedItem(key, value) {
     try {
       await this.pool.query(
-        "INSERT INTO settings (`key`, value) VALUES (?, ?) " +
+        "INSERT INTO settings (user_id, `key`, value) VALUES (?, ?, ?) " +
           "ON DUPLICATE KEY UPDATE value = VALUES(value)",
-        [key, value]
+        [this.identity, key, value]
       );
     } catch (error) {
       throw new StorageError(
@@ -182,7 +193,10 @@ class MysqlStorage {
 
   async deleteCachedItem(key) {
     try {
-      await this.pool.query("DELETE FROM settings WHERE `key` = ?", [key]);
+      await this.pool.query(
+        "DELETE FROM settings WHERE user_id = ? AND `key` = ?",
+        [this.identity, key]
+      );
     } catch (error) {
       throw new StorageError(
         `Failed to delete cached item '${key}': ${error.message}`,
@@ -199,8 +213,10 @@ class MysqlStorage {
       const actualLimit =
         request.limit != null ? request.limit : 4294967295;
 
-      const whereClauses = [];
-      const params = [];
+      // Tenant scoping is always the first WHERE clause; subsequent dynamic
+      // filters add more clauses and parameters.
+      const whereClauses = ["p.user_id = ?"];
+      const params = [this.identity];
 
       if (request.typeFilter && request.typeFilter.length > 0) {
         const placeholders = request.typeFilter.map(() => "?");
@@ -354,8 +370,8 @@ class MysqlStorage {
         const spark = payment.details?.type === "spark" ? 1 : null;
 
         await conn.query(
-          `INSERT INTO payments (id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `INSERT INTO payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON DUPLICATE KEY UPDATE
              payment_type=VALUES(payment_type),
              status=VALUES(status),
@@ -367,6 +383,7 @@ class MysqlStorage {
              deposit_tx_id=VALUES(deposit_tx_id),
              spark=VALUES(spark)`,
           [
+            this.identity,
             payment.id,
             payment.paymentType,
             payment.status,
@@ -386,12 +403,13 @@ class MysqlStorage {
             payment.details.htlcDetails != null)
         ) {
           await conn.query(
-            `INSERT INTO payment_details_spark (payment_id, invoice_details, htlc_details)
-             VALUES (?, ?, ?)
+            `INSERT INTO payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
+             VALUES (?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE
                invoice_details=COALESCE(VALUES(invoice_details), invoice_details),
                htlc_details=COALESCE(VALUES(htlc_details), htlc_details)`,
             [
+              this.identity,
               payment.id,
               payment.details.invoiceDetails
                 ? JSON.stringify(payment.details.invoiceDetails)
@@ -406,8 +424,8 @@ class MysqlStorage {
         if (payment.details?.type === "lightning") {
           await conn.query(
             `INSERT INTO payment_details_lightning
-              (payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+              (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
               ON DUPLICATE KEY UPDATE
                 invoice=VALUES(invoice),
                 payment_hash=VALUES(payment_hash),
@@ -417,6 +435,7 @@ class MysqlStorage {
                 htlc_status=COALESCE(VALUES(htlc_status), htlc_status),
                 htlc_expiry_time=COALESCE(VALUES(htlc_expiry_time), htlc_expiry_time)`,
             [
+              this.identity,
               payment.id,
               payment.details.invoice,
               payment.details.htlcDetails.paymentHash,
@@ -432,14 +451,15 @@ class MysqlStorage {
         if (payment.details?.type === "token") {
           await conn.query(
             `INSERT INTO payment_details_token
-              (payment_id, metadata, tx_hash, tx_type, invoice_details)
-              VALUES (?, ?, ?, ?, ?)
+              (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
+              VALUES (?, ?, ?, ?, ?, ?)
               ON DUPLICATE KEY UPDATE
                 metadata=VALUES(metadata),
                 tx_hash=VALUES(tx_hash),
                 tx_type=VALUES(tx_type),
                 invoice_details=COALESCE(VALUES(invoice_details), invoice_details)`,
             [
+              this.identity,
               payment.id,
               JSON.stringify(payment.details.metadata),
               payment.details.txHash,
@@ -467,8 +487,8 @@ class MysqlStorage {
       }
 
       const [rows] = await this.pool.query(
-        `${SELECT_PAYMENT_SQL} WHERE p.id = ?`,
-        [id]
+        `${SELECT_PAYMENT_SQL} WHERE p.user_id = ? AND p.id = ?`,
+        [this.identity, id]
       );
 
       if (rows.length === 0) {
@@ -492,8 +512,8 @@ class MysqlStorage {
       }
 
       const [rows] = await this.pool.query(
-        `${SELECT_PAYMENT_SQL} WHERE l.invoice = ?`,
-        [invoice]
+        `${SELECT_PAYMENT_SQL} WHERE p.user_id = ? AND l.invoice = ?`,
+        [this.identity, invoice]
       );
 
       if (rows.length === 0) {
@@ -516,18 +536,19 @@ class MysqlStorage {
         return {};
       }
 
-      // Early exit if no related payments exist. mysql2 returns EXISTS as 0/1.
+      // Early exit if no related payments exist for this tenant. mysql2 returns EXISTS as 0/1.
       const [hasRelatedRows] = await this.pool.query(
-        "SELECT EXISTS(SELECT 1 FROM payment_metadata WHERE parent_payment_id IS NOT NULL LIMIT 1) AS has_related"
+        "SELECT EXISTS(SELECT 1 FROM payment_metadata WHERE user_id = ? AND parent_payment_id IS NOT NULL LIMIT 1) AS has_related",
+        [this.identity]
       );
       if (!hasRelatedRows[0].has_related) {
         return {};
       }
 
       const placeholders = parentPaymentIds.map(() => "?");
-      const query = `${SELECT_PAYMENT_SQL} WHERE pm.parent_payment_id IN (${placeholders.join(", ")}) ORDER BY p.timestamp ASC`;
+      const query = `${SELECT_PAYMENT_SQL} WHERE p.user_id = ? AND pm.parent_payment_id IN (${placeholders.join(", ")}) ORDER BY p.timestamp ASC`;
 
-      const [rows] = await this.pool.query(query, parentPaymentIds);
+      const [rows] = await this.pool.query(query, [this.identity, ...parentPaymentIds]);
 
       const result = {};
       for (const row of rows) {
@@ -551,8 +572,8 @@ class MysqlStorage {
   async insertPaymentMetadata(paymentId, metadata) {
     try {
       await this.pool.query(
-        `INSERT INTO payment_metadata (payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
-         VALUES (?, ?, ?, ?, ?, ?, ?)
+        `INSERT INTO payment_metadata (user_id, payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
          ON DUPLICATE KEY UPDATE
            parent_payment_id = COALESCE(VALUES(parent_payment_id), parent_payment_id),
            lnurl_pay_info = COALESCE(VALUES(lnurl_pay_info), lnurl_pay_info),
@@ -561,6 +582,7 @@ class MysqlStorage {
            conversion_info = COALESCE(VALUES(conversion_info), conversion_info),
            conversion_status = COALESCE(VALUES(conversion_status), conversion_status)`,
         [
+          this.identity,
           paymentId,
           metadata.parentPaymentId,
           metadata.lnurlPayInfo
@@ -589,10 +611,10 @@ class MysqlStorage {
   async addDeposit(txid, vout, amountSats, isMature) {
     try {
       await this.pool.query(
-        `INSERT INTO unclaimed_deposits (txid, vout, amount_sats, is_mature)
-         VALUES (?, ?, ?, ?)
+        `INSERT INTO unclaimed_deposits (user_id, txid, vout, amount_sats, is_mature)
+         VALUES (?, ?, ?, ?, ?)
          ON DUPLICATE KEY UPDATE is_mature = VALUES(is_mature), amount_sats = VALUES(amount_sats)`,
-        [txid, vout, amountSats, isMature ? 1 : 0]
+        [this.identity, txid, vout, amountSats, isMature ? 1 : 0]
       );
     } catch (error) {
       throw new StorageError(
@@ -605,8 +627,8 @@ class MysqlStorage {
   async deleteDeposit(txid, vout) {
     try {
       await this.pool.query(
-        "DELETE FROM unclaimed_deposits WHERE txid = ? AND vout = ?",
-        [txid, vout]
+        "DELETE FROM unclaimed_deposits WHERE user_id = ? AND txid = ? AND vout = ?",
+        [this.identity, txid, vout]
       );
     } catch (error) {
       throw new StorageError(
@@ -619,7 +641,8 @@ class MysqlStorage {
   async listDeposits() {
     try {
       const [rows] = await this.pool.query(
-        "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM unclaimed_deposits"
+        "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM unclaimed_deposits WHERE user_id = ?",
+        [this.identity]
       );
 
       return rows.map((row) => ({
@@ -646,15 +669,15 @@ class MysqlStorage {
         await this.pool.query(
           `UPDATE unclaimed_deposits
            SET claim_error = ?, refund_tx = NULL, refund_tx_id = NULL
-           WHERE txid = ? AND vout = ?`,
-          [JSON.stringify(payload.error), txid, vout]
+           WHERE user_id = ? AND txid = ? AND vout = ?`,
+          [JSON.stringify(payload.error), this.identity, txid, vout]
         );
       } else if (payload.type === "refund") {
         await this.pool.query(
           `UPDATE unclaimed_deposits
            SET refund_tx = ?, refund_tx_id = ?, claim_error = NULL
-           WHERE txid = ? AND vout = ?`,
-          [payload.refundTx, payload.refundTxid, txid, vout]
+           WHERE user_id = ? AND txid = ? AND vout = ?`,
+          [payload.refundTx, payload.refundTxid, this.identity, txid, vout]
         );
       } else {
         throw new StorageError(`Unknown payload type: ${payload.type}`);
@@ -673,13 +696,14 @@ class MysqlStorage {
       await this._withTransaction(async (conn) => {
         for (const item of metadata) {
           await conn.query(
-            `INSERT INTO lnurl_receive_metadata (payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
-             VALUES (?, ?, ?, ?)
+            `INSERT INTO lnurl_receive_metadata (user_id, payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
+             VALUES (?, ?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE
                nostr_zap_request = VALUES(nostr_zap_request),
                nostr_zap_receipt = VALUES(nostr_zap_receipt),
                sender_comment = VALUES(sender_comment)`,
             [
+              this.identity,
               item.paymentHash,
               item.nostrZapRequest || null,
               item.nostrZapReceipt || null,
@@ -801,9 +825,10 @@ class MysqlStorage {
       const [rows] = await this.pool.query(
         `SELECT id, name, payment_identifier, created_at, updated_at
          FROM contacts
+         WHERE user_id = ?
          ORDER BY name ASC
          LIMIT ? OFFSET ?`,
-        [limit, offset]
+        [this.identity, limit, offset]
       );
 
       return rows.map((row) => ({
@@ -826,8 +851,8 @@ class MysqlStorage {
       const [rows] = await this.pool.query(
         `SELECT id, name, payment_identifier, created_at, updated_at
          FROM contacts
-         WHERE id = ?`,
-        [id]
+         WHERE user_id = ? AND id = ?`,
+        [this.identity, id]
       );
 
       if (rows.length === 0) {
@@ -850,13 +875,14 @@ class MysqlStorage {
   async insertContact(contact) {
     try {
       await this.pool.query(
-        `INSERT INTO contacts (id, name, payment_identifier, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?)
+        `INSERT INTO contacts (user_id, id, name, payment_identifier, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)
          ON DUPLICATE KEY UPDATE
            name = VALUES(name),
            payment_identifier = VALUES(payment_identifier),
            updated_at = VALUES(updated_at)`,
         [
+          this.identity,
           contact.id,
           contact.name,
           contact.paymentIdentifier,
@@ -874,7 +900,10 @@ class MysqlStorage {
 
   async deleteContact(id) {
     try {
-      await this.pool.query("DELETE FROM contacts WHERE id = ?", [id]);
+      await this.pool.query(
+        "DELETE FROM contacts WHERE user_id = ? AND id = ?",
+        [this.identity, id]
+      );
     } catch (error) {
       throw new StorageError(
         `Failed to delete contact: ${error.message}`,
@@ -888,21 +917,25 @@ class MysqlStorage {
   async syncAddOutgoingChange(record) {
     try {
       return await this._withTransaction(async (conn) => {
+        // The local queue revision is per-tenant — two tenants don't share a queue.
         const [revisionRows] = await conn.query(
-          "SELECT COALESCE(MAX(revision), 0) + 1 AS revision FROM sync_outgoing"
+          "SELECT COALESCE(MAX(revision), 0) + 1 AS revision FROM sync_outgoing WHERE user_id = ?",
+          [this.identity]
         );
         const revision = BigInt(revisionRows[0].revision);
 
         await conn.query(
           `INSERT INTO sync_outgoing (
+            user_id,
             record_type,
             data_id,
             schema_version,
             commit_time,
             updated_fields_json,
             revision
-          ) VALUES (?, ?, ?, ?, ?, ?)`,
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
           [
+            this.identity,
             record.id.type,
             record.id.dataId,
             record.schemaVersion,
@@ -927,8 +960,8 @@ class MysqlStorage {
     try {
       await this._withTransaction(async (conn) => {
         const [deleteResult] = await conn.query(
-          "DELETE FROM sync_outgoing WHERE record_type = ? AND data_id = ? AND revision = ?",
-          [record.id.type, record.id.dataId, localRevision.toString()]
+          "DELETE FROM sync_outgoing WHERE user_id = ? AND record_type = ? AND data_id = ? AND revision = ?",
+          [this.identity, record.id.type, record.id.dataId, localRevision.toString()]
         );
 
         if (deleteResult.affectedRows === 0) {
@@ -943,19 +976,21 @@ class MysqlStorage {
 
         await conn.query(
           `INSERT INTO sync_state (
+            user_id,
             record_type,
             data_id,
             revision,
             schema_version,
             commit_time,
             data
-          ) VALUES (?, ?, ?, ?, ?, ?)
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)
           ON DUPLICATE KEY UPDATE
             schema_version = VALUES(schema_version),
             commit_time = VALUES(commit_time),
             data = VALUES(data),
             revision = VALUES(revision)`,
           [
+            this.identity,
             record.id.type,
             record.id.dataId,
             record.revision.toString(),
@@ -965,9 +1000,11 @@ class MysqlStorage {
           ]
         );
 
+        // Upsert this tenant's revision row; fresh tenants without a row get one.
         await conn.query(
-          "UPDATE sync_revision SET revision = GREATEST(revision, ?)",
-          [record.revision.toString()]
+          `INSERT INTO sync_revision (user_id, revision) VALUES (?, ?)
+           ON DUPLICATE KEY UPDATE revision = GREATEST(revision, VALUES(revision))`,
+          [this.identity, record.revision.toString()]
         );
       });
     } catch (error) {
@@ -996,10 +1033,12 @@ class MysqlStorage {
         FROM sync_outgoing o
         LEFT JOIN sync_state e ON
           o.record_type = e.record_type AND
-          o.data_id = e.data_id
+          o.data_id = e.data_id AND
+          o.user_id = e.user_id
+        WHERE o.user_id = ?
         ORDER BY o.revision ASC
         LIMIT ?`,
-        [limit]
+        [this.identity, limit]
       );
 
       return rows.map((row) => {
@@ -1032,8 +1071,10 @@ class MysqlStorage {
 
   async syncGetLastRevision() {
     try {
+      // A tenant that hasn't synced anything yet may have no row; treat as 0.
       const [rows] = await this.pool.query(
-        "SELECT revision FROM sync_revision"
+        "SELECT revision FROM sync_revision WHERE user_id = ?",
+        [this.identity]
       );
       return rows.length > 0 ? BigInt(rows[0].revision) : BigInt(0);
     } catch (error) {
@@ -1054,18 +1095,20 @@ class MysqlStorage {
         for (const record of records) {
           await conn.query(
             `INSERT INTO sync_incoming (
+              user_id,
               record_type,
               data_id,
               schema_version,
               commit_time,
               data,
               revision
-            ) VALUES (?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
             ON DUPLICATE KEY UPDATE
               schema_version = VALUES(schema_version),
               commit_time = VALUES(commit_time),
               data = VALUES(data)`,
             [
+              this.identity,
               record.id.type,
               record.id.dataId,
               record.schemaVersion,
@@ -1089,10 +1132,11 @@ class MysqlStorage {
     try {
       await this.pool.query(
         `DELETE FROM sync_incoming
-         WHERE record_type = ?
+         WHERE user_id = ?
+         AND record_type = ?
          AND data_id = ?
          AND revision = ?`,
-        [record.id.type, record.id.dataId, record.revision.toString()]
+        [this.identity, record.id.type, record.id.dataId, record.revision.toString()]
       );
     } catch (error) {
       throw new StorageError(
@@ -1115,10 +1159,11 @@ class MysqlStorage {
                 e.data AS existing_data,
                 e.revision AS existing_revision
          FROM sync_incoming i
-         LEFT JOIN sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id
+         LEFT JOIN sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id AND i.user_id = e.user_id
+         WHERE i.user_id = ?
          ORDER BY i.revision ASC
          LIMIT ?`,
-        [limit]
+        [this.identity, limit]
       );
 
       return rows.map((row) => {
@@ -1166,9 +1211,12 @@ class MysqlStorage {
         FROM sync_outgoing o
         LEFT JOIN sync_state e ON
           o.record_type = e.record_type AND
-          o.data_id = e.data_id
+          o.data_id = e.data_id AND
+          o.user_id = e.user_id
+        WHERE o.user_id = ?
         ORDER BY o.revision DESC
-        LIMIT 1`
+        LIMIT 1`,
+        [this.identity]
       );
 
       if (rows.length === 0) {
@@ -1208,19 +1256,21 @@ class MysqlStorage {
       await this._withTransaction(async (conn) => {
         await conn.query(
           `INSERT INTO sync_state (
+            user_id,
             record_type,
             data_id,
             revision,
             schema_version,
             commit_time,
             data
-          ) VALUES (?, ?, ?, ?, ?, ?)
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)
           ON DUPLICATE KEY UPDATE
             schema_version = VALUES(schema_version),
             commit_time = VALUES(commit_time),
             data = VALUES(data),
             revision = VALUES(revision)`,
           [
+            this.identity,
             record.id.type,
             record.id.dataId,
             record.revision.toString(),
@@ -1231,8 +1281,9 @@ class MysqlStorage {
         );
 
         await conn.query(
-          "UPDATE sync_revision SET revision = GREATEST(revision, ?)",
-          [record.revision.toString()]
+          `INSERT INTO sync_revision (user_id, revision) VALUES (?, ?)
+           ON DUPLICATE KEY UPDATE revision = GREATEST(revision, VALUES(revision))`,
+          [this.identity, record.revision.toString()]
         );
       });
     } catch (error) {
@@ -1281,9 +1332,13 @@ function createMysqlPool(config) {
 
 /**
  * Create a MysqlStorage instance from an existing mysql2 pool.
+ *
+ * @param {import('mysql2/promise').Pool} pool - An existing connection pool
+ * @param {Buffer|Uint8Array} identity - 33-byte tenant identity (secp256k1 pubkey)
+ * @param {object} [logger]
  */
-async function createMysqlStorageWithPool(pool, logger = null) {
-  const storage = new MysqlStorage(pool, logger);
+async function createMysqlStorageWithPool(pool, identity, logger = null) {
+  const storage = new MysqlStorage(pool, identity, logger);
   await storage.initialize();
   return storage;
 }
@@ -1291,10 +1346,14 @@ async function createMysqlStorageWithPool(pool, logger = null) {
 /**
  * Create a MysqlStorage instance from a config object.
  * Use defaultMysqlStorageConfig to create a config with sensible defaults.
+ *
+ * @param {object} config - MySQL storage config
+ * @param {Buffer|Uint8Array} identity - 33-byte tenant identity (secp256k1 pubkey)
+ * @param {object} [logger]
  */
-async function createMysqlStorage(config, logger = null) {
+async function createMysqlStorage(config, identity, logger = null) {
   const pool = createMysqlPool(config);
-  return createMysqlStorageWithPool(pool, logger);
+  return createMysqlStorageWithPool(pool, identity, logger);
 }
 
 module.exports = {

--- a/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
@@ -24,6 +24,35 @@ const MIGRATION_LOCK_NAME = "breez_mysql_migration_lock";
 /** Seconds to wait when acquiring the migration lock. */
 const MIGRATION_LOCK_TIMEOUT = 60;
 
+/**
+ * Runs a single migration step. Plain strings are run as-is; tagged objects
+ * (`{ op: 'dropPrimaryKey', table }`) are guarded against partial-apply replay
+ * by checking `information_schema` first. MySQL DDL implicitly commits, so
+ * if the migration crashes between two DDL statements the version row never
+ * gets recorded — and on retry, an unguarded DROP PRIMARY KEY would fail
+ * (`ER_CANT_DROP_FIELD_OR_KEY`) because the PK is already gone.
+ */
+async function runMigrationStep(conn, step) {
+  if (typeof step === "string") {
+    await conn.query(step);
+    return;
+  }
+  if (step.op === "dropPrimaryKey") {
+    const [rows] = await conn.query(
+      `SELECT COUNT(*) AS c FROM information_schema.table_constraints
+       WHERE table_schema = DATABASE()
+         AND table_name = ?
+         AND constraint_type = 'PRIMARY KEY'`,
+      [step.table]
+    );
+    if (rows[0].c > 0) {
+      await conn.query(`ALTER TABLE \`${step.table}\` DROP PRIMARY KEY`);
+    }
+    return;
+  }
+  throw new Error(`Unknown migration step op: ${JSON.stringify(step)}`);
+}
+
 class MysqlMigrationManager {
   constructor(logger = null) {
     this.logger = logger;
@@ -32,9 +61,14 @@ class MysqlMigrationManager {
   /**
    * Run all pending migrations. Holds a session-scoped GET_LOCK for the full
    * sequence so concurrent processes serialize.
+   *
    * @param {import('mysql2/promise').Pool} pool
+   * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+   *   identifying the tenant. Used to backfill `user_id` columns in the
+   *   multi-tenant migration so that pre-existing single-tenant data remains
+   *   readable.
    */
-  async migrate(pool) {
+  async migrate(pool, identity) {
     const conn = await pool.getConnection();
     try {
       const [lockRows] = await conn.query(
@@ -62,7 +96,7 @@ class MysqlMigrationManager {
         );
         const currentVersion = versionRows[0].version;
 
-        const migrations = this._getMigrations();
+        const migrations = this._getMigrations(identity);
 
         if (currentVersion >= migrations.length) {
           this._log("info", `Database is up to date (version ${currentVersion})`);
@@ -80,8 +114,8 @@ class MysqlMigrationManager {
           const version = i + 1;
           this._log("debug", `Running migration ${version}: ${migration.name}`);
 
-          for (const sql of migration.sql) {
-            await conn.query(sql);
+          for (const step of migration.sql) {
+            await runMigrationStep(conn, step);
           }
 
           await conn.query(
@@ -118,7 +152,26 @@ class MysqlMigrationManager {
     }
   }
 
-  _getMigrations() {
+  /**
+   * @param {Buffer|Uint8Array} identity - 33-byte tenant identity. Inlined as
+   *   an `UNHEX('...')` literal in the multi-tenant scoping migration. Safe
+   *   because the bytes come from a typed secp256k1 pubkey (character set
+   *   `[0-9a-f]{66}` after hex encoding) — not user-controlled input.
+   */
+  _getMigrations(identity) {
+    const idHex = Buffer.from(identity).toString("hex");
+    const idLit = `UNHEX('${idHex}')`;
+
+    // Per-table backfill: ADD COLUMN nullable -> UPDATE -> SET NOT NULL +
+    // drop/recreate PK. Returns an array of statements. Tables with backticked
+    // names (e.g. `settings` uses `key`) need the caller to backtick `pkCols`.
+    const scopeTable = (table, pkCols) => [
+      `ALTER TABLE \`${table}\` ADD COLUMN user_id VARBINARY(33) NULL`,
+      `UPDATE \`${table}\` SET user_id = ${idLit} WHERE user_id IS NULL`,
+      `ALTER TABLE \`${table}\` MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+      `ALTER TABLE \`${table}\` DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, ${pkCols})`,
+    ];
+
     return [
       {
         name: "Create all tables at final schema",
@@ -267,6 +320,64 @@ class MysqlMigrationManager {
         name: "Add conversion_status to payment_metadata",
         sql: [
           `ALTER TABLE payment_metadata ADD COLUMN conversion_status VARCHAR(64) NULL`,
+        ],
+      },
+      {
+        name: "Multi-tenant scoping: add user_id and rewrite primary keys",
+        sql: [
+          // Per-user tables.
+          ...scopeTable("payments", "id"),
+          `DROP INDEX idx_payments_timestamp ON payments`,
+          `DROP INDEX idx_payments_payment_type ON payments`,
+          `DROP INDEX idx_payments_status ON payments`,
+          `CREATE INDEX idx_payments_user_timestamp ON payments(user_id, timestamp)`,
+          `CREATE INDEX idx_payments_user_payment_type ON payments(user_id, payment_type)`,
+          `CREATE INDEX idx_payments_user_status ON payments(user_id, status)`,
+
+          ...scopeTable("payment_metadata", "payment_id"),
+          `DROP INDEX idx_payment_metadata_parent ON payment_metadata`,
+          `CREATE INDEX idx_payment_metadata_user_parent
+             ON payment_metadata(user_id, parent_payment_id)`,
+
+          ...scopeTable("payment_details_lightning", "payment_id"),
+          `DROP INDEX idx_payment_details_lightning_invoice ON payment_details_lightning`,
+          `DROP INDEX idx_payment_details_lightning_payment_hash ON payment_details_lightning`,
+          `CREATE INDEX idx_payment_details_lightning_user_invoice
+             ON payment_details_lightning(user_id, invoice(255))`,
+          `CREATE INDEX idx_payment_details_lightning_user_payment_hash
+             ON payment_details_lightning(user_id, payment_hash)`,
+
+          ...scopeTable("payment_details_token", "payment_id"),
+          ...scopeTable("payment_details_spark", "payment_id"),
+          ...scopeTable("lnurl_receive_metadata", "payment_hash"),
+          ...scopeTable("unclaimed_deposits", "txid, vout"),
+          ...scopeTable("contacts", "id"),
+          ...scopeTable("settings", "`key`"),
+
+          // sync_revision was a singleton (PK id=1, CHECK id=1). Drop the PK
+          // and the id column, then re-key by user_id.
+          { op: "dropPrimaryKey", table: "sync_revision" },
+          `ALTER TABLE sync_revision DROP COLUMN id`,
+          `ALTER TABLE sync_revision ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE sync_revision SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE sync_revision MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE sync_revision ADD PRIMARY KEY (user_id)`,
+
+          // sync_outgoing has no PK, only an index — just add user_id and
+          // rewrite the index.
+          `ALTER TABLE sync_outgoing ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE sync_outgoing SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE sync_outgoing MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `DROP INDEX idx_sync_outgoing_data_id_record_type ON sync_outgoing`,
+          `CREATE INDEX idx_sync_outgoing_user_record_type_data_id
+             ON sync_outgoing(user_id, record_type, data_id)`,
+
+          ...scopeTable("sync_state", "record_type, data_id"),
+
+          ...scopeTable("sync_incoming", "record_type, data_id, revision"),
+          `DROP INDEX idx_sync_incoming_revision ON sync_incoming`,
+          `CREATE INDEX idx_sync_incoming_user_revision
+             ON sync_incoming(user_id, revision)`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/js/mysql-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/index.cjs
@@ -27,11 +27,28 @@ try {
 const { TokenStoreError } = require("./errors.cjs");
 const { MysqlTokenStoreMigrationManager } = require("./migrations.cjs");
 
-const TOKEN_STORE_WRITE_LOCK_NAME = "token_store_write_lock";
+/**
+ * Domain prefix mixed into the per-tenant `GET_LOCK` name. Distinct prefixes
+ * guarantee that tree-store and token-store locks never collide.
+ */
+const TOKEN_STORE_LOCK_PREFIX = "breez-spark-sdk:token:";
+/** Seconds to wait when acquiring the write lock. */
 const WRITE_LOCK_TIMEOUT_SECS = 30;
 
 const SPENT_MARKER_CLEANUP_THRESHOLD_MS = 5 * 60 * 1000;
 const RESERVATION_TIMEOUT_SECS = 300;
+
+/**
+ * Derive a stable per-tenant lock name from a tenant identity pubkey. Hashes
+ * a domain prefix together with the identity (SHA-256, first 8 bytes hex).
+ */
+function _identityLockName(prefix, identity) {
+  const crypto = require("crypto");
+  const hash = crypto.createHash("sha256");
+  hash.update(prefix);
+  hash.update(Buffer.from(identity));
+  return prefix + hash.digest("hex").slice(0, 16);
+}
 
 function parseJson(value) {
   if (value == null) return null;
@@ -50,15 +67,28 @@ function buildPlaceholders(n) {
 }
 
 class MysqlTokenStore {
-  constructor(pool, logger = null) {
+  /**
+   * @param {import('mysql2/promise').Pool} pool
+   * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+   *   identifying the tenant. All reads and writes are scoped by this.
+   * @param {object} [logger]
+   */
+  constructor(pool, identity, logger = null) {
+    if (!identity || identity.length !== 33) {
+      throw new TokenStoreError(
+        "tenant identity (33-byte secp256k1 pubkey) is required"
+      );
+    }
     this.pool = pool;
+    this.identity = Buffer.from(identity);
+    this.lockName = _identityLockName(TOKEN_STORE_LOCK_PREFIX, identity);
     this.logger = logger;
   }
 
   async initialize() {
     try {
       const migrationManager = new MysqlTokenStoreMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool);
+      await migrationManager.migrate(this.pool, this.identity);
       return this;
     } catch (error) {
       throw new TokenStoreError(
@@ -89,7 +119,7 @@ class MysqlTokenStore {
     try {
       const [lockRows] = await conn.query(
         "SELECT GET_LOCK(?, ?) AS acquired",
-        [TOKEN_STORE_WRITE_LOCK_NAME, WRITE_LOCK_TIMEOUT_SECS]
+        [this.lockName, WRITE_LOCK_TIMEOUT_SECS]
       );
       if (!lockRows || lockRows[0].acquired !== 1) {
         throw new TokenStoreError(
@@ -108,7 +138,7 @@ class MysqlTokenStore {
     } finally {
       if (lockAcquired) {
         await conn
-          .query("SELECT RELEASE_LOCK(?)", [TOKEN_STORE_WRITE_LOCK_NAME])
+          .query("SELECT RELEASE_LOCK(?)", [this.lockName])
           .catch(() => {});
       }
       conn.release();
@@ -146,16 +176,21 @@ class MysqlTokenStore {
       const refreshTimestamp = new Date(refreshStartedAtMs);
 
       await this._withWriteTransaction(async (conn) => {
+        // Drop expired reservations BEFORE evaluating has_active_swap, otherwise a stale
+        // Swap reservation (from a crashed client or a swap whose finalize/cancel never
+        // ran) keeps has_active_swap true forever, which makes setTokensOutputs
+        // early-return and never reach any subsequent reconciliation. The reservation
+        // pins itself in place and the local token-output set freezes.
         await this._cleanupStaleReservations(conn);
 
         const [swapRows] = await conn.query(
           `SELECT
-            (SELECT EXISTS(SELECT 1 FROM token_reservations WHERE purpose = 'Swap')) AS has_active_swap,
+            (SELECT EXISTS(SELECT 1 FROM token_reservations WHERE user_id = ? AND purpose = 'Swap')) AS has_active_swap,
             COALESCE(
-              (SELECT (last_completed_at >= ?) FROM token_swap_status WHERE id = 1),
+              (SELECT (last_completed_at >= ?) FROM token_swap_status WHERE user_id = ?),
               0
             ) AS swap_completed`,
-          [refreshTimestamp]
+          [this.identity, refreshTimestamp, this.identity]
         );
         const hasActiveSwap = !!swapRows[0].has_active_swap;
         const swapCompleted = !!swapRows[0].swap_completed;
@@ -167,19 +202,19 @@ class MysqlTokenStore {
           refreshTimestamp.getTime() - SPENT_MARKER_CLEANUP_THRESHOLD_MS
         );
         await conn.query(
-          "DELETE FROM token_spent_outputs WHERE spent_at < ?",
-          [cleanupCutoff]
+          "DELETE FROM token_spent_outputs WHERE user_id = ? AND spent_at < ?",
+          [this.identity, cleanupCutoff]
         );
 
         const [spentRows] = await conn.query(
-          "SELECT output_id FROM token_spent_outputs WHERE spent_at >= ?",
-          [refreshTimestamp]
+          "SELECT output_id FROM token_spent_outputs WHERE user_id = ? AND spent_at >= ?",
+          [this.identity, refreshTimestamp]
         );
         const spentIds = new Set(spentRows.map((r) => r.output_id));
 
         await conn.query(
-          "DELETE FROM token_outputs WHERE reservation_id IS NULL AND added_at < ?",
-          [refreshTimestamp]
+          "DELETE FROM token_outputs WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
+          [this.identity, refreshTimestamp]
         );
 
         const incomingOutputIds = new Set();
@@ -192,7 +227,10 @@ class MysqlTokenStore {
         const [reservedRows] = await conn.query(
           `SELECT r.id, o.id AS output_id
            FROM token_reservations r
-           JOIN token_outputs o ON o.reservation_id = r.id`
+           JOIN token_outputs o
+             ON o.reservation_id = r.id AND o.user_id = r.user_id
+           WHERE r.user_id = ?`,
+          [this.identity]
         );
 
         const reservationOutputs = new Map();
@@ -221,12 +259,12 @@ class MysqlTokenStore {
         if (reservationsToDelete.length > 0) {
           const placeholders = buildPlaceholders(reservationsToDelete.length);
           await conn.query(
-            `DELETE FROM token_outputs WHERE reservation_id IN (${placeholders})`,
-            reservationsToDelete
+            `DELETE FROM token_outputs WHERE user_id = ? AND reservation_id IN (${placeholders})`,
+            [this.identity, ...reservationsToDelete]
           );
           await conn.query(
-            `DELETE FROM token_reservations WHERE id IN (${placeholders})`,
-            reservationsToDelete
+            `DELETE FROM token_reservations WHERE user_id = ? AND id IN (${placeholders})`,
+            [this.identity, ...reservationsToDelete]
           );
         }
 
@@ -235,35 +273,40 @@ class MysqlTokenStore {
             outputsToRemoveFromReservation.length
           );
           await conn.query(
-            `DELETE FROM token_outputs WHERE id IN (${placeholders})`,
-            outputsToRemoveFromReservation
+            `DELETE FROM token_outputs WHERE user_id = ? AND id IN (${placeholders})`,
+            [this.identity, ...outputsToRemoveFromReservation]
           );
 
           const [emptyRows] = await conn.query(
             `SELECT r.id FROM token_reservations r
-             LEFT JOIN token_outputs o ON o.reservation_id = r.id
-             WHERE o.id IS NULL`
+             LEFT JOIN token_outputs o
+               ON o.reservation_id = r.id AND o.user_id = r.user_id
+             WHERE r.user_id = ? AND o.id IS NULL`,
+            [this.identity]
           );
           const emptyIds = emptyRows.map((r) => r.id);
           if (emptyIds.length > 0) {
             const emptyPlaceholders = buildPlaceholders(emptyIds.length);
             await conn.query(
-              `DELETE FROM token_reservations WHERE id IN (${emptyPlaceholders})`,
-              emptyIds
+              `DELETE FROM token_reservations WHERE user_id = ? AND id IN (${emptyPlaceholders})`,
+              [this.identity, ...emptyIds]
             );
           }
         }
 
         const [reservedOutputRows] = await conn.query(
-          "SELECT id FROM token_outputs WHERE reservation_id IS NOT NULL"
+          "SELECT id FROM token_outputs WHERE user_id = ? AND reservation_id IS NOT NULL",
+          [this.identity]
         );
         const reservedOutputIds = new Set(reservedOutputRows.map((r) => r.id));
 
         await conn.query(
           `DELETE FROM token_metadata
-           WHERE identifier NOT IN (
-             SELECT DISTINCT token_identifier FROM token_outputs
-           )`
+           WHERE user_id = ?
+             AND identifier NOT IN (
+               SELECT DISTINCT token_identifier FROM token_outputs WHERE user_id = ?
+             )`,
+          [this.identity, this.identity]
         );
 
         for (const to of tokenOutputs) {
@@ -302,22 +345,26 @@ class MysqlTokenStore {
    */
   async getTokenBalances() {
     try {
-      const [rows] = await this.pool.query(`
-        SELECT m.identifier, m.issuer_public_key, m.name, m.ticker, m.decimals,
-               m.max_supply, m.is_freezable, m.creation_entity_public_key,
-               CAST(COALESCE(SUM(
-                 CASE
-                   WHEN o.reservation_id IS NULL THEN CAST(o.token_amount AS DECIMAL(65,0))
-                   WHEN r.purpose = 'Swap' THEN CAST(o.token_amount AS DECIMAL(65,0))
-                   ELSE 0
-                 END
-               ), 0) AS CHAR) AS balance
-        FROM token_metadata m
-        JOIN token_outputs o ON o.token_identifier = m.identifier
-        LEFT JOIN token_reservations r ON o.reservation_id = r.id
-        GROUP BY m.identifier, m.issuer_public_key, m.name, m.ticker,
-                 m.decimals, m.max_supply, m.is_freezable, m.creation_entity_public_key
-      `);
+      const [rows] = await this.pool.query(
+        `SELECT m.identifier, m.issuer_public_key, m.name, m.ticker, m.decimals,
+                m.max_supply, m.is_freezable, m.creation_entity_public_key,
+                CAST(COALESCE(SUM(
+                  CASE
+                    WHEN o.reservation_id IS NULL THEN CAST(o.token_amount AS DECIMAL(65,0))
+                    WHEN r.purpose = 'Swap' THEN CAST(o.token_amount AS DECIMAL(65,0))
+                    ELSE 0
+                  END
+                ), 0) AS CHAR) AS balance
+         FROM token_metadata m
+         JOIN token_outputs o
+           ON o.token_identifier = m.identifier AND o.user_id = m.user_id
+         LEFT JOIN token_reservations r
+           ON o.reservation_id = r.id AND o.user_id = r.user_id
+         WHERE m.user_id = ?
+         GROUP BY m.identifier, m.issuer_public_key, m.name, m.ticker,
+                  m.decimals, m.max_supply, m.is_freezable, m.creation_entity_public_key`,
+        [this.identity]
+      );
       return rows.map((row) => ({
         metadata: {
           identifier: row.identifier,
@@ -350,9 +397,13 @@ class MysqlTokenStore {
                 o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                 r.purpose
          FROM token_metadata m
-         LEFT JOIN token_outputs o ON o.token_identifier = m.identifier
-         LEFT JOIN token_reservations r ON o.reservation_id = r.id
-         ORDER BY m.identifier, CAST(o.token_amount AS DECIMAL(65,0)) ASC`
+         LEFT JOIN token_outputs o
+           ON o.token_identifier = m.identifier AND o.user_id = m.user_id
+         LEFT JOIN token_reservations r
+           ON o.reservation_id = r.id AND o.user_id = r.user_id
+         WHERE m.user_id = ?
+         ORDER BY m.identifier, CAST(o.token_amount AS DECIMAL(65,0)) ASC`,
+        [this.identity]
       );
 
       const map = new Map();
@@ -418,11 +469,13 @@ class MysqlTokenStore {
                 o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                 r.purpose
          FROM token_metadata m
-         LEFT JOIN token_outputs o ON o.token_identifier = m.identifier
-         LEFT JOIN token_reservations r ON o.reservation_id = r.id
-         WHERE ${whereClause}
+         LEFT JOIN token_outputs o
+           ON o.token_identifier = m.identifier AND o.user_id = m.user_id
+         LEFT JOIN token_reservations r
+           ON o.reservation_id = r.id AND o.user_id = r.user_id
+         WHERE m.user_id = ? AND ${whereClause}
          ORDER BY CAST(o.token_amount AS DECIMAL(65,0)) ASC`,
-        [param]
+        [this.identity, param]
       );
 
       if (rows.length === 0) {
@@ -475,8 +528,8 @@ class MysqlTokenStore {
         if (outputIds.length > 0) {
           const placeholders = buildPlaceholders(outputIds.length);
           await conn.query(
-            `DELETE FROM token_spent_outputs WHERE output_id IN (${placeholders})`,
-            outputIds
+            `DELETE FROM token_spent_outputs WHERE user_id = ? AND output_id IN (${placeholders})`,
+            [this.identity, ...outputIds]
           );
         }
 
@@ -531,8 +584,8 @@ class MysqlTokenStore {
         }
 
         const [metadataRows] = await conn.query(
-          "SELECT * FROM token_metadata WHERE identifier = ?",
-          [tokenIdentifier]
+          "SELECT * FROM token_metadata WHERE user_id = ? AND identifier = ?",
+          [this.identity, tokenIdentifier]
         );
 
         if (metadataRows.length === 0) {
@@ -549,8 +602,8 @@ class MysqlTokenStore {
                   o.token_public_key, o.token_amount, o.token_identifier,
                   o.prev_tx_hash, o.prev_tx_vout
            FROM token_outputs o
-           WHERE o.token_identifier = ? AND o.reservation_id IS NULL`,
-          [tokenIdentifier]
+           WHERE o.user_id = ? AND o.token_identifier = ? AND o.reservation_id IS NULL`,
+          [this.identity, tokenIdentifier]
         );
 
         let outputs = outputRows.map((row) => this._outputFromRow(row));
@@ -635,16 +688,16 @@ class MysqlTokenStore {
         const reservationId = this._generateId();
 
         await conn.query(
-          "INSERT INTO token_reservations (id, purpose) VALUES (?, ?)",
-          [reservationId, purpose]
+          "INSERT INTO token_reservations (user_id, id, purpose) VALUES (?, ?, ?)",
+          [this.identity, reservationId, purpose]
         );
 
         const selectedIds = selectedOutputs.map((o) => o.output.id);
         if (selectedIds.length > 0) {
           const placeholders = buildPlaceholders(selectedIds.length);
           await conn.query(
-            `UPDATE token_outputs SET reservation_id = ? WHERE id IN (${placeholders})`,
-            [reservationId, ...selectedIds]
+            `UPDATE token_outputs SET reservation_id = ? WHERE user_id = ? AND id IN (${placeholders})`,
+            [reservationId, this.identity, ...selectedIds]
           );
         }
 
@@ -665,11 +718,16 @@ class MysqlTokenStore {
   async cancelReservation(id) {
     try {
       await this._withTransaction(async (conn) => {
+        // Clear reservation_id from outputs first — the composite FK uses NO
+        // ACTION (a whole-row SET NULL would null user_id, which is NOT NULL).
         await conn.query(
-          "UPDATE token_outputs SET reservation_id = NULL WHERE reservation_id = ?",
-          [id]
+          "UPDATE token_outputs SET reservation_id = NULL WHERE user_id = ? AND reservation_id = ?",
+          [this.identity, id]
         );
-        await conn.query("DELETE FROM token_reservations WHERE id = ?", [id]);
+        await conn.query(
+          "DELETE FROM token_reservations WHERE user_id = ? AND id = ?",
+          [this.identity, id]
+        );
       });
     } catch (error) {
       if (error instanceof TokenStoreError) throw error;
@@ -688,8 +746,8 @@ class MysqlTokenStore {
       // the just-spent output as Available.
       await this._withWriteTransaction(async (conn) => {
         const [reservationRows] = await conn.query(
-          "SELECT purpose FROM token_reservations WHERE id = ?",
-          [id]
+          "SELECT purpose FROM token_reservations WHERE user_id = ? AND id = ?",
+          [this.identity, id]
         );
         if (reservationRows.length === 0) {
           return;
@@ -697,39 +755,53 @@ class MysqlTokenStore {
         const isSwap = reservationRows[0].purpose === "Swap";
 
         const [reservedRows] = await conn.query(
-          "SELECT id FROM token_outputs WHERE reservation_id = ?",
-          [id]
+          "SELECT id FROM token_outputs WHERE user_id = ? AND reservation_id = ?",
+          [this.identity, id]
         );
         const reservedOutputIds = reservedRows.map((r) => r.id);
 
         if (reservedOutputIds.length > 0) {
           const valueClauses = new Array(reservedOutputIds.length)
-            .fill("(?)")
+            .fill("(?, ?)")
             .join(", ");
+          const params = [];
+          for (const outputId of reservedOutputIds) {
+            params.push(this.identity, outputId);
+          }
           // Suppress duplicate-PK errors only.
           await conn.query(
-            `INSERT INTO token_spent_outputs (output_id) VALUES ${valueClauses}
+            `INSERT INTO token_spent_outputs (user_id, output_id) VALUES ${valueClauses}
              ON DUPLICATE KEY UPDATE output_id = output_id`,
-            reservedOutputIds
+            params
           );
         }
 
-        await conn.query("DELETE FROM token_outputs WHERE reservation_id = ?", [
-          id,
-        ]);
-        await conn.query("DELETE FROM token_reservations WHERE id = ?", [id]);
+        await conn.query(
+          "DELETE FROM token_outputs WHERE user_id = ? AND reservation_id = ?",
+          [this.identity, id]
+        );
+        await conn.query(
+          "DELETE FROM token_reservations WHERE user_id = ? AND id = ?",
+          [this.identity, id]
+        );
 
+        // UPSERT so a tenant that joined after the multi-tenant migration
+        // (and thus has no row) gets one created lazily.
         if (isSwap) {
           await conn.query(
-            "UPDATE token_swap_status SET last_completed_at = NOW(6) WHERE id = 1"
+            `INSERT INTO token_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
+             ON DUPLICATE KEY UPDATE last_completed_at = VALUES(last_completed_at)`,
+            [this.identity]
           );
         }
 
         await conn.query(
           `DELETE FROM token_metadata
-           WHERE identifier NOT IN (
-             SELECT DISTINCT token_identifier FROM token_outputs
-           )`
+           WHERE user_id = ?
+             AND identifier NOT IN (
+               SELECT DISTINCT token_identifier FROM token_outputs WHERE user_id = ?
+             )`,
+          [this.identity, this.identity]
         );
       });
     } catch (error) {
@@ -769,20 +841,36 @@ class MysqlTokenStore {
     });
   }
 
+  /// Cleans up stale reservations for THIS tenant. Releases dependent outputs
+  /// by clearing reservation_id first, then deletes the parent rows — the
+  /// composite FK uses NO ACTION because column-list SET NULL would null
+  /// user_id (NOT NULL).
   async _cleanupStaleReservations(conn) {
     await conn.query(
+      `UPDATE token_outputs SET reservation_id = NULL
+       WHERE user_id = ?
+         AND reservation_id IN (
+           SELECT id FROM (
+             SELECT id FROM token_reservations
+             WHERE user_id = ?
+               AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
+           ) AS stale
+         )`,
+      [this.identity, this.identity, RESERVATION_TIMEOUT_SECS]
+    );
+    await conn.query(
       `DELETE FROM token_reservations
-       WHERE created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)`,
-      [RESERVATION_TIMEOUT_SECS]
+       WHERE user_id = ? AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)`,
+      [this.identity, RESERVATION_TIMEOUT_SECS]
     );
   }
 
   async _upsertMetadata(conn, metadata) {
     await conn.query(
       `INSERT INTO token_metadata
-        (identifier, issuer_public_key, name, ticker, decimals, max_supply,
+        (user_id, identifier, issuer_public_key, name, ticker, decimals, max_supply,
          is_freezable, creation_entity_public_key)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          issuer_public_key = VALUES(issuer_public_key),
          name = VALUES(name),
@@ -792,6 +880,7 @@ class MysqlTokenStore {
          is_freezable = VALUES(is_freezable),
          creation_entity_public_key = VALUES(creation_entity_public_key)`,
       [
+        this.identity,
         metadata.identifier,
         metadata.issuerPublicKey,
         metadata.name,
@@ -805,17 +894,18 @@ class MysqlTokenStore {
   }
 
   async _insertSingleOutput(conn, tokenIdentifier, output) {
-    // ON DUPLICATE KEY UPDATE id = id no-ops on the (id) primary key
+    // ON DUPLICATE KEY UPDATE id = id no-ops on the (user_id, id) primary key
     // conflict only — unlike INSERT IGNORE, FK / NOT NULL / type errors
     // still propagate.
     await conn.query(
       `INSERT INTO token_outputs
-        (id, token_identifier, owner_public_key, revocation_commitment,
+        (user_id, id, token_identifier, owner_public_key, revocation_commitment,
          withdraw_bond_sats, withdraw_relative_block_locktime,
          token_public_key, token_amount, prev_tx_hash, prev_tx_vout, added_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(6))
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(6))
        ON DUPLICATE KEY UPDATE id = id`,
       [
+        this.identity,
         output.output.id,
         tokenIdentifier,
         output.output.ownerPublicKey,
@@ -873,13 +963,19 @@ function createMysqlPool(config) {
   });
 }
 
-async function createMysqlTokenStore(config, logger = null) {
+/**
+ * @param {object} config - MySQL configuration
+ * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+ *   identifying the tenant. All reads and writes are scoped by this.
+ * @param {object} [logger]
+ */
+async function createMysqlTokenStore(config, identity, logger = null) {
   const pool = createMysqlPool(config);
-  return createMysqlTokenStoreWithPool(pool, logger);
+  return createMysqlTokenStoreWithPool(pool, identity, logger);
 }
 
-async function createMysqlTokenStoreWithPool(pool, logger = null) {
-  const store = new MysqlTokenStore(pool, logger);
+async function createMysqlTokenStoreWithPool(pool, identity, logger = null) {
+  const store = new MysqlTokenStore(pool, identity, logger);
   await store.initialize();
   return store;
 }

--- a/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
@@ -8,12 +8,52 @@ const TOKEN_MIGRATIONS_TABLE = "token_schema_migrations";
 const MIGRATION_LOCK_NAME = "breez_mysql_token_store_migration_lock";
 const MIGRATION_LOCK_TIMEOUT = 60;
 
+/**
+ * Runs a single migration step. Plain strings are run as-is; tagged objects
+ * (`{ op: 'dropPrimaryKey', table }`) are guarded against partial-apply replay
+ * by checking `information_schema` first. MySQL DDL implicitly commits, so
+ * if the migration crashes between two DDL statements the version row never
+ * gets recorded — and on retry, an unguarded DROP PRIMARY KEY would fail
+ * (`ER_CANT_DROP_FIELD_OR_KEY`) because the PK is already gone.
+ */
+async function runMigrationStep(conn, step) {
+  if (typeof step === "string") {
+    await conn.query(step);
+    return;
+  }
+  if (step.op === "dropPrimaryKey") {
+    const [rows] = await conn.query(
+      `SELECT COUNT(*) AS c FROM information_schema.table_constraints
+       WHERE table_schema = DATABASE()
+         AND table_name = ?
+         AND constraint_type = 'PRIMARY KEY'`,
+      [step.table]
+    );
+    if (rows[0].c > 0) {
+      await conn.query(`ALTER TABLE \`${step.table}\` DROP PRIMARY KEY`);
+    }
+    return;
+  }
+  throw new Error(`Unknown migration step op: ${JSON.stringify(step)}`);
+}
+
 class MysqlTokenStoreMigrationManager {
   constructor(logger = null) {
     this.logger = logger;
   }
 
-  async migrate(pool) {
+  /**
+   * @param {import('mysql2/promise').Pool} pool
+   * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+   *   identifying the tenant. Used to backfill `user_id` columns in the
+   *   multi-tenant scoping migration. Required.
+   */
+  async migrate(pool, identity) {
+    if (!identity || identity.length !== 33) {
+      throw new TokenStoreError(
+        "tenant identity (33-byte secp256k1 pubkey) is required"
+      );
+    }
     const conn = await pool.getConnection();
     try {
       const [lockRows] = await conn.query(
@@ -41,7 +81,7 @@ class MysqlTokenStoreMigrationManager {
         );
         const currentVersion = versionRows[0].version;
 
-        const migrations = this._getMigrations();
+        const migrations = this._getMigrations(identity);
 
         if (currentVersion >= migrations.length) {
           await conn.query("COMMIT");
@@ -51,8 +91,8 @@ class MysqlTokenStoreMigrationManager {
         for (let i = currentVersion; i < migrations.length; i++) {
           const migration = migrations[i];
           const version = i + 1;
-          for (const sql of migration.sql) {
-            await conn.query(sql);
+          for (const step of migration.sql) {
+            await runMigrationStep(conn, step);
           }
           await conn.query(
             `INSERT INTO \`${TOKEN_MIGRATIONS_TABLE}\` (version) VALUES (?)`,
@@ -77,7 +117,16 @@ class MysqlTokenStoreMigrationManager {
     }
   }
 
-  _getMigrations() {
+  /**
+   * @param {Buffer|Uint8Array} identity - tenant identity inlined as a hex
+   *   `UNHEX('…')` literal in the multi-tenant scoping migration. Safe because
+   *   the bytes come from a typed secp256k1 pubkey (`[0-9a-f]{66}` after hex
+   *   encoding) — not user-controlled input.
+   */
+  _getMigrations(identity) {
+    const idHex = Buffer.from(identity).toString("hex");
+    const idLit = `UNHEX('${idHex}')`;
+
     return [
       {
         name: "Create token store tables",
@@ -132,6 +181,71 @@ class MysqlTokenStoreMigrationManager {
           )`,
           `INSERT INTO token_swap_status (id) VALUES (1)
             ON DUPLICATE KEY UPDATE id = id`,
+        ],
+      },
+      {
+        // Mirrors Rust migration 2 in spark-mysql/src/token_store.rs and the
+        // postgres equivalent. Adds user_id to every token-store table
+        // (including token_metadata — per-tenant to avoid 0-balance leakage
+        // for tokens a tenant never owned), backfills with the connecting
+        // tenant, and rewrites primary keys / FKs / indexes to lead with
+        // user_id. Composite FKs use NO ACTION because column-list SET NULL
+        // would null user_id (NOT NULL).
+        name: "Multi-tenant scoping: add user_id and rewrite primary keys / FKs",
+        sql: [
+          // Drop dependent FKs FIRST so we can rewrite the parent PKs.
+          `ALTER TABLE token_outputs DROP FOREIGN KEY fk_token_outputs_metadata`,
+          `ALTER TABLE token_outputs DROP FOREIGN KEY fk_token_outputs_reservation`,
+
+          // token_metadata: per-tenant scoping (privacy — see header).
+          `ALTER TABLE token_metadata ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE token_metadata SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE token_metadata MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE token_metadata DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, identifier)`,
+          `DROP INDEX idx_token_metadata_issuer_pk ON token_metadata`,
+          `CREATE INDEX idx_token_metadata_user_issuer_pk
+             ON token_metadata (user_id, issuer_public_key)`,
+
+          // token_reservations: scope by user_id.
+          `ALTER TABLE token_reservations ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE token_reservations SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE token_reservations MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE token_reservations DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)`,
+
+          // token_outputs: scope by user_id, rekey, re-add composite FKs.
+          `ALTER TABLE token_outputs ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE token_outputs SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE token_outputs MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE token_outputs DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)`,
+          `ALTER TABLE token_outputs
+             ADD CONSTRAINT fk_token_outputs_metadata_user
+             FOREIGN KEY (user_id, token_identifier)
+             REFERENCES token_metadata(user_id, identifier)`,
+          `ALTER TABLE token_outputs
+             ADD CONSTRAINT fk_token_outputs_reservation_user
+             FOREIGN KEY (user_id, reservation_id)
+             REFERENCES token_reservations(user_id, id)`,
+          `DROP INDEX idx_token_outputs_identifier ON token_outputs`,
+          `DROP INDEX idx_token_outputs_reservation ON token_outputs`,
+          `CREATE INDEX idx_token_outputs_user_identifier
+             ON token_outputs (user_id, token_identifier)`,
+          `CREATE INDEX idx_token_outputs_user_reservation
+             ON token_outputs (user_id, reservation_id)`,
+
+          // token_spent_outputs: scope by user_id.
+          `ALTER TABLE token_spent_outputs ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE token_spent_outputs SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE token_spent_outputs MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE token_spent_outputs DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, output_id)`,
+
+          // token_swap_status was a singleton (PK id=1, CHECK id=1). Drop the
+          // PK and the id column, then re-key by user_id.
+          { op: "dropPrimaryKey", table: "token_swap_status" },
+          `ALTER TABLE token_swap_status DROP COLUMN id`,
+          `ALTER TABLE token_swap_status ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE token_swap_status SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE token_swap_status MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE token_swap_status ADD PRIMARY KEY (user_id)`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -33,15 +33,27 @@ const { TreeStoreError } = require("./errors.cjs");
 const { MysqlTreeStoreMigrationManager } = require("./migrations.cjs");
 
 /**
- * Named lock that serializes all tree store writes across processes.
- * Mirrors the Rust constant `TREE_STORE_WRITE_LOCK_NAME`.
+ * Domain prefix mixed into the per-tenant `GET_LOCK` name. Distinct prefixes
+ * guarantee that tree-store and token-store locks never collide.
  */
-const TREE_STORE_WRITE_LOCK_NAME = "tree_store_write_lock";
+const TREE_STORE_LOCK_PREFIX = "breez-spark-sdk:tree:";
 /** Seconds to wait when acquiring the write lock. */
 const WRITE_LOCK_TIMEOUT_SECS = 30;
 
 const RESERVATION_TIMEOUT_SECS = 300;
 const SPENT_MARKER_CLEANUP_THRESHOLD_MS = 5 * 60 * 1000;
+
+/**
+ * Derive a stable per-tenant lock name from a tenant identity pubkey. Hashes
+ * a domain prefix together with the identity (SHA-256, first 8 bytes hex).
+ */
+function _identityLockName(prefix, identity) {
+  const crypto = require("crypto");
+  const hash = crypto.createHash("sha256");
+  hash.update(prefix);
+  hash.update(Buffer.from(identity));
+  return prefix + hash.digest("hex").slice(0, 16);
+}
 
 /** mysql2 may return JSON columns as either parsed objects or raw strings. */
 function parseJson(value) {
@@ -62,15 +74,28 @@ function buildPlaceholders(n) {
 }
 
 class MysqlTreeStore {
-  constructor(pool, logger = null) {
+  /**
+   * @param {import('mysql2/promise').Pool} pool
+   * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+   *   identifying the tenant. All reads and writes are scoped by this.
+   * @param {object} [logger]
+   */
+  constructor(pool, identity, logger = null) {
+    if (!identity || identity.length !== 33) {
+      throw new TreeStoreError(
+        "tenant identity (33-byte secp256k1 pubkey) is required"
+      );
+    }
     this.pool = pool;
+    this.identity = Buffer.from(identity);
+    this.lockName = _identityLockName(TREE_STORE_LOCK_PREFIX, identity);
     this.logger = logger;
   }
 
   async initialize() {
     try {
       const migrationManager = new MysqlTreeStoreMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool);
+      await migrationManager.migrate(this.pool, this.identity);
       return this;
     } catch (error) {
       throw new TreeStoreError(
@@ -101,7 +126,7 @@ class MysqlTreeStore {
     try {
       const [lockRows] = await conn.query(
         "SELECT GET_LOCK(?, ?) AS acquired",
-        [TREE_STORE_WRITE_LOCK_NAME, WRITE_LOCK_TIMEOUT_SECS]
+        [this.lockName, WRITE_LOCK_TIMEOUT_SECS]
       );
       if (!lockRows || lockRows[0].acquired !== 1) {
         throw new TreeStoreError(
@@ -120,7 +145,7 @@ class MysqlTreeStore {
     } finally {
       if (lockAcquired) {
         await conn
-          .query("SELECT RELEASE_LOCK(?)", [TREE_STORE_WRITE_LOCK_NAME])
+          .query("SELECT RELEASE_LOCK(?)", [this.lockName])
           .catch(() => {});
       }
       conn.release();
@@ -180,14 +205,18 @@ class MysqlTreeStore {
    */
   async getAvailableBalance() {
     try {
-      const [rows] = await this.pool.query(`
-        SELECT COALESCE(SUM(l.value), 0) AS balance
-        FROM tree_leaves l
-        LEFT JOIN tree_reservations r ON l.reservation_id = r.id
-        WHERE
-          (l.reservation_id IS NULL AND l.status = 'Available')
-          OR r.purpose = 'Swap'
-      `);
+      const [rows] = await this.pool.query(
+        `SELECT COALESCE(SUM(l.value), 0) AS balance
+         FROM tree_leaves l
+         LEFT JOIN tree_reservations r
+           ON l.reservation_id = r.id AND l.user_id = r.user_id
+         WHERE l.user_id = ?
+           AND (
+             (l.reservation_id IS NULL AND l.status = 'Available')
+             OR r.purpose = 'Swap'
+           )`,
+        [this.identity]
+      );
       return BigInt(rows[0].balance);
     } catch (error) {
       throw new TreeStoreError(
@@ -199,12 +228,15 @@ class MysqlTreeStore {
 
   async getLeaves() {
     try {
-      const [rows] = await this.pool.query(`
-        SELECT l.id, l.status, l.is_missing_from_operators, l.data,
-               l.reservation_id, r.purpose
-        FROM tree_leaves l
-        LEFT JOIN tree_reservations r ON l.reservation_id = r.id
-      `);
+      const [rows] = await this.pool.query(
+        `SELECT l.id, l.status, l.is_missing_from_operators, l.data,
+                l.reservation_id, r.purpose
+         FROM tree_leaves l
+         LEFT JOIN tree_reservations r
+           ON l.reservation_id = r.id AND l.user_id = r.user_id
+         WHERE l.user_id = ?`,
+        [this.identity]
+      );
 
       const available = [];
       const notAvailable = [];
@@ -264,12 +296,12 @@ class MysqlTreeStore {
 
         const [swapRows] = await conn.query(
           `SELECT
-            (SELECT EXISTS(SELECT 1 FROM tree_reservations WHERE purpose = 'Swap')) AS has_active_swap,
+            (SELECT EXISTS(SELECT 1 FROM tree_reservations WHERE user_id = ? AND purpose = 'Swap')) AS has_active_swap,
             COALESCE(
-              (SELECT (last_completed_at >= ?) FROM tree_swap_status WHERE id = 1),
+              (SELECT (last_completed_at >= ?) FROM tree_swap_status WHERE user_id = ?),
               0
             ) AS swap_completed_during_refresh`,
-          [refreshTimestamp]
+          [this.identity, refreshTimestamp, this.identity]
         );
         const hasActiveSwap = !!swapRows[0].has_active_swap;
         const swapCompletedDuringRefresh = !!swapRows[0].swap_completed_during_refresh;
@@ -281,14 +313,17 @@ class MysqlTreeStore {
         await this._cleanupSpentMarkers(conn, refreshTimestamp);
 
         const [spentRows] = await conn.query(
-          "SELECT leaf_id FROM tree_spent_leaves WHERE spent_at >= ?",
-          [refreshTimestamp]
+          "SELECT leaf_id FROM tree_spent_leaves WHERE user_id = ? AND spent_at >= ?",
+          [this.identity, refreshTimestamp]
         );
         const spentIds = new Set(spentRows.map((r) => r.leaf_id));
 
+        // Includes leaves released earlier in this transaction by
+        // _cleanupStaleReservations (which now NULLs reservation_id explicitly,
+        // since the composite FK uses NO ACTION).
         await conn.query(
-          "DELETE FROM tree_leaves WHERE reservation_id IS NULL AND added_at < ?",
-          [refreshTimestamp]
+          "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
+          [this.identity, refreshTimestamp]
         );
 
         await this._batchUpsertLeaves(conn, leaves, false, spentIds);
@@ -307,18 +342,22 @@ class MysqlTreeStore {
     try {
       await this._withTransaction(async (conn) => {
         const [existsRows] = await conn.query(
-          "SELECT id FROM tree_reservations WHERE id = ?",
-          [id]
+          "SELECT id FROM tree_reservations WHERE user_id = ? AND id = ?",
+          [this.identity, id]
         );
 
         if (existsRows.length === 0) {
           return;
         }
 
-        await conn.query("DELETE FROM tree_leaves WHERE reservation_id = ?", [
-          id,
-        ]);
-        await conn.query("DELETE FROM tree_reservations WHERE id = ?", [id]);
+        await conn.query(
+          "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+          [this.identity, id]
+        );
+        await conn.query(
+          "DELETE FROM tree_reservations WHERE user_id = ? AND id = ?",
+          [this.identity, id]
+        );
 
         if (leavesToKeep && leavesToKeep.length > 0) {
           await this._batchUpsertLeaves(conn, leavesToKeep, false, null);
@@ -341,33 +380,40 @@ class MysqlTreeStore {
       // just-spent leaf as Available.
       await this._withWriteTransaction(async (conn) => {
         const [resRows] = await conn.query(
-          "SELECT id, purpose FROM tree_reservations WHERE id = ?",
-          [id]
+          "SELECT id, purpose FROM tree_reservations WHERE user_id = ? AND id = ?",
+          [this.identity, id]
         );
 
         let isSwap = false;
         if (resRows.length > 0) {
           isSwap = resRows[0].purpose === "Swap";
           const [leafRows] = await conn.query(
-            "SELECT id FROM tree_leaves WHERE reservation_id = ?",
-            [id]
+            "SELECT id FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+            [this.identity, id]
           );
           const reservedLeafIds = leafRows.map((r) => r.id);
           await this._batchInsertSpentLeaves(conn, reservedLeafIds);
           await conn.query(
-            "DELETE FROM tree_leaves WHERE reservation_id = ?",
-            [id]
+            "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+            [this.identity, id]
           );
-          await conn.query("DELETE FROM tree_reservations WHERE id = ?", [id]);
+          await conn.query(
+            "DELETE FROM tree_reservations WHERE user_id = ? AND id = ?",
+            [this.identity, id]
+          );
         }
 
         if (newLeaves && newLeaves.length > 0) {
           await this._batchUpsertLeaves(conn, newLeaves, false, null);
         }
 
+        // UPSERT so a tenant that joined after the multi-tenant migration
+        // (and thus has no row) gets one created lazily.
         if (isSwap && newLeaves && newLeaves.length > 0) {
           await conn.query(
-            "UPDATE tree_swap_status SET last_completed_at = NOW(6) WHERE id = 1"
+            `INSERT INTO tree_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
+             ON DUPLICATE KEY UPDATE last_completed_at = VALUES(last_completed_at)`,
+            [this.identity]
           );
         }
       });
@@ -386,26 +432,22 @@ class MysqlTreeStore {
         const targetAmount = targetAmounts ? this._totalSats(targetAmounts) : 0;
         const maxTarget = this._maxTargetForPrefilter(targetAmounts);
 
-        // True total available across ALL eligible leaves — required for the
-        // WaitForPending decision. Must NOT be derived from the prefiltered
-        // slim set since the prefilter excludes big leaves.
         const [totalRows] = await conn.query(
           `SELECT COALESCE(SUM(value), 0) AS total
            FROM tree_leaves
-           WHERE status = 'Available'
+           WHERE user_id = ?
+             AND status = 'Available'
              AND is_missing_from_operators = 0
-             AND reservation_id IS NULL`
+             AND reservation_id IS NULL`,
+          [this.identity]
         );
         const available = Number(totalRows[0].total);
 
-        // Slim projection: only (id, value) for leaves the selection might use.
-        // Includes all leaves with value <= maxTarget plus the smallest leaf
-        // with value > maxTarget (covers the minimum-amount fallback case
-        // where one larger leaf is sufficient).
         const [slimRows] = await conn.query(
           `SELECT id, value
            FROM tree_leaves
-           WHERE status = 'Available'
+           WHERE user_id = ?
+             AND status = 'Available'
              AND is_missing_from_operators = 0
              AND reservation_id IS NULL
              AND (
@@ -413,7 +455,8 @@ class MysqlTreeStore {
                OR id = (
                  SELECT id FROM (
                    SELECT id FROM tree_leaves
-                   WHERE status = 'Available'
+                   WHERE user_id = ?
+                     AND status = 'Available'
                      AND is_missing_from_operators = 0
                      AND reservation_id IS NULL
                      AND value > ?
@@ -422,7 +465,7 @@ class MysqlTreeStore {
                  ) AS smallest_over
                )
              )`,
-          [maxTarget, maxTarget]
+          [this.identity, maxTarget, this.identity, maxTarget]
         );
 
         const slimLeaves = slimRows.map((r) => ({
@@ -536,8 +579,8 @@ class MysqlTreeStore {
     try {
       return await this._withTransaction(async (conn) => {
         const [existsRows] = await conn.query(
-          "SELECT id FROM tree_reservations WHERE id = ?",
-          [reservationId]
+          "SELECT id FROM tree_reservations WHERE user_id = ? AND id = ?",
+          [this.identity, reservationId]
         );
 
         if (existsRows.length === 0) {
@@ -545,15 +588,15 @@ class MysqlTreeStore {
         }
 
         const [oldLeafRows] = await conn.query(
-          "SELECT id FROM tree_leaves WHERE reservation_id = ?",
-          [reservationId]
+          "SELECT id FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+          [this.identity, reservationId]
         );
         const oldLeafIds = oldLeafRows.map((r) => r.id);
 
         await this._batchInsertSpentLeaves(conn, oldLeafIds);
         await conn.query(
-          "DELETE FROM tree_leaves WHERE reservation_id = ?",
-          [reservationId]
+          "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+          [this.identity, reservationId]
         );
 
         await this._batchUpsertLeaves(conn, changeLeaves, false, null);
@@ -563,8 +606,8 @@ class MysqlTreeStore {
         await this._batchSetReservationId(conn, reservationId, reservedLeafIds);
 
         await conn.query(
-          "UPDATE tree_reservations SET pending_change_amount = 0 WHERE id = ?",
-          [reservationId]
+          "UPDATE tree_reservations SET pending_change_amount = 0 WHERE user_id = ? AND id = ?",
+          [this.identity, reservationId]
         );
 
         return { id: reservationId, leaves: reservedLeaves };
@@ -620,8 +663,8 @@ class MysqlTreeStore {
     if (!ids || ids.length === 0) return [];
     const placeholders = ids.map(() => "?").join(", ");
     const [rows] = await conn.query(
-      `SELECT data FROM tree_leaves WHERE id IN (${placeholders})`,
-      ids
+      `SELECT data FROM tree_leaves WHERE user_id = ? AND id IN (${placeholders})`,
+      [this.identity, ...ids]
     );
     return rows.map((r) => parseJson(r.data));
   }
@@ -739,15 +782,16 @@ class MysqlTreeStore {
 
   async _calculatePendingBalance(conn) {
     const [rows] = await conn.query(
-      "SELECT COALESCE(SUM(pending_change_amount), 0) AS pending FROM tree_reservations"
+      "SELECT COALESCE(SUM(pending_change_amount), 0) AS pending FROM tree_reservations WHERE user_id = ?",
+      [this.identity]
     );
     return Number(rows[0].pending);
   }
 
   async _createReservation(conn, reservationId, leaves, purpose, pendingChange) {
     await conn.query(
-      "INSERT INTO tree_reservations (id, purpose, pending_change_amount) VALUES (?, ?, ?)",
-      [reservationId, purpose, pendingChange]
+      "INSERT INTO tree_reservations (user_id, id, purpose, pending_change_amount) VALUES (?, ?, ?, ?)",
+      [this.identity, reservationId, purpose, pendingChange]
     );
 
     const leafIds = leaves.map((l) => l.id);
@@ -764,11 +808,12 @@ class MysqlTreeStore {
     if (filtered.length === 0) return;
 
     const valueClauses = new Array(filtered.length)
-      .fill("(?, ?, ?, ?, ?, NOW(6))")
+      .fill("(?, ?, ?, ?, ?, ?, NOW(6))")
       .join(", ");
     const params = [];
     for (const leaf of filtered) {
       params.push(
+        this.identity,
         leaf.id,
         leaf.status,
         isMissingFromOperators ? 1 : 0,
@@ -778,7 +823,7 @@ class MysqlTreeStore {
     }
 
     await conn.query(
-      `INSERT INTO tree_leaves (id, status, is_missing_from_operators, data, value, added_at)
+      `INSERT INTO tree_leaves (user_id, id, status, is_missing_from_operators, data, value, added_at)
        VALUES ${valueClauses}
        ON DUPLICATE KEY UPDATE
          status = VALUES(status),
@@ -795,22 +840,26 @@ class MysqlTreeStore {
 
     const placeholders = buildPlaceholders(leafIds.length);
     await conn.query(
-      `UPDATE tree_leaves SET reservation_id = ? WHERE id IN (${placeholders})`,
-      [reservationId, ...leafIds]
+      `UPDATE tree_leaves SET reservation_id = ? WHERE user_id = ? AND id IN (${placeholders})`,
+      [reservationId, this.identity, ...leafIds]
     );
   }
 
   async _batchInsertSpentLeaves(conn, leafIds) {
     if (leafIds.length === 0) return;
 
-    const valueClauses = new Array(leafIds.length).fill("(?)").join(", ");
+    const valueClauses = new Array(leafIds.length).fill("(?, ?)").join(", ");
+    const params = [];
+    for (const id of leafIds) {
+      params.push(this.identity, id);
+    }
     // Suppress duplicate-PK errors only — unlike INSERT IGNORE, real
     // problems (FK violations, NOT NULL violations, type errors) still
     // propagate.
     await conn.query(
-      `INSERT INTO tree_spent_leaves (leaf_id) VALUES ${valueClauses}
+      `INSERT INTO tree_spent_leaves (user_id, leaf_id) VALUES ${valueClauses}
        ON DUPLICATE KEY UPDATE leaf_id = leaf_id`,
-      leafIds
+      params
     );
   }
 
@@ -819,16 +868,32 @@ class MysqlTreeStore {
 
     const placeholders = buildPlaceholders(leafIds.length);
     await conn.query(
-      `DELETE FROM tree_spent_leaves WHERE leaf_id IN (${placeholders})`,
-      leafIds
+      `DELETE FROM tree_spent_leaves WHERE user_id = ? AND leaf_id IN (${placeholders})`,
+      [this.identity, ...leafIds]
     );
   }
 
+  /// Cleans up stale reservations for THIS tenant. Releases dependent leaves
+  /// by clearing reservation_id first, then deletes the parent rows — the
+  /// composite FK uses NO ACTION because column-list SET NULL would null
+  /// user_id (NOT NULL).
   async _cleanupStaleReservations(conn) {
     await conn.query(
+      `UPDATE tree_leaves SET reservation_id = NULL
+       WHERE user_id = ?
+         AND reservation_id IN (
+           SELECT id FROM (
+             SELECT id FROM tree_reservations
+             WHERE user_id = ?
+               AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
+           ) AS stale
+         )`,
+      [this.identity, this.identity, RESERVATION_TIMEOUT_SECS]
+    );
+    await conn.query(
       `DELETE FROM tree_reservations
-       WHERE created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)`,
-      [RESERVATION_TIMEOUT_SECS]
+       WHERE user_id = ? AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)`,
+      [this.identity, RESERVATION_TIMEOUT_SECS]
     );
   }
 
@@ -837,9 +902,10 @@ class MysqlTreeStore {
       refreshTimestamp.getTime() - SPENT_MARKER_CLEANUP_THRESHOLD_MS
     );
 
-    await conn.query("DELETE FROM tree_spent_leaves WHERE spent_at < ?", [
-      cleanupCutoff,
-    ]);
+    await conn.query(
+      "DELETE FROM tree_spent_leaves WHERE user_id = ? AND spent_at < ?",
+      [this.identity, cleanupCutoff]
+    );
   }
 }
 
@@ -854,13 +920,13 @@ function createMysqlPool(config) {
   });
 }
 
-async function createMysqlTreeStore(config, logger = null) {
+async function createMysqlTreeStore(config, identity, logger = null) {
   const pool = createMysqlPool(config);
-  return createMysqlTreeStoreWithPool(pool, logger);
+  return createMysqlTreeStoreWithPool(pool, identity, logger);
 }
 
-async function createMysqlTreeStoreWithPool(pool, logger = null) {
-  const store = new MysqlTreeStore(pool, logger);
+async function createMysqlTreeStoreWithPool(pool, identity, logger = null) {
+  const store = new MysqlTreeStore(pool, identity, logger);
   await store.initialize();
   return store;
 }

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
@@ -8,12 +8,41 @@ const TREE_MIGRATIONS_TABLE = "tree_schema_migrations";
 const MIGRATION_LOCK_NAME = "breez_mysql_tree_store_migration_lock";
 const MIGRATION_LOCK_TIMEOUT = 60;
 
+/**
+ * Runs a single migration step. Plain strings are run as-is; tagged objects
+ * (`{ op: 'dropPrimaryKey', table }`) are guarded against partial-apply replay
+ * by checking `information_schema` first. MySQL DDL implicitly commits, so
+ * if the migration crashes between two DDL statements the version row never
+ * gets recorded — and on retry, an unguarded DROP PRIMARY KEY would fail
+ * (`ER_CANT_DROP_FIELD_OR_KEY`) because the PK is already gone.
+ */
+async function runMigrationStep(conn, step) {
+  if (typeof step === "string") {
+    await conn.query(step);
+    return;
+  }
+  if (step.op === "dropPrimaryKey") {
+    const [rows] = await conn.query(
+      `SELECT COUNT(*) AS c FROM information_schema.table_constraints
+       WHERE table_schema = DATABASE()
+         AND table_name = ?
+         AND constraint_type = 'PRIMARY KEY'`,
+      [step.table]
+    );
+    if (rows[0].c > 0) {
+      await conn.query(`ALTER TABLE \`${step.table}\` DROP PRIMARY KEY`);
+    }
+    return;
+  }
+  throw new Error(`Unknown migration step op: ${JSON.stringify(step)}`);
+}
+
 class MysqlTreeStoreMigrationManager {
   constructor(logger = null) {
     this.logger = logger;
   }
 
-  async migrate(pool) {
+  async migrate(pool, identity) {
     const conn = await pool.getConnection();
     try {
       const [lockRows] = await conn.query(
@@ -41,7 +70,7 @@ class MysqlTreeStoreMigrationManager {
         );
         const currentVersion = versionRows[0].version;
 
-        const migrations = this._getMigrations();
+        const migrations = this._getMigrations(identity);
 
         if (currentVersion >= migrations.length) {
           await conn.query("COMMIT");
@@ -51,8 +80,8 @@ class MysqlTreeStoreMigrationManager {
         for (let i = currentVersion; i < migrations.length; i++) {
           const migration = migrations[i];
           const version = i + 1;
-          for (const sql of migration.sql) {
-            await conn.query(sql);
+          for (const step of migration.sql) {
+            await runMigrationStep(conn, step);
           }
           await conn.query(
             `INSERT INTO \`${TREE_MIGRATIONS_TABLE}\` (version) VALUES (?)`,
@@ -77,7 +106,10 @@ class MysqlTreeStoreMigrationManager {
     }
   }
 
-  _getMigrations() {
+  _getMigrations(identity) {
+    const idHex = Buffer.from(identity).toString("hex");
+    const idLit = `UNHEX('${idHex}')`;
+
     return [
       {
         name: "Create tree store tables",
@@ -131,6 +163,55 @@ class MysqlTreeStoreMigrationManager {
             WHERE value = 0`,
           `CREATE INDEX idx_tree_leaves_slim
             ON tree_leaves(status, is_missing_from_operators, reservation_id, value)`,
+        ],
+      },
+      {
+        name: "Multi-tenant scoping: add user_id and rewrite primary keys / FKs",
+        sql: [
+          // Drop the existing FK so we can rewrite the parent PK.
+          `ALTER TABLE tree_leaves DROP FOREIGN KEY fk_tree_leaves_reservation`,
+
+          // tree_reservations: scope by user_id.
+          `ALTER TABLE tree_reservations ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE tree_reservations SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE tree_reservations MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE tree_reservations DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)`,
+
+          // tree_leaves: scope by user_id, rekey, re-add composite FK.
+          `ALTER TABLE tree_leaves ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE tree_leaves SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE tree_leaves MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE tree_leaves DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)`,
+          `ALTER TABLE tree_leaves
+             ADD CONSTRAINT fk_tree_leaves_reservation_user
+             FOREIGN KEY (user_id, reservation_id)
+             REFERENCES tree_reservations(user_id, id)`,
+          `DROP INDEX idx_tree_leaves_available ON tree_leaves`,
+          `DROP INDEX idx_tree_leaves_reservation ON tree_leaves`,
+          `DROP INDEX idx_tree_leaves_added_at ON tree_leaves`,
+          `DROP INDEX idx_tree_leaves_slim ON tree_leaves`,
+          `CREATE INDEX idx_tree_leaves_user_available
+             ON tree_leaves(user_id, status, is_missing_from_operators)`,
+          `CREATE INDEX idx_tree_leaves_user_reservation
+             ON tree_leaves(user_id, reservation_id)`,
+          `CREATE INDEX idx_tree_leaves_user_added_at ON tree_leaves(user_id, added_at)`,
+          `CREATE INDEX idx_tree_leaves_user_slim
+             ON tree_leaves(user_id, status, is_missing_from_operators, reservation_id, value)`,
+
+          // tree_spent_leaves: scope by user_id.
+          `ALTER TABLE tree_spent_leaves ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE tree_spent_leaves SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE tree_spent_leaves MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE tree_spent_leaves DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, leaf_id)`,
+
+          // tree_swap_status was a singleton (PK id=1, CHECK id=1). Drop the PK
+          // and the id column, then re-key by user_id.
+          { op: "dropPrimaryKey", table: "tree_swap_status" },
+          `ALTER TABLE tree_swap_status DROP COLUMN id`,
+          `ALTER TABLE tree_swap_status ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE tree_swap_status SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE tree_swap_status MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE tree_swap_status ADD PRIMARY KEY (user_id)`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
@@ -63,15 +63,26 @@ const SELECT_PAYMENT_SQL = `
            lrm.payment_hash AS lnurl_payment_hash,
            pm.parent_payment_id
       FROM payments p
-      LEFT JOIN payment_details_lightning l ON p.id = l.payment_id
-      LEFT JOIN payment_details_token t ON p.id = t.payment_id
-      LEFT JOIN payment_details_spark s ON p.id = s.payment_id
-      LEFT JOIN payment_metadata pm ON p.id = pm.payment_id
-      LEFT JOIN lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash`;
+      LEFT JOIN payment_details_lightning l ON p.id = l.payment_id AND p.user_id = l.user_id
+      LEFT JOIN payment_details_token t ON p.id = t.payment_id AND p.user_id = t.user_id
+      LEFT JOIN payment_details_spark s ON p.id = s.payment_id AND p.user_id = s.user_id
+      LEFT JOIN payment_metadata pm ON p.id = pm.payment_id AND p.user_id = pm.user_id
+      LEFT JOIN lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash AND l.user_id = lrm.user_id`;
 
 class PostgresStorage {
-  constructor(pool, logger = null) {
+  /**
+   * @param {import('pg').Pool} pool - Connection pool (may be shared with other tenants).
+   * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+   *   uniquely identifying this tenant. All reads and writes are scoped to it
+   *   so that multiple instances with distinct identities can share one DB.
+   * @param {object} [logger]
+   */
+  constructor(pool, identity, logger = null) {
+    if (!identity) {
+      throw new StorageError("PostgresStorage requires a tenant identity");
+    }
     this.pool = pool;
+    this.identity = Buffer.from(identity);
     this.logger = logger;
   }
 
@@ -81,7 +92,7 @@ class PostgresStorage {
   async initialize() {
     try {
       const migrationManager = new PostgresMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool);
+      await migrationManager.migrate(this.pool, this.identity);
       return this;
     } catch (error) {
       throw new StorageError(
@@ -127,8 +138,8 @@ class PostgresStorage {
   async getCachedItem(key) {
     try {
       const result = await this.pool.query(
-        "SELECT value FROM settings WHERE key = $1",
-        [key]
+        "SELECT value FROM settings WHERE user_id = $1 AND key = $2",
+        [this.identity, key]
       );
       return result.rows.length > 0 ? result.rows[0].value : null;
     } catch (error) {
@@ -142,9 +153,9 @@ class PostgresStorage {
   async setCachedItem(key, value) {
     try {
       await this.pool.query(
-        `INSERT INTO settings (key, value) VALUES ($1, $2)
-         ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value`,
-        [key, value]
+        `INSERT INTO settings (user_id, key, value) VALUES ($1, $2, $3)
+         ON CONFLICT(user_id, key) DO UPDATE SET value = EXCLUDED.value`,
+        [this.identity, key, value]
       );
     } catch (error) {
       throw new StorageError(
@@ -156,7 +167,10 @@ class PostgresStorage {
 
   async deleteCachedItem(key) {
     try {
-      await this.pool.query("DELETE FROM settings WHERE key = $1", [key]);
+      await this.pool.query(
+        "DELETE FROM settings WHERE user_id = $1 AND key = $2",
+        [this.identity, key]
+      );
     } catch (error) {
       throw new StorageError(
         `Failed to delete cached item '${key}': ${error.message}`,
@@ -173,9 +187,10 @@ class PostgresStorage {
       const actualLimit =
         request.limit != null ? request.limit : 4294967295;
 
-      const whereClauses = [];
-      const params = [];
-      let paramIdx = 1;
+      // Tenant scoping is always $1; dynamic filters use $2 onwards.
+      const whereClauses = ["p.user_id = $1"];
+      const params = [this.identity];
+      let paramIdx = 2;
 
       // Filter by payment type
       if (request.typeFilter && request.typeFilter.length > 0) {
@@ -349,9 +364,9 @@ class PostgresStorage {
         const spark = payment.details?.type === "spark" ? true : null;
 
         await client.query(
-          `INSERT INTO payments (id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-           ON CONFLICT(id) DO UPDATE SET
+          `INSERT INTO payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+           ON CONFLICT(user_id, id) DO UPDATE SET
              payment_type=EXCLUDED.payment_type,
              status=EXCLUDED.status,
              amount=EXCLUDED.amount,
@@ -362,6 +377,7 @@ class PostgresStorage {
              deposit_tx_id=EXCLUDED.deposit_tx_id,
              spark=EXCLUDED.spark`,
           [
+            this.identity,
             payment.id,
             payment.paymentType,
             payment.status,
@@ -381,12 +397,13 @@ class PostgresStorage {
             payment.details.htlcDetails != null)
         ) {
           await client.query(
-            `INSERT INTO payment_details_spark (payment_id, invoice_details, htlc_details)
-             VALUES ($1, $2, $3)
-             ON CONFLICT(payment_id) DO UPDATE SET
+            `INSERT INTO payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT(user_id, payment_id) DO UPDATE SET
                invoice_details=COALESCE(EXCLUDED.invoice_details, payment_details_spark.invoice_details),
                htlc_details=COALESCE(EXCLUDED.htlc_details, payment_details_spark.htlc_details)`,
             [
+              this.identity,
               payment.id,
               payment.details.invoiceDetails
                 ? JSON.stringify(payment.details.invoiceDetails)
@@ -401,9 +418,9 @@ class PostgresStorage {
         if (payment.details?.type === "lightning") {
           await client.query(
             `INSERT INTO payment_details_lightning
-              (payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
-              VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-              ON CONFLICT(payment_id) DO UPDATE SET
+              (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
+              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+              ON CONFLICT(user_id, payment_id) DO UPDATE SET
                 invoice=EXCLUDED.invoice,
                 payment_hash=EXCLUDED.payment_hash,
                 destination_pubkey=EXCLUDED.destination_pubkey,
@@ -412,6 +429,7 @@ class PostgresStorage {
                 htlc_status=COALESCE(EXCLUDED.htlc_status, payment_details_lightning.htlc_status),
                 htlc_expiry_time=COALESCE(EXCLUDED.htlc_expiry_time, payment_details_lightning.htlc_expiry_time)`,
             [
+              this.identity,
               payment.id,
               payment.details.invoice,
               payment.details.htlcDetails.paymentHash,
@@ -427,14 +445,15 @@ class PostgresStorage {
         if (payment.details?.type === "token") {
           await client.query(
             `INSERT INTO payment_details_token
-              (payment_id, metadata, tx_hash, tx_type, invoice_details)
-              VALUES ($1, $2, $3, $4, $5)
-              ON CONFLICT(payment_id) DO UPDATE SET
+              (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
+              VALUES ($1, $2, $3, $4, $5, $6)
+              ON CONFLICT(user_id, payment_id) DO UPDATE SET
                 metadata=EXCLUDED.metadata,
                 tx_hash=EXCLUDED.tx_hash,
                 tx_type=EXCLUDED.tx_type,
                 invoice_details=COALESCE(EXCLUDED.invoice_details, payment_details_token.invoice_details)`,
             [
+              this.identity,
               payment.id,
               JSON.stringify(payment.details.metadata),
               payment.details.txHash,
@@ -462,8 +481,8 @@ class PostgresStorage {
       }
 
       const result = await this.pool.query(
-        `${SELECT_PAYMENT_SQL} WHERE p.id = $1`,
-        [id]
+        `${SELECT_PAYMENT_SQL} WHERE p.user_id = $1 AND p.id = $2`,
+        [this.identity, id]
       );
 
       if (result.rows.length === 0) {
@@ -487,8 +506,8 @@ class PostgresStorage {
       }
 
       const result = await this.pool.query(
-        `${SELECT_PAYMENT_SQL} WHERE l.invoice = $1`,
-        [invoice]
+        `${SELECT_PAYMENT_SQL} WHERE p.user_id = $1 AND l.invoice = $2`,
+        [this.identity, invoice]
       );
 
       if (result.rows.length === 0) {
@@ -511,22 +530,24 @@ class PostgresStorage {
         return {};
       }
 
-      // Early exit if no related payments exist
+      // Early exit if no related payments exist for this tenant
       const hasRelatedResult = await this.pool.query(
-        "SELECT EXISTS(SELECT 1 FROM payment_metadata WHERE parent_payment_id IS NOT NULL LIMIT 1)"
+        "SELECT EXISTS(SELECT 1 FROM payment_metadata WHERE user_id = $1 AND parent_payment_id IS NOT NULL LIMIT 1)",
+        [this.identity]
       );
       if (!hasRelatedResult.rows[0].exists) {
         return {};
       }
 
+      // $1 is reserved for user_id; parent ids start at $2.
       const placeholders = parentPaymentIds.map(
-        (_, i) => `$${i + 1}`
+        (_, i) => `$${i + 2}`
       );
-      const query = `${SELECT_PAYMENT_SQL} WHERE pm.parent_payment_id IN (${placeholders.join(", ")}) ORDER BY p.timestamp ASC`;
+      const query = `${SELECT_PAYMENT_SQL} WHERE p.user_id = $1 AND pm.parent_payment_id IN (${placeholders.join(", ")}) ORDER BY p.timestamp ASC`;
 
       const queryResult = await this.pool.query(
         query,
-        parentPaymentIds
+        [this.identity, ...parentPaymentIds]
       );
 
       const result = {};
@@ -551,9 +572,9 @@ class PostgresStorage {
   async insertPaymentMetadata(paymentId, metadata) {
     try {
       await this.pool.query(
-        `INSERT INTO payment_metadata (payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
-         ON CONFLICT(payment_id) DO UPDATE SET
+        `INSERT INTO payment_metadata (user_id, payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         ON CONFLICT(user_id, payment_id) DO UPDATE SET
            parent_payment_id = COALESCE(EXCLUDED.parent_payment_id, payment_metadata.parent_payment_id),
            lnurl_pay_info = COALESCE(EXCLUDED.lnurl_pay_info, payment_metadata.lnurl_pay_info),
            lnurl_withdraw_info = COALESCE(EXCLUDED.lnurl_withdraw_info, payment_metadata.lnurl_withdraw_info),
@@ -561,6 +582,7 @@ class PostgresStorage {
            conversion_info = COALESCE(EXCLUDED.conversion_info, payment_metadata.conversion_info),
            conversion_status = COALESCE(EXCLUDED.conversion_status, payment_metadata.conversion_status)`,
         [
+          this.identity,
           paymentId,
           metadata.parentPaymentId,
           metadata.lnurlPayInfo
@@ -589,10 +611,10 @@ class PostgresStorage {
   async addDeposit(txid, vout, amountSats, isMature) {
     try {
       await this.pool.query(
-        `INSERT INTO unclaimed_deposits (txid, vout, amount_sats, is_mature)
-         VALUES ($1, $2, $3, $4)
-         ON CONFLICT(txid, vout) DO UPDATE SET is_mature = EXCLUDED.is_mature, amount_sats = EXCLUDED.amount_sats`,
-        [txid, vout, amountSats, isMature]
+        `INSERT INTO unclaimed_deposits (user_id, txid, vout, amount_sats, is_mature)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT(user_id, txid, vout) DO UPDATE SET is_mature = EXCLUDED.is_mature, amount_sats = EXCLUDED.amount_sats`,
+        [this.identity, txid, vout, amountSats, isMature]
       );
     } catch (error) {
       throw new StorageError(
@@ -605,8 +627,8 @@ class PostgresStorage {
   async deleteDeposit(txid, vout) {
     try {
       await this.pool.query(
-        "DELETE FROM unclaimed_deposits WHERE txid = $1 AND vout = $2",
-        [txid, vout]
+        "DELETE FROM unclaimed_deposits WHERE user_id = $1 AND txid = $2 AND vout = $3",
+        [this.identity, txid, vout]
       );
     } catch (error) {
       throw new StorageError(
@@ -619,7 +641,8 @@ class PostgresStorage {
   async listDeposits() {
     try {
       const result = await this.pool.query(
-        "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM unclaimed_deposits"
+        "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM unclaimed_deposits WHERE user_id = $1",
+        [this.identity]
       );
 
       return result.rows.map((row) => ({
@@ -645,15 +668,15 @@ class PostgresStorage {
         await this.pool.query(
           `UPDATE unclaimed_deposits
            SET claim_error = $1, refund_tx = NULL, refund_tx_id = NULL
-           WHERE txid = $2 AND vout = $3`,
-          [JSON.stringify(payload.error), txid, vout]
+           WHERE user_id = $2 AND txid = $3 AND vout = $4`,
+          [JSON.stringify(payload.error), this.identity, txid, vout]
         );
       } else if (payload.type === "refund") {
         await this.pool.query(
           `UPDATE unclaimed_deposits
            SET refund_tx = $1, refund_tx_id = $2, claim_error = NULL
-           WHERE txid = $3 AND vout = $4`,
-          [payload.refundTx, payload.refundTxid, txid, vout]
+           WHERE user_id = $3 AND txid = $4 AND vout = $5`,
+          [payload.refundTx, payload.refundTxid, this.identity, txid, vout]
         );
       } else {
         throw new StorageError(`Unknown payload type: ${payload.type}`);
@@ -672,13 +695,14 @@ class PostgresStorage {
       await this._withTransaction(async (client) => {
         for (const item of metadata) {
           await client.query(
-            `INSERT INTO lnurl_receive_metadata (payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
-             VALUES ($1, $2, $3, $4)
-             ON CONFLICT(payment_hash) DO UPDATE SET
+            `INSERT INTO lnurl_receive_metadata (user_id, payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
+             VALUES ($1, $2, $3, $4, $5)
+             ON CONFLICT(user_id, payment_hash) DO UPDATE SET
                nostr_zap_request = EXCLUDED.nostr_zap_request,
                nostr_zap_receipt = EXCLUDED.nostr_zap_receipt,
                sender_comment = EXCLUDED.sender_comment`,
             [
+              this.identity,
               item.paymentHash,
               item.nostrZapRequest || null,
               item.nostrZapReceipt || null,
@@ -833,9 +857,10 @@ class PostgresStorage {
       const result = await this.pool.query(
         `SELECT id, name, payment_identifier, created_at, updated_at
          FROM contacts
+         WHERE user_id = $1
          ORDER BY name ASC
-         LIMIT $1 OFFSET $2`,
-        [limit, offset]
+         LIMIT $2 OFFSET $3`,
+        [this.identity, limit, offset]
       );
 
       return result.rows.map((row) => ({
@@ -858,8 +883,8 @@ class PostgresStorage {
       const result = await this.pool.query(
         `SELECT id, name, payment_identifier, created_at, updated_at
          FROM contacts
-         WHERE id = $1`,
-        [id]
+         WHERE user_id = $1 AND id = $2`,
+        [this.identity, id]
       );
 
       if (result.rows.length === 0) {
@@ -885,13 +910,14 @@ class PostgresStorage {
   async insertContact(contact) {
     try {
       await this.pool.query(
-        `INSERT INTO contacts (id, name, payment_identifier, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5)
-         ON CONFLICT(id) DO UPDATE SET
+        `INSERT INTO contacts (user_id, id, name, payment_identifier, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ON CONFLICT(user_id, id) DO UPDATE SET
            name = EXCLUDED.name,
            payment_identifier = EXCLUDED.payment_identifier,
            updated_at = EXCLUDED.updated_at`,
         [
+          this.identity,
           contact.id,
           contact.name,
           contact.paymentIdentifier,
@@ -909,7 +935,10 @@ class PostgresStorage {
 
   async deleteContact(id) {
     try {
-      await this.pool.query("DELETE FROM contacts WHERE id = $1", [id]);
+      await this.pool.query(
+        "DELETE FROM contacts WHERE user_id = $1 AND id = $2",
+        [this.identity, id]
+      );
     } catch (error) {
       throw new StorageError(
         `Failed to delete contact: ${error.message}`,
@@ -923,21 +952,25 @@ class PostgresStorage {
   async syncAddOutgoingChange(record) {
     try {
       return await this._withTransaction(async (client) => {
+        // Local queue revision is per-tenant — two tenants don't share a queue.
         const revisionResult = await client.query(
-          "SELECT COALESCE(MAX(revision), 0) + 1 AS revision FROM sync_outgoing"
+          "SELECT COALESCE(MAX(revision), 0) + 1 AS revision FROM sync_outgoing WHERE user_id = $1",
+          [this.identity]
         );
         const revision = BigInt(revisionResult.rows[0].revision);
 
         await client.query(
           `INSERT INTO sync_outgoing (
+            user_id,
             record_type,
             data_id,
             schema_version,
             commit_time,
             updated_fields_json,
             revision
-          ) VALUES ($1, $2, $3, $4, $5, $6)`,
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
           [
+            this.identity,
             record.id.type,
             record.id.dataId,
             record.schemaVersion,
@@ -962,8 +995,9 @@ class PostgresStorage {
     try {
       await this._withTransaction(async (client) => {
         const deleteResult = await client.query(
-          "DELETE FROM sync_outgoing WHERE record_type = $1 AND data_id = $2 AND revision = $3",
+          "DELETE FROM sync_outgoing WHERE user_id = $1 AND record_type = $2 AND data_id = $3 AND revision = $4",
           [
+            this.identity,
             record.id.type,
             record.id.dataId,
             localRevision.toString(),
@@ -981,19 +1015,21 @@ class PostgresStorage {
 
         await client.query(
           `INSERT INTO sync_state (
+            user_id,
             record_type,
             data_id,
             revision,
             schema_version,
             commit_time,
             data
-          ) VALUES ($1, $2, $3, $4, $5, $6)
-          ON CONFLICT(record_type, data_id) DO UPDATE SET
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+          ON CONFLICT(user_id, record_type, data_id) DO UPDATE SET
             schema_version = EXCLUDED.schema_version,
             commit_time = EXCLUDED.commit_time,
             data = EXCLUDED.data,
             revision = EXCLUDED.revision`,
           [
+            this.identity,
             record.id.type,
             record.id.dataId,
             record.revision.toString(),
@@ -1003,9 +1039,11 @@ class PostgresStorage {
           ]
         );
 
+        // Upsert this tenant's revision row; fresh tenants without a row get one.
         await client.query(
-          "UPDATE sync_revision SET revision = GREATEST(revision, $1)",
-          [record.revision.toString()]
+          `INSERT INTO sync_revision (user_id, revision) VALUES ($1, $2)
+           ON CONFLICT (user_id) DO UPDATE SET revision = GREATEST(sync_revision.revision, EXCLUDED.revision)`,
+          [this.identity, record.revision.toString()]
         );
       });
     } catch (error) {
@@ -1034,10 +1072,12 @@ class PostgresStorage {
         FROM sync_outgoing o
         LEFT JOIN sync_state e ON
           o.record_type = e.record_type AND
-          o.data_id = e.data_id
+          o.data_id = e.data_id AND
+          o.user_id = e.user_id
+        WHERE o.user_id = $1
         ORDER BY o.revision ASC
-        LIMIT $1`,
-        [limit]
+        LIMIT $2`,
+        [this.identity, limit]
       );
 
       return result.rows.map((row) => {
@@ -1082,8 +1122,10 @@ class PostgresStorage {
 
   async syncGetLastRevision() {
     try {
+      // A tenant that hasn't synced anything yet may have no row; treat as 0.
       const result = await this.pool.query(
-        "SELECT revision FROM sync_revision"
+        "SELECT revision FROM sync_revision WHERE user_id = $1",
+        [this.identity]
       );
       return result.rows.length > 0
         ? BigInt(result.rows[0].revision)
@@ -1106,18 +1148,20 @@ class PostgresStorage {
         for (const record of records) {
           await client.query(
             `INSERT INTO sync_incoming (
+              user_id,
               record_type,
               data_id,
               schema_version,
               commit_time,
               data,
               revision
-            ) VALUES ($1, $2, $3, $4, $5, $6)
-            ON CONFLICT(record_type, data_id, revision) DO UPDATE SET
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT(user_id, record_type, data_id, revision) DO UPDATE SET
               schema_version = EXCLUDED.schema_version,
               commit_time = EXCLUDED.commit_time,
               data = EXCLUDED.data`,
             [
+              this.identity,
               record.id.type,
               record.id.dataId,
               record.schemaVersion,
@@ -1141,10 +1185,11 @@ class PostgresStorage {
     try {
       await this.pool.query(
         `DELETE FROM sync_incoming
-         WHERE record_type = $1
-         AND data_id = $2
-         AND revision = $3`,
-        [record.id.type, record.id.dataId, record.revision.toString()]
+         WHERE user_id = $1
+         AND record_type = $2
+         AND data_id = $3
+         AND revision = $4`,
+        [this.identity, record.id.type, record.id.dataId, record.revision.toString()]
       );
     } catch (error) {
       throw new StorageError(
@@ -1167,10 +1212,11 @@ class PostgresStorage {
                 e.data AS existing_data,
                 e.revision AS existing_revision
          FROM sync_incoming i
-         LEFT JOIN sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id
+         LEFT JOIN sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id AND i.user_id = e.user_id
+         WHERE i.user_id = $1
          ORDER BY i.revision ASC
-         LIMIT $1`,
-        [limit]
+         LIMIT $2`,
+        [this.identity, limit]
       );
 
       return result.rows.map((row) => {
@@ -1230,9 +1276,12 @@ class PostgresStorage {
         FROM sync_outgoing o
         LEFT JOIN sync_state e ON
           o.record_type = e.record_type AND
-          o.data_id = e.data_id
+          o.data_id = e.data_id AND
+          o.user_id = e.user_id
+        WHERE o.user_id = $1
         ORDER BY o.revision DESC
-        LIMIT 1`
+        LIMIT 1`,
+        [this.identity]
       );
 
       if (result.rows.length === 0) {
@@ -1284,19 +1333,21 @@ class PostgresStorage {
       await this._withTransaction(async (client) => {
         await client.query(
           `INSERT INTO sync_state (
+            user_id,
             record_type,
             data_id,
             revision,
             schema_version,
             commit_time,
             data
-          ) VALUES ($1, $2, $3, $4, $5, $6)
-          ON CONFLICT(record_type, data_id) DO UPDATE SET
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+          ON CONFLICT(user_id, record_type, data_id) DO UPDATE SET
             schema_version = EXCLUDED.schema_version,
             commit_time = EXCLUDED.commit_time,
             data = EXCLUDED.data,
             revision = EXCLUDED.revision`,
           [
+            this.identity,
             record.id.type,
             record.id.dataId,
             record.revision.toString(),
@@ -1307,8 +1358,9 @@ class PostgresStorage {
         );
 
         await client.query(
-          "UPDATE sync_revision SET revision = GREATEST(revision, $1)",
-          [record.revision.toString()]
+          `INSERT INTO sync_revision (user_id, revision) VALUES ($1, $2)
+           ON CONFLICT (user_id) DO UPDATE SET revision = GREATEST(sync_revision.revision, EXCLUDED.revision)`,
+          [this.identity, record.revision.toString()]
         );
       });
     } catch (error) {
@@ -1350,12 +1402,14 @@ function defaultPostgresStorageConfig(connectionString) {
  * @param {number} config.maxPoolSize - Maximum number of connections in the pool
  * @param {number} config.createTimeoutSecs - Timeout in seconds for establishing a new connection
  * @param {number} config.recycleTimeoutSecs - Timeout in seconds before recycling an idle connection
+ * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+ *   uniquely identifying this tenant.
  * @param {object} [logger] - Optional logger
  * @returns {Promise<PostgresStorage>}
  */
-async function createPostgresStorage(config, logger = null) {
+async function createPostgresStorage(config, identity, logger = null) {
   const pool = createPostgresPool(config);
-  return createPostgresStorageWithPool(pool, logger);
+  return createPostgresStorageWithPool(pool, identity, logger);
 }
 
 /**
@@ -1378,11 +1432,12 @@ function createPostgresPool(config) {
  * Create a PostgresStorage instance from an existing pg.Pool.
  *
  * @param {pg.Pool} pool - An existing connection pool
+ * @param {Buffer|Uint8Array} identity - 33-byte tenant identity (secp256k1 pubkey).
  * @param {object} [logger] - Optional logger
  * @returns {Promise<PostgresStorage>}
  */
-async function createPostgresStorageWithPool(pool, logger = null) {
-  const storage = new PostgresStorage(pool, logger);
+async function createPostgresStorageWithPool(pool, identity, logger = null) {
+  const storage = new PostgresStorage(pool, identity, logger);
   await storage.initialize();
   return storage;
 }

--- a/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
@@ -20,9 +20,14 @@ class PostgresMigrationManager {
 
   /**
    * Run all pending migrations inside a single transaction with an advisory lock.
+   *
    * @param {import('pg').Pool} pool
+   * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+   *   identifying the tenant. Used to backfill `user_id` columns in the
+   *   multi-tenant migration so that pre-existing single-tenant data remains
+   *   readable.
    */
-  async migrate(pool) {
+  async migrate(pool, identity) {
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
@@ -44,7 +49,7 @@ class PostgresMigrationManager {
       );
       const currentVersion = versionResult.rows[0].version;
 
-      const migrations = this._getMigrations();
+      const migrations = this._getMigrations(identity);
 
       if (currentVersion >= migrations.length) {
         this._log("info", `Database is up to date (version ${currentVersion})`);
@@ -97,8 +102,27 @@ class PostgresMigrationManager {
    * Single migration creating all tables at their final schema.
    * This mirrors the Rust-native PostgresStorage schema but uses camelCase
    * enum values (as produced by the WASM bridge).
+   *
+   * @param {Buffer|Uint8Array} identity - 33-byte tenant identity. Inlined as
+   *   a hex BYTEA literal in the multi-tenant scoping migration. Safe because
+   *   the bytes come from a typed secp256k1 pubkey (character set
+   *   `[0-9a-f]{66}` after hex encoding) — not user-controlled input.
    */
-  _getMigrations() {
+  _getMigrations(identity) {
+    const idHex = Buffer.from(identity).toString("hex");
+    const idLit = `'\\x${idHex}'::bytea`;
+
+    // Helper for the per-table backfill: ADD COLUMN nullable -> UPDATE -> SET
+    // NOT NULL + drop/recreate PK. Returns an array of statements.
+    const scopeTable = (table, pkCols) => [
+      `ALTER TABLE ${table} ADD COLUMN user_id BYTEA`,
+      `UPDATE ${table} SET user_id = ${idLit}`,
+      `ALTER TABLE ${table}
+         ALTER COLUMN user_id SET NOT NULL,
+         DROP CONSTRAINT IF EXISTS ${table}_pkey,
+         ADD PRIMARY KEY (user_id, ${pkCols})`,
+    ];
+
     return [
       {
         name: "Create all tables at final schema",
@@ -252,10 +276,67 @@ class PostgresMigrationManager {
           `ALTER TABLE unclaimed_deposits ADD COLUMN is_mature BOOLEAN NOT NULL DEFAULT TRUE`,
         ],
       },
-      { 
+      {
         name: "Add conversion_status to payment_metadata",
         sql: [
           `ALTER TABLE payment_metadata ADD COLUMN IF NOT EXISTS conversion_status TEXT`,
+        ],
+      },
+      {
+        name: "Multi-tenant scoping: add user_id and rewrite primary keys",
+        sql: [
+          // Per-user tables
+          ...scopeTable("payments", "id"),
+          `DROP INDEX IF EXISTS idx_payments_timestamp`,
+          `DROP INDEX IF EXISTS idx_payments_payment_type`,
+          `DROP INDEX IF EXISTS idx_payments_status`,
+          `CREATE INDEX idx_payments_user_timestamp ON payments(user_id, timestamp)`,
+          `CREATE INDEX idx_payments_user_payment_type ON payments(user_id, payment_type)`,
+          `CREATE INDEX idx_payments_user_status ON payments(user_id, status)`,
+
+          ...scopeTable("payment_metadata", "payment_id"),
+          `DROP INDEX IF EXISTS idx_payment_metadata_parent`,
+          `CREATE INDEX idx_payment_metadata_user_parent
+             ON payment_metadata(user_id, parent_payment_id)`,
+
+          ...scopeTable("payment_details_lightning", "payment_id"),
+          `DROP INDEX IF EXISTS idx_payment_details_lightning_invoice`,
+          `DROP INDEX IF EXISTS idx_payment_details_lightning_payment_hash`,
+          `CREATE INDEX idx_payment_details_lightning_user_invoice
+             ON payment_details_lightning(user_id, invoice)`,
+          `CREATE INDEX idx_payment_details_lightning_user_payment_hash
+             ON payment_details_lightning(user_id, payment_hash)`,
+
+          ...scopeTable("payment_details_token", "payment_id"),
+          ...scopeTable("payment_details_spark", "payment_id"),
+          ...scopeTable("lnurl_receive_metadata", "payment_hash"),
+          ...scopeTable("unclaimed_deposits", "txid, vout"),
+          ...scopeTable("contacts", "id"),
+          ...scopeTable("settings", "key"),
+
+          // sync_revision: drop the singleton id (CASCADE removes PK + CHECK),
+          // then re-key by user_id so each tenant has its own revision row.
+          `ALTER TABLE sync_revision DROP COLUMN id CASCADE`,
+          `ALTER TABLE sync_revision ADD COLUMN user_id BYTEA`,
+          `UPDATE sync_revision SET user_id = ${idLit}`,
+          `ALTER TABLE sync_revision
+             ALTER COLUMN user_id SET NOT NULL,
+             ADD PRIMARY KEY (user_id)`,
+
+          // sync_outgoing has no PK, only an index — just add user_id and rewrite the index.
+          `ALTER TABLE sync_outgoing ADD COLUMN user_id BYTEA`,
+          `UPDATE sync_outgoing SET user_id = ${idLit}`,
+          `ALTER TABLE sync_outgoing ALTER COLUMN user_id SET NOT NULL`,
+          `DROP INDEX IF EXISTS idx_sync_outgoing_data_id_record_type`,
+          `CREATE INDEX idx_sync_outgoing_user_record_type_data_id
+             ON sync_outgoing(user_id, record_type, data_id)`,
+
+          ...scopeTable("sync_state", "record_type, data_id"),
+
+          ...scopeTable("sync_incoming", "record_type, data_id, revision"),
+          `DROP INDEX IF EXISTS idx_sync_incoming_revision`,
+          `CREATE INDEX idx_sync_incoming_user_revision
+             ON sync_incoming(user_id, revision)`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
@@ -25,10 +25,11 @@ const { TokenStoreError } = require("./errors.cjs");
 const { TokenStoreMigrationManager } = require("./migrations.cjs");
 
 /**
- * Advisory lock key for serializing token store write operations.
- * Matches the Rust constant TOKEN_STORE_WRITE_LOCK_KEY = 0x746F_6B65_6E53_5452
+ * Advisory-lock classid for the token store. Combined with a per-tenant `objid`
+ * (derived from the identity pubkey) so that two tenants never block each
+ * other's writes — only same-tenant writes share the same lock.
  */
-const TOKEN_STORE_WRITE_LOCK_KEY = "8390042714201347154"; // 0x746F6B656E535452 as decimal string
+const TOKEN_STORE_LOCK_CLASSID = 0x746f6b6e; // "tokn" as hex
 
 /**
  * Spent markers are kept for this duration to support multiple SDK instances.
@@ -42,9 +43,32 @@ const SPENT_MARKER_CLEANUP_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
  */
 const RESERVATION_TIMEOUT_SECS = 300; // 5 minutes
 
+/**
+ * Derive a stable 32-bit lock objid from a 33-byte secp256k1 pubkey by
+ * reinterpreting its last 4 bytes as a signed 32-bit integer (big-endian).
+ */
+function _identityLockObjid(identity) {
+  if (!identity || identity.length < 4) return 0;
+  const tail = Buffer.from(identity).slice(-4);
+  return tail.readInt32BE(0);
+}
+
 class PostgresTokenStore {
-  constructor(pool, logger = null) {
+  /**
+   * @param {import('pg').Pool} pool
+   * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+   *   identifying the tenant. All reads and writes are scoped by this.
+   * @param {object} [logger]
+   */
+  constructor(pool, identity, logger = null) {
+    if (!identity || identity.length !== 33) {
+      throw new TokenStoreError(
+        "tenant identity (33-byte secp256k1 pubkey) is required"
+      );
+    }
     this.pool = pool;
+    this.identity = Buffer.from(identity);
+    this.lockObjid = _identityLockObjid(identity);
     this.logger = logger;
   }
 
@@ -54,7 +78,7 @@ class PostgresTokenStore {
   async initialize() {
     try {
       const migrationManager = new TokenStoreMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool);
+      await migrationManager.migrate(this.pool, this.identity);
       return this;
     } catch (error) {
       throw new TokenStoreError(
@@ -86,7 +110,12 @@ class PostgresTokenStore {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
-      await client.query(`SELECT pg_advisory_xact_lock(${TOKEN_STORE_WRITE_LOCK_KEY})`);
+      // Per-tenant advisory lock: classid is constant, objid is derived from
+      // the tenant identity so different tenants don't serialize on each other.
+      await client.query("SELECT pg_advisory_xact_lock($1, $2)", [
+        TOKEN_STORE_LOCK_CLASSID,
+        this.lockObjid,
+      ]);
       const result = await fn(client);
       await client.query("COMMIT");
       return result;
@@ -144,9 +173,16 @@ class PostgresTokenStore {
         // Skip if swap is active or completed during this refresh
         const swapCheckResult = await client.query(
           `SELECT
-            EXISTS(SELECT 1 FROM token_reservations WHERE purpose = 'Swap') AS has_active_swap,
-            COALESCE((SELECT last_completed_at >= $1 FROM token_swap_status WHERE id = 1), FALSE) AS swap_completed`,
-          [refreshTimestamp]
+            EXISTS(
+              SELECT 1 FROM token_reservations
+              WHERE user_id = $1 AND purpose = 'Swap'
+            ) AS has_active_swap,
+            COALESCE(
+              (SELECT last_completed_at >= $2
+               FROM token_swap_status WHERE user_id = $1),
+              FALSE
+            ) AS swap_completed`,
+          [this.identity, refreshTimestamp]
         );
         const { has_active_swap, swap_completed } = swapCheckResult.rows[0];
         if (has_active_swap || swap_completed) {
@@ -156,21 +192,21 @@ class PostgresTokenStore {
         // Clean up old spent markers
         const cleanupCutoff = new Date(refreshTimestamp.getTime() - SPENT_MARKER_CLEANUP_THRESHOLD_MS);
         await client.query(
-          "DELETE FROM token_spent_outputs WHERE spent_at < $1",
-          [cleanupCutoff]
+          "DELETE FROM token_spent_outputs WHERE user_id = $1 AND spent_at < $2",
+          [this.identity, cleanupCutoff]
         );
 
         // Get recent spent output IDs (spent_at >= refresh_timestamp)
         const spentResult = await client.query(
-          "SELECT output_id FROM token_spent_outputs WHERE spent_at >= $1",
-          [refreshTimestamp]
+          "SELECT output_id FROM token_spent_outputs WHERE user_id = $1 AND spent_at >= $2",
+          [this.identity, refreshTimestamp]
         );
         const spentIds = new Set(spentResult.rows.map((r) => r.output_id));
 
         // Delete non-reserved outputs added BEFORE the refresh started
         await client.query(
-          "DELETE FROM token_outputs WHERE reservation_id IS NULL AND added_at < $1",
-          [refreshTimestamp]
+          "DELETE FROM token_outputs WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
+          [this.identity, refreshTimestamp]
         );
 
         // Build a set of all incoming output IDs for reconciliation
@@ -185,7 +221,10 @@ class PostgresTokenStore {
         const reservedRows = await client.query(
           `SELECT r.id, o.id AS output_id
            FROM token_reservations r
-           JOIN token_outputs o ON o.reservation_id = r.id`
+           JOIN token_outputs o
+             ON o.reservation_id = r.id AND o.user_id = r.user_id
+           WHERE r.user_id = $1`,
+          [this.identity]
         );
 
         // Group reserved outputs by reservation ID
@@ -216,51 +255,57 @@ class PostgresTokenStore {
         // Delete outputs whose reservations are being removed entirely
         if (reservationsToDelete.length > 0) {
           await client.query(
-            "DELETE FROM token_outputs WHERE reservation_id = ANY($1)",
-            [reservationsToDelete]
+            "DELETE FROM token_outputs WHERE user_id = $1 AND reservation_id = ANY($2)",
+            [this.identity, reservationsToDelete]
           );
           await client.query(
-            "DELETE FROM token_reservations WHERE id = ANY($1)",
-            [reservationsToDelete]
+            "DELETE FROM token_reservations WHERE user_id = $1 AND id = ANY($2)",
+            [this.identity, reservationsToDelete]
           );
         }
 
         // Delete individual reserved outputs that no longer exist
         if (outputsToRemoveFromReservation.length > 0) {
           await client.query(
-            "DELETE FROM token_outputs WHERE id = ANY($1)",
-            [outputsToRemoveFromReservation]
+            "DELETE FROM token_outputs WHERE user_id = $1 AND id = ANY($2)",
+            [this.identity, outputsToRemoveFromReservation]
           );
 
           // Check if any reservations are now empty
           const emptyReservations = await client.query(
             `SELECT r.id FROM token_reservations r
-             LEFT JOIN token_outputs o ON o.reservation_id = r.id
-             WHERE o.id IS NULL`
+             LEFT JOIN token_outputs o
+               ON o.reservation_id = r.id AND o.user_id = r.user_id
+             WHERE r.user_id = $1 AND o.id IS NULL`,
+            [this.identity]
           );
           const emptyIds = emptyReservations.rows.map((r) => r.id);
           if (emptyIds.length > 0) {
             await client.query(
-              "DELETE FROM token_reservations WHERE id = ANY($1)",
-              [emptyIds]
+              "DELETE FROM token_reservations WHERE user_id = $1 AND id = ANY($2)",
+              [this.identity, emptyIds]
             );
           }
         }
 
         // Collect IDs of currently reserved outputs (that survived reconciliation)
         const reservedOutputIdsResult = await client.query(
-          "SELECT id FROM token_outputs WHERE reservation_id IS NOT NULL"
+          "SELECT id FROM token_outputs WHERE user_id = $1 AND reservation_id IS NOT NULL",
+          [this.identity]
         );
         const reservedOutputIds = new Set(
           reservedOutputIdsResult.rows.map((r) => r.id)
         );
 
-        // Delete orphan metadata
+        // Delete orphan metadata (per-tenant)
         await client.query(
           `DELETE FROM token_metadata
-           WHERE identifier NOT IN (
-             SELECT DISTINCT token_identifier FROM token_outputs
-           )`
+           WHERE user_id = $1
+             AND identifier NOT IN (
+               SELECT DISTINCT token_identifier
+               FROM token_outputs WHERE user_id = $1
+             )`,
+          [this.identity]
         );
 
         // Insert new metadata and outputs, excluding spent and reserved
@@ -301,7 +346,8 @@ class PostgresTokenStore {
    */
   async getTokenBalances() {
     try {
-      const result = await this.pool.query(`
+      const result = await this.pool.query(
+        `
         SELECT m.identifier, m.issuer_public_key, m.name, m.ticker, m.decimals,
                m.max_supply, m.is_freezable, m.creation_entity_public_key,
                COALESCE(SUM(
@@ -312,11 +358,16 @@ class PostgresTokenStore {
                  END
                ), 0)::text AS balance
         FROM token_metadata m
-        JOIN token_outputs o ON o.token_identifier = m.identifier
-        LEFT JOIN token_reservations r ON o.reservation_id = r.id
+        JOIN token_outputs o
+          ON o.token_identifier = m.identifier AND o.user_id = m.user_id
+        LEFT JOIN token_reservations r
+          ON o.reservation_id = r.id AND o.user_id = r.user_id
+        WHERE m.user_id = $1
         GROUP BY m.identifier, m.issuer_public_key, m.name, m.ticker,
                  m.decimals, m.max_supply, m.is_freezable, m.creation_entity_public_key
-      `);
+      `,
+        [this.identity]
+      );
       return result.rows.map((row) => ({
         metadata: {
           identifier: row.identifier,
@@ -349,9 +400,13 @@ class PostgresTokenStore {
                 o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                 r.purpose
          FROM token_metadata m
-         LEFT JOIN token_outputs o ON o.token_identifier = m.identifier
-         LEFT JOIN token_reservations r ON o.reservation_id = r.id
-         ORDER BY m.identifier, o.token_amount::NUMERIC ASC`
+         LEFT JOIN token_outputs o
+           ON o.token_identifier = m.identifier AND o.user_id = m.user_id
+         LEFT JOIN token_reservations r
+           ON o.reservation_id = r.id AND o.user_id = r.user_id
+         WHERE m.user_id = $1
+         ORDER BY m.identifier, o.token_amount::NUMERIC ASC`,
+        [this.identity]
       );
 
       const map = new Map();
@@ -422,11 +477,13 @@ class PostgresTokenStore {
                 o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                 r.purpose
          FROM token_metadata m
-         LEFT JOIN token_outputs o ON o.token_identifier = m.identifier
-         LEFT JOIN token_reservations r ON o.reservation_id = r.id
-         WHERE ${whereClause}
+         LEFT JOIN token_outputs o
+           ON o.token_identifier = m.identifier AND o.user_id = m.user_id
+         LEFT JOIN token_reservations r
+           ON o.reservation_id = r.id AND o.user_id = r.user_id
+         WHERE m.user_id = $2 AND ${whereClause}
          ORDER BY o.token_amount::NUMERIC ASC`,
-        [param]
+        [param, this.identity]
       );
 
       if (result.rows.length === 0) {
@@ -483,8 +540,8 @@ class PostgresTokenStore {
         const outputIds = tokenOutputs.outputs.map((o) => o.output.id);
         if (outputIds.length > 0) {
           await client.query(
-            "DELETE FROM token_spent_outputs WHERE output_id = ANY($1)",
-            [outputIds]
+            "DELETE FROM token_spent_outputs WHERE user_id = $1 AND output_id = ANY($2)",
+            [this.identity, outputIds]
           );
         }
 
@@ -544,8 +601,8 @@ class PostgresTokenStore {
 
         // Get metadata
         const metadataResult = await client.query(
-          "SELECT * FROM token_metadata WHERE identifier = $1",
-          [tokenIdentifier]
+          "SELECT * FROM token_metadata WHERE user_id = $1 AND identifier = $2",
+          [this.identity, tokenIdentifier]
         );
 
         if (metadataResult.rows.length === 0) {
@@ -563,8 +620,10 @@ class PostgresTokenStore {
                   o.token_public_key, o.token_amount, o.token_identifier,
                   o.prev_tx_hash, o.prev_tx_vout
            FROM token_outputs o
-           WHERE o.token_identifier = $1 AND o.reservation_id IS NULL`,
-          [tokenIdentifier]
+           WHERE o.user_id = $1
+             AND o.token_identifier = $2
+             AND o.reservation_id IS NULL`,
+          [this.identity, tokenIdentifier]
         );
 
         let outputs = outputRows.rows.map((row) => this._outputFromRow(row));
@@ -650,16 +709,16 @@ class PostgresTokenStore {
         const reservationId = this._generateId();
 
         await client.query(
-          "INSERT INTO token_reservations (id, purpose) VALUES ($1, $2)",
-          [reservationId, purpose]
+          "INSERT INTO token_reservations (user_id, id, purpose) VALUES ($1, $2, $3)",
+          [this.identity, reservationId, purpose]
         );
 
         // Set reservation_id on selected outputs
         const selectedIds = selectedOutputs.map((o) => o.output.id);
         if (selectedIds.length > 0) {
           await client.query(
-            "UPDATE token_outputs SET reservation_id = $1 WHERE id = ANY($2)",
-            [reservationId, selectedIds]
+            "UPDATE token_outputs SET reservation_id = $1 WHERE user_id = $3 AND id = ANY($2)",
+            [reservationId, selectedIds, this.identity]
           );
         }
 
@@ -687,16 +746,18 @@ class PostgresTokenStore {
   async cancelReservation(id) {
     try {
       await this._withTransaction(async (client) => {
-        // Clear reservation_id from outputs
+        // Clear reservation_id from outputs first — the composite FK uses NO
+        // ACTION (column-list SET NULL is PG15+ and a whole-row SET NULL would
+        // null user_id, which is NOT NULL).
         await client.query(
-          "UPDATE token_outputs SET reservation_id = NULL WHERE reservation_id = $1",
-          [id]
+          "UPDATE token_outputs SET reservation_id = NULL WHERE user_id = $1 AND reservation_id = $2",
+          [this.identity, id]
         );
 
         // Delete the reservation
         await client.query(
-          "DELETE FROM token_reservations WHERE id = $1",
-          [id]
+          "DELETE FROM token_reservations WHERE user_id = $1 AND id = $2",
+          [this.identity, id]
         );
       });
     } catch (error) {
@@ -721,8 +782,8 @@ class PostgresTokenStore {
       await this._withWriteTransaction(async (client) => {
         // Get reservation purpose
         const reservationResult = await client.query(
-          "SELECT purpose FROM token_reservations WHERE id = $1",
-          [id]
+          "SELECT purpose FROM token_reservations WHERE user_id = $1 AND id = $2",
+          [this.identity, id]
         );
         if (reservationResult.rows.length === 0) {
           return; // Non-existing reservation
@@ -731,45 +792,53 @@ class PostgresTokenStore {
 
         // Get reserved output IDs and mark them as spent
         const reservedOutputsResult = await client.query(
-          "SELECT id FROM token_outputs WHERE reservation_id = $1",
-          [id]
+          "SELECT id FROM token_outputs WHERE user_id = $1 AND reservation_id = $2",
+          [this.identity, id]
         );
         const reservedOutputIds = reservedOutputsResult.rows.map((r) => r.id);
 
         if (reservedOutputIds.length > 0) {
           await client.query(
-            `INSERT INTO token_spent_outputs (output_id)
-             SELECT * FROM UNNEST($1::text[])
+            `INSERT INTO token_spent_outputs (user_id, output_id)
+             SELECT $2, output_id FROM UNNEST($1::text[]) AS t(output_id)
              ON CONFLICT DO NOTHING`,
-            [reservedOutputIds]
+            [reservedOutputIds, this.identity]
           );
         }
 
         // Delete reserved outputs
         await client.query(
-          "DELETE FROM token_outputs WHERE reservation_id = $1",
-          [id]
+          "DELETE FROM token_outputs WHERE user_id = $1 AND reservation_id = $2",
+          [this.identity, id]
         );
 
         // Delete the reservation
         await client.query(
-          "DELETE FROM token_reservations WHERE id = $1",
-          [id]
+          "DELETE FROM token_reservations WHERE user_id = $1 AND id = $2",
+          [this.identity, id]
         );
 
-        // If this was a swap reservation, update last_completed_at
+        // If this was a swap reservation, update last_completed_at. UPSERT so a
+        // tenant that joined after migration 2 (and thus has no row) gets one.
         if (isSwap) {
           await client.query(
-            "UPDATE token_swap_status SET last_completed_at = NOW() WHERE id = 1"
+            `INSERT INTO token_swap_status (user_id, last_completed_at)
+             VALUES ($1, NOW())
+             ON CONFLICT (user_id) DO UPDATE
+               SET last_completed_at = EXCLUDED.last_completed_at`,
+            [this.identity]
           );
         }
 
-        // Clean up orphaned metadata
+        // Clean up orphaned metadata (per-tenant)
         await client.query(
           `DELETE FROM token_metadata
-           WHERE identifier NOT IN (
-             SELECT DISTINCT token_identifier FROM token_outputs
-           )`
+           WHERE user_id = $1
+             AND identifier NOT IN (
+               SELECT DISTINCT token_identifier
+               FROM token_outputs WHERE user_id = $1
+             )`,
+          [this.identity]
         );
       });
     } catch (error) {
@@ -815,15 +884,27 @@ class PostgresTokenStore {
   }
 
   /**
-   * Delete reservations that have exceeded the timeout.
-   * Called during setTokensOutputs to clean up stale reservations from crashed clients.
-   * The ON DELETE SET NULL foreign key constraint automatically releases the outputs.
+   * Delete reservations that have exceeded the timeout. Releases outputs by
+   * clearing reservation_id explicitly, then deletes the parents — the
+   * composite FK uses NO ACTION (column-list SET NULL is PG15+ and a
+   * whole-row SET NULL would null user_id, NOT NULL).
    */
   async _cleanupStaleReservations(client) {
     await client.query(
+      `UPDATE token_outputs SET reservation_id = NULL
+       WHERE user_id = $2
+         AND reservation_id IN (
+           SELECT id FROM token_reservations
+           WHERE user_id = $2
+             AND created_at < NOW() - make_interval(secs => $1)
+         )`,
+      [RESERVATION_TIMEOUT_SECS, this.identity]
+    );
+    await client.query(
       `DELETE FROM token_reservations
-       WHERE created_at < NOW() - make_interval(secs => $1)`,
-      [RESERVATION_TIMEOUT_SECS]
+       WHERE user_id = $2
+         AND created_at < NOW() - make_interval(secs => $1)`,
+      [RESERVATION_TIMEOUT_SECS, this.identity]
     );
   }
 
@@ -833,10 +914,10 @@ class PostgresTokenStore {
   async _upsertMetadata(client, metadata) {
     await client.query(
       `INSERT INTO token_metadata
-        (identifier, issuer_public_key, name, ticker, decimals, max_supply,
+        (user_id, identifier, issuer_public_key, name, ticker, decimals, max_supply,
          is_freezable, creation_entity_public_key)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-       ON CONFLICT (identifier) DO UPDATE SET
+       VALUES ($9, $1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (user_id, identifier) DO UPDATE SET
          issuer_public_key = EXCLUDED.issuer_public_key,
          name = EXCLUDED.name,
          ticker = EXCLUDED.ticker,
@@ -853,6 +934,7 @@ class PostgresTokenStore {
         metadata.maxSupply,
         metadata.isFreezable,
         metadata.creationEntityPublicKey || null,
+        this.identity,
       ]
     );
   }
@@ -863,11 +945,11 @@ class PostgresTokenStore {
   async _insertSingleOutput(client, tokenIdentifier, output) {
     await client.query(
       `INSERT INTO token_outputs
-        (id, token_identifier, owner_public_key, revocation_commitment,
+        (user_id, id, token_identifier, owner_public_key, revocation_commitment,
          withdraw_bond_sats, withdraw_relative_block_locktime,
          token_public_key, token_amount, prev_tx_hash, prev_tx_vout, added_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
-       ON CONFLICT (id) DO NOTHING`,
+       VALUES ($11, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+       ON CONFLICT (user_id, id) DO NOTHING`,
       [
         output.output.id,
         tokenIdentifier,
@@ -879,6 +961,7 @@ class PostgresTokenStore {
         output.output.tokenAmount,
         output.prevTxHash,
         output.prevTxVout,
+        this.identity,
       ]
     );
   }
@@ -930,28 +1013,30 @@ class PostgresTokenStore {
  * @param {number} config.maxPoolSize - Maximum number of connections in the pool
  * @param {number} config.createTimeoutSecs - Timeout in seconds for establishing a new connection
  * @param {number} config.recycleTimeoutSecs - Timeout in seconds before recycling an idle connection
+ * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey scoping reads/writes
  * @param {object} [logger] - Optional logger
  * @returns {Promise<PostgresTokenStore>}
  */
-async function createPostgresTokenStore(config, logger = null) {
+async function createPostgresTokenStore(config, identity, logger = null) {
   const pool = new pg.Pool({
     connectionString: config.connectionString,
     max: config.maxPoolSize,
     connectionTimeoutMillis: config.createTimeoutSecs * 1000,
     idleTimeoutMillis: config.recycleTimeoutSecs * 1000,
   });
-  return createPostgresTokenStoreWithPool(pool, logger);
+  return createPostgresTokenStoreWithPool(pool, identity, logger);
 }
 
 /**
  * Create a PostgresTokenStore instance from an existing pg.Pool.
  *
  * @param {pg.Pool} pool - An existing connection pool
+ * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey scoping reads/writes
  * @param {object} [logger] - Optional logger
  * @returns {Promise<PostgresTokenStore>}
  */
-async function createPostgresTokenStoreWithPool(pool, logger = null) {
-  const store = new PostgresTokenStore(pool, logger);
+async function createPostgresTokenStoreWithPool(pool, identity, logger = null) {
+  const store = new PostgresTokenStore(pool, identity, logger);
   await store.initialize();
   return store;
 }

--- a/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
@@ -25,11 +25,10 @@ const { TokenStoreError } = require("./errors.cjs");
 const { TokenStoreMigrationManager } = require("./migrations.cjs");
 
 /**
- * Advisory-lock classid for the token store. Combined with a per-tenant `objid`
- * (derived from the identity pubkey) so that two tenants never block each
- * other's writes — only same-tenant writes share the same lock.
+ * Domain prefix mixed into the per-tenant advisory-lock key. Distinct prefixes
+ * guarantee that locks from different stores (tree, token, …) never collide.
  */
-const TOKEN_STORE_LOCK_CLASSID = 0x746f6b6e; // "tokn" as hex
+const TOKEN_STORE_LOCK_PREFIX = "breez-spark-sdk:token:";
 
 /**
  * Spent markers are kept for this duration to support multiple SDK instances.
@@ -44,13 +43,18 @@ const SPENT_MARKER_CLEANUP_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 const RESERVATION_TIMEOUT_SECS = 300; // 5 minutes
 
 /**
- * Derive a stable 32-bit lock objid from a 33-byte secp256k1 pubkey by
- * reinterpreting its last 4 bytes as a signed 32-bit integer (big-endian).
+ * Derive a stable per-tenant 64-bit advisory-lock key by hashing a domain
+ * prefix together with the identity pubkey and folding the first 8 bytes of
+ * the SHA-256 digest into a signed big-endian i64 — the type expected by
+ * `pg_advisory_xact_lock(bigint)`. The 64-bit space keeps cross-tenant
+ * collisions negligible (~1.2e-10 at 65k tenants).
  */
-function _identityLockObjid(identity) {
-  if (!identity || identity.length < 4) return 0;
-  const tail = Buffer.from(identity).slice(-4);
-  return tail.readInt32BE(0);
+function _identityLockKey(prefix, identity) {
+  const crypto = require("crypto");
+  const hash = crypto.createHash("sha256");
+  hash.update(prefix);
+  hash.update(Buffer.from(identity));
+  return hash.digest().readBigInt64BE(0);
 }
 
 class PostgresTokenStore {
@@ -68,7 +72,7 @@ class PostgresTokenStore {
     }
     this.pool = pool;
     this.identity = Buffer.from(identity);
-    this.lockObjid = _identityLockObjid(identity);
+    this.lockKey = _identityLockKey(TOKEN_STORE_LOCK_PREFIX, identity);
     this.logger = logger;
   }
 
@@ -110,12 +114,10 @@ class PostgresTokenStore {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
-      // Per-tenant advisory lock: classid is constant, objid is derived from
-      // the tenant identity so different tenants don't serialize on each other.
-      await client.query("SELECT pg_advisory_xact_lock($1, $2)", [
-        TOKEN_STORE_LOCK_CLASSID,
-        this.lockObjid,
-      ]);
+      // Per-tenant advisory lock: 64-bit key derived from a token-store domain
+      // prefix and the tenant identity, so different tenants don't serialize
+      // on each other and tree/token locks never collide.
+      await client.query("SELECT pg_advisory_xact_lock($1)", [this.lockKey]);
       const result = await fn(client);
       await client.query("COMMIT");
       return result;

--- a/crates/breez-sdk/wasm/js/postgres-token-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-token-store/migrations.cjs
@@ -22,8 +22,16 @@ class TokenStoreMigrationManager {
   /**
    * Run all pending migrations inside a single transaction with an advisory lock.
    * @param {import('pg').Pool} pool
+   * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+   *   identifying the tenant. Used to backfill `user_id` columns in the
+   *   multi-tenant scoping migration. Required.
    */
-  async migrate(pool) {
+  async migrate(pool, identity) {
+    if (!identity || identity.length !== 33) {
+      throw new TokenStoreError(
+        "tenant identity (33-byte secp256k1 pubkey) is required"
+      );
+    }
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
@@ -45,7 +53,7 @@ class TokenStoreMigrationManager {
       );
       const currentVersion = versionResult.rows[0].version;
 
-      const migrations = this._getMigrations();
+      const migrations = this._getMigrations(identity);
 
       if (currentVersion >= migrations.length) {
         this._log("info", `Token store database is up to date (version ${currentVersion})`);
@@ -96,8 +104,16 @@ class TokenStoreMigrationManager {
 
   /**
    * Migrations matching the Rust PostgresTokenStore schema exactly.
+   *
+   * @param {Buffer|Uint8Array} identity - tenant identity inlined as a hex
+   *   BYTEA literal in the multi-tenant scoping migration. Safe because the
+   *   bytes come from a typed secp256k1 pubkey (`[0-9a-f]{66}` after hex
+   *   encoding) — not user-controlled input.
    */
-  _getMigrations() {
+  _getMigrations(identity) {
+    const idHex = Buffer.from(identity).toString("hex");
+    const idLit = `'\\x${idHex}'::bytea`;
+
     return [
       {
         name: "Create token store tables with race condition protection",
@@ -154,6 +170,79 @@ class TokenStoreMigrationManager {
           )`,
 
           `INSERT INTO token_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING`,
+        ],
+      },
+      {
+        // Mirrors Rust migration 2 in spark-postgres/src/token_store.rs.
+        // Adds user_id to every token-store table (including token_metadata —
+        // per-tenant to avoid 0-balance leakage for tokens a tenant never
+        // owned), backfills with the connecting tenant, and rewrites primary
+        // keys / FKs / indexes to lead with user_id. Composite FKs use NO
+        // ACTION because column-list SET NULL is PG15+ and a whole-row SET
+        // NULL would null user_id (NOT NULL).
+        name: "Multi-tenant scoping: add user_id and rewrite primary keys",
+        sql: [
+          // Drop dependent FKs FIRST so we can rebuild parent PKs they
+          // reference. Inline `REFERENCES` clauses get auto-named
+          // `<table>_<column>_fkey`.
+          `ALTER TABLE token_outputs
+             DROP CONSTRAINT IF EXISTS token_outputs_reservation_id_fkey`,
+          `ALTER TABLE token_outputs
+             DROP CONSTRAINT IF EXISTS token_outputs_token_identifier_fkey`,
+
+          // token_metadata: per-tenant scoping (privacy — see header).
+          `ALTER TABLE token_metadata ADD COLUMN user_id BYTEA`,
+          `UPDATE token_metadata SET user_id = ${idLit}`,
+          `ALTER TABLE token_metadata
+             ALTER COLUMN user_id SET NOT NULL,
+             DROP CONSTRAINT IF EXISTS token_metadata_pkey,
+             ADD PRIMARY KEY (user_id, identifier)`,
+          `DROP INDEX IF EXISTS idx_token_metadata_issuer_pk`,
+          `CREATE INDEX idx_token_metadata_user_issuer_pk
+             ON token_metadata (user_id, issuer_public_key)`,
+
+          // token_reservations: scope by user_id.
+          `ALTER TABLE token_reservations ADD COLUMN user_id BYTEA`,
+          `UPDATE token_reservations SET user_id = ${idLit}`,
+          `ALTER TABLE token_reservations
+             ALTER COLUMN user_id SET NOT NULL,
+             DROP CONSTRAINT IF EXISTS token_reservations_pkey,
+             ADD PRIMARY KEY (user_id, id)`,
+
+          // token_outputs: scope by user_id, rekey, re-add composite FKs.
+          `ALTER TABLE token_outputs ADD COLUMN user_id BYTEA`,
+          `UPDATE token_outputs SET user_id = ${idLit}`,
+          `ALTER TABLE token_outputs
+             ALTER COLUMN user_id SET NOT NULL,
+             DROP CONSTRAINT IF EXISTS token_outputs_pkey,
+             ADD PRIMARY KEY (user_id, id),
+             ADD FOREIGN KEY (user_id, token_identifier)
+                REFERENCES token_metadata(user_id, identifier),
+             ADD FOREIGN KEY (user_id, reservation_id)
+                REFERENCES token_reservations(user_id, id)`,
+          `DROP INDEX IF EXISTS idx_token_outputs_identifier`,
+          `DROP INDEX IF EXISTS idx_token_outputs_reservation`,
+          `CREATE INDEX idx_token_outputs_user_identifier
+             ON token_outputs (user_id, token_identifier)`,
+          `CREATE INDEX idx_token_outputs_user_reservation
+             ON token_outputs (user_id, reservation_id)
+             WHERE reservation_id IS NOT NULL`,
+
+          // token_spent_outputs: scope by user_id.
+          `ALTER TABLE token_spent_outputs ADD COLUMN user_id BYTEA`,
+          `UPDATE token_spent_outputs SET user_id = ${idLit}`,
+          `ALTER TABLE token_spent_outputs
+             ALTER COLUMN user_id SET NOT NULL,
+             DROP CONSTRAINT IF EXISTS token_spent_outputs_pkey,
+             ADD PRIMARY KEY (user_id, output_id)`,
+
+          // token_swap_status: drop the singleton id, rekey by user_id.
+          `ALTER TABLE token_swap_status DROP COLUMN id CASCADE`,
+          `ALTER TABLE token_swap_status ADD COLUMN user_id BYTEA`,
+          `UPDATE token_swap_status SET user_id = ${idLit}`,
+          `ALTER TABLE token_swap_status
+             ALTER COLUMN user_id SET NOT NULL,
+             ADD PRIMARY KEY (user_id)`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -25,10 +25,11 @@ const { TreeStoreError } = require("./errors.cjs");
 const { TreeStoreMigrationManager } = require("./migrations.cjs");
 
 /**
- * Advisory lock key for serializing tree store write operations.
- * Matches the Rust constant TREE_STORE_WRITE_LOCK_KEY = 0x7472_6565_5354_4f52
+ * Advisory-lock classid for the tree store. Combined with a per-tenant `objid`
+ * (derived from the identity pubkey) so that two tenants never block each
+ * other's writes — only same-tenant writes serialize on the same lock.
  */
-const TREE_STORE_WRITE_LOCK_KEY = "8390880541608791890"; // 0x7472656553544f52 as decimal string
+const TREE_STORE_LOCK_CLASSID = 0x74726565; // "tree" as hex
 
 /**
  * Timeout for reservations in seconds. Reservations older than this are stale.
@@ -40,9 +41,32 @@ const RESERVATION_TIMEOUT_SECS = 300; // 5 minutes
  */
 const SPENT_MARKER_CLEANUP_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
+/**
+ * Derive a stable 32-bit lock objid from a 33-byte secp256k1 pubkey by
+ * reinterpreting its last 4 bytes as a signed 32-bit integer (big-endian).
+ */
+function _identityLockObjid(identity) {
+  if (!identity || identity.length < 4) return 0;
+  const tail = Buffer.from(identity).slice(-4);
+  return tail.readInt32BE(0);
+}
+
 class PostgresTreeStore {
-  constructor(pool, logger = null) {
+  /**
+   * @param {import('pg').Pool} pool
+   * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+   *   identifying the tenant. All reads and writes are scoped by this.
+   * @param {object} [logger]
+   */
+  constructor(pool, identity, logger = null) {
+    if (!identity || identity.length !== 33) {
+      throw new TreeStoreError(
+        "tenant identity (33-byte secp256k1 pubkey) is required"
+      );
+    }
     this.pool = pool;
+    this.identity = Buffer.from(identity);
+    this.lockObjid = _identityLockObjid(identity);
     this.logger = logger;
   }
 
@@ -52,7 +76,7 @@ class PostgresTreeStore {
   async initialize() {
     try {
       const migrationManager = new TreeStoreMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool);
+      await migrationManager.migrate(this.pool, this.identity);
       return this;
     } catch (error) {
       throw new TreeStoreError(
@@ -84,7 +108,12 @@ class PostgresTreeStore {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
-      await client.query(`SELECT pg_advisory_xact_lock(${TREE_STORE_WRITE_LOCK_KEY})`);
+      // Per-tenant advisory lock: classid is constant, objid is derived from
+      // the tenant identity so different tenants don't serialize on each other.
+      await client.query("SELECT pg_advisory_xact_lock($1, $2)", [
+        TREE_STORE_LOCK_CLASSID,
+        this.lockObjid,
+      ]);
       const result = await fn(client);
       await client.query("COMMIT");
       return result;
@@ -160,14 +189,20 @@ class PostgresTreeStore {
    */
   async getAvailableBalance() {
     try {
-      const result = await this.pool.query(`
+      const result = await this.pool.query(
+        `
         SELECT COALESCE(SUM((l.data->>'value')::bigint), 0)::bigint AS balance
         FROM tree_leaves l
-        LEFT JOIN tree_reservations r ON l.reservation_id = r.id
-        WHERE
-          (l.reservation_id IS NULL AND l.status = 'Available')
-          OR r.purpose = 'Swap'
-      `);
+        LEFT JOIN tree_reservations r
+          ON l.reservation_id = r.id AND l.user_id = r.user_id
+        WHERE l.user_id = $1
+          AND (
+            (l.reservation_id IS NULL AND l.status = 'Available')
+            OR r.purpose = 'Swap'
+          )
+      `,
+        [this.identity]
+      );
       return BigInt(result.rows[0].balance);
     } catch (error) {
       throw new TreeStoreError(
@@ -179,12 +214,17 @@ class PostgresTreeStore {
 
   async getLeaves() {
     try {
-      const result = await this.pool.query(`
+      const result = await this.pool.query(
+        `
         SELECT l.id, l.status, l.is_missing_from_operators, l.data,
                l.reservation_id, r.purpose
         FROM tree_leaves l
-        LEFT JOIN tree_reservations r ON l.reservation_id = r.id
-      `);
+        LEFT JOIN tree_reservations r
+          ON l.reservation_id = r.id AND l.user_id = r.user_id
+        WHERE l.user_id = $1
+      `,
+        [this.identity]
+      );
 
       const available = [];
       const notAvailable = [];
@@ -246,11 +286,21 @@ class PostgresTreeStore {
         await this._cleanupStaleReservations(client);
 
         // Check for active swap or swap completed during refresh
-        const swapCheckResult = await client.query(`
+        const swapCheckResult = await client.query(
+          `
           SELECT
-            EXISTS(SELECT 1 FROM tree_reservations WHERE purpose = 'Swap') AS has_active_swap,
-            COALESCE((SELECT last_completed_at >= $1 FROM tree_swap_status WHERE id = 1), FALSE) AS swap_completed_during_refresh
-        `, [refreshTimestamp]);
+            EXISTS(
+              SELECT 1 FROM tree_reservations
+              WHERE user_id = $1 AND purpose = 'Swap'
+            ) AS has_active_swap,
+            COALESCE(
+              (SELECT last_completed_at >= $2
+               FROM tree_swap_status WHERE user_id = $1),
+              FALSE
+            ) AS swap_completed_during_refresh
+        `,
+          [this.identity, refreshTimestamp]
+        );
 
         const { has_active_swap, swap_completed_during_refresh } = swapCheckResult.rows[0];
 
@@ -262,18 +312,18 @@ class PostgresTreeStore {
         await this._cleanupSpentMarkers(client, refreshTimestamp);
 
         const spentResult = await client.query(
-          "SELECT leaf_id FROM tree_spent_leaves WHERE spent_at >= $1",
-          [refreshTimestamp]
+          "SELECT leaf_id FROM tree_spent_leaves WHERE user_id = $1 AND spent_at >= $2",
+          [this.identity, refreshTimestamp]
         );
         const spentIds = new Set(spentResult.rows.map((r) => r.leaf_id));
 
         // Delete non-reserved leaves added before refresh started.
-        // Includes leaves released earlier in this transaction by _cleanupStaleReservations
-        // (FK ON DELETE SET NULL) — those rows kept their old added_at, so they are
-        // dropped here and re-fetched from the operator response in the upsert below.
+        // Includes leaves released earlier in this transaction by
+        // _cleanupStaleReservations (which now NULLs reservation_id explicitly,
+        // since the composite FK uses NO ACTION).
         await client.query(
-          "DELETE FROM tree_leaves WHERE reservation_id IS NULL AND added_at < $1",
-          [refreshTimestamp]
+          "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
+          [this.identity, refreshTimestamp]
         );
 
         // Upsert all leaves (filtering spent)
@@ -306,8 +356,8 @@ class PostgresTreeStore {
     try {
       await this._withTransaction(async (client) => {
         const res = await client.query(
-          "SELECT id FROM tree_reservations WHERE id = $1",
-          [id]
+          "SELECT id FROM tree_reservations WHERE user_id = $1 AND id = $2",
+          [this.identity, id]
         );
 
         if (res.rows.length === 0) {
@@ -315,13 +365,13 @@ class PostgresTreeStore {
         }
 
         await client.query(
-          "DELETE FROM tree_leaves WHERE reservation_id = $1",
-          [id]
+          "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+          [this.identity, id]
         );
 
         await client.query(
-          "DELETE FROM tree_reservations WHERE id = $1",
-          [id]
+          "DELETE FROM tree_reservations WHERE user_id = $1 AND id = $2",
+          [this.identity, id]
         );
 
         if (leavesToKeep && leavesToKeep.length > 0) {
@@ -351,8 +401,8 @@ class PostgresTreeStore {
       await this._withWriteTransaction(async (client) => {
         // Check if reservation exists and get purpose
         const res = await client.query(
-          "SELECT id, purpose FROM tree_reservations WHERE id = $1",
-          [id]
+          "SELECT id, purpose FROM tree_reservations WHERE user_id = $1 AND id = $2",
+          [this.identity, id]
         );
 
         let isSwap = false;
@@ -360,18 +410,18 @@ class PostgresTreeStore {
         if (res.rows.length > 0) {
           isSwap = res.rows[0].purpose === "Swap";
           const leafResult = await client.query(
-            "SELECT id FROM tree_leaves WHERE reservation_id = $1",
-            [id]
+            "SELECT id FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+            [this.identity, id]
           );
           reservedLeafIds = leafResult.rows.map((r) => r.id);
           await this._batchInsertSpentLeaves(client, reservedLeafIds);
           await client.query(
-            "DELETE FROM tree_leaves WHERE reservation_id = $1",
-            [id]
+            "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+            [this.identity, id]
           );
           await client.query(
-            "DELETE FROM tree_reservations WHERE id = $1",
-            [id]
+            "DELETE FROM tree_reservations WHERE user_id = $1 AND id = $2",
+            [this.identity, id]
           );
         }
 
@@ -380,10 +430,15 @@ class PostgresTreeStore {
           await this._batchUpsertLeaves(client, newLeaves, false, null);
         }
 
-        // If swap with new leaves, update last_completed_at
+        // If swap with new leaves, update last_completed_at. UPSERT so a tenant
+        // that joined after migration 3 (and thus has no row) gets one created.
         if (isSwap && newLeaves && newLeaves.length > 0) {
           await client.query(
-            "UPDATE tree_swap_status SET last_completed_at = NOW() WHERE id = 1"
+            `INSERT INTO tree_swap_status (user_id, last_completed_at)
+             VALUES ($1, NOW())
+             ON CONFLICT (user_id) DO UPDATE
+               SET last_completed_at = EXCLUDED.last_completed_at`,
+            [this.identity]
           );
         }
       });
@@ -412,13 +467,17 @@ class PostgresTreeStore {
         // True total available, computed server-side over ALL eligible leaves.
         // Required for the WaitForPending decision below — must NOT be derived
         // from the prefiltered set since the prefilter may exclude big leaves.
-        const totalResult = await client.query(`
+        const totalResult = await client.query(
+          `
           SELECT COALESCE(SUM((data->>'value')::bigint), 0)::bigint AS total
           FROM tree_leaves
-          WHERE status = 'Available'
+          WHERE user_id = $1
+            AND status = 'Available'
             AND is_missing_from_operators = FALSE
             AND reservation_id IS NULL
-        `);
+        `,
+          [this.identity]
+        );
         const available = Number(totalResult.rows[0].total);
 
         // Slim projection: only (id, value) for leaves the selection might use.
@@ -426,25 +485,30 @@ class PostgresTreeStore {
         // small-leaf accumulators for the minimum-amount path) plus the single
         // smallest leaf with value > maxTarget (covers the minimum-amount
         // fallback case where one larger leaf is sufficient).
-        const slimResult = await client.query(`
+        const slimResult = await client.query(
+          `
           SELECT id, (data->>'value')::bigint AS value
           FROM tree_leaves
-          WHERE status = 'Available'
+          WHERE user_id = $1
+            AND status = 'Available'
             AND is_missing_from_operators = FALSE
             AND reservation_id IS NULL
             AND (
-              (data->>'value')::bigint <= $1
+              (data->>'value')::bigint <= $2
               OR id = (
                 SELECT id FROM tree_leaves
-                WHERE status = 'Available'
+                WHERE user_id = $1
+                  AND status = 'Available'
                   AND is_missing_from_operators = FALSE
                   AND reservation_id IS NULL
-                  AND (data->>'value')::bigint > $1
+                  AND (data->>'value')::bigint > $2
                 ORDER BY (data->>'value')::bigint
                 LIMIT 1
               )
             )
-        `, [maxTarget]);
+        `,
+          [this.identity, maxTarget]
+        );
 
         const slimLeaves = slimResult.rows.map((r) => ({
           id: r.id,
@@ -543,8 +607,8 @@ class PostgresTreeStore {
   async _fetchFullLeavesByIds(client, ids) {
     if (!ids || ids.length === 0) return [];
     const result = await client.query(
-      "SELECT data FROM tree_leaves WHERE id = ANY($1)",
-      [ids]
+      "SELECT data FROM tree_leaves WHERE user_id = $2 AND id = ANY($1)",
+      [ids, this.identity]
     );
     return result.rows.map((r) => r.data);
   }
@@ -577,8 +641,8 @@ class PostgresTreeStore {
       return await this._withTransaction(async (client) => {
         // Check if reservation exists
         const res = await client.query(
-          "SELECT id FROM tree_reservations WHERE id = $1",
-          [reservationId]
+          "SELECT id FROM tree_reservations WHERE user_id = $1 AND id = $2",
+          [this.identity, reservationId]
         );
 
         if (res.rows.length === 0) {
@@ -587,15 +651,15 @@ class PostgresTreeStore {
 
         // Get old reserved leaf IDs and mark as spent
         const oldLeavesResult = await client.query(
-          "SELECT id FROM tree_leaves WHERE reservation_id = $1",
-          [reservationId]
+          "SELECT id FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+          [this.identity, reservationId]
         );
         const oldLeafIds = oldLeavesResult.rows.map((r) => r.id);
 
         await this._batchInsertSpentLeaves(client, oldLeafIds);
         await client.query(
-          "DELETE FROM tree_leaves WHERE reservation_id = $1",
-          [reservationId]
+          "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+          [this.identity, reservationId]
         );
 
         // Upsert change leaves to available pool
@@ -610,8 +674,8 @@ class PostgresTreeStore {
 
         // Clear pending change amount
         await client.query(
-          "UPDATE tree_reservations SET pending_change_amount = 0 WHERE id = $1",
-          [reservationId]
+          "UPDATE tree_reservations SET pending_change_amount = 0 WHERE user_id = $1 AND id = $2",
+          [this.identity, reservationId]
         );
 
         return {
@@ -793,7 +857,8 @@ class PostgresTreeStore {
    */
   async _calculatePendingBalance(client) {
     const result = await client.query(
-      "SELECT COALESCE(SUM(pending_change_amount), 0)::BIGINT AS pending FROM tree_reservations"
+      "SELECT COALESCE(SUM(pending_change_amount), 0)::BIGINT AS pending FROM tree_reservations WHERE user_id = $1",
+      [this.identity]
     );
     return Number(result.rows[0].pending);
   }
@@ -803,8 +868,8 @@ class PostgresTreeStore {
    */
   async _createReservation(client, reservationId, leaves, purpose, pendingChange) {
     await client.query(
-      "INSERT INTO tree_reservations (id, purpose, pending_change_amount) VALUES ($1, $2, $3)",
-      [reservationId, purpose, pendingChange]
+      "INSERT INTO tree_reservations (user_id, id, purpose, pending_change_amount) VALUES ($1, $2, $3, $4)",
+      [this.identity, reservationId, purpose, pendingChange]
     );
 
     const leafIds = leaves.map((l) => l.id);
@@ -829,16 +894,16 @@ class PostgresTreeStore {
     const dataValues = filtered.map((l) => JSON.stringify(l));
 
     await client.query(
-      `INSERT INTO tree_leaves (id, status, is_missing_from_operators, data, added_at)
-       SELECT id, status, missing, data::jsonb, NOW()
+      `INSERT INTO tree_leaves (user_id, id, status, is_missing_from_operators, data, added_at)
+       SELECT $5, id, status, missing, data::jsonb, NOW()
        FROM UNNEST($1::text[], $2::text[], $3::bool[], $4::text[])
            AS t(id, status, missing, data)
-       ON CONFLICT (id) DO UPDATE SET
+       ON CONFLICT (user_id, id) DO UPDATE SET
          status = EXCLUDED.status,
          is_missing_from_operators = EXCLUDED.is_missing_from_operators,
          data = EXCLUDED.data,
          added_at = NOW()`,
-      [ids, statuses, missingFlags, dataValues]
+      [ids, statuses, missingFlags, dataValues, this.identity]
     );
   }
 
@@ -849,8 +914,8 @@ class PostgresTreeStore {
     if (leafIds.length === 0) return;
 
     await client.query(
-      "UPDATE tree_leaves SET reservation_id = $1 WHERE id = ANY($2)",
-      [reservationId, leafIds]
+      "UPDATE tree_leaves SET reservation_id = $1 WHERE user_id = $3 AND id = ANY($2)",
+      [reservationId, leafIds, this.identity]
     );
   }
 
@@ -861,8 +926,10 @@ class PostgresTreeStore {
     if (leafIds.length === 0) return;
 
     await client.query(
-      "INSERT INTO tree_spent_leaves (leaf_id) SELECT * FROM UNNEST($1::text[]) ON CONFLICT DO NOTHING",
-      [leafIds]
+      `INSERT INTO tree_spent_leaves (user_id, leaf_id)
+       SELECT $2, leaf_id FROM UNNEST($1::text[]) AS t(leaf_id)
+       ON CONFLICT DO NOTHING`,
+      [leafIds, this.identity]
     );
   }
 
@@ -873,19 +940,33 @@ class PostgresTreeStore {
     if (leafIds.length === 0) return;
 
     await client.query(
-      "DELETE FROM tree_spent_leaves WHERE leaf_id = ANY($1)",
-      [leafIds]
+      "DELETE FROM tree_spent_leaves WHERE user_id = $2 AND leaf_id = ANY($1)",
+      [leafIds, this.identity]
     );
   }
 
   /**
-   * Clean up stale reservations.
+   * Clean up stale reservations. Releases the leaves by clearing their
+   * reservation_id first, then deletes the parent reservations — the composite
+   * FK uses NO ACTION (the default) since column-list SET NULL is PG15+ and a
+   * whole-row SET NULL would null user_id (NOT NULL).
    */
   async _cleanupStaleReservations(client) {
     await client.query(
+      `UPDATE tree_leaves SET reservation_id = NULL
+       WHERE user_id = $2
+         AND reservation_id IN (
+           SELECT id FROM tree_reservations
+           WHERE user_id = $2
+             AND created_at < NOW() - make_interval(secs => $1)
+         )`,
+      [RESERVATION_TIMEOUT_SECS, this.identity]
+    );
+    await client.query(
       `DELETE FROM tree_reservations
-       WHERE created_at < NOW() - make_interval(secs => $1)`,
-      [RESERVATION_TIMEOUT_SECS]
+       WHERE user_id = $2
+         AND created_at < NOW() - make_interval(secs => $1)`,
+      [RESERVATION_TIMEOUT_SECS, this.identity]
     );
   }
 
@@ -897,8 +978,8 @@ class PostgresTreeStore {
     const cleanupCutoff = new Date(refreshTimestamp.getTime() - thresholdMs);
 
     await client.query(
-      "DELETE FROM tree_spent_leaves WHERE spent_at < $1",
-      [cleanupCutoff]
+      "DELETE FROM tree_spent_leaves WHERE user_id = $2 AND spent_at < $1",
+      [cleanupCutoff, this.identity]
     );
   }
 }
@@ -911,28 +992,30 @@ class PostgresTreeStore {
  * @param {number} config.maxPoolSize - Maximum number of connections in the pool
  * @param {number} config.createTimeoutSecs - Timeout in seconds for establishing a new connection
  * @param {number} config.recycleTimeoutSecs - Timeout in seconds before recycling an idle connection
+ * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey scoping reads/writes
  * @param {object} [logger] - Optional logger
  * @returns {Promise<PostgresTreeStore>}
  */
-async function createPostgresTreeStore(config, logger = null) {
+async function createPostgresTreeStore(config, identity, logger = null) {
   const pool = new pg.Pool({
     connectionString: config.connectionString,
     max: config.maxPoolSize,
     connectionTimeoutMillis: config.createTimeoutSecs * 1000,
     idleTimeoutMillis: config.recycleTimeoutSecs * 1000,
   });
-  return createPostgresTreeStoreWithPool(pool, logger);
+  return createPostgresTreeStoreWithPool(pool, identity, logger);
 }
 
 /**
  * Create a PostgresTreeStore instance from an existing pg.Pool.
  *
  * @param {pg.Pool} pool - An existing connection pool
+ * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey scoping reads/writes
  * @param {object} [logger] - Optional logger
  * @returns {Promise<PostgresTreeStore>}
  */
-async function createPostgresTreeStoreWithPool(pool, logger = null) {
-  const store = new PostgresTreeStore(pool, logger);
+async function createPostgresTreeStoreWithPool(pool, identity, logger = null) {
+  const store = new PostgresTreeStore(pool, identity, logger);
   await store.initialize();
   return store;
 }

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -25,11 +25,10 @@ const { TreeStoreError } = require("./errors.cjs");
 const { TreeStoreMigrationManager } = require("./migrations.cjs");
 
 /**
- * Advisory-lock classid for the tree store. Combined with a per-tenant `objid`
- * (derived from the identity pubkey) so that two tenants never block each
- * other's writes — only same-tenant writes serialize on the same lock.
+ * Domain prefix mixed into the per-tenant advisory-lock key. Distinct prefixes
+ * guarantee that locks from different stores (tree, token, …) never collide.
  */
-const TREE_STORE_LOCK_CLASSID = 0x74726565; // "tree" as hex
+const TREE_STORE_LOCK_PREFIX = "breez-spark-sdk:tree:";
 
 /**
  * Timeout for reservations in seconds. Reservations older than this are stale.
@@ -42,13 +41,18 @@ const RESERVATION_TIMEOUT_SECS = 300; // 5 minutes
 const SPENT_MARKER_CLEANUP_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
- * Derive a stable 32-bit lock objid from a 33-byte secp256k1 pubkey by
- * reinterpreting its last 4 bytes as a signed 32-bit integer (big-endian).
+ * Derive a stable per-tenant 64-bit advisory-lock key by hashing a domain
+ * prefix together with the identity pubkey and folding the first 8 bytes of
+ * the SHA-256 digest into a signed big-endian i64 — the type expected by
+ * `pg_advisory_xact_lock(bigint)`. The 64-bit space keeps cross-tenant
+ * collisions negligible (~1.2e-10 at 65k tenants).
  */
-function _identityLockObjid(identity) {
-  if (!identity || identity.length < 4) return 0;
-  const tail = Buffer.from(identity).slice(-4);
-  return tail.readInt32BE(0);
+function _identityLockKey(prefix, identity) {
+  const crypto = require("crypto");
+  const hash = crypto.createHash("sha256");
+  hash.update(prefix);
+  hash.update(Buffer.from(identity));
+  return hash.digest().readBigInt64BE(0);
 }
 
 class PostgresTreeStore {
@@ -66,7 +70,7 @@ class PostgresTreeStore {
     }
     this.pool = pool;
     this.identity = Buffer.from(identity);
-    this.lockObjid = _identityLockObjid(identity);
+    this.lockKey = _identityLockKey(TREE_STORE_LOCK_PREFIX, identity);
     this.logger = logger;
   }
 
@@ -108,12 +112,10 @@ class PostgresTreeStore {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
-      // Per-tenant advisory lock: classid is constant, objid is derived from
-      // the tenant identity so different tenants don't serialize on each other.
-      await client.query("SELECT pg_advisory_xact_lock($1, $2)", [
-        TREE_STORE_LOCK_CLASSID,
-        this.lockObjid,
-      ]);
+      // Per-tenant advisory lock: 64-bit key derived from a tree-store domain
+      // prefix and the tenant identity, so different tenants don't serialize
+      // on each other and tree/token locks never collide.
+      await client.query("SELECT pg_advisory_xact_lock($1)", [this.lockKey]);
       const result = await fn(client);
       await client.query("COMMIT");
       return result;

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/migrations.cjs
@@ -22,8 +22,16 @@ class TreeStoreMigrationManager {
   /**
    * Run all pending migrations inside a single transaction with an advisory lock.
    * @param {import('pg').Pool} pool
+   * @param {Buffer|Uint8Array} identity - 33-byte secp256k1 compressed pubkey
+   *   identifying the tenant. Used to backfill `user_id` columns in the
+   *   multi-tenant scoping migration. Required.
    */
-  async migrate(pool) {
+  async migrate(pool, identity) {
+    if (!identity || identity.length !== 33) {
+      throw new TreeStoreError(
+        "tenant identity (33-byte secp256k1 pubkey) is required"
+      );
+    }
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
@@ -45,7 +53,7 @@ class TreeStoreMigrationManager {
       );
       const currentVersion = versionResult.rows[0].version;
 
-      const migrations = this._getMigrations();
+      const migrations = this._getMigrations(identity);
 
       if (currentVersion >= migrations.length) {
         this._log("info", `Tree store database is up to date (version ${currentVersion})`);
@@ -96,8 +104,16 @@ class TreeStoreMigrationManager {
 
   /**
    * Migrations matching the Rust PostgresTreeStore schema exactly.
+   *
+   * @param {Buffer|Uint8Array} identity - tenant identity inlined as a hex
+   *   BYTEA literal in the multi-tenant scoping migration. Safe because the
+   *   bytes come from a typed secp256k1 pubkey (`[0-9a-f]{66}` after hex
+   *   encoding) — not user-controlled input.
    */
-  _getMigrations() {
+  _getMigrations(identity) {
+    const idHex = Buffer.from(identity).toString("hex");
+    const idLit = `'\\x${idHex}'::bytea`;
+
     return [
       {
         name: "Create tree store tables",
@@ -141,6 +157,67 @@ class TreeStoreMigrationManager {
             last_completed_at TIMESTAMPTZ
           )`,
           `INSERT INTO tree_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING`,
+        ],
+      },
+      {
+        // Mirrors Rust migration 3 in spark-postgres/src/tree_store.rs.
+        // Adds user_id to every tree-store table, backfills with the connecting
+        // tenant's identity, and rewrites primary keys / FKs / indexes to lead
+        // with user_id. The composite FK uses NO ACTION (the default) instead
+        // of the previous single-column ON DELETE SET NULL — PG-only column-list
+        // SET NULL is PG15+, and a whole-row SET NULL would null user_id (NOT
+        // NULL). cleanupStaleReservations now releases leaves explicitly.
+        name: "Multi-tenant scoping: add user_id and rewrite primary keys",
+        sql: [
+          // Drop the old single-column FK FIRST, before touching the
+          // tree_reservations PK it depends on.
+          `ALTER TABLE tree_leaves
+             DROP CONSTRAINT IF EXISTS tree_leaves_reservation_id_fkey`,
+
+          // tree_reservations: scope by user_id.
+          `ALTER TABLE tree_reservations ADD COLUMN user_id BYTEA`,
+          `UPDATE tree_reservations SET user_id = ${idLit}`,
+          `ALTER TABLE tree_reservations
+             ALTER COLUMN user_id SET NOT NULL,
+             DROP CONSTRAINT IF EXISTS tree_reservations_pkey,
+             ADD PRIMARY KEY (user_id, id)`,
+
+          // tree_leaves: add user_id, rekey, and re-add the composite FK.
+          `ALTER TABLE tree_leaves ADD COLUMN user_id BYTEA`,
+          `UPDATE tree_leaves SET user_id = ${idLit}`,
+          `ALTER TABLE tree_leaves
+             ALTER COLUMN user_id SET NOT NULL,
+             DROP CONSTRAINT IF EXISTS tree_leaves_pkey,
+             ADD PRIMARY KEY (user_id, id),
+             ADD FOREIGN KEY (user_id, reservation_id)
+                REFERENCES tree_reservations(user_id, id)`,
+          `DROP INDEX IF EXISTS idx_tree_leaves_available`,
+          `DROP INDEX IF EXISTS idx_tree_leaves_reservation`,
+          `DROP INDEX IF EXISTS idx_tree_leaves_added_at`,
+          `CREATE INDEX idx_tree_leaves_user_available
+             ON tree_leaves(user_id, status, is_missing_from_operators)
+             WHERE status = 'Available' AND is_missing_from_operators = FALSE`,
+          `CREATE INDEX idx_tree_leaves_user_reservation
+             ON tree_leaves(user_id, reservation_id)
+             WHERE reservation_id IS NOT NULL`,
+          `CREATE INDEX idx_tree_leaves_user_added_at ON tree_leaves(user_id, added_at)`,
+
+          // tree_spent_leaves: scope by user_id.
+          `ALTER TABLE tree_spent_leaves ADD COLUMN user_id BYTEA`,
+          `UPDATE tree_spent_leaves SET user_id = ${idLit}`,
+          `ALTER TABLE tree_spent_leaves
+             ALTER COLUMN user_id SET NOT NULL,
+             DROP CONSTRAINT IF EXISTS tree_spent_leaves_pkey,
+             ADD PRIMARY KEY (user_id, leaf_id)`,
+
+          // tree_swap_status was a singleton (PK id=1, CHECK id=1). Drop the id
+          // column (CASCADE removes both PK and CHECK), then re-key by user_id.
+          `ALTER TABLE tree_swap_status DROP COLUMN id CASCADE`,
+          `ALTER TABLE tree_swap_status ADD COLUMN user_id BYTEA`,
+          `UPDATE tree_swap_status SET user_id = ${idLit}`,
+          `ALTER TABLE tree_swap_status
+             ALTER COLUMN user_id SET NOT NULL,
+             ADD PRIMARY KEY (user_id)`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/src/persist/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/mysql.rs
@@ -11,6 +11,7 @@ extern "C" {
     #[wasm_bindgen(js_name = "createMysqlStorage", catch)]
     async fn create_mysql_storage(
         config: MysqlStorageConfig,
+        identity: &[u8],
         logger: Option<&crate::logger::Logger>,
     ) -> Result<Storage, JsValue>;
 }
@@ -21,6 +22,14 @@ extern "C" {
     #[wasm_bindgen(js_name = "createTestConnectionString", catch)]
     async fn create_test_connection_string(test_name: &str) -> Result<JsValue, JsValue>;
 }
+
+/// Fixed 33-byte test identity. Each test gets its own isolated DB via
+/// `createTestConnectionString`, so a single shared identity is fine.
+const TEST_IDENTITY: [u8; 33] = [
+    0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+    0x20,
+];
 
 /// Helper to create a `WasmStorage` instance for testing using mysql-storage.
 async fn create_test_storage(test_name: &str) -> WasmStorage {
@@ -33,7 +42,7 @@ async fn create_test_storage(test_name: &str) -> WasmStorage {
 
     let config = crate::sdk_builder::default_mysql_storage_config(&conn_string);
 
-    let storage = create_mysql_storage(config, None)
+    let storage = create_mysql_storage(config, &TEST_IDENTITY, None)
         .await
         .expect("Failed to create mysql storage instance");
     WasmStorage { storage }

--- a/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
@@ -11,6 +11,7 @@ extern "C" {
     #[wasm_bindgen(js_name = "createPostgresStorage", catch)]
     async fn create_postgres_storage(
         config: PostgresStorageConfig,
+        identity: &[u8],
         logger: Option<&crate::logger::Logger>,
     ) -> Result<Storage, JsValue>;
 }
@@ -21,6 +22,14 @@ extern "C" {
     #[wasm_bindgen(js_name = "createTestConnectionString", catch)]
     async fn create_test_connection_string(test_name: &str) -> Result<JsValue, JsValue>;
 }
+
+/// Fixed 33-byte test identity. Each test gets its own isolated DB via
+/// `createTestConnectionString`, so a single shared identity is fine.
+const TEST_IDENTITY: [u8; 33] = [
+    0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+    0x20,
+];
 
 /// Helper to create a WasmStorage instance for testing using postgres-storage
 async fn create_test_storage(test_name: &str) -> WasmStorage {
@@ -33,7 +42,7 @@ async fn create_test_storage(test_name: &str) -> WasmStorage {
 
     let config = crate::sdk_builder::default_postgres_storage_config(&conn_string);
 
-    let storage = create_postgres_storage(config, None)
+    let storage = create_postgres_storage(config, &TEST_IDENTITY, None)
         .await
         .expect("Failed to create postgres storage instance");
     WasmStorage { storage }

--- a/crates/breez-sdk/wasm/src/sdk_builder.rs
+++ b/crates/breez-sdk/wasm/src/sdk_builder.rs
@@ -277,12 +277,8 @@ impl SdkBuilder {
                 let identity_bytes = identity_pub_key.serialize();
 
                 let storage = Arc::new(WasmStorage {
-                    storage: create_postgres_storage_with_pool(
-                        &pool,
-                        &identity_bytes,
-                        logger_ref,
-                    )
-                    .await?,
+                    storage: create_postgres_storage_with_pool(&pool, &identity_bytes, logger_ref)
+                        .await?,
                 });
                 self.builder = self.builder.with_storage(storage);
 

--- a/crates/breez-sdk/wasm/src/sdk_builder.rs
+++ b/crates/breez-sdk/wasm/src/sdk_builder.rs
@@ -289,7 +289,8 @@ impl SdkBuilder {
                 self.builder = self.builder.with_tree_store(tree_store);
 
                 let token_store_js =
-                    create_postgres_token_store_with_pool(&pool, logger_ref).await?;
+                    create_postgres_token_store_with_pool(&pool, &identity_bytes, logger_ref)
+                        .await?;
                 let token_store = Arc::new(WasmTokenStore::new(token_store_js));
                 self.builder = self.builder.with_token_output_store(token_store);
             }
@@ -382,6 +383,7 @@ extern "C" {
     #[wasm_bindgen(js_name = "createPostgresTokenStoreWithPool", catch)]
     async fn create_postgres_token_store_with_pool(
         pool: &JsPool,
+        identity: &[u8],
         logger: Option<&Logger>,
     ) -> Result<TokenStoreJs, JsValue>;
 

--- a/crates/breez-sdk/wasm/src/sdk_builder.rs
+++ b/crates/breez-sdk/wasm/src/sdk_builder.rs
@@ -282,7 +282,9 @@ impl SdkBuilder {
                 });
                 self.builder = self.builder.with_storage(storage);
 
-                let tree_store_js = create_postgres_tree_store_with_pool(&pool, logger_ref).await?;
+                let tree_store_js =
+                    create_postgres_tree_store_with_pool(&pool, &identity_bytes, logger_ref)
+                        .await?;
                 let tree_store = Arc::new(WasmTreeStore::new(tree_store_js));
                 self.builder = self.builder.with_tree_store(tree_store);
 
@@ -373,6 +375,7 @@ extern "C" {
     #[wasm_bindgen(js_name = "createPostgresTreeStoreWithPool", catch)]
     async fn create_postgres_tree_store_with_pool(
         pool: &JsPool,
+        identity: &[u8],
         logger: Option<&Logger>,
     ) -> Result<TreeStoreJs, JsValue>;
 

--- a/crates/breez-sdk/wasm/src/sdk_builder.rs
+++ b/crates/breez-sdk/wasm/src/sdk_builder.rs
@@ -300,16 +300,32 @@ impl SdkBuilder {
                 // Create a single shared mysql2 pool for all stores.
                 let pool = create_mysql_pool(config.clone())?;
 
+                // Derive tenant identity from the seed and pass to the JS
+                // stores so they can scope every read/write by `user_id`.
+                let key_set = KeySet::new(
+                    &self.seed.to_bytes()?,
+                    self.network.into(),
+                    self.key_set_type.into(),
+                    self.use_address_index,
+                    self.account_number,
+                )
+                .map_err(WasmError::new)?;
+                let identity_pub_key = key_set.identity_key_pair.public_key();
+                let identity_bytes = identity_pub_key.serialize();
+
                 let storage = Arc::new(WasmStorage {
-                    storage: create_mysql_storage_with_pool(&pool, logger_ref).await?,
+                    storage: create_mysql_storage_with_pool(&pool, &identity_bytes, logger_ref)
+                        .await?,
                 });
                 self.builder = self.builder.with_storage(storage);
 
-                let tree_store_js = create_mysql_tree_store_with_pool(&pool, logger_ref).await?;
+                let tree_store_js =
+                    create_mysql_tree_store_with_pool(&pool, &identity_bytes, logger_ref).await?;
                 let tree_store = Arc::new(WasmTreeStore::new(tree_store_js));
                 self.builder = self.builder.with_tree_store(tree_store);
 
-                let token_store_js = create_mysql_token_store_with_pool(&pool, logger_ref).await?;
+                let token_store_js =
+                    create_mysql_token_store_with_pool(&pool, &identity_bytes, logger_ref).await?;
                 let token_store = Arc::new(WasmTokenStore::new(token_store_js));
                 self.builder = self.builder.with_token_output_store(token_store);
             }
@@ -393,18 +409,21 @@ extern "C" {
     #[wasm_bindgen(js_name = "createMysqlStorageWithPool", catch)]
     async fn create_mysql_storage_with_pool(
         pool: &JsPool,
+        identity: &[u8],
         logger: Option<&Logger>,
     ) -> Result<crate::persist::Storage, JsValue>;
 
     #[wasm_bindgen(js_name = "createMysqlTreeStoreWithPool", catch)]
     async fn create_mysql_tree_store_with_pool(
         pool: &JsPool,
+        identity: &[u8],
         logger: Option<&Logger>,
     ) -> Result<TreeStoreJs, JsValue>;
 
     #[wasm_bindgen(js_name = "createMysqlTokenStoreWithPool", catch)]
     async fn create_mysql_token_store_with_pool(
         pool: &JsPool,
+        identity: &[u8],
         logger: Option<&Logger>,
     ) -> Result<TokenStoreJs, JsValue>;
 }

--- a/crates/breez-sdk/wasm/src/sdk_builder.rs
+++ b/crates/breez-sdk/wasm/src/sdk_builder.rs
@@ -263,8 +263,26 @@ impl SdkBuilder {
                 // Create a single shared pool for all postgres stores
                 let pool = create_postgres_pool(config.clone())?;
 
+                // Derive tenant identity from the seed and pass to the JS storage so it
+                // can scope every read/write by `user_id`.
+                let key_set = KeySet::new(
+                    &self.seed.to_bytes()?,
+                    self.network.into(),
+                    self.key_set_type.into(),
+                    self.use_address_index,
+                    self.account_number,
+                )
+                .map_err(WasmError::new)?;
+                let identity_pub_key = key_set.identity_key_pair.public_key();
+                let identity_bytes = identity_pub_key.serialize();
+
                 let storage = Arc::new(WasmStorage {
-                    storage: create_postgres_storage_with_pool(&pool, logger_ref).await?,
+                    storage: create_postgres_storage_with_pool(
+                        &pool,
+                        &identity_bytes,
+                        logger_ref,
+                    )
+                    .await?,
                 });
                 self.builder = self.builder.with_storage(storage);
 
@@ -352,6 +370,7 @@ extern "C" {
     #[wasm_bindgen(js_name = "createPostgresStorageWithPool", catch)]
     async fn create_postgres_storage_with_pool(
         pool: &JsPool,
+        identity: &[u8],
         logger: Option<&Logger>,
     ) -> Result<crate::persist::Storage, JsValue>;
 

--- a/crates/breez-sdk/wasm/src/tree_store/tests.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests.rs
@@ -10,6 +10,7 @@ extern "C" {
     #[wasm_bindgen(js_name = "createPostgresTreeStore", catch)]
     async fn create_postgres_tree_store(
         config: PostgresStorageConfig,
+        identity: &[u8],
         logger: Option<&crate::logger::Logger>,
     ) -> Result<TreeStoreJs, JsValue>;
 }
@@ -20,6 +21,14 @@ extern "C" {
     #[wasm_bindgen(js_name = "createTestConnectionString", catch)]
     async fn create_test_connection_string(test_name: &str) -> Result<JsValue, JsValue>;
 }
+
+/// Fixed 33-byte test identity. Each test gets its own isolated DB via
+/// `createTestConnectionString`, so a single shared identity is fine.
+const TEST_IDENTITY: [u8; 33] = [
+    0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+    0x20,
+];
 
 /// Helper to create a WasmTreeStore instance for testing
 async fn create_test_tree_store(test_name: &str) -> WasmTreeStore {
@@ -32,7 +41,7 @@ async fn create_test_tree_store(test_name: &str) -> WasmTreeStore {
 
     let config = crate::sdk_builder::default_postgres_storage_config(&conn_string);
 
-    let tree_store_js = create_postgres_tree_store(config, None)
+    let tree_store_js = create_postgres_tree_store(config, &TEST_IDENTITY, None)
         .await
         .expect("Failed to create postgres tree store instance");
     WasmTreeStore::new(tree_store_js)

--- a/crates/spark-mysql/Cargo.toml
+++ b/crates/spark-mysql/Cargo.toml
@@ -11,7 +11,9 @@ workspace = true
 
 [dependencies]
 async-trait.workspace = true
+bitcoin.workspace = true
 chrono.workspace = true
+hex.workspace = true
 macros.workspace = true
 mysql_async = { workspace = true, features = ["chrono"] }
 platform-utils.workspace = true

--- a/crates/spark-mysql/src/advisory_lock.rs
+++ b/crates/spark-mysql/src/advisory_lock.rs
@@ -1,0 +1,21 @@
+//! Helpers for deriving per-tenant `MySQL` named-lock keys.
+//!
+//! Each store (tree, token, …) picks its own domain prefix and combines it with
+//! the tenant identity pubkey via SHA-256. The hex-encoded first 8 bytes of the
+//! digest are used as the `GET_LOCK` name suffix. Distinct prefixes guarantee
+//! that locks from different stores never collide; the 64-bit space keeps
+//! cross-tenant collisions negligible (~1.2e-10 at 65k tenants).
+
+use bitcoin::hashes::{Hash, HashEngine, sha256};
+
+/// Derives a stable per-tenant lock name from a tenant identity pubkey.
+/// Hashes a domain prefix together with the identity and folds the first 8
+/// bytes of the SHA-256 digest into a hex string. `MySQL` `GET_LOCK` requires
+/// a string name (max 64 chars), so we hex-encode rather than use raw bytes.
+pub(crate) fn identity_lock_name(prefix: &str, identity: &[u8]) -> String {
+    let mut engine = sha256::Hash::engine();
+    engine.input(prefix.as_bytes());
+    engine.input(identity);
+    let digest = sha256::Hash::from_engine(engine);
+    format!("{prefix}{}", hex::encode(&digest.as_byte_array()[..8]))
+}

--- a/crates/spark-mysql/src/lib.rs
+++ b/crates/spark-mysql/src/lib.rs
@@ -11,6 +11,7 @@
 //! Targets `MySQL` 8.0+ (uses native `JSON` type, `CHECK` constraints, and `GET_LOCK`
 //! for application-level write serialization).
 
+mod advisory_lock;
 pub mod config;
 pub mod error;
 pub mod migrations;

--- a/crates/spark-mysql/src/migrations.rs
+++ b/crates/spark-mysql/src/migrations.rs
@@ -62,10 +62,15 @@ const MIGRATION_LOCK_TIMEOUT_SECS: i64 = 60;
 /// structured variants for the non-idempotent DDL — `MySQL` doesn't support
 /// `IF NOT EXISTS` on add/drop column or create index, so the runner emits
 /// an `information_schema` guard before each statement.
-#[derive(Clone, Copy, Debug)]
+///
+/// `Sql` carries an owned `String` so callers can build statements at runtime
+/// (e.g. inlining a tenant identity into a backfill); the structured variants
+/// keep `&'static str` because their identifiers are always known at compile
+/// time.
+#[derive(Clone, Debug)]
 pub enum Migration {
     /// Run the SQL statement as-is. Errors propagate.
-    Sql(&'static str),
+    Sql(String),
 
     /// `ALTER TABLE <table> ADD COLUMN <column> <definition>`, guarded by an
     /// `information_schema.columns` lookup so re-running an already applied
@@ -101,6 +106,29 @@ pub enum Migration {
         name: &'static str,
         table: &'static str,
     },
+
+    /// Drops a foreign-key constraint on `table` named `name`, guarded by an
+    /// `information_schema.table_constraints` lookup so re-running an already
+    /// applied migration is a no-op. Needed when rewriting parent PKs to lead
+    /// with `user_id`: dependent FKs must be dropped first.
+    DropForeignKey {
+        name: &'static str,
+        table: &'static str,
+    },
+
+    /// `ALTER TABLE <table> DROP PRIMARY KEY`, guarded by an
+    /// `information_schema.table_constraints` lookup so re-running an already
+    /// applied migration is a no-op. Needed when rewriting PKs to lead with
+    /// `user_id`: a partial-apply replay would otherwise fail with
+    /// `ER_CANT_DROP_FIELD_OR_KEY`.
+    DropPrimaryKey { table: &'static str },
+}
+
+impl Migration {
+    /// Convenience constructor for the common case of a `&'static str` literal.
+    pub fn sql(s: &str) -> Self {
+        Self::Sql(s.to_string())
+    }
 }
 
 /// Runs database migrations with version tracking and concurrency control.
@@ -119,7 +147,7 @@ pub enum Migration {
 pub async fn run_migrations(
     pool: &Pool,
     migrations_table: &str,
-    migrations: &[&[Migration]],
+    migrations: &[Vec<Migration>],
 ) -> Result<(), MysqlError> {
     let mut conn = pool
         .get_conn()
@@ -159,7 +187,7 @@ pub async fn run_migrations(
 async fn run_migrations_inner(
     conn: &mut mysql_async::Conn,
     migrations_table: &str,
-    migrations: &[&[Migration]],
+    migrations: &[Vec<Migration>],
 ) -> Result<(), MysqlError> {
     // Begin transaction. Migration table creation lives inside the transaction
     // for parity with the postgres impl, but note that DDL implicitly commits
@@ -193,8 +221,8 @@ async fn run_migrations_inner(
     for (i, migration) in migrations.iter().enumerate() {
         let version = i32::try_from(i + 1).unwrap_or(i32::MAX);
         if version > current_version {
-            for step in *migration {
-                run_step(conn, version, *step).await?;
+            for step in migration {
+                run_step(conn, version, step).await?;
             }
             let insert_sql = format!("INSERT INTO `{migrations_table}` (version) VALUES (?)");
             conn.exec_drop(&insert_sql, (version,))
@@ -214,11 +242,11 @@ async fn run_migrations_inner(
 async fn run_step(
     conn: &mut mysql_async::Conn,
     version: i32,
-    step: Migration,
+    step: &Migration,
 ) -> Result<(), MysqlError> {
     match step {
         Migration::Sql(sql) => conn
-            .query_drop(sql)
+            .query_drop(sql.as_str())
             .await
             .map_err(|e| MysqlError::Database(format!("Migration {version} failed: {e}"))),
 
@@ -277,6 +305,30 @@ async fn run_step(
                 ))
             })
         }
+
+        Migration::DropForeignKey { name, table } => {
+            if !foreign_key_exists(conn, table, name).await? {
+                return Ok(());
+            }
+            let sql = format!("ALTER TABLE `{table}` DROP FOREIGN KEY `{name}`");
+            conn.query_drop(&sql).await.map_err(|e| {
+                MysqlError::Database(format!(
+                    "Migration {version} DROP FOREIGN KEY {name} on {table} failed: {e}"
+                ))
+            })
+        }
+
+        Migration::DropPrimaryKey { table } => {
+            if !primary_key_exists(conn, table).await? {
+                return Ok(());
+            }
+            let sql = format!("ALTER TABLE `{table}` DROP PRIMARY KEY");
+            conn.query_drop(&sql).await.map_err(|e| {
+                MysqlError::Database(format!(
+                    "Migration {version} DROP PRIMARY KEY on {table} failed: {e}"
+                ))
+            })
+        }
     }
 }
 
@@ -312,6 +364,44 @@ async fn index_exists(
                AND table_name = ?
                AND index_name = ?",
             (table, index_name),
+        )
+        .await
+        .map_err(map_db_error)?;
+    Ok(count.unwrap_or(0) > 0)
+}
+
+/// Checks `information_schema.table_constraints` for a given foreign-key
+/// constraint on the current schema.
+async fn foreign_key_exists(
+    conn: &mut mysql_async::Conn,
+    table: &str,
+    fk_name: &str,
+) -> Result<bool, MysqlError> {
+    let count: Option<i64> = conn
+        .exec_first(
+            "SELECT COUNT(*) FROM information_schema.table_constraints
+             WHERE table_schema = DATABASE()
+               AND table_name = ?
+               AND constraint_name = ?
+               AND constraint_type = 'FOREIGN KEY'",
+            (table, fk_name),
+        )
+        .await
+        .map_err(map_db_error)?;
+    Ok(count.unwrap_or(0) > 0)
+}
+
+/// Checks `information_schema.table_constraints` for a primary-key constraint
+/// on the current schema. A PRIMARY KEY constraint is always named `PRIMARY`
+/// in `MySQL`.
+async fn primary_key_exists(conn: &mut mysql_async::Conn, table: &str) -> Result<bool, MysqlError> {
+    let count: Option<i64> = conn
+        .exec_first(
+            "SELECT COUNT(*) FROM information_schema.table_constraints
+             WHERE table_schema = DATABASE()
+               AND table_name = ?
+               AND constraint_type = 'PRIMARY KEY'",
+            (table,),
         )
         .await
         .map_err(map_db_error)?;
@@ -365,11 +455,11 @@ mod tests {
         // ADD COLUMN and CREATE INDEX statements must succeed despite the
         // objects already existing. The DROP at the end must also succeed
         // even though we never created `dropme`.
-        let migrations: Vec<&[Migration]> = vec![
-            &[Migration::Sql(
+        let migrations: Vec<Vec<Migration>> = vec![
+            vec![Migration::sql(
                 "CREATE TABLE IF NOT EXISTS example (id VARCHAR(64) PRIMARY KEY, data JSON NOT NULL)",
             )],
-            &[
+            vec![
                 Migration::AddColumn {
                     table: "example",
                     column: "value",

--- a/crates/spark-mysql/src/token_store.rs
+++ b/crates/spark-mysql/src/token_store.rs
@@ -20,6 +20,7 @@ use spark_wallet::{
 use tracing::{trace, warn};
 use uuid::Uuid;
 
+use crate::advisory_lock::identity_lock_name;
 use crate::config::MysqlStorageConfig;
 use crate::error::MysqlError;
 use crate::migrations::{Migration, run_migrations};
@@ -27,15 +28,185 @@ use crate::pool::create_pool;
 
 const TOKEN_MIGRATIONS_TABLE: &str = "token_schema_migrations";
 
-const TOKEN_STORE_WRITE_LOCK_NAME: &str = "token_store_write_lock";
+/// Domain prefix mixed into the per-tenant `GET_LOCK` name so the token store's
+/// locks never collide with the tree store's, even when two tenants share a
+/// database.
+const TOKEN_STORE_LOCK_PREFIX: &str = "breez-spark-sdk:token:";
 const WRITE_LOCK_TIMEOUT_SECS: i64 = 30;
 
 const SPENT_MARKER_CLEANUP_THRESHOLD_MS: i64 = 5 * 60 * 1000;
 const RESERVATION_TIMEOUT_SECS: i64 = 300;
 
 /// `MySQL`-backed token output store implementation.
+///
+/// Each instance is scoped to a single tenant identity so multiple tenants
+/// can share one `MySQL` database without cross-pollinating token state.
 pub struct MysqlTokenStore {
     pool: Pool,
+    /// 33-byte secp256k1 compressed pubkey identifying this tenant. All reads
+    /// and writes are filtered by `user_id = self.identity`.
+    identity: Vec<u8>,
+    /// Stable per-tenant `GET_LOCK` name derived from `identity`.
+    lock_name: String,
+}
+
+/// Builds the multi-tenant scoping migration for the token store. Adds
+/// `user_id VARBINARY(33)` to every per-user table (including
+/// `token_metadata` — metadata is per-tenant to avoid 0-balance leakage for
+/// tokens a tenant never owned), backfills with the connecting tenant, and
+/// rewrites primary keys / FKs to lead with `user_id`.
+#[allow(clippy::too_many_lines)]
+fn token_store_multi_tenant_migration(identity: &[u8]) -> Vec<Migration> {
+    let id_hex = hex::encode(identity);
+    let id_lit = format!("UNHEX('{id_hex}')");
+
+    let mut stmts: Vec<Migration> = Vec::new();
+
+    // Drop the existing FKs FIRST so we can rewrite the parent PKs they
+    // reference. Both FKs were defined with explicit `CONSTRAINT` clauses.
+    stmts.push(Migration::DropForeignKey {
+        name: "fk_token_outputs_metadata",
+        table: "token_outputs",
+    });
+    stmts.push(Migration::DropForeignKey {
+        name: "fk_token_outputs_reservation",
+        table: "token_outputs",
+    });
+
+    // token_metadata: scope per-tenant. Required even though metadata never
+    // structurally collides — leaking a token's mere existence (e.g. a
+    // 0-balance entry for a token a tenant never held) would be a privacy
+    // regression.
+    stmts.push(Migration::AddColumn {
+        table: "token_metadata",
+        column: "user_id",
+        definition: "VARBINARY(33) NULL",
+    });
+    stmts.push(Migration::Sql(format!(
+        "UPDATE token_metadata SET user_id = {id_lit} WHERE user_id IS NULL"
+    )));
+    stmts.push(Migration::sql(
+        "ALTER TABLE token_metadata MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+    ));
+    stmts.push(Migration::sql(
+        "ALTER TABLE token_metadata DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, identifier)",
+    ));
+    stmts.push(Migration::DropIndex {
+        name: "idx_token_metadata_issuer_pk",
+        table: "token_metadata",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_token_metadata_user_issuer_pk",
+        table: "token_metadata",
+        columns: "(user_id, issuer_public_key)",
+    });
+
+    // token_reservations: scope by user_id.
+    stmts.push(Migration::AddColumn {
+        table: "token_reservations",
+        column: "user_id",
+        definition: "VARBINARY(33) NULL",
+    });
+    stmts.push(Migration::Sql(format!(
+        "UPDATE token_reservations SET user_id = {id_lit} WHERE user_id IS NULL"
+    )));
+    stmts.push(Migration::sql(
+        "ALTER TABLE token_reservations MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+    ));
+    stmts.push(Migration::sql(
+        "ALTER TABLE token_reservations DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)",
+    ));
+
+    // token_outputs: scope by user_id, rekey, re-add composite FKs.
+    stmts.push(Migration::AddColumn {
+        table: "token_outputs",
+        column: "user_id",
+        definition: "VARBINARY(33) NULL",
+    });
+    stmts.push(Migration::Sql(format!(
+        "UPDATE token_outputs SET user_id = {id_lit} WHERE user_id IS NULL"
+    )));
+    stmts.push(Migration::sql(
+        "ALTER TABLE token_outputs MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+    ));
+    stmts.push(Migration::sql(
+        "ALTER TABLE token_outputs DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)",
+    ));
+    // Re-add the FKs as composite, scoped by user_id. The reservation FK uses
+    // NO ACTION (the default) instead of the previous `ON DELETE SET NULL`:
+    // a whole-row SET NULL would null `user_id` (NOT NULL).
+    stmts.push(Migration::sql(
+        "ALTER TABLE token_outputs \
+         ADD CONSTRAINT fk_token_outputs_metadata_user \
+         FOREIGN KEY (user_id, token_identifier) \
+         REFERENCES token_metadata(user_id, identifier)",
+    ));
+    stmts.push(Migration::sql(
+        "ALTER TABLE token_outputs \
+         ADD CONSTRAINT fk_token_outputs_reservation_user \
+         FOREIGN KEY (user_id, reservation_id) \
+         REFERENCES token_reservations(user_id, id)",
+    ));
+    stmts.push(Migration::DropIndex {
+        name: "idx_token_outputs_identifier",
+        table: "token_outputs",
+    });
+    stmts.push(Migration::DropIndex {
+        name: "idx_token_outputs_reservation",
+        table: "token_outputs",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_token_outputs_user_identifier",
+        table: "token_outputs",
+        columns: "(user_id, token_identifier)",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_token_outputs_user_reservation",
+        table: "token_outputs",
+        columns: "(user_id, reservation_id)",
+    });
+
+    // token_spent_outputs: scope by user_id.
+    stmts.push(Migration::AddColumn {
+        table: "token_spent_outputs",
+        column: "user_id",
+        definition: "VARBINARY(33) NULL",
+    });
+    stmts.push(Migration::Sql(format!(
+        "UPDATE token_spent_outputs SET user_id = {id_lit} WHERE user_id IS NULL"
+    )));
+    stmts.push(Migration::sql(
+        "ALTER TABLE token_spent_outputs MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+    ));
+    stmts.push(Migration::sql(
+        "ALTER TABLE token_spent_outputs DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, output_id)",
+    ));
+
+    // token_swap_status was a singleton (PK id=1, CHECK id=1). Drop the PK
+    // and the id column, then re-key by user_id.
+    stmts.push(Migration::DropPrimaryKey {
+        table: "token_swap_status",
+    });
+    stmts.push(Migration::DropColumn {
+        table: "token_swap_status",
+        column: "id",
+    });
+    stmts.push(Migration::AddColumn {
+        table: "token_swap_status",
+        column: "user_id",
+        definition: "VARBINARY(33) NULL",
+    });
+    stmts.push(Migration::Sql(format!(
+        "UPDATE token_swap_status SET user_id = {id_lit} WHERE user_id IS NULL"
+    )));
+    stmts.push(Migration::sql(
+        "ALTER TABLE token_swap_status MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+    ));
+    stmts.push(Migration::sql(
+        "ALTER TABLE token_swap_status ADD PRIMARY KEY (user_id)",
+    ));
+
+    stmts
 }
 
 #[async_trait]
@@ -49,10 +220,11 @@ impl TokenOutputStore for MysqlTokenStore {
         let refresh_timestamp: DateTime<Utc> = refresh_started_at.into();
 
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
-        Self::acquire_write_lock(&mut conn).await?;
-        let result =
-            Self::set_tokens_outputs_inner(&mut conn, token_outputs, refresh_timestamp).await;
-        Self::release_write_lock_quiet(&mut conn).await;
+        self.acquire_write_lock(&mut conn).await?;
+        let result = self
+            .set_tokens_outputs_inner(&mut conn, token_outputs, refresh_timestamp)
+            .await;
+        self.release_write_lock_quiet(&mut conn).await;
         result
     }
 
@@ -66,7 +238,7 @@ impl TokenOutputStore for MysqlTokenStore {
         // `token_amount` is stored as VARCHAR — cast to DECIMAL(65,0) so the
         // SUM works across full u128 range, then return as TEXT for parsing.
         let rows: Vec<Row> = conn
-            .query(
+            .exec(
                 r"SELECT m.identifier, m.issuer_public_key, m.name, m.ticker, m.decimals,
                          m.max_supply, m.is_freezable, m.creation_entity_public_key,
                          CAST(COALESCE(SUM(
@@ -77,10 +249,14 @@ impl TokenOutputStore for MysqlTokenStore {
                             END
                          ), 0) AS CHAR) AS balance
                   FROM token_metadata m
-                  JOIN token_outputs o ON o.token_identifier = m.identifier
-                  LEFT JOIN token_reservations r ON o.reservation_id = r.id
+                  JOIN token_outputs o
+                    ON o.token_identifier = m.identifier AND o.user_id = m.user_id
+                  LEFT JOIN token_reservations r
+                    ON o.reservation_id = r.id AND o.user_id = r.user_id
+                  WHERE m.user_id = ?
                   GROUP BY m.identifier, m.issuer_public_key, m.name, m.ticker,
                            m.decimals, m.max_supply, m.is_freezable, m.creation_entity_public_key",
+                (self.identity.clone(),),
             )
             .await
             .map_err(map_err)?;
@@ -100,7 +276,7 @@ impl TokenOutputStore for MysqlTokenStore {
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
 
         let rows: Vec<Row> = conn
-            .query(
+            .exec(
                 r"SELECT m.identifier, m.issuer_public_key, m.name, m.ticker, m.decimals,
                          m.max_supply, m.is_freezable, m.creation_entity_public_key,
                          o.id AS output_id, o.owner_public_key, o.revocation_commitment,
@@ -109,9 +285,13 @@ impl TokenOutputStore for MysqlTokenStore {
                          o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                          r.purpose
                   FROM token_metadata m
-                  LEFT JOIN token_outputs o ON o.token_identifier = m.identifier
-                  LEFT JOIN token_reservations r ON o.reservation_id = r.id
+                  LEFT JOIN token_outputs o
+                    ON o.token_identifier = m.identifier AND o.user_id = m.user_id
+                  LEFT JOIN token_reservations r
+                    ON o.reservation_id = r.id AND o.user_id = r.user_id
+                  WHERE m.user_id = ?
                   ORDER BY m.identifier, CAST(o.token_amount AS DECIMAL(65,0)) ASC",
+                (self.identity.clone(),),
             )
             .await
             .map_err(map_err)?;
@@ -179,13 +359,18 @@ impl TokenOutputStore for MysqlTokenStore {
                      o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                      r.purpose
               FROM token_metadata m
-              LEFT JOIN token_outputs o ON o.token_identifier = m.identifier
-              LEFT JOIN token_reservations r ON o.reservation_id = r.id
-              WHERE {where_clause}
+              LEFT JOIN token_outputs o
+                ON o.token_identifier = m.identifier AND o.user_id = m.user_id
+              LEFT JOIN token_reservations r
+                ON o.reservation_id = r.id AND o.user_id = r.user_id
+              WHERE m.user_id = ? AND {where_clause}
               ORDER BY CAST(o.token_amount AS DECIMAL(65,0)) ASC"
         );
 
-        let rows: Vec<Row> = conn.exec(&query, (param,)).await.map_err(map_err)?;
+        let rows: Vec<Row> = conn
+            .exec(&query, (self.identity.clone(), param))
+            .await
+            .map_err(map_err)?;
 
         if rows.is_empty() {
             return Err(TokenOutputServiceError::Generic(
@@ -232,7 +417,8 @@ impl TokenOutputStore for MysqlTokenStore {
             .await
             .map_err(map_err)?;
 
-        Self::upsert_metadata(&mut tx, &token_outputs.metadata).await?;
+        self.upsert_metadata(&mut tx, &token_outputs.metadata)
+            .await?;
 
         let output_ids: Vec<String> = token_outputs
             .outputs
@@ -241,16 +427,20 @@ impl TokenOutputStore for MysqlTokenStore {
             .collect();
         if !output_ids.is_empty() {
             let placeholders = build_placeholders(output_ids.len());
-            let sql =
-                format!("DELETE FROM token_spent_outputs WHERE output_id IN ({placeholders})");
-            let params: Vec<Value> = output_ids.iter().cloned().map(Value::from).collect();
+            let sql = format!(
+                "DELETE FROM token_spent_outputs WHERE user_id = ? AND output_id IN ({placeholders})"
+            );
+            let mut params: Vec<Value> = Vec::with_capacity(output_ids.len().saturating_add(1));
+            params.push(Value::from(self.identity.clone()));
+            params.extend(output_ids.iter().cloned().map(Value::from));
             tx.exec_drop(&sql, Params::Positional(params))
                 .await
                 .map_err(map_err)?;
         }
 
         for output in &token_outputs.outputs {
-            Self::insert_single_output(&mut tx, &token_outputs.metadata.identifier, output).await?;
+            self.insert_single_output(&mut tx, &token_outputs.metadata.identifier, output)
+                .await?;
         }
 
         tx.commit().await.map_err(map_err)?;
@@ -289,17 +479,18 @@ impl TokenOutputStore for MysqlTokenStore {
         }
 
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
-        Self::acquire_write_lock(&mut conn).await?;
-        let result = Self::reserve_token_outputs_inner(
-            &mut conn,
-            token_identifier,
-            target,
-            purpose,
-            preferred_outputs,
-            selection_strategy,
-        )
-        .await;
-        Self::release_write_lock_quiet(&mut conn).await;
+        self.acquire_write_lock(&mut conn).await?;
+        let result = self
+            .reserve_token_outputs_inner(
+                &mut conn,
+                token_identifier,
+                target,
+                purpose,
+                preferred_outputs,
+                selection_strategy,
+            )
+            .await;
+        self.release_write_lock_quiet(&mut conn).await;
         result
     }
 
@@ -309,7 +500,7 @@ impl TokenOutputStore for MysqlTokenStore {
     ) -> Result<(), TokenOutputServiceError> {
         // Scoped to a single `reservation_id`; row-level FK + MVCC suffice.
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
-        Self::cancel_reservation_inner(&mut conn, id).await?;
+        self.cancel_reservation_inner(&mut conn, id).await?;
         trace!("Canceled token outputs reservation: {}", id);
         Ok(())
     }
@@ -322,9 +513,9 @@ impl TokenOutputStore for MysqlTokenStore {
         // snapshot and the upsert that consumes it cannot interleave with this
         // transaction's spent-marker write.
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
-        Self::acquire_write_lock(&mut conn).await?;
-        let result = Self::finalize_reservation_inner(&mut conn, id).await;
-        Self::release_write_lock_quiet(&mut conn).await;
+        self.acquire_write_lock(&mut conn).await?;
+        let result = self.finalize_reservation_inner(&mut conn, id).await;
+        self.release_write_lock_quiet(&mut conn).await;
         result?;
         trace!("Finalized token outputs reservation: {}", id);
         Ok(())
@@ -342,106 +533,124 @@ impl TokenOutputStore for MysqlTokenStore {
 }
 
 impl MysqlTokenStore {
-    pub async fn from_config(config: MysqlStorageConfig) -> Result<Self, MysqlError> {
+    /// `identity` is the 33-byte secp256k1 pubkey of the tenant.
+    pub async fn from_config(
+        config: MysqlStorageConfig,
+        identity: &[u8],
+    ) -> Result<Self, MysqlError> {
         let pool = create_pool(&config)?;
-        Self::init(pool).await
+        Self::init(pool, identity).await
     }
 
-    pub async fn from_pool(pool: Pool) -> Result<Self, MysqlError> {
-        Self::init(pool).await
+    /// `identity` is the 33-byte secp256k1 pubkey of the tenant.
+    pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
+        Self::init(pool, identity).await
     }
 
-    async fn init(pool: Pool) -> Result<Self, MysqlError> {
-        let store = Self { pool };
+    async fn init(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
+        let store = Self {
+            pool,
+            identity: identity.to_vec(),
+            lock_name: identity_lock_name(TOKEN_STORE_LOCK_PREFIX, identity),
+        };
         store.migrate().await?;
         Ok(store)
     }
 
     async fn migrate(&self) -> Result<(), MysqlError> {
-        run_migrations(&self.pool, TOKEN_MIGRATIONS_TABLE, &Self::migrations()).await
+        run_migrations(
+            &self.pool,
+            TOKEN_MIGRATIONS_TABLE,
+            &Self::migrations(&self.identity),
+        )
+        .await
     }
 
-    fn migrations() -> Vec<&'static [Migration]> {
-        vec![&[
-            Migration::Sql(
-                "CREATE TABLE IF NOT EXISTS token_metadata (
-                    identifier VARCHAR(255) NOT NULL PRIMARY KEY,
-                    issuer_public_key VARCHAR(255) NOT NULL,
-                    name VARCHAR(255) NOT NULL,
-                    ticker VARCHAR(64) NOT NULL,
-                    decimals INT NOT NULL,
-                    max_supply VARCHAR(128) NOT NULL,
-                    is_freezable TINYINT(1) NOT NULL,
-                    creation_entity_public_key VARCHAR(255) NULL
-                )",
-            ),
-            Migration::CreateIndex {
-                name: "idx_token_metadata_issuer_pk",
-                table: "token_metadata",
-                columns: "(issuer_public_key)",
-            },
-            Migration::Sql(
-                "CREATE TABLE IF NOT EXISTS token_reservations (
-                    id VARCHAR(255) NOT NULL PRIMARY KEY,
-                    purpose VARCHAR(64) NOT NULL,
-                    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
-                )",
-            ),
-            Migration::Sql(
-                "CREATE TABLE IF NOT EXISTS token_outputs (
-                    id VARCHAR(255) NOT NULL PRIMARY KEY,
-                    token_identifier VARCHAR(255) NOT NULL,
-                    owner_public_key VARCHAR(255) NOT NULL,
-                    revocation_commitment VARCHAR(255) NOT NULL,
-                    withdraw_bond_sats BIGINT NOT NULL,
-                    withdraw_relative_block_locktime BIGINT NOT NULL,
-                    token_public_key VARCHAR(255) NULL,
-                    token_amount VARCHAR(128) NOT NULL,
-                    prev_tx_hash VARCHAR(255) NOT NULL,
-                    prev_tx_vout INT NOT NULL,
-                    reservation_id VARCHAR(255) NULL,
-                    added_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-                    CONSTRAINT fk_token_outputs_metadata FOREIGN KEY (token_identifier)
-                        REFERENCES token_metadata(identifier),
-                    CONSTRAINT fk_token_outputs_reservation FOREIGN KEY (reservation_id)
-                        REFERENCES token_reservations(id) ON DELETE SET NULL
-                )",
-            ),
-            Migration::CreateIndex {
-                name: "idx_token_outputs_identifier",
-                table: "token_outputs",
-                columns: "(token_identifier)",
-            },
-            Migration::CreateIndex {
-                name: "idx_token_outputs_reservation",
-                table: "token_outputs",
-                columns: "(reservation_id)",
-            },
-            Migration::Sql(
-                "CREATE TABLE IF NOT EXISTS token_spent_outputs (
-                    output_id VARCHAR(255) NOT NULL PRIMARY KEY,
-                    spent_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
-                )",
-            ),
-            Migration::Sql(
-                "CREATE TABLE IF NOT EXISTS token_swap_status (
-                    id INT NOT NULL PRIMARY KEY DEFAULT 1,
-                    last_completed_at DATETIME(6) NULL,
-                    CHECK (id = 1)
-                )",
-            ),
-            Migration::Sql(
-                "INSERT INTO token_swap_status (id) VALUES (1)
-                 ON DUPLICATE KEY UPDATE id = id",
-            ),
-        ]]
+    fn migrations(identity: &[u8]) -> Vec<Vec<Migration>> {
+        vec![
+            vec![
+                Migration::sql(
+                    "CREATE TABLE IF NOT EXISTS token_metadata (
+                        identifier VARCHAR(255) NOT NULL PRIMARY KEY,
+                        issuer_public_key VARCHAR(255) NOT NULL,
+                        name VARCHAR(255) NOT NULL,
+                        ticker VARCHAR(64) NOT NULL,
+                        decimals INT NOT NULL,
+                        max_supply VARCHAR(128) NOT NULL,
+                        is_freezable TINYINT(1) NOT NULL,
+                        creation_entity_public_key VARCHAR(255) NULL
+                    )",
+                ),
+                Migration::CreateIndex {
+                    name: "idx_token_metadata_issuer_pk",
+                    table: "token_metadata",
+                    columns: "(issuer_public_key)",
+                },
+                Migration::sql(
+                    "CREATE TABLE IF NOT EXISTS token_reservations (
+                        id VARCHAR(255) NOT NULL PRIMARY KEY,
+                        purpose VARCHAR(64) NOT NULL,
+                        created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+                    )",
+                ),
+                Migration::sql(
+                    "CREATE TABLE IF NOT EXISTS token_outputs (
+                        id VARCHAR(255) NOT NULL PRIMARY KEY,
+                        token_identifier VARCHAR(255) NOT NULL,
+                        owner_public_key VARCHAR(255) NOT NULL,
+                        revocation_commitment VARCHAR(255) NOT NULL,
+                        withdraw_bond_sats BIGINT NOT NULL,
+                        withdraw_relative_block_locktime BIGINT NOT NULL,
+                        token_public_key VARCHAR(255) NULL,
+                        token_amount VARCHAR(128) NOT NULL,
+                        prev_tx_hash VARCHAR(255) NOT NULL,
+                        prev_tx_vout INT NOT NULL,
+                        reservation_id VARCHAR(255) NULL,
+                        added_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                        CONSTRAINT fk_token_outputs_metadata FOREIGN KEY (token_identifier)
+                            REFERENCES token_metadata(identifier),
+                        CONSTRAINT fk_token_outputs_reservation FOREIGN KEY (reservation_id)
+                            REFERENCES token_reservations(id) ON DELETE SET NULL
+                    )",
+                ),
+                Migration::CreateIndex {
+                    name: "idx_token_outputs_identifier",
+                    table: "token_outputs",
+                    columns: "(token_identifier)",
+                },
+                Migration::CreateIndex {
+                    name: "idx_token_outputs_reservation",
+                    table: "token_outputs",
+                    columns: "(reservation_id)",
+                },
+                Migration::sql(
+                    "CREATE TABLE IF NOT EXISTS token_spent_outputs (
+                        output_id VARCHAR(255) NOT NULL PRIMARY KEY,
+                        spent_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+                    )",
+                ),
+                Migration::sql(
+                    "CREATE TABLE IF NOT EXISTS token_swap_status (
+                        id INT NOT NULL PRIMARY KEY DEFAULT 1,
+                        last_completed_at DATETIME(6) NULL,
+                        CHECK (id = 1)
+                    )",
+                ),
+                Migration::sql(
+                    "INSERT INTO token_swap_status (id) VALUES (1)
+                     ON DUPLICATE KEY UPDATE id = id",
+                ),
+            ],
+            // Migration 2: Multi-tenant scoping.
+            token_store_multi_tenant_migration(identity),
+        ]
     }
 
-    async fn acquire_write_lock(conn: &mut Conn) -> Result<(), TokenOutputServiceError> {
+    async fn acquire_write_lock(&self, conn: &mut Conn) -> Result<(), TokenOutputServiceError> {
         let acquired: Option<i64> = conn
             .exec_first(
                 "SELECT GET_LOCK(?, ?)",
-                (TOKEN_STORE_WRITE_LOCK_NAME, WRITE_LOCK_TIMEOUT_SECS),
+                (self.lock_name.as_str(), WRITE_LOCK_TIMEOUT_SECS),
             )
             .await
             .map_err(map_err)?;
@@ -453,14 +662,15 @@ impl MysqlTokenStore {
         Ok(())
     }
 
-    async fn release_write_lock_quiet(conn: &mut Conn) {
+    async fn release_write_lock_quiet(&self, conn: &mut Conn) {
         let _ = conn
-            .exec_drop("SELECT RELEASE_LOCK(?)", (TOKEN_STORE_WRITE_LOCK_NAME,))
+            .exec_drop("SELECT RELEASE_LOCK(?)", (self.lock_name.as_str(),))
             .await;
     }
 
     #[allow(clippy::too_many_lines, clippy::cast_possible_wrap)]
     async fn set_tokens_outputs_inner(
+        &self,
         conn: &mut Conn,
         token_outputs: &[TokenOutputs],
         refresh_timestamp: DateTime<Utc>,
@@ -470,17 +680,21 @@ impl MysqlTokenStore {
             .await
             .map_err(map_err)?;
 
-        Self::cleanup_stale_reservations(&mut tx).await?;
+        self.cleanup_stale_reservations(&mut tx).await?;
 
         let row: Option<(i64, i64)> = tx
             .exec_first(
                 r"SELECT
-                    (SELECT EXISTS(SELECT 1 FROM token_reservations WHERE purpose = 'Swap')) AS has_active_swap,
+                    (SELECT EXISTS(SELECT 1 FROM token_reservations WHERE user_id = ? AND purpose = 'Swap')) AS has_active_swap,
                     COALESCE(
-                        (SELECT (last_completed_at >= ?) FROM token_swap_status WHERE id = 1),
+                        (SELECT (last_completed_at >= ?) FROM token_swap_status WHERE user_id = ?),
                         0
                     ) AS swap_completed_during_refresh",
-                (refresh_timestamp.naive_utc(),),
+                (
+                    self.identity.clone(),
+                    refresh_timestamp.naive_utc(),
+                    self.identity.clone(),
+                ),
             )
             .await
             .map_err(map_err)?;
@@ -494,25 +708,24 @@ impl MysqlTokenStore {
                 "Skipping set_tokens_outputs: active_swap={}, swap_completed_during_refresh={}",
                 has_active_swap, swap_completed_during_refresh
             );
-            // Drop the in-flight cleanup work by letting the transaction roll
-            // back on drop, matching the postgres impl.
             return Ok(());
         }
 
-        Self::cleanup_spent_markers(&mut tx, refresh_timestamp).await?;
+        self.cleanup_spent_markers(&mut tx, refresh_timestamp)
+            .await?;
 
         let spent_rows: Vec<String> = tx
             .exec(
-                "SELECT output_id FROM token_spent_outputs WHERE spent_at >= ?",
-                (refresh_timestamp.naive_utc(),),
+                "SELECT output_id FROM token_spent_outputs WHERE user_id = ? AND spent_at >= ?",
+                (self.identity.clone(), refresh_timestamp.naive_utc()),
             )
             .await
             .map_err(map_err)?;
         let spent_ids: HashSet<String> = spent_rows.into_iter().collect();
 
         tx.exec_drop(
-            "DELETE FROM token_outputs WHERE reservation_id IS NULL AND added_at < ?",
-            (refresh_timestamp.naive_utc(),),
+            "DELETE FROM token_outputs WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
+            (self.identity.clone(), refresh_timestamp.naive_utc()),
         )
         .await
         .map_err(map_err)?;
@@ -523,10 +736,13 @@ impl MysqlTokenStore {
             .collect();
 
         let reserved_pairs: Vec<(String, String)> = tx
-            .query(
+            .exec(
                 r"SELECT r.id, o.id
                   FROM token_reservations r
-                  JOIN token_outputs o ON o.reservation_id = r.id",
+                  JOIN token_outputs o
+                    ON o.reservation_id = r.id AND o.user_id = r.user_id
+                  WHERE r.user_id = ?",
+                (self.identity.clone(),),
             )
             .await
             .map_err(map_err)?;
@@ -559,23 +775,24 @@ impl MysqlTokenStore {
 
         if !reservations_to_delete.is_empty() {
             let placeholders = build_placeholders(reservations_to_delete.len());
-            let outputs_sql =
-                format!("DELETE FROM token_outputs WHERE reservation_id IN ({placeholders})");
-            let outputs_params: Vec<Value> = reservations_to_delete
-                .iter()
-                .cloned()
-                .map(Value::from)
-                .collect();
+            let outputs_sql = format!(
+                "DELETE FROM token_outputs WHERE user_id = ? AND reservation_id IN ({placeholders})"
+            );
+            let mut outputs_params: Vec<Value> =
+                Vec::with_capacity(reservations_to_delete.len().saturating_add(1));
+            outputs_params.push(Value::from(self.identity.clone()));
+            outputs_params.extend(reservations_to_delete.iter().cloned().map(Value::from));
             tx.exec_drop(&outputs_sql, Params::Positional(outputs_params))
                 .await
                 .map_err(map_err)?;
 
-            let res_sql = format!("DELETE FROM token_reservations WHERE id IN ({placeholders})");
-            let res_params: Vec<Value> = reservations_to_delete
-                .iter()
-                .cloned()
-                .map(Value::from)
-                .collect();
+            let res_sql = format!(
+                "DELETE FROM token_reservations WHERE user_id = ? AND id IN ({placeholders})"
+            );
+            let mut res_params: Vec<Value> =
+                Vec::with_capacity(reservations_to_delete.len().saturating_add(1));
+            res_params.push(Value::from(self.identity.clone()));
+            res_params.extend(reservations_to_delete.iter().cloned().map(Value::from));
             tx.exec_drop(&res_sql, Params::Positional(res_params))
                 .await
                 .map_err(map_err)?;
@@ -583,28 +800,39 @@ impl MysqlTokenStore {
 
         if !outputs_to_remove_from_reservation.is_empty() {
             let placeholders = build_placeholders(outputs_to_remove_from_reservation.len());
-            let sql = format!("DELETE FROM token_outputs WHERE id IN ({placeholders})");
-            let params: Vec<Value> = outputs_to_remove_from_reservation
-                .iter()
-                .cloned()
-                .map(Value::from)
-                .collect();
+            let sql =
+                format!("DELETE FROM token_outputs WHERE user_id = ? AND id IN ({placeholders})");
+            let mut params: Vec<Value> =
+                Vec::with_capacity(outputs_to_remove_from_reservation.len().saturating_add(1));
+            params.push(Value::from(self.identity.clone()));
+            params.extend(
+                outputs_to_remove_from_reservation
+                    .iter()
+                    .cloned()
+                    .map(Value::from),
+            );
             tx.exec_drop(&sql, Params::Positional(params))
                 .await
                 .map_err(map_err)?;
 
             let empty_ids: Vec<String> = tx
-                .query(
+                .exec(
                     r"SELECT r.id FROM token_reservations r
-                      LEFT JOIN token_outputs o ON o.reservation_id = r.id
-                      WHERE o.id IS NULL",
+                      LEFT JOIN token_outputs o
+                        ON o.reservation_id = r.id AND o.user_id = r.user_id
+                      WHERE r.user_id = ? AND o.id IS NULL",
+                    (self.identity.clone(),),
                 )
                 .await
                 .map_err(map_err)?;
             if !empty_ids.is_empty() {
                 let placeholders = build_placeholders(empty_ids.len());
-                let sql = format!("DELETE FROM token_reservations WHERE id IN ({placeholders})");
-                let params: Vec<Value> = empty_ids.iter().cloned().map(Value::from).collect();
+                let sql = format!(
+                    "DELETE FROM token_reservations WHERE user_id = ? AND id IN ({placeholders})"
+                );
+                let mut params: Vec<Value> = Vec::with_capacity(empty_ids.len().saturating_add(1));
+                params.push(Value::from(self.identity.clone()));
+                params.extend(empty_ids.iter().cloned().map(Value::from));
                 tx.exec_drop(&sql, Params::Positional(params))
                     .await
                     .map_err(map_err)?;
@@ -612,23 +840,29 @@ impl MysqlTokenStore {
         }
 
         let reserved_output_ids: HashSet<String> = tx
-            .query::<String, _>("SELECT id FROM token_outputs WHERE reservation_id IS NOT NULL")
+            .exec::<String, _, _>(
+                "SELECT id FROM token_outputs WHERE user_id = ? AND reservation_id IS NOT NULL",
+                (self.identity.clone(),),
+            )
             .await
             .map_err(map_err)?
             .into_iter()
             .collect();
 
-        tx.query_drop(
+        // Drop tenant-scoped metadata rows that no longer have any outputs.
+        tx.exec_drop(
             r"DELETE FROM token_metadata
-              WHERE identifier NOT IN (
-                  SELECT DISTINCT token_identifier FROM token_outputs
+              WHERE user_id = ?
+                AND identifier NOT IN (
+                  SELECT DISTINCT token_identifier FROM token_outputs WHERE user_id = ?
               )",
+            (self.identity.clone(), self.identity.clone()),
         )
         .await
         .map_err(map_err)?;
 
         for to in token_outputs {
-            Self::upsert_metadata(&mut tx, &to.metadata).await?;
+            self.upsert_metadata(&mut tx, &to.metadata).await?;
 
             for output in &to.outputs {
                 if reserved_output_ids.contains(&output.output.id)
@@ -636,7 +870,8 @@ impl MysqlTokenStore {
                 {
                     continue;
                 }
-                Self::insert_single_output(&mut tx, &to.metadata.identifier, output).await?;
+                self.insert_single_output(&mut tx, &to.metadata.identifier, output)
+                    .await?;
             }
         }
 
@@ -648,6 +883,7 @@ impl MysqlTokenStore {
 
     #[allow(clippy::too_many_lines, clippy::arithmetic_side_effects)]
     async fn reserve_token_outputs_inner(
+        &self,
         conn: &mut Conn,
         token_identifier: &str,
         target: ReservationTarget,
@@ -662,8 +898,8 @@ impl MysqlTokenStore {
 
         let metadata_row: Option<Row> = tx
             .exec_first(
-                "SELECT * FROM token_metadata WHERE identifier = ?",
-                (token_identifier,),
+                "SELECT * FROM token_metadata WHERE user_id = ? AND identifier = ?",
+                (self.identity.clone(), token_identifier),
             )
             .await
             .map_err(map_err)?;
@@ -681,8 +917,8 @@ impl MysqlTokenStore {
                          o.token_public_key, o.token_amount, o.prev_tx_hash, o.prev_tx_vout,
                          o.token_identifier
                   FROM token_outputs o
-                  WHERE o.token_identifier = ? AND o.reservation_id IS NULL",
-                (token_identifier,),
+                  WHERE o.user_id = ? AND o.token_identifier = ? AND o.reservation_id IS NULL",
+                (self.identity.clone(), token_identifier),
             )
             .await
             .map_err(map_err)?;
@@ -748,8 +984,8 @@ impl MysqlTokenStore {
         };
 
         tx.exec_drop(
-            "INSERT INTO token_reservations (id, purpose) VALUES (?, ?)",
-            (&reservation_id, purpose_str),
+            "INSERT INTO token_reservations (user_id, id, purpose) VALUES (?, ?, ?)",
+            (self.identity.clone(), &reservation_id, purpose_str),
         )
         .await
         .map_err(map_err)?;
@@ -760,10 +996,12 @@ impl MysqlTokenStore {
             .collect();
         if !selected_ids.is_empty() {
             let placeholders = build_placeholders(selected_ids.len());
-            let sql =
-                format!("UPDATE token_outputs SET reservation_id = ? WHERE id IN ({placeholders})");
-            let mut params: Vec<Value> = Vec::with_capacity(selected_ids.len() + 1);
+            let sql = format!(
+                "UPDATE token_outputs SET reservation_id = ? WHERE user_id = ? AND id IN ({placeholders})"
+            );
+            let mut params: Vec<Value> = Vec::with_capacity(selected_ids.len() + 2);
             params.push(Value::from(reservation_id.clone()));
+            params.push(Value::from(self.identity.clone()));
             for id in &selected_ids {
                 params.push(Value::from(id.clone()));
             }
@@ -784,6 +1022,7 @@ impl MysqlTokenStore {
     }
 
     async fn cancel_reservation_inner(
+        &self,
         conn: &mut Conn,
         id: &TokenOutputsReservationId,
     ) -> Result<(), TokenOutputServiceError> {
@@ -793,21 +1032,25 @@ impl MysqlTokenStore {
             .map_err(map_err)?;
 
         tx.exec_drop(
-            "UPDATE token_outputs SET reservation_id = NULL WHERE reservation_id = ?",
-            (id,),
+            "UPDATE token_outputs SET reservation_id = NULL WHERE user_id = ? AND reservation_id = ?",
+            (self.identity.clone(), id),
         )
         .await
         .map_err(map_err)?;
 
-        tx.exec_drop("DELETE FROM token_reservations WHERE id = ?", (id,))
-            .await
-            .map_err(map_err)?;
+        tx.exec_drop(
+            "DELETE FROM token_reservations WHERE user_id = ? AND id = ?",
+            (self.identity.clone(), id),
+        )
+        .await
+        .map_err(map_err)?;
 
         tx.commit().await.map_err(map_err)?;
         Ok(())
     }
 
     async fn finalize_reservation_inner(
+        &self,
         conn: &mut Conn,
         id: &TokenOutputsReservationId,
     ) -> Result<(), TokenOutputServiceError> {
@@ -817,7 +1060,10 @@ impl MysqlTokenStore {
             .map_err(map_err)?;
 
         let purpose: Option<String> = tx
-            .exec_first("SELECT purpose FROM token_reservations WHERE id = ?", (id,))
+            .exec_first(
+                "SELECT purpose FROM token_reservations WHERE user_id = ? AND id = ?",
+                (self.identity.clone(), id),
+            )
             .await
             .map_err(map_err)?;
 
@@ -831,20 +1077,23 @@ impl MysqlTokenStore {
 
         let reserved_output_ids: Vec<String> = tx
             .exec(
-                "SELECT id FROM token_outputs WHERE reservation_id = ?",
-                (id,),
+                "SELECT id FROM token_outputs WHERE user_id = ? AND reservation_id = ?",
+                (self.identity.clone(), id),
             )
             .await
             .map_err(map_err)?;
 
         if !reserved_output_ids.is_empty() {
-            let mut sql = String::from("INSERT INTO token_spent_outputs (output_id) VALUES ");
-            let mut params: Vec<Value> = Vec::with_capacity(reserved_output_ids.len());
+            let mut sql =
+                String::from("INSERT INTO token_spent_outputs (user_id, output_id) VALUES ");
+            let mut params: Vec<Value> =
+                Vec::with_capacity(reserved_output_ids.len().saturating_mul(2));
             for (i, oid) in reserved_output_ids.iter().enumerate() {
                 if i > 0 {
                     sql.push_str(", ");
                 }
-                sql.push_str("(?)");
+                sql.push_str("(?, ?)");
+                params.push(Value::from(self.identity.clone()));
                 params.push(Value::from(oid.clone()));
             }
             // Suppress duplicate-PK errors only.
@@ -854,25 +1103,40 @@ impl MysqlTokenStore {
                 .map_err(map_err)?;
         }
 
-        tx.exec_drop("DELETE FROM token_outputs WHERE reservation_id = ?", (id,))
-            .await
-            .map_err(map_err)?;
+        tx.exec_drop(
+            "DELETE FROM token_outputs WHERE user_id = ? AND reservation_id = ?",
+            (self.identity.clone(), id),
+        )
+        .await
+        .map_err(map_err)?;
 
-        tx.exec_drop("DELETE FROM token_reservations WHERE id = ?", (id,))
-            .await
-            .map_err(map_err)?;
+        tx.exec_drop(
+            "DELETE FROM token_reservations WHERE user_id = ? AND id = ?",
+            (self.identity.clone(), id),
+        )
+        .await
+        .map_err(map_err)?;
 
+        // UPSERT the per-tenant swap-status row so a tenant that joined after
+        // the multi-tenant migration (and thus has no row) gets one created
+        // lazily.
         if is_swap {
-            tx.query_drop("UPDATE token_swap_status SET last_completed_at = NOW(6) WHERE id = 1")
-                .await
-                .map_err(map_err)?;
+            tx.exec_drop(
+                "INSERT INTO token_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
+                 ON DUPLICATE KEY UPDATE last_completed_at = VALUES(last_completed_at)",
+                (self.identity.clone(),),
+            )
+            .await
+            .map_err(map_err)?;
         }
 
-        tx.query_drop(
+        tx.exec_drop(
             r"DELETE FROM token_metadata
-              WHERE identifier NOT IN (
-                  SELECT DISTINCT token_identifier FROM token_outputs
+              WHERE user_id = ?
+                AND identifier NOT IN (
+                  SELECT DISTINCT token_identifier FROM token_outputs WHERE user_id = ?
               )",
+            (self.identity.clone(), self.identity.clone()),
         )
         .await
         .map_err(map_err)?;
@@ -883,21 +1147,23 @@ impl MysqlTokenStore {
 
     #[allow(clippy::cast_possible_wrap)]
     async fn insert_single_output(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
         token_identifier: &str,
         output: &TokenOutputWithPrevOut,
     ) -> Result<(), TokenOutputServiceError> {
         tx.exec_drop(
-            // ON DUPLICATE KEY UPDATE id = id no-ops on the (id) primary key
-            // conflict only — unlike INSERT IGNORE, FK / NOT NULL / type
-            // errors still propagate.
+            // ON DUPLICATE KEY UPDATE id = id no-ops on the (user_id, id)
+            // primary key conflict only — unlike INSERT IGNORE, FK / NOT NULL
+            // / type errors still propagate.
             r"INSERT INTO token_outputs
-                (id, token_identifier, owner_public_key, revocation_commitment,
+                (user_id, id, token_identifier, owner_public_key, revocation_commitment,
                  withdraw_bond_sats, withdraw_relative_block_locktime,
                  token_public_key, token_amount, prev_tx_hash, prev_tx_vout, added_at)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(6))
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(6))
               ON DUPLICATE KEY UPDATE id = id",
             (
+                self.identity.clone(),
                 &output.output.id,
                 token_identifier,
                 output.output.owner_public_key.to_string(),
@@ -917,14 +1183,15 @@ impl MysqlTokenStore {
 
     #[allow(clippy::cast_possible_wrap)]
     async fn upsert_metadata(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
         metadata: &TokenMetadata,
     ) -> Result<(), TokenOutputServiceError> {
         tx.exec_drop(
             r"INSERT INTO token_metadata
-                (identifier, issuer_public_key, name, ticker, decimals, max_supply,
+                (user_id, identifier, issuer_public_key, name, ticker, decimals, max_supply,
                  is_freezable, creation_entity_public_key)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
               ON DUPLICATE KEY UPDATE
                 issuer_public_key = VALUES(issuer_public_key),
                 name = VALUES(name),
@@ -934,6 +1201,7 @@ impl MysqlTokenStore {
                 is_freezable = VALUES(is_freezable),
                 creation_entity_public_key = VALUES(creation_entity_public_key)",
             (
+                self.identity.clone(),
                 &metadata.identifier,
                 metadata.issuer_public_key.to_string(),
                 &metadata.name,
@@ -949,14 +1217,37 @@ impl MysqlTokenStore {
         Ok(())
     }
 
+    /// Cleans up stale reservations for THIS tenant. Releases dependent
+    /// outputs by clearing `reservation_id` first (the composite FK uses NO
+    /// ACTION because column-list SET NULL would null `user_id`).
     async fn cleanup_stale_reservations(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
     ) -> Result<u64, TokenOutputServiceError> {
+        tx.exec_drop(
+            r"UPDATE token_outputs SET reservation_id = NULL
+              WHERE user_id = ?
+                AND reservation_id IN (
+                    SELECT id FROM (
+                        SELECT id FROM token_reservations
+                        WHERE user_id = ?
+                          AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
+                    ) AS stale
+                )",
+            (
+                self.identity.clone(),
+                self.identity.clone(),
+                RESERVATION_TIMEOUT_SECS,
+            ),
+        )
+        .await
+        .map_err(map_err)?;
+
         let mut result = tx
             .exec_iter(
                 "DELETE FROM token_reservations
-                 WHERE created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)",
-                (RESERVATION_TIMEOUT_SECS,),
+                 WHERE user_id = ? AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)",
+                (self.identity.clone(), RESERVATION_TIMEOUT_SECS),
             )
             .await
             .map_err(map_err)?;
@@ -970,6 +1261,7 @@ impl MysqlTokenStore {
     }
 
     async fn cleanup_spent_markers(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
         refresh_timestamp: DateTime<Utc>,
     ) -> Result<(), TokenOutputServiceError> {
@@ -979,8 +1271,8 @@ impl MysqlTokenStore {
             .unwrap_or(refresh_timestamp);
 
         tx.exec_drop(
-            "DELETE FROM token_spent_outputs WHERE spent_at < ?",
-            (cleanup_cutoff.naive_utc(),),
+            "DELETE FROM token_spent_outputs WHERE user_id = ? AND spent_at < ?",
+            (self.identity.clone(), cleanup_cutoff.naive_utc()),
         )
         .await
         .map_err(map_err)?;
@@ -1120,16 +1412,26 @@ fn map_err<E: std::fmt::Display>(e: E) -> TokenOutputServiceError {
     TokenOutputServiceError::Generic(e.to_string())
 }
 
+/// Creates a `MysqlTokenStore` from a configuration.
+///
+/// `identity` is the 33-byte secp256k1 pubkey scoping all reads and writes.
 pub async fn create_mysql_token_store(
     config: MysqlStorageConfig,
+    identity: &[u8],
 ) -> Result<Arc<dyn TokenOutputStore>, MysqlError> {
-    Ok(Arc::new(MysqlTokenStore::from_config(config).await?))
+    Ok(Arc::new(
+        MysqlTokenStore::from_config(config, identity).await?,
+    ))
 }
 
+/// Creates a `MysqlTokenStore` from an existing connection pool.
+///
+/// `identity` is the 33-byte secp256k1 pubkey scoping all reads and writes.
 pub async fn create_mysql_token_store_from_pool(
     pool: Pool,
+    identity: &[u8],
 ) -> Result<Arc<dyn TokenOutputStore>, MysqlError> {
-    Ok(Arc::new(MysqlTokenStore::from_pool(pool).await?))
+    Ok(Arc::new(MysqlTokenStore::from_pool(pool, identity).await?))
 }
 
 #[cfg(test)]
@@ -1138,6 +1440,14 @@ mod tests {
     use spark_wallet::token_store_tests as shared_tests;
     use testcontainers::{ContainerAsync, runners::AsyncRunner};
     use testcontainers_modules::mysql::Mysql;
+
+    /// Fixed 33-byte test identity. Tests run in their own ephemeral container,
+    /// so a single shared identity is fine — the schema still gets exercised.
+    pub(super) const TEST_IDENTITY: [u8; 33] = [
+        0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+        0x1e, 0x1f, 0x20,
+    ];
 
     struct MysqlTokenStoreTestFixture {
         store: MysqlTokenStore,
@@ -1159,10 +1469,12 @@ mod tests {
 
             let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
 
-            let store =
-                MysqlTokenStore::from_config(MysqlStorageConfig::with_defaults(connection_string))
-                    .await
-                    .expect("Failed to create MysqlTokenStore");
+            let store = MysqlTokenStore::from_config(
+                MysqlStorageConfig::with_defaults(connection_string),
+                &TEST_IDENTITY,
+            )
+            .await
+            .expect("Failed to create MysqlTokenStore");
 
             Self { store, container }
         }
@@ -1444,12 +1756,13 @@ mod tests {
             .await
             .unwrap();
 
-        // Hold the named lock on a separate connection.
+        // Hold the per-tenant named lock on a separate connection.
+        let lock_name = fixture.store.lock_name.clone();
         let mut holder = fixture.store.pool.get_conn().await.unwrap();
         let acquired: Option<i64> = holder
             .exec_first(
                 "SELECT GET_LOCK(?, ?)",
-                (TOKEN_STORE_WRITE_LOCK_NAME, WRITE_LOCK_TIMEOUT_SECS),
+                (lock_name.as_str(), WRITE_LOCK_TIMEOUT_SECS),
             )
             .await
             .unwrap();
@@ -1469,7 +1782,7 @@ mod tests {
         );
 
         holder
-            .exec_drop("SELECT RELEASE_LOCK(?)", (TOKEN_STORE_WRITE_LOCK_NAME,))
+            .exec_drop("SELECT RELEASE_LOCK(?)", (lock_name.as_str(),))
             .await
             .unwrap();
         drop(holder);
@@ -1479,5 +1792,288 @@ mod tests {
             .expect("finalize_reservation did not complete after lock released")
             .unwrap()
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_stale_swap_reservation_does_not_block_set_tokens_outputs() {
+        // Regression test mirroring the tree store fix: a stale Swap reservation
+        // must be cleaned up before has_active_swap is evaluated, otherwise the
+        // reservation pins itself in place and the local token-output set freezes.
+        let fixture = MysqlTokenStoreTestFixture::new().await;
+        let token1 = shared_tests::create_token_outputs(1, vec![100, 200]);
+        fixture
+            .store
+            .set_tokens_outputs(
+                std::slice::from_ref(&token1),
+                shared_tests::future_refresh_start(),
+            )
+            .await
+            .unwrap();
+
+        let reservation = fixture
+            .store
+            .reserve_token_outputs(
+                "token-1",
+                ReservationTarget::MinTotalValue(100),
+                TokenReservationPurpose::Swap,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let stored = fixture
+            .store
+            .get_token_outputs(GetTokenOutputsFilter::Identifier("token-1"))
+            .await
+            .unwrap();
+        assert!(!stored.reserved_for_swap.is_empty());
+
+        // Backdate the swap reservation past the 5-minute timeout.
+        let mut conn = fixture.store.pool.get_conn().await.unwrap();
+        conn.exec_drop(
+            "UPDATE token_reservations SET created_at = DATE_SUB(NOW(6), INTERVAL 10 MINUTE) WHERE id = ?",
+            (&reservation.id,),
+        )
+        .await
+        .unwrap();
+        drop(conn);
+
+        // set_tokens_outputs brings fresh data including a new output. Pre-fix:
+        // skipped on has_active_swap, the new output is dropped and the reservation
+        // lingers forever. Post-fix: cleanup runs first, the stale reservation is
+        // dropped, has_active_swap is false, set_tokens_outputs applies.
+        let token1_refresh = shared_tests::create_token_outputs(1, vec![100, 200, 300]);
+        fixture
+            .store
+            .set_tokens_outputs(
+                std::slice::from_ref(&token1_refresh),
+                shared_tests::future_refresh_start(),
+            )
+            .await
+            .unwrap();
+
+        let stored = fixture
+            .store
+            .get_token_outputs(GetTokenOutputsFilter::Identifier("token-1"))
+            .await
+            .unwrap();
+        assert!(
+            stored.reserved_for_swap.is_empty(),
+            "Stale swap reservation should be cleaned up"
+        );
+        assert_eq!(
+            stored.available.len(),
+            3,
+            "set_tokens_outputs should have proceeded and applied the operator's view (3 outputs)"
+        );
+        assert!(
+            stored
+                .available
+                .iter()
+                .any(|o| o.output.token_amount == 300),
+            "the 300-amount output from the refresh should be present"
+        );
+    }
+
+    // ==================== Multi-tenant isolation ====================
+
+    /// A second 33-byte test identity (must differ from `TEST_IDENTITY`).
+    const TEST_IDENTITY_B: [u8; 33] = [
+        0x03, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae,
+        0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd,
+        0xbe, 0xbf, 0xc0,
+    ];
+
+    /// Two `MysqlTokenStore` instances with distinct identities sharing one
+    /// connection pool / DB. The container must be kept alive for the test.
+    struct TwoTenantTokenFixture {
+        a: MysqlTokenStore,
+        b: MysqlTokenStore,
+        #[allow(dead_code)]
+        container: ContainerAsync<Mysql>,
+    }
+
+    impl TwoTenantTokenFixture {
+        async fn new() -> Self {
+            let container = Mysql::default()
+                .start()
+                .await
+                .expect("Failed to start MySQL container");
+
+            let host_port = container
+                .get_host_port_ipv4(3306)
+                .await
+                .expect("Failed to get host port");
+
+            let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
+
+            let config = MysqlStorageConfig::with_defaults(connection_string);
+            let pool = create_pool(&config).expect("Failed to create pool");
+
+            let a = MysqlTokenStore::from_pool(pool.clone(), &TEST_IDENTITY)
+                .await
+                .expect("Failed to create tenant A");
+            let b = MysqlTokenStore::from_pool(pool, &TEST_IDENTITY_B)
+                .await
+                .expect("Failed to create tenant B");
+
+            Self { a, b, container }
+        }
+    }
+
+    /// End-to-end isolation: every `TokenOutputStore` method must keep tenants
+    /// A and B from observing each other's data. Critically, `token_metadata`
+    /// is per-tenant — both tenants seeding the same `identifier` ("token-1")
+    /// must coexist without collision and without leaking each other's
+    /// balances.
+    #[tokio::test]
+    #[allow(clippy::too_many_lines, clippy::similar_names)]
+    async fn test_two_tenant_isolation() {
+        let fx = TwoTenantTokenFixture::new().await;
+
+        let a_token1 = shared_tests::create_token_outputs(1, vec![100, 200]);
+        let b_token1 = shared_tests::create_token_outputs(1, vec![500, 1_000, 2_000]);
+        let b_only_token2 = shared_tests::create_token_outputs(2, vec![777]);
+
+        fx.a.set_tokens_outputs(
+            std::slice::from_ref(&a_token1),
+            shared_tests::future_refresh_start(),
+        )
+        .await
+        .unwrap();
+        fx.b.set_tokens_outputs(
+            &[b_token1, b_only_token2],
+            shared_tests::future_refresh_start(),
+        )
+        .await
+        .unwrap();
+
+        let listed_a = fx.a.list_tokens_outputs().await.unwrap();
+        let listed_b = fx.b.list_tokens_outputs().await.unwrap();
+        assert_eq!(listed_a.len(), 1, "A only sees its own token");
+        assert_eq!(listed_b.len(), 2, "B sees its two tokens");
+        assert!(
+            !listed_a.iter().any(|t| t.metadata.identifier == "token-2"),
+            "A must not see B's token-2 (no zero-balance leakage)"
+        );
+        assert_eq!(listed_a[0].available.len(), 2, "A has 2 outputs of token-1");
+        let listed_b_t1 = listed_b
+            .iter()
+            .find(|t| t.metadata.identifier == "token-1")
+            .unwrap();
+        assert_eq!(listed_b_t1.available.len(), 3, "B has 3 outputs of token-1");
+
+        let bal_a = fx.a.get_token_balances().await.unwrap();
+        let bal_b = fx.b.get_token_balances().await.unwrap();
+        assert_eq!(bal_a.len(), 1);
+        assert_eq!(bal_a[0].0.identifier, "token-1");
+        assert_eq!(bal_a[0].1, 300, "A's token-1 balance is just A's outputs");
+        let bal_b_map: HashMap<String, u128> =
+            bal_b.into_iter().map(|(m, v)| (m.identifier, v)).collect();
+        assert_eq!(bal_b_map.get("token-1"), Some(&3_500));
+        assert_eq!(bal_b_map.get("token-2"), Some(&777));
+
+        let got_a =
+            fx.a.get_token_outputs(GetTokenOutputsFilter::Identifier("token-1"))
+                .await
+                .unwrap();
+        assert_eq!(got_a.available.len(), 2);
+
+        let got_a_t2 =
+            fx.a.get_token_outputs(GetTokenOutputsFilter::Identifier("token-2"))
+                .await;
+        assert!(
+            matches!(got_a_t2, Err(TokenOutputServiceError::Generic(_))),
+            "A must not be able to read B's token-2 metadata"
+        );
+
+        let res_a =
+            fx.a.reserve_token_outputs(
+                "token-1",
+                ReservationTarget::MinTotalValue(100),
+                TokenReservationPurpose::Payment,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(!res_a.token_outputs.outputs.is_empty());
+
+        let view_b = fx.b.list_tokens_outputs().await.unwrap();
+        let view_b_t1 = view_b
+            .iter()
+            .find(|t| t.metadata.identifier == "token-1")
+            .unwrap();
+        assert!(
+            view_b_t1.reserved_for_payment.is_empty(),
+            "B must not see A's reservation"
+        );
+        assert_eq!(view_b_t1.available.len(), 3);
+
+        let res_a_t2 =
+            fx.a.reserve_token_outputs(
+                "token-2",
+                ReservationTarget::MinTotalValue(100),
+                TokenReservationPurpose::Payment,
+                None,
+                None,
+            )
+            .await;
+        assert!(
+            res_a_t2.is_err(),
+            "A must not be able to reserve from B's token-2"
+        );
+
+        fx.a.finalize_reservation(&res_a.id).await.unwrap();
+        let view_b = fx.b.list_tokens_outputs().await.unwrap();
+        let view_b_t1 = view_b
+            .iter()
+            .find(|t| t.metadata.identifier == "token-1")
+            .unwrap();
+        assert_eq!(view_b_t1.available.len(), 3, "B's outputs untouched");
+        assert_eq!(fx.b.get_token_balances().await.unwrap().len(), 2);
+
+        // swap-status row is per tenant.
+        let res_b_swap =
+            fx.b.reserve_token_outputs(
+                "token-1",
+                ReservationTarget::MinTotalValue(500),
+                TokenReservationPurpose::Swap,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let listed_a = fx.a.list_tokens_outputs().await.unwrap();
+        assert!(
+            listed_a.iter().all(|t| t.reserved_for_swap.is_empty()),
+            "A must not see B's swap reservation"
+        );
+        fx.b.finalize_reservation(&res_b_swap.id).await.unwrap();
+
+        // insert_token_outputs on A only inserts into A's namespace. Use
+        // identifier_no=2 so the metadata identifier ("token-2") collides
+        // with B's existing entry — both tenants must end up with their own
+        // row.
+        let a_token2 = shared_tests::create_token_outputs(2, vec![999]);
+        fx.a.insert_token_outputs(&a_token2).await.unwrap();
+
+        let bal_a = fx.a.get_token_balances().await.unwrap();
+        let bal_a_t2 = bal_a
+            .iter()
+            .find(|(m, _)| m.identifier == "token-2")
+            .expect("A should now have its own token-2");
+        assert_eq!(bal_a_t2.1, 999, "A's token-2 balance is A's output only");
+
+        let bal_b = fx.b.get_token_balances().await.unwrap();
+        let bal_b_t2 = bal_b
+            .iter()
+            .find(|(m, _)| m.identifier == "token-2")
+            .expect("B's token-2 still present");
+        assert_eq!(
+            bal_b_t2.1, 777,
+            "B's token-2 balance unchanged by A's insert"
+        );
     }
 }

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -34,6 +34,7 @@ use tokio::sync::watch;
 use tracing::{debug, info, trace};
 use uuid::Uuid;
 
+use crate::advisory_lock::identity_lock_name;
 use crate::config::MysqlStorageConfig;
 use crate::error::MysqlError;
 use crate::migrations::{Migration, run_migrations};
@@ -42,10 +43,11 @@ use crate::pool::create_pool;
 /// Name of the schema migrations table for `MysqlTreeStore`.
 const TREE_MIGRATIONS_TABLE: &str = "tree_schema_migrations";
 
-/// Named lock used to serialize tree store write operations across connections.
-/// `MySQL` `GET_LOCK` is session-scoped, so we acquire it at the start of each
-/// write and release it explicitly before returning.
-const TREE_STORE_WRITE_LOCK_NAME: &str = "tree_store_write_lock";
+/// Domain prefix mixed into the per-tenant `GET_LOCK` name so the tree store's
+/// locks never collide with the token store's, even when two tenants share a
+/// database. The full lock name is `<prefix><hex(sha256(prefix||identity)[..8])>`,
+/// ensuring distinct tenants never serialize on each other's writes.
+const TREE_STORE_LOCK_PREFIX: &str = "breez-spark-sdk:tree:";
 
 /// Timeout (seconds) when waiting on the write lock. Long enough to outlast
 /// brief contention, short enough to surface true deadlocks instead of hanging.
@@ -81,11 +83,165 @@ impl LeafLike for SlimLeaf {
 /// `MySQL`-backed tree store implementation.
 ///
 /// Uses an application-level named lock to serialize writes (`GET_LOCK`) and
-/// row-level FK constraints to keep reservations and leaves in sync.
+/// row-level FK constraints to keep reservations and leaves in sync. Each
+/// instance is scoped to a single tenant identity so that multiple tenants
+/// can share one `MySQL` database without cross-pollinating tree state.
 pub struct MysqlTreeStore {
     pool: Pool,
+    /// 33-byte secp256k1 compressed pubkey identifying this tenant. All reads
+    /// and writes are filtered by `user_id = self.identity`.
+    identity: Vec<u8>,
+    /// Stable per-tenant `GET_LOCK` name derived from `identity`. Two tenants
+    /// don't serialize on each other's writes; same-tenant writes still
+    /// serialize on the same lock.
+    lock_name: String,
     balance_changed_tx: Arc<watch::Sender<()>>,
     balance_changed_rx: watch::Receiver<()>,
+}
+
+/// Builds the multi-tenant scoping migration for the tree store. Adds
+/// `user_id VARBINARY(33)` to every per-user table, backfills with the
+/// connecting tenant's identity, and rewrites primary keys / FKs to lead
+/// with `user_id`.
+#[allow(clippy::too_many_lines)]
+fn tree_store_multi_tenant_migration(identity: &[u8]) -> Vec<Migration> {
+    let id_hex = hex::encode(identity);
+    let id_lit = format!("UNHEX('{id_hex}')");
+
+    let mut stmts: Vec<Migration> = Vec::new();
+
+    // Drop the existing FK from tree_leaves(reservation_id) -> tree_reservations(id)
+    // FIRST, before we touch the parent's PK that it depends on. The `MySQL`
+    // FK was named via a CONSTRAINT clause on creation as
+    // `fk_tree_leaves_reservation`.
+    stmts.push(Migration::DropForeignKey {
+        name: "fk_tree_leaves_reservation",
+        table: "tree_leaves",
+    });
+
+    // tree_reservations: scope by user_id. Add the column nullable, backfill,
+    // make NOT NULL, and rewrite the PK to lead with user_id.
+    stmts.push(Migration::AddColumn {
+        table: "tree_reservations",
+        column: "user_id",
+        definition: "VARBINARY(33) NULL",
+    });
+    stmts.push(Migration::Sql(format!(
+        "UPDATE tree_reservations SET user_id = {id_lit} WHERE user_id IS NULL"
+    )));
+    stmts.push(Migration::sql(
+        "ALTER TABLE tree_reservations MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+    ));
+    stmts.push(Migration::sql(
+        "ALTER TABLE tree_reservations DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)",
+    ));
+
+    // tree_leaves: same pattern, plus re-add the composite FK to the new
+    // tree_reservations PK. The composite FK uses the default ON DELETE NO
+    // ACTION instead of the previous `ON DELETE SET NULL`: a whole-row SET NULL
+    // would null `user_id` (NOT NULL) and `MySQL` doesn't support column-list
+    // SET NULL. Callers (`cleanup_stale_reservations`, `cancel_reservation`,
+    // `finalize_reservation`) explicitly clear `reservation_id` before
+    // deleting the parent reservation row.
+    stmts.push(Migration::AddColumn {
+        table: "tree_leaves",
+        column: "user_id",
+        definition: "VARBINARY(33) NULL",
+    });
+    stmts.push(Migration::Sql(format!(
+        "UPDATE tree_leaves SET user_id = {id_lit} WHERE user_id IS NULL"
+    )));
+    stmts.push(Migration::sql(
+        "ALTER TABLE tree_leaves MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+    ));
+    stmts.push(Migration::sql(
+        "ALTER TABLE tree_leaves DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)",
+    ));
+    stmts.push(Migration::sql(
+        "ALTER TABLE tree_leaves \
+         ADD CONSTRAINT fk_tree_leaves_reservation_user \
+         FOREIGN KEY (user_id, reservation_id) \
+         REFERENCES tree_reservations(user_id, id)",
+    ));
+    stmts.push(Migration::DropIndex {
+        name: "idx_tree_leaves_available",
+        table: "tree_leaves",
+    });
+    stmts.push(Migration::DropIndex {
+        name: "idx_tree_leaves_reservation",
+        table: "tree_leaves",
+    });
+    stmts.push(Migration::DropIndex {
+        name: "idx_tree_leaves_added_at",
+        table: "tree_leaves",
+    });
+    stmts.push(Migration::DropIndex {
+        name: "idx_tree_leaves_slim",
+        table: "tree_leaves",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_tree_leaves_user_available",
+        table: "tree_leaves",
+        columns: "(user_id, status, is_missing_from_operators)",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_tree_leaves_user_reservation",
+        table: "tree_leaves",
+        columns: "(user_id, reservation_id)",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_tree_leaves_user_added_at",
+        table: "tree_leaves",
+        columns: "(user_id, added_at)",
+    });
+    stmts.push(Migration::CreateIndex {
+        name: "idx_tree_leaves_user_slim",
+        table: "tree_leaves",
+        columns: "(user_id, status, is_missing_from_operators, reservation_id, value)",
+    });
+
+    // tree_spent_leaves: scope by user_id.
+    stmts.push(Migration::AddColumn {
+        table: "tree_spent_leaves",
+        column: "user_id",
+        definition: "VARBINARY(33) NULL",
+    });
+    stmts.push(Migration::Sql(format!(
+        "UPDATE tree_spent_leaves SET user_id = {id_lit} WHERE user_id IS NULL"
+    )));
+    stmts.push(Migration::sql(
+        "ALTER TABLE tree_spent_leaves MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+    ));
+    stmts.push(Migration::sql(
+        "ALTER TABLE tree_spent_leaves DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, leaf_id)",
+    ));
+
+    // tree_swap_status was a singleton (PK id=1, CHECK id=1). Drop the PK and
+    // the id column, then re-key by user_id so each tenant has its own
+    // swap-status row.
+    stmts.push(Migration::DropPrimaryKey {
+        table: "tree_swap_status",
+    });
+    stmts.push(Migration::DropColumn {
+        table: "tree_swap_status",
+        column: "id",
+    });
+    stmts.push(Migration::AddColumn {
+        table: "tree_swap_status",
+        column: "user_id",
+        definition: "VARBINARY(33) NULL",
+    });
+    stmts.push(Migration::Sql(format!(
+        "UPDATE tree_swap_status SET user_id = {id_lit} WHERE user_id IS NULL"
+    )));
+    stmts.push(Migration::sql(
+        "ALTER TABLE tree_swap_status MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+    ));
+    stmts.push(Migration::sql(
+        "ALTER TABLE tree_swap_status ADD PRIMARY KEY (user_id)",
+    ));
+
+    stmts
 }
 
 #[async_trait]
@@ -106,7 +262,7 @@ impl TreeStore for MysqlTreeStore {
         // No global write lock: `add_leaves` is scoped to inserting/updating
         // a known set of leaf rows; row-level locks + InnoDB MVCC are
         // sufficient. Mirrors the postgres impl's lock-removal change.
-        Self::add_leaves_inner(&mut conn, leaves).await?;
+        self.add_leaves_inner(&mut conn, leaves).await?;
         self.notify_balance_change();
         Ok(())
     }
@@ -118,13 +274,17 @@ impl TreeStore for MysqlTreeStore {
         // included). Avoids fetching every leaf's `data` JSON when callers
         // only need the spendable total.
         let row: Option<i64> = conn
-            .query_first(
+            .exec_first(
                 r"SELECT COALESCE(SUM(l.value), 0) AS balance
                   FROM tree_leaves l
-                  LEFT JOIN tree_reservations r ON l.reservation_id = r.id
-                  WHERE
-                      (l.reservation_id IS NULL AND l.status = 'Available')
-                      OR r.purpose = 'Swap'",
+                  LEFT JOIN tree_reservations r
+                    ON l.reservation_id = r.id AND l.user_id = r.user_id
+                  WHERE l.user_id = ?
+                    AND (
+                        (l.reservation_id IS NULL AND l.status = 'Available')
+                        OR r.purpose = 'Swap'
+                    )",
+                (self.identity.clone(),),
             )
             .await
             .map_err(map_err)?;
@@ -135,11 +295,14 @@ impl TreeStore for MysqlTreeStore {
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
 
         let rows: Vec<(String, String, bool, String, Option<String>, Option<String>)> = conn
-            .query(
+            .exec(
                 r"SELECT l.id, l.status, l.is_missing_from_operators, l.data,
                          l.reservation_id, r.purpose
                   FROM tree_leaves l
-                  LEFT JOIN tree_reservations r ON l.reservation_id = r.id",
+                  LEFT JOIN tree_reservations r
+                    ON l.reservation_id = r.id AND l.user_id = r.user_id
+                  WHERE l.user_id = ?",
+                (self.identity.clone(),),
             )
             .await
             .map_err(map_err)?;
@@ -190,15 +353,16 @@ impl TreeStore for MysqlTreeStore {
         let refresh_timestamp: DateTime<Utc> = refresh_started_at.into();
 
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
-        Self::acquire_write_lock(&mut conn).await?;
-        let result = Self::set_leaves_inner(
-            &mut conn,
-            leaves,
-            missing_operators_leaves,
-            refresh_timestamp,
-        )
-        .await;
-        Self::release_write_lock_quiet(&mut conn).await;
+        self.acquire_write_lock(&mut conn).await?;
+        let result = self
+            .set_leaves_inner(
+                &mut conn,
+                leaves,
+                missing_operators_leaves,
+                refresh_timestamp,
+            )
+            .await;
+        self.release_write_lock_quiet(&mut conn).await;
         result?;
         self.notify_balance_change();
         Ok(())
@@ -211,7 +375,8 @@ impl TreeStore for MysqlTreeStore {
     ) -> Result<(), TreeServiceError> {
         // Scoped to a single `reservation_id`; row-level FK + MVCC suffice.
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
-        Self::cancel_reservation_inner(&mut conn, id, leaves_to_keep).await?;
+        self.cancel_reservation_inner(&mut conn, id, leaves_to_keep)
+            .await?;
         self.notify_balance_change();
         Ok(())
     }
@@ -227,9 +392,11 @@ impl TreeStore for MysqlTreeStore {
         // our marker and the upsert would write the just-spent leaf back as
         // Available.
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
-        Self::acquire_write_lock(&mut conn).await?;
-        let result = Self::finalize_reservation_inner(&mut conn, id, new_leaves).await;
-        Self::release_write_lock_quiet(&mut conn).await;
+        self.acquire_write_lock(&mut conn).await?;
+        let result = self
+            .finalize_reservation_inner(&mut conn, id, new_leaves)
+            .await;
+        self.release_write_lock_quiet(&mut conn).await;
         result?;
         trace!("Finalized reservation: {id}");
         self.notify_balance_change();
@@ -247,18 +414,19 @@ impl TreeStore for MysqlTreeStore {
         let reservation_id = Uuid::now_v7().to_string();
 
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
-        Self::acquire_write_lock(&mut conn).await?;
+        self.acquire_write_lock(&mut conn).await?;
 
-        let result = Self::try_reserve_leaves_inner(
-            &mut conn,
-            &reservation_id,
-            target_amounts,
-            target_amount,
-            exact_only,
-            purpose,
-        )
-        .await;
-        Self::release_write_lock_quiet(&mut conn).await;
+        let result = self
+            .try_reserve_leaves_inner(
+                &mut conn,
+                &reservation_id,
+                target_amounts,
+                target_amount,
+                exact_only,
+                purpose,
+            )
+            .await;
+        self.release_write_lock_quiet(&mut conn).await;
         let reserve_result = result?;
         if matches!(reserve_result, ReserveResult::Success(_)) {
             self.notify_balance_change();
@@ -287,13 +455,9 @@ impl TreeStore for MysqlTreeStore {
     ) -> Result<LeavesReservation, TreeServiceError> {
         // Scoped to a single `reservation_id`; row-level FK + MVCC suffice.
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
-        let reservation = Self::update_reservation_inner(
-            &mut conn,
-            reservation_id,
-            reserved_leaves,
-            change_leaves,
-        )
-        .await?;
+        let reservation = self
+            .update_reservation_inner(&mut conn, reservation_id, reserved_leaves, change_leaves)
+            .await?;
         trace!(
             "Updated reservation {}: reserved {} leaves, added {} change leaves",
             reservation_id,
@@ -307,21 +471,28 @@ impl TreeStore for MysqlTreeStore {
 
 impl MysqlTreeStore {
     /// Creates a new `MysqlTreeStore` from a configuration.
-    pub async fn from_config(config: MysqlStorageConfig) -> Result<Self, MysqlError> {
+    /// `identity` is the 33-byte secp256k1 pubkey of the tenant.
+    pub async fn from_config(
+        config: MysqlStorageConfig,
+        identity: &[u8],
+    ) -> Result<Self, MysqlError> {
         let pool = create_pool(&config)?;
-        Self::init(pool).await
+        Self::init(pool, identity).await
     }
 
     /// Creates a new `MysqlTreeStore` from an existing connection pool.
-    pub async fn from_pool(pool: Pool) -> Result<Self, MysqlError> {
-        Self::init(pool).await
+    /// `identity` is the 33-byte secp256k1 pubkey of the tenant.
+    pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
+        Self::init(pool, identity).await
     }
 
-    async fn init(pool: Pool) -> Result<Self, MysqlError> {
+    async fn init(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
         let (balance_changed_tx, balance_changed_rx) = watch::channel(());
 
         let store = Self {
             pool,
+            identity: identity.to_vec(),
+            lock_name: identity_lock_name(TREE_STORE_LOCK_PREFIX, identity),
             balance_changed_tx: Arc::new(balance_changed_tx),
             balance_changed_rx,
         };
@@ -333,17 +504,22 @@ impl MysqlTreeStore {
     }
 
     async fn migrate(&self) -> Result<(), MysqlError> {
-        run_migrations(&self.pool, TREE_MIGRATIONS_TABLE, &Self::migrations()).await
+        run_migrations(
+            &self.pool,
+            TREE_MIGRATIONS_TABLE,
+            &Self::migrations(&self.identity),
+        )
+        .await
     }
 
-    fn migrations() -> Vec<&'static [Migration]> {
+    fn migrations(identity: &[u8]) -> Vec<Vec<Migration>> {
         vec![
             // Migration 1: Initial tree tables.
             //
             // Reservations are referenced via FK so that ON DELETE SET NULL
             // releases the leaves automatically when a reservation is dropped.
-            &[
-                Migration::Sql(
+            vec![
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS tree_reservations (
                         id VARCHAR(255) NOT NULL PRIMARY KEY,
                         purpose VARCHAR(64) NOT NULL,
@@ -351,7 +527,7 @@ impl MysqlTreeStore {
                         created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
                     )",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS tree_leaves (
                         id VARCHAR(255) NOT NULL PRIMARY KEY,
                         status VARCHAR(64) NOT NULL,
@@ -364,7 +540,7 @@ impl MysqlTreeStore {
                             REFERENCES tree_reservations(id) ON DELETE SET NULL
                     )",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS tree_spent_leaves (
                         leaf_id VARCHAR(255) NOT NULL PRIMARY KEY,
                         spent_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
@@ -387,15 +563,15 @@ impl MysqlTreeStore {
                 },
             ],
             // Migration 2: Swap status tracking.
-            &[
-                Migration::Sql(
+            vec![
+                Migration::sql(
                     "CREATE TABLE IF NOT EXISTS tree_swap_status (
                         id INT NOT NULL PRIMARY KEY DEFAULT 1,
                         last_completed_at DATETIME(6) NULL,
                         CHECK (id = 1)
                     )",
                 ),
-                Migration::Sql(
+                Migration::sql(
                     "INSERT INTO tree_swap_status (id) VALUES (1)
                      ON DUPLICATE KEY UPDATE id = id",
                 ),
@@ -406,7 +582,7 @@ impl MysqlTreeStore {
             // `(data->>'value')::bigint` expression. Also adds a composite index
             // `(status, is_missing_from_operators, reservation_id, value)` so
             // the slim selection in `try_reserve_leaves` is index-only.
-            &[
+            vec![
                 Migration::AddColumn {
                     table: "tree_leaves",
                     column: "value",
@@ -415,7 +591,7 @@ impl MysqlTreeStore {
                 // Backfill existing rows from the JSON. Re-running this is a
                 // no-op because by then `value` is already populated and the
                 // `WHERE value = 0` predicate filters everything out.
-                Migration::Sql(
+                Migration::sql(
                     "UPDATE tree_leaves
                         SET value = CAST(JSON_UNQUOTE(JSON_EXTRACT(data, '$.value')) AS UNSIGNED)
                         WHERE value = 0",
@@ -426,6 +602,12 @@ impl MysqlTreeStore {
                     columns: "(status, is_missing_from_operators, reservation_id, value)",
                 },
             ],
+            // Migration 4: Multi-tenant scoping. Adds user_id to every tree-
+            // store table, backfills with the connecting tenant's identity, and
+            // rewrites primary keys / FKs / indexes to lead with user_id. The
+            // `tree_swap_status` singleton is restructured the same way as
+            // `sync_revision` in the SDK-core storage.
+            tree_store_multi_tenant_migration(identity),
         ]
     }
 
@@ -433,13 +615,14 @@ impl MysqlTreeStore {
         let _ = self.balance_changed_tx.send(());
     }
 
-    /// Acquires the write lock for this connection. Held until `release_write_lock`
-    /// is called or the connection is returned to the pool.
-    async fn acquire_write_lock(conn: &mut Conn) -> Result<(), TreeServiceError> {
+    /// Acquires the per-tenant write lock for this connection. Held until
+    /// `release_write_lock_quiet` is called or the connection is returned to
+    /// the pool.
+    async fn acquire_write_lock(&self, conn: &mut Conn) -> Result<(), TreeServiceError> {
         let acquired: Option<i64> = conn
             .exec_first(
                 "SELECT GET_LOCK(?, ?)",
-                (TREE_STORE_WRITE_LOCK_NAME, WRITE_LOCK_TIMEOUT_SECS),
+                (self.lock_name.as_str(), WRITE_LOCK_TIMEOUT_SECS),
             )
             .await
             .map_err(map_err)?;
@@ -453,9 +636,9 @@ impl MysqlTreeStore {
 
     /// Releases the write lock, swallowing any error so it doesn't mask the
     /// caller's actual result.
-    async fn release_write_lock_quiet(conn: &mut Conn) {
+    async fn release_write_lock_quiet(&self, conn: &mut Conn) {
         let _ = conn
-            .exec_drop("SELECT RELEASE_LOCK(?)", (TREE_STORE_WRITE_LOCK_NAME,))
+            .exec_drop("SELECT RELEASE_LOCK(?)", (self.lock_name.as_str(),))
             .await;
     }
 
@@ -470,6 +653,7 @@ impl MysqlTreeStore {
     }
 
     async fn add_leaves_inner(
+        &self,
         conn: &mut Conn,
         leaves: &[TreeNode],
     ) -> Result<(), TreeServiceError> {
@@ -479,8 +663,9 @@ impl MysqlTreeStore {
             .map_err(map_err)?;
 
         let leaf_ids: Vec<String> = leaves.iter().map(|l| l.id.to_string()).collect();
-        Self::batch_remove_spent_leaves(&mut tx, &leaf_ids).await?;
-        Self::batch_upsert_leaves(&mut tx, leaves, false, None).await?;
+        self.batch_remove_spent_leaves(&mut tx, &leaf_ids).await?;
+        self.batch_upsert_leaves(&mut tx, leaves, false, None)
+            .await?;
 
         tx.commit().await.map_err(map_err)?;
         tracing::trace!(
@@ -491,6 +676,7 @@ impl MysqlTreeStore {
     }
 
     async fn set_leaves_inner(
+        &self,
         conn: &mut Conn,
         leaves: &[TreeNode],
         missing_operators_leaves: &[TreeNode],
@@ -501,19 +687,23 @@ impl MysqlTreeStore {
             .await
             .map_err(map_err)?;
 
-        Self::cleanup_stale_reservations(&mut tx).await?;
+        self.cleanup_stale_reservations(&mut tx).await?;
 
         // Check if any swap reservation is currently active, or if a swap completed
         // after this refresh started (making the refresh data potentially inconsistent).
         let row: Option<(i64, i64)> = tx
             .exec_first(
                 r"SELECT
-                    (SELECT EXISTS(SELECT 1 FROM tree_reservations WHERE purpose = 'Swap')) AS has_active_swap,
+                    (SELECT EXISTS(SELECT 1 FROM tree_reservations WHERE user_id = ? AND purpose = 'Swap')) AS has_active_swap,
                     COALESCE(
-                        (SELECT (last_completed_at >= ?) FROM tree_swap_status WHERE id = 1),
+                        (SELECT (last_completed_at >= ?) FROM tree_swap_status WHERE user_id = ?),
                         0
                     ) AS swap_completed_during_refresh",
-                (refresh_timestamp.naive_utc(),),
+                (
+                    self.identity.clone(),
+                    refresh_timestamp.naive_utc(),
+                    self.identity.clone(),
+                ),
             )
             .await
             .map_err(map_err)?;
@@ -527,19 +717,16 @@ impl MysqlTreeStore {
                 "leaf_lifecycle set_leaves: SKIP active_swap={} swap_completed_during_refresh={} refresh_timestamp={:?}",
                 has_active_swap, swap_completed_during_refresh, refresh_timestamp
             );
-            // Drop the in-flight cleanup work by letting the transaction roll
-            // back on drop, matching the postgres impl. The
-            // `cleanup_stale_reservations` DELETE is idempotent so the next
-            // refresh re-runs it harmlessly.
             return Ok(());
         }
 
-        Self::cleanup_spent_markers(&mut tx, refresh_timestamp).await?;
+        self.cleanup_spent_markers(&mut tx, refresh_timestamp)
+            .await?;
 
         let spent_rows: Vec<String> = tx
             .exec(
-                "SELECT leaf_id FROM tree_spent_leaves WHERE spent_at >= ?",
-                (refresh_timestamp.naive_utc(),),
+                "SELECT leaf_id FROM tree_spent_leaves WHERE user_id = ? AND spent_at >= ?",
+                (self.identity.clone(), refresh_timestamp.naive_utc()),
             )
             .await
             .map_err(map_err)?;
@@ -551,16 +738,20 @@ impl MysqlTreeStore {
             spent_ids
         );
 
-        // Delete non-reserved leaves added before refresh started.
+        // Delete non-reserved leaves added before refresh started. Includes
+        // leaves released earlier in this transaction by
+        // `cleanup_stale_reservations` (which clears `reservation_id`
+        // explicitly because the composite FK uses NO ACTION).
         tx.exec_drop(
-            "DELETE FROM tree_leaves WHERE reservation_id IS NULL AND added_at < ?",
-            (refresh_timestamp.naive_utc(),),
+            "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
+            (self.identity.clone(), refresh_timestamp.naive_utc()),
         )
         .await
         .map_err(map_err)?;
 
-        Self::batch_upsert_leaves(&mut tx, leaves, false, Some(&spent_ids)).await?;
-        Self::batch_upsert_leaves(&mut tx, missing_operators_leaves, true, Some(&spent_ids))
+        self.batch_upsert_leaves(&mut tx, leaves, false, Some(&spent_ids))
+            .await?;
+        self.batch_upsert_leaves(&mut tx, missing_operators_leaves, true, Some(&spent_ids))
             .await?;
 
         tx.commit().await.map_err(map_err)?;
@@ -568,6 +759,7 @@ impl MysqlTreeStore {
     }
 
     async fn cancel_reservation_inner(
+        &self,
         conn: &mut Conn,
         id: &LeavesReservationId,
         leaves_to_keep: &[TreeNode],
@@ -578,7 +770,10 @@ impl MysqlTreeStore {
             .map_err(map_err)?;
 
         let exists: Option<String> = tx
-            .exec_first("SELECT id FROM tree_reservations WHERE id = ?", (id,))
+            .exec_first(
+                "SELECT id FROM tree_reservations WHERE user_id = ? AND id = ?",
+                (self.identity.clone(), id),
+            )
             .await
             .map_err(map_err)?;
         if exists.is_none() {
@@ -587,7 +782,10 @@ impl MysqlTreeStore {
         }
 
         let prior_leaf_ids: Vec<String> = tx
-            .exec("SELECT id FROM tree_leaves WHERE reservation_id = ?", (id,))
+            .exec(
+                "SELECT id FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+                (self.identity.clone(), id),
+            )
             .await
             .map_err(map_err)?;
         let keep_ids: Vec<String> = leaves_to_keep.iter().map(|l| l.id.to_string()).collect();
@@ -600,21 +798,29 @@ impl MysqlTreeStore {
             id, prior_leaf_ids, keep_ids, dropped_ids
         );
 
-        tx.exec_drop("DELETE FROM tree_leaves WHERE reservation_id = ?", (id,))
-            .await
-            .map_err(map_err)?;
+        tx.exec_drop(
+            "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+            (self.identity.clone(), id),
+        )
+        .await
+        .map_err(map_err)?;
 
-        tx.exec_drop("DELETE FROM tree_reservations WHERE id = ?", (id,))
-            .await
-            .map_err(map_err)?;
+        tx.exec_drop(
+            "DELETE FROM tree_reservations WHERE user_id = ? AND id = ?",
+            (self.identity.clone(), id),
+        )
+        .await
+        .map_err(map_err)?;
 
-        Self::batch_upsert_leaves(&mut tx, leaves_to_keep, false, None).await?;
+        self.batch_upsert_leaves(&mut tx, leaves_to_keep, false, None)
+            .await?;
 
         tx.commit().await.map_err(map_err)?;
         Ok(())
     }
 
     async fn finalize_reservation_inner(
+        &self,
         conn: &mut Conn,
         id: &LeavesReservationId,
         new_leaves: Option<&[TreeNode]>,
@@ -625,14 +831,20 @@ impl MysqlTreeStore {
             .map_err(map_err)?;
 
         let purpose: Option<String> = tx
-            .exec_first("SELECT purpose FROM tree_reservations WHERE id = ?", (id,))
+            .exec_first(
+                "SELECT purpose FROM tree_reservations WHERE user_id = ? AND id = ?",
+                (self.identity.clone(), id),
+            )
             .await
             .map_err(map_err)?;
 
         let (is_swap, reserved_leaf_ids) = if let Some(purpose) = purpose {
             let is_swap = purpose == "Swap";
             let leaf_ids: Vec<String> = tx
-                .exec("SELECT id FROM tree_leaves WHERE reservation_id = ?", (id,))
+                .exec(
+                    "SELECT id FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+                    (self.identity.clone(), id),
+                )
                 .await
                 .map_err(map_err)?;
             (is_swap, leaf_ids)
@@ -647,15 +859,22 @@ impl MysqlTreeStore {
             reserved_leaf_ids,
             new_leaves.map_or(0, <[TreeNode]>::len)
         );
-        Self::batch_insert_spent_leaves(&mut tx, &reserved_leaf_ids).await?;
+        self.batch_insert_spent_leaves(&mut tx, &reserved_leaf_ids)
+            .await?;
 
-        tx.exec_drop("DELETE FROM tree_leaves WHERE reservation_id = ?", (id,))
-            .await
-            .map_err(map_err)?;
+        tx.exec_drop(
+            "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+            (self.identity.clone(), id),
+        )
+        .await
+        .map_err(map_err)?;
 
-        tx.exec_drop("DELETE FROM tree_reservations WHERE id = ?", (id,))
-            .await
-            .map_err(map_err)?;
+        tx.exec_drop(
+            "DELETE FROM tree_reservations WHERE user_id = ? AND id = ?",
+            (self.identity.clone(), id),
+        )
+        .await
+        .map_err(map_err)?;
 
         if let Some(leaves) = new_leaves {
             for l in leaves {
@@ -664,13 +883,21 @@ impl MysqlTreeStore {
                     l.id, l.value, id
                 );
             }
-            Self::batch_upsert_leaves(&mut tx, leaves, false, None).await?;
+            self.batch_upsert_leaves(&mut tx, leaves, false, None)
+                .await?;
         }
 
+        // If swap with new leaves, update last_completed_at. UPSERT so a
+        // tenant that joined after the multi-tenant migration (and thus has
+        // no row) gets one created lazily.
         if is_swap && new_leaves.is_some() {
-            tx.query_drop("UPDATE tree_swap_status SET last_completed_at = NOW(6) WHERE id = 1")
-                .await
-                .map_err(map_err)?;
+            tx.exec_drop(
+                "INSERT INTO tree_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
+                 ON DUPLICATE KEY UPDATE last_completed_at = VALUES(last_completed_at)",
+                (self.identity.clone(),),
+            )
+            .await
+            .map_err(map_err)?;
         }
 
         tx.commit().await.map_err(map_err)?;
@@ -679,6 +906,7 @@ impl MysqlTreeStore {
 
     #[allow(clippy::arithmetic_side_effects, clippy::too_many_lines)]
     async fn try_reserve_leaves_inner(
+        &self,
         conn: &mut Conn,
         reservation_id: &str,
         target_amounts: Option<&TargetAmounts>,
@@ -697,28 +925,27 @@ impl MysqlTreeStore {
         // WaitForPending decision. Must NOT be derived from the prefiltered
         // slim set since the prefilter excludes big leaves.
         let total_row: Option<i64> = tx
-            .query_first(
+            .exec_first(
                 r"SELECT COALESCE(SUM(value), 0) AS total
                   FROM tree_leaves
-                  WHERE status = 'Available'
+                  WHERE user_id = ?
+                    AND status = 'Available'
                     AND is_missing_from_operators = 0
                     AND reservation_id IS NULL",
+                (self.identity.clone(),),
             )
             .await
             .map_err(map_err)?;
         let available: u64 = u64::try_from(total_row.unwrap_or(0)).unwrap_or(0);
 
         // Slim projection of selection candidates: id + value only.
-        // Includes all leaves with value <= max_target (covers exact-match +
-        // minimum-amount accumulators) plus the smallest leaf with value >
-        // max_target (covers the minimum-amount fallback case where one larger
-        // leaf is sufficient).
         let max_target_signed: i64 = i64::try_from(max_target).unwrap_or(i64::MAX);
         let slim_rows: Vec<(String, i64)> = tx
             .exec(
                 r"SELECT id, value
                   FROM tree_leaves
-                  WHERE status = 'Available'
+                  WHERE user_id = ?
+                    AND status = 'Available'
                     AND is_missing_from_operators = 0
                     AND reservation_id IS NULL
                     AND (
@@ -726,7 +953,8 @@ impl MysqlTreeStore {
                       OR id = (
                         SELECT id FROM (
                           SELECT id FROM tree_leaves
-                          WHERE status = 'Available'
+                          WHERE user_id = ?
+                            AND status = 'Available'
                             AND is_missing_from_operators = 0
                             AND reservation_id IS NULL
                             AND value > ?
@@ -735,7 +963,12 @@ impl MysqlTreeStore {
                         ) AS smallest_over
                       )
                     )",
-                (max_target_signed, max_target_signed),
+                (
+                    self.identity.clone(),
+                    max_target_signed,
+                    self.identity.clone(),
+                    max_target_signed,
+                ),
             )
             .await
             .map_err(map_err)?;
@@ -748,7 +981,7 @@ impl MysqlTreeStore {
             })
             .collect();
 
-        let pending = Self::calculate_pending_balance(&mut tx).await?;
+        let pending = self.calculate_pending_balance(&mut tx).await?;
 
         // Try exact selection on the slim set — uses the same generic
         // `select_helper` algorithm as the in-memory store.
@@ -765,8 +998,8 @@ impl MysqlTreeStore {
                 if selected_ids.is_empty() {
                     return Err(TreeServiceError::NonReservableLeaves);
                 }
-                let selected_leaves = Self::resolve_full_leaves(&mut tx, &selected_ids).await?;
-                Self::create_reservation(&mut tx, reservation_id, &selected_leaves, purpose, 0)
+                let selected_leaves = self.resolve_full_leaves(&mut tx, &selected_ids).await?;
+                self.create_reservation(&mut tx, reservation_id, &selected_leaves, purpose, 0)
                     .await?;
                 tx.commit().await.map_err(map_err)?;
                 Ok(ReserveResult::Success(LeavesReservation::new(
@@ -777,14 +1010,14 @@ impl MysqlTreeStore {
             Err(_) if !exact_only => {
                 if let Ok(Some(min_slim)) = select_leaves_by_minimum_amount(&slim, target_amount) {
                     let min_ids: Vec<String> = min_slim.iter().map(|l| l.id.clone()).collect();
-                    let selected_leaves = Self::resolve_full_leaves(&mut tx, &min_ids).await?;
+                    let selected_leaves = self.resolve_full_leaves(&mut tx, &min_ids).await?;
                     let reserved_amount: u64 = selected_leaves.iter().map(|l| l.value).sum();
                     let pending_change = if reserved_amount > target_amount && target_amount > 0 {
                         reserved_amount - target_amount
                     } else {
                         0
                     };
-                    Self::create_reservation(
+                    self.create_reservation(
                         &mut tx,
                         reservation_id,
                         &selected_leaves,
@@ -859,6 +1092,7 @@ impl MysqlTreeStore {
     /// picked, preserving the algorithm's selection order. Typically 1-3 rows
     /// even when the slim candidate set was thousands.
     async fn resolve_full_leaves(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
         ids: &[String],
     ) -> Result<Vec<TreeNode>, TreeServiceError> {
@@ -866,8 +1100,12 @@ impl MysqlTreeStore {
             return Ok(Vec::new());
         }
         let placeholders = build_placeholders(ids.len());
-        let sql = format!("SELECT id, data FROM tree_leaves WHERE id IN ({placeholders})");
-        let params: Vec<Value> = ids.iter().cloned().map(Value::from).collect();
+        let sql = format!(
+            "SELECT id, data FROM tree_leaves WHERE user_id = ? AND id IN ({placeholders})"
+        );
+        let mut params: Vec<Value> = Vec::with_capacity(ids.len().saturating_add(1));
+        params.push(Value::from(self.identity.clone()));
+        params.extend(ids.iter().cloned().map(Value::from));
         let rows: Vec<(String, String)> = tx
             .exec(&sql, Params::Positional(params))
             .await
@@ -889,6 +1127,7 @@ impl MysqlTreeStore {
     }
 
     async fn update_reservation_inner(
+        &self,
         conn: &mut Conn,
         reservation_id: &LeavesReservationId,
         reserved_leaves: &[TreeNode],
@@ -901,8 +1140,8 @@ impl MysqlTreeStore {
 
         let exists: Option<String> = tx
             .exec_first(
-                "SELECT id FROM tree_reservations WHERE id = ?",
-                (reservation_id,),
+                "SELECT id FROM tree_reservations WHERE user_id = ? AND id = ?",
+                (self.identity.clone(), reservation_id),
             )
             .await
             .map_err(map_err)?;
@@ -915,29 +1154,33 @@ impl MysqlTreeStore {
 
         let old_reserved_leaf_ids: Vec<String> = tx
             .exec(
-                "SELECT id FROM tree_leaves WHERE reservation_id = ?",
-                (reservation_id,),
+                "SELECT id FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+                (self.identity.clone(), reservation_id),
             )
             .await
             .map_err(map_err)?;
 
-        Self::batch_insert_spent_leaves(&mut tx, &old_reserved_leaf_ids).await?;
+        self.batch_insert_spent_leaves(&mut tx, &old_reserved_leaf_ids)
+            .await?;
         tx.exec_drop(
-            "DELETE FROM tree_leaves WHERE reservation_id = ?",
-            (reservation_id,),
+            "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+            (self.identity.clone(), reservation_id),
         )
         .await
         .map_err(map_err)?;
 
-        Self::batch_upsert_leaves(&mut tx, change_leaves, false, None).await?;
-        Self::batch_upsert_leaves(&mut tx, reserved_leaves, false, None).await?;
+        self.batch_upsert_leaves(&mut tx, change_leaves, false, None)
+            .await?;
+        self.batch_upsert_leaves(&mut tx, reserved_leaves, false, None)
+            .await?;
 
         let leaf_ids: Vec<String> = reserved_leaves.iter().map(|l| l.id.to_string()).collect();
-        Self::batch_set_reservation_id(&mut tx, reservation_id, &leaf_ids).await?;
+        self.batch_set_reservation_id(&mut tx, reservation_id, &leaf_ids)
+            .await?;
 
         tx.exec_drop(
-            "UPDATE tree_reservations SET pending_change_amount = 0 WHERE id = ?",
-            (reservation_id,),
+            "UPDATE tree_reservations SET pending_change_amount = 0 WHERE user_id = ? AND id = ?",
+            (self.identity.clone(), reservation_id),
         )
         .await
         .map_err(map_err)?;
@@ -951,10 +1194,14 @@ impl MysqlTreeStore {
     }
 
     async fn calculate_pending_balance(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
     ) -> Result<u64, TreeServiceError> {
         let row: Option<i64> = tx
-            .query_first("SELECT COALESCE(SUM(pending_change_amount), 0) FROM tree_reservations")
+            .exec_first(
+                "SELECT COALESCE(SUM(pending_change_amount), 0) FROM tree_reservations WHERE user_id = ?",
+                (self.identity.clone(),),
+            )
             .await
             .map_err(map_err)?;
 
@@ -966,6 +1213,7 @@ impl MysqlTreeStore {
     /// Uses `ON DUPLICATE KEY UPDATE` to replace existing leaves.
     #[allow(clippy::arithmetic_side_effects)] // `len * 4` for params capacity, bounded by leaves slice
     async fn batch_upsert_leaves(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
         leaves: &[TreeNode],
         is_missing_from_operators: bool,
@@ -993,18 +1241,19 @@ impl MysqlTreeStore {
             return Ok(());
         }
 
-        // Build VALUES (?, ?, ?, ?, ?, NOW(6)), …
+        // Build VALUES (?, ?, ?, ?, ?, ?, NOW(6)), … with user_id as the first column.
         let mut sql = String::from(
-            "INSERT INTO tree_leaves (id, status, is_missing_from_operators, data, value, added_at) VALUES ",
+            "INSERT INTO tree_leaves (user_id, id, status, is_missing_from_operators, data, value, added_at) VALUES ",
         );
-        let mut params: Vec<Value> = Vec::with_capacity(filtered.len() * 5);
+        let mut params: Vec<Value> = Vec::with_capacity(filtered.len() * 6);
         for (i, leaf) in filtered.iter().enumerate() {
             if i > 0 {
                 sql.push_str(", ");
             }
-            sql.push_str("(?, ?, ?, ?, ?, NOW(6))");
+            sql.push_str("(?, ?, ?, ?, ?, ?, NOW(6))");
             #[allow(clippy::cast_possible_wrap)]
             let value_i64 = leaf.value as i64;
+            params.push(Value::from(self.identity.clone()));
             params.push(Value::from(leaf.id.to_string()));
             params.push(Value::from(leaf.status.to_string()));
             params.push(Value::from(is_missing_from_operators));
@@ -1027,8 +1276,9 @@ impl MysqlTreeStore {
         Ok(())
     }
 
-    #[allow(clippy::arithmetic_side_effects)] // `len + 1` for params capacity
+    #[allow(clippy::arithmetic_side_effects)] // `len + 2` for params capacity
     async fn batch_set_reservation_id(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
         reservation_id: &str,
         leaf_ids: &[String],
@@ -1038,10 +1288,13 @@ impl MysqlTreeStore {
         }
 
         let placeholders = build_placeholders(leaf_ids.len());
-        let sql = format!("UPDATE tree_leaves SET reservation_id = ? WHERE id IN ({placeholders})");
+        let sql = format!(
+            "UPDATE tree_leaves SET reservation_id = ? WHERE user_id = ? AND id IN ({placeholders})"
+        );
 
-        let mut params: Vec<Value> = Vec::with_capacity(leaf_ids.len() + 1);
+        let mut params: Vec<Value> = Vec::with_capacity(leaf_ids.len() + 2);
         params.push(Value::from(reservation_id));
+        params.push(Value::from(self.identity.clone()));
         for id in leaf_ids {
             params.push(Value::from(id.clone()));
         }
@@ -1054,6 +1307,7 @@ impl MysqlTreeStore {
     }
 
     async fn batch_insert_spent_leaves(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
         leaf_ids: &[String],
     ) -> Result<(), TreeServiceError> {
@@ -1061,13 +1315,14 @@ impl MysqlTreeStore {
             return Ok(());
         }
 
-        let mut sql = String::from("INSERT INTO tree_spent_leaves (leaf_id) VALUES ");
-        let mut params: Vec<Value> = Vec::with_capacity(leaf_ids.len());
+        let mut sql = String::from("INSERT INTO tree_spent_leaves (user_id, leaf_id) VALUES ");
+        let mut params: Vec<Value> = Vec::with_capacity(leaf_ids.len().saturating_mul(2));
         for (i, id) in leaf_ids.iter().enumerate() {
             if i > 0 {
                 sql.push_str(", ");
             }
-            sql.push_str("(?)");
+            sql.push_str("(?, ?)");
+            params.push(Value::from(self.identity.clone()));
             params.push(Value::from(id.clone()));
         }
         // Suppress duplicate-PK errors only — unlike INSERT IGNORE, real
@@ -1083,6 +1338,7 @@ impl MysqlTreeStore {
     }
 
     async fn batch_remove_spent_leaves(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
         leaf_ids: &[String],
     ) -> Result<(), TreeServiceError> {
@@ -1091,9 +1347,13 @@ impl MysqlTreeStore {
         }
 
         let placeholders = build_placeholders(leaf_ids.len());
-        let sql = format!("DELETE FROM tree_spent_leaves WHERE leaf_id IN ({placeholders})");
+        let sql = format!(
+            "DELETE FROM tree_spent_leaves WHERE user_id = ? AND leaf_id IN ({placeholders})"
+        );
 
-        let params: Vec<Value> = leaf_ids.iter().cloned().map(Value::from).collect();
+        let mut params: Vec<Value> = Vec::with_capacity(leaf_ids.len().saturating_add(1));
+        params.push(Value::from(self.identity.clone()));
+        params.extend(leaf_ids.iter().cloned().map(Value::from));
         let mut result = tx
             .exec_iter(&sql, Params::Positional(params))
             .await
@@ -1112,14 +1372,39 @@ impl MysqlTreeStore {
         Ok(())
     }
 
+    /// Cleans up stale reservations for THIS tenant. Releases dependent leaves
+    /// by clearing their `reservation_id` first, then deletes the parent
+    /// reservation rows — the composite FK uses NO ACTION because column-list
+    /// SET NULL would null `user_id` (NOT NULL).
     async fn cleanup_stale_reservations(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
     ) -> Result<u64, TreeServiceError> {
+        // Release dependent leaves before dropping the parent rows.
+        tx.exec_drop(
+            r"UPDATE tree_leaves SET reservation_id = NULL
+              WHERE user_id = ?
+                AND reservation_id IN (
+                    SELECT id FROM (
+                        SELECT id FROM tree_reservations
+                        WHERE user_id = ?
+                          AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
+                    ) AS stale
+                )",
+            (
+                self.identity.clone(),
+                self.identity.clone(),
+                RESERVATION_TIMEOUT_SECS,
+            ),
+        )
+        .await
+        .map_err(map_err)?;
+
         let mut result = tx
             .exec_iter(
                 "DELETE FROM tree_reservations
-                 WHERE created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)",
-                (RESERVATION_TIMEOUT_SECS,),
+                 WHERE user_id = ? AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)",
+                (self.identity.clone(), RESERVATION_TIMEOUT_SECS),
             )
             .await
             .map_err(map_err)?;
@@ -1134,6 +1419,7 @@ impl MysqlTreeStore {
     }
 
     async fn cleanup_spent_markers(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
         refresh_timestamp: DateTime<Utc>,
     ) -> Result<u64, TreeServiceError> {
@@ -1144,8 +1430,8 @@ impl MysqlTreeStore {
 
         let mut result = tx
             .exec_iter(
-                "DELETE FROM tree_spent_leaves WHERE spent_at < ?",
-                (cleanup_cutoff.naive_utc(),),
+                "DELETE FROM tree_spent_leaves WHERE user_id = ? AND spent_at < ?",
+                (self.identity.clone(), cleanup_cutoff.naive_utc()),
             )
             .await
             .map_err(map_err)?;
@@ -1160,6 +1446,7 @@ impl MysqlTreeStore {
     }
 
     async fn create_reservation(
+        &self,
         tx: &mut mysql_async::Transaction<'_>,
         reservation_id: &str,
         leaves: &[TreeNode],
@@ -1170,8 +1457,8 @@ impl MysqlTreeStore {
         let pending_i64 = pending_change as i64;
 
         tx.exec_drop(
-            "INSERT INTO tree_reservations (id, purpose, pending_change_amount) VALUES (?, ?, ?)",
-            (reservation_id, purpose.to_string(), pending_i64),
+            "INSERT INTO tree_reservations (user_id, id, purpose, pending_change_amount) VALUES (?, ?, ?, ?)",
+            (self.identity.clone(), reservation_id, purpose.to_string(), pending_i64),
         )
         .await
         .map_err(map_err)?;
@@ -1181,7 +1468,8 @@ impl MysqlTreeStore {
             "leaf_lifecycle reserve: reservation={} purpose={:?} leaf_ids={:?}",
             reservation_id, purpose, leaf_ids
         );
-        Self::batch_set_reservation_id(tx, reservation_id, &leaf_ids).await?;
+        self.batch_set_reservation_id(tx, reservation_id, &leaf_ids)
+            .await?;
 
         Ok(())
     }
@@ -1204,17 +1492,25 @@ fn map_err<E: std::fmt::Display>(e: E) -> TreeServiceError {
 }
 
 /// Creates a `MysqlTreeStore` instance from a configuration.
+///
+/// `identity` is the 33-byte secp256k1 pubkey scoping all reads and writes.
 pub async fn create_mysql_tree_store(
     config: MysqlStorageConfig,
+    identity: &[u8],
 ) -> Result<Arc<dyn TreeStore>, MysqlError> {
-    Ok(Arc::new(MysqlTreeStore::from_config(config).await?))
+    Ok(Arc::new(
+        MysqlTreeStore::from_config(config, identity).await?,
+    ))
 }
 
 /// Creates a `MysqlTreeStore` instance from an existing connection pool.
+///
+/// `identity` is the 33-byte secp256k1 pubkey scoping all reads and writes.
 pub async fn create_mysql_tree_store_from_pool(
     pool: Pool,
+    identity: &[u8],
 ) -> Result<Arc<dyn TreeStore>, MysqlError> {
-    Ok(Arc::new(MysqlTreeStore::from_pool(pool).await?))
+    Ok(Arc::new(MysqlTreeStore::from_pool(pool, identity).await?))
 }
 
 #[cfg(test)]
@@ -1224,6 +1520,14 @@ mod tests {
     use std::sync::Arc;
     use testcontainers::{ContainerAsync, runners::AsyncRunner};
     use testcontainers_modules::mysql::Mysql;
+
+    /// Fixed 33-byte test identity. Tests run in their own ephemeral container,
+    /// so a single shared identity is fine — the schema still gets exercised.
+    pub(super) const TEST_IDENTITY: [u8; 33] = [
+        0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+        0x1e, 0x1f, 0x20,
+    ];
 
     /// Helper struct that holds the container and store together.
     /// The container must be kept alive for the duration of the test.
@@ -1249,10 +1553,12 @@ mod tests {
             // and no password.
             let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
 
-            let store =
-                MysqlTreeStore::from_config(MysqlStorageConfig::with_defaults(connection_string))
-                    .await
-                    .expect("Failed to create MysqlTreeStore");
+            let store = MysqlTreeStore::from_config(
+                MysqlStorageConfig::with_defaults(connection_string),
+                &TEST_IDENTITY,
+            )
+            .await
+            .expect("Failed to create MysqlTreeStore");
 
             Self { store, container }
         }
@@ -1743,12 +2049,14 @@ mod tests {
         .await
         .unwrap();
 
-        // Hold the named lock on a separate connection so finalize must wait.
+        // Hold the per-tenant named lock on a separate connection so finalize
+        // must wait. Must use the same lock name as `acquire_write_lock`.
+        let lock_name = fixture.store.lock_name.clone();
         let mut holder = fixture.store.pool.get_conn().await.unwrap();
         let acquired: Option<i64> = holder
             .exec_first(
                 "SELECT GET_LOCK(?, ?)",
-                (TREE_STORE_WRITE_LOCK_NAME, WRITE_LOCK_TIMEOUT_SECS),
+                (lock_name.as_str(), WRITE_LOCK_TIMEOUT_SECS),
             )
             .await
             .unwrap();
@@ -1771,7 +2079,7 @@ mod tests {
 
         // Release the lock — finalize should complete shortly.
         holder
-            .exec_drop("SELECT RELEASE_LOCK(?)", (TREE_STORE_WRITE_LOCK_NAME,))
+            .exec_drop("SELECT RELEASE_LOCK(?)", (lock_name.as_str(),))
             .await
             .unwrap();
         drop(holder);
@@ -1790,5 +2098,506 @@ mod tests {
                 .any(|l| l.id.to_string() == "locked_leaf"),
             "Spent leaf should not be Available"
         );
+    }
+
+    #[tokio::test]
+    async fn test_fresh_reservation_not_cleaned_up() {
+        // Test that fresh (non-stale) reservations are NOT cleaned up during set_leaves
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        let leaves = vec![
+            create_test_tree_node("node1", 100),
+            create_test_tree_node("node2", 200),
+        ];
+        fixture.store.add_leaves(&leaves).await.unwrap();
+
+        // Create a reservation (this will have a fresh created_at timestamp)
+        let _reservation = reserve_leaves(
+            &fixture.store,
+            Some(&TargetAmounts::new_amount_and_fee(100, None)),
+            true,
+            ReservationPurpose::Payment,
+        )
+        .await
+        .unwrap();
+
+        // Verify the reservation exists
+        let all_leaves = fixture.store.get_leaves().await.unwrap();
+        assert_eq!(all_leaves.reserved_for_payment.len(), 1);
+
+        // Call set_leaves - should NOT clean up fresh reservation
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let refresh_start = SystemTime::now();
+        let refresh_leaves = vec![
+            create_test_tree_node("node1", 100),
+            create_test_tree_node("node2", 200),
+        ];
+        fixture
+            .store
+            .set_leaves(&refresh_leaves, &[], refresh_start)
+            .await
+            .unwrap();
+
+        // Verify the fresh reservation was NOT cleaned up
+        let all_leaves = fixture.store.get_leaves().await.unwrap();
+        assert_eq!(
+            all_leaves.reserved_for_payment.len(),
+            1,
+            "Fresh reservation should NOT be cleaned up"
+        );
+        assert_eq!(all_leaves.available.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_stale_swap_reservation_does_not_block_set_leaves() {
+        // Regression test: a stale Swap reservation must be cleaned up before
+        // has_active_swap is evaluated, otherwise the reservation pins itself in
+        // place — set_leaves early-returns on has_active_swap, never reaches the
+        // cleanup, and the wallet's leaf set freezes at the snapshot when the swap
+        // started.
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        let leaves = vec![
+            create_test_tree_node("node1", 100),
+            create_test_tree_node("node2", 200),
+        ];
+        fixture.store.add_leaves(&leaves).await.unwrap();
+
+        let reservation = reserve_leaves(
+            &fixture.store,
+            Some(&TargetAmounts::new_amount_and_fee(100, None)),
+            true,
+            ReservationPurpose::Swap,
+        )
+        .await
+        .unwrap();
+
+        let all_leaves = fixture.store.get_leaves().await.unwrap();
+        assert_eq!(all_leaves.reserved_for_swap.len(), 1);
+        assert_eq!(all_leaves.available.len(), 1);
+
+        // Backdate the swap reservation past the 5-minute timeout.
+        let mut conn = fixture.store.pool.get_conn().await.unwrap();
+        conn.exec_drop(
+            "UPDATE tree_reservations SET created_at = DATE_SUB(NOW(6), INTERVAL 10 MINUTE) WHERE id = ?",
+            (&reservation.id,),
+        )
+        .await
+        .unwrap();
+        drop(conn);
+
+        // set_leaves brings fresh data from the operator that includes both leaves
+        // plus a new one. Pre-fix: skipped on has_active_swap, the new leaf is lost
+        // and the reservation lingers forever. Post-fix: cleanup runs first, the
+        // stale reservation is dropped, has_active_swap is false, set_leaves applies.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let refresh_start = SystemTime::now();
+        let refresh_leaves = vec![
+            create_test_tree_node("node1", 100),
+            create_test_tree_node("node2", 200),
+            create_test_tree_node("node3", 300),
+        ];
+        fixture
+            .store
+            .set_leaves(&refresh_leaves, &[], refresh_start)
+            .await
+            .unwrap();
+
+        let all_leaves = fixture.store.get_leaves().await.unwrap();
+        assert!(
+            all_leaves.reserved_for_swap.is_empty(),
+            "Stale swap reservation should be cleaned up"
+        );
+        assert_eq!(
+            all_leaves.available.len(),
+            3,
+            "set_leaves should have proceeded and applied the operator's view (3 leaves)"
+        );
+        assert!(
+            all_leaves
+                .available
+                .iter()
+                .any(|l| l.id.to_string() == "node3"),
+            "node3 from the refresh should be present"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_reserve_cancel_cycle() {
+        // Test rapid reserve/cancel cycles don't deadlock
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        let store = Arc::new(fixture.store);
+
+        // Add leaves
+        let mut leaves = Vec::new();
+        for i in 0..20 {
+            leaves.push(create_test_tree_node(&format!("node{i}"), 10));
+        }
+        store.add_leaves(&leaves).await.unwrap();
+
+        // Spawn concurrent reserve/cancel cycles using JoinSet
+        let mut join_set = tokio::task::JoinSet::new();
+        for i in 0..5 {
+            let store_clone = Arc::clone(&store);
+            join_set.spawn(async move {
+                for cycle in 0..3 {
+                    let result = store_clone
+                        .try_reserve_leaves(
+                            Some(&TargetAmounts::new_amount_and_fee(10, None)),
+                            true,
+                            ReservationPurpose::Payment,
+                        )
+                        .await?;
+
+                    if let ReserveResult::Success(reservation) = result {
+                        store_clone
+                            .cancel_reservation(&reservation.id, &reservation.leaves)
+                            .await?;
+                    }
+                    tracing::debug!("Task {i} cycle {cycle} complete");
+                }
+                Ok::<_, TreeServiceError>((i, "completed cycles"))
+            });
+        }
+
+        // Wait for all with global timeout
+        tokio::time::timeout(std::time::Duration::from_mins(1), async {
+            while let Some(result) = join_set.join_next().await {
+                match result {
+                    Ok(Ok((i, msg))) => tracing::info!("Task {i}: {msg}"),
+                    Ok(Err(e)) => panic!("Task failed with error: {e:?}"),
+                    Err(e) => panic!("Task panicked: {e:?}"),
+                }
+            }
+        })
+        .await
+        .expect("Test timed out - possible deadlock");
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_set_leaves_and_reserve() {
+        // Test that concurrent set_leaves and reserve operations don't deadlock
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        let store = Arc::new(fixture.store);
+
+        // Add initial leaves
+        let mut leaves = Vec::new();
+        for i in 0..50 {
+            leaves.push(create_test_tree_node(&format!("node{i}"), 10));
+        }
+        store.add_leaves(&leaves).await.unwrap();
+
+        // Small delay to ensure leaves are added
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // Spawn concurrent operations using JoinSet
+        let mut join_set = tokio::task::JoinSet::new();
+
+        // Spawn set_leaves tasks
+        for i in 0..2 {
+            let store_clone = Arc::clone(&store);
+            join_set.spawn(async move {
+                let refresh_start = SystemTime::now();
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+                let mut new_leaves = Vec::new();
+                for j in 0..50 {
+                    new_leaves.push(create_test_tree_node(&format!("node{j}"), 10));
+                }
+
+                store_clone
+                    .set_leaves(&new_leaves, &[], refresh_start)
+                    .await
+                    .map(|()| (i, "set_leaves complete"))
+            });
+        }
+
+        // Spawn reserve tasks
+        for i in 0..5 {
+            let store_clone = Arc::clone(&store);
+            join_set.spawn(async move {
+                let result = store_clone
+                    .try_reserve_leaves(
+                        Some(&TargetAmounts::new_amount_and_fee(10, None)),
+                        true,
+                        ReservationPurpose::Payment,
+                    )
+                    .await;
+
+                match result {
+                    Ok(ReserveResult::Success(reservation)) => {
+                        store_clone
+                            .cancel_reservation(&reservation.id, &reservation.leaves)
+                            .await?;
+                        Ok((100 + i, "reserve success"))
+                    }
+                    Ok(_) => Ok((100 + i, "no leaves available")),
+                    Err(e) => Err(e),
+                }
+            });
+        }
+
+        // Wait for all with global timeout
+        tokio::time::timeout(std::time::Duration::from_mins(1), async {
+            while let Some(result) = join_set.join_next().await {
+                match result {
+                    Ok(Ok((i, msg))) => tracing::info!("Task {i}: {msg}"),
+                    Ok(Err(e)) => panic!("Task failed with error: {e:?}"),
+                    Err(e) => panic!("Task panicked: {e:?}"),
+                }
+            }
+        })
+        .await
+        .expect("Test timed out - possible deadlock");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::arithmetic_side_effects)]
+    async fn test_high_concurrency_reserve_finalize() {
+        // Stress test: 50 concurrent payment-like operations (reserve -> finalize)
+        // This simulates the parallel_perf benchmark scenario.
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        let store = Arc::new(fixture.store);
+
+        // Add many small leaves
+        let mut leaves = Vec::new();
+        for i in 0..200 {
+            leaves.push(create_test_tree_node(&format!("leaf{i}"), 1));
+        }
+        store.add_leaves(&leaves).await.unwrap();
+
+        // Spawn 50 concurrent reserve->finalize operations
+        let start_time = std::time::Instant::now();
+        let mut join_set: tokio::task::JoinSet<Result<(i32, &'static str), TreeServiceError>> =
+            tokio::task::JoinSet::new();
+        for i in 0..50 {
+            let store_clone = Arc::clone(&store);
+            join_set.spawn(async move {
+                // Reserve 1 sat
+                let result = store_clone
+                    .try_reserve_leaves(
+                        Some(&TargetAmounts::new_amount_and_fee(1, None)),
+                        true,
+                        ReservationPurpose::Payment,
+                    )
+                    .await?;
+
+                match result {
+                    ReserveResult::Success(reservation) => {
+                        // Finalize immediately (simulating successful payment)
+                        store_clone
+                            .finalize_reservation(&reservation.id, None)
+                            .await?;
+                        Ok((i, "success"))
+                    }
+                    ReserveResult::InsufficientFunds => Ok((i, "insufficient")),
+                    ReserveResult::WaitForPending { .. } => Ok((i, "wait_pending")),
+                }
+            });
+        }
+
+        // Wait for all with timeout
+        let mut successes = 0;
+        let mut insufficient = 0;
+        let timeout_result = tokio::time::timeout(std::time::Duration::from_mins(2), async {
+            while let Some(result) = join_set.join_next().await {
+                match result {
+                    Ok(Ok((i, status))) => {
+                        tracing::debug!("Task {i}: {status}");
+                        if status == "success" {
+                            successes += 1;
+                        } else if status == "insufficient" {
+                            insufficient += 1;
+                        }
+                    }
+                    Ok(Err(e)) => panic!("Task failed with error: {e:?}"),
+                    Err(e) => panic!("Task panicked: {e:?}"),
+                }
+            }
+            (successes, insufficient)
+        })
+        .await
+        .expect("Test timed out after 120s - possible deadlock");
+
+        let elapsed = start_time.elapsed();
+        eprintln!(
+            "50 concurrent reserve+finalize completed in {:?} ({} successes, {} insufficient)",
+            elapsed, timeout_result.0, timeout_result.1
+        );
+
+        // With 200 leaves and 50 concurrent requests for 1 sat each,
+        // we should have at least some successes
+        assert!(
+            timeout_result.0 > 0,
+            "Expected at least one successful reservation"
+        );
+    }
+
+    // ==================== Multi-tenant isolation ====================
+
+    /// A second 33-byte test identity (must differ from `TEST_IDENTITY`).
+    const TEST_IDENTITY_B: [u8; 33] = [
+        0x03, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae,
+        0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd,
+        0xbe, 0xbf, 0xc0,
+    ];
+
+    /// Two `MysqlTreeStore` instances with distinct identities sharing one
+    /// connection pool / DB. The container must be kept alive for the test.
+    struct TwoTenantTreeFixture {
+        a: MysqlTreeStore,
+        b: MysqlTreeStore,
+        #[allow(dead_code)]
+        container: ContainerAsync<Mysql>,
+    }
+
+    impl TwoTenantTreeFixture {
+        async fn new() -> Self {
+            let container = Mysql::default()
+                .start()
+                .await
+                .expect("Failed to start MySQL container");
+
+            let host_port = container
+                .get_host_port_ipv4(3306)
+                .await
+                .expect("Failed to get host port");
+
+            let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
+
+            let config = MysqlStorageConfig::with_defaults(connection_string);
+            let pool = create_pool(&config).expect("Failed to create pool");
+
+            let a = MysqlTreeStore::from_pool(pool.clone(), &TEST_IDENTITY)
+                .await
+                .expect("Failed to create tenant A");
+            let b = MysqlTreeStore::from_pool(pool, &TEST_IDENTITY_B)
+                .await
+                .expect("Failed to create tenant B");
+
+            Self { a, b, container }
+        }
+    }
+
+    /// End-to-end isolation: every `TreeStore` method must keep tenants A and B
+    /// from observing each other's data. Exercises leaves, reservations, the
+    /// finalize→spent path, and the per-tenant swap-status row, asserting that
+    /// writes by A are invisible to B (and vice versa). Uses identical leaf
+    /// IDs across tenants to also confirm the composite primary keys land.
+    #[tokio::test]
+    async fn test_two_tenant_isolation() {
+        let fx = TwoTenantTreeFixture::new().await;
+
+        // --- add_leaves: same IDs, different per-tenant values ---
+        let leaves_a = vec![
+            create_test_tree_node("shared_leaf_1", 100),
+            create_test_tree_node("shared_leaf_2", 200),
+        ];
+        let leaves_b = vec![
+            create_test_tree_node("shared_leaf_1", 1_000),
+            create_test_tree_node("shared_leaf_2", 2_000),
+            create_test_tree_node("only_b_leaf", 500),
+        ];
+        fx.a.add_leaves(&leaves_a).await.unwrap();
+        fx.b.add_leaves(&leaves_b).await.unwrap();
+
+        let view_a = fx.a.get_leaves().await.unwrap();
+        let view_b = fx.b.get_leaves().await.unwrap();
+        assert_eq!(view_a.available.len(), 2, "A sees its 2 leaves");
+        assert_eq!(view_b.available.len(), 3, "B sees its 3 leaves");
+        assert!(
+            !view_a
+                .available
+                .iter()
+                .any(|l| l.id.to_string() == "only_b_leaf")
+        );
+        assert_eq!(
+            view_a.available.iter().map(|l| l.value).sum::<u64>(),
+            300,
+            "A's total reflects A's amounts only"
+        );
+        assert_eq!(
+            view_b.available.iter().map(|l| l.value).sum::<u64>(),
+            3_500,
+            "B's total reflects B's amounts only"
+        );
+
+        assert_eq!(fx.a.get_available_balance().await.unwrap(), 300);
+        assert_eq!(fx.b.get_available_balance().await.unwrap(), 3_500);
+
+        // --- reserve_leaves on A must not consume B's leaves ---
+        let res_a = shared_tests::reserve_leaves(
+            &fx.a,
+            Some(&TargetAmounts::new_amount_and_fee(100, None)),
+            true,
+            ReservationPurpose::Payment,
+        )
+        .await
+        .unwrap();
+        assert_eq!(res_a.leaves.len(), 1);
+
+        let view_b = fx.b.get_leaves().await.unwrap();
+        assert!(view_b.reserved_for_payment.is_empty());
+        assert_eq!(view_b.available.len(), 3);
+        assert_eq!(fx.b.get_available_balance().await.unwrap(), 3_500);
+
+        let view_a = fx.a.get_leaves().await.unwrap();
+        assert_eq!(view_a.reserved_for_payment.len(), 1);
+        assert_eq!(view_a.available.len(), 1);
+
+        // --- finalize on A (spent marker) does not touch B's identical-ID leaf ---
+        fx.a.finalize_reservation(&res_a.id, None).await.unwrap();
+
+        let view_a = fx.a.get_leaves().await.unwrap();
+        assert!(
+            !view_a
+                .available
+                .iter()
+                .any(|l| l.id.to_string() == "shared_leaf_1")
+        );
+        let view_b = fx.b.get_leaves().await.unwrap();
+        assert!(
+            view_b
+                .available
+                .iter()
+                .any(|l| l.id.to_string() == "shared_leaf_1"),
+            "B's shared_leaf_1 must survive A's finalize"
+        );
+
+        // --- set_leaves on A must not touch B's data ---
+        let refresh_start = SystemTime::now();
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let refresh_a = vec![create_test_tree_node("a_only_post_refresh", 42)];
+        fx.a.set_leaves(&refresh_a, &[], refresh_start)
+            .await
+            .unwrap();
+
+        let view_a = fx.a.get_leaves().await.unwrap();
+        assert_eq!(view_a.available.len(), 1);
+        assert_eq!(view_a.available[0].id.to_string(), "a_only_post_refresh");
+        let view_b = fx.b.get_leaves().await.unwrap();
+        assert_eq!(view_b.available.len(), 3, "B unaffected by A's set_leaves");
+
+        // --- B can perform a swap-finalize without A's swap-status row ever
+        // existing (lazy upsert per tenant). B's reservation must not block A. ---
+        let res_b_swap = shared_tests::reserve_leaves(
+            &fx.b,
+            Some(&TargetAmounts::new_amount_and_fee(1_000, None)),
+            true,
+            ReservationPurpose::Swap,
+        )
+        .await
+        .unwrap();
+        let view_a = fx.a.get_leaves().await.unwrap();
+        assert!(
+            view_a.reserved_for_swap.is_empty(),
+            "A must not see B's swap reservation"
+        );
+        let new_b_leaf = create_test_tree_node("b_swap_change", 600);
+        fx.b.finalize_reservation(&res_b_swap.id, Some(&[new_b_leaf]))
+            .await
+            .unwrap();
+
+        let view_a = fx.a.get_leaves().await.unwrap();
+        assert_eq!(view_a.available.len(), 1);
+        assert_eq!(view_a.available[0].id.to_string(), "a_only_post_refresh");
     }
 }

--- a/crates/spark-postgres/Cargo.toml
+++ b/crates/spark-postgres/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 async-trait.workspace = true
+bitcoin.workspace = true
 chrono.workspace = true
 deadpool.workspace = true
 deadpool-postgres.workspace = true
@@ -19,7 +20,6 @@ macros.workspace = true
 platform-utils.workspace = true
 rustls.workspace = true
 serde.workspace = true
-sha2.workspace = true
 serde_json.workspace = true
 spark-wallet.workspace = true
 thiserror.workspace = true

--- a/crates/spark-postgres/Cargo.toml
+++ b/crates/spark-postgres/Cargo.toml
@@ -14,6 +14,7 @@ async-trait.workspace = true
 chrono.workspace = true
 deadpool.workspace = true
 deadpool-postgres.workspace = true
+hex.workspace = true
 macros.workspace = true
 platform-utils.workspace = true
 rustls.workspace = true

--- a/crates/spark-postgres/Cargo.toml
+++ b/crates/spark-postgres/Cargo.toml
@@ -19,6 +19,7 @@ macros.workspace = true
 platform-utils.workspace = true
 rustls.workspace = true
 serde.workspace = true
+sha2.workspace = true
 serde_json.workspace = true
 spark-wallet.workspace = true
 thiserror.workspace = true

--- a/crates/spark-postgres/src/advisory_lock.rs
+++ b/crates/spark-postgres/src/advisory_lock.rs
@@ -1,0 +1,23 @@
+//! Helpers for deriving per-tenant `PostgreSQL` advisory-lock keys.
+//!
+//! Each store (tree, token, …) picks its own domain prefix and combines it with
+//! the tenant identity pubkey via SHA-256, taking the first 8 bytes of the
+//! digest as a 64-bit lock key. The 64-bit space keeps cross-tenant collisions
+//! negligible (~1.2e-10 at 65k tenants) while distinct prefixes guarantee that
+//! locks from different stores never collide.
+
+use sha2::{Digest, Sha256};
+
+/// Derives a stable 64-bit advisory-lock key from a tenant identity pubkey.
+/// Hashes a domain prefix together with the identity and folds the first 8
+/// bytes of the SHA-256 digest into an `i64` (the type expected by
+/// `pg_advisory_xact_lock(bigint)`).
+pub(crate) fn identity_lock_key(prefix: &[u8], identity: &[u8]) -> i64 {
+    let mut hasher = Sha256::new();
+    hasher.update(prefix);
+    hasher.update(identity);
+    let digest = hasher.finalize();
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(&digest[..8]);
+    i64::from_be_bytes(buf)
+}

--- a/crates/spark-postgres/src/advisory_lock.rs
+++ b/crates/spark-postgres/src/advisory_lock.rs
@@ -6,18 +6,18 @@
 //! negligible (~1.2e-10 at 65k tenants) while distinct prefixes guarantee that
 //! locks from different stores never collide.
 
-use sha2::{Digest, Sha256};
+use bitcoin::hashes::{Hash, HashEngine, sha256};
 
 /// Derives a stable 64-bit advisory-lock key from a tenant identity pubkey.
 /// Hashes a domain prefix together with the identity and folds the first 8
 /// bytes of the SHA-256 digest into an `i64` (the type expected by
 /// `pg_advisory_xact_lock(bigint)`).
 pub(crate) fn identity_lock_key(prefix: &[u8], identity: &[u8]) -> i64 {
-    let mut hasher = Sha256::new();
-    hasher.update(prefix);
-    hasher.update(identity);
-    let digest = hasher.finalize();
+    let mut engine = sha256::Hash::engine();
+    engine.input(prefix);
+    engine.input(identity);
+    let digest = sha256::Hash::from_engine(engine);
     let mut buf = [0u8; 8];
-    buf.copy_from_slice(&digest[..8]);
+    buf.copy_from_slice(&digest.as_byte_array()[..8]);
     i64::from_be_bytes(buf)
 }

--- a/crates/spark-postgres/src/lib.rs
+++ b/crates/spark-postgres/src/lib.rs
@@ -8,6 +8,7 @@
 //! configuration, and a generic migration runner) that can be reused by downstream
 //! crates for their own `PostgreSQL` storage needs.
 
+mod advisory_lock;
 pub mod config;
 pub mod error;
 pub mod migrations;

--- a/crates/spark-postgres/src/migrations.rs
+++ b/crates/spark-postgres/src/migrations.rs
@@ -16,12 +16,14 @@ use crate::pool::{map_db_error, map_pool_error};
 /// # Arguments
 /// * `pool` - The connection pool to use
 /// * `migrations_table` - Name of the table to track migration versions (e.g., `schema_migrations`)
-/// * `migrations` - List of migrations, where each migration is a list of SQL statements
+/// * `migrations` - List of migrations, where each migration is a list of SQL statements.
+///   Statements are owned `String`s so callers can build them at runtime (e.g. inlining a
+///   tenant identity into a backfill).
 #[allow(clippy::arithmetic_side_effects)]
 pub async fn run_migrations(
     pool: &Pool,
     migrations_table: &str,
-    migrations: &[&[&str]],
+    migrations: &[Vec<String>],
 ) -> Result<(), PostgresError> {
     let mut client = pool.get().await.map_err(map_pool_error)?;
 
@@ -63,8 +65,8 @@ pub async fn run_migrations(
     for (i, migration) in migrations.iter().enumerate() {
         let version = i32::try_from(i + 1).unwrap_or(i32::MAX);
         if version > current_version {
-            for statement in *migration {
-                tx.execute(*statement, &[]).await.map_err(|e| {
+            for statement in migration {
+                tx.execute(statement.as_str(), &[]).await.map_err(|e| {
                     PostgresError::Database(format!("Migration {version} failed: {e}"))
                 })?;
             }

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -775,10 +775,10 @@ impl PostgresTokenStore {
     }
 
     /// Returns the list of migrations for the token store.
-    fn migrations() -> Vec<&'static [&'static str]> {
+    fn migrations() -> Vec<Vec<String>> {
         vec![
             // Migration 1: Token store tables with race condition protection
-            &[
+            vec![
                 "CREATE TABLE IF NOT EXISTS token_metadata (
                     identifier TEXT PRIMARY KEY,
                     issuer_public_key TEXT NOT NULL,
@@ -788,14 +788,17 @@ impl PostgresTokenStore {
                     max_supply TEXT NOT NULL,
                     is_freezable BOOLEAN NOT NULL,
                     creation_entity_public_key TEXT
-                )",
+                )"
+                .to_string(),
                 "CREATE INDEX IF NOT EXISTS idx_token_metadata_issuer_pk
-                    ON token_metadata (issuer_public_key)",
+                    ON token_metadata (issuer_public_key)"
+                    .to_string(),
                 "CREATE TABLE IF NOT EXISTS token_reservations (
                     id TEXT PRIMARY KEY,
                     purpose TEXT NOT NULL,
                     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                )",
+                )"
+                .to_string(),
                 "CREATE TABLE IF NOT EXISTS token_outputs (
                     id TEXT PRIMARY KEY,
                     token_identifier TEXT NOT NULL REFERENCES token_metadata(identifier),
@@ -809,20 +812,25 @@ impl PostgresTokenStore {
                     prev_tx_vout INTEGER NOT NULL,
                     reservation_id TEXT REFERENCES token_reservations(id) ON DELETE SET NULL,
                     added_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                )",
+                )"
+                .to_string(),
                 "CREATE INDEX IF NOT EXISTS idx_token_outputs_identifier
-                    ON token_outputs (token_identifier)",
+                    ON token_outputs (token_identifier)"
+                    .to_string(),
                 "CREATE INDEX IF NOT EXISTS idx_token_outputs_reservation
-                    ON token_outputs (reservation_id) WHERE reservation_id IS NOT NULL",
+                    ON token_outputs (reservation_id) WHERE reservation_id IS NOT NULL"
+                    .to_string(),
                 "CREATE TABLE IF NOT EXISTS token_spent_outputs (
                     output_id TEXT PRIMARY KEY,
                     spent_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                )",
+                )"
+                .to_string(),
                 "CREATE TABLE IF NOT EXISTS token_swap_status (
                     id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
                     last_completed_at TIMESTAMPTZ
-                )",
-                "INSERT INTO token_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING",
+                )"
+                .to_string(),
+                "INSERT INTO token_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING".to_string(),
             ],
         ]
     }

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -19,6 +19,7 @@ use spark_wallet::{
 use tracing::{trace, warn};
 use uuid::Uuid;
 
+use crate::advisory_lock::identity_lock_key;
 use crate::config::PostgresStorageConfig;
 use crate::error::PostgresError;
 use crate::migrations::run_migrations;
@@ -27,10 +28,10 @@ use crate::pool::create_pool;
 /// Name of the schema migrations table for `PostgresTokenStore`.
 const TOKEN_MIGRATIONS_TABLE: &str = "token_schema_migrations";
 
-/// Advisory-lock classid for the token store. Combined with a per-tenant
-/// `objid` (derived from the identity pubkey) so two tenants don't serialize
-/// on each other's writes — only same-tenant writes share the same lock.
-const TOKEN_STORE_LOCK_CLASSID: i32 = 0x746F_6B6E; // "tokn" as hex
+/// Domain prefix mixed into the per-tenant advisory lock hash so the token
+/// store's locks never collide with the tree store's, even when two tenants
+/// share a database.
+const TOKEN_STORE_LOCK_PREFIX: &[u8] = b"breez-spark-sdk:token:";
 
 /// Spent markers are kept in the database for this duration to support multiple
 /// SDK instances sharing the same postgres database. During `set_tokens_outputs`, spent
@@ -51,20 +52,10 @@ pub struct PostgresTokenStore {
     /// 33-byte secp256k1 compressed pubkey identifying this tenant. All reads
     /// and writes are filtered by `user_id = self.identity`.
     identity: Vec<u8>,
-    /// Stable per-tenant lock objid derived from `identity`. Used as the
-    /// second argument to `pg_advisory_xact_lock(classid, objid)`.
-    lock_objid: i32,
-}
-
-/// Derive a stable 32-bit lock objid from a 33-byte secp256k1 pubkey.
-/// Reuses the same scheme as the tree store so behavior is consistent.
-fn identity_lock_objid(identity: &[u8]) -> i32 {
-    let buf: [u8; 4] = identity
-        .rchunks(4)
-        .next()
-        .and_then(|tail| tail.try_into().ok())
-        .unwrap_or([0u8; 4]);
-    i32::from_be_bytes(buf)
+    /// Stable per-tenant 64-bit advisory lock key derived from `identity`.
+    /// Passed to the single-arg form `pg_advisory_xact_lock(bigint)` so two
+    /// tenants don't serialize on each other's writes.
+    lock_key: i64,
 }
 
 /// Builds the multi-tenant scoping migration for the token store. Adds
@@ -922,7 +913,7 @@ impl PostgresTokenStore {
         let store = Self {
             pool,
             identity: identity.to_vec(),
-            lock_objid: identity_lock_objid(identity),
+            lock_key: identity_lock_key(TOKEN_STORE_LOCK_PREFIX, identity),
         };
         store.migrate().await?;
         Ok(store)
@@ -1005,19 +996,16 @@ impl PostgresTokenStore {
     }
 
     /// Acquires an exclusive advisory lock for write operations.
-    /// Per-tenant: combines `TOKEN_STORE_LOCK_CLASSID` with the tenant-specific
-    /// `objid` so concurrent writes from different tenants do not block each
-    /// other. Same-tenant writes still serialize on the same lock.
+    /// Per-tenant: keyed by `lock_key` (64-bit hash of a token-store domain
+    /// prefix + identity) so concurrent writes from different tenants do not
+    /// block each other. Same-tenant writes still serialize on the same lock.
     async fn acquire_write_lock(
         &self,
         tx: &tokio_postgres::Transaction<'_>,
     ) -> Result<(), TokenOutputServiceError> {
-        tx.execute(
-            "SELECT pg_advisory_xact_lock($1, $2)",
-            &[&TOKEN_STORE_LOCK_CLASSID, &self.lock_objid],
-        )
-        .await
-        .map_err(map_err)?;
+        tx.execute("SELECT pg_advisory_xact_lock($1)", &[&self.lock_key])
+            .await
+            .map_err(map_err)?;
         Ok(())
     }
 
@@ -1669,15 +1657,12 @@ mod tests {
             .unwrap();
 
         // Hold the token-store write lock on a separate connection. Must use
-        // the same (classid, objid) pair as `acquire_write_lock`.
-        let lock_objid = fixture.store.lock_objid;
+        // the same key as `acquire_write_lock`.
+        let lock_key = fixture.store.lock_key;
         let mut holder = fixture.store.pool.get().await.unwrap();
         let holder_tx = holder.transaction().await.unwrap();
         holder_tx
-            .execute(
-                "SELECT pg_advisory_xact_lock($1, $2)",
-                &[&TOKEN_STORE_LOCK_CLASSID, &lock_objid],
-            )
+            .execute("SELECT pg_advisory_xact_lock($1)", &[&lock_key])
             .await
             .unwrap();
 

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -27,10 +27,10 @@ use crate::pool::create_pool;
 /// Name of the schema migrations table for `PostgresTokenStore`.
 const TOKEN_MIGRATIONS_TABLE: &str = "token_schema_migrations";
 
-/// Advisory lock key for serializing token store write operations.
-/// This prevents deadlocks by ensuring only one write transaction runs at a time.
-/// The lock is automatically released when the transaction commits or rolls back.
-const TOKEN_STORE_WRITE_LOCK_KEY: i64 = 0x746F_6B65_6E53_5452; // "toknSTR" as hex
+/// Advisory-lock classid for the token store. Combined with a per-tenant
+/// `objid` (derived from the identity pubkey) so two tenants don't serialize
+/// on each other's writes — only same-tenant writes share the same lock.
+const TOKEN_STORE_LOCK_CLASSID: i32 = 0x746F_6B6E; // "tokn" as hex
 
 /// Spent markers are kept in the database for this duration to support multiple
 /// SDK instances sharing the same postgres database. During `set_tokens_outputs`, spent
@@ -43,8 +43,112 @@ const SPENT_MARKER_CLEANUP_THRESHOLD_MS: i64 = 5 * 60 * 1000; // 5 minutes
 const RESERVATION_TIMEOUT_SECS: f64 = 300.0; // 5 minutes
 
 /// `PostgreSQL`-backed token output store implementation.
+///
+/// Each instance is scoped to a single tenant identity so multiple tenants
+/// can share one Postgres database without cross-pollinating token state.
 pub struct PostgresTokenStore {
     pool: Pool,
+    /// 33-byte secp256k1 compressed pubkey identifying this tenant. All reads
+    /// and writes are filtered by `user_id = self.identity`.
+    identity: Vec<u8>,
+    /// Stable per-tenant lock objid derived from `identity`. Used as the
+    /// second argument to `pg_advisory_xact_lock(classid, objid)`.
+    lock_objid: i32,
+}
+
+/// Derive a stable 32-bit lock objid from a 33-byte secp256k1 pubkey.
+/// Reuses the same scheme as the tree store so behavior is consistent.
+fn identity_lock_objid(identity: &[u8]) -> i32 {
+    let buf: [u8; 4] = identity
+        .rchunks(4)
+        .next()
+        .and_then(|tail| tail.try_into().ok())
+        .unwrap_or([0u8; 4]);
+    i32::from_be_bytes(buf)
+}
+
+/// Builds the multi-tenant scoping migration for the token store. Adds
+/// `user_id BYTEA` to every per-user table (including `token_metadata` —
+/// metadata is per-tenant to avoid 0-balance leakage for tokens a tenant
+/// never owned), backfills with the connecting tenant, and rewrites primary
+/// keys / FKs to lead with `user_id`. The composite FK from `token_outputs`
+/// to `token_reservations` uses NO ACTION (the default) — column-list SET
+/// NULL is PG15+ and a whole-row SET NULL would null `user_id` (NOT NULL).
+fn token_store_multi_tenant_migration(identity: &[u8]) -> Vec<String> {
+    let id_hex = hex::encode(identity);
+    let id_lit = format!("'\\x{id_hex}'::bytea");
+
+    vec![
+        // Drop dependent FKs FIRST so we can rebuild the parent PKs they
+        // reference. Inline `REFERENCES` clauses get auto-named
+        // `<table>_<column>_fkey` so we drop those exact names if present.
+        "ALTER TABLE token_outputs DROP CONSTRAINT IF EXISTS token_outputs_reservation_id_fkey"
+            .to_string(),
+        "ALTER TABLE token_outputs DROP CONSTRAINT IF EXISTS token_outputs_token_identifier_fkey"
+            .to_string(),
+        // token_metadata: scope per-tenant. Required even though metadata
+        // never structurally collides — leaking a token's mere existence
+        // (e.g. a 0-balance entry for a token a tenant never held) would be
+        // a privacy regression.
+        "ALTER TABLE token_metadata ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE token_metadata SET user_id = {id_lit}"),
+        "ALTER TABLE token_metadata \
+         ALTER COLUMN user_id SET NOT NULL, \
+         DROP CONSTRAINT IF EXISTS token_metadata_pkey, \
+         ADD PRIMARY KEY (user_id, identifier)"
+            .to_string(),
+        "DROP INDEX IF EXISTS idx_token_metadata_issuer_pk".to_string(),
+        "CREATE INDEX idx_token_metadata_user_issuer_pk \
+         ON token_metadata (user_id, issuer_public_key)"
+            .to_string(),
+        // token_reservations: scope by user_id.
+        "ALTER TABLE token_reservations ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE token_reservations SET user_id = {id_lit}"),
+        "ALTER TABLE token_reservations \
+         ALTER COLUMN user_id SET NOT NULL, \
+         DROP CONSTRAINT IF EXISTS token_reservations_pkey, \
+         ADD PRIMARY KEY (user_id, id)"
+            .to_string(),
+        // token_outputs: scope by user_id, rekey, re-add composite FKs.
+        "ALTER TABLE token_outputs ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE token_outputs SET user_id = {id_lit}"),
+        "ALTER TABLE token_outputs \
+         ALTER COLUMN user_id SET NOT NULL, \
+         DROP CONSTRAINT IF EXISTS token_outputs_pkey, \
+         ADD PRIMARY KEY (user_id, id), \
+         ADD FOREIGN KEY (user_id, token_identifier) \
+            REFERENCES token_metadata(user_id, identifier), \
+         ADD FOREIGN KEY (user_id, reservation_id) \
+            REFERENCES token_reservations(user_id, id)"
+            .to_string(),
+        "DROP INDEX IF EXISTS idx_token_outputs_identifier".to_string(),
+        "DROP INDEX IF EXISTS idx_token_outputs_reservation".to_string(),
+        "CREATE INDEX idx_token_outputs_user_identifier \
+         ON token_outputs (user_id, token_identifier)"
+            .to_string(),
+        "CREATE INDEX idx_token_outputs_user_reservation \
+         ON token_outputs (user_id, reservation_id) \
+         WHERE reservation_id IS NOT NULL"
+            .to_string(),
+        // token_spent_outputs: scope by user_id.
+        "ALTER TABLE token_spent_outputs ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE token_spent_outputs SET user_id = {id_lit}"),
+        "ALTER TABLE token_spent_outputs \
+         ALTER COLUMN user_id SET NOT NULL, \
+         DROP CONSTRAINT IF EXISTS token_spent_outputs_pkey, \
+         ADD PRIMARY KEY (user_id, output_id)"
+            .to_string(),
+        // token_swap_status was a singleton (PK id=1, CHECK id=1). Drop the
+        // id column (CASCADE removes both PK and CHECK), then re-key by
+        // user_id so each tenant has its own swap-status row.
+        "ALTER TABLE token_swap_status DROP COLUMN id CASCADE".to_string(),
+        "ALTER TABLE token_swap_status ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE token_swap_status SET user_id = {id_lit}"),
+        "ALTER TABLE token_swap_status \
+         ALTER COLUMN user_id SET NOT NULL, \
+         ADD PRIMARY KEY (user_id)"
+            .to_string(),
+    ]
 }
 
 #[async_trait]
@@ -61,14 +165,14 @@ impl TokenOutputStore for PostgresTokenStore {
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
 
-        Self::acquire_write_lock(&tx).await?;
+        self.acquire_write_lock(&tx).await?;
 
         // Drop expired reservations BEFORE evaluating has_active_swap, otherwise a stale
         // Swap reservation (from a crashed client or a swap whose finalize/cancel never
         // ran) keeps has_active_swap true forever, which makes set_tokens_outputs
         // early-return and never reach any subsequent reconciliation. The reservation
         // pins itself in place and the local token-output set freezes.
-        Self::cleanup_stale_reservations(&tx).await?;
+        self.cleanup_stale_reservations(&tx).await?;
 
         // Skip if swap is active or completed during this refresh
         let (has_active_swap, swap_completed_during_refresh): (bool, bool) = {
@@ -76,10 +180,17 @@ impl TokenOutputStore for PostgresTokenStore {
                 .query_one(
                     r"
                     SELECT
-                        EXISTS(SELECT 1 FROM token_reservations WHERE purpose = 'Swap'),
-                        COALESCE((SELECT last_completed_at >= $1 FROM token_swap_status WHERE id = 1), FALSE)
+                        EXISTS(
+                            SELECT 1 FROM token_reservations
+                            WHERE user_id = $1 AND purpose = 'Swap'
+                        ),
+                        COALESCE(
+                            (SELECT last_completed_at >= $2
+                             FROM token_swap_status WHERE user_id = $1),
+                            FALSE
+                        )
                     ",
-                    &[&refresh_timestamp],
+                    &[&self.identity, &refresh_timestamp],
                 )
                 .await
                 .map_err(map_err)?;
@@ -95,7 +206,7 @@ impl TokenOutputStore for PostgresTokenStore {
         }
 
         // Clean up old spent markers
-        Self::cleanup_spent_markers(&tx, refresh_timestamp).await?;
+        self.cleanup_spent_markers(&tx, refresh_timestamp).await?;
 
         // Get recent spent output IDs (spent_at >= refresh_timestamp).
         // Older spent markers are ignored - if the refresh started after the spend,
@@ -103,8 +214,9 @@ impl TokenOutputStore for PostgresTokenStore {
         let spent_ids: HashSet<String> = {
             let rows = tx
                 .query(
-                    "SELECT output_id FROM token_spent_outputs WHERE spent_at >= $1",
-                    &[&refresh_timestamp],
+                    "SELECT output_id FROM token_spent_outputs \
+                     WHERE user_id = $1 AND spent_at >= $2",
+                    &[&self.identity, &refresh_timestamp],
                 )
                 .await
                 .map_err(map_err)?;
@@ -114,8 +226,9 @@ impl TokenOutputStore for PostgresTokenStore {
         // Delete non-reserved outputs added BEFORE the refresh started.
         // Outputs added after will be preserved (they were inserted while refresh was in progress).
         tx.execute(
-            "DELETE FROM token_outputs WHERE reservation_id IS NULL AND added_at < $1",
-            &[&refresh_timestamp],
+            "DELETE FROM token_outputs \
+             WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
+            &[&self.identity, &refresh_timestamp],
         )
         .await
         .map_err(map_err)?;
@@ -131,8 +244,10 @@ impl TokenOutputStore for PostgresTokenStore {
             .query(
                 r"SELECT r.id, o.id AS output_id
                   FROM token_reservations r
-                  JOIN token_outputs o ON o.reservation_id = r.id",
-                &[],
+                  JOIN token_outputs o
+                    ON o.reservation_id = r.id AND o.user_id = r.user_id
+                  WHERE r.user_id = $1",
+                &[&self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -171,15 +286,15 @@ impl TokenOutputStore for PostgresTokenStore {
         // Delete outputs whose reservations are being removed entirely
         if !reservations_to_delete.is_empty() {
             tx.execute(
-                "DELETE FROM token_outputs WHERE reservation_id = ANY($1)",
-                &[&reservations_to_delete],
+                "DELETE FROM token_outputs WHERE user_id = $1 AND reservation_id = ANY($2)",
+                &[&self.identity, &reservations_to_delete],
             )
             .await
             .map_err(map_err)?;
 
             tx.execute(
-                "DELETE FROM token_reservations WHERE id = ANY($1)",
-                &[&reservations_to_delete],
+                "DELETE FROM token_reservations WHERE user_id = $1 AND id = ANY($2)",
+                &[&self.identity, &reservations_to_delete],
             )
             .await
             .map_err(map_err)?;
@@ -188,8 +303,8 @@ impl TokenOutputStore for PostgresTokenStore {
         // Delete individual reserved outputs that no longer exist
         if !outputs_to_remove_from_reservation.is_empty() {
             tx.execute(
-                "DELETE FROM token_outputs WHERE id = ANY($1)",
-                &[&outputs_to_remove_from_reservation],
+                "DELETE FROM token_outputs WHERE user_id = $1 AND id = ANY($2)",
+                &[&self.identity, &outputs_to_remove_from_reservation],
             )
             .await
             .map_err(map_err)?;
@@ -198,9 +313,10 @@ impl TokenOutputStore for PostgresTokenStore {
             let empty_reservations = tx
                 .query(
                     r"SELECT r.id FROM token_reservations r
-                      LEFT JOIN token_outputs o ON o.reservation_id = r.id
-                      WHERE o.id IS NULL",
-                    &[],
+                      LEFT JOIN token_outputs o
+                        ON o.reservation_id = r.id AND o.user_id = r.user_id
+                      WHERE r.user_id = $1 AND o.id IS NULL",
+                    &[&self.identity],
                 )
                 .await
                 .map_err(map_err)?;
@@ -208,8 +324,8 @@ impl TokenOutputStore for PostgresTokenStore {
                 empty_reservations.iter().map(|row| row.get("id")).collect();
             if !empty_ids.is_empty() {
                 tx.execute(
-                    "DELETE FROM token_reservations WHERE id = ANY($1)",
-                    &[&empty_ids],
+                    "DELETE FROM token_reservations WHERE user_id = $1 AND id = ANY($2)",
+                    &[&self.identity, &empty_ids],
                 )
                 .await
                 .map_err(map_err)?;
@@ -220,21 +336,24 @@ impl TokenOutputStore for PostgresTokenStore {
         let reserved_output_ids: HashSet<String> = {
             let rows = tx
                 .query(
-                    "SELECT id FROM token_outputs WHERE reservation_id IS NOT NULL",
-                    &[],
+                    "SELECT id FROM token_outputs \
+                     WHERE user_id = $1 AND reservation_id IS NOT NULL",
+                    &[&self.identity],
                 )
                 .await
                 .map_err(map_err)?;
             rows.iter().map(|r| r.get("id")).collect()
         };
 
-        // Delete metadata not referenced by any remaining outputs or incoming data
+        // Delete metadata not referenced by any remaining outputs (per-tenant).
         tx.execute(
             r"DELETE FROM token_metadata
-              WHERE identifier NOT IN (
-                  SELECT DISTINCT token_identifier FROM token_outputs
-              )",
-            &[],
+              WHERE user_id = $1
+                AND identifier NOT IN (
+                    SELECT DISTINCT token_identifier
+                    FROM token_outputs WHERE user_id = $1
+                )",
+            &[&self.identity],
         )
         .await
         .map_err(map_err)?;
@@ -242,7 +361,7 @@ impl TokenOutputStore for PostgresTokenStore {
         // Insert new metadata and outputs, excluding spent and reserved
         for to in token_outputs {
             // Upsert metadata
-            Self::upsert_metadata(&tx, &to.metadata).await?;
+            self.upsert_metadata(&tx, &to.metadata).await?;
 
             // Insert outputs that aren't currently reserved or spent
             for output in &to.outputs {
@@ -251,7 +370,8 @@ impl TokenOutputStore for PostgresTokenStore {
                 {
                     continue;
                 }
-                Self::insert_single_output(&tx, &to.metadata.identifier, output).await?;
+                self.insert_single_output(&tx, &to.metadata.identifier, output)
+                    .await?;
             }
         }
 
@@ -280,11 +400,14 @@ impl TokenOutputStore for PostgresTokenStore {
                             END
                          ), 0)::text AS balance
                   FROM token_metadata m
-                  JOIN token_outputs o ON o.token_identifier = m.identifier
-                  LEFT JOIN token_reservations r ON o.reservation_id = r.id
+                  JOIN token_outputs o
+                    ON o.token_identifier = m.identifier AND o.user_id = m.user_id
+                  LEFT JOIN token_reservations r
+                    ON o.reservation_id = r.id AND o.user_id = r.user_id
+                  WHERE m.user_id = $1
                   GROUP BY m.identifier, m.issuer_public_key, m.name, m.ticker,
                            m.decimals, m.max_supply, m.is_freezable, m.creation_entity_public_key",
-                &[],
+                &[&self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -313,10 +436,13 @@ impl TokenOutputStore for PostgresTokenStore {
                          o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                          r.purpose
                   FROM token_metadata m
-                  LEFT JOIN token_outputs o ON o.token_identifier = m.identifier
-                  LEFT JOIN token_reservations r ON o.reservation_id = r.id
+                  LEFT JOIN token_outputs o
+                    ON o.token_identifier = m.identifier AND o.user_id = m.user_id
+                  LEFT JOIN token_reservations r
+                    ON o.reservation_id = r.id AND o.user_id = r.user_id
+                  WHERE m.user_id = $1
                   ORDER BY m.identifier, o.token_amount::NUMERIC ASC",
-                &[],
+                &[&self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -381,13 +507,18 @@ impl TokenOutputStore for PostgresTokenStore {
                      o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                      r.purpose
               FROM token_metadata m
-              LEFT JOIN token_outputs o ON o.token_identifier = m.identifier
-              LEFT JOIN token_reservations r ON o.reservation_id = r.id
-              WHERE {where_clause}
+              LEFT JOIN token_outputs o
+                ON o.token_identifier = m.identifier AND o.user_id = m.user_id
+              LEFT JOIN token_reservations r
+                ON o.reservation_id = r.id AND o.user_id = r.user_id
+              WHERE m.user_id = $2 AND {where_clause}
               ORDER BY o.token_amount::NUMERIC ASC"
         );
 
-        let rows = client.query(&query, &[&param]).await.map_err(map_err)?;
+        let rows = client
+            .query(&query, &[&param, &self.identity])
+            .await
+            .map_err(map_err)?;
 
         if rows.is_empty() {
             return Err(TokenOutputServiceError::Generic(
@@ -431,7 +562,7 @@ impl TokenOutputStore for PostgresTokenStore {
         let tx = client.transaction().await.map_err(map_err)?;
 
         // Upsert metadata
-        Self::upsert_metadata(&tx, &token_outputs.metadata).await?;
+        self.upsert_metadata(&tx, &token_outputs.metadata).await?;
 
         // Remove inserted output IDs from spent markers (output returned to us)
         let output_ids: Vec<String> = token_outputs
@@ -441,8 +572,8 @@ impl TokenOutputStore for PostgresTokenStore {
             .collect();
         if !output_ids.is_empty() {
             tx.execute(
-                "DELETE FROM token_spent_outputs WHERE output_id = ANY($1)",
-                &[&output_ids],
+                "DELETE FROM token_spent_outputs WHERE user_id = $1 AND output_id = ANY($2)",
+                &[&self.identity, &output_ids],
             )
             .await
             .map_err(map_err)?;
@@ -450,7 +581,8 @@ impl TokenOutputStore for PostgresTokenStore {
 
         // Insert outputs where id not already present
         for output in &token_outputs.outputs {
-            Self::insert_single_output(&tx, &token_outputs.metadata.identifier, output).await?;
+            self.insert_single_output(&tx, &token_outputs.metadata.identifier, output)
+                .await?;
         }
 
         tx.commit().await.map_err(map_err)?;
@@ -491,13 +623,13 @@ impl TokenOutputStore for PostgresTokenStore {
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
 
-        Self::acquire_write_lock(&tx).await?;
+        self.acquire_write_lock(&tx).await?;
 
         // Get metadata
         let metadata_row = tx
             .query_opt(
-                "SELECT * FROM token_metadata WHERE identifier = $1",
-                &[&token_identifier],
+                "SELECT * FROM token_metadata WHERE user_id = $1 AND identifier = $2",
+                &[&self.identity, &token_identifier],
             )
             .await
             .map_err(map_err)?
@@ -516,8 +648,10 @@ impl TokenOutputStore for PostgresTokenStore {
                          o.token_public_key, o.token_amount, o.prev_tx_hash, o.prev_tx_vout,
                          o.token_identifier AS identifier
                   FROM token_outputs o
-                  WHERE o.token_identifier = $1 AND o.reservation_id IS NULL",
-                &[&token_identifier],
+                  WHERE o.user_id = $1
+                    AND o.token_identifier = $2
+                    AND o.reservation_id IS NULL",
+                &[&self.identity, &token_identifier],
             )
             .await
             .map_err(map_err)?;
@@ -587,8 +721,8 @@ impl TokenOutputStore for PostgresTokenStore {
         };
 
         tx.execute(
-            "INSERT INTO token_reservations (id, purpose) VALUES ($1, $2)",
-            &[&reservation_id, &purpose_str],
+            "INSERT INTO token_reservations (user_id, id, purpose) VALUES ($1, $2, $3)",
+            &[&self.identity, &reservation_id, &purpose_str],
         )
         .await
         .map_err(map_err)?;
@@ -599,8 +733,9 @@ impl TokenOutputStore for PostgresTokenStore {
             .map(|o| o.output.id.clone())
             .collect();
         tx.execute(
-            "UPDATE token_outputs SET reservation_id = $1 WHERE id = ANY($2)",
-            &[&reservation_id, &selected_ids],
+            "UPDATE token_outputs SET reservation_id = $1 \
+             WHERE user_id = $3 AND id = ANY($2)",
+            &[&reservation_id, &selected_ids, &self.identity],
         )
         .await
         .map_err(map_err)?;
@@ -625,19 +760,24 @@ impl TokenOutputStore for PostgresTokenStore {
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
 
-        // Clear reservation_id from outputs (ON DELETE SET NULL would do this,
-        // but we do it explicitly for clarity)
+        // Clear reservation_id from outputs first — the composite FK uses NO
+        // ACTION (column-list SET NULL is PG15+ and a whole-row SET NULL would
+        // null user_id, which is NOT NULL).
         tx.execute(
-            "UPDATE token_outputs SET reservation_id = NULL WHERE reservation_id = $1",
-            &[id],
+            "UPDATE token_outputs SET reservation_id = NULL \
+             WHERE user_id = $1 AND reservation_id = $2",
+            &[&self.identity, id],
         )
         .await
         .map_err(map_err)?;
 
         // Delete the reservation
-        tx.execute("DELETE FROM token_reservations WHERE id = $1", &[id])
-            .await
-            .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM token_reservations WHERE user_id = $1 AND id = $2",
+            &[&self.identity, id],
+        )
+        .await
+        .map_err(map_err)?;
 
         tx.commit().await.map_err(map_err)?;
 
@@ -655,13 +795,13 @@ impl TokenOutputStore for PostgresTokenStore {
         // Serialize against `set_tokens_outputs` so its `token_spent_outputs`
         // snapshot and the upsert that consumes it cannot interleave with this
         // transaction's spent-marker write.
-        Self::acquire_write_lock(&tx).await?;
+        self.acquire_write_lock(&tx).await?;
 
         // Get reservation purpose and reserved output IDs
         let reservation_row = tx
             .query_opt(
-                "SELECT purpose FROM token_reservations WHERE id = $1",
-                &[id],
+                "SELECT purpose FROM token_reservations WHERE user_id = $1 AND id = $2",
+                &[&self.identity, id],
             )
             .await
             .map_err(map_err)?;
@@ -677,8 +817,8 @@ impl TokenOutputStore for PostgresTokenStore {
         let reserved_output_ids: Vec<String> = {
             let rows = tx
                 .query(
-                    "SELECT id FROM token_outputs WHERE reservation_id = $1",
-                    &[id],
+                    "SELECT id FROM token_outputs WHERE user_id = $1 AND reservation_id = $2",
+                    &[&self.identity, id],
                 )
                 .await
                 .map_err(map_err)?;
@@ -688,42 +828,53 @@ impl TokenOutputStore for PostgresTokenStore {
         // Batch insert spent output markers
         if !reserved_output_ids.is_empty() {
             tx.execute(
-                r"INSERT INTO token_spent_outputs (output_id)
-                  SELECT * FROM UNNEST($1::text[])
+                r"INSERT INTO token_spent_outputs (user_id, output_id)
+                  SELECT $2, output_id FROM UNNEST($1::text[]) AS t(output_id)
                   ON CONFLICT DO NOTHING",
-                &[&reserved_output_ids],
+                &[&reserved_output_ids, &self.identity],
             )
             .await
             .map_err(map_err)?;
         }
 
         // Delete reserved outputs
-        tx.execute("DELETE FROM token_outputs WHERE reservation_id = $1", &[id])
-            .await
-            .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM token_outputs WHERE user_id = $1 AND reservation_id = $2",
+            &[&self.identity, id],
+        )
+        .await
+        .map_err(map_err)?;
 
         // Delete the reservation
-        tx.execute("DELETE FROM token_reservations WHERE id = $1", &[id])
-            .await
-            .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM token_reservations WHERE user_id = $1 AND id = $2",
+            &[&self.identity, id],
+        )
+        .await
+        .map_err(map_err)?;
 
-        // If this was a swap reservation, update last_completed_at
+        // If this was a swap reservation, update last_completed_at. UPSERT so a
+        // tenant that joined after migration 2 (and thus has no row) gets one.
         if is_swap {
             tx.execute(
-                "UPDATE token_swap_status SET last_completed_at = NOW() WHERE id = 1",
-                &[],
+                "INSERT INTO token_swap_status (user_id, last_completed_at) \
+                 VALUES ($1, NOW()) \
+                 ON CONFLICT (user_id) DO UPDATE SET last_completed_at = EXCLUDED.last_completed_at",
+                &[&self.identity],
             )
             .await
             .map_err(map_err)?;
         }
 
-        // Clean up any orphaned metadata
+        // Clean up any orphaned metadata (per-tenant).
         tx.execute(
             r"DELETE FROM token_metadata
-              WHERE identifier NOT IN (
-                  SELECT DISTINCT token_identifier FROM token_outputs
-              )",
-            &[],
+              WHERE user_id = $1
+                AND identifier NOT IN (
+                    SELECT DISTINCT token_identifier
+                    FROM token_outputs WHERE user_id = $1
+                )",
+            &[&self.identity],
         )
         .await
         .map_err(map_err)?;
@@ -749,33 +900,46 @@ impl PostgresTokenStore {
     /// Creates a new `PostgresTokenStore` from a configuration.
     ///
     /// This creates its own connection pool and runs token store migrations.
-    pub async fn from_config(config: PostgresStorageConfig) -> Result<Self, PostgresError> {
+    /// `identity` is the 33-byte secp256k1 pubkey of the tenant.
+    pub async fn from_config(
+        config: PostgresStorageConfig,
+        identity: &[u8],
+    ) -> Result<Self, PostgresError> {
         let pool = create_pool(&config)?;
-        Self::init(pool).await
+        Self::init(pool, identity).await
     }
 
     /// Creates a new `PostgresTokenStore` from an existing connection pool.
     ///
     /// This reuses the provided pool and runs token store migrations.
     /// Useful when sharing a pool with other components (e.g., `PostgresStorage`).
-    pub async fn from_pool(pool: Pool) -> Result<Self, PostgresError> {
-        Self::init(pool).await
+    pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
+        Self::init(pool, identity).await
     }
 
     /// Shared initialization logic for both constructors.
-    async fn init(pool: Pool) -> Result<Self, PostgresError> {
-        let store = Self { pool };
+    async fn init(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
+        let store = Self {
+            pool,
+            identity: identity.to_vec(),
+            lock_objid: identity_lock_objid(identity),
+        };
         store.migrate().await?;
         Ok(store)
     }
 
     /// Runs database migrations for token store tables.
     async fn migrate(&self) -> Result<(), PostgresError> {
-        run_migrations(&self.pool, TOKEN_MIGRATIONS_TABLE, &Self::migrations()).await
+        run_migrations(
+            &self.pool,
+            TOKEN_MIGRATIONS_TABLE,
+            &Self::migrations(&self.identity),
+        )
+        .await
     }
 
     /// Returns the list of migrations for the token store.
-    fn migrations() -> Vec<Vec<String>> {
+    fn migrations(identity: &[u8]) -> Vec<Vec<String>> {
         vec![
             // Migration 1: Token store tables with race condition protection
             vec![
@@ -832,16 +996,25 @@ impl PostgresTokenStore {
                 .to_string(),
                 "INSERT INTO token_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING".to_string(),
             ],
+            // Migration 2: Multi-tenant scoping. Adds user_id to every token-store
+            // table (including `token_metadata` — per-tenant to avoid 0-balance
+            // leakage), backfills with the connecting tenant, and rewrites primary
+            // keys / FKs / indexes to lead with user_id.
+            token_store_multi_tenant_migration(identity),
         ]
     }
 
     /// Acquires an exclusive advisory lock for write operations.
+    /// Per-tenant: combines `TOKEN_STORE_LOCK_CLASSID` with the tenant-specific
+    /// `objid` so concurrent writes from different tenants do not block each
+    /// other. Same-tenant writes still serialize on the same lock.
     async fn acquire_write_lock(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
     ) -> Result<(), TokenOutputServiceError> {
         tx.execute(
-            "SELECT pg_advisory_xact_lock($1)",
-            &[&TOKEN_STORE_WRITE_LOCK_KEY],
+            "SELECT pg_advisory_xact_lock($1, $2)",
+            &[&TOKEN_STORE_LOCK_CLASSID, &self.lock_objid],
         )
         .await
         .map_err(map_err)?;
@@ -851,17 +1024,18 @@ impl PostgresTokenStore {
     /// Inserts a single output into the database.
     #[allow(clippy::cast_possible_wrap)]
     async fn insert_single_output(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
         token_identifier: &str,
         output: &TokenOutputWithPrevOut,
     ) -> Result<(), TokenOutputServiceError> {
         tx.execute(
             r"INSERT INTO token_outputs
-                (id, token_identifier, owner_public_key, revocation_commitment,
+                (user_id, id, token_identifier, owner_public_key, revocation_commitment,
                  withdraw_bond_sats, withdraw_relative_block_locktime,
                  token_public_key, token_amount, prev_tx_hash, prev_tx_vout, added_at)
-              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
-              ON CONFLICT (id) DO NOTHING",
+              VALUES ($11, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+              ON CONFLICT (user_id, id) DO NOTHING",
             &[
                 &output.output.id,
                 &token_identifier,
@@ -873,6 +1047,7 @@ impl PostgresTokenStore {
                 &output.output.token_amount.to_string(),
                 &output.prev_tx_hash,
                 &(output.prev_tx_vout as i32),
+                &self.identity,
             ],
         )
         .await
@@ -883,15 +1058,16 @@ impl PostgresTokenStore {
     /// Upserts token metadata.
     #[allow(clippy::cast_possible_wrap)]
     async fn upsert_metadata(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
         metadata: &TokenMetadata,
     ) -> Result<(), TokenOutputServiceError> {
         tx.execute(
             r"INSERT INTO token_metadata
-                (identifier, issuer_public_key, name, ticker, decimals, max_supply,
+                (user_id, identifier, issuer_public_key, name, ticker, decimals, max_supply,
                  is_freezable, creation_entity_public_key)
-              VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-              ON CONFLICT (identifier) DO UPDATE SET
+              VALUES ($9, $1, $2, $3, $4, $5, $6, $7, $8)
+              ON CONFLICT (user_id, identifier) DO UPDATE SET
                 issuer_public_key = EXCLUDED.issuer_public_key,
                 name = EXCLUDED.name,
                 ticker = EXCLUDED.ticker,
@@ -908,6 +1084,7 @@ impl PostgresTokenStore {
                 &metadata.max_supply.to_string(),
                 &metadata.is_freezable,
                 &metadata.creation_entity_public_key.map(|pk| pk.to_string()),
+                &self.identity,
             ],
         )
         .await
@@ -916,16 +1093,35 @@ impl PostgresTokenStore {
     }
 
     /// Deletes reservations that have exceeded the timeout.
-    /// Called during `set_tokens_outputs` to clean up stale reservations from crashed clients.
-    /// The `ON DELETE SET NULL` foreign key constraint automatically releases the outputs.
+    /// Called during `set_tokens_outputs` to clean up stale reservations from
+    /// crashed clients. Releases the outputs by clearing their `reservation_id`
+    /// first, then deletes the parent reservations — the composite FK uses NO
+    /// ACTION because column-list SET NULL is PG15+ and a whole-row SET NULL
+    /// would null `user_id` (NOT NULL).
     async fn cleanup_stale_reservations(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
     ) -> Result<u64, TokenOutputServiceError> {
+        // Release outputs still pointing at any soon-to-be-deleted reservation.
+        tx.execute(
+            r"UPDATE token_outputs SET reservation_id = NULL
+              WHERE user_id = $2
+                AND reservation_id IN (
+                    SELECT id FROM token_reservations
+                    WHERE user_id = $2
+                      AND created_at < NOW() - make_interval(secs => $1)
+                )",
+            &[&RESERVATION_TIMEOUT_SECS, &self.identity],
+        )
+        .await
+        .map_err(map_err)?;
+
         let result = tx
             .execute(
                 r"DELETE FROM token_reservations
-                  WHERE created_at < NOW() - make_interval(secs => $1)",
-                &[&RESERVATION_TIMEOUT_SECS],
+                  WHERE user_id = $2
+                    AND created_at < NOW() - make_interval(secs => $1)",
+                &[&RESERVATION_TIMEOUT_SECS, &self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -939,6 +1135,7 @@ impl PostgresTokenStore {
 
     /// Cleans up spent markers older than the cleanup threshold relative to refresh timestamp.
     async fn cleanup_spent_markers(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
         refresh_timestamp: chrono::DateTime<chrono::Utc>,
     ) -> Result<(), TokenOutputServiceError> {
@@ -948,8 +1145,8 @@ impl PostgresTokenStore {
             .unwrap_or(refresh_timestamp);
 
         tx.execute(
-            "DELETE FROM token_spent_outputs WHERE spent_at < $1",
-            &[&cleanup_cutoff],
+            "DELETE FROM token_spent_outputs WHERE user_id = $2 AND spent_at < $1",
+            &[&cleanup_cutoff, &self.identity],
         )
         .await
         .map_err(map_err)?;
@@ -1037,10 +1234,14 @@ fn map_err<E: std::fmt::Display>(e: E) -> TokenOutputServiceError {
 /// # Arguments
 ///
 /// * `config` - Configuration for the `PostgreSQL` connection pool
+/// * `identity` - 33-byte secp256k1 pubkey scoping all reads and writes
 pub async fn create_postgres_token_store(
     config: PostgresStorageConfig,
+    identity: &[u8],
 ) -> Result<Arc<dyn TokenOutputStore>, PostgresError> {
-    Ok(Arc::new(PostgresTokenStore::from_config(config).await?))
+    Ok(Arc::new(
+        PostgresTokenStore::from_config(config, identity).await?,
+    ))
 }
 
 /// Creates a `PostgresTokenStore` instance from an existing connection pool.
@@ -1050,10 +1251,14 @@ pub async fn create_postgres_token_store(
 /// # Arguments
 ///
 /// * `pool` - An existing deadpool-postgres connection pool
+/// * `identity` - 33-byte secp256k1 pubkey scoping all reads and writes
 pub async fn create_postgres_token_store_from_pool(
     pool: Pool,
+    identity: &[u8],
 ) -> Result<Arc<dyn TokenOutputStore>, PostgresError> {
-    Ok(Arc::new(PostgresTokenStore::from_pool(pool).await?))
+    Ok(Arc::new(
+        PostgresTokenStore::from_pool(pool, identity).await?,
+    ))
 }
 
 #[cfg(test)]
@@ -1062,6 +1267,14 @@ mod tests {
     use spark_wallet::token_store_tests as shared_tests;
     use testcontainers::{ContainerAsync, runners::AsyncRunner};
     use testcontainers_modules::postgres::Postgres;
+
+    /// Fixed 33-byte test identity. Tests run in their own ephemeral container,
+    /// so a single shared identity is fine — the schema still gets exercised.
+    const TEST_IDENTITY: [u8; 33] = [
+        0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+        0x1e, 0x1f, 0x20,
+    ];
 
     /// Helper struct that holds the container and store together.
     /// The container must be kept alive for the duration of the test.
@@ -1087,9 +1300,10 @@ mod tests {
                 "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
             );
 
-            let store = PostgresTokenStore::from_config(PostgresStorageConfig::with_defaults(
-                connection_string,
-            ))
+            let store = PostgresTokenStore::from_config(
+                PostgresStorageConfig::with_defaults(connection_string),
+                &TEST_IDENTITY,
+            )
             .await
             .expect("Failed to create PostgresTokenStore");
 
@@ -1454,13 +1668,15 @@ mod tests {
             .await
             .unwrap();
 
-        // Hold the token-store write lock on a separate connection.
+        // Hold the token-store write lock on a separate connection. Must use
+        // the same (classid, objid) pair as `acquire_write_lock`.
+        let lock_objid = fixture.store.lock_objid;
         let mut holder = fixture.store.pool.get().await.unwrap();
         let holder_tx = holder.transaction().await.unwrap();
         holder_tx
             .execute(
-                "SELECT pg_advisory_xact_lock($1)",
-                &[&TOKEN_STORE_WRITE_LOCK_KEY],
+                "SELECT pg_advisory_xact_lock($1, $2)",
+                &[&TOKEN_STORE_LOCK_CLASSID, &lock_objid],
             )
             .await
             .unwrap();

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -1702,4 +1702,225 @@ mod tests {
             .unwrap()
             .unwrap();
     }
+
+    // ==================== Multi-tenant isolation ====================
+
+    /// A second 33-byte test identity (must differ from `TEST_IDENTITY`).
+    const TEST_IDENTITY_B: [u8; 33] = [
+        0x03, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae,
+        0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd,
+        0xbe, 0xbf, 0xc0,
+    ];
+
+    /// Two `PostgresTokenStore` instances with distinct identities sharing one
+    /// connection pool / DB. The container must be kept alive for the test.
+    struct TwoTenantTokenFixture {
+        a: PostgresTokenStore,
+        b: PostgresTokenStore,
+        #[allow(dead_code)]
+        container: ContainerAsync<Postgres>,
+    }
+
+    impl TwoTenantTokenFixture {
+        async fn new() -> Self {
+            let container = Postgres::default()
+                .start()
+                .await
+                .expect("Failed to start PostgreSQL container");
+
+            let host_port = container
+                .get_host_port_ipv4(5432)
+                .await
+                .expect("Failed to get host port");
+
+            let connection_string = format!(
+                "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
+            );
+
+            let config = PostgresStorageConfig::with_defaults(connection_string);
+            let pool = create_pool(&config).expect("Failed to create pool");
+
+            let a = PostgresTokenStore::from_pool(pool.clone(), &TEST_IDENTITY)
+                .await
+                .expect("Failed to create tenant A");
+            let b = PostgresTokenStore::from_pool(pool, &TEST_IDENTITY_B)
+                .await
+                .expect("Failed to create tenant B");
+
+            Self { a, b, container }
+        }
+    }
+
+    /// End-to-end isolation: every `TokenOutputStore` method must keep tenants
+    /// A and B from observing each other's data. Critically, `token_metadata`
+    /// is per-tenant — both tenants seeding the same `identifier` ("token-1")
+    /// must coexist without collision and without leaking each other's
+    /// balances. Exercises set/insert/list/get/balance/reserve/finalize and
+    /// the per-tenant swap-status row.
+    #[tokio::test]
+    #[allow(clippy::too_many_lines, clippy::similar_names)]
+    async fn test_two_tenant_isolation() {
+        let fx = TwoTenantTokenFixture::new().await;
+
+        // Both tenants seed the SAME token identifier with different output sets.
+        // shared_tests::create_token_outputs derives output IDs from identifier
+        // and amount, so tenants picking different amounts get different IDs —
+        // that's deliberate so we don't fight the schema's composite output PK
+        // unrelated to what we're checking here. The metadata identifier is
+        // identical across tenants and is the privacy-sensitive surface.
+        let a_token1 = shared_tests::create_token_outputs(1, vec![100, 200]);
+        let b_token1 = shared_tests::create_token_outputs(1, vec![500, 1_000, 2_000]);
+        // Plus a token only B holds — A must never see it (0-balance leakage).
+        let b_only_token2 = shared_tests::create_token_outputs(2, vec![777]);
+
+        fx.a.set_tokens_outputs(
+            std::slice::from_ref(&a_token1),
+            shared_tests::future_refresh_start(),
+        )
+        .await
+        .unwrap();
+        fx.b.set_tokens_outputs(
+            &[b_token1, b_only_token2],
+            shared_tests::future_refresh_start(),
+        )
+        .await
+        .unwrap();
+
+        // --- list_tokens_outputs respects tenant scope ---
+        let listed_a = fx.a.list_tokens_outputs().await.unwrap();
+        let listed_b = fx.b.list_tokens_outputs().await.unwrap();
+        assert_eq!(listed_a.len(), 1, "A only sees its own token");
+        assert_eq!(listed_b.len(), 2, "B sees its two tokens");
+        assert!(
+            !listed_a.iter().any(|t| t.metadata.identifier == "token-2"),
+            "A must not see B's token-2 (no zero-balance leakage)"
+        );
+        assert_eq!(listed_a[0].available.len(), 2, "A has 2 outputs of token-1");
+        let listed_b_t1 = listed_b
+            .iter()
+            .find(|t| t.metadata.identifier == "token-1")
+            .unwrap();
+        assert_eq!(listed_b_t1.available.len(), 3, "B has 3 outputs of token-1");
+
+        // --- get_token_balances per tenant ---
+        let bal_a = fx.a.get_token_balances().await.unwrap();
+        let bal_b = fx.b.get_token_balances().await.unwrap();
+        assert_eq!(bal_a.len(), 1);
+        assert_eq!(bal_a[0].0.identifier, "token-1");
+        assert_eq!(bal_a[0].1, 300, "A's token-1 balance is just A's outputs");
+        let bal_b_map: std::collections::HashMap<String, u128> =
+            bal_b.into_iter().map(|(m, v)| (m.identifier, v)).collect();
+        assert_eq!(bal_b_map.get("token-1"), Some(&3_500));
+        assert_eq!(bal_b_map.get("token-2"), Some(&777));
+
+        // --- get_token_outputs by identifier respects scope ---
+        let got_a =
+            fx.a.get_token_outputs(GetTokenOutputsFilter::Identifier("token-1"))
+                .await
+                .unwrap();
+        assert_eq!(got_a.available.len(), 2);
+
+        // A must NOT find B's "token-2".
+        let got_a_t2 =
+            fx.a.get_token_outputs(GetTokenOutputsFilter::Identifier("token-2"))
+                .await;
+        assert!(
+            matches!(got_a_t2, Err(TokenOutputServiceError::Generic(_))),
+            "A must not be able to read B's token-2 metadata"
+        );
+
+        // --- reserve on A must not consume B's outputs ---
+        let res_a =
+            fx.a.reserve_token_outputs(
+                "token-1",
+                ReservationTarget::MinTotalValue(100),
+                TokenReservationPurpose::Payment,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(!res_a.token_outputs.outputs.is_empty());
+
+        let view_b = fx.b.list_tokens_outputs().await.unwrap();
+        let view_b_t1 = view_b
+            .iter()
+            .find(|t| t.metadata.identifier == "token-1")
+            .unwrap();
+        assert!(
+            view_b_t1.reserved_for_payment.is_empty(),
+            "B must not see A's reservation"
+        );
+        assert_eq!(view_b_t1.available.len(), 3);
+
+        // --- A reserving "token-2" must fail (B's token, A doesn't see it) ---
+        let res_a_t2 =
+            fx.a.reserve_token_outputs(
+                "token-2",
+                ReservationTarget::MinTotalValue(100),
+                TokenReservationPurpose::Payment,
+                None,
+                None,
+            )
+            .await;
+        assert!(
+            res_a_t2.is_err(),
+            "A must not be able to reserve from B's token-2"
+        );
+
+        // --- finalize on A must not affect B's outputs ---
+        fx.a.finalize_reservation(&res_a.id).await.unwrap();
+        let view_b = fx.b.list_tokens_outputs().await.unwrap();
+        let view_b_t1 = view_b
+            .iter()
+            .find(|t| t.metadata.identifier == "token-1")
+            .unwrap();
+        assert_eq!(view_b_t1.available.len(), 3, "B's outputs untouched");
+        assert_eq!(fx.b.get_token_balances().await.unwrap().len(), 2);
+
+        // --- swap-status row is per tenant: B's swap finalize lazily upserts
+        // B's row even though only A had ever set_tokens_outputs first. ---
+        let res_b_swap =
+            fx.b.reserve_token_outputs(
+                "token-1",
+                ReservationTarget::MinTotalValue(500),
+                TokenReservationPurpose::Swap,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        // A sees nothing about B's swap.
+        let listed_a = fx.a.list_tokens_outputs().await.unwrap();
+        assert!(
+            listed_a.iter().all(|t| t.reserved_for_swap.is_empty()),
+            "A must not see B's swap reservation"
+        );
+        fx.b.finalize_reservation(&res_b_swap.id).await.unwrap();
+
+        // --- insert_token_outputs on A only inserts into A's namespace ---
+        // Use identifier_no=2 so the metadata identifier ("token-2") collides
+        // with B's existing entry — that exercises per-tenant `token_metadata`:
+        // both tenants must end up with their own row, and A's outputs/balance
+        // for "token-2" must differ from B's.
+        let a_token2 = shared_tests::create_token_outputs(2, vec![999]);
+        fx.a.insert_token_outputs(&a_token2).await.unwrap();
+
+        let bal_a = fx.a.get_token_balances().await.unwrap();
+        let bal_a_t2 = bal_a
+            .iter()
+            .find(|(m, _)| m.identifier == "token-2")
+            .expect("A should now have its own token-2");
+        assert_eq!(bal_a_t2.1, 999, "A's token-2 balance is A's output only");
+
+        let bal_b = fx.b.get_token_balances().await.unwrap();
+        let bal_b_t2 = bal_b
+            .iter()
+            .find(|(m, _)| m.identifier == "token-2")
+            .expect("B's token-2 still present");
+        assert_eq!(
+            bal_b_t2.1, 777,
+            "B's token-2 balance unchanged by A's insert"
+        );
+    }
 }

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -2262,4 +2262,183 @@ mod tests {
             "Spent leaf should not be Available"
         );
     }
+
+    // ==================== Multi-tenant isolation ====================
+
+    /// A second 33-byte test identity (must differ from `TEST_IDENTITY`).
+    const TEST_IDENTITY_B: [u8; 33] = [
+        0x03, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae,
+        0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd,
+        0xbe, 0xbf, 0xc0,
+    ];
+
+    /// Two `PostgresTreeStore` instances with distinct identities sharing one
+    /// connection pool / DB. The container must be kept alive for the test.
+    struct TwoTenantTreeFixture {
+        a: PostgresTreeStore,
+        b: PostgresTreeStore,
+        #[allow(dead_code)]
+        container: ContainerAsync<Postgres>,
+    }
+
+    impl TwoTenantTreeFixture {
+        async fn new() -> Self {
+            let container = Postgres::default()
+                .start()
+                .await
+                .expect("Failed to start PostgreSQL container");
+
+            let host_port = container
+                .get_host_port_ipv4(5432)
+                .await
+                .expect("Failed to get host port");
+
+            let connection_string = format!(
+                "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
+            );
+
+            let config = PostgresStorageConfig::with_defaults(connection_string);
+            let pool = create_pool(&config).expect("Failed to create pool");
+
+            let a = PostgresTreeStore::from_pool(pool.clone(), &TEST_IDENTITY)
+                .await
+                .expect("Failed to create tenant A");
+            let b = PostgresTreeStore::from_pool(pool, &TEST_IDENTITY_B)
+                .await
+                .expect("Failed to create tenant B");
+
+            Self { a, b, container }
+        }
+    }
+
+    /// End-to-end isolation: every `TreeStore` method must keep tenants A and B
+    /// from observing each other's data. Exercises leaves, reservations, the
+    /// finalize→spent path, and the per-tenant swap-status row, asserting that
+    /// writes by A are invisible to B (and vice versa). Uses identical leaf
+    /// IDs across tenants to also confirm the composite primary keys land.
+    #[tokio::test]
+    async fn test_two_tenant_isolation() {
+        let fx = TwoTenantTreeFixture::new().await;
+
+        // --- add_leaves: same IDs, different per-tenant values ---
+        let leaves_a = vec![
+            create_test_tree_node("shared_leaf_1", 100),
+            create_test_tree_node("shared_leaf_2", 200),
+        ];
+        let leaves_b = vec![
+            create_test_tree_node("shared_leaf_1", 1_000),
+            create_test_tree_node("shared_leaf_2", 2_000),
+            create_test_tree_node("only_b_leaf", 500),
+        ];
+        fx.a.add_leaves(&leaves_a).await.unwrap();
+        fx.b.add_leaves(&leaves_b).await.unwrap();
+
+        // get_leaves only returns the calling tenant's rows.
+        let view_a = fx.a.get_leaves().await.unwrap();
+        let view_b = fx.b.get_leaves().await.unwrap();
+        assert_eq!(view_a.available.len(), 2, "A sees its 2 leaves");
+        assert_eq!(view_b.available.len(), 3, "B sees its 3 leaves");
+        assert!(
+            !view_a
+                .available
+                .iter()
+                .any(|l| l.id.to_string() == "only_b_leaf")
+        );
+        assert_eq!(
+            view_a.available.iter().map(|l| l.value).sum::<u64>(),
+            300,
+            "A's total reflects A's amounts only"
+        );
+        assert_eq!(
+            view_b.available.iter().map(|l| l.value).sum::<u64>(),
+            3_500,
+            "B's total reflects B's amounts only"
+        );
+
+        // get_available_balance respects scoping.
+        assert_eq!(fx.a.get_available_balance().await.unwrap(), 300);
+        assert_eq!(fx.b.get_available_balance().await.unwrap(), 3_500);
+
+        // --- reserve_leaves on A must not consume B's leaves ---
+        let res_a = reserve_leaves(
+            &fx.a,
+            Some(&TargetAmounts::new_amount_and_fee(100, None)),
+            true,
+            ReservationPurpose::Payment,
+        )
+        .await
+        .unwrap();
+        assert_eq!(res_a.leaves.len(), 1);
+
+        // B sees no reservations and its full balance is intact.
+        let view_b = fx.b.get_leaves().await.unwrap();
+        assert!(view_b.reserved_for_payment.is_empty());
+        assert_eq!(view_b.available.len(), 3);
+        assert_eq!(fx.b.get_available_balance().await.unwrap(), 3_500);
+
+        // A sees its reservation; available is reduced.
+        let view_a = fx.a.get_leaves().await.unwrap();
+        assert_eq!(view_a.reserved_for_payment.len(), 1);
+        assert_eq!(view_a.available.len(), 1);
+
+        // --- finalize on A (spent marker) does not touch B's identical-ID leaf ---
+        fx.a.finalize_reservation(&res_a.id, None).await.unwrap();
+
+        // The just-spent leaf is gone from A but still present in B (different
+        // composite PK, different spent-marker scope).
+        let view_a = fx.a.get_leaves().await.unwrap();
+        assert!(
+            !view_a
+                .available
+                .iter()
+                .any(|l| l.id.to_string() == "shared_leaf_1")
+        );
+        let view_b = fx.b.get_leaves().await.unwrap();
+        assert!(
+            view_b
+                .available
+                .iter()
+                .any(|l| l.id.to_string() == "shared_leaf_1"),
+            "B's shared_leaf_1 must survive A's finalize"
+        );
+
+        // --- set_leaves on A must not touch B's data ---
+        let refresh_start = SystemTime::now();
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let refresh_a = vec![create_test_tree_node("a_only_post_refresh", 42)];
+        fx.a.set_leaves(&refresh_a, &[], refresh_start)
+            .await
+            .unwrap();
+
+        let view_a = fx.a.get_leaves().await.unwrap();
+        assert_eq!(view_a.available.len(), 1);
+        assert_eq!(view_a.available[0].id.to_string(), "a_only_post_refresh");
+        let view_b = fx.b.get_leaves().await.unwrap();
+        assert_eq!(view_b.available.len(), 3, "B unaffected by A's set_leaves");
+
+        // --- B can perform a swap-finalize without A's swap-status row ever
+        // existing (lazy upsert per tenant). B's reservation must not block A. ---
+        let res_b_swap = reserve_leaves(
+            &fx.b,
+            Some(&TargetAmounts::new_amount_and_fee(1_000, None)),
+            true,
+            ReservationPurpose::Swap,
+        )
+        .await
+        .unwrap();
+        let view_a = fx.a.get_leaves().await.unwrap();
+        assert!(
+            view_a.reserved_for_swap.is_empty(),
+            "A must not see B's swap reservation"
+        );
+        let new_b_leaf = create_test_tree_node("b_swap_change", 600);
+        fx.b.finalize_reservation(&res_b_swap.id, Some(&[new_b_leaf]))
+            .await
+            .unwrap();
+
+        // A is still entirely unaffected.
+        let view_a = fx.a.get_leaves().await.unwrap();
+        assert_eq!(view_a.available.len(), 1);
+        assert_eq!(view_a.available[0].id.to_string(), "a_only_post_refresh");
+    }
 }

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -20,6 +20,7 @@ use tokio::sync::watch;
 use tracing::{debug, info, trace};
 use uuid::Uuid;
 
+use crate::advisory_lock::identity_lock_key;
 use crate::config::PostgresStorageConfig;
 use crate::error::PostgresError;
 use crate::migrations::run_migrations;
@@ -46,10 +47,10 @@ impl LeafLike for SlimLeaf {
     }
 }
 
-/// Advisory-lock classid for the tree store. Combined with a per-tenant `objid`
-/// (derived from the identity pubkey) so that two tenants never block each
-/// other's writes — only same-tenant writes serialize on the same lock.
-const TREE_STORE_LOCK_CLASSID: i32 = 0x7472_6565; // "tree" as hex
+/// Domain prefix mixed into the per-tenant advisory lock hash so the tree
+/// store's locks never collide with the token store's, even when two tenants
+/// share a database.
+const TREE_STORE_LOCK_PREFIX: &[u8] = b"breez-spark-sdk:tree:";
 
 /// Timeout for reservations in seconds. Reservations older than this are considered stale
 /// and will be cleaned up during `set_leaves()` to release leaves locked by crashed clients.
@@ -69,25 +70,12 @@ pub struct PostgresTreeStore {
     /// 33-byte secp256k1 compressed pubkey identifying this tenant. All reads
     /// and writes are filtered by `user_id = self.identity`.
     identity: Vec<u8>,
-    /// Stable per-tenant lock objid derived from `identity`. Used as the
-    /// second argument to `pg_advisory_xact_lock(classid, objid)` so concurrent
-    /// writes from different tenants do not block each other.
-    lock_objid: i32,
+    /// Stable per-tenant 64-bit advisory lock key derived from `identity`.
+    /// Passed to the single-arg form `pg_advisory_xact_lock(bigint)` so two
+    /// tenants don't serialize on each other's writes.
+    lock_key: i64,
     balance_changed_tx: Arc<watch::Sender<()>>,
     balance_changed_rx: watch::Receiver<()>,
-}
-
-/// Derives a stable 32-bit lock objid from a 33-byte secp256k1 pubkey.
-/// Uses the last 4 bytes of the pubkey x-coordinate (well-distributed by
-/// construction) reinterpreted as i32. Tail-takes via `chunks` so an
-/// unexpectedly short input simply yields zero rather than underflowing.
-fn identity_lock_objid(identity: &[u8]) -> i32 {
-    let buf: [u8; 4] = identity
-        .rchunks(4)
-        .next()
-        .and_then(|tail| tail.try_into().ok())
-        .unwrap_or([0u8; 4]);
-    i32::from_be_bytes(buf)
 }
 
 /// Builds the multi-tenant scoping migration for the tree store. The literal
@@ -836,7 +824,7 @@ impl PostgresTreeStore {
         let store = Self {
             pool,
             identity: identity.to_vec(),
-            lock_objid: identity_lock_objid(identity),
+            lock_key: identity_lock_key(TREE_STORE_LOCK_PREFIX, identity),
             balance_changed_tx: Arc::new(balance_changed_tx),
             balance_changed_rx,
         };
@@ -1147,20 +1135,17 @@ impl PostgresTreeStore {
     }
 
     /// Acquires an exclusive advisory lock for write operations.
-    /// Per-tenant: combines `TREE_STORE_LOCK_CLASSID` with the tenant-specific
-    /// `objid` so concurrent writes from different tenants do not block each
-    /// other. Same-tenant writes still serialize on the same lock.
+    /// Per-tenant: keyed by `lock_key` (64-bit hash of a tree-store domain
+    /// prefix + identity) so concurrent writes from different tenants do not
+    /// block each other. Same-tenant writes still serialize on the same lock.
     /// The lock is automatically released when the transaction commits or rolls back.
     async fn acquire_write_lock(
         &self,
         tx: &tokio_postgres::Transaction<'_>,
     ) -> Result<(), TreeServiceError> {
-        tx.execute(
-            "SELECT pg_advisory_xact_lock($1, $2)",
-            &[&TREE_STORE_LOCK_CLASSID, &self.lock_objid],
-        )
-        .await
-        .map_err(map_err)?;
+        tx.execute("SELECT pg_advisory_xact_lock($1)", &[&self.lock_key])
+            .await
+            .map_err(map_err)?;
         Ok(())
     }
 
@@ -2214,15 +2199,12 @@ mod tests {
         .unwrap();
 
         // Hold the advisory lock on a separate connection so finalize must wait.
-        // Must use the same (classid, objid) pair as `acquire_write_lock`.
-        let lock_objid = fixture.store.lock_objid;
+        // Must use the same key as `acquire_write_lock`.
+        let lock_key = fixture.store.lock_key;
         let mut holder = fixture.store.pool.get().await.unwrap();
         let holder_tx = holder.transaction().await.unwrap();
         holder_tx
-            .execute(
-                "SELECT pg_advisory_xact_lock($1, $2)",
-                &[&TREE_STORE_LOCK_CLASSID, &lock_objid],
-            )
+            .execute("SELECT pg_advisory_xact_lock($1)", &[&lock_key])
             .await
             .unwrap();
 

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -46,10 +46,10 @@ impl LeafLike for SlimLeaf {
     }
 }
 
-/// Advisory lock key for serializing tree store write operations.
-/// This prevents deadlocks by ensuring only one write transaction runs at a time.
-/// The lock is automatically released when the transaction commits or rolls back.
-const TREE_STORE_WRITE_LOCK_KEY: i64 = 0x7472_6565_5354_4f52; // "treeTOR" as hex
+/// Advisory-lock classid for the tree store. Combined with a per-tenant `objid`
+/// (derived from the identity pubkey) so that two tenants never block each
+/// other's writes — only same-tenant writes serialize on the same lock.
+const TREE_STORE_LOCK_CLASSID: i32 = 0x7472_6565; // "tree" as hex
 
 /// Timeout for reservations in seconds. Reservations older than this are considered stale
 /// and will be cleaned up during `set_leaves()` to release leaves locked by crashed clients.
@@ -61,11 +61,103 @@ const SPENT_MARKER_CLEANUP_THRESHOLD_MS: i64 = 5 * 60 * 1000; // 5 minutes
 ///
 /// This implementation uses database-level concurrency control (row locking)
 /// to safely handle concurrent operations, making it suitable for multi-instance
-/// deployments.
+/// deployments. Each instance is scoped to a single tenant identity so that
+/// multiple tenants can share one Postgres database without cross-pollinating
+/// tree state.
 pub struct PostgresTreeStore {
     pool: Pool,
+    /// 33-byte secp256k1 compressed pubkey identifying this tenant. All reads
+    /// and writes are filtered by `user_id = self.identity`.
+    identity: Vec<u8>,
+    /// Stable per-tenant lock objid derived from `identity`. Used as the
+    /// second argument to `pg_advisory_xact_lock(classid, objid)` so concurrent
+    /// writes from different tenants do not block each other.
+    lock_objid: i32,
     balance_changed_tx: Arc<watch::Sender<()>>,
     balance_changed_rx: watch::Receiver<()>,
+}
+
+/// Derives a stable 32-bit lock objid from a 33-byte secp256k1 pubkey.
+/// Uses the last 4 bytes of the pubkey x-coordinate (well-distributed by
+/// construction) reinterpreted as i32. Tail-takes via `chunks` so an
+/// unexpectedly short input simply yields zero rather than underflowing.
+fn identity_lock_objid(identity: &[u8]) -> i32 {
+    let buf: [u8; 4] = identity
+        .rchunks(4)
+        .next()
+        .and_then(|tail| tail.try_into().ok())
+        .unwrap_or([0u8; 4]);
+    i32::from_be_bytes(buf)
+}
+
+/// Builds the multi-tenant scoping migration for the tree store. The literal
+/// `identity` hex is inlined as a BYTEA literal (safe — typed pubkey bytes,
+/// character set restricted to `[0-9a-f]{66}`).
+fn tree_store_multi_tenant_migration(identity: &[u8]) -> Vec<String> {
+    let id_hex = hex::encode(identity);
+    let id_lit = format!("'\\x{id_hex}'::bytea");
+
+    vec![
+        // tree_leaves: drop the old single-column FK to tree_reservations(id)
+        // FIRST, before we touch the tree_reservations PK it depends on.
+        "ALTER TABLE tree_leaves DROP CONSTRAINT IF EXISTS tree_leaves_reservation_id_fkey"
+            .to_string(),
+        // tree_reservations: scope by user_id.
+        "ALTER TABLE tree_reservations ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE tree_reservations SET user_id = {id_lit}"),
+        "ALTER TABLE tree_reservations \
+         ALTER COLUMN user_id SET NOT NULL, \
+         DROP CONSTRAINT IF EXISTS tree_reservations_pkey, \
+         ADD PRIMARY KEY (user_id, id)"
+            .to_string(),
+        // tree_leaves: add user_id, rekey, and re-add the composite FK to the
+        // new tree_reservations PK.
+        "ALTER TABLE tree_leaves ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE tree_leaves SET user_id = {id_lit}"),
+        // The composite FK uses NO ACTION (the default) instead of the previous
+        // single-column `ON DELETE SET NULL`: PG-only column-list SET NULL is
+        // PG15+, and a whole-row SET NULL would try to null `user_id` too.
+        // Callers (`cleanup_stale_reservations`, `cancel_reservation`,
+        // `finalize_reservation`) explicitly clear `reservation_id` before
+        // deleting the parent reservation row.
+        "ALTER TABLE tree_leaves \
+         ALTER COLUMN user_id SET NOT NULL, \
+         DROP CONSTRAINT IF EXISTS tree_leaves_pkey, \
+         ADD PRIMARY KEY (user_id, id), \
+         ADD FOREIGN KEY (user_id, reservation_id) \
+            REFERENCES tree_reservations(user_id, id)"
+            .to_string(),
+        "DROP INDEX IF EXISTS idx_tree_leaves_available".to_string(),
+        "DROP INDEX IF EXISTS idx_tree_leaves_reservation".to_string(),
+        "DROP INDEX IF EXISTS idx_tree_leaves_added_at".to_string(),
+        "CREATE INDEX idx_tree_leaves_user_available \
+         ON tree_leaves(user_id, status, is_missing_from_operators) \
+         WHERE status = 'Available' AND is_missing_from_operators = FALSE"
+            .to_string(),
+        "CREATE INDEX idx_tree_leaves_user_reservation \
+         ON tree_leaves(user_id, reservation_id) \
+         WHERE reservation_id IS NOT NULL"
+            .to_string(),
+        "CREATE INDEX idx_tree_leaves_user_added_at ON tree_leaves(user_id, added_at)".to_string(),
+        // tree_spent_leaves: scope by user_id.
+        "ALTER TABLE tree_spent_leaves ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE tree_spent_leaves SET user_id = {id_lit}"),
+        "ALTER TABLE tree_spent_leaves \
+         ALTER COLUMN user_id SET NOT NULL, \
+         DROP CONSTRAINT IF EXISTS tree_spent_leaves_pkey, \
+         ADD PRIMARY KEY (user_id, leaf_id)"
+            .to_string(),
+        // tree_swap_status was a singleton (PK id=1, CHECK id=1). Drop the id
+        // column (CASCADE removes both PK and CHECK), then re-key by user_id so
+        // each tenant has its own swap-status row.
+        "ALTER TABLE tree_swap_status DROP COLUMN id CASCADE".to_string(),
+        "ALTER TABLE tree_swap_status ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE tree_swap_status SET user_id = {id_lit}"),
+        "ALTER TABLE tree_swap_status \
+         ALTER COLUMN user_id SET NOT NULL, \
+         ADD PRIMARY KEY (user_id)"
+            .to_string(),
+    ]
 }
 
 #[async_trait]
@@ -90,11 +182,11 @@ impl TreeStore for PostgresTreeStore {
         // our perspective. This handles the case where the same leaf returns to us
         // after we sent it to someone else.
         let leaf_ids: Vec<String> = leaves.iter().map(|l| l.id.to_string()).collect();
-        Self::batch_remove_spent_leaves(&tx, &leaf_ids).await?;
+        self.batch_remove_spent_leaves(&tx, &leaf_ids).await?;
 
         // Batch insert all leaves (no filtering needed since we just removed any
         // that were in spent_leaves)
-        Self::batch_upsert_leaves(&tx, leaves, false, None).await?;
+        self.batch_upsert_leaves(&tx, leaves, false, None).await?;
 
         tx.commit().await.map_err(map_err)?;
         tracing::trace!(
@@ -112,12 +204,15 @@ impl TreeStore for PostgresTreeStore {
                 r"
                 SELECT COALESCE(SUM((l.data->>'value')::bigint), 0)::bigint AS balance
                 FROM tree_leaves l
-                LEFT JOIN tree_reservations r ON l.reservation_id = r.id
-                WHERE
+                LEFT JOIN tree_reservations r
+                  ON l.reservation_id = r.id AND l.user_id = r.user_id
+                WHERE l.user_id = $1
+                  AND (
                     (l.reservation_id IS NULL AND l.status = 'Available')
                     OR r.purpose = 'Swap'
+                  )
                 ",
-                &[],
+                &[&self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -134,9 +229,11 @@ impl TreeStore for PostgresTreeStore {
                 SELECT l.id, l.status, l.is_missing_from_operators, l.data,
                        l.reservation_id, r.purpose
                 FROM tree_leaves l
-                LEFT JOIN tree_reservations r ON l.reservation_id = r.id
+                LEFT JOIN tree_reservations r
+                  ON l.reservation_id = r.id AND l.user_id = r.user_id
+                WHERE l.user_id = $1
                 ",
-                &[],
+                &[&self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -194,13 +291,13 @@ impl TreeStore for PostgresTreeStore {
         let tx = client.transaction().await.map_err(map_err)?;
 
         // Acquire advisory lock to prevent deadlocks with concurrent operations
-        Self::acquire_write_lock(&tx).await?;
+        self.acquire_write_lock(&tx).await?;
 
         // Drop expired reservations BEFORE evaluating has_active_swap, otherwise a stale
         // Swap reservation (from a crashed client or a swap whose finalize/cancel never
         // ran) keeps has_active_swap true forever, which makes set_leaves early-return
         // and never reach the cleanup again. The reservation pins itself in place.
-        Self::cleanup_stale_reservations(&tx).await?;
+        self.cleanup_stale_reservations(&tx).await?;
 
         // Check if any swap reservation is currently active, or if a swap completed
         // after this refresh started (making the refresh data potentially inconsistent).
@@ -209,10 +306,17 @@ impl TreeStore for PostgresTreeStore {
                 .query_one(
                     r"
                     SELECT
-                        EXISTS(SELECT 1 FROM tree_reservations WHERE purpose = 'Swap'),
-                        COALESCE((SELECT last_completed_at >= $1 FROM tree_swap_status WHERE id = 1), FALSE)
+                        EXISTS(
+                            SELECT 1 FROM tree_reservations
+                            WHERE user_id = $1 AND purpose = 'Swap'
+                        ),
+                        COALESCE(
+                            (SELECT last_completed_at >= $2
+                             FROM tree_swap_status WHERE user_id = $1),
+                            FALSE
+                        )
                     ",
-                    &[&refresh_timestamp],
+                    &[&self.identity, &refresh_timestamp],
                 )
                 .await
                 .map_err(map_err)?;
@@ -227,13 +331,14 @@ impl TreeStore for PostgresTreeStore {
             return Ok(());
         }
 
-        Self::cleanup_spent_markers(&tx, refresh_timestamp).await?;
+        self.cleanup_spent_markers(&tx, refresh_timestamp).await?;
 
         let spent_ids: HashSet<String> = {
             let rows = tx
                 .query(
-                    "SELECT leaf_id FROM tree_spent_leaves WHERE spent_at >= $1",
-                    &[&refresh_timestamp],
+                    "SELECT leaf_id FROM tree_spent_leaves \
+                     WHERE user_id = $1 AND spent_at >= $2",
+                    &[&self.identity, &refresh_timestamp],
                 )
                 .await
                 .map_err(map_err)?;
@@ -252,8 +357,9 @@ impl TreeStore for PostgresTreeStore {
         // (FK ON DELETE SET NULL) — those rows kept their old added_at, so they are
         // dropped here and re-fetched from the operator response in the upsert below.
         tx.execute(
-            "DELETE FROM tree_leaves WHERE reservation_id IS NULL AND added_at < $1",
-            &[&refresh_timestamp],
+            "DELETE FROM tree_leaves \
+             WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
+            &[&self.identity, &refresh_timestamp],
         )
         .await
         .map_err(map_err)?;
@@ -261,8 +367,10 @@ impl TreeStore for PostgresTreeStore {
         // Upsert all leaves. batch_upsert_leaves handles spent filtering via skip_ids,
         // and its ON CONFLICT clause preserves reservation_id (not in the UPDATE SET list).
         // Reserved leaves are also immune to timestamp-based deletion (WHERE reservation_id IS NULL).
-        Self::batch_upsert_leaves(&tx, leaves, false, Some(&spent_ids)).await?;
-        Self::batch_upsert_leaves(&tx, missing_operators_leaves, true, Some(&spent_ids)).await?;
+        self.batch_upsert_leaves(&tx, leaves, false, Some(&spent_ids))
+            .await?;
+        self.batch_upsert_leaves(&tx, missing_operators_leaves, true, Some(&spent_ids))
+            .await?;
 
         tx.commit().await.map_err(map_err)?;
         self.notify_balance_change();
@@ -278,7 +386,10 @@ impl TreeStore for PostgresTreeStore {
         let tx = client.transaction().await.map_err(map_err)?;
 
         let reservation = tx
-            .query_opt("SELECT id FROM tree_reservations WHERE id = $1", &[id])
+            .query_opt(
+                "SELECT id FROM tree_reservations WHERE user_id = $1 AND id = $2",
+                &[&self.identity, id],
+            )
             .await
             .map_err(map_err)?;
 
@@ -288,8 +399,8 @@ impl TreeStore for PostgresTreeStore {
 
         let prior_leaf_ids: Vec<String> = tx
             .query(
-                "SELECT id FROM tree_leaves WHERE reservation_id = $1",
-                &[id],
+                "SELECT id FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+                &[&self.identity, id],
             )
             .await
             .map_err(map_err)?
@@ -306,15 +417,22 @@ impl TreeStore for PostgresTreeStore {
             id, prior_leaf_ids, keep_ids, dropped_ids
         );
 
-        tx.execute("DELETE FROM tree_leaves WHERE reservation_id = $1", &[id])
-            .await
-            .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+            &[&self.identity, id],
+        )
+        .await
+        .map_err(map_err)?;
 
-        tx.execute("DELETE FROM tree_reservations WHERE id = $1", &[id])
-            .await
-            .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM tree_reservations WHERE user_id = $1 AND id = $2",
+            &[&self.identity, id],
+        )
+        .await
+        .map_err(map_err)?;
 
-        Self::batch_upsert_leaves(&tx, leaves_to_keep, false, None).await?;
+        self.batch_upsert_leaves(&tx, leaves_to_keep, false, None)
+            .await?;
 
         tx.commit().await.map_err(map_err)?;
         self.notify_balance_change();
@@ -334,13 +452,13 @@ impl TreeStore for PostgresTreeStore {
         // transaction's spent-marker write — otherwise the snapshot would miss
         // our marker and the upsert would write the just-spent leaf back as
         // Available.
-        Self::acquire_write_lock(&tx).await?;
+        self.acquire_write_lock(&tx).await?;
 
         // Check if reservation exists and get its purpose
         let reservation = tx
             .query_opt(
-                "SELECT id, purpose FROM tree_reservations WHERE id = $1",
-                &[id],
+                "SELECT id, purpose FROM tree_reservations WHERE user_id = $1 AND id = $2",
+                &[&self.identity, id],
             )
             .await
             .map_err(map_err)?;
@@ -349,8 +467,8 @@ impl TreeStore for PostgresTreeStore {
             let is_swap = row.get::<_, String>("purpose") == "Swap";
             let leaf_ids: Vec<String> = tx
                 .query(
-                    "SELECT id FROM tree_leaves WHERE reservation_id = $1",
-                    &[id],
+                    "SELECT id FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+                    &[&self.identity, id],
                 )
                 .await
                 .map_err(map_err)?
@@ -369,15 +487,22 @@ impl TreeStore for PostgresTreeStore {
             reserved_leaf_ids,
             new_leaves.map_or(0, <[TreeNode]>::len)
         );
-        Self::batch_insert_spent_leaves(&tx, &reserved_leaf_ids).await?;
+        self.batch_insert_spent_leaves(&tx, &reserved_leaf_ids)
+            .await?;
 
-        tx.execute("DELETE FROM tree_leaves WHERE reservation_id = $1", &[id])
-            .await
-            .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+            &[&self.identity, id],
+        )
+        .await
+        .map_err(map_err)?;
 
-        tx.execute("DELETE FROM tree_reservations WHERE id = $1", &[id])
-            .await
-            .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM tree_reservations WHERE user_id = $1 AND id = $2",
+            &[&self.identity, id],
+        )
+        .await
+        .map_err(map_err)?;
 
         if let Some(leaves) = new_leaves {
             for l in leaves {
@@ -386,16 +511,19 @@ impl TreeStore for PostgresTreeStore {
                     l.id, l.value, id
                 );
             }
-            Self::batch_upsert_leaves(&tx, leaves, false, None).await?;
+            self.batch_upsert_leaves(&tx, leaves, false, None).await?;
         }
 
         // If this was a swap with new leaves, update last_completed_at.
         // This is used to detect if a refresh started before a swap finished,
-        // which would cause stale data to be applied.
+        // which would cause stale data to be applied. UPSERT so a tenant
+        // that joined after migration 3 (and thus has no row) gets one created.
         if is_swap && new_leaves.is_some() {
             tx.execute(
-                "UPDATE tree_swap_status SET last_completed_at = NOW() WHERE id = 1",
-                &[],
+                "INSERT INTO tree_swap_status (user_id, last_completed_at) \
+                 VALUES ($1, NOW()) \
+                 ON CONFLICT (user_id) DO UPDATE SET last_completed_at = EXCLUDED.last_completed_at",
+                &[&self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -423,7 +551,7 @@ impl TreeStore for PostgresTreeStore {
         let tx = client.transaction().await.map_err(map_err)?;
 
         // Acquire advisory lock to prevent deadlocks with concurrent operations
-        Self::acquire_write_lock(&tx).await?;
+        self.acquire_write_lock(&tx).await?;
 
         // True total available across ALL eligible leaves — required for the
         // WaitForPending decision. Must NOT be derived from the prefiltered
@@ -433,11 +561,12 @@ impl TreeStore for PostgresTreeStore {
                 r"
                 SELECT COALESCE(SUM((data->>'value')::bigint), 0)::bigint AS total
                 FROM tree_leaves
-                WHERE status = 'Available'
+                WHERE user_id = $1
+                  AND status = 'Available'
                   AND is_missing_from_operators = FALSE
                   AND reservation_id IS NULL
                 ",
-                &[],
+                &[&self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -454,23 +583,25 @@ impl TreeStore for PostgresTreeStore {
                 r"
                 SELECT id, (data->>'value')::bigint AS value
                 FROM tree_leaves
-                WHERE status = 'Available'
+                WHERE user_id = $1
+                  AND status = 'Available'
                   AND is_missing_from_operators = FALSE
                   AND reservation_id IS NULL
                   AND (
-                    (data->>'value')::bigint <= $1
+                    (data->>'value')::bigint <= $2
                     OR id = (
                       SELECT id FROM tree_leaves
-                      WHERE status = 'Available'
+                      WHERE user_id = $1
+                        AND status = 'Available'
                         AND is_missing_from_operators = FALSE
                         AND reservation_id IS NULL
-                        AND (data->>'value')::bigint > $1
+                        AND (data->>'value')::bigint > $2
                       ORDER BY (data->>'value')::bigint
                       LIMIT 1
                     )
                   )
                 ",
-                &[&max_target_signed],
+                &[&self.identity, &max_target_signed],
             )
             .await
             .map_err(map_err)?;
@@ -487,7 +618,7 @@ impl TreeStore for PostgresTreeStore {
             .collect();
 
         // Calculate pending balance within the same transaction for consistency
-        let pending = Self::calculate_pending_balance(&tx).await?;
+        let pending = self.calculate_pending_balance(&tx).await?;
 
         // Try exact selection on the slim set — uses the same generic
         // `select_helper` algorithm as the in-memory store.
@@ -504,7 +635,7 @@ impl TreeStore for PostgresTreeStore {
                 if selected_ids.is_empty() {
                     return Err(TreeServiceError::NonReservableLeaves);
                 }
-                let selected_leaves = Self::resolve_full_leaves(&tx, &selected_ids).await?;
+                let selected_leaves = self.resolve_full_leaves(&tx, &selected_ids).await?;
                 self.create_reservation(&tx, &reservation_id, &selected_leaves, purpose, 0)
                     .await?;
                 tx.commit().await.map_err(map_err)?;
@@ -517,7 +648,7 @@ impl TreeStore for PostgresTreeStore {
             Err(_) if !exact_only => {
                 if let Ok(Some(min_slim)) = select_leaves_by_minimum_amount(&slim, target_amount) {
                     let min_ids: Vec<String> = min_slim.iter().map(|l| l.id.clone()).collect();
-                    let selected_leaves = Self::resolve_full_leaves(&tx, &min_ids).await?;
+                    let selected_leaves = self.resolve_full_leaves(&tx, &min_ids).await?;
                     let reserved_amount: u64 = selected_leaves.iter().map(|l| l.value).sum();
                     let pending_change = if reserved_amount > target_amount && target_amount > 0 {
                         reserved_amount - target_amount
@@ -604,8 +735,8 @@ impl TreeStore for PostgresTreeStore {
 
         let reservation = tx
             .query_opt(
-                "SELECT id FROM tree_reservations WHERE id = $1",
-                &[reservation_id],
+                "SELECT id FROM tree_reservations WHERE user_id = $1 AND id = $2",
+                &[&self.identity, reservation_id],
             )
             .await
             .map_err(map_err)?;
@@ -620,8 +751,8 @@ impl TreeStore for PostgresTreeStore {
         let old_reserved_leaf_ids: Vec<String> = {
             let rows = tx
                 .query(
-                    "SELECT id FROM tree_leaves WHERE reservation_id = $1",
-                    &[reservation_id],
+                    "SELECT id FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+                    &[&self.identity, reservation_id],
                 )
                 .await
                 .map_err(map_err)?;
@@ -629,28 +760,33 @@ impl TreeStore for PostgresTreeStore {
         };
 
         // Mark old leaves as spent and delete them (they no longer exist after the swap)
-        Self::batch_insert_spent_leaves(&tx, &old_reserved_leaf_ids).await?;
+        self.batch_insert_spent_leaves(&tx, &old_reserved_leaf_ids)
+            .await?;
         tx.execute(
-            "DELETE FROM tree_leaves WHERE reservation_id = $1",
-            &[reservation_id],
+            "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+            &[&self.identity, reservation_id],
         )
         .await
         .map_err(map_err)?;
 
         // Batch upsert change leaves to available pool with fresh timestamp (race condition fix)
-        Self::batch_upsert_leaves(&tx, change_leaves, false, None).await?;
+        self.batch_upsert_leaves(&tx, change_leaves, false, None)
+            .await?;
 
         // Batch upsert reserved leaves with fresh timestamp
-        Self::batch_upsert_leaves(&tx, reserved_leaves, false, None).await?;
+        self.batch_upsert_leaves(&tx, reserved_leaves, false, None)
+            .await?;
 
         // Set reservation_id on reserved leaves
         let leaf_ids: Vec<String> = reserved_leaves.iter().map(|l| l.id.to_string()).collect();
-        Self::batch_set_reservation_id(&tx, reservation_id, &leaf_ids).await?;
+        self.batch_set_reservation_id(&tx, reservation_id, &leaf_ids)
+            .await?;
 
         // Clear pending change amount
         tx.execute(
-            "UPDATE tree_reservations SET pending_change_amount = 0 WHERE id = $1",
-            &[reservation_id],
+            "UPDATE tree_reservations SET pending_change_amount = 0 \
+             WHERE user_id = $1 AND id = $2",
+            &[&self.identity, reservation_id],
         )
         .await
         .map_err(map_err)?;
@@ -676,25 +812,31 @@ impl PostgresTreeStore {
     /// Creates a new `PostgresTreeStore` from a configuration.
     ///
     /// This creates its own connection pool and runs tree store migrations.
-    pub async fn from_config(config: PostgresStorageConfig) -> Result<Self, PostgresError> {
+    /// `identity` is the 33-byte secp256k1 pubkey of the tenant.
+    pub async fn from_config(
+        config: PostgresStorageConfig,
+        identity: &[u8],
+    ) -> Result<Self, PostgresError> {
         let pool = create_pool(&config)?;
-        Self::init(pool).await
+        Self::init(pool, identity).await
     }
 
     /// Creates a new `PostgresTreeStore` from an existing connection pool.
     ///
     /// This reuses the provided pool and runs tree store migrations.
     /// Useful when sharing a pool with other components (e.g., `PostgresStorage`).
-    pub async fn from_pool(pool: Pool) -> Result<Self, PostgresError> {
-        Self::init(pool).await
+    pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
+        Self::init(pool, identity).await
     }
 
     /// Shared initialization logic for both constructors.
-    async fn init(pool: Pool) -> Result<Self, PostgresError> {
+    async fn init(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
         let (balance_changed_tx, balance_changed_rx) = watch::channel(());
 
         let store = Self {
             pool,
+            identity: identity.to_vec(),
+            lock_objid: identity_lock_objid(identity),
             balance_changed_tx: Arc::new(balance_changed_tx),
             balance_changed_rx,
         };
@@ -707,11 +849,16 @@ impl PostgresTreeStore {
 
     /// Runs database migrations for tree store tables.
     async fn migrate(&self) -> Result<(), PostgresError> {
-        run_migrations(&self.pool, TREE_MIGRATIONS_TABLE, &Self::migrations()).await
+        run_migrations(
+            &self.pool,
+            TREE_MIGRATIONS_TABLE,
+            &Self::migrations(&self.identity),
+        )
+        .await
     }
 
     /// Returns the list of migrations for the tree store.
-    fn migrations() -> Vec<Vec<String>> {
+    fn migrations(identity: &[u8]) -> Vec<Vec<String>> {
         vec![
             // Migration 1: Initial tree tables
             vec![
@@ -748,6 +895,13 @@ impl PostgresTreeStore {
                 )".to_string(),
                 "INSERT INTO tree_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING".to_string(),
             ],
+            // Migration 3: Multi-tenant scoping. Adds user_id to every tree-store
+            // table, backfills with the connecting tenant's identity, and rewrites
+            // primary keys / FKs / indexes to lead with user_id. The
+            // `tree_swap_status` singleton is restructured the same way as
+            // `sync_revision` in the SDK-core storage. See `multi_tenant_migration`
+            // for the SQL.
+            tree_store_multi_tenant_migration(identity),
         ]
     }
 
@@ -762,12 +916,14 @@ impl PostgresTreeStore {
 
     /// Calculates the pending balance from in-flight swaps within a transaction.
     async fn calculate_pending_balance(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
     ) -> Result<u64, TreeServiceError> {
         let row = tx
             .query_one(
-                "SELECT COALESCE(SUM(pending_change_amount), 0)::BIGINT FROM tree_reservations",
-                &[],
+                "SELECT COALESCE(SUM(pending_change_amount), 0)::BIGINT \
+                 FROM tree_reservations WHERE user_id = $1",
+                &[&self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -792,6 +948,7 @@ impl PostgresTreeStore {
     /// Optionally skips leaves whose IDs are in the `skip_ids` set.
     /// Uses ON CONFLICT DO UPDATE to replace existing leaves (matching `InMemoryTreeStore` behavior).
     async fn batch_upsert_leaves(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
         leaves: &[TreeNode],
         is_missing_from_operators: bool,
@@ -833,17 +990,23 @@ impl PostgresTreeStore {
 
         tx.execute(
             r"
-            INSERT INTO tree_leaves (id, status, is_missing_from_operators, data, added_at)
-            SELECT id, status, missing, data, NOW()
+            INSERT INTO tree_leaves (user_id, id, status, is_missing_from_operators, data, added_at)
+            SELECT $5, id, status, missing, data, NOW()
             FROM UNNEST($1::text[], $2::text[], $3::bool[], $4::jsonb[])
                 AS t(id, status, missing, data)
-            ON CONFLICT (id) DO UPDATE SET
+            ON CONFLICT (user_id, id) DO UPDATE SET
                 status = EXCLUDED.status,
                 is_missing_from_operators = EXCLUDED.is_missing_from_operators,
                 data = EXCLUDED.data,
                 added_at = NOW()
             ",
-            &[&ids, &statuses, &missing_flags, &data_values],
+            &[
+                &ids,
+                &statuses,
+                &missing_flags,
+                &data_values,
+                &self.identity,
+            ],
         )
         .await
         .map_err(map_err)?;
@@ -853,6 +1016,7 @@ impl PostgresTreeStore {
 
     /// Batch sets `reservation_id` on leaves using UNNEST.
     async fn batch_set_reservation_id(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
         reservation_id: &str,
         leaf_ids: &[String],
@@ -865,9 +1029,9 @@ impl PostgresTreeStore {
             r"
             UPDATE tree_leaves
             SET reservation_id = $1
-            WHERE id = ANY($2)
+            WHERE user_id = $3 AND id = ANY($2)
             ",
-            &[&reservation_id, &leaf_ids],
+            &[&reservation_id, &leaf_ids, &self.identity],
         )
         .await
         .map_err(map_err)?;
@@ -877,6 +1041,7 @@ impl PostgresTreeStore {
 
     /// Batch inserts spent leaf markers using UNNEST.
     async fn batch_insert_spent_leaves(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
         leaf_ids: &[String],
     ) -> Result<(), TreeServiceError> {
@@ -886,11 +1051,11 @@ impl PostgresTreeStore {
 
         tx.execute(
             r"
-            INSERT INTO tree_spent_leaves (leaf_id)
-            SELECT * FROM UNNEST($1::text[])
+            INSERT INTO tree_spent_leaves (user_id, leaf_id)
+            SELECT $2, leaf_id FROM UNNEST($1::text[]) AS t(leaf_id)
             ON CONFLICT DO NOTHING
             ",
-            &[&leaf_ids],
+            &[&leaf_ids, &self.identity],
         )
         .await
         .map_err(map_err)?;
@@ -902,6 +1067,7 @@ impl PostgresTreeStore {
     /// This is called when receiving a leaf back (e.g., from a claimed transfer)
     /// to clear the "spent" status from when we previously sent it.
     async fn batch_remove_spent_leaves(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
         leaf_ids: &[String],
     ) -> Result<(), TreeServiceError> {
@@ -913,9 +1079,9 @@ impl PostgresTreeStore {
             .execute(
                 r"
                 DELETE FROM tree_spent_leaves
-                WHERE leaf_id = ANY($1)
+                WHERE user_id = $2 AND leaf_id = ANY($1)
                 ",
-                &[&leaf_ids],
+                &[&leaf_ids, &self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -949,6 +1115,7 @@ impl PostgresTreeStore {
     /// picked, preserving the algorithm's selection order. Typically 1-3 rows
     /// even when the slim candidate set was thousands.
     async fn resolve_full_leaves(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
         ids: &[String],
     ) -> Result<Vec<TreeNode>, TreeServiceError> {
@@ -957,8 +1124,8 @@ impl PostgresTreeStore {
         }
         let rows = tx
             .query(
-                "SELECT id, data FROM tree_leaves WHERE id = ANY($1)",
-                &[&ids],
+                "SELECT id, data FROM tree_leaves WHERE user_id = $2 AND id = ANY($1)",
+                &[&ids, &self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -980,14 +1147,17 @@ impl PostgresTreeStore {
     }
 
     /// Acquires an exclusive advisory lock for write operations.
-    /// This serializes all tree store writes to prevent deadlocks.
+    /// Per-tenant: combines `TREE_STORE_LOCK_CLASSID` with the tenant-specific
+    /// `objid` so concurrent writes from different tenants do not block each
+    /// other. Same-tenant writes still serialize on the same lock.
     /// The lock is automatically released when the transaction commits or rolls back.
     async fn acquire_write_lock(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
     ) -> Result<(), TreeServiceError> {
         tx.execute(
-            "SELECT pg_advisory_xact_lock($1)",
-            &[&TREE_STORE_WRITE_LOCK_KEY],
+            "SELECT pg_advisory_xact_lock($1, $2)",
+            &[&TREE_STORE_LOCK_CLASSID, &self.lock_objid],
         )
         .await
         .map_err(map_err)?;
@@ -996,15 +1166,35 @@ impl PostgresTreeStore {
 
     /// Deletes reservations that have exceeded the timeout.
     /// Called during `set_leaves` to clean up stale reservations from crashed clients.
-    /// The `ON DELETE SET NULL` foreign key constraint automatically releases the leaves.
+    /// Releases the leaves by clearing their `reservation_id` first, then deletes
+    /// the parent reservations. The composite FK uses NO ACTION (the default)
+    /// because PG-only column-list `SET NULL (reservation_id)` is PG15+ and a
+    /// whole-row SET NULL would try to null `user_id` (NOT NULL).
     async fn cleanup_stale_reservations(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
     ) -> Result<u64, TreeServiceError> {
+        // Release leaves still pointing at any soon-to-be-deleted reservation,
+        // matching the previous `ON DELETE SET NULL` behavior.
+        tx.execute(
+            r"UPDATE tree_leaves SET reservation_id = NULL
+              WHERE user_id = $2
+                AND reservation_id IN (
+                    SELECT id FROM tree_reservations
+                    WHERE user_id = $2
+                      AND created_at < NOW() - make_interval(secs => $1)
+                )",
+            &[&RESERVATION_TIMEOUT_SECS, &self.identity],
+        )
+        .await
+        .map_err(map_err)?;
+
         let result = tx
             .execute(
                 r"DELETE FROM tree_reservations
-                  WHERE created_at < NOW() - make_interval(secs => $1)",
-                &[&RESERVATION_TIMEOUT_SECS],
+                  WHERE user_id = $2
+                    AND created_at < NOW() - make_interval(secs => $1)",
+                &[&RESERVATION_TIMEOUT_SECS, &self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -1022,6 +1212,7 @@ impl PostgresTreeStore {
     /// `spent_at < refresh_timestamp` are ignored (treated as deleted) but not actually
     /// removed until they exceed this threshold.
     async fn cleanup_spent_markers(
+        &self,
         tx: &tokio_postgres::Transaction<'_>,
         refresh_timestamp: chrono::DateTime<chrono::Utc>,
     ) -> Result<u64, TreeServiceError> {
@@ -1032,8 +1223,8 @@ impl PostgresTreeStore {
 
         let result = tx
             .execute(
-                r"DELETE FROM tree_spent_leaves WHERE spent_at < $1",
-                &[&cleanup_cutoff],
+                r"DELETE FROM tree_spent_leaves WHERE user_id = $2 AND spent_at < $1",
+                &[&cleanup_cutoff, &self.identity],
             )
             .await
             .map_err(map_err)?;
@@ -1060,8 +1251,14 @@ impl PostgresTreeStore {
         let pending_i64 = pending_change as i64;
 
         tx.execute(
-            "INSERT INTO tree_reservations (id, purpose, pending_change_amount) VALUES ($1, $2, $3)",
-            &[&reservation_id, &purpose.to_string(), &pending_i64],
+            "INSERT INTO tree_reservations (user_id, id, purpose, pending_change_amount) \
+             VALUES ($1, $2, $3, $4)",
+            &[
+                &self.identity,
+                &reservation_id,
+                &purpose.to_string(),
+                &pending_i64,
+            ],
         )
         .await
         .map_err(map_err)?;
@@ -1071,7 +1268,8 @@ impl PostgresTreeStore {
             "leaf_lifecycle reserve: reservation={} purpose={:?} leaf_ids={:?}",
             reservation_id, purpose, leaf_ids
         );
-        Self::batch_set_reservation_id(tx, reservation_id, &leaf_ids).await?;
+        self.batch_set_reservation_id(tx, reservation_id, &leaf_ids)
+            .await?;
 
         Ok(())
     }
@@ -1090,10 +1288,14 @@ fn map_err<E: std::fmt::Display>(e: E) -> TreeServiceError {
 /// # Arguments
 ///
 /// * `config` - Configuration for the `PostgreSQL` connection pool
+/// * `identity` - 33-byte secp256k1 pubkey scoping all reads and writes
 pub async fn create_postgres_tree_store(
     config: PostgresStorageConfig,
+    identity: &[u8],
 ) -> Result<Arc<dyn TreeStore>, PostgresError> {
-    Ok(Arc::new(PostgresTreeStore::from_config(config).await?))
+    Ok(Arc::new(
+        PostgresTreeStore::from_config(config, identity).await?,
+    ))
 }
 
 /// Creates a `PostgresTreeStore` instance from an existing connection pool.
@@ -1103,10 +1305,14 @@ pub async fn create_postgres_tree_store(
 /// # Arguments
 ///
 /// * `pool` - An existing deadpool-postgres connection pool
+/// * `identity` - 33-byte secp256k1 pubkey scoping all reads and writes
 pub async fn create_postgres_tree_store_from_pool(
     pool: Pool,
+    identity: &[u8],
 ) -> Result<Arc<dyn TreeStore>, PostgresError> {
-    Ok(Arc::new(PostgresTreeStore::from_pool(pool).await?))
+    Ok(Arc::new(
+        PostgresTreeStore::from_pool(pool, identity).await?,
+    ))
 }
 
 #[cfg(test)]
@@ -1116,6 +1322,14 @@ mod tests {
     use std::sync::Arc;
     use testcontainers::{ContainerAsync, runners::AsyncRunner};
     use testcontainers_modules::postgres::Postgres;
+
+    /// Fixed 33-byte test identity. Tests run in their own ephemeral container,
+    /// so a single shared identity is fine — the schema still gets exercised.
+    const TEST_IDENTITY: [u8; 33] = [
+        0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+        0x1e, 0x1f, 0x20,
+    ];
 
     /// Helper struct that holds the container and store together.
     /// The container must be kept alive for the duration of the test.
@@ -1141,9 +1355,10 @@ mod tests {
                 "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
             );
 
-            let store = PostgresTreeStore::from_config(PostgresStorageConfig::with_defaults(
-                connection_string,
-            ))
+            let store = PostgresTreeStore::from_config(
+                PostgresStorageConfig::with_defaults(connection_string),
+                &TEST_IDENTITY,
+            )
             .await
             .expect("Failed to create PostgresTreeStore");
 
@@ -1999,12 +2214,14 @@ mod tests {
         .unwrap();
 
         // Hold the advisory lock on a separate connection so finalize must wait.
+        // Must use the same (classid, objid) pair as `acquire_write_lock`.
+        let lock_objid = fixture.store.lock_objid;
         let mut holder = fixture.store.pool.get().await.unwrap();
         let holder_tx = holder.transaction().await.unwrap();
         holder_tx
             .execute(
-                "SELECT pg_advisory_xact_lock($1)",
-                &[&TREE_STORE_WRITE_LOCK_KEY],
+                "SELECT pg_advisory_xact_lock($1, $2)",
+                &[&TREE_STORE_LOCK_CLASSID, &lock_objid],
             )
             .await
             .unwrap();

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -711,16 +711,16 @@ impl PostgresTreeStore {
     }
 
     /// Returns the list of migrations for the tree store.
-    fn migrations() -> Vec<&'static [&'static str]> {
+    fn migrations() -> Vec<Vec<String>> {
         vec![
             // Migration 1: Initial tree tables
-            &[
+            vec![
                 "CREATE TABLE IF NOT EXISTS tree_reservations (
                     id TEXT PRIMARY KEY,
                     purpose TEXT NOT NULL,
                     pending_change_amount BIGINT NOT NULL DEFAULT 0,
                     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                )",
+                )".to_string(),
                 "CREATE TABLE IF NOT EXISTS tree_leaves (
                     id TEXT PRIMARY KEY,
                     status TEXT NOT NULL,
@@ -729,24 +729,24 @@ impl PostgresTreeStore {
                     data JSONB NOT NULL,
                     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                     added_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                )",
+                )".to_string(),
                 "CREATE TABLE IF NOT EXISTS tree_spent_leaves (
                     leaf_id TEXT PRIMARY KEY,
                     spent_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                )",
+                )".to_string(),
                 "CREATE INDEX IF NOT EXISTS idx_tree_leaves_available ON tree_leaves(status, is_missing_from_operators)
-                    WHERE status = 'Available' AND is_missing_from_operators = FALSE",
+                    WHERE status = 'Available' AND is_missing_from_operators = FALSE".to_string(),
                 "CREATE INDEX IF NOT EXISTS idx_tree_leaves_reservation ON tree_leaves(reservation_id)
-                    WHERE reservation_id IS NOT NULL",
-                "CREATE INDEX IF NOT EXISTS idx_tree_leaves_added_at ON tree_leaves(added_at)",
+                    WHERE reservation_id IS NOT NULL".to_string(),
+                "CREATE INDEX IF NOT EXISTS idx_tree_leaves_added_at ON tree_leaves(added_at)".to_string(),
             ],
             // Migration 2: Add swap status tracking for race condition fix
-            &[
+            vec![
                 "CREATE TABLE IF NOT EXISTS tree_swap_status (
                     id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
                     last_completed_at TIMESTAMPTZ
-                )",
-                "INSERT INTO tree_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING",
+                )".to_string(),
+                "INSERT INTO tree_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING".to_string(),
             ],
         ]
     }


### PR DESCRIPTION
Adds multi-tenant support to all three Postgres-backed stores (storage, tree, token) so multiple SDK instances can safely share one Postgres database, scoped by the tenant's identity pubkey.