### PR TITLE
fix(sync-cli): prevent GHA expression substitution inside Python heredoc

### DIFF
--- a/.github/workflows/sync-cli.yml
+++ b/.github/workflows/sync-cli.yml
@@ -215,16 +215,13 @@ jobs:
           sys.path.insert(0, "crates/breez-sdk/bindings/examples/cli/sync-prompts")
           from generate import generate_prompt
 
-          prompt = generate_prompt(os.environ["LANG"])
-
-          # Resolve GitHub Actions expressions that would normally be
-          # evaluated in YAML but aren't when the prompt is assembled dynamically
-          replacements = {
-              "${{ steps.diff-info.outputs.diff_summary }}": os.environ.get("DIFF_SUMMARY", ""),
-              "${{ steps.diff-info.outputs.diff_base }}": os.environ.get("DIFF_BASE", ""),
-          }
-          for expr, value in replacements.items():
-              prompt = prompt.replace(expr, value)
+          prompt = generate_prompt(
+              os.environ["LANG"],
+              extra_vars={
+                  "DIFF_SUMMARY": os.environ.get("DIFF_SUMMARY", ""),
+                  "DIFF_BASE": os.environ.get("DIFF_BASE", ""),
+              },
+          )
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               f.write("content<<EOPROMPT_DELIM_7f3a\n")

--- a/crates/breez-sdk/bindings/examples/cli/sync-prompts/generate.py
+++ b/crates/breez-sdk/bindings/examples/cli/sync-prompts/generate.py
@@ -139,9 +139,16 @@ def render_template(template: str, variables: dict[str, str]) -> str:
     return result
 
 
-def generate_prompt(lang_id: str) -> str:
-    """Generate the rendered prompt for a language."""
+def generate_prompt(lang_id: str, extra_vars: dict[str, str] | None = None) -> str:
+    """Generate the rendered prompt for a language.
+
+    `extra_vars` are merged into the per-language config before rendering,
+    used by the sync workflow to inject runtime values like the diff
+    summary and base SHA. Keys are uppercased to match {{KEY}} placeholders.
+    """
     config = load_lang_config(lang_id)
+    if extra_vars:
+        config = {**config, **extra_vars}
     template = PROMPT_TEMPLATE.read_text()
     return render_template(template, config)
 

--- a/crates/breez-sdk/bindings/examples/cli/sync-prompts/prompt-template.md
+++ b/crates/breez-sdk/bindings/examples/cli/sync-prompts/prompt-template.md
@@ -3,7 +3,7 @@
 Your job is to update the {{LANG_NAME}} CLI to match the current Rust CLI.
 
 ### What changed
-${{ steps.diff-info.outputs.diff_summary }}
+{{DIFF_SUMMARY}}
 
 ### Step 1: Learn the {{LANG_NAME}} SDK API
 Before comparing anything, read these {{LANG_NAME}} SDK snippets at `{{SNIPPET_DIR}}`:
@@ -14,7 +14,7 @@ Before comparing anything, read these {{LANG_NAME}} SDK snippets at `{{SNIPPET_D
 These snippets are compiled and tested — they are the ground truth for what methods exist and how they are called in {{LANG_NAME}}. You will need this context to identify real divergences vs naming conventions.
 
 ### Step 2: Analyze the changes
-If a diff base was provided, run: `git diff ${{ steps.diff-info.outputs.diff_base }} HEAD -- 'crates/breez-sdk/cli/src/' 'crates/breez-sdk/cli/README.md'`
+If a diff base was provided, run: `git diff {{DIFF_BASE}} HEAD -- 'crates/breez-sdk/cli/src/' 'crates/breez-sdk/cli/README.md'`
 The diff is a hint for what changed recently, but it may not reveal all differences.
 
 **Always read the current Rust CLI source files and compare them against the {{LANG_NAME}} CLI.** The Rust CLI is the source of truth. Read each mapped file pair (see Step 3) and perform this comparison for each pair:


### PR DESCRIPTION
## Summary

The Sync CLI Languages workflow has been failing on every run since the [Mar 26 rewrite](https://github.com/breez/spark-sdk/commit/33c2c86c) ([sync-cli runs](https://github.com/breez/spark-sdk/actions/workflows/sync-cli.yml)). The `Generate sync prompt` step has been crashing with:

```
File "<stdin>", line 10
    "Rust CLI changes since 5bbd4ce6b48fbb6a01e3ac34c75111b7dba73f18:
    ^
SyntaxError: unterminated string literal (detected at line 10)
```

### Root cause

`.github/workflows/sync-cli.yml` had literal `${{ steps.diff-info.outputs.diff_summary }}` strings as Python dictionary keys inside a `python3 << 'PYEOF'` heredoc. GitHub Actions evaluates `${{ ... }}` expressions inside `run:` blocks **before** bash receives the heredoc, so by the time Python ran, the dict keys had been replaced with the actual multi-line diff content, breaking Python syntax. The single-quoted heredoc only protects against shell variable expansion, not GHA expression substitution.

### Fix

Eliminated the entire bug class by removing GHA-expression placeholders from the prompt template and routing the runtime values through the existing `{{KEY}}` substitution pipeline:

1. **`prompt-template.md`** — replaced `${{ steps.diff-info.outputs.diff_summary }}` and `${{ steps.diff-info.outputs.diff_base }}` with `{{DIFF_SUMMARY}}` and `{{DIFF_BASE}}`, matching the convention already used for `{{LANG_NAME}}`, `{{SNIPPET_DIR}}`, etc.
2. **`generate.py`** — added an optional `extra_vars` parameter to `generate_prompt()` so callers can inject runtime values that get merged into the per-language config before rendering.
3. **`sync-cli.yml`** — dropped the buggy `replacements` dict and pass `DIFF_SUMMARY`/`DIFF_BASE` via the new `extra_vars` parameter. The heredoc now contains zero `${{ ... }}` expressions.

## Test plan

Verified locally (cannot trigger `repository_dispatch` from a branch, so this needs to be merged and observed on the next sync):

- [x] Reproduced the original `SyntaxError` by simulating GHA expression substitution.
- [x] Re-ran the fixed heredoc with realistic env values (multi-line `DIFF_SUMMARY`, full SHA `DIFF_BASE`) and confirmed correct substitution into the rendered prompt.
- [x] Verified all 8 languages (csharp, flutter, golang, kotlin-multiplatform, python, react-native, swift, wasm) render with no leftover `{{...}}` placeholders.
- [x] Verified the empty-`DIFF_BASE` branch still renders the same as before (matches the pre-rewrite full-comparison message).
- [x] Verified no remaining `${{ ... }}` expressions inside any Python heredoc in the workflow.
- [ ] After merge, watch the next `sync-cli` run on `main` to confirm the `Generate sync prompt` step succeeds for all matrix entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)