### PR TITLE
fix: align token invoice signing hash with spark-token-primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4782,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "spark-token-primitives"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d155f13255bbe0b53214979bce25ef6b92a7179b2370f67f37ae5ff1abaa67f"
+checksum = "8de059d7cbb2b65fe6c8831ff57ae0408a7624b65a74b5a31a3109707bb9f86c"
 dependencies = [
  "bech32",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4687,6 +4687,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "spark-token-primitives",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -4777,6 +4778,21 @@ dependencies = [
  "tracing",
  "uuid",
  "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "spark-token-primitives"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d155f13255bbe0b53214979bce25ef6b92a7179b2370f67f37ae5ff1abaa67f"
+dependencies = [
+ "bech32",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ serde_with = "3.13.0"
 shlex = "1.3.0"
 spark = { path = "crates/spark", default-features = false }
 spark-postgres = { path = "crates/spark-postgres" }
-spark-token-primitives = "0.1.1"
+spark-token-primitives = "0.1.2"
 spark-wallet = { path = "crates/spark-wallet", default-features = false }
 syn = "2.0.105"
 test-log = { version = "0.2.18", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,6 +196,7 @@ serde_with = "3.13.0"
 shlex = "1.3.0"
 spark = { path = "crates/spark", default-features = false }
 spark-postgres = { path = "crates/spark-postgres" }
+spark-token-primitives = "0.1.1"
 spark-wallet = { path = "crates/spark-wallet", default-features = false }
 syn = "2.0.105"
 test-log = { version = "0.2.18", default-features = false }

--- a/crates/spark/Cargo.toml
+++ b/crates/spark/Cargo.toml
@@ -33,6 +33,7 @@ rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
+spark-token-primitives.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tower-service.workspace = true

--- a/crates/spark/src/address/mod.rs
+++ b/crates/spark/src/address/mod.rs
@@ -379,11 +379,21 @@ impl SparkAddress {
                     all_hashes.push(sha256::Hash::hash(&[0; 32]).to_byte_array().to_vec());
                 }
 
-                all_hashes.push(
-                    sha256::Hash::hash(&u128::to_unpadded_be_bytes(&payment.amount.unwrap_or(0)))
-                        .to_byte_array()
-                        .to_vec(),
-                );
+                // Match JS/Go/spark-token-primitives: None/empty amount hashes empty bytes,
+                // not `[0]`. A present amount hashes its canonical unpadded big-endian
+                // representation (the convention all senders use).
+                match payment.amount {
+                    Some(amount) => {
+                        all_hashes.push(
+                            sha256::Hash::hash(&u128::to_unpadded_be_bytes(&amount))
+                                .to_byte_array()
+                                .to_vec(),
+                        );
+                    }
+                    None => {
+                        all_hashes.push(sha256::Hash::hash(&[]).to_byte_array().to_vec());
+                    }
+                }
             }
             Some(SparkAddressPaymentType::SatsPayment(payment)) => {
                 all_hashes.push(sha256::Hash::hash(&[2]).to_byte_array().to_vec());
@@ -951,5 +961,147 @@ mod tests {
         // Parsing should work but then fail when converting the proto payment intent
         let result = SparkAddress::from_str(&address);
         assert!(result.is_err());
+    }
+
+    /// Cross-language signing-hash fixtures. JS is the source of truth; these vectors are
+    /// shared with Go and spark-token-primitives. If this test fails, Breez's hash has drifted
+    /// from the rest of the ecosystem and signatures produced elsewhere will not verify.
+    mod invoice_hash_fixtures {
+        use super::super::*;
+        use base64::{Engine, engine::general_purpose::STANDARD};
+        use macros::test_all;
+        use platform_utils::time::{Duration, UNIX_EPOCH};
+        use serde::Deserialize;
+
+        const FIXTURE_JSON: &str =
+            include_str!("../../testdata/token_invoice_signing_hash_cases.json");
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct FixtureFile {
+            test_cases: Vec<FixtureCase>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct FixtureCase {
+            name: String,
+            network: String,
+            receiver_public_key: String,
+            expected_hash: String,
+            spark_invoice_fields: FixtureFields,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct FixtureFields {
+            version: u32,
+            id: String,
+            #[serde(default)]
+            memo: Option<String>,
+            #[serde(default)]
+            sender_public_key: Option<String>,
+            #[serde(default)]
+            expiry_time: Option<String>,
+            #[serde(default)]
+            tokens_payment: Option<FixtureTokens>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct FixtureTokens {
+            #[serde(default)]
+            token_identifier: Option<String>,
+            #[serde(default)]
+            amount: Option<String>,
+        }
+
+        fn b64(s: &str) -> Vec<u8> {
+            STANDARD.decode(s).unwrap()
+        }
+
+        fn parse_network(s: &str) -> Network {
+            match s {
+                "MAINNET" => Network::Mainnet,
+                "REGTEST" => Network::Regtest,
+                "TESTNET" => Network::Testnet,
+                "SIGNET" => Network::Signet,
+                other => panic!("unknown network {other}"),
+            }
+        }
+
+        // Hand-parse the single RFC3339 timestamp used by the fixtures. Keeps tests free of
+        // a time-parsing dependency; update the match arms if new fixture cases are added.
+        fn fixture_expiry_seconds(s: &str) -> u64 {
+            match s {
+                "2025-08-16T22:12:17.791Z" => 1_755_382_337,
+                other => panic!("unhandled fixture expiry time: {other}"),
+            }
+        }
+
+        fn hash_for_case(tc: &FixtureCase) -> Vec<u8> {
+            let network = parse_network(&tc.network);
+            let receiver_pk = PublicKey::from_slice(&b64(&tc.receiver_public_key)).unwrap();
+
+            let id_bytes: [u8; 16] = b64(&tc.spark_invoice_fields.id).try_into().unwrap();
+            let id = uuid::Uuid::from_bytes(id_bytes);
+
+            let sender_public_key = tc
+                .spark_invoice_fields
+                .sender_public_key
+                .as_deref()
+                .map(|s| PublicKey::from_slice(&b64(s)).unwrap());
+
+            let expiry_time = tc
+                .spark_invoice_fields
+                .expiry_time
+                .as_deref()
+                .map(|s| UNIX_EPOCH + Duration::from_secs(fixture_expiry_seconds(s)));
+
+            let payment_type = tc.spark_invoice_fields.tokens_payment.as_ref().map(|tp| {
+                let token_identifier = tp.token_identifier.as_deref().map(|s| {
+                    let raw = b64(s);
+                    assert_eq!(raw.len(), 32, "fixture token id must be 32 bytes");
+                    bech32m_encode_token_id(&raw, network).unwrap()
+                });
+                let amount = tp
+                    .amount
+                    .as_deref()
+                    .map(|s| u128::from_unpadded_be_bytes(&b64(s)).unwrap());
+                SparkAddressPaymentType::TokensPayment(TokensPayment {
+                    token_identifier,
+                    amount,
+                })
+            });
+
+            let fields = SparkInvoiceFields {
+                id,
+                version: tc.spark_invoice_fields.version,
+                memo: tc.spark_invoice_fields.memo.clone(),
+                sender_public_key,
+                expiry_time,
+                payment_type,
+            };
+
+            SparkAddress::new(receiver_pk, network, Some(fields))
+                .compute_invoice_hash()
+                .unwrap()
+        }
+
+        #[test_all]
+        fn compute_invoice_hash_matches_cross_language_fixtures() {
+            let fixture: FixtureFile = serde_json::from_str(FIXTURE_JSON).unwrap();
+            assert!(!fixture.test_cases.is_empty(), "no fixture cases loaded");
+
+            for tc in &fixture.test_cases {
+                let hash = hash_for_case(tc);
+                assert_eq!(
+                    hex::encode(&hash),
+                    tc.expected_hash,
+                    "fixture case `{}` hash mismatch",
+                    tc.name
+                );
+            }
+        }
     }
 }

--- a/crates/spark/src/address/mod.rs
+++ b/crates/spark/src/address/mod.rs
@@ -401,19 +401,14 @@ impl SparkAddress {
             ));
         }
 
-        let payment_type = invoice_fields
-            .payment_type
-            .as_ref()
-            .ok_or_else(|| AddressError::Other("No payment type".to_string()))?;
-
-        if let SparkAddressPaymentType::TokensPayment(payment) = payment_type {
-            return Ok(self
-                .prepare_token_invoice_via_primitives(payment)?
-                .spark_invoice_hash);
-        }
-
-        let SparkAddressPaymentType::SatsPayment(payment) = payment_type else {
-            unreachable!("token payment handled above");
+        let payment = match invoice_fields.payment_type.as_ref() {
+            Some(SparkAddressPaymentType::TokensPayment(payment)) => {
+                return Ok(self
+                    .prepare_token_invoice_via_primitives(payment)?
+                    .spark_invoice_hash);
+            }
+            Some(SparkAddressPaymentType::SatsPayment(payment)) => payment,
+            None => return Err(AddressError::Other("No payment type".to_string())),
         };
 
         let mut all_hashes = vec![

--- a/crates/spark/src/address/mod.rs
+++ b/crates/spark/src/address/mod.rs
@@ -24,6 +24,10 @@ use prost::{Message as ProstMessage, encoding};
 
 use error::AddressError;
 use platform_utils::time::{SystemTime, UNIX_EPOCH};
+use spark_token_primitives::{
+    FinalizeTokenInvoiceRequest, PrepareTokenInvoiceRequest, PreparedTokenInvoice,
+    finalize_token_invoice, prepare_token_invoice,
+};
 use uuid::Uuid;
 
 use crate::Network;
@@ -293,33 +297,97 @@ impl SparkAddress {
             ));
         }
 
-        let spark_invoice_fields: Option<ProtoSparkInvoiceFields> = self
+        let invoice_fields = self
             .spark_invoice_fields
-            .clone()
-            .map(|f| f.try_into())
+            .as_ref()
+            .ok_or_else(|| AddressError::Other("No invoice fields".to_string()))?;
+
+        match &invoice_fields.payment_type {
+            Some(SparkAddressPaymentType::TokensPayment(payment)) => {
+                let prepared = self.prepare_token_invoice_via_primitives(payment)?;
+                let signature = signer
+                    .sign_hash_schnorr_with_identity_key(&prepared.spark_invoice_hash)
+                    .await
+                    .map_err(|e| {
+                        AddressError::Other(format!("Failed to sign invoice hash: {e}"))
+                    })?;
+                finalize_token_invoice(FinalizeTokenInvoiceRequest {
+                    receiver_identity_public_key: self.identity_public_key.serialize().to_vec(),
+                    network: network_as_u32(self.network),
+                    spark_invoice_fields_bytes: prepared.spark_invoice_fields_bytes,
+                    signature: Some(signature.serialize().to_vec()),
+                })
+                .map_err(|e| AddressError::Other(format!("Failed to finalize token invoice: {e}")))
+            }
+            Some(SparkAddressPaymentType::SatsPayment(_)) => {
+                let spark_invoice_fields: Option<ProtoSparkInvoiceFields> =
+                    Some(invoice_fields.clone().try_into()?);
+
+                let invoice_hash = self.compute_invoice_hash()?;
+
+                let signature = signer
+                    .sign_hash_schnorr_with_identity_key(&invoice_hash)
+                    .await
+                    .map_err(|e| {
+                        AddressError::Other(format!("Failed to sign invoice hash: {e}"))
+                    })?;
+
+                let proto_address = ProtoSparkAddress {
+                    identity_public_key: self.identity_public_key.serialize().to_vec(),
+                    spark_invoice_fields,
+                    signature: Some(signature.serialize().to_vec()),
+                };
+
+                let payload_bytes = encode_spark_address_canonical(&proto_address);
+                let hrp = Self::network_to_hrp(&self.network);
+                Ok(bech32::encode::<Bech32m>(hrp, &payload_bytes).unwrap())
+            }
+            None => Err(AddressError::Other("No payment type".to_string())),
+        }
+    }
+
+    fn prepare_token_invoice_via_primitives(
+        &self,
+        payment: &TokensPayment,
+    ) -> Result<PreparedTokenInvoice, AddressError> {
+        let invoice_fields = self
+            .spark_invoice_fields
+            .as_ref()
+            .ok_or_else(|| AddressError::Other("No invoice fields".to_string()))?;
+
+        let token_identifier = payment
+            .token_identifier
+            .as_deref()
+            .map(|id| {
+                bech32m_decode_token_id(id, None)
+                    .map_err(|e| AddressError::Other(format!("Invalid token identifier: {e}")))
+            })
             .transpose()?;
 
-        let invoice_hash = self.compute_invoice_hash()?;
+        let token_amount = payment.amount.map(|a| a.to_unpadded_be_bytes());
 
-        let signature = signer
-            .sign_hash_schnorr_with_identity_key(&invoice_hash)
-            .await
-            .map_err(|e| AddressError::Other(format!("Failed to sign invoice hash: {e}")))?;
+        let sender_spark_address = invoice_fields
+            .sender_public_key
+            .map(|pk| SparkAddress::new(pk, self.network, None).to_address_string())
+            .transpose()?;
 
-        let proto_address = ProtoSparkAddress {
-            identity_public_key: self.identity_public_key.serialize().to_vec(),
-            spark_invoice_fields,
-            signature: Some(signature.serialize().to_vec()),
-        };
+        let expiry_time_unix_millis = invoice_fields.expiry_time.map(|t| {
+            t.duration_since(UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0)
+        });
 
-        // Use canonical encoding for server compatibility
-        let payload_bytes = encode_spark_address_canonical(&proto_address);
-
-        let hrp = Self::network_to_hrp(&self.network);
-
-        // This is safe to unwrap, because we are using a valid HRP and payload
-        let address = bech32::encode::<Bech32m>(hrp, &payload_bytes).unwrap();
-        Ok(address)
+        prepare_token_invoice(PrepareTokenInvoiceRequest {
+            receiver_identity_public_key: self.identity_public_key.serialize().to_vec(),
+            network: network_as_u32(self.network),
+            token_identifier,
+            token_amount,
+            memo: invoice_fields.memo.clone(),
+            sender_spark_address,
+            expiry_time_unix_millis,
+            invoice_id: Some(invoice_fields.id.as_bytes().to_vec()),
+        })
+        .map_err(|e| AddressError::Other(format!("Failed to prepare token invoice: {e}")))
     }
 
     fn compute_invoice_hash(&self) -> Result<Vec<u8>, AddressError> {
@@ -333,82 +401,41 @@ impl SparkAddress {
             ));
         }
 
+        let payment_type = invoice_fields
+            .payment_type
+            .as_ref()
+            .ok_or_else(|| AddressError::Other("No payment type".to_string()))?;
+
+        if let SparkAddressPaymentType::TokensPayment(payment) = payment_type {
+            return Ok(self
+                .prepare_token_invoice_via_primitives(payment)?
+                .spark_invoice_hash);
+        }
+
+        let SparkAddressPaymentType::SatsPayment(payment) = payment_type else {
+            unreachable!("token payment handled above");
+        };
+
         let mut all_hashes = vec![
             sha256::Hash::hash(&invoice_fields.version.to_be_bytes())
                 .to_byte_array()
                 .to_vec(),
-        ];
-
-        all_hashes.push(
             sha256::Hash::hash(invoice_fields.id.as_bytes())
                 .to_byte_array()
                 .to_vec(),
-        );
-
-        all_hashes.push(
             sha256::Hash::hash(
                 &sha256::Hash::hash(&get_magic_network_identifier(self.network)).to_byte_array(),
             )
             .to_byte_array()
             .to_vec(),
-        );
-
-        all_hashes.push(
             sha256::Hash::hash(&self.identity_public_key.serialize())
                 .to_byte_array()
                 .to_vec(),
-        );
-
-        match &invoice_fields.payment_type {
-            Some(SparkAddressPaymentType::TokensPayment(payment)) => {
-                all_hashes.push(sha256::Hash::hash(&[1]).to_byte_array().to_vec());
-
-                if let Some(token_identifier) = &payment.token_identifier {
-                    all_hashes.push(
-                        sha256::Hash::hash(
-                            &bech32m_decode_token_id(token_identifier, None)
-                                .map_err(|e| {
-                                    AddressError::Other(format!("Invalid token identifier: {e}"))
-                                })?
-                                .to_vec(),
-                        )
-                        .to_byte_array()
-                        .to_vec(),
-                    );
-                } else {
-                    all_hashes.push(sha256::Hash::hash(&[0; 32]).to_byte_array().to_vec());
-                }
-
-                // Match JS/Go/spark-token-primitives: None/empty amount hashes empty bytes,
-                // not `[0]`. A present amount hashes its canonical unpadded big-endian
-                // representation (the convention all senders use).
-                match payment.amount {
-                    Some(amount) => {
-                        all_hashes.push(
-                            sha256::Hash::hash(&u128::to_unpadded_be_bytes(&amount))
-                                .to_byte_array()
-                                .to_vec(),
-                        );
-                    }
-                    None => {
-                        all_hashes.push(sha256::Hash::hash(&[]).to_byte_array().to_vec());
-                    }
-                }
-            }
-            Some(SparkAddressPaymentType::SatsPayment(payment)) => {
-                all_hashes.push(sha256::Hash::hash(&[2]).to_byte_array().to_vec());
-
-                let amount = payment.amount.unwrap_or(0);
-                all_hashes.push(
-                    sha256::Hash::hash(&amount.to_be_bytes())
-                        .to_byte_array()
-                        .to_vec(),
-                );
-            }
-            None => {
-                return Err(AddressError::Other("No payment type".to_string()));
-            }
-        }
+            sha256::Hash::hash(&[2]).to_byte_array().to_vec(),
+            sha256::Hash::hash(&payment.amount.unwrap_or(0).to_be_bytes())
+                .to_byte_array()
+                .to_vec(),
+        ];
 
         if let Some(memo) = &invoice_fields.memo {
             all_hashes.push(sha256::Hash::hash(memo.as_bytes()).to_byte_array().to_vec());
@@ -440,10 +467,12 @@ impl SparkAddress {
         for hash in all_hashes {
             engine.input(&hash);
         }
-        let final_hash = sha256::Hash::from_engine(engine).to_byte_array().to_vec();
-
-        Ok(final_hash)
+        Ok(sha256::Hash::from_engine(engine).to_byte_array().to_vec())
     }
+}
+
+fn network_as_u32(network: Network) -> u32 {
+    u32::try_from(network.to_proto_network() as i32).expect("network proto value is non-negative")
 }
 
 /// Returns 4 bytes of the magic network identifier for the given network.
@@ -592,6 +621,13 @@ mod tests {
         let secp = Secp256k1::new();
         let (secret_key, _) = secp.generate_keypair(&mut bitcoin::secp256k1::rand::thread_rng());
         PublicKey::from_slice(&secret_key.public_key(&secp).serialize()).unwrap()
+    }
+
+    fn ms_aligned_now() -> SystemTime {
+        let since_epoch = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default();
+        UNIX_EPOCH + platform_utils::time::Duration::from_millis(since_epoch.as_millis() as u64)
     }
 
     #[test_all]
@@ -799,7 +835,7 @@ mod tests {
             id: uuid::Uuid::now_v7(),
             version: 1,
             sender_public_key: Some(sender_public_key),
-            expiry_time: Some(SystemTime::now()),
+            expiry_time: Some(ms_aligned_now()),
             payment_type: Some(SparkAddressPaymentType::TokensPayment(TokensPayment {
                 token_identifier: Some(
                     "btknrt15xy2yxnpacs2yl00fnajxylsljq9y0uesr6qylyxq2lxnum8r63qfues7q".to_string(),
@@ -898,7 +934,7 @@ mod tests {
             id: uuid::Uuid::now_v7(),
             version: 1,
             sender_public_key: Some(sender_public_key),
-            expiry_time: Some(SystemTime::now()),
+            expiry_time: Some(ms_aligned_now()),
             payment_type: Some(SparkAddressPaymentType::TokensPayment(TokensPayment {
                 token_identifier: Some(
                     "btknrt15xy2yxnpacs2yl00fnajxylsljq9y0uesr6qylyxq2lxnum8r63qfues7q".to_string(),

--- a/crates/spark/testdata/token_invoice_signing_hash_cases.json
+++ b/crates/spark/testdata/token_invoice_signing_hash_cases.json
@@ -1,0 +1,130 @@
+{
+  "description": "Cross-language hash cases for token invoice signing hash (SparkInvoiceFields + receiver public key + network)",
+  "testCases": [
+    {
+      "name": "minimal_tokens_payment",
+      "description": "Minimal token invoice with identifier and amount",
+      "network": "REGTEST",
+      "receiverPublicKey": "AmyUO/73EEA3HKHB0e4dWyA1c9yX/fZJegt05a7AIg4h",
+      "expectedHash": "33ecaf82bcdfb4c17cffbb387c2e3b62b95a63d40d55a7a4ccdc44a91fccc2f8",
+      "sparkInvoiceFields": {
+        "version": 1,
+        "id": "AZi07D0gfkuyiBEH7PZNSQ==",
+        "tokensPayment": {
+          "tokenIdentifier": "SQRt1nu+X8jjq7RbxPgJuctctYcaGSkvpccSA4lkE2M=",
+          "amount": "A+g="
+        }
+      }
+    },
+    {
+      "name": "with_memo",
+      "description": "Token invoice including memo",
+      "network": "REGTEST",
+      "receiverPublicKey": "AmyUO/73EEA3HKHB0e4dWyA1c9yX/fZJegt05a7AIg4h",
+      "expectedHash": "1015bb840c28a5ab45a675f88db0294efc1c50436cddb763bfad47d5c10c3920",
+      "sparkInvoiceFields": {
+        "version": 1,
+        "id": "AZi07D0gfkuyiBEH7PZNSQ==",
+        "tokensPayment": {
+          "tokenIdentifier": "SQRt1nu+X8jjq7RbxPgJuctctYcaGSkvpccSA4lkE2M=",
+          "amount": "A+g="
+        },
+        "memo": "memo"
+      }
+    },
+    {
+      "name": "with_sender_public_key",
+      "description": "Token invoice including sender public key",
+      "network": "REGTEST",
+      "receiverPublicKey": "AmyUO/73EEA3HKHB0e4dWyA1c9yX/fZJegt05a7AIg4h",
+      "expectedHash": "e01c323e86cac2ea3f16c77857d758384dc5860671836646b8c0d6f5b937791e",
+      "sparkInvoiceFields": {
+        "version": 1,
+        "id": "AZi07D0gfkuyiBEH7PZNSQ==",
+        "tokensPayment": {
+          "tokenIdentifier": "SQRt1nu+X8jjq7RbxPgJuctctYcaGSkvpccSA4lkE2M=",
+          "amount": "A+g="
+        },
+        "senderPublicKey": "ArDjIDEh3p3wvXwrOEYQDiXGMxA5LgWWHYBC+oGQbW8r"
+      }
+    },
+    {
+      "name": "with_expiry_time",
+      "description": "Token invoice including expiry time",
+      "network": "REGTEST",
+      "receiverPublicKey": "AmyUO/73EEA3HKHB0e4dWyA1c9yX/fZJegt05a7AIg4h",
+      "expectedHash": "ce50a6c601a947dbdcb644973770aab221444e9876c49f1bdbfaa487eb34e298",
+      "sparkInvoiceFields": {
+        "version": 1,
+        "id": "AZi07D0gfkuyiBEH7PZNSQ==",
+        "tokensPayment": {
+          "tokenIdentifier": "SQRt1nu+X8jjq7RbxPgJuctctYcaGSkvpccSA4lkE2M=",
+          "amount": "A+g="
+        },
+        "expiryTime": "2025-08-16T22:12:17.791Z"
+      }
+    },
+    {
+      "name": "all_fields_set",
+      "description": "Token invoice with memo, sender public key, and expiry",
+      "network": "REGTEST",
+      "receiverPublicKey": "AmyUO/73EEA3HKHB0e4dWyA1c9yX/fZJegt05a7AIg4h",
+      "expectedHash": "21f91b971cccc74f76fcac5384ba99d8629baff87d602f9614f6c032a2e6fb2d",
+      "sparkInvoiceFields": {
+        "version": 1,
+        "id": "AZi07D0gfkuyiBEH7PZNSQ==",
+        "tokensPayment": {
+          "tokenIdentifier": "SQRt1nu+X8jjq7RbxPgJuctctYcaGSkvpccSA4lkE2M=",
+          "amount": "A+g="
+        },
+        "memo": "memo",
+        "senderPublicKey": "ArDjIDEh3p3wvXwrOEYQDiXGMxA5LgWWHYBC+oGQbW8r",
+        "expiryTime": "2025-08-16T22:12:17.791Z"
+      }
+    },
+    {
+      "name": "tokens_only_identifier",
+      "description": "Token invoice with identifier only",
+      "network": "REGTEST",
+      "receiverPublicKey": "AmyUO/73EEA3HKHB0e4dWyA1c9yX/fZJegt05a7AIg4h",
+      "expectedHash": "31f5b9d1422d4d6c8d69bc859cd930120479d910a00297694e41d34bf4a9adb9",
+      "sparkInvoiceFields": {
+        "version": 1,
+        "id": "AZi07D0gfkuyiBEH7PZNSQ==",
+        "tokensPayment": {
+          "tokenIdentifier": "SQRt1nu+X8jjq7RbxPgJuctctYcaGSkvpccSA4lkE2M="
+        }
+      }
+    },
+    {
+      "name": "tokens_only_amount",
+      "description": "Token invoice with amount only",
+      "network": "REGTEST",
+      "receiverPublicKey": "AmyUO/73EEA3HKHB0e4dWyA1c9yX/fZJegt05a7AIg4h",
+      "expectedHash": "1b6ddf390f77f9da2a2f82b7ae13b1e0139361a41b2a1d0f26646a6b5694c5f0",
+      "sparkInvoiceFields": {
+        "version": 1,
+        "id": "AZi07D0gfkuyiBEH7PZNSQ==",
+        "tokensPayment": {
+          "amount": "AQ=="
+        }
+      }
+    },
+    {
+      "name": "mainnet_changes_hash",
+      "description": "Same invoice fields on a different network",
+      "network": "MAINNET",
+      "receiverPublicKey": "AmyUO/73EEA3HKHB0e4dWyA1c9yX/fZJegt05a7AIg4h",
+      "expectedHash": "e65beaf4c798de9f0931556c4a60856418f630c32ad48c7b55294f1930705e89",
+      "sparkInvoiceFields": {
+        "version": 1,
+        "id": "AZi07D0gfkuyiBEH7PZNSQ==",
+        "tokensPayment": {
+          "tokenIdentifier": "SQRt1nu+X8jjq7RbxPgJuctctYcaGSkvpccSA4lkE2M=",
+          "amount": "A+g="
+        },
+        "memo": "memo"
+      }
+    }
+  ]
+}

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -3164,6 +3164,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "spark-token-primitives",
  "thiserror 2.0.17",
  "tokio",
  "tonic",
@@ -3173,6 +3174,21 @@ dependencies = [
  "tracing",
  "unicode-normalization",
  "utils",
+ "uuid",
+]
+
+[[package]]
+name = "spark-token-primitives"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de059d7cbb2b65fe6c8831ff57ae0408a7624b65a74b5a31a3109707bb9f86c"
+dependencies = [
+ "bech32",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "sha2",
+ "thiserror 1.0.69",
  "uuid",
 ]
 


### PR DESCRIPTION
There was a difference in hashing amount-less invoices, `TokensPayment { amount: None } ` hashed `sha256([0x00])` because `u128::to_unpadded_be_bytes(0)` returns `[0]`, while everyone else hashes `sha256(empty)`.

This PR migrates the hashing to spark-token-primitives for token invoices