### PR TITLE
feat: add ability to external define database schemas

### DIFF
--- a/crates/breez-sdk/core/src/persist/mysql/base.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/base.rs
@@ -34,6 +34,11 @@ pub struct MysqlStorageConfig {
     /// Only used when the connection string requests TLS
     /// (`ssl-mode=verify_ca` or `ssl-mode=verify_identity`).
     pub root_ca_pem: Option<String>,
+
+    /// If true, the SDK trusts that the database schema is managed by the
+    /// embedding service and skips all migrations, including writes to the
+    /// schema migrations tables.
+    pub schema_managed_externally: bool,
 }
 
 impl From<MysqlStorageConfig> for spark_mysql::MysqlStorageConfig {
@@ -43,6 +48,7 @@ impl From<MysqlStorageConfig> for spark_mysql::MysqlStorageConfig {
             max_pool_size: config.max_pool_size,
             recycle_timeout_secs: config.recycle_timeout_secs,
             root_ca_pem: config.root_ca_pem,
+            schema_managed_externally: config.schema_managed_externally,
         }
     }
 }
@@ -54,6 +60,7 @@ impl From<spark_mysql::MysqlStorageConfig> for MysqlStorageConfig {
             max_pool_size: config.max_pool_size,
             recycle_timeout_secs: config.recycle_timeout_secs,
             root_ca_pem: config.root_ca_pem,
+            schema_managed_externally: config.schema_managed_externally,
         }
     }
 }
@@ -124,28 +131,43 @@ pub(super) async fn run_migrations(
 pub(crate) async fn create_mysql_tree_store(
     pool: mysql_async::Pool,
     identity: &[u8],
+    schema_managed_externally: bool,
 ) -> Result<Arc<dyn TreeStore>, StorageError> {
-    spark_mysql::create_mysql_tree_store_from_pool(pool, identity)
-        .await
-        .map_err(StorageError::from)
+    spark_mysql::create_mysql_tree_store_from_pool_with_schema_management(
+        pool,
+        identity,
+        schema_managed_externally,
+    )
+    .await
+    .map_err(StorageError::from)
 }
 
 /// Creates a `MysqlTokenStore` instance for use with the SDK, using an existing pool.
 pub(crate) async fn create_mysql_token_store(
     pool: mysql_async::Pool,
     identity: &[u8],
+    schema_managed_externally: bool,
 ) -> Result<Arc<dyn TokenOutputStore>, StorageError> {
-    spark_mysql::create_mysql_token_store_from_pool(pool, identity)
-        .await
-        .map_err(StorageError::from)
+    spark_mysql::create_mysql_token_store_from_pool_with_schema_management(
+        pool,
+        identity,
+        schema_managed_externally,
+    )
+    .await
+    .map_err(StorageError::from)
 }
 
 /// Creates a `MysqlSessionManager` instance for use with the SDK, using an existing pool.
 pub(crate) async fn create_mysql_session_manager(
     pool: mysql_async::Pool,
     identity: &[u8],
+    schema_managed_externally: bool,
 ) -> Result<Arc<dyn SessionManager>, StorageError> {
-    spark_mysql::create_mysql_session_manager_from_pool(pool, identity)
-        .await
-        .map_err(StorageError::from)
+    spark_mysql::create_mysql_session_manager_from_pool_with_schema_management(
+        pool,
+        identity,
+        schema_managed_externally,
+    )
+    .await
+    .map_err(StorageError::from)
 }

--- a/crates/breez-sdk/core/src/persist/mysql/base.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/base.rs
@@ -35,10 +35,13 @@ pub struct MysqlStorageConfig {
     /// (`ssl-mode=verify_ca` or `ssl-mode=verify_identity`).
     pub root_ca_pem: Option<String>,
 
-    /// If true, the SDK trusts that the database schema is managed by the
-    /// embedding service and skips all migrations, including writes to the
-    /// schema migrations tables.
-    pub schema_managed_externally: bool,
+    /// Whether the SDK should run schema migrations on startup.
+    ///
+    /// Set to `false` when the database schema is owned and migrated by the
+    /// embedding service; the SDK will trust the existing schema and skip all
+    /// migrations, including writes to the schema migrations tables. Defaults
+    /// to `true`.
+    pub run_migration: bool,
 }
 
 impl From<MysqlStorageConfig> for spark_mysql::MysqlStorageConfig {
@@ -48,7 +51,7 @@ impl From<MysqlStorageConfig> for spark_mysql::MysqlStorageConfig {
             max_pool_size: config.max_pool_size,
             recycle_timeout_secs: config.recycle_timeout_secs,
             root_ca_pem: config.root_ca_pem,
-            schema_managed_externally: config.schema_managed_externally,
+            run_migration: config.run_migration,
         }
     }
 }
@@ -60,7 +63,7 @@ impl From<spark_mysql::MysqlStorageConfig> for MysqlStorageConfig {
             max_pool_size: config.max_pool_size,
             recycle_timeout_secs: config.recycle_timeout_secs,
             root_ca_pem: config.root_ca_pem,
-            schema_managed_externally: config.schema_managed_externally,
+            run_migration: config.run_migration,
         }
     }
 }
@@ -131,43 +134,31 @@ pub(super) async fn run_migrations(
 pub(crate) async fn create_mysql_tree_store(
     pool: mysql_async::Pool,
     identity: &[u8],
-    schema_managed_externally: bool,
+    run_migration: bool,
 ) -> Result<Arc<dyn TreeStore>, StorageError> {
-    spark_mysql::create_mysql_tree_store_from_pool_with_schema_management(
-        pool,
-        identity,
-        schema_managed_externally,
-    )
-    .await
-    .map_err(StorageError::from)
+    spark_mysql::create_mysql_tree_store_from_pool(pool, identity, run_migration)
+        .await
+        .map_err(StorageError::from)
 }
 
 /// Creates a `MysqlTokenStore` instance for use with the SDK, using an existing pool.
 pub(crate) async fn create_mysql_token_store(
     pool: mysql_async::Pool,
     identity: &[u8],
-    schema_managed_externally: bool,
+    run_migration: bool,
 ) -> Result<Arc<dyn TokenOutputStore>, StorageError> {
-    spark_mysql::create_mysql_token_store_from_pool_with_schema_management(
-        pool,
-        identity,
-        schema_managed_externally,
-    )
-    .await
-    .map_err(StorageError::from)
+    spark_mysql::create_mysql_token_store_from_pool(pool, identity, run_migration)
+        .await
+        .map_err(StorageError::from)
 }
 
 /// Creates a `MysqlSessionManager` instance for use with the SDK, using an existing pool.
 pub(crate) async fn create_mysql_session_manager(
     pool: mysql_async::Pool,
     identity: &[u8],
-    schema_managed_externally: bool,
+    run_migration: bool,
 ) -> Result<Arc<dyn SessionManager>, StorageError> {
-    spark_mysql::create_mysql_session_manager_from_pool_with_schema_management(
-        pool,
-        identity,
-        schema_managed_externally,
-    )
-    .await
-    .map_err(StorageError::from)
+    spark_mysql::create_mysql_session_manager_from_pool(pool, identity, run_migration)
+        .await
+        .map_err(StorageError::from)
 }

--- a/crates/breez-sdk/core/src/persist/mysql/pool.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/pool.rs
@@ -18,7 +18,7 @@ use super::{MysqlStorageConfig, base::create_pool};
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct MysqlConnectionPool {
     pub(crate) inner: mysql_async::Pool,
-    pub(crate) schema_managed_externally: bool,
+    pub(crate) run_migration: bool,
 }
 
 /// Creates a shareable `MySQL` connection pool from the given configuration.
@@ -33,7 +33,7 @@ pub fn create_mysql_connection_pool(
     let inner = create_pool(config).map_err(SdkError::from)?;
     Ok(Arc::new(MysqlConnectionPool {
         inner,
-        schema_managed_externally: config.schema_managed_externally,
+        run_migration: config.run_migration,
     }))
 }
 

--- a/crates/breez-sdk/core/src/persist/mysql/pool.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/pool.rs
@@ -18,6 +18,7 @@ use super::{MysqlStorageConfig, base::create_pool};
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct MysqlConnectionPool {
     pub(crate) inner: mysql_async::Pool,
+    pub(crate) schema_managed_externally: bool,
 }
 
 /// Creates a shareable `MySQL` connection pool from the given configuration.
@@ -30,7 +31,10 @@ pub fn create_mysql_connection_pool(
     config: &MysqlStorageConfig,
 ) -> Result<Arc<MysqlConnectionPool>, SdkError> {
     let inner = create_pool(config).map_err(SdkError::from)?;
-    Ok(Arc::new(MysqlConnectionPool { inner }))
+    Ok(Arc::new(MysqlConnectionPool {
+        inner,
+        schema_managed_externally: config.schema_managed_externally,
+    }))
 }
 
 #[cfg(test)]

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -48,31 +48,26 @@ pub(crate) struct MysqlStorage {
 impl MysqlStorage {
     #[cfg(test)]
     pub async fn new(config: MysqlStorageConfig, identity: &[u8]) -> Result<Self, StorageError> {
-        let schema_managed_externally = config.schema_managed_externally;
+        let run_migration = config.run_migration;
         let pool = create_pool(&config)?;
-        Self::new_with_pool_and_schema_management(pool, identity, schema_managed_externally).await
-    }
-
-    /// Creates a new `MysqlStorage` using an existing connection pool. Each
-    /// `MysqlStorage` is scoped to a single tenant `identity`.
-    pub async fn new_with_pool(pool: Pool, identity: &[u8]) -> Result<Self, StorageError> {
-        Self::new_with_pool_and_schema_management(pool, identity, false).await
+        Self::new_with_pool(pool, identity, run_migration).await
     }
 
     /// Creates a new `MysqlStorage` using an existing connection pool.
     ///
-    /// When `schema_managed_externally` is true, initialization trusts the
-    /// existing schema and skips SDK storage migrations entirely.
-    pub async fn new_with_pool_and_schema_management(
+    /// Each `MysqlStorage` is scoped to a single tenant `identity`. When
+    /// `run_migration` is `false`, initialization trusts the existing schema
+    /// and skips SDK storage migrations entirely.
+    pub async fn new_with_pool(
         pool: Pool,
         identity: &[u8],
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<Self, StorageError> {
         let storage = Self {
             pool,
             identity: identity.to_vec(),
         };
-        if !schema_managed_externally {
+        if run_migration {
             storage.migrate().await?;
         }
         Ok(storage)

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -48,18 +48,33 @@ pub(crate) struct MysqlStorage {
 impl MysqlStorage {
     #[cfg(test)]
     pub async fn new(config: MysqlStorageConfig, identity: &[u8]) -> Result<Self, StorageError> {
+        let schema_managed_externally = config.schema_managed_externally;
         let pool = create_pool(&config)?;
-        Self::new_with_pool(pool, identity).await
+        Self::new_with_pool_and_schema_management(pool, identity, schema_managed_externally).await
     }
 
     /// Creates a new `MysqlStorage` using an existing connection pool. Each
     /// `MysqlStorage` is scoped to a single tenant `identity`.
     pub async fn new_with_pool(pool: Pool, identity: &[u8]) -> Result<Self, StorageError> {
+        Self::new_with_pool_and_schema_management(pool, identity, false).await
+    }
+
+    /// Creates a new `MysqlStorage` using an existing connection pool.
+    ///
+    /// When `schema_managed_externally` is true, initialization trusts the
+    /// existing schema and skips SDK storage migrations entirely.
+    pub async fn new_with_pool_and_schema_management(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, StorageError> {
         let storage = Self {
             pool,
             identity: identity.to_vec(),
         };
-        storage.migrate().await?;
+        if !schema_managed_externally {
+            storage.migrate().await?;
+        }
         Ok(storage)
     }
 

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -2040,10 +2040,10 @@ mod tests {
             let config = MysqlStorageConfig::with_defaults(connection_string);
             let pool = create_pool(&config).expect("Failed to create pool");
 
-            let a = MysqlStorage::new_with_pool(pool.clone(), &TEST_IDENTITY_A)
+            let a = MysqlStorage::new_with_pool(pool.clone(), &TEST_IDENTITY_A, true)
                 .await
                 .expect("Failed to create tenant A");
-            let b = MysqlStorage::new_with_pool(pool, &TEST_IDENTITY_B)
+            let b = MysqlStorage::new_with_pool(pool, &TEST_IDENTITY_B, true)
                 .await
                 .expect("Failed to create tenant B");
 

--- a/crates/breez-sdk/core/src/persist/postgres/base.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/base.rs
@@ -88,10 +88,13 @@ pub struct PostgresStorageConfig {
     /// Only used with `sslmode=verify-ca` or `sslmode=verify-full`.
     pub root_ca_pem: Option<String>,
 
-    /// If true, the SDK trusts that the database schema is managed by the
-    /// embedding service and skips all migrations, including writes to the
-    /// schema migrations tables.
-    pub schema_managed_externally: bool,
+    /// Whether the SDK should run schema migrations on startup.
+    ///
+    /// Set to `false` when the database schema is owned and migrated by the
+    /// embedding service; the SDK will trust the existing schema and skip all
+    /// migrations, including writes to the schema migrations tables. Defaults
+    /// to `true`.
+    pub run_migration: bool,
 }
 
 impl From<PostgresStorageConfig> for spark_postgres::PostgresStorageConfig {
@@ -104,7 +107,7 @@ impl From<PostgresStorageConfig> for spark_postgres::PostgresStorageConfig {
             recycle_timeout_secs: config.recycle_timeout_secs,
             queue_mode: config.queue_mode.into(),
             root_ca_pem: config.root_ca_pem,
-            schema_managed_externally: config.schema_managed_externally,
+            run_migration: config.run_migration,
         }
     }
 }
@@ -119,7 +122,7 @@ impl From<spark_postgres::PostgresStorageConfig> for PostgresStorageConfig {
             recycle_timeout_secs: config.recycle_timeout_secs,
             queue_mode: config.queue_mode.into(),
             root_ca_pem: config.root_ca_pem,
-            schema_managed_externally: config.schema_managed_externally,
+            run_migration: config.run_migration,
         }
     }
 }
@@ -201,43 +204,31 @@ pub(super) async fn run_migrations(
 pub(crate) async fn create_postgres_tree_store(
     pool: deadpool_postgres::Pool,
     identity: &[u8],
-    schema_managed_externally: bool,
+    run_migration: bool,
 ) -> Result<Arc<dyn TreeStore>, StorageError> {
-    spark_postgres::create_postgres_tree_store_from_pool_with_schema_management(
-        pool,
-        identity,
-        schema_managed_externally,
-    )
-    .await
-    .map_err(StorageError::from)
+    spark_postgres::create_postgres_tree_store_from_pool(pool, identity, run_migration)
+        .await
+        .map_err(StorageError::from)
 }
 
 /// Creates a `PostgresTokenStore` instance for use with the SDK, using an existing pool.
 pub(crate) async fn create_postgres_token_store(
     pool: deadpool_postgres::Pool,
     identity: &[u8],
-    schema_managed_externally: bool,
+    run_migration: bool,
 ) -> Result<Arc<dyn TokenOutputStore>, StorageError> {
-    spark_postgres::create_postgres_token_store_from_pool_with_schema_management(
-        pool,
-        identity,
-        schema_managed_externally,
-    )
-    .await
-    .map_err(StorageError::from)
+    spark_postgres::create_postgres_token_store_from_pool(pool, identity, run_migration)
+        .await
+        .map_err(StorageError::from)
 }
 
 /// Creates a `PostgresSessionManager` instance for use with the SDK, using an existing pool.
 pub(crate) async fn create_postgres_session_manager(
     pool: deadpool_postgres::Pool,
     identity: &[u8],
-    schema_managed_externally: bool,
+    run_migration: bool,
 ) -> Result<Arc<dyn SessionManager>, StorageError> {
-    spark_postgres::create_postgres_session_manager_from_pool_with_schema_management(
-        pool,
-        identity,
-        schema_managed_externally,
-    )
-    .await
-    .map_err(StorageError::from)
+    spark_postgres::create_postgres_session_manager_from_pool(pool, identity, run_migration)
+        .await
+        .map_err(StorageError::from)
 }

--- a/crates/breez-sdk/core/src/persist/postgres/base.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/base.rs
@@ -87,6 +87,11 @@ pub struct PostgresStorageConfig {
     /// If `None`, uses Mozilla's root certificate store (via webpki-roots).
     /// Only used with `sslmode=verify-ca` or `sslmode=verify-full`.
     pub root_ca_pem: Option<String>,
+
+    /// If true, the SDK trusts that the database schema is managed by the
+    /// embedding service and skips all migrations, including writes to the
+    /// schema migrations tables.
+    pub schema_managed_externally: bool,
 }
 
 impl From<PostgresStorageConfig> for spark_postgres::PostgresStorageConfig {
@@ -99,6 +104,7 @@ impl From<PostgresStorageConfig> for spark_postgres::PostgresStorageConfig {
             recycle_timeout_secs: config.recycle_timeout_secs,
             queue_mode: config.queue_mode.into(),
             root_ca_pem: config.root_ca_pem,
+            schema_managed_externally: config.schema_managed_externally,
         }
     }
 }
@@ -113,6 +119,7 @@ impl From<spark_postgres::PostgresStorageConfig> for PostgresStorageConfig {
             recycle_timeout_secs: config.recycle_timeout_secs,
             queue_mode: config.queue_mode.into(),
             root_ca_pem: config.root_ca_pem,
+            schema_managed_externally: config.schema_managed_externally,
         }
     }
 }
@@ -194,28 +201,43 @@ pub(super) async fn run_migrations(
 pub(crate) async fn create_postgres_tree_store(
     pool: deadpool_postgres::Pool,
     identity: &[u8],
+    schema_managed_externally: bool,
 ) -> Result<Arc<dyn TreeStore>, StorageError> {
-    spark_postgres::create_postgres_tree_store_from_pool(pool, identity)
-        .await
-        .map_err(StorageError::from)
+    spark_postgres::create_postgres_tree_store_from_pool_with_schema_management(
+        pool,
+        identity,
+        schema_managed_externally,
+    )
+    .await
+    .map_err(StorageError::from)
 }
 
 /// Creates a `PostgresTokenStore` instance for use with the SDK, using an existing pool.
 pub(crate) async fn create_postgres_token_store(
     pool: deadpool_postgres::Pool,
     identity: &[u8],
+    schema_managed_externally: bool,
 ) -> Result<Arc<dyn TokenOutputStore>, StorageError> {
-    spark_postgres::create_postgres_token_store_from_pool(pool, identity)
-        .await
-        .map_err(StorageError::from)
+    spark_postgres::create_postgres_token_store_from_pool_with_schema_management(
+        pool,
+        identity,
+        schema_managed_externally,
+    )
+    .await
+    .map_err(StorageError::from)
 }
 
 /// Creates a `PostgresSessionManager` instance for use with the SDK, using an existing pool.
 pub(crate) async fn create_postgres_session_manager(
     pool: deadpool_postgres::Pool,
     identity: &[u8],
+    schema_managed_externally: bool,
 ) -> Result<Arc<dyn SessionManager>, StorageError> {
-    spark_postgres::create_postgres_session_manager_from_pool(pool, identity)
-        .await
-        .map_err(StorageError::from)
+    spark_postgres::create_postgres_session_manager_from_pool_with_schema_management(
+        pool,
+        identity,
+        schema_managed_externally,
+    )
+    .await
+    .map_err(StorageError::from)
 }

--- a/crates/breez-sdk/core/src/persist/postgres/pool.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/pool.rs
@@ -22,7 +22,7 @@ use super::{PostgresStorageConfig, base::create_pool};
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct PostgresConnectionPool {
     pub(crate) inner: deadpool_postgres::Pool,
-    pub(crate) schema_managed_externally: bool,
+    pub(crate) run_migration: bool,
 }
 
 /// Creates a shareable Postgres connection pool from the given configuration.
@@ -37,7 +37,7 @@ pub fn create_postgres_connection_pool(
     let inner = create_pool(config).map_err(SdkError::from)?;
     Ok(Arc::new(PostgresConnectionPool {
         inner,
-        schema_managed_externally: config.schema_managed_externally,
+        run_migration: config.run_migration,
     }))
 }
 

--- a/crates/breez-sdk/core/src/persist/postgres/pool.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/pool.rs
@@ -22,6 +22,7 @@ use super::{PostgresStorageConfig, base::create_pool};
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct PostgresConnectionPool {
     pub(crate) inner: deadpool_postgres::Pool,
+    pub(crate) schema_managed_externally: bool,
 }
 
 /// Creates a shareable Postgres connection pool from the given configuration.
@@ -34,7 +35,10 @@ pub fn create_postgres_connection_pool(
     config: &PostgresStorageConfig,
 ) -> Result<Arc<PostgresConnectionPool>, SdkError> {
     let inner = create_pool(config).map_err(SdkError::from)?;
-    Ok(Arc::new(PostgresConnectionPool { inner }))
+    Ok(Arc::new(PostgresConnectionPool {
+        inner,
+        schema_managed_externally: config.schema_managed_externally,
+    }))
 }
 
 #[cfg(test)]

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -73,33 +73,27 @@ impl PostgresStorage {
     /// A new `PostgresStorage` instance or an error
     #[cfg(test)]
     pub async fn new(config: PostgresStorageConfig, identity: &[u8]) -> Result<Self, StorageError> {
-        let schema_managed_externally = config.schema_managed_externally;
+        let run_migration = config.run_migration;
         let pool = create_pool(&config)?;
-        Self::new_with_pool_and_schema_management(pool, identity, schema_managed_externally).await
+        Self::new_with_pool(pool, identity, run_migration).await
     }
 
     /// Creates a new `PostgresStorage` using an existing connection pool.
     ///
     /// This allows sharing a single pool across multiple store implementations.
-    /// Each `PostgresStorage` is scoped to a single tenant `identity`.
-    pub async fn new_with_pool(pool: Pool, identity: &[u8]) -> Result<Self, StorageError> {
-        Self::new_with_pool_and_schema_management(pool, identity, false).await
-    }
-
-    /// Creates a new `PostgresStorage` using an existing connection pool.
-    ///
-    /// When `schema_managed_externally` is true, initialization trusts the
-    /// existing schema and skips SDK storage migrations entirely.
-    pub async fn new_with_pool_and_schema_management(
+    /// Each `PostgresStorage` is scoped to a single tenant `identity`. When
+    /// `run_migration` is `false`, initialization trusts the existing schema
+    /// and skips SDK storage migrations entirely.
+    pub async fn new_with_pool(
         pool: Pool,
         identity: &[u8],
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<Self, StorageError> {
         let storage = Self {
             pool,
             identity: identity.to_vec(),
         };
-        if !schema_managed_externally {
+        if run_migration {
             storage.migrate().await?;
         }
         Ok(storage)

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -1916,10 +1916,10 @@ mod tests {
             let config = PostgresStorageConfig::with_defaults(connection_string);
             let pool = create_pool(&config).expect("Failed to create pool");
 
-            let a = PostgresStorage::new_with_pool(pool.clone(), &TEST_IDENTITY_A)
+            let a = PostgresStorage::new_with_pool(pool.clone(), &TEST_IDENTITY_A, true)
                 .await
                 .expect("Failed to create tenant A");
-            let b = PostgresStorage::new_with_pool(pool, &TEST_IDENTITY_B)
+            let b = PostgresStorage::new_with_pool(pool, &TEST_IDENTITY_B, true)
                 .await
                 .expect("Failed to create tenant B");
 

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -73,8 +73,9 @@ impl PostgresStorage {
     /// A new `PostgresStorage` instance or an error
     #[cfg(test)]
     pub async fn new(config: PostgresStorageConfig, identity: &[u8]) -> Result<Self, StorageError> {
+        let schema_managed_externally = config.schema_managed_externally;
         let pool = create_pool(&config)?;
-        Self::new_with_pool(pool, identity).await
+        Self::new_with_pool_and_schema_management(pool, identity, schema_managed_externally).await
     }
 
     /// Creates a new `PostgresStorage` using an existing connection pool.
@@ -82,11 +83,25 @@ impl PostgresStorage {
     /// This allows sharing a single pool across multiple store implementations.
     /// Each `PostgresStorage` is scoped to a single tenant `identity`.
     pub async fn new_with_pool(pool: Pool, identity: &[u8]) -> Result<Self, StorageError> {
+        Self::new_with_pool_and_schema_management(pool, identity, false).await
+    }
+
+    /// Creates a new `PostgresStorage` using an existing connection pool.
+    ///
+    /// When `schema_managed_externally` is true, initialization trusts the
+    /// existing schema and skips SDK storage migrations entirely.
+    pub async fn new_with_pool_and_schema_management(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, StorageError> {
         let storage = Self {
             pool,
             identity: identity.to_vec(),
         };
-        storage.migrate().await?;
+        if !schema_managed_externally {
+            storage.migrate().await?;
+        }
         Ok(storage)
     }
 

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -579,7 +579,7 @@ impl SdkBuilder {
                 .await
                 .map_err(|e| SdkError::Generic(e.to_string()))?
                 .serialize();
-            Some((pool.inner.clone(), identity, pool.schema_managed_externally))
+            Some((pool.inner.clone(), identity, pool.run_migration))
         } else {
             None
         };
@@ -595,7 +595,7 @@ impl SdkBuilder {
                 .await
                 .map_err(|e| SdkError::Generic(e.to_string()))?
                 .serialize();
-            Some((pool.inner.clone(), identity, pool.schema_managed_externally))
+            Some((pool.inner.clone(), identity, pool.run_migration))
         } else {
             None
         };
@@ -628,21 +628,17 @@ impl SdkBuilder {
                 not(all(target_family = "wasm", target_os = "unknown"))
             ))]
             if s.is_none()
-                && let Some((ref pool, ref identity, schema_managed_externally)) = postgres_backend
+                && let Some((ref pool, ref identity, run_migration)) = postgres_backend
             {
-                let storage = if schema_managed_externally {
-                    crate::persist::postgres::PostgresStorage::new_with_pool_and_schema_management(
+                s = Some(Arc::new(
+                    crate::persist::postgres::PostgresStorage::new_with_pool(
                         pool.clone(),
                         identity,
-                        true,
+                        run_migration,
                     )
                     .await
-                } else {
-                    crate::persist::postgres::PostgresStorage::new_with_pool(pool.clone(), identity)
-                        .await
-                }
-                .map_err(|e| SdkError::Generic(e.to_string()))?;
-                s = Some(Arc::new(storage));
+                    .map_err(|e| SdkError::Generic(e.to_string()))?,
+                ));
             }
 
             #[cfg(all(
@@ -650,20 +646,17 @@ impl SdkBuilder {
                 not(all(target_family = "wasm", target_os = "unknown"))
             ))]
             if s.is_none()
-                && let Some((ref pool, ref identity, schema_managed_externally)) = mysql_backend
+                && let Some((ref pool, ref identity, run_migration)) = mysql_backend
             {
-                let storage = if schema_managed_externally {
-                    crate::persist::mysql::MysqlStorage::new_with_pool_and_schema_management(
+                s = Some(Arc::new(
+                    crate::persist::mysql::MysqlStorage::new_with_pool(
                         pool.clone(),
                         identity,
-                        true,
+                        run_migration,
                     )
                     .await
-                } else {
-                    crate::persist::mysql::MysqlStorage::new_with_pool(pool.clone(), identity).await
-                }
-                .map_err(|e| SdkError::Generic(e.to_string()))?;
-                s = Some(Arc::new(storage));
+                    .map_err(|e| SdkError::Generic(e.to_string()))?,
+                ));
             }
 
             s.ok_or_else(|| SdkError::Generic("No storage configured".to_string()))?
@@ -709,13 +702,13 @@ impl SdkBuilder {
 
         #[cfg(feature = "postgres")]
         if tree_store.is_none()
-            && let Some((ref pool, ref identity, schema_managed_externally)) = postgres_backend
+            && let Some((ref pool, ref identity, run_migration)) = postgres_backend
         {
             tree_store = Some(
                 crate::persist::postgres::create_postgres_tree_store(
                     pool.clone(),
                     identity,
-                    schema_managed_externally,
+                    run_migration,
                 )
                 .await?,
             );
@@ -723,13 +716,13 @@ impl SdkBuilder {
 
         #[cfg(feature = "mysql")]
         if tree_store.is_none()
-            && let Some((ref pool, ref identity, schema_managed_externally)) = mysql_backend
+            && let Some((ref pool, ref identity, run_migration)) = mysql_backend
         {
             tree_store = Some(
                 crate::persist::mysql::create_mysql_tree_store(
                     pool.clone(),
                     identity,
-                    schema_managed_externally,
+                    run_migration,
                 )
                 .await?,
             );
@@ -741,13 +734,13 @@ impl SdkBuilder {
 
         #[cfg(feature = "postgres")]
         if token_output_store.is_none()
-            && let Some((ref pool, ref identity, schema_managed_externally)) = postgres_backend
+            && let Some((ref pool, ref identity, run_migration)) = postgres_backend
         {
             token_output_store = Some(
                 crate::persist::postgres::create_postgres_token_store(
                     pool.clone(),
                     identity,
-                    schema_managed_externally,
+                    run_migration,
                 )
                 .await?,
             );
@@ -755,13 +748,13 @@ impl SdkBuilder {
 
         #[cfg(feature = "mysql")]
         if token_output_store.is_none()
-            && let Some((ref pool, ref identity, schema_managed_externally)) = mysql_backend
+            && let Some((ref pool, ref identity, run_migration)) = mysql_backend
         {
             token_output_store = Some(
                 crate::persist::mysql::create_mysql_token_store(
                     pool.clone(),
                     identity,
-                    schema_managed_externally,
+                    run_migration,
                 )
                 .await?,
             );
@@ -774,13 +767,13 @@ impl SdkBuilder {
 
         #[cfg(feature = "postgres")]
         if inner_session_manager.is_none()
-            && let Some((ref pool, ref identity, schema_managed_externally)) = postgres_backend
+            && let Some((ref pool, ref identity, run_migration)) = postgres_backend
         {
             inner_session_manager = Some(
                 crate::persist::postgres::create_postgres_session_manager(
                     pool.clone(),
                     identity,
-                    schema_managed_externally,
+                    run_migration,
                 )
                 .await?,
             );
@@ -788,13 +781,13 @@ impl SdkBuilder {
 
         #[cfg(feature = "mysql")]
         if inner_session_manager.is_none()
-            && let Some((ref pool, ref identity, schema_managed_externally)) = mysql_backend
+            && let Some((ref pool, ref identity, run_migration)) = mysql_backend
         {
             inner_session_manager = Some(
                 crate::persist::mysql::create_mysql_session_manager(
                     pool.clone(),
                     identity,
-                    schema_managed_externally,
+                    run_migration,
                 )
                 .await?,
             );

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -579,7 +579,7 @@ impl SdkBuilder {
                 .await
                 .map_err(|e| SdkError::Generic(e.to_string()))?
                 .serialize();
-            Some((pool.inner.clone(), identity))
+            Some((pool.inner.clone(), identity, pool.schema_managed_externally))
         } else {
             None
         };
@@ -595,7 +595,7 @@ impl SdkBuilder {
                 .await
                 .map_err(|e| SdkError::Generic(e.to_string()))?
                 .serialize();
-            Some((pool.inner.clone(), identity))
+            Some((pool.inner.clone(), identity, pool.schema_managed_externally))
         } else {
             None
         };
@@ -628,16 +628,21 @@ impl SdkBuilder {
                 not(all(target_family = "wasm", target_os = "unknown"))
             ))]
             if s.is_none()
-                && let Some((ref pool, ref identity)) = postgres_backend
+                && let Some((ref pool, ref identity, schema_managed_externally)) = postgres_backend
             {
-                s = Some(Arc::new(
-                    crate::persist::postgres::PostgresStorage::new_with_pool(
+                let storage = if schema_managed_externally {
+                    crate::persist::postgres::PostgresStorage::new_with_pool_and_schema_management(
                         pool.clone(),
                         identity,
+                        true,
                     )
                     .await
-                    .map_err(|e| SdkError::Generic(e.to_string()))?,
-                ));
+                } else {
+                    crate::persist::postgres::PostgresStorage::new_with_pool(pool.clone(), identity)
+                        .await
+                }
+                .map_err(|e| SdkError::Generic(e.to_string()))?;
+                s = Some(Arc::new(storage));
             }
 
             #[cfg(all(
@@ -645,13 +650,20 @@ impl SdkBuilder {
                 not(all(target_family = "wasm", target_os = "unknown"))
             ))]
             if s.is_none()
-                && let Some((ref pool, ref identity)) = mysql_backend
+                && let Some((ref pool, ref identity, schema_managed_externally)) = mysql_backend
             {
-                s = Some(Arc::new(
-                    crate::persist::mysql::MysqlStorage::new_with_pool(pool.clone(), identity)
-                        .await
-                        .map_err(|e| SdkError::Generic(e.to_string()))?,
-                ));
+                let storage = if schema_managed_externally {
+                    crate::persist::mysql::MysqlStorage::new_with_pool_and_schema_management(
+                        pool.clone(),
+                        identity,
+                        true,
+                    )
+                    .await
+                } else {
+                    crate::persist::mysql::MysqlStorage::new_with_pool(pool.clone(), identity).await
+                }
+                .map_err(|e| SdkError::Generic(e.to_string()))?;
+                s = Some(Arc::new(storage));
             }
 
             s.ok_or_else(|| SdkError::Generic("No storage configured".to_string()))?
@@ -697,20 +709,30 @@ impl SdkBuilder {
 
         #[cfg(feature = "postgres")]
         if tree_store.is_none()
-            && let Some((ref pool, ref identity)) = postgres_backend
+            && let Some((ref pool, ref identity, schema_managed_externally)) = postgres_backend
         {
             tree_store = Some(
-                crate::persist::postgres::create_postgres_tree_store(pool.clone(), identity)
-                    .await?,
+                crate::persist::postgres::create_postgres_tree_store(
+                    pool.clone(),
+                    identity,
+                    schema_managed_externally,
+                )
+                .await?,
             );
         }
 
         #[cfg(feature = "mysql")]
         if tree_store.is_none()
-            && let Some((ref pool, ref identity)) = mysql_backend
+            && let Some((ref pool, ref identity, schema_managed_externally)) = mysql_backend
         {
-            tree_store =
-                Some(crate::persist::mysql::create_mysql_tree_store(pool.clone(), identity).await?);
+            tree_store = Some(
+                crate::persist::mysql::create_mysql_tree_store(
+                    pool.clone(),
+                    identity,
+                    schema_managed_externally,
+                )
+                .await?,
+            );
         }
 
         // Create token output store if configured
@@ -719,20 +741,29 @@ impl SdkBuilder {
 
         #[cfg(feature = "postgres")]
         if token_output_store.is_none()
-            && let Some((ref pool, ref identity)) = postgres_backend
+            && let Some((ref pool, ref identity, schema_managed_externally)) = postgres_backend
         {
             token_output_store = Some(
-                crate::persist::postgres::create_postgres_token_store(pool.clone(), identity)
-                    .await?,
+                crate::persist::postgres::create_postgres_token_store(
+                    pool.clone(),
+                    identity,
+                    schema_managed_externally,
+                )
+                .await?,
             );
         }
 
         #[cfg(feature = "mysql")]
         if token_output_store.is_none()
-            && let Some((ref pool, ref identity)) = mysql_backend
+            && let Some((ref pool, ref identity, schema_managed_externally)) = mysql_backend
         {
             token_output_store = Some(
-                crate::persist::mysql::create_mysql_token_store(pool.clone(), identity).await?,
+                crate::persist::mysql::create_mysql_token_store(
+                    pool.clone(),
+                    identity,
+                    schema_managed_externally,
+                )
+                .await?,
             );
         }
 
@@ -743,20 +774,29 @@ impl SdkBuilder {
 
         #[cfg(feature = "postgres")]
         if inner_session_manager.is_none()
-            && let Some((ref pool, ref identity)) = postgres_backend
+            && let Some((ref pool, ref identity, schema_managed_externally)) = postgres_backend
         {
             inner_session_manager = Some(
-                crate::persist::postgres::create_postgres_session_manager(pool.clone(), identity)
-                    .await?,
+                crate::persist::postgres::create_postgres_session_manager(
+                    pool.clone(),
+                    identity,
+                    schema_managed_externally,
+                )
+                .await?,
             );
         }
 
         #[cfg(feature = "mysql")]
         if inner_session_manager.is_none()
-            && let Some((ref pool, ref identity)) = mysql_backend
+            && let Some((ref pool, ref identity, schema_managed_externally)) = mysql_backend
         {
             inner_session_manager = Some(
-                crate::persist::mysql::create_mysql_session_manager(pool.clone(), identity).await?,
+                crate::persist::mysql::create_mysql_session_manager(
+                    pool.clone(),
+                    identity,
+                    schema_managed_externally,
+                )
+                .await?,
             );
         }
 

--- a/crates/breez-sdk/wasm/js/mysql-session-manager/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-session-manager/index.cjs
@@ -33,7 +33,7 @@ class MysqlSessionManager {
    *   identifying the tenant. All reads and writes are scoped by this.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null) {
+  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
     if (!identity || identity.length !== 33) {
       throw new SessionManagerError(
         "tenant identity (33-byte secp256k1 pubkey) is required"
@@ -42,12 +42,15 @@ class MysqlSessionManager {
     this.pool = pool;
     this.identity = Buffer.from(identity);
     this.logger = logger;
+    this.schemaManagedExternally = schemaManagedExternally;
   }
 
   async initialize() {
     try {
-      const migrationManager = new MysqlSessionManagerMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool);
+      if (!this.schemaManagedExternally) {
+        const migrationManager = new MysqlSessionManagerMigrationManager(this.logger);
+        await migrationManager.migrate(this.pool);
+      }
       return this;
     } catch (error) {
       throw new SessionManagerError(
@@ -125,13 +128,28 @@ function _decodePubkey(hex) {
 
 async function createMysqlSessionManager(poolConfig, identity, logger = null) {
   const pool = mysql.createPool(poolConfig);
-  const manager = new MysqlSessionManager(pool, identity, logger);
+  const manager = new MysqlSessionManager(
+    pool,
+    identity,
+    logger,
+    poolConfig.schemaManagedExternally === true
+  );
   await manager.initialize();
   return manager;
 }
 
-async function createMysqlSessionManagerWithPool(pool, identity, logger = null) {
-  const manager = new MysqlSessionManager(pool, identity, logger);
+async function createMysqlSessionManagerWithPool(
+  pool,
+  identity,
+  logger = null,
+  schemaManagedExternally = false
+) {
+  const manager = new MysqlSessionManager(
+    pool,
+    identity,
+    logger,
+    schemaManagedExternally
+  );
   await manager.initialize();
   return manager;
 }

--- a/crates/breez-sdk/wasm/js/mysql-session-manager/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-session-manager/index.cjs
@@ -33,7 +33,7 @@ class MysqlSessionManager {
    *   identifying the tenant. All reads and writes are scoped by this.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
+  constructor(pool, identity, logger = null, runMigration = true) {
     if (!identity || identity.length !== 33) {
       throw new SessionManagerError(
         "tenant identity (33-byte secp256k1 pubkey) is required"
@@ -42,12 +42,12 @@ class MysqlSessionManager {
     this.pool = pool;
     this.identity = Buffer.from(identity);
     this.logger = logger;
-    this.schemaManagedExternally = schemaManagedExternally;
+    this.runMigration = runMigration;
   }
 
   async initialize() {
     try {
-      if (!this.schemaManagedExternally) {
+      if (this.runMigration) {
         const migrationManager = new MysqlSessionManagerMigrationManager(this.logger);
         await migrationManager.migrate(this.pool);
       }
@@ -132,7 +132,7 @@ async function createMysqlSessionManager(poolConfig, identity, logger = null) {
     pool,
     identity,
     logger,
-    poolConfig.schemaManagedExternally === true
+    poolConfig.runMigration !== false
   );
   await manager.initialize();
   return manager;
@@ -142,13 +142,13 @@ async function createMysqlSessionManagerWithPool(
   pool,
   identity,
   logger = null,
-  schemaManagedExternally = false
+  runMigration = true
 ) {
   const manager = new MysqlSessionManager(
     pool,
     identity,
     logger,
-    schemaManagedExternally
+    runMigration
   );
   await manager.initialize();
   return manager;

--- a/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
@@ -107,20 +107,23 @@ class MysqlStorage {
    *   so that multiple instances with distinct identities can share one DB.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null) {
+  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
     if (!identity) {
       throw new StorageError("MysqlStorage requires a tenant identity");
     }
     this.pool = pool;
     this.identity = Buffer.from(identity);
     this.logger = logger;
+    this.schemaManagedExternally = schemaManagedExternally;
   }
 
   /** Initialize the database (run migrations). */
   async initialize() {
     try {
-      const migrationManager = new MysqlMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool, this.identity);
+      if (!this.schemaManagedExternally) {
+        const migrationManager = new MysqlMigrationManager(this.logger);
+        await migrationManager.migrate(this.pool, this.identity);
+      }
       return this;
     } catch (error) {
       throw new StorageError(
@@ -1314,6 +1317,7 @@ function defaultMysqlStorageConfig(connectionString) {
     maxPoolSize: 10,
     createTimeoutSecs: 0,
     recycleTimeoutSecs: 10,
+    schemaManagedExternally: false,
   };
 }
 
@@ -1338,8 +1342,18 @@ function createMysqlPool(config) {
  * @param {Buffer|Uint8Array} identity - 33-byte tenant identity (secp256k1 pubkey)
  * @param {object} [logger]
  */
-async function createMysqlStorageWithPool(pool, identity, logger = null) {
-  const storage = new MysqlStorage(pool, identity, logger);
+async function createMysqlStorageWithPool(
+  pool,
+  identity,
+  logger = null,
+  schemaManagedExternally = false
+) {
+  const storage = new MysqlStorage(
+    pool,
+    identity,
+    logger,
+    schemaManagedExternally
+  );
   await storage.initialize();
   return storage;
 }
@@ -1354,7 +1368,12 @@ async function createMysqlStorageWithPool(pool, identity, logger = null) {
  */
 async function createMysqlStorage(config, identity, logger = null) {
   const pool = createMysqlPool(config);
-  return createMysqlStorageWithPool(pool, identity, logger);
+  return createMysqlStorageWithPool(
+    pool,
+    identity,
+    logger,
+    config.schemaManagedExternally === true
+  );
 }
 
 module.exports = {

--- a/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
@@ -107,20 +107,20 @@ class MysqlStorage {
    *   so that multiple instances with distinct identities can share one DB.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
+  constructor(pool, identity, logger = null, runMigration = true) {
     if (!identity) {
       throw new StorageError("MysqlStorage requires a tenant identity");
     }
     this.pool = pool;
     this.identity = Buffer.from(identity);
     this.logger = logger;
-    this.schemaManagedExternally = schemaManagedExternally;
+    this.runMigration = runMigration;
   }
 
   /** Initialize the database (run migrations). */
   async initialize() {
     try {
-      if (!this.schemaManagedExternally) {
+      if (this.runMigration) {
         const migrationManager = new MysqlMigrationManager(this.logger);
         await migrationManager.migrate(this.pool, this.identity);
       }
@@ -1317,7 +1317,7 @@ function defaultMysqlStorageConfig(connectionString) {
     maxPoolSize: 10,
     createTimeoutSecs: 0,
     recycleTimeoutSecs: 10,
-    schemaManagedExternally: false,
+    runMigration: true,
   };
 }
 
@@ -1346,13 +1346,13 @@ async function createMysqlStorageWithPool(
   pool,
   identity,
   logger = null,
-  schemaManagedExternally = false
+  runMigration = true
 ) {
   const storage = new MysqlStorage(
     pool,
     identity,
     logger,
-    schemaManagedExternally
+    runMigration
   );
   await storage.initialize();
   return storage;
@@ -1372,7 +1372,7 @@ async function createMysqlStorage(config, identity, logger = null) {
     pool,
     identity,
     logger,
-    config.schemaManagedExternally === true
+    config.runMigration !== false
   );
 }
 

--- a/crates/breez-sdk/wasm/js/mysql-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/index.cjs
@@ -73,7 +73,7 @@ class MysqlTokenStore {
    *   identifying the tenant. All reads and writes are scoped by this.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
+  constructor(pool, identity, logger = null, runMigration = true) {
     if (!identity || identity.length !== 33) {
       throw new TokenStoreError(
         "tenant identity (33-byte secp256k1 pubkey) is required"
@@ -83,12 +83,12 @@ class MysqlTokenStore {
     this.identity = Buffer.from(identity);
     this.lockName = _identityLockName(TOKEN_STORE_LOCK_PREFIX, identity);
     this.logger = logger;
-    this.schemaManagedExternally = schemaManagedExternally;
+    this.runMigration = runMigration;
   }
 
   async initialize() {
     try {
-      if (!this.schemaManagedExternally) {
+      if (this.runMigration) {
         const migrationManager = new MysqlTokenStoreMigrationManager(this.logger);
         await migrationManager.migrate(this.pool, this.identity);
       }
@@ -970,7 +970,7 @@ async function createMysqlTokenStore(config, identity, logger = null) {
     pool,
     identity,
     logger,
-    config.schemaManagedExternally === true
+    config.runMigration !== false
   );
 }
 
@@ -978,13 +978,13 @@ async function createMysqlTokenStoreWithPool(
   pool,
   identity,
   logger = null,
-  schemaManagedExternally = false
+  runMigration = true
 ) {
   const store = new MysqlTokenStore(
     pool,
     identity,
     logger,
-    schemaManagedExternally
+    runMigration
   );
   await store.initialize();
   return store;

--- a/crates/breez-sdk/wasm/js/mysql-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/index.cjs
@@ -73,7 +73,7 @@ class MysqlTokenStore {
    *   identifying the tenant. All reads and writes are scoped by this.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null) {
+  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
     if (!identity || identity.length !== 33) {
       throw new TokenStoreError(
         "tenant identity (33-byte secp256k1 pubkey) is required"
@@ -83,12 +83,15 @@ class MysqlTokenStore {
     this.identity = Buffer.from(identity);
     this.lockName = _identityLockName(TOKEN_STORE_LOCK_PREFIX, identity);
     this.logger = logger;
+    this.schemaManagedExternally = schemaManagedExternally;
   }
 
   async initialize() {
     try {
-      const migrationManager = new MysqlTokenStoreMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool, this.identity);
+      if (!this.schemaManagedExternally) {
+        const migrationManager = new MysqlTokenStoreMigrationManager(this.logger);
+        await migrationManager.migrate(this.pool, this.identity);
+      }
       return this;
     } catch (error) {
       throw new TokenStoreError(
@@ -963,11 +966,26 @@ function createMysqlPool(config) {
  */
 async function createMysqlTokenStore(config, identity, logger = null) {
   const pool = createMysqlPool(config);
-  return createMysqlTokenStoreWithPool(pool, identity, logger);
+  return createMysqlTokenStoreWithPool(
+    pool,
+    identity,
+    logger,
+    config.schemaManagedExternally === true
+  );
 }
 
-async function createMysqlTokenStoreWithPool(pool, identity, logger = null) {
-  const store = new MysqlTokenStore(pool, identity, logger);
+async function createMysqlTokenStoreWithPool(
+  pool,
+  identity,
+  logger = null,
+  schemaManagedExternally = false
+) {
+  const store = new MysqlTokenStore(
+    pool,
+    identity,
+    logger,
+    schemaManagedExternally
+  );
   await store.initialize();
   return store;
 }

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -80,7 +80,7 @@ class MysqlTreeStore {
    *   identifying the tenant. All reads and writes are scoped by this.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
+  constructor(pool, identity, logger = null, runMigration = true) {
     if (!identity || identity.length !== 33) {
       throw new TreeStoreError(
         "tenant identity (33-byte secp256k1 pubkey) is required"
@@ -90,12 +90,12 @@ class MysqlTreeStore {
     this.identity = Buffer.from(identity);
     this.lockName = _identityLockName(TREE_STORE_LOCK_PREFIX, identity);
     this.logger = logger;
-    this.schemaManagedExternally = schemaManagedExternally;
+    this.runMigration = runMigration;
   }
 
   async initialize() {
     try {
-      if (!this.schemaManagedExternally) {
+      if (this.runMigration) {
         const migrationManager = new MysqlTreeStoreMigrationManager(this.logger);
         await migrationManager.migrate(this.pool, this.identity);
       }
@@ -931,7 +931,7 @@ async function createMysqlTreeStore(config, identity, logger = null) {
     pool,
     identity,
     logger,
-    config.schemaManagedExternally === true
+    config.runMigration !== false
   );
 }
 
@@ -939,13 +939,13 @@ async function createMysqlTreeStoreWithPool(
   pool,
   identity,
   logger = null,
-  schemaManagedExternally = false
+  runMigration = true
 ) {
   const store = new MysqlTreeStore(
     pool,
     identity,
     logger,
-    schemaManagedExternally
+    runMigration
   );
   await store.initialize();
   return store;

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -80,7 +80,7 @@ class MysqlTreeStore {
    *   identifying the tenant. All reads and writes are scoped by this.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null) {
+  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
     if (!identity || identity.length !== 33) {
       throw new TreeStoreError(
         "tenant identity (33-byte secp256k1 pubkey) is required"
@@ -90,12 +90,15 @@ class MysqlTreeStore {
     this.identity = Buffer.from(identity);
     this.lockName = _identityLockName(TREE_STORE_LOCK_PREFIX, identity);
     this.logger = logger;
+    this.schemaManagedExternally = schemaManagedExternally;
   }
 
   async initialize() {
     try {
-      const migrationManager = new MysqlTreeStoreMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool, this.identity);
+      if (!this.schemaManagedExternally) {
+        const migrationManager = new MysqlTreeStoreMigrationManager(this.logger);
+        await migrationManager.migrate(this.pool, this.identity);
+      }
       return this;
     } catch (error) {
       throw new TreeStoreError(
@@ -924,11 +927,26 @@ function createMysqlPool(config) {
 
 async function createMysqlTreeStore(config, identity, logger = null) {
   const pool = createMysqlPool(config);
-  return createMysqlTreeStoreWithPool(pool, identity, logger);
+  return createMysqlTreeStoreWithPool(
+    pool,
+    identity,
+    logger,
+    config.schemaManagedExternally === true
+  );
 }
 
-async function createMysqlTreeStoreWithPool(pool, identity, logger = null) {
-  const store = new MysqlTreeStore(pool, identity, logger);
+async function createMysqlTreeStoreWithPool(
+  pool,
+  identity,
+  logger = null,
+  schemaManagedExternally = false
+) {
+  const store = new MysqlTreeStore(
+    pool,
+    identity,
+    logger,
+    schemaManagedExternally
+  );
   await store.initialize();
   return store;
 }

--- a/crates/breez-sdk/wasm/js/postgres-session-manager/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-session-manager/index.cjs
@@ -39,7 +39,7 @@ class PostgresSessionManager {
    *   identifying the tenant. All reads and writes are scoped by this.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null) {
+  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
     if (!identity || identity.length !== 33) {
       throw new SessionManagerError(
         "tenant identity (33-byte secp256k1 pubkey) is required"
@@ -48,12 +48,15 @@ class PostgresSessionManager {
     this.pool = pool;
     this.identity = Buffer.from(identity);
     this.logger = logger;
+    this.schemaManagedExternally = schemaManagedExternally;
   }
 
   async initialize() {
     try {
-      const migrationManager = new SessionManagerMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool);
+      if (!this.schemaManagedExternally) {
+        const migrationManager = new SessionManagerMigrationManager(this.logger);
+        await migrationManager.migrate(this.pool);
+      }
       return this;
     } catch (error) {
       throw new SessionManagerError(
@@ -142,7 +145,12 @@ function _decodePubkey(hex) {
  */
 async function createPostgresSessionManager(poolConfig, identity, logger = null) {
   const pool = new pg.Pool(poolConfig);
-  const manager = new PostgresSessionManager(pool, identity, logger);
+  const manager = new PostgresSessionManager(
+    pool,
+    identity,
+    logger,
+    poolConfig.schemaManagedExternally === true
+  );
   await manager.initialize();
   return manager;
 }
@@ -151,8 +159,18 @@ async function createPostgresSessionManager(poolConfig, identity, logger = null)
  * Wraps an existing pool — useful when sharing the pool with the storage,
  * tree store, and token store implementations.
  */
-async function createPostgresSessionManagerWithPool(pool, identity, logger = null) {
-  const manager = new PostgresSessionManager(pool, identity, logger);
+async function createPostgresSessionManagerWithPool(
+  pool,
+  identity,
+  logger = null,
+  schemaManagedExternally = false
+) {
+  const manager = new PostgresSessionManager(
+    pool,
+    identity,
+    logger,
+    schemaManagedExternally
+  );
   await manager.initialize();
   return manager;
 }

--- a/crates/breez-sdk/wasm/js/postgres-session-manager/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-session-manager/index.cjs
@@ -39,7 +39,7 @@ class PostgresSessionManager {
    *   identifying the tenant. All reads and writes are scoped by this.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
+  constructor(pool, identity, logger = null, runMigration = true) {
     if (!identity || identity.length !== 33) {
       throw new SessionManagerError(
         "tenant identity (33-byte secp256k1 pubkey) is required"
@@ -48,12 +48,12 @@ class PostgresSessionManager {
     this.pool = pool;
     this.identity = Buffer.from(identity);
     this.logger = logger;
-    this.schemaManagedExternally = schemaManagedExternally;
+    this.runMigration = runMigration;
   }
 
   async initialize() {
     try {
-      if (!this.schemaManagedExternally) {
+      if (this.runMigration) {
         const migrationManager = new SessionManagerMigrationManager(this.logger);
         await migrationManager.migrate(this.pool);
       }
@@ -149,7 +149,7 @@ async function createPostgresSessionManager(poolConfig, identity, logger = null)
     pool,
     identity,
     logger,
-    poolConfig.schemaManagedExternally === true
+    poolConfig.runMigration !== false
   );
   await manager.initialize();
   return manager;
@@ -163,13 +163,13 @@ async function createPostgresSessionManagerWithPool(
   pool,
   identity,
   logger = null,
-  schemaManagedExternally = false
+  runMigration = true
 ) {
   const manager = new PostgresSessionManager(
     pool,
     identity,
     logger,
-    schemaManagedExternally
+    runMigration
   );
   await manager.initialize();
   return manager;

--- a/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
@@ -77,14 +77,14 @@ class PostgresStorage {
    *   so that multiple instances with distinct identities can share one DB.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
+  constructor(pool, identity, logger = null, runMigration = true) {
     if (!identity) {
       throw new StorageError("PostgresStorage requires a tenant identity");
     }
     this.pool = pool;
     this.identity = Buffer.from(identity);
     this.logger = logger;
-    this.schemaManagedExternally = schemaManagedExternally;
+    this.runMigration = runMigration;
   }
 
   /**
@@ -92,7 +92,7 @@ class PostgresStorage {
    */
   async initialize() {
     try {
-      if (!this.schemaManagedExternally) {
+      if (this.runMigration) {
         const migrationManager = new PostgresMigrationManager(this.logger);
         await migrationManager.migrate(this.pool, this.identity);
       }
@@ -1393,7 +1393,7 @@ function defaultPostgresStorageConfig(connectionString) {
     maxPoolSize: 10,
     createTimeoutSecs: 0,
     recycleTimeoutSecs: 10,
-    schemaManagedExternally: false,
+    runMigration: true,
   };
 }
 
@@ -1417,7 +1417,7 @@ async function createPostgresStorage(config, identity, logger = null) {
     pool,
     identity,
     logger,
-    config.schemaManagedExternally === true
+    config.runMigration !== false
   );
 }
 
@@ -1449,13 +1449,13 @@ async function createPostgresStorageWithPool(
   pool,
   identity,
   logger = null,
-  schemaManagedExternally = false
+  runMigration = true
 ) {
   const storage = new PostgresStorage(
     pool,
     identity,
     logger,
-    schemaManagedExternally
+    runMigration
   );
   await storage.initialize();
   return storage;

--- a/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
@@ -77,13 +77,14 @@ class PostgresStorage {
    *   so that multiple instances with distinct identities can share one DB.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null) {
+  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
     if (!identity) {
       throw new StorageError("PostgresStorage requires a tenant identity");
     }
     this.pool = pool;
     this.identity = Buffer.from(identity);
     this.logger = logger;
+    this.schemaManagedExternally = schemaManagedExternally;
   }
 
   /**
@@ -91,8 +92,10 @@ class PostgresStorage {
    */
   async initialize() {
     try {
-      const migrationManager = new PostgresMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool, this.identity);
+      if (!this.schemaManagedExternally) {
+        const migrationManager = new PostgresMigrationManager(this.logger);
+        await migrationManager.migrate(this.pool, this.identity);
+      }
       return this;
     } catch (error) {
       throw new StorageError(
@@ -1390,6 +1393,7 @@ function defaultPostgresStorageConfig(connectionString) {
     maxPoolSize: 10,
     createTimeoutSecs: 0,
     recycleTimeoutSecs: 10,
+    schemaManagedExternally: false,
   };
 }
 
@@ -1409,7 +1413,12 @@ function defaultPostgresStorageConfig(connectionString) {
  */
 async function createPostgresStorage(config, identity, logger = null) {
   const pool = createPostgresPool(config);
-  return createPostgresStorageWithPool(pool, identity, logger);
+  return createPostgresStorageWithPool(
+    pool,
+    identity,
+    logger,
+    config.schemaManagedExternally === true
+  );
 }
 
 /**
@@ -1436,8 +1445,18 @@ function createPostgresPool(config) {
  * @param {object} [logger] - Optional logger
  * @returns {Promise<PostgresStorage>}
  */
-async function createPostgresStorageWithPool(pool, identity, logger = null) {
-  const storage = new PostgresStorage(pool, identity, logger);
+async function createPostgresStorageWithPool(
+  pool,
+  identity,
+  logger = null,
+  schemaManagedExternally = false
+) {
+  const storage = new PostgresStorage(
+    pool,
+    identity,
+    logger,
+    schemaManagedExternally
+  );
   await storage.initialize();
   return storage;
 }

--- a/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
@@ -64,7 +64,7 @@ class PostgresTokenStore {
    *   identifying the tenant. All reads and writes are scoped by this.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
+  constructor(pool, identity, logger = null, runMigration = true) {
     if (!identity || identity.length !== 33) {
       throw new TokenStoreError(
         "tenant identity (33-byte secp256k1 pubkey) is required"
@@ -74,7 +74,7 @@ class PostgresTokenStore {
     this.identity = Buffer.from(identity);
     this.lockKey = _identityLockKey(TOKEN_STORE_LOCK_PREFIX, identity);
     this.logger = logger;
-    this.schemaManagedExternally = schemaManagedExternally;
+    this.runMigration = runMigration;
   }
 
   /**
@@ -82,7 +82,7 @@ class PostgresTokenStore {
    */
   async initialize() {
     try {
-      if (!this.schemaManagedExternally) {
+      if (this.runMigration) {
         const migrationManager = new TokenStoreMigrationManager(this.logger);
         await migrationManager.migrate(this.pool, this.identity);
       }
@@ -1022,7 +1022,7 @@ async function createPostgresTokenStore(config, identity, logger = null) {
     pool,
     identity,
     logger,
-    config.schemaManagedExternally === true
+    config.runMigration !== false
   );
 }
 
@@ -1038,13 +1038,13 @@ async function createPostgresTokenStoreWithPool(
   pool,
   identity,
   logger = null,
-  schemaManagedExternally = false
+  runMigration = true
 ) {
   const store = new PostgresTokenStore(
     pool,
     identity,
     logger,
-    schemaManagedExternally
+    runMigration
   );
   await store.initialize();
   return store;

--- a/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
@@ -64,7 +64,7 @@ class PostgresTokenStore {
    *   identifying the tenant. All reads and writes are scoped by this.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null) {
+  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
     if (!identity || identity.length !== 33) {
       throw new TokenStoreError(
         "tenant identity (33-byte secp256k1 pubkey) is required"
@@ -74,6 +74,7 @@ class PostgresTokenStore {
     this.identity = Buffer.from(identity);
     this.lockKey = _identityLockKey(TOKEN_STORE_LOCK_PREFIX, identity);
     this.logger = logger;
+    this.schemaManagedExternally = schemaManagedExternally;
   }
 
   /**
@@ -81,8 +82,10 @@ class PostgresTokenStore {
    */
   async initialize() {
     try {
-      const migrationManager = new TokenStoreMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool, this.identity);
+      if (!this.schemaManagedExternally) {
+        const migrationManager = new TokenStoreMigrationManager(this.logger);
+        await migrationManager.migrate(this.pool, this.identity);
+      }
       return this;
     } catch (error) {
       throw new TokenStoreError(
@@ -1015,7 +1018,12 @@ async function createPostgresTokenStore(config, identity, logger = null) {
     connectionTimeoutMillis: config.createTimeoutSecs * 1000,
     idleTimeoutMillis: config.recycleTimeoutSecs * 1000,
   });
-  return createPostgresTokenStoreWithPool(pool, identity, logger);
+  return createPostgresTokenStoreWithPool(
+    pool,
+    identity,
+    logger,
+    config.schemaManagedExternally === true
+  );
 }
 
 /**
@@ -1026,8 +1034,18 @@ async function createPostgresTokenStore(config, identity, logger = null) {
  * @param {object} [logger] - Optional logger
  * @returns {Promise<PostgresTokenStore>}
  */
-async function createPostgresTokenStoreWithPool(pool, identity, logger = null) {
-  const store = new PostgresTokenStore(pool, identity, logger);
+async function createPostgresTokenStoreWithPool(
+  pool,
+  identity,
+  logger = null,
+  schemaManagedExternally = false
+) {
+  const store = new PostgresTokenStore(
+    pool,
+    identity,
+    logger,
+    schemaManagedExternally
+  );
   await store.initialize();
   return store;
 }

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -62,7 +62,7 @@ class PostgresTreeStore {
    *   identifying the tenant. All reads and writes are scoped by this.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
+  constructor(pool, identity, logger = null, runMigration = true) {
     if (!identity || identity.length !== 33) {
       throw new TreeStoreError(
         "tenant identity (33-byte secp256k1 pubkey) is required"
@@ -72,7 +72,7 @@ class PostgresTreeStore {
     this.identity = Buffer.from(identity);
     this.lockKey = _identityLockKey(TREE_STORE_LOCK_PREFIX, identity);
     this.logger = logger;
-    this.schemaManagedExternally = schemaManagedExternally;
+    this.runMigration = runMigration;
   }
 
   /**
@@ -80,7 +80,7 @@ class PostgresTreeStore {
    */
   async initialize() {
     try {
-      if (!this.schemaManagedExternally) {
+      if (this.runMigration) {
         const migrationManager = new TreeStoreMigrationManager(this.logger);
         await migrationManager.migrate(this.pool, this.identity);
       }
@@ -1012,7 +1012,7 @@ async function createPostgresTreeStore(config, identity, logger = null) {
     pool,
     identity,
     logger,
-    config.schemaManagedExternally === true
+    config.runMigration !== false
   );
 }
 
@@ -1028,13 +1028,13 @@ async function createPostgresTreeStoreWithPool(
   pool,
   identity,
   logger = null,
-  schemaManagedExternally = false
+  runMigration = true
 ) {
   const store = new PostgresTreeStore(
     pool,
     identity,
     logger,
-    schemaManagedExternally
+    runMigration
   );
   await store.initialize();
   return store;

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -62,7 +62,7 @@ class PostgresTreeStore {
    *   identifying the tenant. All reads and writes are scoped by this.
    * @param {object} [logger]
    */
-  constructor(pool, identity, logger = null) {
+  constructor(pool, identity, logger = null, schemaManagedExternally = false) {
     if (!identity || identity.length !== 33) {
       throw new TreeStoreError(
         "tenant identity (33-byte secp256k1 pubkey) is required"
@@ -72,6 +72,7 @@ class PostgresTreeStore {
     this.identity = Buffer.from(identity);
     this.lockKey = _identityLockKey(TREE_STORE_LOCK_PREFIX, identity);
     this.logger = logger;
+    this.schemaManagedExternally = schemaManagedExternally;
   }
 
   /**
@@ -79,8 +80,10 @@ class PostgresTreeStore {
    */
   async initialize() {
     try {
-      const migrationManager = new TreeStoreMigrationManager(this.logger);
-      await migrationManager.migrate(this.pool, this.identity);
+      if (!this.schemaManagedExternally) {
+        const migrationManager = new TreeStoreMigrationManager(this.logger);
+        await migrationManager.migrate(this.pool, this.identity);
+      }
       return this;
     } catch (error) {
       throw new TreeStoreError(
@@ -1005,7 +1008,12 @@ async function createPostgresTreeStore(config, identity, logger = null) {
     connectionTimeoutMillis: config.createTimeoutSecs * 1000,
     idleTimeoutMillis: config.recycleTimeoutSecs * 1000,
   });
-  return createPostgresTreeStoreWithPool(pool, identity, logger);
+  return createPostgresTreeStoreWithPool(
+    pool,
+    identity,
+    logger,
+    config.schemaManagedExternally === true
+  );
 }
 
 /**
@@ -1016,8 +1024,18 @@ async function createPostgresTreeStore(config, identity, logger = null) {
  * @param {object} [logger] - Optional logger
  * @returns {Promise<PostgresTreeStore>}
  */
-async function createPostgresTreeStoreWithPool(pool, identity, logger = null) {
-  const store = new PostgresTreeStore(pool, identity, logger);
+async function createPostgresTreeStoreWithPool(
+  pool,
+  identity,
+  logger = null,
+  schemaManagedExternally = false
+) {
+  const store = new PostgresTreeStore(
+    pool,
+    identity,
+    logger,
+    schemaManagedExternally
+  );
   await store.initialize();
   return store;
 }

--- a/crates/breez-sdk/wasm/src/models/mysql_pool.rs
+++ b/crates/breez-sdk/wasm/src/models/mysql_pool.rs
@@ -13,18 +13,25 @@ use crate::sdk_builder::MysqlStorageConfig;
 #[wasm_bindgen]
 pub struct MysqlConnectionPool {
     pub(crate) inner: Rc<JsPool>,
+    pub(crate) schema_managed_externally: bool,
 }
 
 impl MysqlConnectionPool {
     pub(crate) fn cloned_inner(&self) -> Rc<JsPool> {
         Rc::clone(&self.inner)
     }
+
+    pub(crate) fn schema_managed_externally(&self) -> bool {
+        self.schema_managed_externally
+    }
 }
 
 /// Creates a shareable MySQL connection pool from the given config.
 #[wasm_bindgen(js_name = "createMysqlConnectionPool")]
 pub fn create_mysql_connection_pool(config: MysqlStorageConfig) -> WasmResult<MysqlConnectionPool> {
+    let schema_managed_externally = config.schema_managed_externally;
     Ok(MysqlConnectionPool {
         inner: Rc::new(create_mysql_pool(config)?),
+        schema_managed_externally,
     })
 }

--- a/crates/breez-sdk/wasm/src/models/mysql_pool.rs
+++ b/crates/breez-sdk/wasm/src/models/mysql_pool.rs
@@ -13,7 +13,7 @@ use crate::sdk_builder::MysqlStorageConfig;
 #[wasm_bindgen]
 pub struct MysqlConnectionPool {
     pub(crate) inner: Rc<JsPool>,
-    pub(crate) schema_managed_externally: bool,
+    pub(crate) run_migration: bool,
 }
 
 impl MysqlConnectionPool {
@@ -21,17 +21,17 @@ impl MysqlConnectionPool {
         Rc::clone(&self.inner)
     }
 
-    pub(crate) fn schema_managed_externally(&self) -> bool {
-        self.schema_managed_externally
+    pub(crate) fn run_migration(&self) -> bool {
+        self.run_migration
     }
 }
 
 /// Creates a shareable MySQL connection pool from the given config.
 #[wasm_bindgen(js_name = "createMysqlConnectionPool")]
 pub fn create_mysql_connection_pool(config: MysqlStorageConfig) -> WasmResult<MysqlConnectionPool> {
-    let schema_managed_externally = config.schema_managed_externally;
+    let run_migration = config.run_migration;
     Ok(MysqlConnectionPool {
         inner: Rc::new(create_mysql_pool(config)?),
-        schema_managed_externally,
+        run_migration,
     })
 }

--- a/crates/breez-sdk/wasm/src/models/postgres_pool.rs
+++ b/crates/breez-sdk/wasm/src/models/postgres_pool.rs
@@ -19,11 +19,16 @@ use crate::sdk_builder::PostgresStorageConfig;
 #[wasm_bindgen]
 pub struct PostgresConnectionPool {
     pub(crate) inner: Rc<JsPool>,
+    pub(crate) schema_managed_externally: bool,
 }
 
 impl PostgresConnectionPool {
     pub(crate) fn cloned_inner(&self) -> Rc<JsPool> {
         Rc::clone(&self.inner)
+    }
+
+    pub(crate) fn schema_managed_externally(&self) -> bool {
+        self.schema_managed_externally
     }
 }
 
@@ -32,7 +37,9 @@ impl PostgresConnectionPool {
 pub fn create_postgres_connection_pool(
     config: PostgresStorageConfig,
 ) -> WasmResult<PostgresConnectionPool> {
+    let schema_managed_externally = config.schema_managed_externally;
     Ok(PostgresConnectionPool {
         inner: Rc::new(create_postgres_pool(config)?),
+        schema_managed_externally,
     })
 }

--- a/crates/breez-sdk/wasm/src/models/postgres_pool.rs
+++ b/crates/breez-sdk/wasm/src/models/postgres_pool.rs
@@ -19,7 +19,7 @@ use crate::sdk_builder::PostgresStorageConfig;
 #[wasm_bindgen]
 pub struct PostgresConnectionPool {
     pub(crate) inner: Rc<JsPool>,
-    pub(crate) schema_managed_externally: bool,
+    pub(crate) run_migration: bool,
 }
 
 impl PostgresConnectionPool {
@@ -27,8 +27,8 @@ impl PostgresConnectionPool {
         Rc::clone(&self.inner)
     }
 
-    pub(crate) fn schema_managed_externally(&self) -> bool {
-        self.schema_managed_externally
+    pub(crate) fn run_migration(&self) -> bool {
+        self.run_migration
     }
 }
 
@@ -37,9 +37,9 @@ impl PostgresConnectionPool {
 pub fn create_postgres_connection_pool(
     config: PostgresStorageConfig,
 ) -> WasmResult<PostgresConnectionPool> {
-    let schema_managed_externally = config.schema_managed_externally;
+    let run_migration = config.run_migration;
     Ok(PostgresConnectionPool {
         inner: Rc::new(create_postgres_pool(config)?),
-        schema_managed_externally,
+        run_migration,
     })
 }

--- a/crates/breez-sdk/wasm/src/persist/pool.rs
+++ b/crates/breez-sdk/wasm/src/persist/pool.rs
@@ -23,7 +23,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<crate::persist::Storage, JsValue>;
 
     #[wasm_bindgen(js_name = "createPostgresTreeStoreWithPool", catch)]
@@ -31,7 +31,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<TreeStoreJs, JsValue>;
 
     #[wasm_bindgen(js_name = "createPostgresTokenStoreWithPool", catch)]
@@ -39,7 +39,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<TokenStoreJs, JsValue>;
 
     #[wasm_bindgen(js_name = "createPostgresSessionManagerWithPool", catch)]
@@ -47,7 +47,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<SessionManager, JsValue>;
 
     #[wasm_bindgen(js_name = "createMysqlPool", catch)]
@@ -58,7 +58,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<crate::persist::Storage, JsValue>;
 
     #[wasm_bindgen(js_name = "createMysqlTreeStoreWithPool", catch)]
@@ -66,7 +66,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<TreeStoreJs, JsValue>;
 
     #[wasm_bindgen(js_name = "createMysqlTokenStoreWithPool", catch)]
@@ -74,7 +74,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<TokenStoreJs, JsValue>;
 
     #[wasm_bindgen(js_name = "createMysqlSessionManagerWithPool", catch)]
@@ -82,6 +82,6 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<SessionManager, JsValue>;
 }

--- a/crates/breez-sdk/wasm/src/persist/pool.rs
+++ b/crates/breez-sdk/wasm/src/persist/pool.rs
@@ -23,6 +23,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
+        schema_managed_externally: bool,
     ) -> Result<crate::persist::Storage, JsValue>;
 
     #[wasm_bindgen(js_name = "createPostgresTreeStoreWithPool", catch)]
@@ -30,6 +31,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
+        schema_managed_externally: bool,
     ) -> Result<TreeStoreJs, JsValue>;
 
     #[wasm_bindgen(js_name = "createPostgresTokenStoreWithPool", catch)]
@@ -37,6 +39,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
+        schema_managed_externally: bool,
     ) -> Result<TokenStoreJs, JsValue>;
 
     #[wasm_bindgen(js_name = "createPostgresSessionManagerWithPool", catch)]
@@ -44,6 +47,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
+        schema_managed_externally: bool,
     ) -> Result<SessionManager, JsValue>;
 
     #[wasm_bindgen(js_name = "createMysqlPool", catch)]
@@ -54,6 +58,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
+        schema_managed_externally: bool,
     ) -> Result<crate::persist::Storage, JsValue>;
 
     #[wasm_bindgen(js_name = "createMysqlTreeStoreWithPool", catch)]
@@ -61,6 +66,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
+        schema_managed_externally: bool,
     ) -> Result<TreeStoreJs, JsValue>;
 
     #[wasm_bindgen(js_name = "createMysqlTokenStoreWithPool", catch)]
@@ -68,6 +74,7 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
+        schema_managed_externally: bool,
     ) -> Result<TokenStoreJs, JsValue>;
 
     #[wasm_bindgen(js_name = "createMysqlSessionManagerWithPool", catch)]
@@ -75,5 +82,6 @@ extern "C" {
         pool: &JsPool,
         identity: &[u8],
         logger: Option<&Logger>,
+        schema_managed_externally: bool,
     ) -> Result<SessionManager, JsValue>;
 }

--- a/crates/breez-sdk/wasm/src/sdk_builder.rs
+++ b/crates/breez-sdk/wasm/src/sdk_builder.rs
@@ -44,10 +44,15 @@ pub struct PostgresStorageConfig {
     pub create_timeout_secs: u32,
     /// Timeout in seconds before recycling an idle connection.
     pub recycle_timeout_secs: u32,
-    /// If true, the SDK trusts that the database schema is managed by the
-    /// embedding service and skips all migrations.
-    #[serde(default)]
-    pub schema_managed_externally: bool,
+    /// Whether the SDK should run schema migrations on startup. Set to
+    /// `false` when the embedding service owns and migrates the database
+    /// schema. Defaults to `true`.
+    #[serde(default = "default_run_migration")]
+    pub run_migration: bool,
+}
+
+fn default_run_migration() -> bool {
+    true
 }
 
 /// Creates a default PostgreSQL storage configuration with sensible defaults.
@@ -63,7 +68,7 @@ pub fn default_postgres_storage_config(connection_string: &str) -> PostgresStora
         max_pool_size: 10,
         create_timeout_secs: 0,
         recycle_timeout_secs: 10,
-        schema_managed_externally: false,
+        run_migration: true,
     }
 }
 
@@ -80,10 +85,11 @@ pub struct MysqlStorageConfig {
     pub create_timeout_secs: u32,
     /// Timeout in seconds before recycling an idle connection.
     pub recycle_timeout_secs: u32,
-    /// If true, the SDK trusts that the database schema is managed by the
-    /// embedding service and skips all migrations.
-    #[serde(default)]
-    pub schema_managed_externally: bool,
+    /// Whether the SDK should run schema migrations on startup. Set to
+    /// `false` when the embedding service owns and migrates the database
+    /// schema. Defaults to `true`.
+    #[serde(default = "default_run_migration")]
+    pub run_migration: bool,
 }
 
 /// Creates a default MySQL storage configuration with sensible defaults.
@@ -99,7 +105,7 @@ pub fn default_mysql_storage_config(connection_string: &str) -> MysqlStorageConf
         max_pool_size: 10,
         create_timeout_secs: 0,
         recycle_timeout_secs: 10,
-        schema_managed_externally: false,
+        run_migration: true,
     }
 }
 
@@ -185,7 +191,7 @@ impl SdkBuilder {
     /// to multiple `SdkBuilder`s to share connections across SDKs.
     #[wasm_bindgen(js_name = "withPostgresConnectionPool")]
     pub fn with_postgres_connection_pool(mut self, pool: &PostgresConnectionPool) -> Self {
-        self.postgres_pool = Some((pool.cloned_inner(), pool.schema_managed_externally()));
+        self.postgres_pool = Some((pool.cloned_inner(), pool.run_migration()));
         self
     }
 
@@ -194,25 +200,25 @@ impl SdkBuilder {
     /// `SdkBuilder`s to share connections across SDKs.
     #[wasm_bindgen(js_name = "withMysqlConnectionPool")]
     pub fn with_mysql_connection_pool(mut self, pool: &MysqlConnectionPool) -> Self {
-        self.mysql_pool = Some((pool.cloned_inner(), pool.schema_managed_externally()));
+        self.mysql_pool = Some((pool.cloned_inner(), pool.run_migration()));
         self
     }
 
     /// **Deprecated.** Call `withPostgresConnectionPool(config)` and `withPostgresConnectionPool(pool)` instead.
     #[wasm_bindgen(js_name = "withPostgresBackend")]
     pub fn with_postgres_backend(mut self, config: PostgresStorageConfig) -> WasmResult<Self> {
-        let schema_managed_externally = config.schema_managed_externally;
+        let run_migration = config.run_migration;
         let pool = create_postgres_pool(config)?;
-        self.postgres_pool = Some((Rc::new(pool), schema_managed_externally));
+        self.postgres_pool = Some((Rc::new(pool), run_migration));
         Ok(self)
     }
 
     /// **Deprecated.** Call `withMysqlConnectionPool(config)` and `withMysqlConnectionPool(pool)` instead.
     #[wasm_bindgen(js_name = "withMysqlBackend")]
     pub fn with_mysql_backend(mut self, config: MysqlStorageConfig) -> WasmResult<Self> {
-        let schema_managed_externally = config.schema_managed_externally;
+        let run_migration = config.run_migration;
         let pool = create_mysql_pool(config)?;
-        self.mysql_pool = Some((Rc::new(pool), schema_managed_externally));
+        self.mysql_pool = Some((Rc::new(pool), run_migration));
         Ok(self)
     }
 
@@ -338,7 +344,7 @@ impl SdkBuilder {
                 let storage_arc = Arc::new(WasmStorage { storage });
                 self.builder = self.builder.with_storage(storage_arc);
             }
-            (None, None, Some((pool_rc, schema_managed_externally)), None) => {
+            (None, None, Some((pool_rc, run_migration)), None) => {
                 let pool: &JsPool = pool_rc;
                 let logger_ref = get_wasm_logger_ref();
 
@@ -360,7 +366,7 @@ impl SdkBuilder {
                         pool,
                         &identity_bytes,
                         logger_ref,
-                        *schema_managed_externally,
+                        *run_migration,
                     )
                     .await?,
                 });
@@ -370,7 +376,7 @@ impl SdkBuilder {
                     pool,
                     &identity_bytes,
                     logger_ref,
-                    *schema_managed_externally,
+                    *run_migration,
                 )
                 .await?;
                 let tree_store = Arc::new(WasmTreeStore::new(tree_store_js));
@@ -380,7 +386,7 @@ impl SdkBuilder {
                     pool,
                     &identity_bytes,
                     logger_ref,
-                    *schema_managed_externally,
+                    *run_migration,
                 )
                 .await?;
                 let token_store = Arc::new(WasmTokenStore::new(token_store_js));
@@ -391,7 +397,7 @@ impl SdkBuilder {
                         pool,
                         &identity_bytes,
                         logger_ref,
-                        *schema_managed_externally,
+                        *run_migration,
                     )
                     .await?;
                     let session_manager = Arc::new(WasmSessionManager {
@@ -400,7 +406,7 @@ impl SdkBuilder {
                     self.builder = self.builder.with_session_manager(session_manager);
                 }
             }
-            (None, None, None, Some((pool_rc, schema_managed_externally))) => {
+            (None, None, None, Some((pool_rc, run_migration))) => {
                 let pool: &JsPool = pool_rc;
                 let logger_ref = get_wasm_logger_ref();
 
@@ -422,7 +428,7 @@ impl SdkBuilder {
                         pool,
                         &identity_bytes,
                         logger_ref,
-                        *schema_managed_externally,
+                        *run_migration,
                     )
                     .await?,
                 });
@@ -432,7 +438,7 @@ impl SdkBuilder {
                     pool,
                     &identity_bytes,
                     logger_ref,
-                    *schema_managed_externally,
+                    *run_migration,
                 )
                 .await?;
                 let tree_store = Arc::new(WasmTreeStore::new(tree_store_js));
@@ -442,7 +448,7 @@ impl SdkBuilder {
                     pool,
                     &identity_bytes,
                     logger_ref,
-                    *schema_managed_externally,
+                    *run_migration,
                 )
                 .await?;
                 let token_store = Arc::new(WasmTokenStore::new(token_store_js));
@@ -453,7 +459,7 @@ impl SdkBuilder {
                         pool,
                         &identity_bytes,
                         logger_ref,
-                        *schema_managed_externally,
+                        *run_migration,
                     )
                     .await?;
                     let session_manager = Arc::new(WasmSessionManager {

--- a/crates/breez-sdk/wasm/src/sdk_builder.rs
+++ b/crates/breez-sdk/wasm/src/sdk_builder.rs
@@ -44,6 +44,10 @@ pub struct PostgresStorageConfig {
     pub create_timeout_secs: u32,
     /// Timeout in seconds before recycling an idle connection.
     pub recycle_timeout_secs: u32,
+    /// If true, the SDK trusts that the database schema is managed by the
+    /// embedding service and skips all migrations.
+    #[serde(default)]
+    pub schema_managed_externally: bool,
 }
 
 /// Creates a default PostgreSQL storage configuration with sensible defaults.
@@ -59,6 +63,7 @@ pub fn default_postgres_storage_config(connection_string: &str) -> PostgresStora
         max_pool_size: 10,
         create_timeout_secs: 0,
         recycle_timeout_secs: 10,
+        schema_managed_externally: false,
     }
 }
 
@@ -75,6 +80,10 @@ pub struct MysqlStorageConfig {
     pub create_timeout_secs: u32,
     /// Timeout in seconds before recycling an idle connection.
     pub recycle_timeout_secs: u32,
+    /// If true, the SDK trusts that the database schema is managed by the
+    /// embedding service and skips all migrations.
+    #[serde(default)]
+    pub schema_managed_externally: bool,
 }
 
 /// Creates a default MySQL storage configuration with sensible defaults.
@@ -90,6 +99,7 @@ pub fn default_mysql_storage_config(connection_string: &str) -> MysqlStorageConf
         max_pool_size: 10,
         create_timeout_secs: 0,
         recycle_timeout_secs: 10,
+        schema_managed_externally: false,
     }
 }
 
@@ -100,8 +110,8 @@ pub struct SdkBuilder {
     seed: breez_sdk_spark::Seed,
     default_storage_dir: Option<String>,
     storage: Option<Storage>,
-    postgres_pool: Option<Rc<JsPool>>,
-    mysql_pool: Option<Rc<JsPool>>,
+    postgres_pool: Option<(Rc<JsPool>, bool)>,
+    mysql_pool: Option<(Rc<JsPool>, bool)>,
     /// Tracks whether the integrator supplied a session manager via
     /// [`with_session_manager`]. When `true`, the postgres / mysql pool
     /// branches in `build()` skip auto-creating one so they don't override
@@ -175,7 +185,7 @@ impl SdkBuilder {
     /// to multiple `SdkBuilder`s to share connections across SDKs.
     #[wasm_bindgen(js_name = "withPostgresConnectionPool")]
     pub fn with_postgres_connection_pool(mut self, pool: &PostgresConnectionPool) -> Self {
-        self.postgres_pool = Some(pool.cloned_inner());
+        self.postgres_pool = Some((pool.cloned_inner(), pool.schema_managed_externally()));
         self
     }
 
@@ -184,23 +194,25 @@ impl SdkBuilder {
     /// `SdkBuilder`s to share connections across SDKs.
     #[wasm_bindgen(js_name = "withMysqlConnectionPool")]
     pub fn with_mysql_connection_pool(mut self, pool: &MysqlConnectionPool) -> Self {
-        self.mysql_pool = Some(pool.cloned_inner());
+        self.mysql_pool = Some((pool.cloned_inner(), pool.schema_managed_externally()));
         self
     }
 
     /// **Deprecated.** Call `withPostgresConnectionPool(config)` and `withPostgresConnectionPool(pool)` instead.
     #[wasm_bindgen(js_name = "withPostgresBackend")]
     pub fn with_postgres_backend(mut self, config: PostgresStorageConfig) -> WasmResult<Self> {
+        let schema_managed_externally = config.schema_managed_externally;
         let pool = create_postgres_pool(config)?;
-        self.postgres_pool = Some(Rc::new(pool));
+        self.postgres_pool = Some((Rc::new(pool), schema_managed_externally));
         Ok(self)
     }
 
     /// **Deprecated.** Call `withMysqlConnectionPool(config)` and `withMysqlConnectionPool(pool)` instead.
     #[wasm_bindgen(js_name = "withMysqlBackend")]
     pub fn with_mysql_backend(mut self, config: MysqlStorageConfig) -> WasmResult<Self> {
+        let schema_managed_externally = config.schema_managed_externally;
         let pool = create_mysql_pool(config)?;
-        self.mysql_pool = Some(Rc::new(pool));
+        self.mysql_pool = Some((Rc::new(pool), schema_managed_externally));
         Ok(self)
     }
 
@@ -326,7 +338,7 @@ impl SdkBuilder {
                 let storage_arc = Arc::new(WasmStorage { storage });
                 self.builder = self.builder.with_storage(storage_arc);
             }
-            (None, None, Some(pool_rc), None) => {
+            (None, None, Some((pool_rc, schema_managed_externally)), None) => {
                 let pool: &JsPool = pool_rc;
                 let logger_ref = get_wasm_logger_ref();
 
@@ -344,19 +356,33 @@ impl SdkBuilder {
                 let identity_bytes = identity_pub_key.serialize();
 
                 let storage = Arc::new(WasmStorage {
-                    storage: create_postgres_storage_with_pool(pool, &identity_bytes, logger_ref)
-                        .await?,
+                    storage: create_postgres_storage_with_pool(
+                        pool,
+                        &identity_bytes,
+                        logger_ref,
+                        *schema_managed_externally,
+                    )
+                    .await?,
                 });
                 self.builder = self.builder.with_storage(storage);
 
-                let tree_store_js =
-                    create_postgres_tree_store_with_pool(pool, &identity_bytes, logger_ref).await?;
+                let tree_store_js = create_postgres_tree_store_with_pool(
+                    pool,
+                    &identity_bytes,
+                    logger_ref,
+                    *schema_managed_externally,
+                )
+                .await?;
                 let tree_store = Arc::new(WasmTreeStore::new(tree_store_js));
                 self.builder = self.builder.with_tree_store(tree_store);
 
-                let token_store_js =
-                    create_postgres_token_store_with_pool(pool, &identity_bytes, logger_ref)
-                        .await?;
+                let token_store_js = create_postgres_token_store_with_pool(
+                    pool,
+                    &identity_bytes,
+                    logger_ref,
+                    *schema_managed_externally,
+                )
+                .await?;
                 let token_store = Arc::new(WasmTokenStore::new(token_store_js));
                 self.builder = self.builder.with_token_output_store(token_store);
 
@@ -365,6 +391,7 @@ impl SdkBuilder {
                         pool,
                         &identity_bytes,
                         logger_ref,
+                        *schema_managed_externally,
                     )
                     .await?;
                     let session_manager = Arc::new(WasmSessionManager {
@@ -373,7 +400,7 @@ impl SdkBuilder {
                     self.builder = self.builder.with_session_manager(session_manager);
                 }
             }
-            (None, None, None, Some(pool_rc)) => {
+            (None, None, None, Some((pool_rc, schema_managed_externally))) => {
                 let pool: &JsPool = pool_rc;
                 let logger_ref = get_wasm_logger_ref();
 
@@ -391,25 +418,44 @@ impl SdkBuilder {
                 let identity_bytes = identity_pub_key.serialize();
 
                 let storage = Arc::new(WasmStorage {
-                    storage: create_mysql_storage_with_pool(pool, &identity_bytes, logger_ref)
-                        .await?,
+                    storage: create_mysql_storage_with_pool(
+                        pool,
+                        &identity_bytes,
+                        logger_ref,
+                        *schema_managed_externally,
+                    )
+                    .await?,
                 });
                 self.builder = self.builder.with_storage(storage);
 
-                let tree_store_js =
-                    create_mysql_tree_store_with_pool(pool, &identity_bytes, logger_ref).await?;
+                let tree_store_js = create_mysql_tree_store_with_pool(
+                    pool,
+                    &identity_bytes,
+                    logger_ref,
+                    *schema_managed_externally,
+                )
+                .await?;
                 let tree_store = Arc::new(WasmTreeStore::new(tree_store_js));
                 self.builder = self.builder.with_tree_store(tree_store);
 
-                let token_store_js =
-                    create_mysql_token_store_with_pool(pool, &identity_bytes, logger_ref).await?;
+                let token_store_js = create_mysql_token_store_with_pool(
+                    pool,
+                    &identity_bytes,
+                    logger_ref,
+                    *schema_managed_externally,
+                )
+                .await?;
                 let token_store = Arc::new(WasmTokenStore::new(token_store_js));
                 self.builder = self.builder.with_token_output_store(token_store);
 
                 if !self.user_session_manager {
-                    let session_manager_js =
-                        create_mysql_session_manager_with_pool(pool, &identity_bytes, logger_ref)
-                            .await?;
+                    let session_manager_js = create_mysql_session_manager_with_pool(
+                        pool,
+                        &identity_bytes,
+                        logger_ref,
+                        *schema_managed_externally,
+                    )
+                    .await?;
                     let session_manager = Arc::new(WasmSessionManager {
                         session_manager: session_manager_js,
                     });

--- a/crates/spark-mysql/src/config.rs
+++ b/crates/spark-mysql/src/config.rs
@@ -25,10 +25,13 @@ pub struct MysqlStorageConfig {
     /// `ssl-mode=verify_identity`).
     pub root_ca_pem: Option<String>,
 
-    /// If true, the SDK trusts that the database schema is managed by the
-    /// embedding service and skips all migrations, including writes to the
-    /// schema migrations tables.
-    pub schema_managed_externally: bool,
+    /// Whether the SDK should run schema migrations on startup.
+    ///
+    /// Set to `false` when the database schema is owned and migrated by the
+    /// embedding service; the SDK will trust the existing schema and skip all
+    /// migrations, including writes to the schema migrations tables. Defaults
+    /// to `true`.
+    pub run_migration: bool,
 }
 
 impl MysqlStorageConfig {
@@ -40,7 +43,7 @@ impl MysqlStorageConfig {
             max_pool_size: DEFAULT_MAX_POOL_SIZE,
             recycle_timeout_secs: None,
             root_ca_pem: None,
-            schema_managed_externally: false,
+            run_migration: true,
         }
     }
 }

--- a/crates/spark-mysql/src/config.rs
+++ b/crates/spark-mysql/src/config.rs
@@ -24,6 +24,11 @@ pub struct MysqlStorageConfig {
     /// Only used when the connection string requests TLS (`ssl-mode=verify_ca`,
     /// `ssl-mode=verify_identity`).
     pub root_ca_pem: Option<String>,
+
+    /// If true, the SDK trusts that the database schema is managed by the
+    /// embedding service and skips all migrations, including writes to the
+    /// schema migrations tables.
+    pub schema_managed_externally: bool,
 }
 
 impl MysqlStorageConfig {
@@ -35,6 +40,7 @@ impl MysqlStorageConfig {
             max_pool_size: DEFAULT_MAX_POOL_SIZE,
             recycle_timeout_secs: None,
             root_ca_pem: None,
+            schema_managed_externally: false,
         }
     }
 }

--- a/crates/spark-mysql/src/lib.rs
+++ b/crates/spark-mysql/src/lib.rs
@@ -24,11 +24,16 @@ pub use config::{MysqlStorageConfig, default_mysql_storage_config};
 pub use error::MysqlError;
 pub use session_manager::{
     MysqlSessionManager, create_mysql_session_manager, create_mysql_session_manager_from_pool,
+    create_mysql_session_manager_from_pool_with_schema_management,
 };
 pub use token_store::{
     MysqlTokenStore, create_mysql_token_store, create_mysql_token_store_from_pool,
+    create_mysql_token_store_from_pool_with_schema_management,
 };
-pub use tree_store::{MysqlTreeStore, create_mysql_tree_store, create_mysql_tree_store_from_pool};
+pub use tree_store::{
+    MysqlTreeStore, create_mysql_tree_store, create_mysql_tree_store_from_pool,
+    create_mysql_tree_store_from_pool_with_schema_management,
+};
 
 pub use migrations::{Migration, run_migrations};
 pub use pool::{create_pool, map_db_error, tx_opts};

--- a/crates/spark-mysql/src/lib.rs
+++ b/crates/spark-mysql/src/lib.rs
@@ -28,9 +28,7 @@ pub use session_manager::{
 pub use token_store::{
     MysqlTokenStore, create_mysql_token_store, create_mysql_token_store_from_pool,
 };
-pub use tree_store::{
-    MysqlTreeStore, create_mysql_tree_store, create_mysql_tree_store_from_pool,
-};
+pub use tree_store::{MysqlTreeStore, create_mysql_tree_store, create_mysql_tree_store_from_pool};
 
 pub use migrations::{Migration, run_migrations};
 pub use pool::{create_pool, map_db_error, tx_opts};

--- a/crates/spark-mysql/src/lib.rs
+++ b/crates/spark-mysql/src/lib.rs
@@ -24,15 +24,12 @@ pub use config::{MysqlStorageConfig, default_mysql_storage_config};
 pub use error::MysqlError;
 pub use session_manager::{
     MysqlSessionManager, create_mysql_session_manager, create_mysql_session_manager_from_pool,
-    create_mysql_session_manager_from_pool_with_schema_management,
 };
 pub use token_store::{
     MysqlTokenStore, create_mysql_token_store, create_mysql_token_store_from_pool,
-    create_mysql_token_store_from_pool_with_schema_management,
 };
 pub use tree_store::{
     MysqlTreeStore, create_mysql_tree_store, create_mysql_tree_store_from_pool,
-    create_mysql_tree_store_from_pool_with_schema_management,
 };
 
 pub use migrations::{Migration, run_migrations};

--- a/crates/spark-mysql/src/session_manager.rs
+++ b/crates/spark-mysql/src/session_manager.rs
@@ -91,38 +91,26 @@ impl MysqlSessionManager {
         config: MysqlStorageConfig,
         identity: &[u8],
     ) -> Result<Self, MysqlError> {
-        let schema_managed_externally = config.schema_managed_externally;
+        let run_migration = config.run_migration;
         let pool = create_pool(&config)?;
-        Self::init(pool, identity, schema_managed_externally).await
-    }
-
-    /// `identity` is the 33-byte secp256k1 pubkey of the tenant.
-    pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
-        Self::init(pool, identity, false).await
+        Self::from_pool(pool, identity, run_migration).await
     }
 
     /// Creates a new `MysqlSessionManager` from an existing connection pool.
     ///
-    /// When `schema_managed_externally` is true, initialization trusts the
-    /// existing schema and skips session manager migrations entirely.
-    pub async fn from_pool_with_schema_management(
+    /// `identity` is the 33-byte secp256k1 pubkey of the tenant. When
+    /// `run_migration` is `false`, initialization trusts the existing schema
+    /// and skips session manager migrations entirely.
+    pub async fn from_pool(
         pool: Pool,
         identity: &[u8],
-        schema_managed_externally: bool,
-    ) -> Result<Self, MysqlError> {
-        Self::init(pool, identity, schema_managed_externally).await
-    }
-
-    async fn init(
-        pool: Pool,
-        identity: &[u8],
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<Self, MysqlError> {
         let store = Self {
             pool,
             identity: identity.to_vec(),
         };
-        if !schema_managed_externally {
+        if run_migration {
             store.migrate().await?;
         }
         Ok(store)
@@ -164,31 +152,15 @@ pub async fn create_mysql_session_manager(
 /// Creates a `MysqlSessionManager` from an existing connection pool.
 ///
 /// `identity` is the 33-byte secp256k1 pubkey scoping all reads and writes.
+/// When `run_migration` is `false`, skips SDK-managed schema migrations and
+/// trusts that the `sessions` table already exists.
 pub async fn create_mysql_session_manager_from_pool(
     pool: Pool,
     identity: &[u8],
+    run_migration: bool,
 ) -> Result<Arc<dyn SessionManager>, MysqlError> {
     Ok(Arc::new(
-        MysqlSessionManager::from_pool(pool, identity).await?,
-    ))
-}
-
-/// Creates a `MysqlSessionManager` from an existing connection pool.
-///
-/// If `schema_managed_externally` is true, skips SDK-managed schema
-/// migrations and trusts that the `sessions` table already exists.
-pub async fn create_mysql_session_manager_from_pool_with_schema_management(
-    pool: Pool,
-    identity: &[u8],
-    schema_managed_externally: bool,
-) -> Result<Arc<dyn SessionManager>, MysqlError> {
-    Ok(Arc::new(
-        MysqlSessionManager::from_pool_with_schema_management(
-            pool,
-            identity,
-            schema_managed_externally,
-        )
-        .await?,
+        MysqlSessionManager::from_pool(pool, identity, run_migration).await?,
     ))
 }
 

--- a/crates/spark-mysql/src/session_manager.rs
+++ b/crates/spark-mysql/src/session_manager.rs
@@ -91,21 +91,40 @@ impl MysqlSessionManager {
         config: MysqlStorageConfig,
         identity: &[u8],
     ) -> Result<Self, MysqlError> {
+        let schema_managed_externally = config.schema_managed_externally;
         let pool = create_pool(&config)?;
-        Self::init(pool, identity).await
+        Self::init(pool, identity, schema_managed_externally).await
     }
 
     /// `identity` is the 33-byte secp256k1 pubkey of the tenant.
     pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
-        Self::init(pool, identity).await
+        Self::init(pool, identity, false).await
     }
 
-    async fn init(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
+    /// Creates a new `MysqlSessionManager` from an existing connection pool.
+    ///
+    /// When `schema_managed_externally` is true, initialization trusts the
+    /// existing schema and skips session manager migrations entirely.
+    pub async fn from_pool_with_schema_management(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, MysqlError> {
+        Self::init(pool, identity, schema_managed_externally).await
+    }
+
+    async fn init(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, MysqlError> {
         let store = Self {
             pool,
             identity: identity.to_vec(),
         };
-        store.migrate().await?;
+        if !schema_managed_externally {
+            store.migrate().await?;
+        }
         Ok(store)
     }
 
@@ -151,6 +170,25 @@ pub async fn create_mysql_session_manager_from_pool(
 ) -> Result<Arc<dyn SessionManager>, MysqlError> {
     Ok(Arc::new(
         MysqlSessionManager::from_pool(pool, identity).await?,
+    ))
+}
+
+/// Creates a `MysqlSessionManager` from an existing connection pool.
+///
+/// If `schema_managed_externally` is true, skips SDK-managed schema
+/// migrations and trusts that the `sessions` table already exists.
+pub async fn create_mysql_session_manager_from_pool_with_schema_management(
+    pool: Pool,
+    identity: &[u8],
+    schema_managed_externally: bool,
+) -> Result<Arc<dyn SessionManager>, MysqlError> {
+    Ok(Arc::new(
+        MysqlSessionManager::from_pool_with_schema_management(
+            pool,
+            identity,
+            schema_managed_externally,
+        )
+        .await?,
     ))
 }
 

--- a/crates/spark-mysql/src/token_store.rs
+++ b/crates/spark-mysql/src/token_store.rs
@@ -535,22 +535,41 @@ impl MysqlTokenStore {
         config: MysqlStorageConfig,
         identity: &[u8],
     ) -> Result<Self, MysqlError> {
+        let schema_managed_externally = config.schema_managed_externally;
         let pool = create_pool(&config)?;
-        Self::init(pool, identity).await
+        Self::init(pool, identity, schema_managed_externally).await
     }
 
     /// `identity` is the 33-byte secp256k1 pubkey of the tenant.
     pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
-        Self::init(pool, identity).await
+        Self::init(pool, identity, false).await
     }
 
-    async fn init(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
+    /// Creates a new `MysqlTokenStore` from an existing connection pool.
+    ///
+    /// When `schema_managed_externally` is true, initialization trusts the
+    /// existing schema and skips token store migrations entirely.
+    pub async fn from_pool_with_schema_management(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, MysqlError> {
+        Self::init(pool, identity, schema_managed_externally).await
+    }
+
+    async fn init(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, MysqlError> {
         let store = Self {
             pool,
             identity: identity.to_vec(),
             lock_name: identity_lock_name(TOKEN_STORE_LOCK_PREFIX, identity),
         };
-        store.migrate().await?;
+        if !schema_managed_externally {
+            store.migrate().await?;
+        }
         Ok(store)
     }
 
@@ -1417,6 +1436,25 @@ pub async fn create_mysql_token_store_from_pool(
     identity: &[u8],
 ) -> Result<Arc<dyn TokenOutputStore>, MysqlError> {
     Ok(Arc::new(MysqlTokenStore::from_pool(pool, identity).await?))
+}
+
+/// Creates a `MysqlTokenStore` from an existing connection pool.
+///
+/// If `schema_managed_externally` is true, skips SDK-managed schema
+/// migrations and trusts that all required tables, columns, and indexes exist.
+pub async fn create_mysql_token_store_from_pool_with_schema_management(
+    pool: Pool,
+    identity: &[u8],
+    schema_managed_externally: bool,
+) -> Result<Arc<dyn TokenOutputStore>, MysqlError> {
+    Ok(Arc::new(
+        MysqlTokenStore::from_pool_with_schema_management(
+            pool,
+            identity,
+            schema_managed_externally,
+        )
+        .await?,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/spark-mysql/src/token_store.rs
+++ b/crates/spark-mysql/src/token_store.rs
@@ -535,39 +535,27 @@ impl MysqlTokenStore {
         config: MysqlStorageConfig,
         identity: &[u8],
     ) -> Result<Self, MysqlError> {
-        let schema_managed_externally = config.schema_managed_externally;
+        let run_migration = config.run_migration;
         let pool = create_pool(&config)?;
-        Self::init(pool, identity, schema_managed_externally).await
-    }
-
-    /// `identity` is the 33-byte secp256k1 pubkey of the tenant.
-    pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
-        Self::init(pool, identity, false).await
+        Self::from_pool(pool, identity, run_migration).await
     }
 
     /// Creates a new `MysqlTokenStore` from an existing connection pool.
     ///
-    /// When `schema_managed_externally` is true, initialization trusts the
-    /// existing schema and skips token store migrations entirely.
-    pub async fn from_pool_with_schema_management(
+    /// `identity` is the 33-byte secp256k1 pubkey of the tenant. When
+    /// `run_migration` is `false`, initialization trusts the existing schema
+    /// and skips token store migrations entirely.
+    pub async fn from_pool(
         pool: Pool,
         identity: &[u8],
-        schema_managed_externally: bool,
-    ) -> Result<Self, MysqlError> {
-        Self::init(pool, identity, schema_managed_externally).await
-    }
-
-    async fn init(
-        pool: Pool,
-        identity: &[u8],
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<Self, MysqlError> {
         let store = Self {
             pool,
             identity: identity.to_vec(),
             lock_name: identity_lock_name(TOKEN_STORE_LOCK_PREFIX, identity),
         };
-        if !schema_managed_externally {
+        if run_migration {
             store.migrate().await?;
         }
         Ok(store)
@@ -1431,29 +1419,15 @@ pub async fn create_mysql_token_store(
 /// Creates a `MysqlTokenStore` from an existing connection pool.
 ///
 /// `identity` is the 33-byte secp256k1 pubkey scoping all reads and writes.
+/// When `run_migration` is `false`, skips SDK-managed schema migrations and
+/// trusts that all required tables, columns, and indexes exist.
 pub async fn create_mysql_token_store_from_pool(
     pool: Pool,
     identity: &[u8],
-) -> Result<Arc<dyn TokenOutputStore>, MysqlError> {
-    Ok(Arc::new(MysqlTokenStore::from_pool(pool, identity).await?))
-}
-
-/// Creates a `MysqlTokenStore` from an existing connection pool.
-///
-/// If `schema_managed_externally` is true, skips SDK-managed schema
-/// migrations and trusts that all required tables, columns, and indexes exist.
-pub async fn create_mysql_token_store_from_pool_with_schema_management(
-    pool: Pool,
-    identity: &[u8],
-    schema_managed_externally: bool,
+    run_migration: bool,
 ) -> Result<Arc<dyn TokenOutputStore>, MysqlError> {
     Ok(Arc::new(
-        MysqlTokenStore::from_pool_with_schema_management(
-            pool,
-            identity,
-            schema_managed_externally,
-        )
-        .await?,
+        MysqlTokenStore::from_pool(pool, identity, run_migration).await?,
     ))
 }
 
@@ -1934,10 +1908,10 @@ mod tests {
             let config = MysqlStorageConfig::with_defaults(connection_string);
             let pool = create_pool(&config).expect("Failed to create pool");
 
-            let a = MysqlTokenStore::from_pool(pool.clone(), &TEST_IDENTITY)
+            let a = MysqlTokenStore::from_pool(pool.clone(), &TEST_IDENTITY, true)
                 .await
                 .expect("Failed to create tenant A");
-            let b = MysqlTokenStore::from_pool(pool, &TEST_IDENTITY_B)
+            let b = MysqlTokenStore::from_pool(pool, &TEST_IDENTITY_B, true)
                 .await
                 .expect("Failed to create tenant B");
 

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -476,33 +476,20 @@ impl MysqlTreeStore {
         config: MysqlStorageConfig,
         identity: &[u8],
     ) -> Result<Self, MysqlError> {
-        let schema_managed_externally = config.schema_managed_externally;
+        let run_migration = config.run_migration;
         let pool = create_pool(&config)?;
-        Self::init(pool, identity, schema_managed_externally).await
-    }
-
-    /// Creates a new `MysqlTreeStore` from an existing connection pool.
-    /// `identity` is the 33-byte secp256k1 pubkey of the tenant.
-    pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
-        Self::init(pool, identity, false).await
+        Self::from_pool(pool, identity, run_migration).await
     }
 
     /// Creates a new `MysqlTreeStore` from an existing connection pool.
     ///
-    /// When `schema_managed_externally` is true, initialization trusts the
-    /// existing schema and skips tree store migrations entirely.
-    pub async fn from_pool_with_schema_management(
+    /// `identity` is the 33-byte secp256k1 pubkey of the tenant. When
+    /// `run_migration` is `false`, initialization trusts the existing schema
+    /// and skips tree store migrations entirely.
+    pub async fn from_pool(
         pool: Pool,
         identity: &[u8],
-        schema_managed_externally: bool,
-    ) -> Result<Self, MysqlError> {
-        Self::init(pool, identity, schema_managed_externally).await
-    }
-
-    async fn init(
-        pool: Pool,
-        identity: &[u8],
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<Self, MysqlError> {
         let (balance_changed_tx, balance_changed_rx) = watch::channel(());
 
@@ -514,7 +501,7 @@ impl MysqlTreeStore {
             balance_changed_rx,
         };
 
-        if !schema_managed_externally {
+        if run_migration {
             store.migrate().await?;
         }
         store.notify_balance_change();
@@ -1507,25 +1494,15 @@ pub async fn create_mysql_tree_store(
 /// Creates a `MysqlTreeStore` instance from an existing connection pool.
 ///
 /// `identity` is the 33-byte secp256k1 pubkey scoping all reads and writes.
+/// When `run_migration` is `false`, skips SDK-managed schema migrations and
+/// trusts that all required tables, columns, and indexes exist.
 pub async fn create_mysql_tree_store_from_pool(
     pool: Pool,
     identity: &[u8],
-) -> Result<Arc<dyn TreeStore>, MysqlError> {
-    Ok(Arc::new(MysqlTreeStore::from_pool(pool, identity).await?))
-}
-
-/// Creates a `MysqlTreeStore` instance from an existing connection pool.
-///
-/// If `schema_managed_externally` is true, skips SDK-managed schema
-/// migrations and trusts that all required tables, columns, and indexes exist.
-pub async fn create_mysql_tree_store_from_pool_with_schema_management(
-    pool: Pool,
-    identity: &[u8],
-    schema_managed_externally: bool,
+    run_migration: bool,
 ) -> Result<Arc<dyn TreeStore>, MysqlError> {
     Ok(Arc::new(
-        MysqlTreeStore::from_pool_with_schema_management(pool, identity, schema_managed_externally)
-            .await?,
+        MysqlTreeStore::from_pool(pool, identity, run_migration).await?,
     ))
 }
 
@@ -2482,10 +2459,10 @@ mod tests {
             let config = MysqlStorageConfig::with_defaults(connection_string);
             let pool = create_pool(&config).expect("Failed to create pool");
 
-            let a = MysqlTreeStore::from_pool(pool.clone(), &TEST_IDENTITY)
+            let a = MysqlTreeStore::from_pool(pool.clone(), &TEST_IDENTITY, true)
                 .await
                 .expect("Failed to create tenant A");
-            let b = MysqlTreeStore::from_pool(pool, &TEST_IDENTITY_B)
+            let b = MysqlTreeStore::from_pool(pool, &TEST_IDENTITY_B, true)
                 .await
                 .expect("Failed to create tenant B");
 

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -476,17 +476,34 @@ impl MysqlTreeStore {
         config: MysqlStorageConfig,
         identity: &[u8],
     ) -> Result<Self, MysqlError> {
+        let schema_managed_externally = config.schema_managed_externally;
         let pool = create_pool(&config)?;
-        Self::init(pool, identity).await
+        Self::init(pool, identity, schema_managed_externally).await
     }
 
     /// Creates a new `MysqlTreeStore` from an existing connection pool.
     /// `identity` is the 33-byte secp256k1 pubkey of the tenant.
     pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
-        Self::init(pool, identity).await
+        Self::init(pool, identity, false).await
     }
 
-    async fn init(pool: Pool, identity: &[u8]) -> Result<Self, MysqlError> {
+    /// Creates a new `MysqlTreeStore` from an existing connection pool.
+    ///
+    /// When `schema_managed_externally` is true, initialization trusts the
+    /// existing schema and skips tree store migrations entirely.
+    pub async fn from_pool_with_schema_management(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, MysqlError> {
+        Self::init(pool, identity, schema_managed_externally).await
+    }
+
+    async fn init(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, MysqlError> {
         let (balance_changed_tx, balance_changed_rx) = watch::channel(());
 
         let store = Self {
@@ -497,7 +514,9 @@ impl MysqlTreeStore {
             balance_changed_rx,
         };
 
-        store.migrate().await?;
+        if !schema_managed_externally {
+            store.migrate().await?;
+        }
         store.notify_balance_change();
 
         Ok(store)
@@ -1493,6 +1512,21 @@ pub async fn create_mysql_tree_store_from_pool(
     identity: &[u8],
 ) -> Result<Arc<dyn TreeStore>, MysqlError> {
     Ok(Arc::new(MysqlTreeStore::from_pool(pool, identity).await?))
+}
+
+/// Creates a `MysqlTreeStore` instance from an existing connection pool.
+///
+/// If `schema_managed_externally` is true, skips SDK-managed schema
+/// migrations and trusts that all required tables, columns, and indexes exist.
+pub async fn create_mysql_tree_store_from_pool_with_schema_management(
+    pool: Pool,
+    identity: &[u8],
+    schema_managed_externally: bool,
+) -> Result<Arc<dyn TreeStore>, MysqlError> {
+    Ok(Arc::new(
+        MysqlTreeStore::from_pool_with_schema_management(pool, identity, schema_managed_externally)
+            .await?,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/spark-postgres/src/config.rs
+++ b/crates/spark-postgres/src/config.rs
@@ -74,10 +74,13 @@ pub struct PostgresStorageConfig {
     /// Only used with `sslmode=verify-ca` or `sslmode=verify-full`.
     pub root_ca_pem: Option<String>,
 
-    /// If true, the SDK trusts that the database schema is managed by the
-    /// embedding service and skips all migrations, including writes to the
-    /// schema migrations tables.
-    pub schema_managed_externally: bool,
+    /// Whether the SDK should run schema migrations on startup.
+    ///
+    /// Set to `false` when the database schema is owned and migrated by the
+    /// embedding service; the SDK will trust the existing schema and skip all
+    /// migrations, including writes to the schema migrations tables. Defaults
+    /// to `true`.
+    pub run_migration: bool,
 }
 
 impl PostgresStorageConfig {
@@ -100,7 +103,7 @@ impl PostgresStorageConfig {
             recycle_timeout_secs: defaults.timeouts.recycle.map(|d| d.as_secs()),
             queue_mode: defaults.queue_mode.into(),
             root_ca_pem: None,
-            schema_managed_externally: false,
+            run_migration: true,
         }
     }
 }
@@ -117,7 +120,7 @@ impl PostgresStorageConfig {
 /// - `recycle_timeout_secs`: `None` (no timeout)
 /// - `queue_mode`: FIFO
 /// - `root_ca_pem`: `None` (uses Mozilla's root certificate store)
-/// - `schema_managed_externally`: `false` (SDK runs migrations)
+/// - `run_migration`: `true` (SDK runs migrations)
 #[must_use]
 pub fn default_postgres_storage_config(connection_string: String) -> PostgresStorageConfig {
     PostgresStorageConfig::with_defaults(connection_string)

--- a/crates/spark-postgres/src/config.rs
+++ b/crates/spark-postgres/src/config.rs
@@ -73,6 +73,11 @@ pub struct PostgresStorageConfig {
     /// If `None`, uses Mozilla's root certificate store (via webpki-roots).
     /// Only used with `sslmode=verify-ca` or `sslmode=verify-full`.
     pub root_ca_pem: Option<String>,
+
+    /// If true, the SDK trusts that the database schema is managed by the
+    /// embedding service and skips all migrations, including writes to the
+    /// schema migrations tables.
+    pub schema_managed_externally: bool,
 }
 
 impl PostgresStorageConfig {
@@ -95,6 +100,7 @@ impl PostgresStorageConfig {
             recycle_timeout_secs: defaults.timeouts.recycle.map(|d| d.as_secs()),
             queue_mode: defaults.queue_mode.into(),
             root_ca_pem: None,
+            schema_managed_externally: false,
         }
     }
 }
@@ -111,6 +117,7 @@ impl PostgresStorageConfig {
 /// - `recycle_timeout_secs`: `None` (no timeout)
 /// - `queue_mode`: FIFO
 /// - `root_ca_pem`: `None` (uses Mozilla's root certificate store)
+/// - `schema_managed_externally`: `false` (SDK runs migrations)
 #[must_use]
 pub fn default_postgres_storage_config(connection_string: String) -> PostgresStorageConfig {
     PostgresStorageConfig::with_defaults(connection_string)

--- a/crates/spark-postgres/src/lib.rs
+++ b/crates/spark-postgres/src/lib.rs
@@ -23,15 +23,12 @@ pub use error::PostgresError;
 pub use session_manager::{
     PostgresSessionManager, create_postgres_session_manager,
     create_postgres_session_manager_from_pool,
-    create_postgres_session_manager_from_pool_with_schema_management,
 };
 pub use token_store::{
     PostgresTokenStore, create_postgres_token_store, create_postgres_token_store_from_pool,
-    create_postgres_token_store_from_pool_with_schema_management,
 };
 pub use tree_store::{
     PostgresTreeStore, create_postgres_tree_store, create_postgres_tree_store_from_pool,
-    create_postgres_tree_store_from_pool_with_schema_management,
 };
 
 // Re-export pool infrastructure for downstream crates

--- a/crates/spark-postgres/src/lib.rs
+++ b/crates/spark-postgres/src/lib.rs
@@ -23,12 +23,15 @@ pub use error::PostgresError;
 pub use session_manager::{
     PostgresSessionManager, create_postgres_session_manager,
     create_postgres_session_manager_from_pool,
+    create_postgres_session_manager_from_pool_with_schema_management,
 };
 pub use token_store::{
     PostgresTokenStore, create_postgres_token_store, create_postgres_token_store_from_pool,
+    create_postgres_token_store_from_pool_with_schema_management,
 };
 pub use tree_store::{
     PostgresTreeStore, create_postgres_tree_store, create_postgres_tree_store_from_pool,
+    create_postgres_tree_store_from_pool_with_schema_management,
 };
 
 // Re-export pool infrastructure for downstream crates

--- a/crates/spark-postgres/src/session_manager.rs
+++ b/crates/spark-postgres/src/session_manager.rs
@@ -85,23 +85,42 @@ impl PostgresSessionManager {
         config: PostgresStorageConfig,
         identity: &[u8],
     ) -> Result<Self, PostgresError> {
+        let schema_managed_externally = config.schema_managed_externally;
         let pool = create_pool(&config)?;
-        Self::init(pool, identity).await
+        Self::init(pool, identity, schema_managed_externally).await
     }
 
     /// Creates a new `PostgresSessionManager` from an existing connection pool.
     ///
     /// Useful when sharing a pool with other components (e.g., `PostgresStorage`).
     pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
-        Self::init(pool, identity).await
+        Self::init(pool, identity, false).await
     }
 
-    async fn init(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
+    /// Creates a new `PostgresSessionManager` from an existing connection pool.
+    ///
+    /// When `schema_managed_externally` is true, initialization trusts the
+    /// existing schema and skips session manager migrations entirely.
+    pub async fn from_pool_with_schema_management(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, PostgresError> {
+        Self::init(pool, identity, schema_managed_externally).await
+    }
+
+    async fn init(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, PostgresError> {
         let store = Self {
             pool,
             identity: identity.to_vec(),
         };
-        store.migrate().await?;
+        if !schema_managed_externally {
+            store.migrate().await?;
+        }
         Ok(store)
     }
 
@@ -148,6 +167,25 @@ pub async fn create_postgres_session_manager_from_pool(
 ) -> Result<Arc<dyn SessionManager>, PostgresError> {
     Ok(Arc::new(
         PostgresSessionManager::from_pool(pool, identity).await?,
+    ))
+}
+
+/// Creates a `PostgresSessionManager` from an existing connection pool.
+///
+/// If `schema_managed_externally` is true, skips SDK-managed schema
+/// migrations and trusts that the `sessions` table already exists.
+pub async fn create_postgres_session_manager_from_pool_with_schema_management(
+    pool: Pool,
+    identity: &[u8],
+    schema_managed_externally: bool,
+) -> Result<Arc<dyn SessionManager>, PostgresError> {
+    Ok(Arc::new(
+        PostgresSessionManager::from_pool_with_schema_management(
+            pool,
+            identity,
+            schema_managed_externally,
+        )
+        .await?,
     ))
 }
 

--- a/crates/spark-postgres/src/session_manager.rs
+++ b/crates/spark-postgres/src/session_manager.rs
@@ -85,40 +85,26 @@ impl PostgresSessionManager {
         config: PostgresStorageConfig,
         identity: &[u8],
     ) -> Result<Self, PostgresError> {
-        let schema_managed_externally = config.schema_managed_externally;
+        let run_migration = config.run_migration;
         let pool = create_pool(&config)?;
-        Self::init(pool, identity, schema_managed_externally).await
+        Self::from_pool(pool, identity, run_migration).await
     }
 
     /// Creates a new `PostgresSessionManager` from an existing connection pool.
     ///
     /// Useful when sharing a pool with other components (e.g., `PostgresStorage`).
-    pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
-        Self::init(pool, identity, false).await
-    }
-
-    /// Creates a new `PostgresSessionManager` from an existing connection pool.
-    ///
-    /// When `schema_managed_externally` is true, initialization trusts the
-    /// existing schema and skips session manager migrations entirely.
-    pub async fn from_pool_with_schema_management(
+    /// When `run_migration` is `false`, initialization trusts the existing
+    /// schema and skips session manager migrations entirely.
+    pub async fn from_pool(
         pool: Pool,
         identity: &[u8],
-        schema_managed_externally: bool,
-    ) -> Result<Self, PostgresError> {
-        Self::init(pool, identity, schema_managed_externally).await
-    }
-
-    async fn init(
-        pool: Pool,
-        identity: &[u8],
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<Self, PostgresError> {
         let store = Self {
             pool,
             identity: identity.to_vec(),
         };
-        if !schema_managed_externally {
+        if run_migration {
             store.migrate().await?;
         }
         Ok(store)
@@ -161,31 +147,15 @@ pub async fn create_postgres_session_manager(
 /// Creates a `PostgresSessionManager` from an existing connection pool.
 ///
 /// `identity` is the 33-byte secp256k1 pubkey scoping all reads and writes.
+/// When `run_migration` is `false`, skips SDK-managed schema migrations and
+/// trusts that the `sessions` table already exists.
 pub async fn create_postgres_session_manager_from_pool(
     pool: Pool,
     identity: &[u8],
+    run_migration: bool,
 ) -> Result<Arc<dyn SessionManager>, PostgresError> {
     Ok(Arc::new(
-        PostgresSessionManager::from_pool(pool, identity).await?,
-    ))
-}
-
-/// Creates a `PostgresSessionManager` from an existing connection pool.
-///
-/// If `schema_managed_externally` is true, skips SDK-managed schema
-/// migrations and trusts that the `sessions` table already exists.
-pub async fn create_postgres_session_manager_from_pool_with_schema_management(
-    pool: Pool,
-    identity: &[u8],
-    schema_managed_externally: bool,
-) -> Result<Arc<dyn SessionManager>, PostgresError> {
-    Ok(Arc::new(
-        PostgresSessionManager::from_pool_with_schema_management(
-            pool,
-            identity,
-            schema_managed_externally,
-        )
-        .await?,
+        PostgresSessionManager::from_pool(pool, identity, run_migration).await?,
     ))
 }
 

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -896,43 +896,27 @@ impl PostgresTokenStore {
         config: PostgresStorageConfig,
         identity: &[u8],
     ) -> Result<Self, PostgresError> {
-        let schema_managed_externally = config.schema_managed_externally;
+        let run_migration = config.run_migration;
         let pool = create_pool(&config)?;
-        Self::init(pool, identity, schema_managed_externally).await
+        Self::from_pool(pool, identity, run_migration).await
     }
 
     /// Creates a new `PostgresTokenStore` from an existing connection pool.
     ///
-    /// This reuses the provided pool and runs token store migrations.
     /// Useful when sharing a pool with other components (e.g., `PostgresStorage`).
-    pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
-        Self::init(pool, identity, false).await
-    }
-
-    /// Creates a new `PostgresTokenStore` from an existing connection pool.
-    ///
-    /// When `schema_managed_externally` is true, initialization trusts the
-    /// existing schema and skips token store migrations entirely.
-    pub async fn from_pool_with_schema_management(
+    /// When `run_migration` is `false`, initialization trusts the existing
+    /// schema and skips token store migrations entirely.
+    pub async fn from_pool(
         pool: Pool,
         identity: &[u8],
-        schema_managed_externally: bool,
-    ) -> Result<Self, PostgresError> {
-        Self::init(pool, identity, schema_managed_externally).await
-    }
-
-    /// Shared initialization logic for both constructors.
-    async fn init(
-        pool: Pool,
-        identity: &[u8],
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<Self, PostgresError> {
         let store = Self {
             pool,
             identity: identity.to_vec(),
             lock_key: identity_lock_key(TOKEN_STORE_LOCK_PREFIX, identity),
         };
-        if !schema_managed_externally {
+        if run_migration {
             store.migrate().await?;
         }
         Ok(store)
@@ -1259,31 +1243,15 @@ pub async fn create_postgres_token_store(
 ///
 /// * `pool` - An existing deadpool-postgres connection pool
 /// * `identity` - 33-byte secp256k1 pubkey scoping all reads and writes
+/// * `run_migration` - Whether to run token store migrations. Set to `false`
+///   when the embedding service owns the schema.
 pub async fn create_postgres_token_store_from_pool(
     pool: Pool,
     identity: &[u8],
+    run_migration: bool,
 ) -> Result<Arc<dyn TokenOutputStore>, PostgresError> {
     Ok(Arc::new(
-        PostgresTokenStore::from_pool(pool, identity).await?,
-    ))
-}
-
-/// Creates a `PostgresTokenStore` instance from an existing connection pool.
-///
-/// If `schema_managed_externally` is true, skips SDK-managed schema
-/// migrations and trusts that all required tables, columns, and indexes exist.
-pub async fn create_postgres_token_store_from_pool_with_schema_management(
-    pool: Pool,
-    identity: &[u8],
-    schema_managed_externally: bool,
-) -> Result<Arc<dyn TokenOutputStore>, PostgresError> {
-    Ok(Arc::new(
-        PostgresTokenStore::from_pool_with_schema_management(
-            pool,
-            identity,
-            schema_managed_externally,
-        )
-        .await?,
+        PostgresTokenStore::from_pool(pool, identity, run_migration).await?,
     ))
 }
 
@@ -1763,10 +1731,10 @@ mod tests {
             let config = PostgresStorageConfig::with_defaults(connection_string);
             let pool = create_pool(&config).expect("Failed to create pool");
 
-            let a = PostgresTokenStore::from_pool(pool.clone(), &TEST_IDENTITY)
+            let a = PostgresTokenStore::from_pool(pool.clone(), &TEST_IDENTITY, true)
                 .await
                 .expect("Failed to create tenant A");
-            let b = PostgresTokenStore::from_pool(pool, &TEST_IDENTITY_B)
+            let b = PostgresTokenStore::from_pool(pool, &TEST_IDENTITY_B, true)
                 .await
                 .expect("Failed to create tenant B");
 

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -896,8 +896,9 @@ impl PostgresTokenStore {
         config: PostgresStorageConfig,
         identity: &[u8],
     ) -> Result<Self, PostgresError> {
+        let schema_managed_externally = config.schema_managed_externally;
         let pool = create_pool(&config)?;
-        Self::init(pool, identity).await
+        Self::init(pool, identity, schema_managed_externally).await
     }
 
     /// Creates a new `PostgresTokenStore` from an existing connection pool.
@@ -905,17 +906,35 @@ impl PostgresTokenStore {
     /// This reuses the provided pool and runs token store migrations.
     /// Useful when sharing a pool with other components (e.g., `PostgresStorage`).
     pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
-        Self::init(pool, identity).await
+        Self::init(pool, identity, false).await
+    }
+
+    /// Creates a new `PostgresTokenStore` from an existing connection pool.
+    ///
+    /// When `schema_managed_externally` is true, initialization trusts the
+    /// existing schema and skips token store migrations entirely.
+    pub async fn from_pool_with_schema_management(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, PostgresError> {
+        Self::init(pool, identity, schema_managed_externally).await
     }
 
     /// Shared initialization logic for both constructors.
-    async fn init(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
+    async fn init(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, PostgresError> {
         let store = Self {
             pool,
             identity: identity.to_vec(),
             lock_key: identity_lock_key(TOKEN_STORE_LOCK_PREFIX, identity),
         };
-        store.migrate().await?;
+        if !schema_managed_externally {
+            store.migrate().await?;
+        }
         Ok(store)
     }
 
@@ -1246,6 +1265,25 @@ pub async fn create_postgres_token_store_from_pool(
 ) -> Result<Arc<dyn TokenOutputStore>, PostgresError> {
     Ok(Arc::new(
         PostgresTokenStore::from_pool(pool, identity).await?,
+    ))
+}
+
+/// Creates a `PostgresTokenStore` instance from an existing connection pool.
+///
+/// If `schema_managed_externally` is true, skips SDK-managed schema
+/// migrations and trusts that all required tables, columns, and indexes exist.
+pub async fn create_postgres_token_store_from_pool_with_schema_management(
+    pool: Pool,
+    identity: &[u8],
+    schema_managed_externally: bool,
+) -> Result<Arc<dyn TokenOutputStore>, PostgresError> {
+    Ok(Arc::new(
+        PostgresTokenStore::from_pool_with_schema_management(
+            pool,
+            identity,
+            schema_managed_externally,
+        )
+        .await?,
     ))
 }
 

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -805,36 +805,20 @@ impl PostgresTreeStore {
         config: PostgresStorageConfig,
         identity: &[u8],
     ) -> Result<Self, PostgresError> {
-        let schema_managed_externally = config.schema_managed_externally;
+        let run_migration = config.run_migration;
         let pool = create_pool(&config)?;
-        Self::init(pool, identity, schema_managed_externally).await
+        Self::from_pool(pool, identity, run_migration).await
     }
 
     /// Creates a new `PostgresTreeStore` from an existing connection pool.
     ///
-    /// This reuses the provided pool and runs tree store migrations.
     /// Useful when sharing a pool with other components (e.g., `PostgresStorage`).
-    pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
-        Self::init(pool, identity, false).await
-    }
-
-    /// Creates a new `PostgresTreeStore` from an existing connection pool.
-    ///
-    /// When `schema_managed_externally` is true, initialization trusts the
-    /// existing schema and skips tree store migrations entirely.
-    pub async fn from_pool_with_schema_management(
+    /// When `run_migration` is `false`, initialization trusts the existing
+    /// schema and skips tree store migrations entirely.
+    pub async fn from_pool(
         pool: Pool,
         identity: &[u8],
-        schema_managed_externally: bool,
-    ) -> Result<Self, PostgresError> {
-        Self::init(pool, identity, schema_managed_externally).await
-    }
-
-    /// Shared initialization logic for both constructors.
-    async fn init(
-        pool: Pool,
-        identity: &[u8],
-        schema_managed_externally: bool,
+        run_migration: bool,
     ) -> Result<Self, PostgresError> {
         let (balance_changed_tx, balance_changed_rx) = watch::channel(());
 
@@ -846,7 +830,7 @@ impl PostgresTreeStore {
             balance_changed_rx,
         };
 
-        if !schema_managed_externally {
+        if run_migration {
             store.migrate().await?;
         }
         store.notify_balance_change();
@@ -1310,31 +1294,15 @@ pub async fn create_postgres_tree_store(
 ///
 /// * `pool` - An existing deadpool-postgres connection pool
 /// * `identity` - 33-byte secp256k1 pubkey scoping all reads and writes
+/// * `run_migration` - Whether to run tree store migrations. Set to `false`
+///   when the embedding service owns the schema.
 pub async fn create_postgres_tree_store_from_pool(
     pool: Pool,
     identity: &[u8],
+    run_migration: bool,
 ) -> Result<Arc<dyn TreeStore>, PostgresError> {
     Ok(Arc::new(
-        PostgresTreeStore::from_pool(pool, identity).await?,
-    ))
-}
-
-/// Creates a `PostgresTreeStore` instance from an existing connection pool.
-///
-/// If `schema_managed_externally` is true, skips SDK-managed schema
-/// migrations and trusts that all required tables, columns, and indexes exist.
-pub async fn create_postgres_tree_store_from_pool_with_schema_management(
-    pool: Pool,
-    identity: &[u8],
-    schema_managed_externally: bool,
-) -> Result<Arc<dyn TreeStore>, PostgresError> {
-    Ok(Arc::new(
-        PostgresTreeStore::from_pool_with_schema_management(
-            pool,
-            identity,
-            schema_managed_externally,
-        )
-        .await?,
+        PostgresTreeStore::from_pool(pool, identity, run_migration).await?,
     ))
 }
 
@@ -2320,10 +2288,10 @@ mod tests {
             let config = PostgresStorageConfig::with_defaults(connection_string);
             let pool = create_pool(&config).expect("Failed to create pool");
 
-            let a = PostgresTreeStore::from_pool(pool.clone(), &TEST_IDENTITY)
+            let a = PostgresTreeStore::from_pool(pool.clone(), &TEST_IDENTITY, true)
                 .await
                 .expect("Failed to create tenant A");
-            let b = PostgresTreeStore::from_pool(pool, &TEST_IDENTITY_B)
+            let b = PostgresTreeStore::from_pool(pool, &TEST_IDENTITY_B, true)
                 .await
                 .expect("Failed to create tenant B");
 

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -805,8 +805,9 @@ impl PostgresTreeStore {
         config: PostgresStorageConfig,
         identity: &[u8],
     ) -> Result<Self, PostgresError> {
+        let schema_managed_externally = config.schema_managed_externally;
         let pool = create_pool(&config)?;
-        Self::init(pool, identity).await
+        Self::init(pool, identity, schema_managed_externally).await
     }
 
     /// Creates a new `PostgresTreeStore` from an existing connection pool.
@@ -814,11 +815,27 @@ impl PostgresTreeStore {
     /// This reuses the provided pool and runs tree store migrations.
     /// Useful when sharing a pool with other components (e.g., `PostgresStorage`).
     pub async fn from_pool(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
-        Self::init(pool, identity).await
+        Self::init(pool, identity, false).await
+    }
+
+    /// Creates a new `PostgresTreeStore` from an existing connection pool.
+    ///
+    /// When `schema_managed_externally` is true, initialization trusts the
+    /// existing schema and skips tree store migrations entirely.
+    pub async fn from_pool_with_schema_management(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, PostgresError> {
+        Self::init(pool, identity, schema_managed_externally).await
     }
 
     /// Shared initialization logic for both constructors.
-    async fn init(pool: Pool, identity: &[u8]) -> Result<Self, PostgresError> {
+    async fn init(
+        pool: Pool,
+        identity: &[u8],
+        schema_managed_externally: bool,
+    ) -> Result<Self, PostgresError> {
         let (balance_changed_tx, balance_changed_rx) = watch::channel(());
 
         let store = Self {
@@ -829,7 +846,9 @@ impl PostgresTreeStore {
             balance_changed_rx,
         };
 
-        store.migrate().await?;
+        if !schema_managed_externally {
+            store.migrate().await?;
+        }
         store.notify_balance_change();
 
         Ok(store)
@@ -1297,6 +1316,25 @@ pub async fn create_postgres_tree_store_from_pool(
 ) -> Result<Arc<dyn TreeStore>, PostgresError> {
     Ok(Arc::new(
         PostgresTreeStore::from_pool(pool, identity).await?,
+    ))
+}
+
+/// Creates a `PostgresTreeStore` instance from an existing connection pool.
+///
+/// If `schema_managed_externally` is true, skips SDK-managed schema
+/// migrations and trusts that all required tables, columns, and indexes exist.
+pub async fn create_postgres_tree_store_from_pool_with_schema_management(
+    pool: Pool,
+    identity: &[u8],
+    schema_managed_externally: bool,
+) -> Result<Arc<dyn TreeStore>, PostgresError> {
+    Ok(Arc::new(
+        PostgresTreeStore::from_pool_with_schema_management(
+            pool,
+            identity,
+            schema_managed_externally,
+        )
+        .await?,
     ))
 }
 

--- a/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
+++ b/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
@@ -106,7 +106,7 @@ namespace BreezSdkSnippets
                 maxPoolSize = 8u,        // Max connections in pool
                 waitTimeoutSecs = 30ul,  // Timeout waiting for connection
                 // If your service owns SDK-compatible schema migrations:
-                schemaManagedExternally = true
+                runMigration = false
             };
 
             // Construct the connection pool. The same pool can be passed to

--- a/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
+++ b/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
@@ -104,7 +104,9 @@ namespace BreezSdkSnippets
             postgresConfig = postgresConfig with
             {
                 maxPoolSize = 8u,        // Max connections in pool
-                waitTimeoutSecs = 30ul   // Timeout waiting for connection
+                waitTimeoutSecs = 30ul,  // Timeout waiting for connection
+                // If your service owns SDK-compatible schema migrations:
+                schemaManagedExternally = true
             };
 
             // Construct the connection pool. The same pool can be passed to

--- a/docs/breez-sdk/snippets/go/sdk_building.go
+++ b/docs/breez-sdk/snippets/go/sdk_building.go
@@ -103,7 +103,7 @@ func InitSdkPostgres() (*breez_sdk_spark.BreezSdk, error) {
 	waitTimeoutSecs := uint64(30)
 	postgresConfig.WaitTimeoutSecs = &waitTimeoutSecs // Timeout waiting for connection
 	// If your service owns SDK-compatible schema migrations:
-	postgresConfig.SchemaManagedExternally = true
+	postgresConfig.RunMigration = false
 
 	// Construct the connection pool. The same pool can be passed to multiple
 	// SdkBuilders to share connections across SDKs; per-tenant scoping (rows

--- a/docs/breez-sdk/snippets/go/sdk_building.go
+++ b/docs/breez-sdk/snippets/go/sdk_building.go
@@ -102,6 +102,8 @@ func InitSdkPostgres() (*breez_sdk_spark.BreezSdk, error) {
 	postgresConfig.MaxPoolSize = 8 // Max connections in pool
 	waitTimeoutSecs := uint64(30)
 	postgresConfig.WaitTimeoutSecs = &waitTimeoutSecs // Timeout waiting for connection
+	// If your service owns SDK-compatible schema migrations:
+	postgresConfig.SchemaManagedExternally = true
 
 	// Construct the connection pool. The same pool can be passed to multiple
 	// SdkBuilders to share connections across SDKs; per-tenant scoping (rows

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
@@ -94,7 +94,7 @@ class SdkBuilding {
         postgresConfig.maxPoolSize = 8u // Max connections in pool
         postgresConfig.waitTimeoutSecs = 30u // Timeout waiting for connection
         // If your service owns SDK-compatible schema migrations:
-        postgresConfig.schemaManagedExternally = true
+        postgresConfig.runMigration = false
 
         // Construct the connection pool. The same pool can be passed to
         // multiple SdkBuilders to share connections across SDKs; per-tenant

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
@@ -93,6 +93,8 @@ class SdkBuilding {
         // Optionally pool settings can be adjusted. Some examples:
         postgresConfig.maxPoolSize = 8u // Max connections in pool
         postgresConfig.waitTimeoutSecs = 30u // Timeout waiting for connection
+        // If your service owns SDK-compatible schema migrations:
+        postgresConfig.schemaManagedExternally = true
 
         // Construct the connection pool. The same pool can be passed to
         // multiple SdkBuilders to share connections across SDKs; per-tenant

--- a/docs/breez-sdk/snippets/python/src/sdk_building.py
+++ b/docs/breez-sdk/snippets/python/src/sdk_building.py
@@ -108,6 +108,8 @@ async def init_sdk_postgres():
     # Optionally pool settings can be adjusted. Some examples:
     postgres_config.max_pool_size = 8  # Max connections in pool
     postgres_config.wait_timeout_secs = 30  # Timeout waiting for connection
+    # If your service owns SDK-compatible schema migrations:
+    postgres_config.schema_managed_externally = True
 
     # Construct the connection pool. The same pool can be passed to multiple
     # SdkBuilders to share connections across SDKs; per-tenant scoping (rows

--- a/docs/breez-sdk/snippets/python/src/sdk_building.py
+++ b/docs/breez-sdk/snippets/python/src/sdk_building.py
@@ -109,7 +109,7 @@ async def init_sdk_postgres():
     postgres_config.max_pool_size = 8  # Max connections in pool
     postgres_config.wait_timeout_secs = 30  # Timeout waiting for connection
     # If your service owns SDK-compatible schema migrations:
-    postgres_config.schema_managed_externally = True
+    postgres_config.run_migration = False
 
     # Construct the connection pool. The same pool can be passed to multiple
     # SdkBuilders to share connections across SDKs; per-tenant scoping (rows

--- a/docs/breez-sdk/snippets/rust/src/sdk_building.rs
+++ b/docs/breez-sdk/snippets/rust/src/sdk_building.rs
@@ -104,7 +104,7 @@ pub(crate) async fn init_sdk_postgres() -> Result<BreezSdk> {
     postgres_config.max_pool_size = 8; // Max connections in pool
     postgres_config.wait_timeout_secs = Some(30); // Timeout waiting for connection
     // If your service owns SDK-compatible schema migrations:
-    postgres_config.schema_managed_externally = true;
+    postgres_config.run_migration = false;
 
     // Construct the connection pool. The same `Arc<PostgresConnectionPool>`
     // can be passed to multiple SdkBuilders to share connections across SDKs;

--- a/docs/breez-sdk/snippets/rust/src/sdk_building.rs
+++ b/docs/breez-sdk/snippets/rust/src/sdk_building.rs
@@ -103,6 +103,8 @@ pub(crate) async fn init_sdk_postgres() -> Result<BreezSdk> {
     // Optionally pool settings can be adjusted. Some examples:
     postgres_config.max_pool_size = 8; // Max connections in pool
     postgres_config.wait_timeout_secs = Some(30); // Timeout waiting for connection
+    // If your service owns SDK-compatible schema migrations:
+    postgres_config.schema_managed_externally = true;
 
     // Construct the connection pool. The same `Arc<PostgresConnectionPool>`
     // can be passed to multiple SdkBuilders to share connections across SDKs;

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
@@ -92,7 +92,7 @@ func initSdkPostgres() async throws -> BreezSdk {
     postgresConfig.maxPoolSize = UInt32(8) // Max connections in pool
     postgresConfig.waitTimeoutSecs = UInt64(30) // Timeout waiting for connection
     // If your service owns SDK-compatible schema migrations:
-    postgresConfig.schemaManagedExternally = true
+    postgresConfig.runMigration = false
 
     // Construct the connection pool. The same pool can be passed to
     // multiple SdkBuilders to share connections across SDKs; per-tenant

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
@@ -91,6 +91,8 @@ func initSdkPostgres() async throws -> BreezSdk {
     // Optionally pool settings can be adjusted. Some examples:
     postgresConfig.maxPoolSize = UInt32(8) // Max connections in pool
     postgresConfig.waitTimeoutSecs = UInt64(30) // Timeout waiting for connection
+    // If your service owns SDK-compatible schema migrations:
+    postgresConfig.schemaManagedExternally = true
 
     // Construct the connection pool. The same pool can be passed to
     // multiple SdkBuilders to share connections across SDKs; per-tenant

--- a/docs/breez-sdk/snippets/wasm/sdk_building.ts
+++ b/docs/breez-sdk/snippets/wasm/sdk_building.ts
@@ -75,7 +75,7 @@ const exampleWithPostgresStorage = async () => {
   pgConfig.createTimeoutSecs = 30 // Timeout for establishing a new connection
   pgConfig.recycleTimeoutSecs = 30 // Timeout for recycling an idle connection
   // If your service owns SDK-compatible schema migrations:
-  pgConfig.schemaManagedExternally = true
+  pgConfig.runMigration = false
 
   // Construct the connection pool. The same pool handle can be passed to
   // multiple SdkBuilders to share connections across SDKs; per-tenant

--- a/docs/breez-sdk/snippets/wasm/sdk_building.ts
+++ b/docs/breez-sdk/snippets/wasm/sdk_building.ts
@@ -74,6 +74,8 @@ const exampleWithPostgresStorage = async () => {
   pgConfig.maxPoolSize = 8 // Max connections in pool
   pgConfig.createTimeoutSecs = 30 // Timeout for establishing a new connection
   pgConfig.recycleTimeoutSecs = 30 // Timeout for recycling an idle connection
+  // If your service owns SDK-compatible schema migrations:
+  pgConfig.schemaManagedExternally = true
 
   // Construct the connection pool. The same pool handle can be passed to
   // multiple SdkBuilders to share connections across SDKs; per-tenant

--- a/docs/breez-sdk/src/guide/customizing.md
+++ b/docs/breez-sdk/src/guide/customizing.md
@@ -32,6 +32,8 @@ When using the SDK Builder, you either have to provide a Storage implementation 
 
 The SDK includes a PostgreSQL backend as an alternative to file-based storage. Construct a connection pool once with {{#name create_postgres_connection_pool}} and pass it to the builder via {{#name with_postgres_connection_pool}} — this configures PostgreSQL for all stores (storage, tree store, and token store), which is suitable for server-side deployments with horizontal scaling. The same pool can be shared across multiple `SdkBuilder` instances; per-tenant scoping (rows isolated by seed identity) is preserved.
 
+If your service owns the database schema and applies SDK-compatible migrations externally, set `schema_managed_externally`/`schemaManagedExternally` on the storage config before creating the pool. The SDK will trust the existing schema and skip all migration runs, including writes to schema migration tables.
+
 **Note:** Not available for React Native or Flutter. For JavaScript/TypeScript, only supported in Node.js (not in the browser).
 
 {{#tabs sdk_building:init-sdk-postgres}}

--- a/docs/breez-sdk/src/guide/customizing.md
+++ b/docs/breez-sdk/src/guide/customizing.md
@@ -32,7 +32,7 @@ When using the SDK Builder, you either have to provide a Storage implementation 
 
 The SDK includes a PostgreSQL backend as an alternative to file-based storage. Construct a connection pool once with {{#name create_postgres_connection_pool}} and pass it to the builder via {{#name with_postgres_connection_pool}} — this configures PostgreSQL for all stores (storage, tree store, and token store), which is suitable for server-side deployments with horizontal scaling. The same pool can be shared across multiple `SdkBuilder` instances; per-tenant scoping (rows isolated by seed identity) is preserved.
 
-If your service owns the database schema and applies SDK-compatible migrations externally, set `schema_managed_externally`/`schemaManagedExternally` on the storage config before creating the pool. The SDK will trust the existing schema and skip all migration runs, including writes to schema migration tables.
+If your service owns the database schema and applies SDK-compatible migrations externally, set `run_migration`/`runMigration` to `false` on the storage config before creating the pool. The SDK will trust the existing schema and skip all migration runs, including writes to schema migration tables.
 
 **Note:** Not available for React Native or Flutter. For JavaScript/TypeScript, only supported in Node.js (not in the browser).
 

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -2524,7 +2524,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2561,9 +2561,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a `schema_managed_externally` / `schemaManagedExternally` option for Postgres and MySQL SDK storage configs.

When enabled, Breez trusts that the embedding service owns and applies the database schema, so initialization skips SDK-managed migrations entirely, including writes to schema migration tables. The flag is captured on shared connection pools and threaded through storage, tree store, token store, session manager, and WASM Node backends so service-managed schemas work without fake migration-version rows.