### PR TITLE
CI (Swift): Keep package symlinks when zipping bindings

### DIFF
--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -136,6 +136,7 @@ jobs:
           install_name_tool -id @rpath/breez_sdk_sparkFFI.framework/breez_sdk_sparkFFI build/crates/breez-sdk/bindings/langs/swift/breez_sdk_sparkFFI.xcframework/ios-arm64/breez_sdk_sparkFFI.framework/breez_sdk_sparkFFI
           install_name_tool -id @rpath/breez_sdk_sparkFFI.framework/breez_sdk_sparkFFI build/crates/breez-sdk/bindings/langs/swift/breez_sdk_sparkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdk_sparkFFI.framework/breez_sdk_sparkFFI
           install_name_tool -id @rpath/breez_sdk_sparkFFI.framework/Versions/A/breez_sdk_sparkFFI build/crates/breez-sdk/bindings/langs/swift/breez_sdk_sparkFFI.xcframework/macos-arm64_x86_64/breez_sdk_sparkFFI.framework/Versions/A/breez_sdk_sparkFFI
+          ln -sf Versions/Current/breez_sdk_sparkFFI build/crates/breez-sdk/bindings/langs/swift/breez_sdk_sparkFFI.xcframework/macos-arm64_x86_64/breez_sdk_sparkFFI.framework/breez_sdk_sparkFFI
 
       - name: Embed dSYMs in xcframework
         run: |

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Compress XCFramework
         working-directory: build/crates/breez-sdk/bindings/langs/swift
         run: |
-          zip -9 -r breez_sdk_sparkFFI.xcframework.zip breez_sdk_sparkFFI.xcframework
+          zip -9 -r -y breez_sdk_sparkFFI.xcframework.zip breez_sdk_sparkFFI.xcframework
           echo "XCF_CHECKSUM=`swift package compute-checksum breez_sdk_sparkFFI.xcframework.zip`" >> $GITHUB_ENV
 
       - name: Remove dist Sources


### PR DESCRIPTION
This fixes an issue in macOS deployments where missing symlinks would break the macOS versioned structure. Does not affect iOS as it uses a flat layout (non-versioned).