### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
@@ -47,7 +47,9 @@ make run-mainnet
     --network                           Network to use: regtest, mainnet (default: regtest)
     --account-number                    Account number for the Spark signer
     --postgres-connection-string        PostgreSQL connection string (not yet supported, uses SQLite)
-    --stable-balance-token-identifier   Stable balance token identifier
+    --mysql-connection-string           MySQL connection string (not yet supported, uses SQLite)
+    --stable-balance-token              Stable balance token in TICKER:token_identifier format (repeatable)
+    --stable-balance-default-active-label  Default active label for stable balance
     --stable-balance-threshold          Stable balance threshold in sats
     --passkey                           Use passkey with PRF provider (file, yubikey, or fido2)
     --label                             Label for seed derivation (requires --passkey)
@@ -91,6 +93,7 @@ Once the CLI is running, type `help` to see all available commands:
 - `issuer <subcommand>` — Token issuer commands
 - `contacts <subcommand>` — Contacts commands (add, update, delete, list)
 - `webhooks <subcommand>` — Webhook commands (register, unregister, list)
+- `stable-balance <subcommand>` — Stable balance commands (get, set, unset)
 
 ## Passkey
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:breez_cli/cli.dart';
 import 'package:breez_cli/passkey.dart';
+import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
 
 Future<void> main(List<String> arguments) async {
   final parser =
@@ -14,7 +15,12 @@ Future<void> main(List<String> arguments) async {
           'postgres-connection-string',
           help: 'PostgreSQL connection string (uses SQLite by default)',
         )
-        ..addOption('stable-balance-token-identifier', help: 'Stable balance token identifier')
+        ..addOption('mysql-connection-string', help: 'MySQL connection string (uses SQLite by default)')
+        ..addMultiOption(
+          'stable-balance-token',
+          help: 'Stable balance token in TICKER:token_identifier format (repeatable)',
+        )
+        ..addOption('stable-balance-default-active-label', help: 'Default active label for stable balance')
         ..addOption('stable-balance-threshold', help: 'Stable balance threshold in sats')
         ..addOption(
           'passkey',
@@ -58,7 +64,28 @@ Future<void> main(List<String> arguments) async {
   final accountNumberStr = results.option('account-number');
   final accountNumber = accountNumberStr != null ? int.parse(accountNumberStr) : null;
   final postgresConnectionString = results.option('postgres-connection-string');
-  final stableBalanceTokenIdentifier = results.option('stable-balance-token-identifier');
+  final mysqlConnectionString = results.option('mysql-connection-string');
+
+  if (postgresConnectionString != null && mysqlConnectionString != null) {
+    stderr.writeln(
+      'Error: --postgres-connection-string and --mysql-connection-string are mutually exclusive',
+    );
+    exit(1);
+  }
+
+  final stableBalanceTokenStrings = results.multiOption('stable-balance-token');
+  final stableBalanceTokens = <StableBalanceToken>[];
+  for (final s in stableBalanceTokenStrings) {
+    final colonIdx = s.indexOf(':');
+    if (colonIdx < 0) {
+      stderr.writeln("Invalid token format '$s', expected LABEL:token_identifier");
+      exit(1);
+    }
+    final label = s.substring(0, colonIdx);
+    final tokenIdentifier = s.substring(colonIdx + 1);
+    stableBalanceTokens.add(StableBalanceToken(label: label, tokenIdentifier: tokenIdentifier));
+  }
+  final stableBalanceDefaultActiveLabel = results.option('stable-balance-default-active-label');
   final stableBalanceThresholdStr = results.option('stable-balance-threshold');
   final stableBalanceThreshold =
       stableBalanceThresholdStr != null ? BigInt.parse(stableBalanceThresholdStr) : null;
@@ -103,7 +130,9 @@ Future<void> main(List<String> arguments) async {
     network: network,
     accountNumber: accountNumber,
     postgresConnectionString: postgresConnectionString,
-    stableBalanceTokenIdentifier: stableBalanceTokenIdentifier,
+    mysqlConnectionString: mysqlConnectionString,
+    stableBalanceTokens: stableBalanceTokens,
+    stableBalanceDefaultActiveLabel: stableBalanceDefaultActiveLabel,
     stableBalanceThreshold: stableBalanceThreshold,
     passkeyConfig: passkeyConfig,
   );

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/cli.dart
@@ -11,6 +11,7 @@ import 'passkey.dart';
 import 'persistence.dart';
 import 'readline.dart';
 import 'serialization.dart';
+import 'stable_balance.dart';
 import 'webhooks.dart';
 
 Future<void> runCli({
@@ -18,7 +19,9 @@ Future<void> runCli({
   required String network,
   int? accountNumber,
   String? postgresConnectionString,
-  String? stableBalanceTokenIdentifier,
+  String? mysqlConnectionString,
+  List<StableBalanceToken> stableBalanceTokens = const [],
+  String? stableBalanceDefaultActiveLabel,
   BigInt? stableBalanceThreshold,
   PasskeyConfig? passkeyConfig,
 }) async {
@@ -38,11 +41,11 @@ Future<void> runCli({
     config = config.copyWith(apiKey: apiKey);
   }
 
-  if (stableBalanceTokenIdentifier != null) {
+  if (stableBalanceTokens.isNotEmpty) {
     config = config.copyWith(
       stableBalanceConfig: StableBalanceConfig(
-        tokens: [StableBalanceToken(label: "USDB", tokenIdentifier: stableBalanceTokenIdentifier)],
-        defaultActiveLabel: "USDB",
+        tokens: stableBalanceTokens,
+        defaultActiveLabel: stableBalanceDefaultActiveLabel,
         thresholdSats: stableBalanceThreshold,
         maxSlippageBps: null,
       ),
@@ -60,9 +63,13 @@ Future<void> runCli({
   var builder = SdkBuilder(config: config, seed: seed);
 
   if (postgresConnectionString != null) {
-    // PostgreSQL storage is not yet available in the Flutter/Dart SDK bindings.
     stderr.writeln(
       'Warning: --postgres-connection-string is not yet supported in the Dart CLI. '
+      'Using default SQLite storage instead.',
+    );
+  } else if (mysqlConnectionString != null) {
+    stderr.writeln(
+      'Warning: --mysql-connection-string is not yet supported in the Dart CLI. '
       'Using default SQLite storage instead.',
     );
   }
@@ -120,6 +127,7 @@ Future<void> _runRepl(
     ...issuerCommandNames,
     ...contactsCommandNames,
     ...webhookCommandNames,
+    ...stableBalanceCommandNames,
     'exit',
     'quit',
     'help',
@@ -155,6 +163,8 @@ Future<void> _runRepl(
         await dispatchContactsCommand(cmdArgs, sdk);
       } else if (cmdName == 'webhooks') {
         await dispatchWebhookCommand(cmdArgs, sdk);
+      } else if (cmdName == 'stable-balance') {
+        await dispatchStableBalanceCommand(cmdArgs, sdk);
       } else if (registry.containsKey(cmdName)) {
         final entry = registry[cmdName]!;
         await entry.handler(sdk, tokenIssuer, cmdArgs);
@@ -194,6 +204,9 @@ void _printHelp(Map<String, CommandEntry> registry) {
   );
   stdout.writeln(
     '  ${'webhooks <subcommand>'.padRight(40)} Webhook commands (use \'webhooks help\' for details)',
+  );
+  stdout.writeln(
+    '  ${'stable-balance <subcommand>'.padRight(40)} Stable balance commands (use \'stable-balance help\' for details)',
   );
   stdout.writeln('  ${'exit / quit'.padRight(40)} Exit the CLI');
   stdout.writeln('  ${'help'.padRight(40)} Show this help message');

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -450,6 +450,7 @@ Future<void> _handleLnurlPay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String>
         ..addOption('comment', abbr: 'c')
         ..addOption('validate', abbr: 'v')
         ..addOption('idempotency-key', abbr: 'i')
+        ..addOption('token-identifier', abbr: 't')
         ..addOption('from-token')
         ..addOption('convert-max-slippage-bps', abbr: 's')
         ..addFlag('fees-included', defaultsTo: false);
@@ -463,6 +464,7 @@ Future<void> _handleLnurlPay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String>
   }
   final lnurl = results.rest.first;
 
+  final tokenIdentifier = results.option('token-identifier');
   final fromToken = results.option('from-token');
   final slippageStr = results.option('convert-max-slippage-bps');
   final slippage = slippageStr != null ? int.parse(slippageStr) : null;
@@ -494,7 +496,11 @@ Future<void> _handleLnurlPay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String>
   final k = BigInt.from(1000);
   final minSendable = (payRequest.minSendable + k - BigInt.one) ~/ k;
   final maxSendable = payRequest.maxSendable ~/ k;
-  final amountStr = prompt('Amount to pay (min $minSendable sat, max $maxSendable sat): ');
+  final promptText =
+      tokenIdentifier == null
+          ? 'Amount to pay (min $minSendable sat, max $maxSendable sat): '
+          : 'Amount to pay (min $minSendable sat, max $maxSendable sat) in token base units: ';
+  final amountStr = prompt(promptText);
   final amountSats = BigInt.parse(amountStr);
 
   final prepareResponse = await sdk.prepareLnurlPay(
@@ -503,6 +509,7 @@ Future<void> _handleLnurlPay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String>
       comment: results.option('comment'),
       payRequest: payRequest,
       validateSuccessActionUrl: _parseBool(results.option('validate')),
+      tokenIdentifier: tokenIdentifier,
       conversionOptions: conversionOptions,
       feePolicy: feePolicy,
     ),

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/stable_balance.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/stable_balance.dart
@@ -1,0 +1,80 @@
+import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
+
+import 'serialization.dart';
+
+/// Stable balance subcommand names (used for tab completion).
+const stableBalanceCommandNames = ['stable-balance get', 'stable-balance set', 'stable-balance unset'];
+
+typedef StableBalanceHandler = Future<void> Function(BreezSdk sdk, List<String> args);
+
+class _StableBalanceEntry {
+  final String description;
+  final StableBalanceHandler handler;
+  const _StableBalanceEntry(this.description, this.handler);
+}
+
+Map<String, _StableBalanceEntry>? _registry;
+
+Map<String, _StableBalanceEntry> _getRegistry() {
+  return _registry ??= {
+    'get': _StableBalanceEntry('Get the stable balance active label', _handleGet),
+    'set': _StableBalanceEntry('Set the stable balance active label', _handleSet),
+    'unset': _StableBalanceEntry('Unset stable balance', _handleUnset),
+  };
+}
+
+/// Dispatch a stable-balance subcommand given the args after 'stable-balance'.
+Future<void> dispatchStableBalanceCommand(List<String> args, BreezSdk sdk) async {
+  final registry = _getRegistry();
+
+  if (args.isEmpty || args[0] == 'help' || args[0] == '--help') {
+    print('\nStable balance subcommands:\n');
+    for (final entry in registry.entries.toList()..sort((a, b) => a.key.compareTo(b.key))) {
+      print('  stable-balance ${entry.key.padRight(30)} ${entry.value.description}');
+    }
+    print('');
+    return;
+  }
+
+  final subName = args[0];
+  final subArgs = args.sublist(1);
+
+  if (!registry.containsKey(subName)) {
+    print("Unknown stable-balance subcommand: $subName. Use 'stable-balance help' for available commands.");
+    return;
+  }
+
+  await registry[subName]!.handler(sdk, subArgs);
+}
+
+// --- get ---
+
+Future<void> _handleGet(BreezSdk sdk, List<String> args) async {
+  final settings = await sdk.getUserSettings();
+  printValue(settings.stableBalanceActiveLabel);
+}
+
+// --- set ---
+
+Future<void> _handleSet(BreezSdk sdk, List<String> args) async {
+  if (args.isEmpty || args.first == 'help' || args.first == '--help') {
+    print('Usage: stable-balance set <label>');
+    return;
+  }
+  final label = args[0];
+  await sdk.updateUserSettings(
+    request: UpdateUserSettingsRequest(stableBalanceActiveLabel: StableBalanceActiveLabel_Set(label: label)),
+  );
+  final settings = await sdk.getUserSettings();
+  printValue(settings);
+}
+
+// --- unset ---
+
+Future<void> _handleUnset(BreezSdk sdk, List<String> args) async {
+  await sdk.updateUserSettings(
+    request: UpdateUserSettingsRequest(stableBalanceActiveLabel: StableBalanceActiveLabel_Unset()),
+  );
+  final settings = await sdk.getUserSettings();
+  printValue(settings);
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
@@ -48,7 +48,8 @@ make clean            Remove venv and build artifacts
 | `--network` | `regtest` | Network to use (`regtest` or `mainnet`) |
 | `--account-number` | - | Account number for the Spark signer |
 | `--postgres-connection-string` | - | PostgreSQL connection string (uses SQLite by default) |
-| `--stable-balance-token-identifier` | - | Stable balance token identifier |
+| `--stable-balance-token` | - | Stable balance tokens in `LABEL:token_identifier` format (repeatable) |
+| `--stable-balance-default-active-label` | - | Default active label for stable balance (must match a token label) |
 | `--stable-balance-threshold` | - | Stable balance threshold in sats |
 | `--passkey` | - | Use Passkey with PRF provider (`file`, `yubikey` or `fido2`) |
 | `--label` | `Default` | Requires `--passkey`. The label to use |
@@ -75,6 +76,8 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 **Lightning address**: `get-lightning-address`, `register-lightning-address`, `delete-lightning-address`, `check-lightning-address-available`
 
 **Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`, `issuer <subcommand>`
+
+**Stable balance**: `stable-balance get`, `stable-balance set`, `stable-balance unset`
 
 **Contacts**: `contacts add`, `contacts update`, `contacts delete`, `contacts list`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -342,8 +342,15 @@ async def _handle_pay(sdk, _token_issuer, session, args):
 
     if prepare_response.conversion_estimate is not None:
         est = prepare_response.conversion_estimate
-        units = "sats" if isinstance(est.options.conversion_type, ConversionType.FROM_BITCOIN) else "token base units"
-        print(f"Estimated conversion of {est.amount} {units} with a {est.fee} {units} fee")
+        if isinstance(est.options.conversion_type, ConversionType.FROM_BITCOIN):
+            in_units, out_units = "sats", "token base units"
+        else:
+            in_units, out_units = "token base units", "sats"
+        print(
+            f"Estimated conversion from {est.amount_in} {in_units} "
+            f"to {est.amount_out} {out_units} "
+            f"with a {est.fee} token base units fee"
+        )
         line = await session.prompt_async("Do you want to continue (y/n): ", default="y")
         if line.strip().lower() != "y":
             print("Payment cancelled")
@@ -370,6 +377,7 @@ def _build_lnurl_pay_parser():
     p.add_argument("-v", "--validate", type=lambda v: v.lower() in ("true", "1", "yes"), default=None,
                    dest="validate_success_url")
     p.add_argument("-i", "--idempotency-key", default=None)
+    p.add_argument("-t", "--token-identifier", default=None)
     p.add_argument("--from-token", default=None)
     p.add_argument("-s", "--convert-max-slippage-bps", type=int, default=None)
     p.add_argument("--fees-included", action="store_true", default=False)
@@ -397,18 +405,24 @@ async def _handle_lnurl_pay(sdk, _token_issuer, session, args):
         print("Invalid input: expected LNURL-pay or Lightning address")
         return
 
+    token_identifier = args.token_identifier
+
     min_sendable = math.ceil(pay_request.min_sendable / 1000)
     max_sendable = pay_request.max_sendable // 1000
-    prompt = f"Amount to pay (min {min_sendable} sat, max {max_sendable} sat): "
+    if token_identifier is None:
+        prompt = f"Amount to pay (min {min_sendable} sat, max {max_sendable} sat): "
+    else:
+        prompt = f"Amount to pay (min {min_sendable} sat, max {max_sendable} sat) in token base units: "
     amount_str = await session.prompt_async(prompt)
-    amount_sats = int(amount_str.strip())
+    amount = int(amount_str.strip())
 
     prepare_response = await sdk.prepare_lnurl_pay(
         request=PrepareLnurlPayRequest(
-            amount_sats=amount_sats,
+            amount=amount,
             comment=args.comment,
             pay_request=pay_request,
             validate_success_action_url=args.validate_success_url,
+            token_identifier=token_identifier,
             conversion_options=conversion_options,
             fee_policy=fee_policy,
         )
@@ -416,7 +430,15 @@ async def _handle_lnurl_pay(sdk, _token_issuer, session, args):
 
     if prepare_response.conversion_estimate is not None:
         est = prepare_response.conversion_estimate
-        print(f"Estimated conversion of {est.amount} token base units with a {est.fee} token base units fee")
+        if isinstance(est.options.conversion_type, ConversionType.FROM_BITCOIN):
+            in_units, out_units = "sats", "token base units"
+        else:
+            in_units, out_units = "token base units", "sats"
+        print(
+            f"Estimated conversion from {est.amount_in} {in_units} "
+            f"to {est.amount_out} {out_units} "
+            f"with a {est.fee} token base units fee"
+        )
         line = await session.prompt_async("Do you want to continue (y/n): ", default="y")
         if line.strip().lower() != "y":
             print("Payment cancelled")

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
@@ -28,6 +28,7 @@ from breez_sdk_spark import (
 from breez_cli.commands import COMMAND_NAMES, build_command_registry
 from breez_cli.contacts import CONTACTS_COMMAND_NAMES, dispatch_contacts_command
 from breez_cli.issuer import ISSUER_COMMAND_NAMES, dispatch_issuer_command
+from breez_cli.stable_balance import STABLE_BALANCE_COMMAND_NAMES, dispatch_stable_balance_command
 from breez_cli.webhooks import WEBHOOKS_COMMAND_NAMES, dispatch_webhooks_command
 from breez_cli.passkey import create_provider, resolve_passkey_seed
 from breez_cli.persistence import CliPersistence
@@ -60,7 +61,10 @@ def expand_path(path: str) -> Path:
 )
 @click.option("--account-number", type=int, default=None, help="Account number for the Spark signer")
 @click.option("--postgres-connection-string", default=None, help="PostgreSQL connection string")
-@click.option("--stable-balance-token-identifier", default=None, help="Stable balance token identifier")
+@click.option("--stable-balance-token", "stable_balance_tokens", multiple=True,
+              help='Stable balance tokens in "LABEL:token_identifier" format (repeatable)')
+@click.option("--stable-balance-default-active-label", default=None,
+              help="Default active label for stable balance (must match a token label)")
 @click.option("--stable-balance-threshold", type=int, default=None, help="Stable balance threshold in sats")
 @click.option("--passkey", "passkey_provider", default=None, help="Use passkey with file, yubikey, or fido2 provider")
 @click.option("--label", default=None, help="Label for seed derivation (requires --passkey)")
@@ -68,7 +72,8 @@ def expand_path(path: str) -> Path:
 @click.option("--store-label", is_flag=True, default=False, help="Publish the label to Nostr (requires --passkey and --label)")
 @click.option("--rpid", default=None, help="Relying party ID for FIDO2 provider (requires --passkey)")
 async def main(data_dir, network, account_number, postgres_connection_string,
-               stable_balance_token_identifier, stable_balance_threshold,
+               stable_balance_tokens, stable_balance_default_active_label,
+               stable_balance_threshold,
                passkey_provider, label, list_labels, store_label, rpid):
     """CLI client for Breez SDK with Spark."""
     data_dir = expand_path(data_dir)
@@ -97,10 +102,18 @@ async def main(data_dir, network, account_number, postgres_connection_string,
     config = default_config(network=network_enum)
     config.api_key = breez_api_key
 
-    if stable_balance_token_identifier:
+    if stable_balance_tokens:
+        tokens = []
+        for s in stable_balance_tokens:
+            if ":" not in s:
+                raise click.UsageError(
+                    f"Invalid token format '{s}', expected LABEL:token_identifier"
+                )
+            token_label, token_identifier = s.split(":", 1)
+            tokens.append(StableBalanceToken(label=token_label, token_identifier=token_identifier))
         config.stable_balance_config = StableBalanceConfig(
-            tokens=[StableBalanceToken(label="USDB", token_identifier=stable_balance_token_identifier)],
-            default_active_label="USDB",
+            tokens=tokens,
+            default_active_label=stable_balance_default_active_label,
             threshold_sats=stable_balance_threshold,
             max_slippage_bps=None,
         )
@@ -140,7 +153,7 @@ async def main(data_dir, network, account_number, postgres_connection_string,
 
 async def run_repl(sdk, token_issuer, network, persistence):
     history_file = persistence.history_file()
-    all_commands = sorted(set(COMMAND_NAMES + CONTACTS_COMMAND_NAMES + ISSUER_COMMAND_NAMES + WEBHOOKS_COMMAND_NAMES + ["exit", "quit", "help"]))
+    all_commands = sorted(set(COMMAND_NAMES + CONTACTS_COMMAND_NAMES + ISSUER_COMMAND_NAMES + STABLE_BALANCE_COMMAND_NAMES + WEBHOOKS_COMMAND_NAMES + ["exit", "quit", "help"]))
     session = PromptSession(
         history=FileHistory(history_file),
         auto_suggest=AutoSuggestFromHistory(),
@@ -182,6 +195,8 @@ async def run_repl(sdk, token_issuer, network, persistence):
                 await dispatch_contacts_command(cmd_args, sdk)
             elif cmd_name == "issuer":
                 await dispatch_issuer_command(cmd_args, token_issuer)
+            elif cmd_name == "stable-balance":
+                await dispatch_stable_balance_command(cmd_args, sdk)
             elif cmd_name == "webhooks":
                 await dispatch_webhooks_command(cmd_args, sdk)
             elif cmd_name in registry:
@@ -220,6 +235,7 @@ def print_help(registry):
         print(f"  {name:40s} {desc}")
     print(f"\n  {'contacts <subcommand>':40s} Contacts commands (use 'contacts help' for details)")
     print(f"  {'issuer <subcommand>':40s} Token issuer commands (use 'issuer help' for details)")
+    print(f"  {'stable-balance <subcommand>':40s} Stable balance commands (use 'stable-balance help' for details)")
     print(f"  {'webhooks <subcommand>':40s} Webhook commands (use 'webhooks help' for details)")
     print(f"  {'exit / quit':40s} Exit the CLI")
     print(f"  {'help':40s} Show this help message")

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/stable_balance.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/stable_balance.py
@@ -1,0 +1,112 @@
+import argparse
+
+from breez_sdk_spark import (
+    StableBalanceActiveLabel,
+    UpdateUserSettingsRequest,
+)
+
+from breez_cli.serialization import print_value
+
+# Stable balance subcommand names (used for REPL completion)
+STABLE_BALANCE_COMMAND_NAMES = [
+    "stable-balance get",
+    "stable-balance set",
+    "stable-balance unset",
+]
+
+
+def _parser(name, description=""):
+    return argparse.ArgumentParser(prog=f"stable-balance {name}", description=description)
+
+
+# --- get ---
+
+def _build_get_parser():
+    return _parser("get", "Get the stable balance active label")
+
+async def _handle_get(sdk, _args):
+    settings = await sdk.get_user_settings()
+    print_value(settings.stable_balance_active_label)
+
+
+# --- set ---
+
+def _build_set_parser():
+    p = _parser("set", "Set the stable balance active label")
+    p.add_argument("label", help='The label to activate (e.g. "USDB")')
+    return p
+
+async def _handle_set(sdk, args):
+    await sdk.update_user_settings(
+        request=UpdateUserSettingsRequest(
+            spark_private_mode_enabled=None,
+            stable_balance_active_label=StableBalanceActiveLabel.SET(label=args.label),
+        )
+    )
+    settings = await sdk.get_user_settings()
+    print_value(settings)
+
+
+# --- unset ---
+
+def _build_unset_parser():
+    return _parser("unset", "Unset stable balance")
+
+async def _handle_unset(sdk, _args):
+    await sdk.update_user_settings(
+        request=UpdateUserSettingsRequest(
+            spark_private_mode_enabled=None,
+            stable_balance_active_label=StableBalanceActiveLabel.UNSET(),
+        )
+    )
+    settings = await sdk.get_user_settings()
+    print_value(settings)
+
+
+# ---------------------------------------------------------------------------
+# Registry and dispatch
+# ---------------------------------------------------------------------------
+
+def _build_stable_balance_registry():
+    return {
+        "get": (_build_get_parser(), _handle_get),
+        "set": (_build_set_parser(), _handle_set),
+        "unset": (_build_unset_parser(), _handle_unset),
+    }
+
+
+_REGISTRY = None
+
+def _get_registry():
+    global _REGISTRY
+    if _REGISTRY is None:
+        _REGISTRY = _build_stable_balance_registry()
+    return _REGISTRY
+
+
+async def dispatch_stable_balance_command(args, sdk):
+    """Dispatch a stable-balance subcommand given the args after 'stable-balance'."""
+    registry = _get_registry()
+
+    if not args or args[0] == "help":
+        print("\nStable balance subcommands:\n")
+        for name, (parser, _) in sorted(registry.items()):
+            desc = parser.description or ""
+            print(f"  stable-balance {name:30s} {desc}")
+        print()
+        return
+
+    sub_name = args[0]
+    sub_args = args[1:]
+
+    if sub_name not in registry:
+        print(f"Unknown stable-balance subcommand: {sub_name}. Use 'stable-balance help' for available commands.")
+        return
+
+    parser, handler = registry[sub_name]
+    try:
+        parsed = parser.parse_args(sub_args)
+    except SystemExit:
+        return
+
+    await handler(sdk, parsed)

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
@@ -59,6 +59,9 @@ declare module '@breeztech/breez-sdk-spark-react-native' {
   export const WebhookEventType: any;
   export type WebhookEventType = any;
 
+  export const StableBalanceActiveLabel: any;
+  export type StableBalanceActiveLabel = any;
+
   // --- values only ---
   export const defaultConfig: any;
   export const SdkEvent_Tags: any;

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -42,6 +42,7 @@ import { formatValue } from './serialization'
 import { dispatchIssuerCommand } from './issuer'
 import { dispatchContactsCommand } from './contacts'
 import { dispatchWebhooksCommand } from './webhooks'
+import { dispatchStableBalanceCommand } from './stable_balance'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -173,6 +174,7 @@ export const COMMAND_NAMES = [
   'issuer',
   'contacts',
   'webhooks',
+  'stable-balance',
 ]
 
 // ---------------------------------------------------------------------------
@@ -213,6 +215,7 @@ export function buildCommandRegistry(): Map<string, CommandDef> {
     { name: 'issuer', description: 'Token issuer commands (use "issuer help" for details)', run: handleIssuer },
     { name: 'contacts', description: 'Contacts commands (use "contacts help" for details)', run: handleContacts },
     { name: 'webhooks', description: 'Webhook commands (use "webhooks help" for details)', run: handleWebhooks },
+    { name: 'stable-balance', description: 'Stable balance commands (use "stable-balance help" for details)', run: handleStableBalance },
   ]
 
   for (const cmd of commands) {
@@ -649,7 +652,7 @@ async function handleLnurlPay(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerI
   const flagArgs = args
 
   if (positional.length < 1) {
-    return 'Usage: lnurl-pay <lnurl_or_address> [-a <amount_sats>] [-c <comment>] [-v <true/false>] [-i <idempotency_key>] [--from-token <token_id>] [-s <max_slippage_bps>] [--fees-included]'
+    return 'Usage: lnurl-pay <lnurl_or_address> [-a <amount>] [-c <comment>] [-v <true/false>] [-i <idempotency_key>] [-t <token_identifier>] [--from-token <token_id>] [-s <max_slippage_bps>] [--fees-included]'
   }
 
   const lnurl = positional[0]
@@ -657,6 +660,7 @@ async function handleLnurlPay(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerI
   const validateStr = parseFlag(flagArgs, '--validate', '-v')
   const validateSuccessUrl = validateStr !== undefined ? validateStr === 'true' : undefined
   const idempotencyKey = parseFlag(flagArgs, '--idempotency-key', '-i')
+  const tokenIdentifier = parseFlag(flagArgs, '--token-identifier', '-t')
   const convertFromTokenIdentifier = parseFlag(flagArgs, '--from-token')
   const maxSlippageBps = parseNumericFlag(flagArgs, '--convert-max-slippage-bps', '-s')
   const feesIncluded = hasFlag(flagArgs, '--fees-included')
@@ -691,21 +695,23 @@ async function handleLnurlPay(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerI
 
   // In the Rust CLI, this prompts for amount interactively.
   // Since we cannot prompt interactively in a single command, require amount as a flag.
-  const amountSatsStr = parseFlag(flagArgs, '--amount', '-a')
-  if (!amountSatsStr) {
+  const amountStr = parseFlag(flagArgs, '--amount', '-a')
+  if (!amountStr) {
     lines.push(formatValue(payRequest))
     lines.push('')
-    lines.push('Please provide amount with -a flag: lnurl-pay <lnurl> -a <amount_sats>')
+    const unitHint = tokenIdentifier ? ' (in token base units)' : ''
+    lines.push(`Please provide amount with -a flag${unitHint}: lnurl-pay <lnurl> -a <amount>`)
     return lines.join('\n')
   }
 
-  const amountSats = BigInt(amountSatsStr)
+  const amount = BigInt(amountStr)
 
   const prepareResponse = await sdk.prepareLnurlPay({
-    amountSats,
+    amount,
     payRequest: payRequest as any,
     comment,
     validateSuccessActionUrl: validateSuccessUrl,
+    tokenIdentifier,
     conversionOptions,
     feePolicy,
   })
@@ -1095,4 +1101,10 @@ async function handleContacts(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerI
 
 async function handleWebhooks(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
   return dispatchWebhooksCommand(args, sdk)
+}
+
+// --- stable-balance (delegation) ---
+
+async function handleStableBalance(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
+  return dispatchStableBalanceCommand(args, sdk)
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/stable_balance.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/stable_balance.ts
@@ -1,0 +1,93 @@
+/**
+ * Stable balance subcommands.
+ *
+ * Mirrors the Rust CLI `stable-balance` subcommands:
+ *   get, set, unset
+ */
+
+import { StableBalanceActiveLabel } from '@breeztech/breez-sdk-spark-react-native'
+import type { BreezSdkInterface } from '@breeztech/breez-sdk-spark-react-native'
+import { formatValue } from './serialization'
+
+/** All stable-balance subcommand names for help and completion. */
+export const STABLE_BALANCE_COMMAND_NAMES = [
+  'get',
+  'set',
+  'unset',
+]
+
+/**
+ * Dispatch a stable-balance subcommand.
+ *
+ * @param args - The arguments after "stable-balance" (e.g., ["set", "USDB"])
+ * @param sdk - The BreezSdkInterface instance
+ * @returns A string result to display
+ */
+export async function dispatchStableBalanceCommand(
+  args: string[],
+  sdk: BreezSdkInterface
+): Promise<string> {
+  if (args.length === 0 || args[0] === 'help') {
+    return printStableBalanceHelp()
+  }
+
+  const subcommand = args[0]
+  const subArgs = args.slice(1)
+
+  switch (subcommand) {
+    case 'get':
+      return handleGet(sdk)
+    case 'set':
+      return handleSet(sdk, subArgs)
+    case 'unset':
+      return handleUnset(sdk)
+    default:
+      return `Unknown stable-balance subcommand: ${subcommand}. Use 'stable-balance help' for available commands.`
+  }
+}
+
+function printStableBalanceHelp(): string {
+  const lines = [
+    '',
+    'Stable balance subcommands:',
+    '  stable-balance get                     Get the stable balance active label',
+    '  stable-balance set <label>             Set the stable balance active label',
+    '  stable-balance unset                   Unset stable balance',
+    '',
+  ]
+  return lines.join('\n')
+}
+
+// --- get ---
+
+async function handleGet(sdk: BreezSdkInterface): Promise<string> {
+  const settings = await sdk.getUserSettings()
+  return formatValue(settings.stableBalanceActiveLabel)
+}
+
+// --- set ---
+
+async function handleSet(sdk: BreezSdkInterface, args: string[]): Promise<string> {
+  if (args.length < 1) {
+    return 'Usage: stable-balance set <label>'
+  }
+
+  const label = args[0]
+  await sdk.updateUserSettings({
+    sparkPrivateModeEnabled: undefined,
+    stableBalanceActiveLabel: new StableBalanceActiveLabel.Set({ label }),
+  })
+  const settings = await sdk.getUserSettings()
+  return formatValue(settings)
+}
+
+// --- unset ---
+
+async function handleUnset(sdk: BreezSdkInterface): Promise<string> {
+  await sdk.updateUserSettings({
+    sparkPrivateModeEnabled: undefined,
+    stableBalanceActiveLabel: new StableBalanceActiveLabel.Unset(),
+  })
+  const settings = await sdk.getUserSettings()
+  return formatValue(settings)
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
@@ -52,7 +52,9 @@ node src/main.js [OPTIONS]
 | `--network` | `regtest` | Network to use (`regtest` or `mainnet`) |
 | `--account-number` | - | Account number for the Spark signer |
 | `--postgres-connection-string` | - | PostgreSQL connection string (uses SQLite by default) |
-| `--stable-balance-token-identifier` | - | Stable balance token identifier |
+| `--mysql-connection-string` | - | MySQL connection string (mutually exclusive with `--postgres-connection-string`) |
+| `--stable-balance-token` | - | Stable balance token in `LABEL:token_identifier` format (repeatable) |
+| `--stable-balance-default-active-label` | - | Default active label for stable balance |
 | `--stable-balance-threshold` | - | Stable balance threshold in sats |
 | `--passkey` | - | Use Passkey with PRF provider (`file`, `yubikey` or `fido2`) |
 | `--label` | `Default` | Requires `--passkey`. The label to use |
@@ -68,6 +70,9 @@ node src/main.js --data-dir ~/.breez/my-wallet
 
 # Use PostgreSQL storage
 node src/main.js --postgres-connection-string "host=localhost user=postgres dbname=spark"
+
+# Use MySQL storage
+node src/main.js --mysql-connection-string "mysql://user:pass@localhost:3306/spark"
 
 # Use a custom account number
 node src/main.js --account-number 21
@@ -90,6 +95,8 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 **Contacts**: `contacts add`, `contacts update`, `contacts delete`, `contacts list`
 
 **Webhooks**: `webhooks register`, `webhooks unregister`, `webhooks list`
+
+**Stable Balance**: `stable-balance get`, `stable-balance set`, `stable-balance unset`
 
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -6,6 +6,7 @@ const { printValue } = require('./serialization')
 const { registerIssuerCommands } = require('./issuer')
 const { registerContactsCommands } = require('./contacts')
 const { registerWebhooksCommands } = require('./webhooks')
+const { registerStableBalanceCommands } = require('./stable-balance')
 
 // ---------------------------------------------------------------------------
 // Command names for tab completion
@@ -55,7 +56,10 @@ const COMMAND_NAMES = [
   'contacts list',
   'webhooks register',
   'webhooks unregister',
-  'webhooks list'
+  'webhooks list',
+  'stable-balance get',
+  'stable-balance set',
+  'stable-balance unset'
 ]
 
 /**
@@ -326,9 +330,11 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
       // Handle conversion estimate confirmation
       if (prepareResponse.conversionEstimate) {
         const estimate = prepareResponse.conversionEstimate
-        const units = estimate.options && estimate.options.conversionType &&
-          estimate.options.conversionType.type === 'fromBitcoin' ? 'sats' : 'token base units'
-        console.log(`Estimated conversion of ${estimate.amount} ${units} with a ${estimate.fee} ${units} fee`)
+        const [inUnits, outUnits] = estimate.options && estimate.options.conversionType &&
+          estimate.options.conversionType.type === 'fromBitcoin'
+          ? ['sats', 'token base units']
+          : ['token base units', 'sats']
+        console.log(`Estimated conversion from ${estimate.amountIn} ${inUnits} to ${estimate.amountOut} ${outUnits} with a ${estimate.fee} token base units fee`)
         const answer = await questionWithDefault(rl, 'Do you want to continue (y/n): ', 'y')
         if (answer.toLowerCase() !== 'y') {
           throw new Error('Payment cancelled')
@@ -355,6 +361,7 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
     .option('-c, --comment <text>', 'Optional comment for the invoice')
     .option('-v, --validate [value]', 'Validate the success action URL')
     .option('-i, --idempotency-key <key>', 'Optional idempotency key')
+    .option('-t, --token-identifier <id>', 'Optional token identifier (amount in token base units)')
     .option('--from-token <identifier>', 'Convert from the specified token to Bitcoin')
     .option('-s, --convert-max-slippage-bps <bps>', 'Max slippage in basis points for conversion', parseInt)
     .option('--fees-included', 'Deduct fees from the specified amount', false)
@@ -385,21 +392,22 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
 
       const minSendable = Math.ceil(payRequest.minSendable / 1000)
       const maxSendable = Math.floor(payRequest.maxSendable / 1000)
-      const amountStr = await question(rl, `Amount to pay (min ${minSendable} sat, max ${maxSendable} sat): `)
-      const amountSats = parseInt(amountStr, 10)
-      if (isNaN(amountSats)) {
-        throw new Error('Invalid amount provided')
-      }
+      const prompt = options.tokenIdentifier
+        ? `Amount to pay (min ${minSendable} sat, max ${maxSendable} sat) in token base units: `
+        : `Amount to pay (min ${minSendable} sat, max ${maxSendable} sat): `
+      const amountStr = await question(rl, prompt)
+      const amount = BigInt(amountStr)
 
       const validateSuccessActionUrl = options.validate != null
         ? options.validate === 'true' || options.validate === true
         : undefined
 
       const prepareResponse = await sdk.prepareLnurlPay({
-        amountSats,
+        amount,
         comment: options.comment,
         payRequest,
         validateSuccessActionUrl,
+        tokenIdentifier: options.tokenIdentifier,
         conversionOptions,
         feePolicy
       })
@@ -407,7 +415,11 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
       // Handle conversion estimate confirmation
       if (prepareResponse.conversionEstimate) {
         const estimate = prepareResponse.conversionEstimate
-        console.log(`Estimated conversion of ${estimate.amount} token base units with a ${estimate.fee} token base units fee`)
+        const [inUnits, outUnits] = estimate.options && estimate.options.conversionType &&
+          estimate.options.conversionType.type === 'fromBitcoin'
+          ? ['sats', 'token base units']
+          : ['token base units', 'sats']
+        console.log(`Estimated conversion from ${estimate.amountIn} ${inUnits} to ${estimate.amountOut} ${outUnits} with a ${estimate.fee} token base units fee`)
         const answer = await questionWithDefault(rl, 'Do you want to continue (y/n): ', 'y')
         if (answer.toLowerCase() !== 'y') {
           throw new Error('Payment cancelled')
@@ -739,7 +751,7 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
       if (options.private != null) {
         sparkPrivateModeEnabled = options.private === 'true' || options.private === true
       }
-      await sdk.updateUserSettings({ sparkPrivateModeEnabled })
+      await sdk.updateUserSettings({ sparkPrivateModeEnabled, stableBalanceActiveLabel: undefined })
       console.log('User settings updated')
     })
 
@@ -761,6 +773,9 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
 
   // --- webhooks subcommands ---
   registerWebhooksCommands(program, getSdk)
+
+  // --- stable-balance subcommands ---
+  registerStableBalanceCommands(program, getSdk)
 
   return program
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
@@ -10,8 +10,10 @@ const { parse: parseShell } = require('shell-quote')
 
 const {
   SdkBuilder,
+  createMysqlConnectionPool,
   createPostgresConnectionPool,
   defaultConfig,
+  defaultMysqlStorageConfig,
   defaultPostgresStorageConfig,
   initLogging,
   getSparkStatus
@@ -32,7 +34,9 @@ function parseCliArgs() {
     network: 'regtest',
     accountNumber: undefined,
     postgresConnectionString: undefined,
-    stableBalanceTokenIdentifier: undefined,
+    mysqlConnectionString: undefined,
+    stableBalanceTokens: [],
+    stableBalanceDefaultActiveLabel: undefined,
     stableBalanceThreshold: undefined,
     passkey: undefined,
     label: undefined,
@@ -56,8 +60,14 @@ function parseCliArgs() {
       case '--postgres-connection-string':
         opts.postgresConnectionString = args[++i]
         break
-      case '--stable-balance-token-identifier':
-        opts.stableBalanceTokenIdentifier = args[++i]
+      case '--mysql-connection-string':
+        opts.mysqlConnectionString = args[++i]
+        break
+      case '--stable-balance-token':
+        opts.stableBalanceTokens.push(args[++i])
+        break
+      case '--stable-balance-default-active-label':
+        opts.stableBalanceDefaultActiveLabel = args[++i]
         break
       case '--stable-balance-threshold':
         opts.stableBalanceThreshold = parseInt(args[++i], 10)
@@ -86,7 +96,9 @@ function parseCliArgs() {
         console.log('  --network <network>                          Network to use: regtest or mainnet (default: regtest)')
         console.log('  --account-number <number>                    Account number for the Spark signer')
         console.log('  --postgres-connection-string <string>        PostgreSQL connection string')
-        console.log('  --stable-balance-token-identifier <string>   Stable balance token identifier')
+        console.log('  --mysql-connection-string <string>           MySQL connection string')
+        console.log('  --stable-balance-token <LABEL:id>            Stable balance token in LABEL:token_identifier format (repeatable)')
+        console.log('  --stable-balance-default-active-label <label> Default active label for stable balance')
         console.log('  --stable-balance-threshold <number>          Stable balance threshold in sats')
         console.log('  --passkey <provider>                         Use passkey with PRF provider (file, yubikey, or fido2)')
         console.log('  --label <name>                               Label for seed derivation (requires --passkey)')
@@ -129,6 +141,11 @@ function parseCliArgs() {
 
   if (opts.listLabels && (opts.label || opts.storeLabel)) {
     console.error('--list-labels conflicts with --label and --store-label')
+    process.exit(1)
+  }
+
+  if (opts.postgresConnectionString && opts.mysqlConnectionString) {
+    console.error('--postgres-connection-string and --mysql-connection-string are mutually exclusive')
     process.exit(1)
   }
 
@@ -213,12 +230,22 @@ async function main() {
   }
 
   // Stable balance config
-  if (opts.stableBalanceTokenIdentifier) {
+  if (opts.stableBalanceTokens.length > 0) {
+    const tokens = opts.stableBalanceTokens.map((s) => {
+      const colonIdx = s.indexOf(':')
+      if (colonIdx === -1) {
+        throw new Error(`Invalid token format '${s}', expected LABEL:token_identifier`)
+      }
+      return {
+        label: s.slice(0, colonIdx),
+        tokenIdentifier: s.slice(colonIdx + 1)
+      }
+    })
     config.stableBalanceConfig = {
-      tokenIdentifier: opts.stableBalanceTokenIdentifier,
+      tokens,
+      defaultActiveLabel: opts.stableBalanceDefaultActiveLabel,
       thresholdSats: opts.stableBalanceThreshold,
-      maxSlippageBps: undefined,
-      reservedSats: undefined
+      maxSlippageBps: undefined
     }
   }
 
@@ -247,6 +274,11 @@ async function main() {
       defaultPostgresStorageConfig(opts.postgresConnectionString)
     )
     sdkBuilder = sdkBuilder.withPostgresConnectionPool(pool)
+  } else if (opts.mysqlConnectionString) {
+    const pool = createMysqlConnectionPool(
+      defaultMysqlStorageConfig(opts.mysqlConnectionString)
+    )
+    sdkBuilder = sdkBuilder.withMysqlConnectionPool(pool)
   } else {
     sdkBuilder = await sdkBuilder.withDefaultStorage(dataDir)
   }

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/stable-balance.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/stable-balance.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const { Command } = require('commander')
+const { printValue } = require('./serialization')
+
+/**
+ * Register all stable-balance subcommands on the given commander program.
+ *
+ * @param {Command} program - The parent commander program (or subcommand)
+ * @param {() => object} getSdk - Function that returns the SDK instance
+ */
+function registerStableBalanceCommands(program, getSdk) {
+  const stableBalance = program
+    .command('stable-balance')
+    .description('Stable balance related commands')
+
+  // --- get ---
+  stableBalance
+    .command('get')
+    .description('Get the stable balance active label')
+    .action(async () => {
+      const sdk = getSdk()
+      const settings = await sdk.getUserSettings()
+      printValue(settings.stableBalanceActiveLabel)
+    })
+
+  // --- set ---
+  stableBalance
+    .command('set')
+    .description('Set the stable balance active label')
+    .argument('<label>', 'The label to activate (e.g. "USDB")')
+    .action(async (label) => {
+      const sdk = getSdk()
+      await sdk.updateUserSettings({
+        sparkPrivateModeEnabled: undefined,
+        stableBalanceActiveLabel: { type: 'set', label }
+      })
+      const settings = await sdk.getUserSettings()
+      printValue(settings)
+    })
+
+  // --- unset ---
+  stableBalance
+    .command('unset')
+    .description('Unset stable balance')
+    .action(async () => {
+      const sdk = getSdk()
+      await sdk.updateUserSettings({
+        sparkPrivateModeEnabled: undefined,
+        stableBalanceActiveLabel: { type: 'unset' }
+      })
+      const settings = await sdk.getUserSettings()
+      printValue(settings)
+    })
+}
+
+module.exports = { registerStableBalanceCommands }


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`5af6fe7`](https://github.com/breez/spark-sdk/commit/5af6fe7c69f4a3c3cad5889f47b6c1e55b6c9163)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/25562624467)

**Language status:**
- :next_track_button: C# (no changes needed)
- :white_check_mark: Dart
- :next_track_button: Go (no changes needed)
- :next_track_button: Kotlin (no changes needed)
- :white_check_mark: Python
- :white_check_mark: React Native
- :next_track_button: Swift (no changes needed)
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- Rust CLI changed from `with_postgres_backend()`/`with_mysql_backend()` to `create_postgres_connection_pool()` + `with_postgres_connection_pool()` (and MySQL equivalent) — C# CLI already uses the new pool-based pattern for Postgres
- MySQL connection support exists in Rust CLI but not in C# CLI — no MySQL SDK bindings available in C# (`CreateMysqlConnectionPool`, `WithMysqlConnectionPool` do not exist in the C# SDK)

## Applied
- (none — C# CLI is already in sync with the Rust CLI changes)

## Skipped
- MySQL connection pool support: Rust CLI uses `create_mysql_connection_pool()` + `with_mysql_connection_pool()`, but the C# SDK bindings do not expose MySQL methods (`CreateMysqlConnectionPool`, `DefaultMysqlStorageConfig`, `WithMysqlConnectionPool` are absent from all C# binding files and snippets). This is a pre-existing gap, not introduced by the recent change.

### Dart
## Divergences
- `lnurl-pay` command missing `--token-identifier` / `-t` option (present in Rust, missing in Dart)
- Missing `stable-balance` subcommand group (Rust has `get`, `set`, `unset`; Dart had none)
- `--mysql-connection-string` CLI flag missing from Dart CLI (present in Rust)
- Stable balance token flags use different format: Rust uses repeatable `--stable-balance-token TICKER:identifier` with `--stable-balance-default-active-label`; Dart used single `--stable-balance-token-identifier` with hardcoded "USDB" label
- Rust CLI changed from `with_postgres_backend`/`with_mysql_backend` to `create_postgres_connection_pool`/`create_mysql_connection_pool` + `with_postgres_connection_pool`/`with_mysql_connection_pool`

## Applied
- Added `--token-identifier` / `-t` option to `lnurl-pay` command handler, passes it to `PrepareLnurlPayRequest` and adjusts prompt text (commands.dart)
- Created `stable_balance.dart` with `get`, `set`, `unset` subcommands using `StableBalanceActiveLabel_Set`/`StableBalanceActiveLabel_Unset` (new file)
- Wired up `stable-balance` dispatch in REPL loop, tab completion list, and help output (cli.dart)
- Added `--mysql-connection-string` CLI flag with mutual exclusion validation and unsupported warning (bin/breez_cli.dart, cli.dart)
- Changed `--stable-balance-token-identifier` to repeatable `--stable-balance-token` with `TICKER:token_identifier` parsing format (bin/breez_cli.dart)
- Added `--stable-balance-default-active-label` CLI flag (bin/breez_cli.dart)
- Updated `runCli()` signature to accept `List<StableBalanceToken>`, `stableBalanceDefaultActiveLabel`, and `mysqlConnectionString` (cli.dart)
- Updated README CLI Options table and Commands list with new flags and `stable-balance` subcommand (README.md)

## Skipped
- Postgres/MySQL storage backend: Rust CLI changed from `with_postgres_backend`/`with_mysql_backend` to `create_postgres_connection_pool`/`with_postgres_connection_pool` (and MySQL equivalent), but the Flutter/FRB SDK bindings do not expose any of these methods (`SdkBuilder` only has `withDefaultStorage`, `withKeySet`, `withRestChainService`, `withConnectionManager`, `withSspConnectionManager`). The Dart CLI correctly prints a warning and falls back to SQLite storage. No Dart packages were evaluated as this requires SDK-level binding support.

### Kotlin
## Divergences
- Rust CLI changed `with_postgres_backend()` → `create_postgres_connection_pool()` + `with_postgres_connection_pool()` — Kotlin CLI already uses the new API (Main.kt:258-260)
- Rust CLI changed `with_mysql_backend()` → `create_mysql_connection_pool()` + `with_mysql_connection_pool()` — Kotlin CLI never had MySQL support (pre-existing gap, not introduced by this diff)

## Applied
- (none — the Kotlin CLI already matches the Rust CLI for the recent connection pool API change)

## Skipped
- MySQL `--mysql-connection-string` flag and `createMysqlConnectionPool` + `withMysqlConnectionPool` init: pre-existing gap not introduced by the diff (commit 43d0018b only changed the API pattern for an already-missing feature)

### Python
## Divergences
- Rust CLI uses `create_mysql_connection_pool` + `with_mysql_connection_pool` for MySQL storage; Python CLI has no `--mysql-connection-string` flag
- Rust CLI uses repeatable `--stable-balance-token` with `LABEL:token_identifier` format; Python CLI used single `--stable-balance-token-identifier` with hardcoded "USDB" label
- Rust CLI has `--stable-balance-default-active-label` flag; Python CLI was missing it
- Rust CLI has `StableBalance` command group (get/set/unset); Python CLI was missing it entirely
- Rust CLI `lnurl-pay` has `--token-identifier` (`-t`) flag; Python CLI was missing it
- Rust CLI `PrepareLnurlPayRequest` uses `amount` field; Python CLI used `amount_sats` (incorrect field name)
- Rust CLI `PrepareLnurlPayRequest` passes `token_identifier`; Python CLI omitted it
- Rust CLI `lnurl-pay` prompt changes based on token_identifier presence; Python CLI always showed sats prompt
- Rust CLI conversion estimate uses `amount_in`/`amount_out` fields; Python CLI used outdated `amount` field in both `pay` and `lnurl-pay` handlers

## Applied
- Updated `--stable-balance-token` flag to be repeatable with `LABEL:token_identifier` format in `main.py`
- Added `--stable-balance-default-active-label` flag to `main.py`
- Updated stable balance config construction to parse multiple tokens in `main.py`
- Created `stable_balance.py` with get/set/unset subcommands matching Rust `stable_balance.rs`
- Added `stable-balance` command dispatch to REPL loop in `main.py`
- Added `stable-balance` to help output and command completion in `main.py`
- Added `-t`/`--token-identifier` flag to `lnurl-pay` parser in `commands.py`
- Fixed `amount_sats` → `amount` field name in `PrepareLnurlPayRequest` in `commands.py`
- Added `token_identifier` parameter to `PrepareLnurlPayRequest` in `commands.py`
- Updated `lnurl-pay` prompt to vary based on `token_identifier` presence in `commands.py`
- Fixed conversion estimate display to use `amount_in`/`amount_out` in both `pay` and `lnurl-pay` handlers in `commands.py`
- Updated `README.md` CLI options table with new stable balance flags
- Added `stable-balance` commands to Available Commands section in `README.md`

## Skipped
- MySQL connection string support: `create_mysql_connection_pool` and `default_mysql_storage_config` are feature-gated behind `feature = "mysql"` in Rust and not exposed in the Python UniFFI bindings. No Python snippets or binding definitions exist for MySQL. No viable alternative was found.

### React Native
## Divergences
- `lnurl-pay` handler passed `amountSats` field to `prepareLnurlPay` instead of `amount` (incorrect field name vs SDK API)
- `lnurl-pay` handler missing `tokenIdentifier` flag parsing and pass-through to `prepareLnurlPay`
- Missing `stable-balance` command group (Rust has `get`, `set`, `unset` subcommands; React Native had none)
- Rust `main.rs` now uses `create_postgres_connection_pool`/`create_mysql_connection_pool` instead of `with_postgres_backend`/`with_mysql_backend` (N/A for React Native — mobile app uses SQLite only)

## Applied
- Fixed `lnurl-pay` field name from `amountSats` to `amount` in `prepareLnurlPay` call (`commands.ts`)
- Added `--token-identifier` / `-t` flag parsing to `lnurl-pay` and pass it to `prepareLnurlPay` (`commands.ts`)
- Updated `lnurl-pay` usage help text to include `-t <token_identifier>` option (`commands.ts`)
- Created `stable_balance.ts` with `get`, `set`, `unset` subcommands using `StableBalanceActiveLabel` SDK type
- Registered `stable-balance` command in `COMMAND_NAMES` and `buildCommandRegistry()` (`commands.ts`)
- Added `StableBalanceActiveLabel` export to `breez-sdk-spark-react-native.d.ts`

## Skipped
- Postgres/MySQL connection pool changes (`create_postgres_connection_pool`/`create_mysql_connection_pool`) — React Native CLI is a mobile app using SQLite via `withDefaultStorage`; database backend selection is not applicable

### TypeScript
## Divergences
- Missing `--mysql-connection-string` CLI flag and MySQL connection pool creation in main.js
- Stable balance config used old format (`--stable-balance-token-identifier` single value) instead of new `--stable-balance-token` repeatable flag with `LABEL:token_identifier` format
- Missing `--stable-balance-default-active-label` CLI flag
- Missing `stable-balance` subcommand group (get/set/unset) present in Rust CLI
- `lnurl-pay` command missing `-t, --token-identifier` option
- `lnurl-pay` used wrong field name `amountSats` (parseInt) instead of `amount` (BigInt) in `prepareLnurlPay` call
- `lnurl-pay` prompt did not adapt text for token payments
- Conversion estimate output in both `pay` and `lnurl-pay` used wrong field (`estimate.amount`) instead of `estimate.amountIn`/`estimate.amountOut` with in/out unit labels
- `set-user-settings` did not pass `stableBalanceActiveLabel` field to `updateUserSettings`
- README missing MySQL option, had outdated stable balance options, and missing stable-balance commands

## Applied
- Added `createMysqlConnectionPool` and `defaultMysqlStorageConfig` imports and MySQL pool creation logic in main.js
- Added `--mysql-connection-string` flag with mutual exclusion check against `--postgres-connection-string` in main.js
- Replaced `--stable-balance-token-identifier` with repeatable `--stable-balance-token` flag (LABEL:token_identifier format) in main.js
- Added `--stable-balance-default-active-label` flag in main.js
- Updated stable balance config construction to use `{ tokens, defaultActiveLabel, thresholdSats, maxSlippageBps }` format in main.js
- Created stable-balance.js with get/set/unset subcommands matching Rust CLI's StableBalance command group
- Added `-t, --token-identifier` option to `lnurl-pay` command in commands.js
- Fixed `prepareLnurlPay` to use `amount` (BigInt) field and pass `tokenIdentifier` in commands.js
- Added adaptive prompt text for token payments in `lnurl-pay` in commands.js
- Fixed conversion estimate output in `pay` and `lnurl-pay` to use `amountIn`/`amountOut` with proper in/out unit labels in commands.js
- Added `stableBalanceActiveLabel: undefined` to `set-user-settings` updateUserSettings call in commands.js
- Registered stable-balance subcommands in commands.js buildProgram
- Added stable-balance command names to COMMAND_NAMES for tab completion in commands.js
- Updated README.md with MySQL option, new stable balance options, and stable-balance commands

## Skipped
- Nothing skipped; all divergences were addressed

</details>