### PR TITLE
Add Postgres/MySQL `brz_` prefixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,15 @@ All implementations run the **same shared test suite** in `crates/breez-sdk/core
 
 JS implementations also have migration files (`migrations.cjs`) alongside their `index.cjs`.
 
+### Postgres/MySQL `brz_` Naming Convention
+
+All SDK-owned Postgres and MySQL schema identifiers — tables, indexes, and named constraints (PKs, FKs) — are prefixed with `brz_` (e.g. `brz_payments`, `brz_idx_payments_user_timestamp`, `brz_fk_token_outputs_metadata_user`). This isolates the SDK's schema from customer-managed tables sharing the same database. **SQLite and IndexedDB backends do NOT use the prefix** — those are per-user isolated databases with no collision risk.
+
+When adding a new table, index, or named constraint to a Postgres/MySQL migration:
+1. Use the `brz_` prefix in the `CREATE` statement and every query that references it.
+2. Add the new identifier to the corresponding store's `SCHEMA_RENAMES` const so existing deployments upgrade cleanly. The const is consumed by `run_migrations(.., Some(&SCHEMA_RENAMES))` in `crates/spark-postgres/src/migrations.rs` / `crates/spark-mysql/src/migrations.rs`.
+3. Mirror the same change in the WASM JS package's `migrations.cjs` (the `_applySchemaRenames` method).
+
 ### Data Flow
 
 ```

--- a/crates/breez-sdk/breez-itest/tests/session_persistence.rs
+++ b/crates/breez-sdk/breez-itest/tests/session_persistence.rs
@@ -75,7 +75,7 @@ impl SessionPersistenceFixture {
 
         let rows = client
             .query(
-                "SELECT service_identity_key, token, expiration FROM sessions \
+                "SELECT service_identity_key, token, expiration FROM brz_sessions \
                  WHERE user_id = $1 \
                  ORDER BY service_identity_key",
                 &[&self.identity],
@@ -107,7 +107,10 @@ impl SessionPersistenceFixture {
             }
         });
         client
-            .execute("DELETE FROM sessions WHERE user_id = $1", &[&self.identity])
+            .execute(
+                "DELETE FROM brz_sessions WHERE user_id = $1",
+                &[&self.identity],
+            )
             .await?;
         Ok(())
     }

--- a/crates/breez-sdk/breez-itest/tests/session_persistence_mysql.rs
+++ b/crates/breez-sdk/breez-itest/tests/session_persistence_mysql.rs
@@ -65,7 +65,7 @@ impl MysqlSessionPersistenceFixture {
         let mut conn = pool.get_conn().await?;
         let rows: Vec<(Vec<u8>, String, i64)> = conn
             .exec(
-                "SELECT service_identity_key, token, expiration FROM sessions \
+                "SELECT service_identity_key, token, expiration FROM brz_sessions \
                  WHERE user_id = ? \
                  ORDER BY service_identity_key",
                 (self.identity.clone(),),
@@ -74,7 +74,7 @@ impl MysqlSessionPersistenceFixture {
         drop(conn);
         pool.disconnect().await?;
 
-        let sessions = rows
+        let brz_sessions = rows
             .into_iter()
             .map(|(service_identity_key, token, expiration)| SessionRow {
                 service_identity_key,
@@ -82,14 +82,14 @@ impl MysqlSessionPersistenceFixture {
                 expiration: u64::try_from(expiration).unwrap_or_default(),
             })
             .collect();
-        Ok(sessions)
+        Ok(brz_sessions)
     }
 
     async fn clear_sessions(&self) -> Result<()> {
         let pool = mysql_async::Pool::from_url(self.connection_string.as_str())?;
         let mut conn = pool.get_conn().await?;
         conn.exec_drop(
-            "DELETE FROM sessions WHERE user_id = ?",
+            "DELETE FROM brz_sessions WHERE user_id = ?",
             (self.identity.clone(),),
         )
         .await?;

--- a/crates/breez-sdk/breez-itest/tests/session_persistence_mysql.rs
+++ b/crates/breez-sdk/breez-itest/tests/session_persistence_mysql.rs
@@ -74,7 +74,7 @@ impl MysqlSessionPersistenceFixture {
         drop(conn);
         pool.disconnect().await?;
 
-        let brz_sessions = rows
+        let sessions = rows
             .into_iter()
             .map(|(service_identity_key, token, expiration)| SessionRow {
                 service_identity_key,
@@ -82,7 +82,7 @@ impl MysqlSessionPersistenceFixture {
                 expiration: u64::try_from(expiration).unwrap_or_default(),
             })
             .collect();
-        Ok(brz_sessions)
+        Ok(sessions)
     }
 
     async fn clear_sessions(&self) -> Result<()> {

--- a/crates/breez-sdk/core/src/persist/mysql/base.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/base.rs
@@ -154,13 +154,18 @@ pub(crate) fn create_pool(config: &MysqlStorageConfig) -> Result<mysql_async::Po
     spark_mysql::create_pool(&sm_config).map_err(StorageError::from)
 }
 
-/// Runs database migrations with version tracking and concurrency control.
+pub(super) use spark_mysql::SchemaRenames;
+
+/// Runs database migrations with version tracking and concurrency control,
+/// optionally applying a one-shot schema rename first (under the same
+/// named lock).
 pub(super) async fn run_migrations(
     pool: &mysql_async::Pool,
     migrations_table: &str,
     migrations: &[Vec<Migration>],
+    renames: Option<&SchemaRenames<'_>>,
 ) -> Result<(), StorageError> {
-    spark_mysql::run_migrations(pool, migrations_table, migrations)
+    spark_mysql::run_migrations(pool, migrations_table, migrations, renames)
         .await
         .map_err(StorageError::from)
 }

--- a/crates/breez-sdk/core/src/persist/mysql/base.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/base.rs
@@ -156,9 +156,7 @@ pub(crate) fn create_pool(config: &MysqlStorageConfig) -> Result<mysql_async::Po
 
 pub(super) use spark_mysql::SchemaRenames;
 
-/// Runs database migrations with version tracking and concurrency control,
-/// optionally applying a one-shot schema rename first (under the same
-/// named lock).
+/// Wraps [`spark_mysql::run_migrations`] with `StorageError` mapping.
 pub(super) async fn run_migrations(
     pool: &mysql_async::Pool,
     migrations_table: &str,

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -92,6 +92,48 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
             "idx_sync_incoming_user_revision",
             "brz_idx_sync_incoming_user_revision",
         ),
+        // Pre-multi-tenant indexes (still present on version < 16 DBs).
+        // The multi-tenant migration drops these via the post-rename names.
+        (
+            "brz_payments",
+            "idx_payments_timestamp",
+            "brz_idx_payments_timestamp",
+        ),
+        (
+            "brz_payments",
+            "idx_payments_payment_type",
+            "brz_idx_payments_payment_type",
+        ),
+        (
+            "brz_payments",
+            "idx_payments_status",
+            "brz_idx_payments_status",
+        ),
+        (
+            "brz_payment_metadata",
+            "idx_payment_metadata_parent",
+            "brz_idx_payment_metadata_parent",
+        ),
+        (
+            "brz_payment_details_lightning",
+            "idx_payment_details_lightning_invoice",
+            "brz_idx_payment_details_lightning_invoice",
+        ),
+        (
+            "brz_payment_details_lightning",
+            "idx_payment_details_lightning_payment_hash",
+            "brz_idx_payment_details_lightning_payment_hash",
+        ),
+        (
+            "brz_sync_outgoing",
+            "idx_sync_outgoing_data_id_record_type",
+            "brz_idx_sync_outgoing_data_id_record_type",
+        ),
+        (
+            "brz_sync_incoming",
+            "idx_sync_incoming_revision",
+            "brz_idx_sync_incoming_revision",
+        ),
     ],
     foreign_keys: &[],
 };
@@ -2657,6 +2699,240 @@ mod tests {
                 created_at BIGINT NOT NULL,
                 updated_at BIGINT NOT NULL,
                 PRIMARY KEY (user_id, id)
+            )"
+            .to_string(),
+        ]
+    }
+
+    /// `MySQL` counterpart of the Postgres
+    /// `test_rename_against_pre_tenant_legacy_schema`. Validates that the
+    /// rename + multi-tenant migration leaves no orphan unprefixed indexes
+    /// on any brz_ table.
+    #[tokio::test]
+    async fn test_rename_against_pre_tenant_legacy_schema() {
+        let container = Mysql::default()
+            .start()
+            .await
+            .expect("Failed to start MySQL container");
+        let host_port = container
+            .get_host_port_ipv4(3306)
+            .await
+            .expect("Failed to get host port");
+        let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
+
+        let pool = create_pool(&MysqlStorageConfig::with_defaults(
+            connection_string.clone(),
+        ))
+        .expect("create pool");
+        {
+            let mut conn = pool.get_conn().await.expect("get_conn");
+            for stmt in pre_tenant_legacy_schema_sql() {
+                conn.query_drop(&stmt).await.unwrap_or_else(|e| {
+                    panic!("pre-tenant legacy schema setup failed at\n{stmt}\n=> {e}")
+                });
+            }
+            conn.query_drop(
+                "INSERT INTO payments
+                 (id, payment_type, status, amount, fees, timestamp, method)
+                 VALUES ('p1', 'receive', 'completed', '1000', '0', 100, 'lightning')",
+            )
+            .await
+            .expect("seed payment");
+            conn.query_drop(
+                "INSERT INTO settings (`key`, value) VALUES ('seed_key', 'seed_value')",
+            )
+            .await
+            .expect("seed setting");
+        }
+
+        let storage = MysqlStorage::new(
+            MysqlStorageConfig::with_defaults(connection_string),
+            &TEST_IDENTITY_A,
+        )
+        .await
+        .expect("migrate against pre-tenant schema");
+
+        let mut conn = pool.get_conn().await.expect("get_conn");
+
+        // The bug check: no unprefixed `idx_*` index on any brz_ table.
+        // `information_schema.statistics` lists one row per (table, index,
+        // column) — DISTINCT collapses to unique (table, index) pairs.
+        let orphan_rows: Vec<(String, String)> = conn
+            .exec(
+                "SELECT DISTINCT table_name, index_name
+                 FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name LIKE 'brz\\_%'
+                   AND index_name LIKE 'idx\\_%'",
+                (),
+            )
+            .await
+            .expect("scan orphan indexes");
+        assert!(
+            orphan_rows.is_empty(),
+            "found orphan unprefixed indexes after upgrade: {orphan_rows:?}"
+        );
+
+        let version: Option<i32> = conn
+            .exec_first("SELECT MAX(version) FROM brz_schema_migrations", ())
+            .await
+            .unwrap();
+        assert_eq!(version, Some(16), "migration must advance to 16");
+
+        let payment_count: Option<i64> = conn
+            .exec_first("SELECT COUNT(*) FROM brz_payments WHERE id = 'p1'", ())
+            .await
+            .unwrap();
+        assert_eq!(payment_count, Some(1), "seed payment must survive upgrade");
+
+        let setting = storage
+            .get_cached_item("seed_key".to_string())
+            .await
+            .expect("get_cached_item");
+        assert_eq!(setting.as_deref(), Some("seed_value"));
+    }
+
+    /// Pre-multi-tenant `MySQL` schema snapshot (version=15).
+    #[allow(clippy::too_many_lines)]
+    fn pre_tenant_legacy_schema_sql() -> Vec<String> {
+        vec![
+            "CREATE TABLE schema_migrations (
+                version INT PRIMARY KEY,
+                applied_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+            )"
+            .to_string(),
+            (1..=15)
+                .map(|v| format!("INSERT INTO schema_migrations (version) VALUES ({v})"))
+                .collect::<Vec<_>>()
+                .join(";"),
+            "CREATE TABLE payments (
+                id VARCHAR(255) NOT NULL PRIMARY KEY,
+                payment_type VARCHAR(64) NOT NULL,
+                status VARCHAR(64) NOT NULL,
+                amount VARCHAR(64) NOT NULL,
+                fees VARCHAR(64) NOT NULL,
+                timestamp BIGINT NOT NULL,
+                method VARCHAR(64) NULL,
+                withdraw_tx_id VARCHAR(255) NULL,
+                deposit_tx_id VARCHAR(255) NULL,
+                spark TINYINT(1) NULL
+            )"
+            .to_string(),
+            "CREATE TABLE settings (
+                `key` VARCHAR(255) NOT NULL PRIMARY KEY,
+                value LONGTEXT NOT NULL
+            )"
+            .to_string(),
+            "CREATE TABLE unclaimed_deposits (
+                txid VARCHAR(255) NOT NULL,
+                vout INT NOT NULL,
+                amount_sats BIGINT NULL,
+                claim_error JSON NULL,
+                refund_tx LONGTEXT NULL,
+                refund_tx_id VARCHAR(255) NULL,
+                is_mature TINYINT(1) NOT NULL DEFAULT 1,
+                PRIMARY KEY (txid, vout)
+            )"
+            .to_string(),
+            "CREATE TABLE payment_metadata (
+                payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
+                parent_payment_id VARCHAR(255) NULL,
+                lnurl_pay_info JSON NULL,
+                lnurl_withdraw_info JSON NULL,
+                lnurl_description LONGTEXT NULL,
+                conversion_info JSON NULL,
+                conversion_status VARCHAR(64) NULL
+            )"
+            .to_string(),
+            "CREATE TABLE payment_details_lightning (
+                payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
+                invoice LONGTEXT NOT NULL,
+                payment_hash VARCHAR(255) NOT NULL,
+                destination_pubkey VARCHAR(255) NOT NULL,
+                description LONGTEXT NULL,
+                htlc_status VARCHAR(64) NOT NULL DEFAULT 'WaitingForPreimage',
+                htlc_expiry_time BIGINT NOT NULL DEFAULT 0
+            )"
+            .to_string(),
+            "CREATE TABLE payment_details_token (
+                payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
+                metadata JSON NOT NULL,
+                tx_hash VARCHAR(255) NOT NULL,
+                invoice_details JSON NULL,
+                tx_type VARCHAR(64) NOT NULL DEFAULT 'transfer'
+            )"
+            .to_string(),
+            "CREATE TABLE payment_details_spark (
+                payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
+                invoice_details JSON NULL,
+                htlc_details JSON NULL
+            )"
+            .to_string(),
+            "CREATE TABLE lnurl_receive_metadata (
+                payment_hash VARCHAR(255) NOT NULL PRIMARY KEY,
+                nostr_zap_request LONGTEXT NULL,
+                nostr_zap_receipt LONGTEXT NULL,
+                sender_comment LONGTEXT NULL
+            )"
+            .to_string(),
+            "CREATE TABLE sync_revision (
+                id INT NOT NULL PRIMARY KEY DEFAULT 1,
+                revision BIGINT NOT NULL DEFAULT 0,
+                CHECK (id = 1)
+            )"
+            .to_string(),
+            "INSERT INTO sync_revision (id, revision) VALUES (1, 0)".to_string(),
+            "CREATE TABLE sync_outgoing (
+                record_type VARCHAR(255) NOT NULL,
+                data_id VARCHAR(255) NOT NULL,
+                schema_version VARCHAR(64) NOT NULL,
+                commit_time BIGINT NOT NULL,
+                updated_fields_json JSON NOT NULL,
+                revision BIGINT NOT NULL
+            )"
+            .to_string(),
+            "CREATE INDEX idx_sync_outgoing_data_id_record_type
+             ON sync_outgoing(record_type, data_id)"
+                .to_string(),
+            "CREATE TABLE sync_state (
+                record_type VARCHAR(255) NOT NULL,
+                data_id VARCHAR(255) NOT NULL,
+                schema_version VARCHAR(64) NOT NULL,
+                commit_time BIGINT NOT NULL,
+                data JSON NOT NULL,
+                revision BIGINT NOT NULL,
+                PRIMARY KEY(record_type, data_id)
+            )"
+            .to_string(),
+            "CREATE TABLE sync_incoming (
+                record_type VARCHAR(255) NOT NULL,
+                data_id VARCHAR(255) NOT NULL,
+                schema_version VARCHAR(64) NOT NULL,
+                commit_time BIGINT NOT NULL,
+                data JSON NOT NULL,
+                revision BIGINT NOT NULL,
+                PRIMARY KEY(record_type, data_id, revision)
+            )"
+            .to_string(),
+            "CREATE INDEX idx_sync_incoming_revision ON sync_incoming(revision)".to_string(),
+            "CREATE INDEX idx_payments_timestamp ON payments(timestamp)".to_string(),
+            "CREATE INDEX idx_payments_payment_type ON payments(payment_type)".to_string(),
+            "CREATE INDEX idx_payments_status ON payments(status)".to_string(),
+            "CREATE INDEX idx_payment_details_lightning_invoice
+             ON payment_details_lightning(invoice(255))"
+                .to_string(),
+            "CREATE INDEX idx_payment_metadata_parent
+             ON payment_metadata(parent_payment_id)"
+                .to_string(),
+            "CREATE INDEX idx_payment_details_lightning_payment_hash
+             ON payment_details_lightning(payment_hash)"
+                .to_string(),
+            "CREATE TABLE contacts (
+                id VARCHAR(255) NOT NULL PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                payment_identifier VARCHAR(255) NOT NULL,
+                created_at BIGINT NOT NULL,
+                updated_at BIGINT NOT NULL
             )"
             .to_string(),
         ]

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -32,12 +32,7 @@ use super::base::{MysqlStorageConfig, create_pool};
 
 const MIGRATIONS_TABLE: &str = "brz_schema_migrations";
 
-/// Old-to-`brz_*` rename map for the breez-sdk core `MySQL` persist schema.
-/// Applied on first startup after upgrading to the prefixed schema. The
-/// indexes listed are the ones present after the multi-tenant migration.
-/// `MySQL` primary keys are always named `PRIMARY` (table-scoped) and there
-/// are no foreign keys in the core schema, so this rename only covers
-/// tables and indexes.
+/// Pre-prefix rename map for upgrading core persist deployments.
 const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
     old_migrations_table: "schema_migrations",
     new_migrations_table: MIGRATIONS_TABLE,
@@ -1739,7 +1734,7 @@ fn map_payment(row: &Row) -> Result<Payment, StorageError> {
             let htlc_status: SparkHtlcStatus = htlc_status_str
                 .ok_or_else(|| {
                     StorageError::Implementation(
-                        "htlc_status is required for Lightning brz_payments".to_string(),
+                        "htlc_status is required for Lightning payments".to_string(),
                     )
                 })
                 .and_then(|s| {
@@ -2396,5 +2391,274 @@ mod tests {
                 .unwrap();
         assert_eq!(list_b_final.len(), 1);
         assert_eq!(list_b_final[0].id, "pmt_shared_id");
+    }
+
+    /// `MySQL` counterpart of the Postgres `test_rename_against_real_legacy_schema`.
+    /// Validates the real `SCHEMA_RENAMES` constant against a hand-rolled
+    /// snapshot of the pre-`brz_*` post-multi-tenant schema. A typo in the
+    /// rename map (table, index, or FK name) would fail here.
+    #[tokio::test]
+    async fn test_rename_against_real_legacy_schema() {
+        let container = Mysql::default()
+            .start()
+            .await
+            .expect("Failed to start MySQL container");
+        let host_port = container
+            .get_host_port_ipv4(3306)
+            .await
+            .expect("Failed to get host port");
+        let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
+
+        let pool = create_pool(&MysqlStorageConfig::with_defaults(
+            connection_string.clone(),
+        ))
+        .expect("create pool");
+        let id_lit = format!("UNHEX('{}')", hex::encode(TEST_IDENTITY_A));
+        {
+            let mut conn = pool.get_conn().await.expect("get_conn");
+            for stmt in legacy_schema_sql() {
+                conn.query_drop(&stmt)
+                    .await
+                    .unwrap_or_else(|e| panic!("legacy schema setup failed at\n{stmt}\n=> {e}"));
+            }
+            conn.query_drop(format!(
+                "INSERT INTO payments
+                 (user_id, id, payment_type, status, amount, fees, timestamp, method)
+                 VALUES ({id_lit}, 'p1', 'receive', 'completed', '1000', '0', 100, 'lightning')"
+            ))
+            .await
+            .expect("seed payment");
+            conn.query_drop(format!(
+                "INSERT INTO settings (user_id, `key`, value)
+                 VALUES ({id_lit}, 'seed_key', 'seed_value')"
+            ))
+            .await
+            .expect("seed setting");
+        }
+
+        let storage = MysqlStorage::new(
+            MysqlStorageConfig::with_defaults(connection_string),
+            &TEST_IDENTITY_A,
+        )
+        .await
+        .expect("migrate against legacy schema");
+
+        let mut conn = pool.get_conn().await.expect("get_conn");
+
+        let legacy_count: Option<i64> = conn
+            .exec_first(
+                "SELECT COUNT(*) FROM information_schema.tables
+                 WHERE table_schema = DATABASE() AND table_name = 'schema_migrations'",
+                (),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            legacy_count,
+            Some(0),
+            "legacy schema_migrations must be renamed"
+        );
+
+        let version: Option<i32> = conn
+            .exec_first("SELECT MAX(version) FROM brz_schema_migrations", ())
+            .await
+            .unwrap();
+        assert_eq!(version, Some(16), "migration version must be preserved");
+
+        let payment_count: Option<i64> = conn
+            .exec_first("SELECT COUNT(*) FROM brz_payments WHERE id = 'p1'", ())
+            .await
+            .unwrap();
+        assert_eq!(payment_count, Some(1), "seed payment must survive rename");
+
+        let setting = storage
+            .get_cached_item("seed_key".to_string())
+            .await
+            .expect("get_cached_item");
+        assert_eq!(setting.as_deref(), Some("seed_value"));
+
+        storage
+            .set_cached_item(
+                "post_rename_key".to_string(),
+                "post_rename_value".to_string(),
+            )
+            .await
+            .expect("set_cached_item");
+        let written = storage
+            .get_cached_item("post_rename_key".to_string())
+            .await
+            .expect("get_cached_item");
+        assert_eq!(written.as_deref(), Some("post_rename_value"));
+    }
+
+    /// Hand-rolled snapshot of the pre-PR `MySQL` schema in its terminal
+    /// (post-multi-tenant, version-16) state. Mirror additions here when
+    /// extending the SDK schema, so this test continues to validate that
+    /// `SCHEMA_RENAMES` covers every new identifier.
+    #[allow(clippy::too_many_lines)]
+    fn legacy_schema_sql() -> Vec<String> {
+        vec![
+            "CREATE TABLE schema_migrations (
+                version INT PRIMARY KEY,
+                applied_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+            )"
+            .to_string(),
+            (1..=16)
+                .map(|v| format!("INSERT INTO schema_migrations (version) VALUES ({v})"))
+                .collect::<Vec<_>>()
+                .join(";"),
+            "CREATE TABLE payments (
+                user_id VARBINARY(33) NOT NULL,
+                id VARCHAR(255) NOT NULL,
+                payment_type VARCHAR(64) NOT NULL,
+                status VARCHAR(64) NOT NULL,
+                amount VARCHAR(64) NOT NULL,
+                fees VARCHAR(64) NOT NULL,
+                timestamp BIGINT NOT NULL,
+                method VARCHAR(64) NULL,
+                withdraw_tx_id VARCHAR(255) NULL,
+                deposit_tx_id VARCHAR(255) NULL,
+                spark TINYINT(1) NULL,
+                PRIMARY KEY (user_id, id)
+            )"
+            .to_string(),
+            "CREATE INDEX idx_payments_user_timestamp ON payments(user_id, timestamp)".to_string(),
+            "CREATE INDEX idx_payments_user_payment_type ON payments(user_id, payment_type)"
+                .to_string(),
+            "CREATE INDEX idx_payments_user_status ON payments(user_id, status)".to_string(),
+            "CREATE TABLE settings (
+                user_id VARBINARY(33) NOT NULL,
+                `key` VARCHAR(255) NOT NULL,
+                value LONGTEXT NOT NULL,
+                PRIMARY KEY (user_id, `key`)
+            )"
+            .to_string(),
+            "CREATE TABLE unclaimed_deposits (
+                user_id VARBINARY(33) NOT NULL,
+                txid VARCHAR(255) NOT NULL,
+                vout INT NOT NULL,
+                amount_sats BIGINT NULL,
+                claim_error JSON NULL,
+                refund_tx LONGTEXT NULL,
+                refund_tx_id VARCHAR(255) NULL,
+                is_mature TINYINT(1) NOT NULL DEFAULT 1,
+                PRIMARY KEY (user_id, txid, vout)
+            )"
+            .to_string(),
+            "CREATE TABLE payment_metadata (
+                user_id VARBINARY(33) NOT NULL,
+                payment_id VARCHAR(255) NOT NULL,
+                parent_payment_id VARCHAR(255) NULL,
+                lnurl_pay_info JSON NULL,
+                lnurl_withdraw_info JSON NULL,
+                lnurl_description LONGTEXT NULL,
+                conversion_info JSON NULL,
+                conversion_status VARCHAR(64) NULL,
+                PRIMARY KEY (user_id, payment_id)
+            )"
+            .to_string(),
+            "CREATE INDEX idx_payment_metadata_user_parent
+             ON payment_metadata(user_id, parent_payment_id)"
+                .to_string(),
+            "CREATE TABLE payment_details_lightning (
+                user_id VARBINARY(33) NOT NULL,
+                payment_id VARCHAR(255) NOT NULL,
+                invoice LONGTEXT NOT NULL,
+                payment_hash VARCHAR(255) NOT NULL,
+                destination_pubkey VARCHAR(255) NOT NULL,
+                description LONGTEXT NULL,
+                htlc_status VARCHAR(64) NOT NULL DEFAULT 'WaitingForPreimage',
+                htlc_expiry_time BIGINT NOT NULL DEFAULT 0,
+                PRIMARY KEY (user_id, payment_id)
+            )"
+            .to_string(),
+            "CREATE INDEX idx_payment_details_lightning_user_invoice
+             ON payment_details_lightning(user_id, invoice(255))"
+                .to_string(),
+            "CREATE INDEX idx_payment_details_lightning_user_payment_hash
+             ON payment_details_lightning(user_id, payment_hash)"
+                .to_string(),
+            "CREATE TABLE payment_details_token (
+                user_id VARBINARY(33) NOT NULL,
+                payment_id VARCHAR(255) NOT NULL,
+                metadata JSON NOT NULL,
+                tx_hash VARCHAR(255) NOT NULL,
+                invoice_details JSON NULL,
+                tx_type VARCHAR(64) NOT NULL DEFAULT 'transfer',
+                PRIMARY KEY (user_id, payment_id)
+            )"
+            .to_string(),
+            "CREATE TABLE payment_details_spark (
+                user_id VARBINARY(33) NOT NULL,
+                payment_id VARCHAR(255) NOT NULL,
+                invoice_details JSON NULL,
+                htlc_details JSON NULL,
+                PRIMARY KEY (user_id, payment_id)
+            )"
+            .to_string(),
+            "CREATE TABLE lnurl_receive_metadata (
+                user_id VARBINARY(33) NOT NULL,
+                payment_hash VARCHAR(255) NOT NULL,
+                nostr_zap_request LONGTEXT NULL,
+                nostr_zap_receipt LONGTEXT NULL,
+                sender_comment LONGTEXT NULL,
+                PRIMARY KEY (user_id, payment_hash)
+            )"
+            .to_string(),
+            "CREATE TABLE sync_revision (
+                user_id VARBINARY(33) NOT NULL,
+                revision BIGINT NOT NULL DEFAULT 0,
+                PRIMARY KEY (user_id)
+            )"
+            .to_string(),
+            "CREATE TABLE sync_outgoing (
+                user_id VARBINARY(33) NOT NULL,
+                record_type VARCHAR(255) NOT NULL,
+                data_id VARCHAR(255) NOT NULL,
+                schema_version VARCHAR(64) NOT NULL,
+                commit_time BIGINT NOT NULL,
+                updated_fields_json JSON NOT NULL,
+                revision BIGINT NOT NULL
+            )"
+            .to_string(),
+            "CREATE INDEX idx_sync_outgoing_user_record_type_data_id
+             ON sync_outgoing(user_id, record_type, data_id)"
+                .to_string(),
+            "CREATE TABLE sync_state (
+                user_id VARBINARY(33) NOT NULL,
+                record_type VARCHAR(255) NOT NULL,
+                data_id VARCHAR(255) NOT NULL,
+                schema_version VARCHAR(64) NOT NULL,
+                commit_time BIGINT NOT NULL,
+                data JSON NOT NULL,
+                revision BIGINT NOT NULL,
+                PRIMARY KEY (user_id, record_type, data_id)
+            )"
+            .to_string(),
+            "CREATE TABLE sync_incoming (
+                user_id VARBINARY(33) NOT NULL,
+                record_type VARCHAR(255) NOT NULL,
+                data_id VARCHAR(255) NOT NULL,
+                schema_version VARCHAR(64) NOT NULL,
+                commit_time BIGINT NOT NULL,
+                data JSON NOT NULL,
+                revision BIGINT NOT NULL,
+                PRIMARY KEY (user_id, record_type, data_id, revision)
+            )"
+            .to_string(),
+            "CREATE INDEX idx_sync_incoming_user_revision
+             ON sync_incoming(user_id, revision)"
+                .to_string(),
+            "CREATE TABLE contacts (
+                user_id VARBINARY(33) NOT NULL,
+                id VARCHAR(255) NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                payment_identifier VARCHAR(255) NOT NULL,
+                created_at BIGINT NOT NULL,
+                updated_at BIGINT NOT NULL,
+                PRIMARY KEY (user_id, id)
+            )"
+            .to_string(),
+        ]
     }
 }

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -26,11 +26,80 @@ use crate::{
     },
 };
 
-use super::base::{Migration, map_db_error, run_migrations};
+use super::base::{Migration, SchemaRenames, map_db_error, run_migrations};
 #[cfg(test)]
 use super::base::{MysqlStorageConfig, create_pool};
 
-const MIGRATIONS_TABLE: &str = "schema_migrations";
+const MIGRATIONS_TABLE: &str = "brz_schema_migrations";
+
+/// Old-to-`brz_*` rename map for the breez-sdk core `MySQL` persist schema.
+/// Applied on first startup after upgrading to the prefixed schema. The
+/// indexes listed are the ones present after the multi-tenant migration.
+/// `MySQL` primary keys are always named `PRIMARY` (table-scoped) and there
+/// are no foreign keys in the core schema, so this rename only covers
+/// tables and indexes.
+const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
+    old_migrations_table: "schema_migrations",
+    new_migrations_table: MIGRATIONS_TABLE,
+    tables: &[
+        ("payments", "brz_payments"),
+        ("settings", "brz_settings"),
+        ("unclaimed_deposits", "brz_unclaimed_deposits"),
+        ("payment_metadata", "brz_payment_metadata"),
+        ("payment_details_lightning", "brz_payment_details_lightning"),
+        ("payment_details_token", "brz_payment_details_token"),
+        ("payment_details_spark", "brz_payment_details_spark"),
+        ("lnurl_receive_metadata", "brz_lnurl_receive_metadata"),
+        ("sync_revision", "brz_sync_revision"),
+        ("sync_outgoing", "brz_sync_outgoing"),
+        ("sync_state", "brz_sync_state"),
+        ("sync_incoming", "brz_sync_incoming"),
+        ("contacts", "brz_contacts"),
+    ],
+    indexes: &[
+        (
+            "brz_payments",
+            "idx_payments_user_timestamp",
+            "brz_idx_payments_user_timestamp",
+        ),
+        (
+            "brz_payments",
+            "idx_payments_user_payment_type",
+            "brz_idx_payments_user_payment_type",
+        ),
+        (
+            "brz_payments",
+            "idx_payments_user_status",
+            "brz_idx_payments_user_status",
+        ),
+        (
+            "brz_payment_metadata",
+            "idx_payment_metadata_user_parent",
+            "brz_idx_payment_metadata_user_parent",
+        ),
+        (
+            "brz_payment_details_lightning",
+            "idx_payment_details_lightning_user_invoice",
+            "brz_idx_payment_details_lightning_user_invoice",
+        ),
+        (
+            "brz_payment_details_lightning",
+            "idx_payment_details_lightning_user_payment_hash",
+            "brz_idx_payment_details_lightning_user_payment_hash",
+        ),
+        (
+            "brz_sync_outgoing",
+            "idx_sync_outgoing_user_record_type_data_id",
+            "brz_idx_sync_outgoing_user_record_type_data_id",
+        ),
+        (
+            "brz_sync_incoming",
+            "idx_sync_incoming_user_revision",
+            "brz_idx_sync_incoming_user_revision",
+        ),
+    ],
+    foreign_keys: &[],
+};
 
 /// `MySQL`-based storage implementation using `mysql_async`'s connection pool.
 ///
@@ -78,6 +147,7 @@ impl MysqlStorage {
             &self.pool,
             MIGRATIONS_TABLE,
             &Self::migrations(&self.identity),
+            Some(&SCHEMA_RENAMES),
         )
         .await
     }
@@ -88,7 +158,7 @@ impl MysqlStorage {
             // Migration 1: Core tables
             vec![
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS payments (
+                    "CREATE TABLE IF NOT EXISTS brz_payments (
                         id VARCHAR(255) NOT NULL PRIMARY KEY,
                         payment_type VARCHAR(64) NOT NULL,
                         status VARCHAR(64) NOT NULL,
@@ -102,13 +172,13 @@ impl MysqlStorage {
                     )",
                 ),
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS settings (
+                    "CREATE TABLE IF NOT EXISTS brz_settings (
                         `key` VARCHAR(255) NOT NULL PRIMARY KEY,
                         value LONGTEXT NOT NULL
                     )",
                 ),
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS unclaimed_deposits (
+                    "CREATE TABLE IF NOT EXISTS brz_unclaimed_deposits (
                         txid VARCHAR(255) NOT NULL,
                         vout INT NOT NULL,
                         amount_sats BIGINT NULL,
@@ -119,7 +189,7 @@ impl MysqlStorage {
                     )",
                 ),
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS payment_metadata (
+                    "CREATE TABLE IF NOT EXISTS brz_payment_metadata (
                         payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
                         parent_payment_id VARCHAR(255) NULL,
                         lnurl_pay_info JSON NULL,
@@ -129,7 +199,7 @@ impl MysqlStorage {
                     )",
                 ),
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS payment_details_lightning (
+                    "CREATE TABLE IF NOT EXISTS brz_payment_details_lightning (
                         payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
                         invoice LONGTEXT NOT NULL,
                         payment_hash VARCHAR(255) NOT NULL,
@@ -139,7 +209,7 @@ impl MysqlStorage {
                     )",
                 ),
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS payment_details_token (
+                    "CREATE TABLE IF NOT EXISTS brz_payment_details_token (
                         payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
                         metadata JSON NOT NULL,
                         tx_hash VARCHAR(255) NOT NULL,
@@ -147,14 +217,14 @@ impl MysqlStorage {
                     )",
                 ),
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS payment_details_spark (
+                    "CREATE TABLE IF NOT EXISTS brz_payment_details_spark (
                         payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
                         invoice_details JSON NULL,
                         htlc_details JSON NULL
                     )",
                 ),
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS lnurl_receive_metadata (
+                    "CREATE TABLE IF NOT EXISTS brz_lnurl_receive_metadata (
                         payment_hash VARCHAR(255) NOT NULL PRIMARY KEY,
                         nostr_zap_request LONGTEXT NULL,
                         nostr_zap_receipt LONGTEXT NULL,
@@ -165,18 +235,18 @@ impl MysqlStorage {
             // Migration 2: Sync tables
             vec![
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS sync_revision (
+                    "CREATE TABLE IF NOT EXISTS brz_sync_revision (
                         id INT NOT NULL PRIMARY KEY DEFAULT 1,
                         revision BIGINT NOT NULL DEFAULT 0,
                         CHECK (id = 1)
                     )",
                 ),
                 Migration::sql(
-                    "INSERT INTO sync_revision (id, revision) VALUES (1, 0)
+                    "INSERT INTO brz_sync_revision (id, revision) VALUES (1, 0)
                      ON DUPLICATE KEY UPDATE id = id",
                 ),
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS sync_outgoing (
+                    "CREATE TABLE IF NOT EXISTS brz_sync_outgoing (
                         record_type VARCHAR(255) NOT NULL,
                         data_id VARCHAR(255) NOT NULL,
                         schema_version VARCHAR(64) NOT NULL,
@@ -186,12 +256,12 @@ impl MysqlStorage {
                     )",
                 ),
                 Migration::CreateIndex {
-                    name: "idx_sync_outgoing_data_id_record_type",
-                    table: "sync_outgoing",
+                    name: "brz_idx_sync_outgoing_data_id_record_type",
+                    table: "brz_sync_outgoing",
                     columns: "(record_type, data_id)",
                 },
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS sync_state (
+                    "CREATE TABLE IF NOT EXISTS brz_sync_state (
                         record_type VARCHAR(255) NOT NULL,
                         data_id VARCHAR(255) NOT NULL,
                         schema_version VARCHAR(64) NOT NULL,
@@ -202,7 +272,7 @@ impl MysqlStorage {
                     )",
                 ),
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS sync_incoming (
+                    "CREATE TABLE IF NOT EXISTS brz_sync_incoming (
                         record_type VARCHAR(255) NOT NULL,
                         data_id VARCHAR(255) NOT NULL,
                         schema_version VARCHAR(64) NOT NULL,
@@ -213,62 +283,62 @@ impl MysqlStorage {
                     )",
                 ),
                 Migration::CreateIndex {
-                    name: "idx_sync_incoming_revision",
-                    table: "sync_incoming",
+                    name: "brz_idx_sync_incoming_revision",
+                    table: "brz_sync_incoming",
                     columns: "(revision)",
                 },
             ],
             // Migration 3: Indexes
             vec![
                 Migration::CreateIndex {
-                    name: "idx_payments_timestamp",
-                    table: "payments",
+                    name: "brz_idx_payments_timestamp",
+                    table: "brz_payments",
                     columns: "(timestamp)",
                 },
                 Migration::CreateIndex {
-                    name: "idx_payments_payment_type",
-                    table: "payments",
+                    name: "brz_idx_payments_payment_type",
+                    table: "brz_payments",
                     columns: "(payment_type)",
                 },
                 Migration::CreateIndex {
-                    name: "idx_payments_status",
-                    table: "payments",
+                    name: "brz_idx_payments_status",
+                    table: "brz_payments",
                     columns: "(status)",
                 },
                 Migration::CreateIndex {
-                    name: "idx_payment_details_lightning_invoice",
-                    table: "payment_details_lightning",
+                    name: "brz_idx_payment_details_lightning_invoice",
+                    table: "brz_payment_details_lightning",
                     columns: "(invoice(255))",
                 },
                 Migration::CreateIndex {
-                    name: "idx_payment_metadata_parent",
-                    table: "payment_metadata",
+                    name: "brz_idx_payment_metadata_parent",
+                    table: "brz_payment_metadata",
                     columns: "(parent_payment_id)",
                 },
             ],
             // Migration 4: Add tx_type to token payments
             vec![Migration::AddColumn {
-                table: "payment_details_token",
+                table: "brz_payment_details_token",
                 column: "tx_type",
                 definition: "VARCHAR(64) NOT NULL DEFAULT 'transfer'",
             }],
             // Migration 5: Clear sync tables to force re-sync
             vec![
-                Migration::sql("DELETE FROM sync_outgoing"),
-                Migration::sql("DELETE FROM sync_incoming"),
-                Migration::sql("DELETE FROM sync_state"),
-                Migration::sql("UPDATE sync_revision SET revision = 0"),
-                Migration::sql("DELETE FROM settings WHERE `key` = 'sync_initial_complete'"),
+                Migration::sql("DELETE FROM brz_sync_outgoing"),
+                Migration::sql("DELETE FROM brz_sync_incoming"),
+                Migration::sql("DELETE FROM brz_sync_state"),
+                Migration::sql("UPDATE brz_sync_revision SET revision = 0"),
+                Migration::sql("DELETE FROM brz_settings WHERE `key` = 'sync_initial_complete'"),
             ],
             // Migration 6: Add htlc_status and htlc_expiry_time to lightning payments
             vec![
                 Migration::AddColumn {
-                    table: "payment_details_lightning",
+                    table: "brz_payment_details_lightning",
                     column: "htlc_status",
                     definition: "VARCHAR(64) NOT NULL DEFAULT 'WaitingForPreimage'",
                 },
                 Migration::AddColumn {
-                    table: "payment_details_lightning",
+                    table: "brz_payment_details_lightning",
                     column: "htlc_expiry_time",
                     definition: "BIGINT NOT NULL DEFAULT 0",
                 },
@@ -276,41 +346,41 @@ impl MysqlStorage {
             // Migration 7: Backfill htlc_status for existing Lightning payments
             vec![
                 Migration::sql(
-                    "UPDATE payment_details_lightning
+                    "UPDATE brz_payment_details_lightning
                      SET htlc_status = CASE
-                             WHEN (SELECT status FROM payments WHERE id = payment_id) = 'completed' THEN 'PreimageShared'
-                             WHEN (SELECT status FROM payments WHERE id = payment_id) = 'pending' THEN 'WaitingForPreimage'
+                             WHEN (SELECT status FROM brz_payments WHERE id = payment_id) = 'completed' THEN 'PreimageShared'
+                             WHEN (SELECT status FROM brz_payments WHERE id = payment_id) = 'pending' THEN 'WaitingForPreimage'
                              ELSE 'Returned'
                          END",
                 ),
                 Migration::sql(
-                    "UPDATE settings
+                    "UPDATE brz_settings
                      SET value = JSON_SET(value, '$.offset', 0)
                      WHERE `key` = 'sync_offset' AND value IS NOT NULL",
                 ),
             ],
-            // Migration 8: lnurl_receive_metadata preimage column (added then later dropped)
+            // Migration 8: brz_lnurl_receive_metadata preimage column (added then later dropped)
             vec![
                 Migration::AddColumn {
-                    table: "lnurl_receive_metadata",
+                    table: "brz_lnurl_receive_metadata",
                     column: "preimage",
                     definition: "VARCHAR(255) NULL",
                 },
-                Migration::sql("DELETE FROM settings WHERE `key` = 'lnurl_metadata_updated_after'"),
+                Migration::sql("DELETE FROM brz_settings WHERE `key` = 'lnurl_metadata_updated_after'"),
             ],
             // Migration 9: Clear cached lightning address (schema changed)
             vec![Migration::sql(
-                "DELETE FROM settings WHERE `key` = 'lightning_address'",
+                "DELETE FROM brz_settings WHERE `key` = 'lightning_address'",
             )],
-            // Migration 10: Index on payment_hash for JOIN with lnurl_receive_metadata
+            // Migration 10: Index on payment_hash for JOIN with brz_lnurl_receive_metadata
             vec![Migration::CreateIndex {
-                name: "idx_payment_details_lightning_payment_hash",
-                table: "payment_details_lightning",
+                name: "brz_idx_payment_details_lightning_payment_hash",
+                table: "brz_payment_details_lightning",
                 columns: "(payment_hash)",
             }],
             // Migration 11: Contacts table
             vec![Migration::sql(
-                "CREATE TABLE IF NOT EXISTS contacts (
+                "CREATE TABLE IF NOT EXISTS brz_contacts (
                         id VARCHAR(255) NOT NULL PRIMARY KEY,
                         name VARCHAR(255) NOT NULL,
                         payment_identifier VARCHAR(255) NOT NULL,
@@ -318,24 +388,24 @@ impl MysqlStorage {
                         updated_at BIGINT NOT NULL
                     )",
             )],
-            // Migration 12: Drop preimage column from lnurl_receive_metadata
+            // Migration 12: Drop preimage column from brz_lnurl_receive_metadata
             vec![Migration::DropColumn {
-                table: "lnurl_receive_metadata",
+                table: "brz_lnurl_receive_metadata",
                 column: "preimage",
             }],
             // Migration 13: Clear cached lightning address again (format changed)
             vec![Migration::sql(
-                "DELETE FROM settings WHERE `key` = 'lightning_address'",
+                "DELETE FROM brz_settings WHERE `key` = 'lightning_address'",
             )],
-            // Migration 14: Add is_mature to unclaimed_deposits
+            // Migration 14: Add is_mature to brz_unclaimed_deposits
             vec![Migration::AddColumn {
-                table: "unclaimed_deposits",
+                table: "brz_unclaimed_deposits",
                 column: "is_mature",
                 definition: "TINYINT(1) NOT NULL DEFAULT 1",
             }],
-            // Migration 15: Add conversion_status to payment_metadata
+            // Migration 15: Add conversion_status to brz_payment_metadata
             vec![Migration::AddColumn {
-                table: "payment_metadata",
+                table: "brz_payment_metadata",
                 column: "conversion_status",
                 definition: "VARCHAR(64) NULL",
             }],
@@ -387,135 +457,135 @@ fn multi_tenant_migration(identity: &[u8]) -> Vec<Migration> {
         )));
     };
 
-    scope_table("payments", "id", &mut stmts);
+    scope_table("brz_payments", "id", &mut stmts);
     stmts.push(Migration::DropIndex {
-        name: "idx_payments_timestamp",
-        table: "payments",
+        name: "brz_idx_payments_timestamp",
+        table: "brz_payments",
     });
     stmts.push(Migration::DropIndex {
-        name: "idx_payments_payment_type",
-        table: "payments",
+        name: "brz_idx_payments_payment_type",
+        table: "brz_payments",
     });
     stmts.push(Migration::DropIndex {
-        name: "idx_payments_status",
-        table: "payments",
+        name: "brz_idx_payments_status",
+        table: "brz_payments",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_payments_user_timestamp",
-        table: "payments",
+        name: "brz_idx_payments_user_timestamp",
+        table: "brz_payments",
         columns: "(user_id, timestamp)",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_payments_user_payment_type",
-        table: "payments",
+        name: "brz_idx_payments_user_payment_type",
+        table: "brz_payments",
         columns: "(user_id, payment_type)",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_payments_user_status",
-        table: "payments",
+        name: "brz_idx_payments_user_status",
+        table: "brz_payments",
         columns: "(user_id, status)",
     });
 
-    scope_table("payment_metadata", "payment_id", &mut stmts);
+    scope_table("brz_payment_metadata", "payment_id", &mut stmts);
     stmts.push(Migration::DropIndex {
-        name: "idx_payment_metadata_parent",
-        table: "payment_metadata",
+        name: "brz_idx_payment_metadata_parent",
+        table: "brz_payment_metadata",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_payment_metadata_user_parent",
-        table: "payment_metadata",
+        name: "brz_idx_payment_metadata_user_parent",
+        table: "brz_payment_metadata",
         columns: "(user_id, parent_payment_id)",
     });
 
-    scope_table("payment_details_lightning", "payment_id", &mut stmts);
+    scope_table("brz_payment_details_lightning", "payment_id", &mut stmts);
     stmts.push(Migration::DropIndex {
-        name: "idx_payment_details_lightning_invoice",
-        table: "payment_details_lightning",
+        name: "brz_idx_payment_details_lightning_invoice",
+        table: "brz_payment_details_lightning",
     });
     stmts.push(Migration::DropIndex {
-        name: "idx_payment_details_lightning_payment_hash",
-        table: "payment_details_lightning",
+        name: "brz_idx_payment_details_lightning_payment_hash",
+        table: "brz_payment_details_lightning",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_payment_details_lightning_user_invoice",
-        table: "payment_details_lightning",
+        name: "brz_idx_payment_details_lightning_user_invoice",
+        table: "brz_payment_details_lightning",
         columns: "(user_id, invoice(255))",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_payment_details_lightning_user_payment_hash",
-        table: "payment_details_lightning",
+        name: "brz_idx_payment_details_lightning_user_payment_hash",
+        table: "brz_payment_details_lightning",
         columns: "(user_id, payment_hash)",
     });
 
-    scope_table("payment_details_token", "payment_id", &mut stmts);
-    scope_table("payment_details_spark", "payment_id", &mut stmts);
-    scope_table("lnurl_receive_metadata", "payment_hash", &mut stmts);
-    scope_table("unclaimed_deposits", "txid, vout", &mut stmts);
-    scope_table("contacts", "id", &mut stmts);
-    scope_table("settings", "`key`", &mut stmts);
+    scope_table("brz_payment_details_token", "payment_id", &mut stmts);
+    scope_table("brz_payment_details_spark", "payment_id", &mut stmts);
+    scope_table("brz_lnurl_receive_metadata", "payment_hash", &mut stmts);
+    scope_table("brz_unclaimed_deposits", "txid, vout", &mut stmts);
+    scope_table("brz_contacts", "id", &mut stmts);
+    scope_table("brz_settings", "`key`", &mut stmts);
 
-    // sync_revision was a single-row table (PK id=1, CHECK id=1). Drop the
+    // brz_sync_revision was a single-row table (PK id=1, CHECK id=1). Drop the
     // PK and the id column, then re-key by user_id. (`MySQL` 8 auto-drops
     // the dependent CHECK constraint when its sole referenced column goes.)
     stmts.push(Migration::DropPrimaryKey {
-        table: "sync_revision",
+        table: "brz_sync_revision",
     });
     stmts.push(Migration::DropColumn {
-        table: "sync_revision",
+        table: "brz_sync_revision",
         column: "id",
     });
     stmts.push(Migration::AddColumn {
-        table: "sync_revision",
+        table: "brz_sync_revision",
         column: "user_id",
         definition: "VARBINARY(33) NULL",
     });
     stmts.push(Migration::Sql(format!(
-        "UPDATE sync_revision SET user_id = {id_lit} WHERE user_id IS NULL"
+        "UPDATE brz_sync_revision SET user_id = {id_lit} WHERE user_id IS NULL"
     )));
     stmts.push(Migration::sql(
-        "ALTER TABLE sync_revision MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+        "ALTER TABLE brz_sync_revision MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
     ));
     stmts.push(Migration::sql(
-        "ALTER TABLE sync_revision ADD PRIMARY KEY (user_id)",
+        "ALTER TABLE brz_sync_revision ADD PRIMARY KEY (user_id)",
     ));
 
-    // sync_outgoing has no PK, only an index — just add user_id and rewrite
+    // brz_sync_outgoing has no PK, only an index — just add user_id and rewrite
     // the index.
     stmts.push(Migration::AddColumn {
-        table: "sync_outgoing",
+        table: "brz_sync_outgoing",
         column: "user_id",
         definition: "VARBINARY(33) NULL",
     });
     stmts.push(Migration::Sql(format!(
-        "UPDATE sync_outgoing SET user_id = {id_lit} WHERE user_id IS NULL"
+        "UPDATE brz_sync_outgoing SET user_id = {id_lit} WHERE user_id IS NULL"
     )));
     stmts.push(Migration::sql(
-        "ALTER TABLE sync_outgoing MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+        "ALTER TABLE brz_sync_outgoing MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
     ));
     stmts.push(Migration::DropIndex {
-        name: "idx_sync_outgoing_data_id_record_type",
-        table: "sync_outgoing",
+        name: "brz_idx_sync_outgoing_data_id_record_type",
+        table: "brz_sync_outgoing",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_sync_outgoing_user_record_type_data_id",
-        table: "sync_outgoing",
+        name: "brz_idx_sync_outgoing_user_record_type_data_id",
+        table: "brz_sync_outgoing",
         columns: "(user_id, record_type, data_id)",
     });
 
-    scope_table("sync_state", "record_type, data_id", &mut stmts);
+    scope_table("brz_sync_state", "record_type, data_id", &mut stmts);
 
     scope_table(
-        "sync_incoming",
+        "brz_sync_incoming",
         "record_type, data_id, revision",
         &mut stmts,
     );
     stmts.push(Migration::DropIndex {
-        name: "idx_sync_incoming_revision",
-        table: "sync_incoming",
+        name: "brz_idx_sync_incoming_revision",
+        table: "brz_sync_incoming",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_sync_incoming_user_revision",
-        table: "sync_incoming",
+        name: "brz_idx_sync_incoming_user_revision",
+        table: "brz_sync_incoming",
         columns: "(user_id, revision)",
     });
 
@@ -731,7 +801,7 @@ impl Storage for MysqlStorage {
             };
 
         tx.exec_drop(
-            "INSERT INTO payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+            "INSERT INTO brz_payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                  ON DUPLICATE KEY UPDATE
                     payment_type = VALUES(payment_type),
@@ -770,7 +840,7 @@ impl Storage for MysqlStorage {
                     let invoice_json = to_json_string_opt(invoice_details.as_ref())?;
                     let htlc_json = to_json_string_opt(htlc_details.as_ref())?;
                     tx.exec_drop(
-                        "INSERT INTO payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
+                        "INSERT INTO brz_payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
                              VALUES (?, ?, ?, ?)
                              ON DUPLICATE KEY UPDATE
                                 invoice_details = COALESCE(VALUES(invoice_details), invoice_details),
@@ -792,7 +862,7 @@ impl Storage for MysqlStorage {
                     .map_err(|e| StorageError::Serialization(e.to_string()))?;
                 let invoice_json = to_json_string_opt(invoice_details.as_ref())?;
                 tx.exec_drop(
-                    "INSERT INTO payment_details_token (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
+                    "INSERT INTO brz_payment_details_token (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
                          VALUES (?, ?, ?, ?, ?, ?)
                          ON DUPLICATE KEY UPDATE
                             metadata = VALUES(metadata),
@@ -823,7 +893,7 @@ impl Storage for MysqlStorage {
                 let htlc_status = htlc_details.status.to_string();
                 let htlc_expiry_time = i64::try_from(htlc_details.expiry_time)?;
                 tx.exec_drop(
-                    "INSERT INTO payment_details_lightning (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
+                    "INSERT INTO brz_payment_details_lightning (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
                          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                          ON DUPLICATE KEY UPDATE
                             invoice = VALUES(invoice),
@@ -871,7 +941,7 @@ impl Storage for MysqlStorage {
             .map(std::string::ToString::to_string);
 
         conn.exec_drop(
-            "INSERT INTO payment_metadata (user_id, payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
+            "INSERT INTO brz_payment_metadata (user_id, payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE
                 parent_payment_id = COALESCE(VALUES(parent_payment_id), parent_payment_id),
@@ -901,7 +971,7 @@ impl Storage for MysqlStorage {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
 
         conn.exec_drop(
-            "INSERT INTO settings (user_id, `key`, value) VALUES (?, ?, ?)
+            "INSERT INTO brz_settings (user_id, `key`, value) VALUES (?, ?, ?)
              ON DUPLICATE KEY UPDATE value = VALUES(value)",
             (self.identity.clone(), key, value),
         )
@@ -916,7 +986,7 @@ impl Storage for MysqlStorage {
 
         let row: Option<String> = conn
             .exec_first(
-                "SELECT value FROM settings WHERE user_id = ? AND `key` = ?",
+                "SELECT value FROM brz_settings WHERE user_id = ? AND `key` = ?",
                 (self.identity.clone(), key),
             )
             .await
@@ -929,7 +999,7 @@ impl Storage for MysqlStorage {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
 
         conn.exec_drop(
-            "DELETE FROM settings WHERE user_id = ? AND `key` = ?",
+            "DELETE FROM brz_settings WHERE user_id = ? AND `key` = ?",
             (self.identity.clone(), key),
         )
         .await
@@ -979,7 +1049,7 @@ impl Storage for MysqlStorage {
 
         let has_related: bool = conn
             .exec_first::<i64, _, _>(
-                "SELECT EXISTS(SELECT 1 FROM payment_metadata WHERE user_id = ? AND parent_payment_id IS NOT NULL LIMIT 1)",
+                "SELECT EXISTS(SELECT 1 FROM brz_payment_metadata WHERE user_id = ? AND parent_payment_id IS NOT NULL LIMIT 1)",
                 (self.identity.clone(),),
             )
             .await
@@ -1024,7 +1094,7 @@ impl Storage for MysqlStorage {
     ) -> Result<(), StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
         conn.exec_drop(
-            "INSERT INTO unclaimed_deposits (user_id, txid, vout, amount_sats, is_mature)
+            "INSERT INTO brz_unclaimed_deposits (user_id, txid, vout, amount_sats, is_mature)
              VALUES (?, ?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE is_mature = VALUES(is_mature), amount_sats = VALUES(amount_sats)",
             (
@@ -1043,7 +1113,7 @@ impl Storage for MysqlStorage {
     async fn delete_deposit(&self, txid: String, vout: u32) -> Result<(), StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
         conn.exec_drop(
-            "DELETE FROM unclaimed_deposits WHERE user_id = ? AND txid = ? AND vout = ?",
+            "DELETE FROM brz_unclaimed_deposits WHERE user_id = ? AND txid = ? AND vout = ?",
             (self.identity.clone(), txid, i32::try_from(vout)?),
         )
         .await
@@ -1055,7 +1125,7 @@ impl Storage for MysqlStorage {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
         let rows: Vec<Row> = conn
             .exec(
-                "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM unclaimed_deposits WHERE user_id = ?",
+                "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM brz_unclaimed_deposits WHERE user_id = ?",
                 (self.identity.clone(),),
             )
             .await
@@ -1099,7 +1169,7 @@ impl Storage for MysqlStorage {
                 let error_json = serde_json::to_string(&error)
                     .map_err(|e| StorageError::Serialization(e.to_string()))?;
                 conn.exec_drop(
-                    "UPDATE unclaimed_deposits SET claim_error = ?, refund_tx = NULL, refund_tx_id = NULL WHERE user_id = ? AND txid = ? AND vout = ?",
+                    "UPDATE brz_unclaimed_deposits SET claim_error = ?, refund_tx = NULL, refund_tx_id = NULL WHERE user_id = ? AND txid = ? AND vout = ?",
                     (error_json, self.identity.clone(), txid, i32::try_from(vout)?),
                 )
                 .await
@@ -1110,7 +1180,7 @@ impl Storage for MysqlStorage {
                 refund_tx,
             } => {
                 conn.exec_drop(
-                    "UPDATE unclaimed_deposits SET refund_tx = ?, refund_tx_id = ?, claim_error = NULL WHERE user_id = ? AND txid = ? AND vout = ?",
+                    "UPDATE brz_unclaimed_deposits SET refund_tx = ?, refund_tx_id = ?, claim_error = NULL WHERE user_id = ? AND txid = ? AND vout = ?",
                     (refund_tx, refund_txid, self.identity.clone(), txid, i32::try_from(vout)?),
                 )
                 .await
@@ -1127,7 +1197,7 @@ impl Storage for MysqlStorage {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
         for m in metadata {
             conn.exec_drop(
-                "INSERT INTO lnurl_receive_metadata (user_id, payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
+                "INSERT INTO brz_lnurl_receive_metadata (user_id, payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
                  VALUES (?, ?, ?, ?, ?)
                  ON DUPLICATE KEY UPDATE
                     nostr_zap_request = VALUES(nostr_zap_request),
@@ -1152,7 +1222,7 @@ impl Storage for MysqlStorage {
         let rows: Vec<(String, String, String, i64, i64)> = conn
             .exec(
                 "SELECT id, name, payment_identifier, created_at, updated_at
-                 FROM contacts WHERE user_id = ? ORDER BY name ASC LIMIT ? OFFSET ?",
+                 FROM brz_contacts WHERE user_id = ? ORDER BY name ASC LIMIT ? OFFSET ?",
                 (self.identity.clone(), limit, offset),
             )
             .await
@@ -1176,7 +1246,7 @@ impl Storage for MysqlStorage {
         let row: Option<(String, String, String, i64, i64)> = conn
             .exec_first(
                 "SELECT id, name, payment_identifier, created_at, updated_at
-                 FROM contacts WHERE user_id = ? AND id = ?",
+                 FROM brz_contacts WHERE user_id = ? AND id = ?",
                 (self.identity.clone(), id),
             )
             .await
@@ -1195,7 +1265,7 @@ impl Storage for MysqlStorage {
     async fn insert_contact(&self, contact: Contact) -> Result<(), StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
         conn.exec_drop(
-            "INSERT INTO contacts (user_id, id, name, payment_identifier, created_at, updated_at)
+            "INSERT INTO brz_contacts (user_id, id, name, payment_identifier, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE
                name = VALUES(name),
@@ -1218,7 +1288,7 @@ impl Storage for MysqlStorage {
     async fn delete_contact(&self, id: String) -> Result<(), StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
         conn.exec_drop(
-            "DELETE FROM contacts WHERE user_id = ? AND id = ?",
+            "DELETE FROM brz_contacts WHERE user_id = ? AND id = ?",
             (self.identity.clone(), id),
         )
         .await
@@ -1240,7 +1310,7 @@ impl Storage for MysqlStorage {
         // The local queue revision is per-tenant — two tenants don't share a queue.
         let local_revision: i64 = tx
             .exec_first(
-                "SELECT COALESCE(MAX(revision), 0) + 1 FROM sync_outgoing WHERE user_id = ?",
+                "SELECT COALESCE(MAX(revision), 0) + 1 FROM brz_sync_outgoing WHERE user_id = ?",
                 (self.identity.clone(),),
             )
             .await
@@ -1252,7 +1322,7 @@ impl Storage for MysqlStorage {
         let commit_time = chrono::Utc::now().timestamp();
 
         tx.exec_drop(
-            "INSERT INTO sync_outgoing (user_id, record_type, data_id, schema_version, commit_time, updated_fields_json, revision)
+            "INSERT INTO brz_sync_outgoing (user_id, record_type, data_id, schema_version, commit_time, updated_fields_json, revision)
                  VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 self.identity.clone(),
@@ -1285,7 +1355,7 @@ impl Storage for MysqlStorage {
 
         let mut result = tx
             .exec_iter(
-                "DELETE FROM sync_outgoing WHERE user_id = ? AND record_type = ? AND data_id = ? AND revision = ?",
+                "DELETE FROM brz_sync_outgoing WHERE user_id = ? AND record_type = ? AND data_id = ? AND revision = ?",
                 (
                     self.identity.clone(),
                     record.id.r#type.clone(),
@@ -1300,7 +1370,7 @@ impl Storage for MysqlStorage {
 
         if rows_deleted == 0 {
             warn!(
-                "complete_outgoing_sync: DELETE from sync_outgoing matched 0 rows \
+                "complete_outgoing_sync: DELETE from brz_sync_outgoing matched 0 rows \
                  (type={}, data_id={}, revision={})",
                 record.id.r#type, record.id.data_id, local_revision
             );
@@ -1311,7 +1381,7 @@ impl Storage for MysqlStorage {
         let commit_time = chrono::Utc::now().timestamp();
 
         tx.exec_drop(
-            "INSERT INTO sync_state (user_id, record_type, data_id, schema_version, commit_time, data, revision)
+            "INSERT INTO brz_sync_state (user_id, record_type, data_id, schema_version, commit_time, data, revision)
                  VALUES (?, ?, ?, ?, ?, ?, ?)
                  ON DUPLICATE KEY UPDATE
                     schema_version = VALUES(schema_version),
@@ -1335,7 +1405,7 @@ impl Storage for MysqlStorage {
         // backfill, but a fresh tenant joining a shared DB after the migration
         // won't have one yet.
         tx.exec_drop(
-            "INSERT INTO sync_revision (user_id, revision) VALUES (?, ?)
+            "INSERT INTO brz_sync_revision (user_id, revision) VALUES (?, ?)
              ON DUPLICATE KEY UPDATE revision = GREATEST(revision, VALUES(revision))",
             (self.identity.clone(), i64::try_from(record.revision)?),
         )
@@ -1357,8 +1427,8 @@ impl Storage for MysqlStorage {
             .exec(
                 "SELECT o.record_type, o.data_id, o.schema_version, o.commit_time, o.updated_fields_json, o.revision,
                         e.schema_version AS existing_schema_version, e.commit_time AS existing_commit_time, e.data AS existing_data, e.revision AS existing_revision
-                 FROM sync_outgoing o
-                 LEFT JOIN sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id AND o.user_id = e.user_id
+                 FROM brz_sync_outgoing o
+                 LEFT JOIN brz_sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id AND o.user_id = e.user_id
                  WHERE o.user_id = ?
                  ORDER BY o.revision ASC
                  LIMIT ?",
@@ -1401,7 +1471,7 @@ impl Storage for MysqlStorage {
         // A tenant that hasn't synced anything yet may have no row; treat as 0.
         let revision: i64 = conn
             .exec_first(
-                "SELECT revision FROM sync_revision WHERE user_id = ?",
+                "SELECT revision FROM brz_sync_revision WHERE user_id = ?",
                 (self.identity.clone(),),
             )
             .await
@@ -1423,7 +1493,7 @@ impl Storage for MysqlStorage {
             let data_json = serde_json::to_string(&record.data)
                 .map_err(|e| StorageError::Serialization(e.to_string()))?;
             conn.exec_drop(
-                "INSERT INTO sync_incoming (user_id, record_type, data_id, schema_version, commit_time, data, revision)
+                "INSERT INTO brz_sync_incoming (user_id, record_type, data_id, schema_version, commit_time, data, revision)
                  VALUES (?, ?, ?, ?, ?, ?, ?)
                  ON DUPLICATE KEY UPDATE
                     schema_version = VALUES(schema_version),
@@ -1450,7 +1520,7 @@ impl Storage for MysqlStorage {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
 
         conn.exec_drop(
-            "DELETE FROM sync_incoming WHERE user_id = ? AND record_type = ? AND data_id = ? AND revision = ?",
+            "DELETE FROM brz_sync_incoming WHERE user_id = ? AND record_type = ? AND data_id = ? AND revision = ?",
             (
                 self.identity.clone(),
                 record.id.r#type,
@@ -1471,8 +1541,8 @@ impl Storage for MysqlStorage {
             .exec(
                 "SELECT i.record_type, i.data_id, i.schema_version, i.data, i.revision,
                         e.schema_version AS existing_schema_version, e.commit_time AS existing_commit_time, e.data AS existing_data, e.revision AS existing_revision
-                 FROM sync_incoming i
-                 LEFT JOIN sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id AND i.user_id = e.user_id
+                 FROM brz_sync_incoming i
+                 LEFT JOIN brz_sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id AND i.user_id = e.user_id
                  WHERE i.user_id = ?
                  ORDER BY i.revision ASC
                  LIMIT ?",
@@ -1519,8 +1589,8 @@ impl Storage for MysqlStorage {
             .exec_first(
                 "SELECT o.record_type, o.data_id, o.schema_version, o.commit_time, o.updated_fields_json, o.revision,
                         e.schema_version AS existing_schema_version, e.commit_time AS existing_commit_time, e.data AS existing_data, e.revision AS existing_revision
-                 FROM sync_outgoing o
-                 LEFT JOIN sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id AND o.user_id = e.user_id
+                 FROM brz_sync_outgoing o
+                 LEFT JOIN brz_sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id AND o.user_id = e.user_id
                  WHERE o.user_id = ?
                  ORDER BY o.revision DESC
                  LIMIT 1",
@@ -1569,7 +1639,7 @@ impl Storage for MysqlStorage {
         let commit_time = chrono::Utc::now().timestamp();
 
         tx.exec_drop(
-            "INSERT INTO sync_state (user_id, record_type, data_id, schema_version, commit_time, data, revision)
+            "INSERT INTO brz_sync_state (user_id, record_type, data_id, schema_version, commit_time, data, revision)
                  VALUES (?, ?, ?, ?, ?, ?, ?)
                  ON DUPLICATE KEY UPDATE
                     schema_version = VALUES(schema_version),
@@ -1590,7 +1660,7 @@ impl Storage for MysqlStorage {
         .map_err(map_db_error)?;
 
         tx.exec_drop(
-            "INSERT INTO sync_revision (user_id, revision) VALUES (?, ?)
+            "INSERT INTO brz_sync_revision (user_id, revision) VALUES (?, ?)
              ON DUPLICATE KEY UPDATE revision = GREATEST(revision, VALUES(revision))",
             (self.identity.clone(), i64::try_from(record.revision)?),
         )
@@ -1638,12 +1708,12 @@ const SELECT_PAYMENT_SQL: &str = "
            lrm.payment_hash AS lnurl_payment_hash,
            pm.conversion_status,
            pm.parent_payment_id
-      FROM payments p
-      LEFT JOIN payment_details_lightning l ON p.id = l.payment_id AND p.user_id = l.user_id
-      LEFT JOIN payment_details_token t ON p.id = t.payment_id AND p.user_id = t.user_id
-      LEFT JOIN payment_details_spark s ON p.id = s.payment_id AND p.user_id = s.user_id
-      LEFT JOIN payment_metadata pm ON p.id = pm.payment_id AND p.user_id = pm.user_id
-      LEFT JOIN lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash AND l.user_id = lrm.user_id";
+      FROM brz_payments p
+      LEFT JOIN brz_payment_details_lightning l ON p.id = l.payment_id AND p.user_id = l.user_id
+      LEFT JOIN brz_payment_details_token t ON p.id = t.payment_id AND p.user_id = t.user_id
+      LEFT JOIN brz_payment_details_spark s ON p.id = s.payment_id AND p.user_id = s.user_id
+      LEFT JOIN brz_payment_metadata pm ON p.id = pm.payment_id AND p.user_id = pm.user_id
+      LEFT JOIN brz_lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash AND l.user_id = lrm.user_id";
 
 #[allow(clippy::too_many_lines)]
 fn map_payment(row: &Row) -> Result<Payment, StorageError> {
@@ -1669,7 +1739,7 @@ fn map_payment(row: &Row) -> Result<Payment, StorageError> {
             let htlc_status: SparkHtlcStatus = htlc_status_str
                 .ok_or_else(|| {
                     StorageError::Implementation(
-                        "htlc_status is required for Lightning payments".to_string(),
+                        "htlc_status is required for Lightning brz_payments".to_string(),
                     )
                 })
                 .and_then(|s| {
@@ -2053,8 +2123,8 @@ mod tests {
 
     /// End-to-end isolation: every Storage method must keep tenants A and B
     /// from observing each other's data. The test exercises each per-user
-    /// table — `payments`, `payment_metadata`, `lnurl_receive_metadata`,
-    /// `contacts`, `unclaimed_deposits`, `settings`, and the sync mirror
+    /// table — `brz_payments`, `brz_payment_metadata`, `brz_lnurl_receive_metadata`,
+    /// `brz_contacts`, `brz_unclaimed_deposits`, `brz_settings`, and the sync mirror
     /// tables — and asserts that writes by A are invisible to B (and vice
     /// versa). It is the regression net for "forgot the WHERE clause" bugs
     /// in any future query.
@@ -2263,7 +2333,7 @@ mod tests {
             panic!("expected lnurl metadata to be visible to each tenant");
         }
 
-        // --- sync state (sync_outgoing, sync_state, sync_revision) ---
+        // --- sync state (brz_sync_outgoing, brz_sync_state, brz_sync_revision) ---
         let rec_id = RecordId::new("contact".to_string(), "rec_shared".to_string());
         let updated_a: HashMap<String, String> = HashMap::new();
         fx.a.add_outgoing_change(UnversionedRecordChange {

--- a/crates/breez-sdk/core/src/persist/postgres/base.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/base.rs
@@ -189,9 +189,7 @@ pub(crate) fn create_pool(
 
 pub(super) use spark_postgres::SchemaRenames;
 
-/// Runs database migrations with version tracking and concurrency control,
-/// optionally applying a one-shot schema rename first (under the same
-/// transaction-level advisory lock).
+/// Wraps [`spark_postgres::run_migrations`] with `StorageError` mapping.
 pub(super) async fn run_migrations(
     pool: &deadpool_postgres::Pool,
     migrations_table: &str,

--- a/crates/breez-sdk/core/src/persist/postgres/base.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/base.rs
@@ -187,13 +187,18 @@ pub(crate) fn create_pool(
     spark_postgres::create_pool(&sp_config).map_err(StorageError::from)
 }
 
-/// Runs database migrations with version tracking and concurrency control.
+pub(super) use spark_postgres::SchemaRenames;
+
+/// Runs database migrations with version tracking and concurrency control,
+/// optionally applying a one-shot schema rename first (under the same
+/// transaction-level advisory lock).
 pub(super) async fn run_migrations(
     pool: &deadpool_postgres::Pool,
     migrations_table: &str,
     migrations: &[Vec<String>],
+    renames: Option<&SchemaRenames<'_>>,
 ) -> Result<(), StorageError> {
-    spark_postgres::run_migrations(pool, migrations_table, migrations)
+    spark_postgres::run_migrations(pool, migrations_table, migrations, renames)
         .await
         .map_err(StorageError::from)
 }

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -54,6 +54,7 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
         ("contacts", "brz_contacts"),
     ],
     indexes: &[
+        // Post-multi-tenant indexes (current state on version >= 16 DBs).
         (
             "idx_payments_user_timestamp",
             "brz_idx_payments_user_timestamp",
@@ -82,6 +83,32 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
         (
             "idx_sync_incoming_user_revision",
             "brz_idx_sync_incoming_user_revision",
+        ),
+        // Pre-multi-tenant indexes (still present on version < 16 DBs).
+        // The multi-tenant migration drops these via `DROP INDEX IF EXISTS
+        // brz_idx_*`, so the rename moves them under the prefix first.
+        ("idx_payments_timestamp", "brz_idx_payments_timestamp"),
+        ("idx_payments_payment_type", "brz_idx_payments_payment_type"),
+        ("idx_payments_status", "brz_idx_payments_status"),
+        (
+            "idx_payment_metadata_parent",
+            "brz_idx_payment_metadata_parent",
+        ),
+        (
+            "idx_payment_details_lightning_invoice",
+            "brz_idx_payment_details_lightning_invoice",
+        ),
+        (
+            "idx_payment_details_lightning_payment_hash",
+            "brz_idx_payment_details_lightning_payment_hash",
+        ),
+        (
+            "idx_sync_outgoing_data_id_record_type",
+            "brz_idx_sync_outgoing_data_id_record_type",
+        ),
+        (
+            "idx_sync_incoming_revision",
+            "brz_idx_sync_incoming_revision",
         ),
     ],
     constraints: &[
@@ -2888,6 +2915,264 @@ mod tests {
                 created_at BIGINT NOT NULL,
                 updated_at BIGINT NOT NULL,
                 PRIMARY KEY (user_id, id)
+            )"
+            .to_string(),
+        ]
+    }
+
+    /// End-to-end rename against a **pre-multi-tenant** legacy schema
+    /// (version=15): unprefixed tables without `user_id`, pre-tenant
+    /// indexes only. After `migrate()`, the rename moves pre-tenant indexes
+    /// under `brz_*`, then migration 16 (multi-tenant) drops them and
+    /// creates `brz_*_user_*` variants. No unprefixed `idx_*` should
+    /// survive on any brz_ table.
+    #[tokio::test]
+    async fn test_rename_against_pre_tenant_legacy_schema() {
+        let container = Postgres::default()
+            .start()
+            .await
+            .expect("Failed to start PostgreSQL container");
+        let host_port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("Failed to get host port");
+        let connection_string = format!(
+            "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
+        );
+
+        let pool = create_pool(&PostgresStorageConfig::with_defaults(
+            connection_string.clone(),
+        ))
+        .expect("create pool");
+        {
+            let client = pool.get().await.expect("get_conn");
+            for stmt in pre_tenant_legacy_schema_sql() {
+                client.batch_execute(&stmt).await.unwrap_or_else(|e| {
+                    panic!("pre-tenant legacy schema setup failed at\n{stmt}\n=> {e}")
+                });
+            }
+            // Seed data must survive the rename + the multi-tenant
+            // migration's user_id backfill.
+            client
+                .execute(
+                    "INSERT INTO payments
+                     (id, payment_type, status, amount, fees, timestamp, method)
+                     VALUES ('p1', 'receive', 'completed', '1000', '0', 100, 'lightning')",
+                    &[],
+                )
+                .await
+                .expect("seed payment");
+            client
+                .execute(
+                    "INSERT INTO settings (key, value) VALUES ('seed_key', 'seed_value')",
+                    &[],
+                )
+                .await
+                .expect("seed setting");
+        }
+
+        // Build storage with run_migration=true — fires rename then runs
+        // migration 16 (the only one left after seed at version=15).
+        let storage = PostgresStorage::new(
+            PostgresStorageConfig::with_defaults(connection_string),
+            &TEST_IDENTITY_A,
+        )
+        .await
+        .expect("migrate against pre-tenant schema");
+
+        let client = pool.get().await.expect("get_conn");
+
+        // The bug check: no unprefixed `idx_*` index should remain on any
+        // brz_ table after the rename + multi-tenant migration.
+        let orphan_rows = client
+            .query(
+                "SELECT indexname, tablename FROM pg_indexes
+                 WHERE schemaname = current_schema()
+                   AND tablename LIKE 'brz_%'
+                   AND indexname LIKE 'idx_%'",
+                &[],
+            )
+            .await
+            .expect("scan orphan indexes");
+        let orphans: Vec<(String, String)> = orphan_rows
+            .iter()
+            .map(|r| (r.get::<_, String>(0), r.get::<_, String>(1)))
+            .collect();
+        assert!(
+            orphans.is_empty(),
+            "found orphan unprefixed indexes after upgrade: {orphans:?}"
+        );
+
+        // Migration version advanced from 15 to 16.
+        let version: i32 = client
+            .query_one("SELECT MAX(version) FROM brz_schema_migrations", &[])
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(version, 16, "migration must advance to 16");
+
+        // Seed data preserved (multi-tenant backfilled user_id to current tenant).
+        let payment_count: i64 = client
+            .query_one("SELECT COUNT(*) FROM brz_payments WHERE id = 'p1'", &[])
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(payment_count, 1, "seed payment must survive upgrade");
+
+        let setting = storage
+            .get_cached_item("seed_key".to_string())
+            .await
+            .expect("get_cached_item");
+        assert_eq!(setting.as_deref(), Some("seed_value"));
+    }
+
+    /// Pre-multi-tenant schema snapshot (version=15): unprefixed tables
+    /// without `user_id`, pre-tenant indexes, no post-tenant indexes.
+    /// Captures the SDK schema state just before migration 16.
+    #[allow(clippy::too_many_lines)]
+    fn pre_tenant_legacy_schema_sql() -> Vec<String> {
+        vec![
+            "CREATE TABLE schema_migrations (
+                version INTEGER PRIMARY KEY,
+                applied_at TIMESTAMPTZ DEFAULT NOW()
+            )"
+            .to_string(),
+            "INSERT INTO schema_migrations (version)
+             SELECT generate_series(1, 15)"
+                .to_string(),
+            // Core tables (migration 1) — no user_id, simple PKs.
+            "CREATE TABLE payments (
+                id TEXT PRIMARY KEY,
+                payment_type TEXT NOT NULL,
+                status TEXT NOT NULL,
+                amount TEXT NOT NULL,
+                fees TEXT NOT NULL,
+                timestamp BIGINT NOT NULL,
+                method TEXT,
+                withdraw_tx_id TEXT,
+                deposit_tx_id TEXT,
+                spark BOOLEAN
+            )"
+            .to_string(),
+            "CREATE TABLE settings (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )"
+            .to_string(),
+            "CREATE TABLE unclaimed_deposits (
+                txid TEXT NOT NULL,
+                vout INTEGER NOT NULL,
+                amount_sats BIGINT,
+                claim_error JSONB,
+                refund_tx TEXT,
+                refund_tx_id TEXT,
+                is_mature BOOLEAN NOT NULL DEFAULT TRUE,
+                PRIMARY KEY (txid, vout)
+            )"
+            .to_string(),
+            "CREATE TABLE payment_metadata (
+                payment_id TEXT PRIMARY KEY,
+                parent_payment_id TEXT,
+                lnurl_pay_info JSONB,
+                lnurl_withdraw_info JSONB,
+                lnurl_description TEXT,
+                conversion_info JSONB,
+                conversion_status TEXT
+            )"
+            .to_string(),
+            "CREATE TABLE payment_details_lightning (
+                payment_id TEXT PRIMARY KEY,
+                invoice TEXT NOT NULL,
+                payment_hash TEXT NOT NULL,
+                destination_pubkey TEXT NOT NULL,
+                description TEXT,
+                htlc_status TEXT NOT NULL DEFAULT 'WaitingForPreimage',
+                htlc_expiry_time BIGINT NOT NULL DEFAULT 0
+            )"
+            .to_string(),
+            "CREATE TABLE payment_details_token (
+                payment_id TEXT PRIMARY KEY,
+                metadata JSONB NOT NULL,
+                tx_hash TEXT NOT NULL,
+                invoice_details JSONB,
+                tx_type TEXT NOT NULL DEFAULT 'transfer'
+            )"
+            .to_string(),
+            "CREATE TABLE payment_details_spark (
+                payment_id TEXT PRIMARY KEY,
+                invoice_details JSONB,
+                htlc_details JSONB
+            )"
+            .to_string(),
+            "CREATE TABLE lnurl_receive_metadata (
+                payment_hash TEXT PRIMARY KEY,
+                nostr_zap_request TEXT,
+                nostr_zap_receipt TEXT,
+                sender_comment TEXT
+            )"
+            .to_string(),
+            // Sync tables (migration 2) — including pre-tenant indexes.
+            "CREATE TABLE sync_revision (
+                id INTEGER PRIMARY KEY DEFAULT 1,
+                revision BIGINT NOT NULL DEFAULT 0,
+                CHECK (id = 1)
+            )"
+            .to_string(),
+            "INSERT INTO sync_revision (id, revision) VALUES (1, 0)".to_string(),
+            "CREATE TABLE sync_outgoing (
+                record_type TEXT NOT NULL,
+                data_id TEXT NOT NULL,
+                schema_version TEXT NOT NULL,
+                commit_time BIGINT NOT NULL,
+                updated_fields_json JSONB NOT NULL,
+                revision BIGINT NOT NULL
+            )"
+            .to_string(),
+            "CREATE INDEX idx_sync_outgoing_data_id_record_type
+             ON sync_outgoing(record_type, data_id)"
+                .to_string(),
+            "CREATE TABLE sync_state (
+                record_type TEXT NOT NULL,
+                data_id TEXT NOT NULL,
+                schema_version TEXT NOT NULL,
+                commit_time BIGINT NOT NULL,
+                data JSONB NOT NULL,
+                revision BIGINT NOT NULL,
+                PRIMARY KEY(record_type, data_id)
+            )"
+            .to_string(),
+            "CREATE TABLE sync_incoming (
+                record_type TEXT NOT NULL,
+                data_id TEXT NOT NULL,
+                schema_version TEXT NOT NULL,
+                commit_time BIGINT NOT NULL,
+                data JSONB NOT NULL,
+                revision BIGINT NOT NULL,
+                PRIMARY KEY(record_type, data_id, revision)
+            )"
+            .to_string(),
+            "CREATE INDEX idx_sync_incoming_revision ON sync_incoming(revision)".to_string(),
+            // Pre-tenant indexes on payments etc. (migration 3).
+            "CREATE INDEX idx_payments_timestamp ON payments(timestamp)".to_string(),
+            "CREATE INDEX idx_payments_payment_type ON payments(payment_type)".to_string(),
+            "CREATE INDEX idx_payments_status ON payments(status)".to_string(),
+            "CREATE INDEX idx_payment_details_lightning_invoice
+             ON payment_details_lightning(invoice)"
+                .to_string(),
+            "CREATE INDEX idx_payment_metadata_parent
+             ON payment_metadata(parent_payment_id)"
+                .to_string(),
+            // Migration 10 index on payment_hash.
+            "CREATE INDEX idx_payment_details_lightning_payment_hash
+             ON payment_details_lightning(payment_hash)"
+                .to_string(),
+            // Migration 11 contacts table.
+            "CREATE TABLE contacts (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                payment_identifier TEXT NOT NULL,
+                created_at BIGINT NOT NULL,
+                updated_at BIGINT NOT NULL
             )"
             .to_string(),
         ]

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -34,12 +34,7 @@ use super::base::{SchemaRenames, map_db_error, map_pool_error, run_migrations};
 /// Name of the schema migrations table for `PostgresStorage`.
 const MIGRATIONS_TABLE: &str = "brz_schema_migrations";
 
-/// Old-to-`brz_*` rename map for the breez-sdk core persist schema.
-/// Applied on first startup after upgrading to the prefixed schema. The
-/// indexes listed are the ones present after the multi-tenant migration
-/// (the original pre-tenant index names were dropped by that migration).
-/// All primary keys are Postgres-default-named `<table>_pkey` and renamed
-/// alongside their tables.
+/// Pre-prefix rename map for upgrading core persist deployments.
 const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
     old_migrations_table: "schema_migrations",
     new_migrations_table: MIGRATIONS_TABLE,
@@ -1687,7 +1682,7 @@ fn map_payment(row: &Row) -> Result<Payment, StorageError> {
             let htlc_status: SparkHtlcStatus = htlc_status_str
                 .ok_or_else(|| {
                     StorageError::Implementation(
-                        "htlc_status is required for Lightning brz_payments".to_string(),
+                        "htlc_status is required for Lightning payments".to_string(),
                     )
                 })
                 .and_then(|s| {
@@ -2398,7 +2393,7 @@ mod tests {
                     .unwrap();
             }
 
-            // Step 2: Insert Lightning brz_payments with different statuses
+            // Step 2: Insert Lightning payments with different statuses
             // Completed payment
             client
                 .execute(
@@ -2596,5 +2591,305 @@ mod tests {
         assert!(result.is_ok(), "Expected valid PEM to parse successfully");
         let store = result.unwrap();
         assert_eq!(store.len(), 1, "Expected exactly one certificate in store");
+    }
+
+    /// Validates the real `SCHEMA_RENAMES` constant against a hand-rolled
+    /// snapshot of the pre-`brz_*` post-multi-tenant schema (i.e. a customer
+    /// upgrading from the version of the SDK immediately prior to this PR).
+    /// Seeds a payment, runs the SDK's `migrate()` (which fires the rename),
+    /// then verifies the renamed schema is functional via the storage trait.
+    ///
+    /// A typo in `SCHEMA_RENAMES` — wrong table, index, or constraint name —
+    /// would fail here either at the rename step or when storage queries
+    /// hit a missing identifier.
+    #[tokio::test]
+    async fn test_rename_against_real_legacy_schema() {
+        let container = Postgres::default()
+            .start()
+            .await
+            .expect("Failed to start PostgreSQL container");
+        let host_port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("Failed to get host port");
+        let connection_string = format!(
+            "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
+        );
+
+        // Seed the legacy (pre-prefix) post-multi-tenant schema directly.
+        // Captures the state of a customer at the migration version
+        // immediately prior to this PR — `schema_migrations` at version 16,
+        // every table user_id-scoped, post-tenant indexes in place.
+        let pool = create_pool(&PostgresStorageConfig::with_defaults(
+            connection_string.clone(),
+        ))
+        .expect("create pool");
+        let id_lit = format!("'\\x{}'::bytea", hex::encode(TEST_IDENTITY_A));
+        {
+            let client = pool.get().await.expect("get_conn");
+            for stmt in legacy_schema_sql() {
+                client
+                    .batch_execute(&stmt)
+                    .await
+                    .unwrap_or_else(|e| panic!("legacy schema setup failed at\n{stmt}\n=> {e}"));
+            }
+            // Seed: a payment + a setting. Both must survive the rename
+            // and be readable via the storage trait after.
+            client
+                .execute(
+                    &format!(
+                        "INSERT INTO payments
+                         (user_id, id, payment_type, status, amount, fees, timestamp, method)
+                         VALUES ({id_lit}, 'p1', 'receive', 'completed', '1000', '0', 100, 'lightning')"
+                    ),
+                    &[],
+                )
+                .await
+                .expect("seed payment");
+            client
+                .execute(
+                    &format!(
+                        "INSERT INTO settings (user_id, key, value)
+                         VALUES ({id_lit}, 'seed_key', 'seed_value')"
+                    ),
+                    &[],
+                )
+                .await
+                .expect("seed setting");
+        }
+
+        // Build storage with run_migration=true — fires the rename block,
+        // then run_migrations sees schema_migrations at version 16 (now
+        // renamed to brz_schema_migrations) and skips all version-tracked
+        // steps. Net effect: schema is renamed, no migrations re-run.
+        let storage = PostgresStorage::new(
+            PostgresStorageConfig::with_defaults(connection_string),
+            &TEST_IDENTITY_A,
+        )
+        .await
+        .expect("migrate against legacy schema");
+
+        // Legacy tracker is gone; new one carries the same version row.
+        let client = pool.get().await.expect("get_conn");
+        let legacy_gone: bool = client
+            .query_one(
+                "SELECT NOT EXISTS (SELECT 1 FROM information_schema.tables
+                                    WHERE table_schema = current_schema()
+                                      AND table_name = 'schema_migrations')",
+                &[],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert!(legacy_gone, "legacy schema_migrations must be renamed");
+
+        let version: i32 = client
+            .query_one("SELECT MAX(version) FROM brz_schema_migrations", &[])
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(version, 16, "migration version must be preserved");
+
+        // Seed payment row is preserved on the renamed table — proves the
+        // table + PK constraint rename worked and the columns line up.
+        let payment_row_count: i64 = client
+            .query_one("SELECT COUNT(*) FROM brz_payments WHERE id = 'p1'", &[])
+            .await
+            .unwrap()
+            .get(0);
+        assert_eq!(payment_row_count, 1, "seed payment must survive rename");
+
+        // Settings round-trip via the trait — proves brz_settings is wired.
+        let setting = storage
+            .get_cached_item("seed_key".to_string())
+            .await
+            .expect("get_cached_item");
+        assert_eq!(setting.as_deref(), Some("seed_value"));
+
+        // Write through the trait — proves the post-rename schema accepts
+        // new writes via every index/constraint the SDK uses.
+        storage
+            .set_cached_item(
+                "post_rename_key".to_string(),
+                "post_rename_value".to_string(),
+            )
+            .await
+            .expect("set_cached_item");
+        let written = storage
+            .get_cached_item("post_rename_key".to_string())
+            .await
+            .expect("get_cached_item");
+        assert_eq!(written.as_deref(), Some("post_rename_value"));
+    }
+
+    /// Hand-rolled snapshot of the pre-PR schema in its terminal
+    /// (post-multi-tenant, version-16) state. Maintained alongside
+    /// `SCHEMA_RENAMES` — when adding a new table, index, or constraint
+    /// to the SDK schema, mirror the addition here so this test continues
+    /// to validate that the rename map covers it.
+    #[allow(clippy::too_many_lines)]
+    fn legacy_schema_sql() -> Vec<String> {
+        vec![
+            "CREATE TABLE schema_migrations (
+                version INTEGER PRIMARY KEY,
+                applied_at TIMESTAMPTZ DEFAULT NOW()
+            )"
+            .to_string(),
+            "INSERT INTO schema_migrations (version)
+             SELECT generate_series(1, 16)"
+                .to_string(),
+            "CREATE TABLE payments (
+                user_id BYTEA NOT NULL,
+                id TEXT NOT NULL,
+                payment_type TEXT NOT NULL,
+                status TEXT NOT NULL,
+                amount TEXT NOT NULL,
+                fees TEXT NOT NULL,
+                timestamp BIGINT NOT NULL,
+                method TEXT,
+                withdraw_tx_id TEXT,
+                deposit_tx_id TEXT,
+                spark BOOLEAN,
+                PRIMARY KEY (user_id, id)
+            )"
+            .to_string(),
+            "CREATE INDEX idx_payments_user_timestamp ON payments(user_id, timestamp)".to_string(),
+            "CREATE INDEX idx_payments_user_payment_type ON payments(user_id, payment_type)"
+                .to_string(),
+            "CREATE INDEX idx_payments_user_status ON payments(user_id, status)".to_string(),
+            "CREATE TABLE settings (
+                user_id BYTEA NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT NOT NULL,
+                PRIMARY KEY (user_id, key)
+            )"
+            .to_string(),
+            "CREATE TABLE unclaimed_deposits (
+                user_id BYTEA NOT NULL,
+                txid TEXT NOT NULL,
+                vout INTEGER NOT NULL,
+                amount_sats BIGINT,
+                claim_error JSONB,
+                refund_tx TEXT,
+                refund_tx_id TEXT,
+                is_mature BOOLEAN NOT NULL DEFAULT TRUE,
+                PRIMARY KEY (user_id, txid, vout)
+            )"
+            .to_string(),
+            "CREATE TABLE payment_metadata (
+                user_id BYTEA NOT NULL,
+                payment_id TEXT NOT NULL,
+                parent_payment_id TEXT,
+                lnurl_pay_info JSONB,
+                lnurl_withdraw_info JSONB,
+                lnurl_description TEXT,
+                conversion_info JSONB,
+                conversion_status TEXT,
+                PRIMARY KEY (user_id, payment_id)
+            )"
+            .to_string(),
+            "CREATE INDEX idx_payment_metadata_user_parent
+             ON payment_metadata(user_id, parent_payment_id)"
+                .to_string(),
+            "CREATE TABLE payment_details_lightning (
+                user_id BYTEA NOT NULL,
+                payment_id TEXT NOT NULL,
+                invoice TEXT NOT NULL,
+                payment_hash TEXT NOT NULL,
+                destination_pubkey TEXT NOT NULL,
+                description TEXT,
+                htlc_status TEXT NOT NULL DEFAULT 'WaitingForPreimage',
+                htlc_expiry_time BIGINT NOT NULL DEFAULT 0,
+                PRIMARY KEY (user_id, payment_id)
+            )"
+            .to_string(),
+            "CREATE INDEX idx_payment_details_lightning_user_invoice
+             ON payment_details_lightning(user_id, invoice)"
+                .to_string(),
+            "CREATE INDEX idx_payment_details_lightning_user_payment_hash
+             ON payment_details_lightning(user_id, payment_hash)"
+                .to_string(),
+            "CREATE TABLE payment_details_token (
+                user_id BYTEA NOT NULL,
+                payment_id TEXT NOT NULL,
+                metadata JSONB NOT NULL,
+                tx_hash TEXT NOT NULL,
+                invoice_details JSONB,
+                tx_type TEXT NOT NULL DEFAULT 'transfer',
+                PRIMARY KEY (user_id, payment_id)
+            )"
+            .to_string(),
+            "CREATE TABLE payment_details_spark (
+                user_id BYTEA NOT NULL,
+                payment_id TEXT NOT NULL,
+                invoice_details JSONB,
+                htlc_details JSONB,
+                PRIMARY KEY (user_id, payment_id)
+            )"
+            .to_string(),
+            "CREATE TABLE lnurl_receive_metadata (
+                user_id BYTEA NOT NULL,
+                payment_hash TEXT NOT NULL,
+                nostr_zap_request TEXT,
+                nostr_zap_receipt TEXT,
+                sender_comment TEXT,
+                PRIMARY KEY (user_id, payment_hash)
+            )"
+            .to_string(),
+            "CREATE TABLE sync_revision (
+                user_id BYTEA NOT NULL,
+                revision BIGINT NOT NULL DEFAULT 0,
+                PRIMARY KEY (user_id)
+            )"
+            .to_string(),
+            "CREATE TABLE sync_outgoing (
+                user_id BYTEA NOT NULL,
+                record_type TEXT NOT NULL,
+                data_id TEXT NOT NULL,
+                schema_version TEXT NOT NULL,
+                commit_time BIGINT NOT NULL,
+                updated_fields_json JSONB NOT NULL,
+                revision BIGINT NOT NULL
+            )"
+            .to_string(),
+            "CREATE INDEX idx_sync_outgoing_user_record_type_data_id
+             ON sync_outgoing(user_id, record_type, data_id)"
+                .to_string(),
+            "CREATE TABLE sync_state (
+                user_id BYTEA NOT NULL,
+                record_type TEXT NOT NULL,
+                data_id TEXT NOT NULL,
+                schema_version TEXT NOT NULL,
+                commit_time BIGINT NOT NULL,
+                data JSONB NOT NULL,
+                revision BIGINT NOT NULL,
+                PRIMARY KEY (user_id, record_type, data_id)
+            )"
+            .to_string(),
+            "CREATE TABLE sync_incoming (
+                user_id BYTEA NOT NULL,
+                record_type TEXT NOT NULL,
+                data_id TEXT NOT NULL,
+                schema_version TEXT NOT NULL,
+                commit_time BIGINT NOT NULL,
+                data JSONB NOT NULL,
+                revision BIGINT NOT NULL,
+                PRIMARY KEY (user_id, record_type, data_id, revision)
+            )"
+            .to_string(),
+            "CREATE INDEX idx_sync_incoming_user_revision
+             ON sync_incoming(user_id, revision)"
+                .to_string(),
+            "CREATE TABLE contacts (
+                user_id BYTEA NOT NULL,
+                id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                payment_identifier TEXT NOT NULL,
+                created_at BIGINT NOT NULL,
+                updated_at BIGINT NOT NULL,
+                PRIMARY KEY (user_id, id)
+            )"
+            .to_string(),
+        ]
     }
 }

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -29,10 +29,113 @@ use crate::{
 
 #[cfg(test)]
 use super::base::{PostgresStorageConfig, create_pool};
-use super::base::{map_db_error, map_pool_error, run_migrations};
+use super::base::{SchemaRenames, map_db_error, map_pool_error, run_migrations};
 
 /// Name of the schema migrations table for `PostgresStorage`.
-const MIGRATIONS_TABLE: &str = "schema_migrations";
+const MIGRATIONS_TABLE: &str = "brz_schema_migrations";
+
+/// Old-to-`brz_*` rename map for the breez-sdk core persist schema.
+/// Applied on first startup after upgrading to the prefixed schema. The
+/// indexes listed are the ones present after the multi-tenant migration
+/// (the original pre-tenant index names were dropped by that migration).
+/// All primary keys are Postgres-default-named `<table>_pkey` and renamed
+/// alongside their tables.
+const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
+    old_migrations_table: "schema_migrations",
+    new_migrations_table: MIGRATIONS_TABLE,
+    tables: &[
+        ("payments", "brz_payments"),
+        ("settings", "brz_settings"),
+        ("unclaimed_deposits", "brz_unclaimed_deposits"),
+        ("payment_metadata", "brz_payment_metadata"),
+        ("payment_details_lightning", "brz_payment_details_lightning"),
+        ("payment_details_token", "brz_payment_details_token"),
+        ("payment_details_spark", "brz_payment_details_spark"),
+        ("lnurl_receive_metadata", "brz_lnurl_receive_metadata"),
+        ("sync_revision", "brz_sync_revision"),
+        ("sync_outgoing", "brz_sync_outgoing"),
+        ("sync_state", "brz_sync_state"),
+        ("sync_incoming", "brz_sync_incoming"),
+        ("contacts", "brz_contacts"),
+    ],
+    indexes: &[
+        (
+            "idx_payments_user_timestamp",
+            "brz_idx_payments_user_timestamp",
+        ),
+        (
+            "idx_payments_user_payment_type",
+            "brz_idx_payments_user_payment_type",
+        ),
+        ("idx_payments_user_status", "brz_idx_payments_user_status"),
+        (
+            "idx_payment_metadata_user_parent",
+            "brz_idx_payment_metadata_user_parent",
+        ),
+        (
+            "idx_payment_details_lightning_user_invoice",
+            "brz_idx_payment_details_lightning_user_invoice",
+        ),
+        (
+            "idx_payment_details_lightning_user_payment_hash",
+            "brz_idx_payment_details_lightning_user_payment_hash",
+        ),
+        (
+            "idx_sync_outgoing_user_record_type_data_id",
+            "brz_idx_sync_outgoing_user_record_type_data_id",
+        ),
+        (
+            "idx_sync_incoming_user_revision",
+            "brz_idx_sync_incoming_user_revision",
+        ),
+    ],
+    constraints: &[
+        ("brz_payments", "payments_pkey", "brz_payments_pkey"),
+        ("brz_settings", "settings_pkey", "brz_settings_pkey"),
+        (
+            "brz_unclaimed_deposits",
+            "unclaimed_deposits_pkey",
+            "brz_unclaimed_deposits_pkey",
+        ),
+        (
+            "brz_payment_metadata",
+            "payment_metadata_pkey",
+            "brz_payment_metadata_pkey",
+        ),
+        (
+            "brz_payment_details_lightning",
+            "payment_details_lightning_pkey",
+            "brz_payment_details_lightning_pkey",
+        ),
+        (
+            "brz_payment_details_token",
+            "payment_details_token_pkey",
+            "brz_payment_details_token_pkey",
+        ),
+        (
+            "brz_payment_details_spark",
+            "payment_details_spark_pkey",
+            "brz_payment_details_spark_pkey",
+        ),
+        (
+            "brz_lnurl_receive_metadata",
+            "lnurl_receive_metadata_pkey",
+            "brz_lnurl_receive_metadata_pkey",
+        ),
+        (
+            "brz_sync_revision",
+            "sync_revision_pkey",
+            "brz_sync_revision_pkey",
+        ),
+        ("brz_sync_state", "sync_state_pkey", "brz_sync_state_pkey"),
+        (
+            "brz_sync_incoming",
+            "sync_incoming_pkey",
+            "brz_sync_incoming_pkey",
+        ),
+        ("brz_contacts", "contacts_pkey", "brz_contacts_pkey"),
+    ],
+};
 
 /// PostgreSQL-based storage implementation using connection pooling.
 ///
@@ -104,6 +207,7 @@ impl PostgresStorage {
             &self.pool,
             MIGRATIONS_TABLE,
             &Self::migrations(&self.identity),
+            Some(&SCHEMA_RENAMES),
         )
         .await
     }
@@ -113,7 +217,7 @@ impl PostgresStorage {
         vec![
             // Migration 1: Core tables
             vec![
-                "CREATE TABLE IF NOT EXISTS payments (
+                "CREATE TABLE IF NOT EXISTS brz_payments (
                     id TEXT PRIMARY KEY,
                     payment_type TEXT NOT NULL,
                     status TEXT NOT NULL,
@@ -125,11 +229,11 @@ impl PostgresStorage {
                     deposit_tx_id TEXT,
                     spark BOOLEAN
                 )".to_string(),
-                "CREATE TABLE IF NOT EXISTS settings (
+                "CREATE TABLE IF NOT EXISTS brz_settings (
                     key TEXT PRIMARY KEY,
                     value TEXT NOT NULL
                 )".to_string(),
-                "CREATE TABLE IF NOT EXISTS unclaimed_deposits (
+                "CREATE TABLE IF NOT EXISTS brz_unclaimed_deposits (
                     txid TEXT NOT NULL,
                     vout INTEGER NOT NULL,
                     amount_sats BIGINT,
@@ -138,7 +242,7 @@ impl PostgresStorage {
                     refund_tx_id TEXT,
                     PRIMARY KEY (txid, vout)
                 )".to_string(),
-                "CREATE TABLE IF NOT EXISTS payment_metadata (
+                "CREATE TABLE IF NOT EXISTS brz_payment_metadata (
                     payment_id TEXT PRIMARY KEY,
                     parent_payment_id TEXT,
                     lnurl_pay_info JSONB,
@@ -146,7 +250,7 @@ impl PostgresStorage {
                     lnurl_description TEXT,
                     conversion_info JSONB
                 )".to_string(),
-                "CREATE TABLE IF NOT EXISTS payment_details_lightning (
+                "CREATE TABLE IF NOT EXISTS brz_payment_details_lightning (
                     payment_id TEXT PRIMARY KEY,
                     invoice TEXT NOT NULL,
                     payment_hash TEXT NOT NULL,
@@ -154,18 +258,18 @@ impl PostgresStorage {
                     description TEXT,
                     preimage TEXT
                 )".to_string(),
-                "CREATE TABLE IF NOT EXISTS payment_details_token (
+                "CREATE TABLE IF NOT EXISTS brz_payment_details_token (
                     payment_id TEXT PRIMARY KEY,
                     metadata JSONB NOT NULL,
                     tx_hash TEXT NOT NULL,
                     invoice_details JSONB
                 )".to_string(),
-                "CREATE TABLE IF NOT EXISTS payment_details_spark (
+                "CREATE TABLE IF NOT EXISTS brz_payment_details_spark (
                     payment_id TEXT PRIMARY KEY,
                     invoice_details JSONB,
                     htlc_details JSONB
                 )".to_string(),
-                "CREATE TABLE IF NOT EXISTS lnurl_receive_metadata (
+                "CREATE TABLE IF NOT EXISTS brz_lnurl_receive_metadata (
                     payment_hash TEXT PRIMARY KEY,
                     nostr_zap_request TEXT,
                     nostr_zap_receipt TEXT,
@@ -174,16 +278,16 @@ impl PostgresStorage {
             ],
             // Migration 2: Sync tables
             vec![
-                // sync_revision: tracks the last committed revision (from server-acknowledged
+                // brz_sync_revision: tracks the last committed revision (from server-acknowledged
                 // or server-received records). Does NOT include pending outgoing queue ids.
-                // sync_outgoing.revision stores a local queue id for ordering/de-duplication only.
-                "CREATE TABLE IF NOT EXISTS sync_revision (
+                // brz_sync_outgoing.revision stores a local queue id for ordering/de-duplication only.
+                "CREATE TABLE IF NOT EXISTS brz_sync_revision (
                     id INTEGER PRIMARY KEY DEFAULT 1,
                     revision BIGINT NOT NULL DEFAULT 0,
                     CHECK (id = 1)
                 )".to_string(),
-                "INSERT INTO sync_revision (id, revision) VALUES (1, 0) ON CONFLICT (id) DO NOTHING".to_string(),
-                "CREATE TABLE IF NOT EXISTS sync_outgoing (
+                "INSERT INTO brz_sync_revision (id, revision) VALUES (1, 0) ON CONFLICT (id) DO NOTHING".to_string(),
+                "CREATE TABLE IF NOT EXISTS brz_sync_outgoing (
                     record_type TEXT NOT NULL,
                     data_id TEXT NOT NULL,
                     schema_version TEXT NOT NULL,
@@ -191,8 +295,8 @@ impl PostgresStorage {
                     updated_fields_json JSONB NOT NULL,
                     revision BIGINT NOT NULL
                 )".to_string(),
-                "CREATE INDEX IF NOT EXISTS idx_sync_outgoing_data_id_record_type ON sync_outgoing(record_type, data_id)".to_string(),
-                "CREATE TABLE IF NOT EXISTS sync_state (
+                "CREATE INDEX IF NOT EXISTS brz_idx_sync_outgoing_data_id_record_type ON brz_sync_outgoing(record_type, data_id)".to_string(),
+                "CREATE TABLE IF NOT EXISTS brz_sync_state (
                     record_type TEXT NOT NULL,
                     data_id TEXT NOT NULL,
                     schema_version TEXT NOT NULL,
@@ -201,7 +305,7 @@ impl PostgresStorage {
                     revision BIGINT NOT NULL,
                     PRIMARY KEY(record_type, data_id)
                 )".to_string(),
-                "CREATE TABLE IF NOT EXISTS sync_incoming (
+                "CREATE TABLE IF NOT EXISTS brz_sync_incoming (
                     record_type TEXT NOT NULL,
                     data_id TEXT NOT NULL,
                     schema_version TEXT NOT NULL,
@@ -210,79 +314,79 @@ impl PostgresStorage {
                     revision BIGINT NOT NULL,
                     PRIMARY KEY(record_type, data_id, revision)
                 )".to_string(),
-                "CREATE INDEX IF NOT EXISTS idx_sync_incoming_revision ON sync_incoming(revision)".to_string(),
+                "CREATE INDEX IF NOT EXISTS brz_idx_sync_incoming_revision ON brz_sync_incoming(revision)".to_string(),
             ],
             // Migration 3: Indexes
             vec![
-                "CREATE INDEX IF NOT EXISTS idx_payments_timestamp ON payments(timestamp)".to_string(),
-                "CREATE INDEX IF NOT EXISTS idx_payments_payment_type ON payments(payment_type)".to_string(),
-                "CREATE INDEX IF NOT EXISTS idx_payments_status ON payments(status)".to_string(),
-                "CREATE INDEX IF NOT EXISTS idx_payment_details_lightning_invoice ON payment_details_lightning(invoice)".to_string(),
-                "CREATE INDEX IF NOT EXISTS idx_payment_metadata_parent ON payment_metadata(parent_payment_id)".to_string(),
+                "CREATE INDEX IF NOT EXISTS brz_idx_payments_timestamp ON brz_payments(timestamp)".to_string(),
+                "CREATE INDEX IF NOT EXISTS brz_idx_payments_payment_type ON brz_payments(payment_type)".to_string(),
+                "CREATE INDEX IF NOT EXISTS brz_idx_payments_status ON brz_payments(status)".to_string(),
+                "CREATE INDEX IF NOT EXISTS brz_idx_payment_details_lightning_invoice ON brz_payment_details_lightning(invoice)".to_string(),
+                "CREATE INDEX IF NOT EXISTS brz_idx_payment_metadata_parent ON brz_payment_metadata(parent_payment_id)".to_string(),
             ],
             // Migration 4: Add tx_type to token payments
             vec![
-                "ALTER TABLE payment_details_token ADD COLUMN tx_type TEXT NOT NULL DEFAULT 'transfer'".to_string(),
+                "ALTER TABLE brz_payment_details_token ADD COLUMN tx_type TEXT NOT NULL DEFAULT 'transfer'".to_string(),
             ],
             // Migration 5: Clear sync tables to force re-sync
             vec![
-                "DELETE FROM sync_outgoing".to_string(),
-                "DELETE FROM sync_incoming".to_string(),
-                "DELETE FROM sync_state".to_string(),
-                "UPDATE sync_revision SET revision = 0".to_string(),
-                "DELETE FROM settings WHERE key = 'sync_initial_complete'".to_string(),
+                "DELETE FROM brz_sync_outgoing".to_string(),
+                "DELETE FROM brz_sync_incoming".to_string(),
+                "DELETE FROM brz_sync_state".to_string(),
+                "UPDATE brz_sync_revision SET revision = 0".to_string(),
+                "DELETE FROM brz_settings WHERE key = 'sync_initial_complete'".to_string(),
             ],
             // Migration 6: Add htlc_status and htlc_expiry_time to lightning payments
             vec![
-                "ALTER TABLE payment_details_lightning ADD COLUMN htlc_status TEXT NOT NULL DEFAULT 'WaitingForPreimage'".to_string(),
-                "ALTER TABLE payment_details_lightning ADD COLUMN htlc_expiry_time BIGINT NOT NULL DEFAULT 0".to_string(),
+                "ALTER TABLE brz_payment_details_lightning ADD COLUMN htlc_status TEXT NOT NULL DEFAULT 'WaitingForPreimage'".to_string(),
+                "ALTER TABLE brz_payment_details_lightning ADD COLUMN htlc_expiry_time BIGINT NOT NULL DEFAULT 0".to_string(),
             ],
             // Migration 7: Backfill htlc_status for existing Lightning payments
             vec![
-                "UPDATE payment_details_lightning
+                "UPDATE brz_payment_details_lightning
                  SET htlc_status = CASE
-                         WHEN (SELECT status FROM payments WHERE id = payment_id) = 'completed' THEN 'PreimageShared'
-                         WHEN (SELECT status FROM payments WHERE id = payment_id) = 'pending' THEN 'WaitingForPreimage'
+                         WHEN (SELECT status FROM brz_payments WHERE id = payment_id) = 'completed' THEN 'PreimageShared'
+                         WHEN (SELECT status FROM brz_payments WHERE id = payment_id) = 'pending' THEN 'WaitingForPreimage'
                          ELSE 'Returned'
                      END".to_string(),
-                "UPDATE settings
+                "UPDATE brz_settings
                  SET value = jsonb_set(value::jsonb, '{offset}', '0')::text
                  WHERE key = 'sync_offset' AND value IS NOT NULL".to_string(),
             ],
             // Migration 8: Add preimage column for LUD-21 and NIP-57 support
             vec![
-                "ALTER TABLE lnurl_receive_metadata ADD COLUMN IF NOT EXISTS preimage TEXT".to_string(),
+                "ALTER TABLE brz_lnurl_receive_metadata ADD COLUMN IF NOT EXISTS preimage TEXT".to_string(),
                 // Clear the lnurl_metadata_updated_after setting to force re-sync
                 // This ensures clients get the new preimage field from the server
-                "DELETE FROM settings WHERE key = 'lnurl_metadata_updated_after'".to_string(),
+                "DELETE FROM brz_settings WHERE key = 'lnurl_metadata_updated_after'".to_string(),
             ],
             // Migration 9: Clear cached lightning address - schema changed from string to LnurlInfo struct
             vec![
-                "DELETE FROM settings WHERE key = 'lightning_address'".to_string(),
+                "DELETE FROM brz_settings WHERE key = 'lightning_address'".to_string(),
             ],
-            // Migration 10: Add index on payment_hash for JOIN with lnurl_receive_metadata
+            // Migration 10: Add index on payment_hash for JOIN with brz_lnurl_receive_metadata
             vec![
-                "CREATE INDEX IF NOT EXISTS idx_payment_details_lightning_payment_hash ON payment_details_lightning(payment_hash)".to_string(),
+                "CREATE INDEX IF NOT EXISTS brz_idx_payment_details_lightning_payment_hash ON brz_payment_details_lightning(payment_hash)".to_string(),
             ],
             // Migration 11: Contacts table
-            vec!["CREATE TABLE IF NOT EXISTS contacts (
+            vec!["CREATE TABLE IF NOT EXISTS brz_contacts (
                     id TEXT PRIMARY KEY,
                     name TEXT NOT NULL,
                     payment_identifier TEXT NOT NULL,
                     created_at BIGINT NOT NULL,
                     updated_at BIGINT NOT NULL
                 )".to_string()],
-            // Migration 12: Drop preimage column from lnurl_receive_metadata - no longer needed
+            // Migration 12: Drop preimage column from brz_lnurl_receive_metadata - no longer needed
             // since the server handles preimage tracking via webhooks.
-            vec!["ALTER TABLE lnurl_receive_metadata DROP COLUMN IF EXISTS preimage".to_string()],
+            vec!["ALTER TABLE brz_lnurl_receive_metadata DROP COLUMN IF EXISTS preimage".to_string()],
             // Migration 13: Clear cached lightning address - format changed to CachedLightningAddress wrapper
-            vec!["DELETE FROM settings WHERE key = 'lightning_address'".to_string()],
-            // Migration 14: Add is_mature to unclaimed_deposits
+            vec!["DELETE FROM brz_settings WHERE key = 'lightning_address'".to_string()],
+            // Migration 14: Add is_mature to brz_unclaimed_deposits
             vec![
-                "ALTER TABLE unclaimed_deposits ADD COLUMN is_mature BOOLEAN NOT NULL DEFAULT TRUE".to_string(),
+                "ALTER TABLE brz_unclaimed_deposits ADD COLUMN is_mature BOOLEAN NOT NULL DEFAULT TRUE".to_string(),
             ],
-            // Migration 15: Add conversion_status to payment_metadata
-            vec!["ALTER TABLE payment_metadata ADD COLUMN IF NOT EXISTS conversion_status TEXT".to_string()],
+            // Migration 15: Add conversion_status to brz_payment_metadata
+            vec!["ALTER TABLE brz_payment_metadata ADD COLUMN IF NOT EXISTS conversion_status TEXT".to_string()],
             // Migration 16: Multi-tenant scoping. Adds a `user_id BYTEA` column to every
             // per-user table, backfills it to the current tenant's identity (so existing
             // single-tenant deployments remain readable), sets NOT NULL, and rewrites
@@ -319,82 +423,85 @@ fn multi_tenant_migration(identity: &[u8]) -> Vec<String> {
 
     let mut stmts = Vec::new();
 
-    stmts.extend(scope_table("payments", "id"));
-    // Per-user index rewrite for payments
-    stmts.push("DROP INDEX IF EXISTS idx_payments_timestamp".to_string());
-    stmts.push("DROP INDEX IF EXISTS idx_payments_payment_type".to_string());
-    stmts.push("DROP INDEX IF EXISTS idx_payments_status".to_string());
+    stmts.extend(scope_table("brz_payments", "id"));
+    // Per-user index rewrite for brz_payments
+    stmts.push("DROP INDEX IF EXISTS brz_idx_payments_timestamp".to_string());
+    stmts.push("DROP INDEX IF EXISTS brz_idx_payments_payment_type".to_string());
+    stmts.push("DROP INDEX IF EXISTS brz_idx_payments_status".to_string());
     stmts.push(
-        "CREATE INDEX idx_payments_user_timestamp ON payments(user_id, timestamp)".to_string(),
-    );
-    stmts.push(
-        "CREATE INDEX idx_payments_user_payment_type ON payments(user_id, payment_type)"
-            .to_string(),
-    );
-    stmts.push("CREATE INDEX idx_payments_user_status ON payments(user_id, status)".to_string());
-
-    stmts.extend(scope_table("payment_metadata", "payment_id"));
-    stmts.push("DROP INDEX IF EXISTS idx_payment_metadata_parent".to_string());
-    stmts.push(
-        "CREATE INDEX idx_payment_metadata_user_parent \
-         ON payment_metadata(user_id, parent_payment_id)"
-            .to_string(),
-    );
-
-    stmts.extend(scope_table("payment_details_lightning", "payment_id"));
-    stmts.push("DROP INDEX IF EXISTS idx_payment_details_lightning_invoice".to_string());
-    stmts.push("DROP INDEX IF EXISTS idx_payment_details_lightning_payment_hash".to_string());
-    stmts.push(
-        "CREATE INDEX idx_payment_details_lightning_user_invoice \
-         ON payment_details_lightning(user_id, invoice)"
+        "CREATE INDEX brz_idx_payments_user_timestamp ON brz_payments(user_id, timestamp)"
             .to_string(),
     );
     stmts.push(
-        "CREATE INDEX idx_payment_details_lightning_user_payment_hash \
-         ON payment_details_lightning(user_id, payment_hash)"
+        "CREATE INDEX brz_idx_payments_user_payment_type ON brz_payments(user_id, payment_type)"
+            .to_string(),
+    );
+    stmts.push(
+        "CREATE INDEX brz_idx_payments_user_status ON brz_payments(user_id, status)".to_string(),
+    );
+
+    stmts.extend(scope_table("brz_payment_metadata", "payment_id"));
+    stmts.push("DROP INDEX IF EXISTS brz_idx_payment_metadata_parent".to_string());
+    stmts.push(
+        "CREATE INDEX brz_idx_payment_metadata_user_parent \
+         ON brz_payment_metadata(user_id, parent_payment_id)"
             .to_string(),
     );
 
-    stmts.extend(scope_table("payment_details_token", "payment_id"));
-    stmts.extend(scope_table("payment_details_spark", "payment_id"));
-    stmts.extend(scope_table("lnurl_receive_metadata", "payment_hash"));
-    stmts.extend(scope_table("unclaimed_deposits", "txid, vout"));
-    stmts.extend(scope_table("contacts", "id"));
-    stmts.extend(scope_table("settings", "key"));
+    stmts.extend(scope_table("brz_payment_details_lightning", "payment_id"));
+    stmts.push("DROP INDEX IF EXISTS brz_idx_payment_details_lightning_invoice".to_string());
+    stmts.push("DROP INDEX IF EXISTS brz_idx_payment_details_lightning_payment_hash".to_string());
+    stmts.push(
+        "CREATE INDEX brz_idx_payment_details_lightning_user_invoice \
+         ON brz_payment_details_lightning(user_id, invoice)"
+            .to_string(),
+    );
+    stmts.push(
+        "CREATE INDEX brz_idx_payment_details_lightning_user_payment_hash \
+         ON brz_payment_details_lightning(user_id, payment_hash)"
+            .to_string(),
+    );
 
-    // sync_revision was a single-row table (PK id=1, CHECK id=1). Drop the id column
+    stmts.extend(scope_table("brz_payment_details_token", "payment_id"));
+    stmts.extend(scope_table("brz_payment_details_spark", "payment_id"));
+    stmts.extend(scope_table("brz_lnurl_receive_metadata", "payment_hash"));
+    stmts.extend(scope_table("brz_unclaimed_deposits", "txid, vout"));
+    stmts.extend(scope_table("brz_contacts", "id"));
+    stmts.extend(scope_table("brz_settings", "key"));
+
+    // brz_sync_revision was a single-row table (PK id=1, CHECK id=1). Drop the id column
     // (CASCADE clears the PK and the CHECK), then re-key by user_id so every tenant
     // has its own revision counter.
-    stmts.push("ALTER TABLE sync_revision DROP COLUMN id CASCADE".to_string());
-    stmts.push("ALTER TABLE sync_revision ADD COLUMN user_id BYTEA".to_string());
-    stmts.push(format!("UPDATE sync_revision SET user_id = {id_lit}"));
+    stmts.push("ALTER TABLE brz_sync_revision DROP COLUMN id CASCADE".to_string());
+    stmts.push("ALTER TABLE brz_sync_revision ADD COLUMN user_id BYTEA".to_string());
+    stmts.push(format!("UPDATE brz_sync_revision SET user_id = {id_lit}"));
     stmts.push(
-        "ALTER TABLE sync_revision \
+        "ALTER TABLE brz_sync_revision \
          ALTER COLUMN user_id SET NOT NULL, \
          ADD PRIMARY KEY (user_id)"
             .to_string(),
     );
 
-    // sync_outgoing has no PK, only an index — just add user_id and rewrite the index.
-    stmts.push("ALTER TABLE sync_outgoing ADD COLUMN user_id BYTEA".to_string());
-    stmts.push(format!("UPDATE sync_outgoing SET user_id = {id_lit}"));
-    stmts.push("ALTER TABLE sync_outgoing ALTER COLUMN user_id SET NOT NULL".to_string());
-    stmts.push("DROP INDEX IF EXISTS idx_sync_outgoing_data_id_record_type".to_string());
+    // brz_sync_outgoing has no PK, only an index — just add user_id and rewrite the index.
+    stmts.push("ALTER TABLE brz_sync_outgoing ADD COLUMN user_id BYTEA".to_string());
+    stmts.push(format!("UPDATE brz_sync_outgoing SET user_id = {id_lit}"));
+    stmts.push("ALTER TABLE brz_sync_outgoing ALTER COLUMN user_id SET NOT NULL".to_string());
+    stmts.push("DROP INDEX IF EXISTS brz_idx_sync_outgoing_data_id_record_type".to_string());
     stmts.push(
-        "CREATE INDEX idx_sync_outgoing_user_record_type_data_id \
-         ON sync_outgoing(user_id, record_type, data_id)"
+        "CREATE INDEX brz_idx_sync_outgoing_user_record_type_data_id \
+         ON brz_sync_outgoing(user_id, record_type, data_id)"
             .to_string(),
     );
 
-    stmts.extend(scope_table("sync_state", "record_type, data_id"));
+    stmts.extend(scope_table("brz_sync_state", "record_type, data_id"));
 
     stmts.extend(scope_table(
-        "sync_incoming",
+        "brz_sync_incoming",
         "record_type, data_id, revision",
     ));
-    stmts.push("DROP INDEX IF EXISTS idx_sync_incoming_revision".to_string());
+    stmts.push("DROP INDEX IF EXISTS brz_idx_sync_incoming_revision".to_string());
     stmts.push(
-        "CREATE INDEX idx_sync_incoming_user_revision ON sync_incoming(user_id, revision)"
+        "CREATE INDEX brz_idx_sync_incoming_user_revision ON brz_sync_incoming(user_id, revision)"
             .to_string(),
     );
 
@@ -657,7 +764,7 @@ impl Storage for PostgresStorage {
 
         // Insert or update main payment record (including detail columns atomically)
         tx.execute(
-            "INSERT INTO payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+            "INSERT INTO brz_payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
                  VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
                  ON CONFLICT(user_id, id) DO UPDATE SET
                     payment_type = EXCLUDED.payment_type,
@@ -695,11 +802,11 @@ impl Storage for PostgresStorage {
                     let invoice_json = to_json_opt(invoice_details.as_ref())?;
                     let htlc_json = to_json_opt(htlc_details.as_ref())?;
                     tx.execute(
-                        "INSERT INTO payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
+                        "INSERT INTO brz_payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
                              VALUES ($1, $2, $3, $4)
                              ON CONFLICT(user_id, payment_id) DO UPDATE SET
-                                invoice_details = COALESCE(EXCLUDED.invoice_details, payment_details_spark.invoice_details),
-                                htlc_details = COALESCE(EXCLUDED.htlc_details, payment_details_spark.htlc_details)",
+                                invoice_details = COALESCE(EXCLUDED.invoice_details, brz_payment_details_spark.invoice_details),
+                                htlc_details = COALESCE(EXCLUDED.htlc_details, brz_payment_details_spark.htlc_details)",
                         &[&self.identity, &payment.id, &invoice_json, &htlc_json],
                     )
                     .await?;
@@ -716,13 +823,13 @@ impl Storage for PostgresStorage {
                     .map_err(|e| StorageError::Serialization(e.to_string()))?;
                 let invoice_json = to_json_opt(invoice_details.as_ref())?;
                 tx.execute(
-                    "INSERT INTO payment_details_token (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
+                    "INSERT INTO brz_payment_details_token (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
                          VALUES ($1, $2, $3, $4, $5, $6)
                          ON CONFLICT(user_id, payment_id) DO UPDATE SET
                             metadata = EXCLUDED.metadata,
                             tx_hash = EXCLUDED.tx_hash,
                             tx_type = EXCLUDED.tx_type,
-                            invoice_details = COALESCE(EXCLUDED.invoice_details, payment_details_token.invoice_details)",
+                            invoice_details = COALESCE(EXCLUDED.invoice_details, brz_payment_details_token.invoice_details)",
                     &[&self.identity, &payment.id, &metadata_json, &tx_hash, &tx_type.to_string(), &invoice_json],
                 )
                 .await?;
@@ -739,16 +846,16 @@ impl Storage for PostgresStorage {
                 let htlc_status = htlc_details.status.to_string();
                 let htlc_expiry_time = i64::try_from(htlc_details.expiry_time)?;
                 tx.execute(
-                    "INSERT INTO payment_details_lightning (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
+                    "INSERT INTO brz_payment_details_lightning (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
                          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
                          ON CONFLICT(user_id, payment_id) DO UPDATE SET
                             invoice = EXCLUDED.invoice,
                             payment_hash = EXCLUDED.payment_hash,
                             destination_pubkey = EXCLUDED.destination_pubkey,
                             description = EXCLUDED.description,
-                            preimage = COALESCE(EXCLUDED.preimage, payment_details_lightning.preimage),
-                            htlc_status = COALESCE(EXCLUDED.htlc_status, payment_details_lightning.htlc_status),
-                            htlc_expiry_time = COALESCE(EXCLUDED.htlc_expiry_time, payment_details_lightning.htlc_expiry_time)",
+                            preimage = COALESCE(EXCLUDED.preimage, brz_payment_details_lightning.preimage),
+                            htlc_status = COALESCE(EXCLUDED.htlc_status, brz_payment_details_lightning.htlc_status),
+                            htlc_expiry_time = COALESCE(EXCLUDED.htlc_expiry_time, brz_payment_details_lightning.htlc_expiry_time)",
                     &[&self.identity, &payment.id, &invoice, payment_hash, &destination_pubkey, &description, preimage, &htlc_status, &htlc_expiry_time],
                 )
                 .await?;
@@ -779,15 +886,15 @@ impl Storage for PostgresStorage {
 
         client
             .execute(
-                "INSERT INTO payment_metadata (user_id, payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
+                "INSERT INTO brz_payment_metadata (user_id, payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
                  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
                  ON CONFLICT(user_id, payment_id) DO UPDATE SET
-                    parent_payment_id = COALESCE(EXCLUDED.parent_payment_id, payment_metadata.parent_payment_id),
-                    lnurl_pay_info = COALESCE(EXCLUDED.lnurl_pay_info, payment_metadata.lnurl_pay_info),
-                    lnurl_withdraw_info = COALESCE(EXCLUDED.lnurl_withdraw_info, payment_metadata.lnurl_withdraw_info),
-                    lnurl_description = COALESCE(EXCLUDED.lnurl_description, payment_metadata.lnurl_description),
-                    conversion_info = COALESCE(EXCLUDED.conversion_info, payment_metadata.conversion_info),
-                    conversion_status = COALESCE(EXCLUDED.conversion_status, payment_metadata.conversion_status)",
+                    parent_payment_id = COALESCE(EXCLUDED.parent_payment_id, brz_payment_metadata.parent_payment_id),
+                    lnurl_pay_info = COALESCE(EXCLUDED.lnurl_pay_info, brz_payment_metadata.lnurl_pay_info),
+                    lnurl_withdraw_info = COALESCE(EXCLUDED.lnurl_withdraw_info, brz_payment_metadata.lnurl_withdraw_info),
+                    lnurl_description = COALESCE(EXCLUDED.lnurl_description, brz_payment_metadata.lnurl_description),
+                    conversion_info = COALESCE(EXCLUDED.conversion_info, brz_payment_metadata.conversion_info),
+                    conversion_status = COALESCE(EXCLUDED.conversion_status, brz_payment_metadata.conversion_status)",
                 &[
                     &self.identity,
                     &payment_id,
@@ -809,7 +916,7 @@ impl Storage for PostgresStorage {
 
         client
             .execute(
-                "INSERT INTO settings (user_id, key, value) VALUES ($1, $2, $3)
+                "INSERT INTO brz_settings (user_id, key, value) VALUES ($1, $2, $3)
                  ON CONFLICT(user_id, key) DO UPDATE SET value = EXCLUDED.value",
                 &[&self.identity, &key, &value],
             )
@@ -823,7 +930,7 @@ impl Storage for PostgresStorage {
 
         let row = client
             .query_opt(
-                "SELECT value FROM settings WHERE user_id = $1 AND key = $2",
+                "SELECT value FROM brz_settings WHERE user_id = $1 AND key = $2",
                 &[&self.identity, &key],
             )
             .await?;
@@ -836,7 +943,7 @@ impl Storage for PostgresStorage {
 
         client
             .execute(
-                "DELETE FROM settings WHERE user_id = $1 AND key = $2",
+                "DELETE FROM brz_settings WHERE user_id = $1 AND key = $2",
                 &[&self.identity, &key],
             )
             .await?;
@@ -884,7 +991,7 @@ impl Storage for PostgresStorage {
         // Early exit if no related payments exist for this tenant
         let has_related: bool = client
             .query_one(
-                "SELECT EXISTS(SELECT 1 FROM payment_metadata WHERE user_id = $1 AND parent_payment_id IS NOT NULL LIMIT 1)",
+                "SELECT EXISTS(SELECT 1 FROM brz_payment_metadata WHERE user_id = $1 AND parent_payment_id IS NOT NULL LIMIT 1)",
                 &[&self.identity],
             )
             .await
@@ -936,7 +1043,7 @@ impl Storage for PostgresStorage {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         client
             .execute(
-                "INSERT INTO unclaimed_deposits (user_id, txid, vout, amount_sats, is_mature)
+                "INSERT INTO brz_unclaimed_deposits (user_id, txid, vout, amount_sats, is_mature)
                  VALUES ($1, $2, $3, $4, $5)
                  ON CONFLICT(user_id, txid, vout) DO UPDATE SET is_mature = EXCLUDED.is_mature, amount_sats = EXCLUDED.amount_sats",
                 &[
@@ -955,7 +1062,7 @@ impl Storage for PostgresStorage {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         client
             .execute(
-                "DELETE FROM unclaimed_deposits WHERE user_id = $1 AND txid = $2 AND vout = $3",
+                "DELETE FROM brz_unclaimed_deposits WHERE user_id = $1 AND txid = $2 AND vout = $3",
                 &[&self.identity, &txid, &i32::try_from(vout)?],
             )
             .await?;
@@ -966,7 +1073,7 @@ impl Storage for PostgresStorage {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         let rows = client
             .query(
-                "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM unclaimed_deposits WHERE user_id = $1",
+                "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM brz_unclaimed_deposits WHERE user_id = $1",
                 &[&self.identity],
             )
             .await?;
@@ -1006,7 +1113,7 @@ impl Storage for PostgresStorage {
                     .map_err(|e| StorageError::Serialization(e.to_string()))?;
                 client
                     .execute(
-                        "UPDATE unclaimed_deposits SET claim_error = $1, refund_tx = NULL, refund_tx_id = NULL WHERE user_id = $2 AND txid = $3 AND vout = $4",
+                        "UPDATE brz_unclaimed_deposits SET claim_error = $1, refund_tx = NULL, refund_tx_id = NULL WHERE user_id = $2 AND txid = $3 AND vout = $4",
                         &[&error_json, &self.identity, &txid, &i32::try_from(vout)?],
                     )
                     .await?;
@@ -1017,7 +1124,7 @@ impl Storage for PostgresStorage {
             } => {
                 client
                     .execute(
-                        "UPDATE unclaimed_deposits SET refund_tx = $1, refund_tx_id = $2, claim_error = NULL WHERE user_id = $3 AND txid = $4 AND vout = $5",
+                        "UPDATE brz_unclaimed_deposits SET refund_tx = $1, refund_tx_id = $2, claim_error = NULL WHERE user_id = $3 AND txid = $4 AND vout = $5",
                         &[&refund_tx, &refund_txid, &self.identity, &txid, &i32::try_from(vout)?],
                     )
                     .await?;
@@ -1034,7 +1141,7 @@ impl Storage for PostgresStorage {
         for m in metadata {
             client
                 .execute(
-                    "INSERT INTO lnurl_receive_metadata (user_id, payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
+                    "INSERT INTO brz_lnurl_receive_metadata (user_id, payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
                      VALUES ($1, $2, $3, $4, $5)
                      ON CONFLICT(user_id, payment_hash) DO UPDATE SET
                         nostr_zap_request = EXCLUDED.nostr_zap_request,
@@ -1058,7 +1165,7 @@ impl Storage for PostgresStorage {
         let rows = client
             .query(
                 "SELECT id, name, payment_identifier, created_at, updated_at
-                 FROM contacts WHERE user_id = $1 ORDER BY name ASC LIMIT $2 OFFSET $3",
+                 FROM brz_contacts WHERE user_id = $1 ORDER BY name ASC LIMIT $2 OFFSET $3",
                 &[&self.identity, &limit, &offset],
             )
             .await?;
@@ -1081,7 +1188,7 @@ impl Storage for PostgresStorage {
         let row = client
             .query_opt(
                 "SELECT id, name, payment_identifier, created_at, updated_at
-                 FROM contacts WHERE user_id = $1 AND id = $2",
+                 FROM brz_contacts WHERE user_id = $1 AND id = $2",
                 &[&self.identity, &id],
             )
             .await?
@@ -1099,7 +1206,7 @@ impl Storage for PostgresStorage {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         let result = client
             .execute(
-                "INSERT INTO contacts (user_id, id, name, payment_identifier, created_at, updated_at)
+                "INSERT INTO brz_contacts (user_id, id, name, payment_identifier, created_at, updated_at)
                  VALUES ($1, $2, $3, $4, $5, $6)
                  ON CONFLICT (user_id, id) DO UPDATE SET
                    name = EXCLUDED.name,
@@ -1126,7 +1233,7 @@ impl Storage for PostgresStorage {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         client
             .execute(
-                "DELETE FROM contacts WHERE user_id = $1 AND id = $2",
+                "DELETE FROM brz_contacts WHERE user_id = $1 AND id = $2",
                 &[&self.identity, &id],
             )
             .await?;
@@ -1148,7 +1255,7 @@ impl Storage for PostgresStorage {
         // Scoped per-tenant so two tenants don't share a queue.
         let local_revision: i64 = tx
             .query_one(
-                "SELECT COALESCE(MAX(revision), 0) + 1 FROM sync_outgoing WHERE user_id = $1",
+                "SELECT COALESCE(MAX(revision), 0) + 1 FROM brz_sync_outgoing WHERE user_id = $1",
                 &[&self.identity],
             )
             .await
@@ -1160,7 +1267,7 @@ impl Storage for PostgresStorage {
         let commit_time = chrono::Utc::now().timestamp();
 
         tx.execute(
-            "INSERT INTO sync_outgoing (user_id, record_type, data_id, schema_version, commit_time, updated_fields_json, revision)
+            "INSERT INTO brz_sync_outgoing (user_id, record_type, data_id, schema_version, commit_time, updated_fields_json, revision)
                  VALUES ($1, $2, $3, $4, $5, $6, $7)",
             &[
                 &self.identity,
@@ -1197,7 +1304,7 @@ impl Storage for PostgresStorage {
 
         let rows_deleted = tx
             .execute(
-                "DELETE FROM sync_outgoing WHERE user_id = $1 AND record_type = $2 AND data_id = $3 AND revision = $4",
+                "DELETE FROM brz_sync_outgoing WHERE user_id = $1 AND record_type = $2 AND data_id = $3 AND revision = $4",
                 &[
                     &self.identity,
                     &record.id.r#type,
@@ -1210,7 +1317,7 @@ impl Storage for PostgresStorage {
 
         if rows_deleted == 0 {
             warn!(
-                "complete_outgoing_sync: DELETE from sync_outgoing matched 0 rows \
+                "complete_outgoing_sync: DELETE from brz_sync_outgoing matched 0 rows \
                  (type={}, data_id={}, revision={})",
                 record.id.r#type, record.id.data_id, local_revision
             );
@@ -1221,7 +1328,7 @@ impl Storage for PostgresStorage {
         let commit_time = chrono::Utc::now().timestamp();
 
         tx.execute(
-            "INSERT INTO sync_state (user_id, record_type, data_id, schema_version, commit_time, data, revision)
+            "INSERT INTO brz_sync_state (user_id, record_type, data_id, schema_version, commit_time, data, revision)
                  VALUES ($1, $2, $3, $4, $5, $6, $7)
                  ON CONFLICT(user_id, record_type, data_id) DO UPDATE SET
                     schema_version = EXCLUDED.schema_version,
@@ -1244,8 +1351,8 @@ impl Storage for PostgresStorage {
         // Upsert this tenant's revision row. The migration creates a row at backfill, but
         // a fresh tenant joining a shared DB after migration won't have one yet.
         tx.execute(
-            "INSERT INTO sync_revision (user_id, revision) VALUES ($1, $2) \
-             ON CONFLICT (user_id) DO UPDATE SET revision = GREATEST(sync_revision.revision, EXCLUDED.revision)",
+            "INSERT INTO brz_sync_revision (user_id, revision) VALUES ($1, $2) \
+             ON CONFLICT (user_id) DO UPDATE SET revision = GREATEST(brz_sync_revision.revision, EXCLUDED.revision)",
             &[&self.identity, &i64::try_from(record.revision)?],
         )
         .await
@@ -1268,8 +1375,8 @@ impl Storage for PostgresStorage {
             .query(
                 "SELECT o.record_type, o.data_id, o.schema_version, o.commit_time, o.updated_fields_json, o.revision,
                         e.schema_version AS existing_schema_version, e.commit_time AS existing_commit_time, e.data AS existing_data, e.revision AS existing_revision
-                 FROM sync_outgoing o
-                 LEFT JOIN sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id AND o.user_id = e.user_id
+                 FROM brz_sync_outgoing o
+                 LEFT JOIN brz_sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id AND o.user_id = e.user_id
                  WHERE o.user_id = $1
                  ORDER BY o.revision ASC
                  LIMIT $2",
@@ -1310,7 +1417,7 @@ impl Storage for PostgresStorage {
         // A tenant that hasn't synced anything yet may not have a row. Treat missing as 0.
         let revision: i64 = client
             .query_opt(
-                "SELECT revision FROM sync_revision WHERE user_id = $1",
+                "SELECT revision FROM brz_sync_revision WHERE user_id = $1",
                 &[&self.identity],
             )
             .await
@@ -1333,7 +1440,7 @@ impl Storage for PostgresStorage {
                 .map_err(|e| StorageError::Serialization(e.to_string()))?;
             client
                 .execute(
-                    "INSERT INTO sync_incoming (user_id, record_type, data_id, schema_version, commit_time, data, revision)
+                    "INSERT INTO brz_sync_incoming (user_id, record_type, data_id, schema_version, commit_time, data, revision)
                      VALUES ($1, $2, $3, $4, $5, $6, $7)
                      ON CONFLICT(user_id, record_type, data_id, revision) DO UPDATE SET
                         schema_version = EXCLUDED.schema_version,
@@ -1361,7 +1468,7 @@ impl Storage for PostgresStorage {
 
         client
             .execute(
-                "DELETE FROM sync_incoming WHERE user_id = $1 AND record_type = $2 AND data_id = $3 AND revision = $4",
+                "DELETE FROM brz_sync_incoming WHERE user_id = $1 AND record_type = $2 AND data_id = $3 AND revision = $4",
                 &[
                     &self.identity,
                     &record.id.r#type,
@@ -1382,8 +1489,8 @@ impl Storage for PostgresStorage {
             .query(
                 "SELECT i.record_type, i.data_id, i.schema_version, i.data, i.revision,
                         e.schema_version AS existing_schema_version, e.commit_time AS existing_commit_time, e.data AS existing_data, e.revision AS existing_revision
-                 FROM sync_incoming i
-                 LEFT JOIN sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id AND i.user_id = e.user_id
+                 FROM brz_sync_incoming i
+                 LEFT JOIN brz_sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id AND i.user_id = e.user_id
                  WHERE i.user_id = $1
                  ORDER BY i.revision ASC
                  LIMIT $2",
@@ -1429,8 +1536,8 @@ impl Storage for PostgresStorage {
             .query_opt(
                 "SELECT o.record_type, o.data_id, o.schema_version, o.commit_time, o.updated_fields_json, o.revision,
                         e.schema_version AS existing_schema_version, e.commit_time AS existing_commit_time, e.data AS existing_data, e.revision AS existing_revision
-                 FROM sync_outgoing o
-                 LEFT JOIN sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id AND o.user_id = e.user_id
+                 FROM brz_sync_outgoing o
+                 LEFT JOIN brz_sync_state e ON o.record_type = e.record_type AND o.data_id = e.data_id AND o.user_id = e.user_id
                  WHERE o.user_id = $1
                  ORDER BY o.revision DESC
                  LIMIT 1",
@@ -1477,7 +1584,7 @@ impl Storage for PostgresStorage {
         let commit_time = chrono::Utc::now().timestamp();
 
         tx.execute(
-            "INSERT INTO sync_state (user_id, record_type, data_id, schema_version, commit_time, data, revision)
+            "INSERT INTO brz_sync_state (user_id, record_type, data_id, schema_version, commit_time, data, revision)
                  VALUES ($1, $2, $3, $4, $5, $6, $7)
                  ON CONFLICT(user_id, record_type, data_id) DO UPDATE SET
                     schema_version = EXCLUDED.schema_version,
@@ -1499,8 +1606,8 @@ impl Storage for PostgresStorage {
 
         // Upsert this tenant's revision row.
         tx.execute(
-            "INSERT INTO sync_revision (user_id, revision) VALUES ($1, $2) \
-             ON CONFLICT (user_id) DO UPDATE SET revision = GREATEST(sync_revision.revision, EXCLUDED.revision)",
+            "INSERT INTO brz_sync_revision (user_id, revision) VALUES ($1, $2) \
+             ON CONFLICT (user_id) DO UPDATE SET revision = GREATEST(brz_sync_revision.revision, EXCLUDED.revision)",
             &[&self.identity, &i64::try_from(record.revision)?],
         )
         .await
@@ -1549,12 +1656,12 @@ const SELECT_PAYMENT_SQL: &str = "
            lrm.payment_hash AS lnurl_payment_hash,
            pm.conversion_status,
            pm.parent_payment_id
-      FROM payments p
-      LEFT JOIN payment_details_lightning l ON p.id = l.payment_id AND p.user_id = l.user_id
-      LEFT JOIN payment_details_token t ON p.id = t.payment_id AND p.user_id = t.user_id
-      LEFT JOIN payment_details_spark s ON p.id = s.payment_id AND p.user_id = s.user_id
-      LEFT JOIN payment_metadata pm ON p.id = pm.payment_id AND p.user_id = pm.user_id
-      LEFT JOIN lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash AND l.user_id = lrm.user_id";
+      FROM brz_payments p
+      LEFT JOIN brz_payment_details_lightning l ON p.id = l.payment_id AND p.user_id = l.user_id
+      LEFT JOIN brz_payment_details_token t ON p.id = t.payment_id AND p.user_id = t.user_id
+      LEFT JOIN brz_payment_details_spark s ON p.id = s.payment_id AND p.user_id = s.user_id
+      LEFT JOIN brz_payment_metadata pm ON p.id = pm.payment_id AND p.user_id = pm.user_id
+      LEFT JOIN brz_lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash AND l.user_id = lrm.user_id";
 
 #[allow(clippy::too_many_lines)]
 fn map_payment(row: &Row) -> Result<Payment, StorageError> {
@@ -1580,7 +1687,7 @@ fn map_payment(row: &Row) -> Result<Payment, StorageError> {
             let htlc_status: SparkHtlcStatus = htlc_status_str
                 .ok_or_else(|| {
                     StorageError::Implementation(
-                        "htlc_status is required for Lightning payments".to_string(),
+                        "htlc_status is required for Lightning brz_payments".to_string(),
                     )
                 })
                 .and_then(|s| {
@@ -1929,8 +2036,8 @@ mod tests {
 
     /// End-to-end isolation: every Storage method must keep tenants A and B
     /// from observing each other's data. The test exercises each per-user
-    /// table — `payments`, `payment_metadata`, `lnurl_receive_metadata`,
-    /// `contacts`, `unclaimed_deposits`, `settings`, and the sync mirror
+    /// table — `brz_payments`, `brz_payment_metadata`, `brz_lnurl_receive_metadata`,
+    /// `brz_contacts`, `brz_unclaimed_deposits`, `brz_settings`, and the sync mirror
     /// tables — and asserts that writes by A are invisible to B (and vice
     /// versa). It is the regression net for "forgot the WHERE clause" bugs
     /// in any future query.
@@ -2146,7 +2253,7 @@ mod tests {
             panic!("expected lnurl metadata to be visible to each tenant");
         }
 
-        // --- sync state (sync_outgoing, sync_state, sync_revision) ---
+        // --- sync state (brz_sync_outgoing, brz_sync_state, brz_sync_revision) ---
         let rec_id = RecordId::new("contact".to_string(), "rec_shared".to_string());
         let updated_a: HashMap<String, String> = HashMap::new();
         fx.a.add_outgoing_change(UnversionedRecordChange {
@@ -2263,10 +2370,10 @@ mod tests {
                 }
             });
 
-            // Create the schema_migrations table
+            // Create the brz_schema_migrations table
             client
                 .execute(
-                    "CREATE TABLE IF NOT EXISTS schema_migrations (
+                    "CREATE TABLE IF NOT EXISTS brz_schema_migrations (
                         version INTEGER PRIMARY KEY,
                         applied_at TIMESTAMPTZ DEFAULT NOW()
                     )",
@@ -2284,18 +2391,18 @@ mod tests {
                 }
                 client
                     .execute(
-                        "INSERT INTO schema_migrations (version) VALUES ($1)",
+                        "INSERT INTO brz_schema_migrations (version) VALUES ($1)",
                         &[&version],
                     )
                     .await
                     .unwrap();
             }
 
-            // Step 2: Insert Lightning payments with different statuses
+            // Step 2: Insert Lightning brz_payments with different statuses
             // Completed payment
             client
                 .execute(
-                    "INSERT INTO payments (id, payment_type, status, amount, fees, timestamp, method)
+                    "INSERT INTO brz_payments (id, payment_type, status, amount, fees, timestamp, method)
                      VALUES ($1, $2, $3, $4, $5, $6, $7)",
                     &[
                         &"ln-completed",
@@ -2311,7 +2418,7 @@ mod tests {
                 .unwrap();
             client
                 .execute(
-                    "INSERT INTO payment_details_lightning (payment_id, invoice, payment_hash, destination_pubkey, preimage)
+                    "INSERT INTO brz_payment_details_lightning (payment_id, invoice, payment_hash, destination_pubkey, preimage)
                      VALUES ($1, $2, $3, $4, $5)",
                     &[
                         &"ln-completed",
@@ -2327,7 +2434,7 @@ mod tests {
             // Pending payment
             client
                 .execute(
-                    "INSERT INTO payments (id, payment_type, status, amount, fees, timestamp, method)
+                    "INSERT INTO brz_payments (id, payment_type, status, amount, fees, timestamp, method)
                      VALUES ($1, $2, $3, $4, $5, $6, $7)",
                     &[
                         &"ln-pending",
@@ -2343,7 +2450,7 @@ mod tests {
                 .unwrap();
             client
                 .execute(
-                    "INSERT INTO payment_details_lightning (payment_id, invoice, payment_hash, destination_pubkey)
+                    "INSERT INTO brz_payment_details_lightning (payment_id, invoice, payment_hash, destination_pubkey)
                      VALUES ($1, $2, $3, $4)",
                     &[
                         &"ln-pending",
@@ -2358,7 +2465,7 @@ mod tests {
             // Failed payment
             client
                 .execute(
-                    "INSERT INTO payments (id, payment_type, status, amount, fees, timestamp, method)
+                    "INSERT INTO brz_payments (id, payment_type, status, amount, fees, timestamp, method)
                      VALUES ($1, $2, $3, $4, $5, $6, $7)",
                     &[
                         &"ln-failed",
@@ -2374,7 +2481,7 @@ mod tests {
                 .unwrap();
             client
                 .execute(
-                    "INSERT INTO payment_details_lightning (payment_id, invoice, payment_hash, destination_pubkey)
+                    "INSERT INTO brz_payment_details_lightning (payment_id, invoice, payment_hash, destination_pubkey)
                      VALUES ($1, $2, $3, $4)",
                     &[
                         &"ln-failed",

--- a/crates/breez-sdk/lnurl/Cargo.lock
+++ b/crates/breez-sdk/lnurl/Cargo.lock
@@ -2801,7 +2801,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -2838,9 +2838,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3538,6 +3538,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "spark-token-primitives",
  "thiserror 2.0.16",
  "tokio",
  "tonic",
@@ -3547,6 +3548,21 @@ dependencies = [
  "tracing",
  "unicode-normalization",
  "utils",
+ "uuid",
+]
+
+[[package]]
+name = "spark-token-primitives"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de059d7cbb2b65fe6c8831ff57ae0408a7624b65a74b5a31a3109707bb9f86c"
+dependencies = [
+ "bech32",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "sha2",
+ "thiserror 1.0.69",
  "uuid",
 ]
 

--- a/crates/breez-sdk/wasm/js/mysql-session-manager/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-session-manager/index.cjs
@@ -75,7 +75,7 @@ class MysqlSessionManager {
     const serviceKey = _decodePubkey(serviceIdentityKey);
     try {
       const [rows] = await this.pool.execute(
-        `SELECT token, expiration FROM sessions
+        `SELECT token, expiration FROM brz_sessions
          WHERE user_id = ? AND service_identity_key = ?`,
         [this.identity, serviceKey]
       );
@@ -103,7 +103,7 @@ class MysqlSessionManager {
     const serviceKey = _decodePubkey(serviceIdentityKey);
     try {
       await this.pool.execute(
-        `INSERT INTO sessions (user_id, service_identity_key, token, expiration)
+        `INSERT INTO brz_sessions (user_id, service_identity_key, token, expiration)
          VALUES (?, ?, ?, ?)
          ON DUPLICATE KEY UPDATE token = VALUES(token), expiration = VALUES(expiration)`,
         [this.identity, serviceKey, session.token, session.expiration]

--- a/crates/breez-sdk/wasm/js/mysql-session-manager/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-session-manager/migrations.cjs
@@ -5,7 +5,7 @@
 
 const { SessionManagerError } = require("./errors.cjs");
 
-const SESSION_MIGRATIONS_TABLE = "session_schema_migrations";
+const SESSION_MIGRATIONS_TABLE = "brz_session_schema_migrations";
 const MIGRATION_LOCK_NAME = "breez_mysql_session_manager_migration_lock";
 const MIGRATION_LOCK_TIMEOUT = 60;
 
@@ -31,6 +31,8 @@ class MysqlSessionManagerMigrationManager {
       }
 
       try {
+        await this._applySchemaRenames(conn);
+
         await conn.query("START TRANSACTION");
 
         await conn.query(`
@@ -81,12 +83,41 @@ class MysqlSessionManagerMigrationManager {
     }
   }
 
+  /**
+   * Renames legacy unprefixed session objects to their `brz_` equivalents on
+   * first startup after the prefix change. Gated on the legacy
+   * `session_schema_migrations` table as canary. MySQL DDL is not
+   * transactional, so each rename is preceded by an info_schema probe to
+   * make a partial-rename replay safe.
+   * @param {import('mysql2/promise').PoolConnection} conn
+   */
+  async _applySchemaRenames(conn) {
+    if (!(await _mysqlTableExists(conn, "session_schema_migrations"))) {
+      return;
+    }
+
+    if (
+      (await _mysqlTableExists(conn, "sessions")) &&
+      !(await _mysqlTableExists(conn, "brz_sessions"))
+    ) {
+      await conn.query("RENAME TABLE `sessions` TO `brz_sessions`");
+    }
+
+    if (await _mysqlTableExists(conn, "session_schema_migrations")) {
+      if (!(await _mysqlTableExists(conn, SESSION_MIGRATIONS_TABLE))) {
+        await conn.query(
+          `RENAME TABLE \`session_schema_migrations\` TO \`${SESSION_MIGRATIONS_TABLE}\``
+        );
+      }
+    }
+  }
+
   _getMigrations() {
     return [
       {
-        name: "Create sessions table",
+        name: "Create brz_sessions table",
         sql: [
-          `CREATE TABLE IF NOT EXISTS sessions (
+          `CREATE TABLE IF NOT EXISTS brz_sessions (
             user_id VARBINARY(33) NOT NULL,
             service_identity_key VARBINARY(33) NOT NULL,
             token TEXT NOT NULL,
@@ -97,6 +128,15 @@ class MysqlSessionManagerMigrationManager {
       },
     ];
   }
+}
+
+async function _mysqlTableExists(conn, tableName) {
+  const [rows] = await conn.query(
+    `SELECT COUNT(*) AS c FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND table_name = ?`,
+    [tableName]
+  );
+  return Number(rows[0].c) > 0;
 }
 
 module.exports = { MysqlSessionManagerMigrationManager };

--- a/crates/breez-sdk/wasm/js/mysql-session-manager/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-session-manager/migrations.cjs
@@ -84,11 +84,8 @@ class MysqlSessionManagerMigrationManager {
   }
 
   /**
-   * Renames legacy unprefixed session objects to their `brz_` equivalents on
-   * first startup after the prefix change. Gated on the legacy
-   * `session_schema_migrations` table as canary. MySQL DDL is not
-   * transactional, so each rename is preceded by an info_schema probe to
-   * make a partial-rename replay safe.
+   * Pre-prefix rename. Canary-gated on the legacy `session_schema_migrations`
+   * table.
    * @param {import('mysql2/promise').PoolConnection} conn
    */
   async _applySchemaRenames(conn) {

--- a/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
@@ -354,7 +354,7 @@ class MysqlStorage {
     } catch (error) {
       if (error instanceof StorageError) throw error;
       throw new StorageError(
-        `Failed to list brz_payments (request: ${JSON.stringify(request)}): ${error.message}`,
+        `Failed to list payments (request: ${JSON.stringify(request)}): ${error.message}`,
         error
       );
     }
@@ -540,7 +540,7 @@ class MysqlStorage {
         return {};
       }
 
-      // Early exit if no related brz_payments exist for this tenant. mysql2 returns EXISTS as 0/1.
+      // Early exit if no related payments exist for this tenant. mysql2 returns EXISTS as 0/1.
       const [hasRelatedRows] = await this.pool.query(
         "SELECT EXISTS(SELECT 1 FROM brz_payment_metadata WHERE user_id = ? AND parent_payment_id IS NOT NULL LIMIT 1) AS has_related",
         [this.identity]
@@ -567,7 +567,7 @@ class MysqlStorage {
     } catch (error) {
       if (error instanceof StorageError) throw error;
       throw new StorageError(
-        `Failed to get brz_payments by parent ids: ${error.message}`,
+        `Failed to get payments by parent ids: ${error.message}`,
         error
       );
     }
@@ -844,7 +844,7 @@ class MysqlStorage {
       }));
     } catch (error) {
       throw new StorageError(
-        `Failed to list brz_contacts: ${error.message}`,
+        `Failed to list contacts: ${error.message}`,
         error
       );
     }
@@ -1301,7 +1301,7 @@ class MysqlStorage {
 }
 
 /**
- * Creates a MysqlStorageConfig with the given connection string and default pool brz_settings.
+ * Creates a MysqlStorageConfig with the given connection string and default pool settings.
  *
  * Default values:
  * - maxPoolSize: 10

--- a/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
@@ -75,12 +75,12 @@ const SELECT_PAYMENT_SQL = `
            lrm.sender_comment AS lnurl_sender_comment,
            lrm.payment_hash AS lnurl_payment_hash,
            pm.parent_payment_id
-      FROM payments p
-      LEFT JOIN payment_details_lightning l ON p.id = l.payment_id AND p.user_id = l.user_id
-      LEFT JOIN payment_details_token t ON p.id = t.payment_id AND p.user_id = t.user_id
-      LEFT JOIN payment_details_spark s ON p.id = s.payment_id AND p.user_id = s.user_id
-      LEFT JOIN payment_metadata pm ON p.id = pm.payment_id AND p.user_id = pm.user_id
-      LEFT JOIN lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash AND l.user_id = lrm.user_id`;
+      FROM brz_payments p
+      LEFT JOIN brz_payment_details_lightning l ON p.id = l.payment_id AND p.user_id = l.user_id
+      LEFT JOIN brz_payment_details_token t ON p.id = t.payment_id AND p.user_id = t.user_id
+      LEFT JOIN brz_payment_details_spark s ON p.id = s.payment_id AND p.user_id = s.user_id
+      LEFT JOIN brz_payment_metadata pm ON p.id = pm.payment_id AND p.user_id = pm.user_id
+      LEFT JOIN brz_lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash AND l.user_id = lrm.user_id`;
 
 /**
  * mysql2 may return JSON columns as either parsed objects or raw strings
@@ -168,7 +168,7 @@ class MysqlStorage {
   async getCachedItem(key) {
     try {
       const [rows] = await this.pool.query(
-        "SELECT value FROM settings WHERE user_id = ? AND `key` = ?",
+        "SELECT value FROM brz_settings WHERE user_id = ? AND `key` = ?",
         [this.identity, key]
       );
       return rows.length > 0 ? rows[0].value : null;
@@ -183,7 +183,7 @@ class MysqlStorage {
   async setCachedItem(key, value) {
     try {
       await this.pool.query(
-        "INSERT INTO settings (user_id, `key`, value) VALUES (?, ?, ?) " +
+        "INSERT INTO brz_settings (user_id, `key`, value) VALUES (?, ?, ?) " +
           "ON DUPLICATE KEY UPDATE value = VALUES(value)",
         [this.identity, key, value]
       );
@@ -198,7 +198,7 @@ class MysqlStorage {
   async deleteCachedItem(key) {
     try {
       await this.pool.query(
-        "DELETE FROM settings WHERE user_id = ? AND `key` = ?",
+        "DELETE FROM brz_settings WHERE user_id = ? AND `key` = ?",
         [this.identity, key]
       );
     } catch (error) {
@@ -354,7 +354,7 @@ class MysqlStorage {
     } catch (error) {
       if (error instanceof StorageError) throw error;
       throw new StorageError(
-        `Failed to list payments (request: ${JSON.stringify(request)}): ${error.message}`,
+        `Failed to list brz_payments (request: ${JSON.stringify(request)}): ${error.message}`,
         error
       );
     }
@@ -374,7 +374,7 @@ class MysqlStorage {
         const spark = payment.details?.type === "spark" ? 1 : null;
 
         await conn.query(
-          `INSERT INTO payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+          `INSERT INTO brz_payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON DUPLICATE KEY UPDATE
              payment_type=VALUES(payment_type),
@@ -407,7 +407,7 @@ class MysqlStorage {
             payment.details.htlcDetails != null)
         ) {
           await conn.query(
-            `INSERT INTO payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
+            `INSERT INTO brz_payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
              VALUES (?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE
                invoice_details=COALESCE(VALUES(invoice_details), invoice_details),
@@ -427,7 +427,7 @@ class MysqlStorage {
 
         if (payment.details?.type === "lightning") {
           await conn.query(
-            `INSERT INTO payment_details_lightning
+            `INSERT INTO brz_payment_details_lightning
               (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
               ON DUPLICATE KEY UPDATE
@@ -454,7 +454,7 @@ class MysqlStorage {
 
         if (payment.details?.type === "token") {
           await conn.query(
-            `INSERT INTO payment_details_token
+            `INSERT INTO brz_payment_details_token
               (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
               VALUES (?, ?, ?, ?, ?, ?)
               ON DUPLICATE KEY UPDATE
@@ -540,9 +540,9 @@ class MysqlStorage {
         return {};
       }
 
-      // Early exit if no related payments exist for this tenant. mysql2 returns EXISTS as 0/1.
+      // Early exit if no related brz_payments exist for this tenant. mysql2 returns EXISTS as 0/1.
       const [hasRelatedRows] = await this.pool.query(
-        "SELECT EXISTS(SELECT 1 FROM payment_metadata WHERE user_id = ? AND parent_payment_id IS NOT NULL LIMIT 1) AS has_related",
+        "SELECT EXISTS(SELECT 1 FROM brz_payment_metadata WHERE user_id = ? AND parent_payment_id IS NOT NULL LIMIT 1) AS has_related",
         [this.identity]
       );
       if (!hasRelatedRows[0].has_related) {
@@ -567,7 +567,7 @@ class MysqlStorage {
     } catch (error) {
       if (error instanceof StorageError) throw error;
       throw new StorageError(
-        `Failed to get payments by parent ids: ${error.message}`,
+        `Failed to get brz_payments by parent ids: ${error.message}`,
         error
       );
     }
@@ -576,7 +576,7 @@ class MysqlStorage {
   async insertPaymentMetadata(paymentId, metadata) {
     try {
       await this.pool.query(
-        `INSERT INTO payment_metadata (user_id, payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
+        `INSERT INTO brz_payment_metadata (user_id, payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
          ON DUPLICATE KEY UPDATE
            parent_payment_id = COALESCE(VALUES(parent_payment_id), parent_payment_id),
@@ -615,7 +615,7 @@ class MysqlStorage {
   async addDeposit(txid, vout, amountSats, isMature) {
     try {
       await this.pool.query(
-        `INSERT INTO unclaimed_deposits (user_id, txid, vout, amount_sats, is_mature)
+        `INSERT INTO brz_unclaimed_deposits (user_id, txid, vout, amount_sats, is_mature)
          VALUES (?, ?, ?, ?, ?)
          ON DUPLICATE KEY UPDATE is_mature = VALUES(is_mature), amount_sats = VALUES(amount_sats)`,
         [this.identity, txid, vout, amountSats, isMature ? 1 : 0]
@@ -631,7 +631,7 @@ class MysqlStorage {
   async deleteDeposit(txid, vout) {
     try {
       await this.pool.query(
-        "DELETE FROM unclaimed_deposits WHERE user_id = ? AND txid = ? AND vout = ?",
+        "DELETE FROM brz_unclaimed_deposits WHERE user_id = ? AND txid = ? AND vout = ?",
         [this.identity, txid, vout]
       );
     } catch (error) {
@@ -645,7 +645,7 @@ class MysqlStorage {
   async listDeposits() {
     try {
       const [rows] = await this.pool.query(
-        "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM unclaimed_deposits WHERE user_id = ?",
+        "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM brz_unclaimed_deposits WHERE user_id = ?",
         [this.identity]
       );
 
@@ -671,14 +671,14 @@ class MysqlStorage {
     try {
       if (payload.type === "claimError") {
         await this.pool.query(
-          `UPDATE unclaimed_deposits
+          `UPDATE brz_unclaimed_deposits
            SET claim_error = ?, refund_tx = NULL, refund_tx_id = NULL
            WHERE user_id = ? AND txid = ? AND vout = ?`,
           [JSON.stringify(payload.error), this.identity, txid, vout]
         );
       } else if (payload.type === "refund") {
         await this.pool.query(
-          `UPDATE unclaimed_deposits
+          `UPDATE brz_unclaimed_deposits
            SET refund_tx = ?, refund_tx_id = ?, claim_error = NULL
            WHERE user_id = ? AND txid = ? AND vout = ?`,
           [payload.refundTx, payload.refundTxid, this.identity, txid, vout]
@@ -700,7 +700,7 @@ class MysqlStorage {
       await this._withTransaction(async (conn) => {
         for (const item of metadata) {
           await conn.query(
-            `INSERT INTO lnurl_receive_metadata (user_id, payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
+            `INSERT INTO brz_lnurl_receive_metadata (user_id, payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
              VALUES (?, ?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE
                nostr_zap_request = VALUES(nostr_zap_request),
@@ -828,7 +828,7 @@ class MysqlStorage {
 
       const [rows] = await this.pool.query(
         `SELECT id, name, payment_identifier, created_at, updated_at
-         FROM contacts
+         FROM brz_contacts
          WHERE user_id = ?
          ORDER BY name ASC
          LIMIT ? OFFSET ?`,
@@ -844,7 +844,7 @@ class MysqlStorage {
       }));
     } catch (error) {
       throw new StorageError(
-        `Failed to list contacts: ${error.message}`,
+        `Failed to list brz_contacts: ${error.message}`,
         error
       );
     }
@@ -854,7 +854,7 @@ class MysqlStorage {
     try {
       const [rows] = await this.pool.query(
         `SELECT id, name, payment_identifier, created_at, updated_at
-         FROM contacts
+         FROM brz_contacts
          WHERE user_id = ? AND id = ?`,
         [this.identity, id]
       );
@@ -879,7 +879,7 @@ class MysqlStorage {
   async insertContact(contact) {
     try {
       await this.pool.query(
-        `INSERT INTO contacts (user_id, id, name, payment_identifier, created_at, updated_at)
+        `INSERT INTO brz_contacts (user_id, id, name, payment_identifier, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?)
          ON DUPLICATE KEY UPDATE
            name = VALUES(name),
@@ -905,7 +905,7 @@ class MysqlStorage {
   async deleteContact(id) {
     try {
       await this.pool.query(
-        "DELETE FROM contacts WHERE user_id = ? AND id = ?",
+        "DELETE FROM brz_contacts WHERE user_id = ? AND id = ?",
         [this.identity, id]
       );
     } catch (error) {
@@ -923,13 +923,13 @@ class MysqlStorage {
       return await this._withTransaction(async (conn) => {
         // The local queue revision is per-tenant — two tenants don't share a queue.
         const [revisionRows] = await conn.query(
-          "SELECT COALESCE(MAX(revision), 0) + 1 AS revision FROM sync_outgoing WHERE user_id = ?",
+          "SELECT COALESCE(MAX(revision), 0) + 1 AS revision FROM brz_sync_outgoing WHERE user_id = ?",
           [this.identity]
         );
         const revision = BigInt(revisionRows[0].revision);
 
         await conn.query(
-          `INSERT INTO sync_outgoing (
+          `INSERT INTO brz_sync_outgoing (
             user_id,
             record_type,
             data_id,
@@ -964,12 +964,12 @@ class MysqlStorage {
     try {
       await this._withTransaction(async (conn) => {
         const [deleteResult] = await conn.query(
-          "DELETE FROM sync_outgoing WHERE user_id = ? AND record_type = ? AND data_id = ? AND revision = ?",
+          "DELETE FROM brz_sync_outgoing WHERE user_id = ? AND record_type = ? AND data_id = ? AND revision = ?",
           [this.identity, record.id.type, record.id.dataId, localRevision.toString()]
         );
 
         if (deleteResult.affectedRows === 0) {
-          const msg = `complete_outgoing_sync: DELETE from sync_outgoing matched 0 rows (type=${record.id.type}, data_id=${record.id.dataId}, revision=${localRevision})`;
+          const msg = `complete_outgoing_sync: DELETE from brz_sync_outgoing matched 0 rows (type=${record.id.type}, data_id=${record.id.dataId}, revision=${localRevision})`;
           if (this.logger && typeof this.logger.log === "function") {
             this.logger.log({ line: msg, level: "warn" });
           } else {
@@ -979,7 +979,7 @@ class MysqlStorage {
         }
 
         await conn.query(
-          `INSERT INTO sync_state (
+          `INSERT INTO brz_sync_state (
             user_id,
             record_type,
             data_id,
@@ -1006,7 +1006,7 @@ class MysqlStorage {
 
         // Upsert this tenant's revision row; fresh tenants without a row get one.
         await conn.query(
-          `INSERT INTO sync_revision (user_id, revision) VALUES (?, ?)
+          `INSERT INTO brz_sync_revision (user_id, revision) VALUES (?, ?)
            ON DUPLICATE KEY UPDATE revision = GREATEST(revision, VALUES(revision))`,
           [this.identity, record.revision.toString()]
         );
@@ -1034,8 +1034,8 @@ class MysqlStorage {
           e.commit_time AS existing_commit_time,
           e.data AS existing_data,
           e.revision AS existing_revision
-        FROM sync_outgoing o
-        LEFT JOIN sync_state e ON
+        FROM brz_sync_outgoing o
+        LEFT JOIN brz_sync_state e ON
           o.record_type = e.record_type AND
           o.data_id = e.data_id AND
           o.user_id = e.user_id
@@ -1077,7 +1077,7 @@ class MysqlStorage {
     try {
       // A tenant that hasn't synced anything yet may have no row; treat as 0.
       const [rows] = await this.pool.query(
-        "SELECT revision FROM sync_revision WHERE user_id = ?",
+        "SELECT revision FROM brz_sync_revision WHERE user_id = ?",
         [this.identity]
       );
       return rows.length > 0 ? BigInt(rows[0].revision) : BigInt(0);
@@ -1098,7 +1098,7 @@ class MysqlStorage {
       await this._withTransaction(async (conn) => {
         for (const record of records) {
           await conn.query(
-            `INSERT INTO sync_incoming (
+            `INSERT INTO brz_sync_incoming (
               user_id,
               record_type,
               data_id,
@@ -1135,7 +1135,7 @@ class MysqlStorage {
   async syncDeleteIncomingRecord(record) {
     try {
       await this.pool.query(
-        `DELETE FROM sync_incoming
+        `DELETE FROM brz_sync_incoming
          WHERE user_id = ?
          AND record_type = ?
          AND data_id = ?
@@ -1162,8 +1162,8 @@ class MysqlStorage {
                 e.commit_time AS existing_commit_time,
                 e.data AS existing_data,
                 e.revision AS existing_revision
-         FROM sync_incoming i
-         LEFT JOIN sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id AND i.user_id = e.user_id
+         FROM brz_sync_incoming i
+         LEFT JOIN brz_sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id AND i.user_id = e.user_id
          WHERE i.user_id = ?
          ORDER BY i.revision ASC
          LIMIT ?`,
@@ -1212,8 +1212,8 @@ class MysqlStorage {
           e.commit_time AS existing_commit_time,
           e.data AS existing_data,
           e.revision AS existing_revision
-        FROM sync_outgoing o
-        LEFT JOIN sync_state e ON
+        FROM brz_sync_outgoing o
+        LEFT JOIN brz_sync_state e ON
           o.record_type = e.record_type AND
           o.data_id = e.data_id AND
           o.user_id = e.user_id
@@ -1259,7 +1259,7 @@ class MysqlStorage {
     try {
       await this._withTransaction(async (conn) => {
         await conn.query(
-          `INSERT INTO sync_state (
+          `INSERT INTO brz_sync_state (
             user_id,
             record_type,
             data_id,
@@ -1285,7 +1285,7 @@ class MysqlStorage {
         );
 
         await conn.query(
-          `INSERT INTO sync_revision (user_id, revision) VALUES (?, ?)
+          `INSERT INTO brz_sync_revision (user_id, revision) VALUES (?, ?)
            ON DUPLICATE KEY UPDATE revision = GREATEST(revision, VALUES(revision))`,
           [this.identity, record.revision.toString()]
         );
@@ -1301,7 +1301,7 @@ class MysqlStorage {
 }
 
 /**
- * Creates a MysqlStorageConfig with the given connection string and default pool settings.
+ * Creates a MysqlStorageConfig with the given connection string and default pool brz_settings.
  *
  * Default values:
  * - maxPoolSize: 10

--- a/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
@@ -218,6 +218,35 @@ class MysqlMigrationManager {
         "idx_sync_incoming_user_revision",
         "brz_idx_sync_incoming_user_revision",
       ],
+      // Pre-multi-tenant indexes (still present on version < 16 DBs).
+      ["brz_payments", "idx_payments_timestamp", "brz_idx_payments_timestamp"],
+      ["brz_payments", "idx_payments_payment_type", "brz_idx_payments_payment_type"],
+      ["brz_payments", "idx_payments_status", "brz_idx_payments_status"],
+      [
+        "brz_payment_metadata",
+        "idx_payment_metadata_parent",
+        "brz_idx_payment_metadata_parent",
+      ],
+      [
+        "brz_payment_details_lightning",
+        "idx_payment_details_lightning_invoice",
+        "brz_idx_payment_details_lightning_invoice",
+      ],
+      [
+        "brz_payment_details_lightning",
+        "idx_payment_details_lightning_payment_hash",
+        "brz_idx_payment_details_lightning_payment_hash",
+      ],
+      [
+        "brz_sync_outgoing",
+        "idx_sync_outgoing_data_id_record_type",
+        "brz_idx_sync_outgoing_data_id_record_type",
+      ],
+      [
+        "brz_sync_incoming",
+        "idx_sync_incoming_revision",
+        "brz_idx_sync_incoming_revision",
+      ],
     ];
     for (const [table, oldName, newName] of indexRenames) {
       if (

--- a/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
@@ -11,7 +11,7 @@
  * - pg_advisory_xact_lock → GET_LOCK/RELEASE_LOCK
  * - reserved word `key` quoted with backticks
  *
- * Uses a schema_migrations table + GET_LOCK to safely run migrations from
+ * Uses a brz_schema_migrations table + GET_LOCK to safely run migrations from
  * concurrent processes. Unlike pg's transaction-scoped advisory locks, MySQL
  * named locks are session-scoped, so we explicitly RELEASE_LOCK after the
  * commit (or on error in finally).
@@ -82,17 +82,19 @@ class MysqlMigrationManager {
       }
 
       try {
+        await this._applySchemaRenames(conn);
+
         await conn.query("START TRANSACTION");
 
         await conn.query(`
-          CREATE TABLE IF NOT EXISTS schema_migrations (
+          CREATE TABLE IF NOT EXISTS brz_schema_migrations (
             version INT PRIMARY KEY,
             applied_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
           )
         `);
 
         const [versionRows] = await conn.query(
-          "SELECT COALESCE(MAX(version), 0) AS version FROM schema_migrations"
+          "SELECT COALESCE(MAX(version), 0) AS version FROM brz_schema_migrations"
         );
         const currentVersion = versionRows[0].version;
 
@@ -119,7 +121,7 @@ class MysqlMigrationManager {
           }
 
           await conn.query(
-            "INSERT INTO schema_migrations (version) VALUES (?)",
+            "INSERT INTO brz_schema_migrations (version) VALUES (?)",
             [version]
           );
         }
@@ -153,6 +155,94 @@ class MysqlMigrationManager {
   }
 
   /**
+   * Renames legacy unprefixed core-storage objects to their `brz_`
+   * equivalents on first startup after the prefix change. Gated on the
+   * legacy `schema_migrations` table as canary. MySQL primary keys are
+   * always named `PRIMARY` (table-scoped) and there are no foreign keys
+   * in the core schema, so only tables and indexes need renaming.
+   * @param {import('mysql2/promise').PoolConnection} conn
+   */
+  async _applySchemaRenames(conn) {
+    if (!(await _mysqlTableExists(conn, "schema_migrations"))) {
+      return;
+    }
+
+    const tableRenames = [
+      ["payments", "brz_payments"],
+      ["settings", "brz_settings"],
+      ["unclaimed_deposits", "brz_unclaimed_deposits"],
+      ["payment_metadata", "brz_payment_metadata"],
+      ["payment_details_lightning", "brz_payment_details_lightning"],
+      ["payment_details_token", "brz_payment_details_token"],
+      ["payment_details_spark", "brz_payment_details_spark"],
+      ["lnurl_receive_metadata", "brz_lnurl_receive_metadata"],
+      ["sync_revision", "brz_sync_revision"],
+      ["sync_outgoing", "brz_sync_outgoing"],
+      ["sync_state", "brz_sync_state"],
+      ["sync_incoming", "brz_sync_incoming"],
+      ["contacts", "brz_contacts"],
+    ];
+    for (const [oldName, newName] of tableRenames) {
+      if (
+        (await _mysqlTableExists(conn, oldName)) &&
+        !(await _mysqlTableExists(conn, newName))
+      ) {
+        await conn.query(`RENAME TABLE \`${oldName}\` TO \`${newName}\``);
+      }
+    }
+
+    const indexRenames = [
+      ["brz_payments", "idx_payments_user_timestamp", "brz_idx_payments_user_timestamp"],
+      ["brz_payments", "idx_payments_user_payment_type", "brz_idx_payments_user_payment_type"],
+      ["brz_payments", "idx_payments_user_status", "brz_idx_payments_user_status"],
+      [
+        "brz_payment_metadata",
+        "idx_payment_metadata_user_parent",
+        "brz_idx_payment_metadata_user_parent",
+      ],
+      [
+        "brz_payment_details_lightning",
+        "idx_payment_details_lightning_user_invoice",
+        "brz_idx_payment_details_lightning_user_invoice",
+      ],
+      [
+        "brz_payment_details_lightning",
+        "idx_payment_details_lightning_user_payment_hash",
+        "brz_idx_payment_details_lightning_user_payment_hash",
+      ],
+      [
+        "brz_sync_outgoing",
+        "idx_sync_outgoing_user_record_type_data_id",
+        "brz_idx_sync_outgoing_user_record_type_data_id",
+      ],
+      [
+        "brz_sync_incoming",
+        "idx_sync_incoming_user_revision",
+        "brz_idx_sync_incoming_user_revision",
+      ],
+    ];
+    for (const [table, oldName, newName] of indexRenames) {
+      if (
+        (await _mysqlIndexExists(conn, table, oldName)) &&
+        !(await _mysqlIndexExists(conn, table, newName))
+      ) {
+        await conn.query(
+          `ALTER TABLE \`${table}\` RENAME INDEX \`${oldName}\` TO \`${newName}\``
+        );
+      }
+    }
+
+    if (
+      (await _mysqlTableExists(conn, "schema_migrations")) &&
+      !(await _mysqlTableExists(conn, "brz_schema_migrations"))
+    ) {
+      await conn.query(
+        "RENAME TABLE `schema_migrations` TO `brz_schema_migrations`"
+      );
+    }
+  }
+
+  /**
    * @param {Buffer|Uint8Array} identity - 33-byte tenant identity. Inlined as
    *   an `UNHEX('...')` literal in the multi-tenant scoping migration. Safe
    *   because the bytes come from a typed secp256k1 pubkey (character set
@@ -164,7 +254,7 @@ class MysqlMigrationManager {
 
     // Per-table backfill: ADD COLUMN nullable -> UPDATE -> SET NOT NULL +
     // drop/recreate PK. Returns an array of statements. Tables with backticked
-    // names (e.g. `settings` uses `key`) need the caller to backtick `pkCols`.
+    // names (e.g. `brz_settings` uses `key`) need the caller to backtick `pkCols`.
     const scopeTable = (table, pkCols) => [
       `ALTER TABLE \`${table}\` ADD COLUMN user_id VARBINARY(33) NULL`,
       `UPDATE \`${table}\` SET user_id = ${idLit} WHERE user_id IS NULL`,
@@ -177,7 +267,7 @@ class MysqlMigrationManager {
         name: "Create all tables at final schema",
         sql: [
           // -- Core tables --
-          `CREATE TABLE IF NOT EXISTS payments (
+          `CREATE TABLE IF NOT EXISTS brz_payments (
             id VARCHAR(255) NOT NULL PRIMARY KEY,
             payment_type VARCHAR(64) NOT NULL,
             status VARCHAR(64) NOT NULL,
@@ -190,12 +280,12 @@ class MysqlMigrationManager {
             spark TINYINT(1) NULL
           )`,
 
-          `CREATE TABLE IF NOT EXISTS settings (
+          `CREATE TABLE IF NOT EXISTS brz_settings (
             \`key\` VARCHAR(255) NOT NULL PRIMARY KEY,
             value LONGTEXT NOT NULL
           )`,
 
-          `CREATE TABLE IF NOT EXISTS unclaimed_deposits (
+          `CREATE TABLE IF NOT EXISTS brz_unclaimed_deposits (
             txid VARCHAR(255) NOT NULL,
             vout INT NOT NULL,
             amount_sats BIGINT NULL,
@@ -205,7 +295,7 @@ class MysqlMigrationManager {
             PRIMARY KEY (txid, vout)
           )`,
 
-          `CREATE TABLE IF NOT EXISTS payment_metadata (
+          `CREATE TABLE IF NOT EXISTS brz_payment_metadata (
             payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
             parent_payment_id VARCHAR(255) NULL,
             lnurl_pay_info JSON NULL,
@@ -214,7 +304,7 @@ class MysqlMigrationManager {
             conversion_info JSON NULL
           )`,
 
-          `CREATE TABLE IF NOT EXISTS payment_details_lightning (
+          `CREATE TABLE IF NOT EXISTS brz_payment_details_lightning (
             payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
             invoice LONGTEXT NOT NULL,
             payment_hash VARCHAR(255) NOT NULL,
@@ -225,7 +315,7 @@ class MysqlMigrationManager {
             htlc_expiry_time BIGINT NOT NULL
           )`,
 
-          `CREATE TABLE IF NOT EXISTS payment_details_token (
+          `CREATE TABLE IF NOT EXISTS brz_payment_details_token (
             payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
             metadata JSON NOT NULL,
             tx_hash VARCHAR(255) NOT NULL,
@@ -233,13 +323,13 @@ class MysqlMigrationManager {
             invoice_details JSON NULL
           )`,
 
-          `CREATE TABLE IF NOT EXISTS payment_details_spark (
+          `CREATE TABLE IF NOT EXISTS brz_payment_details_spark (
             payment_id VARCHAR(255) NOT NULL PRIMARY KEY,
             invoice_details JSON NULL,
             htlc_details JSON NULL
           )`,
 
-          `CREATE TABLE IF NOT EXISTS lnurl_receive_metadata (
+          `CREATE TABLE IF NOT EXISTS brz_lnurl_receive_metadata (
             payment_hash VARCHAR(255) NOT NULL PRIMARY KEY,
             nostr_zap_request LONGTEXT NULL,
             nostr_zap_receipt LONGTEXT NULL,
@@ -247,15 +337,15 @@ class MysqlMigrationManager {
           )`,
 
           // -- Sync tables --
-          `CREATE TABLE IF NOT EXISTS sync_revision (
+          `CREATE TABLE IF NOT EXISTS brz_sync_revision (
             id INT NOT NULL PRIMARY KEY DEFAULT 1,
             revision BIGINT NOT NULL DEFAULT 0,
             CHECK (id = 1)
           )`,
-          `INSERT INTO sync_revision (id, revision) VALUES (1, 0)
+          `INSERT INTO brz_sync_revision (id, revision) VALUES (1, 0)
             ON DUPLICATE KEY UPDATE id = id`,
 
-          `CREATE TABLE IF NOT EXISTS sync_outgoing (
+          `CREATE TABLE IF NOT EXISTS brz_sync_outgoing (
             record_type VARCHAR(255) NOT NULL,
             data_id VARCHAR(255) NOT NULL,
             schema_version VARCHAR(64) NOT NULL,
@@ -264,7 +354,7 @@ class MysqlMigrationManager {
             revision BIGINT NOT NULL
           )`,
 
-          `CREATE TABLE IF NOT EXISTS sync_state (
+          `CREATE TABLE IF NOT EXISTS brz_sync_state (
             record_type VARCHAR(255) NOT NULL,
             data_id VARCHAR(255) NOT NULL,
             schema_version VARCHAR(64) NOT NULL,
@@ -274,7 +364,7 @@ class MysqlMigrationManager {
             PRIMARY KEY (record_type, data_id)
           )`,
 
-          `CREATE TABLE IF NOT EXISTS sync_incoming (
+          `CREATE TABLE IF NOT EXISTS brz_sync_incoming (
             record_type VARCHAR(255) NOT NULL,
             data_id VARCHAR(255) NOT NULL,
             schema_version VARCHAR(64) NOT NULL,
@@ -285,23 +375,23 @@ class MysqlMigrationManager {
           )`,
 
           // -- Indexes --
-          `CREATE INDEX idx_payments_timestamp ON payments(timestamp)`,
-          `CREATE INDEX idx_payments_payment_type ON payments(payment_type)`,
-          `CREATE INDEX idx_payments_status ON payments(status)`,
-          `CREATE INDEX idx_payment_details_lightning_invoice
-            ON payment_details_lightning(invoice(255))`,
-          `CREATE INDEX idx_payment_details_lightning_payment_hash
-            ON payment_details_lightning(payment_hash)`,
-          `CREATE INDEX idx_payment_metadata_parent ON payment_metadata(parent_payment_id)`,
-          `CREATE INDEX idx_sync_outgoing_data_id_record_type
-            ON sync_outgoing(record_type, data_id)`,
-          `CREATE INDEX idx_sync_incoming_revision ON sync_incoming(revision)`,
+          `CREATE INDEX brz_idx_payments_timestamp ON brz_payments(timestamp)`,
+          `CREATE INDEX brz_idx_payments_payment_type ON brz_payments(payment_type)`,
+          `CREATE INDEX brz_idx_payments_status ON brz_payments(status)`,
+          `CREATE INDEX brz_idx_payment_details_lightning_invoice
+            ON brz_payment_details_lightning(invoice(255))`,
+          `CREATE INDEX brz_idx_payment_details_lightning_payment_hash
+            ON brz_payment_details_lightning(payment_hash)`,
+          `CREATE INDEX brz_idx_payment_metadata_parent ON brz_payment_metadata(parent_payment_id)`,
+          `CREATE INDEX brz_idx_sync_outgoing_data_id_record_type
+            ON brz_sync_outgoing(record_type, data_id)`,
+          `CREATE INDEX brz_idx_sync_incoming_revision ON brz_sync_incoming(revision)`,
         ],
       },
       {
-        name: "Create contacts table",
+        name: "Create brz_contacts table",
         sql: [
-          `CREATE TABLE IF NOT EXISTS contacts (
+          `CREATE TABLE IF NOT EXISTS brz_contacts (
             id VARCHAR(255) NOT NULL PRIMARY KEY,
             name VARCHAR(255) NOT NULL,
             payment_identifier VARCHAR(255) NOT NULL,
@@ -311,77 +401,95 @@ class MysqlMigrationManager {
         ],
       },
       {
-        name: "Add is_mature to unclaimed_deposits",
+        name: "Add is_mature to brz_unclaimed_deposits",
         sql: [
-          `ALTER TABLE unclaimed_deposits ADD COLUMN is_mature TINYINT(1) NOT NULL DEFAULT 1`,
+          `ALTER TABLE brz_unclaimed_deposits ADD COLUMN is_mature TINYINT(1) NOT NULL DEFAULT 1`,
         ],
       },
       {
-        name: "Add conversion_status to payment_metadata",
+        name: "Add conversion_status to brz_payment_metadata",
         sql: [
-          `ALTER TABLE payment_metadata ADD COLUMN conversion_status VARCHAR(64) NULL`,
+          `ALTER TABLE brz_payment_metadata ADD COLUMN conversion_status VARCHAR(64) NULL`,
         ],
       },
       {
         name: "Multi-tenant scoping: add user_id and rewrite primary keys",
         sql: [
           // Per-user tables.
-          ...scopeTable("payments", "id"),
-          `DROP INDEX idx_payments_timestamp ON payments`,
-          `DROP INDEX idx_payments_payment_type ON payments`,
-          `DROP INDEX idx_payments_status ON payments`,
-          `CREATE INDEX idx_payments_user_timestamp ON payments(user_id, timestamp)`,
-          `CREATE INDEX idx_payments_user_payment_type ON payments(user_id, payment_type)`,
-          `CREATE INDEX idx_payments_user_status ON payments(user_id, status)`,
+          ...scopeTable("brz_payments", "id"),
+          `DROP INDEX brz_idx_payments_timestamp ON brz_payments`,
+          `DROP INDEX brz_idx_payments_payment_type ON brz_payments`,
+          `DROP INDEX brz_idx_payments_status ON brz_payments`,
+          `CREATE INDEX brz_idx_payments_user_timestamp ON brz_payments(user_id, timestamp)`,
+          `CREATE INDEX brz_idx_payments_user_payment_type ON brz_payments(user_id, payment_type)`,
+          `CREATE INDEX brz_idx_payments_user_status ON brz_payments(user_id, status)`,
 
-          ...scopeTable("payment_metadata", "payment_id"),
-          `DROP INDEX idx_payment_metadata_parent ON payment_metadata`,
-          `CREATE INDEX idx_payment_metadata_user_parent
-             ON payment_metadata(user_id, parent_payment_id)`,
+          ...scopeTable("brz_payment_metadata", "payment_id"),
+          `DROP INDEX brz_idx_payment_metadata_parent ON brz_payment_metadata`,
+          `CREATE INDEX brz_idx_payment_metadata_user_parent
+             ON brz_payment_metadata(user_id, parent_payment_id)`,
 
-          ...scopeTable("payment_details_lightning", "payment_id"),
-          `DROP INDEX idx_payment_details_lightning_invoice ON payment_details_lightning`,
-          `DROP INDEX idx_payment_details_lightning_payment_hash ON payment_details_lightning`,
-          `CREATE INDEX idx_payment_details_lightning_user_invoice
-             ON payment_details_lightning(user_id, invoice(255))`,
-          `CREATE INDEX idx_payment_details_lightning_user_payment_hash
-             ON payment_details_lightning(user_id, payment_hash)`,
+          ...scopeTable("brz_payment_details_lightning", "payment_id"),
+          `DROP INDEX brz_idx_payment_details_lightning_invoice ON brz_payment_details_lightning`,
+          `DROP INDEX brz_idx_payment_details_lightning_payment_hash ON brz_payment_details_lightning`,
+          `CREATE INDEX brz_idx_payment_details_lightning_user_invoice
+             ON brz_payment_details_lightning(user_id, invoice(255))`,
+          `CREATE INDEX brz_idx_payment_details_lightning_user_payment_hash
+             ON brz_payment_details_lightning(user_id, payment_hash)`,
 
-          ...scopeTable("payment_details_token", "payment_id"),
-          ...scopeTable("payment_details_spark", "payment_id"),
-          ...scopeTable("lnurl_receive_metadata", "payment_hash"),
-          ...scopeTable("unclaimed_deposits", "txid, vout"),
-          ...scopeTable("contacts", "id"),
-          ...scopeTable("settings", "`key`"),
+          ...scopeTable("brz_payment_details_token", "payment_id"),
+          ...scopeTable("brz_payment_details_spark", "payment_id"),
+          ...scopeTable("brz_lnurl_receive_metadata", "payment_hash"),
+          ...scopeTable("brz_unclaimed_deposits", "txid, vout"),
+          ...scopeTable("brz_contacts", "id"),
+          ...scopeTable("brz_settings", "`key`"),
 
-          // sync_revision was a singleton (PK id=1, CHECK id=1). Drop the PK
+          // brz_sync_revision was a singleton (PK id=1, CHECK id=1). Drop the PK
           // and the id column, then re-key by user_id.
-          { op: "dropPrimaryKey", table: "sync_revision" },
-          `ALTER TABLE sync_revision DROP COLUMN id`,
-          `ALTER TABLE sync_revision ADD COLUMN user_id VARBINARY(33) NULL`,
-          `UPDATE sync_revision SET user_id = ${idLit} WHERE user_id IS NULL`,
-          `ALTER TABLE sync_revision MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
-          `ALTER TABLE sync_revision ADD PRIMARY KEY (user_id)`,
+          { op: "dropPrimaryKey", table: "brz_sync_revision" },
+          `ALTER TABLE brz_sync_revision DROP COLUMN id`,
+          `ALTER TABLE brz_sync_revision ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE brz_sync_revision SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE brz_sync_revision MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE brz_sync_revision ADD PRIMARY KEY (user_id)`,
 
-          // sync_outgoing has no PK, only an index — just add user_id and
+          // brz_sync_outgoing has no PK, only an index — just add user_id and
           // rewrite the index.
-          `ALTER TABLE sync_outgoing ADD COLUMN user_id VARBINARY(33) NULL`,
-          `UPDATE sync_outgoing SET user_id = ${idLit} WHERE user_id IS NULL`,
-          `ALTER TABLE sync_outgoing MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
-          `DROP INDEX idx_sync_outgoing_data_id_record_type ON sync_outgoing`,
-          `CREATE INDEX idx_sync_outgoing_user_record_type_data_id
-             ON sync_outgoing(user_id, record_type, data_id)`,
+          `ALTER TABLE brz_sync_outgoing ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE brz_sync_outgoing SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE brz_sync_outgoing MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `DROP INDEX brz_idx_sync_outgoing_data_id_record_type ON brz_sync_outgoing`,
+          `CREATE INDEX brz_idx_sync_outgoing_user_record_type_data_id
+             ON brz_sync_outgoing(user_id, record_type, data_id)`,
 
-          ...scopeTable("sync_state", "record_type, data_id"),
+          ...scopeTable("brz_sync_state", "record_type, data_id"),
 
-          ...scopeTable("sync_incoming", "record_type, data_id, revision"),
-          `DROP INDEX idx_sync_incoming_revision ON sync_incoming`,
-          `CREATE INDEX idx_sync_incoming_user_revision
-             ON sync_incoming(user_id, revision)`,
+          ...scopeTable("brz_sync_incoming", "record_type, data_id, revision"),
+          `DROP INDEX brz_idx_sync_incoming_revision ON brz_sync_incoming`,
+          `CREATE INDEX brz_idx_sync_incoming_user_revision
+             ON brz_sync_incoming(user_id, revision)`,
         ],
       },
     ];
   }
+}
+
+async function _mysqlTableExists(conn, tableName) {
+  const [rows] = await conn.query(
+    `SELECT COUNT(*) AS c FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND table_name = ?`,
+    [tableName]
+  );
+  return Number(rows[0].c) > 0;
+}
+
+async function _mysqlIndexExists(conn, tableName, indexName) {
+  const [rows] = await conn.query(
+    `SELECT COUNT(*) AS c FROM information_schema.statistics
+     WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?`,
+    [tableName, indexName]
+  );
+  return Number(rows[0].c) > 0;
 }
 
 module.exports = { MysqlMigrationManager };

--- a/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
@@ -155,11 +155,9 @@ class MysqlMigrationManager {
   }
 
   /**
-   * Renames legacy unprefixed core-storage objects to their `brz_`
-   * equivalents on first startup after the prefix change. Gated on the
-   * legacy `schema_migrations` table as canary. MySQL primary keys are
-   * always named `PRIMARY` (table-scoped) and there are no foreign keys
-   * in the core schema, so only tables and indexes need renaming.
+   * Pre-prefix rename. Canary-gated on the legacy `schema_migrations`
+   * table. MySQL PKs are always named `PRIMARY` and the core schema has
+   * no FKs, so only tables and indexes need renaming.
    * @param {import('mysql2/promise').PoolConnection} conn
    */
   async _applySchemaRenames(conn) {

--- a/crates/breez-sdk/wasm/js/mysql-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/index.cjs
@@ -204,9 +204,9 @@ class MysqlTokenStore {
 
         const [swapRows] = await conn.query(
           `SELECT
-            (SELECT EXISTS(SELECT 1 FROM token_reservations WHERE user_id = ? AND purpose = 'Swap')) AS has_active_swap,
+            (SELECT EXISTS(SELECT 1 FROM brz_token_reservations WHERE user_id = ? AND purpose = 'Swap')) AS has_active_swap,
             COALESCE(
-              (SELECT (last_completed_at >= ?) FROM token_swap_status WHERE user_id = ?),
+              (SELECT (last_completed_at >= ?) FROM brz_token_swap_status WHERE user_id = ?),
               0
             ) AS swap_completed`,
           [this.identity, refreshTimestamp, this.identity]
@@ -221,18 +221,18 @@ class MysqlTokenStore {
           refreshTimestamp.getTime() - SPENT_MARKER_CLEANUP_THRESHOLD_MS
         );
         await conn.query(
-          "DELETE FROM token_spent_outputs WHERE user_id = ? AND spent_at < ?",
+          "DELETE FROM brz_token_spent_outputs WHERE user_id = ? AND spent_at < ?",
           [this.identity, cleanupCutoff]
         );
 
         const [spentRows] = await conn.query(
-          "SELECT output_id FROM token_spent_outputs WHERE user_id = ? AND spent_at >= ?",
+          "SELECT output_id FROM brz_token_spent_outputs WHERE user_id = ? AND spent_at >= ?",
           [this.identity, refreshTimestamp]
         );
         const spentIds = new Set(spentRows.map((r) => r.output_id));
 
         await conn.query(
-          "DELETE FROM token_outputs WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
+          "DELETE FROM brz_token_outputs WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
           [this.identity, refreshTimestamp]
         );
 
@@ -245,8 +245,8 @@ class MysqlTokenStore {
 
         const [reservedRows] = await conn.query(
           `SELECT r.id, o.id AS output_id
-           FROM token_reservations r
-           JOIN token_outputs o
+           FROM brz_token_reservations r
+           JOIN brz_token_outputs o
              ON o.reservation_id = r.id AND o.user_id = r.user_id
            WHERE r.user_id = ?`,
           [this.identity]
@@ -278,11 +278,11 @@ class MysqlTokenStore {
         if (reservationsToDelete.length > 0) {
           const placeholders = buildPlaceholders(reservationsToDelete.length);
           await conn.query(
-            `DELETE FROM token_outputs WHERE user_id = ? AND reservation_id IN (${placeholders})`,
+            `DELETE FROM brz_token_outputs WHERE user_id = ? AND reservation_id IN (${placeholders})`,
             [this.identity, ...reservationsToDelete]
           );
           await conn.query(
-            `DELETE FROM token_reservations WHERE user_id = ? AND id IN (${placeholders})`,
+            `DELETE FROM brz_token_reservations WHERE user_id = ? AND id IN (${placeholders})`,
             [this.identity, ...reservationsToDelete]
           );
         }
@@ -292,13 +292,13 @@ class MysqlTokenStore {
             outputsToRemoveFromReservation.length
           );
           await conn.query(
-            `DELETE FROM token_outputs WHERE user_id = ? AND id IN (${placeholders})`,
+            `DELETE FROM brz_token_outputs WHERE user_id = ? AND id IN (${placeholders})`,
             [this.identity, ...outputsToRemoveFromReservation]
           );
 
           const [emptyRows] = await conn.query(
-            `SELECT r.id FROM token_reservations r
-             LEFT JOIN token_outputs o
+            `SELECT r.id FROM brz_token_reservations r
+             LEFT JOIN brz_token_outputs o
                ON o.reservation_id = r.id AND o.user_id = r.user_id
              WHERE r.user_id = ? AND o.id IS NULL`,
             [this.identity]
@@ -307,23 +307,23 @@ class MysqlTokenStore {
           if (emptyIds.length > 0) {
             const emptyPlaceholders = buildPlaceholders(emptyIds.length);
             await conn.query(
-              `DELETE FROM token_reservations WHERE user_id = ? AND id IN (${emptyPlaceholders})`,
+              `DELETE FROM brz_token_reservations WHERE user_id = ? AND id IN (${emptyPlaceholders})`,
               [this.identity, ...emptyIds]
             );
           }
         }
 
         const [reservedOutputRows] = await conn.query(
-          "SELECT id FROM token_outputs WHERE user_id = ? AND reservation_id IS NOT NULL",
+          "SELECT id FROM brz_token_outputs WHERE user_id = ? AND reservation_id IS NOT NULL",
           [this.identity]
         );
         const reservedOutputIds = new Set(reservedOutputRows.map((r) => r.id));
 
         await conn.query(
-          `DELETE FROM token_metadata
+          `DELETE FROM brz_token_metadata
            WHERE user_id = ?
              AND identifier NOT IN (
-               SELECT DISTINCT token_identifier FROM token_outputs WHERE user_id = ?
+               SELECT DISTINCT token_identifier FROM brz_token_outputs WHERE user_id = ?
              )`,
           [this.identity, this.identity]
         );
@@ -374,10 +374,10 @@ class MysqlTokenStore {
                     ELSE 0
                   END
                 ), 0) AS CHAR) AS balance
-         FROM token_metadata m
-         JOIN token_outputs o
+         FROM brz_token_metadata m
+         JOIN brz_token_outputs o
            ON o.token_identifier = m.identifier AND o.user_id = m.user_id
-         LEFT JOIN token_reservations r
+         LEFT JOIN brz_token_reservations r
            ON o.reservation_id = r.id AND o.user_id = r.user_id
          WHERE m.user_id = ?
          GROUP BY m.identifier, m.issuer_public_key, m.name, m.ticker,
@@ -415,10 +415,10 @@ class MysqlTokenStore {
                 o.token_public_key, o.token_amount, o.token_identifier,
                 o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                 r.purpose
-         FROM token_metadata m
-         LEFT JOIN token_outputs o
+         FROM brz_token_metadata m
+         LEFT JOIN brz_token_outputs o
            ON o.token_identifier = m.identifier AND o.user_id = m.user_id
-         LEFT JOIN token_reservations r
+         LEFT JOIN brz_token_reservations r
            ON o.reservation_id = r.id AND o.user_id = r.user_id
          WHERE m.user_id = ?
          ORDER BY m.identifier, CAST(o.token_amount AS DECIMAL(65,0)) ASC`,
@@ -487,10 +487,10 @@ class MysqlTokenStore {
                 o.token_public_key, o.token_amount, o.token_identifier,
                 o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                 r.purpose
-         FROM token_metadata m
-         LEFT JOIN token_outputs o
+         FROM brz_token_metadata m
+         LEFT JOIN brz_token_outputs o
            ON o.token_identifier = m.identifier AND o.user_id = m.user_id
-         LEFT JOIN token_reservations r
+         LEFT JOIN brz_token_reservations r
            ON o.reservation_id = r.id AND o.user_id = r.user_id
          WHERE m.user_id = ? AND ${whereClause}
          ORDER BY CAST(o.token_amount AS DECIMAL(65,0)) ASC`,
@@ -544,7 +544,7 @@ class MysqlTokenStore {
         if (outputIds.length > 0) {
           const placeholders = buildPlaceholders(outputIds.length);
           await conn.query(
-            `DELETE FROM token_spent_outputs WHERE user_id = ? AND output_id IN (${placeholders})`,
+            `DELETE FROM brz_token_spent_outputs WHERE user_id = ? AND output_id IN (${placeholders})`,
             [this.identity, ...outputIds]
           );
         }
@@ -593,7 +593,7 @@ class MysqlTokenStore {
         }
 
         const [metadataRows] = await conn.query(
-          "SELECT * FROM token_metadata WHERE user_id = ? AND identifier = ?",
+          "SELECT * FROM brz_token_metadata WHERE user_id = ? AND identifier = ?",
           [this.identity, tokenIdentifier]
         );
 
@@ -610,7 +610,7 @@ class MysqlTokenStore {
                   o.withdraw_bond_sats, o.withdraw_relative_block_locktime,
                   o.token_public_key, o.token_amount, o.token_identifier,
                   o.prev_tx_hash, o.prev_tx_vout
-           FROM token_outputs o
+           FROM brz_token_outputs o
            WHERE o.user_id = ? AND o.token_identifier = ? AND o.reservation_id IS NULL`,
           [this.identity, tokenIdentifier]
         );
@@ -697,7 +697,7 @@ class MysqlTokenStore {
         const reservationId = this._generateId();
 
         await conn.query(
-          "INSERT INTO token_reservations (user_id, id, purpose) VALUES (?, ?, ?)",
+          "INSERT INTO brz_token_reservations (user_id, id, purpose) VALUES (?, ?, ?)",
           [this.identity, reservationId, purpose]
         );
 
@@ -705,7 +705,7 @@ class MysqlTokenStore {
         if (selectedIds.length > 0) {
           const placeholders = buildPlaceholders(selectedIds.length);
           await conn.query(
-            `UPDATE token_outputs SET reservation_id = ? WHERE user_id = ? AND id IN (${placeholders})`,
+            `UPDATE brz_token_outputs SET reservation_id = ? WHERE user_id = ? AND id IN (${placeholders})`,
             [reservationId, this.identity, ...selectedIds]
           );
         }
@@ -730,11 +730,11 @@ class MysqlTokenStore {
         // Clear reservation_id from outputs first — the composite FK uses NO
         // ACTION (a whole-row SET NULL would null user_id, which is NOT NULL).
         await conn.query(
-          "UPDATE token_outputs SET reservation_id = NULL WHERE user_id = ? AND reservation_id = ?",
+          "UPDATE brz_token_outputs SET reservation_id = NULL WHERE user_id = ? AND reservation_id = ?",
           [this.identity, id]
         );
         await conn.query(
-          "DELETE FROM token_reservations WHERE user_id = ? AND id = ?",
+          "DELETE FROM brz_token_reservations WHERE user_id = ? AND id = ?",
           [this.identity, id]
         );
       });
@@ -751,11 +751,11 @@ class MysqlTokenStore {
     try {
       // _withWriteTransaction acquires the GET_LOCK so this serializes
       // against `setTokensOutputs`. Without it, a concurrent setTokensOutputs
-      // could read token_spent_outputs before our marker commits and re-insert
+      // could read brz_token_spent_outputs before our marker commits and re-insert
       // the just-spent output as Available.
       await this._withWriteTransaction(async (conn) => {
         const [reservationRows] = await conn.query(
-          "SELECT purpose FROM token_reservations WHERE user_id = ? AND id = ?",
+          "SELECT purpose FROM brz_token_reservations WHERE user_id = ? AND id = ?",
           [this.identity, id]
         );
         if (reservationRows.length === 0) {
@@ -764,7 +764,7 @@ class MysqlTokenStore {
         const isSwap = reservationRows[0].purpose === "Swap";
 
         const [reservedRows] = await conn.query(
-          "SELECT id FROM token_outputs WHERE user_id = ? AND reservation_id = ?",
+          "SELECT id FROM brz_token_outputs WHERE user_id = ? AND reservation_id = ?",
           [this.identity, id]
         );
         const reservedOutputIds = reservedRows.map((r) => r.id);
@@ -779,18 +779,18 @@ class MysqlTokenStore {
           }
           // Suppress duplicate-PK errors only.
           await conn.query(
-            `INSERT INTO token_spent_outputs (user_id, output_id) VALUES ${valueClauses}
+            `INSERT INTO brz_token_spent_outputs (user_id, output_id) VALUES ${valueClauses}
              ON DUPLICATE KEY UPDATE output_id = output_id`,
             params
           );
         }
 
         await conn.query(
-          "DELETE FROM token_outputs WHERE user_id = ? AND reservation_id = ?",
+          "DELETE FROM brz_token_outputs WHERE user_id = ? AND reservation_id = ?",
           [this.identity, id]
         );
         await conn.query(
-          "DELETE FROM token_reservations WHERE user_id = ? AND id = ?",
+          "DELETE FROM brz_token_reservations WHERE user_id = ? AND id = ?",
           [this.identity, id]
         );
 
@@ -798,17 +798,17 @@ class MysqlTokenStore {
         // (and thus has no row) gets one created lazily.
         if (isSwap) {
           await conn.query(
-            `INSERT INTO token_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
+            `INSERT INTO brz_token_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
              ON DUPLICATE KEY UPDATE last_completed_at = VALUES(last_completed_at)`,
             [this.identity]
           );
         }
 
         await conn.query(
-          `DELETE FROM token_metadata
+          `DELETE FROM brz_token_metadata
            WHERE user_id = ?
              AND identifier NOT IN (
-               SELECT DISTINCT token_identifier FROM token_outputs WHERE user_id = ?
+               SELECT DISTINCT token_identifier FROM brz_token_outputs WHERE user_id = ?
              )`,
           [this.identity, this.identity]
         );
@@ -856,11 +856,11 @@ class MysqlTokenStore {
   /// user_id (NOT NULL).
   async _cleanupStaleReservations(conn) {
     await conn.query(
-      `UPDATE token_outputs SET reservation_id = NULL
+      `UPDATE brz_token_outputs SET reservation_id = NULL
        WHERE user_id = ?
          AND reservation_id IN (
            SELECT id FROM (
-             SELECT id FROM token_reservations
+             SELECT id FROM brz_token_reservations
              WHERE user_id = ?
                AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
            ) AS stale
@@ -868,7 +868,7 @@ class MysqlTokenStore {
       [this.identity, this.identity, RESERVATION_TIMEOUT_SECS]
     );
     await conn.query(
-      `DELETE FROM token_reservations
+      `DELETE FROM brz_token_reservations
        WHERE user_id = ? AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)`,
       [this.identity, RESERVATION_TIMEOUT_SECS]
     );
@@ -876,7 +876,7 @@ class MysqlTokenStore {
 
   async _upsertMetadata(conn, metadata) {
     await conn.query(
-      `INSERT INTO token_metadata
+      `INSERT INTO brz_token_metadata
         (user_id, identifier, issuer_public_key, name, ticker, decimals, max_supply,
          is_freezable, creation_entity_public_key)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -907,7 +907,7 @@ class MysqlTokenStore {
     // conflict only — unlike INSERT IGNORE, FK / NOT NULL / type errors
     // still propagate.
     await conn.query(
-      `INSERT INTO token_outputs
+      `INSERT INTO brz_token_outputs
         (user_id, id, token_identifier, owner_public_key, revocation_commitment,
          withdraw_bond_sats, withdraw_relative_block_locktime,
          token_public_key, token_amount, prev_tx_hash, prev_tx_vout, added_at)

--- a/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
@@ -202,6 +202,22 @@ class MysqlTokenStoreMigrationManager {
         "idx_token_outputs_user_reservation",
         "brz_idx_token_outputs_user_reservation",
       ],
+      // Pre-multi-tenant indexes (dropped by the multi-tenant migration).
+      [
+        "brz_token_metadata",
+        "idx_token_metadata_issuer_pk",
+        "brz_idx_token_metadata_issuer_pk",
+      ],
+      [
+        "brz_token_outputs",
+        "idx_token_outputs_identifier",
+        "brz_idx_token_outputs_identifier",
+      ],
+      [
+        "brz_token_outputs",
+        "idx_token_outputs_reservation",
+        "brz_idx_token_outputs_reservation",
+      ],
     ];
     for (const [table, oldName, newName] of indexRenames) {
       if (

--- a/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
@@ -270,10 +270,9 @@ class MysqlTokenStoreMigrationManager {
         continue;
       }
       await conn.query(
-        `ALTER TABLE \`${fk.table}\` DROP FOREIGN KEY \`${fk.oldName}\``
-      );
-      await conn.query(
-        `ALTER TABLE \`${fk.table}\` ADD CONSTRAINT \`${fk.newName}\` ${fk.definition}`
+        `ALTER TABLE \`${fk.table}\`` +
+          ` DROP FOREIGN KEY \`${fk.oldName}\`,` +
+          ` ADD CONSTRAINT \`${fk.newName}\` ${fk.definition}`
       );
     }
 

--- a/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
@@ -161,9 +161,8 @@ class MysqlTokenStoreMigrationManager {
    *   encoding) — not user-controlled input.
    */
   /**
-   * Renames legacy unprefixed token-store objects to their `brz_` equivalents
-   * on first startup after the prefix change. Gated on the legacy
-   * `token_schema_migrations` table as canary.
+   * Pre-prefix rename. Canary-gated on the legacy `token_schema_migrations`
+   * table.
    * @param {import('mysql2/promise').PoolConnection} conn
    */
   async _applySchemaRenames(conn) {
@@ -229,6 +228,22 @@ class MysqlTokenStoreMigrationManager {
         newName: "brz_fk_token_outputs_reservation_user",
         definition:
           "FOREIGN KEY (user_id, reservation_id) REFERENCES `brz_token_reservations`(user_id, id)",
+      },
+      // Pre-multi-tenant FKs (single-column). Rename so the post-tenant
+      // migration's drop-foreign-key steps find them.
+      {
+        table: "brz_token_outputs",
+        oldName: "fk_token_outputs_metadata",
+        newName: "brz_fk_token_outputs_metadata",
+        definition:
+          "FOREIGN KEY (token_identifier) REFERENCES `brz_token_metadata`(identifier)",
+      },
+      {
+        table: "brz_token_outputs",
+        oldName: "fk_token_outputs_reservation",
+        newName: "brz_fk_token_outputs_reservation",
+        definition:
+          "FOREIGN KEY (reservation_id) REFERENCES `brz_token_reservations`(id) ON DELETE SET NULL",
       },
     ];
     for (const fk of fkRenames) {

--- a/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
@@ -4,7 +4,7 @@
 
 const { TokenStoreError } = require("./errors.cjs");
 
-const TOKEN_MIGRATIONS_TABLE = "token_schema_migrations";
+const TOKEN_MIGRATIONS_TABLE = "brz_token_schema_migrations";
 const MIGRATION_LOCK_NAME = "breez_mysql_token_store_migration_lock";
 const MIGRATION_LOCK_TIMEOUT = 60;
 
@@ -102,6 +102,8 @@ class MysqlTokenStoreMigrationManager {
       }
 
       try {
+        await this._applySchemaRenames(conn);
+
         await conn.query("START TRANSACTION");
 
         await conn.query(`
@@ -158,13 +160,109 @@ class MysqlTokenStoreMigrationManager {
    *   the bytes come from a typed secp256k1 pubkey (`[0-9a-f]{66}` after hex
    *   encoding) — not user-controlled input.
    */
+  /**
+   * Renames legacy unprefixed token-store objects to their `brz_` equivalents
+   * on first startup after the prefix change. Gated on the legacy
+   * `token_schema_migrations` table as canary.
+   * @param {import('mysql2/promise').PoolConnection} conn
+   */
+  async _applySchemaRenames(conn) {
+    if (!(await _mysqlTableExists(conn, "token_schema_migrations"))) {
+      return;
+    }
+
+    const tableRenames = [
+      ["token_metadata", "brz_token_metadata"],
+      ["token_reservations", "brz_token_reservations"],
+      ["token_outputs", "brz_token_outputs"],
+      ["token_spent_outputs", "brz_token_spent_outputs"],
+      ["token_swap_status", "brz_token_swap_status"],
+    ];
+    for (const [oldName, newName] of tableRenames) {
+      if (
+        (await _mysqlTableExists(conn, oldName)) &&
+        !(await _mysqlTableExists(conn, newName))
+      ) {
+        await conn.query(`RENAME TABLE \`${oldName}\` TO \`${newName}\``);
+      }
+    }
+
+    const indexRenames = [
+      [
+        "brz_token_metadata",
+        "idx_token_metadata_user_issuer_pk",
+        "brz_idx_token_metadata_user_issuer_pk",
+      ],
+      [
+        "brz_token_outputs",
+        "idx_token_outputs_user_identifier",
+        "brz_idx_token_outputs_user_identifier",
+      ],
+      [
+        "brz_token_outputs",
+        "idx_token_outputs_user_reservation",
+        "brz_idx_token_outputs_user_reservation",
+      ],
+    ];
+    for (const [table, oldName, newName] of indexRenames) {
+      if (
+        (await _mysqlIndexExists(conn, table, oldName)) &&
+        !(await _mysqlIndexExists(conn, table, newName))
+      ) {
+        await conn.query(
+          `ALTER TABLE \`${table}\` RENAME INDEX \`${oldName}\` TO \`${newName}\``
+        );
+      }
+    }
+
+    const fkRenames = [
+      {
+        table: "brz_token_outputs",
+        oldName: "fk_token_outputs_metadata_user",
+        newName: "brz_fk_token_outputs_metadata_user",
+        definition:
+          "FOREIGN KEY (user_id, token_identifier) REFERENCES `brz_token_metadata`(user_id, identifier)",
+      },
+      {
+        table: "brz_token_outputs",
+        oldName: "fk_token_outputs_reservation_user",
+        newName: "brz_fk_token_outputs_reservation_user",
+        definition:
+          "FOREIGN KEY (user_id, reservation_id) REFERENCES `brz_token_reservations`(user_id, id)",
+      },
+    ];
+    for (const fk of fkRenames) {
+      if (await _mysqlForeignKeyExists(conn, fk.table, fk.newName)) {
+        continue;
+      }
+      if (!(await _mysqlForeignKeyExists(conn, fk.table, fk.oldName))) {
+        continue;
+      }
+      await conn.query(
+        `ALTER TABLE \`${fk.table}\` DROP FOREIGN KEY \`${fk.oldName}\``
+      );
+      await conn.query(
+        `ALTER TABLE \`${fk.table}\` ADD CONSTRAINT \`${fk.newName}\` ${fk.definition}`
+      );
+    }
+
+    if (
+      (await _mysqlTableExists(conn, "token_schema_migrations")) &&
+      !(await _mysqlTableExists(conn, TOKEN_MIGRATIONS_TABLE))
+    ) {
+      await conn.query(
+        `RENAME TABLE \`token_schema_migrations\` TO \`${TOKEN_MIGRATIONS_TABLE}\``
+      );
+    }
+  }
+
   _getMigrations(identity) {
     const idHex = Buffer.from(identity).toString("hex");
     const idLit = `UNHEX('${idHex}')`;
     const foreignKeyModeEnforced = this.foreignKeyMode === "Enforced";
 
     const initialSql = [
-          `CREATE TABLE IF NOT EXISTS token_metadata (
+          `CREATE TABLE IF NOT EXISTS brz_token_metadata (
             identifier VARCHAR(255) NOT NULL PRIMARY KEY,
             issuer_public_key VARCHAR(255) NOT NULL,
             name VARCHAR(255) NOT NULL,
@@ -174,14 +272,14 @@ class MysqlTokenStoreMigrationManager {
             is_freezable TINYINT(1) NOT NULL,
             creation_entity_public_key VARCHAR(255) NULL
           )`,
-          `CREATE INDEX idx_token_metadata_issuer_pk
-            ON token_metadata (issuer_public_key)`,
-          `CREATE TABLE IF NOT EXISTS token_reservations (
+          `CREATE INDEX brz_idx_token_metadata_issuer_pk
+            ON brz_token_metadata (issuer_public_key)`,
+          `CREATE TABLE IF NOT EXISTS brz_token_reservations (
             id VARCHAR(255) NOT NULL PRIMARY KEY,
             purpose VARCHAR(64) NOT NULL,
             created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
           )`,
-          `CREATE TABLE IF NOT EXISTS token_outputs (
+          `CREATE TABLE IF NOT EXISTS brz_token_outputs (
             id VARCHAR(255) NOT NULL PRIMARY KEY,
             token_identifier VARCHAR(255) NOT NULL,
             owner_public_key VARCHAR(255) NOT NULL,
@@ -195,15 +293,15 @@ class MysqlTokenStoreMigrationManager {
             reservation_id VARCHAR(255) NULL,
             added_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
           )`,
-          `CREATE INDEX idx_token_outputs_identifier
-            ON token_outputs (token_identifier)`,
-          `CREATE INDEX idx_token_outputs_reservation
-            ON token_outputs (reservation_id)`,
-          `CREATE TABLE IF NOT EXISTS token_spent_outputs (
+          `CREATE INDEX brz_idx_token_outputs_identifier
+            ON brz_token_outputs (token_identifier)`,
+          `CREATE INDEX brz_idx_token_outputs_reservation
+            ON brz_token_outputs (reservation_id)`,
+          `CREATE TABLE IF NOT EXISTS brz_token_spent_outputs (
             output_id VARCHAR(255) NOT NULL PRIMARY KEY,
             spent_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
           )`,
-          `CREATE TABLE IF NOT EXISTS token_swap_status (
+          `CREATE TABLE IF NOT EXISTS brz_token_swap_status (
             id INT NOT NULL PRIMARY KEY DEFAULT 1,
             last_completed_at DATETIME(6) NULL,
             CHECK (id = 1)
@@ -213,15 +311,15 @@ class MysqlTokenStoreMigrationManager {
       initialSql.push(
         {
           op: "addForeignKey",
-          table: "token_outputs",
-          name: "fk_token_outputs_metadata",
-          definition: `FOREIGN KEY (token_identifier) REFERENCES token_metadata(identifier)`,
+          table: "brz_token_outputs",
+          name: "brz_fk_token_outputs_metadata",
+          definition: `FOREIGN KEY (token_identifier) REFERENCES brz_token_metadata(identifier)`,
         },
         {
           op: "addForeignKey",
-          table: "token_outputs",
-          name: "fk_token_outputs_reservation",
-          definition: `FOREIGN KEY (reservation_id) REFERENCES token_reservations(id) ON DELETE SET NULL`,
+          table: "brz_token_outputs",
+          name: "brz_fk_token_outputs_reservation",
+          definition: `FOREIGN KEY (reservation_id) REFERENCES brz_token_reservations(id) ON DELETE SET NULL`,
         }
       );
     }
@@ -231,14 +329,14 @@ class MysqlTokenStoreMigrationManager {
         name: "Create token store tables",
         sql: [
           ...initialSql,
-          `INSERT INTO token_swap_status (id) VALUES (1)
+          `INSERT INTO brz_token_swap_status (id) VALUES (1)
             ON DUPLICATE KEY UPDATE id = id`,
         ],
       },
       {
         // Mirrors Rust migration 2 in spark-mysql/src/token_store.rs and the
         // postgres equivalent. Adds user_id to every token-store table
-        // (including token_metadata — per-tenant to avoid 0-balance leakage
+        // (including brz_token_metadata — per-tenant to avoid 0-balance leakage
         // for tokens a tenant never owned), backfills with the connecting
         // tenant, and rewrites primary keys / FKs / indexes to lead with
         // user_id. Composite FKs use NO ACTION because column-list SET NULL
@@ -251,76 +349,106 @@ class MysqlTokenStoreMigrationManager {
           // erroring.
           {
             op: "dropForeignKey",
-            table: "token_outputs",
-            name: "fk_token_outputs_metadata",
+            table: "brz_token_outputs",
+            name: "brz_fk_token_outputs_metadata",
           },
           {
             op: "dropForeignKey",
-            table: "token_outputs",
-            name: "fk_token_outputs_reservation",
+            table: "brz_token_outputs",
+            name: "brz_fk_token_outputs_reservation",
           },
 
-          // token_metadata: per-tenant scoping (privacy — see header).
-          `ALTER TABLE token_metadata ADD COLUMN user_id VARBINARY(33) NULL`,
-          `UPDATE token_metadata SET user_id = ${idLit} WHERE user_id IS NULL`,
-          `ALTER TABLE token_metadata MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
-          `ALTER TABLE token_metadata DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, identifier)`,
-          `DROP INDEX idx_token_metadata_issuer_pk ON token_metadata`,
-          `CREATE INDEX idx_token_metadata_user_issuer_pk
-             ON token_metadata (user_id, issuer_public_key)`,
+          // brz_token_metadata: per-tenant scoping (privacy — see header).
+          `ALTER TABLE brz_token_metadata ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE brz_token_metadata SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE brz_token_metadata MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE brz_token_metadata DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, identifier)`,
+          `DROP INDEX brz_idx_token_metadata_issuer_pk ON brz_token_metadata`,
+          `CREATE INDEX brz_idx_token_metadata_user_issuer_pk
+             ON brz_token_metadata (user_id, issuer_public_key)`,
 
-          // token_reservations: scope by user_id.
-          `ALTER TABLE token_reservations ADD COLUMN user_id VARBINARY(33) NULL`,
-          `UPDATE token_reservations SET user_id = ${idLit} WHERE user_id IS NULL`,
-          `ALTER TABLE token_reservations MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
-          `ALTER TABLE token_reservations DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)`,
+          // brz_token_reservations: scope by user_id.
+          `ALTER TABLE brz_token_reservations ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE brz_token_reservations SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE brz_token_reservations MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE brz_token_reservations DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)`,
 
-          // token_outputs: scope by user_id, rekey, optionally re-add composite FKs.
-          `ALTER TABLE token_outputs ADD COLUMN user_id VARBINARY(33) NULL`,
-          `UPDATE token_outputs SET user_id = ${idLit} WHERE user_id IS NULL`,
-          `ALTER TABLE token_outputs MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
-          `ALTER TABLE token_outputs DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)`,
+          // brz_token_outputs: scope by user_id, rekey, optionally re-add composite FKs.
+          `ALTER TABLE brz_token_outputs ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE brz_token_outputs SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE brz_token_outputs MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE brz_token_outputs DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)`,
           ...(foreignKeyModeEnforced
             ? [
                 {
                   op: "addForeignKey",
-                  table: "token_outputs",
-                  name: "fk_token_outputs_metadata_user",
-                  definition: `FOREIGN KEY (user_id, token_identifier) REFERENCES token_metadata(user_id, identifier)`,
+                  table: "brz_token_outputs",
+                  name: "brz_fk_token_outputs_metadata_user",
+                  definition: `FOREIGN KEY (user_id, token_identifier) REFERENCES brz_token_metadata(user_id, identifier)`,
                 },
                 {
                   op: "addForeignKey",
-                  table: "token_outputs",
-                  name: "fk_token_outputs_reservation_user",
-                  definition: `FOREIGN KEY (user_id, reservation_id) REFERENCES token_reservations(user_id, id)`,
+                  table: "brz_token_outputs",
+                  name: "brz_fk_token_outputs_reservation_user",
+                  definition: `FOREIGN KEY (user_id, reservation_id) REFERENCES brz_token_reservations(user_id, id)`,
                 },
               ]
             : []),
-          `DROP INDEX idx_token_outputs_identifier ON token_outputs`,
-          `DROP INDEX idx_token_outputs_reservation ON token_outputs`,
-          `CREATE INDEX idx_token_outputs_user_identifier
-             ON token_outputs (user_id, token_identifier)`,
-          `CREATE INDEX idx_token_outputs_user_reservation
-             ON token_outputs (user_id, reservation_id)`,
+          `DROP INDEX brz_idx_token_outputs_identifier ON brz_token_outputs`,
+          `DROP INDEX brz_idx_token_outputs_reservation ON brz_token_outputs`,
+          `CREATE INDEX brz_idx_token_outputs_user_identifier
+             ON brz_token_outputs (user_id, token_identifier)`,
+          `CREATE INDEX brz_idx_token_outputs_user_reservation
+             ON brz_token_outputs (user_id, reservation_id)`,
 
-          // token_spent_outputs: scope by user_id.
-          `ALTER TABLE token_spent_outputs ADD COLUMN user_id VARBINARY(33) NULL`,
-          `UPDATE token_spent_outputs SET user_id = ${idLit} WHERE user_id IS NULL`,
-          `ALTER TABLE token_spent_outputs MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
-          `ALTER TABLE token_spent_outputs DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, output_id)`,
+          // brz_token_spent_outputs: scope by user_id.
+          `ALTER TABLE brz_token_spent_outputs ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE brz_token_spent_outputs SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE brz_token_spent_outputs MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE brz_token_spent_outputs DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, output_id)`,
 
-          // token_swap_status was a singleton (PK id=1, CHECK id=1). Drop the
+          // brz_token_swap_status was a singleton (PK id=1, CHECK id=1). Drop the
           // PK and the id column, then re-key by user_id.
-          { op: "dropPrimaryKey", table: "token_swap_status" },
-          `ALTER TABLE token_swap_status DROP COLUMN id`,
-          `ALTER TABLE token_swap_status ADD COLUMN user_id VARBINARY(33) NULL`,
-          `UPDATE token_swap_status SET user_id = ${idLit} WHERE user_id IS NULL`,
-          `ALTER TABLE token_swap_status MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
-          `ALTER TABLE token_swap_status ADD PRIMARY KEY (user_id)`,
+          { op: "dropPrimaryKey", table: "brz_token_swap_status" },
+          `ALTER TABLE brz_token_swap_status DROP COLUMN id`,
+          `ALTER TABLE brz_token_swap_status ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE brz_token_swap_status SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE brz_token_swap_status MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE brz_token_swap_status ADD PRIMARY KEY (user_id)`,
         ],
       },
     ];
   }
+}
+
+async function _mysqlTableExists(conn, tableName) {
+  const [rows] = await conn.query(
+    `SELECT COUNT(*) AS c FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND table_name = ?`,
+    [tableName]
+  );
+  return Number(rows[0].c) > 0;
+}
+
+async function _mysqlIndexExists(conn, tableName, indexName) {
+  const [rows] = await conn.query(
+    `SELECT COUNT(*) AS c FROM information_schema.statistics
+     WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?`,
+    [tableName, indexName]
+  );
+  return Number(rows[0].c) > 0;
+}
+
+async function _mysqlForeignKeyExists(conn, tableName, constraintName) {
+  const [rows] = await conn.query(
+    `SELECT COUNT(*) AS c FROM information_schema.table_constraints
+     WHERE table_schema = DATABASE()
+       AND table_name = ?
+       AND constraint_type = 'FOREIGN KEY'
+       AND constraint_name = ?`,
+    [tableName, constraintName]
+  );
+  return Number(rows[0].c) > 0;
 }
 
 module.exports = { MysqlTokenStoreMigrationManager };

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -226,8 +226,8 @@ class MysqlTreeStore {
     try {
       const [rows] = await this.pool.query(
         `SELECT COALESCE(SUM(l.value), 0) AS balance
-         FROM tree_leaves l
-         LEFT JOIN tree_reservations r
+         FROM brz_tree_leaves l
+         LEFT JOIN brz_tree_reservations r
            ON l.reservation_id = r.id AND l.user_id = r.user_id
          WHERE l.user_id = ?
            AND (
@@ -250,8 +250,8 @@ class MysqlTreeStore {
       const [rows] = await this.pool.query(
         `SELECT l.id, l.status, l.is_missing_from_operators, l.data,
                 l.reservation_id, r.purpose
-         FROM tree_leaves l
-         LEFT JOIN tree_reservations r
+         FROM brz_tree_leaves l
+         LEFT JOIN brz_tree_reservations r
            ON l.reservation_id = r.id AND l.user_id = r.user_id
          WHERE l.user_id = ?`,
         [this.identity]
@@ -315,9 +315,9 @@ class MysqlTreeStore {
 
         const [swapRows] = await conn.query(
           `SELECT
-            (SELECT EXISTS(SELECT 1 FROM tree_reservations WHERE user_id = ? AND purpose = 'Swap')) AS has_active_swap,
+            (SELECT EXISTS(SELECT 1 FROM brz_tree_reservations WHERE user_id = ? AND purpose = 'Swap')) AS has_active_swap,
             COALESCE(
-              (SELECT (last_completed_at >= ?) FROM tree_swap_status WHERE user_id = ?),
+              (SELECT (last_completed_at >= ?) FROM brz_tree_swap_status WHERE user_id = ?),
               0
             ) AS swap_completed_during_refresh`,
           [this.identity, refreshTimestamp, this.identity]
@@ -332,7 +332,7 @@ class MysqlTreeStore {
         await this._cleanupSpentMarkers(conn, refreshTimestamp);
 
         const [spentRows] = await conn.query(
-          "SELECT leaf_id FROM tree_spent_leaves WHERE user_id = ? AND spent_at >= ?",
+          "SELECT leaf_id FROM brz_tree_spent_leaves WHERE user_id = ? AND spent_at >= ?",
           [this.identity, refreshTimestamp]
         );
         const spentIds = new Set(spentRows.map((r) => r.leaf_id));
@@ -341,7 +341,7 @@ class MysqlTreeStore {
         // _cleanupStaleReservations (which now NULLs reservation_id explicitly,
         // since the composite FK uses NO ACTION).
         await conn.query(
-          "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
+          "DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
           [this.identity, refreshTimestamp]
         );
 
@@ -361,7 +361,7 @@ class MysqlTreeStore {
     try {
       await this._withTransaction(async (conn) => {
         const [existsRows] = await conn.query(
-          "SELECT id FROM tree_reservations WHERE user_id = ? AND id = ?",
+          "SELECT id FROM brz_tree_reservations WHERE user_id = ? AND id = ?",
           [this.identity, id]
         );
 
@@ -370,11 +370,11 @@ class MysqlTreeStore {
         }
 
         await conn.query(
-          "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+          "DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
           [this.identity, id]
         );
         await conn.query(
-          "DELETE FROM tree_reservations WHERE user_id = ? AND id = ?",
+          "DELETE FROM brz_tree_reservations WHERE user_id = ? AND id = ?",
           [this.identity, id]
         );
 
@@ -395,11 +395,11 @@ class MysqlTreeStore {
     try {
       // _withWriteTransaction acquires the GET_LOCK so this serializes
       // against `setLeaves`. Without it, a concurrent setLeaves could read
-      // tree_spent_leaves before our marker commits and re-insert the
+      // brz_tree_spent_leaves before our marker commits and re-insert the
       // just-spent leaf as Available.
       await this._withWriteTransaction(async (conn) => {
         const [resRows] = await conn.query(
-          "SELECT id, purpose FROM tree_reservations WHERE user_id = ? AND id = ?",
+          "SELECT id, purpose FROM brz_tree_reservations WHERE user_id = ? AND id = ?",
           [this.identity, id]
         );
 
@@ -407,17 +407,17 @@ class MysqlTreeStore {
         if (resRows.length > 0) {
           isSwap = resRows[0].purpose === "Swap";
           const [leafRows] = await conn.query(
-            "SELECT id FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+            "SELECT id FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
             [this.identity, id]
           );
           const reservedLeafIds = leafRows.map((r) => r.id);
           await this._batchInsertSpentLeaves(conn, reservedLeafIds);
           await conn.query(
-            "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+            "DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
             [this.identity, id]
           );
           await conn.query(
-            "DELETE FROM tree_reservations WHERE user_id = ? AND id = ?",
+            "DELETE FROM brz_tree_reservations WHERE user_id = ? AND id = ?",
             [this.identity, id]
           );
         }
@@ -430,7 +430,7 @@ class MysqlTreeStore {
         // (and thus has no row) gets one created lazily.
         if (isSwap && newLeaves && newLeaves.length > 0) {
           await conn.query(
-            `INSERT INTO tree_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
+            `INSERT INTO brz_tree_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
              ON DUPLICATE KEY UPDATE last_completed_at = VALUES(last_completed_at)`,
             [this.identity]
           );
@@ -453,7 +453,7 @@ class MysqlTreeStore {
 
         const [totalRows] = await conn.query(
           `SELECT COALESCE(SUM(value), 0) AS total
-           FROM tree_leaves
+           FROM brz_tree_leaves
            WHERE user_id = ?
              AND status = 'Available'
              AND is_missing_from_operators = 0
@@ -464,7 +464,7 @@ class MysqlTreeStore {
 
         const [slimRows] = await conn.query(
           `SELECT id, value
-           FROM tree_leaves
+           FROM brz_tree_leaves
            WHERE user_id = ?
              AND status = 'Available'
              AND is_missing_from_operators = 0
@@ -473,7 +473,7 @@ class MysqlTreeStore {
                value <= ?
                OR id = (
                  SELECT id FROM (
-                   SELECT id FROM tree_leaves
+                   SELECT id FROM brz_tree_leaves
                    WHERE user_id = ?
                      AND status = 'Available'
                      AND is_missing_from_operators = 0
@@ -598,7 +598,7 @@ class MysqlTreeStore {
     try {
       return await this._withTransaction(async (conn) => {
         const [existsRows] = await conn.query(
-          "SELECT id FROM tree_reservations WHERE user_id = ? AND id = ?",
+          "SELECT id FROM brz_tree_reservations WHERE user_id = ? AND id = ?",
           [this.identity, reservationId]
         );
 
@@ -607,14 +607,14 @@ class MysqlTreeStore {
         }
 
         const [oldLeafRows] = await conn.query(
-          "SELECT id FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+          "SELECT id FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
           [this.identity, reservationId]
         );
         const oldLeafIds = oldLeafRows.map((r) => r.id);
 
         await this._batchInsertSpentLeaves(conn, oldLeafIds);
         await conn.query(
-          "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+          "DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
           [this.identity, reservationId]
         );
 
@@ -625,7 +625,7 @@ class MysqlTreeStore {
         await this._batchSetReservationId(conn, reservationId, reservedLeafIds);
 
         await conn.query(
-          "UPDATE tree_reservations SET pending_change_amount = 0 WHERE user_id = ? AND id = ?",
+          "UPDATE brz_tree_reservations SET pending_change_amount = 0 WHERE user_id = ? AND id = ?",
           [this.identity, reservationId]
         );
 
@@ -682,7 +682,7 @@ class MysqlTreeStore {
     if (!ids || ids.length === 0) return [];
     const placeholders = ids.map(() => "?").join(", ");
     const [rows] = await conn.query(
-      `SELECT data FROM tree_leaves WHERE user_id = ? AND id IN (${placeholders})`,
+      `SELECT data FROM brz_tree_leaves WHERE user_id = ? AND id IN (${placeholders})`,
       [this.identity, ...ids]
     );
     return rows.map((r) => parseJson(r.data));
@@ -801,7 +801,7 @@ class MysqlTreeStore {
 
   async _calculatePendingBalance(conn) {
     const [rows] = await conn.query(
-      "SELECT COALESCE(SUM(pending_change_amount), 0) AS pending FROM tree_reservations WHERE user_id = ?",
+      "SELECT COALESCE(SUM(pending_change_amount), 0) AS pending FROM brz_tree_reservations WHERE user_id = ?",
       [this.identity]
     );
     return Number(rows[0].pending);
@@ -809,7 +809,7 @@ class MysqlTreeStore {
 
   async _createReservation(conn, reservationId, leaves, purpose, pendingChange) {
     await conn.query(
-      "INSERT INTO tree_reservations (user_id, id, purpose, pending_change_amount) VALUES (?, ?, ?, ?)",
+      "INSERT INTO brz_tree_reservations (user_id, id, purpose, pending_change_amount) VALUES (?, ?, ?, ?)",
       [this.identity, reservationId, purpose, pendingChange]
     );
 
@@ -842,7 +842,7 @@ class MysqlTreeStore {
     }
 
     await conn.query(
-      `INSERT INTO tree_leaves (user_id, id, status, is_missing_from_operators, data, value, added_at)
+      `INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, value, added_at)
        VALUES ${valueClauses}
        ON DUPLICATE KEY UPDATE
          status = VALUES(status),
@@ -859,7 +859,7 @@ class MysqlTreeStore {
 
     const placeholders = buildPlaceholders(leafIds.length);
     await conn.query(
-      `UPDATE tree_leaves SET reservation_id = ? WHERE user_id = ? AND id IN (${placeholders})`,
+      `UPDATE brz_tree_leaves SET reservation_id = ? WHERE user_id = ? AND id IN (${placeholders})`,
       [reservationId, this.identity, ...leafIds]
     );
   }
@@ -876,7 +876,7 @@ class MysqlTreeStore {
     // problems (FK violations, NOT NULL violations, type errors) still
     // propagate.
     await conn.query(
-      `INSERT INTO tree_spent_leaves (user_id, leaf_id) VALUES ${valueClauses}
+      `INSERT INTO brz_tree_spent_leaves (user_id, leaf_id) VALUES ${valueClauses}
        ON DUPLICATE KEY UPDATE leaf_id = leaf_id`,
       params
     );
@@ -887,7 +887,7 @@ class MysqlTreeStore {
 
     const placeholders = buildPlaceholders(leafIds.length);
     await conn.query(
-      `DELETE FROM tree_spent_leaves WHERE user_id = ? AND leaf_id IN (${placeholders})`,
+      `DELETE FROM brz_tree_spent_leaves WHERE user_id = ? AND leaf_id IN (${placeholders})`,
       [this.identity, ...leafIds]
     );
   }
@@ -898,11 +898,11 @@ class MysqlTreeStore {
   /// user_id (NOT NULL).
   async _cleanupStaleReservations(conn) {
     await conn.query(
-      `UPDATE tree_leaves SET reservation_id = NULL
+      `UPDATE brz_tree_leaves SET reservation_id = NULL
        WHERE user_id = ?
          AND reservation_id IN (
            SELECT id FROM (
-             SELECT id FROM tree_reservations
+             SELECT id FROM brz_tree_reservations
              WHERE user_id = ?
                AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
            ) AS stale
@@ -910,7 +910,7 @@ class MysqlTreeStore {
       [this.identity, this.identity, RESERVATION_TIMEOUT_SECS]
     );
     await conn.query(
-      `DELETE FROM tree_reservations
+      `DELETE FROM brz_tree_reservations
        WHERE user_id = ? AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)`,
       [this.identity, RESERVATION_TIMEOUT_SECS]
     );
@@ -922,7 +922,7 @@ class MysqlTreeStore {
     );
 
     await conn.query(
-      "DELETE FROM tree_spent_leaves WHERE user_id = ? AND spent_at < ?",
+      "DELETE FROM brz_tree_spent_leaves WHERE user_id = ? AND spent_at < ?",
       [this.identity, cleanupCutoff]
     );
   }

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
@@ -177,6 +177,11 @@ class MysqlTreeStoreMigrationManager {
       ],
       ["brz_tree_leaves", "idx_tree_leaves_user_added_at", "brz_idx_tree_leaves_user_added_at"],
       ["brz_tree_leaves", "idx_tree_leaves_user_slim", "brz_idx_tree_leaves_user_slim"],
+      // Pre-multi-tenant indexes (dropped by the multi-tenant migration).
+      ["brz_tree_leaves", "idx_tree_leaves_available", "brz_idx_tree_leaves_available"],
+      ["brz_tree_leaves", "idx_tree_leaves_reservation", "brz_idx_tree_leaves_reservation"],
+      ["brz_tree_leaves", "idx_tree_leaves_added_at", "brz_idx_tree_leaves_added_at"],
+      ["brz_tree_leaves", "idx_tree_leaves_slim", "brz_idx_tree_leaves_slim"],
     ];
     for (const [table, oldName, newName] of indexRenames) {
       if (

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
@@ -222,10 +222,9 @@ class MysqlTreeStoreMigrationManager {
         continue;
       }
       await conn.query(
-        `ALTER TABLE \`${fk.table}\` DROP FOREIGN KEY \`${fk.oldName}\``
-      );
-      await conn.query(
-        `ALTER TABLE \`${fk.table}\` ADD CONSTRAINT \`${fk.newName}\` ${fk.definition}`
+        `ALTER TABLE \`${fk.table}\`` +
+          ` DROP FOREIGN KEY \`${fk.oldName}\`,` +
+          ` ADD CONSTRAINT \`${fk.newName}\` ${fk.definition}`
       );
     }
 

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
@@ -144,11 +144,8 @@ class MysqlTreeStoreMigrationManager {
   }
 
   /**
-   * Renames legacy unprefixed tree-store objects to their `brz_` equivalents
-   * on first startup after the prefix change. Gated on the legacy
-   * `tree_schema_migrations` table as canary. MySQL DDL is not transactional,
-   * so each rename is preceded by an info_schema probe to make a partial
-   * rename replayable.
+   * Pre-prefix rename. Canary-gated on the legacy `tree_schema_migrations`
+   * table.
    * @param {import('mysql2/promise').PoolConnection} conn
    */
   async _applySchemaRenames(conn) {
@@ -201,6 +198,15 @@ class MysqlTreeStoreMigrationManager {
         newName: "brz_fk_tree_leaves_reservation_user",
         definition:
           "FOREIGN KEY (user_id, reservation_id) REFERENCES `brz_tree_reservations`(user_id, id)",
+      },
+      // Pre-multi-tenant FK (single-column). Rename so the post-tenant
+      // migration's drop-foreign-key step finds it.
+      {
+        table: "brz_tree_leaves",
+        oldName: "fk_tree_leaves_reservation",
+        newName: "brz_fk_tree_leaves_reservation",
+        definition:
+          "FOREIGN KEY (reservation_id) REFERENCES `brz_tree_reservations`(id) ON DELETE SET NULL",
       },
     ];
     for (const fk of fkRenames) {

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
@@ -4,7 +4,7 @@
 
 const { TreeStoreError } = require("./errors.cjs");
 
-const TREE_MIGRATIONS_TABLE = "tree_schema_migrations";
+const TREE_MIGRATIONS_TABLE = "brz_tree_schema_migrations";
 const MIGRATION_LOCK_NAME = "breez_mysql_tree_store_migration_lock";
 const MIGRATION_LOCK_TIMEOUT = 60;
 
@@ -91,6 +91,8 @@ class MysqlTreeStoreMigrationManager {
       }
 
       try {
+        await this._applySchemaRenames(conn);
+
         await conn.query("START TRANSACTION");
 
         await conn.query(`
@@ -141,19 +143,104 @@ class MysqlTreeStoreMigrationManager {
     }
   }
 
+  /**
+   * Renames legacy unprefixed tree-store objects to their `brz_` equivalents
+   * on first startup after the prefix change. Gated on the legacy
+   * `tree_schema_migrations` table as canary. MySQL DDL is not transactional,
+   * so each rename is preceded by an info_schema probe to make a partial
+   * rename replayable.
+   * @param {import('mysql2/promise').PoolConnection} conn
+   */
+  async _applySchemaRenames(conn) {
+    if (!(await _mysqlTableExists(conn, "tree_schema_migrations"))) {
+      return;
+    }
+
+    const tableRenames = [
+      ["tree_reservations", "brz_tree_reservations"],
+      ["tree_leaves", "brz_tree_leaves"],
+      ["tree_spent_leaves", "brz_tree_spent_leaves"],
+      ["tree_swap_status", "brz_tree_swap_status"],
+    ];
+    for (const [oldName, newName] of tableRenames) {
+      if (
+        (await _mysqlTableExists(conn, oldName)) &&
+        !(await _mysqlTableExists(conn, newName))
+      ) {
+        await conn.query(`RENAME TABLE \`${oldName}\` TO \`${newName}\``);
+      }
+    }
+
+    const indexRenames = [
+      ["brz_tree_leaves", "idx_tree_leaves_user_available", "brz_idx_tree_leaves_user_available"],
+      [
+        "brz_tree_leaves",
+        "idx_tree_leaves_user_reservation",
+        "brz_idx_tree_leaves_user_reservation",
+      ],
+      ["brz_tree_leaves", "idx_tree_leaves_user_added_at", "brz_idx_tree_leaves_user_added_at"],
+      ["brz_tree_leaves", "idx_tree_leaves_user_slim", "brz_idx_tree_leaves_user_slim"],
+    ];
+    for (const [table, oldName, newName] of indexRenames) {
+      if (
+        (await _mysqlIndexExists(conn, table, oldName)) &&
+        !(await _mysqlIndexExists(conn, table, newName))
+      ) {
+        await conn.query(
+          `ALTER TABLE \`${table}\` RENAME INDEX \`${oldName}\` TO \`${newName}\``
+        );
+      }
+    }
+
+    // MySQL has no RENAME CONSTRAINT for foreign keys: drop the legacy FK
+    // and re-add it under the brz_ name.
+    const fkRenames = [
+      {
+        table: "brz_tree_leaves",
+        oldName: "fk_tree_leaves_reservation_user",
+        newName: "brz_fk_tree_leaves_reservation_user",
+        definition:
+          "FOREIGN KEY (user_id, reservation_id) REFERENCES `brz_tree_reservations`(user_id, id)",
+      },
+    ];
+    for (const fk of fkRenames) {
+      if (await _mysqlForeignKeyExists(conn, fk.table, fk.newName)) {
+        continue;
+      }
+      if (!(await _mysqlForeignKeyExists(conn, fk.table, fk.oldName))) {
+        continue;
+      }
+      await conn.query(
+        `ALTER TABLE \`${fk.table}\` DROP FOREIGN KEY \`${fk.oldName}\``
+      );
+      await conn.query(
+        `ALTER TABLE \`${fk.table}\` ADD CONSTRAINT \`${fk.newName}\` ${fk.definition}`
+      );
+    }
+
+    if (
+      (await _mysqlTableExists(conn, "tree_schema_migrations")) &&
+      !(await _mysqlTableExists(conn, TREE_MIGRATIONS_TABLE))
+    ) {
+      await conn.query(
+        `RENAME TABLE \`tree_schema_migrations\` TO \`${TREE_MIGRATIONS_TABLE}\``
+      );
+    }
+  }
+
   _getMigrations(identity) {
     const idHex = Buffer.from(identity).toString("hex");
     const idLit = `UNHEX('${idHex}')`;
     const foreignKeyModeEnforced = this.foreignKeyMode === "Enforced";
 
     const initialSql = [
-          `CREATE TABLE IF NOT EXISTS tree_reservations (
+          `CREATE TABLE IF NOT EXISTS brz_tree_reservations (
             id VARCHAR(255) NOT NULL PRIMARY KEY,
             purpose VARCHAR(64) NOT NULL,
             pending_change_amount BIGINT NOT NULL DEFAULT 0,
             created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
           )`,
-          `CREATE TABLE IF NOT EXISTS tree_leaves (
+          `CREATE TABLE IF NOT EXISTS brz_tree_leaves (
             id VARCHAR(255) NOT NULL PRIMARY KEY,
             status VARCHAR(64) NOT NULL,
             is_missing_from_operators TINYINT(1) NOT NULL DEFAULT 0,
@@ -162,21 +249,21 @@ class MysqlTreeStoreMigrationManager {
             created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
             added_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
           )`,
-          `CREATE TABLE IF NOT EXISTS tree_spent_leaves (
+          `CREATE TABLE IF NOT EXISTS brz_tree_spent_leaves (
             leaf_id VARCHAR(255) NOT NULL PRIMARY KEY,
             spent_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
           )`,
-          `CREATE INDEX idx_tree_leaves_available
-            ON tree_leaves(status, is_missing_from_operators)`,
-          `CREATE INDEX idx_tree_leaves_reservation ON tree_leaves(reservation_id)`,
-          `CREATE INDEX idx_tree_leaves_added_at ON tree_leaves(added_at)`,
+          `CREATE INDEX brz_idx_tree_leaves_available
+            ON brz_tree_leaves(status, is_missing_from_operators)`,
+          `CREATE INDEX brz_idx_tree_leaves_reservation ON brz_tree_leaves(reservation_id)`,
+          `CREATE INDEX brz_idx_tree_leaves_added_at ON brz_tree_leaves(added_at)`,
     ];
     if (foreignKeyModeEnforced) {
       initialSql.push({
         op: "addForeignKey",
-        table: "tree_leaves",
-        name: "fk_tree_leaves_reservation",
-        definition: `FOREIGN KEY (reservation_id) REFERENCES tree_reservations(id) ON DELETE SET NULL`,
+        table: "brz_tree_leaves",
+        name: "brz_fk_tree_leaves_reservation",
+        definition: `FOREIGN KEY (reservation_id) REFERENCES brz_tree_reservations(id) ON DELETE SET NULL`,
       });
     }
 
@@ -188,25 +275,25 @@ class MysqlTreeStoreMigrationManager {
       {
         name: "Add swap status tracking",
         sql: [
-          `CREATE TABLE IF NOT EXISTS tree_swap_status (
+          `CREATE TABLE IF NOT EXISTS brz_tree_swap_status (
             id INT NOT NULL PRIMARY KEY DEFAULT 1,
             last_completed_at DATETIME(6) NULL,
             CHECK (id = 1)
           )`,
-          `INSERT INTO tree_swap_status (id) VALUES (1)
+          `INSERT INTO brz_tree_swap_status (id) VALUES (1)
             ON DUPLICATE KEY UPDATE id = id`,
         ],
       },
       {
         name: "Promote leaf value to BIGINT column with covering index",
         sql: [
-          `ALTER TABLE tree_leaves
+          `ALTER TABLE brz_tree_leaves
             ADD COLUMN value BIGINT NOT NULL DEFAULT 0`,
-          `UPDATE tree_leaves
+          `UPDATE brz_tree_leaves
             SET value = CAST(JSON_UNQUOTE(JSON_EXTRACT(data, '$.value')) AS UNSIGNED)
             WHERE value = 0`,
-          `CREATE INDEX idx_tree_leaves_slim
-            ON tree_leaves(status, is_missing_from_operators, reservation_id, value)`,
+          `CREATE INDEX brz_idx_tree_leaves_slim
+            ON brz_tree_leaves(status, is_missing_from_operators, reservation_id, value)`,
         ],
       },
       {
@@ -217,61 +304,91 @@ class MysqlTreeStoreMigrationManager {
           // FK was never created) skip the DROP rather than erroring.
           {
             op: "dropForeignKey",
-            table: "tree_leaves",
-            name: "fk_tree_leaves_reservation",
+            table: "brz_tree_leaves",
+            name: "brz_fk_tree_leaves_reservation",
           },
 
-          // tree_reservations: scope by user_id.
-          `ALTER TABLE tree_reservations ADD COLUMN user_id VARBINARY(33) NULL`,
-          `UPDATE tree_reservations SET user_id = ${idLit} WHERE user_id IS NULL`,
-          `ALTER TABLE tree_reservations MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
-          `ALTER TABLE tree_reservations DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)`,
+          // brz_tree_reservations: scope by user_id.
+          `ALTER TABLE brz_tree_reservations ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE brz_tree_reservations SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE brz_tree_reservations MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE brz_tree_reservations DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)`,
 
-          // tree_leaves: scope by user_id, rekey, optionally re-add composite FK.
-          `ALTER TABLE tree_leaves ADD COLUMN user_id VARBINARY(33) NULL`,
-          `UPDATE tree_leaves SET user_id = ${idLit} WHERE user_id IS NULL`,
-          `ALTER TABLE tree_leaves MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
-          `ALTER TABLE tree_leaves DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)`,
+          // brz_tree_leaves: scope by user_id, rekey, optionally re-add composite FK.
+          `ALTER TABLE brz_tree_leaves ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE brz_tree_leaves SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE brz_tree_leaves MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE brz_tree_leaves DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)`,
           ...(foreignKeyModeEnforced
             ? [
                 {
                   op: "addForeignKey",
-                  table: "tree_leaves",
-                  name: "fk_tree_leaves_reservation_user",
-                  definition: `FOREIGN KEY (user_id, reservation_id) REFERENCES tree_reservations(user_id, id)`,
+                  table: "brz_tree_leaves",
+                  name: "brz_fk_tree_leaves_reservation_user",
+                  definition: `FOREIGN KEY (user_id, reservation_id) REFERENCES brz_tree_reservations(user_id, id)`,
                 },
               ]
             : []),
-          `DROP INDEX idx_tree_leaves_available ON tree_leaves`,
-          `DROP INDEX idx_tree_leaves_reservation ON tree_leaves`,
-          `DROP INDEX idx_tree_leaves_added_at ON tree_leaves`,
-          `DROP INDEX idx_tree_leaves_slim ON tree_leaves`,
-          `CREATE INDEX idx_tree_leaves_user_available
-             ON tree_leaves(user_id, status, is_missing_from_operators)`,
-          `CREATE INDEX idx_tree_leaves_user_reservation
-             ON tree_leaves(user_id, reservation_id)`,
-          `CREATE INDEX idx_tree_leaves_user_added_at ON tree_leaves(user_id, added_at)`,
-          `CREATE INDEX idx_tree_leaves_user_slim
-             ON tree_leaves(user_id, status, is_missing_from_operators, reservation_id, value)`,
+          `DROP INDEX brz_idx_tree_leaves_available ON brz_tree_leaves`,
+          `DROP INDEX brz_idx_tree_leaves_reservation ON brz_tree_leaves`,
+          `DROP INDEX brz_idx_tree_leaves_added_at ON brz_tree_leaves`,
+          `DROP INDEX brz_idx_tree_leaves_slim ON brz_tree_leaves`,
+          `CREATE INDEX brz_idx_tree_leaves_user_available
+             ON brz_tree_leaves(user_id, status, is_missing_from_operators)`,
+          `CREATE INDEX brz_idx_tree_leaves_user_reservation
+             ON brz_tree_leaves(user_id, reservation_id)`,
+          `CREATE INDEX brz_idx_tree_leaves_user_added_at ON brz_tree_leaves(user_id, added_at)`,
+          `CREATE INDEX brz_idx_tree_leaves_user_slim
+             ON brz_tree_leaves(user_id, status, is_missing_from_operators, reservation_id, value)`,
 
-          // tree_spent_leaves: scope by user_id.
-          `ALTER TABLE tree_spent_leaves ADD COLUMN user_id VARBINARY(33) NULL`,
-          `UPDATE tree_spent_leaves SET user_id = ${idLit} WHERE user_id IS NULL`,
-          `ALTER TABLE tree_spent_leaves MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
-          `ALTER TABLE tree_spent_leaves DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, leaf_id)`,
+          // brz_tree_spent_leaves: scope by user_id.
+          `ALTER TABLE brz_tree_spent_leaves ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE brz_tree_spent_leaves SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE brz_tree_spent_leaves MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE brz_tree_spent_leaves DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, leaf_id)`,
 
-          // tree_swap_status was a singleton (PK id=1, CHECK id=1). Drop the PK
+          // brz_tree_swap_status was a singleton (PK id=1, CHECK id=1). Drop the PK
           // and the id column, then re-key by user_id.
-          { op: "dropPrimaryKey", table: "tree_swap_status" },
-          `ALTER TABLE tree_swap_status DROP COLUMN id`,
-          `ALTER TABLE tree_swap_status ADD COLUMN user_id VARBINARY(33) NULL`,
-          `UPDATE tree_swap_status SET user_id = ${idLit} WHERE user_id IS NULL`,
-          `ALTER TABLE tree_swap_status MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
-          `ALTER TABLE tree_swap_status ADD PRIMARY KEY (user_id)`,
+          { op: "dropPrimaryKey", table: "brz_tree_swap_status" },
+          `ALTER TABLE brz_tree_swap_status DROP COLUMN id`,
+          `ALTER TABLE brz_tree_swap_status ADD COLUMN user_id VARBINARY(33) NULL`,
+          `UPDATE brz_tree_swap_status SET user_id = ${idLit} WHERE user_id IS NULL`,
+          `ALTER TABLE brz_tree_swap_status MODIFY COLUMN user_id VARBINARY(33) NOT NULL`,
+          `ALTER TABLE brz_tree_swap_status ADD PRIMARY KEY (user_id)`,
         ],
       },
     ];
   }
+}
+
+async function _mysqlTableExists(conn, tableName) {
+  const [rows] = await conn.query(
+    `SELECT COUNT(*) AS c FROM information_schema.tables
+     WHERE table_schema = DATABASE() AND table_name = ?`,
+    [tableName]
+  );
+  return Number(rows[0].c) > 0;
+}
+
+async function _mysqlIndexExists(conn, tableName, indexName) {
+  const [rows] = await conn.query(
+    `SELECT COUNT(*) AS c FROM information_schema.statistics
+     WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?`,
+    [tableName, indexName]
+  );
+  return Number(rows[0].c) > 0;
+}
+
+async function _mysqlForeignKeyExists(conn, tableName, constraintName) {
+  const [rows] = await conn.query(
+    `SELECT COUNT(*) AS c FROM information_schema.table_constraints
+     WHERE table_schema = DATABASE()
+       AND table_name = ?
+       AND constraint_type = 'FOREIGN KEY'
+       AND constraint_name = ?`,
+    [tableName, constraintName]
+  );
+  return Number(rows[0].c) > 0;
 }
 
 module.exports = { MysqlTreeStoreMigrationManager };

--- a/crates/breez-sdk/wasm/js/postgres-session-manager/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-session-manager/index.cjs
@@ -7,7 +7,7 @@
  * `setSession(serviceIdentityKey, session)` upserts a session.
  *
  * Tenant identity is bound at construction so multiple tenants can share
- * a single Postgres database without leaking sessions across tenants.
+ * a single Postgres database without leaking brz_sessions across tenants.
  */
 
 let pg;
@@ -84,7 +84,7 @@ class PostgresSessionManager {
     const serviceKey = _decodePubkey(serviceIdentityKey);
     try {
       const { rows } = await this.pool.query(
-        `SELECT token, expiration FROM sessions
+        `SELECT token, expiration FROM brz_sessions
          WHERE user_id = $1 AND service_identity_key = $2`,
         [this.identity, serviceKey]
       );
@@ -113,7 +113,7 @@ class PostgresSessionManager {
     const serviceKey = _decodePubkey(serviceIdentityKey);
     try {
       await this.pool.query(
-        `INSERT INTO sessions (user_id, service_identity_key, token, expiration)
+        `INSERT INTO brz_sessions (user_id, service_identity_key, token, expiration)
          VALUES ($1, $2, $3, $4)
          ON CONFLICT (user_id, service_identity_key)
          DO UPDATE SET token = EXCLUDED.token, expiration = EXCLUDED.expiration`,

--- a/crates/breez-sdk/wasm/js/postgres-session-manager/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-session-manager/migrations.cjs
@@ -97,12 +97,8 @@ class SessionManagerMigrationManager {
   }
 
   /**
-   * Renames legacy unprefixed tables / indexes / constraints to their `brz_`
-   * equivalents on first startup after the prefix change. Gated on a canary
-   * check against the legacy `session_schema_migrations` table: if it
-   * doesn't exist, either the DB is fresh or already upgraded, and no
-   * renames run. Postgres DDL is transactional, so this runs inside the
-   * caller's transaction and rolls back atomically on failure.
+   * Pre-prefix rename. Canary-gated on the legacy `session_schema_migrations`
+   * table.
    * @param {import('pg').PoolClient} client
    */
   async _applySchemaRenames(client) {

--- a/crates/breez-sdk/wasm/js/postgres-session-manager/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-session-manager/migrations.cjs
@@ -1,7 +1,7 @@
 /**
  * Database Migration Manager for Breez SDK PostgreSQL Session Manager.
  *
- * Uses a session_schema_migrations table + pg_advisory_xact_lock to safely
+ * Uses a brz_session_schema_migrations table + pg_advisory_xact_lock to safely
  * run migrations from concurrent processes. Mirrors the schema produced by
  * the Rust `PostgresSessionManager`.
  */
@@ -32,15 +32,17 @@ class SessionManagerMigrationManager {
       await client.query("BEGIN");
       await client.query(`SELECT pg_advisory_xact_lock(${MIGRATION_LOCK_ID})`);
 
+      await this._applySchemaRenames(client);
+
       await client.query(`
-        CREATE TABLE IF NOT EXISTS session_schema_migrations (
+        CREATE TABLE IF NOT EXISTS brz_session_schema_migrations (
           version INTEGER PRIMARY KEY,
           applied_at TIMESTAMPTZ DEFAULT NOW()
         )
       `);
 
       const versionResult = await client.query(
-        "SELECT COALESCE(MAX(version), 0) AS version FROM session_schema_migrations"
+        "SELECT COALESCE(MAX(version), 0) AS version FROM brz_session_schema_migrations"
       );
       const currentVersion = versionResult.rows[0].version;
 
@@ -73,7 +75,7 @@ class SessionManagerMigrationManager {
         }
 
         await client.query(
-          "INSERT INTO session_schema_migrations (version) VALUES ($1)",
+          "INSERT INTO brz_session_schema_migrations (version) VALUES ($1)",
           [version]
         );
       }
@@ -94,6 +96,47 @@ class SessionManagerMigrationManager {
     }
   }
 
+  /**
+   * Renames legacy unprefixed tables / indexes / constraints to their `brz_`
+   * equivalents on first startup after the prefix change. Gated on a canary
+   * check against the legacy `session_schema_migrations` table: if it
+   * doesn't exist, either the DB is fresh or already upgraded, and no
+   * renames run. Postgres DDL is transactional, so this runs inside the
+   * caller's transaction and rolls back atomically on failure.
+   * @param {import('pg').PoolClient} client
+   */
+  async _applySchemaRenames(client) {
+    const canary = await client.query(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.tables
+         WHERE table_schema = current_schema()
+           AND table_name = 'session_schema_migrations'
+       ) AS exists`
+    );
+    if (!canary.rows[0].exists) {
+      return;
+    }
+
+    // Rename data tables first, then their auto-named PK constraints, then
+    // the migrations tracking table (which doubles as the rename canary).
+    await client.query(`ALTER TABLE IF EXISTS sessions RENAME TO brz_sessions`);
+    await client.query(
+      `DO $$ BEGIN
+         IF EXISTS (
+           SELECT 1 FROM information_schema.table_constraints
+           WHERE table_schema = current_schema()
+             AND table_name = 'brz_sessions'
+             AND constraint_name = 'sessions_pkey'
+         ) THEN
+           ALTER TABLE brz_sessions RENAME CONSTRAINT sessions_pkey TO brz_sessions_pkey;
+         END IF;
+       END $$`
+    );
+    await client.query(
+      `ALTER TABLE IF EXISTS session_schema_migrations RENAME TO brz_session_schema_migrations`
+    );
+  }
+
   _log(level, message) {
     if (this.logger && typeof this.logger.log === "function") {
       this.logger.log({ line: message, level });
@@ -108,9 +151,9 @@ class SessionManagerMigrationManager {
   _getMigrations() {
     return [
       {
-        name: "Create sessions table",
+        name: "Create brz_sessions table",
         sql: [
-          `CREATE TABLE IF NOT EXISTS sessions (
+          `CREATE TABLE IF NOT EXISTS brz_sessions (
             user_id BYTEA NOT NULL,
             service_identity_key BYTEA NOT NULL,
             token TEXT NOT NULL,

--- a/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
@@ -62,12 +62,12 @@ const SELECT_PAYMENT_SQL = `
            lrm.sender_comment AS lnurl_sender_comment,
            lrm.payment_hash AS lnurl_payment_hash,
            pm.parent_payment_id
-      FROM payments p
-      LEFT JOIN payment_details_lightning l ON p.id = l.payment_id AND p.user_id = l.user_id
-      LEFT JOIN payment_details_token t ON p.id = t.payment_id AND p.user_id = t.user_id
-      LEFT JOIN payment_details_spark s ON p.id = s.payment_id AND p.user_id = s.user_id
-      LEFT JOIN payment_metadata pm ON p.id = pm.payment_id AND p.user_id = pm.user_id
-      LEFT JOIN lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash AND l.user_id = lrm.user_id`;
+      FROM brz_payments p
+      LEFT JOIN brz_payment_details_lightning l ON p.id = l.payment_id AND p.user_id = l.user_id
+      LEFT JOIN brz_payment_details_token t ON p.id = t.payment_id AND p.user_id = t.user_id
+      LEFT JOIN brz_payment_details_spark s ON p.id = s.payment_id AND p.user_id = s.user_id
+      LEFT JOIN brz_payment_metadata pm ON p.id = pm.payment_id AND p.user_id = pm.user_id
+      LEFT JOIN brz_lnurl_receive_metadata lrm ON l.payment_hash = lrm.payment_hash AND l.user_id = lrm.user_id`;
 
 class PostgresStorage {
   /**
@@ -141,7 +141,7 @@ class PostgresStorage {
   async getCachedItem(key) {
     try {
       const result = await this.pool.query(
-        "SELECT value FROM settings WHERE user_id = $1 AND key = $2",
+        "SELECT value FROM brz_settings WHERE user_id = $1 AND key = $2",
         [this.identity, key]
       );
       return result.rows.length > 0 ? result.rows[0].value : null;
@@ -156,7 +156,7 @@ class PostgresStorage {
   async setCachedItem(key, value) {
     try {
       await this.pool.query(
-        `INSERT INTO settings (user_id, key, value) VALUES ($1, $2, $3)
+        `INSERT INTO brz_settings (user_id, key, value) VALUES ($1, $2, $3)
          ON CONFLICT(user_id, key) DO UPDATE SET value = EXCLUDED.value`,
         [this.identity, key, value]
       );
@@ -171,7 +171,7 @@ class PostgresStorage {
   async deleteCachedItem(key) {
     try {
       await this.pool.query(
-        "DELETE FROM settings WHERE user_id = $1 AND key = $2",
+        "DELETE FROM brz_settings WHERE user_id = $1 AND key = $2",
         [this.identity, key]
       );
     } catch (error) {
@@ -330,7 +330,7 @@ class PostgresStorage {
         }
       }
 
-      // Exclude child payments
+      // Exclude child brz_payments
       whereClauses.push("pm.parent_payment_id IS NULL");
 
       const whereSql =
@@ -347,7 +347,7 @@ class PostgresStorage {
     } catch (error) {
       if (error instanceof StorageError) throw error;
       throw new StorageError(
-        `Failed to list payments (request: ${JSON.stringify(request)}): ${error.message}`,
+        `Failed to list brz_payments (request: ${JSON.stringify(request)}): ${error.message}`,
         error
       );
     }
@@ -367,7 +367,7 @@ class PostgresStorage {
         const spark = payment.details?.type === "spark" ? true : null;
 
         await client.query(
-          `INSERT INTO payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+          `INSERT INTO brz_payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
            ON CONFLICT(user_id, id) DO UPDATE SET
              payment_type=EXCLUDED.payment_type,
@@ -400,11 +400,11 @@ class PostgresStorage {
             payment.details.htlcDetails != null)
         ) {
           await client.query(
-            `INSERT INTO payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
+            `INSERT INTO brz_payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
              VALUES ($1, $2, $3, $4)
              ON CONFLICT(user_id, payment_id) DO UPDATE SET
-               invoice_details=COALESCE(EXCLUDED.invoice_details, payment_details_spark.invoice_details),
-               htlc_details=COALESCE(EXCLUDED.htlc_details, payment_details_spark.htlc_details)`,
+               invoice_details=COALESCE(EXCLUDED.invoice_details, brz_payment_details_spark.invoice_details),
+               htlc_details=COALESCE(EXCLUDED.htlc_details, brz_payment_details_spark.htlc_details)`,
             [
               this.identity,
               payment.id,
@@ -420,7 +420,7 @@ class PostgresStorage {
 
         if (payment.details?.type === "lightning") {
           await client.query(
-            `INSERT INTO payment_details_lightning
+            `INSERT INTO brz_payment_details_lightning
               (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
               ON CONFLICT(user_id, payment_id) DO UPDATE SET
@@ -428,9 +428,9 @@ class PostgresStorage {
                 payment_hash=EXCLUDED.payment_hash,
                 destination_pubkey=EXCLUDED.destination_pubkey,
                 description=EXCLUDED.description,
-                preimage=COALESCE(EXCLUDED.preimage, payment_details_lightning.preimage),
-                htlc_status=COALESCE(EXCLUDED.htlc_status, payment_details_lightning.htlc_status),
-                htlc_expiry_time=COALESCE(EXCLUDED.htlc_expiry_time, payment_details_lightning.htlc_expiry_time)`,
+                preimage=COALESCE(EXCLUDED.preimage, brz_payment_details_lightning.preimage),
+                htlc_status=COALESCE(EXCLUDED.htlc_status, brz_payment_details_lightning.htlc_status),
+                htlc_expiry_time=COALESCE(EXCLUDED.htlc_expiry_time, brz_payment_details_lightning.htlc_expiry_time)`,
             [
               this.identity,
               payment.id,
@@ -447,14 +447,14 @@ class PostgresStorage {
 
         if (payment.details?.type === "token") {
           await client.query(
-            `INSERT INTO payment_details_token
+            `INSERT INTO brz_payment_details_token
               (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
               VALUES ($1, $2, $3, $4, $5, $6)
               ON CONFLICT(user_id, payment_id) DO UPDATE SET
                 metadata=EXCLUDED.metadata,
                 tx_hash=EXCLUDED.tx_hash,
                 tx_type=EXCLUDED.tx_type,
-                invoice_details=COALESCE(EXCLUDED.invoice_details, payment_details_token.invoice_details)`,
+                invoice_details=COALESCE(EXCLUDED.invoice_details, brz_payment_details_token.invoice_details)`,
             [
               this.identity,
               payment.id,
@@ -533,9 +533,9 @@ class PostgresStorage {
         return {};
       }
 
-      // Early exit if no related payments exist for this tenant
+      // Early exit if no related brz_payments exist for this tenant
       const hasRelatedResult = await this.pool.query(
-        "SELECT EXISTS(SELECT 1 FROM payment_metadata WHERE user_id = $1 AND parent_payment_id IS NOT NULL LIMIT 1)",
+        "SELECT EXISTS(SELECT 1 FROM brz_payment_metadata WHERE user_id = $1 AND parent_payment_id IS NOT NULL LIMIT 1)",
         [this.identity]
       );
       if (!hasRelatedResult.rows[0].exists) {
@@ -566,7 +566,7 @@ class PostgresStorage {
     } catch (error) {
       if (error instanceof StorageError) throw error;
       throw new StorageError(
-        `Failed to get payments by parent ids: ${error.message}`,
+        `Failed to get brz_payments by parent ids: ${error.message}`,
         error
       );
     }
@@ -575,15 +575,15 @@ class PostgresStorage {
   async insertPaymentMetadata(paymentId, metadata) {
     try {
       await this.pool.query(
-        `INSERT INTO payment_metadata (user_id, payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
+        `INSERT INTO brz_payment_metadata (user_id, payment_id, parent_payment_id, lnurl_pay_info, lnurl_withdraw_info, lnurl_description, conversion_info, conversion_status)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
          ON CONFLICT(user_id, payment_id) DO UPDATE SET
-           parent_payment_id = COALESCE(EXCLUDED.parent_payment_id, payment_metadata.parent_payment_id),
-           lnurl_pay_info = COALESCE(EXCLUDED.lnurl_pay_info, payment_metadata.lnurl_pay_info),
-           lnurl_withdraw_info = COALESCE(EXCLUDED.lnurl_withdraw_info, payment_metadata.lnurl_withdraw_info),
-           lnurl_description = COALESCE(EXCLUDED.lnurl_description, payment_metadata.lnurl_description),
-           conversion_info = COALESCE(EXCLUDED.conversion_info, payment_metadata.conversion_info),
-           conversion_status = COALESCE(EXCLUDED.conversion_status, payment_metadata.conversion_status)`,
+           parent_payment_id = COALESCE(EXCLUDED.parent_payment_id, brz_payment_metadata.parent_payment_id),
+           lnurl_pay_info = COALESCE(EXCLUDED.lnurl_pay_info, brz_payment_metadata.lnurl_pay_info),
+           lnurl_withdraw_info = COALESCE(EXCLUDED.lnurl_withdraw_info, brz_payment_metadata.lnurl_withdraw_info),
+           lnurl_description = COALESCE(EXCLUDED.lnurl_description, brz_payment_metadata.lnurl_description),
+           conversion_info = COALESCE(EXCLUDED.conversion_info, brz_payment_metadata.conversion_info),
+           conversion_status = COALESCE(EXCLUDED.conversion_status, brz_payment_metadata.conversion_status)`,
         [
           this.identity,
           paymentId,
@@ -614,7 +614,7 @@ class PostgresStorage {
   async addDeposit(txid, vout, amountSats, isMature) {
     try {
       await this.pool.query(
-        `INSERT INTO unclaimed_deposits (user_id, txid, vout, amount_sats, is_mature)
+        `INSERT INTO brz_unclaimed_deposits (user_id, txid, vout, amount_sats, is_mature)
          VALUES ($1, $2, $3, $4, $5)
          ON CONFLICT(user_id, txid, vout) DO UPDATE SET is_mature = EXCLUDED.is_mature, amount_sats = EXCLUDED.amount_sats`,
         [this.identity, txid, vout, amountSats, isMature]
@@ -630,7 +630,7 @@ class PostgresStorage {
   async deleteDeposit(txid, vout) {
     try {
       await this.pool.query(
-        "DELETE FROM unclaimed_deposits WHERE user_id = $1 AND txid = $2 AND vout = $3",
+        "DELETE FROM brz_unclaimed_deposits WHERE user_id = $1 AND txid = $2 AND vout = $3",
         [this.identity, txid, vout]
       );
     } catch (error) {
@@ -644,7 +644,7 @@ class PostgresStorage {
   async listDeposits() {
     try {
       const result = await this.pool.query(
-        "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM unclaimed_deposits WHERE user_id = $1",
+        "SELECT txid, vout, amount_sats, is_mature, claim_error, refund_tx, refund_tx_id FROM brz_unclaimed_deposits WHERE user_id = $1",
         [this.identity]
       );
 
@@ -669,14 +669,14 @@ class PostgresStorage {
     try {
       if (payload.type === "claimError") {
         await this.pool.query(
-          `UPDATE unclaimed_deposits
+          `UPDATE brz_unclaimed_deposits
            SET claim_error = $1, refund_tx = NULL, refund_tx_id = NULL
            WHERE user_id = $2 AND txid = $3 AND vout = $4`,
           [JSON.stringify(payload.error), this.identity, txid, vout]
         );
       } else if (payload.type === "refund") {
         await this.pool.query(
-          `UPDATE unclaimed_deposits
+          `UPDATE brz_unclaimed_deposits
            SET refund_tx = $1, refund_tx_id = $2, claim_error = NULL
            WHERE user_id = $3 AND txid = $4 AND vout = $5`,
           [payload.refundTx, payload.refundTxid, this.identity, txid, vout]
@@ -698,7 +698,7 @@ class PostgresStorage {
       await this._withTransaction(async (client) => {
         for (const item of metadata) {
           await client.query(
-            `INSERT INTO lnurl_receive_metadata (user_id, payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
+            `INSERT INTO brz_lnurl_receive_metadata (user_id, payment_hash, nostr_zap_request, nostr_zap_receipt, sender_comment)
              VALUES ($1, $2, $3, $4, $5)
              ON CONFLICT(user_id, payment_hash) DO UPDATE SET
                nostr_zap_request = EXCLUDED.nostr_zap_request,
@@ -859,7 +859,7 @@ class PostgresStorage {
 
       const result = await this.pool.query(
         `SELECT id, name, payment_identifier, created_at, updated_at
-         FROM contacts
+         FROM brz_contacts
          WHERE user_id = $1
          ORDER BY name ASC
          LIMIT $2 OFFSET $3`,
@@ -875,7 +875,7 @@ class PostgresStorage {
       }));
     } catch (error) {
       throw new StorageError(
-        `Failed to list contacts: ${error.message}`,
+        `Failed to list brz_contacts: ${error.message}`,
         error
       );
     }
@@ -885,7 +885,7 @@ class PostgresStorage {
     try {
       const result = await this.pool.query(
         `SELECT id, name, payment_identifier, created_at, updated_at
-         FROM contacts
+         FROM brz_contacts
          WHERE user_id = $1 AND id = $2`,
         [this.identity, id]
       );
@@ -913,7 +913,7 @@ class PostgresStorage {
   async insertContact(contact) {
     try {
       await this.pool.query(
-        `INSERT INTO contacts (user_id, id, name, payment_identifier, created_at, updated_at)
+        `INSERT INTO brz_contacts (user_id, id, name, payment_identifier, created_at, updated_at)
          VALUES ($1, $2, $3, $4, $5, $6)
          ON CONFLICT(user_id, id) DO UPDATE SET
            name = EXCLUDED.name,
@@ -939,7 +939,7 @@ class PostgresStorage {
   async deleteContact(id) {
     try {
       await this.pool.query(
-        "DELETE FROM contacts WHERE user_id = $1 AND id = $2",
+        "DELETE FROM brz_contacts WHERE user_id = $1 AND id = $2",
         [this.identity, id]
       );
     } catch (error) {
@@ -957,13 +957,13 @@ class PostgresStorage {
       return await this._withTransaction(async (client) => {
         // Local queue revision is per-tenant — two tenants don't share a queue.
         const revisionResult = await client.query(
-          "SELECT COALESCE(MAX(revision), 0) + 1 AS revision FROM sync_outgoing WHERE user_id = $1",
+          "SELECT COALESCE(MAX(revision), 0) + 1 AS revision FROM brz_sync_outgoing WHERE user_id = $1",
           [this.identity]
         );
         const revision = BigInt(revisionResult.rows[0].revision);
 
         await client.query(
-          `INSERT INTO sync_outgoing (
+          `INSERT INTO brz_sync_outgoing (
             user_id,
             record_type,
             data_id,
@@ -998,7 +998,7 @@ class PostgresStorage {
     try {
       await this._withTransaction(async (client) => {
         const deleteResult = await client.query(
-          "DELETE FROM sync_outgoing WHERE user_id = $1 AND record_type = $2 AND data_id = $3 AND revision = $4",
+          "DELETE FROM brz_sync_outgoing WHERE user_id = $1 AND record_type = $2 AND data_id = $3 AND revision = $4",
           [
             this.identity,
             record.id.type,
@@ -1008,7 +1008,7 @@ class PostgresStorage {
         );
 
         if (deleteResult.rowCount === 0) {
-          const msg = `complete_outgoing_sync: DELETE from sync_outgoing matched 0 rows (type=${record.id.type}, data_id=${record.id.dataId}, revision=${localRevision})`;
+          const msg = `complete_outgoing_sync: DELETE from brz_sync_outgoing matched 0 rows (type=${record.id.type}, data_id=${record.id.dataId}, revision=${localRevision})`;
           if (this.logger && typeof this.logger.log === "function") {
             this.logger.log({ line: msg, level: "warn" });
           } else {
@@ -1017,7 +1017,7 @@ class PostgresStorage {
         }
 
         await client.query(
-          `INSERT INTO sync_state (
+          `INSERT INTO brz_sync_state (
             user_id,
             record_type,
             data_id,
@@ -1044,8 +1044,8 @@ class PostgresStorage {
 
         // Upsert this tenant's revision row; fresh tenants without a row get one.
         await client.query(
-          `INSERT INTO sync_revision (user_id, revision) VALUES ($1, $2)
-           ON CONFLICT (user_id) DO UPDATE SET revision = GREATEST(sync_revision.revision, EXCLUDED.revision)`,
+          `INSERT INTO brz_sync_revision (user_id, revision) VALUES ($1, $2)
+           ON CONFLICT (user_id) DO UPDATE SET revision = GREATEST(brz_sync_revision.revision, EXCLUDED.revision)`,
           [this.identity, record.revision.toString()]
         );
       });
@@ -1072,8 +1072,8 @@ class PostgresStorage {
           e.commit_time as existing_commit_time,
           e.data as existing_data,
           e.revision as existing_revision
-        FROM sync_outgoing o
-        LEFT JOIN sync_state e ON
+        FROM brz_sync_outgoing o
+        LEFT JOIN brz_sync_state e ON
           o.record_type = e.record_type AND
           o.data_id = e.data_id AND
           o.user_id = e.user_id
@@ -1127,7 +1127,7 @@ class PostgresStorage {
     try {
       // A tenant that hasn't synced anything yet may have no row; treat as 0.
       const result = await this.pool.query(
-        "SELECT revision FROM sync_revision WHERE user_id = $1",
+        "SELECT revision FROM brz_sync_revision WHERE user_id = $1",
         [this.identity]
       );
       return result.rows.length > 0
@@ -1150,7 +1150,7 @@ class PostgresStorage {
       await this._withTransaction(async (client) => {
         for (const record of records) {
           await client.query(
-            `INSERT INTO sync_incoming (
+            `INSERT INTO brz_sync_incoming (
               user_id,
               record_type,
               data_id,
@@ -1187,7 +1187,7 @@ class PostgresStorage {
   async syncDeleteIncomingRecord(record) {
     try {
       await this.pool.query(
-        `DELETE FROM sync_incoming
+        `DELETE FROM brz_sync_incoming
          WHERE user_id = $1
          AND record_type = $2
          AND data_id = $3
@@ -1214,8 +1214,8 @@ class PostgresStorage {
                 e.commit_time AS existing_commit_time,
                 e.data AS existing_data,
                 e.revision AS existing_revision
-         FROM sync_incoming i
-         LEFT JOIN sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id AND i.user_id = e.user_id
+         FROM brz_sync_incoming i
+         LEFT JOIN brz_sync_state e ON i.record_type = e.record_type AND i.data_id = e.data_id AND i.user_id = e.user_id
          WHERE i.user_id = $1
          ORDER BY i.revision ASC
          LIMIT $2`,
@@ -1276,8 +1276,8 @@ class PostgresStorage {
           e.commit_time as existing_commit_time,
           e.data as existing_data,
           e.revision as existing_revision
-        FROM sync_outgoing o
-        LEFT JOIN sync_state e ON
+        FROM brz_sync_outgoing o
+        LEFT JOIN brz_sync_state e ON
           o.record_type = e.record_type AND
           o.data_id = e.data_id AND
           o.user_id = e.user_id
@@ -1335,7 +1335,7 @@ class PostgresStorage {
     try {
       await this._withTransaction(async (client) => {
         await client.query(
-          `INSERT INTO sync_state (
+          `INSERT INTO brz_sync_state (
             user_id,
             record_type,
             data_id,
@@ -1361,8 +1361,8 @@ class PostgresStorage {
         );
 
         await client.query(
-          `INSERT INTO sync_revision (user_id, revision) VALUES ($1, $2)
-           ON CONFLICT (user_id) DO UPDATE SET revision = GREATEST(sync_revision.revision, EXCLUDED.revision)`,
+          `INSERT INTO brz_sync_revision (user_id, revision) VALUES ($1, $2)
+           ON CONFLICT (user_id) DO UPDATE SET revision = GREATEST(brz_sync_revision.revision, EXCLUDED.revision)`,
           [this.identity, record.revision.toString()]
         );
       });
@@ -1377,7 +1377,7 @@ class PostgresStorage {
 }
 
 /**
- * Creates a PostgresStorageConfig with the given connection string and default pool settings.
+ * Creates a PostgresStorageConfig with the given connection string and default pool brz_settings.
  *
  * Default values (from pg.Pool):
  * - maxPoolSize: 10

--- a/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
@@ -330,7 +330,7 @@ class PostgresStorage {
         }
       }
 
-      // Exclude child brz_payments
+      // Exclude child payments
       whereClauses.push("pm.parent_payment_id IS NULL");
 
       const whereSql =
@@ -347,7 +347,7 @@ class PostgresStorage {
     } catch (error) {
       if (error instanceof StorageError) throw error;
       throw new StorageError(
-        `Failed to list brz_payments (request: ${JSON.stringify(request)}): ${error.message}`,
+        `Failed to list payments (request: ${JSON.stringify(request)}): ${error.message}`,
         error
       );
     }
@@ -533,7 +533,7 @@ class PostgresStorage {
         return {};
       }
 
-      // Early exit if no related brz_payments exist for this tenant
+      // Early exit if no related payments exist for this tenant
       const hasRelatedResult = await this.pool.query(
         "SELECT EXISTS(SELECT 1 FROM brz_payment_metadata WHERE user_id = $1 AND parent_payment_id IS NOT NULL LIMIT 1)",
         [this.identity]
@@ -566,7 +566,7 @@ class PostgresStorage {
     } catch (error) {
       if (error instanceof StorageError) throw error;
       throw new StorageError(
-        `Failed to get brz_payments by parent ids: ${error.message}`,
+        `Failed to get payments by parent ids: ${error.message}`,
         error
       );
     }
@@ -875,7 +875,7 @@ class PostgresStorage {
       }));
     } catch (error) {
       throw new StorageError(
-        `Failed to list brz_contacts: ${error.message}`,
+        `Failed to list contacts: ${error.message}`,
         error
       );
     }
@@ -1377,7 +1377,7 @@ class PostgresStorage {
 }
 
 /**
- * Creates a PostgresStorageConfig with the given connection string and default pool brz_settings.
+ * Creates a PostgresStorageConfig with the given connection string and default pool settings.
  *
  * Default values (from pg.Pool):
  * - maxPoolSize: 10

--- a/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
@@ -1,7 +1,7 @@
 /**
  * Database Migration Manager for Breez SDK PostgreSQL Storage
  *
- * Uses a schema_migrations table + pg_advisory_xact_lock to safely run
+ * Uses a brz_schema_migrations table + pg_advisory_xact_lock to safely run
  * migrations from concurrent processes.
  */
 
@@ -35,9 +35,11 @@ class PostgresMigrationManager {
       // Transaction-level advisory lock — automatically released on COMMIT/ROLLBACK
       await client.query(`SELECT pg_advisory_xact_lock(${MIGRATION_LOCK_ID})`);
 
+      await this._applySchemaRenames(client);
+
       // Create the migrations tracking table if needed
       await client.query(`
-        CREATE TABLE IF NOT EXISTS schema_migrations (
+        CREATE TABLE IF NOT EXISTS brz_schema_migrations (
           version INTEGER PRIMARY KEY,
           applied_at TIMESTAMPTZ DEFAULT NOW()
         )
@@ -45,7 +47,7 @@ class PostgresMigrationManager {
 
       // Get current version
       const versionResult = await client.query(
-        "SELECT COALESCE(MAX(version), 0) AS version FROM schema_migrations"
+        "SELECT COALESCE(MAX(version), 0) AS version FROM brz_schema_migrations"
       );
       const currentVersion = versionResult.rows[0].version;
 
@@ -72,7 +74,7 @@ class PostgresMigrationManager {
         }
 
         await client.query(
-          "INSERT INTO schema_migrations (version) VALUES ($1)",
+          "INSERT INTO brz_schema_migrations (version) VALUES ($1)",
           [version]
         );
       }
@@ -88,6 +90,116 @@ class PostgresMigrationManager {
     } finally {
       client.release();
     }
+  }
+
+  /**
+   * Renames legacy unprefixed core-storage objects to their `brz_` equivalents
+   * on first startup after the prefix change. Gated on a canary check against
+   * the legacy `schema_migrations` table.
+   * @param {import('pg').PoolClient} client
+   */
+  async _applySchemaRenames(client) {
+    const canary = await client.query(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.tables
+         WHERE table_schema = current_schema()
+           AND table_name = 'schema_migrations'
+       ) AS exists`
+    );
+    if (!canary.rows[0].exists) {
+      return;
+    }
+
+    const tableRenames = [
+      ["payments", "brz_payments"],
+      ["settings", "brz_settings"],
+      ["unclaimed_deposits", "brz_unclaimed_deposits"],
+      ["payment_metadata", "brz_payment_metadata"],
+      ["payment_details_lightning", "brz_payment_details_lightning"],
+      ["payment_details_token", "brz_payment_details_token"],
+      ["payment_details_spark", "brz_payment_details_spark"],
+      ["lnurl_receive_metadata", "brz_lnurl_receive_metadata"],
+      ["sync_revision", "brz_sync_revision"],
+      ["sync_outgoing", "brz_sync_outgoing"],
+      ["sync_state", "brz_sync_state"],
+      ["sync_incoming", "brz_sync_incoming"],
+      ["contacts", "brz_contacts"],
+    ];
+    for (const [oldName, newName] of tableRenames) {
+      await client.query(`ALTER TABLE IF EXISTS ${oldName} RENAME TO ${newName}`);
+    }
+
+    const indexRenames = [
+      ["idx_payments_user_timestamp", "brz_idx_payments_user_timestamp"],
+      ["idx_payments_user_payment_type", "brz_idx_payments_user_payment_type"],
+      ["idx_payments_user_status", "brz_idx_payments_user_status"],
+      ["idx_payment_metadata_user_parent", "brz_idx_payment_metadata_user_parent"],
+      [
+        "idx_payment_details_lightning_user_invoice",
+        "brz_idx_payment_details_lightning_user_invoice",
+      ],
+      [
+        "idx_payment_details_lightning_user_payment_hash",
+        "brz_idx_payment_details_lightning_user_payment_hash",
+      ],
+      [
+        "idx_sync_outgoing_user_record_type_data_id",
+        "brz_idx_sync_outgoing_user_record_type_data_id",
+      ],
+      ["idx_sync_incoming_user_revision", "brz_idx_sync_incoming_user_revision"],
+    ];
+    for (const [oldName, newName] of indexRenames) {
+      await client.query(`ALTER INDEX IF EXISTS ${oldName} RENAME TO ${newName}`);
+    }
+
+    const constraintRenames = [
+      ["brz_payments", "payments_pkey", "brz_payments_pkey"],
+      ["brz_settings", "settings_pkey", "brz_settings_pkey"],
+      ["brz_unclaimed_deposits", "unclaimed_deposits_pkey", "brz_unclaimed_deposits_pkey"],
+      ["brz_payment_metadata", "payment_metadata_pkey", "brz_payment_metadata_pkey"],
+      [
+        "brz_payment_details_lightning",
+        "payment_details_lightning_pkey",
+        "brz_payment_details_lightning_pkey",
+      ],
+      [
+        "brz_payment_details_token",
+        "payment_details_token_pkey",
+        "brz_payment_details_token_pkey",
+      ],
+      [
+        "brz_payment_details_spark",
+        "payment_details_spark_pkey",
+        "brz_payment_details_spark_pkey",
+      ],
+      [
+        "brz_lnurl_receive_metadata",
+        "lnurl_receive_metadata_pkey",
+        "brz_lnurl_receive_metadata_pkey",
+      ],
+      ["brz_sync_revision", "sync_revision_pkey", "brz_sync_revision_pkey"],
+      ["brz_sync_state", "sync_state_pkey", "brz_sync_state_pkey"],
+      ["brz_sync_incoming", "sync_incoming_pkey", "brz_sync_incoming_pkey"],
+      ["brz_contacts", "contacts_pkey", "brz_contacts_pkey"],
+    ];
+    for (const [table, oldName, newName] of constraintRenames) {
+      await client.query(
+        `DO $$ BEGIN
+           IF EXISTS (
+             SELECT 1 FROM information_schema.table_constraints
+             WHERE table_schema = current_schema()
+               AND table_name = '${table}'
+               AND constraint_name = '${oldName}'
+           ) THEN
+             ALTER TABLE ${table} RENAME CONSTRAINT ${oldName} TO ${newName};
+           END IF;
+         END $$`
+      );
+    }
+
+    await client.query(
+      `ALTER TABLE IF EXISTS schema_migrations RENAME TO brz_schema_migrations`
+    );
   }
 
   _log(level, message) {
@@ -128,7 +240,7 @@ class PostgresMigrationManager {
         name: "Create all tables at final schema",
         sql: [
           // -- Core tables --
-          `CREATE TABLE IF NOT EXISTS payments (
+          `CREATE TABLE IF NOT EXISTS brz_payments (
             id TEXT PRIMARY KEY,
             payment_type TEXT NOT NULL,
             status TEXT NOT NULL,
@@ -141,12 +253,12 @@ class PostgresMigrationManager {
             spark BOOLEAN
           )`,
 
-          `CREATE TABLE IF NOT EXISTS settings (
+          `CREATE TABLE IF NOT EXISTS brz_settings (
             key TEXT PRIMARY KEY,
             value TEXT NOT NULL
           )`,
 
-          `CREATE TABLE IF NOT EXISTS unclaimed_deposits (
+          `CREATE TABLE IF NOT EXISTS brz_unclaimed_deposits (
             txid TEXT NOT NULL,
             vout INTEGER NOT NULL,
             amount_sats BIGINT,
@@ -156,7 +268,7 @@ class PostgresMigrationManager {
             PRIMARY KEY (txid, vout)
           )`,
 
-          `CREATE TABLE IF NOT EXISTS payment_metadata (
+          `CREATE TABLE IF NOT EXISTS brz_payment_metadata (
             payment_id TEXT PRIMARY KEY,
             parent_payment_id TEXT,
             lnurl_pay_info JSONB,
@@ -165,7 +277,7 @@ class PostgresMigrationManager {
             conversion_info JSONB
           )`,
 
-          `CREATE TABLE IF NOT EXISTS payment_details_lightning (
+          `CREATE TABLE IF NOT EXISTS brz_payment_details_lightning (
             payment_id TEXT PRIMARY KEY,
             invoice TEXT NOT NULL,
             payment_hash TEXT NOT NULL,
@@ -176,7 +288,7 @@ class PostgresMigrationManager {
             htlc_expiry_time BIGINT NOT NULL
           )`,
 
-          `CREATE TABLE IF NOT EXISTS payment_details_token (
+          `CREATE TABLE IF NOT EXISTS brz_payment_details_token (
             payment_id TEXT PRIMARY KEY,
             metadata JSONB NOT NULL,
             tx_hash TEXT NOT NULL,
@@ -184,13 +296,13 @@ class PostgresMigrationManager {
             invoice_details JSONB
           )`,
 
-          `CREATE TABLE IF NOT EXISTS payment_details_spark (
+          `CREATE TABLE IF NOT EXISTS brz_payment_details_spark (
             payment_id TEXT PRIMARY KEY,
             invoice_details JSONB,
             htlc_details JSONB
           )`,
 
-          `CREATE TABLE IF NOT EXISTS lnurl_receive_metadata (
+          `CREATE TABLE IF NOT EXISTS brz_lnurl_receive_metadata (
             payment_hash TEXT PRIMARY KEY,
             nostr_zap_request TEXT,
             nostr_zap_receipt TEXT,
@@ -199,14 +311,14 @@ class PostgresMigrationManager {
           )`,
 
           // -- Sync tables --
-          `CREATE TABLE IF NOT EXISTS sync_revision (
+          `CREATE TABLE IF NOT EXISTS brz_sync_revision (
             id INTEGER PRIMARY KEY DEFAULT 1,
             revision BIGINT NOT NULL DEFAULT 0,
             CHECK (id = 1)
           )`,
-          `INSERT INTO sync_revision (id, revision) VALUES (1, 0) ON CONFLICT (id) DO NOTHING`,
+          `INSERT INTO brz_sync_revision (id, revision) VALUES (1, 0) ON CONFLICT (id) DO NOTHING`,
 
-          `CREATE TABLE IF NOT EXISTS sync_outgoing (
+          `CREATE TABLE IF NOT EXISTS brz_sync_outgoing (
             record_type TEXT NOT NULL,
             data_id TEXT NOT NULL,
             schema_version TEXT NOT NULL,
@@ -215,7 +327,7 @@ class PostgresMigrationManager {
             revision BIGINT NOT NULL
           )`,
 
-          `CREATE TABLE IF NOT EXISTS sync_state (
+          `CREATE TABLE IF NOT EXISTS brz_sync_state (
             record_type TEXT NOT NULL,
             data_id TEXT NOT NULL,
             schema_version TEXT NOT NULL,
@@ -225,7 +337,7 @@ class PostgresMigrationManager {
             PRIMARY KEY (record_type, data_id)
           )`,
 
-          `CREATE TABLE IF NOT EXISTS sync_incoming (
+          `CREATE TABLE IF NOT EXISTS brz_sync_incoming (
             record_type TEXT NOT NULL,
             data_id TEXT NOT NULL,
             schema_version TEXT NOT NULL,
@@ -236,20 +348,20 @@ class PostgresMigrationManager {
           )`,
 
           // -- Indexes --
-          `CREATE INDEX IF NOT EXISTS idx_payments_timestamp ON payments(timestamp)`,
-          `CREATE INDEX IF NOT EXISTS idx_payments_payment_type ON payments(payment_type)`,
-          `CREATE INDEX IF NOT EXISTS idx_payments_status ON payments(status)`,
-          `CREATE INDEX IF NOT EXISTS idx_payment_details_lightning_invoice ON payment_details_lightning(invoice)`,
-          `CREATE INDEX IF NOT EXISTS idx_payment_details_lightning_payment_hash ON payment_details_lightning(payment_hash)`,
-          `CREATE INDEX IF NOT EXISTS idx_payment_metadata_parent ON payment_metadata(parent_payment_id)`,
-          `CREATE INDEX IF NOT EXISTS idx_sync_outgoing_data_id_record_type ON sync_outgoing(record_type, data_id)`,
-          `CREATE INDEX IF NOT EXISTS idx_sync_incoming_revision ON sync_incoming(revision)`,
+          `CREATE INDEX IF NOT EXISTS brz_idx_payments_timestamp ON brz_payments(timestamp)`,
+          `CREATE INDEX IF NOT EXISTS brz_idx_payments_payment_type ON brz_payments(payment_type)`,
+          `CREATE INDEX IF NOT EXISTS brz_idx_payments_status ON brz_payments(status)`,
+          `CREATE INDEX IF NOT EXISTS brz_idx_payment_details_lightning_invoice ON brz_payment_details_lightning(invoice)`,
+          `CREATE INDEX IF NOT EXISTS brz_idx_payment_details_lightning_payment_hash ON brz_payment_details_lightning(payment_hash)`,
+          `CREATE INDEX IF NOT EXISTS brz_idx_payment_metadata_parent ON brz_payment_metadata(parent_payment_id)`,
+          `CREATE INDEX IF NOT EXISTS brz_idx_sync_outgoing_data_id_record_type ON brz_sync_outgoing(record_type, data_id)`,
+          `CREATE INDEX IF NOT EXISTS brz_idx_sync_incoming_revision ON brz_sync_incoming(revision)`,
         ],
       },
       {
-        name: "Create contacts table",
+        name: "Create brz_contacts table",
         sql: [
-          `CREATE TABLE IF NOT EXISTS contacts (
+          `CREATE TABLE IF NOT EXISTS brz_contacts (
             id TEXT PRIMARY KEY,
             name TEXT NOT NULL,
             payment_identifier TEXT NOT NULL,
@@ -259,84 +371,84 @@ class PostgresMigrationManager {
         ],
       },
       {
-        name: "Drop preimage column from lnurl_receive_metadata",
+        name: "Drop preimage column from brz_lnurl_receive_metadata",
         sql: [
-          `ALTER TABLE lnurl_receive_metadata DROP COLUMN IF EXISTS preimage`,
+          `ALTER TABLE brz_lnurl_receive_metadata DROP COLUMN IF EXISTS preimage`,
         ],
       },
       {
         name: "Clear cached lightning address for CachedLightningAddress format change",
         sql: [
-          `DELETE FROM settings WHERE key = 'lightning_address'`,
+          `DELETE FROM brz_settings WHERE key = 'lightning_address'`,
         ],
       },
       {
-        name: "Add is_mature to unclaimed_deposits",
+        name: "Add is_mature to brz_unclaimed_deposits",
         sql: [
-          `ALTER TABLE unclaimed_deposits ADD COLUMN is_mature BOOLEAN NOT NULL DEFAULT TRUE`,
+          `ALTER TABLE brz_unclaimed_deposits ADD COLUMN is_mature BOOLEAN NOT NULL DEFAULT TRUE`,
         ],
       },
       {
-        name: "Add conversion_status to payment_metadata",
+        name: "Add conversion_status to brz_payment_metadata",
         sql: [
-          `ALTER TABLE payment_metadata ADD COLUMN IF NOT EXISTS conversion_status TEXT`,
+          `ALTER TABLE brz_payment_metadata ADD COLUMN IF NOT EXISTS conversion_status TEXT`,
         ],
       },
       {
         name: "Multi-tenant scoping: add user_id and rewrite primary keys",
         sql: [
           // Per-user tables
-          ...scopeTable("payments", "id"),
-          `DROP INDEX IF EXISTS idx_payments_timestamp`,
-          `DROP INDEX IF EXISTS idx_payments_payment_type`,
-          `DROP INDEX IF EXISTS idx_payments_status`,
-          `CREATE INDEX idx_payments_user_timestamp ON payments(user_id, timestamp)`,
-          `CREATE INDEX idx_payments_user_payment_type ON payments(user_id, payment_type)`,
-          `CREATE INDEX idx_payments_user_status ON payments(user_id, status)`,
+          ...scopeTable("brz_payments", "id"),
+          `DROP INDEX IF EXISTS brz_idx_payments_timestamp`,
+          `DROP INDEX IF EXISTS brz_idx_payments_payment_type`,
+          `DROP INDEX IF EXISTS brz_idx_payments_status`,
+          `CREATE INDEX brz_idx_payments_user_timestamp ON brz_payments(user_id, timestamp)`,
+          `CREATE INDEX brz_idx_payments_user_payment_type ON brz_payments(user_id, payment_type)`,
+          `CREATE INDEX brz_idx_payments_user_status ON brz_payments(user_id, status)`,
 
-          ...scopeTable("payment_metadata", "payment_id"),
-          `DROP INDEX IF EXISTS idx_payment_metadata_parent`,
-          `CREATE INDEX idx_payment_metadata_user_parent
-             ON payment_metadata(user_id, parent_payment_id)`,
+          ...scopeTable("brz_payment_metadata", "payment_id"),
+          `DROP INDEX IF EXISTS brz_idx_payment_metadata_parent`,
+          `CREATE INDEX brz_idx_payment_metadata_user_parent
+             ON brz_payment_metadata(user_id, parent_payment_id)`,
 
-          ...scopeTable("payment_details_lightning", "payment_id"),
-          `DROP INDEX IF EXISTS idx_payment_details_lightning_invoice`,
-          `DROP INDEX IF EXISTS idx_payment_details_lightning_payment_hash`,
-          `CREATE INDEX idx_payment_details_lightning_user_invoice
-             ON payment_details_lightning(user_id, invoice)`,
-          `CREATE INDEX idx_payment_details_lightning_user_payment_hash
-             ON payment_details_lightning(user_id, payment_hash)`,
+          ...scopeTable("brz_payment_details_lightning", "payment_id"),
+          `DROP INDEX IF EXISTS brz_idx_payment_details_lightning_invoice`,
+          `DROP INDEX IF EXISTS brz_idx_payment_details_lightning_payment_hash`,
+          `CREATE INDEX brz_idx_payment_details_lightning_user_invoice
+             ON brz_payment_details_lightning(user_id, invoice)`,
+          `CREATE INDEX brz_idx_payment_details_lightning_user_payment_hash
+             ON brz_payment_details_lightning(user_id, payment_hash)`,
 
-          ...scopeTable("payment_details_token", "payment_id"),
-          ...scopeTable("payment_details_spark", "payment_id"),
-          ...scopeTable("lnurl_receive_metadata", "payment_hash"),
-          ...scopeTable("unclaimed_deposits", "txid, vout"),
-          ...scopeTable("contacts", "id"),
-          ...scopeTable("settings", "key"),
+          ...scopeTable("brz_payment_details_token", "payment_id"),
+          ...scopeTable("brz_payment_details_spark", "payment_id"),
+          ...scopeTable("brz_lnurl_receive_metadata", "payment_hash"),
+          ...scopeTable("brz_unclaimed_deposits", "txid, vout"),
+          ...scopeTable("brz_contacts", "id"),
+          ...scopeTable("brz_settings", "key"),
 
-          // sync_revision: drop the singleton id (CASCADE removes PK + CHECK),
+          // brz_sync_revision: drop the singleton id (CASCADE removes PK + CHECK),
           // then re-key by user_id so each tenant has its own revision row.
-          `ALTER TABLE sync_revision DROP COLUMN id CASCADE`,
-          `ALTER TABLE sync_revision ADD COLUMN user_id BYTEA`,
-          `UPDATE sync_revision SET user_id = ${idLit}`,
-          `ALTER TABLE sync_revision
+          `ALTER TABLE brz_sync_revision DROP COLUMN id CASCADE`,
+          `ALTER TABLE brz_sync_revision ADD COLUMN user_id BYTEA`,
+          `UPDATE brz_sync_revision SET user_id = ${idLit}`,
+          `ALTER TABLE brz_sync_revision
              ALTER COLUMN user_id SET NOT NULL,
              ADD PRIMARY KEY (user_id)`,
 
-          // sync_outgoing has no PK, only an index — just add user_id and rewrite the index.
-          `ALTER TABLE sync_outgoing ADD COLUMN user_id BYTEA`,
-          `UPDATE sync_outgoing SET user_id = ${idLit}`,
-          `ALTER TABLE sync_outgoing ALTER COLUMN user_id SET NOT NULL`,
-          `DROP INDEX IF EXISTS idx_sync_outgoing_data_id_record_type`,
-          `CREATE INDEX idx_sync_outgoing_user_record_type_data_id
-             ON sync_outgoing(user_id, record_type, data_id)`,
+          // brz_sync_outgoing has no PK, only an index — just add user_id and rewrite the index.
+          `ALTER TABLE brz_sync_outgoing ADD COLUMN user_id BYTEA`,
+          `UPDATE brz_sync_outgoing SET user_id = ${idLit}`,
+          `ALTER TABLE brz_sync_outgoing ALTER COLUMN user_id SET NOT NULL`,
+          `DROP INDEX IF EXISTS brz_idx_sync_outgoing_data_id_record_type`,
+          `CREATE INDEX brz_idx_sync_outgoing_user_record_type_data_id
+             ON brz_sync_outgoing(user_id, record_type, data_id)`,
 
-          ...scopeTable("sync_state", "record_type, data_id"),
+          ...scopeTable("brz_sync_state", "record_type, data_id"),
 
-          ...scopeTable("sync_incoming", "record_type, data_id, revision"),
-          `DROP INDEX IF EXISTS idx_sync_incoming_revision`,
-          `CREATE INDEX idx_sync_incoming_user_revision
-             ON sync_incoming(user_id, revision)`,
+          ...scopeTable("brz_sync_incoming", "record_type, data_id, revision"),
+          `DROP INDEX IF EXISTS brz_idx_sync_incoming_revision`,
+          `CREATE INDEX brz_idx_sync_incoming_user_revision
+             ON brz_sync_incoming(user_id, revision)`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
@@ -145,6 +145,24 @@ class PostgresMigrationManager {
         "brz_idx_sync_outgoing_user_record_type_data_id",
       ],
       ["idx_sync_incoming_user_revision", "brz_idx_sync_incoming_user_revision"],
+      // Pre-multi-tenant indexes (still present on version < 16 DBs).
+      ["idx_payments_timestamp", "brz_idx_payments_timestamp"],
+      ["idx_payments_payment_type", "brz_idx_payments_payment_type"],
+      ["idx_payments_status", "brz_idx_payments_status"],
+      ["idx_payment_metadata_parent", "brz_idx_payment_metadata_parent"],
+      [
+        "idx_payment_details_lightning_invoice",
+        "brz_idx_payment_details_lightning_invoice",
+      ],
+      [
+        "idx_payment_details_lightning_payment_hash",
+        "brz_idx_payment_details_lightning_payment_hash",
+      ],
+      [
+        "idx_sync_outgoing_data_id_record_type",
+        "brz_idx_sync_outgoing_data_id_record_type",
+      ],
+      ["idx_sync_incoming_revision", "brz_idx_sync_incoming_revision"],
     ];
     for (const [oldName, newName] of indexRenames) {
       await client.query(`ALTER INDEX IF EXISTS ${oldName} RENAME TO ${newName}`);

--- a/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
@@ -93,9 +93,7 @@ class PostgresMigrationManager {
   }
 
   /**
-   * Renames legacy unprefixed core-storage objects to their `brz_` equivalents
-   * on first startup after the prefix change. Gated on a canary check against
-   * the legacy `schema_migrations` table.
+   * Pre-prefix rename. Canary-gated on the legacy `schema_migrations` table.
    * @param {import('pg').PoolClient} client
    */
   async _applySchemaRenames(client) {

--- a/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-token-store/index.cjs
@@ -179,12 +179,12 @@ class PostgresTokenStore {
         const swapCheckResult = await client.query(
           `SELECT
             EXISTS(
-              SELECT 1 FROM token_reservations
+              SELECT 1 FROM brz_token_reservations
               WHERE user_id = $1 AND purpose = 'Swap'
             ) AS has_active_swap,
             COALESCE(
               (SELECT last_completed_at >= $2
-               FROM token_swap_status WHERE user_id = $1),
+               FROM brz_token_swap_status WHERE user_id = $1),
               FALSE
             ) AS swap_completed`,
           [this.identity, refreshTimestamp]
@@ -197,20 +197,20 @@ class PostgresTokenStore {
         // Clean up old spent markers
         const cleanupCutoff = new Date(refreshTimestamp.getTime() - SPENT_MARKER_CLEANUP_THRESHOLD_MS);
         await client.query(
-          "DELETE FROM token_spent_outputs WHERE user_id = $1 AND spent_at < $2",
+          "DELETE FROM brz_token_spent_outputs WHERE user_id = $1 AND spent_at < $2",
           [this.identity, cleanupCutoff]
         );
 
         // Get recent spent output IDs (spent_at >= refresh_timestamp)
         const spentResult = await client.query(
-          "SELECT output_id FROM token_spent_outputs WHERE user_id = $1 AND spent_at >= $2",
+          "SELECT output_id FROM brz_token_spent_outputs WHERE user_id = $1 AND spent_at >= $2",
           [this.identity, refreshTimestamp]
         );
         const spentIds = new Set(spentResult.rows.map((r) => r.output_id));
 
         // Delete non-reserved outputs added BEFORE the refresh started
         await client.query(
-          "DELETE FROM token_outputs WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
+          "DELETE FROM brz_token_outputs WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
           [this.identity, refreshTimestamp]
         );
 
@@ -225,8 +225,8 @@ class PostgresTokenStore {
         // Reconcile reservations: find reserved outputs that no longer exist
         const reservedRows = await client.query(
           `SELECT r.id, o.id AS output_id
-           FROM token_reservations r
-           JOIN token_outputs o
+           FROM brz_token_reservations r
+           JOIN brz_token_outputs o
              ON o.reservation_id = r.id AND o.user_id = r.user_id
            WHERE r.user_id = $1`,
           [this.identity]
@@ -260,11 +260,11 @@ class PostgresTokenStore {
         // Delete outputs whose reservations are being removed entirely
         if (reservationsToDelete.length > 0) {
           await client.query(
-            "DELETE FROM token_outputs WHERE user_id = $1 AND reservation_id = ANY($2)",
+            "DELETE FROM brz_token_outputs WHERE user_id = $1 AND reservation_id = ANY($2)",
             [this.identity, reservationsToDelete]
           );
           await client.query(
-            "DELETE FROM token_reservations WHERE user_id = $1 AND id = ANY($2)",
+            "DELETE FROM brz_token_reservations WHERE user_id = $1 AND id = ANY($2)",
             [this.identity, reservationsToDelete]
           );
         }
@@ -272,14 +272,14 @@ class PostgresTokenStore {
         // Delete individual reserved outputs that no longer exist
         if (outputsToRemoveFromReservation.length > 0) {
           await client.query(
-            "DELETE FROM token_outputs WHERE user_id = $1 AND id = ANY($2)",
+            "DELETE FROM brz_token_outputs WHERE user_id = $1 AND id = ANY($2)",
             [this.identity, outputsToRemoveFromReservation]
           );
 
           // Check if any reservations are now empty
           const emptyReservations = await client.query(
-            `SELECT r.id FROM token_reservations r
-             LEFT JOIN token_outputs o
+            `SELECT r.id FROM brz_token_reservations r
+             LEFT JOIN brz_token_outputs o
                ON o.reservation_id = r.id AND o.user_id = r.user_id
              WHERE r.user_id = $1 AND o.id IS NULL`,
             [this.identity]
@@ -287,7 +287,7 @@ class PostgresTokenStore {
           const emptyIds = emptyReservations.rows.map((r) => r.id);
           if (emptyIds.length > 0) {
             await client.query(
-              "DELETE FROM token_reservations WHERE user_id = $1 AND id = ANY($2)",
+              "DELETE FROM brz_token_reservations WHERE user_id = $1 AND id = ANY($2)",
               [this.identity, emptyIds]
             );
           }
@@ -295,7 +295,7 @@ class PostgresTokenStore {
 
         // Collect IDs of currently reserved outputs (that survived reconciliation)
         const reservedOutputIdsResult = await client.query(
-          "SELECT id FROM token_outputs WHERE user_id = $1 AND reservation_id IS NOT NULL",
+          "SELECT id FROM brz_token_outputs WHERE user_id = $1 AND reservation_id IS NOT NULL",
           [this.identity]
         );
         const reservedOutputIds = new Set(
@@ -304,11 +304,11 @@ class PostgresTokenStore {
 
         // Delete orphan metadata (per-tenant)
         await client.query(
-          `DELETE FROM token_metadata
+          `DELETE FROM brz_token_metadata
            WHERE user_id = $1
              AND identifier NOT IN (
                SELECT DISTINCT token_identifier
-               FROM token_outputs WHERE user_id = $1
+               FROM brz_token_outputs WHERE user_id = $1
              )`,
           [this.identity]
         );
@@ -362,10 +362,10 @@ class PostgresTokenStore {
                    ELSE 0
                  END
                ), 0)::text AS balance
-        FROM token_metadata m
-        JOIN token_outputs o
+        FROM brz_token_metadata m
+        JOIN brz_token_outputs o
           ON o.token_identifier = m.identifier AND o.user_id = m.user_id
-        LEFT JOIN token_reservations r
+        LEFT JOIN brz_token_reservations r
           ON o.reservation_id = r.id AND o.user_id = r.user_id
         WHERE m.user_id = $1
         GROUP BY m.identifier, m.issuer_public_key, m.name, m.ticker,
@@ -404,10 +404,10 @@ class PostgresTokenStore {
                 o.token_public_key, o.token_amount, o.token_identifier,
                 o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                 r.purpose
-         FROM token_metadata m
-         LEFT JOIN token_outputs o
+         FROM brz_token_metadata m
+         LEFT JOIN brz_token_outputs o
            ON o.token_identifier = m.identifier AND o.user_id = m.user_id
-         LEFT JOIN token_reservations r
+         LEFT JOIN brz_token_reservations r
            ON o.reservation_id = r.id AND o.user_id = r.user_id
          WHERE m.user_id = $1
          ORDER BY m.identifier, o.token_amount::NUMERIC ASC`,
@@ -481,10 +481,10 @@ class PostgresTokenStore {
                 o.token_public_key, o.token_amount, o.token_identifier,
                 o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                 r.purpose
-         FROM token_metadata m
-         LEFT JOIN token_outputs o
+         FROM brz_token_metadata m
+         LEFT JOIN brz_token_outputs o
            ON o.token_identifier = m.identifier AND o.user_id = m.user_id
-         LEFT JOIN token_reservations r
+         LEFT JOIN brz_token_reservations r
            ON o.reservation_id = r.id AND o.user_id = r.user_id
          WHERE m.user_id = $2 AND ${whereClause}
          ORDER BY o.token_amount::NUMERIC ASC`,
@@ -541,7 +541,7 @@ class PostgresTokenStore {
         const outputIds = tokenOutputs.outputs.map((o) => o.output.id);
         if (outputIds.length > 0) {
           await client.query(
-            "DELETE FROM token_spent_outputs WHERE user_id = $1 AND output_id = ANY($2)",
+            "DELETE FROM brz_token_spent_outputs WHERE user_id = $1 AND output_id = ANY($2)",
             [this.identity, outputIds]
           );
         }
@@ -595,7 +595,7 @@ class PostgresTokenStore {
 
         // Get metadata
         const metadataResult = await client.query(
-          "SELECT * FROM token_metadata WHERE user_id = $1 AND identifier = $2",
+          "SELECT * FROM brz_token_metadata WHERE user_id = $1 AND identifier = $2",
           [this.identity, tokenIdentifier]
         );
 
@@ -613,7 +613,7 @@ class PostgresTokenStore {
                   o.withdraw_bond_sats, o.withdraw_relative_block_locktime,
                   o.token_public_key, o.token_amount, o.token_identifier,
                   o.prev_tx_hash, o.prev_tx_vout
-           FROM token_outputs o
+           FROM brz_token_outputs o
            WHERE o.user_id = $1
              AND o.token_identifier = $2
              AND o.reservation_id IS NULL`,
@@ -703,7 +703,7 @@ class PostgresTokenStore {
         const reservationId = this._generateId();
 
         await client.query(
-          "INSERT INTO token_reservations (user_id, id, purpose) VALUES ($1, $2, $3)",
+          "INSERT INTO brz_token_reservations (user_id, id, purpose) VALUES ($1, $2, $3)",
           [this.identity, reservationId, purpose]
         );
 
@@ -711,7 +711,7 @@ class PostgresTokenStore {
         const selectedIds = selectedOutputs.map((o) => o.output.id);
         if (selectedIds.length > 0) {
           await client.query(
-            "UPDATE token_outputs SET reservation_id = $1 WHERE user_id = $3 AND id = ANY($2)",
+            "UPDATE brz_token_outputs SET reservation_id = $1 WHERE user_id = $3 AND id = ANY($2)",
             [reservationId, selectedIds, this.identity]
           );
         }
@@ -744,13 +744,13 @@ class PostgresTokenStore {
         // ACTION (column-list SET NULL is PG15+ and a whole-row SET NULL would
         // null user_id, which is NOT NULL).
         await client.query(
-          "UPDATE token_outputs SET reservation_id = NULL WHERE user_id = $1 AND reservation_id = $2",
+          "UPDATE brz_token_outputs SET reservation_id = NULL WHERE user_id = $1 AND reservation_id = $2",
           [this.identity, id]
         );
 
         // Delete the reservation
         await client.query(
-          "DELETE FROM token_reservations WHERE user_id = $1 AND id = $2",
+          "DELETE FROM brz_token_reservations WHERE user_id = $1 AND id = $2",
           [this.identity, id]
         );
       });
@@ -771,12 +771,12 @@ class PostgresTokenStore {
     try {
       // _withWriteTransaction acquires the advisory lock so this serializes
       // against `setTokensOutputs`. Without it, a concurrent setTokensOutputs
-      // could read token_spent_outputs before our marker commits and re-insert
+      // could read brz_token_spent_outputs before our marker commits and re-insert
       // the just-spent output as Available.
       await this._withWriteTransaction(async (client) => {
         // Get reservation purpose
         const reservationResult = await client.query(
-          "SELECT purpose FROM token_reservations WHERE user_id = $1 AND id = $2",
+          "SELECT purpose FROM brz_token_reservations WHERE user_id = $1 AND id = $2",
           [this.identity, id]
         );
         if (reservationResult.rows.length === 0) {
@@ -786,14 +786,14 @@ class PostgresTokenStore {
 
         // Get reserved output IDs and mark them as spent
         const reservedOutputsResult = await client.query(
-          "SELECT id FROM token_outputs WHERE user_id = $1 AND reservation_id = $2",
+          "SELECT id FROM brz_token_outputs WHERE user_id = $1 AND reservation_id = $2",
           [this.identity, id]
         );
         const reservedOutputIds = reservedOutputsResult.rows.map((r) => r.id);
 
         if (reservedOutputIds.length > 0) {
           await client.query(
-            `INSERT INTO token_spent_outputs (user_id, output_id)
+            `INSERT INTO brz_token_spent_outputs (user_id, output_id)
              SELECT $2, output_id FROM UNNEST($1::text[]) AS t(output_id)
              ON CONFLICT DO NOTHING`,
             [reservedOutputIds, this.identity]
@@ -802,13 +802,13 @@ class PostgresTokenStore {
 
         // Delete reserved outputs
         await client.query(
-          "DELETE FROM token_outputs WHERE user_id = $1 AND reservation_id = $2",
+          "DELETE FROM brz_token_outputs WHERE user_id = $1 AND reservation_id = $2",
           [this.identity, id]
         );
 
         // Delete the reservation
         await client.query(
-          "DELETE FROM token_reservations WHERE user_id = $1 AND id = $2",
+          "DELETE FROM brz_token_reservations WHERE user_id = $1 AND id = $2",
           [this.identity, id]
         );
 
@@ -816,7 +816,7 @@ class PostgresTokenStore {
         // tenant that joined after migration 2 (and thus has no row) gets one.
         if (isSwap) {
           await client.query(
-            `INSERT INTO token_swap_status (user_id, last_completed_at)
+            `INSERT INTO brz_token_swap_status (user_id, last_completed_at)
              VALUES ($1, NOW())
              ON CONFLICT (user_id) DO UPDATE
                SET last_completed_at = EXCLUDED.last_completed_at`,
@@ -826,11 +826,11 @@ class PostgresTokenStore {
 
         // Clean up orphaned metadata (per-tenant)
         await client.query(
-          `DELETE FROM token_metadata
+          `DELETE FROM brz_token_metadata
            WHERE user_id = $1
              AND identifier NOT IN (
                SELECT DISTINCT token_identifier
-               FROM token_outputs WHERE user_id = $1
+               FROM brz_token_outputs WHERE user_id = $1
              )`,
           [this.identity]
         );
@@ -885,17 +885,17 @@ class PostgresTokenStore {
    */
   async _cleanupStaleReservations(client) {
     await client.query(
-      `UPDATE token_outputs SET reservation_id = NULL
+      `UPDATE brz_token_outputs SET reservation_id = NULL
        WHERE user_id = $2
          AND reservation_id IN (
-           SELECT id FROM token_reservations
+           SELECT id FROM brz_token_reservations
            WHERE user_id = $2
              AND created_at < NOW() - make_interval(secs => $1)
          )`,
       [RESERVATION_TIMEOUT_SECS, this.identity]
     );
     await client.query(
-      `DELETE FROM token_reservations
+      `DELETE FROM brz_token_reservations
        WHERE user_id = $2
          AND created_at < NOW() - make_interval(secs => $1)`,
       [RESERVATION_TIMEOUT_SECS, this.identity]
@@ -907,7 +907,7 @@ class PostgresTokenStore {
    */
   async _upsertMetadata(client, metadata) {
     await client.query(
-      `INSERT INTO token_metadata
+      `INSERT INTO brz_token_metadata
         (user_id, identifier, issuer_public_key, name, ticker, decimals, max_supply,
          is_freezable, creation_entity_public_key)
        VALUES ($9, $1, $2, $3, $4, $5, $6, $7, $8)
@@ -938,7 +938,7 @@ class PostgresTokenStore {
    */
   async _insertSingleOutput(client, tokenIdentifier, output) {
     await client.query(
-      `INSERT INTO token_outputs
+      `INSERT INTO brz_token_outputs
         (user_id, id, token_identifier, owner_public_key, revocation_commitment,
          withdraw_bond_sats, withdraw_relative_block_locktime,
          token_public_key, token_amount, prev_tx_hash, prev_tx_vout, added_at)

--- a/crates/breez-sdk/wasm/js/postgres-token-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-token-store/migrations.cjs
@@ -1,7 +1,7 @@
 /**
  * Database Migration Manager for Breez SDK PostgreSQL Token Store
  *
- * Uses a token_schema_migrations table + pg_advisory_xact_lock to safely run
+ * Uses a brz_token_schema_migrations table + pg_advisory_xact_lock to safely run
  * migrations from concurrent processes.
  */
 
@@ -39,9 +39,11 @@ class TokenStoreMigrationManager {
       // Transaction-level advisory lock — automatically released on COMMIT/ROLLBACK
       await client.query(`SELECT pg_advisory_xact_lock(${MIGRATION_LOCK_ID})`);
 
+      await this._applySchemaRenames(client);
+
       // Create the migrations tracking table if needed
       await client.query(`
-        CREATE TABLE IF NOT EXISTS token_schema_migrations (
+        CREATE TABLE IF NOT EXISTS brz_token_schema_migrations (
           version INTEGER PRIMARY KEY,
           applied_at TIMESTAMPTZ DEFAULT NOW()
         )
@@ -49,7 +51,7 @@ class TokenStoreMigrationManager {
 
       // Get current version
       const versionResult = await client.query(
-        "SELECT COALESCE(MAX(version), 0) AS version FROM token_schema_migrations"
+        "SELECT COALESCE(MAX(version), 0) AS version FROM brz_token_schema_migrations"
       );
       const currentVersion = versionResult.rows[0].version;
 
@@ -76,7 +78,7 @@ class TokenStoreMigrationManager {
         }
 
         await client.query(
-          "INSERT INTO token_schema_migrations (version) VALUES ($1)",
+          "INSERT INTO brz_token_schema_migrations (version) VALUES ($1)",
           [version]
         );
       }
@@ -92,6 +94,81 @@ class TokenStoreMigrationManager {
     } finally {
       client.release();
     }
+  }
+
+  /**
+   * Renames legacy unprefixed token-store objects to their `brz_` equivalents
+   * on first startup after the prefix change. Gated on the legacy
+   * `token_schema_migrations` table as canary.
+   * @param {import('pg').PoolClient} client
+   */
+  async _applySchemaRenames(client) {
+    const canary = await client.query(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.tables
+         WHERE table_schema = current_schema()
+           AND table_name = 'token_schema_migrations'
+       ) AS exists`
+    );
+    if (!canary.rows[0].exists) {
+      return;
+    }
+
+    const tableRenames = [
+      ["token_metadata", "brz_token_metadata"],
+      ["token_reservations", "brz_token_reservations"],
+      ["token_outputs", "brz_token_outputs"],
+      ["token_spent_outputs", "brz_token_spent_outputs"],
+      ["token_swap_status", "brz_token_swap_status"],
+    ];
+    for (const [oldName, newName] of tableRenames) {
+      await client.query(`ALTER TABLE IF EXISTS ${oldName} RENAME TO ${newName}`);
+    }
+
+    const indexRenames = [
+      ["idx_token_metadata_user_issuer_pk", "brz_idx_token_metadata_user_issuer_pk"],
+      ["idx_token_outputs_user_identifier", "brz_idx_token_outputs_user_identifier"],
+      ["idx_token_outputs_user_reservation", "brz_idx_token_outputs_user_reservation"],
+    ];
+    for (const [oldName, newName] of indexRenames) {
+      await client.query(`ALTER INDEX IF EXISTS ${oldName} RENAME TO ${newName}`);
+    }
+
+    const constraintRenames = [
+      ["brz_token_metadata", "token_metadata_pkey", "brz_token_metadata_pkey"],
+      ["brz_token_reservations", "token_reservations_pkey", "brz_token_reservations_pkey"],
+      ["brz_token_outputs", "token_outputs_pkey", "brz_token_outputs_pkey"],
+      [
+        "brz_token_outputs",
+        "token_outputs_user_id_token_identifier_fkey",
+        "brz_token_outputs_user_id_token_identifier_fkey",
+      ],
+      [
+        "brz_token_outputs",
+        "token_outputs_user_id_reservation_id_fkey",
+        "brz_token_outputs_user_id_reservation_id_fkey",
+      ],
+      ["brz_token_spent_outputs", "token_spent_outputs_pkey", "brz_token_spent_outputs_pkey"],
+      ["brz_token_swap_status", "token_swap_status_pkey", "brz_token_swap_status_pkey"],
+    ];
+    for (const [table, oldName, newName] of constraintRenames) {
+      await client.query(
+        `DO $$ BEGIN
+           IF EXISTS (
+             SELECT 1 FROM information_schema.table_constraints
+             WHERE table_schema = current_schema()
+               AND table_name = '${table}'
+               AND constraint_name = '${oldName}'
+           ) THEN
+             ALTER TABLE ${table} RENAME CONSTRAINT ${oldName} TO ${newName};
+           END IF;
+         END $$`
+      );
+    }
+
+    await client.query(
+      `ALTER TABLE IF EXISTS token_schema_migrations RENAME TO brz_token_schema_migrations`
+    );
   }
 
   _log(level, message) {
@@ -118,7 +195,7 @@ class TokenStoreMigrationManager {
       {
         name: "Create token store tables with race condition protection",
         sql: [
-          `CREATE TABLE IF NOT EXISTS token_metadata (
+          `CREATE TABLE IF NOT EXISTS brz_token_metadata (
             identifier TEXT PRIMARY KEY,
             issuer_public_key TEXT NOT NULL,
             name TEXT NOT NULL,
@@ -129,18 +206,18 @@ class TokenStoreMigrationManager {
             creation_entity_public_key TEXT
           )`,
 
-          `CREATE INDEX IF NOT EXISTS idx_token_metadata_issuer_pk
-            ON token_metadata (issuer_public_key)`,
+          `CREATE INDEX IF NOT EXISTS brz_idx_token_metadata_issuer_pk
+            ON brz_token_metadata (issuer_public_key)`,
 
-          `CREATE TABLE IF NOT EXISTS token_reservations (
+          `CREATE TABLE IF NOT EXISTS brz_token_reservations (
             id TEXT PRIMARY KEY,
             purpose TEXT NOT NULL,
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
           )`,
 
-          `CREATE TABLE IF NOT EXISTS token_outputs (
+          `CREATE TABLE IF NOT EXISTS brz_token_outputs (
             id TEXT PRIMARY KEY,
-            token_identifier TEXT NOT NULL REFERENCES token_metadata(identifier),
+            token_identifier TEXT NOT NULL REFERENCES brz_token_metadata(identifier),
             owner_public_key TEXT NOT NULL,
             revocation_commitment TEXT NOT NULL,
             withdraw_bond_sats BIGINT NOT NULL,
@@ -149,32 +226,32 @@ class TokenStoreMigrationManager {
             token_amount TEXT NOT NULL,
             prev_tx_hash TEXT NOT NULL,
             prev_tx_vout INTEGER NOT NULL,
-            reservation_id TEXT REFERENCES token_reservations(id) ON DELETE SET NULL,
+            reservation_id TEXT REFERENCES brz_token_reservations(id) ON DELETE SET NULL,
             added_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
           )`,
 
-          `CREATE INDEX IF NOT EXISTS idx_token_outputs_identifier
-            ON token_outputs (token_identifier)`,
+          `CREATE INDEX IF NOT EXISTS brz_idx_token_outputs_identifier
+            ON brz_token_outputs (token_identifier)`,
 
-          `CREATE INDEX IF NOT EXISTS idx_token_outputs_reservation
-            ON token_outputs (reservation_id) WHERE reservation_id IS NOT NULL`,
+          `CREATE INDEX IF NOT EXISTS brz_idx_token_outputs_reservation
+            ON brz_token_outputs (reservation_id) WHERE reservation_id IS NOT NULL`,
 
-          `CREATE TABLE IF NOT EXISTS token_spent_outputs (
+          `CREATE TABLE IF NOT EXISTS brz_token_spent_outputs (
             output_id TEXT PRIMARY KEY,
             spent_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
           )`,
 
-          `CREATE TABLE IF NOT EXISTS token_swap_status (
+          `CREATE TABLE IF NOT EXISTS brz_token_swap_status (
             id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
             last_completed_at TIMESTAMPTZ
           )`,
 
-          `INSERT INTO token_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING`,
+          `INSERT INTO brz_token_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING`,
         ],
       },
       {
         // Mirrors Rust migration 2 in spark-postgres/src/token_store.rs.
-        // Adds user_id to every token-store table (including token_metadata —
+        // Adds user_id to every token-store table (including brz_token_metadata —
         // per-tenant to avoid 0-balance leakage for tokens a tenant never
         // owned), backfills with the connecting tenant, and rewrites primary
         // keys / FKs / indexes to lead with user_id. Composite FKs use NO
@@ -185,62 +262,62 @@ class TokenStoreMigrationManager {
           // Drop dependent FKs FIRST so we can rebuild parent PKs they
           // reference. Inline `REFERENCES` clauses get auto-named
           // `<table>_<column>_fkey`.
-          `ALTER TABLE token_outputs
-             DROP CONSTRAINT IF EXISTS token_outputs_reservation_id_fkey`,
-          `ALTER TABLE token_outputs
-             DROP CONSTRAINT IF EXISTS token_outputs_token_identifier_fkey`,
+          `ALTER TABLE brz_token_outputs
+             DROP CONSTRAINT IF EXISTS brz_token_outputs_reservation_id_fkey`,
+          `ALTER TABLE brz_token_outputs
+             DROP CONSTRAINT IF EXISTS brz_token_outputs_token_identifier_fkey`,
 
-          // token_metadata: per-tenant scoping (privacy — see header).
-          `ALTER TABLE token_metadata ADD COLUMN user_id BYTEA`,
-          `UPDATE token_metadata SET user_id = ${idLit}`,
-          `ALTER TABLE token_metadata
+          // brz_token_metadata: per-tenant scoping (privacy — see header).
+          `ALTER TABLE brz_token_metadata ADD COLUMN user_id BYTEA`,
+          `UPDATE brz_token_metadata SET user_id = ${idLit}`,
+          `ALTER TABLE brz_token_metadata
              ALTER COLUMN user_id SET NOT NULL,
-             DROP CONSTRAINT IF EXISTS token_metadata_pkey,
+             DROP CONSTRAINT IF EXISTS brz_token_metadata_pkey,
              ADD PRIMARY KEY (user_id, identifier)`,
-          `DROP INDEX IF EXISTS idx_token_metadata_issuer_pk`,
-          `CREATE INDEX idx_token_metadata_user_issuer_pk
-             ON token_metadata (user_id, issuer_public_key)`,
+          `DROP INDEX IF EXISTS brz_idx_token_metadata_issuer_pk`,
+          `CREATE INDEX brz_idx_token_metadata_user_issuer_pk
+             ON brz_token_metadata (user_id, issuer_public_key)`,
 
-          // token_reservations: scope by user_id.
-          `ALTER TABLE token_reservations ADD COLUMN user_id BYTEA`,
-          `UPDATE token_reservations SET user_id = ${idLit}`,
-          `ALTER TABLE token_reservations
+          // brz_token_reservations: scope by user_id.
+          `ALTER TABLE brz_token_reservations ADD COLUMN user_id BYTEA`,
+          `UPDATE brz_token_reservations SET user_id = ${idLit}`,
+          `ALTER TABLE brz_token_reservations
              ALTER COLUMN user_id SET NOT NULL,
-             DROP CONSTRAINT IF EXISTS token_reservations_pkey,
+             DROP CONSTRAINT IF EXISTS brz_token_reservations_pkey,
              ADD PRIMARY KEY (user_id, id)`,
 
-          // token_outputs: scope by user_id, rekey, re-add composite FKs.
-          `ALTER TABLE token_outputs ADD COLUMN user_id BYTEA`,
-          `UPDATE token_outputs SET user_id = ${idLit}`,
-          `ALTER TABLE token_outputs
+          // brz_token_outputs: scope by user_id, rekey, re-add composite FKs.
+          `ALTER TABLE brz_token_outputs ADD COLUMN user_id BYTEA`,
+          `UPDATE brz_token_outputs SET user_id = ${idLit}`,
+          `ALTER TABLE brz_token_outputs
              ALTER COLUMN user_id SET NOT NULL,
-             DROP CONSTRAINT IF EXISTS token_outputs_pkey,
+             DROP CONSTRAINT IF EXISTS brz_token_outputs_pkey,
              ADD PRIMARY KEY (user_id, id),
              ADD FOREIGN KEY (user_id, token_identifier)
-                REFERENCES token_metadata(user_id, identifier),
+                REFERENCES brz_token_metadata(user_id, identifier),
              ADD FOREIGN KEY (user_id, reservation_id)
-                REFERENCES token_reservations(user_id, id)`,
-          `DROP INDEX IF EXISTS idx_token_outputs_identifier`,
-          `DROP INDEX IF EXISTS idx_token_outputs_reservation`,
-          `CREATE INDEX idx_token_outputs_user_identifier
-             ON token_outputs (user_id, token_identifier)`,
-          `CREATE INDEX idx_token_outputs_user_reservation
-             ON token_outputs (user_id, reservation_id)
+                REFERENCES brz_token_reservations(user_id, id)`,
+          `DROP INDEX IF EXISTS brz_idx_token_outputs_identifier`,
+          `DROP INDEX IF EXISTS brz_idx_token_outputs_reservation`,
+          `CREATE INDEX brz_idx_token_outputs_user_identifier
+             ON brz_token_outputs (user_id, token_identifier)`,
+          `CREATE INDEX brz_idx_token_outputs_user_reservation
+             ON brz_token_outputs (user_id, reservation_id)
              WHERE reservation_id IS NOT NULL`,
 
-          // token_spent_outputs: scope by user_id.
-          `ALTER TABLE token_spent_outputs ADD COLUMN user_id BYTEA`,
-          `UPDATE token_spent_outputs SET user_id = ${idLit}`,
-          `ALTER TABLE token_spent_outputs
+          // brz_token_spent_outputs: scope by user_id.
+          `ALTER TABLE brz_token_spent_outputs ADD COLUMN user_id BYTEA`,
+          `UPDATE brz_token_spent_outputs SET user_id = ${idLit}`,
+          `ALTER TABLE brz_token_spent_outputs
              ALTER COLUMN user_id SET NOT NULL,
-             DROP CONSTRAINT IF EXISTS token_spent_outputs_pkey,
+             DROP CONSTRAINT IF EXISTS brz_token_spent_outputs_pkey,
              ADD PRIMARY KEY (user_id, output_id)`,
 
-          // token_swap_status: drop the singleton id, rekey by user_id.
-          `ALTER TABLE token_swap_status DROP COLUMN id CASCADE`,
-          `ALTER TABLE token_swap_status ADD COLUMN user_id BYTEA`,
-          `UPDATE token_swap_status SET user_id = ${idLit}`,
-          `ALTER TABLE token_swap_status
+          // brz_token_swap_status: drop the singleton id, rekey by user_id.
+          `ALTER TABLE brz_token_swap_status DROP COLUMN id CASCADE`,
+          `ALTER TABLE brz_token_swap_status ADD COLUMN user_id BYTEA`,
+          `UPDATE brz_token_swap_status SET user_id = ${idLit}`,
+          `ALTER TABLE brz_token_swap_status
              ALTER COLUMN user_id SET NOT NULL,
              ADD PRIMARY KEY (user_id)`,
         ],

--- a/crates/breez-sdk/wasm/js/postgres-token-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-token-store/migrations.cjs
@@ -97,9 +97,8 @@ class TokenStoreMigrationManager {
   }
 
   /**
-   * Renames legacy unprefixed token-store objects to their `brz_` equivalents
-   * on first startup after the prefix change. Gated on the legacy
-   * `token_schema_migrations` table as canary.
+   * Pre-prefix rename. Canary-gated on the legacy `token_schema_migrations`
+   * table.
    * @param {import('pg').PoolClient} client
    */
   async _applySchemaRenames(client) {
@@ -147,6 +146,18 @@ class TokenStoreMigrationManager {
         "brz_token_outputs",
         "token_outputs_user_id_reservation_id_fkey",
         "brz_token_outputs_user_id_reservation_id_fkey",
+      ],
+      // Pre-multi-tenant FKs (single-column). Rename so the post-tenant
+      // migration's `DROP CONSTRAINT IF EXISTS brz_*_fkey` finds them.
+      [
+        "brz_token_outputs",
+        "token_outputs_token_identifier_fkey",
+        "brz_token_outputs_token_identifier_fkey",
+      ],
+      [
+        "brz_token_outputs",
+        "token_outputs_reservation_id_fkey",
+        "brz_token_outputs_reservation_id_fkey",
       ],
       ["brz_token_spent_outputs", "token_spent_outputs_pkey", "brz_token_spent_outputs_pkey"],
       ["brz_token_swap_status", "token_swap_status_pkey", "brz_token_swap_status_pkey"],

--- a/crates/breez-sdk/wasm/js/postgres-token-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-token-store/migrations.cjs
@@ -128,6 +128,10 @@ class TokenStoreMigrationManager {
       ["idx_token_metadata_user_issuer_pk", "brz_idx_token_metadata_user_issuer_pk"],
       ["idx_token_outputs_user_identifier", "brz_idx_token_outputs_user_identifier"],
       ["idx_token_outputs_user_reservation", "brz_idx_token_outputs_user_reservation"],
+      // Pre-multi-tenant indexes (dropped by the multi-tenant migration).
+      ["idx_token_metadata_issuer_pk", "brz_idx_token_metadata_issuer_pk"],
+      ["idx_token_outputs_identifier", "brz_idx_token_outputs_identifier"],
+      ["idx_token_outputs_reservation", "brz_idx_token_outputs_reservation"],
     ];
     for (const [oldName, newName] of indexRenames) {
       await client.query(`ALTER INDEX IF EXISTS ${oldName} RENAME TO ${newName}`);

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -197,8 +197,8 @@ class PostgresTreeStore {
       const result = await this.pool.query(
         `
         SELECT COALESCE(SUM((l.data->>'value')::bigint), 0)::bigint AS balance
-        FROM tree_leaves l
-        LEFT JOIN tree_reservations r
+        FROM brz_tree_leaves l
+        LEFT JOIN brz_tree_reservations r
           ON l.reservation_id = r.id AND l.user_id = r.user_id
         WHERE l.user_id = $1
           AND (
@@ -223,8 +223,8 @@ class PostgresTreeStore {
         `
         SELECT l.id, l.status, l.is_missing_from_operators, l.data,
                l.reservation_id, r.purpose
-        FROM tree_leaves l
-        LEFT JOIN tree_reservations r
+        FROM brz_tree_leaves l
+        LEFT JOIN brz_tree_reservations r
           ON l.reservation_id = r.id AND l.user_id = r.user_id
         WHERE l.user_id = $1
       `,
@@ -295,12 +295,12 @@ class PostgresTreeStore {
           `
           SELECT
             EXISTS(
-              SELECT 1 FROM tree_reservations
+              SELECT 1 FROM brz_tree_reservations
               WHERE user_id = $1 AND purpose = 'Swap'
             ) AS has_active_swap,
             COALESCE(
               (SELECT last_completed_at >= $2
-               FROM tree_swap_status WHERE user_id = $1),
+               FROM brz_tree_swap_status WHERE user_id = $1),
               FALSE
             ) AS swap_completed_during_refresh
         `,
@@ -317,7 +317,7 @@ class PostgresTreeStore {
         await this._cleanupSpentMarkers(client, refreshTimestamp);
 
         const spentResult = await client.query(
-          "SELECT leaf_id FROM tree_spent_leaves WHERE user_id = $1 AND spent_at >= $2",
+          "SELECT leaf_id FROM brz_tree_spent_leaves WHERE user_id = $1 AND spent_at >= $2",
           [this.identity, refreshTimestamp]
         );
         const spentIds = new Set(spentResult.rows.map((r) => r.leaf_id));
@@ -327,7 +327,7 @@ class PostgresTreeStore {
         // _cleanupStaleReservations (which now NULLs reservation_id explicitly,
         // since the composite FK uses NO ACTION).
         await client.query(
-          "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
+          "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
           [this.identity, refreshTimestamp]
         );
 
@@ -361,7 +361,7 @@ class PostgresTreeStore {
     try {
       await this._withTransaction(async (client) => {
         const res = await client.query(
-          "SELECT id FROM tree_reservations WHERE user_id = $1 AND id = $2",
+          "SELECT id FROM brz_tree_reservations WHERE user_id = $1 AND id = $2",
           [this.identity, id]
         );
 
@@ -370,12 +370,12 @@ class PostgresTreeStore {
         }
 
         await client.query(
-          "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+          "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
           [this.identity, id]
         );
 
         await client.query(
-          "DELETE FROM tree_reservations WHERE user_id = $1 AND id = $2",
+          "DELETE FROM brz_tree_reservations WHERE user_id = $1 AND id = $2",
           [this.identity, id]
         );
 
@@ -401,12 +401,12 @@ class PostgresTreeStore {
     try {
       // _withWriteTransaction acquires the advisory lock so this serializes
       // against `setLeaves`. Without it, a concurrent setLeaves could read
-      // tree_spent_leaves before our marker commits and re-insert the
+      // brz_tree_spent_leaves before our marker commits and re-insert the
       // just-spent leaf as Available.
       await this._withWriteTransaction(async (client) => {
         // Check if reservation exists and get purpose
         const res = await client.query(
-          "SELECT id, purpose FROM tree_reservations WHERE user_id = $1 AND id = $2",
+          "SELECT id, purpose FROM brz_tree_reservations WHERE user_id = $1 AND id = $2",
           [this.identity, id]
         );
 
@@ -415,17 +415,17 @@ class PostgresTreeStore {
         if (res.rows.length > 0) {
           isSwap = res.rows[0].purpose === "Swap";
           const leafResult = await client.query(
-            "SELECT id FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+            "SELECT id FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
             [this.identity, id]
           );
           reservedLeafIds = leafResult.rows.map((r) => r.id);
           await this._batchInsertSpentLeaves(client, reservedLeafIds);
           await client.query(
-            "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+            "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
             [this.identity, id]
           );
           await client.query(
-            "DELETE FROM tree_reservations WHERE user_id = $1 AND id = $2",
+            "DELETE FROM brz_tree_reservations WHERE user_id = $1 AND id = $2",
             [this.identity, id]
           );
         }
@@ -439,7 +439,7 @@ class PostgresTreeStore {
         // that joined after migration 3 (and thus has no row) gets one created.
         if (isSwap && newLeaves && newLeaves.length > 0) {
           await client.query(
-            `INSERT INTO tree_swap_status (user_id, last_completed_at)
+            `INSERT INTO brz_tree_swap_status (user_id, last_completed_at)
              VALUES ($1, NOW())
              ON CONFLICT (user_id) DO UPDATE
                SET last_completed_at = EXCLUDED.last_completed_at`,
@@ -475,7 +475,7 @@ class PostgresTreeStore {
         const totalResult = await client.query(
           `
           SELECT COALESCE(SUM((data->>'value')::bigint), 0)::bigint AS total
-          FROM tree_leaves
+          FROM brz_tree_leaves
           WHERE user_id = $1
             AND status = 'Available'
             AND is_missing_from_operators = FALSE
@@ -493,7 +493,7 @@ class PostgresTreeStore {
         const slimResult = await client.query(
           `
           SELECT id, (data->>'value')::bigint AS value
-          FROM tree_leaves
+          FROM brz_tree_leaves
           WHERE user_id = $1
             AND status = 'Available'
             AND is_missing_from_operators = FALSE
@@ -501,7 +501,7 @@ class PostgresTreeStore {
             AND (
               (data->>'value')::bigint <= $2
               OR id = (
-                SELECT id FROM tree_leaves
+                SELECT id FROM brz_tree_leaves
                 WHERE user_id = $1
                   AND status = 'Available'
                   AND is_missing_from_operators = FALSE
@@ -612,7 +612,7 @@ class PostgresTreeStore {
   async _fetchFullLeavesByIds(client, ids) {
     if (!ids || ids.length === 0) return [];
     const result = await client.query(
-      "SELECT data FROM tree_leaves WHERE user_id = $2 AND id = ANY($1)",
+      "SELECT data FROM brz_tree_leaves WHERE user_id = $2 AND id = ANY($1)",
       [ids, this.identity]
     );
     return result.rows.map((r) => r.data);
@@ -646,7 +646,7 @@ class PostgresTreeStore {
       return await this._withTransaction(async (client) => {
         // Check if reservation exists
         const res = await client.query(
-          "SELECT id FROM tree_reservations WHERE user_id = $1 AND id = $2",
+          "SELECT id FROM brz_tree_reservations WHERE user_id = $1 AND id = $2",
           [this.identity, reservationId]
         );
 
@@ -656,14 +656,14 @@ class PostgresTreeStore {
 
         // Get old reserved leaf IDs and mark as spent
         const oldLeavesResult = await client.query(
-          "SELECT id FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+          "SELECT id FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
           [this.identity, reservationId]
         );
         const oldLeafIds = oldLeavesResult.rows.map((r) => r.id);
 
         await this._batchInsertSpentLeaves(client, oldLeafIds);
         await client.query(
-          "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+          "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
           [this.identity, reservationId]
         );
 
@@ -679,7 +679,7 @@ class PostgresTreeStore {
 
         // Clear pending change amount
         await client.query(
-          "UPDATE tree_reservations SET pending_change_amount = 0 WHERE user_id = $1 AND id = $2",
+          "UPDATE brz_tree_reservations SET pending_change_amount = 0 WHERE user_id = $1 AND id = $2",
           [this.identity, reservationId]
         );
 
@@ -862,7 +862,7 @@ class PostgresTreeStore {
    */
   async _calculatePendingBalance(client) {
     const result = await client.query(
-      "SELECT COALESCE(SUM(pending_change_amount), 0)::BIGINT AS pending FROM tree_reservations WHERE user_id = $1",
+      "SELECT COALESCE(SUM(pending_change_amount), 0)::BIGINT AS pending FROM brz_tree_reservations WHERE user_id = $1",
       [this.identity]
     );
     return Number(result.rows[0].pending);
@@ -873,7 +873,7 @@ class PostgresTreeStore {
    */
   async _createReservation(client, reservationId, leaves, purpose, pendingChange) {
     await client.query(
-      "INSERT INTO tree_reservations (user_id, id, purpose, pending_change_amount) VALUES ($1, $2, $3, $4)",
+      "INSERT INTO brz_tree_reservations (user_id, id, purpose, pending_change_amount) VALUES ($1, $2, $3, $4)",
       [this.identity, reservationId, purpose, pendingChange]
     );
 
@@ -882,7 +882,7 @@ class PostgresTreeStore {
   }
 
   /**
-   * Batch upsert leaves into tree_leaves table.
+   * Batch upsert leaves into brz_tree_leaves table.
    */
   async _batchUpsertLeaves(client, leaves, isMissingFromOperators, skipIds) {
     if (!leaves || leaves.length === 0) return;
@@ -899,7 +899,7 @@ class PostgresTreeStore {
     const dataValues = filtered.map((l) => JSON.stringify(l));
 
     await client.query(
-      `INSERT INTO tree_leaves (user_id, id, status, is_missing_from_operators, data, added_at)
+      `INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, added_at)
        SELECT $5, id, status, missing, data::jsonb, NOW()
        FROM UNNEST($1::text[], $2::text[], $3::bool[], $4::text[])
            AS t(id, status, missing, data)
@@ -919,7 +919,7 @@ class PostgresTreeStore {
     if (leafIds.length === 0) return;
 
     await client.query(
-      "UPDATE tree_leaves SET reservation_id = $1 WHERE user_id = $3 AND id = ANY($2)",
+      "UPDATE brz_tree_leaves SET reservation_id = $1 WHERE user_id = $3 AND id = ANY($2)",
       [reservationId, leafIds, this.identity]
     );
   }
@@ -931,7 +931,7 @@ class PostgresTreeStore {
     if (leafIds.length === 0) return;
 
     await client.query(
-      `INSERT INTO tree_spent_leaves (user_id, leaf_id)
+      `INSERT INTO brz_tree_spent_leaves (user_id, leaf_id)
        SELECT $2, leaf_id FROM UNNEST($1::text[]) AS t(leaf_id)
        ON CONFLICT DO NOTHING`,
       [leafIds, this.identity]
@@ -945,7 +945,7 @@ class PostgresTreeStore {
     if (leafIds.length === 0) return;
 
     await client.query(
-      "DELETE FROM tree_spent_leaves WHERE user_id = $2 AND leaf_id = ANY($1)",
+      "DELETE FROM brz_tree_spent_leaves WHERE user_id = $2 AND leaf_id = ANY($1)",
       [leafIds, this.identity]
     );
   }
@@ -958,17 +958,17 @@ class PostgresTreeStore {
    */
   async _cleanupStaleReservations(client) {
     await client.query(
-      `UPDATE tree_leaves SET reservation_id = NULL
+      `UPDATE brz_tree_leaves SET reservation_id = NULL
        WHERE user_id = $2
          AND reservation_id IN (
-           SELECT id FROM tree_reservations
+           SELECT id FROM brz_tree_reservations
            WHERE user_id = $2
              AND created_at < NOW() - make_interval(secs => $1)
          )`,
       [RESERVATION_TIMEOUT_SECS, this.identity]
     );
     await client.query(
-      `DELETE FROM tree_reservations
+      `DELETE FROM brz_tree_reservations
        WHERE user_id = $2
          AND created_at < NOW() - make_interval(secs => $1)`,
       [RESERVATION_TIMEOUT_SECS, this.identity]
@@ -983,7 +983,7 @@ class PostgresTreeStore {
     const cleanupCutoff = new Date(refreshTimestamp.getTime() - thresholdMs);
 
     await client.query(
-      "DELETE FROM tree_spent_leaves WHERE user_id = $2 AND spent_at < $1",
+      "DELETE FROM brz_tree_spent_leaves WHERE user_id = $2 AND spent_at < $1",
       [cleanupCutoff, this.identity]
     );
   }

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/migrations.cjs
@@ -1,7 +1,7 @@
 /**
  * Database Migration Manager for Breez SDK PostgreSQL Tree Store
  *
- * Uses a tree_schema_migrations table + pg_advisory_xact_lock to safely run
+ * Uses a brz_tree_schema_migrations table + pg_advisory_xact_lock to safely run
  * migrations from concurrent processes.
  */
 
@@ -39,9 +39,11 @@ class TreeStoreMigrationManager {
       // Transaction-level advisory lock — automatically released on COMMIT/ROLLBACK
       await client.query(`SELECT pg_advisory_xact_lock(${MIGRATION_LOCK_ID})`);
 
+      await this._applySchemaRenames(client);
+
       // Create the migrations tracking table if needed
       await client.query(`
-        CREATE TABLE IF NOT EXISTS tree_schema_migrations (
+        CREATE TABLE IF NOT EXISTS brz_tree_schema_migrations (
           version INTEGER PRIMARY KEY,
           applied_at TIMESTAMPTZ DEFAULT NOW()
         )
@@ -49,7 +51,7 @@ class TreeStoreMigrationManager {
 
       // Get current version
       const versionResult = await client.query(
-        "SELECT COALESCE(MAX(version), 0) AS version FROM tree_schema_migrations"
+        "SELECT COALESCE(MAX(version), 0) AS version FROM brz_tree_schema_migrations"
       );
       const currentVersion = versionResult.rows[0].version;
 
@@ -76,7 +78,7 @@ class TreeStoreMigrationManager {
         }
 
         await client.query(
-          "INSERT INTO tree_schema_migrations (version) VALUES ($1)",
+          "INSERT INTO brz_tree_schema_migrations (version) VALUES ($1)",
           [version]
         );
       }
@@ -92,6 +94,78 @@ class TreeStoreMigrationManager {
     } finally {
       client.release();
     }
+  }
+
+  /**
+   * Renames legacy unprefixed tree-store objects to their `brz_` equivalents
+   * on first startup after the prefix change. Gated on a canary check
+   * against the legacy `tree_schema_migrations` table.
+   * @param {import('pg').PoolClient} client
+   */
+  async _applySchemaRenames(client) {
+    const canary = await client.query(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.tables
+         WHERE table_schema = current_schema()
+           AND table_name = 'tree_schema_migrations'
+       ) AS exists`
+    );
+    if (!canary.rows[0].exists) {
+      return;
+    }
+
+    const tableRenames = [
+      ["tree_reservations", "brz_tree_reservations"],
+      ["tree_leaves", "brz_tree_leaves"],
+      ["tree_spent_leaves", "brz_tree_spent_leaves"],
+      ["tree_swap_status", "brz_tree_swap_status"],
+    ];
+    for (const [oldName, newName] of tableRenames) {
+      await client.query(
+        `ALTER TABLE IF EXISTS ${oldName} RENAME TO ${newName}`
+      );
+    }
+
+    const indexRenames = [
+      ["idx_tree_leaves_user_available", "brz_idx_tree_leaves_user_available"],
+      ["idx_tree_leaves_user_reservation", "brz_idx_tree_leaves_user_reservation"],
+      ["idx_tree_leaves_user_added_at", "brz_idx_tree_leaves_user_added_at"],
+    ];
+    for (const [oldName, newName] of indexRenames) {
+      await client.query(
+        `ALTER INDEX IF EXISTS ${oldName} RENAME TO ${newName}`
+      );
+    }
+
+    const constraintRenames = [
+      ["brz_tree_reservations", "tree_reservations_pkey", "brz_tree_reservations_pkey"],
+      ["brz_tree_leaves", "tree_leaves_pkey", "brz_tree_leaves_pkey"],
+      [
+        "brz_tree_leaves",
+        "tree_leaves_user_id_reservation_id_fkey",
+        "brz_tree_leaves_user_id_reservation_id_fkey",
+      ],
+      ["brz_tree_spent_leaves", "tree_spent_leaves_pkey", "brz_tree_spent_leaves_pkey"],
+      ["brz_tree_swap_status", "tree_swap_status_pkey", "brz_tree_swap_status_pkey"],
+    ];
+    for (const [table, oldName, newName] of constraintRenames) {
+      await client.query(
+        `DO $$ BEGIN
+           IF EXISTS (
+             SELECT 1 FROM information_schema.table_constraints
+             WHERE table_schema = current_schema()
+               AND table_name = '${table}'
+               AND constraint_name = '${oldName}'
+           ) THEN
+             ALTER TABLE ${table} RENAME CONSTRAINT ${oldName} TO ${newName};
+           END IF;
+         END $$`
+      );
+    }
+
+    await client.query(
+      `ALTER TABLE IF EXISTS tree_schema_migrations RENAME TO brz_tree_schema_migrations`
+    );
   }
 
   _log(level, message) {
@@ -118,45 +192,45 @@ class TreeStoreMigrationManager {
       {
         name: "Create tree store tables",
         sql: [
-          `CREATE TABLE IF NOT EXISTS tree_reservations (
+          `CREATE TABLE IF NOT EXISTS brz_tree_reservations (
             id TEXT PRIMARY KEY,
             purpose TEXT NOT NULL,
             pending_change_amount BIGINT NOT NULL DEFAULT 0,
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
           )`,
 
-          `CREATE TABLE IF NOT EXISTS tree_leaves (
+          `CREATE TABLE IF NOT EXISTS brz_tree_leaves (
             id TEXT PRIMARY KEY,
             status TEXT NOT NULL,
             is_missing_from_operators BOOLEAN NOT NULL DEFAULT FALSE,
-            reservation_id TEXT REFERENCES tree_reservations(id) ON DELETE SET NULL,
+            reservation_id TEXT REFERENCES brz_tree_reservations(id) ON DELETE SET NULL,
             data JSONB NOT NULL,
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             added_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
           )`,
 
-          `CREATE TABLE IF NOT EXISTS tree_spent_leaves (
+          `CREATE TABLE IF NOT EXISTS brz_tree_spent_leaves (
             leaf_id TEXT PRIMARY KEY,
             spent_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
           )`,
 
-          `CREATE INDEX IF NOT EXISTS idx_tree_leaves_available ON tree_leaves(status, is_missing_from_operators)
+          `CREATE INDEX IF NOT EXISTS brz_idx_tree_leaves_available ON brz_tree_leaves(status, is_missing_from_operators)
             WHERE status = 'Available' AND is_missing_from_operators = FALSE`,
 
-          `CREATE INDEX IF NOT EXISTS idx_tree_leaves_reservation ON tree_leaves(reservation_id)
+          `CREATE INDEX IF NOT EXISTS brz_idx_tree_leaves_reservation ON brz_tree_leaves(reservation_id)
             WHERE reservation_id IS NOT NULL`,
 
-          `CREATE INDEX IF NOT EXISTS idx_tree_leaves_added_at ON tree_leaves(added_at)`,
+          `CREATE INDEX IF NOT EXISTS brz_idx_tree_leaves_added_at ON brz_tree_leaves(added_at)`,
         ],
       },
       {
         name: "Add swap status tracking",
         sql: [
-          `CREATE TABLE IF NOT EXISTS tree_swap_status (
+          `CREATE TABLE IF NOT EXISTS brz_tree_swap_status (
             id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
             last_completed_at TIMESTAMPTZ
           )`,
-          `INSERT INTO tree_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING`,
+          `INSERT INTO brz_tree_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING`,
         ],
       },
       {
@@ -170,52 +244,52 @@ class TreeStoreMigrationManager {
         name: "Multi-tenant scoping: add user_id and rewrite primary keys",
         sql: [
           // Drop the old single-column FK FIRST, before touching the
-          // tree_reservations PK it depends on.
-          `ALTER TABLE tree_leaves
-             DROP CONSTRAINT IF EXISTS tree_leaves_reservation_id_fkey`,
+          // brz_tree_reservations PK it depends on.
+          `ALTER TABLE brz_tree_leaves
+             DROP CONSTRAINT IF EXISTS brz_tree_leaves_reservation_id_fkey`,
 
-          // tree_reservations: scope by user_id.
-          `ALTER TABLE tree_reservations ADD COLUMN user_id BYTEA`,
-          `UPDATE tree_reservations SET user_id = ${idLit}`,
-          `ALTER TABLE tree_reservations
+          // brz_tree_reservations: scope by user_id.
+          `ALTER TABLE brz_tree_reservations ADD COLUMN user_id BYTEA`,
+          `UPDATE brz_tree_reservations SET user_id = ${idLit}`,
+          `ALTER TABLE brz_tree_reservations
              ALTER COLUMN user_id SET NOT NULL,
-             DROP CONSTRAINT IF EXISTS tree_reservations_pkey,
+             DROP CONSTRAINT IF EXISTS brz_tree_reservations_pkey,
              ADD PRIMARY KEY (user_id, id)`,
 
-          // tree_leaves: add user_id, rekey, and re-add the composite FK.
-          `ALTER TABLE tree_leaves ADD COLUMN user_id BYTEA`,
-          `UPDATE tree_leaves SET user_id = ${idLit}`,
-          `ALTER TABLE tree_leaves
+          // brz_tree_leaves: add user_id, rekey, and re-add the composite FK.
+          `ALTER TABLE brz_tree_leaves ADD COLUMN user_id BYTEA`,
+          `UPDATE brz_tree_leaves SET user_id = ${idLit}`,
+          `ALTER TABLE brz_tree_leaves
              ALTER COLUMN user_id SET NOT NULL,
-             DROP CONSTRAINT IF EXISTS tree_leaves_pkey,
+             DROP CONSTRAINT IF EXISTS brz_tree_leaves_pkey,
              ADD PRIMARY KEY (user_id, id),
              ADD FOREIGN KEY (user_id, reservation_id)
-                REFERENCES tree_reservations(user_id, id)`,
-          `DROP INDEX IF EXISTS idx_tree_leaves_available`,
-          `DROP INDEX IF EXISTS idx_tree_leaves_reservation`,
-          `DROP INDEX IF EXISTS idx_tree_leaves_added_at`,
-          `CREATE INDEX idx_tree_leaves_user_available
-             ON tree_leaves(user_id, status, is_missing_from_operators)
+                REFERENCES brz_tree_reservations(user_id, id)`,
+          `DROP INDEX IF EXISTS brz_idx_tree_leaves_available`,
+          `DROP INDEX IF EXISTS brz_idx_tree_leaves_reservation`,
+          `DROP INDEX IF EXISTS brz_idx_tree_leaves_added_at`,
+          `CREATE INDEX brz_idx_tree_leaves_user_available
+             ON brz_tree_leaves(user_id, status, is_missing_from_operators)
              WHERE status = 'Available' AND is_missing_from_operators = FALSE`,
-          `CREATE INDEX idx_tree_leaves_user_reservation
-             ON tree_leaves(user_id, reservation_id)
+          `CREATE INDEX brz_idx_tree_leaves_user_reservation
+             ON brz_tree_leaves(user_id, reservation_id)
              WHERE reservation_id IS NOT NULL`,
-          `CREATE INDEX idx_tree_leaves_user_added_at ON tree_leaves(user_id, added_at)`,
+          `CREATE INDEX brz_idx_tree_leaves_user_added_at ON brz_tree_leaves(user_id, added_at)`,
 
-          // tree_spent_leaves: scope by user_id.
-          `ALTER TABLE tree_spent_leaves ADD COLUMN user_id BYTEA`,
-          `UPDATE tree_spent_leaves SET user_id = ${idLit}`,
-          `ALTER TABLE tree_spent_leaves
+          // brz_tree_spent_leaves: scope by user_id.
+          `ALTER TABLE brz_tree_spent_leaves ADD COLUMN user_id BYTEA`,
+          `UPDATE brz_tree_spent_leaves SET user_id = ${idLit}`,
+          `ALTER TABLE brz_tree_spent_leaves
              ALTER COLUMN user_id SET NOT NULL,
-             DROP CONSTRAINT IF EXISTS tree_spent_leaves_pkey,
+             DROP CONSTRAINT IF EXISTS brz_tree_spent_leaves_pkey,
              ADD PRIMARY KEY (user_id, leaf_id)`,
 
-          // tree_swap_status was a singleton (PK id=1, CHECK id=1). Drop the id
+          // brz_tree_swap_status was a singleton (PK id=1, CHECK id=1). Drop the id
           // column (CASCADE removes both PK and CHECK), then re-key by user_id.
-          `ALTER TABLE tree_swap_status DROP COLUMN id CASCADE`,
-          `ALTER TABLE tree_swap_status ADD COLUMN user_id BYTEA`,
-          `UPDATE tree_swap_status SET user_id = ${idLit}`,
-          `ALTER TABLE tree_swap_status
+          `ALTER TABLE brz_tree_swap_status DROP COLUMN id CASCADE`,
+          `ALTER TABLE brz_tree_swap_status ADD COLUMN user_id BYTEA`,
+          `UPDATE brz_tree_swap_status SET user_id = ${idLit}`,
+          `ALTER TABLE brz_tree_swap_status
              ALTER COLUMN user_id SET NOT NULL,
              ADD PRIMARY KEY (user_id)`,
         ],

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/migrations.cjs
@@ -129,6 +129,10 @@ class TreeStoreMigrationManager {
       ["idx_tree_leaves_user_available", "brz_idx_tree_leaves_user_available"],
       ["idx_tree_leaves_user_reservation", "brz_idx_tree_leaves_user_reservation"],
       ["idx_tree_leaves_user_added_at", "brz_idx_tree_leaves_user_added_at"],
+      // Pre-multi-tenant indexes (dropped by the multi-tenant migration).
+      ["idx_tree_leaves_available", "brz_idx_tree_leaves_available"],
+      ["idx_tree_leaves_reservation", "brz_idx_tree_leaves_reservation"],
+      ["idx_tree_leaves_added_at", "brz_idx_tree_leaves_added_at"],
     ];
     for (const [oldName, newName] of indexRenames) {
       await client.query(

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/migrations.cjs
@@ -97,9 +97,8 @@ class TreeStoreMigrationManager {
   }
 
   /**
-   * Renames legacy unprefixed tree-store objects to their `brz_` equivalents
-   * on first startup after the prefix change. Gated on a canary check
-   * against the legacy `tree_schema_migrations` table.
+   * Pre-prefix rename. Canary-gated on the legacy `tree_schema_migrations`
+   * table.
    * @param {import('pg').PoolClient} client
    */
   async _applySchemaRenames(client) {
@@ -144,6 +143,13 @@ class TreeStoreMigrationManager {
         "brz_tree_leaves",
         "tree_leaves_user_id_reservation_id_fkey",
         "brz_tree_leaves_user_id_reservation_id_fkey",
+      ],
+      // Pre-multi-tenant FK (single-column). Rename so the post-tenant
+      // migration's `DROP CONSTRAINT IF EXISTS brz_*_fkey` finds it.
+      [
+        "brz_tree_leaves",
+        "tree_leaves_reservation_id_fkey",
+        "brz_tree_leaves_reservation_id_fkey",
       ],
       ["brz_tree_spent_leaves", "tree_spent_leaves_pkey", "brz_tree_spent_leaves_pkey"],
       ["brz_tree_swap_status", "tree_swap_status_pkey", "brz_tree_swap_status_pkey"],

--- a/crates/breez-sdk/wasm/src/persist/tests/mysql_foreign_keys.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/mysql_foreign_keys.rs
@@ -85,10 +85,10 @@ async fn test_tree_store_disabled_foreign_key_mode() {
     let count = count_fks(
         &conn_string,
         &[
-            "tree_leaves",
-            "tree_reservations",
-            "tree_spent_leaves",
-            "tree_swap_status",
+            "brz_tree_leaves",
+            "brz_tree_reservations",
+            "brz_tree_spent_leaves",
+            "brz_tree_swap_status",
         ],
     )
     .await;
@@ -106,11 +106,11 @@ async fn test_token_store_disabled_foreign_key_mode() {
     let count = count_fks(
         &conn_string,
         &[
-            "token_metadata",
-            "token_outputs",
-            "token_reservations",
-            "token_spent_outputs",
-            "token_swap_status",
+            "brz_token_metadata",
+            "brz_token_outputs",
+            "brz_token_reservations",
+            "brz_token_spent_outputs",
+            "brz_token_swap_status",
         ],
     )
     .await;
@@ -119,7 +119,7 @@ async fn test_token_store_disabled_foreign_key_mode() {
 
 /// `Enforced` mode runs both initial-FK adds and the multi-tenant rewrites:
 /// the originals are dropped in migration 2 and replaced by the composite
-/// `*_user` variants — final FK count is 1 on tree_leaves, 2 on token_outputs.
+/// `*_user` variants — final FK count is 1 on brz_tree_leaves, 2 on brz_token_outputs.
 #[wasm_bindgen_test]
 async fn test_tree_store_enforced_foreign_key_mode() {
     let conn_string = fresh_test_db("my_tree_fk_enforced").await;
@@ -131,10 +131,10 @@ async fn test_tree_store_enforced_foreign_key_mode() {
     let count = count_fks(
         &conn_string,
         &[
-            "tree_leaves",
-            "tree_reservations",
-            "tree_spent_leaves",
-            "tree_swap_status",
+            "brz_tree_leaves",
+            "brz_tree_reservations",
+            "brz_tree_spent_leaves",
+            "brz_tree_swap_status",
         ],
     )
     .await;
@@ -152,11 +152,11 @@ async fn test_token_store_enforced_foreign_key_mode() {
     let count = count_fks(
         &conn_string,
         &[
-            "token_metadata",
-            "token_outputs",
-            "token_reservations",
-            "token_spent_outputs",
-            "token_swap_status",
+            "brz_token_metadata",
+            "brz_token_outputs",
+            "brz_token_reservations",
+            "brz_token_spent_outputs",
+            "brz_token_swap_status",
         ],
     )
     .await;

--- a/crates/spark-mysql/src/lib.rs
+++ b/crates/spark-mysql/src/lib.rs
@@ -30,7 +30,7 @@ pub use token_store::{
 };
 pub use tree_store::{MysqlTreeStore, create_mysql_tree_store, create_mysql_tree_store_from_pool};
 
-pub use migrations::{Migration, run_migrations};
+pub use migrations::{FkRename, Migration, SchemaRenames, run_migrations};
 pub use pool::{create_pool, map_db_error, tx_opts};
 
 pub use mysql_async;

--- a/crates/spark-mysql/src/migrations.rs
+++ b/crates/spark-mysql/src/migrations.rs
@@ -145,69 +145,48 @@ impl Migration {
     }
 }
 
-/// Rename map for a single foreign key. `MySQL` has no `RENAME CONSTRAINT`
-/// for foreign keys, so [`run_migrations`] drops the old FK and re-adds it
-/// under `new_name` using `definition`. The `table` field is the table's
-/// **new** name (the table is renamed before FK changes are applied).
+/// `MySQL` FK rename. `MySQL` has no `RENAME CONSTRAINT` for foreign keys, so
+/// [`run_migrations`] drops the old FK and re-adds it under `new_name`
+/// using `definition`. `table` is the new (post-rename) table name.
 pub struct FkRename<'a> {
     pub table: &'a str,
     pub old_name: &'a str,
     pub new_name: &'a str,
     /// Body after `ADD CONSTRAINT <new_name>`, e.g.
-    /// `"FOREIGN KEY (user_id, reservation_id) REFERENCES new_parent(user_id, id)"`.
+    /// `"FOREIGN KEY (col) REFERENCES other(col) ON DELETE SET NULL"`.
     pub definition: &'a str,
 }
 
-/// One-shot rename map passed to [`run_migrations`] when upgrading an
-/// existing deployment to a renamed schema. Describes how to transition
-/// every Breez-owned schema object — tables, indexes, foreign keys, plus
-/// the per-store schema migrations tracking table itself — from its old
-/// name to its new name. The original use case is applying a `brz_`
-/// namespace prefix.
+/// One-shot pre-prefix rename map for [`run_migrations`]. Lists every
+/// owned table / index / FK to move, plus the migrations tracker itself.
+/// `old_migrations_table` is the canary — if missing, the rename is
+/// skipped (DB is fresh or already upgraded).
 ///
-/// `old_migrations_table` doubles as the **canary**: the helper probes
-/// `information_schema.tables` for it; if missing, the DB is either fresh or
-/// already upgraded and the call is a near-no-op.
-///
-/// `MySQL` primary keys are always named `PRIMARY` (table-scoped), so unlike
-/// the Postgres counterpart this struct has no separate `pk_constraints`
-/// field — PKs travel with their tables automatically.
+/// `MySQL` PKs are always named `PRIMARY` (table-scoped), so PKs travel
+/// with their tables automatically.
 pub struct SchemaRenames<'a> {
     /// Old name of the per-store schema migrations table; used as the
     /// canary check.
     pub old_migrations_table: &'a str,
-    /// New name of the per-store schema migrations table. Also doubles as
-    /// the named-lock identity, so this helper and `run_migrations`
-    /// serialize on the same `GET_LOCK` key.
+    /// New name of the per-store schema migrations table. Must match the
+    /// `migrations_table` argument to [`run_migrations`].
     pub new_migrations_table: &'a str,
     /// `(old_table, new_table)` pairs.
     pub tables: &'a [(&'a str, &'a str)],
-    /// `(parent_table_new_name, old_index, new_index)` triples. `MySQL`
-    /// indexes are scoped to a table and renamed via
-    /// `ALTER TABLE <table> RENAME INDEX <old> TO <new>`.
+    /// `(parent_table_new_name, old_index, new_index)` triples — `MySQL`
+    /// indexes are renamed via `ALTER TABLE <table> RENAME INDEX <old> TO <new>`.
     pub indexes: &'a [(&'a str, &'a str, &'a str)],
     /// Foreign keys to drop-and-recreate under the new name.
     pub foreign_keys: &'a [FkRename<'a>],
 }
 
-/// Renames every object listed in `renames` from its old name to its new
-/// name. Intended to run once before [`run_migrations`] when upgrading an
-/// existing deployment to a renamed schema (the original use case is
-/// applying a `brz_` namespace prefix).
+/// Applies a one-shot schema rename on the caller's connection. Returns
+/// early if the canary `renames.old_migrations_table` is absent.
 ///
-/// Gated on the canary check against `renames.old_migrations_table`: if
-/// that table doesn't exist, the function returns early. The DB is either
-/// fresh (no objects to rename yet) or already upgraded (the migrations
-/// tracking table has already been renamed to `new_migrations_table`). In
-/// both cases there is nothing to do.
-///
-/// All renames run while holding the same named lock that [`run_migrations`]
-/// uses (derived from `new_migrations_table`), so concurrent SDK instances
-/// starting at the same time serialize cleanly. `MySQL` DDL implicitly
-/// commits, so the migrations tracking table is renamed **last** — a crash
-/// mid-rename leaves the canary pointing at the old name and the next
-/// attempt re-runs (each rename is guarded by an `information_schema` probe,
-/// making the replay idempotent).
+/// `MySQL` DDL auto-commits, so renames aren't transactional — the migrations
+/// tracking table is renamed **last** so a crash mid-sequence leaves the
+/// canary pointing at the old name. Each step is `information_schema`-guarded
+/// so the replay is idempotent.
 async fn apply_renames(
     conn: &mut mysql_async::Conn,
     renames: &SchemaRenames<'_>,
@@ -217,9 +196,8 @@ async fn apply_renames(
         return Ok(());
     }
 
-    // Each step is guarded with an information_schema probe so a crash
-    // mid-sequence can be replayed safely (`MySQL` DDL implicitly commits, so
-    // we cannot rely on transactional rollback).
+    // Each step is information_schema-guarded for replay safety after a
+    // crash mid-sequence (DDL auto-commits in `MySQL`).
     for (old, new) in renames.tables {
         if !table_exists(conn, old).await? || table_exists(conn, new).await? {
             continue;
@@ -302,25 +280,19 @@ async fn table_exists(conn: &mut mysql_async::Conn, table: &str) -> Result<bool,
 ///
 /// This function:
 /// - Acquires a named lock (derived from the migrations table name) to prevent concurrent migrations
-/// - Optionally applies a one-shot schema rename before running migrations
-///   (see [`SchemaRenames`]) — useful when upgrading an existing deployment
-///   whose tables were created under different names
+/// - Optionally applies a one-shot schema rename first (see [`SchemaRenames`])
 /// - Creates the migrations tracking table if it doesn't exist
 /// - Applies only new migrations (based on version number)
 /// - Releases the lock before returning
 ///
-/// The rename block and the version-tracked migrations run under the same
-/// `GET_LOCK`, so the whole schema transition is one critical section on
-/// the session connection.
+/// Rename + migrations share one `GET_LOCK` on the session connection.
 ///
 /// # Arguments
 /// * `pool` - The connection pool to use
 /// * `migrations_table` - Name of the table to track migration versions (e.g., `schema_migrations`)
 /// * `migrations` - List of migrations, where each migration is a list of [`Migration`] steps
-/// * `renames` - Optional one-shot rename map for upgrading from an
-///   unprefixed schema. When `Some`, the runner probes the canary table and,
-///   if present, renames everything before processing version-tracked
-///   migrations. When `None`, no rename is attempted.
+/// * `renames` - When `Some`, applied before migrations; canary-gated so
+///   fresh / already-upgraded DBs pay only one probe.
 #[allow(clippy::arithmetic_side_effects)]
 pub async fn run_migrations(
     pool: &Pool,
@@ -627,7 +599,7 @@ mod tests {
         let container: ContainerAsync<Mysql> = Mysql::default()
             .start()
             .await
-            .expect("Failed to start MySQL container");
+            .expect("Failed to start `MySQL` container");
         let host_port = container
             .get_host_port_ipv4(3306)
             .await
@@ -687,18 +659,16 @@ mod tests {
             .expect("second re-run should be a no-op");
     }
 
-    /// Verifies that an existing deployment with the legacy unprefixed schema
-    /// gets upgraded to `brz_`-prefixed names without data loss when
-    /// `run_migrations` is called with `Some(&renames)`. Exercises the full
-    /// rename surface: tables, indexes, foreign keys (drop+recreate), plus
-    /// the migrations tracking table that doubles as the canary.
+    /// End-to-end rename: tables, indexes, FK (drop+recreate), and
+    /// migrations tracker all move from legacy to `brz_*` with seed data
+    /// preserved.
     #[tokio::test]
     #[allow(clippy::too_many_lines)]
     async fn test_bootstrap_rename_upgrades_legacy_schema() {
         let container: ContainerAsync<Mysql> = Mysql::default()
             .start()
             .await
-            .expect("Failed to start MySQL container");
+            .expect("Failed to start `MySQL` container");
         let host_port = container
             .get_host_port_ipv4(3306)
             .await
@@ -848,5 +818,82 @@ mod tests {
         run_migrations(&pool, "brz_widget_migrations", &[], Some(&renames))
             .await
             .expect("re-run should be idempotent");
+    }
+
+    /// Rename must skip listed objects that don't exist (partial pre-prefix
+    /// schema, e.g. a customer at an older migration version).
+    #[tokio::test]
+    async fn test_bootstrap_rename_tolerates_missing_objects() {
+        let container: ContainerAsync<Mysql> = Mysql::default()
+            .start()
+            .await
+            .expect("Failed to start MySQL container");
+        let host_port = container
+            .get_host_port_ipv4(3306)
+            .await
+            .expect("Failed to get host port");
+        let pool = create_pool(&MysqlStorageConfig::with_defaults(format!(
+            "mysql://root@127.0.0.1:{host_port}/test"
+        )))
+        .expect("Failed to create pool");
+
+        // Pre-populate the canary + a bare table — no index, no FK. The
+        // rename map below lists objects that don't exist.
+        let mut conn = pool.get_conn().await.expect("get_conn");
+        conn.query_drop(
+            "CREATE TABLE widgets (
+                id VARCHAR(64) NOT NULL PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )",
+        )
+        .await
+        .expect("create table");
+        conn.query_drop("INSERT INTO widgets (id, name) VALUES ('w1', 'alpha')")
+            .await
+            .expect("seed row");
+        conn.query_drop(
+            "CREATE TABLE legacy_widget_migrations (
+                version INT PRIMARY KEY,
+                applied_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+            )",
+        )
+        .await
+        .expect("create canary");
+        conn.query_drop("INSERT INTO legacy_widget_migrations (version) VALUES (1)")
+            .await
+            .expect("seed version row");
+        drop(conn);
+
+        let renames = SchemaRenames {
+            old_migrations_table: "legacy_widget_migrations",
+            new_migrations_table: "brz_widget_migrations",
+            tables: &[("widgets", "brz_widgets")],
+            indexes: &[(
+                "brz_widgets",
+                "idx_widgets_missing",
+                "brz_idx_widgets_missing",
+            )],
+            foreign_keys: &[FkRename {
+                table: "brz_widgets",
+                old_name: "fk_widgets_missing",
+                new_name: "brz_fk_widgets_missing",
+                definition: "FOREIGN KEY (id) REFERENCES brz_widgets(id)",
+            }],
+        };
+
+        run_migrations(&pool, "brz_widget_migrations", &[], Some(&renames))
+            .await
+            .expect("rename must skip missing objects without erroring");
+
+        let mut conn = pool.get_conn().await.expect("get_conn");
+        let row: Option<(String, String)> = conn
+            .exec_first("SELECT id, name FROM brz_widgets WHERE id = 'w1'", ())
+            .await
+            .expect("probe brz_widgets");
+        assert_eq!(
+            row,
+            Some(("w1".to_string(), "alpha".to_string())),
+            "table + data preserved despite missing index/FK"
+        );
     }
 }

--- a/crates/spark-mysql/src/migrations.rs
+++ b/crates/spark-mysql/src/migrations.rs
@@ -227,24 +227,14 @@ async fn apply_renames(
         if !foreign_key_exists(conn, fk.table, fk.old_name).await? {
             continue;
         }
-        let drop_sql = format!(
-            "ALTER TABLE `{}` DROP FOREIGN KEY `{}`",
-            fk.table, fk.old_name
+        let alter_sql = format!(
+            "ALTER TABLE `{}` DROP FOREIGN KEY `{}`, ADD CONSTRAINT `{}` {}",
+            fk.table, fk.old_name, fk.new_name, fk.definition
         );
-        conn.query_drop(&drop_sql).await.map_err(|e| {
+        conn.query_drop(&alter_sql).await.map_err(|e| {
             MysqlError::Database(format!(
-                "Failed to drop old FK {} on {}: {e}",
-                fk.old_name, fk.table
-            ))
-        })?;
-        let add_sql = format!(
-            "ALTER TABLE `{}` ADD CONSTRAINT `{}` {}",
-            fk.table, fk.new_name, fk.definition
-        );
-        conn.query_drop(&add_sql).await.map_err(|e| {
-            MysqlError::Database(format!(
-                "Failed to add new FK {} on {}: {e}",
-                fk.new_name, fk.table
+                "Failed to rename FK {} -> {} on {}: {e}",
+                fk.old_name, fk.new_name, fk.table
             ))
         })?;
     }
@@ -805,6 +795,21 @@ mod tests {
             .await
             .expect("probe brz fk");
         assert_eq!(new_fk_count, Some(1), "FK must be renamed");
+
+        // The renamed FK must still functionally enforce referential
+        // integrity — inserting a row whose parent_id has no matching
+        // parent row should fail. Catches the case where the rename
+        // produced a constraint by name but lost its referent (e.g. wrong
+        // column or wrong parent in the combined ALTER).
+        let violation = conn
+            .query_drop(
+                "INSERT INTO brz_widgets (id, parent_id) VALUES ('w_orphan', 'missing_parent')",
+            )
+            .await;
+        assert!(
+            violation.is_err(),
+            "renamed FK must still reject orphan parent_id"
+        );
 
         let version: Option<i32> = conn
             .exec_first("SELECT MAX(version) FROM brz_widget_migrations", ())

--- a/crates/spark-mysql/src/migrations.rs
+++ b/crates/spark-mysql/src/migrations.rs
@@ -145,23 +145,188 @@ impl Migration {
     }
 }
 
+/// Rename map for a single foreign key. `MySQL` has no `RENAME CONSTRAINT`
+/// for foreign keys, so [`run_migrations`] drops the old FK and re-adds it
+/// under `new_name` using `definition`. The `table` field is the table's
+/// **new** name (the table is renamed before FK changes are applied).
+pub struct FkRename<'a> {
+    pub table: &'a str,
+    pub old_name: &'a str,
+    pub new_name: &'a str,
+    /// Body after `ADD CONSTRAINT <new_name>`, e.g.
+    /// `"FOREIGN KEY (user_id, reservation_id) REFERENCES new_parent(user_id, id)"`.
+    pub definition: &'a str,
+}
+
+/// One-shot rename map passed to [`run_migrations`] when upgrading an
+/// existing deployment to a renamed schema. Describes how to transition
+/// every Breez-owned schema object — tables, indexes, foreign keys, plus
+/// the per-store schema migrations tracking table itself — from its old
+/// name to its new name. The original use case is applying a `brz_`
+/// namespace prefix.
+///
+/// `old_migrations_table` doubles as the **canary**: the helper probes
+/// `information_schema.tables` for it; if missing, the DB is either fresh or
+/// already upgraded and the call is a near-no-op.
+///
+/// `MySQL` primary keys are always named `PRIMARY` (table-scoped), so unlike
+/// the Postgres counterpart this struct has no separate `pk_constraints`
+/// field — PKs travel with their tables automatically.
+pub struct SchemaRenames<'a> {
+    /// Old name of the per-store schema migrations table; used as the
+    /// canary check.
+    pub old_migrations_table: &'a str,
+    /// New name of the per-store schema migrations table. Also doubles as
+    /// the named-lock identity, so this helper and `run_migrations`
+    /// serialize on the same `GET_LOCK` key.
+    pub new_migrations_table: &'a str,
+    /// `(old_table, new_table)` pairs.
+    pub tables: &'a [(&'a str, &'a str)],
+    /// `(parent_table_new_name, old_index, new_index)` triples. `MySQL`
+    /// indexes are scoped to a table and renamed via
+    /// `ALTER TABLE <table> RENAME INDEX <old> TO <new>`.
+    pub indexes: &'a [(&'a str, &'a str, &'a str)],
+    /// Foreign keys to drop-and-recreate under the new name.
+    pub foreign_keys: &'a [FkRename<'a>],
+}
+
+/// Renames every object listed in `renames` from its old name to its new
+/// name. Intended to run once before [`run_migrations`] when upgrading an
+/// existing deployment to a renamed schema (the original use case is
+/// applying a `brz_` namespace prefix).
+///
+/// Gated on the canary check against `renames.old_migrations_table`: if
+/// that table doesn't exist, the function returns early. The DB is either
+/// fresh (no objects to rename yet) or already upgraded (the migrations
+/// tracking table has already been renamed to `new_migrations_table`). In
+/// both cases there is nothing to do.
+///
+/// All renames run while holding the same named lock that [`run_migrations`]
+/// uses (derived from `new_migrations_table`), so concurrent SDK instances
+/// starting at the same time serialize cleanly. `MySQL` DDL implicitly
+/// commits, so the migrations tracking table is renamed **last** — a crash
+/// mid-rename leaves the canary pointing at the old name and the next
+/// attempt re-runs (each rename is guarded by an `information_schema` probe,
+/// making the replay idempotent).
+async fn apply_renames(
+    conn: &mut mysql_async::Conn,
+    renames: &SchemaRenames<'_>,
+) -> Result<(), MysqlError> {
+    // Canary: if the old migrations table doesn't exist, nothing to do.
+    if !table_exists(conn, renames.old_migrations_table).await? {
+        return Ok(());
+    }
+
+    // Each step is guarded with an information_schema probe so a crash
+    // mid-sequence can be replayed safely (`MySQL` DDL implicitly commits, so
+    // we cannot rely on transactional rollback).
+    for (old, new) in renames.tables {
+        if !table_exists(conn, old).await? || table_exists(conn, new).await? {
+            continue;
+        }
+        let sql = format!("RENAME TABLE `{old}` TO `{new}`");
+        conn.query_drop(&sql).await.map_err(|e| {
+            MysqlError::Database(format!("Failed to rename table {old} -> {new}: {e}"))
+        })?;
+    }
+
+    for (table, old, new) in renames.indexes {
+        if !index_exists(conn, table, old).await? || index_exists(conn, table, new).await? {
+            continue;
+        }
+        let sql = format!("ALTER TABLE `{table}` RENAME INDEX `{old}` TO `{new}`");
+        conn.query_drop(&sql).await.map_err(|e| {
+            MysqlError::Database(format!(
+                "Failed to rename index {old} -> {new} on {table}: {e}"
+            ))
+        })?;
+    }
+
+    for fk in renames.foreign_keys {
+        if foreign_key_exists(conn, fk.table, fk.new_name).await? {
+            continue;
+        }
+        if !foreign_key_exists(conn, fk.table, fk.old_name).await? {
+            continue;
+        }
+        let drop_sql = format!(
+            "ALTER TABLE `{}` DROP FOREIGN KEY `{}`",
+            fk.table, fk.old_name
+        );
+        conn.query_drop(&drop_sql).await.map_err(|e| {
+            MysqlError::Database(format!(
+                "Failed to drop old FK {} on {}: {e}",
+                fk.old_name, fk.table
+            ))
+        })?;
+        let add_sql = format!(
+            "ALTER TABLE `{}` ADD CONSTRAINT `{}` {}",
+            fk.table, fk.new_name, fk.definition
+        );
+        conn.query_drop(&add_sql).await.map_err(|e| {
+            MysqlError::Database(format!(
+                "Failed to add new FK {} on {}: {e}",
+                fk.new_name, fk.table
+            ))
+        })?;
+    }
+
+    // Rename the migrations tracking table last; it doubles as the canary
+    // that the rename completed.
+    if table_exists(conn, renames.old_migrations_table).await?
+        && !table_exists(conn, renames.new_migrations_table).await?
+    {
+        let sql = format!(
+            "RENAME TABLE `{}` TO `{}`",
+            renames.old_migrations_table, renames.new_migrations_table
+        );
+        conn.query_drop(&sql).await.map_err(map_db_error)?;
+    }
+
+    Ok(())
+}
+
+async fn table_exists(conn: &mut mysql_async::Conn, table: &str) -> Result<bool, MysqlError> {
+    let count: Option<i64> = conn
+        .exec_first(
+            "SELECT COUNT(*) FROM information_schema.tables
+             WHERE table_schema = DATABASE() AND table_name = ?",
+            (table,),
+        )
+        .await
+        .map_err(map_db_error)?;
+    Ok(count.unwrap_or(0) > 0)
+}
+
 /// Runs database migrations with version tracking and concurrency control.
 ///
 /// This function:
 /// - Acquires a named lock (derived from the migrations table name) to prevent concurrent migrations
-/// - Creates a migrations tracking table if it doesn't exist
+/// - Optionally applies a one-shot schema rename before running migrations
+///   (see [`SchemaRenames`]) — useful when upgrading an existing deployment
+///   whose tables were created under different names
+/// - Creates the migrations tracking table if it doesn't exist
 /// - Applies only new migrations (based on version number)
 /// - Releases the lock before returning
+///
+/// The rename block and the version-tracked migrations run under the same
+/// `GET_LOCK`, so the whole schema transition is one critical section on
+/// the session connection.
 ///
 /// # Arguments
 /// * `pool` - The connection pool to use
 /// * `migrations_table` - Name of the table to track migration versions (e.g., `schema_migrations`)
 /// * `migrations` - List of migrations, where each migration is a list of [`Migration`] steps
+/// * `renames` - Optional one-shot rename map for upgrading from an
+///   unprefixed schema. When `Some`, the runner probes the canary table and,
+///   if present, renames everything before processing version-tracked
+///   migrations. When `None`, no rename is attempted.
 #[allow(clippy::arithmetic_side_effects)]
 pub async fn run_migrations(
     pool: &Pool,
     migrations_table: &str,
     migrations: &[Vec<Migration>],
+    renames: Option<&SchemaRenames<'_>>,
 ) -> Result<(), MysqlError> {
     let mut conn = pool
         .get_conn()
@@ -171,8 +336,8 @@ pub async fn run_migrations(
     let lock_name = format!("migration_lock_{migrations_table}");
 
     // Acquire GET_LOCK on the session connection. Returns 1 if granted, 0 on
-    // timeout, NULL on error. We hold this for the full migration sequence and
-    // release it explicitly below.
+    // timeout, NULL on error. We hold this for the full migration sequence
+    // (including the optional schema rename) and release it explicitly below.
     let acquired: Option<i64> = conn
         .exec_first(
             "SELECT GET_LOCK(?, ?)",
@@ -188,7 +353,7 @@ pub async fn run_migrations(
         )));
     }
 
-    let result = run_migrations_inner(&mut conn, migrations_table, migrations).await;
+    let result = run_migrations_inner(&mut conn, migrations_table, migrations, renames).await;
 
     // Always release the lock, even on failure. Ignore release errors so we
     // don't mask the underlying migration error.
@@ -202,10 +367,15 @@ async fn run_migrations_inner(
     conn: &mut mysql_async::Conn,
     migrations_table: &str,
     migrations: &[Vec<Migration>],
+    renames: Option<&SchemaRenames<'_>>,
 ) -> Result<(), MysqlError> {
+    if let Some(renames) = renames {
+        apply_renames(conn, renames).await?;
+    }
+
     // Begin transaction. Migration table creation lives inside the transaction
     // for parity with the postgres impl, but note that DDL implicitly commits
-    // in MySQL — this transaction only protects DML statements between DDL
+    // in `MySQL` — this transaction only protects DML statements between DDL
     // boundaries. Idempotency is ensured by the structured `Migration`
     // variants, not by transactional rollback.
     conn.query_drop("START TRANSACTION")
@@ -507,13 +677,176 @@ mod tests {
             ],
         ];
 
-        run_migrations(&pool, "test_schema_migrations", &migrations)
+        run_migrations(&pool, "test_schema_migrations", &migrations, None)
             .await
             .expect("re-run should be idempotent");
 
         // And re-running again must also succeed (no version-row regression).
-        run_migrations(&pool, "test_schema_migrations", &migrations)
+        run_migrations(&pool, "test_schema_migrations", &migrations, None)
             .await
             .expect("second re-run should be a no-op");
+    }
+
+    /// Verifies that an existing deployment with the legacy unprefixed schema
+    /// gets upgraded to `brz_`-prefixed names without data loss when
+    /// `run_migrations` is called with `Some(&renames)`. Exercises the full
+    /// rename surface: tables, indexes, foreign keys (drop+recreate), plus
+    /// the migrations tracking table that doubles as the canary.
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    async fn test_bootstrap_rename_upgrades_legacy_schema() {
+        let container: ContainerAsync<Mysql> = Mysql::default()
+            .start()
+            .await
+            .expect("Failed to start MySQL container");
+        let host_port = container
+            .get_host_port_ipv4(3306)
+            .await
+            .expect("Failed to get host port");
+        let pool = create_pool(&MysqlStorageConfig::with_defaults(format!(
+            "mysql://root@127.0.0.1:{host_port}/test"
+        )))
+        .expect("Failed to create pool");
+
+        // Pre-populate as a pre-prefix deployment would: legacy parent +
+        // child with an explicit FK, an index on the child, and a
+        // migrations tracker carrying a version row. Seed a data row that
+        // must survive the rename.
+        let mut conn = pool.get_conn().await.expect("get_conn");
+        conn.query_drop(
+            "CREATE TABLE widget_parents (
+                id VARCHAR(64) NOT NULL PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )",
+        )
+        .await
+        .expect("create parent");
+        conn.query_drop(
+            "CREATE TABLE widgets (
+                id VARCHAR(64) NOT NULL PRIMARY KEY,
+                parent_id VARCHAR(64) NOT NULL,
+                CONSTRAINT fk_widgets_parent FOREIGN KEY (parent_id)
+                    REFERENCES widget_parents(id)
+            )",
+        )
+        .await
+        .expect("create child");
+        conn.query_drop("CREATE INDEX idx_widgets_parent ON widgets(parent_id)")
+            .await
+            .expect("create index");
+        conn.query_drop("INSERT INTO widget_parents (id, name) VALUES ('p1', 'alpha')")
+            .await
+            .expect("seed parent");
+        conn.query_drop("INSERT INTO widgets (id, parent_id) VALUES ('w1', 'p1')")
+            .await
+            .expect("seed child");
+        conn.query_drop(
+            "CREATE TABLE legacy_widget_migrations (
+                version INT PRIMARY KEY,
+                applied_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+            )",
+        )
+        .await
+        .expect("create legacy migrations");
+        conn.query_drop("INSERT INTO legacy_widget_migrations (version) VALUES (1)")
+            .await
+            .expect("seed version row");
+        drop(conn);
+
+        let renames = SchemaRenames {
+            old_migrations_table: "legacy_widget_migrations",
+            new_migrations_table: "brz_widget_migrations",
+            tables: &[
+                ("widget_parents", "brz_widget_parents"),
+                ("widgets", "brz_widgets"),
+            ],
+            indexes: &[(
+                "brz_widgets",
+                "idx_widgets_parent",
+                "brz_idx_widgets_parent",
+            )],
+            foreign_keys: &[FkRename {
+                table: "brz_widgets",
+                old_name: "fk_widgets_parent",
+                new_name: "brz_fk_widgets_parent",
+                definition: "FOREIGN KEY (parent_id) REFERENCES `brz_widget_parents`(id)",
+            }],
+        };
+
+        // run_migrations with an empty migration list — we're only exercising
+        // the rename block.
+        run_migrations(&pool, "brz_widget_migrations", &[], Some(&renames))
+            .await
+            .expect("rename should succeed");
+
+        let mut conn = pool.get_conn().await.expect("get_conn");
+
+        let new_table_count: Option<i64> = conn
+            .exec_first(
+                "SELECT COUNT(*) FROM information_schema.tables
+                 WHERE table_schema = DATABASE() AND table_name = 'brz_widgets'",
+                (),
+            )
+            .await
+            .expect("probe brz_widgets");
+        assert_eq!(new_table_count, Some(1), "brz_widgets must exist");
+
+        let old_table_count: Option<i64> = conn
+            .exec_first(
+                "SELECT COUNT(*) FROM information_schema.tables
+                 WHERE table_schema = DATABASE() AND table_name = 'widgets'",
+                (),
+            )
+            .await
+            .expect("probe widgets");
+        assert_eq!(old_table_count, Some(0), "legacy widgets must be gone");
+
+        let row: Option<(String, String)> = conn
+            .exec_first("SELECT id, parent_id FROM brz_widgets WHERE id = 'w1'", ())
+            .await
+            .expect("seed row preserved");
+        assert_eq!(
+            row,
+            Some(("w1".to_string(), "p1".to_string())),
+            "seed data must survive the rename"
+        );
+
+        let new_index_count: Option<i64> = conn
+            .exec_first(
+                "SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'brz_widgets'
+                   AND index_name = 'brz_idx_widgets_parent'",
+                (),
+            )
+            .await
+            .expect("probe brz index");
+        assert_eq!(new_index_count, Some(1), "index must be renamed");
+
+        let new_fk_count: Option<i64> = conn
+            .exec_first(
+                "SELECT COUNT(*) FROM information_schema.table_constraints
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'brz_widgets'
+                   AND constraint_type = 'FOREIGN KEY'
+                   AND constraint_name = 'brz_fk_widgets_parent'",
+                (),
+            )
+            .await
+            .expect("probe brz fk");
+        assert_eq!(new_fk_count, Some(1), "FK must be renamed");
+
+        let version: Option<i32> = conn
+            .exec_first("SELECT MAX(version) FROM brz_widget_migrations", ())
+            .await
+            .expect("probe canary table");
+        assert_eq!(version, Some(1), "version row must survive");
+
+        drop(conn);
+
+        // Re-running must be a no-op (canary is gone now, returns early).
+        run_migrations(&pool, "brz_widget_migrations", &[], Some(&renames))
+            .await
+            .expect("re-run should be idempotent");
     }
 }

--- a/crates/spark-mysql/src/session_manager.rs
+++ b/crates/spark-mysql/src/session_manager.rs
@@ -13,10 +13,23 @@ use spark_wallet::{Session, SessionManager, SessionManagerError};
 
 use crate::config::MysqlStorageConfig;
 use crate::error::MysqlError;
-use crate::migrations::{Migration, run_migrations};
+use crate::migrations::{Migration, SchemaRenames, run_migrations};
 use crate::pool::create_pool;
 
-const SESSION_MIGRATIONS_TABLE: &str = "session_schema_migrations";
+const SESSION_MIGRATIONS_TABLE: &str = "brz_session_schema_migrations";
+
+/// Old-to-`brz_*` rename map for the session manager schema. Applied on
+/// first startup after upgrading to the prefixed schema. The sessions table
+/// only has a `PRIMARY` constraint (`MySQL` primary keys are always named
+/// `PRIMARY`, table-scoped) and no indexes / FKs, so the rename is just the
+/// table itself plus the migrations tracking table.
+const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
+    old_migrations_table: "session_schema_migrations",
+    new_migrations_table: SESSION_MIGRATIONS_TABLE,
+    tables: &[("sessions", "brz_sessions")],
+    indexes: &[],
+    foreign_keys: &[],
+};
 
 /// `MySQL`-backed session manager.
 ///
@@ -39,7 +52,7 @@ impl SessionManager for MysqlSessionManager {
         let service_key = service_identity_key.serialize().to_vec();
         let row: Option<Row> = conn
             .exec_first(
-                "SELECT token, expiration FROM sessions \
+                "SELECT token, expiration FROM brz_sessions \
                  WHERE user_id = ? AND service_identity_key = ?",
                 (self.identity.clone(), service_key),
             )
@@ -69,7 +82,7 @@ impl SessionManager for MysqlSessionManager {
         let expiration = i64::try_from(session.expiration)
             .map_err(|e| SessionManagerError::Generic(format!("expiration overflow: {e}")))?;
         conn.exec_drop(
-            "INSERT INTO sessions (user_id, service_identity_key, token, expiration) \
+            "INSERT INTO brz_sessions (user_id, service_identity_key, token, expiration) \
              VALUES (?, ?, ?, ?) \
              ON DUPLICATE KEY UPDATE token = VALUES(token), expiration = VALUES(expiration)",
             (
@@ -117,12 +130,18 @@ impl MysqlSessionManager {
     }
 
     async fn migrate(&self) -> Result<(), MysqlError> {
-        run_migrations(&self.pool, SESSION_MIGRATIONS_TABLE, &Self::migrations()).await
+        run_migrations(
+            &self.pool,
+            SESSION_MIGRATIONS_TABLE,
+            &Self::migrations(),
+            Some(&SCHEMA_RENAMES),
+        )
+        .await
     }
 
     fn migrations() -> Vec<Vec<Migration>> {
         vec![vec![Migration::sql(
-            "CREATE TABLE IF NOT EXISTS sessions (
+            "CREATE TABLE IF NOT EXISTS brz_sessions (
                 user_id VARBINARY(33) NOT NULL,
                 service_identity_key VARBINARY(33) NOT NULL,
                 token TEXT NOT NULL,

--- a/crates/spark-mysql/src/session_manager.rs
+++ b/crates/spark-mysql/src/session_manager.rs
@@ -18,11 +18,9 @@ use crate::pool::create_pool;
 
 const SESSION_MIGRATIONS_TABLE: &str = "brz_session_schema_migrations";
 
-/// Old-to-`brz_*` rename map for the session manager schema. Applied on
-/// first startup after upgrading to the prefixed schema. The sessions table
-/// only has a `PRIMARY` constraint (`MySQL` primary keys are always named
-/// `PRIMARY`, table-scoped) and no indexes / FKs, so the rename is just the
-/// table itself plus the migrations tracking table.
+/// Pre-prefix rename map for upgrading session-manager deployments.
+/// `MySQL` PKs are always named `PRIMARY` (table-scoped), so only the table
+/// and migrations tracker need renaming.
 const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
     old_migrations_table: "session_schema_migrations",
     new_migrations_table: SESSION_MIGRATIONS_TABLE,

--- a/crates/spark-mysql/src/token_store.rs
+++ b/crates/spark-mysql/src/token_store.rs
@@ -23,10 +23,59 @@ use uuid::Uuid;
 use crate::advisory_lock::identity_lock_name;
 use crate::config::{MysqlForeignKeyMode, MysqlStorageConfig};
 use crate::error::MysqlError;
-use crate::migrations::{Migration, run_migrations};
+use crate::migrations::{FkRename, Migration, SchemaRenames, run_migrations};
 use crate::pool::{create_pool, tx_opts};
 
-const TOKEN_MIGRATIONS_TABLE: &str = "token_schema_migrations";
+const TOKEN_MIGRATIONS_TABLE: &str = "brz_token_schema_migrations";
+
+/// Old-to-`brz_*` rename map for the token store schema. Applied on first
+/// startup after upgrading to the prefixed schema. The indexes and FKs listed
+/// are the ones present after the multi-tenant migration. Composite FKs are
+/// dropped and re-added (`MySQL` has no `RENAME CONSTRAINT` for FKs).
+const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
+    old_migrations_table: "token_schema_migrations",
+    new_migrations_table: TOKEN_MIGRATIONS_TABLE,
+    tables: &[
+        ("token_metadata", "brz_token_metadata"),
+        ("token_reservations", "brz_token_reservations"),
+        ("token_outputs", "brz_token_outputs"),
+        ("token_spent_outputs", "brz_token_spent_outputs"),
+        ("token_swap_status", "brz_token_swap_status"),
+    ],
+    indexes: &[
+        (
+            "brz_token_metadata",
+            "idx_token_metadata_user_issuer_pk",
+            "brz_idx_token_metadata_user_issuer_pk",
+        ),
+        (
+            "brz_token_outputs",
+            "idx_token_outputs_user_identifier",
+            "brz_idx_token_outputs_user_identifier",
+        ),
+        (
+            "brz_token_outputs",
+            "idx_token_outputs_user_reservation",
+            "brz_idx_token_outputs_user_reservation",
+        ),
+    ],
+    foreign_keys: &[
+        FkRename {
+            table: "brz_token_outputs",
+            old_name: "fk_token_outputs_metadata_user",
+            new_name: "brz_fk_token_outputs_metadata_user",
+            definition: "FOREIGN KEY (user_id, token_identifier) \
+                         REFERENCES brz_token_metadata(user_id, identifier)",
+        },
+        FkRename {
+            table: "brz_token_outputs",
+            old_name: "fk_token_outputs_reservation_user",
+            new_name: "brz_fk_token_outputs_reservation_user",
+            definition: "FOREIGN KEY (user_id, reservation_id) \
+                         REFERENCES brz_token_reservations(user_id, id)",
+        },
+    ],
+};
 
 /// Domain prefix mixed into the per-tenant `GET_LOCK` name so the token store's
 /// locks never collide with the tree store's, even when two tenants share a
@@ -53,7 +102,7 @@ pub struct MysqlTokenStore {
 
 /// Builds the multi-tenant scoping migration for the token store. Adds
 /// `user_id VARBINARY(33)` to every per-user table (including
-/// `token_metadata` — metadata is per-tenant to avoid 0-balance leakage for
+/// `brz_token_metadata` — metadata is per-tenant to avoid 0-balance leakage for
 /// tokens a tenant never owned), backfills with the connecting tenant, and
 /// rewrites primary keys / optional FKs to lead with `user_id`.
 #[allow(clippy::too_many_lines)]
@@ -69,148 +118,148 @@ fn token_store_multi_tenant_migration(
     // Drop the existing FKs FIRST so we can rewrite the parent PKs they
     // reference. Both FKs were defined with explicit `CONSTRAINT` clauses.
     stmts.push(Migration::DropForeignKey {
-        name: "fk_token_outputs_metadata",
-        table: "token_outputs",
+        name: "brz_fk_token_outputs_metadata",
+        table: "brz_token_outputs",
     });
     stmts.push(Migration::DropForeignKey {
-        name: "fk_token_outputs_reservation",
-        table: "token_outputs",
+        name: "brz_fk_token_outputs_reservation",
+        table: "brz_token_outputs",
     });
 
-    // token_metadata: scope per-tenant. Required even though metadata never
+    // brz_token_metadata: scope per-tenant. Required even though metadata never
     // structurally collides — leaking a token's mere existence (e.g. a
     // 0-balance entry for a token a tenant never held) would be a privacy
     // regression.
     stmts.push(Migration::AddColumn {
-        table: "token_metadata",
+        table: "brz_token_metadata",
         column: "user_id",
         definition: "VARBINARY(33) NULL",
     });
     stmts.push(Migration::Sql(format!(
-        "UPDATE token_metadata SET user_id = {id_lit} WHERE user_id IS NULL"
+        "UPDATE brz_token_metadata SET user_id = {id_lit} WHERE user_id IS NULL"
     )));
     stmts.push(Migration::sql(
-        "ALTER TABLE token_metadata MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+        "ALTER TABLE brz_token_metadata MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
     ));
     stmts.push(Migration::sql(
-        "ALTER TABLE token_metadata DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, identifier)",
+        "ALTER TABLE brz_token_metadata DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, identifier)",
     ));
     stmts.push(Migration::DropIndex {
-        name: "idx_token_metadata_issuer_pk",
-        table: "token_metadata",
+        name: "brz_idx_token_metadata_issuer_pk",
+        table: "brz_token_metadata",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_token_metadata_user_issuer_pk",
-        table: "token_metadata",
+        name: "brz_idx_token_metadata_user_issuer_pk",
+        table: "brz_token_metadata",
         columns: "(user_id, issuer_public_key)",
     });
 
-    // token_reservations: scope by user_id.
+    // brz_token_reservations: scope by user_id.
     stmts.push(Migration::AddColumn {
-        table: "token_reservations",
+        table: "brz_token_reservations",
         column: "user_id",
         definition: "VARBINARY(33) NULL",
     });
     stmts.push(Migration::Sql(format!(
-        "UPDATE token_reservations SET user_id = {id_lit} WHERE user_id IS NULL"
+        "UPDATE brz_token_reservations SET user_id = {id_lit} WHERE user_id IS NULL"
     )));
     stmts.push(Migration::sql(
-        "ALTER TABLE token_reservations MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+        "ALTER TABLE brz_token_reservations MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
     ));
     stmts.push(Migration::sql(
-        "ALTER TABLE token_reservations DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)",
+        "ALTER TABLE brz_token_reservations DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)",
     ));
 
-    // token_outputs: scope by user_id, rekey, re-add composite FKs when
+    // brz_token_outputs: scope by user_id, rekey, re-add composite FKs when
     // foreign keys are enabled.
     stmts.push(Migration::AddColumn {
-        table: "token_outputs",
+        table: "brz_token_outputs",
         column: "user_id",
         definition: "VARBINARY(33) NULL",
     });
     stmts.push(Migration::Sql(format!(
-        "UPDATE token_outputs SET user_id = {id_lit} WHERE user_id IS NULL"
+        "UPDATE brz_token_outputs SET user_id = {id_lit} WHERE user_id IS NULL"
     )));
     stmts.push(Migration::sql(
-        "ALTER TABLE token_outputs MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+        "ALTER TABLE brz_token_outputs MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
     ));
     stmts.push(Migration::sql(
-        "ALTER TABLE token_outputs DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)",
+        "ALTER TABLE brz_token_outputs DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)",
     ));
     // Re-add the FKs as composite, scoped by user_id. The reservation FK uses
     // NO ACTION (the default) instead of the previous `ON DELETE SET NULL`:
     // a whole-row SET NULL would null `user_id` (NOT NULL).
     if foreign_key_mode.creates_constraints() {
         stmts.push(Migration::AddForeignKey {
-            name: "fk_token_outputs_metadata_user",
-            table: "token_outputs",
+            name: "brz_fk_token_outputs_metadata_user",
+            table: "brz_token_outputs",
             definition: "FOREIGN KEY (user_id, token_identifier) \
-                         REFERENCES token_metadata(user_id, identifier)",
+                         REFERENCES brz_token_metadata(user_id, identifier)",
         });
         stmts.push(Migration::AddForeignKey {
-            name: "fk_token_outputs_reservation_user",
-            table: "token_outputs",
+            name: "brz_fk_token_outputs_reservation_user",
+            table: "brz_token_outputs",
             definition: "FOREIGN KEY (user_id, reservation_id) \
-                         REFERENCES token_reservations(user_id, id)",
+                         REFERENCES brz_token_reservations(user_id, id)",
         });
     }
     stmts.push(Migration::DropIndex {
-        name: "idx_token_outputs_identifier",
-        table: "token_outputs",
+        name: "brz_idx_token_outputs_identifier",
+        table: "brz_token_outputs",
     });
     stmts.push(Migration::DropIndex {
-        name: "idx_token_outputs_reservation",
-        table: "token_outputs",
+        name: "brz_idx_token_outputs_reservation",
+        table: "brz_token_outputs",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_token_outputs_user_identifier",
-        table: "token_outputs",
+        name: "brz_idx_token_outputs_user_identifier",
+        table: "brz_token_outputs",
         columns: "(user_id, token_identifier)",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_token_outputs_user_reservation",
-        table: "token_outputs",
+        name: "brz_idx_token_outputs_user_reservation",
+        table: "brz_token_outputs",
         columns: "(user_id, reservation_id)",
     });
 
-    // token_spent_outputs: scope by user_id.
+    // brz_token_spent_outputs: scope by user_id.
     stmts.push(Migration::AddColumn {
-        table: "token_spent_outputs",
+        table: "brz_token_spent_outputs",
         column: "user_id",
         definition: "VARBINARY(33) NULL",
     });
     stmts.push(Migration::Sql(format!(
-        "UPDATE token_spent_outputs SET user_id = {id_lit} WHERE user_id IS NULL"
+        "UPDATE brz_token_spent_outputs SET user_id = {id_lit} WHERE user_id IS NULL"
     )));
     stmts.push(Migration::sql(
-        "ALTER TABLE token_spent_outputs MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+        "ALTER TABLE brz_token_spent_outputs MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
     ));
     stmts.push(Migration::sql(
-        "ALTER TABLE token_spent_outputs DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, output_id)",
+        "ALTER TABLE brz_token_spent_outputs DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, output_id)",
     ));
 
-    // token_swap_status was a singleton (PK id=1, CHECK id=1). Drop the PK
+    // brz_token_swap_status was a singleton (PK id=1, CHECK id=1). Drop the PK
     // and the id column, then re-key by user_id.
     stmts.push(Migration::DropPrimaryKey {
-        table: "token_swap_status",
+        table: "brz_token_swap_status",
     });
     stmts.push(Migration::DropColumn {
-        table: "token_swap_status",
+        table: "brz_token_swap_status",
         column: "id",
     });
     stmts.push(Migration::AddColumn {
-        table: "token_swap_status",
+        table: "brz_token_swap_status",
         column: "user_id",
         definition: "VARBINARY(33) NULL",
     });
     stmts.push(Migration::Sql(format!(
-        "UPDATE token_swap_status SET user_id = {id_lit} WHERE user_id IS NULL"
+        "UPDATE brz_token_swap_status SET user_id = {id_lit} WHERE user_id IS NULL"
     )));
     stmts.push(Migration::sql(
-        "ALTER TABLE token_swap_status MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+        "ALTER TABLE brz_token_swap_status MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
     ));
     stmts.push(Migration::sql(
-        "ALTER TABLE token_swap_status ADD PRIMARY KEY (user_id)",
+        "ALTER TABLE brz_token_swap_status ADD PRIMARY KEY (user_id)",
     ));
 
     stmts
@@ -255,10 +304,10 @@ impl TokenOutputStore for MysqlTokenStore {
                               ELSE 0
                             END
                          ), 0) AS CHAR) AS balance
-                  FROM token_metadata m
-                  JOIN token_outputs o
+                  FROM brz_token_metadata m
+                  JOIN brz_token_outputs o
                     ON o.token_identifier = m.identifier AND o.user_id = m.user_id
-                  LEFT JOIN token_reservations r
+                  LEFT JOIN brz_token_reservations r
                     ON o.reservation_id = r.id AND o.user_id = r.user_id
                   WHERE m.user_id = ?
                   GROUP BY m.identifier, m.issuer_public_key, m.name, m.ticker,
@@ -291,10 +340,10 @@ impl TokenOutputStore for MysqlTokenStore {
                          o.token_public_key, o.token_amount,
                          o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                          r.purpose
-                  FROM token_metadata m
-                  LEFT JOIN token_outputs o
+                  FROM brz_token_metadata m
+                  LEFT JOIN brz_token_outputs o
                     ON o.token_identifier = m.identifier AND o.user_id = m.user_id
-                  LEFT JOIN token_reservations r
+                  LEFT JOIN brz_token_reservations r
                     ON o.reservation_id = r.id AND o.user_id = r.user_id
                   WHERE m.user_id = ?
                   ORDER BY m.identifier, CAST(o.token_amount AS DECIMAL(65,0)) ASC",
@@ -365,10 +414,10 @@ impl TokenOutputStore for MysqlTokenStore {
                      o.token_public_key, o.token_amount,
                      o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                      r.purpose
-              FROM token_metadata m
-              LEFT JOIN token_outputs o
+              FROM brz_token_metadata m
+              LEFT JOIN brz_token_outputs o
                 ON o.token_identifier = m.identifier AND o.user_id = m.user_id
-              LEFT JOIN token_reservations r
+              LEFT JOIN brz_token_reservations r
                 ON o.reservation_id = r.id AND o.user_id = r.user_id
               WHERE m.user_id = ? AND {where_clause}
               ORDER BY CAST(o.token_amount AS DECIMAL(65,0)) ASC"
@@ -432,7 +481,7 @@ impl TokenOutputStore for MysqlTokenStore {
         if !output_ids.is_empty() {
             let placeholders = build_placeholders(output_ids.len());
             let sql = format!(
-                "DELETE FROM token_spent_outputs WHERE user_id = ? AND output_id IN ({placeholders})"
+                "DELETE FROM brz_token_spent_outputs WHERE user_id = ? AND output_id IN ({placeholders})"
             );
             let mut params: Vec<Value> = Vec::with_capacity(output_ids.len().saturating_add(1));
             params.push(Value::from(self.identity.clone()));
@@ -513,7 +562,7 @@ impl TokenOutputStore for MysqlTokenStore {
         &self,
         id: &TokenOutputsReservationId,
     ) -> Result<(), TokenOutputServiceError> {
-        // Serialize against `set_tokens_outputs` so its `token_spent_outputs`
+        // Serialize against `set_tokens_outputs` so its `brz_token_spent_outputs`
         // snapshot and the upsert that consumes it cannot interleave with this
         // transaction's spent-marker write.
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
@@ -576,6 +625,7 @@ impl MysqlTokenStore {
             &self.pool,
             TOKEN_MIGRATIONS_TABLE,
             &Self::migrations(&self.identity, self.foreign_key_mode),
+            Some(&SCHEMA_RENAMES),
         )
         .await
     }
@@ -583,7 +633,7 @@ impl MysqlTokenStore {
     fn migrations(identity: &[u8], foreign_key_mode: MysqlForeignKeyMode) -> Vec<Vec<Migration>> {
         let mut initial = vec![
             Migration::sql(
-                "CREATE TABLE IF NOT EXISTS token_metadata (
+                "CREATE TABLE IF NOT EXISTS brz_token_metadata (
                     identifier VARCHAR(255) NOT NULL PRIMARY KEY,
                     issuer_public_key VARCHAR(255) NOT NULL,
                     name VARCHAR(255) NOT NULL,
@@ -595,19 +645,19 @@ impl MysqlTokenStore {
                 )",
             ),
             Migration::CreateIndex {
-                name: "idx_token_metadata_issuer_pk",
-                table: "token_metadata",
+                name: "brz_idx_token_metadata_issuer_pk",
+                table: "brz_token_metadata",
                 columns: "(issuer_public_key)",
             },
             Migration::sql(
-                "CREATE TABLE IF NOT EXISTS token_reservations (
+                "CREATE TABLE IF NOT EXISTS brz_token_reservations (
                     id VARCHAR(255) NOT NULL PRIMARY KEY,
                     purpose VARCHAR(64) NOT NULL,
                     created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
                 )",
             ),
             Migration::sql(
-                "CREATE TABLE IF NOT EXISTS token_outputs (
+                "CREATE TABLE IF NOT EXISTS brz_token_outputs (
                     id VARCHAR(255) NOT NULL PRIMARY KEY,
                     token_identifier VARCHAR(255) NOT NULL,
                     owner_public_key VARCHAR(255) NOT NULL,
@@ -623,45 +673,45 @@ impl MysqlTokenStore {
                 )",
             ),
             Migration::CreateIndex {
-                name: "idx_token_outputs_identifier",
-                table: "token_outputs",
+                name: "brz_idx_token_outputs_identifier",
+                table: "brz_token_outputs",
                 columns: "(token_identifier)",
             },
             Migration::CreateIndex {
-                name: "idx_token_outputs_reservation",
-                table: "token_outputs",
+                name: "brz_idx_token_outputs_reservation",
+                table: "brz_token_outputs",
                 columns: "(reservation_id)",
             },
             Migration::sql(
-                "CREATE TABLE IF NOT EXISTS token_spent_outputs (
+                "CREATE TABLE IF NOT EXISTS brz_token_spent_outputs (
                     output_id VARCHAR(255) NOT NULL PRIMARY KEY,
                     spent_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
                 )",
             ),
             Migration::sql(
-                "CREATE TABLE IF NOT EXISTS token_swap_status (
+                "CREATE TABLE IF NOT EXISTS brz_token_swap_status (
                     id INT NOT NULL PRIMARY KEY DEFAULT 1,
                     last_completed_at DATETIME(6) NULL,
                     CHECK (id = 1)
                 )",
             ),
             Migration::sql(
-                "INSERT INTO token_swap_status (id) VALUES (1)
+                "INSERT INTO brz_token_swap_status (id) VALUES (1)
                  ON DUPLICATE KEY UPDATE id = id",
             ),
         ];
         if foreign_key_mode.creates_constraints() {
             initial.push(Migration::AddForeignKey {
-                name: "fk_token_outputs_metadata",
-                table: "token_outputs",
+                name: "brz_fk_token_outputs_metadata",
+                table: "brz_token_outputs",
                 definition: "FOREIGN KEY (token_identifier) \
-                             REFERENCES token_metadata(identifier)",
+                             REFERENCES brz_token_metadata(identifier)",
             });
             initial.push(Migration::AddForeignKey {
-                name: "fk_token_outputs_reservation",
-                table: "token_outputs",
+                name: "brz_fk_token_outputs_reservation",
+                table: "brz_token_outputs",
                 definition: "FOREIGN KEY (reservation_id) \
-                             REFERENCES token_reservations(id) ON DELETE SET NULL",
+                             REFERENCES brz_token_reservations(id) ON DELETE SET NULL",
             });
         }
         vec![
@@ -707,9 +757,9 @@ impl MysqlTokenStore {
         let row: Option<(i64, i64)> = tx
             .exec_first(
                 r"SELECT
-                    (SELECT EXISTS(SELECT 1 FROM token_reservations WHERE user_id = ? AND purpose = 'Swap')) AS has_active_swap,
+                    (SELECT EXISTS(SELECT 1 FROM brz_token_reservations WHERE user_id = ? AND purpose = 'Swap')) AS has_active_swap,
                     COALESCE(
-                        (SELECT (last_completed_at >= ?) FROM token_swap_status WHERE user_id = ?),
+                        (SELECT (last_completed_at >= ?) FROM brz_token_swap_status WHERE user_id = ?),
                         0
                     ) AS swap_completed_during_refresh",
                 (
@@ -738,7 +788,7 @@ impl MysqlTokenStore {
 
         let spent_rows: Vec<String> = tx
             .exec(
-                "SELECT output_id FROM token_spent_outputs WHERE user_id = ? AND spent_at >= ?",
+                "SELECT output_id FROM brz_token_spent_outputs WHERE user_id = ? AND spent_at >= ?",
                 (self.identity.clone(), refresh_timestamp.naive_utc()),
             )
             .await
@@ -746,7 +796,7 @@ impl MysqlTokenStore {
         let spent_ids: HashSet<String> = spent_rows.into_iter().collect();
 
         tx.exec_drop(
-            "DELETE FROM token_outputs WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
+            "DELETE FROM brz_token_outputs WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
             (self.identity.clone(), refresh_timestamp.naive_utc()),
         )
         .await
@@ -760,8 +810,8 @@ impl MysqlTokenStore {
         let reserved_pairs: Vec<(String, String)> = tx
             .exec(
                 r"SELECT r.id, o.id
-                  FROM token_reservations r
-                  JOIN token_outputs o
+                  FROM brz_token_reservations r
+                  JOIN brz_token_outputs o
                     ON o.reservation_id = r.id AND o.user_id = r.user_id
                   WHERE r.user_id = ?",
                 (self.identity.clone(),),
@@ -798,7 +848,7 @@ impl MysqlTokenStore {
         if !reservations_to_delete.is_empty() {
             let placeholders = build_placeholders(reservations_to_delete.len());
             let outputs_sql = format!(
-                "DELETE FROM token_outputs WHERE user_id = ? AND reservation_id IN ({placeholders})"
+                "DELETE FROM brz_token_outputs WHERE user_id = ? AND reservation_id IN ({placeholders})"
             );
             let mut outputs_params: Vec<Value> =
                 Vec::with_capacity(reservations_to_delete.len().saturating_add(1));
@@ -809,7 +859,7 @@ impl MysqlTokenStore {
                 .map_err(map_err)?;
 
             let res_sql = format!(
-                "DELETE FROM token_reservations WHERE user_id = ? AND id IN ({placeholders})"
+                "DELETE FROM brz_token_reservations WHERE user_id = ? AND id IN ({placeholders})"
             );
             let mut res_params: Vec<Value> =
                 Vec::with_capacity(reservations_to_delete.len().saturating_add(1));
@@ -822,8 +872,9 @@ impl MysqlTokenStore {
 
         if !outputs_to_remove_from_reservation.is_empty() {
             let placeholders = build_placeholders(outputs_to_remove_from_reservation.len());
-            let sql =
-                format!("DELETE FROM token_outputs WHERE user_id = ? AND id IN ({placeholders})");
+            let sql = format!(
+                "DELETE FROM brz_token_outputs WHERE user_id = ? AND id IN ({placeholders})"
+            );
             let mut params: Vec<Value> =
                 Vec::with_capacity(outputs_to_remove_from_reservation.len().saturating_add(1));
             params.push(Value::from(self.identity.clone()));
@@ -839,8 +890,8 @@ impl MysqlTokenStore {
 
             let empty_ids: Vec<String> = tx
                 .exec(
-                    r"SELECT r.id FROM token_reservations r
-                      LEFT JOIN token_outputs o
+                    r"SELECT r.id FROM brz_token_reservations r
+                      LEFT JOIN brz_token_outputs o
                         ON o.reservation_id = r.id AND o.user_id = r.user_id
                       WHERE r.user_id = ? AND o.id IS NULL",
                     (self.identity.clone(),),
@@ -850,7 +901,7 @@ impl MysqlTokenStore {
             if !empty_ids.is_empty() {
                 let placeholders = build_placeholders(empty_ids.len());
                 let sql = format!(
-                    "DELETE FROM token_reservations WHERE user_id = ? AND id IN ({placeholders})"
+                    "DELETE FROM brz_token_reservations WHERE user_id = ? AND id IN ({placeholders})"
                 );
                 let mut params: Vec<Value> = Vec::with_capacity(empty_ids.len().saturating_add(1));
                 params.push(Value::from(self.identity.clone()));
@@ -863,7 +914,7 @@ impl MysqlTokenStore {
 
         let reserved_output_ids: HashSet<String> = tx
             .exec::<String, _, _>(
-                "SELECT id FROM token_outputs WHERE user_id = ? AND reservation_id IS NOT NULL",
+                "SELECT id FROM brz_token_outputs WHERE user_id = ? AND reservation_id IS NOT NULL",
                 (self.identity.clone(),),
             )
             .await
@@ -873,10 +924,10 @@ impl MysqlTokenStore {
 
         // Drop tenant-scoped metadata rows that no longer have any outputs.
         tx.exec_drop(
-            r"DELETE FROM token_metadata
+            r"DELETE FROM brz_token_metadata
               WHERE user_id = ?
                 AND identifier NOT IN (
-                  SELECT DISTINCT token_identifier FROM token_outputs WHERE user_id = ?
+                  SELECT DISTINCT token_identifier FROM brz_token_outputs WHERE user_id = ?
               )",
             (self.identity.clone(), self.identity.clone()),
         )
@@ -917,7 +968,7 @@ impl MysqlTokenStore {
 
         let metadata_row: Option<Row> = tx
             .exec_first(
-                "SELECT * FROM token_metadata WHERE user_id = ? AND identifier = ?",
+                "SELECT * FROM brz_token_metadata WHERE user_id = ? AND identifier = ?",
                 (self.identity.clone(), token_identifier),
             )
             .await
@@ -935,7 +986,7 @@ impl MysqlTokenStore {
                          o.withdraw_bond_sats, o.withdraw_relative_block_locktime,
                          o.token_public_key, o.token_amount, o.prev_tx_hash, o.prev_tx_vout,
                          o.token_identifier
-                  FROM token_outputs o
+                  FROM brz_token_outputs o
                   WHERE o.user_id = ? AND o.token_identifier = ? AND o.reservation_id IS NULL",
                 (self.identity.clone(), token_identifier),
             )
@@ -1003,7 +1054,7 @@ impl MysqlTokenStore {
         };
 
         tx.exec_drop(
-            "INSERT INTO token_reservations (user_id, id, purpose) VALUES (?, ?, ?)",
+            "INSERT INTO brz_token_reservations (user_id, id, purpose) VALUES (?, ?, ?)",
             (self.identity.clone(), &reservation_id, purpose_str),
         )
         .await
@@ -1016,7 +1067,7 @@ impl MysqlTokenStore {
         if !selected_ids.is_empty() {
             let placeholders = build_placeholders(selected_ids.len());
             let sql = format!(
-                "UPDATE token_outputs SET reservation_id = ? WHERE user_id = ? AND id IN ({placeholders})"
+                "UPDATE brz_token_outputs SET reservation_id = ? WHERE user_id = ? AND id IN ({placeholders})"
             );
             let mut params: Vec<Value> = Vec::with_capacity(selected_ids.len() + 2);
             params.push(Value::from(reservation_id.clone()));
@@ -1048,14 +1099,14 @@ impl MysqlTokenStore {
         let mut tx = conn.start_transaction(tx_opts()).await.map_err(map_err)?;
 
         tx.exec_drop(
-            "UPDATE token_outputs SET reservation_id = NULL WHERE user_id = ? AND reservation_id = ?",
+            "UPDATE brz_token_outputs SET reservation_id = NULL WHERE user_id = ? AND reservation_id = ?",
             (self.identity.clone(), id),
         )
         .await
         .map_err(map_err)?;
 
         tx.exec_drop(
-            "DELETE FROM token_reservations WHERE user_id = ? AND id = ?",
+            "DELETE FROM brz_token_reservations WHERE user_id = ? AND id = ?",
             (self.identity.clone(), id),
         )
         .await
@@ -1074,7 +1125,7 @@ impl MysqlTokenStore {
 
         let purpose: Option<String> = tx
             .exec_first(
-                "SELECT purpose FROM token_reservations WHERE user_id = ? AND id = ?",
+                "SELECT purpose FROM brz_token_reservations WHERE user_id = ? AND id = ?",
                 (self.identity.clone(), id),
             )
             .await
@@ -1090,7 +1141,7 @@ impl MysqlTokenStore {
 
         let reserved_output_ids: Vec<String> = tx
             .exec(
-                "SELECT id FROM token_outputs WHERE user_id = ? AND reservation_id = ?",
+                "SELECT id FROM brz_token_outputs WHERE user_id = ? AND reservation_id = ?",
                 (self.identity.clone(), id),
             )
             .await
@@ -1098,7 +1149,7 @@ impl MysqlTokenStore {
 
         if !reserved_output_ids.is_empty() {
             let mut sql =
-                String::from("INSERT INTO token_spent_outputs (user_id, output_id) VALUES ");
+                String::from("INSERT INTO brz_token_spent_outputs (user_id, output_id) VALUES ");
             let mut params: Vec<Value> =
                 Vec::with_capacity(reserved_output_ids.len().saturating_mul(2));
             for (i, oid) in reserved_output_ids.iter().enumerate() {
@@ -1117,14 +1168,14 @@ impl MysqlTokenStore {
         }
 
         tx.exec_drop(
-            "DELETE FROM token_outputs WHERE user_id = ? AND reservation_id = ?",
+            "DELETE FROM brz_token_outputs WHERE user_id = ? AND reservation_id = ?",
             (self.identity.clone(), id),
         )
         .await
         .map_err(map_err)?;
 
         tx.exec_drop(
-            "DELETE FROM token_reservations WHERE user_id = ? AND id = ?",
+            "DELETE FROM brz_token_reservations WHERE user_id = ? AND id = ?",
             (self.identity.clone(), id),
         )
         .await
@@ -1135,7 +1186,7 @@ impl MysqlTokenStore {
         // lazily.
         if is_swap {
             tx.exec_drop(
-                "INSERT INTO token_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
+                "INSERT INTO brz_token_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
                  ON DUPLICATE KEY UPDATE last_completed_at = VALUES(last_completed_at)",
                 (self.identity.clone(),),
             )
@@ -1144,10 +1195,10 @@ impl MysqlTokenStore {
         }
 
         tx.exec_drop(
-            r"DELETE FROM token_metadata
+            r"DELETE FROM brz_token_metadata
               WHERE user_id = ?
                 AND identifier NOT IN (
-                  SELECT DISTINCT token_identifier FROM token_outputs WHERE user_id = ?
+                  SELECT DISTINCT token_identifier FROM brz_token_outputs WHERE user_id = ?
               )",
             (self.identity.clone(), self.identity.clone()),
         )
@@ -1169,7 +1220,7 @@ impl MysqlTokenStore {
             // ON DUPLICATE KEY UPDATE id = id no-ops on the (user_id, id)
             // primary key conflict only — unlike INSERT IGNORE, FK / NOT NULL
             // / type errors still propagate.
-            r"INSERT INTO token_outputs
+            r"INSERT INTO brz_token_outputs
                 (user_id, id, token_identifier, owner_public_key, revocation_commitment,
                  withdraw_bond_sats, withdraw_relative_block_locktime,
                  token_public_key, token_amount, prev_tx_hash, prev_tx_vout, added_at)
@@ -1201,7 +1252,7 @@ impl MysqlTokenStore {
         metadata: &TokenMetadata,
     ) -> Result<(), TokenOutputServiceError> {
         tx.exec_drop(
-            r"INSERT INTO token_metadata
+            r"INSERT INTO brz_token_metadata
                 (user_id, identifier, issuer_public_key, name, ticker, decimals, max_supply,
                  is_freezable, creation_entity_public_key)
               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -1238,11 +1289,11 @@ impl MysqlTokenStore {
         tx: &mut mysql_async::Transaction<'_>,
     ) -> Result<u64, TokenOutputServiceError> {
         tx.exec_drop(
-            r"UPDATE token_outputs SET reservation_id = NULL
+            r"UPDATE brz_token_outputs SET reservation_id = NULL
               WHERE user_id = ?
                 AND reservation_id IN (
                     SELECT id FROM (
-                        SELECT id FROM token_reservations
+                        SELECT id FROM brz_token_reservations
                         WHERE user_id = ?
                           AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
                     ) AS stale
@@ -1258,7 +1309,7 @@ impl MysqlTokenStore {
 
         let mut result = tx
             .exec_iter(
-                "DELETE FROM token_reservations
+                "DELETE FROM brz_token_reservations
                  WHERE user_id = ? AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)",
                 (self.identity.clone(), RESERVATION_TIMEOUT_SECS),
             )
@@ -1284,7 +1335,7 @@ impl MysqlTokenStore {
             .unwrap_or(refresh_timestamp);
 
         tx.exec_drop(
-            "DELETE FROM token_spent_outputs WHERE user_id = ? AND spent_at < ?",
+            "DELETE FROM brz_token_spent_outputs WHERE user_id = ? AND spent_at < ?",
             (self.identity.clone(), cleanup_cutoff.naive_utc()),
         )
         .await
@@ -1487,19 +1538,19 @@ mod tests {
 
         assert!(has_add_foreign_key(
             &migrations,
-            "fk_token_outputs_metadata"
+            "brz_fk_token_outputs_metadata"
         ));
         assert!(has_add_foreign_key(
             &migrations,
-            "fk_token_outputs_reservation"
+            "brz_fk_token_outputs_reservation"
         ));
         assert!(has_add_foreign_key(
             &migrations,
-            "fk_token_outputs_metadata_user"
+            "brz_fk_token_outputs_metadata_user"
         ));
         assert!(has_add_foreign_key(
             &migrations,
-            "fk_token_outputs_reservation_user"
+            "brz_fk_token_outputs_reservation_user"
         ));
     }
 
@@ -1511,15 +1562,15 @@ mod tests {
         assert!(migrations.iter().flatten().any(|migration| matches!(
             migration,
             Migration::DropForeignKey {
-                name: "fk_token_outputs_metadata",
-                table: "token_outputs"
+                name: "brz_fk_token_outputs_metadata",
+                table: "brz_token_outputs"
             }
         )));
         assert!(migrations.iter().flatten().any(|migration| matches!(
             migration,
             Migration::DropForeignKey {
-                name: "fk_token_outputs_reservation",
-                table: "token_outputs"
+                name: "brz_fk_token_outputs_reservation",
+                table: "brz_token_outputs"
             }
         )));
     }
@@ -1573,8 +1624,8 @@ mod tests {
     }
 
     /// `Enforced` mode runs both initial-FK adds and the multi-tenant
-    /// rewrites: the originals (`fk_token_outputs_metadata`,
-    /// `fk_token_outputs_reservation`) are dropped in migration 2 and
+    /// rewrites: the originals (`brz_fk_token_outputs_metadata`,
+    /// `brz_fk_token_outputs_reservation`) are dropped in migration 2 and
     /// replaced by the composite `*_user` variants, so final FK count is 2.
     #[tokio::test]
     async fn test_new_with_enforced_foreign_key_mode() {
@@ -1598,11 +1649,11 @@ mod tests {
                  WHERE constraint_schema = DATABASE()
                    AND constraint_type = 'FOREIGN KEY'
                    AND table_name IN (
-                       'token_metadata',
-                       'token_outputs',
-                       'token_reservations',
-                       'token_spent_outputs',
-                       'token_swap_status'
+                       'brz_token_metadata',
+                       'brz_token_outputs',
+                       'brz_token_reservations',
+                       'brz_token_spent_outputs',
+                       'brz_token_swap_status'
                    )",
             )
             .await
@@ -1852,7 +1903,7 @@ mod tests {
         shared_tests::test_spent_outputs_not_restored_by_set_tokens_outputs(&fixture.store).await;
     }
 
-    // ==================== MySQL-Specific Tests ====================
+    // ==================== `MySQL`-Specific Tests ====================
 
     #[tokio::test]
     async fn test_finalize_reservation_blocked_by_write_lock() {
@@ -1956,7 +2007,7 @@ mod tests {
         // Backdate the swap reservation past the 5-minute timeout.
         let mut conn = fixture.store.pool.get_conn().await.unwrap();
         conn.exec_drop(
-            "UPDATE token_reservations SET created_at = DATE_SUB(NOW(6), INTERVAL 10 MINUTE) WHERE id = ?",
+            "UPDATE brz_token_reservations SET created_at = DATE_SUB(NOW(6), INTERVAL 10 MINUTE) WHERE id = ?",
             (&reservation.id,),
         )
         .await
@@ -2057,7 +2108,7 @@ mod tests {
     }
 
     /// End-to-end isolation: every `TokenOutputStore` method must keep tenants
-    /// A and B from observing each other's data. Critically, `token_metadata`
+    /// A and B from observing each other's data. Critically, `brz_token_metadata`
     /// is per-tenant — both tenants seeding the same `identifier` ("token-1")
     /// must coexist without collision and without leaking each other's
     /// balances.

--- a/crates/spark-mysql/src/token_store.rs
+++ b/crates/spark-mysql/src/token_store.rs
@@ -28,10 +28,7 @@ use crate::pool::{create_pool, tx_opts};
 
 const TOKEN_MIGRATIONS_TABLE: &str = "brz_token_schema_migrations";
 
-/// Old-to-`brz_*` rename map for the token store schema. Applied on first
-/// startup after upgrading to the prefixed schema. The indexes and FKs listed
-/// are the ones present after the multi-tenant migration. Composite FKs are
-/// dropped and re-added (`MySQL` has no `RENAME CONSTRAINT` for FKs).
+/// Pre-prefix rename map for upgrading token-store deployments.
 const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
     old_migrations_table: "token_schema_migrations",
     new_migrations_table: TOKEN_MIGRATIONS_TABLE,
@@ -73,6 +70,22 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
             new_name: "brz_fk_token_outputs_reservation_user",
             definition: "FOREIGN KEY (user_id, reservation_id) \
                          REFERENCES brz_token_reservations(user_id, id)",
+        },
+        // Pre-multi-tenant FKs (single-column). Rename so the post-tenant
+        // migration's `DropForeignKey { name: "brz_fk_..." }` finds them.
+        FkRename {
+            table: "brz_token_outputs",
+            old_name: "fk_token_outputs_metadata",
+            new_name: "brz_fk_token_outputs_metadata",
+            definition: "FOREIGN KEY (token_identifier) \
+                         REFERENCES brz_token_metadata(identifier)",
+        },
+        FkRename {
+            table: "brz_token_outputs",
+            old_name: "fk_token_outputs_reservation",
+            new_name: "brz_fk_token_outputs_reservation",
+            definition: "FOREIGN KEY (reservation_id) \
+                         REFERENCES brz_token_reservations(id) ON DELETE SET NULL",
         },
     ],
 };

--- a/crates/spark-mysql/src/token_store.rs
+++ b/crates/spark-mysql/src/token_store.rs
@@ -40,6 +40,7 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
         ("token_swap_status", "brz_token_swap_status"),
     ],
     indexes: &[
+        // Post-multi-tenant indexes.
         (
             "brz_token_metadata",
             "idx_token_metadata_user_issuer_pk",
@@ -54,6 +55,22 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
             "brz_token_outputs",
             "idx_token_outputs_user_reservation",
             "brz_idx_token_outputs_user_reservation",
+        ),
+        // Pre-multi-tenant indexes (dropped by the multi-tenant migration).
+        (
+            "brz_token_metadata",
+            "idx_token_metadata_issuer_pk",
+            "brz_idx_token_metadata_issuer_pk",
+        ),
+        (
+            "brz_token_outputs",
+            "idx_token_outputs_identifier",
+            "brz_idx_token_outputs_identifier",
+        ),
+        (
+            "brz_token_outputs",
+            "idx_token_outputs_reservation",
+            "brz_idx_token_outputs_reservation",
         ),
     ],
     foreign_keys: &[

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -74,6 +74,27 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
             "idx_tree_leaves_user_slim",
             "brz_idx_tree_leaves_user_slim",
         ),
+        // Pre-multi-tenant indexes (dropped by the multi-tenant migration).
+        (
+            "brz_tree_leaves",
+            "idx_tree_leaves_available",
+            "brz_idx_tree_leaves_available",
+        ),
+        (
+            "brz_tree_leaves",
+            "idx_tree_leaves_reservation",
+            "brz_idx_tree_leaves_reservation",
+        ),
+        (
+            "brz_tree_leaves",
+            "idx_tree_leaves_added_at",
+            "brz_idx_tree_leaves_added_at",
+        ),
+        (
+            "brz_tree_leaves",
+            "idx_tree_leaves_slim",
+            "brz_idx_tree_leaves_slim",
+        ),
     ],
     foreign_keys: &[
         FkRename {

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -37,11 +37,56 @@ use uuid::Uuid;
 use crate::advisory_lock::identity_lock_name;
 use crate::config::{MysqlForeignKeyMode, MysqlStorageConfig};
 use crate::error::MysqlError;
-use crate::migrations::{Migration, run_migrations};
+use crate::migrations::{FkRename, Migration, SchemaRenames, run_migrations};
 use crate::pool::{create_pool, tx_opts};
 
 /// Name of the schema migrations table for `MysqlTreeStore`.
-const TREE_MIGRATIONS_TABLE: &str = "tree_schema_migrations";
+const TREE_MIGRATIONS_TABLE: &str = "brz_tree_schema_migrations";
+
+/// Old-to-`brz_*` rename map for the tree store schema. Applied on first
+/// startup after upgrading to the prefixed schema. The indexes and FK listed
+/// are the ones present after the multi-tenant migration (the original
+/// pre-tenant index and FK names were dropped). The composite FK is dropped
+/// and re-added (`MySQL` has no `RENAME CONSTRAINT` for FKs).
+const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
+    old_migrations_table: "tree_schema_migrations",
+    new_migrations_table: TREE_MIGRATIONS_TABLE,
+    tables: &[
+        ("tree_reservations", "brz_tree_reservations"),
+        ("tree_leaves", "brz_tree_leaves"),
+        ("tree_spent_leaves", "brz_tree_spent_leaves"),
+        ("tree_swap_status", "brz_tree_swap_status"),
+    ],
+    indexes: &[
+        (
+            "brz_tree_leaves",
+            "idx_tree_leaves_user_available",
+            "brz_idx_tree_leaves_user_available",
+        ),
+        (
+            "brz_tree_leaves",
+            "idx_tree_leaves_user_reservation",
+            "brz_idx_tree_leaves_user_reservation",
+        ),
+        (
+            "brz_tree_leaves",
+            "idx_tree_leaves_user_added_at",
+            "brz_idx_tree_leaves_user_added_at",
+        ),
+        (
+            "brz_tree_leaves",
+            "idx_tree_leaves_user_slim",
+            "brz_idx_tree_leaves_user_slim",
+        ),
+    ],
+    foreign_keys: &[FkRename {
+        table: "brz_tree_leaves",
+        old_name: "fk_tree_leaves_reservation_user",
+        new_name: "brz_fk_tree_leaves_reservation_user",
+        definition: "FOREIGN KEY (user_id, reservation_id) \
+                     REFERENCES brz_tree_reservations(user_id, id)",
+    }],
+};
 
 /// Domain prefix mixed into the per-tenant `GET_LOCK` name so the tree store's
 /// locks never collide with the token store's, even when two tenants share a
@@ -115,34 +160,34 @@ fn tree_store_multi_tenant_migration(
 
     let mut stmts: Vec<Migration> = Vec::new();
 
-    // Drop the existing FK from tree_leaves(reservation_id) -> tree_reservations(id)
+    // Drop the existing FK from brz_tree_leaves(reservation_id) -> brz_tree_reservations(id)
     // FIRST, before we touch the parent's PK that it depends on. The `MySQL`
     // FK was named via a CONSTRAINT clause on creation as
-    // `fk_tree_leaves_reservation`.
+    // `brz_fk_tree_leaves_reservation`.
     stmts.push(Migration::DropForeignKey {
-        name: "fk_tree_leaves_reservation",
-        table: "tree_leaves",
+        name: "brz_fk_tree_leaves_reservation",
+        table: "brz_tree_leaves",
     });
 
-    // tree_reservations: scope by user_id. Add the column nullable, backfill,
+    // brz_tree_reservations: scope by user_id. Add the column nullable, backfill,
     // make NOT NULL, and rewrite the PK to lead with user_id.
     stmts.push(Migration::AddColumn {
-        table: "tree_reservations",
+        table: "brz_tree_reservations",
         column: "user_id",
         definition: "VARBINARY(33) NULL",
     });
     stmts.push(Migration::Sql(format!(
-        "UPDATE tree_reservations SET user_id = {id_lit} WHERE user_id IS NULL"
+        "UPDATE brz_tree_reservations SET user_id = {id_lit} WHERE user_id IS NULL"
     )));
     stmts.push(Migration::sql(
-        "ALTER TABLE tree_reservations MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+        "ALTER TABLE brz_tree_reservations MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
     ));
     stmts.push(Migration::sql(
-        "ALTER TABLE tree_reservations DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)",
+        "ALTER TABLE brz_tree_reservations DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)",
     ));
 
-    // tree_leaves: same pattern, plus re-add the composite FK to the new
-    // tree_reservations PK when foreign keys are enabled. The composite FK
+    // brz_tree_leaves: same pattern, plus re-add the composite FK to the new
+    // brz_tree_reservations PK when foreign keys are enabled. The composite FK
     // uses the default ON DELETE NO ACTION instead of the previous `ON DELETE
     // SET NULL`: a whole-row SET NULL would null `user_id` (NOT NULL) and
     // `MySQL` doesn't support column-list SET NULL. Callers
@@ -150,103 +195,103 @@ fn tree_store_multi_tenant_migration(
     // `finalize_reservation`) explicitly clear `reservation_id` before
     // deleting the parent reservation row.
     stmts.push(Migration::AddColumn {
-        table: "tree_leaves",
+        table: "brz_tree_leaves",
         column: "user_id",
         definition: "VARBINARY(33) NULL",
     });
     stmts.push(Migration::Sql(format!(
-        "UPDATE tree_leaves SET user_id = {id_lit} WHERE user_id IS NULL"
+        "UPDATE brz_tree_leaves SET user_id = {id_lit} WHERE user_id IS NULL"
     )));
     stmts.push(Migration::sql(
-        "ALTER TABLE tree_leaves MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+        "ALTER TABLE brz_tree_leaves MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
     ));
     stmts.push(Migration::sql(
-        "ALTER TABLE tree_leaves DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)",
+        "ALTER TABLE brz_tree_leaves DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, id)",
     ));
     if foreign_key_mode.creates_constraints() {
         stmts.push(Migration::AddForeignKey {
-            name: "fk_tree_leaves_reservation_user",
-            table: "tree_leaves",
+            name: "brz_fk_tree_leaves_reservation_user",
+            table: "brz_tree_leaves",
             definition: "FOREIGN KEY (user_id, reservation_id) \
-                         REFERENCES tree_reservations(user_id, id)",
+                         REFERENCES brz_tree_reservations(user_id, id)",
         });
     }
     stmts.push(Migration::DropIndex {
-        name: "idx_tree_leaves_available",
-        table: "tree_leaves",
+        name: "brz_idx_tree_leaves_available",
+        table: "brz_tree_leaves",
     });
     stmts.push(Migration::DropIndex {
-        name: "idx_tree_leaves_reservation",
-        table: "tree_leaves",
+        name: "brz_idx_tree_leaves_reservation",
+        table: "brz_tree_leaves",
     });
     stmts.push(Migration::DropIndex {
-        name: "idx_tree_leaves_added_at",
-        table: "tree_leaves",
+        name: "brz_idx_tree_leaves_added_at",
+        table: "brz_tree_leaves",
     });
     stmts.push(Migration::DropIndex {
-        name: "idx_tree_leaves_slim",
-        table: "tree_leaves",
+        name: "brz_idx_tree_leaves_slim",
+        table: "brz_tree_leaves",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_tree_leaves_user_available",
-        table: "tree_leaves",
+        name: "brz_idx_tree_leaves_user_available",
+        table: "brz_tree_leaves",
         columns: "(user_id, status, is_missing_from_operators)",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_tree_leaves_user_reservation",
-        table: "tree_leaves",
+        name: "brz_idx_tree_leaves_user_reservation",
+        table: "brz_tree_leaves",
         columns: "(user_id, reservation_id)",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_tree_leaves_user_added_at",
-        table: "tree_leaves",
+        name: "brz_idx_tree_leaves_user_added_at",
+        table: "brz_tree_leaves",
         columns: "(user_id, added_at)",
     });
     stmts.push(Migration::CreateIndex {
-        name: "idx_tree_leaves_user_slim",
-        table: "tree_leaves",
+        name: "brz_idx_tree_leaves_user_slim",
+        table: "brz_tree_leaves",
         columns: "(user_id, status, is_missing_from_operators, reservation_id, value)",
     });
 
-    // tree_spent_leaves: scope by user_id.
+    // brz_tree_spent_leaves: scope by user_id.
     stmts.push(Migration::AddColumn {
-        table: "tree_spent_leaves",
+        table: "brz_tree_spent_leaves",
         column: "user_id",
         definition: "VARBINARY(33) NULL",
     });
     stmts.push(Migration::Sql(format!(
-        "UPDATE tree_spent_leaves SET user_id = {id_lit} WHERE user_id IS NULL"
+        "UPDATE brz_tree_spent_leaves SET user_id = {id_lit} WHERE user_id IS NULL"
     )));
     stmts.push(Migration::sql(
-        "ALTER TABLE tree_spent_leaves MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+        "ALTER TABLE brz_tree_spent_leaves MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
     ));
     stmts.push(Migration::sql(
-        "ALTER TABLE tree_spent_leaves DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, leaf_id)",
+        "ALTER TABLE brz_tree_spent_leaves DROP PRIMARY KEY, ADD PRIMARY KEY (user_id, leaf_id)",
     ));
 
-    // tree_swap_status was a singleton (PK id=1, CHECK id=1). Drop the PK and
+    // brz_tree_swap_status was a singleton (PK id=1, CHECK id=1). Drop the PK and
     // the id column, then re-key by user_id so each tenant has its own
     // swap-status row.
     stmts.push(Migration::DropPrimaryKey {
-        table: "tree_swap_status",
+        table: "brz_tree_swap_status",
     });
     stmts.push(Migration::DropColumn {
-        table: "tree_swap_status",
+        table: "brz_tree_swap_status",
         column: "id",
     });
     stmts.push(Migration::AddColumn {
-        table: "tree_swap_status",
+        table: "brz_tree_swap_status",
         column: "user_id",
         definition: "VARBINARY(33) NULL",
     });
     stmts.push(Migration::Sql(format!(
-        "UPDATE tree_swap_status SET user_id = {id_lit} WHERE user_id IS NULL"
+        "UPDATE brz_tree_swap_status SET user_id = {id_lit} WHERE user_id IS NULL"
     )));
     stmts.push(Migration::sql(
-        "ALTER TABLE tree_swap_status MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
+        "ALTER TABLE brz_tree_swap_status MODIFY COLUMN user_id VARBINARY(33) NOT NULL",
     ));
     stmts.push(Migration::sql(
-        "ALTER TABLE tree_swap_status ADD PRIMARY KEY (user_id)",
+        "ALTER TABLE brz_tree_swap_status ADD PRIMARY KEY (user_id)",
     ));
 
     stmts
@@ -284,8 +329,8 @@ impl TreeStore for MysqlTreeStore {
         let row: Option<i64> = conn
             .exec_first(
                 r"SELECT COALESCE(SUM(l.value), 0) AS balance
-                  FROM tree_leaves l
-                  LEFT JOIN tree_reservations r
+                  FROM brz_tree_leaves l
+                  LEFT JOIN brz_tree_reservations r
                     ON l.reservation_id = r.id AND l.user_id = r.user_id
                   WHERE l.user_id = ?
                     AND (
@@ -306,8 +351,8 @@ impl TreeStore for MysqlTreeStore {
             .exec(
                 r"SELECT l.id, l.status, l.is_missing_from_operators, l.data,
                          l.reservation_id, r.purpose
-                  FROM tree_leaves l
-                  LEFT JOIN tree_reservations r
+                  FROM brz_tree_leaves l
+                  LEFT JOIN brz_tree_reservations r
                     ON l.reservation_id = r.id AND l.user_id = r.user_id
                   WHERE l.user_id = ?",
                 (self.identity.clone(),),
@@ -394,7 +439,7 @@ impl TreeStore for MysqlTreeStore {
         id: &LeavesReservationId,
         new_leaves: Option<&[TreeNode]>,
     ) -> Result<(), TreeServiceError> {
-        // Serialize against `set_leaves` so its `tree_spent_leaves` snapshot
+        // Serialize against `set_leaves` so its `brz_tree_spent_leaves` snapshot
         // and the upsert that consumes it cannot interleave with this
         // transaction's spent-marker write — otherwise the snapshot would miss
         // our marker and the upsert would write the just-spent leaf back as
@@ -525,6 +570,7 @@ impl MysqlTreeStore {
             &self.pool,
             TREE_MIGRATIONS_TABLE,
             &Self::migrations(&self.identity, self.foreign_key_mode),
+            Some(&SCHEMA_RENAMES),
         )
         .await
     }
@@ -537,7 +583,7 @@ impl MysqlTreeStore {
         // This FK is omitted when foreign keys are disabled.
         let mut initial = vec![
             Migration::sql(
-                "CREATE TABLE IF NOT EXISTS tree_reservations (
+                "CREATE TABLE IF NOT EXISTS brz_tree_reservations (
                     id VARCHAR(255) NOT NULL PRIMARY KEY,
                     purpose VARCHAR(64) NOT NULL,
                     pending_change_amount BIGINT NOT NULL DEFAULT 0,
@@ -545,7 +591,7 @@ impl MysqlTreeStore {
                 )",
             ),
             Migration::sql(
-                "CREATE TABLE IF NOT EXISTS tree_leaves (
+                "CREATE TABLE IF NOT EXISTS brz_tree_leaves (
                     id VARCHAR(255) NOT NULL PRIMARY KEY,
                     status VARCHAR(64) NOT NULL,
                     is_missing_from_operators TINYINT(1) NOT NULL DEFAULT 0,
@@ -556,33 +602,33 @@ impl MysqlTreeStore {
                 )",
             ),
             Migration::sql(
-                "CREATE TABLE IF NOT EXISTS tree_spent_leaves (
+                "CREATE TABLE IF NOT EXISTS brz_tree_spent_leaves (
                     leaf_id VARCHAR(255) NOT NULL PRIMARY KEY,
                     spent_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
                 )",
             ),
             Migration::CreateIndex {
-                name: "idx_tree_leaves_available",
-                table: "tree_leaves",
+                name: "brz_idx_tree_leaves_available",
+                table: "brz_tree_leaves",
                 columns: "(status, is_missing_from_operators)",
             },
             Migration::CreateIndex {
-                name: "idx_tree_leaves_reservation",
-                table: "tree_leaves",
+                name: "brz_idx_tree_leaves_reservation",
+                table: "brz_tree_leaves",
                 columns: "(reservation_id)",
             },
             Migration::CreateIndex {
-                name: "idx_tree_leaves_added_at",
-                table: "tree_leaves",
+                name: "brz_idx_tree_leaves_added_at",
+                table: "brz_tree_leaves",
                 columns: "(added_at)",
             },
         ];
         if foreign_key_mode.creates_constraints() {
             initial.push(Migration::AddForeignKey {
-                name: "fk_tree_leaves_reservation",
-                table: "tree_leaves",
+                name: "brz_fk_tree_leaves_reservation",
+                table: "brz_tree_leaves",
                 definition: "FOREIGN KEY (reservation_id) \
-                             REFERENCES tree_reservations(id) ON DELETE SET NULL",
+                             REFERENCES brz_tree_reservations(id) ON DELETE SET NULL",
             });
         }
 
@@ -591,14 +637,14 @@ impl MysqlTreeStore {
             // Migration 2: Swap status tracking.
             vec![
                 Migration::sql(
-                    "CREATE TABLE IF NOT EXISTS tree_swap_status (
+                    "CREATE TABLE IF NOT EXISTS brz_tree_swap_status (
                         id INT NOT NULL PRIMARY KEY DEFAULT 1,
                         last_completed_at DATETIME(6) NULL,
                         CHECK (id = 1)
                     )",
                 ),
                 Migration::sql(
-                    "INSERT INTO tree_swap_status (id) VALUES (1)
+                    "INSERT INTO brz_tree_swap_status (id) VALUES (1)
                      ON DUPLICATE KEY UPDATE id = id",
                 ),
             ],
@@ -610,7 +656,7 @@ impl MysqlTreeStore {
             // the slim selection in `try_reserve_leaves` is index-only.
             vec![
                 Migration::AddColumn {
-                    table: "tree_leaves",
+                    table: "brz_tree_leaves",
                     column: "value",
                     definition: "BIGINT NOT NULL DEFAULT 0",
                 },
@@ -618,20 +664,20 @@ impl MysqlTreeStore {
                 // no-op because by then `value` is already populated and the
                 // `WHERE value = 0` predicate filters everything out.
                 Migration::sql(
-                    "UPDATE tree_leaves
+                    "UPDATE brz_tree_leaves
                         SET value = CAST(JSON_UNQUOTE(JSON_EXTRACT(data, '$.value')) AS UNSIGNED)
                         WHERE value = 0",
                 ),
                 Migration::CreateIndex {
-                    name: "idx_tree_leaves_slim",
-                    table: "tree_leaves",
+                    name: "brz_idx_tree_leaves_slim",
+                    table: "brz_tree_leaves",
                     columns: "(status, is_missing_from_operators, reservation_id, value)",
                 },
             ],
             // Migration 4: Multi-tenant scoping. Adds user_id to every tree-
             // store table, backfills with the connecting tenant's identity, and
             // rewrites primary keys / optional FKs / indexes to lead with
-            // user_id. The `tree_swap_status` singleton is restructured the
+            // user_id. The `brz_tree_swap_status` singleton is restructured the
             // same way as `sync_revision` in the SDK-core storage.
             tree_store_multi_tenant_migration(identity, foreign_key_mode),
         ]
@@ -714,9 +760,9 @@ impl MysqlTreeStore {
         let row: Option<(i64, i64)> = tx
             .exec_first(
                 r"SELECT
-                    (SELECT EXISTS(SELECT 1 FROM tree_reservations WHERE user_id = ? AND purpose = 'Swap')) AS has_active_swap,
+                    (SELECT EXISTS(SELECT 1 FROM brz_tree_reservations WHERE user_id = ? AND purpose = 'Swap')) AS has_active_swap,
                     COALESCE(
-                        (SELECT (last_completed_at >= ?) FROM tree_swap_status WHERE user_id = ?),
+                        (SELECT (last_completed_at >= ?) FROM brz_tree_swap_status WHERE user_id = ?),
                         0
                     ) AS swap_completed_during_refresh",
                 (
@@ -745,7 +791,7 @@ impl MysqlTreeStore {
 
         let spent_rows: Vec<String> = tx
             .exec(
-                "SELECT leaf_id FROM tree_spent_leaves WHERE user_id = ? AND spent_at >= ?",
+                "SELECT leaf_id FROM brz_tree_spent_leaves WHERE user_id = ? AND spent_at >= ?",
                 (self.identity.clone(), refresh_timestamp.naive_utc()),
             )
             .await
@@ -763,7 +809,7 @@ impl MysqlTreeStore {
         // `cleanup_stale_reservations` (which clears `reservation_id`
         // explicitly because the composite FK uses NO ACTION).
         tx.exec_drop(
-            "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
+            "DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
             (self.identity.clone(), refresh_timestamp.naive_utc()),
         )
         .await
@@ -788,7 +834,7 @@ impl MysqlTreeStore {
 
         let exists: Option<String> = tx
             .exec_first(
-                "SELECT id FROM tree_reservations WHERE user_id = ? AND id = ?",
+                "SELECT id FROM brz_tree_reservations WHERE user_id = ? AND id = ?",
                 (self.identity.clone(), id),
             )
             .await
@@ -800,7 +846,7 @@ impl MysqlTreeStore {
 
         let prior_leaf_ids: Vec<String> = tx
             .exec(
-                "SELECT id FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+                "SELECT id FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
                 (self.identity.clone(), id),
             )
             .await
@@ -816,14 +862,14 @@ impl MysqlTreeStore {
         );
 
         tx.exec_drop(
-            "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+            "DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
             (self.identity.clone(), id),
         )
         .await
         .map_err(map_err)?;
 
         tx.exec_drop(
-            "DELETE FROM tree_reservations WHERE user_id = ? AND id = ?",
+            "DELETE FROM brz_tree_reservations WHERE user_id = ? AND id = ?",
             (self.identity.clone(), id),
         )
         .await
@@ -846,7 +892,7 @@ impl MysqlTreeStore {
 
         let purpose: Option<String> = tx
             .exec_first(
-                "SELECT purpose FROM tree_reservations WHERE user_id = ? AND id = ?",
+                "SELECT purpose FROM brz_tree_reservations WHERE user_id = ? AND id = ?",
                 (self.identity.clone(), id),
             )
             .await
@@ -856,7 +902,7 @@ impl MysqlTreeStore {
             let is_swap = purpose == "Swap";
             let leaf_ids: Vec<String> = tx
                 .exec(
-                    "SELECT id FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+                    "SELECT id FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
                     (self.identity.clone(), id),
                 )
                 .await
@@ -877,14 +923,14 @@ impl MysqlTreeStore {
             .await?;
 
         tx.exec_drop(
-            "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+            "DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
             (self.identity.clone(), id),
         )
         .await
         .map_err(map_err)?;
 
         tx.exec_drop(
-            "DELETE FROM tree_reservations WHERE user_id = ? AND id = ?",
+            "DELETE FROM brz_tree_reservations WHERE user_id = ? AND id = ?",
             (self.identity.clone(), id),
         )
         .await
@@ -906,7 +952,7 @@ impl MysqlTreeStore {
         // no row) gets one created lazily.
         if is_swap && new_leaves.is_some() {
             tx.exec_drop(
-                "INSERT INTO tree_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
+                "INSERT INTO brz_tree_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
                  ON DUPLICATE KEY UPDATE last_completed_at = VALUES(last_completed_at)",
                 (self.identity.clone(),),
             )
@@ -938,7 +984,7 @@ impl MysqlTreeStore {
         let total_row: Option<i64> = tx
             .exec_first(
                 r"SELECT COALESCE(SUM(value), 0) AS total
-                  FROM tree_leaves
+                  FROM brz_tree_leaves
                   WHERE user_id = ?
                     AND status = 'Available'
                     AND is_missing_from_operators = 0
@@ -954,7 +1000,7 @@ impl MysqlTreeStore {
         let slim_rows: Vec<(String, i64)> = tx
             .exec(
                 r"SELECT id, value
-                  FROM tree_leaves
+                  FROM brz_tree_leaves
                   WHERE user_id = ?
                     AND status = 'Available'
                     AND is_missing_from_operators = 0
@@ -963,7 +1009,7 @@ impl MysqlTreeStore {
                       value <= ?
                       OR id = (
                         SELECT id FROM (
-                          SELECT id FROM tree_leaves
+                          SELECT id FROM brz_tree_leaves
                           WHERE user_id = ?
                             AND status = 'Available'
                             AND is_missing_from_operators = 0
@@ -1112,7 +1158,7 @@ impl MysqlTreeStore {
         }
         let placeholders = build_placeholders(ids.len());
         let sql = format!(
-            "SELECT id, data FROM tree_leaves WHERE user_id = ? AND id IN ({placeholders})"
+            "SELECT id, data FROM brz_tree_leaves WHERE user_id = ? AND id IN ({placeholders})"
         );
         let mut params: Vec<Value> = Vec::with_capacity(ids.len().saturating_add(1));
         params.push(Value::from(self.identity.clone()));
@@ -1148,7 +1194,7 @@ impl MysqlTreeStore {
 
         let exists: Option<String> = tx
             .exec_first(
-                "SELECT id FROM tree_reservations WHERE user_id = ? AND id = ?",
+                "SELECT id FROM brz_tree_reservations WHERE user_id = ? AND id = ?",
                 (self.identity.clone(), reservation_id),
             )
             .await
@@ -1162,7 +1208,7 @@ impl MysqlTreeStore {
 
         let old_reserved_leaf_ids: Vec<String> = tx
             .exec(
-                "SELECT id FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+                "SELECT id FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
                 (self.identity.clone(), reservation_id),
             )
             .await
@@ -1171,7 +1217,7 @@ impl MysqlTreeStore {
         self.batch_insert_spent_leaves(&mut tx, &old_reserved_leaf_ids)
             .await?;
         tx.exec_drop(
-            "DELETE FROM tree_leaves WHERE user_id = ? AND reservation_id = ?",
+            "DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
             (self.identity.clone(), reservation_id),
         )
         .await
@@ -1187,7 +1233,7 @@ impl MysqlTreeStore {
             .await?;
 
         tx.exec_drop(
-            "UPDATE tree_reservations SET pending_change_amount = 0 WHERE user_id = ? AND id = ?",
+            "UPDATE brz_tree_reservations SET pending_change_amount = 0 WHERE user_id = ? AND id = ?",
             (self.identity.clone(), reservation_id),
         )
         .await
@@ -1207,7 +1253,7 @@ impl MysqlTreeStore {
     ) -> Result<u64, TreeServiceError> {
         let row: Option<i64> = tx
             .exec_first(
-                "SELECT COALESCE(SUM(pending_change_amount), 0) FROM tree_reservations WHERE user_id = ?",
+                "SELECT COALESCE(SUM(pending_change_amount), 0) FROM brz_tree_reservations WHERE user_id = ?",
                 (self.identity.clone(),),
             )
             .await
@@ -1216,7 +1262,7 @@ impl MysqlTreeStore {
         Ok(u64::try_from(row.unwrap_or(0)).unwrap_or(0))
     }
 
-    /// Batch upserts leaves into `tree_leaves` table.
+    /// Batch upserts leaves into `brz_tree_leaves` table.
     /// Optionally skips leaves whose IDs are in the `skip_ids` set.
     /// Uses `ON DUPLICATE KEY UPDATE` to replace existing leaves.
     #[allow(clippy::arithmetic_side_effects)] // `len * 4` for params capacity, bounded by leaves slice
@@ -1251,7 +1297,7 @@ impl MysqlTreeStore {
 
         // Build VALUES (?, ?, ?, ?, ?, ?, NOW(6)), … with user_id as the first column.
         let mut sql = String::from(
-            "INSERT INTO tree_leaves (user_id, id, status, is_missing_from_operators, data, value, added_at) VALUES ",
+            "INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, value, added_at) VALUES ",
         );
         let mut params: Vec<Value> = Vec::with_capacity(filtered.len() * 6);
         for (i, leaf) in filtered.iter().enumerate() {
@@ -1297,7 +1343,7 @@ impl MysqlTreeStore {
 
         let placeholders = build_placeholders(leaf_ids.len());
         let sql = format!(
-            "UPDATE tree_leaves SET reservation_id = ? WHERE user_id = ? AND id IN ({placeholders})"
+            "UPDATE brz_tree_leaves SET reservation_id = ? WHERE user_id = ? AND id IN ({placeholders})"
         );
 
         let mut params: Vec<Value> = Vec::with_capacity(leaf_ids.len() + 2);
@@ -1323,7 +1369,7 @@ impl MysqlTreeStore {
             return Ok(());
         }
 
-        let mut sql = String::from("INSERT INTO tree_spent_leaves (user_id, leaf_id) VALUES ");
+        let mut sql = String::from("INSERT INTO brz_tree_spent_leaves (user_id, leaf_id) VALUES ");
         let mut params: Vec<Value> = Vec::with_capacity(leaf_ids.len().saturating_mul(2));
         for (i, id) in leaf_ids.iter().enumerate() {
             if i > 0 {
@@ -1356,7 +1402,7 @@ impl MysqlTreeStore {
 
         let placeholders = build_placeholders(leaf_ids.len());
         let sql = format!(
-            "DELETE FROM tree_spent_leaves WHERE user_id = ? AND leaf_id IN ({placeholders})"
+            "DELETE FROM brz_tree_spent_leaves WHERE user_id = ? AND leaf_id IN ({placeholders})"
         );
 
         let mut params: Vec<Value> = Vec::with_capacity(leaf_ids.len().saturating_add(1));
@@ -1390,11 +1436,11 @@ impl MysqlTreeStore {
     ) -> Result<u64, TreeServiceError> {
         // Release dependent leaves before dropping the parent rows.
         tx.exec_drop(
-            r"UPDATE tree_leaves SET reservation_id = NULL
+            r"UPDATE brz_tree_leaves SET reservation_id = NULL
               WHERE user_id = ?
                 AND reservation_id IN (
                     SELECT id FROM (
-                        SELECT id FROM tree_reservations
+                        SELECT id FROM brz_tree_reservations
                         WHERE user_id = ?
                           AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
                     ) AS stale
@@ -1410,7 +1456,7 @@ impl MysqlTreeStore {
 
         let mut result = tx
             .exec_iter(
-                "DELETE FROM tree_reservations
+                "DELETE FROM brz_tree_reservations
                  WHERE user_id = ? AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)",
                 (self.identity.clone(), RESERVATION_TIMEOUT_SECS),
             )
@@ -1438,7 +1484,7 @@ impl MysqlTreeStore {
 
         let mut result = tx
             .exec_iter(
-                "DELETE FROM tree_spent_leaves WHERE user_id = ? AND spent_at < ?",
+                "DELETE FROM brz_tree_spent_leaves WHERE user_id = ? AND spent_at < ?",
                 (self.identity.clone(), cleanup_cutoff.naive_utc()),
             )
             .await
@@ -1465,7 +1511,7 @@ impl MysqlTreeStore {
         let pending_i64 = pending_change as i64;
 
         tx.exec_drop(
-            "INSERT INTO tree_reservations (user_id, id, purpose, pending_change_amount) VALUES (?, ?, ?, ?)",
+            "INSERT INTO brz_tree_reservations (user_id, id, purpose, pending_change_amount) VALUES (?, ?, ?, ?)",
             (self.identity.clone(), reservation_id, purpose.to_string(), pending_i64),
         )
         .await
@@ -1562,11 +1608,11 @@ mod tests {
 
         assert!(has_add_foreign_key(
             &migrations,
-            "fk_tree_leaves_reservation"
+            "brz_fk_tree_leaves_reservation"
         ));
         assert!(has_add_foreign_key(
             &migrations,
-            "fk_tree_leaves_reservation_user"
+            "brz_fk_tree_leaves_reservation_user"
         ));
     }
 
@@ -1578,8 +1624,8 @@ mod tests {
         assert!(migrations.iter().flatten().any(|migration| matches!(
             migration,
             Migration::DropForeignKey {
-                name: "fk_tree_leaves_reservation",
-                table: "tree_leaves"
+                name: "brz_fk_tree_leaves_reservation",
+                table: "brz_tree_leaves"
             }
         )));
     }
@@ -1652,9 +1698,9 @@ mod tests {
         assert_eq!(count_tree_store_foreign_keys(&fixture).await, 0);
     }
 
-    /// `Enforced` mode runs the initial FK add (`fk_tree_leaves_reservation`)
+    /// `Enforced` mode runs the initial FK add (`brz_fk_tree_leaves_reservation`)
     /// and the multi-tenant rewrite: the original is dropped in migration 4
-    /// and replaced by the composite `fk_tree_leaves_reservation_user`, so
+    /// and replaced by the composite `brz_fk_tree_leaves_reservation_user`, so
     /// final FK count is 1.
     #[tokio::test]
     async fn test_new_with_enforced_foreign_key_mode() {
@@ -1679,10 +1725,10 @@ mod tests {
                  WHERE constraint_schema = DATABASE()
                    AND constraint_type = 'FOREIGN KEY'
                    AND table_name IN (
-                       'tree_leaves',
-                       'tree_reservations',
-                       'tree_spent_leaves',
-                       'tree_swap_status'
+                       'brz_tree_leaves',
+                       'brz_tree_reservations',
+                       'brz_tree_spent_leaves',
+                       'brz_tree_swap_status'
                    )",
             )
             .await
@@ -2013,7 +2059,7 @@ mod tests {
         shared_tests::test_update_reservation_preserves_purpose(&fixture.store).await;
     }
 
-    // ==================== MySQL-Specific Tests ====================
+    // ==================== `MySQL`-Specific Tests ====================
 
     #[tokio::test]
     async fn test_stale_reservation_cleanup() {
@@ -2040,7 +2086,7 @@ mod tests {
         // Backdate the reservation past the timeout.
         let mut conn = fixture.store.pool.get_conn().await.unwrap();
         conn.exec_drop(
-            "UPDATE tree_reservations SET created_at = DATE_SUB(NOW(6), INTERVAL 10 MINUTE) WHERE id = ?",
+            "UPDATE brz_tree_reservations SET created_at = DATE_SUB(NOW(6), INTERVAL 10 MINUTE) WHERE id = ?",
             (&reservation.id,),
         )
         .await
@@ -2282,7 +2328,7 @@ mod tests {
         // Backdate the swap reservation past the 5-minute timeout.
         let mut conn = fixture.store.pool.get_conn().await.unwrap();
         conn.exec_drop(
-            "UPDATE tree_reservations SET created_at = DATE_SUB(NOW(6), INTERVAL 10 MINUTE) WHERE id = ?",
+            "UPDATE brz_tree_reservations SET created_at = DATE_SUB(NOW(6), INTERVAL 10 MINUTE) WHERE id = ?",
             (&reservation.id,),
         )
         .await

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -43,11 +43,7 @@ use crate::pool::{create_pool, tx_opts};
 /// Name of the schema migrations table for `MysqlTreeStore`.
 const TREE_MIGRATIONS_TABLE: &str = "brz_tree_schema_migrations";
 
-/// Old-to-`brz_*` rename map for the tree store schema. Applied on first
-/// startup after upgrading to the prefixed schema. The indexes and FK listed
-/// are the ones present after the multi-tenant migration (the original
-/// pre-tenant index and FK names were dropped). The composite FK is dropped
-/// and re-added (`MySQL` has no `RENAME CONSTRAINT` for FKs).
+/// Pre-prefix rename map for upgrading tree-store deployments.
 const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
     old_migrations_table: "tree_schema_migrations",
     new_migrations_table: TREE_MIGRATIONS_TABLE,
@@ -79,13 +75,24 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
             "brz_idx_tree_leaves_user_slim",
         ),
     ],
-    foreign_keys: &[FkRename {
-        table: "brz_tree_leaves",
-        old_name: "fk_tree_leaves_reservation_user",
-        new_name: "brz_fk_tree_leaves_reservation_user",
-        definition: "FOREIGN KEY (user_id, reservation_id) \
-                     REFERENCES brz_tree_reservations(user_id, id)",
-    }],
+    foreign_keys: &[
+        FkRename {
+            table: "brz_tree_leaves",
+            old_name: "fk_tree_leaves_reservation_user",
+            new_name: "brz_fk_tree_leaves_reservation_user",
+            definition: "FOREIGN KEY (user_id, reservation_id) \
+                         REFERENCES brz_tree_reservations(user_id, id)",
+        },
+        // Pre-multi-tenant FK (single-column). Rename so the post-tenant
+        // migration's `DropForeignKey { name: "brz_fk_..." }` finds it.
+        FkRename {
+            table: "brz_tree_leaves",
+            old_name: "fk_tree_leaves_reservation",
+            new_name: "brz_fk_tree_leaves_reservation",
+            definition: "FOREIGN KEY (reservation_id) \
+                         REFERENCES brz_tree_reservations(id) ON DELETE SET NULL",
+        },
+    ],
 };
 
 /// Domain prefix mixed into the per-tenant `GET_LOCK` name so the tree store's

--- a/crates/spark-postgres/src/lib.rs
+++ b/crates/spark-postgres/src/lib.rs
@@ -32,7 +32,7 @@ pub use tree_store::{
 };
 
 // Re-export pool infrastructure for downstream crates
-pub use migrations::run_migrations;
+pub use migrations::{SchemaRenames, run_migrations};
 pub use pool::{create_pool, map_db_error, map_pool_error};
 
 pub use deadpool_postgres;

--- a/crates/spark-postgres/src/migrations.rs
+++ b/crates/spark-postgres/src/migrations.rs
@@ -6,16 +6,10 @@ use tokio_postgres::Transaction;
 use crate::error::PostgresError;
 use crate::pool::{map_db_error, map_pool_error};
 
-/// One-shot rename map passed to [`run_migrations`] when upgrading an
-/// existing deployment to a renamed schema. Describes how to transition
-/// every Breez-owned schema object — tables, indexes, constraints, plus the
-/// per-store schema migrations tracking table itself — from its old name to
-/// its new name. The original use case is applying a `brz_` namespace
-/// prefix.
-///
-/// `old_migrations_table` doubles as the **canary**: the runner probes
-/// `information_schema.tables` for it; if missing, the DB is either fresh
-/// or already upgraded and the rename block is skipped.
+/// One-shot pre-prefix rename map for [`run_migrations`]. Lists every
+/// owned table / index / constraint to move, plus the migrations tracker
+/// itself. `old_migrations_table` is the canary — if missing, the rename
+/// is skipped (DB is fresh or already upgraded).
 pub struct SchemaRenames<'a> {
     /// Old name of the per-store schema migrations table; used as the canary
     /// check.
@@ -37,16 +31,12 @@ pub struct SchemaRenames<'a> {
 ///
 /// This function:
 /// - Acquires an advisory lock (derived from `migration_lock_{table_name}`) to prevent concurrent migrations
-/// - Optionally applies a one-shot schema rename before running migrations
-///   (see [`SchemaRenames`]) — useful when upgrading an existing deployment
-///   whose tables were created under different names
+/// - Optionally applies a one-shot schema rename first (see [`SchemaRenames`])
 /// - Creates the migrations tracking table if it doesn't exist
 /// - Applies only new migrations (based on version number)
 /// - Commits all changes in a single transaction
 ///
-/// The rename block and the version-tracked migrations run under the same
-/// `pg_advisory_xact_lock`, so the whole schema transition is one critical
-/// section.
+/// Rename + migrations share one transaction and one `pg_advisory_xact_lock`.
 ///
 /// # Arguments
 /// * `pool` - The connection pool to use
@@ -54,10 +44,8 @@ pub struct SchemaRenames<'a> {
 /// * `migrations` - List of migrations, where each migration is a list of SQL statements.
 ///   Statements are owned `String`s so callers can build them at runtime (e.g. inlining a
 ///   tenant identity into a backfill).
-/// * `renames` - Optional one-shot rename map for upgrading from an
-///   unprefixed schema. When `Some`, the runner probes the canary table and,
-///   if present, renames everything before processing version-tracked
-///   migrations. When `None`, no rename is attempted.
+/// * `renames` - When `Some`, applied before migrations; canary-gated so
+///   fresh / already-upgraded DBs pay only one probe.
 #[allow(clippy::arithmetic_side_effects)]
 pub async fn run_migrations(
     pool: &Pool,
@@ -128,9 +116,8 @@ pub async fn run_migrations(
     Ok(())
 }
 
-/// Applies a one-shot schema rename inside the caller's transaction. Gated
-/// on the canary check against `renames.old_migrations_table`: if that
-/// table doesn't exist, returns early (the DB is fresh or already upgraded).
+/// Applies a one-shot schema rename inside the caller's transaction.
+/// Returns early if the canary `renames.old_migrations_table` is absent.
 async fn apply_renames_in_tx(
     tx: &Transaction<'_>,
     renames: &SchemaRenames<'_>,
@@ -149,24 +136,36 @@ async fn apply_renames_in_tx(
         return Ok(());
     }
 
-    // Order matters only for readability — Postgres wraps the whole sequence
-    // in one transaction so a crash rolls everything back.
+    // Each rename is guarded — pre-prefix DBs may be at any migration version,
+    // so listed objects aren't guaranteed to exist. `RENAME CONSTRAINT`
+    // has no IF EXISTS in Postgres, hence the DO block.
     for (old, new) in renames.tables {
-        let sql = format!("ALTER TABLE {old} RENAME TO {new}");
+        let sql = format!("ALTER TABLE IF EXISTS {old} RENAME TO {new}");
         tx.execute(&sql, &[]).await.map_err(|e| {
             PostgresError::Database(format!("Failed to rename table {old} -> {new}: {e}"))
         })?;
     }
 
     for (old, new) in renames.indexes {
-        let sql = format!("ALTER INDEX {old} RENAME TO {new}");
+        let sql = format!("ALTER INDEX IF EXISTS {old} RENAME TO {new}");
         tx.execute(&sql, &[]).await.map_err(|e| {
             PostgresError::Database(format!("Failed to rename index {old} -> {new}: {e}"))
         })?;
     }
 
     for (table, old, new) in renames.constraints {
-        let sql = format!("ALTER TABLE {table} RENAME CONSTRAINT {old} TO {new}");
+        let sql = format!(
+            "DO $$ BEGIN
+               IF EXISTS (
+                 SELECT 1 FROM information_schema.table_constraints
+                 WHERE table_schema = current_schema()
+                   AND table_name = '{table}'
+                   AND constraint_name = '{old}'
+               ) THEN
+                 ALTER TABLE {table} RENAME CONSTRAINT {old} TO {new};
+               END IF;
+             END $$"
+        );
         tx.execute(&sql, &[]).await.map_err(|e| {
             PostgresError::Database(format!(
                 "Failed to rename constraint {old} -> {new} on {table}: {e}"
@@ -177,7 +176,7 @@ async fn apply_renames_in_tx(
     // Rename the migrations tracking table last; it doubles as the canary
     // signaling that the rename is complete.
     let sql = format!(
-        "ALTER TABLE {} RENAME TO {}",
+        "ALTER TABLE IF EXISTS {} RENAME TO {}",
         renames.old_migrations_table, renames.new_migrations_table
     );
     tx.execute(&sql, &[]).await.map_err(map_db_error)?;
@@ -193,11 +192,8 @@ mod tests {
     use testcontainers::{ContainerAsync, runners::AsyncRunner};
     use testcontainers_modules::postgres::Postgres;
 
-    /// Verifies that an existing deployment with the legacy unprefixed schema
-    /// gets upgraded to `brz_`-prefixed names without data loss when
-    /// `run_migrations` is called with `Some(&renames)`. Exercises the full
-    /// rename surface: tables, indexes, named PK constraint, plus the
-    /// migrations tracking table that doubles as the canary.
+    /// End-to-end rename: tables, indexes, PK constraint, and migrations
+    /// tracker all move from legacy to `brz_*` with seed data preserved.
     #[tokio::test]
     #[allow(clippy::too_many_lines)]
     async fn test_bootstrap_rename_upgrades_legacy_schema() {
@@ -320,5 +316,70 @@ mod tests {
         run_migrations(&pool, "brz_widget_migrations", &[], Some(&renames))
             .await
             .expect("re-run should be idempotent");
+    }
+
+    /// Rename must skip listed objects that don't exist (partial pre-prefix
+    /// schema, e.g. a customer at an older migration version).
+    #[tokio::test]
+    async fn test_bootstrap_rename_tolerates_missing_objects() {
+        let container: ContainerAsync<Postgres> = Postgres::default()
+            .start()
+            .await
+            .expect("Failed to start PostgreSQL container");
+        let host_port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("Failed to get host port");
+        let pool = create_pool(&PostgresStorageConfig::with_defaults(format!(
+            "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
+        )))
+        .expect("Failed to create pool");
+
+        // Pre-populate ONLY the canary + the table — no index, no PK
+        // constraint name. The rename map below lists an index and a
+        // constraint that don't exist.
+        {
+            let client = pool.get().await.expect("get_conn");
+            client
+                .batch_execute(
+                    "CREATE TABLE widgets (id TEXT, name TEXT NOT NULL);
+                     INSERT INTO widgets (id, name) VALUES ('w1', 'alpha');
+                     CREATE TABLE legacy_widget_migrations (
+                         version INTEGER PRIMARY KEY,
+                         applied_at TIMESTAMPTZ DEFAULT NOW()
+                     );
+                     INSERT INTO legacy_widget_migrations (version) VALUES (1);",
+                )
+                .await
+                .expect("seed partial legacy schema");
+        }
+
+        let renames = SchemaRenames {
+            old_migrations_table: "legacy_widget_migrations",
+            new_migrations_table: "brz_widget_migrations",
+            tables: &[("widgets", "brz_widgets")],
+            indexes: &[("idx_widgets_missing", "brz_idx_widgets_missing")],
+            constraints: &[(
+                "brz_widgets",
+                "widgets_missing_constraint",
+                "brz_widgets_missing_constraint",
+            )],
+        };
+
+        run_migrations(&pool, "brz_widget_migrations", &[], Some(&renames))
+            .await
+            .expect("rename must skip missing objects without erroring");
+
+        let client = pool.get().await.expect("get_conn");
+        let row: Option<(String, String)> = client
+            .query_opt("SELECT id, name FROM brz_widgets WHERE id = 'w1'", &[])
+            .await
+            .expect("probe brz_widgets")
+            .map(|r| (r.get(0), r.get(1)));
+        assert_eq!(
+            row,
+            Some(("w1".to_string(), "alpha".to_string())),
+            "table + data preserved despite missing index/constraint"
+        );
     }
 }

--- a/crates/spark-postgres/src/migrations.rs
+++ b/crates/spark-postgres/src/migrations.rs
@@ -1,17 +1,52 @@
 //! Generic `PostgreSQL` migration runner with version tracking and concurrency control.
 
 use deadpool_postgres::Pool;
+use tokio_postgres::Transaction;
 
 use crate::error::PostgresError;
 use crate::pool::{map_db_error, map_pool_error};
+
+/// One-shot rename map passed to [`run_migrations`] when upgrading an
+/// existing deployment to a renamed schema. Describes how to transition
+/// every Breez-owned schema object — tables, indexes, constraints, plus the
+/// per-store schema migrations tracking table itself — from its old name to
+/// its new name. The original use case is applying a `brz_` namespace
+/// prefix.
+///
+/// `old_migrations_table` doubles as the **canary**: the runner probes
+/// `information_schema.tables` for it; if missing, the DB is either fresh
+/// or already upgraded and the rename block is skipped.
+pub struct SchemaRenames<'a> {
+    /// Old name of the per-store schema migrations table; used as the canary
+    /// check.
+    pub old_migrations_table: &'a str,
+    /// New name of the per-store schema migrations table. Must match the
+    /// `migrations_table` argument to [`run_migrations`].
+    pub new_migrations_table: &'a str,
+    /// `(old_table, new_table)` pairs.
+    pub tables: &'a [(&'a str, &'a str)],
+    /// `(old_index, new_index)` pairs.
+    pub indexes: &'a [(&'a str, &'a str)],
+    /// `(parent_table_new_name, old_constraint, new_constraint)` triples.
+    /// The table reference uses the **renamed** table name because
+    /// constraints are renamed after their parent table.
+    pub constraints: &'a [(&'a str, &'a str, &'a str)],
+}
 
 /// Runs database migrations with version tracking and concurrency control.
 ///
 /// This function:
 /// - Acquires an advisory lock (derived from `migration_lock_{table_name}`) to prevent concurrent migrations
-/// - Creates a migrations tracking table if it doesn't exist
+/// - Optionally applies a one-shot schema rename before running migrations
+///   (see [`SchemaRenames`]) — useful when upgrading an existing deployment
+///   whose tables were created under different names
+/// - Creates the migrations tracking table if it doesn't exist
 /// - Applies only new migrations (based on version number)
 /// - Commits all changes in a single transaction
+///
+/// The rename block and the version-tracked migrations run under the same
+/// `pg_advisory_xact_lock`, so the whole schema transition is one critical
+/// section.
 ///
 /// # Arguments
 /// * `pool` - The connection pool to use
@@ -19,11 +54,16 @@ use crate::pool::{map_db_error, map_pool_error};
 /// * `migrations` - List of migrations, where each migration is a list of SQL statements.
 ///   Statements are owned `String`s so callers can build them at runtime (e.g. inlining a
 ///   tenant identity into a backfill).
+/// * `renames` - Optional one-shot rename map for upgrading from an
+///   unprefixed schema. When `Some`, the runner probes the canary table and,
+///   if present, renames everything before processing version-tracked
+///   migrations. When `None`, no rename is attempted.
 #[allow(clippy::arithmetic_side_effects)]
 pub async fn run_migrations(
     pool: &Pool,
     migrations_table: &str,
     migrations: &[Vec<String>],
+    renames: Option<&SchemaRenames<'_>>,
 ) -> Result<(), PostgresError> {
     let mut client = pool.get().await.map_err(map_pool_error)?;
 
@@ -31,9 +71,10 @@ pub async fn run_migrations(
     let lock_name = format!("migration_lock_{migrations_table}");
     let lock_id: i64 = lock_name.bytes().map(i64::from).sum();
 
-    // Run all migrations in a single transaction with a transaction-level advisory lock.
-    // pg_advisory_xact_lock is automatically released on commit/rollback, making it safe
-    // with connection pools (no risk of leaked locks if the task is cancelled or panics).
+    // Run renames + version-tracked migrations under one transaction-level
+    // advisory lock. pg_advisory_xact_lock auto-releases on commit/rollback,
+    // making it safe with connection pools (no risk of leaked locks if the
+    // task is cancelled or panics).
     let tx = client.transaction().await.map_err(map_db_error)?;
 
     tx.execute("SELECT pg_advisory_xact_lock($1)", &[&lock_id])
@@ -41,6 +82,10 @@ pub async fn run_migrations(
         .map_err(|e| {
             PostgresError::Initialization(format!("Failed to acquire migration lock: {e}"))
         })?;
+
+    if let Some(renames) = renames {
+        apply_renames_in_tx(&tx, renames).await?;
+    }
 
     // Create migrations table if it doesn't exist
     // Note: table names cannot be parameterized in PostgreSQL, so we use format!
@@ -81,4 +126,199 @@ pub async fn run_migrations(
     tx.commit().await.map_err(map_db_error)?;
 
     Ok(())
+}
+
+/// Applies a one-shot schema rename inside the caller's transaction. Gated
+/// on the canary check against `renames.old_migrations_table`: if that
+/// table doesn't exist, returns early (the DB is fresh or already upgraded).
+async fn apply_renames_in_tx(
+    tx: &Transaction<'_>,
+    renames: &SchemaRenames<'_>,
+) -> Result<(), PostgresError> {
+    let canary_sql = "SELECT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = current_schema() AND table_name = $1
+    )";
+    let old_exists: bool = tx
+        .query_one(canary_sql, &[&renames.old_migrations_table])
+        .await
+        .map_err(map_db_error)?
+        .get(0);
+
+    if !old_exists {
+        return Ok(());
+    }
+
+    // Order matters only for readability — Postgres wraps the whole sequence
+    // in one transaction so a crash rolls everything back.
+    for (old, new) in renames.tables {
+        let sql = format!("ALTER TABLE {old} RENAME TO {new}");
+        tx.execute(&sql, &[]).await.map_err(|e| {
+            PostgresError::Database(format!("Failed to rename table {old} -> {new}: {e}"))
+        })?;
+    }
+
+    for (old, new) in renames.indexes {
+        let sql = format!("ALTER INDEX {old} RENAME TO {new}");
+        tx.execute(&sql, &[]).await.map_err(|e| {
+            PostgresError::Database(format!("Failed to rename index {old} -> {new}: {e}"))
+        })?;
+    }
+
+    for (table, old, new) in renames.constraints {
+        let sql = format!("ALTER TABLE {table} RENAME CONSTRAINT {old} TO {new}");
+        tx.execute(&sql, &[]).await.map_err(|e| {
+            PostgresError::Database(format!(
+                "Failed to rename constraint {old} -> {new} on {table}: {e}"
+            ))
+        })?;
+    }
+
+    // Rename the migrations tracking table last; it doubles as the canary
+    // signaling that the rename is complete.
+    let sql = format!(
+        "ALTER TABLE {} RENAME TO {}",
+        renames.old_migrations_table, renames.new_migrations_table
+    );
+    tx.execute(&sql, &[]).await.map_err(map_db_error)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PostgresStorageConfig;
+    use crate::pool::create_pool;
+    use testcontainers::{ContainerAsync, runners::AsyncRunner};
+    use testcontainers_modules::postgres::Postgres;
+
+    /// Verifies that an existing deployment with the legacy unprefixed schema
+    /// gets upgraded to `brz_`-prefixed names without data loss when
+    /// `run_migrations` is called with `Some(&renames)`. Exercises the full
+    /// rename surface: tables, indexes, named PK constraint, plus the
+    /// migrations tracking table that doubles as the canary.
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    async fn test_bootstrap_rename_upgrades_legacy_schema() {
+        let container: ContainerAsync<Postgres> = Postgres::default()
+            .start()
+            .await
+            .expect("Failed to start PostgreSQL container");
+        let host_port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("Failed to get host port");
+        let pool = create_pool(&PostgresStorageConfig::with_defaults(format!(
+            "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
+        )))
+        .expect("Failed to create pool");
+
+        // Pre-populate the schema as a pre-prefix deployment would have it:
+        // legacy table + legacy index + legacy migrations tracker with a
+        // recorded version, all unprefixed. Seed a data row that must survive
+        // the rename.
+        {
+            let client = pool.get().await.expect("get_conn");
+            client
+                .batch_execute(
+                    "CREATE TABLE widgets (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+                     CREATE INDEX idx_widgets_name ON widgets(name);
+                     INSERT INTO widgets (id, name) VALUES ('w1', 'alpha');
+                     CREATE TABLE legacy_widget_migrations (
+                         version INTEGER PRIMARY KEY,
+                         applied_at TIMESTAMPTZ DEFAULT NOW()
+                     );
+                     INSERT INTO legacy_widget_migrations (version) VALUES (1);",
+                )
+                .await
+                .expect("seed legacy schema");
+        }
+
+        let renames = SchemaRenames {
+            old_migrations_table: "legacy_widget_migrations",
+            new_migrations_table: "brz_widget_migrations",
+            tables: &[("widgets", "brz_widgets")],
+            indexes: &[("idx_widgets_name", "brz_idx_widgets_name")],
+            constraints: &[("brz_widgets", "widgets_pkey", "brz_widgets_pkey")],
+        };
+
+        // run_migrations with an empty migration list — we're only exercising
+        // the rename block and the migrations-table-version round-trip.
+        run_migrations(&pool, "brz_widget_migrations", &[], Some(&renames))
+            .await
+            .expect("rename should succeed");
+
+        let client = pool.get().await.expect("get_conn");
+
+        let new_table_exists: bool = client
+            .query_one(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                                WHERE table_schema = current_schema()
+                                  AND table_name = 'brz_widgets')",
+                &[],
+            )
+            .await
+            .expect("probe brz_widgets")
+            .get(0);
+        assert!(new_table_exists, "brz_widgets must exist after rename");
+
+        let old_table_exists: bool = client
+            .query_one(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                                WHERE table_schema = current_schema()
+                                  AND table_name = 'widgets')",
+                &[],
+            )
+            .await
+            .expect("probe widgets")
+            .get(0);
+        assert!(!old_table_exists, "legacy widgets table must be gone");
+
+        let row = client
+            .query_one("SELECT id, name FROM brz_widgets WHERE id = 'w1'", &[])
+            .await
+            .expect("seed row preserved");
+        let id: String = row.get(0);
+        let name: String = row.get(1);
+        assert_eq!(id, "w1");
+        assert_eq!(name, "alpha", "seed data must survive the rename");
+
+        let new_index_exists: bool = client
+            .query_one(
+                "SELECT EXISTS (SELECT 1 FROM pg_indexes
+                                WHERE schemaname = current_schema()
+                                  AND indexname = 'brz_idx_widgets_name')",
+                &[],
+            )
+            .await
+            .expect("probe brz index")
+            .get(0);
+        assert!(new_index_exists, "brz_idx_widgets_name must exist");
+
+        let new_pk_exists: bool = client
+            .query_one(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.table_constraints
+                                WHERE table_schema = current_schema()
+                                  AND table_name = 'brz_widgets'
+                                  AND constraint_name = 'brz_widgets_pkey')",
+                &[],
+            )
+            .await
+            .expect("probe brz pk")
+            .get(0);
+        assert!(new_pk_exists, "PK constraint must be renamed");
+
+        let version: i32 = client
+            .query_one("SELECT MAX(version) FROM brz_widget_migrations", &[])
+            .await
+            .expect("probe canary table")
+            .get(0);
+        assert_eq!(version, 1, "migrations tracker version row must survive");
+
+        // Re-running must be a no-op (canary is gone now, returns early).
+        run_migrations(&pool, "brz_widget_migrations", &[], Some(&renames))
+            .await
+            .expect("re-run should be idempotent");
+    }
 }

--- a/crates/spark-postgres/src/session_manager.rs
+++ b/crates/spark-postgres/src/session_manager.rs
@@ -18,8 +18,7 @@ use crate::pool::create_pool;
 
 const SESSION_MIGRATIONS_TABLE: &str = "brz_session_schema_migrations";
 
-/// Old-to-`brz_*` rename map for the session manager schema. Applied on
-/// first startup after upgrading to the prefixed schema.
+/// Pre-prefix rename map for upgrading session-manager deployments.
 const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
     old_migrations_table: "session_schema_migrations",
     new_migrations_table: SESSION_MIGRATIONS_TABLE,

--- a/crates/spark-postgres/src/session_manager.rs
+++ b/crates/spark-postgres/src/session_manager.rs
@@ -13,10 +13,20 @@ use spark_wallet::{Session, SessionManager, SessionManagerError};
 
 use crate::config::PostgresStorageConfig;
 use crate::error::PostgresError;
-use crate::migrations::run_migrations;
+use crate::migrations::{SchemaRenames, run_migrations};
 use crate::pool::create_pool;
 
-const SESSION_MIGRATIONS_TABLE: &str = "session_schema_migrations";
+const SESSION_MIGRATIONS_TABLE: &str = "brz_session_schema_migrations";
+
+/// Old-to-`brz_*` rename map for the session manager schema. Applied on
+/// first startup after upgrading to the prefixed schema.
+const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
+    old_migrations_table: "session_schema_migrations",
+    new_migrations_table: SESSION_MIGRATIONS_TABLE,
+    tables: &[("sessions", "brz_sessions")],
+    indexes: &[],
+    constraints: &[("brz_sessions", "sessions_pkey", "brz_sessions_pkey")],
+};
 
 /// `PostgreSQL`-backed session manager.
 ///
@@ -39,7 +49,7 @@ impl SessionManager for PostgresSessionManager {
         let service_key = service_identity_key.serialize().to_vec();
         let row = client
             .query_opt(
-                r"SELECT token, expiration FROM sessions
+                r"SELECT token, expiration FROM brz_sessions
                   WHERE user_id = $1 AND service_identity_key = $2",
                 &[&self.identity, &service_key],
             )
@@ -64,7 +74,7 @@ impl SessionManager for PostgresSessionManager {
             .map_err(|e| SessionManagerError::Generic(format!("expiration overflow: {e}")))?;
         client
             .execute(
-                r"INSERT INTO sessions (user_id, service_identity_key, token, expiration)
+                r"INSERT INTO brz_sessions (user_id, service_identity_key, token, expiration)
                   VALUES ($1, $2, $3, $4)
                   ON CONFLICT (user_id, service_identity_key)
                   DO UPDATE SET token = EXCLUDED.token, expiration = EXCLUDED.expiration",
@@ -111,12 +121,18 @@ impl PostgresSessionManager {
     }
 
     async fn migrate(&self) -> Result<(), PostgresError> {
-        run_migrations(&self.pool, SESSION_MIGRATIONS_TABLE, &Self::migrations()).await
+        run_migrations(
+            &self.pool,
+            SESSION_MIGRATIONS_TABLE,
+            &Self::migrations(),
+            Some(&SCHEMA_RENAMES),
+        )
+        .await
     }
 
     fn migrations() -> Vec<Vec<String>> {
         vec![vec![
-            "CREATE TABLE IF NOT EXISTS sessions (
+            "CREATE TABLE IF NOT EXISTS brz_sessions (
                 user_id BYTEA NOT NULL,
                 service_identity_key BYTEA NOT NULL,
                 token TEXT NOT NULL,

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -40,6 +40,7 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
         ("token_swap_status", "brz_token_swap_status"),
     ],
     indexes: &[
+        // Post-multi-tenant indexes.
         (
             "idx_token_metadata_user_issuer_pk",
             "brz_idx_token_metadata_user_issuer_pk",
@@ -51,6 +52,19 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
         (
             "idx_token_outputs_user_reservation",
             "brz_idx_token_outputs_user_reservation",
+        ),
+        // Pre-multi-tenant indexes (dropped by the multi-tenant migration).
+        (
+            "idx_token_metadata_issuer_pk",
+            "brz_idx_token_metadata_issuer_pk",
+        ),
+        (
+            "idx_token_outputs_identifier",
+            "brz_idx_token_outputs_identifier",
+        ),
+        (
+            "idx_token_outputs_reservation",
+            "brz_idx_token_outputs_reservation",
         ),
     ],
     constraints: &[

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -22,11 +22,80 @@ use uuid::Uuid;
 use crate::advisory_lock::identity_lock_key;
 use crate::config::PostgresStorageConfig;
 use crate::error::PostgresError;
-use crate::migrations::run_migrations;
+use crate::migrations::{SchemaRenames, run_migrations};
 use crate::pool::create_pool;
 
 /// Name of the schema migrations table for `PostgresTokenStore`.
-const TOKEN_MIGRATIONS_TABLE: &str = "token_schema_migrations";
+const TOKEN_MIGRATIONS_TABLE: &str = "brz_token_schema_migrations";
+
+/// Old-to-`brz_*` rename map for the token store schema. Applied on first
+/// startup after upgrading to the prefixed schema. The indexes listed are the
+/// ones present after the multi-tenant migration (the original pre-tenant
+/// indexes were dropped). The two composite FKs on `brz_token_outputs` were
+/// added inline by the multi-tenant migration without an explicit `CONSTRAINT`
+/// name, so Postgres assigned the listed `_fkey` names by column order.
+const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
+    old_migrations_table: "token_schema_migrations",
+    new_migrations_table: TOKEN_MIGRATIONS_TABLE,
+    tables: &[
+        ("token_metadata", "brz_token_metadata"),
+        ("token_reservations", "brz_token_reservations"),
+        ("token_outputs", "brz_token_outputs"),
+        ("token_spent_outputs", "brz_token_spent_outputs"),
+        ("token_swap_status", "brz_token_swap_status"),
+    ],
+    indexes: &[
+        (
+            "idx_token_metadata_user_issuer_pk",
+            "brz_idx_token_metadata_user_issuer_pk",
+        ),
+        (
+            "idx_token_outputs_user_identifier",
+            "brz_idx_token_outputs_user_identifier",
+        ),
+        (
+            "idx_token_outputs_user_reservation",
+            "brz_idx_token_outputs_user_reservation",
+        ),
+    ],
+    constraints: &[
+        (
+            "brz_token_metadata",
+            "token_metadata_pkey",
+            "brz_token_metadata_pkey",
+        ),
+        (
+            "brz_token_reservations",
+            "token_reservations_pkey",
+            "brz_token_reservations_pkey",
+        ),
+        (
+            "brz_token_outputs",
+            "token_outputs_pkey",
+            "brz_token_outputs_pkey",
+        ),
+        (
+            "brz_token_outputs",
+            "token_outputs_user_id_token_identifier_fkey",
+            "brz_token_outputs_user_id_token_identifier_fkey",
+        ),
+        (
+            "brz_token_outputs",
+            "token_outputs_user_id_reservation_id_fkey",
+            "brz_token_outputs_user_id_reservation_id_fkey",
+        ),
+        (
+            "brz_token_spent_outputs",
+            "token_spent_outputs_pkey",
+            "brz_token_spent_outputs_pkey",
+        ),
+        (
+            "brz_token_swap_status",
+            "token_swap_status_pkey",
+            "brz_token_swap_status_pkey",
+        ),
+    ],
+};
 
 /// Domain prefix mixed into the per-tenant advisory lock hash so the token
 /// store's locks never collide with the tree store's, even when two tenants
@@ -59,11 +128,11 @@ pub struct PostgresTokenStore {
 }
 
 /// Builds the multi-tenant scoping migration for the token store. Adds
-/// `user_id BYTEA` to every per-user table (including `token_metadata` —
+/// `user_id BYTEA` to every per-user table (including `brz_token_metadata` —
 /// metadata is per-tenant to avoid 0-balance leakage for tokens a tenant
 /// never owned), backfills with the connecting tenant, and rewrites primary
-/// keys / FKs to lead with `user_id`. The composite FK from `token_outputs`
-/// to `token_reservations` uses NO ACTION (the default) — column-list SET
+/// keys / FKs to lead with `user_id`. The composite FK from `brz_token_outputs`
+/// to `brz_token_reservations` uses NO ACTION (the default) — column-list SET
 /// NULL is PG15+ and a whole-row SET NULL would null `user_id` (NOT NULL).
 fn token_store_multi_tenant_migration(identity: &[u8]) -> Vec<String> {
     let id_hex = hex::encode(identity);
@@ -73,69 +142,69 @@ fn token_store_multi_tenant_migration(identity: &[u8]) -> Vec<String> {
         // Drop dependent FKs FIRST so we can rebuild the parent PKs they
         // reference. Inline `REFERENCES` clauses get auto-named
         // `<table>_<column>_fkey` so we drop those exact names if present.
-        "ALTER TABLE token_outputs DROP CONSTRAINT IF EXISTS token_outputs_reservation_id_fkey"
+        "ALTER TABLE brz_token_outputs DROP CONSTRAINT IF EXISTS brz_token_outputs_reservation_id_fkey"
             .to_string(),
-        "ALTER TABLE token_outputs DROP CONSTRAINT IF EXISTS token_outputs_token_identifier_fkey"
+        "ALTER TABLE brz_token_outputs DROP CONSTRAINT IF EXISTS brz_token_outputs_token_identifier_fkey"
             .to_string(),
-        // token_metadata: scope per-tenant. Required even though metadata
+        // brz_token_metadata: scope per-tenant. Required even though metadata
         // never structurally collides — leaking a token's mere existence
         // (e.g. a 0-balance entry for a token a tenant never held) would be
         // a privacy regression.
-        "ALTER TABLE token_metadata ADD COLUMN user_id BYTEA".to_string(),
-        format!("UPDATE token_metadata SET user_id = {id_lit}"),
-        "ALTER TABLE token_metadata \
+        "ALTER TABLE brz_token_metadata ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE brz_token_metadata SET user_id = {id_lit}"),
+        "ALTER TABLE brz_token_metadata \
          ALTER COLUMN user_id SET NOT NULL, \
-         DROP CONSTRAINT IF EXISTS token_metadata_pkey, \
+         DROP CONSTRAINT IF EXISTS brz_token_metadata_pkey, \
          ADD PRIMARY KEY (user_id, identifier)"
             .to_string(),
-        "DROP INDEX IF EXISTS idx_token_metadata_issuer_pk".to_string(),
-        "CREATE INDEX idx_token_metadata_user_issuer_pk \
-         ON token_metadata (user_id, issuer_public_key)"
+        "DROP INDEX IF EXISTS brz_idx_token_metadata_issuer_pk".to_string(),
+        "CREATE INDEX brz_idx_token_metadata_user_issuer_pk \
+         ON brz_token_metadata (user_id, issuer_public_key)"
             .to_string(),
-        // token_reservations: scope by user_id.
-        "ALTER TABLE token_reservations ADD COLUMN user_id BYTEA".to_string(),
-        format!("UPDATE token_reservations SET user_id = {id_lit}"),
-        "ALTER TABLE token_reservations \
+        // brz_token_reservations: scope by user_id.
+        "ALTER TABLE brz_token_reservations ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE brz_token_reservations SET user_id = {id_lit}"),
+        "ALTER TABLE brz_token_reservations \
          ALTER COLUMN user_id SET NOT NULL, \
-         DROP CONSTRAINT IF EXISTS token_reservations_pkey, \
+         DROP CONSTRAINT IF EXISTS brz_token_reservations_pkey, \
          ADD PRIMARY KEY (user_id, id)"
             .to_string(),
-        // token_outputs: scope by user_id, rekey, re-add composite FKs.
-        "ALTER TABLE token_outputs ADD COLUMN user_id BYTEA".to_string(),
-        format!("UPDATE token_outputs SET user_id = {id_lit}"),
-        "ALTER TABLE token_outputs \
+        // brz_token_outputs: scope by user_id, rekey, re-add composite FKs.
+        "ALTER TABLE brz_token_outputs ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE brz_token_outputs SET user_id = {id_lit}"),
+        "ALTER TABLE brz_token_outputs \
          ALTER COLUMN user_id SET NOT NULL, \
-         DROP CONSTRAINT IF EXISTS token_outputs_pkey, \
+         DROP CONSTRAINT IF EXISTS brz_token_outputs_pkey, \
          ADD PRIMARY KEY (user_id, id), \
          ADD FOREIGN KEY (user_id, token_identifier) \
-            REFERENCES token_metadata(user_id, identifier), \
+            REFERENCES brz_token_metadata(user_id, identifier), \
          ADD FOREIGN KEY (user_id, reservation_id) \
-            REFERENCES token_reservations(user_id, id)"
+            REFERENCES brz_token_reservations(user_id, id)"
             .to_string(),
-        "DROP INDEX IF EXISTS idx_token_outputs_identifier".to_string(),
-        "DROP INDEX IF EXISTS idx_token_outputs_reservation".to_string(),
-        "CREATE INDEX idx_token_outputs_user_identifier \
-         ON token_outputs (user_id, token_identifier)"
+        "DROP INDEX IF EXISTS brz_idx_token_outputs_identifier".to_string(),
+        "DROP INDEX IF EXISTS brz_idx_token_outputs_reservation".to_string(),
+        "CREATE INDEX brz_idx_token_outputs_user_identifier \
+         ON brz_token_outputs (user_id, token_identifier)"
             .to_string(),
-        "CREATE INDEX idx_token_outputs_user_reservation \
-         ON token_outputs (user_id, reservation_id) \
+        "CREATE INDEX brz_idx_token_outputs_user_reservation \
+         ON brz_token_outputs (user_id, reservation_id) \
          WHERE reservation_id IS NOT NULL"
             .to_string(),
-        // token_spent_outputs: scope by user_id.
-        "ALTER TABLE token_spent_outputs ADD COLUMN user_id BYTEA".to_string(),
-        format!("UPDATE token_spent_outputs SET user_id = {id_lit}"),
-        "ALTER TABLE token_spent_outputs \
+        // brz_token_spent_outputs: scope by user_id.
+        "ALTER TABLE brz_token_spent_outputs ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE brz_token_spent_outputs SET user_id = {id_lit}"),
+        "ALTER TABLE brz_token_spent_outputs \
          ALTER COLUMN user_id SET NOT NULL, \
-         DROP CONSTRAINT IF EXISTS token_spent_outputs_pkey, \
+         DROP CONSTRAINT IF EXISTS brz_token_spent_outputs_pkey, \
          ADD PRIMARY KEY (user_id, output_id)"
             .to_string(),
-        // token_swap_status was a singleton (PK id=1, CHECK id=1). Drop the
+        // brz_token_swap_status was a singleton (PK id=1, CHECK id=1). Drop the
         // id column (CASCADE removes both PK and CHECK), then re-key by
         // user_id so each tenant has its own swap-status row.
-        "ALTER TABLE token_swap_status DROP COLUMN id CASCADE".to_string(),
-        "ALTER TABLE token_swap_status ADD COLUMN user_id BYTEA".to_string(),
-        format!("UPDATE token_swap_status SET user_id = {id_lit}"),
-        "ALTER TABLE token_swap_status \
+        "ALTER TABLE brz_token_swap_status DROP COLUMN id CASCADE".to_string(),
+        "ALTER TABLE brz_token_swap_status ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE brz_token_swap_status SET user_id = {id_lit}"),
+        "ALTER TABLE brz_token_swap_status \
          ALTER COLUMN user_id SET NOT NULL, \
          ADD PRIMARY KEY (user_id)"
             .to_string(),
@@ -172,12 +241,12 @@ impl TokenOutputStore for PostgresTokenStore {
                     r"
                     SELECT
                         EXISTS(
-                            SELECT 1 FROM token_reservations
+                            SELECT 1 FROM brz_token_reservations
                             WHERE user_id = $1 AND purpose = 'Swap'
                         ),
                         COALESCE(
                             (SELECT last_completed_at >= $2
-                             FROM token_swap_status WHERE user_id = $1),
+                             FROM brz_token_swap_status WHERE user_id = $1),
                             FALSE
                         )
                     ",
@@ -205,7 +274,7 @@ impl TokenOutputStore for PostgresTokenStore {
         let spent_ids: HashSet<String> = {
             let rows = tx
                 .query(
-                    "SELECT output_id FROM token_spent_outputs \
+                    "SELECT output_id FROM brz_token_spent_outputs \
                      WHERE user_id = $1 AND spent_at >= $2",
                     &[&self.identity, &refresh_timestamp],
                 )
@@ -217,7 +286,7 @@ impl TokenOutputStore for PostgresTokenStore {
         // Delete non-reserved outputs added BEFORE the refresh started.
         // Outputs added after will be preserved (they were inserted while refresh was in progress).
         tx.execute(
-            "DELETE FROM token_outputs \
+            "DELETE FROM brz_token_outputs \
              WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
             &[&self.identity, &refresh_timestamp],
         )
@@ -234,8 +303,8 @@ impl TokenOutputStore for PostgresTokenStore {
         let reserved_rows = tx
             .query(
                 r"SELECT r.id, o.id AS output_id
-                  FROM token_reservations r
-                  JOIN token_outputs o
+                  FROM brz_token_reservations r
+                  JOIN brz_token_outputs o
                     ON o.reservation_id = r.id AND o.user_id = r.user_id
                   WHERE r.user_id = $1",
                 &[&self.identity],
@@ -277,14 +346,14 @@ impl TokenOutputStore for PostgresTokenStore {
         // Delete outputs whose reservations are being removed entirely
         if !reservations_to_delete.is_empty() {
             tx.execute(
-                "DELETE FROM token_outputs WHERE user_id = $1 AND reservation_id = ANY($2)",
+                "DELETE FROM brz_token_outputs WHERE user_id = $1 AND reservation_id = ANY($2)",
                 &[&self.identity, &reservations_to_delete],
             )
             .await
             .map_err(map_err)?;
 
             tx.execute(
-                "DELETE FROM token_reservations WHERE user_id = $1 AND id = ANY($2)",
+                "DELETE FROM brz_token_reservations WHERE user_id = $1 AND id = ANY($2)",
                 &[&self.identity, &reservations_to_delete],
             )
             .await
@@ -294,7 +363,7 @@ impl TokenOutputStore for PostgresTokenStore {
         // Delete individual reserved outputs that no longer exist
         if !outputs_to_remove_from_reservation.is_empty() {
             tx.execute(
-                "DELETE FROM token_outputs WHERE user_id = $1 AND id = ANY($2)",
+                "DELETE FROM brz_token_outputs WHERE user_id = $1 AND id = ANY($2)",
                 &[&self.identity, &outputs_to_remove_from_reservation],
             )
             .await
@@ -303,8 +372,8 @@ impl TokenOutputStore for PostgresTokenStore {
             // Check if any reservations are now empty after removing individual outputs
             let empty_reservations = tx
                 .query(
-                    r"SELECT r.id FROM token_reservations r
-                      LEFT JOIN token_outputs o
+                    r"SELECT r.id FROM brz_token_reservations r
+                      LEFT JOIN brz_token_outputs o
                         ON o.reservation_id = r.id AND o.user_id = r.user_id
                       WHERE r.user_id = $1 AND o.id IS NULL",
                     &[&self.identity],
@@ -315,7 +384,7 @@ impl TokenOutputStore for PostgresTokenStore {
                 empty_reservations.iter().map(|row| row.get("id")).collect();
             if !empty_ids.is_empty() {
                 tx.execute(
-                    "DELETE FROM token_reservations WHERE user_id = $1 AND id = ANY($2)",
+                    "DELETE FROM brz_token_reservations WHERE user_id = $1 AND id = ANY($2)",
                     &[&self.identity, &empty_ids],
                 )
                 .await
@@ -327,7 +396,7 @@ impl TokenOutputStore for PostgresTokenStore {
         let reserved_output_ids: HashSet<String> = {
             let rows = tx
                 .query(
-                    "SELECT id FROM token_outputs \
+                    "SELECT id FROM brz_token_outputs \
                      WHERE user_id = $1 AND reservation_id IS NOT NULL",
                     &[&self.identity],
                 )
@@ -338,11 +407,11 @@ impl TokenOutputStore for PostgresTokenStore {
 
         // Delete metadata not referenced by any remaining outputs (per-tenant).
         tx.execute(
-            r"DELETE FROM token_metadata
+            r"DELETE FROM brz_token_metadata
               WHERE user_id = $1
                 AND identifier NOT IN (
                     SELECT DISTINCT token_identifier
-                    FROM token_outputs WHERE user_id = $1
+                    FROM brz_token_outputs WHERE user_id = $1
                 )",
             &[&self.identity],
         )
@@ -390,10 +459,10 @@ impl TokenOutputStore for PostgresTokenStore {
                               ELSE 0
                             END
                          ), 0)::text AS balance
-                  FROM token_metadata m
-                  JOIN token_outputs o
+                  FROM brz_token_metadata m
+                  JOIN brz_token_outputs o
                     ON o.token_identifier = m.identifier AND o.user_id = m.user_id
-                  LEFT JOIN token_reservations r
+                  LEFT JOIN brz_token_reservations r
                     ON o.reservation_id = r.id AND o.user_id = r.user_id
                   WHERE m.user_id = $1
                   GROUP BY m.identifier, m.issuer_public_key, m.name, m.ticker,
@@ -426,10 +495,10 @@ impl TokenOutputStore for PostgresTokenStore {
                          o.token_public_key, o.token_amount,
                          o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                          r.purpose
-                  FROM token_metadata m
-                  LEFT JOIN token_outputs o
+                  FROM brz_token_metadata m
+                  LEFT JOIN brz_token_outputs o
                     ON o.token_identifier = m.identifier AND o.user_id = m.user_id
-                  LEFT JOIN token_reservations r
+                  LEFT JOIN brz_token_reservations r
                     ON o.reservation_id = r.id AND o.user_id = r.user_id
                   WHERE m.user_id = $1
                   ORDER BY m.identifier, o.token_amount::NUMERIC ASC",
@@ -497,10 +566,10 @@ impl TokenOutputStore for PostgresTokenStore {
                      o.token_public_key, o.token_amount,
                      o.prev_tx_hash, o.prev_tx_vout, o.reservation_id,
                      r.purpose
-              FROM token_metadata m
-              LEFT JOIN token_outputs o
+              FROM brz_token_metadata m
+              LEFT JOIN brz_token_outputs o
                 ON o.token_identifier = m.identifier AND o.user_id = m.user_id
-              LEFT JOIN token_reservations r
+              LEFT JOIN brz_token_reservations r
                 ON o.reservation_id = r.id AND o.user_id = r.user_id
               WHERE m.user_id = $2 AND {where_clause}
               ORDER BY o.token_amount::NUMERIC ASC"
@@ -563,7 +632,7 @@ impl TokenOutputStore for PostgresTokenStore {
             .collect();
         if !output_ids.is_empty() {
             tx.execute(
-                "DELETE FROM token_spent_outputs WHERE user_id = $1 AND output_id = ANY($2)",
+                "DELETE FROM brz_token_spent_outputs WHERE user_id = $1 AND output_id = ANY($2)",
                 &[&self.identity, &output_ids],
             )
             .await
@@ -619,7 +688,7 @@ impl TokenOutputStore for PostgresTokenStore {
         // Get metadata
         let metadata_row = tx
             .query_opt(
-                "SELECT * FROM token_metadata WHERE user_id = $1 AND identifier = $2",
+                "SELECT * FROM brz_token_metadata WHERE user_id = $1 AND identifier = $2",
                 &[&self.identity, &token_identifier],
             )
             .await
@@ -638,7 +707,7 @@ impl TokenOutputStore for PostgresTokenStore {
                          o.withdraw_bond_sats, o.withdraw_relative_block_locktime,
                          o.token_public_key, o.token_amount, o.prev_tx_hash, o.prev_tx_vout,
                          o.token_identifier AS identifier
-                  FROM token_outputs o
+                  FROM brz_token_outputs o
                   WHERE o.user_id = $1
                     AND o.token_identifier = $2
                     AND o.reservation_id IS NULL",
@@ -712,7 +781,7 @@ impl TokenOutputStore for PostgresTokenStore {
         };
 
         tx.execute(
-            "INSERT INTO token_reservations (user_id, id, purpose) VALUES ($1, $2, $3)",
+            "INSERT INTO brz_token_reservations (user_id, id, purpose) VALUES ($1, $2, $3)",
             &[&self.identity, &reservation_id, &purpose_str],
         )
         .await
@@ -724,7 +793,7 @@ impl TokenOutputStore for PostgresTokenStore {
             .map(|o| o.output.id.clone())
             .collect();
         tx.execute(
-            "UPDATE token_outputs SET reservation_id = $1 \
+            "UPDATE brz_token_outputs SET reservation_id = $1 \
              WHERE user_id = $3 AND id = ANY($2)",
             &[&reservation_id, &selected_ids, &self.identity],
         )
@@ -755,7 +824,7 @@ impl TokenOutputStore for PostgresTokenStore {
         // ACTION (column-list SET NULL is PG15+ and a whole-row SET NULL would
         // null user_id, which is NOT NULL).
         tx.execute(
-            "UPDATE token_outputs SET reservation_id = NULL \
+            "UPDATE brz_token_outputs SET reservation_id = NULL \
              WHERE user_id = $1 AND reservation_id = $2",
             &[&self.identity, id],
         )
@@ -764,7 +833,7 @@ impl TokenOutputStore for PostgresTokenStore {
 
         // Delete the reservation
         tx.execute(
-            "DELETE FROM token_reservations WHERE user_id = $1 AND id = $2",
+            "DELETE FROM brz_token_reservations WHERE user_id = $1 AND id = $2",
             &[&self.identity, id],
         )
         .await
@@ -783,7 +852,7 @@ impl TokenOutputStore for PostgresTokenStore {
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
 
-        // Serialize against `set_tokens_outputs` so its `token_spent_outputs`
+        // Serialize against `set_tokens_outputs` so its `brz_token_spent_outputs`
         // snapshot and the upsert that consumes it cannot interleave with this
         // transaction's spent-marker write.
         self.acquire_write_lock(&tx).await?;
@@ -791,7 +860,7 @@ impl TokenOutputStore for PostgresTokenStore {
         // Get reservation purpose and reserved output IDs
         let reservation_row = tx
             .query_opt(
-                "SELECT purpose FROM token_reservations WHERE user_id = $1 AND id = $2",
+                "SELECT purpose FROM brz_token_reservations WHERE user_id = $1 AND id = $2",
                 &[&self.identity, id],
             )
             .await
@@ -808,7 +877,7 @@ impl TokenOutputStore for PostgresTokenStore {
         let reserved_output_ids: Vec<String> = {
             let rows = tx
                 .query(
-                    "SELECT id FROM token_outputs WHERE user_id = $1 AND reservation_id = $2",
+                    "SELECT id FROM brz_token_outputs WHERE user_id = $1 AND reservation_id = $2",
                     &[&self.identity, id],
                 )
                 .await
@@ -819,7 +888,7 @@ impl TokenOutputStore for PostgresTokenStore {
         // Batch insert spent output markers
         if !reserved_output_ids.is_empty() {
             tx.execute(
-                r"INSERT INTO token_spent_outputs (user_id, output_id)
+                r"INSERT INTO brz_token_spent_outputs (user_id, output_id)
                   SELECT $2, output_id FROM UNNEST($1::text[]) AS t(output_id)
                   ON CONFLICT DO NOTHING",
                 &[&reserved_output_ids, &self.identity],
@@ -830,7 +899,7 @@ impl TokenOutputStore for PostgresTokenStore {
 
         // Delete reserved outputs
         tx.execute(
-            "DELETE FROM token_outputs WHERE user_id = $1 AND reservation_id = $2",
+            "DELETE FROM brz_token_outputs WHERE user_id = $1 AND reservation_id = $2",
             &[&self.identity, id],
         )
         .await
@@ -838,7 +907,7 @@ impl TokenOutputStore for PostgresTokenStore {
 
         // Delete the reservation
         tx.execute(
-            "DELETE FROM token_reservations WHERE user_id = $1 AND id = $2",
+            "DELETE FROM brz_token_reservations WHERE user_id = $1 AND id = $2",
             &[&self.identity, id],
         )
         .await
@@ -848,7 +917,7 @@ impl TokenOutputStore for PostgresTokenStore {
         // tenant that joined after migration 2 (and thus has no row) gets one.
         if is_swap {
             tx.execute(
-                "INSERT INTO token_swap_status (user_id, last_completed_at) \
+                "INSERT INTO brz_token_swap_status (user_id, last_completed_at) \
                  VALUES ($1, NOW()) \
                  ON CONFLICT (user_id) DO UPDATE SET last_completed_at = EXCLUDED.last_completed_at",
                 &[&self.identity],
@@ -859,11 +928,11 @@ impl TokenOutputStore for PostgresTokenStore {
 
         // Clean up any orphaned metadata (per-tenant).
         tx.execute(
-            r"DELETE FROM token_metadata
+            r"DELETE FROM brz_token_metadata
               WHERE user_id = $1
                 AND identifier NOT IN (
                     SELECT DISTINCT token_identifier
-                    FROM token_outputs WHERE user_id = $1
+                    FROM brz_token_outputs WHERE user_id = $1
                 )",
             &[&self.identity],
         )
@@ -928,6 +997,7 @@ impl PostgresTokenStore {
             &self.pool,
             TOKEN_MIGRATIONS_TABLE,
             &Self::migrations(&self.identity),
+            Some(&SCHEMA_RENAMES),
         )
         .await
     }
@@ -937,7 +1007,7 @@ impl PostgresTokenStore {
         vec![
             // Migration 1: Token store tables with race condition protection
             vec![
-                "CREATE TABLE IF NOT EXISTS token_metadata (
+                "CREATE TABLE IF NOT EXISTS brz_token_metadata (
                     identifier TEXT PRIMARY KEY,
                     issuer_public_key TEXT NOT NULL,
                     name TEXT NOT NULL,
@@ -948,18 +1018,18 @@ impl PostgresTokenStore {
                     creation_entity_public_key TEXT
                 )"
                 .to_string(),
-                "CREATE INDEX IF NOT EXISTS idx_token_metadata_issuer_pk
-                    ON token_metadata (issuer_public_key)"
+                "CREATE INDEX IF NOT EXISTS brz_idx_token_metadata_issuer_pk
+                    ON brz_token_metadata (issuer_public_key)"
                     .to_string(),
-                "CREATE TABLE IF NOT EXISTS token_reservations (
+                "CREATE TABLE IF NOT EXISTS brz_token_reservations (
                     id TEXT PRIMARY KEY,
                     purpose TEXT NOT NULL,
                     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
                 )"
                 .to_string(),
-                "CREATE TABLE IF NOT EXISTS token_outputs (
+                "CREATE TABLE IF NOT EXISTS brz_token_outputs (
                     id TEXT PRIMARY KEY,
-                    token_identifier TEXT NOT NULL REFERENCES token_metadata(identifier),
+                    token_identifier TEXT NOT NULL REFERENCES brz_token_metadata(identifier),
                     owner_public_key TEXT NOT NULL,
                     revocation_commitment TEXT NOT NULL,
                     withdraw_bond_sats BIGINT NOT NULL,
@@ -968,30 +1038,31 @@ impl PostgresTokenStore {
                     token_amount TEXT NOT NULL,
                     prev_tx_hash TEXT NOT NULL,
                     prev_tx_vout INTEGER NOT NULL,
-                    reservation_id TEXT REFERENCES token_reservations(id) ON DELETE SET NULL,
+                    reservation_id TEXT REFERENCES brz_token_reservations(id) ON DELETE SET NULL,
                     added_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
                 )"
                 .to_string(),
-                "CREATE INDEX IF NOT EXISTS idx_token_outputs_identifier
-                    ON token_outputs (token_identifier)"
+                "CREATE INDEX IF NOT EXISTS brz_idx_token_outputs_identifier
+                    ON brz_token_outputs (token_identifier)"
                     .to_string(),
-                "CREATE INDEX IF NOT EXISTS idx_token_outputs_reservation
-                    ON token_outputs (reservation_id) WHERE reservation_id IS NOT NULL"
+                "CREATE INDEX IF NOT EXISTS brz_idx_token_outputs_reservation
+                    ON brz_token_outputs (reservation_id) WHERE reservation_id IS NOT NULL"
                     .to_string(),
-                "CREATE TABLE IF NOT EXISTS token_spent_outputs (
+                "CREATE TABLE IF NOT EXISTS brz_token_spent_outputs (
                     output_id TEXT PRIMARY KEY,
                     spent_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
                 )"
                 .to_string(),
-                "CREATE TABLE IF NOT EXISTS token_swap_status (
+                "CREATE TABLE IF NOT EXISTS brz_token_swap_status (
                     id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
                     last_completed_at TIMESTAMPTZ
                 )"
                 .to_string(),
-                "INSERT INTO token_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING".to_string(),
+                "INSERT INTO brz_token_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING"
+                    .to_string(),
             ],
             // Migration 2: Multi-tenant scoping. Adds user_id to every token-store
-            // table (including `token_metadata` — per-tenant to avoid 0-balance
+            // table (including `brz_token_metadata` — per-tenant to avoid 0-balance
             // leakage), backfills with the connecting tenant, and rewrites primary
             // keys / FKs / indexes to lead with user_id.
             token_store_multi_tenant_migration(identity),
@@ -1021,7 +1092,7 @@ impl PostgresTokenStore {
         output: &TokenOutputWithPrevOut,
     ) -> Result<(), TokenOutputServiceError> {
         tx.execute(
-            r"INSERT INTO token_outputs
+            r"INSERT INTO brz_token_outputs
                 (user_id, id, token_identifier, owner_public_key, revocation_commitment,
                  withdraw_bond_sats, withdraw_relative_block_locktime,
                  token_public_key, token_amount, prev_tx_hash, prev_tx_vout, added_at)
@@ -1054,7 +1125,7 @@ impl PostgresTokenStore {
         metadata: &TokenMetadata,
     ) -> Result<(), TokenOutputServiceError> {
         tx.execute(
-            r"INSERT INTO token_metadata
+            r"INSERT INTO brz_token_metadata
                 (user_id, identifier, issuer_public_key, name, ticker, decimals, max_supply,
                  is_freezable, creation_entity_public_key)
               VALUES ($9, $1, $2, $3, $4, $5, $6, $7, $8)
@@ -1095,10 +1166,10 @@ impl PostgresTokenStore {
     ) -> Result<u64, TokenOutputServiceError> {
         // Release outputs still pointing at any soon-to-be-deleted reservation.
         tx.execute(
-            r"UPDATE token_outputs SET reservation_id = NULL
+            r"UPDATE brz_token_outputs SET reservation_id = NULL
               WHERE user_id = $2
                 AND reservation_id IN (
-                    SELECT id FROM token_reservations
+                    SELECT id FROM brz_token_reservations
                     WHERE user_id = $2
                       AND created_at < NOW() - make_interval(secs => $1)
                 )",
@@ -1109,7 +1180,7 @@ impl PostgresTokenStore {
 
         let result = tx
             .execute(
-                r"DELETE FROM token_reservations
+                r"DELETE FROM brz_token_reservations
                   WHERE user_id = $2
                     AND created_at < NOW() - make_interval(secs => $1)",
                 &[&RESERVATION_TIMEOUT_SECS, &self.identity],
@@ -1136,7 +1207,7 @@ impl PostgresTokenStore {
             .unwrap_or(refresh_timestamp);
 
         tx.execute(
-            "DELETE FROM token_spent_outputs WHERE user_id = $2 AND spent_at < $1",
+            "DELETE FROM brz_token_spent_outputs WHERE user_id = $2 AND spent_at < $1",
             &[&cleanup_cutoff, &self.identity],
         )
         .await
@@ -1592,7 +1663,7 @@ mod tests {
         let client = fixture.store.pool.get().await.unwrap();
         client
             .execute(
-                "UPDATE token_reservations SET created_at = NOW() - INTERVAL '10 minutes' WHERE id = $1",
+                "UPDATE brz_token_reservations SET created_at = NOW() - INTERVAL '10 minutes' WHERE id = $1",
                 &[&reservation.id],
             )
             .await
@@ -1743,7 +1814,7 @@ mod tests {
     }
 
     /// End-to-end isolation: every `TokenOutputStore` method must keep tenants
-    /// A and B from observing each other's data. Critically, `token_metadata`
+    /// A and B from observing each other's data. Critically, `brz_token_metadata`
     /// is per-tenant — both tenants seeding the same `identifier` ("token-1")
     /// must coexist without collision and without leaking each other's
     /// balances. Exercises set/insert/list/get/balance/reserve/finalize and
@@ -1891,7 +1962,7 @@ mod tests {
 
         // --- insert_token_outputs on A only inserts into A's namespace ---
         // Use identifier_no=2 so the metadata identifier ("token-2") collides
-        // with B's existing entry — that exercises per-tenant `token_metadata`:
+        // with B's existing entry — that exercises per-tenant `brz_token_metadata`:
         // both tenants must end up with their own row, and A's outputs/balance
         // for "token-2" must differ from B's.
         let a_token2 = shared_tests::create_token_outputs(2, vec![999]);

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -28,12 +28,7 @@ use crate::pool::create_pool;
 /// Name of the schema migrations table for `PostgresTokenStore`.
 const TOKEN_MIGRATIONS_TABLE: &str = "brz_token_schema_migrations";
 
-/// Old-to-`brz_*` rename map for the token store schema. Applied on first
-/// startup after upgrading to the prefixed schema. The indexes listed are the
-/// ones present after the multi-tenant migration (the original pre-tenant
-/// indexes were dropped). The two composite FKs on `brz_token_outputs` were
-/// added inline by the multi-tenant migration without an explicit `CONSTRAINT`
-/// name, so Postgres assigned the listed `_fkey` names by column order.
+/// Pre-prefix rename map for upgrading token-store deployments.
 const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
     old_migrations_table: "token_schema_migrations",
     new_migrations_table: TOKEN_MIGRATIONS_TABLE,
@@ -83,6 +78,18 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
             "brz_token_outputs",
             "token_outputs_user_id_reservation_id_fkey",
             "brz_token_outputs_user_id_reservation_id_fkey",
+        ),
+        // Pre-multi-tenant FKs (single-column). Rename so the post-tenant
+        // migration's `DROP CONSTRAINT IF EXISTS brz_*_fkey` finds them.
+        (
+            "brz_token_outputs",
+            "token_outputs_token_identifier_fkey",
+            "brz_token_outputs_token_identifier_fkey",
+        ),
+        (
+            "brz_token_outputs",
+            "token_outputs_reservation_id_fkey",
+            "brz_token_outputs_reservation_id_fkey",
         ),
         (
             "brz_token_spent_outputs",

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -23,11 +23,69 @@ use uuid::Uuid;
 use crate::advisory_lock::identity_lock_key;
 use crate::config::PostgresStorageConfig;
 use crate::error::PostgresError;
-use crate::migrations::run_migrations;
+use crate::migrations::{SchemaRenames, run_migrations};
 use crate::pool::create_pool;
 
 /// Name of the schema migrations table for `PostgresTreeStore`.
-const TREE_MIGRATIONS_TABLE: &str = "tree_schema_migrations";
+const TREE_MIGRATIONS_TABLE: &str = "brz_tree_schema_migrations";
+
+/// Old-to-`brz_*` rename map for the tree store schema. Applied on first
+/// startup after upgrading to the prefixed schema. The indexes listed are the
+/// ones present after the multi-tenant migration (the original pre-tenant
+/// indexes were dropped by that migration). The composite FK on `brz_tree_leaves`
+/// was added inline by the multi-tenant migration without an explicit
+/// `CONSTRAINT` name, so Postgres assigned `tree_leaves_user_id_reservation_id_fkey`.
+const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
+    old_migrations_table: "tree_schema_migrations",
+    new_migrations_table: TREE_MIGRATIONS_TABLE,
+    tables: &[
+        ("tree_reservations", "brz_tree_reservations"),
+        ("tree_leaves", "brz_tree_leaves"),
+        ("tree_spent_leaves", "brz_tree_spent_leaves"),
+        ("tree_swap_status", "brz_tree_swap_status"),
+    ],
+    indexes: &[
+        (
+            "idx_tree_leaves_user_available",
+            "brz_idx_tree_leaves_user_available",
+        ),
+        (
+            "idx_tree_leaves_user_reservation",
+            "brz_idx_tree_leaves_user_reservation",
+        ),
+        (
+            "idx_tree_leaves_user_added_at",
+            "brz_idx_tree_leaves_user_added_at",
+        ),
+    ],
+    constraints: &[
+        (
+            "brz_tree_reservations",
+            "tree_reservations_pkey",
+            "brz_tree_reservations_pkey",
+        ),
+        (
+            "brz_tree_leaves",
+            "tree_leaves_pkey",
+            "brz_tree_leaves_pkey",
+        ),
+        (
+            "brz_tree_leaves",
+            "tree_leaves_user_id_reservation_id_fkey",
+            "brz_tree_leaves_user_id_reservation_id_fkey",
+        ),
+        (
+            "brz_tree_spent_leaves",
+            "tree_spent_leaves_pkey",
+            "brz_tree_spent_leaves_pkey",
+        ),
+        (
+            "brz_tree_swap_status",
+            "tree_swap_status_pkey",
+            "brz_tree_swap_status_pkey",
+        ),
+    ],
+};
 
 /// Lightweight `(id, value)` pair used by `try_reserve_leaves` to run the
 /// selection algorithm without pulling each leaf's full `data` JSON.
@@ -86,62 +144,63 @@ fn tree_store_multi_tenant_migration(identity: &[u8]) -> Vec<String> {
     let id_lit = format!("'\\x{id_hex}'::bytea");
 
     vec![
-        // tree_leaves: drop the old single-column FK to tree_reservations(id)
-        // FIRST, before we touch the tree_reservations PK it depends on.
-        "ALTER TABLE tree_leaves DROP CONSTRAINT IF EXISTS tree_leaves_reservation_id_fkey"
+        // brz_tree_leaves: drop the old single-column FK to brz_tree_reservations(id)
+        // FIRST, before we touch the brz_tree_reservations PK it depends on.
+        "ALTER TABLE brz_tree_leaves DROP CONSTRAINT IF EXISTS brz_tree_leaves_reservation_id_fkey"
             .to_string(),
-        // tree_reservations: scope by user_id.
-        "ALTER TABLE tree_reservations ADD COLUMN user_id BYTEA".to_string(),
-        format!("UPDATE tree_reservations SET user_id = {id_lit}"),
-        "ALTER TABLE tree_reservations \
+        // brz_tree_reservations: scope by user_id.
+        "ALTER TABLE brz_tree_reservations ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE brz_tree_reservations SET user_id = {id_lit}"),
+        "ALTER TABLE brz_tree_reservations \
          ALTER COLUMN user_id SET NOT NULL, \
-         DROP CONSTRAINT IF EXISTS tree_reservations_pkey, \
+         DROP CONSTRAINT IF EXISTS brz_tree_reservations_pkey, \
          ADD PRIMARY KEY (user_id, id)"
             .to_string(),
-        // tree_leaves: add user_id, rekey, and re-add the composite FK to the
-        // new tree_reservations PK.
-        "ALTER TABLE tree_leaves ADD COLUMN user_id BYTEA".to_string(),
-        format!("UPDATE tree_leaves SET user_id = {id_lit}"),
+        // brz_tree_leaves: add user_id, rekey, and re-add the composite FK to the
+        // new brz_tree_reservations PK.
+        "ALTER TABLE brz_tree_leaves ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE brz_tree_leaves SET user_id = {id_lit}"),
         // The composite FK uses NO ACTION (the default) instead of the previous
         // single-column `ON DELETE SET NULL`: PG-only column-list SET NULL is
         // PG15+, and a whole-row SET NULL would try to null `user_id` too.
         // Callers (`cleanup_stale_reservations`, `cancel_reservation`,
         // `finalize_reservation`) explicitly clear `reservation_id` before
         // deleting the parent reservation row.
-        "ALTER TABLE tree_leaves \
+        "ALTER TABLE brz_tree_leaves \
          ALTER COLUMN user_id SET NOT NULL, \
-         DROP CONSTRAINT IF EXISTS tree_leaves_pkey, \
+         DROP CONSTRAINT IF EXISTS brz_tree_leaves_pkey, \
          ADD PRIMARY KEY (user_id, id), \
          ADD FOREIGN KEY (user_id, reservation_id) \
-            REFERENCES tree_reservations(user_id, id)"
+            REFERENCES brz_tree_reservations(user_id, id)"
             .to_string(),
-        "DROP INDEX IF EXISTS idx_tree_leaves_available".to_string(),
-        "DROP INDEX IF EXISTS idx_tree_leaves_reservation".to_string(),
-        "DROP INDEX IF EXISTS idx_tree_leaves_added_at".to_string(),
-        "CREATE INDEX idx_tree_leaves_user_available \
-         ON tree_leaves(user_id, status, is_missing_from_operators) \
+        "DROP INDEX IF EXISTS brz_idx_tree_leaves_available".to_string(),
+        "DROP INDEX IF EXISTS brz_idx_tree_leaves_reservation".to_string(),
+        "DROP INDEX IF EXISTS brz_idx_tree_leaves_added_at".to_string(),
+        "CREATE INDEX brz_idx_tree_leaves_user_available \
+         ON brz_tree_leaves(user_id, status, is_missing_from_operators) \
          WHERE status = 'Available' AND is_missing_from_operators = FALSE"
             .to_string(),
-        "CREATE INDEX idx_tree_leaves_user_reservation \
-         ON tree_leaves(user_id, reservation_id) \
+        "CREATE INDEX brz_idx_tree_leaves_user_reservation \
+         ON brz_tree_leaves(user_id, reservation_id) \
          WHERE reservation_id IS NOT NULL"
             .to_string(),
-        "CREATE INDEX idx_tree_leaves_user_added_at ON tree_leaves(user_id, added_at)".to_string(),
-        // tree_spent_leaves: scope by user_id.
-        "ALTER TABLE tree_spent_leaves ADD COLUMN user_id BYTEA".to_string(),
-        format!("UPDATE tree_spent_leaves SET user_id = {id_lit}"),
-        "ALTER TABLE tree_spent_leaves \
+        "CREATE INDEX brz_idx_tree_leaves_user_added_at ON brz_tree_leaves(user_id, added_at)"
+            .to_string(),
+        // brz_tree_spent_leaves: scope by user_id.
+        "ALTER TABLE brz_tree_spent_leaves ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE brz_tree_spent_leaves SET user_id = {id_lit}"),
+        "ALTER TABLE brz_tree_spent_leaves \
          ALTER COLUMN user_id SET NOT NULL, \
-         DROP CONSTRAINT IF EXISTS tree_spent_leaves_pkey, \
+         DROP CONSTRAINT IF EXISTS brz_tree_spent_leaves_pkey, \
          ADD PRIMARY KEY (user_id, leaf_id)"
             .to_string(),
-        // tree_swap_status was a singleton (PK id=1, CHECK id=1). Drop the id
+        // brz_tree_swap_status was a singleton (PK id=1, CHECK id=1). Drop the id
         // column (CASCADE removes both PK and CHECK), then re-key by user_id so
         // each tenant has its own swap-status row.
-        "ALTER TABLE tree_swap_status DROP COLUMN id CASCADE".to_string(),
-        "ALTER TABLE tree_swap_status ADD COLUMN user_id BYTEA".to_string(),
-        format!("UPDATE tree_swap_status SET user_id = {id_lit}"),
-        "ALTER TABLE tree_swap_status \
+        "ALTER TABLE brz_tree_swap_status DROP COLUMN id CASCADE".to_string(),
+        "ALTER TABLE brz_tree_swap_status ADD COLUMN user_id BYTEA".to_string(),
+        format!("UPDATE brz_tree_swap_status SET user_id = {id_lit}"),
+        "ALTER TABLE brz_tree_swap_status \
          ALTER COLUMN user_id SET NOT NULL, \
          ADD PRIMARY KEY (user_id)"
             .to_string(),
@@ -191,8 +250,8 @@ impl TreeStore for PostgresTreeStore {
             .query_one(
                 r"
                 SELECT COALESCE(SUM((l.data->>'value')::bigint), 0)::bigint AS balance
-                FROM tree_leaves l
-                LEFT JOIN tree_reservations r
+                FROM brz_tree_leaves l
+                LEFT JOIN brz_tree_reservations r
                   ON l.reservation_id = r.id AND l.user_id = r.user_id
                 WHERE l.user_id = $1
                   AND (
@@ -216,8 +275,8 @@ impl TreeStore for PostgresTreeStore {
                 r"
                 SELECT l.id, l.status, l.is_missing_from_operators, l.data,
                        l.reservation_id, r.purpose
-                FROM tree_leaves l
-                LEFT JOIN tree_reservations r
+                FROM brz_tree_leaves l
+                LEFT JOIN brz_tree_reservations r
                   ON l.reservation_id = r.id AND l.user_id = r.user_id
                 WHERE l.user_id = $1
                 ",
@@ -295,12 +354,12 @@ impl TreeStore for PostgresTreeStore {
                     r"
                     SELECT
                         EXISTS(
-                            SELECT 1 FROM tree_reservations
+                            SELECT 1 FROM brz_tree_reservations
                             WHERE user_id = $1 AND purpose = 'Swap'
                         ),
                         COALESCE(
                             (SELECT last_completed_at >= $2
-                             FROM tree_swap_status WHERE user_id = $1),
+                             FROM brz_tree_swap_status WHERE user_id = $1),
                             FALSE
                         )
                     ",
@@ -324,7 +383,7 @@ impl TreeStore for PostgresTreeStore {
         let spent_ids: HashSet<String> = {
             let rows = tx
                 .query(
-                    "SELECT leaf_id FROM tree_spent_leaves \
+                    "SELECT leaf_id FROM brz_tree_spent_leaves \
                      WHERE user_id = $1 AND spent_at >= $2",
                     &[&self.identity, &refresh_timestamp],
                 )
@@ -345,7 +404,7 @@ impl TreeStore for PostgresTreeStore {
         // (FK ON DELETE SET NULL) — those rows kept their old added_at, so they are
         // dropped here and re-fetched from the operator response in the upsert below.
         tx.execute(
-            "DELETE FROM tree_leaves \
+            "DELETE FROM brz_tree_leaves \
              WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
             &[&self.identity, &refresh_timestamp],
         )
@@ -375,7 +434,7 @@ impl TreeStore for PostgresTreeStore {
 
         let reservation = tx
             .query_opt(
-                "SELECT id FROM tree_reservations WHERE user_id = $1 AND id = $2",
+                "SELECT id FROM brz_tree_reservations WHERE user_id = $1 AND id = $2",
                 &[&self.identity, id],
             )
             .await
@@ -387,7 +446,7 @@ impl TreeStore for PostgresTreeStore {
 
         let prior_leaf_ids: Vec<String> = tx
             .query(
-                "SELECT id FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+                "SELECT id FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
                 &[&self.identity, id],
             )
             .await
@@ -406,14 +465,14 @@ impl TreeStore for PostgresTreeStore {
         );
 
         tx.execute(
-            "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+            "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
             &[&self.identity, id],
         )
         .await
         .map_err(map_err)?;
 
         tx.execute(
-            "DELETE FROM tree_reservations WHERE user_id = $1 AND id = $2",
+            "DELETE FROM brz_tree_reservations WHERE user_id = $1 AND id = $2",
             &[&self.identity, id],
         )
         .await
@@ -435,7 +494,7 @@ impl TreeStore for PostgresTreeStore {
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
 
-        // Serialize against `set_leaves` so its `tree_spent_leaves` snapshot
+        // Serialize against `set_leaves` so its `brz_tree_spent_leaves` snapshot
         // and the upsert that consumes it cannot interleave with this
         // transaction's spent-marker write — otherwise the snapshot would miss
         // our marker and the upsert would write the just-spent leaf back as
@@ -445,7 +504,7 @@ impl TreeStore for PostgresTreeStore {
         // Check if reservation exists and get its purpose
         let reservation = tx
             .query_opt(
-                "SELECT id, purpose FROM tree_reservations WHERE user_id = $1 AND id = $2",
+                "SELECT id, purpose FROM brz_tree_reservations WHERE user_id = $1 AND id = $2",
                 &[&self.identity, id],
             )
             .await
@@ -455,7 +514,7 @@ impl TreeStore for PostgresTreeStore {
             let is_swap = row.get::<_, String>("purpose") == "Swap";
             let leaf_ids: Vec<String> = tx
                 .query(
-                    "SELECT id FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+                    "SELECT id FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
                     &[&self.identity, id],
                 )
                 .await
@@ -479,14 +538,14 @@ impl TreeStore for PostgresTreeStore {
             .await?;
 
         tx.execute(
-            "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+            "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
             &[&self.identity, id],
         )
         .await
         .map_err(map_err)?;
 
         tx.execute(
-            "DELETE FROM tree_reservations WHERE user_id = $1 AND id = $2",
+            "DELETE FROM brz_tree_reservations WHERE user_id = $1 AND id = $2",
             &[&self.identity, id],
         )
         .await
@@ -508,7 +567,7 @@ impl TreeStore for PostgresTreeStore {
         // that joined after migration 3 (and thus has no row) gets one created.
         if is_swap && new_leaves.is_some() {
             tx.execute(
-                "INSERT INTO tree_swap_status (user_id, last_completed_at) \
+                "INSERT INTO brz_tree_swap_status (user_id, last_completed_at) \
                  VALUES ($1, NOW()) \
                  ON CONFLICT (user_id) DO UPDATE SET last_completed_at = EXCLUDED.last_completed_at",
                 &[&self.identity],
@@ -548,7 +607,7 @@ impl TreeStore for PostgresTreeStore {
             .query_one(
                 r"
                 SELECT COALESCE(SUM((data->>'value')::bigint), 0)::bigint AS total
-                FROM tree_leaves
+                FROM brz_tree_leaves
                 WHERE user_id = $1
                   AND status = 'Available'
                   AND is_missing_from_operators = FALSE
@@ -570,7 +629,7 @@ impl TreeStore for PostgresTreeStore {
             .query(
                 r"
                 SELECT id, (data->>'value')::bigint AS value
-                FROM tree_leaves
+                FROM brz_tree_leaves
                 WHERE user_id = $1
                   AND status = 'Available'
                   AND is_missing_from_operators = FALSE
@@ -578,7 +637,7 @@ impl TreeStore for PostgresTreeStore {
                   AND (
                     (data->>'value')::bigint <= $2
                     OR id = (
-                      SELECT id FROM tree_leaves
+                      SELECT id FROM brz_tree_leaves
                       WHERE user_id = $1
                         AND status = 'Available'
                         AND is_missing_from_operators = FALSE
@@ -723,7 +782,7 @@ impl TreeStore for PostgresTreeStore {
 
         let reservation = tx
             .query_opt(
-                "SELECT id FROM tree_reservations WHERE user_id = $1 AND id = $2",
+                "SELECT id FROM brz_tree_reservations WHERE user_id = $1 AND id = $2",
                 &[&self.identity, reservation_id],
             )
             .await
@@ -739,7 +798,7 @@ impl TreeStore for PostgresTreeStore {
         let old_reserved_leaf_ids: Vec<String> = {
             let rows = tx
                 .query(
-                    "SELECT id FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+                    "SELECT id FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
                     &[&self.identity, reservation_id],
                 )
                 .await
@@ -751,7 +810,7 @@ impl TreeStore for PostgresTreeStore {
         self.batch_insert_spent_leaves(&tx, &old_reserved_leaf_ids)
             .await?;
         tx.execute(
-            "DELETE FROM tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+            "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
             &[&self.identity, reservation_id],
         )
         .await
@@ -772,7 +831,7 @@ impl TreeStore for PostgresTreeStore {
 
         // Clear pending change amount
         tx.execute(
-            "UPDATE tree_reservations SET pending_change_amount = 0 \
+            "UPDATE brz_tree_reservations SET pending_change_amount = 0 \
              WHERE user_id = $1 AND id = $2",
             &[&self.identity, reservation_id],
         )
@@ -844,6 +903,7 @@ impl PostgresTreeStore {
             &self.pool,
             TREE_MIGRATIONS_TABLE,
             &Self::migrations(&self.identity),
+            Some(&SCHEMA_RENAMES),
         )
         .await
     }
@@ -853,43 +913,43 @@ impl PostgresTreeStore {
         vec![
             // Migration 1: Initial tree tables
             vec![
-                "CREATE TABLE IF NOT EXISTS tree_reservations (
+                "CREATE TABLE IF NOT EXISTS brz_tree_reservations (
                     id TEXT PRIMARY KEY,
                     purpose TEXT NOT NULL,
                     pending_change_amount BIGINT NOT NULL DEFAULT 0,
                     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
                 )".to_string(),
-                "CREATE TABLE IF NOT EXISTS tree_leaves (
+                "CREATE TABLE IF NOT EXISTS brz_tree_leaves (
                     id TEXT PRIMARY KEY,
                     status TEXT NOT NULL,
                     is_missing_from_operators BOOLEAN NOT NULL DEFAULT FALSE,
-                    reservation_id TEXT REFERENCES tree_reservations(id) ON DELETE SET NULL,
+                    reservation_id TEXT REFERENCES brz_tree_reservations(id) ON DELETE SET NULL,
                     data JSONB NOT NULL,
                     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                     added_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
                 )".to_string(),
-                "CREATE TABLE IF NOT EXISTS tree_spent_leaves (
+                "CREATE TABLE IF NOT EXISTS brz_tree_spent_leaves (
                     leaf_id TEXT PRIMARY KEY,
                     spent_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
                 )".to_string(),
-                "CREATE INDEX IF NOT EXISTS idx_tree_leaves_available ON tree_leaves(status, is_missing_from_operators)
+                "CREATE INDEX IF NOT EXISTS brz_idx_tree_leaves_available ON brz_tree_leaves(status, is_missing_from_operators)
                     WHERE status = 'Available' AND is_missing_from_operators = FALSE".to_string(),
-                "CREATE INDEX IF NOT EXISTS idx_tree_leaves_reservation ON tree_leaves(reservation_id)
+                "CREATE INDEX IF NOT EXISTS brz_idx_tree_leaves_reservation ON brz_tree_leaves(reservation_id)
                     WHERE reservation_id IS NOT NULL".to_string(),
-                "CREATE INDEX IF NOT EXISTS idx_tree_leaves_added_at ON tree_leaves(added_at)".to_string(),
+                "CREATE INDEX IF NOT EXISTS brz_idx_tree_leaves_added_at ON brz_tree_leaves(added_at)".to_string(),
             ],
             // Migration 2: Add swap status tracking for race condition fix
             vec![
-                "CREATE TABLE IF NOT EXISTS tree_swap_status (
+                "CREATE TABLE IF NOT EXISTS brz_tree_swap_status (
                     id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
                     last_completed_at TIMESTAMPTZ
                 )".to_string(),
-                "INSERT INTO tree_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING".to_string(),
+                "INSERT INTO brz_tree_swap_status (id) VALUES (1) ON CONFLICT DO NOTHING".to_string(),
             ],
             // Migration 3: Multi-tenant scoping. Adds user_id to every tree-store
             // table, backfills with the connecting tenant's identity, and rewrites
             // primary keys / FKs / indexes to lead with user_id. The
-            // `tree_swap_status` singleton is restructured the same way as
+            // `brz_tree_swap_status` singleton is restructured the same way as
             // `sync_revision` in the SDK-core storage. See `multi_tenant_migration`
             // for the SQL.
             tree_store_multi_tenant_migration(identity),
@@ -913,7 +973,7 @@ impl PostgresTreeStore {
         let row = tx
             .query_one(
                 "SELECT COALESCE(SUM(pending_change_amount), 0)::BIGINT \
-                 FROM tree_reservations WHERE user_id = $1",
+                 FROM brz_tree_reservations WHERE user_id = $1",
                 &[&self.identity],
             )
             .await
@@ -935,7 +995,7 @@ impl PostgresTreeStore {
             .map_err(|e| TreeServiceError::Generic(format!("Failed to deserialize TreeNode: {e}")))
     }
 
-    /// Batch upserts leaves into `tree_leaves` table using UNNEST.
+    /// Batch upserts leaves into `brz_tree_leaves` table using UNNEST.
     /// Optionally skips leaves whose IDs are in the `skip_ids` set.
     /// Uses ON CONFLICT DO UPDATE to replace existing leaves (matching `InMemoryTreeStore` behavior).
     async fn batch_upsert_leaves(
@@ -981,7 +1041,7 @@ impl PostgresTreeStore {
 
         tx.execute(
             r"
-            INSERT INTO tree_leaves (user_id, id, status, is_missing_from_operators, data, added_at)
+            INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, added_at)
             SELECT $5, id, status, missing, data, NOW()
             FROM UNNEST($1::text[], $2::text[], $3::bool[], $4::jsonb[])
                 AS t(id, status, missing, data)
@@ -1018,7 +1078,7 @@ impl PostgresTreeStore {
 
         tx.execute(
             r"
-            UPDATE tree_leaves
+            UPDATE brz_tree_leaves
             SET reservation_id = $1
             WHERE user_id = $3 AND id = ANY($2)
             ",
@@ -1042,7 +1102,7 @@ impl PostgresTreeStore {
 
         tx.execute(
             r"
-            INSERT INTO tree_spent_leaves (user_id, leaf_id)
+            INSERT INTO brz_tree_spent_leaves (user_id, leaf_id)
             SELECT $2, leaf_id FROM UNNEST($1::text[]) AS t(leaf_id)
             ON CONFLICT DO NOTHING
             ",
@@ -1069,7 +1129,7 @@ impl PostgresTreeStore {
         let result = tx
             .execute(
                 r"
-                DELETE FROM tree_spent_leaves
+                DELETE FROM brz_tree_spent_leaves
                 WHERE user_id = $2 AND leaf_id = ANY($1)
                 ",
                 &[&leaf_ids, &self.identity],
@@ -1115,7 +1175,7 @@ impl PostgresTreeStore {
         }
         let rows = tx
             .query(
-                "SELECT id, data FROM tree_leaves WHERE user_id = $2 AND id = ANY($1)",
+                "SELECT id, data FROM brz_tree_leaves WHERE user_id = $2 AND id = ANY($1)",
                 &[&ids, &self.identity],
             )
             .await
@@ -1165,10 +1225,10 @@ impl PostgresTreeStore {
         // Release leaves still pointing at any soon-to-be-deleted reservation,
         // matching the previous `ON DELETE SET NULL` behavior.
         tx.execute(
-            r"UPDATE tree_leaves SET reservation_id = NULL
+            r"UPDATE brz_tree_leaves SET reservation_id = NULL
               WHERE user_id = $2
                 AND reservation_id IN (
-                    SELECT id FROM tree_reservations
+                    SELECT id FROM brz_tree_reservations
                     WHERE user_id = $2
                       AND created_at < NOW() - make_interval(secs => $1)
                 )",
@@ -1179,7 +1239,7 @@ impl PostgresTreeStore {
 
         let result = tx
             .execute(
-                r"DELETE FROM tree_reservations
+                r"DELETE FROM brz_tree_reservations
                   WHERE user_id = $2
                     AND created_at < NOW() - make_interval(secs => $1)",
                 &[&RESERVATION_TIMEOUT_SECS, &self.identity],
@@ -1211,7 +1271,7 @@ impl PostgresTreeStore {
 
         let result = tx
             .execute(
-                r"DELETE FROM tree_spent_leaves WHERE user_id = $2 AND spent_at < $1",
+                r"DELETE FROM brz_tree_spent_leaves WHERE user_id = $2 AND spent_at < $1",
                 &[&cleanup_cutoff, &self.identity],
             )
             .await
@@ -1239,7 +1299,7 @@ impl PostgresTreeStore {
         let pending_i64 = pending_change as i64;
 
         tx.execute(
-            "INSERT INTO tree_reservations (user_id, id, purpose, pending_change_amount) \
+            "INSERT INTO brz_tree_reservations (user_id, id, purpose, pending_change_amount) \
              VALUES ($1, $2, $3, $4)",
             &[
                 &self.identity,
@@ -1735,7 +1795,7 @@ mod tests {
         let client = fixture.store.pool.get().await.unwrap();
         client
             .execute(
-                "UPDATE tree_reservations SET created_at = NOW() - INTERVAL '10 minutes' WHERE id = $1",
+                "UPDATE brz_tree_reservations SET created_at = NOW() - INTERVAL '10 minutes' WHERE id = $1",
                 &[&reservation.id],
             )
             .await
@@ -1857,7 +1917,7 @@ mod tests {
         let client = fixture.store.pool.get().await.unwrap();
         client
             .execute(
-                "UPDATE tree_reservations SET created_at = NOW() - INTERVAL '10 minutes' WHERE id = $1",
+                "UPDATE brz_tree_reservations SET created_at = NOW() - INTERVAL '10 minutes' WHERE id = $1",
                 &[&reservation.id],
             )
             .await

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -40,6 +40,7 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
         ("tree_swap_status", "brz_tree_swap_status"),
     ],
     indexes: &[
+        // Post-multi-tenant indexes.
         (
             "idx_tree_leaves_user_available",
             "brz_idx_tree_leaves_user_available",
@@ -52,6 +53,13 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
             "idx_tree_leaves_user_added_at",
             "brz_idx_tree_leaves_user_added_at",
         ),
+        // Pre-multi-tenant indexes (dropped by the multi-tenant migration).
+        ("idx_tree_leaves_available", "brz_idx_tree_leaves_available"),
+        (
+            "idx_tree_leaves_reservation",
+            "brz_idx_tree_leaves_reservation",
+        ),
+        ("idx_tree_leaves_added_at", "brz_idx_tree_leaves_added_at"),
     ],
     constraints: &[
         (

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -29,12 +29,7 @@ use crate::pool::create_pool;
 /// Name of the schema migrations table for `PostgresTreeStore`.
 const TREE_MIGRATIONS_TABLE: &str = "brz_tree_schema_migrations";
 
-/// Old-to-`brz_*` rename map for the tree store schema. Applied on first
-/// startup after upgrading to the prefixed schema. The indexes listed are the
-/// ones present after the multi-tenant migration (the original pre-tenant
-/// indexes were dropped by that migration). The composite FK on `brz_tree_leaves`
-/// was added inline by the multi-tenant migration without an explicit
-/// `CONSTRAINT` name, so Postgres assigned `tree_leaves_user_id_reservation_id_fkey`.
+/// Pre-prefix rename map for upgrading tree-store deployments.
 const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
     old_migrations_table: "tree_schema_migrations",
     new_migrations_table: TREE_MIGRATIONS_TABLE,
@@ -73,6 +68,13 @@ const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
             "brz_tree_leaves",
             "tree_leaves_user_id_reservation_id_fkey",
             "brz_tree_leaves_user_id_reservation_id_fkey",
+        ),
+        // Pre-multi-tenant FK (single-column). Rename so the post-tenant
+        // migration's `DROP CONSTRAINT IF EXISTS brz_*_fkey` finds it.
+        (
+            "brz_tree_leaves",
+            "tree_leaves_reservation_id_fkey",
+            "brz_tree_leaves_reservation_id_fkey",
         ),
         (
             "brz_tree_spent_leaves",


### PR DESCRIPTION
Closes the issue raised in [#866](https://github.com/breez/spark-sdk/pull/866):
SDK tables like `payments`, `settings`, `contacts` collide with customer
schemas when integrating into a shared database. 
This PR uses a fixed `brz_` prefix instead of the configurable approach
proposed in #866 — no public API surface change, no config knob.

- **Postgres + MySQL only.** SQLite (mobile/desktop) and IndexedDB (browser)
  are isolated per-user databases with no collision risk and keep their
  current names.
- All SDK-owned identifiers prefixed: tables, indexes (`idx_*` → `brz_idx_*`),
  primary-key constraints (`<table>_pkey` → `brz_<table>_pkey`), and foreign
  keys (`fk_*` → `brz_fk_*`).
- Migration tracking tables also prefixed (`schema_migrations` →
  `brz_schema_migrations`), and serve as the canary for the bootstrap rename.

**Existing-deployment upgrade**

`run_migrations` now takes an optional `SchemaRenames` argument. On startup:
- Canary check probes for the legacy unprefixed migrations table.
- If present, renames every table / index / constraint to its `brz_*` form,
  preserving data and the migrations version row, under the same advisory
  lock (Postgres) or `GET_LOCK` (MySQL) used by the migration runner — one
  critical section, one transaction (Postgres) / session (MySQL).
- If absent, the rename block short-circuits; fresh DBs and already-upgraded
  DBs pay only the canary probe.
