### PR TITLE
feat(spark-wallet): split token output consolidation into N outputs

### DIFF
--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -637,6 +637,21 @@ pub struct OptimizationConfig {
     ///
     /// Default value is 1.
     pub multiplicity: u8,
+    /// Number of token outputs to produce when token-output auto-consolidation
+    /// fires.
+    ///
+    /// Auto-consolidation triggers per-token when the wallet has more than the
+    /// configured threshold of available outputs for that token; instead of
+    /// collapsing them into a single output (which serializes subsequent
+    /// payments), the SDK splits the consolidated balance across this many
+    /// outputs of roughly equal value. Higher values preserve concurrency for
+    /// parallel sends at the cost of a slightly larger output set.
+    ///
+    /// Must be >= 1 and strictly less than the underlying
+    /// `min_outputs_threshold` (default 50).
+    ///
+    /// Default value is 5.
+    pub token_target_output_count: u32,
 }
 
 /// A stable token that can be used for automatic balance conversion.

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -197,6 +197,7 @@ pub fn default_config(network: Network) -> Config {
         optimization_config: OptimizationConfig {
             auto_enabled: true,
             multiplicity: 1,
+            token_target_output_count: 5,
         },
         stable_balance_config: None,
         max_concurrent_claims: 4,

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -517,6 +517,9 @@ impl SdkBuilder {
             self.config.optimization_config.auto_enabled;
         spark_wallet_config.leaf_optimization_options.multiplicity =
             self.config.optimization_config.multiplicity;
+        spark_wallet_config
+            .token_outputs_optimization_options
+            .target_output_count = self.config.optimization_config.token_target_output_count;
         spark_wallet_config.max_concurrent_claims = self.config.max_concurrent_claims;
 
         let shutdown_sender = watch::channel::<()>(()).0;

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -670,6 +670,7 @@ pub struct SparkSspConfig {
 pub struct OptimizationConfig {
     pub auto_enabled: bool,
     pub multiplicity: u8,
+    pub token_target_output_count: u32,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::StableBalanceToken)]

--- a/crates/spark-itest/src/fixtures/setup.rs
+++ b/crates/spark-itest/src/fixtures/setup.rs
@@ -88,6 +88,7 @@ impl TestFixtures {
             leaf_auto_optimize_enabled: false,
             token_outputs_optimization_options: TokenOutputsOptimizationOptions {
                 min_outputs_threshold: 50,
+                target_output_count: 5,
                 auto_optimize_interval: None,
             },
             self_payment_allowed: false,

--- a/crates/spark-wallet/src/config.rs
+++ b/crates/spark-wallet/src/config.rs
@@ -67,6 +67,7 @@ impl SparkWalletConfig {
                 leaf_auto_optimize_enabled: true,
                 token_outputs_optimization_options: TokenOutputsOptimizationOptions {
                     min_outputs_threshold: 50,
+                    target_output_count: 5,
                     auto_optimize_interval: Some(Duration::from_secs(60 * 2)),
                 },
                 self_payment_allowed: false,
@@ -88,6 +89,7 @@ impl SparkWalletConfig {
                 leaf_auto_optimize_enabled: true,
                 token_outputs_optimization_options: TokenOutputsOptimizationOptions {
                     min_outputs_threshold: 50,
+                    target_output_count: 5,
                     auto_optimize_interval: Some(Duration::from_secs(60 * 2)),
                 },
                 self_payment_allowed: false,
@@ -179,7 +181,15 @@ impl SparkWalletConfig {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TokenOutputsOptimizationOptions {
+    /// Auto-consolidation fires for a token when its available output count
+    /// strictly exceeds this threshold.
     pub min_outputs_threshold: u32,
+    /// Number of outputs to produce when consolidation runs. The summed input
+    /// amount is split into this many roughly-equal outputs (any remainder
+    /// becomes a change output to the same self-address). Must be >= 1 and
+    /// strictly less than `min_outputs_threshold` so consolidation can
+    /// converge below the trigger.
+    pub target_output_count: u32,
     pub auto_optimize_interval: Option<Duration>,
 }
 
@@ -190,6 +200,78 @@ impl TokenOutputsOptimizationOptions {
                 "min_outputs_threshold must be greater than 1".to_string(),
             ));
         }
+        if self.target_output_count < 1 {
+            return Err(SparkWalletError::ValidationError(
+                "target_output_count must be at least 1".to_string(),
+            ));
+        }
+        if self.target_output_count >= self.min_outputs_threshold {
+            return Err(SparkWalletError::ValidationError(
+                "target_output_count must be strictly less than min_outputs_threshold".to_string(),
+            ));
+        }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts(
+        min_outputs_threshold: u32,
+        target_output_count: u32,
+    ) -> TokenOutputsOptimizationOptions {
+        TokenOutputsOptimizationOptions {
+            min_outputs_threshold,
+            target_output_count,
+            auto_optimize_interval: None,
+        }
+    }
+
+    #[test]
+    fn default_config_is_valid() {
+        SparkWalletConfig::default_config(Network::Mainnet)
+            .validate()
+            .expect("mainnet default must be valid");
+        SparkWalletConfig::default_config(Network::Regtest)
+            .validate()
+            .expect("regtest default must be valid");
+    }
+
+    #[test]
+    fn rejects_target_equal_to_threshold() {
+        let err = opts(5, 5).validate().unwrap_err();
+        assert!(
+            matches!(err, SparkWalletError::ValidationError(_)),
+            "expected ValidationError, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_target_above_threshold() {
+        opts(5, 6)
+            .validate()
+            .expect_err("target_output_count >= min_outputs_threshold must fail");
+    }
+
+    #[test]
+    fn rejects_target_zero() {
+        opts(50, 0)
+            .validate()
+            .expect_err("target_output_count of 0 must fail");
+    }
+
+    #[test]
+    fn rejects_threshold_le_one() {
+        opts(1, 1)
+            .validate()
+            .expect_err("min_outputs_threshold <= 1 must fail");
+    }
+
+    #[test]
+    fn accepts_target_below_threshold() {
+        opts(50, 5).validate().expect("5 < 50 must pass");
+        opts(3, 1).validate().expect("1 < 3 must pass");
     }
 }

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1637,6 +1637,9 @@ impl SparkWallet {
                 self.config
                     .token_outputs_optimization_options
                     .min_outputs_threshold,
+                self.config
+                    .token_outputs_optimization_options
+                    .target_output_count,
             )
             .await?;
         Ok(())
@@ -2306,6 +2309,7 @@ impl BackgroundProcessor {
                     None,
                     self.token_outputs_optimization_options
                         .min_outputs_threshold,
+                    self.token_outputs_optimization_options.target_output_count,
                 )
                 .await
             {

--- a/crates/spark/src/token/token_service.rs
+++ b/crates/spark/src/token/token_service.rs
@@ -50,6 +50,52 @@ fn is_transaction_preempted_error(error: &OperatorRpcError) -> bool {
     matches!(error, OperatorRpcError::Connection(status) if status.code() == tonic::Code::Aborted)
 }
 
+/// Build the list of `TransferTokenOutput` entries that consolidation should send
+/// to the wallet's own spark address.
+///
+/// The summed input `amount` is split into `target_output_count` outputs of
+/// `amount / target_output_count`. The transfer builder auto-adds any remainder
+/// as a change output to the same address, so the resulting on-chain output
+/// count is exactly `target_output_count`. If the per-output amount would round
+/// down to zero (i.e., `amount < target_output_count`), we fall back to a
+/// single output of `amount` to avoid creating zero-value outputs.
+fn build_consolidation_outputs(
+    token_id: &str,
+    amount: u128,
+    target_output_count: u32,
+    receiver_address: &SparkAddress,
+) -> Vec<TransferTokenOutput> {
+    let n = u128::from(target_output_count);
+    if n <= 1 || amount < n {
+        if amount < n {
+            warn!(
+                "Consolidation amount {} smaller than target_output_count {}; falling back to a single output",
+                amount, target_output_count
+            );
+        }
+        return vec![TransferTokenOutput {
+            token_id: token_id.to_string(),
+            amount,
+            receiver_address: receiver_address.clone(),
+            spark_invoice: None,
+        }];
+    }
+
+    let per_output = amount / n;
+    // Emit (n - 1) explicit outputs of `per_output`. The remainder
+    // (amount - (n - 1) * per_output) becomes the change output added by
+    // build_transfer_token_transaction, also routed back to receiver_address,
+    // landing us at exactly `target_output_count` outputs.
+    (0..(target_output_count - 1))
+        .map(|_| TransferTokenOutput {
+            token_id: token_id.to_string(),
+            amount: per_output,
+            receiver_address: receiver_address.clone(),
+            spark_invoice: None,
+        })
+        .collect()
+}
+
 const HRP_STR_MAINNET: &str = "btkn";
 const HRP_STR_TESTNET: &str = "btknt";
 const HRP_STR_REGTEST: &str = "btknrt";
@@ -501,7 +547,10 @@ impl TokenService {
                 Err(ServiceError::NeededTooManyOutputs)
                     if attempt < MAX_TRANSFER_TOKEN_TOO_MANY_OUTPUTS_RETRY_ATTEMPTS - 1 =>
                 {
-                    self.optimize_token_outputs(Some(&token_id), 2).await?;
+                    // Emergency consolidation during a transfer retry: collapse to a
+                    // single output regardless of the wallet's configured target so the
+                    // next retry has the simplest possible input set to work with.
+                    self.optimize_token_outputs(Some(&token_id), 2, 1).await?;
                     attempt += 1;
                     continue;
                 }
@@ -590,14 +639,32 @@ impl TokenService {
     /// Optimizes token outputs by consolidating them when there are more than the configured threshold.
     /// Processes one token at a time. Token identifier can be provided, otherwise one is automatically selected.
     /// Only optimizes if the number of outputs is greater than the provided `min_outputs_threshold` (min 2).
+    ///
+    /// `target_output_count` controls how many outputs the consolidation transfer produces.
+    /// The summed input amount is split into roughly-equal outputs to the wallet's own
+    /// spark address; any integer-division remainder becomes the change output (also
+    /// self-addressed), so the resulting output count is exactly `target_output_count`.
+    /// If the per-output amount would round down to zero, the consolidation falls back
+    /// to a single output to avoid creating zero-value outputs.
     pub async fn optimize_token_outputs(
         &self,
         token_identifier: Option<&str>,
         min_outputs_threshold: u32,
+        target_output_count: u32,
     ) -> Result<(), ServiceError> {
         if min_outputs_threshold <= 1 {
             return Err(ServiceError::ValidationError(
                 "min_outputs_threshold must be greater than 1".to_string(),
+            ));
+        }
+        if target_output_count < 1 {
+            return Err(ServiceError::ValidationError(
+                "target_output_count must be at least 1".to_string(),
+            ));
+        }
+        if target_output_count >= min_outputs_threshold {
+            return Err(ServiceError::ValidationError(
+                "target_output_count must be strictly less than min_outputs_threshold".to_string(),
             ));
         }
 
@@ -645,21 +712,24 @@ impl TokenService {
                 .map(|o| o.output.token_amount)
                 .sum::<u128>();
 
+            let receiver_address = SparkAddress::new(
+                self.signer.get_identity_public_key().await?,
+                self.network,
+                None,
+            );
+            let receiver_outputs = build_consolidation_outputs(
+                &output.metadata.identifier,
+                amount,
+                target_output_count,
+                &receiver_address,
+            );
+
             let token_transaction = with_reserved_token_outputs(
                 self.token_output_service.as_ref(),
                 self.transfer_tokens_inner(
                     &output.metadata.identifier,
                     reservation.token_outputs.outputs.clone(),
-                    vec![TransferTokenOutput {
-                        token_id: output.metadata.identifier.clone(),
-                        amount,
-                        receiver_address: SparkAddress::new(
-                            self.signer.get_identity_public_key().await?,
-                            self.network,
-                            None,
-                        ),
-                        spark_invoice: None,
-                    }],
+                    receiver_outputs,
                 ),
                 &reservation,
             )

--- a/crates/spark/src/token/token_service.rs
+++ b/crates/spark/src/token/token_service.rs
@@ -1732,15 +1732,21 @@ mod tests {
     use macros::test_all;
     use prost_types::Timestamp;
 
+    use bitcoin::secp256k1::PublicKey;
+
     use crate::{
         Network,
+        address::SparkAddress,
         operator::rpc::{
             self,
             spark_token::{
                 TokenOutput, TokenOutputToSpend, TokenTransferInput, token_transaction::TokenInputs,
             },
         },
-        token::{HashableTokenTransaction, token_service::validate_create_token_params},
+        token::{
+            HashableTokenTransaction,
+            token_service::{build_consolidation_outputs, validate_create_token_params},
+        },
     };
 
     #[cfg(feature = "browser-tests")]
@@ -2023,6 +2029,100 @@ mod tests {
             hex::encode(&decoded),
             "3206c93b24a4d18ea19d0a9a213204af2c7e74a6d16c7535cc5d33eca4ad1eca"
         );
+    }
+
+    fn test_receiver_address() -> SparkAddress {
+        const TEST_PUBKEY_BYTES: [u8; 33] = [
+            3, 141, 37, 201, 160, 148, 226, 93, 184, 201, 131, 47, 222, 91, 55, 171, 38, 95, 13,
+            248, 175, 190, 44, 132, 189, 75, 131, 204, 215, 82, 93, 167, 177,
+        ];
+        SparkAddress {
+            identity_public_key: PublicKey::from_slice(&TEST_PUBKEY_BYTES).unwrap(),
+            network: Network::Mainnet,
+            spark_invoice_fields: None,
+        }
+    }
+
+    const TEST_TOKEN_ID: &str = "btkn1xgrvjwey5ngcagvap2dzzvsy4uk8ua9x69k82dwvt5e7ef9drm9qztux87";
+
+    #[test_all]
+    fn test_build_consolidation_outputs_target_zero_returns_single_output() {
+        let receiver = test_receiver_address();
+        let outputs = build_consolidation_outputs(TEST_TOKEN_ID, 100, 0, &receiver);
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].amount, 100);
+        assert_eq!(outputs[0].token_id, TEST_TOKEN_ID);
+        assert_eq!(outputs[0].receiver_address, receiver);
+        assert!(outputs[0].spark_invoice.is_none());
+    }
+
+    #[test_all]
+    fn test_build_consolidation_outputs_target_one_returns_single_output() {
+        let receiver = test_receiver_address();
+        let outputs = build_consolidation_outputs(TEST_TOKEN_ID, 100, 1, &receiver);
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].amount, 100);
+    }
+
+    #[test_all]
+    fn test_build_consolidation_outputs_amount_less_than_target_falls_back() {
+        let receiver = test_receiver_address();
+        // amount=3, target=5: cannot split into 5 non-zero outputs, fall back to one.
+        let outputs = build_consolidation_outputs(TEST_TOKEN_ID, 3, 5, &receiver);
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].amount, 3);
+    }
+
+    #[test_all]
+    fn test_build_consolidation_outputs_amount_equal_to_target_splits_into_ones() {
+        let receiver = test_receiver_address();
+        // amount=5, target=5: per_output=1, emit 4 outputs of 1; change of 1 is
+        // added by the transfer builder, yielding 5 outputs total.
+        let outputs = build_consolidation_outputs(TEST_TOKEN_ID, 5, 5, &receiver);
+        assert_eq!(outputs.len(), 4);
+        for out in &outputs {
+            assert_eq!(out.amount, 1);
+        }
+    }
+
+    #[test_all]
+    fn test_build_consolidation_outputs_even_split() {
+        let receiver = test_receiver_address();
+        // amount=1000, target=4: per_output=250, emit 3 explicit outputs of 250;
+        // change of 250 lands as the 4th output.
+        let outputs = build_consolidation_outputs(TEST_TOKEN_ID, 1000, 4, &receiver);
+        assert_eq!(outputs.len(), 3);
+        for out in &outputs {
+            assert_eq!(out.amount, 250);
+            assert_eq!(out.token_id, TEST_TOKEN_ID);
+            assert_eq!(out.receiver_address, receiver);
+        }
+    }
+
+    #[test_all]
+    fn test_build_consolidation_outputs_uneven_split_remainder_goes_to_change() {
+        let receiver = test_receiver_address();
+        // amount=1003, target=4: per_output=250, emit 3 explicit outputs of 250.
+        // Change = 1003 - 750 = 253 will be added by the transfer builder.
+        let outputs = build_consolidation_outputs(TEST_TOKEN_ID, 1003, 4, &receiver);
+        assert_eq!(outputs.len(), 3);
+        let explicit_total: u128 = outputs.iter().map(|o| o.amount).sum();
+        assert_eq!(explicit_total, 750);
+        for out in &outputs {
+            assert_eq!(out.amount, 250);
+        }
+    }
+
+    #[test_all]
+    fn test_build_consolidation_outputs_large_u128_amount() {
+        let receiver = test_receiver_address();
+        // Sanity-check that the math does not overflow at the u128 ceiling.
+        let outputs = build_consolidation_outputs(TEST_TOKEN_ID, u128::MAX, 10, &receiver);
+        assert_eq!(outputs.len(), 9);
+        let per_output = u128::MAX / 10;
+        for out in &outputs {
+            assert_eq!(out.amount, per_output);
+        }
     }
 
     #[test_all]

--- a/docs/breez-sdk/snippets/csharp/Config.cs
+++ b/docs/breez-sdk/snippets/csharp/Config.cs
@@ -44,7 +44,7 @@ namespace BreezSdkSnippets
             // ANCHOR: optimization-configuration
             var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
             {
-                optimizationConfig = new OptimizationConfig(autoEnabled: true, multiplicity: 1)
+                optimizationConfig = new OptimizationConfig(autoEnabled: true, multiplicity: 1, tokenTargetOutputCount: 5)
             };
             // ANCHOR_END: optimization-configuration
         }

--- a/docs/breez-sdk/snippets/flutter/lib/config.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/config.dart
@@ -40,7 +40,7 @@ Future<void> configureOptimizationConfiguration() async {
   // ANCHOR: optimization-configuration
   var config = defaultConfig(network: Network.mainnet).copyWith(
       optimizationConfig:
-          OptimizationConfig(autoEnabled: true, multiplicity: 1));
+          OptimizationConfig(autoEnabled: true, multiplicity: 1, tokenTargetOutputCount: 5));
   // ANCHOR_END: optimization-configuration
   print(config);
 }

--- a/docs/breez-sdk/snippets/go/config.go
+++ b/docs/breez-sdk/snippets/go/config.go
@@ -44,7 +44,7 @@ func ConfigurePrivateEnabledDefault() {
 func ConfigureOptimizationConfiguration() {
 	// ANCHOR: optimization-configuration
 	config := breez_sdk_spark.DefaultConfig(breez_sdk_spark.NetworkMainnet)
-	config.OptimizationConfig = breez_sdk_spark.OptimizationConfig{AutoEnabled: true, Multiplicity: 1}
+	config.OptimizationConfig = breez_sdk_spark.OptimizationConfig{AutoEnabled: true, Multiplicity: 1, TokenTargetOutputCount: 5}
 	// ANCHOR_END: optimization-configuration
 	log.Printf("Config: %+v", config)
 }

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
@@ -37,7 +37,7 @@ class Config {
     fun configureOptimizationConfiguration() {
         // ANCHOR: optimization-configuration
         val config = defaultConfig(Network.MAINNET)
-        config.optimizationConfig = OptimizationConfig(autoEnabled = true, multiplicity = 1u)
+        config.optimizationConfig = OptimizationConfig(autoEnabled = true, multiplicity = 1u, tokenTargetOutputCount = 5u)
         // ANCHOR_END: optimization-configuration
         println("Config: $config")
     }

--- a/docs/breez-sdk/snippets/python/src/config.py
+++ b/docs/breez-sdk/snippets/python/src/config.py
@@ -44,7 +44,9 @@ async def configure_private_enabled_default():
 async def configure_optimization_configuration():
     # ANCHOR: optimization-configuration
     config = default_config(network=Network.MAINNET)
-    config.optimization_config = OptimizationConfig(auto_enabled=True, multiplicity=1)
+    config.optimization_config = OptimizationConfig(
+        auto_enabled=True, multiplicity=1, token_target_output_count=5
+    )
     # ANCHOR_END: optimization-configuration
     logging.info(f"Config: {config}")
 

--- a/docs/breez-sdk/snippets/react-native/config.ts
+++ b/docs/breez-sdk/snippets/react-native/config.ts
@@ -40,7 +40,7 @@ const exampleConfigurePrivateEnabledDefault = () => {
 const exampleConfigureOptimizationConfiguration = () => {
   // ANCHOR: optimization-configuration
   const config = defaultConfig(Network.Mainnet)
-  config.optimizationConfig = { autoEnabled: true, multiplicity: 1 }
+  config.optimizationConfig = { autoEnabled: true, multiplicity: 1, tokenTargetOutputCount: 5 }
   // ANCHOR_END: optimization-configuration
   console.log('Config:', config)
 }

--- a/docs/breez-sdk/snippets/rust/src/config.rs
+++ b/docs/breez-sdk/snippets/rust/src/config.rs
@@ -43,6 +43,7 @@ pub(crate) fn configure_optimization_configuration() -> Result<()> {
     config.optimization_config = OptimizationConfig {
         auto_enabled: true,
         multiplicity: 1,
+        token_target_output_count: 5,
     };
     // ANCHOR_END: optimization-configuration
     info!("Config: {:?}", config);

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Config.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Config.swift
@@ -34,7 +34,7 @@ func configurePrivateEnabledDefault() async throws {
 func configureOptimizationConfiguration() async throws {
     // ANCHOR: optimization-configuration
     var config = defaultConfig(network: Network.mainnet)
-    config.optimizationConfig = OptimizationConfig(autoEnabled: true, multiplicity: 1)
+    config.optimizationConfig = OptimizationConfig(autoEnabled: true, multiplicity: 1, tokenTargetOutputCount: 5)
     // ANCHOR_END: optimization-configuration
     print("Config: \(config)")
 }

--- a/docs/breez-sdk/snippets/wasm/config.ts
+++ b/docs/breez-sdk/snippets/wasm/config.ts
@@ -34,7 +34,7 @@ const exampleConfigurePrivateEnabledDefault = async () => {
 const exampleConfigureOptimizationConfiguration = async () => {
   // ANCHOR: optimization-configuration
   const config = defaultConfig('mainnet')
-  config.optimizationConfig = { autoEnabled: true, multiplicity: 1 }
+  config.optimizationConfig = { autoEnabled: true, multiplicity: 1, tokenTargetOutputCount: 5 }
   // ANCHOR_END: optimization-configuration
   console.log('Config:', config)
 }

--- a/docs/breez-sdk/src/guide/config.md
+++ b/docs/breez-sdk/src/guide/config.md
@@ -69,6 +69,7 @@ This configuration controls optimization through the following options:
 
 - **Automatic optimization enabled**: whether optimization runs automatically when a payment is sent or received. Enabled by default.
 - **Multiplicity**: the desired multiplicity for the leaf set. Default value is 1. Setting it to 0 fully optimizes for unilateral exit efficiency. Setting it to a value greater than 0 also optimizes for payment speed, with higher values prioritizing payment speed more aggressively at the cost of higher unilateral exit fees. Values above 5 are intended for high-throughput server environments that require maximum TPS and are not recommended for end-user wallets.
+- **Token target output count**: the number of token outputs to produce when token-output auto-consolidation fires. Auto-consolidation triggers per-token once the wallet exceeds its available-outputs threshold for that token; instead of collapsing them into a single output (which would serialize subsequent sends), the SDK splits the consolidated balance across this many outputs of roughly equal value. Higher values preserve concurrency for parallel sends at the cost of a slightly larger output set. Must be at least 1 and strictly less than the underlying outputs threshold. Default value is 5.
 
 See [Custom leaf optimization](./optimize.md) for more information and recommendations on how to configure optimization.
 

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -73,6 +73,7 @@ pub struct _SparkSspConfig {
 pub struct _OptimizationConfig {
     pub auto_enabled: bool,
     pub multiplicity: u8,
+    pub token_target_output_count: u32,
 }
 
 #[frb(mirror(StableBalanceToken))]


### PR DESCRIPTION
Add `target_output_count` to `TokenOutputsOptimizationOptions` so token output auto-consolidation produces N roughly-equal outputs instead of collapsing into a single one. Default is 5.

When auto-consolidation collapses everything into one output, subsequent payments must serialize on that single output until new ones accumulate. That's bad for server-side wallets doing parallel sends. Splitting into N outputs preserves concurrency.

In `optimize_token_outputs`, for each token over threshold:
- reserve up to MAX_TOKEN_TX_INPUTS smallest outputs (unchanged)
- emit `(N - 1)` explicit `TransferTokenOutput`s of `amount / N` to the wallet's own spark address
- let `build_transfer_token_transaction` auto-add the remainder as the change output (also self-addressed) — net result is exactly N outputs
- if `amount < N`, fall back to a single output and warn

Internal "needed too many outputs" retry path passes `target=1` explicitly — that is emergency consolidation during payment retries where collapsing aggressively is the right move.

Validation: `target_output_count >= 1` and `target_output_count < min_outputs_threshold`.

spark-wallet validation tests covering the new fields are included.