### PR TITLE
Enable MySQL TLS support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1665,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,6 +1967,12 @@ checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -3169,14 +3203,19 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rand 0.8.6",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "socket2 0.5.10",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "twox-hash",
  "url",
+ "webpki",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4388,6 +4427,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4434,6 +4474,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5044,6 +5085,7 @@ dependencies = [
  "macros",
  "mysql_async",
  "platform-utils",
+ "rustls",
  "serde",
  "serde_json",
  "spark-mysql",
@@ -6540,6 +6582,16 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.45.1", default-features = false }
 tokio-postgres = { version = "0.7.10", features = ["with-serde_json-1", "with-chrono-0_4"] }
 tokio-postgres-rustls = "0.13"
-mysql_async = { version = "0.34", default-features = false, features = ["minimal-rust"] }
+mysql_async = { version = "0.34", default-features = false, features = ["minimal-rust", "rustls-tls"] }
 deadpool-postgres = "0.14"
 deadpool = "0.12"
 tokio-test = "0.4.4"

--- a/crates/spark-mysql/Cargo.toml
+++ b/crates/spark-mysql/Cargo.toml
@@ -17,6 +17,7 @@ hex.workspace = true
 macros.workspace = true
 mysql_async = { workspace = true, features = ["chrono"] }
 platform-utils.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 spark-wallet.workspace = true

--- a/crates/spark-mysql/src/migrations.rs
+++ b/crates/spark-mysql/src/migrations.rs
@@ -422,6 +422,7 @@ mod tests {
     /// detect the existing state and no-op rather than abort.
     #[tokio::test]
     async fn test_partial_migration_replay_is_idempotent() {
+        crate::pool::install_rustls_crypto_provider();
         // Container must outlive the test — drop binds the lifetime to the
         // function scope while clippy is happy with a non-underscore name.
         let container: ContainerAsync<Mysql> = Mysql::default()

--- a/crates/spark-mysql/src/pool.rs
+++ b/crates/spark-mysql/src/pool.rs
@@ -35,14 +35,15 @@ pub fn tx_opts() -> TxOpts {
 /// - `verify_ca` / `verify_identity` — TLS with the CA from `root_ca_pem`
 ///   (or system roots if not provided)
 pub fn create_pool(config: &MysqlStorageConfig) -> Result<Pool, MysqlError> {
-    let opts: Opts = Opts::from_url(&config.connection_string)
+    install_rustls_crypto_provider();
+
+    let (connection_string, ssl_mode) = connection_string_and_ssl_mode(&config.connection_string);
+    let opts: Opts = Opts::from_url(&connection_string)
         .map_err(|e| MysqlError::Initialization(format!("Invalid connection string: {e}")))?;
 
     let mut builder = OptsBuilder::from_opts(opts);
 
-    if let Some(ssl_opts) =
-        build_ssl_opts(&config.connection_string, config.root_ca_pem.as_deref())?
-    {
+    if let Some(ssl_opts) = build_ssl_opts(ssl_mode, config.root_ca_pem.as_deref()) {
         builder = builder.ssl_opts(ssl_opts);
     }
 
@@ -60,35 +61,37 @@ pub fn create_pool(config: &MysqlStorageConfig) -> Result<Pool, MysqlError> {
     Ok(Pool::new(builder))
 }
 
+fn install_rustls_crypto_provider() {
+    if rustls::crypto::ring::default_provider()
+        .install_default()
+        .is_err()
+    {
+        tracing::debug!("Failed to install rustls crypto provider, ignoring error");
+    }
+}
+
 /// Parses an `ssl-mode` value from a `MySQL` URL connection string and constructs
 /// matching `SslOpts`.
-#[allow(clippy::unnecessary_wraps)] // future-proofs for cert parsing errors
-fn build_ssl_opts(
-    conn_str: &str,
-    root_ca_pem: Option<&str>,
-) -> Result<Option<SslOpts>, MysqlError> {
-    let ssl_mode = parse_ssl_mode_from_url(conn_str);
+fn build_ssl_opts(ssl_mode: SslModeExt, root_ca_pem: Option<&str>) -> Option<SslOpts> {
     match ssl_mode {
-        SslModeExt::Disabled => Ok(None),
+        SslModeExt::Disabled => None,
         SslModeExt::Preferred | SslModeExt::Required => {
             // Encryption without identity verification.
-            Ok(Some(
-                SslOpts::default().with_danger_accept_invalid_certs(true),
-            ))
+            Some(SslOpts::default().with_danger_accept_invalid_certs(true))
         }
         SslModeExt::VerifyCa => {
             let mut opts = SslOpts::default().with_danger_skip_domain_validation(true);
             if let Some(pem) = root_ca_pem {
                 opts = opts.with_root_certs(vec![pem.as_bytes().to_vec().into()]);
             }
-            Ok(Some(opts))
+            Some(opts)
         }
         SslModeExt::VerifyIdentity => {
             let mut opts = SslOpts::default();
             if let Some(pem) = root_ca_pem {
                 opts = opts.with_root_certs(vec![pem.as_bytes().to_vec().into()]);
             }
-            Ok(Some(opts))
+            Some(opts)
         }
     }
 }
@@ -102,23 +105,35 @@ enum SslModeExt {
     VerifyIdentity,
 }
 
-fn parse_ssl_mode_from_url(conn_str: &str) -> SslModeExt {
-    let Some(query) = conn_str.split_once('?').map(|(_, q)| q) else {
+fn connection_string_and_ssl_mode(conn_str: &str) -> (String, SslModeExt) {
+    let Some((base, query)) = conn_str.split_once('?') else {
         // Default for MySQL clients is preferred when supported, but the safe
         // default for an unspecified backend is no TLS to avoid surprising
         // failures on local docker setups.
-        return SslModeExt::Disabled;
+        return (conn_str.to_string(), SslModeExt::Disabled);
     };
+
+    let mut ssl_mode = SslModeExt::Disabled;
+    let mut retained_params = Vec::new();
 
     for param in query.split('&') {
         if let Some((key, value)) = param.split_once('=') {
             let key_lc = key.to_ascii_lowercase();
             if key_lc == "ssl-mode" || key_lc == "ssl_mode" || key_lc == "sslmode" {
-                return parse_ssl_mode_value(value);
+                ssl_mode = parse_ssl_mode_value(value);
+                continue;
             }
         }
+        retained_params.push(param);
     }
-    SslModeExt::Disabled
+
+    let connection_string = if retained_params.is_empty() {
+        base.to_string()
+    } else {
+        format!("{}?{}", base, retained_params.join("&"))
+    };
+
+    (connection_string, ssl_mode)
 }
 
 #[allow(clippy::match_same_arms)] // explicit "disabled" arm + unknown-fallback arm both default to Disabled
@@ -168,5 +183,34 @@ pub fn map_db_error(e: mysql_async::Error) -> MysqlError {
 impl From<mysql_async::Error> for MysqlError {
     fn from(value: mysql_async::Error) -> Self {
         map_db_error(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_ssl_mode_before_mysql_async_url_parsing() {
+        assert_eq!(
+            connection_string_and_ssl_mode("mysql://u:p@host:3306/db?ssl-mode=required"),
+            ("mysql://u:p@host:3306/db".to_string(), SslModeExt::Required)
+        );
+        assert_eq!(
+            connection_string_and_ssl_mode(
+                "mysql://u:p@host:3306/db?stmt_cache_size=100&ssl_mode=verify_ca&pool_max=4"
+            ),
+            (
+                "mysql://u:p@host:3306/db?stmt_cache_size=100&pool_max=4".to_string(),
+                SslModeExt::VerifyCa,
+            )
+        );
+        assert_eq!(
+            connection_string_and_ssl_mode("mysql://u:p@host:3306/db?sslmode=disabled&pool_min=1"),
+            (
+                "mysql://u:p@host:3306/db?pool_min=1".to_string(),
+                SslModeExt::Disabled,
+            )
+        );
     }
 }

--- a/crates/spark-mysql/src/pool.rs
+++ b/crates/spark-mysql/src/pool.rs
@@ -4,6 +4,7 @@
 //! min/max constraints and idle TTL. We translate `MysqlStorageConfig` knobs
 //! onto the closest `mysql_async` equivalents.
 
+use std::sync::Once;
 use std::time::Duration;
 
 use mysql_async::{
@@ -61,13 +62,26 @@ pub fn create_pool(config: &MysqlStorageConfig) -> Result<Pool, MysqlError> {
     Ok(Pool::new(builder))
 }
 
-fn install_rustls_crypto_provider() {
-    if rustls::crypto::ring::default_provider()
-        .install_default()
-        .is_err()
-    {
-        tracing::debug!("Failed to install rustls crypto provider, ignoring error");
-    }
+/// Installs the rustls Ring crypto provider as the process-level default.
+///
+/// `mysql_async` constructs its own `rustls::ClientConfig` internally and relies on
+/// `CryptoProvider::get_default()`. With both `ring` and `aws_lc_rs` enabled in the
+/// unified workspace build, that auto-detect panics unless a default has already been
+/// installed. We install Ring once per process, here and from each test fixture that
+/// spins up `testcontainers` (whose `bollard` Docker client builds its own
+/// `ClientConfig` before `create_pool` runs).
+pub(crate) fn install_rustls_crypto_provider() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        if rustls::crypto::ring::default_provider()
+            .install_default()
+            .is_err()
+        {
+            tracing::debug!(
+                "rustls crypto provider was already installed by another caller; leaving it in place"
+            );
+        }
+    });
 }
 
 /// Parses an `ssl-mode` value from a `MySQL` URL connection string and constructs

--- a/crates/spark-mysql/src/session_manager.rs
+++ b/crates/spark-mysql/src/session_manager.rs
@@ -177,6 +177,7 @@ mod tests {
 
     impl MysqlSessionManagerTestFixture {
         async fn new() -> Self {
+            crate::pool::install_rustls_crypto_provider();
             let container = Mysql::default()
                 .start()
                 .await

--- a/crates/spark-mysql/src/token_store.rs
+++ b/crates/spark-mysql/src/token_store.rs
@@ -1442,6 +1442,7 @@ mod tests {
 
     impl MysqlTokenStoreTestFixture {
         async fn new() -> Self {
+            crate::pool::install_rustls_crypto_provider();
             let container = Mysql::default()
                 .start()
                 .await
@@ -1881,6 +1882,7 @@ mod tests {
 
     impl TwoTenantTokenFixture {
         async fn new() -> Self {
+            crate::pool::install_rustls_crypto_provider();
             let container = Mysql::default()
                 .start()
                 .await

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -1521,6 +1521,10 @@ mod tests {
 
     impl MysqlTreeStoreTestFixture {
         async fn new() -> Self {
+            // testcontainers' bollard Docker client builds its own rustls
+            // ClientConfig before any pool is created, so install the provider
+            // here too (the call is idempotent via Once).
+            crate::pool::install_rustls_crypto_provider();
             let container = Mysql::default()
                 .start()
                 .await
@@ -2433,6 +2437,7 @@ mod tests {
 
     impl TwoTenantTreeFixture {
         async fn new() -> Self {
+            crate::pool::install_rustls_crypto_provider();
             let container = Mysql::default()
                 .start()
                 .await

--- a/crates/spark-postgres/src/pool.rs
+++ b/crates/spark-postgres/src/pool.rs
@@ -189,14 +189,20 @@ pub fn make_tls_config_verifying(
         root_store
     };
 
+    let provider = Arc::new(default_provider());
+    let builder = ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| {
+            PostgresError::Initialization(format!("Failed to configure rustls protocols: {e}"))
+        })?;
     let config = if verify_hostname {
         // verify-full: use the standard WebPKI verifier which checks hostname
-        ClientConfig::builder()
+        builder
             .with_root_certificates(root_store)
             .with_no_client_auth()
     } else {
         // verify-ca: use our custom verifier that only checks the certificate chain
-        ClientConfig::builder()
+        builder
             .dangerous()
             .with_custom_certificate_verifier(Arc::new(CaOnlyVerifier::new(root_store)))
             .with_no_client_auth()
@@ -208,11 +214,15 @@ pub fn make_tls_config_verifying(
 /// Creates a rustls `ClientConfig` that accepts any server certificate.
 /// This is appropriate for `sslmode=require` which ensures encrypted connections
 /// but does not verify the server's identity.
-fn make_tls_config() -> ClientConfig {
-    ClientConfig::builder()
+fn make_tls_config() -> Result<ClientConfig, PostgresError> {
+    Ok(ClientConfig::builder_with_provider(Arc::new(default_provider()))
+        .with_safe_default_protocol_versions()
+        .map_err(|e| {
+            PostgresError::Initialization(format!("Failed to configure rustls protocols: {e}"))
+        })?
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(NoVerifier))
-        .with_no_client_auth()
+        .with_no_client_auth())
 }
 
 /// Internal representation of SSL modes, including verify-ca and verify-full
@@ -295,7 +305,7 @@ pub fn create_pool(config: &PostgresStorageConfig) -> Result<Pool, PostgresError
                 .map_err(|e| PostgresError::Initialization(e.to_string()))
         }
         SslModeExt::Prefer | SslModeExt::Require => {
-            let tls_config = make_tls_config();
+            let tls_config = make_tls_config()?;
             let tls = MakeRustlsConnect::new(tls_config);
             let manager = deadpool_postgres::Manager::new(pg_config, tls);
             Pool::builder(manager)


### PR DESCRIPTION
Adds Rustls-backed TLS support for the MySQL storage backend.

This enables the mysql_async Rustls feature, installs the Rustls Ring crypto provider before creating MySQL pools, and handles the SDK’s ssl-mode URL parameter before passing connection strings to mysql_async.