### PR TITLE
package JVM native libraries in Breez Spark KMP artifact

### DIFF
--- a/.github/workflows/build-bindings-darwin.yml
+++ b/.github/workflows/build-bindings-darwin.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Upload dummy darwin ${{ matrix.target }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: bindings-dynamic-${{ matrix.target }}
+          name: bindings-${{ matrix.target }}
           path: ./*
 
   build-dsym-dummies:

--- a/.github/workflows/publish-kotlin-multiplatform.yml
+++ b/.github/workflows/publish-kotlin-multiplatform.yml
@@ -96,11 +96,51 @@ jobs:
           name: bindings-kotlin-multiplatform
           path: crates/breez-sdk/bindings/langs/kotlin-multiplatform/breez-sdk-spark-kmp/src
 
+      - name: Download JVM native library for Linux aarch64
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-aarch64-unknown-linux-gnu
+          path: crates/breez-sdk/bindings/langs/kotlin-multiplatform/breez-sdk-spark-kmp/src/jvmMain/resources/linux-aarch64
+
+      - name: Download JVM native library for Linux x86_64
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-x86_64-unknown-linux-gnu
+          path: crates/breez-sdk/bindings/langs/kotlin-multiplatform/breez-sdk-spark-kmp/src/jvmMain/resources/linux-x86-64
+
+      - name: Download JVM native library for macOS
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-dynamic-darwin-universal
+          path: crates/breez-sdk/bindings/langs/kotlin-multiplatform/breez-sdk-spark-kmp/src/jvmMain/resources/darwin
+
       - name: Build Kotlin Multiplatform project
         working-directory: crates/breez-sdk/bindings/langs/kotlin-multiplatform
         env:
           ORG_GRADLE_PROJECT_libraryVersion: ${{ inputs.package-version || '0.0.1' }}
         run: ./gradlew :breez-sdk-spark-kmp:assemble :breez-sdk-spark-kmp-plugin:assemble
+
+      - name: Verify JVM native libraries are packaged
+        working-directory: crates/breez-sdk/bindings/langs/kotlin-multiplatform
+        run: |
+          JAR="$(find breez-sdk-spark-kmp/build/libs -type f -name 'breez-sdk-spark-kmp-jvm*.jar' ! -name '*-sources.jar' ! -name '*-javadoc.jar' -print -quit)"
+          if [ -z "$JAR" ]; then
+            echo "Could not find breez-sdk-spark-kmp JVM jar"
+            exit 1
+          fi
+
+          jar tf "$JAR" > jvm-jar-contents.txt
+
+          require_jar_entry() {
+            if ! grep -Fqx "$1" jvm-jar-contents.txt; then
+              echo "Missing $1 from $JAR"
+              exit 1
+            fi
+          }
+
+          require_jar_entry "linux-aarch64/libbreez_sdk_spark_bindings.so"
+          require_jar_entry "linux-x86-64/libbreez_sdk_spark_bindings.so"
+          require_jar_entry "darwin/libbreez_sdk_spark_bindings.dylib"
 
       - name: Archive aar
         if: ${{ !inputs.publish }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,9 +88,9 @@ jobs:
       # (e.g. bindings-windows: true) if you want to test something.
       repository: ${{ needs.pre-setup.outputs.repository }}
       bindings-android: ${{ !!needs.pre-setup.outputs.android-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.kotlin-multiplatform-package-version || !!needs.pre-setup.outputs.react-native-package-version }}
-      bindings-darwin: ${{  !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.python-package-version || !!needs.pre-setup.outputs.swift-package-version }}
+      bindings-darwin: ${{  !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.kotlin-multiplatform-package-version || !!needs.pre-setup.outputs.python-package-version || !!needs.pre-setup.outputs.swift-package-version }}
       bindings-ios: ${{ !!needs.pre-setup.outputs.kotlin-multiplatform-package-version || !!needs.pre-setup.outputs.swift-package-version || !!needs.pre-setup.outputs.react-native-package-version }}
-      bindings-linux: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.python-package-version }}
+      bindings-linux: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.kotlin-multiplatform-package-version || !!needs.pre-setup.outputs.python-package-version }}
       bindings-wasm: ${{ !!needs.pre-setup.outputs.wasm-package-version }}
       bindings-windows: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.python-package-version }}
       android: ${{ !!needs.pre-setup.outputs.android-package-version }}
@@ -238,6 +238,8 @@ jobs:
     needs:
       - setup
       - build-bindings-android
+      - build-bindings-darwin
+      - build-bindings-linux
     if: ${{ needs.setup.outputs.kotlin-multiplatform == 'true' }}
     uses: ./.github/workflows/publish-kotlin-multiplatform.yml
     with:

--- a/crates/breez-sdk/bindings/Makefile
+++ b/crates/breez-sdk/bindings/Makefile
@@ -116,7 +116,13 @@ package-xcframework: build-ios-universal build-darwin-universal package-xcframew
 
 ## Kotlin Multiplatform
 KMP_BASE := langs/kotlin-multiplatform/breez-sdk-spark-kmp/src
+KMP_JVM_RESOURCES := $(KMP_BASE)/jvmMain/resources
 KOTLIN_PACKAGE := kotlin/breez_sdk_spark
+ifeq ($(UNAME), Darwin)
+	KMP_JVM_NATIVE_TARGETS := build-kotlin-multiplatform-jvm-darwin-binaries
+else ifeq ($(UNAME), Linux)
+	KMP_JVM_NATIVE_TARGETS := build-kotlin-multiplatform-jvm-linux-binaries
+endif
 
 # Build only the minimum needed for uniffi-bindgen (one Android arch)
 build-kotlin-multiplatform-bindgen-only: install-uniffi-bindgen-gobley build-ndk-release-target-aarch64-linux-android
@@ -149,13 +155,24 @@ build-kotlin-multiplatform-bindgen-android-arm64: install-uniffi-bindgen-gobley 
 # Build all binaries + run bindgen
 build-kotlin-multiplatform: build-kotlin-multiplatform-bindgen-only build-ndk-release-target-armv7-linux-androideabi build-ndk-release-target-i686-linux-android build-ndk-release-target-x86_64-linux-android
 
+# Copy JVM native libraries into JNA's expected classpath resource locations.
+build-kotlin-multiplatform-jvm-linux-binaries: build-release-target-aarch64-unknown-linux-gnu build-release-target-x86_64-unknown-linux-gnu
+	mkdir -p $(KMP_JVM_RESOURCES)/linux-aarch64
+	mkdir -p $(KMP_JVM_RESOURCES)/linux-x86-64
+	cp $(TARGET_DIR)aarch64-unknown-linux-gnu/release/$(BIN_NAME).so $(KMP_JVM_RESOURCES)/linux-aarch64/$(BIN_NAME).so
+	cp $(TARGET_DIR)x86_64-unknown-linux-gnu/release/$(BIN_NAME).so $(KMP_JVM_RESOURCES)/linux-x86-64/$(BIN_NAME).so
+
+build-kotlin-multiplatform-jvm-darwin-binaries: build-darwin-universal
+	mkdir -p $(KMP_JVM_RESOURCES)/darwin
+	cp $(TARGET_DIR)darwin-universal/release/$(BIN_NAME).dylib $(KMP_JVM_RESOURCES)/darwin/$(BIN_NAME).dylib
+
 # Package with dummy binaries (useful for testing)
 package-kotlin-multiplatform-dummy-binaries: build-kotlin-multiplatform-bindgen-only
 	cp -r $(FFI_DIR)kmp/* $(KMP_BASE)/
 	cd langs/kotlin-multiplatform && ./gradlew :breez-sdk-spark-kmp:assemble
 
 # Full package with all binaries
-package-kotlin-multiplatform: build-kotlin-multiplatform
+package-kotlin-multiplatform: build-kotlin-multiplatform $(KMP_JVM_NATIVE_TARGETS)
 	cp -r $(FFI_DIR)kmp/* $(KMP_BASE)/
 	rm -f $(FFI_DIR)kotlin/jniLibs/**/*spark.so
 	cp -r $(FFI_DIR)kotlin/jniLibs/ $(KMP_BASE)/androidMain/jniLibs/

--- a/docs/breez-sdk/src/guide/install_kotlin_multiplatform.md
+++ b/docs/breez-sdk/src/guide/install_kotlin_multiplatform.md
@@ -32,6 +32,10 @@ kotlin {
 
 ## Integration
 
+### JVM
+
+The JVM artifact includes the native libraries needed for Linux and macOS. No additional native library installation is required on those platforms.
+
 ### iOS
 
 Install the native binary framework via [Swift Package Manager](#swift-package-manager). The Gradle plugin automatically configures the framework search path from Xcode's build environment.


### PR DESCRIPTION
 ## Summary

  Package Breez Spark KMP JVM native libraries in the published JVM artifact.

  This adds Linux and macOS native resources to the KMP JVM packaging path so JVM consumers can load `libbreez_sdk_spark_bindings` via JNA from the Maven dependency, without vendoring native libraries in downstream apps.

  ## Details

  - Adds JVM native resource packaging for Linux and macOS.
  - Updates KMP publish workflow to build/download Linux and Darwin native artifacts before publishing.
  - Adds a jar-content check to verify expected native resources are packaged.
  - Documents that Linux/macOS JVM consumers do not need a separate native library install.

  ## Verification

  - Built macOS universal dylib locally.
  - Published patched JVM artifact to `mavenLocal`.
  - Verified the jar contains `darwin/libbreez_sdk_spark_bindings.dylib`.
  - Verified demo app can load Breez native bindings from the local SDK jar without a native-library override.