### PR TITLE
Use only ring as crypto provider for rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,28 +347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,24 +464,6 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.11.1",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote 1.0.45",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
 
 [[package]]
 name = "bip39"
@@ -790,7 +750,6 @@ dependencies = [
  "rcgen",
  "rusqlite",
  "rusqlite_migration",
- "rustls",
  "serde",
  "serde_json",
  "spark-mysql",
@@ -954,15 +913,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,17 +1037,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,15 +1107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1292,47 +1222,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-queue"
@@ -1666,12 +1555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +1779,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,7 +1813,7 @@ dependencies = [
  "derive-getters",
  "document-features",
  "hex",
- "itertools 0.14.0",
+ "itertools",
  "postcard",
  "rand_core 0.6.4",
  "serde",
@@ -1968,12 +1857,6 @@ checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -2313,9 +2196,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2806,15 +2698,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2901,16 +2784,6 @@ dependencies = [
  "libc",
  "libz-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
 ]
 
 [[package]]
@@ -3043,18 +2916,12 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -3187,70 +3054,61 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mysql_async"
-version = "0.34.2"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b66e411c31265e879d9814d03721f2daa7ad07337b6308cb4bb0cde7e6fd47"
+checksum = "d1d9585dc9058886ff3a1f48a23024dd1d054264dee7c5ae0e4bd640c953bee5"
 dependencies = [
  "bytes",
- "crossbeam",
+ "crossbeam-queue",
  "flate2",
  "futures-core",
  "futures-sink",
  "futures-util",
  "keyed_priority_queue",
- "lru 0.12.5",
+ "lru",
  "mysql_common",
  "pem",
  "percent-encoding",
- "pin-project",
- "rand 0.8.6",
+ "rand 0.9.4",
  "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "socket2 0.5.10",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "twox-hash",
  "url",
- "webpki",
  "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "mysql_common"
-version = "0.32.4"
+version = "0.35.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
+checksum = "fbb9f371618ce723f095c61fbcdc36e8936956d2b62832f9c7648689b338e052"
 dependencies = [
- "base64 0.21.7",
- "bindgen",
+ "base64 0.22.1",
  "bitflags 2.11.1",
  "btoi",
  "byteorder",
  "bytes",
- "cc",
  "chrono",
- "cmake",
  "crc32fast",
  "flate2",
- "lazy_static",
+ "getrandom 0.3.4",
  "num-bigint",
  "num-traits",
- "rand 0.8.6",
  "regex",
  "saturating",
  "serde",
  "serde_json",
  "sha1 0.10.6",
  "sha2 0.10.9",
- "smallvec",
- "subprocess",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "uuid",
- "zstd",
 ]
 
 [[package]]
@@ -3335,7 +3193,7 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
 dependencies = [
- "lru 0.16.4",
+ "lru",
  "nostr",
  "tokio",
 ]
@@ -3349,7 +3207,7 @@ dependencies = [
  "async-utility",
  "async-wsocket",
  "atomic-destructor",
- "lru 0.16.4",
+ "lru",
  "negentropy",
  "nostr",
  "nostr-database",
@@ -3906,7 +3764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -3926,7 +3784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote 1.0.45",
  "syn",
@@ -3960,7 +3818,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3997,9 +3855,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4428,7 +4286,6 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4475,7 +4332,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5006,7 +4862,6 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.8.6",
- "rustls",
  "serde",
  "serde_json",
  "serde_with",
@@ -5086,7 +4941,6 @@ dependencies = [
  "macros",
  "mysql_async",
  "platform-utils",
- "rustls",
  "serde",
  "serde_json",
  "spark-mysql",
@@ -5254,16 +5108,6 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.45",
  "syn",
-]
-
-[[package]]
-name = "subprocess"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c56e8662b206b9892d7a5a3f2ecdbcb455d3d6b259111373b7e08b8055158a8"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -6068,14 +5912,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "rand 0.8.6",
- "static_assertions",
-]
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -6583,16 +6422,6 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -7296,31 +7125,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.45.1", default-features = false }
 tokio-postgres = { version = "0.7.10", features = ["with-serde_json-1", "with-chrono-0_4"] }
 tokio-postgres-rustls = "0.13"
-mysql_async = { version = "0.34", default-features = false, features = ["minimal-rust", "rustls-tls"] }
+mysql_async = { version = "0.36", default-features = false, features = ["minimal-rust", "rustls-tls", "ring", "tls12"] }
 deadpool-postgres = "0.14"
 deadpool = "0.12"
 tokio-test = "0.4.4"

--- a/crates/breez-sdk/core/Cargo.toml
+++ b/crates/breez-sdk/core/Cargo.toml
@@ -61,7 +61,6 @@ k256 = { workspace = true, features = ["arithmetic"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 rusqlite.workspace = true
 rusqlite_migration.workspace = true
-rustls.workspace = true
 
 # WASM dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -470,16 +470,6 @@ impl SdkBuilder {
     /// Builds the `BreezSdk` instance with the configured components.
     #[allow(clippy::too_many_lines)]
     pub async fn build(self) -> Result<BreezSdk, SdkError> {
-        // The mysql backend's `rustls-tls` feature pulls rustls with both `ring`
-        // and `aws_lc_rs` provider features enabled. With both on, rustls refuses
-        // to auto-pick a process-level CryptoProvider and panics the first time
-        // anything (here, `DefaultHttpClient`) builds a `ClientConfig`. Install
-        // ring up front so reqwest / tonic / bollard all see a default.
-        #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-        {
-            let _ = rustls::crypto::ring::default_provider().install_default();
-        }
-
         // Validate configuration
         self.config.validate()?;
 

--- a/crates/breez-sdk/lnurl/Cargo.lock
+++ b/crates/breez-sdk/lnurl/Cargo.lock
@@ -3535,7 +3535,6 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.8.5",
- "rustls",
  "serde",
  "serde_json",
  "serde_with",

--- a/crates/spark-mysql/Cargo.toml
+++ b/crates/spark-mysql/Cargo.toml
@@ -17,7 +17,6 @@ hex.workspace = true
 macros.workspace = true
 mysql_async = { workspace = true, features = ["chrono"] }
 platform-utils.workspace = true
-rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 spark-wallet.workspace = true

--- a/crates/spark-mysql/src/migrations.rs
+++ b/crates/spark-mysql/src/migrations.rs
@@ -422,7 +422,6 @@ mod tests {
     /// detect the existing state and no-op rather than abort.
     #[tokio::test]
     async fn test_partial_migration_replay_is_idempotent() {
-        crate::pool::install_rustls_crypto_provider();
         // Container must outlive the test — drop binds the lifetime to the
         // function scope while clippy is happy with a non-underscore name.
         let container: ContainerAsync<Mysql> = Mysql::default()

--- a/crates/spark-mysql/src/pool.rs
+++ b/crates/spark-mysql/src/pool.rs
@@ -4,7 +4,6 @@
 //! min/max constraints and idle TTL. We translate `MysqlStorageConfig` knobs
 //! onto the closest `mysql_async` equivalents.
 
-use std::sync::Once;
 use std::time::Duration;
 
 use mysql_async::{
@@ -36,8 +35,6 @@ pub fn tx_opts() -> TxOpts {
 /// - `verify_ca` / `verify_identity` — TLS with the CA from `root_ca_pem`
 ///   (or system roots if not provided)
 pub fn create_pool(config: &MysqlStorageConfig) -> Result<Pool, MysqlError> {
-    install_rustls_crypto_provider();
-
     let (connection_string, ssl_mode) = connection_string_and_ssl_mode(&config.connection_string);
     let opts: Opts = Opts::from_url(&connection_string)
         .map_err(|e| MysqlError::Initialization(format!("Invalid connection string: {e}")))?;
@@ -60,28 +57,6 @@ pub fn create_pool(config: &MysqlStorageConfig) -> Result<Pool, MysqlError> {
     builder = builder.pool_opts(pool_opts);
 
     Ok(Pool::new(builder))
-}
-
-/// Installs the rustls Ring crypto provider as the process-level default.
-///
-/// `mysql_async` constructs its own `rustls::ClientConfig` internally and relies on
-/// `CryptoProvider::get_default()`. With both `ring` and `aws_lc_rs` enabled in the
-/// unified workspace build, that auto-detect panics unless a default has already been
-/// installed. We install Ring once per process, here and from each test fixture that
-/// spins up `testcontainers` (whose `bollard` Docker client builds its own
-/// `ClientConfig` before `create_pool` runs).
-pub(crate) fn install_rustls_crypto_provider() {
-    static ONCE: Once = Once::new();
-    ONCE.call_once(|| {
-        if rustls::crypto::ring::default_provider()
-            .install_default()
-            .is_err()
-        {
-            tracing::debug!(
-                "rustls crypto provider was already installed by another caller; leaving it in place"
-            );
-        }
-    });
 }
 
 /// Parses an `ssl-mode` value from a `MySQL` URL connection string and constructs

--- a/crates/spark-mysql/src/session_manager.rs
+++ b/crates/spark-mysql/src/session_manager.rs
@@ -177,7 +177,6 @@ mod tests {
 
     impl MysqlSessionManagerTestFixture {
         async fn new() -> Self {
-            crate::pool::install_rustls_crypto_provider();
             let container = Mysql::default()
                 .start()
                 .await

--- a/crates/spark-mysql/src/token_store.rs
+++ b/crates/spark-mysql/src/token_store.rs
@@ -1442,7 +1442,6 @@ mod tests {
 
     impl MysqlTokenStoreTestFixture {
         async fn new() -> Self {
-            crate::pool::install_rustls_crypto_provider();
             let container = Mysql::default()
                 .start()
                 .await
@@ -1882,7 +1881,6 @@ mod tests {
 
     impl TwoTenantTokenFixture {
         async fn new() -> Self {
-            crate::pool::install_rustls_crypto_provider();
             let container = Mysql::default()
                 .start()
                 .await

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -1521,10 +1521,6 @@ mod tests {
 
     impl MysqlTreeStoreTestFixture {
         async fn new() -> Self {
-            // testcontainers' bollard Docker client builds its own rustls
-            // ClientConfig before any pool is created, so install the provider
-            // here too (the call is idempotent via Once).
-            crate::pool::install_rustls_crypto_provider();
             let container = Mysql::default()
                 .start()
                 .await
@@ -2437,7 +2433,6 @@ mod tests {
 
     impl TwoTenantTreeFixture {
         async fn new() -> Self {
-            crate::pool::install_rustls_crypto_provider();
             let container = Mysql::default()
                 .start()
                 .await

--- a/crates/spark/Cargo.toml
+++ b/crates/spark/Cargo.toml
@@ -41,7 +41,6 @@ unicode-normalization = "0.1.25"
 
 # Non-Wasm dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-rustls.workspace = true
 tonic = { workspace = true, features = [
     "channel",
     "codegen",

--- a/crates/spark/src/operator/rpc/connection_manager/balanced.rs
+++ b/crates/spark/src/operator/rpc/connection_manager/balanced.rs
@@ -17,12 +17,6 @@ pub struct BalancedConnectionManager {
 
 impl BalancedConnectionManager {
     pub fn new(connections_per_operator: u32) -> Self {
-        if rustls::crypto::ring::default_provider()
-            .install_default()
-            .is_err()
-        {
-            tracing::debug!("Failed to install rustls crypto provider, ignoring error");
-        }
         Self {
             connections_map: RwLock::new(HashMap::new()),
             connections_per_operator: connections_per_operator.max(1),

--- a/crates/spark/src/operator/rpc/connection_manager/default.rs
+++ b/crates/spark/src/operator/rpc/connection_manager/default.rs
@@ -20,16 +20,6 @@ impl Default for DefaultConnectionManager {
 
 impl DefaultConnectionManager {
     pub fn new() -> Self {
-        #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-        {
-            // Install rustls ring crypto provider for native targets only
-            if rustls::crypto::ring::default_provider()
-                .install_default()
-                .is_err()
-            {
-                tracing::debug!("Failed to install rustls crypto provider, ignoring error");
-            }
-        }
         Self {
             connections_map: RwLock::new(HashMap::new()),
         }

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -3226,7 +3226,6 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.8.5",
- "rustls",
  "serde",
  "serde_json",
  "serde_with",


### PR DESCRIPTION
Upgrade to mysql_async 0.26 that allows declaring only ring as default provider.
This enables us remove all the rustls initialization code and also allows rust callers to pick their own provider. 