### PR TITLE
Share Postgres / MySQL connection pools across SDK instances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,7 @@ dependencies = [
  "rand 0.8.6",
  "tempfile",
  "tokio",
+ "tokio-postgres",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
@@ -267,7 +267,8 @@ static async Task RunInteractiveMode(
     if (postgresConnectionString != null)
     {
         var pgConfig = BreezSdkSparkMethods.DefaultPostgresStorageConfig(postgresConnectionString);
-        await builder.WithPostgresBackend(config: pgConfig);
+        var pool = BreezSdkSparkMethods.CreatePostgresConnectionPool(config: pgConfig);
+        await builder.WithPostgresConnectionPool(pool: pool);
     }
     else
     {

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/main.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/main.go
@@ -167,7 +167,12 @@ func main() {
 	builder := breez_sdk_spark.NewSdkBuilder(config, seed)
 	if *postgresConnectionString != "" {
 		pgConfig := breez_sdk_spark.DefaultPostgresStorageConfig(*postgresConnectionString)
-		builder.WithPostgresBackend(pgConfig)
+		pool, err := breez_sdk_spark.CreatePostgresConnectionPool(pgConfig)
+		if err != nil {
+			fmt.Printf("Failed to create postgres connection pool: %v\n", err)
+			os.Exit(1)
+		}
+		builder.WithPostgresConnectionPool(pool)
 	} else {
 		builder.WithDefaultStorage(resolvedDir)
 	}

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Main.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Main.kt
@@ -256,7 +256,8 @@ suspend fun runInteractiveMode(
     val builder = SdkBuilder(config, seed)
     if (postgresConnectionString != null) {
         val pgConfig = defaultPostgresStorageConfig(postgresConnectionString)
-        builder.withPostgresBackend(pgConfig)
+        val pool = createPostgresConnectionPool(pgConfig)
+        builder.withPostgresConnectionPool(pool)
     } else {
         builder.withDefaultStorage(dataDir)
     }

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
@@ -19,6 +19,7 @@ from breez_sdk_spark import (
     Seed,
     StableBalanceConfig,
     StableBalanceToken,
+    create_postgres_connection_pool,
     default_config,
     default_postgres_storage_config,
     init_logging,
@@ -116,7 +117,8 @@ async def main(data_dir, network, account_number, postgres_connection_string,
 
     if postgres_connection_string:
         pg_config = default_postgres_storage_config(connection_string=postgres_connection_string)
-        await builder.with_postgres_backend(config=pg_config)
+        pool = create_postgres_connection_pool(config=pg_config)
+        await builder.with_postgres_connection_pool(pool=pool)
     else:
         await builder.with_default_storage(storage_dir=str(data_dir))
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
@@ -239,7 +239,8 @@ if let passkeyStr = opts.passkey {
 // Build SDK
 let builder = SdkBuilder(config: config, seed: seed)
 if let connectionString = opts.postgresConnectionString {
-    await builder.withPostgresBackend(config: defaultPostgresStorageConfig(connectionString: connectionString))
+    let pool = try createPostgresConnectionPool(config: defaultPostgresStorageConfig(connectionString: connectionString))
+    await builder.withPostgresConnectionPool(pool: pool)
 } else {
     await builder.withDefaultStorage(storageDir: resolvedDir)
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
@@ -10,6 +10,7 @@ const { parse: parseShell } = require('shell-quote')
 
 const {
   SdkBuilder,
+  createPostgresConnectionPool,
   defaultConfig,
   defaultPostgresStorageConfig,
   initLogging,
@@ -242,9 +243,10 @@ async function main() {
   let sdkBuilder = SdkBuilder.new(config, seed)
 
   if (opts.postgresConnectionString) {
-    sdkBuilder = sdkBuilder.withPostgresBackend(
+    const pool = createPostgresConnectionPool(
       defaultPostgresStorageConfig(opts.postgresConnectionString)
     )
+    sdkBuilder = sdkBuilder.withPostgresConnectionPool(pool)
   } else {
     sdkBuilder = await sdkBuilder.withDefaultStorage(dataDir)
   }

--- a/crates/breez-sdk/bindings/examples/cli/sync-prompts/langs/kotlin-multiplatform.toml
+++ b/crates/breez-sdk/bindings/examples/cli/sync-prompts/langs/kotlin-multiplatform.toml
@@ -106,7 +106,7 @@ The Kotlin CLI uses the breez-sdk-spark-kmp bindings (built locally via `make se
 - Sealed class enum variants: `is SdkEvent.Synced`, `is InputType.LnurlPay`
 - Sealed class fields accessed directly: `(input as InputType.LnurlPay).payRequest`
 - SdkBuilder: `SdkBuilder(config, seed)` → `.withDefaultStorage(dir)` → `.build()`
-- `.withDefaultStorage()`, `.withPostgresBackend()`, `.withKeySet()` consume the builder — capture return value
+- `.withDefaultStorage()`, `.withPostgresConnectionPool()`, `.withKeySet()` consume the builder — capture return value
 - Token issuer: `sdk.getTokenIssuer()` → `tokenIssuer.getIssuerTokenBalance()`
 - `Seed` → `Seed.Mnemonic(mnemonic, null)`
 - EventListener is an interface with `suspend fun onEvent(e: SdkEvent)`

--- a/crates/breez-sdk/bindings/examples/cli/sync-prompts/langs/wasm.toml
+++ b/crates/breez-sdk/bindings/examples/cli/sync-prompts/langs/wasm.toml
@@ -101,7 +101,7 @@ The TypeScript CLI uses the `@breeztech/breez-sdk-spark` WASM package (Node.js e
 - Use CommonJS (`require`) not ESM (`import`) — the WASM Node.js bindings use CommonJS
 - `BigInt.prototype.toJSON = function() { return this.toString() }` is needed for JSON serialization of BigInt values
 - `u128` maps to native `BigInt` — parse with `BigInt(str)`, not `parseInt`
-- `SdkBuilder.new(config, seed)` returns a builder; `.withDefaultStorage()` and `.withPostgresBackend()` are chained
+- `SdkBuilder.new(config, seed)` returns a builder; `.withDefaultStorage()` and `.withPostgresConnectionPool()` are chained
 - `Seed` is `{ type: 'mnemonic', mnemonic: str, passphrase: undefined }`
 - `defaultConfig('regtest')` takes a string, not an enum variant
 - Token issuer: `sdk.getTokenIssuer()` → `await tokenIssuer.methodName({...})`

--- a/crates/breez-sdk/bindings/examples/cli/sync-prompts/prompt-template.md
+++ b/crates/breez-sdk/bindings/examples/cli/sync-prompts/prompt-template.md
@@ -26,7 +26,7 @@ For each file pair, list every SDK/builder method call in both versions:
 
 #### 2b. Compare call-by-call
 For each SDK call in the Rust file, find the corresponding call in the {{LANG_NAME}} file. Flag any of these as a **divergence**:
-- Different function name (e.g., `with_postgres_backend()` vs `create_postgres_storage()`)
+- Different function name (e.g., `with_postgres_connection_pool()` vs `create_postgres_storage()`)
 - Different arguments or parameters
 - Extra steps in one version that don't exist in the other (e.g., two-step init vs one-step)
 - Missing calls — an SDK call in Rust with no equivalent in {{LANG_NAME}}
@@ -38,7 +38,7 @@ For each SDK call in the Rust file, find the corresponding call in the {{LANG_NA
 #### 2d. Verify divergences against snippets
 For every divergence found, check the snippets you read in Step 1 (and any additional snippets from `{{SNIPPET_DIR}}` that cover the relevant command). The snippets are always up-to-date — if the Rust CLI uses a function, assume it exists in the {{LANG_NAME}} SDK unless the snippets prove otherwise.
 
-**Do NOT assume SDK API differences are "binding-level" or "expected."** If the Rust CLI calls `with_postgres_backend()` and the {{LANG_NAME}} CLI calls `create_postgres_storage() + with_storage()`, that is a divergence — check the snippets and fix it.
+**Do NOT assume SDK API differences are "binding-level" or "expected."** If the Rust CLI calls `with_postgres_connection_pool()` and the {{LANG_NAME}} CLI calls `create_postgres_storage() + with_storage()`, that is a divergence — check the snippets and fix it.
 
 Only after completing 2a–2d should you decide which divergences to fix.
 

--- a/crates/breez-sdk/breez-bench/Cargo.toml
+++ b/crates/breez-sdk/breez-bench/Cargo.toml
@@ -23,6 +23,10 @@ path = "src/bin/claim_perf.rs"
 name = "concurrent-perf"
 path = "src/bin/concurrent_perf.rs"
 
+[[bin]]
+name = "pool-share-perf"
+path = "src/bin/pool_share_perf.rs"
+
 [dependencies]
 # Reuse all test infrastructure from breez-itest
 breez-sdk-itest = { path = "../breez-itest" }
@@ -52,4 +56,7 @@ bip39 = { workspace = true, features = ["rand"] }
 anyhow.workspace = true
 tempfile = "3"
 dirs.workspace = true
+
+# pool-share-perf only: snapshot pg_stat_activity from a fresh connection
+tokio-postgres.workspace = true
 

--- a/crates/breez-sdk/breez-bench/js/concurrent_perf.js
+++ b/crates/breez-sdk/breez-bench/js/concurrent_perf.js
@@ -12,6 +12,8 @@ const {
   defaultConfig,
   defaultPostgresStorageConfig,
   defaultMysqlStorageConfig,
+  createPostgresConnectionPool,
+  createMysqlConnectionPool,
   initLogging,
 } = require('@breeztech/breez-sdk-spark/nodejs')
 
@@ -187,9 +189,11 @@ async function buildSdk(opts, role, mnemonic, dataDir, storage) {
   let builder = SdkBuilder.new(config, seed)
   const { postgres, mysql } = storage || {}
   if (postgres) {
-    builder = builder.withPostgresBackend(defaultPostgresStorageConfig(postgres))
+    const pool = createPostgresConnectionPool(defaultPostgresStorageConfig(postgres))
+    builder = builder.withPostgresConnectionPool(pool)
   } else if (mysql) {
-    builder = builder.withMysqlBackend(defaultMysqlStorageConfig(mysql))
+    const pool = createMysqlConnectionPool(defaultMysqlStorageConfig(mysql))
+    builder = builder.withMysqlConnectionPool(pool)
   } else {
     builder = await builder.withDefaultStorage(dataDir)
   }

--- a/crates/breez-sdk/breez-bench/src/bin/claim_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/claim_perf.rs
@@ -15,7 +15,9 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
-use breez_sdk_itest::{RegtestFaucet, build_sdk_with_tree_store_config, drop_postgres_database};
+use breez_sdk_itest::{
+    PostgresTreeStore, RegtestFaucet, build_sdk_with_tree_store_config, drop_postgres_database,
+};
 use breez_sdk_spark::{
     BreezSdk, GetInfoRequest, ListPaymentsRequest, Network, PaymentStatus, PaymentType,
     PrepareSendPaymentRequest, ReceivePaymentMethod, ReceivePaymentRequest, SdkEvent,
@@ -167,7 +169,7 @@ async fn run_single_claim_benchmark(
         sender_config,
         None,
         true,
-        sender_postgres,
+        sender_postgres.map(PostgresTreeStore::ConnectionString),
         None,
     )
     .await?;
@@ -186,7 +188,9 @@ async fn run_single_claim_benchmark(
         temp_receiver_config,
         None,
         true,
-        receiver_postgres.clone(),
+        receiver_postgres
+            .clone()
+            .map(PostgresTreeStore::ConnectionString),
         None,
     )
     .await?;
@@ -299,7 +303,7 @@ async fn run_single_claim_benchmark(
         receiver_config,
         None,
         true,
-        receiver_postgres,
+        receiver_postgres.map(PostgresTreeStore::ConnectionString),
         None,
     )
     .await?;

--- a/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
@@ -10,11 +10,15 @@ use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
 use breez_sdk_itest::{
-    RegtestFaucet, build_sdk_with_tree_store_config, drop_mysql_database, drop_postgres_database,
+    MysqlTreeStore, PostgresTreeStore, RegtestFaucet, build_sdk_with_tree_store_config,
+    drop_mysql_database, drop_postgres_database,
 };
 use breez_sdk_spark::{
-    BreezSdk, GetInfoRequest, Network, PrepareSendPaymentRequest, ReceivePaymentMethod,
-    ReceivePaymentRequest, SdkEvent, SendPaymentRequest, SyncWalletRequest, default_config,
+    BreezSdk, GetInfoRequest, MysqlConnectionPool, Network, PostgresConnectionPool,
+    PrepareSendPaymentRequest, ReceivePaymentMethod, ReceivePaymentRequest, SdkEvent,
+    SendPaymentRequest, SyncWalletRequest, create_mysql_connection_pool,
+    create_postgres_connection_pool, default_config, default_mysql_storage_config,
+    default_postgres_storage_config,
 };
 
 use breez_bench::events::{wait_for_claimed_event, wait_for_synced_event};
@@ -193,7 +197,7 @@ async fn main() -> Result<()> {
     );
 
     info!("Initializing sender and receiver SDKs...");
-    let (mut sender, mut receiver, sender_seed) = initialize_sdk_pair(
+    let (mut sender, mut receiver, sender_seed, sender_backend) = initialize_sdk_pair(
         args.no_auto_optimize,
         args.pre_optimize,
         args.sender_postgres.clone(),
@@ -246,8 +250,7 @@ async fn main() -> Result<()> {
                 sender_seed,
                 args.no_auto_optimize,
                 args.pre_optimize,
-                args.sender_postgres.clone(),
-                args.sender_mysql.clone(),
+                &sender_backend,
                 i,
             )
             .await?;
@@ -604,6 +607,52 @@ fn print_summary(
     println!();
 }
 
+/// Sender's shared backend, built once by `initialize_sdk_pair` and reused
+/// by every additional sender so all instances share a single connection
+/// pool. Multi-tenant scoping isolates rows by seed identity, so sharing the
+/// pool is safe even with different SDK seeds.
+#[derive(Clone)]
+enum SenderBackend {
+    None,
+    Postgres(Arc<PostgresConnectionPool>),
+    Mysql(Arc<MysqlConnectionPool>),
+}
+
+impl SenderBackend {
+    fn postgres_tree(&self) -> Option<PostgresTreeStore> {
+        match self {
+            SenderBackend::Postgres(p) => Some(PostgresTreeStore::SharedPool(p.clone())),
+            _ => None,
+        }
+    }
+
+    fn mysql_tree(&self) -> Option<MysqlTreeStore> {
+        match self {
+            SenderBackend::Mysql(p) => Some(MysqlTreeStore::SharedPool(p.clone())),
+            _ => None,
+        }
+    }
+}
+
+/// Builds (and ensures-exists) a Postgres pool for the sender side, sized
+/// for use across multiple SDK instances.
+async fn build_sender_postgres_pool(conn_str: &str) -> Result<Arc<PostgresConnectionPool>> {
+    breez_sdk_itest::ensure_postgres_database_exists(conn_str).await?;
+    let mut pg_config = default_postgres_storage_config(conn_str.to_string());
+    pg_config.max_pool_size = 30;
+    Ok(create_postgres_connection_pool(&pg_config)?)
+}
+
+/// Builds (and ensures-exists) a MySQL pool for the sender side, sized for
+/// use across multiple SDK instances.
+async fn build_sender_mysql_pool(conn_str: &str) -> Result<Arc<MysqlConnectionPool>> {
+    let (admin_url, db_name) = breez_sdk_itest::split_mysql_url(conn_str)?;
+    breez_sdk_itest::ensure_mysql_database_exists(&admin_url, &db_name).await?;
+    let mut my_config = default_mysql_storage_config(conn_str.to_string());
+    my_config.max_pool_size = 30;
+    Ok(create_mysql_connection_pool(&my_config)?)
+}
+
 async fn initialize_sdk_pair(
     no_auto_optimize: bool,
     pre_optimize: Option<u8>,
@@ -611,7 +660,16 @@ async fn initialize_sdk_pair(
     receiver_postgres: Option<String>,
     sender_mysql: Option<String>,
     receiver_mysql: Option<String>,
-) -> Result<(BenchSdkInstance, BenchSdkInstance, [u8; 32])> {
+) -> Result<(BenchSdkInstance, BenchSdkInstance, [u8; 32], SenderBackend)> {
+    // Build the sender backend once. All sender SDKs will share this pool.
+    let sender_backend = if let Some(ref conn_str) = sender_postgres {
+        SenderBackend::Postgres(build_sender_postgres_pool(conn_str).await?)
+    } else if let Some(ref conn_str) = sender_mysql {
+        SenderBackend::Mysql(build_sender_mysql_pool(conn_str).await?)
+    } else {
+        SenderBackend::None
+    };
+
     let sender_dir = tempfile::Builder::new()
         .prefix("concurrent-perf-sender")
         .tempdir()?;
@@ -632,8 +690,8 @@ async fn initialize_sdk_pair(
         sender_config,
         None,
         true,
-        sender_postgres,
-        sender_mysql,
+        sender_backend.postgres_tree(),
+        sender_backend.mysql_tree(),
     )
     .await?;
 
@@ -652,8 +710,8 @@ async fn initialize_sdk_pair(
         receiver_config,
         None,
         true,
-        receiver_postgres,
-        receiver_mysql,
+        receiver_postgres.map(PostgresTreeStore::ConnectionString),
+        receiver_mysql.map(MysqlTreeStore::ConnectionString),
     )
     .await?;
 
@@ -669,6 +727,7 @@ async fn initialize_sdk_pair(
             temp_dir: Some(receiver_dir),
         },
         sender_seed,
+        sender_backend,
     ))
 }
 
@@ -676,8 +735,7 @@ async fn build_extra_sender(
     seed: [u8; 32],
     no_auto_optimize: bool,
     pre_optimize: Option<u8>,
-    sender_postgres: Option<String>,
-    sender_mysql: Option<String>,
+    sender_backend: &SenderBackend,
     instance_index: u32,
 ) -> Result<BenchSdkInstance> {
     let dir = tempfile::Builder::new()
@@ -698,8 +756,8 @@ async fn build_extra_sender(
         config,
         None,
         true,
-        sender_postgres,
-        sender_mysql,
+        sender_backend.postgres_tree(),
+        sender_backend.mysql_tree(),
     )
     .await?;
 

--- a/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
@@ -14,7 +14,9 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
-use breez_sdk_itest::{RegtestFaucet, build_sdk_with_tree_store_config, drop_postgres_database};
+use breez_sdk_itest::{
+    PostgresTreeStore, RegtestFaucet, build_sdk_with_tree_store_config, drop_postgres_database,
+};
 use breez_sdk_spark::{
     BreezSdk, GetInfoRequest, Network, PrepareSendPaymentRequest, ReceivePaymentMethod,
     ReceivePaymentRequest, SdkEvent, SendPaymentRequest, SyncWalletRequest, default_config,
@@ -611,7 +613,7 @@ async fn initialize_sdk_pair(
         sender_config,
         None,
         true,
-        sender_postgres,
+        sender_postgres.map(PostgresTreeStore::ConnectionString),
         None,
     )
     .await?;
@@ -633,7 +635,7 @@ async fn initialize_sdk_pair(
         receiver_config,
         None,
         true,
-        receiver_postgres,
+        receiver_postgres.map(PostgresTreeStore::ConnectionString),
         None,
     )
     .await?;

--- a/crates/breez-sdk/breez-bench/src/bin/pool_share_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/pool_share_perf.rs
@@ -1,0 +1,295 @@
+//! Demonstrates the connection-count economics of sharing a single
+//! `PostgresConnectionPool` across many SDK instances vs giving each
+//! instance its own pool.
+//!
+//! This bench has no payments, faucet, or operator round-trips — just
+//! SDK init + a no-op query through every SDK to force pool acquisition,
+//! plus snapshots of `pg_stat_activity` taken from a separate connection.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Result, bail};
+use clap::{Parser, ValueEnum};
+use futures::future::try_join_all;
+use rand::RngCore;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+use breez_sdk_itest::{drop_postgres_database, ensure_postgres_database_exists};
+use breez_sdk_spark::{
+    BreezSdk, GetInfoRequest, Network, PostgresConnectionPool, SdkBuilder, Seed,
+    create_postgres_connection_pool, default_config, default_postgres_storage_config,
+};
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum Mode {
+    /// One pool, shared across every SDK instance.
+    Shared,
+    /// One pool per SDK instance, all targeting the same database.
+    Separate,
+}
+
+#[derive(Parser, Debug)]
+#[command(name = "pool-share-perf")]
+#[command(about = "Measures DB connection-count economics of shared vs separate pools")]
+struct Args {
+    /// Postgres connection string (key-value form: `host=… port=… user=… password=… dbname=…`).
+    #[arg(long)]
+    postgres: String,
+
+    /// Number of SDK instances to spin up.
+    #[arg(long, default_value = "32")]
+    instances: u32,
+
+    /// Pool topology under test.
+    #[arg(long, value_enum, default_value = "shared")]
+    mode: Mode,
+
+    /// `max_pool_size` to apply to each pool. Lower this when running
+    /// `--mode separate` with many instances to fit under Postgres'
+    /// `max_connections` (default 100).
+    #[arg(long, default_value = "8")]
+    max_pool_size: u32,
+
+    /// Drop and recreate the database before the run.
+    #[arg(long)]
+    clean: bool,
+
+    /// Optional label for the printed summary.
+    #[arg(long)]
+    label: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new(
+            "pool_share_perf=info,\
+             breez_sdk_spark=error,\
+             breez_sdk_itest=error,\
+             warn",
+        )
+    });
+    tracing_subscriber::fmt()
+        .without_time()
+        .with_env_filter(filter)
+        .init();
+
+    let args = Args::parse();
+    if args.instances == 0 {
+        bail!("--instances must be > 0");
+    }
+
+    if args.clean {
+        drop_postgres_database(&args.postgres).await?;
+    }
+    // Make sure the target database exists before we snapshot or build any
+    // SDK (the SDK's pool-creation path expects the DB to exist).
+    ensure_postgres_database_exists(&args.postgres).await?;
+
+    info!("Pool sharing economics test");
+    info!("===========================");
+    info!("Mode:           {:?}", args.mode);
+    info!("Instances:      {}", args.instances);
+    info!("Max pool size:  {}", args.max_pool_size);
+    info!("");
+
+    let dbname = extract_dbname(&args.postgres).unwrap_or_else(|| "postgres".to_string());
+
+    // Snapshot before anything is built.
+    let conn_idle_baseline = pg_connection_count(&args.postgres, &dbname).await?;
+
+    // Build one shared pool up-front (or None for the per-instance path).
+    let shared_pool: Option<Arc<PostgresConnectionPool>> = match args.mode {
+        Mode::Shared => Some(make_pool(&args.postgres, args.max_pool_size)?),
+        Mode::Separate => None,
+    };
+
+    info!("Building {} SDK instance(s)...", args.instances);
+    let init_start = Instant::now();
+    let mut sdks: Vec<BreezSdk> = Vec::with_capacity(args.instances as usize);
+    for _ in 0..args.instances {
+        let mut seed = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut seed);
+
+        let mut config = default_config(Network::Regtest);
+        config.api_key = None;
+        config.real_time_sync_server_url = None;
+        config.lnurl_domain = None;
+        config.optimization_config.auto_enabled = false;
+
+        let mut builder = SdkBuilder::new(config, Seed::Entropy(seed.to_vec()));
+        builder = match (&shared_pool, args.mode) {
+            (Some(pool), _) => builder.with_postgres_connection_pool(Arc::clone(pool)),
+            (None, Mode::Separate) => {
+                let pool = make_pool(&args.postgres, args.max_pool_size)?;
+                builder.with_postgres_connection_pool(pool)
+            }
+            (None, Mode::Shared) => unreachable!(),
+        };
+        let sdk = builder.build().await?;
+        sdks.push(sdk);
+    }
+    let init_duration = init_start.elapsed();
+
+    // After init, before any queries: how many connections are sitting idle?
+    let conn_after_init = pg_connection_count(&args.postgres, &dbname).await?;
+
+    // Force every SDK to actually acquire a connection at the same time —
+    // this is the peak load measurement.
+    info!("Firing concurrent get_info() through every SDK...");
+    let stress_start = Instant::now();
+    let futs = sdks.iter().map(|sdk| {
+        sdk.get_info(GetInfoRequest {
+            ensure_synced: Some(false),
+        })
+    });
+    try_join_all(futs).await?;
+    let stress_duration = stress_start.elapsed();
+
+    let conn_peak = pg_connection_count(&args.postgres, &dbname).await?;
+
+    // Brief settle, then re-snapshot to see how many connections the pool retains.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let conn_idle_after_stress = pg_connection_count(&args.postgres, &dbname).await?;
+
+    info!("Disconnecting all SDKs...");
+    for sdk in &sdks {
+        sdk.disconnect().await?;
+    }
+    drop(sdks);
+
+    // For separate-pool mode, dropping the SDKs drops their pools — connections close.
+    // For shared-pool mode, the pool is still alive (held by `shared_pool`),
+    // so connections stay until we drop it below.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let conn_after_disconnect = pg_connection_count(&args.postgres, &dbname).await?;
+
+    drop(shared_pool);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let conn_after_pool_drop = pg_connection_count(&args.postgres, &dbname).await?;
+
+    print_summary(
+        args.mode,
+        args.instances,
+        args.max_pool_size,
+        args.label.as_deref(),
+        init_duration,
+        stress_duration,
+        Snapshots {
+            idle_baseline: conn_idle_baseline,
+            after_init: conn_after_init,
+            peak: conn_peak,
+            idle_after_stress: conn_idle_after_stress,
+            after_disconnect: conn_after_disconnect,
+            after_pool_drop: conn_after_pool_drop,
+        },
+    );
+
+    Ok(())
+}
+
+fn make_pool(conn_str: &str, max_pool_size: u32) -> Result<Arc<PostgresConnectionPool>> {
+    let mut cfg = default_postgres_storage_config(conn_str.to_string());
+    cfg.max_pool_size = max_pool_size;
+    Ok(create_postgres_connection_pool(&cfg)?)
+}
+
+struct Snapshots {
+    idle_baseline: i64,
+    after_init: i64,
+    peak: i64,
+    idle_after_stress: i64,
+    after_disconnect: i64,
+    after_pool_drop: i64,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_summary(
+    mode: Mode,
+    instances: u32,
+    max_pool_size: u32,
+    label: Option<&str>,
+    init: Duration,
+    stress: Duration,
+    snap: Snapshots,
+) {
+    println!();
+    println!("============================================================");
+    if let Some(l) = label {
+        println!("SUMMARY [{l}]");
+    } else {
+        println!("SUMMARY");
+    }
+    println!("============================================================");
+    println!("Mode:                          {mode:?}");
+    println!("Instances:                     {instances}");
+    println!("max_pool_size per pool:        {max_pool_size}");
+    println!();
+    println!("SDK init time (sequential):    {init:?}");
+    println!("Concurrent get_info() time:    {stress:?}");
+    println!();
+    println!("DB connections to this database (delta from baseline):");
+    println!("  Baseline (before init):      {} ", snap.idle_baseline);
+    println!(
+        "  After init, no queries:      {}  ({:+})",
+        snap.after_init,
+        snap.after_init - snap.idle_baseline
+    );
+    println!(
+        "  Peak (concurrent queries):   {}  ({:+})",
+        snap.peak,
+        snap.peak - snap.idle_baseline
+    );
+    println!(
+        "  Idle after stress:           {}  ({:+})",
+        snap.idle_after_stress,
+        snap.idle_after_stress - snap.idle_baseline
+    );
+    println!(
+        "  After SDK disconnect:        {}  ({:+})",
+        snap.after_disconnect,
+        snap.after_disconnect - snap.idle_baseline
+    );
+    println!(
+        "  After pool dropped:          {}  ({:+})",
+        snap.after_pool_drop,
+        snap.after_pool_drop - snap.idle_baseline
+    );
+    println!("============================================================");
+    println!();
+}
+
+/// Snapshots the number of connections currently open to the named database,
+/// excluding the snapshotting connection itself. Uses a fresh tokio_postgres
+/// client (not the SDK's pool) so the snapshot itself adds at most 1 to the
+/// count and we explicitly exclude it.
+async fn pg_connection_count(conn_str: &str, dbname: &str) -> Result<i64> {
+    // Connect to the same database we're measuring. We exclude pg_backend_pid()
+    // to remove this snapshot's own connection from the count.
+    let (client, connection) = tokio_postgres::connect(conn_str, tokio_postgres::NoTls).await?;
+    let conn_handle = tokio::spawn(connection);
+    let row = client
+        .query_one(
+            "SELECT count(*) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+            &[&dbname],
+        )
+        .await?;
+    let count: i64 = row.get(0);
+    drop(client);
+    let _ = conn_handle.await;
+    Ok(count)
+}
+
+/// Extract the `dbname=…` value from a key-value Postgres connection string.
+fn extract_dbname(conn_str: &str) -> Option<String> {
+    for part in conn_str.split_whitespace() {
+        if let Some((key, value)) = part.split_once('=')
+            && key == "dbname"
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
+}

--- a/crates/breez-sdk/breez-itest/src/helpers.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers.rs
@@ -101,7 +101,8 @@ async fn apply_storage(builder: SdkBuilder, storage_dir: String) -> Result<SdkBu
         let conn_str = format!("{base_url} dbname=ts_{counter}");
         ensure_postgres_database_exists(&conn_str).await?;
         let pg_config = breez_sdk_spark::default_postgres_storage_config(conn_str);
-        return Ok(builder.with_postgres_backend(pg_config));
+        let pool = breez_sdk_spark::create_postgres_connection_pool(&pg_config)?;
+        return Ok(builder.with_postgres_connection_pool(pool));
     }
     if let Some(base_url) = get_mysql_tree_store_base_url().await {
         let counter = MYSQL_TREE_STORE_DB_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -109,7 +110,8 @@ async fn apply_storage(builder: SdkBuilder, storage_dir: String) -> Result<SdkBu
         let conn_str = format!("{base_url}/{db_name}");
         ensure_mysql_database_exists(base_url, &db_name).await?;
         let my_config = breez_sdk_spark::default_mysql_storage_config(conn_str);
-        return Ok(builder.with_mysql_backend(my_config));
+        let pool = breez_sdk_spark::create_mysql_connection_pool(&my_config)?;
+        return Ok(builder.with_mysql_connection_pool(pool));
     }
     Ok(builder.with_default_storage(storage_dir))
 }
@@ -479,7 +481,7 @@ pub async fn drop_mysql_database(conn_str: &str) -> Result<()> {
 
 /// Splits `mysql://user:pass@host:port/<dbname>` into `(admin_url, db_name)`,
 /// where `admin_url` is the URL minus the `/<dbname>` path.
-fn split_mysql_url(conn_str: &str) -> Result<(String, String)> {
+pub fn split_mysql_url(conn_str: &str) -> Result<(String, String)> {
     let (scheme, rest) = conn_str
         .split_once("://")
         .ok_or_else(|| anyhow::anyhow!("Invalid MySQL URL (missing scheme): {conn_str}"))?;
@@ -490,15 +492,33 @@ fn split_mysql_url(conn_str: &str) -> Result<(String, String)> {
     Ok((format!("{scheme}://{authority}"), db_name))
 }
 
-/// Build and initialize a BreezSDK instance with optional PostgreSQL tree store
+/// PostgreSQL tree store input for `build_sdk_with_tree_store_config`.
 ///
-/// Similar to `build_sdk_with_custom_config` but allows specifying a PostgreSQL
-/// connection string for the tree store. This is useful for benchmarks that want
-/// to test SDK performance with different tree store backends.
+/// `ConnectionString` lazily ensures the database exists and builds a fresh
+/// pool for that one SDK. `SharedPool` reuses a pre-built pool across SDK
+/// instances (multi-tenant scoping isolates rows by seed identity).
+pub enum PostgresTreeStore {
+    ConnectionString(String),
+    SharedPool(std::sync::Arc<breez_sdk_spark::PostgresConnectionPool>),
+}
+
+/// MySQL tree store input for `build_sdk_with_tree_store_config`. See
+/// [`PostgresTreeStore`] for semantics.
+pub enum MysqlTreeStore {
+    ConnectionString(String),
+    SharedPool(std::sync::Arc<breez_sdk_spark::MysqlConnectionPool>),
+}
+
+/// Build and initialize a BreezSDK instance with optional PostgreSQL/MySQL
+/// tree store.
 ///
-/// **Important**: Each SDK instance MUST use a separate database. The tree store
-/// tables don't have wallet identity separation, so sharing a database between
-/// multiple SDKs will cause conflicts.
+/// Similar to `build_sdk_with_custom_config` but allows specifying a backend
+/// connection or a pre-built shared pool. Useful for benchmarks that want to
+/// test SDK performance with different tree store backends, or for multi-SDK
+/// setups that share a single connection pool.
+///
+/// Multi-tenant scoping (rows scoped by seed identity) means multiple SDKs
+/// can safely share one database / pool — pass `SharedPool` to do so.
 ///
 /// # Arguments
 /// * `storage_dir` - Directory path for SDK storage
@@ -506,7 +526,8 @@ fn split_mysql_url(conn_str: &str) -> Result<(String, String)> {
 /// * `config` - SDK configuration to use
 /// * `temp_dir` - Optional TempDir to keep alive (prevents premature deletion)
 /// * `apply_sensible_test_defaults` - Whether to apply test defaults to config
-/// * `postgres_tree_store_connection` - Optional PostgreSQL connection string for tree store
+/// * `postgres_tree_store` - Optional PostgreSQL backend (connection or shared pool)
+/// * `mysql_tree_store` - Optional MySQL backend (connection or shared pool)
 ///
 /// # Returns
 /// An SdkInstance containing the SDK, event channel, and optional TempDir
@@ -516,8 +537,8 @@ pub async fn build_sdk_with_tree_store_config(
     mut config: Config,
     temp_dir: Option<tempfile::TempDir>,
     apply_sensible_test_defaults: bool,
-    postgres_tree_store_connection: Option<String>,
-    mysql_tree_store_connection: Option<String>,
+    postgres_tree_store: Option<PostgresTreeStore>,
+    mysql_tree_store: Option<MysqlTreeStore>,
 ) -> Result<SdkInstance> {
     // Apply sensible test defaults if not already configured
     if config.api_key.is_some() && matches!(config.network, Network::Regtest) {
@@ -536,19 +557,34 @@ pub async fn build_sdk_with_tree_store_config(
 
     let mut builder = SdkBuilder::new(config, seed);
 
-    if let Some(conn_str) = postgres_tree_store_connection {
-        ensure_postgres_database_exists(&conn_str).await?;
-        let mut pg_config = breez_sdk_spark::default_postgres_storage_config(conn_str);
-        pg_config.max_pool_size = 30;
-        builder = builder.with_postgres_backend(pg_config);
-    } else if let Some(conn_str) = mysql_tree_store_connection {
-        let (admin_url, db_name) = split_mysql_url(&conn_str)?;
-        ensure_mysql_database_exists(&admin_url, &db_name).await?;
-        let mut my_config = breez_sdk_spark::default_mysql_storage_config(conn_str);
-        my_config.max_pool_size = 30;
-        builder = builder.with_mysql_backend(my_config);
-    } else {
-        builder = apply_storage(builder, storage_dir).await?;
+    match (postgres_tree_store, mysql_tree_store) {
+        (Some(PostgresTreeStore::ConnectionString(conn_str)), None) => {
+            ensure_postgres_database_exists(&conn_str).await?;
+            let mut pg_config = breez_sdk_spark::default_postgres_storage_config(conn_str);
+            pg_config.max_pool_size = 30;
+            let pool = breez_sdk_spark::create_postgres_connection_pool(&pg_config)?;
+            builder = builder.with_postgres_connection_pool(pool);
+        }
+        (Some(PostgresTreeStore::SharedPool(pool)), None) => {
+            builder = builder.with_postgres_connection_pool(pool);
+        }
+        (None, Some(MysqlTreeStore::ConnectionString(conn_str))) => {
+            let (admin_url, db_name) = split_mysql_url(&conn_str)?;
+            ensure_mysql_database_exists(&admin_url, &db_name).await?;
+            let mut my_config = breez_sdk_spark::default_mysql_storage_config(conn_str);
+            my_config.max_pool_size = 30;
+            let pool = breez_sdk_spark::create_mysql_connection_pool(&my_config)?;
+            builder = builder.with_mysql_connection_pool(pool);
+        }
+        (None, Some(MysqlTreeStore::SharedPool(pool))) => {
+            builder = builder.with_mysql_connection_pool(pool);
+        }
+        (None, None) => {
+            builder = apply_storage(builder, storage_dir).await?;
+        }
+        (Some(_), Some(_)) => {
+            anyhow::bail!("only one of postgres_tree_store / mysql_tree_store may be set");
+        }
     }
 
     let sdk = builder.build().await?;
@@ -1452,9 +1488,10 @@ pub async fn build_sdk_with_postgres(
 
     let postgres_config =
         breez_sdk_spark::default_postgres_storage_config(connection_string.to_string());
+    let pool = breez_sdk_spark::create_postgres_connection_pool(&postgres_config)?;
 
     let sdk = breez_sdk_spark::SdkBuilder::new(config, seed)
-        .with_postgres_backend(postgres_config)
+        .with_postgres_connection_pool(pool)
         .build()
         .await?;
 
@@ -1506,9 +1543,10 @@ pub async fn build_sdk_with_mysql(
     let mut mysql_config =
         breez_sdk_spark::default_mysql_storage_config(connection_string.to_string());
     mysql_config.max_pool_size = 30;
+    let pool = breez_sdk_spark::create_mysql_connection_pool(&mysql_config)?;
 
     let sdk = breez_sdk_spark::SdkBuilder::new(config, seed)
-        .with_mysql_backend(mysql_config)
+        .with_mysql_connection_pool(pool)
         .build()
         .await?;
 

--- a/crates/breez-sdk/cli/src/main.rs
+++ b/crates/breez-sdk/cli/src/main.rs
@@ -8,7 +8,8 @@ use std::path::PathBuf;
 use anyhow::{Result, anyhow};
 use breez_sdk_spark::{
     EventListener, Network, SdkBuilder, SdkEvent, Seed, StableBalanceConfig, StableBalanceToken,
-    default_config, default_mysql_storage_config, default_postgres_storage_config,
+    create_mysql_connection_pool, create_postgres_connection_pool, default_config,
+    default_mysql_storage_config, default_postgres_storage_config,
 };
 use clap::Parser;
 use command::{Command, execute_command};
@@ -179,11 +180,12 @@ async fn run_interactive_mode(
 
     let mut sdk_builder = SdkBuilder::new(config, seed);
     if let Some(connection_string) = postgres_connection_string {
-        sdk_builder =
-            sdk_builder.with_postgres_backend(default_postgres_storage_config(connection_string));
+        let pool =
+            create_postgres_connection_pool(&default_postgres_storage_config(connection_string))?;
+        sdk_builder = sdk_builder.with_postgres_connection_pool(pool);
     } else if let Some(connection_string) = mysql_connection_string {
-        sdk_builder =
-            sdk_builder.with_mysql_backend(default_mysql_storage_config(connection_string));
+        let pool = create_mysql_connection_pool(&default_mysql_storage_config(connection_string))?;
+        sdk_builder = sdk_builder.with_mysql_connection_pool(pool);
     } else {
         sdk_builder = sdk_builder.with_default_storage(data_dir.to_string_lossy().to_string());
     }

--- a/crates/breez-sdk/core/src/bindings.rs
+++ b/crates/breez-sdk/core/src/bindings.rs
@@ -123,6 +123,22 @@ impl SdkBuilder {
         let mut builder = self.inner.lock().await;
         *builder = builder.clone().with_postgres_connection_pool(pool);
     }
+
+    /// **Deprecated.** Call `with_postgres_connection_pool(&config)` and `with_postgres_connection_pool(pool) instead`.
+    ///
+    /// Sets `PostgreSQL` as the backend for all stores (storage, tree store, and token store).
+    /// The store instances will be created during `build()`.
+    /// Arguments:
+    /// - `config`: The `PostgreSQL` storage configuration.
+    #[allow(deprecated)]
+    pub async fn with_postgres_backend(
+        &self,
+        config: crate::persist::postgres::PostgresStorageConfig,
+    ) -> Result<(), SdkError> {
+        let mut builder = self.inner.lock().await;
+        *builder = builder.clone().with_postgres_backend(config)?;
+        Ok(())
+    }
 }
 
 #[cfg(all(
@@ -141,5 +157,21 @@ impl SdkBuilder {
     ) {
         let mut builder = self.inner.lock().await;
         *builder = builder.clone().with_mysql_connection_pool(pool);
+    }
+
+    /// **Deprecated.** Call `with_mysql_connection_pool(&config)` and `with_mysql_connection_pool(pool) instead`.
+    ///
+    /// Sets `MySQL` as the backend for all stores (storage, tree store, and token store).
+    /// The store instances will be created during `build()`.
+    /// Arguments:
+    /// - `config`: The `MySQL` storage configuration.
+    #[allow(deprecated)]
+    pub async fn with_mysql_backend(
+        &self,
+        config: crate::persist::mysql::MysqlStorageConfig,
+    ) -> Result<(), SdkError> {
+        let mut builder = self.inner.lock().await;
+        *builder = builder.clone().with_mysql_backend(config)?;
+        Ok(())
     }
 }

--- a/crates/breez-sdk/core/src/bindings.rs
+++ b/crates/breez-sdk/core/src/bindings.rs
@@ -112,16 +112,16 @@ impl SdkBuilder {
 ))]
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl SdkBuilder {
-    /// Sets `PostgreSQL` as the backend for all stores (storage, tree store, and token store).
-    /// The store instances will be created during `build()`.
-    /// Arguments:
-    /// - `config`: The `PostgreSQL` storage configuration.
-    pub async fn with_postgres_backend(
+    /// Sets a shared `PostgreSQL` connection pool as the backend for all
+    /// stores (storage, tree store, and token store). Construct the pool
+    /// via [`create_postgres_connection_pool`](crate::create_postgres_connection_pool) and pass the
+    /// same `Arc` to multiple builders to share connections across SDKs.
+    pub async fn with_postgres_connection_pool(
         &self,
-        config: crate::persist::postgres::PostgresStorageConfig,
+        pool: Arc<crate::persist::postgres::PostgresConnectionPool>,
     ) {
         let mut builder = self.inner.lock().await;
-        *builder = builder.clone().with_postgres_backend(config);
+        *builder = builder.clone().with_postgres_connection_pool(pool);
     }
 }
 
@@ -131,12 +131,15 @@ impl SdkBuilder {
 ))]
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl SdkBuilder {
-    /// Sets `MySQL` as the backend for all stores (storage, tree store, and token store).
-    /// The store instances will be created during `build()`.
-    /// Arguments:
-    /// - `config`: The `MySQL` storage configuration.
-    pub async fn with_mysql_backend(&self, config: crate::persist::mysql::MysqlStorageConfig) {
+    /// Sets a shared `MySQL` connection pool as the backend for all stores
+    /// (storage, tree store, and token store). Construct the pool via
+    /// [`create_mysql_connection_pool`](crate::create_mysql_connection_pool) and pass the same `Arc`
+    /// to multiple builders to share connections across SDKs.
+    pub async fn with_mysql_connection_pool(
+        &self,
+        pool: Arc<crate::persist::mysql::MysqlConnectionPool>,
+    ) {
         let mut builder = self.inner.lock().await;
-        *builder = builder.clone().with_mysql_backend(config);
+        *builder = builder.clone().with_mysql_connection_pool(pool);
     }
 }

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -44,14 +44,18 @@ pub use spark_wallet::KeySet;
     not(all(target_family = "wasm", target_os = "unknown"))
 ))]
 pub use persist::postgres::{
-    PoolQueueMode, PostgresStorageConfig, default_postgres_storage_config,
+    PoolQueueMode, PostgresConnectionPool, PostgresStorageConfig, create_postgres_connection_pool,
+    default_postgres_storage_config,
 };
 
 #[cfg(all(
     feature = "mysql",
     not(all(target_family = "wasm", target_os = "unknown"))
 ))]
-pub use persist::mysql::{MysqlStorageConfig, default_mysql_storage_config};
+pub use persist::mysql::{
+    MysqlConnectionPool, MysqlStorageConfig, create_mysql_connection_pool,
+    default_mysql_storage_config,
+};
 
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 pub use {

--- a/crates/breez-sdk/core/src/persist/mysql/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/mod.rs
@@ -8,14 +8,16 @@
 //! SQL syntax differences vs. `PostgreSQL`.
 
 mod base;
+mod pool;
 mod storage;
 
 // Re-export public configuration types and functions (with UniFFI annotations).
 #[allow(unused_imports)]
 pub use base::{MysqlStorageConfig, default_mysql_storage_config};
+pub use pool::{MysqlConnectionPool, create_mysql_connection_pool};
 
-// Re-export pool factory and store factories
-pub(crate) use base::{create_mysql_token_store, create_mysql_tree_store, create_pool};
+// Re-export store factories
+pub(crate) use base::{create_mysql_token_store, create_mysql_tree_store};
 
 // Re-export storage implementation
 pub(crate) use storage::MysqlStorage;

--- a/crates/breez-sdk/core/src/persist/mysql/pool.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/pool.rs
@@ -1,0 +1,62 @@
+//! Shareable `MySQL` connection pool wrapper.
+
+use std::sync::Arc;
+
+use spark_mysql::mysql_async;
+
+use crate::error::SdkError;
+
+use super::{MysqlStorageConfig, base::create_pool};
+
+/// A shareable `MySQL` connection pool. See
+/// [`PostgresConnectionPool`](crate::PostgresConnectionPool) for sharing semantics and lifecycle.
+///
+// TODO(post-#865): once https://github.com/breez/spark-sdk/pull/865 lands,
+// add `foreign_key_mode: MysqlForeignKeyMode` here, snapshot it from
+// `config.foreign_key_mode` in `create_mysql_connection_pool`, and forward it from the
+// SDK builder to `create_mysql_tree_store` / `create_mysql_token_store`.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct MysqlConnectionPool {
+    pub(crate) inner: mysql_async::Pool,
+}
+
+/// Creates a shareable `MySQL` connection pool from the given configuration.
+///
+/// Hand the returned `Arc` to one or more
+/// [`SdkBuilder::with_mysql_connection_pool`](crate::SdkBuilder::with_mysql_connection_pool)
+/// calls to share a single pool across multiple SDK instances.
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn create_mysql_connection_pool(
+    config: &MysqlStorageConfig,
+) -> Result<Arc<MysqlConnectionPool>, SdkError> {
+    let inner = create_pool(config).map_err(SdkError::from)?;
+    Ok(Arc::new(MysqlConnectionPool { inner }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pool creation parses the URL and builds a `mysql_async::Pool` lazily,
+    /// so this works without a server. Verifies `Arc::clone` semantics — a
+    /// single factory call yields one pool that can be cheaply cloned.
+    #[test]
+    fn pool_arc_is_cheaply_shareable() {
+        let cfg = default_mysql_storage_config("mysql://u:p@127.0.0.1:3306/d".to_string());
+        let pool = create_mysql_connection_pool(&cfg).expect("build pool");
+        assert_eq!(Arc::strong_count(&pool), 1);
+
+        let clone_a = Arc::clone(&pool);
+        let clone_b = Arc::clone(&pool);
+        assert_eq!(Arc::strong_count(&pool), 3);
+
+        drop(clone_a);
+        assert_eq!(Arc::strong_count(&pool), 2);
+        drop(clone_b);
+        assert_eq!(Arc::strong_count(&pool), 1);
+    }
+
+    fn default_mysql_storage_config(connection_string: String) -> MysqlStorageConfig {
+        super::super::default_mysql_storage_config(connection_string)
+    }
+}

--- a/crates/breez-sdk/core/src/persist/postgres/mod.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/mod.rs
@@ -5,13 +5,15 @@
 //! functionality.
 
 mod base;
+mod pool;
 mod storage;
 
 // Re-export public configuration types and functions (with UniFFI annotations)
 pub use base::{PoolQueueMode, PostgresStorageConfig, default_postgres_storage_config};
+pub use pool::{PostgresConnectionPool, create_postgres_connection_pool};
 
-// Re-export pool factory and store factories
-pub(crate) use base::{create_pool, create_postgres_token_store, create_postgres_tree_store};
+// Re-export store factories
+pub(crate) use base::{create_postgres_token_store, create_postgres_tree_store};
 
 // Re-export storage implementation
 pub(crate) use storage::PostgresStorage;

--- a/crates/breez-sdk/core/src/persist/postgres/pool.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/pool.rs
@@ -1,0 +1,68 @@
+//! Shareable Postgres connection pool wrapper.
+
+use std::sync::Arc;
+
+use spark_postgres::deadpool_postgres;
+
+use crate::error::SdkError;
+
+use super::{PostgresStorageConfig, base::create_pool};
+
+/// A shareable Postgres connection pool.
+///
+/// Construct via [`create_postgres_connection_pool`] and pass the same `Arc` to multiple
+/// [`SdkBuilder`](crate::SdkBuilder)s via
+/// [`SdkBuilder::with_postgres_connection_pool`](crate::SdkBuilder::with_postgres_connection_pool).
+/// All SDKs sharing a pool target the same database; per-tenant isolation is
+/// derived from each SDK's seed (the identity public key scopes every row).
+///
+/// The pool's lifecycle is owned by the integrator: it stays alive as long
+/// as any `Arc<PostgresConnectionPool>` is held. [`BreezSdk::disconnect`](crate::BreezSdk::disconnect)
+/// does **not** close the pool.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct PostgresConnectionPool {
+    pub(crate) inner: deadpool_postgres::Pool,
+}
+
+/// Creates a shareable Postgres connection pool from the given configuration.
+///
+/// Hand the returned `Arc` to one or more
+/// [`SdkBuilder::with_postgres_connection_pool`](crate::SdkBuilder::with_postgres_connection_pool)
+/// calls to share a single pool across multiple SDK instances.
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn create_postgres_connection_pool(
+    config: &PostgresStorageConfig,
+) -> Result<Arc<PostgresConnectionPool>, SdkError> {
+    let inner = create_pool(config).map_err(SdkError::from)?;
+    Ok(Arc::new(PostgresConnectionPool { inner }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pool creation builds a deadpool eagerly but does not connect to the
+    /// server until first use, so this works against a non-existent host.
+    /// Verifies `Arc::clone` semantics — a single factory call yields one
+    /// pool that can be cheaply cloned for sharing.
+    #[test]
+    fn pool_arc_is_cheaply_shareable() {
+        let cfg =
+            default_postgres_storage_config("host=localhost port=5432 user=u dbname=d".to_string());
+        let pool = create_postgres_connection_pool(&cfg).expect("build pool");
+        assert_eq!(Arc::strong_count(&pool), 1);
+
+        let clone_a = Arc::clone(&pool);
+        let clone_b = Arc::clone(&pool);
+        assert_eq!(Arc::strong_count(&pool), 3);
+
+        drop(clone_a);
+        assert_eq!(Arc::strong_count(&pool), 2);
+        drop(clone_b);
+        assert_eq!(Arc::strong_count(&pool), 1);
+    }
+
+    fn default_postgres_storage_config(connection_string: String) -> PostgresStorageConfig {
+        super::super::default_postgres_storage_config(connection_string)
+    }
+}

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -65,9 +65,9 @@ pub struct SdkBuilder {
     storage_dir: Option<String>,
     storage: Option<Arc<dyn Storage>>,
     #[cfg(feature = "postgres")]
-    postgres_backend_config: Option<crate::persist::postgres::PostgresStorageConfig>,
+    postgres_pool: Option<Arc<crate::persist::postgres::PostgresConnectionPool>>,
     #[cfg(feature = "mysql")]
-    mysql_backend_config: Option<crate::persist::mysql::MysqlStorageConfig>,
+    mysql_pool: Option<Arc<crate::persist::mysql::MysqlConnectionPool>>,
     chain_service: Option<Arc<dyn BitcoinChainService>>,
     fiat_service: Option<Arc<dyn FiatService>>,
     lnurl_client: Option<Arc<dyn platform_utils::HttpClient>>,
@@ -98,9 +98,9 @@ impl SdkBuilder {
             storage_dir: None,
             storage: None,
             #[cfg(feature = "postgres")]
-            postgres_backend_config: None,
+            postgres_pool: None,
             #[cfg(feature = "mysql")]
-            mysql_backend_config: None,
+            mysql_pool: None,
             chain_service: None,
             fiat_service: None,
             lnurl_client: None,
@@ -124,9 +124,9 @@ impl SdkBuilder {
             storage_dir: None,
             storage: None,
             #[cfg(feature = "postgres")]
-            postgres_backend_config: None,
+            postgres_pool: None,
             #[cfg(feature = "mysql")]
-            mysql_backend_config: None,
+            mysql_pool: None,
             chain_service: None,
             fiat_service: None,
             lnurl_client: None,
@@ -180,28 +180,43 @@ impl SdkBuilder {
         self
     }
 
-    /// Sets `PostgreSQL` as the backend for all stores (storage, tree store, and token store).
-    /// The store instances will be created during `build()`.
-    /// Arguments:
-    /// - `config`: The `PostgreSQL` storage configuration.
+    /// Sets a shared `PostgreSQL` connection pool as the backend for all
+    /// stores (storage, tree store, and token store).
+    ///
+    /// Construct the pool once via
+    /// [`create_postgres_connection_pool`](crate::create_postgres_connection_pool) and pass the same
+    /// `Arc` to multiple `SdkBuilder` instances to share connections across
+    /// SDKs. Per-tenant scoping is derived from each SDK's seed.
+    ///
+    /// # Arguments
+    /// - `pool`: The shared `PostgreSQL` connection pool.
     #[must_use]
     #[cfg(feature = "postgres")]
-    pub fn with_postgres_backend(
+    pub fn with_postgres_connection_pool(
         mut self,
-        config: crate::persist::postgres::PostgresStorageConfig,
+        pool: Arc<crate::persist::postgres::PostgresConnectionPool>,
     ) -> Self {
-        self.postgres_backend_config = Some(config);
+        self.postgres_pool = Some(pool);
         self
     }
 
-    /// Sets `MySQL` as the backend for all stores (storage, tree store, and token store).
-    /// The store instances will be created during `build()`.
-    /// Arguments:
-    /// - `config`: The `MySQL` storage configuration.
+    /// Sets a shared `MySQL` connection pool as the backend for all stores
+    /// (storage, tree store, and token store).
+    ///
+    /// Construct the pool once via [`create_mysql_connection_pool`](crate::create_mysql_connection_pool)
+    /// and pass the same `Arc` to multiple `SdkBuilder` instances to share
+    /// connections across SDKs. Per-tenant scoping is derived from each
+    /// SDK's seed.
+    ///
+    /// # Arguments
+    /// - `pool`: The shared `MySQL` connection pool.
     #[must_use]
     #[cfg(feature = "mysql")]
-    pub fn with_mysql_backend(mut self, config: crate::persist::mysql::MysqlStorageConfig) -> Self {
-        self.mysql_backend_config = Some(config);
+    pub fn with_mysql_connection_pool(
+        mut self,
+        pool: Arc<crate::persist::mysql::MysqlConnectionPool>,
+    ) -> Self {
+        self.mysql_pool = Some(pool);
         self
     }
 
@@ -424,12 +439,12 @@ impl SdkBuilder {
 
         // Validate storage configuration
         #[cfg(feature = "postgres")]
-        let has_postgres = self.postgres_backend_config.is_some();
+        let has_postgres = self.postgres_pool.is_some();
         #[cfg(not(feature = "postgres"))]
         let has_postgres = false;
 
         #[cfg(feature = "mysql")]
-        let has_mysql = self.mysql_backend_config.is_some();
+        let has_mysql = self.mysql_pool.is_some();
         #[cfg(not(feature = "mysql"))]
         let has_mysql = false;
 
@@ -452,36 +467,34 @@ impl SdkBuilder {
             _ => {}
         }
 
-        // Create a shared PostgreSQL pool if postgres backend is configured,
-        // bundled with the tenant identity used to scope every read/write so
-        // storage, tree store, and token store share the same scope.
+        // Read the shared PostgreSQL pool if configured, bundled with the
+        // tenant identity used to scope every read/write so storage, tree
+        // store, and token store share the same scope. The pool itself is
+        // owned by the integrator and may be shared with other SDK instances.
         #[cfg(feature = "postgres")]
-        let postgres_backend = if let Some(ref postgres_config) = self.postgres_backend_config {
-            let pool = crate::persist::postgres::create_pool(postgres_config)
-                .map_err(|e| SdkError::Generic(e.to_string()))?;
+        let postgres_backend = if let Some(ref pool) = self.postgres_pool {
             let identity = spark_signer
                 .get_identity_public_key()
                 .await
                 .map_err(|e| SdkError::Generic(e.to_string()))?
                 .serialize();
-            Some((pool, identity))
+            Some((pool.inner.clone(), identity))
         } else {
             None
         };
 
-        // Create a shared MySQL pool if mysql backend is configured, bundled
-        // with the tenant identity used to scope every read/write so storage,
-        // tree store, and token store share the same scope.
+        // Read the shared MySQL pool if configured, bundled with the tenant
+        // identity used to scope every read/write so storage, tree store, and
+        // token store share the same scope. The pool itself is owned by the
+        // integrator and may be shared with other SDK instances.
         #[cfg(feature = "mysql")]
-        let mysql_backend = if let Some(ref mysql_config) = self.mysql_backend_config {
-            let pool = crate::persist::mysql::create_pool(mysql_config)
-                .map_err(|e| SdkError::Generic(e.to_string()))?;
+        let mysql_backend = if let Some(ref pool) = self.mysql_pool {
             let identity = spark_signer
                 .get_identity_public_key()
                 .await
                 .map_err(|e| SdkError::Generic(e.to_string()))?
                 .serialize();
-            Some((pool, identity))
+            Some((pool.inner.clone(), identity))
         } else {
             None
         };

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -220,6 +220,46 @@ impl SdkBuilder {
         self
     }
 
+    /// Sets a shared `PostgreSQL` connection pool as the backend for all
+    /// stores (storage, tree store, and token store).
+    ///
+    /// Construct the pool once via
+    /// [`create_postgres_connection_pool`](crate::create_postgres_connection_pool) and pass the same
+    /// `Arc` to multiple `SdkBuilder` instances to share connections across
+    /// SDKs. Per-tenant scoping is derived from each SDK's seed.
+    ///
+    /// # Arguments
+    /// - `pool`: The shared `PostgreSQL` connection pool.
+    #[cfg(feature = "postgres")]
+    #[deprecated(
+        note = "Call `create_postgres_connection_pool(&config)` and `with_postgres_connection_pool(pool)` instead."
+    )]
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn with_postgres_backend(
+        self,
+        config: crate::persist::postgres::PostgresStorageConfig,
+    ) -> Result<Self, SdkError> {
+        let pool = crate::persist::postgres::create_postgres_connection_pool(&config)?;
+        Ok(self.with_postgres_connection_pool(pool))
+    }
+
+    /// Sets `MySQL` as the backend for all stores (storage, tree store, and token store).
+    /// The store instances will be created during `build()`.
+    /// Arguments:
+    /// - `config`: The `MySQL` storage configuration.
+    #[cfg(feature = "mysql")]
+    #[deprecated(
+        note = "Call `create_mysql_connection_pool(&config)` and `with_mysql_connection_pool(pool)` instead."
+    )]
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn with_mysql_backend(
+        self,
+        config: crate::persist::mysql::MysqlStorageConfig,
+    ) -> Result<Self, SdkError> {
+        let pool = crate::persist::mysql::create_mysql_connection_pool(&config)?;
+        Ok(self.with_mysql_connection_pool(pool))
+    }
+
     /// Sets the chain service to be used by the SDK.
     /// Arguments:
     /// - `chain_service`: The chain service to be used.

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -2,8 +2,10 @@ pub mod chain_service;
 mod error;
 pub mod fiat_service;
 pub mod issuer;
+pub mod mysql_pool;
 pub mod passkey_prf_provider;
 pub mod payment_observer;
+pub mod postgres_pool;
 pub mod rest_client;
 
 use std::collections::HashMap;

--- a/crates/breez-sdk/wasm/src/models/mysql_pool.rs
+++ b/crates/breez-sdk/wasm/src/models/mysql_pool.rs
@@ -1,0 +1,30 @@
+//! Shareable MySQL connection pool wrapper for WASM.
+
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+
+use crate::error::WasmResult;
+use crate::persist::pool::{JsPool, create_mysql_pool};
+use crate::sdk_builder::MysqlStorageConfig;
+
+/// A shareable MySQL connection pool. See [`PostgresConnectionPool`](super::postgres_pool::PostgresConnectionPool)
+/// for sharing semantics and lifecycle.
+#[wasm_bindgen]
+pub struct MysqlConnectionPool {
+    pub(crate) inner: Rc<JsPool>,
+}
+
+impl MysqlConnectionPool {
+    pub(crate) fn cloned_inner(&self) -> Rc<JsPool> {
+        Rc::clone(&self.inner)
+    }
+}
+
+/// Creates a shareable MySQL connection pool from the given config.
+#[wasm_bindgen(js_name = "createMysqlConnectionPool")]
+pub fn create_mysql_connection_pool(config: MysqlStorageConfig) -> WasmResult<MysqlConnectionPool> {
+    Ok(MysqlConnectionPool {
+        inner: Rc::new(create_mysql_pool(config)?),
+    })
+}

--- a/crates/breez-sdk/wasm/src/models/postgres_pool.rs
+++ b/crates/breez-sdk/wasm/src/models/postgres_pool.rs
@@ -1,0 +1,38 @@
+//! Shareable Postgres connection pool wrapper for WASM.
+
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+
+use crate::error::WasmResult;
+use crate::persist::pool::{JsPool, create_postgres_pool};
+use crate::sdk_builder::PostgresStorageConfig;
+
+/// A shareable Postgres connection pool.
+///
+/// Construct via [`create_postgres_connection_pool`] and pass the same handle to multiple
+/// `SdkBuilder`s via `withPostgresConnectionPool` to share connections across SDKs.
+/// Per-tenant scoping is derived from each SDK's seed.
+///
+/// The pool's lifecycle is controlled by the integrator: it stays alive as
+/// long as any reference is held. `disconnect()` does **not** close the pool.
+#[wasm_bindgen]
+pub struct PostgresConnectionPool {
+    pub(crate) inner: Rc<JsPool>,
+}
+
+impl PostgresConnectionPool {
+    pub(crate) fn cloned_inner(&self) -> Rc<JsPool> {
+        Rc::clone(&self.inner)
+    }
+}
+
+/// Creates a shareable Postgres connection pool from the given config.
+#[wasm_bindgen(js_name = "createPostgresConnectionPool")]
+pub fn create_postgres_connection_pool(
+    config: PostgresStorageConfig,
+) -> WasmResult<PostgresConnectionPool> {
+    Ok(PostgresConnectionPool {
+        inner: Rc::new(create_postgres_pool(config)?),
+    })
+}

--- a/crates/breez-sdk/wasm/src/persist/mod.rs
+++ b/crates/breez-sdk/wasm/src/persist/mod.rs
@@ -1,3 +1,5 @@
+pub mod pool;
+
 #[cfg(test)]
 mod tests;
 

--- a/crates/breez-sdk/wasm/src/persist/pool.rs
+++ b/crates/breez-sdk/wasm/src/persist/pool.rs
@@ -1,0 +1,64 @@
+//! Bindings to the JS-side `pg.Pool` / `mysql2.Pool` factories used by the
+//! WASM SDK. The actual pool objects live on the JS side; on the Rust side
+//! we hold opaque handles via the `JsPool` extern type.
+
+use wasm_bindgen::prelude::*;
+
+use crate::logger::Logger;
+use crate::sdk_builder::{MysqlStorageConfig, PostgresStorageConfig};
+use crate::token_store::TokenStoreJs;
+use crate::tree_store::TreeStoreJs;
+
+#[wasm_bindgen]
+extern "C" {
+    /// JS type representing a `pg.Pool` / `mysql2.Pool` instance.
+    pub type JsPool;
+
+    #[wasm_bindgen(js_name = "createPostgresPool", catch)]
+    pub fn create_postgres_pool(config: PostgresStorageConfig) -> Result<JsPool, JsValue>;
+
+    #[wasm_bindgen(js_name = "createPostgresStorageWithPool", catch)]
+    pub async fn create_postgres_storage_with_pool(
+        pool: &JsPool,
+        identity: &[u8],
+        logger: Option<&Logger>,
+    ) -> Result<crate::persist::Storage, JsValue>;
+
+    #[wasm_bindgen(js_name = "createPostgresTreeStoreWithPool", catch)]
+    pub async fn create_postgres_tree_store_with_pool(
+        pool: &JsPool,
+        identity: &[u8],
+        logger: Option<&Logger>,
+    ) -> Result<TreeStoreJs, JsValue>;
+
+    #[wasm_bindgen(js_name = "createPostgresTokenStoreWithPool", catch)]
+    pub async fn create_postgres_token_store_with_pool(
+        pool: &JsPool,
+        identity: &[u8],
+        logger: Option<&Logger>,
+    ) -> Result<TokenStoreJs, JsValue>;
+
+    #[wasm_bindgen(js_name = "createMysqlPool", catch)]
+    pub fn create_mysql_pool(config: MysqlStorageConfig) -> Result<JsPool, JsValue>;
+
+    #[wasm_bindgen(js_name = "createMysqlStorageWithPool", catch)]
+    pub async fn create_mysql_storage_with_pool(
+        pool: &JsPool,
+        identity: &[u8],
+        logger: Option<&Logger>,
+    ) -> Result<crate::persist::Storage, JsValue>;
+
+    #[wasm_bindgen(js_name = "createMysqlTreeStoreWithPool", catch)]
+    pub async fn create_mysql_tree_store_with_pool(
+        pool: &JsPool,
+        identity: &[u8],
+        logger: Option<&Logger>,
+    ) -> Result<TreeStoreJs, JsValue>;
+
+    #[wasm_bindgen(js_name = "createMysqlTokenStoreWithPool", catch)]
+    pub async fn create_mysql_token_store_with_pool(
+        pool: &JsPool,
+        identity: &[u8],
+        logger: Option<&Logger>,
+    ) -> Result<TokenStoreJs, JsValue>;
+}

--- a/crates/breez-sdk/wasm/src/sdk_builder.rs
+++ b/crates/breez-sdk/wasm/src/sdk_builder.rs
@@ -7,13 +7,22 @@ use crate::{
         Config, Credentials, Seed,
         chain_service::{BitcoinChainService, ChainApiType, WasmBitcoinChainService},
         fiat_service::{FiatService, WasmFiatService},
+        mysql_pool::MysqlConnectionPool,
         payment_observer::{PaymentObserver, WasmPaymentObserver},
+        postgres_pool::PostgresConnectionPool,
         rest_client::{RestClient, WasmRestClient},
     },
-    persist::{Storage, WasmStorage},
+    persist::{
+        Storage, WasmStorage,
+        pool::{
+            JsPool, create_mysql_storage_with_pool, create_mysql_token_store_with_pool,
+            create_mysql_tree_store_with_pool, create_postgres_storage_with_pool,
+            create_postgres_token_store_with_pool, create_postgres_tree_store_with_pool,
+        },
+    },
     sdk::BreezSdk,
-    token_store::{TokenStoreJs, WasmTokenStore},
-    tree_store::{TreeStoreJs, WasmTreeStore},
+    token_store::WasmTokenStore,
+    tree_store::WasmTreeStore,
 };
 use bitcoin::secp256k1::PublicKey;
 use breez_sdk_spark::KeySet;
@@ -88,8 +97,8 @@ pub struct SdkBuilder {
     seed: breez_sdk_spark::Seed,
     default_storage_dir: Option<String>,
     storage: Option<Storage>,
-    postgres_backend_config: Option<PostgresStorageConfig>,
-    mysql_backend_config: Option<MysqlStorageConfig>,
+    postgres_pool: Option<Rc<JsPool>>,
+    mysql_pool: Option<Rc<JsPool>>,
     key_set_type: breez_sdk_spark::KeySetType,
     use_address_index: bool,
     account_number: Option<u32>,
@@ -108,8 +117,8 @@ impl SdkBuilder {
             builder: breez_sdk_spark::SdkBuilder::new(config, seed),
             default_storage_dir: None,
             storage: None,
-            postgres_backend_config: None,
-            mysql_backend_config: None,
+            postgres_pool: None,
+            mysql_pool: None,
             key_set_type: breez_sdk_spark::KeySetType::Default,
             use_address_index: false,
             account_number: None,
@@ -131,8 +140,8 @@ impl SdkBuilder {
             builder: breez_sdk_spark::SdkBuilder::new_with_signer(config_core, signer_adapter),
             default_storage_dir: None,
             storage: None,
-            postgres_backend_config: None,
-            mysql_backend_config: None,
+            postgres_pool: None,
+            mysql_pool: None,
             key_set_type: breez_sdk_spark::KeySetType::Default,
             use_address_index: false,
             account_number: None,
@@ -151,15 +160,21 @@ impl SdkBuilder {
         self
     }
 
-    #[wasm_bindgen(js_name = "withPostgresBackend")]
-    pub fn with_postgres_backend(mut self, config: PostgresStorageConfig) -> Self {
-        self.postgres_backend_config = Some(config);
+    /// Sets a shared `PostgreSQL` connection pool as the backend for all
+    /// stores. Construct via `createPostgresConnectionPool` and pass the same handle
+    /// to multiple `SdkBuilder`s to share connections across SDKs.
+    #[wasm_bindgen(js_name = "withPostgresConnectionPool")]
+    pub fn with_postgres_connection_pool(mut self, pool: &PostgresConnectionPool) -> Self {
+        self.postgres_pool = Some(pool.cloned_inner());
         self
     }
 
-    #[wasm_bindgen(js_name = "withMysqlBackend")]
-    pub fn with_mysql_backend(mut self, config: MysqlStorageConfig) -> Self {
-        self.mysql_backend_config = Some(config);
+    /// Sets a shared `MySQL` connection pool as the backend for all stores.
+    /// Construct via `createMysqlConnectionPool` and pass the same handle to multiple
+    /// `SdkBuilder`s to share connections across SDKs.
+    #[wasm_bindgen(js_name = "withMysqlConnectionPool")]
+    pub fn with_mysql_connection_pool(mut self, pool: &MysqlConnectionPool) -> Self {
+        self.mysql_pool = Some(pool.cloned_inner());
         self
     }
 
@@ -231,8 +246,8 @@ impl SdkBuilder {
         match (
             self.default_storage_dir,
             self.storage,
-            &self.postgres_backend_config,
-            &self.mysql_backend_config,
+            &self.postgres_pool,
+            &self.mysql_pool,
         ) {
             (Some(storage_dir), None, None, None) => {
                 // Create key set to get identity_pub_key for WASM-compatible storage
@@ -257,11 +272,9 @@ impl SdkBuilder {
                 let storage_arc = Arc::new(WasmStorage { storage });
                 self.builder = self.builder.with_storage(storage_arc);
             }
-            (None, None, Some(config), None) => {
+            (None, None, Some(pool_rc), None) => {
+                let pool: &JsPool = pool_rc;
                 let logger_ref = get_wasm_logger_ref();
-
-                // Create a single shared pool for all postgres stores
-                let pool = create_postgres_pool(config.clone())?;
 
                 // Derive tenant identity from the seed and pass to the JS storage so it
                 // can scope every read/write by `user_id`.
@@ -277,28 +290,25 @@ impl SdkBuilder {
                 let identity_bytes = identity_pub_key.serialize();
 
                 let storage = Arc::new(WasmStorage {
-                    storage: create_postgres_storage_with_pool(&pool, &identity_bytes, logger_ref)
+                    storage: create_postgres_storage_with_pool(pool, &identity_bytes, logger_ref)
                         .await?,
                 });
                 self.builder = self.builder.with_storage(storage);
 
                 let tree_store_js =
-                    create_postgres_tree_store_with_pool(&pool, &identity_bytes, logger_ref)
-                        .await?;
+                    create_postgres_tree_store_with_pool(pool, &identity_bytes, logger_ref).await?;
                 let tree_store = Arc::new(WasmTreeStore::new(tree_store_js));
                 self.builder = self.builder.with_tree_store(tree_store);
 
                 let token_store_js =
-                    create_postgres_token_store_with_pool(&pool, &identity_bytes, logger_ref)
+                    create_postgres_token_store_with_pool(pool, &identity_bytes, logger_ref)
                         .await?;
                 let token_store = Arc::new(WasmTokenStore::new(token_store_js));
                 self.builder = self.builder.with_token_output_store(token_store);
             }
-            (None, None, None, Some(config)) => {
+            (None, None, None, Some(pool_rc)) => {
+                let pool: &JsPool = pool_rc;
                 let logger_ref = get_wasm_logger_ref();
-
-                // Create a single shared mysql2 pool for all stores.
-                let pool = create_mysql_pool(config.clone())?;
 
                 // Derive tenant identity from the seed and pass to the JS
                 // stores so they can scope every read/write by `user_id`.
@@ -314,24 +324,24 @@ impl SdkBuilder {
                 let identity_bytes = identity_pub_key.serialize();
 
                 let storage = Arc::new(WasmStorage {
-                    storage: create_mysql_storage_with_pool(&pool, &identity_bytes, logger_ref)
+                    storage: create_mysql_storage_with_pool(pool, &identity_bytes, logger_ref)
                         .await?,
                 });
                 self.builder = self.builder.with_storage(storage);
 
                 let tree_store_js =
-                    create_mysql_tree_store_with_pool(&pool, &identity_bytes, logger_ref).await?;
+                    create_mysql_tree_store_with_pool(pool, &identity_bytes, logger_ref).await?;
                 let tree_store = Arc::new(WasmTreeStore::new(tree_store_js));
                 self.builder = self.builder.with_tree_store(tree_store);
 
                 let token_store_js =
-                    create_mysql_token_store_with_pool(&pool, &identity_bytes, logger_ref).await?;
+                    create_mysql_token_store_with_pool(pool, &identity_bytes, logger_ref).await?;
                 let token_store = Arc::new(WasmTokenStore::new(token_store_js));
                 self.builder = self.builder.with_token_output_store(token_store);
             }
             _ => {
                 return Err(WasmError::new(
-                    "Exactly one of default storage directory, storage, postgres config, or mysql config must be set",
+                    "Exactly one of default storage directory, storage, postgres pool, or mysql pool must be set",
                 ));
             }
         }
@@ -370,60 +380,9 @@ async fn default_storage(
 
 #[wasm_bindgen]
 extern "C" {
-    /// JS type representing a `pg.Pool` instance.
-    type JsPool;
-
     #[wasm_bindgen(js_name = "createDefaultStorage", catch)]
     async fn create_default_storage(
         data_dir: &str,
         logger: Option<&Logger>,
     ) -> Result<crate::persist::Storage, JsValue>;
-
-    #[wasm_bindgen(js_name = "createPostgresPool", catch)]
-    fn create_postgres_pool(config: PostgresStorageConfig) -> Result<JsPool, JsValue>;
-
-    #[wasm_bindgen(js_name = "createPostgresStorageWithPool", catch)]
-    async fn create_postgres_storage_with_pool(
-        pool: &JsPool,
-        identity: &[u8],
-        logger: Option<&Logger>,
-    ) -> Result<crate::persist::Storage, JsValue>;
-
-    #[wasm_bindgen(js_name = "createPostgresTreeStoreWithPool", catch)]
-    async fn create_postgres_tree_store_with_pool(
-        pool: &JsPool,
-        identity: &[u8],
-        logger: Option<&Logger>,
-    ) -> Result<TreeStoreJs, JsValue>;
-
-    #[wasm_bindgen(js_name = "createPostgresTokenStoreWithPool", catch)]
-    async fn create_postgres_token_store_with_pool(
-        pool: &JsPool,
-        identity: &[u8],
-        logger: Option<&Logger>,
-    ) -> Result<TokenStoreJs, JsValue>;
-
-    #[wasm_bindgen(js_name = "createMysqlPool", catch)]
-    fn create_mysql_pool(config: MysqlStorageConfig) -> Result<JsPool, JsValue>;
-
-    #[wasm_bindgen(js_name = "createMysqlStorageWithPool", catch)]
-    async fn create_mysql_storage_with_pool(
-        pool: &JsPool,
-        identity: &[u8],
-        logger: Option<&Logger>,
-    ) -> Result<crate::persist::Storage, JsValue>;
-
-    #[wasm_bindgen(js_name = "createMysqlTreeStoreWithPool", catch)]
-    async fn create_mysql_tree_store_with_pool(
-        pool: &JsPool,
-        identity: &[u8],
-        logger: Option<&Logger>,
-    ) -> Result<TreeStoreJs, JsValue>;
-
-    #[wasm_bindgen(js_name = "createMysqlTokenStoreWithPool", catch)]
-    async fn create_mysql_token_store_with_pool(
-        pool: &JsPool,
-        identity: &[u8],
-        logger: Option<&Logger>,
-    ) -> Result<TokenStoreJs, JsValue>;
 }

--- a/crates/breez-sdk/wasm/src/sdk_builder.rs
+++ b/crates/breez-sdk/wasm/src/sdk_builder.rs
@@ -15,8 +15,9 @@ use crate::{
     persist::{
         Storage, WasmStorage,
         pool::{
-            JsPool, create_mysql_storage_with_pool, create_mysql_token_store_with_pool,
-            create_mysql_tree_store_with_pool, create_postgres_storage_with_pool,
+            JsPool, create_mysql_pool, create_mysql_storage_with_pool,
+            create_mysql_token_store_with_pool, create_mysql_tree_store_with_pool,
+            create_postgres_pool, create_postgres_storage_with_pool,
             create_postgres_token_store_with_pool, create_postgres_tree_store_with_pool,
         },
     },
@@ -176,6 +177,22 @@ impl SdkBuilder {
     pub fn with_mysql_connection_pool(mut self, pool: &MysqlConnectionPool) -> Self {
         self.mysql_pool = Some(pool.cloned_inner());
         self
+    }
+
+    /// **Deprecated.** Call `withPostgresConnectionPool(config)` and `withPostgresConnectionPool(pool)` instead.
+    #[wasm_bindgen(js_name = "withPostgresBackend")]
+    pub fn with_postgres_backend(mut self, config: PostgresStorageConfig) -> WasmResult<Self> {
+        let pool = create_postgres_pool(config)?;
+        self.postgres_pool = Some(Rc::new(pool));
+        Ok(self)
+    }
+
+    /// **Deprecated.** Call `withMysqlConnectionPool(config)` and `withMysqlConnectionPool(pool)` instead.
+    #[wasm_bindgen(js_name = "withMysqlBackend")]
+    pub fn with_mysql_backend(mut self, config: MysqlStorageConfig) -> WasmResult<Self> {
+        let pool = create_mysql_pool(config)?;
+        self.mysql_pool = Some(Rc::new(pool));
+        Ok(self)
     }
 
     #[wasm_bindgen(js_name = "withKeySet")]

--- a/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
+++ b/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
@@ -107,9 +107,14 @@ namespace BreezSdkSnippets
                 waitTimeoutSecs = 30ul   // Timeout waiting for connection
             };
 
+            // Construct the connection pool. The same pool can be passed to
+            // multiple SdkBuilders to share connections across SDKs; per-tenant
+            // scoping (rows isolated by seed identity) is preserved.
+            var pool = BreezSdkSparkMethods.CreatePostgresConnectionPool(config: postgresConfig);
+
             // Build the SDK with PostgreSQL backend (storage, tree store, and token store)
             var builder = new SdkBuilder(config: config, seed: seed);
-            await builder.WithPostgresBackend(config: postgresConfig);
+            await builder.WithPostgresConnectionPool(pool: pool);
             var sdk = await builder.Build();
             // ANCHOR_END: init-sdk-postgres
         }

--- a/docs/breez-sdk/snippets/go/sdk_building.go
+++ b/docs/breez-sdk/snippets/go/sdk_building.go
@@ -103,9 +103,17 @@ func InitSdkPostgres() (*breez_sdk_spark.BreezSdk, error) {
 	waitTimeoutSecs := uint64(30)
 	postgresConfig.WaitTimeoutSecs = &waitTimeoutSecs // Timeout waiting for connection
 
+	// Construct the connection pool. The same pool can be passed to multiple
+	// SdkBuilders to share connections across SDKs; per-tenant scoping (rows
+	// isolated by seed identity) is preserved.
+	pool, err := breez_sdk_spark.CreatePostgresConnectionPool(postgresConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	// Build the SDK with PostgreSQL backend (storage, tree store, and token store)
 	builder := breez_sdk_spark.NewSdkBuilder(config, seed)
-	builder.WithPostgresBackend(postgresConfig)
+	builder.WithPostgresConnectionPool(pool)
 	sdk, err := builder.Build()
 	if err != nil {
 		return nil, err

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
@@ -94,10 +94,15 @@ class SdkBuilding {
         postgresConfig.maxPoolSize = 8u // Max connections in pool
         postgresConfig.waitTimeoutSecs = 30u // Timeout waiting for connection
 
+        // Construct the connection pool. The same pool can be passed to
+        // multiple SdkBuilders to share connections across SDKs; per-tenant
+        // scoping (rows isolated by seed identity) is preserved.
+        val pool = createPostgresConnectionPool(postgresConfig)
+
         try {
             // Build the SDK with PostgreSQL backend (storage, tree store, and token store)
             val builder = SdkBuilder(config, seed)
-            builder.withPostgresBackend(postgresConfig)
+            builder.withPostgresConnectionPool(pool)
             val sdk = builder.build()
         } catch (e: Exception) {
             // handle error

--- a/docs/breez-sdk/snippets/python/src/sdk_building.py
+++ b/docs/breez-sdk/snippets/python/src/sdk_building.py
@@ -3,6 +3,7 @@ import typing
 from breez_sdk_spark import (
     default_config,
     default_postgres_storage_config,
+    create_postgres_connection_pool,
     Network,
     ProvisionalPayment,
     SdkBuilder,
@@ -106,10 +107,15 @@ async def init_sdk_postgres():
     postgres_config.max_pool_size = 8  # Max connections in pool
     postgres_config.wait_timeout_secs = 30  # Timeout waiting for connection
 
+    # Construct the connection pool. The same pool can be passed to multiple
+    # SdkBuilders to share connections across SDKs; per-tenant scoping (rows
+    # isolated by seed identity) is preserved.
+    pool = create_postgres_connection_pool(config=postgres_config)
+
     try:
         # Build the SDK with PostgreSQL backend (storage, tree store, and token store)
         builder = SdkBuilder(config=config, seed=seed)
-        await builder.with_postgres_backend(config=postgres_config)
+        await builder.with_postgres_connection_pool(pool=pool)
         sdk = await builder.build()
         return sdk
     except Exception as error:

--- a/docs/breez-sdk/snippets/rust/Cargo.lock
+++ b/docs/breez-sdk/snippets/rust/Cargo.lock
@@ -3073,9 +3073,11 @@ name = "spark-postgres"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bitcoin",
  "chrono",
  "deadpool",
  "deadpool-postgres",
+ "hex",
  "macros",
  "platform-utils",
  "rustls",

--- a/docs/breez-sdk/snippets/rust/src/sdk_building.rs
+++ b/docs/breez-sdk/snippets/rust/src/sdk_building.rs
@@ -104,9 +104,14 @@ pub(crate) async fn init_sdk_postgres() -> Result<BreezSdk> {
     postgres_config.max_pool_size = 8; // Max connections in pool
     postgres_config.wait_timeout_secs = Some(30); // Timeout waiting for connection
 
+    // Construct the connection pool. The same `Arc<PostgresConnectionPool>`
+    // can be passed to multiple SdkBuilders to share connections across SDKs;
+    // per-tenant scoping (rows isolated by seed identity) is preserved.
+    let pool = create_postgres_connection_pool(&postgres_config)?;
+
     // Build the SDK with PostgreSQL backend (storage, tree store, and token store)
     let sdk = SdkBuilder::new(config, seed)
-        .with_postgres_backend(postgres_config)
+        .with_postgres_connection_pool(pool)
         .build()
         .await?;
     // ANCHOR_END: init-sdk-postgres

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
@@ -92,9 +92,14 @@ func initSdkPostgres() async throws -> BreezSdk {
     postgresConfig.maxPoolSize = UInt32(8) // Max connections in pool
     postgresConfig.waitTimeoutSecs = UInt64(30) // Timeout waiting for connection
 
+    // Construct the connection pool. The same pool can be passed to
+    // multiple SdkBuilders to share connections across SDKs; per-tenant
+    // scoping (rows isolated by seed identity) is preserved.
+    let pool = try createPostgresConnectionPool(config: postgresConfig)
+
     // Build the SDK with PostgreSQL backend (storage, tree store, and token store)
     let builder = SdkBuilder(config: config, seed: seed)
-    await builder.withPostgresBackend(config: postgresConfig)
+    await builder.withPostgresConnectionPool(pool: pool)
     let sdk = try await builder.build()
     // ANCHOR_END: init-sdk-postgres
 

--- a/docs/breez-sdk/snippets/wasm/sdk_building.ts
+++ b/docs/breez-sdk/snippets/wasm/sdk_building.ts
@@ -1,4 +1,9 @@
-import { SdkBuilder, defaultConfig, defaultPostgresStorageConfig } from '@breeztech/breez-sdk-spark'
+import {
+  SdkBuilder,
+  defaultConfig,
+  defaultPostgresStorageConfig,
+  createPostgresConnectionPool
+} from '@breeztech/breez-sdk-spark'
 import type {
   ProvisionalPayment,
   Seed,
@@ -68,9 +73,14 @@ const exampleWithPostgresStorage = async () => {
   pgConfig.createTimeoutSecs = 30 // Timeout for establishing a new connection
   pgConfig.recycleTimeoutSecs = 30 // Timeout for recycling an idle connection
 
+  // Construct the connection pool. The same pool handle can be passed to
+  // multiple SdkBuilders to share connections across SDKs; per-tenant
+  // scoping (rows isolated by seed identity) is preserved.
+  const pool = createPostgresConnectionPool(pgConfig)
+
   // Build the SDK with PostgreSQL backend (storage, tree store, and token store)
   let builder = SdkBuilder.new(config, seed)
-  builder = builder.withPostgresBackend(pgConfig)
+  builder = builder.withPostgresConnectionPool(pool)
   const sdk = await builder.build()
   // ANCHOR_END: init-sdk-postgres
 }

--- a/docs/breez-sdk/src/guide/customizing.md
+++ b/docs/breez-sdk/src/guide/customizing.md
@@ -3,7 +3,7 @@
 Using the SDK Builder gives you more control over the initialization and modular components used when the SDK is running. Below you can find examples of initializing the SDK using the SDK Builder and implementing modular components:
 
 - [Storage](#with-storage) to manage stored data
-- [PostgreSQL Backend](#with-postgres-backend) as an alternative storage backend
+- [PostgreSQL Connection Pool](#with-postgres-connection-pool) as an alternative storage backend
 - [Bitcoin Chain Service](#with-chain-service) to provide network data
 - [LNURL Client](#with-lnurl-client) to make REST requests
 - [Fiat Service](#with-fiat-service) to provide Fiat currencies and exchange rates
@@ -21,12 +21,12 @@ When using the SDK Builder, you either have to provide a Storage implementation 
 
 **Note:** Flutter currently only supports using the default storage.
 
-<h2 id="with-postgres-backend">
-    <a class="header" href="#with-postgres-backend">With PostgreSQL Backend</a>
-    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.SdkBuilder.html#method.with_postgres_backend">API docs</a>
+<h2 id="with-postgres-connection-pool">
+    <a class="header" href="#with-postgres-connection-pool">With PostgreSQL Connection Pool</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.SdkBuilder.html#method.with_postgres_connection_pool">API docs</a>
 </h2>
 
-The SDK includes a PostgreSQL backend as an alternative to file-based storage. A single {{#name with_postgres_backend}} call configures PostgreSQL for all stores (storage, tree store, and token store), which is suitable for server-side deployments with horizontal scaling.
+The SDK includes a PostgreSQL backend as an alternative to file-based storage. Construct a connection pool once with {{#name create_postgres_connection_pool}} and pass it to the builder via {{#name with_postgres_connection_pool}} — this configures PostgreSQL for all stores (storage, tree store, and token store), which is suitable for server-side deployments with horizontal scaling. The same pool can be shared across multiple `SdkBuilder` instances; per-tenant scoping (rows isolated by seed identity) is preserved.
 
 **Note:** Not available for React Native or Flutter. For JavaScript/TypeScript, only supported in Node.js (not in the browser).
 


### PR DESCRIPTION
For multi-tenant server deployments (one Breez SDK per user), the SDK
forced one connection pool per `BreezSdk` — a server hosting N users opened
N independent pools to the same database. This PR replaces the
`with_postgres_backend(config)` / `with_mysql_backend(config)` API with a
shareable wrapper:

- New `create_postgres_connection_pool(config) -> Arc<PostgresConnectionPool>`
  and `create_mysql_connection_pool(config) -> Arc<MysqlConnectionPool>`.
- New `SdkBuilder::with_postgres_connection_pool(pool)` /
  `with_mysql_connection_pool(pool)` — pass the same `Arc` to multiple
  builders to share connections across SDKs.
- Per-tenant scoping (rows isolated by seed identity) is preserved — the
  pool is shared, the data isn't.
- `BreezSdk::disconnect()` does **not** close a shared pool; the pool's
  lifecycle belongs to the integrator and ends when the last `Arc` drops.

**Demonstration**

A new bench `pool-share-perf` builds 32 SDK instances (different seeds /
tenants) against a single Postgres database, once with each instance
getting its own pool, once with all instances sharing one pool. Snapshots
`pg_stat_activity` from a separate connection at each lifecycle step.

| Metric | Separate (32 pools) | Shared (1 pool) | Win |
|---|---|---|---|
| **Peak DB connections** | **96** | **8** | **12× fewer** |
| Idle DB connections (after init) | 96 | 8 | 12× fewer |
| SDK init time (sequential, 32 instances) | 492ms | 148ms | 3.3× faster |
| Concurrent `get_info()` (all 32 in parallel) | 1.47ms | 0.95ms | ~35% faster |
| Connections after `disconnect()` | 0 | 8 | (pool still held by integrator) |
| Connections after pool dropped | 0 | 0 | (pool actually closes) |

**Observations**

- **96 → 8 connections.** Each SDK opens 3 stores (storage / tree
  store / token store) — separate-pool, 32 SDKs × 3 stores = 96 idle
  connections held even with no queries. Shared-pool needs at most
  `max_pool_size = 8` total. With default `max_pool_size = 32`, separate
  mode would want 32 × 3 × 32 = 3072 connections, far past Postgres'
  default `max_connections = 100`. *That's the failure shared-pool fixes.*
- **3.3× faster init** is migration amortization — each separate pool runs
  schema migrations independently; the shared pool runs them once and the
  rest no-op.
- **Lifecycle is correct.** Separate-mode → 0 connections after
  `disconnect()`. Shared-mode → 8 connections persist after `disconnect()`
  because the integrator still holds the `Arc`. After explicitly dropping
  the pool, both go to 0. Confirms the docstring claim.
- **Concurrent-query latency** moved by ~0.5ms; both modes have plenty of
  available connections at this scale, so contention is negligible. The
  metric matters more at higher concurrency.

The existing `concurrent-perf` bench was also re-run end-to-end (4 SDKs
sharing a pool, 100 regtest payments): **100/100 success, throughput
within 1% of baseline, p99 latency improved by 3.25s.**
