### PR TITLE
Add server-mode SDK profile (background_tasks_enabled=false)

### DIFF
--- a/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
@@ -21,7 +21,6 @@ use breez_sdk_spark::{
     default_server_config,
 };
 
-use breez_bench::events::wait_for_claimed_event;
 use breez_bench::stats::DurationStats;
 
 #[derive(Parser, Debug)]
@@ -98,6 +97,7 @@ struct PaymentResult {
 
 struct BenchSdkInstance {
     sdk: BreezSdk,
+    #[allow(dead_code)]
     events: mpsc::Receiver<SdkEvent>,
     #[allow(dead_code)]
     temp_dir: Option<TempDir>,
@@ -900,14 +900,29 @@ async fn fund_via_faucet(
             let extra = needed.clamp(FAUCET_MIN_PER_CALL, FAUCET_MAX_PER_CALL);
             let txid = faucet.fund_address(&deposit_address, extra).await?;
             info!("Top-up faucet txid: {}", txid);
-            wait_for_claimed_event(&mut sdk_instance.events, 240).await?;
-            sdk_instance.sdk.sync_wallet(SyncWalletRequest {}).await?;
-            let after = sdk_instance
-                .sdk
-                .get_info(GetInfoRequest {
-                    ensure_synced: Some(false),
-                })
-                .await?;
+
+            let claim_start = Instant::now();
+            let claim_timeout = Duration::from_secs(240);
+            let balance_before = info.balance_sats;
+            let after = loop {
+                sdk_instance.sdk.sync_wallet(SyncWalletRequest {}).await?;
+                let snap = sdk_instance
+                    .sdk
+                    .get_info(GetInfoRequest {
+                        ensure_synced: Some(false),
+                    })
+                    .await?;
+                if snap.balance_sats > balance_before {
+                    break snap;
+                }
+                if claim_start.elapsed() >= claim_timeout {
+                    bail!(
+                        "Timeout waiting for top-up to land (balance still {} sats)",
+                        snap.balance_sats
+                    );
+                }
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            };
             if after.balance_sats >= min_required {
                 info!("Funded after top-up: {} sats", after.balance_sats);
                 return Ok(());

--- a/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
@@ -17,11 +17,11 @@ use breez_sdk_spark::{
     BreezSdk, GetInfoRequest, MysqlConnectionPool, Network, PostgresConnectionPool,
     PrepareSendPaymentRequest, ReceivePaymentMethod, ReceivePaymentRequest, SdkEvent,
     SendPaymentRequest, SyncWalletRequest, create_mysql_connection_pool,
-    create_postgres_connection_pool, default_config, default_mysql_storage_config,
-    default_postgres_storage_config,
+    create_postgres_connection_pool, default_mysql_storage_config, default_postgres_storage_config,
+    default_server_config,
 };
 
-use breez_bench::events::{wait_for_claimed_event, wait_for_synced_event};
+use breez_bench::events::wait_for_claimed_event;
 use breez_bench::stats::DurationStats;
 
 #[derive(Parser, Debug)]
@@ -197,7 +197,7 @@ async fn main() -> Result<()> {
     );
 
     info!("Initializing sender and receiver SDKs...");
-    let (mut sender, mut receiver, sender_seed, sender_backend) = initialize_sdk_pair(
+    let (mut sender, receiver, sender_seed, sender_backend) = initialize_sdk_pair(
         args.no_auto_optimize,
         args.pre_optimize,
         args.sender_postgres.clone(),
@@ -206,11 +206,6 @@ async fn main() -> Result<()> {
         args.receiver_mysql.clone(),
     )
     .await?;
-
-    info!("Waiting for sender sync...");
-    wait_for_synced_event(&mut sender.events, 120).await?;
-    info!("Waiting for receiver sync...");
-    wait_for_synced_event(&mut receiver.events, 120).await?;
 
     info!(
         "Funding sender with {} sats (need {} sats min)...",
@@ -255,10 +250,6 @@ async fn main() -> Result<()> {
             )
             .await?;
             sender_instances.push(extra);
-        }
-        for (i, inst) in sender_instances.iter_mut().enumerate() {
-            info!("Waiting for sender instance {} initial sync", i);
-            wait_for_synced_event(&mut inst.events, 120).await?;
         }
     }
 
@@ -677,7 +668,7 @@ async fn initialize_sdk_pair(
     let mut sender_seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut sender_seed);
 
-    let mut sender_config = default_config(Network::Regtest);
+    let mut sender_config = default_server_config(Network::Regtest);
     if no_auto_optimize || pre_optimize.is_some() {
         sender_config.optimization_config.auto_enabled = false;
     }
@@ -702,8 +693,7 @@ async fn initialize_sdk_pair(
     let mut receiver_seed = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut receiver_seed);
 
-    let mut receiver_config = default_config(Network::Regtest);
-    receiver_config.optimization_config.auto_enabled = false;
+    let receiver_config = default_server_config(Network::Regtest);
     let itest_receiver = build_sdk_with_tree_store_config(
         receiver_path,
         receiver_seed,
@@ -743,7 +733,7 @@ async fn build_extra_sender(
         .tempdir()?;
     let path = dir.path().to_string_lossy().to_string();
 
-    let mut config = default_config(Network::Regtest);
+    let mut config = default_server_config(Network::Regtest);
     if no_auto_optimize || pre_optimize.is_some() {
         config.optimization_config.auto_enabled = false;
     }
@@ -846,15 +836,29 @@ async fn fund_via_faucet(
         let txid = faucet.fund_address(&deposit_address, chunk).await?;
         info!("Faucet chunk #{} txid: {}", chunk_idx, txid);
 
-        wait_for_claimed_event(&mut sdk_instance.events, 240).await?;
-
-        sdk_instance.sdk.sync_wallet(SyncWalletRequest {}).await?;
-        let after = sdk_instance
-            .sdk
-            .get_info(GetInfoRequest {
-                ensure_synced: Some(false),
-            })
-            .await?;
+        let claim_start = Instant::now();
+        let claim_timeout = Duration::from_secs(240);
+        let balance_before = info.balance_sats;
+        let after = loop {
+            sdk_instance.sdk.sync_wallet(SyncWalletRequest {}).await?;
+            let snap = sdk_instance
+                .sdk
+                .get_info(GetInfoRequest {
+                    ensure_synced: Some(false),
+                })
+                .await?;
+            if snap.balance_sats > balance_before {
+                break snap;
+            }
+            if claim_start.elapsed() >= claim_timeout {
+                bail!(
+                    "Timeout waiting for chunk #{} to land (balance still {} sats)",
+                    chunk_idx,
+                    snap.balance_sats
+                );
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        };
         info!(
             "Balance after chunk #{}: {} sats",
             chunk_idx, after.balance_sats

--- a/crates/breez-sdk/breez-itest/src/concurrent_scenarios.rs
+++ b/crates/breez-sdk/breez-itest/src/concurrent_scenarios.rs
@@ -289,8 +289,7 @@ where
     // `wait_for_balance` only synced instance_0. In client mode the periodic
     // sync loop / event-driven `TransferClaimed` refresh would have updated
     // instances 1 and 2's tree caches by now; in server mode nothing does, so
-    // `ensure_synced=true` below is a no-op and they'd return stale balances.
-    // Drive an explicit 3-way sync at the cross-instance read boundary.
+    // we drive an explicit 3-way sync at the cross-instance read boundary.
     if matches!(mode, RuntimeMode::Server) {
         let (sync_1, sync_2) = tokio::join!(
             instance_1.sdk.sync_wallet(SyncWalletRequest {}),
@@ -300,16 +299,14 @@ where
         sync_2?;
     }
 
+    let ensure_synced = match mode {
+        RuntimeMode::Client => Some(true),
+        RuntimeMode::Server => Some(false),
+    };
     let (info_0, info_1, info_2) = tokio::join!(
-        instance_0.sdk.get_info(GetInfoRequest {
-            ensure_synced: Some(true)
-        }),
-        instance_1.sdk.get_info(GetInfoRequest {
-            ensure_synced: Some(true)
-        }),
-        instance_2.sdk.get_info(GetInfoRequest {
-            ensure_synced: Some(true)
-        })
+        instance_0.sdk.get_info(GetInfoRequest { ensure_synced }),
+        instance_1.sdk.get_info(GetInfoRequest { ensure_synced }),
+        instance_2.sdk.get_info(GetInfoRequest { ensure_synced })
     );
 
     let balance_0 = info_0?.balance_sats;

--- a/crates/breez-sdk/breez-itest/src/concurrent_scenarios.rs
+++ b/crates/breez-sdk/breez-itest/src/concurrent_scenarios.rs
@@ -38,6 +38,24 @@ const PAYMENTS_PER_DIRECTION: usize = 5;
 /// Bidirectional batches in the token stress loop.
 const NUM_BATCHES: usize = 3;
 
+/// Which SDK profile the scenario should run under.
+///
+/// `Client` is the historical default — the SDK runs its periodic-sync loop,
+/// spark-wallet `BackgroundProcessor`, and event-driven payment refresh; the
+/// scenario can therefore rely on assertions like `get_info(ensure_synced=true)`
+/// reading a fresh balance without an explicit sync.
+///
+/// `Server` mirrors `default_server_config`: no background tasks, no event-
+/// driven balance updates, `get_info` reads straight from the local tree-store
+/// cache. The scenario adapts to that contract by driving sync explicitly at
+/// every cross-instance read site and by funding via polling instead of the
+/// `ClaimedDeposits` event channel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RuntimeMode {
+    Client,
+    Server,
+}
+
 /// Comprehensive multi-instance concurrent operations test (BTC).
 ///
 /// Validates that three SDK instances sharing the same backend correctly handle:
@@ -49,18 +67,33 @@ const NUM_BATCHES: usize = 3;
 /// `build_instance` is invoked four times (3 main wallet instances + an
 /// optional warm path); each call must yield a fresh SDK bound to the same
 /// shared backend with the same seed.
+///
+/// `mode` controls how the scenario adapts to the runtime profile. In
+/// `Client` mode it relies on background sync to propagate state across
+/// instances; in `Server` mode it drives every cross-instance reconciliation
+/// with explicit `sync_wallet` calls (server runtime ignores
+/// `ensure_synced=true` and has no event-driven refresh).
 #[allow(clippy::too_many_lines)]
-pub async fn run_concurrent_multi_instance_operations<F, Fut>(build_instance: F) -> Result<()>
+pub async fn run_concurrent_multi_instance_operations<F, Fut>(
+    mode: RuntimeMode,
+    build_instance: F,
+) -> Result<()>
 where
     F: Fn() -> Fut,
     Fut: Future<Output = Result<SdkInstance>>,
 {
-    info!("Creating first SDK instance and funding...");
+    info!("Creating first SDK instance and funding... (mode={mode:?})");
     let mut instance_0 = build_instance().await?;
 
     // Fund the main wallet via faucet (need ~2500 sats: 1000 + 100×5 stress).
+    // In server mode the `ClaimedDeposits` event isn't emitted automatically
+    // (no background processor), so we have to poll the wallet ourselves
+    // through repeated `sync_wallet` + `get_info` calls.
     info!("Funding main wallet via faucet...");
-    ensure_funded(&mut instance_0, 4_000).await?;
+    match mode {
+        RuntimeMode::Client => ensure_funded(&mut instance_0, 4_000).await?,
+        RuntimeMode::Server => ensure_funded_via_polling(&mut instance_0, 4_000).await?,
+    }
 
     // Now create instances 1 and 2 (after funding to avoid claim race).
     info!("Creating additional SDK instances with shared seed...");
@@ -252,6 +285,20 @@ where
         60,
     )
     .await?;
+
+    // `wait_for_balance` only synced instance_0. In client mode the periodic
+    // sync loop / event-driven `TransferClaimed` refresh would have updated
+    // instances 1 and 2's tree caches by now; in server mode nothing does, so
+    // `ensure_synced=true` below is a no-op and they'd return stale balances.
+    // Drive an explicit 3-way sync at the cross-instance read boundary.
+    if matches!(mode, RuntimeMode::Server) {
+        let (sync_1, sync_2) = tokio::join!(
+            instance_1.sdk.sync_wallet(SyncWalletRequest {}),
+            instance_2.sdk.sync_wallet(SyncWalletRequest {})
+        );
+        sync_1?;
+        sync_2?;
+    }
 
     let (info_0, info_1, info_2) = tokio::join!(
         instance_0.sdk.get_info(GetInfoRequest {

--- a/crates/breez-sdk/breez-itest/src/helpers.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers.rs
@@ -1768,7 +1768,6 @@ pub async fn build_sdk_with_postgres_server_mode(
     config.api_key = None;
     config.lnurl_domain = None;
     config.prefer_spark_over_lightning = true;
-    config.sync_interval_secs = 5;
     config.real_time_sync_server_url = None;
     config.optimization_config.auto_enabled = false;
 
@@ -1812,7 +1811,6 @@ pub async fn build_sdk_with_mysql_server_mode(
     config.api_key = None;
     config.lnurl_domain = None;
     config.prefer_spark_over_lightning = true;
-    config.sync_interval_secs = 5;
     config.real_time_sync_server_url = None;
     config.optimization_config.auto_enabled = false;
 

--- a/crates/breez-sdk/breez-itest/src/helpers.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers.rs
@@ -741,11 +741,10 @@ pub async fn build_sdk_with_tree_store_config(
     let event_listener = Box::new(ChannelEventListener { tx });
     let _listener_id = sdk.add_event_listener(event_listener).await;
 
-    // Ensure initial sync completes
-    let _ = sdk
-        .get_info(GetInfoRequest {
-            ensure_synced: Some(true),
-        })
+    // Force an initial full sync. Works in both modes (auto sync on or off)
+    // because `sync_wallet` drives the coordinator directly rather than
+    // waiting on the auto-sync initial-synced watcher.
+    sdk.sync_wallet(breez_sdk_spark::SyncWalletRequest {})
         .await?;
 
     Ok(SdkInstance {

--- a/crates/breez-sdk/breez-itest/src/helpers.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers.rs
@@ -1100,6 +1100,42 @@ async fn ensure_funded_inner(sdk_instance: &mut SdkInstance, min_balance: u64) -
     Ok(())
 }
 
+/// Server-mode variant of [`ensure_funded`].
+///
+/// Identical contract, but routes through `receive_and_fund(.., must_be_claimer=false)`
+/// so the wait loop never depends on a `ClaimedDeposits` SDK event. Server-mode
+/// SDKs don't run the spark-wallet `BackgroundProcessor`, so the event would
+/// never fire on its own; `wait_for_balance` (which polls `sync_wallet` +
+/// `get_info`) is the only mechanism that works in both modes.
+pub async fn ensure_funded_via_polling(
+    sdk_instance: &mut SdkInstance,
+    min_balance: u64,
+) -> Result<()> {
+    let span = sdk_instance.span.clone();
+    return ensure_funded_via_polling_inner(sdk_instance, min_balance)
+        .instrument(span)
+        .await;
+}
+
+async fn ensure_funded_via_polling_inner(
+    sdk_instance: &mut SdkInstance,
+    min_balance: u64,
+) -> Result<()> {
+    sdk_instance.sdk.sync_wallet(SyncWalletRequest {}).await?;
+    let info = sdk_instance
+        .sdk
+        .get_info(GetInfoRequest {
+            ensure_synced: Some(false),
+        })
+        .await?;
+    if info.balance_sats < min_balance {
+        let needed = min_balance - info.balance_sats;
+        info!("Funding wallet via faucet (polling): need {} sats", needed);
+        receive_and_fund(sdk_instance, needed.clamp(10000, 50000), false).await?;
+    }
+    Ok(())
+}
+
 /// Get a deposit address and fund it from the faucet in one operation
 ///
 /// This helper generates a deposit address, funds it, and waits for the claim event.
@@ -1705,6 +1741,98 @@ pub async fn build_sdk_with_mysql(
             ensure_synced: Some(true),
         })
         .await?;
+
+    Ok(SdkInstance {
+        sdk,
+        events: rx,
+        span: tracing::Span::current(),
+        temp_dir: None,
+        data_sync_fixture: None,
+        lnurl_fixture: None,
+    })
+}
+
+/// Server-mode variant of [`build_sdk_with_postgres`].
+///
+/// Same wiring (shared PG pool, shared seed, regtest, no LNURL/RT-sync), but
+/// the config comes from `default_server_config` so the SDK runs with
+/// `background_tasks_enabled=false`: no periodic-sync loop, no spark-wallet
+/// `BackgroundProcessor`, no event-driven payment refresh. Callers must drive
+/// every reconciliation via `sync_wallet` (or use polling helpers like
+/// [`ensure_funded_via_polling`] / [`wait_for_balance`]).
+pub async fn build_sdk_with_postgres_server_mode(
+    connection_string: &str,
+    seed_bytes: [u8; 32],
+) -> Result<SdkInstance> {
+    let mut config = breez_sdk_spark::default_server_config(breez_sdk_spark::Network::Regtest);
+    config.api_key = None;
+    config.lnurl_domain = None;
+    config.prefer_spark_over_lightning = true;
+    config.sync_interval_secs = 5;
+    config.real_time_sync_server_url = None;
+    config.optimization_config.auto_enabled = false;
+
+    let seed = breez_sdk_spark::Seed::Entropy(seed_bytes.to_vec());
+
+    let postgres_config =
+        breez_sdk_spark::default_postgres_storage_config(connection_string.to_string());
+    let pool = breez_sdk_spark::create_postgres_connection_pool(&postgres_config)?;
+
+    let sdk = breez_sdk_spark::SdkBuilder::new(config, seed)
+        .with_postgres_connection_pool(pool)
+        .build()
+        .await?;
+
+    let (tx, rx) = mpsc::channel(100);
+    let event_listener = Box::new(ChannelEventListener { tx });
+    let _listener_id = sdk.add_event_listener(event_listener).await;
+
+    // `ensure_synced=true` is a no-op in server mode; issue an explicit
+    // sync_wallet so the initial tree-store hydrate completes before
+    // returning.
+    sdk.sync_wallet(SyncWalletRequest {}).await?;
+
+    Ok(SdkInstance {
+        sdk,
+        events: rx,
+        span: tracing::Span::current(),
+        temp_dir: None,
+        data_sync_fixture: None,
+        lnurl_fixture: None,
+    })
+}
+
+/// Server-mode variant of [`build_sdk_with_mysql`]. See
+/// [`build_sdk_with_postgres_server_mode`] for the rationale.
+pub async fn build_sdk_with_mysql_server_mode(
+    connection_string: &str,
+    seed_bytes: [u8; 32],
+) -> Result<SdkInstance> {
+    let mut config = breez_sdk_spark::default_server_config(breez_sdk_spark::Network::Regtest);
+    config.api_key = None;
+    config.lnurl_domain = None;
+    config.prefer_spark_over_lightning = true;
+    config.sync_interval_secs = 5;
+    config.real_time_sync_server_url = None;
+    config.optimization_config.auto_enabled = false;
+
+    let seed = breez_sdk_spark::Seed::Entropy(seed_bytes.to_vec());
+
+    let mut mysql_config =
+        breez_sdk_spark::default_mysql_storage_config(connection_string.to_string());
+    mysql_config.max_pool_size = 30;
+    let pool = breez_sdk_spark::create_mysql_connection_pool(&mysql_config)?;
+
+    let sdk = breez_sdk_spark::SdkBuilder::new(config, seed)
+        .with_mysql_connection_pool(pool)
+        .build()
+        .await?;
+
+    let (tx, rx) = mpsc::channel(100);
+    let event_listener = Box::new(ChannelEventListener { tx });
+    let _listener_id = sdk.add_event_listener(event_listener).await;
+
+    sdk.sync_wallet(SyncWalletRequest {}).await?;
 
     Ok(SdkInstance {
         sdk,

--- a/crates/breez-sdk/breez-itest/src/helpers.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers.rs
@@ -1786,9 +1786,9 @@ pub async fn build_sdk_with_postgres_server_mode(
     let event_listener = Box::new(ChannelEventListener { tx });
     let _listener_id = sdk.add_event_listener(event_listener).await;
 
-    // `ensure_synced=true` is a no-op in server mode; issue an explicit
-    // sync_wallet so the initial tree-store hydrate completes before
-    // returning.
+    // `ensure_synced=true` is rejected when `background_tasks_enabled` is
+    // false; issue an explicit sync_wallet so the initial tree-store hydrate
+    // completes before returning.
     sdk.sync_wallet(SyncWalletRequest {}).await?;
 
     Ok(SdkInstance {

--- a/crates/breez-sdk/breez-itest/src/lib.rs
+++ b/crates/breez-sdk/breez-itest/src/lib.rs
@@ -8,7 +8,7 @@ pub mod session_manager_scenarios;
 use std::sync::Arc;
 
 pub use concurrent_scenarios::{
-    run_concurrent_multi_instance_operations, run_concurrent_token_operations,
+    RuntimeMode, run_concurrent_multi_instance_operations, run_concurrent_token_operations,
 };
 pub use faucet::RegtestFaucet;
 pub use fixtures::data_sync::{DataSyncFixture, DataSyncImageConfig};

--- a/crates/breez-sdk/breez-itest/tests/concurrent_storage.rs
+++ b/crates/breez-sdk/breez-itest/tests/concurrent_storage.rs
@@ -77,5 +77,5 @@ impl ConcurrentTestFixture {
 #[test_log::test(tokio::test)]
 async fn test_concurrent_multi_instance_operations() -> Result<()> {
     let fixture = ConcurrentTestFixture::new().await?;
-    run_concurrent_multi_instance_operations(|| fixture.build_instance()).await
+    run_concurrent_multi_instance_operations(RuntimeMode::Client, || fixture.build_instance()).await
 }

--- a/crates/breez-sdk/breez-itest/tests/concurrent_storage_mysql_server_mode.rs
+++ b/crates/breez-sdk/breez-itest/tests/concurrent_storage_mysql_server_mode.rs
@@ -1,9 +1,8 @@
-//! Multi-instance concurrent storage integration test against MySQL.
+//! Server-mode multi-instance concurrent storage test against MySQL.
 //!
-//! Mirrors `concurrent_storage.rs`, swapping the testcontainers backend from
-//! `Postgres` to `Mysql`. Both delegate to the shared scenario in
-//! `breez_sdk_itest::run_concurrent_multi_instance_operations`, so any change
-//! to the workflow runs against both backends automatically.
+//! Mirror of `concurrent_storage_mysql.rs` with the SDK built in server mode
+//! (`default_server_config`, `background_tasks_enabled=false`). See
+//! `concurrent_storage_server_mode.rs` for the rationale.
 
 use anyhow::Result;
 use breez_sdk_itest::*;
@@ -44,12 +43,12 @@ impl MysqlConcurrentTestFixture {
     }
 
     async fn build_instance(&self) -> Result<SdkInstance> {
-        build_sdk_with_mysql(&self.connection_string, self.shared_seed).await
+        build_sdk_with_mysql_server_mode(&self.connection_string, self.shared_seed).await
     }
 }
 
 #[test_log::test(tokio::test)]
-async fn test_mysql_concurrent_multi_instance_operations() -> Result<()> {
+async fn test_mysql_concurrent_multi_instance_operations_server_mode() -> Result<()> {
     let fixture = MysqlConcurrentTestFixture::new().await?;
-    run_concurrent_multi_instance_operations(RuntimeMode::Client, || fixture.build_instance()).await
+    run_concurrent_multi_instance_operations(RuntimeMode::Server, || fixture.build_instance()).await
 }

--- a/crates/breez-sdk/breez-itest/tests/concurrent_storage_server_mode.rs
+++ b/crates/breez-sdk/breez-itest/tests/concurrent_storage_server_mode.rs
@@ -1,0 +1,62 @@
+//! Server-mode multi-instance concurrent storage test against PostgreSQL.
+//!
+//! Mirror of `concurrent_storage.rs`, but each SDK is built with
+//! `default_server_config` (`background_tasks_enabled=false`). The scenario
+//! body in `breez_sdk_itest::run_concurrent_multi_instance_operations` adapts
+//! to the runtime mode internally — funding goes through `ensure_funded_via_polling`
+//! and Scenario 3 drives an explicit 3-way sync before reading balances on all
+//! instances, since server-mode `get_info(ensure_synced=true)` is a no-op and
+//! the SDK doesn't auto-propagate incoming transfers across sibling instances.
+//!
+//! See `concurrent_storage.rs` for the architecture diagram.
+
+use anyhow::Result;
+use breez_sdk_itest::*;
+use rand::RngCore;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+
+struct ConcurrentTestFixture {
+    /// PostgreSQL container — must be kept alive for the test duration.
+    #[allow(dead_code)]
+    pg_container: ContainerAsync<Postgres>,
+    connection_string: String,
+    shared_seed: [u8; 32],
+}
+
+impl ConcurrentTestFixture {
+    async fn new() -> Result<Self> {
+        let pg_container = Postgres::default()
+            .start()
+            .await
+            .expect("Failed to start PostgreSQL container");
+
+        let host_port = pg_container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("Failed to get host port");
+
+        let connection_string = format!(
+            "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
+        );
+
+        let mut shared_seed = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut shared_seed);
+
+        Ok(Self {
+            pg_container,
+            connection_string,
+            shared_seed,
+        })
+    }
+
+    async fn build_instance(&self) -> Result<SdkInstance> {
+        build_sdk_with_postgres_server_mode(&self.connection_string, self.shared_seed).await
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn test_concurrent_multi_instance_operations_server_mode() -> Result<()> {
+    let fixture = ConcurrentTestFixture::new().await?;
+    run_concurrent_multi_instance_operations(RuntimeMode::Server, || fixture.build_instance()).await
+}

--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -10,7 +10,7 @@ use tokio::sync::{Mutex, RwLock, broadcast};
 use tracing::info;
 use uuid::Uuid;
 
-use crate::{DepositInfo, LightningAddressInfo, Payment};
+use crate::{DepositInfo, LightningAddressInfo, Payment, sdk::RuntimeEvent};
 
 /// Events emitted by the SDK
 #[allow(clippy::large_enum_variant)]
@@ -45,15 +45,6 @@ pub enum SdkEvent {
     NewDeposits {
         new_deposits: Vec<DepositInfo>,
     },
-}
-
-/// Internal runtime events consumed by the selected runtime profile.
-///
-/// These events are not forwarded to external SDK listeners; they are only used
-/// to decouple non-runtime-owned modules from runtime-specific background behavior.
-#[derive(Debug, Clone)]
-pub(crate) enum RuntimeEvent {
-    StableBalanceConversionCompleted,
 }
 
 impl SdkEvent {

--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -6,7 +6,7 @@ use std::{
 
 use platform_utils::time::Instant;
 use serde::Serialize;
-use tokio::sync::{Mutex, RwLock, broadcast};
+use tokio::sync::{Mutex, RwLock};
 use tracing::info;
 use uuid::Uuid;
 
@@ -185,7 +185,7 @@ pub struct EventEmitter {
     has_real_time_sync: bool,
     rtsync_failed: AtomicBool,
     listener_index: AtomicU64,
-    runtime_event_sender: broadcast::Sender<RuntimeEvent>,
+    runtime_event_handlers: RwLock<Vec<Box<dyn RuntimeEventHandler>>>,
     /// Internal listeners see ALL events before middleware processing
     internal_listeners: RwLock<BTreeMap<String, Box<dyn EventListener>>>,
     /// Middleware chain that can transform/suppress events
@@ -195,15 +195,19 @@ pub struct EventEmitter {
     synced_event_buffer: Mutex<Option<InternalSyncedEvent>>,
 }
 
+#[macros::async_trait]
+pub(crate) trait RuntimeEventHandler: Send + Sync {
+    async fn handle(&self, event: RuntimeEvent);
+}
+
 impl EventEmitter {
     /// Create a new event emitter
     pub fn new(has_real_time_sync: bool) -> Self {
-        let (runtime_event_sender, _) = broadcast::channel(256);
         Self {
             has_real_time_sync,
             rtsync_failed: AtomicBool::new(false),
             listener_index: AtomicU64::new(0),
-            runtime_event_sender,
+            runtime_event_handlers: RwLock::new(Vec::new()),
             internal_listeners: RwLock::new(BTreeMap::new()),
             middleware: RwLock::new(Vec::new()),
             external_listeners: RwLock::new(BTreeMap::new()),
@@ -268,12 +272,16 @@ impl EventEmitter {
         mw.push(middleware);
     }
 
-    pub(crate) fn subscribe_runtime_events(&self) -> broadcast::Receiver<RuntimeEvent> {
-        self.runtime_event_sender.subscribe()
+    pub(crate) async fn add_runtime_event_handler(&self, handler: Box<dyn RuntimeEventHandler>) {
+        let mut handlers = self.runtime_event_handlers.write().await;
+        handlers.push(handler);
     }
 
-    pub(crate) fn emit_runtime_event(&self, event: RuntimeEvent) {
-        let _ = self.runtime_event_sender.send(event);
+    pub(crate) async fn emit_runtime_event(&self, event: RuntimeEvent) {
+        let handlers = self.runtime_event_handlers.read().await;
+        for handler in handlers.iter() {
+            handler.handle(event.clone()).await;
+        }
     }
 
     /// Emit an event through the three-phase pipeline:

--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -6,7 +6,7 @@ use std::{
 
 use platform_utils::time::Instant;
 use serde::Serialize;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, broadcast};
 use tracing::info;
 use uuid::Uuid;
 
@@ -45,6 +45,15 @@ pub enum SdkEvent {
     NewDeposits {
         new_deposits: Vec<DepositInfo>,
     },
+}
+
+/// Internal runtime events consumed by the selected runtime profile.
+///
+/// These events are not forwarded to external SDK listeners; they are only used
+/// to decouple non-runtime-owned modules from runtime-specific background behavior.
+#[derive(Debug, Clone)]
+pub(crate) enum RuntimeEvent {
+    StableBalanceConversionCompleted,
 }
 
 impl SdkEvent {
@@ -185,6 +194,7 @@ pub struct EventEmitter {
     has_real_time_sync: bool,
     rtsync_failed: AtomicBool,
     listener_index: AtomicU64,
+    runtime_event_sender: broadcast::Sender<RuntimeEvent>,
     /// Internal listeners see ALL events before middleware processing
     internal_listeners: RwLock<BTreeMap<String, Box<dyn EventListener>>>,
     /// Middleware chain that can transform/suppress events
@@ -197,10 +207,12 @@ pub struct EventEmitter {
 impl EventEmitter {
     /// Create a new event emitter
     pub fn new(has_real_time_sync: bool) -> Self {
+        let (runtime_event_sender, _) = broadcast::channel(256);
         Self {
             has_real_time_sync,
             rtsync_failed: AtomicBool::new(false),
             listener_index: AtomicU64::new(0),
+            runtime_event_sender,
             internal_listeners: RwLock::new(BTreeMap::new()),
             middleware: RwLock::new(Vec::new()),
             external_listeners: RwLock::new(BTreeMap::new()),
@@ -263,6 +275,14 @@ impl EventEmitter {
     pub async fn add_middleware(&self, middleware: Box<dyn EventMiddleware>) {
         let mut mw = self.middleware.write().await;
         mw.push(middleware);
+    }
+
+    pub(crate) fn subscribe_runtime_events(&self) -> broadcast::Receiver<RuntimeEvent> {
+        self.runtime_event_sender.subscribe()
+    }
+
+    pub(crate) fn emit_runtime_event(&self, event: RuntimeEvent) {
+        let _ = self.runtime_event_sender.send(event);
     }
 
     /// Emit an event through the three-phase pipeline:

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -41,7 +41,9 @@ pub use persist::{
     PaymentMetadata, SetLnurlMetadataItem, Storage, StorageError, StorageListPaymentsRequest,
     StoragePaymentDetailsFilter, UpdateDepositPayload, path::default_storage_path,
 };
-pub use sdk::{BreezSdk, default_config, get_spark_status, init_logging, parse_input};
+pub use sdk::{
+    BreezSdk, default_config, default_server_config, get_spark_status, init_logging, parse_input,
+};
 pub use sdk_builder::SdkBuilder;
 pub use session_manager::{Session, SessionManager, SessionManagerError};
 pub use spark_wallet::{

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -640,8 +640,11 @@ pub struct Config {
     /// `refund_pending_conversions`, leaf/token optimization, etc.) work
     /// regardless of this flag.
     ///
-    /// `stable_balance_config` is not supported when this is `false`, because
-    /// its conversion worker is a background service.
+    /// When `false`, the SDK rejects builds where fields whose backing
+    /// service is gated off are still in their active shape:
+    /// `stable_balance_config` must be `None`, `real_time_sync_server_url`
+    /// must be `None`, and `optimization_config.auto_enabled` must be `false`.
+    /// `default_server_config` already sets these compatible values.
     pub background_tasks_enabled: bool,
 }
 

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1058,9 +1058,9 @@ pub struct GetInfoRequest {
     /// When `Some(true)`, and `background_tasks_enabled` is `true`, the call
     /// waits for the initial Full sync to complete before returning.
     ///
-    /// When `background_tasks_enabled` is `false` this flag has no effect:
-    /// `get_info` reads balance directly from the spark wallet on every call,
-    /// so the response is always fresh.
+    /// When `background_tasks_enabled` is `false`, setting this to `Some(true)`
+    /// is rejected with an invalid-input error. There is no background sync to
+    /// wait on; call `sync_wallet` explicitly first if you need fresh state.
     pub ensure_synced: Option<bool>,
 }
 

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -636,9 +636,13 @@ pub struct Config {
     /// [`default_server_config`](crate::default_server_config) to get this
     /// preset.
     ///
-    /// Manual operations (`sync_wallet`, `claim_deposits`, `claim_transfers`,
-    /// `recover_lightning_address`, leaf/token optimization, etc.) work in
+    /// Explicit operations (`sync_wallet`, `claim_deposit`,
+    /// `list_unclaimed_deposits`, `refund_deposit`,
+    /// `refund_pending_conversions`, leaf/token optimization, etc.) work in
     /// both modes.
+    ///
+    /// Stable Balance is not supported when this is `false`, because its
+    /// conversion worker is a background service.
     ///
     /// The SDK reads this once while building its internal runtime profile.
     /// Feature code should use the runtime's sync/state/lifecycle services

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -587,6 +587,13 @@ pub struct Config {
     ///
     /// If set to true, the Spark private mode will be enabled on the first initialization of the SDK.
     /// If set to false, no changes will be made to the Spark private mode.
+    ///
+    /// This default is only auto-applied when
+    /// [`background_tasks_enabled`](Self::background_tasks_enabled) is `true`.
+    /// In server mode the SDK does not touch the Spark private mode on
+    /// startup; partners must call
+    /// `update_user_settings({ spark_private_mode_enabled: Some(...) })`
+    /// explicitly on a one-time setup pass.
     pub private_enabled_default: bool,
 
     /// Configuration for leaf optimization.
@@ -613,6 +620,30 @@ pub struct Config {
     /// threshold, and token settings. Use this to connect to alternative Spark
     /// deployments (e.g. dev/staging environments).
     pub spark_config: Option<SparkConfig>,
+
+    /// Runtime profile selector for per-instance background services.
+    ///
+    /// When `true` (default), the SDK runs its standard background work:
+    /// periodic sync, lightning-address recovery, private-mode initialization,
+    /// the leaf and token-output optimizers, the Spark server-event
+    /// subscription, and the real-time sync client (when
+    /// [`real_time_sync_server_url`](Self::real_time_sync_server_url) is set).
+    ///
+    /// When `false`, **no background service is started**, regardless of any
+    /// other setting on this config. This is the mode intended for
+    /// multi-tenant server deployments where the partner orchestrates sync
+    /// and claims explicitly and receives events via webhooks. Use
+    /// [`default_server_config`](crate::default_server_config) to get this
+    /// preset.
+    ///
+    /// Manual operations (`sync_wallet`, `claim_deposits`, `claim_transfers`,
+    /// `recover_lightning_address`, leaf/token optimization, etc.) work in
+    /// both modes.
+    ///
+    /// The SDK reads this once while building its internal runtime profile.
+    /// Feature code should use the runtime's sync/state/lifecycle services
+    /// rather than branching on this field directly.
+    pub background_tasks_enabled: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -1025,6 +1056,12 @@ pub struct Credentials {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct GetInfoRequest {
+    /// In client mode, when `Some(true)` the call waits for the initial Full
+    /// sync to complete before returning.
+    ///
+    /// In server mode this flag has no effect — `get_info` reads balance
+    /// directly from the spark wallet on every call, so the response is
+    /// always fresh.
     pub ensure_synced: Option<bool>,
 }
 

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -585,15 +585,15 @@ pub struct Config {
 
     /// Whether the Spark private mode is enabled by default.
     ///
-    /// If set to true, the Spark private mode will be enabled on the first initialization of the SDK.
-    /// If set to false, no changes will be made to the Spark private mode.
+    /// If set to true, the Spark private mode will be enabled on the first
+    /// initialization of the SDK. If set to false, no changes will be made
+    /// to the Spark private mode.
     ///
-    /// This default is only auto-applied when
-    /// [`background_tasks_enabled`](Self::background_tasks_enabled) is `true`.
-    /// In server mode the SDK does not touch the Spark private mode on
-    /// startup; partners must call
-    /// `update_user_settings({ spark_private_mode_enabled: Some(...) })`
-    /// explicitly on a one-time setup pass.
+    /// This default is only auto-applied when `background_tasks_enabled` is
+    /// `true`. When `background_tasks_enabled` is `false`, the SDK does not
+    /// touch the Spark private mode on startup; call `update_user_settings`
+    /// with `spark_private_mode_enabled` set as needed on a one-time setup
+    /// pass.
     pub private_enabled_default: bool,
 
     /// Configuration for leaf optimization.
@@ -621,32 +621,27 @@ pub struct Config {
     /// deployments (e.g. dev/staging environments).
     pub spark_config: Option<SparkConfig>,
 
-    /// Runtime profile selector for per-instance background services.
+    /// Master switch for per-instance background services.
     ///
     /// When `true` (default), the SDK runs its standard background work:
     /// periodic sync, lightning-address recovery, private-mode initialization,
     /// the leaf and token-output optimizers, the Spark server-event
     /// subscription, and the real-time sync client (when
-    /// [`real_time_sync_server_url`](Self::real_time_sync_server_url) is set).
+    /// `real_time_sync_server_url` is set).
     ///
     /// When `false`, **no background service is started**, regardless of any
-    /// other setting on this config. This is the mode intended for
-    /// multi-tenant server deployments where the partner orchestrates sync
-    /// and claims explicitly and receives events via webhooks. Use
-    /// [`default_server_config`](crate::default_server_config) to get this
-    /// preset.
+    /// other setting on this config. This is intended for multi-tenant server
+    /// deployments where the host application orchestrates sync and claims
+    /// explicitly and receives events via webhooks. Use
+    /// `default_server_config` to get this preset.
     ///
     /// Explicit operations (`sync_wallet`, `claim_deposit`,
     /// `list_unclaimed_deposits`, `refund_deposit`,
-    /// `refund_pending_conversions`, leaf/token optimization, etc.) work in
-    /// both modes.
+    /// `refund_pending_conversions`, leaf/token optimization, etc.) work
+    /// regardless of this flag.
     ///
-    /// Stable Balance is not supported when this is `false`, because its
-    /// conversion worker is a background service.
-    ///
-    /// The SDK reads this once while building its internal runtime profile.
-    /// Feature code should use the runtime's sync/state/lifecycle services
-    /// rather than branching on this field directly.
+    /// `stable_balance_config` is not supported when this is `false`, because
+    /// its conversion worker is a background service.
     pub background_tasks_enabled: bool,
 }
 
@@ -1060,12 +1055,12 @@ pub struct Credentials {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct GetInfoRequest {
-    /// In client mode, when `Some(true)` the call waits for the initial Full
-    /// sync to complete before returning.
+    /// When `Some(true)`, and `background_tasks_enabled` is `true`, the call
+    /// waits for the initial Full sync to complete before returning.
     ///
-    /// In server mode this flag has no effect — `get_info` reads balance
-    /// directly from the spark wallet on every call, so the response is
-    /// always fresh.
+    /// When `background_tasks_enabled` is `false` this flag has no effect:
+    /// `get_info` reads balance directly from the spark wallet on every call,
+    /// so the response is always fresh.
     pub ensure_synced: Option<bool>,
 }
 

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -187,7 +187,7 @@ impl BreezSdk {
     /// Some settings are fetched from the Spark network so network requests are performed.
     pub async fn get_user_settings(&self) -> Result<UserSettings, SdkError> {
         // Ensure spark private mode is initialized to avoid race conditions with the initialization task.
-        self.ensure_spark_private_mode_initialized().await?;
+        self.maybe_ensure_spark_private_mode_initialized().await?;
 
         let spark_user_settings = self.spark_wallet.query_wallet_settings().await?;
 

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -76,25 +76,7 @@ impl BreezSdk {
     /// Returns the balance of the wallet in satoshis
     #[allow(unused_variables)]
     pub async fn get_info(&self, request: GetInfoRequest) -> Result<GetInfoResponse, SdkError> {
-        if request.ensure_synced.unwrap_or_default() {
-            self.initial_synced_watcher
-                .clone()
-                .changed()
-                .await
-                .map_err(|_| {
-                    SdkError::Generic("Failed to receive initial synced signal".to_string())
-                })?;
-        }
-        let object_repository = ObjectCacheRepository::new(self.storage.clone());
-        let account_info = object_repository
-            .fetch_account_info()
-            .await?
-            .unwrap_or_default();
-        Ok(GetInfoResponse {
-            identity_pubkey: self.spark_wallet.get_identity_public_key().to_string(),
-            balance_sats: account_info.balance_sats,
-            token_balances: account_info.token_balances,
-        })
+        self.runtime.get_info(self, request).await
     }
 
     /// List fiat currencies for which there is a known exchange rate,

--- a/crates/breez-sdk/core/src/sdk/deposits.rs
+++ b/crates/breez-sdk/core/src/sdk/deposits.rs
@@ -7,11 +7,9 @@ use tracing::{error, trace};
 
 use crate::{
     ClaimDepositRequest, ClaimDepositResponse, ListUnclaimedDepositsRequest,
-    ListUnclaimedDepositsResponse, RefundDepositRequest, RefundDepositResponse,
-    error::SdkError,
-    models::Payment,
-    persist::UpdateDepositPayload,
-    utils::{payments::get_payment_and_emit_event, utxo_fetcher::CachedUtxoFetcher},
+    ListUnclaimedDepositsResponse, RefundDepositRequest, RefundDepositResponse, error::SdkError,
+    models::Payment, persist::UpdateDepositPayload, sdk::RuntimeEvent,
+    utils::utxo_fetcher::CachedUtxoFetcher,
 };
 
 use super::BreezSdk;
@@ -28,7 +26,7 @@ impl BreezSdk {
         &self,
         request: ClaimDepositRequest,
     ) -> Result<ClaimDepositResponse, SdkError> {
-        self.ensure_spark_private_mode_initialized().await?;
+        self.maybe_ensure_spark_private_mode_initialized().await?;
         let detailed_utxo =
             CachedUtxoFetcher::new(self.chain_service.clone(), self.storage.clone())
                 .fetch_detailed_utxo(&request.txid, request.vout)
@@ -47,7 +45,10 @@ impl BreezSdk {
                 self.storage
                     .delete_deposit(detailed_utxo.txid.to_string(), detailed_utxo.vout)
                     .await?;
-                get_payment_and_emit_event(&self.storage, &self.event_emitter, payment.clone())
+                self.event_emitter
+                    .emit_runtime_event(RuntimeEvent::DepositClaimed {
+                        payment: Box::new(payment.clone()),
+                    })
                     .await;
                 Ok(ClaimDepositResponse { payment })
             }

--- a/crates/breez-sdk/core/src/sdk/deposits.rs
+++ b/crates/breez-sdk/core/src/sdk/deposits.rs
@@ -7,8 +7,11 @@ use tracing::{error, trace};
 
 use crate::{
     ClaimDepositRequest, ClaimDepositResponse, ListUnclaimedDepositsRequest,
-    ListUnclaimedDepositsResponse, RefundDepositRequest, RefundDepositResponse, error::SdkError,
-    models::Payment, persist::UpdateDepositPayload, utils::utxo_fetcher::CachedUtxoFetcher,
+    ListUnclaimedDepositsResponse, RefundDepositRequest, RefundDepositResponse,
+    error::SdkError,
+    models::Payment,
+    persist::UpdateDepositPayload,
+    utils::{payments::get_payment_and_emit_event, utxo_fetcher::CachedUtxoFetcher},
 };
 
 use super::BreezSdk;
@@ -44,6 +47,8 @@ impl BreezSdk {
                 self.storage
                     .delete_deposit(detailed_utxo.txid.to_string(), detailed_utxo.vout)
                     .await?;
+                get_payment_and_emit_event(&self.storage, &self.event_emitter, payment.clone())
+                    .await;
                 Ok(ClaimDepositResponse { payment })
             }
             Err(e) => {

--- a/crates/breez-sdk/core/src/sdk/deposits.rs
+++ b/crates/breez-sdk/core/src/sdk/deposits.rs
@@ -11,7 +11,7 @@ use crate::{
     models::Payment, persist::UpdateDepositPayload, utils::utxo_fetcher::CachedUtxoFetcher,
 };
 
-use super::{BreezSdk, SyncType};
+use super::BreezSdk;
 
 // Retry parameters for looking up the transfer created by a static deposit
 // claim while it propagates across Spark operators.
@@ -44,9 +44,6 @@ impl BreezSdk {
                 self.storage
                     .delete_deposit(detailed_utxo.txid.to_string(), detailed_utxo.vout)
                     .await?;
-                self.sync_coordinator
-                    .trigger_sync_no_wait(SyncType::WalletState, true)
-                    .await;
                 Ok(ClaimDepositResponse { payment })
             }
             Err(e) => {

--- a/crates/breez-sdk/core/src/sdk/init.rs
+++ b/crates/breez-sdk/core/src/sdk/init.rs
@@ -32,6 +32,7 @@ impl BreezSdk {
             lnurl_auth_signer: params.lnurl_auth_signer,
             event_emitter: params.event_emitter,
             shutdown_sender: params.shutdown_sender,
+            runtime: params.runtime,
             sync_coordinator: params.sync_coordinator,
             initial_synced_watcher,
             external_input_parsers,
@@ -46,19 +47,12 @@ impl BreezSdk {
         Ok(sdk)
     }
 
-    /// Starts the SDK's background tasks
-    ///
-    /// This method initiates the following background tasks:
-    /// 1. `spawn_spark_private_mode_initialization`: initializes the spark private mode on startup
-    /// 2. `periodic_sync`: syncs the wallet with the Spark network
-    /// 3. `try_recover_lightning_address`: recovers the lightning address on startup
+    /// Starts the SDK runtime services selected during construction.
     pub(super) fn start(&self, initial_synced_sender: watch::Sender<bool>) {
-        self.spawn_spark_private_mode_initialization();
-        self.periodic_sync(initial_synced_sender);
-        self.try_recover_lightning_address();
+        self.runtime.start_sdk_services(self, initial_synced_sender);
     }
 
-    fn spawn_spark_private_mode_initialization(&self) {
+    pub(crate) fn spawn_spark_private_mode_initialization(&self) {
         let sdk = self.clone();
         let span = tracing::Span::current();
         tokio::spawn(
@@ -72,7 +66,7 @@ impl BreezSdk {
     }
 
     /// Refreshes the user's lightning address on the server on startup.
-    fn try_recover_lightning_address(&self) {
+    pub(crate) fn try_recover_lightning_address(&self) {
         let sdk = self.clone();
         let span = tracing::Span::current();
         tokio::spawn(async move {
@@ -92,6 +86,12 @@ impl BreezSdk {
     }
 
     pub(super) async fn ensure_spark_private_mode_initialized(&self) -> Result<(), SdkError> {
+        self.runtime
+            .ensure_spark_private_mode_initialized(self)
+            .await
+    }
+
+    pub(super) async fn ensure_spark_private_mode_initialized_inner(&self) -> Result<(), SdkError> {
         self.spark_private_mode_initialized
             .get_or_try_init(|| async {
                 // Check if already initialized in storage

--- a/crates/breez-sdk/core/src/sdk/init.rs
+++ b/crates/breez-sdk/core/src/sdk/init.rs
@@ -59,7 +59,7 @@ impl BreezSdk {
         let span = tracing::Span::current();
         tokio::spawn(
             async move {
-                if let Err(e) = sdk.ensure_spark_private_mode_initialized().await {
+                if let Err(e) = sdk.maybe_ensure_spark_private_mode_initialized().await {
                     error!("Failed to initialize spark private mode: {e:?}");
                 }
             }
@@ -87,9 +87,9 @@ impl BreezSdk {
         }.instrument(span));
     }
 
-    pub(super) async fn ensure_spark_private_mode_initialized(&self) -> Result<(), SdkError> {
+    pub(super) async fn maybe_ensure_spark_private_mode_initialized(&self) -> Result<(), SdkError> {
         self.runtime
-            .ensure_spark_private_mode_initialized(self)
+            .maybe_ensure_spark_private_mode_initialized(self)
             .await
     }
 

--- a/crates/breez-sdk/core/src/sdk/init.rs
+++ b/crates/breez-sdk/core/src/sdk/init.rs
@@ -9,7 +9,7 @@ use super::{BreezSdk, BreezSdkParams, helpers::validate_breez_api_key};
 
 impl BreezSdk {
     /// Creates a new instance of the `BreezSdk`
-    pub(crate) fn init_and_start(params: BreezSdkParams) -> Result<Self, SdkError> {
+    pub(crate) async fn init_and_start(params: BreezSdkParams) -> Result<Self, SdkError> {
         // In Regtest we allow running without a Breez API key to facilitate local
         // integration tests. For non-regtest networks, a valid API key is required.
         if !matches!(params.config.network, Network::Regtest) {
@@ -43,13 +43,15 @@ impl BreezSdk {
             partner_headers: params.partner_headers,
         };
 
-        sdk.start(initial_synced_sender);
+        sdk.start(initial_synced_sender).await;
         Ok(sdk)
     }
 
     /// Starts the SDK runtime services selected during construction.
-    pub(super) fn start(&self, initial_synced_sender: watch::Sender<bool>) {
-        self.runtime.start_sdk_services(self, initial_synced_sender);
+    pub(super) async fn start(&self, initial_synced_sender: watch::Sender<bool>) {
+        self.runtime
+            .start_sdk_services(self, initial_synced_sender)
+            .await;
     }
 
     pub(crate) fn spawn_spark_private_mode_initialization(&self) {

--- a/crates/breez-sdk/core/src/sdk/lnurl.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl.rs
@@ -121,7 +121,7 @@ impl BreezSdk {
 
     #[allow(clippy::too_many_lines)]
     pub async fn lnurl_pay(&self, request: LnurlPayRequest) -> Result<LnurlPayResponse, SdkError> {
-        self.ensure_spark_private_mode_initialized().await?;
+        self.maybe_ensure_spark_private_mode_initialized().await?;
 
         let is_fees_included = request.prepare_response.fee_policy == FeePolicy::FeesIncluded;
 
@@ -322,7 +322,7 @@ impl BreezSdk {
         &self,
         request: LnurlWithdrawRequest,
     ) -> Result<LnurlWithdrawResponse, SdkError> {
-        self.ensure_spark_private_mode_initialized().await?;
+        self.maybe_ensure_spark_private_mode_initialized().await?;
         let LnurlWithdrawRequest {
             amount_sats,
             withdraw_request,

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -10,7 +10,7 @@ mod runtime;
 mod sync;
 mod sync_coordinator;
 
-pub(crate) use runtime::{SdkRuntime, runtime_from_config};
+pub(crate) use runtime::{RuntimeEvent, SdkRuntime, runtime_from_config};
 pub(crate) use sync_coordinator::SyncCoordinator;
 
 use bitflags::bitflags;

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -238,9 +238,9 @@ pub fn default_config(network: Network) -> Config {
 /// ephemeral per-request SDK instances incur no implicit setup overhead.
 ///
 /// `get_info` reads balance directly from the spark wallet in this mode
-/// rather than from the background-maintained storage cache, so balance is
-/// always fresh and `ensure_synced=true` is rejected with an invalid-input
-/// error.
+/// rather than from the background-maintained storage cache, so balance 
+/// reflects the latest local sync and `ensure_synced=true` is rejected with 
+/// an invalid-input error
 #[cfg_attr(feature = "uniffi", uniffi::export)]
 pub fn default_server_config(network: Network) -> Config {
     let mut config = default_config(network);

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -63,18 +63,6 @@ pub(crate) struct SyncRequest {
 }
 
 impl SyncRequest {
-    /// Builds a fire-and-forget [`SyncRequest`] with no reply channel.
-    ///
-    /// Used when `sync_wallet_internal` is invoked directly (server mode)
-    /// rather than via the periodic-sync loop's coordinator dispatch.
-    pub(crate) fn fire_and_forget(sync_type: SyncType, force: bool) -> Self {
-        Self {
-            sync_type,
-            reply: Arc::new(Mutex::new(None)),
-            force,
-        }
-    }
-
     pub(crate) async fn reply(&self, error: Option<SdkError>) {
         if let Some(reply) = self.reply.lock().await.take() {
             let _ = match error {

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -238,8 +238,8 @@ pub fn default_config(network: Network) -> Config {
 /// ephemeral per-request SDK instances incur no implicit setup overhead.
 ///
 /// `get_info` reads balance directly from the spark wallet in this mode
-/// rather than from the background-maintained storage cache, so balance 
-/// reflects the latest local sync and `ensure_synced=true` is rejected with 
+/// rather than from the background-maintained storage cache, so balance
+/// reflects the latest local sync and `ensure_synced=true` is rejected with
 /// an invalid-input error
 #[cfg_attr(feature = "uniffi", uniffi::export)]
 pub fn default_server_config(network: Network) -> Config {

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -230,11 +230,11 @@ pub fn default_config(network: Network) -> Config {
 /// orchestrates sync, claiming, and event delivery (typically via webhooks)
 /// explicitly, so an ephemeral SDK instance stays cheap and predictable.
 ///
-/// Other config fields such as
-/// [`real_time_sync_server_url`](Config::real_time_sync_server_url) and
-/// [`optimization_config.auto_enabled`](OptimizationConfig::auto_enabled)
-/// retain their default values; the runtime profile prevents the corresponding
-/// background services from being started.
+/// Config fields whose background services are gated off are reset to their
+/// inactive shape: `real_time_sync_server_url` is set to `None` and
+/// `optimization_config.auto_enabled` to `false`. The SDK rejects builds where
+/// `background_tasks_enabled` is `false` and any of those fields is left in
+/// its active shape, so flip the flag via this helper rather than by hand.
 ///
 /// Explicit operations (`sync_wallet`, `claim_deposit`,
 /// `list_unclaimed_deposits`, `refund_deposit`,
@@ -244,21 +244,21 @@ pub fn default_config(network: Network) -> Config {
 /// Stable Balance is not supported in this mode because its conversion worker
 /// is a background service.
 ///
-/// One-time setup that the client-mode SDK applies automatically — notably
-/// [`private_enabled_default`](Config::private_enabled_default) — is NOT
-/// applied in this mode. Partners drive setup explicitly via
-/// `update_user_settings` (and any other relevant APIs) so ephemeral
-/// per-request SDK instances incur no implicit setup overhead.
+/// One-time setup that the SDK normally applies automatically — notably
+/// `private_enabled_default` — is NOT applied in this mode. Drive setup
+/// explicitly via `update_user_settings` (and any other relevant APIs) so
+/// ephemeral per-request SDK instances incur no implicit setup overhead.
 ///
-/// [`get_info`](crate::BreezSdk::get_info) reads balance directly from the
-/// spark wallet in this mode rather than from the background-maintained
-/// storage cache, so balance is always fresh and
-/// [`GetInfoRequest::ensure_synced`](crate::GetInfoRequest::ensure_synced)
-/// is a no-op.
+/// `get_info` reads balance directly from the spark wallet in this mode
+/// rather than from the background-maintained storage cache, so balance is
+/// always fresh and `ensure_synced=true` is rejected with an invalid-input
+/// error.
 #[cfg_attr(feature = "uniffi", uniffi::export)]
 pub fn default_server_config(network: Network) -> Config {
     let mut config = default_config(network);
     config.background_tasks_enabled = false;
+    config.real_time_sync_server_url = None;
+    config.optimization_config.auto_enabled = false;
     config
 }
 
@@ -419,6 +419,8 @@ mod tests {
         for network in [Network::Mainnet, Network::Regtest] {
             let cfg = default_server_config(network);
             assert!(!cfg.background_tasks_enabled);
+            assert!(cfg.real_time_sync_server_url.is_none());
+            assert!(!cfg.optimization_config.auto_enabled);
         }
     }
 

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -6,9 +6,11 @@ mod init;
 mod lightning_address;
 mod lnurl;
 mod payments;
+mod runtime;
 mod sync;
 mod sync_coordinator;
 
+pub(crate) use runtime::{SdkRuntime, runtime_from_config};
 pub(crate) use sync_coordinator::SyncCoordinator;
 
 use bitflags::bitflags;
@@ -61,6 +63,18 @@ pub(crate) struct SyncRequest {
 }
 
 impl SyncRequest {
+    /// Builds a fire-and-forget [`SyncRequest`] with no reply channel.
+    ///
+    /// Used when `sync_wallet_internal` is invoked directly (server mode)
+    /// rather than via the periodic-sync loop's coordinator dispatch.
+    pub(crate) fn fire_and_forget(sync_type: SyncType, force: bool) -> Self {
+        Self {
+            sync_type,
+            reply: Arc::new(Mutex::new(None)),
+            force,
+        }
+    }
+
     pub(crate) async fn reply(&self, error: Option<SdkError>) {
         if let Some(reply) = self.reply.lock().await.take() {
             let _ = match error {
@@ -86,6 +100,7 @@ pub struct BreezSdk {
     pub(crate) lnurl_auth_signer: Arc<LnurlAuthSignerAdapter>,
     pub(crate) event_emitter: Arc<EventEmitter>,
     pub(crate) shutdown_sender: watch::Sender<()>,
+    pub(crate) runtime: SdkRuntime,
     /// Coordinator for coalescing duplicate sync requests
     pub(crate) sync_coordinator: SyncCoordinator,
     pub(crate) initial_synced_watcher: watch::Receiver<bool>,
@@ -106,6 +121,7 @@ pub(crate) struct BreezSdkParams {
     pub lnurl_server_client: Option<Arc<dyn LnurlServerClient>>,
     pub lnurl_auth_signer: Arc<LnurlAuthSignerAdapter>,
     pub shutdown_sender: watch::Sender<()>,
+    pub runtime: SdkRuntime,
     pub spark_wallet: Arc<SparkWallet>,
     pub event_emitter: Arc<EventEmitter>,
     pub buy_bitcoin_provider: Arc<MoonpayProvider>,
@@ -202,7 +218,44 @@ pub fn default_config(network: Network) -> Config {
         stable_balance_config: None,
         max_concurrent_claims: 4,
         spark_config: Some(default_spark_config(network)),
+        background_tasks_enabled: true,
     }
+}
+
+/// Builds a [`Config`] suitable for multi-tenant server-mode deployments.
+///
+/// This preset returns the same configuration as [`default_config`] with
+/// [`background_tasks_enabled`](Config::background_tasks_enabled) set to
+/// `false`. In server mode, the SDK is treated as a library: the host
+/// orchestrates sync, claiming, and event delivery (typically via webhooks)
+/// explicitly, so an ephemeral SDK instance stays cheap and predictable.
+///
+/// Other config fields such as
+/// [`real_time_sync_server_url`](Config::real_time_sync_server_url) and
+/// [`optimization_config.auto_enabled`](OptimizationConfig::auto_enabled)
+/// retain their default values; the runtime profile prevents the corresponding
+/// background services from being started.
+///
+/// Manual operations (`sync_wallet`, `claim_deposits`, `claim_transfers`,
+/// `recover_lightning_address`, etc.) continue to work and are the intended
+/// entry points in this mode.
+///
+/// One-time setup that the client-mode SDK applies automatically — notably
+/// [`private_enabled_default`](Config::private_enabled_default) — is NOT
+/// applied in this mode. Partners drive setup explicitly via
+/// `update_user_settings` (and any other relevant APIs) so ephemeral
+/// per-request SDK instances incur no implicit setup overhead.
+///
+/// [`get_info`](crate::BreezSdk::get_info) reads balance directly from the
+/// spark wallet in this mode rather than from the background-maintained
+/// storage cache, so balance is always fresh and
+/// [`GetInfoRequest::ensure_synced`](crate::GetInfoRequest::ensure_synced)
+/// is a no-op.
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn default_server_config(network: Network) -> Config {
+    let mut config = default_config(network);
+    config.background_tasks_enabled = false;
+    config
 }
 
 /// Builds the default [`SparkConfig`](crate::models::SparkConfig) for the given network.
@@ -351,4 +404,23 @@ pub async fn get_spark_status() -> Result<crate::SparkStatus, SdkError> {
         status,
         last_updated,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_server_config_disables_background_tasks() {
+        for network in [Network::Mainnet, Network::Regtest] {
+            let cfg = default_server_config(network);
+            assert!(!cfg.background_tasks_enabled);
+        }
+    }
+
+    #[test]
+    fn default_config_enables_background_tasks() {
+        assert!(default_config(Network::Mainnet).background_tasks_enabled);
+        assert!(default_config(Network::Regtest).background_tasks_enabled);
+    }
 }

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -236,9 +236,13 @@ pub fn default_config(network: Network) -> Config {
 /// retain their default values; the runtime profile prevents the corresponding
 /// background services from being started.
 ///
-/// Manual operations (`sync_wallet`, `claim_deposits`, `claim_transfers`,
-/// `recover_lightning_address`, etc.) continue to work and are the intended
+/// Explicit operations (`sync_wallet`, `claim_deposit`,
+/// `list_unclaimed_deposits`, `refund_deposit`,
+/// `refund_pending_conversions`, etc.) continue to work and are the intended
 /// entry points in this mode.
+///
+/// Stable Balance is not supported in this mode because its conversion worker
+/// is a background service.
 ///
 /// One-time setup that the client-mode SDK applies automatically — notably
 /// [`private_enabled_default`](Config::private_enabled_default) — is NOT

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -38,7 +38,7 @@ use platform_utils::tokio;
 use spark_wallet::{InvoiceDescription, Preimage};
 
 use super::{
-    BreezSdk, SyncType,
+    BreezSdk,
     helpers::{InternalEventListener, get_deposit_address, is_payment_match},
 };
 
@@ -427,6 +427,21 @@ impl BreezSdk {
             .map_err(Into::into)
     }
 
+    /// Runs one pass of the pending-conversion refunder.
+    ///
+    /// Iterates over payments whose conversions failed and have a refund
+    /// pending, then attempts to refund each one. This is the same logic the
+    /// SDK runs internally on a periodic schedule when background tasks are
+    /// enabled; surfacing it as an explicit API lets server-mode partners
+    /// drive it (the periodic refunder doesn't run in server mode) and lets
+    /// client-mode partners force an immediate refund pass.
+    pub async fn refund_pending_conversions(&self) -> Result<(), SdkError> {
+        self.token_converter
+            .refund_pending()
+            .await
+            .map_err(Into::into)
+    }
+
     /// Lists payments from the storage with pagination
     ///
     /// This method provides direct access to the payment history stored in the database.
@@ -568,16 +583,14 @@ impl BreezSdk {
         } else {
             Box::pin(self.send_payment_internal(&request, amount_override)).await
         };
-        // Emit payment status event and trigger wallet state sync
-        if let Ok(response) = &res {
-            if !suppress_payment_event {
-                // Emit the payment with metadata already included
-                self.event_emitter
-                    .emit(&SdkEvent::from_payment(response.payment.clone()))
-                    .await;
-            }
-            self.sync_coordinator
-                .trigger_sync_no_wait(SyncType::WalletState, true)
+        // Emit payment status event. Client runtime listens to payment events
+        // and schedules a wallet-state refresh when background sync is active.
+        if let Ok(response) = &res
+            && !suppress_payment_event
+        {
+            // Emit the payment with metadata already included
+            self.event_emitter
+                .emit(&SdkEvent::from_payment(response.payment.clone()))
                 .await;
         }
         res
@@ -823,16 +836,6 @@ impl BreezSdk {
         caller_amount_override: Option<u64>,
         suppress_payment_event: &mut bool,
     ) -> Result<SendPaymentResponse, SdkError> {
-        // Trigger a wallet state sync if converting from Bitcoin to token
-        if matches!(
-            conversion_options.conversion_type,
-            ConversionType::FromBitcoin
-        ) {
-            self.sync_coordinator
-                .trigger_sync_no_wait(SyncType::WalletState, true)
-                .await;
-        }
-
         // Wait for the received conversion payment to complete
         let payment = self
             .wait_for_payment(
@@ -1482,7 +1485,6 @@ impl BreezSdk {
         };
         let spark_wallet = self.spark_wallet.clone();
         let storage = self.storage.clone();
-        let sync_coordinator = self.sync_coordinator.clone();
         let event_emitter = self.event_emitter.clone();
         let payment = payment.clone();
         let payment_id = payment_id.clone();
@@ -1512,9 +1514,6 @@ impl BreezSdk {
                                 }
                                 // Fetch the payment to include already stored metadata
                                 get_payment_and_emit_event(&storage, &event_emitter, payment.clone()).await;
-                                sync_coordinator
-                                    .trigger_sync_no_wait(SyncType::WalletState, true)
-                                    .await;
                                 return;
                             }
                         }

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -49,7 +49,7 @@ impl BreezSdk {
         &self,
         request: ReceivePaymentRequest,
     ) -> Result<ReceivePaymentResponse, SdkError> {
-        self.ensure_spark_private_mode_initialized().await?;
+        self.maybe_ensure_spark_private_mode_initialized().await?;
         match request.payment_method {
             ReceivePaymentMethod::SparkAddress => Ok(ReceivePaymentResponse {
                 fee: 0,
@@ -413,7 +413,7 @@ impl BreezSdk {
         &self,
         request: SendPaymentRequest,
     ) -> Result<SendPaymentResponse, SdkError> {
-        self.ensure_spark_private_mode_initialized().await?;
+        self.maybe_ensure_spark_private_mode_initialized().await?;
         Box::pin(self.maybe_convert_token_send_payment(request, false, None)).await
     }
 

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -431,10 +431,11 @@ impl BreezSdk {
     ///
     /// Iterates over payments whose conversions failed and have a refund
     /// pending, then attempts to refund each one. This is the same logic the
-    /// SDK runs internally on a periodic schedule when background tasks are
-    /// enabled; surfacing it as an explicit API lets server-mode partners
-    /// drive it (the periodic refunder doesn't run in server mode) and lets
-    /// client-mode partners force an immediate refund pass.
+    /// SDK runs internally on a periodic schedule when
+    /// `background_tasks_enabled` is `true`. When background tasks are
+    /// disabled the periodic refunder does not run, and this method is the
+    /// explicit entry point for driving the pass; when background tasks are
+    /// enabled, it can be called to force an immediate refund pass.
     pub async fn refund_pending_conversions(&self) -> Result<(), SdkError> {
         self.token_converter
             .refund_pending()

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -1,0 +1,418 @@
+use std::sync::Arc;
+
+use platform_utils::time::{Duration, SystemTime};
+use platform_utils::tokio;
+use spark_wallet::{WalletEvent, WalletTransfer};
+use tokio::{
+    select,
+    sync::{broadcast, watch},
+};
+use tracing::{Instrument, debug, error, info, trace, warn};
+
+use crate::{
+    GetInfoRequest, GetInfoResponse, Payment,
+    error::SdkError,
+    events::{EventListener, RuntimeEvent, SdkEvent},
+    persist::ObjectCacheRepository,
+    token_conversion::TokenConverter,
+    utils::{payments::get_payment_and_emit_event, run_with_shutdown},
+};
+
+use super::RuntimeProfile;
+use crate::sdk::{
+    BreezSdk, SyncCoordinator, SyncRequest, SyncType,
+    helpers::{BalanceWatcher, update_balances},
+};
+
+pub(super) struct ClientRuntime;
+
+#[macros::async_trait]
+impl RuntimeProfile for ClientRuntime {
+    fn starts_background_services(&self) -> bool {
+        true
+    }
+
+    fn start_sdk_services(&self, sdk: &BreezSdk, initial_synced_sender: watch::Sender<bool>) {
+        register_client_sync_listener(sdk);
+        sdk.spawn_spark_private_mode_initialization();
+        spawn_client_runtime_loop(sdk, initial_synced_sender);
+        sdk.try_recover_lightning_address();
+        spawn_conversion_refunder(
+            Arc::clone(&sdk.token_converter),
+            sdk.shutdown_sender.subscribe(),
+        );
+        if let Some(stable_balance) = &sdk.stable_balance {
+            stable_balance.spawn_conversion_worker(sdk.shutdown_sender.subscribe());
+        }
+    }
+
+    async fn run_user_sync(
+        &self,
+        sdk: &BreezSdk,
+        sync_type: SyncType,
+        force: bool,
+    ) -> Result<(), SdkError> {
+        sdk.sync_coordinator
+            .trigger_sync_and_wait(sync_type, force)
+            .await
+    }
+
+    async fn get_info(
+        &self,
+        sdk: &BreezSdk,
+        request: GetInfoRequest,
+    ) -> Result<GetInfoResponse, SdkError> {
+        if request.ensure_synced.unwrap_or_default() {
+            sdk.initial_synced_watcher
+                .clone()
+                .changed()
+                .await
+                .map_err(|_| {
+                    SdkError::Generic("Failed to receive initial synced signal".to_string())
+                })?;
+        }
+
+        let account_info = ObjectCacheRepository::new(sdk.storage.clone())
+            .fetch_account_info()
+            .await?
+            .unwrap_or_default();
+
+        Ok(GetInfoResponse {
+            identity_pubkey: sdk.spark_wallet.get_identity_public_key().to_string(),
+            balance_sats: account_info.balance_sats,
+            token_balances: account_info.token_balances,
+        })
+    }
+
+    async fn ensure_spark_private_mode_initialized(&self, sdk: &BreezSdk) -> Result<(), SdkError> {
+        sdk.ensure_spark_private_mode_initialized_inner().await
+    }
+}
+
+fn spawn_client_runtime_loop(sdk: &BreezSdk, initial_synced_sender: watch::Sender<bool>) {
+    let sdk = sdk.clone();
+    let mut shutdown_receiver = sdk.shutdown_sender.subscribe();
+    let mut wallet_events = sdk.spark_wallet.subscribe_events();
+    let mut runtime_events = sdk.event_emitter.subscribe_runtime_events();
+    let mut sync_requests = sdk.sync_coordinator.subscribe();
+    let mut last_sync_time = SystemTime::now();
+    let sync_interval = u64::from(sdk.config.sync_interval_secs);
+    let span = tracing::Span::current();
+
+    tokio::spawn(
+        async move {
+            let balance_watcher =
+                BalanceWatcher::new(sdk.spark_wallet.clone(), sdk.storage.clone());
+            let balance_watcher_id = sdk.add_event_listener(Box::new(balance_watcher)).await;
+            sdk.init_jwt().await;
+
+            loop {
+                select! {
+                    _ = shutdown_receiver.changed() => {
+                        if !sdk.remove_event_listener(&balance_watcher_id).await {
+                            error!("Failed to remove balance watcher listener");
+                        }
+                        info!("Client runtime loop shutdown signal received");
+                        return;
+                    }
+
+                    event = wallet_events.recv() => {
+                        on_wallet_event(&sdk, event).await;
+                    }
+
+                    runtime_event = runtime_events.recv() => {
+                        if on_runtime_event(&sdk, runtime_event).await.is_break() {
+                            return;
+                        }
+                    }
+
+                    sync_request = sync_requests.recv() => {
+                        if on_sync_request(
+                            &sdk,
+                            sync_request,
+                            &shutdown_receiver,
+                            &initial_synced_sender,
+                        )
+                        .await
+                        {
+                            last_sync_time = SystemTime::now();
+                        }
+                    }
+
+                    () = sdk.jwt_refresh_interval() => {
+                        refresh_jwt(&sdk).await;
+                    }
+
+                    () = tokio::time::sleep(Duration::from_secs(10)) => {
+                        let now = SystemTime::now();
+                        if let Ok(elapsed) = now.duration_since(last_sync_time) && elapsed.as_secs() >= sync_interval {
+                            sdk.sync_coordinator.trigger_sync_no_wait(SyncType::Full, false).await;
+                        }
+                    }
+                }
+            }
+        }
+        .instrument(span),
+    );
+}
+
+async fn on_wallet_event(sdk: &BreezSdk, event: Result<WalletEvent, broadcast::error::RecvError>) {
+    match event {
+        Ok(event) => {
+            info!("Received event: {event}");
+            trace!("Received event: {:?}", event);
+            let wallet_synced = matches!(&event, WalletEvent::Synced);
+            let transfer_claim_event = matches!(
+                &event,
+                WalletEvent::TransferClaimed(_) | WalletEvent::TransferClaimStarting(_)
+            );
+            let payment_event_emitted = handle_wallet_event(sdk, event).await;
+
+            if wallet_synced {
+                sdk.sync_coordinator
+                    .trigger_sync_no_wait(SyncType::Full, true)
+                    .await;
+            } else if transfer_claim_event && !payment_event_emitted {
+                sdk.sync_coordinator
+                    .trigger_sync_no_wait(SyncType::WalletState, true)
+                    .await;
+            }
+        }
+        Err(e) => {
+            error!("Failed to receive event: {e:?}");
+        }
+    }
+}
+
+async fn on_runtime_event(
+    sdk: &BreezSdk,
+    event: Result<RuntimeEvent, broadcast::error::RecvError>,
+) -> std::ops::ControlFlow<()> {
+    match event {
+        Ok(RuntimeEvent::StableBalanceConversionCompleted) => {
+            sdk.sync_coordinator
+                .trigger_sync_no_wait(SyncType::Full, true)
+                .await;
+            std::ops::ControlFlow::Continue(())
+        }
+        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+            warn!("Runtime event receiver lagged, skipped {skipped} events");
+            std::ops::ControlFlow::Continue(())
+        }
+        Err(broadcast::error::RecvError::Closed) => {
+            info!("Runtime event sender closed");
+            std::ops::ControlFlow::Break(())
+        }
+    }
+}
+
+async fn on_sync_request(
+    sdk: &BreezSdk,
+    sync_request: Result<SyncRequest, broadcast::error::RecvError>,
+    shutdown_receiver: &watch::Receiver<()>,
+    initial_synced_sender: &watch::Sender<bool>,
+) -> bool {
+    let Ok(sync_request) = sync_request else {
+        return false;
+    };
+    info!("Sync trigger changed: {:?}", &sync_request);
+    let cloned_sdk = sdk.clone();
+    let initial_synced_sender = initial_synced_sender.clone();
+    matches!(
+        Box::pin(run_with_shutdown(
+            shutdown_receiver.clone(),
+            "Sync trigger changed",
+            async move {
+                if let Err(e) = cloned_sdk.sync_wallet_internal(&sync_request).await {
+                    error!("Failed to sync wallet: {e:?}");
+                    let () = sync_request.reply(Some(e)).await;
+                    return false;
+                }
+                let () = sync_request.reply(None).await;
+                if sync_request.sync_type.contains(SyncType::Full) {
+                    if let Err(e) = initial_synced_sender.send(true) {
+                        error!("Failed to send initial synced signal: {e:?}");
+                    }
+                    return true;
+                }
+                false
+            }
+        ))
+        .await,
+        Some(true)
+    )
+}
+
+async fn refresh_jwt(sdk: &BreezSdk) {
+    let token = match sdk.new_jwt().await {
+        Ok(token) => token,
+        Err(err) => {
+            warn!("Could not fetch new JWT: {err}");
+            return;
+        }
+    };
+    sdk.set_and_save_jwt(token).await;
+}
+
+async fn handle_wallet_event(sdk: &BreezSdk, event: WalletEvent) -> bool {
+    match event {
+        WalletEvent::DepositConfirmed(_) => {
+            info!("Deposit confirmed");
+            false
+        }
+        WalletEvent::StreamConnected => {
+            info!("Stream connected");
+            false
+        }
+        WalletEvent::StreamDisconnected => {
+            info!("Stream disconnected");
+            false
+        }
+        WalletEvent::Synced => {
+            info!("Synced");
+            false
+        }
+        WalletEvent::TransferClaimed(transfer) => {
+            info!("Transfer claimed");
+            let mut payment_emitted = false;
+            // Drop any unclaimed-deposit record for this outpoint independently
+            // of payment ingestion, so conversion failures do not leave it stale.
+            if let Some((tx_id, vout)) = claim_static_deposit_outpoint(&transfer) {
+                cleanup_claimed_deposit(sdk, &tx_id, vout).await;
+            }
+            if let Ok(mut payment) = Payment::try_from(transfer) {
+                if let Err(e) = sdk.storage.insert_payment(payment.clone()).await {
+                    error!("Failed to insert succeeded payment: {e:?}");
+                }
+
+                // This was already requested at TransferClaimStarting, but it
+                // might still be racing, so ensure metadata before emitting.
+                sdk.sync_single_lnurl_metadata(&mut payment).await;
+
+                if let Err(e) = update_balances(sdk.spark_wallet.clone(), sdk.storage.clone()).await
+                {
+                    error!("Failed to update balances before PaymentSucceeded event: {e:?}");
+                }
+
+                get_payment_and_emit_event(&sdk.storage, &sdk.event_emitter, payment).await;
+                payment_emitted = true;
+            }
+            payment_emitted
+        }
+        WalletEvent::TransferClaimStarting(transfer) => {
+            info!("Transfer claim starting");
+            let mut payment_emitted = false;
+            if let Ok(mut payment) = Payment::try_from(transfer) {
+                if let Err(e) = sdk.storage.insert_payment(payment.clone()).await {
+                    error!("Failed to insert pending payment: {e:?}");
+                }
+
+                sdk.sync_single_lnurl_metadata(&mut payment).await;
+                get_payment_and_emit_event(&sdk.storage, &sdk.event_emitter, payment).await;
+                payment_emitted = true;
+            }
+            payment_emitted
+        }
+        WalletEvent::Optimization(event) => {
+            info!("Optimization event: {:?}", event);
+            false
+        }
+    }
+}
+
+async fn cleanup_claimed_deposit(sdk: &BreezSdk, tx_id: &str, vout: u32) {
+    if let Err(e) = sdk.storage.delete_deposit(tx_id.to_string(), vout).await {
+        error!("Failed to delete claimed deposit {tx_id}:{vout} from storage: {e:?}");
+    }
+}
+
+fn claim_static_deposit_outpoint(transfer: &WalletTransfer) -> Option<(String, u32)> {
+    match transfer.user_request.as_ref()? {
+        spark_wallet::SspUserRequest::ClaimStaticDeposit(info) => {
+            let vout = u32::try_from(info.output_index).ok()?;
+            Some((info.transaction_id.clone(), vout))
+        }
+        _ => None,
+    }
+}
+
+fn register_client_sync_listener(sdk: &BreezSdk) {
+    let event_emitter = sdk.event_emitter.clone();
+    let listener = ClientSyncListener {
+        sync_coordinator: sdk.sync_coordinator.clone(),
+    };
+    let span = tracing::Span::current();
+
+    tokio::spawn(
+        async move {
+            event_emitter
+                .add_internal_listener(Box::new(listener))
+                .await;
+        }
+        .instrument(span),
+    );
+}
+
+struct ClientSyncListener {
+    sync_coordinator: SyncCoordinator,
+}
+
+#[macros::async_trait]
+impl EventListener for ClientSyncListener {
+    async fn on_event(&self, event: SdkEvent) {
+        match event {
+            SdkEvent::PaymentSucceeded { .. }
+            | SdkEvent::PaymentPending { .. }
+            | SdkEvent::PaymentFailed { .. }
+            | SdkEvent::ClaimedDeposits { .. } => {
+                self.sync_coordinator
+                    .trigger_sync_no_wait(SyncType::WalletState, true)
+                    .await;
+            }
+            _ => {}
+        }
+    }
+}
+
+fn spawn_conversion_refunder(
+    token_converter: Arc<dyn TokenConverter>,
+    mut shutdown_receiver: watch::Receiver<()>,
+) {
+    let mut refund_requests = token_converter.subscribe_refund_requests();
+    let span = tracing::Span::current();
+
+    tokio::spawn(
+        async move {
+            loop {
+                if let Err(e) = token_converter.refund_pending().await {
+                    error!("Failed to refund failed conversions: {e:?}");
+                }
+
+                match refund_requests.as_mut() {
+                    Some(trigger_receiver) => {
+                        select! {
+                            _ = shutdown_receiver.changed() => {
+                                info!("Conversion refunder shutdown signal received");
+                                return;
+                            }
+                            _ = trigger_receiver.recv() => {
+                                debug!("Conversion refunder triggered");
+                            }
+                            () = tokio::time::sleep(Duration::from_secs(150)) => {}
+                        }
+                    }
+                    None => {
+                        select! {
+                            _ = shutdown_receiver.changed() => {
+                                info!("Conversion refunder shutdown signal received");
+                                return;
+                            }
+                            () = tokio::time::sleep(Duration::from_secs(150)) => {}
+                        }
+                    }
+                }
+            }
+        }
+        .instrument(span),
+    );
+}

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -32,8 +32,8 @@ impl RuntimeProfile for ClientRuntime {
         true
     }
 
-    fn start_sdk_services(&self, sdk: &BreezSdk, initial_synced_sender: watch::Sender<bool>) {
-        register_client_sync_listener(sdk);
+    async fn start_sdk_services(&self, sdk: &BreezSdk, initial_synced_sender: watch::Sender<bool>) {
+        register_client_sync_listener(sdk).await;
         sdk.spawn_spark_private_mode_initialization();
         spawn_client_runtime_loop(sdk, initial_synced_sender);
         sdk.try_recover_lightning_address();
@@ -336,21 +336,13 @@ fn claim_static_deposit_outpoint(transfer: &WalletTransfer) -> Option<(String, u
     }
 }
 
-fn register_client_sync_listener(sdk: &BreezSdk) {
-    let event_emitter = sdk.event_emitter.clone();
+async fn register_client_sync_listener(sdk: &BreezSdk) {
     let listener = ClientSyncListener {
         sync_coordinator: sdk.sync_coordinator.clone(),
     };
-    let span = tracing::Span::current();
-
-    tokio::spawn(
-        async move {
-            event_emitter
-                .add_internal_listener(Box::new(listener))
-                .await;
-        }
-        .instrument(span),
-    );
+    sdk.event_emitter
+        .add_internal_listener(Box::new(listener))
+        .await;
 }
 
 struct ClientSyncListener {

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -34,6 +34,7 @@ impl RuntimeProfile for ClientRuntime {
 
     async fn start_sdk_services(&self, sdk: &BreezSdk, initial_synced_sender: watch::Sender<bool>) {
         register_client_sync_listener(sdk).await;
+        register_client_runtime_event_handler(sdk).await;
         sdk.spawn_spark_private_mode_initialization();
         spawn_client_runtime_loop(sdk, initial_synced_sender);
         sdk.try_recover_lightning_address();
@@ -84,7 +85,10 @@ impl RuntimeProfile for ClientRuntime {
         })
     }
 
-    async fn ensure_spark_private_mode_initialized(&self, sdk: &BreezSdk) -> Result<(), SdkError> {
+    async fn maybe_ensure_spark_private_mode_initialized(
+        &self,
+        sdk: &BreezSdk,
+    ) -> Result<(), SdkError> {
         sdk.ensure_spark_private_mode_initialized_inner().await
     }
 }
@@ -93,7 +97,6 @@ fn spawn_client_runtime_loop(sdk: &BreezSdk, initial_synced_sender: watch::Sende
     let sdk = sdk.clone();
     let mut shutdown_receiver = sdk.shutdown_sender.subscribe();
     let mut wallet_events = sdk.spark_wallet.subscribe_events();
-    let mut runtime_events = sdk.event_emitter.subscribe_runtime_events();
     let mut sync_requests = sdk.sync_coordinator.subscribe();
     let mut last_sync_time = SystemTime::now();
     let sync_interval = u64::from(sdk.config.sync_interval_secs);
@@ -118,12 +121,6 @@ fn spawn_client_runtime_loop(sdk: &BreezSdk, initial_synced_sender: watch::Sende
 
                     event = wallet_events.recv() => {
                         on_wallet_event(&sdk, event).await;
-                    }
-
-                    runtime_event = runtime_events.recv() => {
-                        if on_runtime_event(&sdk, runtime_event).await.is_break() {
-                            return;
-                        }
                     }
 
                     sync_request = sync_requests.recv() => {
@@ -184,24 +181,33 @@ async fn on_wallet_event(sdk: &BreezSdk, event: Result<WalletEvent, broadcast::e
     }
 }
 
-async fn on_runtime_event(
-    sdk: &BreezSdk,
-    event: Result<RuntimeEvent, broadcast::error::RecvError>,
-) -> std::ops::ControlFlow<()> {
-    match event {
-        Ok(RuntimeEvent::StableBalanceConversionCompleted) => {
-            sdk.sync_coordinator
-                .trigger_sync_no_wait(SyncType::Full, true)
-                .await;
-            std::ops::ControlFlow::Continue(())
-        }
-        Err(broadcast::error::RecvError::Lagged(skipped)) => {
-            warn!("Runtime event receiver lagged, skipped {skipped} events");
-            std::ops::ControlFlow::Continue(())
-        }
-        Err(broadcast::error::RecvError::Closed) => {
-            info!("Runtime event sender closed");
-            std::ops::ControlFlow::Break(())
+async fn register_client_runtime_event_handler(sdk: &BreezSdk) {
+    sdk.event_emitter
+        .add_runtime_event_handler(Box::new(ClientRuntimeEventHandler { sdk: sdk.clone() }))
+        .await;
+}
+
+struct ClientRuntimeEventHandler {
+    sdk: BreezSdk,
+}
+
+#[macros::async_trait]
+impl crate::events::RuntimeEventHandler for ClientRuntimeEventHandler {
+    async fn handle(&self, event: RuntimeEvent) {
+        match event {
+            RuntimeEvent::StableBalanceConversionCompleted => {
+                self.sdk
+                    .sync_coordinator
+                    .trigger_sync_no_wait(SyncType::Full, true)
+                    .await;
+            }
+            RuntimeEvent::DepositClaimed { .. } => {
+                if let Err(e) =
+                    update_balances(self.sdk.spark_wallet.clone(), self.sdk.storage.clone()).await
+                {
+                    error!("Failed to refresh balances after claim_deposit: {e:?}");
+                }
+            }
         }
     }
 }

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -223,7 +223,10 @@ async fn on_sync_request(
             shutdown_receiver.clone(),
             "Sync trigger changed",
             async move {
-                if let Err(e) = cloned_sdk.sync_wallet_internal(&sync_request).await {
+                if let Err(e) = cloned_sdk
+                    .sync_wallet_internal(sync_request.sync_type.clone(), sync_request.force)
+                    .await
+                {
                     error!("Failed to sync wallet: {e:?}");
                     let () = sync_request.reply(Some(e)).await;
                     return false;

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -12,13 +12,13 @@ use tracing::{Instrument, debug, error, info, trace, warn};
 use crate::{
     GetInfoRequest, GetInfoResponse, Payment,
     error::SdkError,
-    events::{EventListener, RuntimeEvent, SdkEvent},
+    events::{EventListener, SdkEvent},
     persist::ObjectCacheRepository,
     token_conversion::TokenConverter,
     utils::{payments::get_payment_and_emit_event, run_with_shutdown},
 };
 
-use super::RuntimeProfile;
+use super::{RuntimeEvent, RuntimeProfile};
 use crate::sdk::{
     BreezSdk, SyncCoordinator, SyncRequest, SyncType,
     helpers::{BalanceWatcher, update_balances},

--- a/crates/breez-sdk/core/src/sdk/runtime/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/mod.rs
@@ -21,6 +21,9 @@ pub(crate) type SdkRuntime = Arc<dyn RuntimeProfile>;
 #[derive(Debug, Clone)]
 pub(crate) enum RuntimeEvent {
     StableBalanceConversionCompleted,
+    DepositClaimed {
+        payment: Box<crate::models::Payment>,
+    },
 }
 
 pub(crate) fn runtime_from_config(config: &Config) -> SdkRuntime {
@@ -50,7 +53,10 @@ pub(crate) trait RuntimeProfile: Send + Sync {
         request: GetInfoRequest,
     ) -> Result<GetInfoResponse, SdkError>;
 
-    async fn ensure_spark_private_mode_initialized(&self, sdk: &BreezSdk) -> Result<(), SdkError>;
+    async fn maybe_ensure_spark_private_mode_initialized(
+        &self,
+        sdk: &BreezSdk,
+    ) -> Result<(), SdkError>;
 }
 
 #[cfg(test)]

--- a/crates/breez-sdk/core/src/sdk/runtime/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/mod.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use tokio::sync::watch;
+
+use crate::{GetInfoRequest, GetInfoResponse, error::SdkError, models::Config};
+
+use super::{BreezSdk, SyncType};
+
+mod client;
+mod server;
+
+use client::ClientRuntime;
+use server::ServerRuntime;
+
+pub(crate) type SdkRuntime = Arc<dyn RuntimeProfile>;
+
+pub(crate) fn runtime_from_config(config: &Config) -> SdkRuntime {
+    if config.background_tasks_enabled {
+        Arc::new(ClientRuntime)
+    } else {
+        Arc::new(ServerRuntime)
+    }
+}
+
+#[macros::async_trait]
+pub(crate) trait RuntimeProfile: Send + Sync {
+    fn starts_background_services(&self) -> bool;
+
+    fn start_sdk_services(&self, sdk: &BreezSdk, initial_synced_sender: watch::Sender<bool>);
+
+    async fn run_user_sync(
+        &self,
+        sdk: &BreezSdk,
+        sync_type: SyncType,
+        force: bool,
+    ) -> Result<(), SdkError>;
+
+    async fn get_info(
+        &self,
+        sdk: &BreezSdk,
+        request: GetInfoRequest,
+    ) -> Result<GetInfoResponse, SdkError>;
+
+    async fn ensure_spark_private_mode_initialized(&self, sdk: &BreezSdk) -> Result<(), SdkError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Network, default_config, default_server_config};
+
+    use super::runtime_from_config;
+
+    #[test]
+    fn runtime_from_default_config_starts_background_services() {
+        let runtime = runtime_from_config(&default_config(Network::Regtest));
+
+        assert!(runtime.starts_background_services());
+    }
+
+    #[test]
+    fn server_runtime_gates_background_services() {
+        let config = default_server_config(Network::Regtest);
+        let runtime = runtime_from_config(&config);
+
+        assert!(!runtime.starts_background_services());
+    }
+}

--- a/crates/breez-sdk/core/src/sdk/runtime/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/mod.rs
@@ -35,7 +35,7 @@ pub(crate) fn runtime_from_config(config: &Config) -> SdkRuntime {
 pub(crate) trait RuntimeProfile: Send + Sync {
     fn starts_background_services(&self) -> bool;
 
-    fn start_sdk_services(&self, sdk: &BreezSdk, initial_synced_sender: watch::Sender<bool>);
+    async fn start_sdk_services(&self, sdk: &BreezSdk, initial_synced_sender: watch::Sender<bool>);
 
     async fn run_user_sync(
         &self,

--- a/crates/breez-sdk/core/src/sdk/runtime/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/mod.rs
@@ -14,6 +14,15 @@ use server::ServerRuntime;
 
 pub(crate) type SdkRuntime = Arc<dyn RuntimeProfile>;
 
+/// Internal runtime events consumed by the selected runtime profile.
+///
+/// These events are not forwarded to external SDK listeners; they decouple
+/// non-runtime-owned modules from runtime-specific background behavior.
+#[derive(Debug, Clone)]
+pub(crate) enum RuntimeEvent {
+    StableBalanceConversionCompleted,
+}
+
 pub(crate) fn runtime_from_config(config: &Config) -> SdkRuntime {
     if config.background_tasks_enabled {
         Arc::new(ClientRuntime)

--- a/crates/breez-sdk/core/src/sdk/runtime/server.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/server.rs
@@ -2,8 +2,9 @@ use tokio::sync::watch;
 
 use crate::{GetInfoRequest, GetInfoResponse, error::SdkError};
 
-use super::RuntimeProfile;
+use super::{RuntimeEvent, RuntimeProfile};
 use crate::sdk::{BreezSdk, SyncType};
+use crate::utils::payments::get_payment_and_emit_event;
 
 pub(super) struct ServerRuntime;
 
@@ -19,6 +20,9 @@ impl RuntimeProfile for ServerRuntime {
         _initial_synced_sender: watch::Sender<bool>,
     ) {
         sdk.spawn_jwt_init();
+        sdk.event_emitter
+            .add_runtime_event_handler(Box::new(ServerRuntimeEventHandler { sdk: sdk.clone() }))
+            .await;
     }
 
     async fn run_user_sync(
@@ -58,7 +62,27 @@ impl RuntimeProfile for ServerRuntime {
         })
     }
 
-    async fn ensure_spark_private_mode_initialized(&self, _sdk: &BreezSdk) -> Result<(), SdkError> {
+    async fn maybe_ensure_spark_private_mode_initialized(
+        &self,
+        _sdk: &BreezSdk,
+    ) -> Result<(), SdkError> {
         Ok(())
+    }
+}
+
+struct ServerRuntimeEventHandler {
+    sdk: BreezSdk,
+}
+
+#[macros::async_trait]
+impl crate::events::RuntimeEventHandler for ServerRuntimeEventHandler {
+    async fn handle(&self, event: RuntimeEvent) {
+        match event {
+            RuntimeEvent::DepositClaimed { payment } => {
+                get_payment_and_emit_event(&self.sdk.storage, &self.sdk.event_emitter, *payment)
+                    .await;
+            }
+            RuntimeEvent::StableBalanceConversionCompleted => {}
+        }
     }
 }

--- a/crates/breez-sdk/core/src/sdk/runtime/server.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/server.rs
@@ -34,8 +34,14 @@ impl RuntimeProfile for ServerRuntime {
     async fn get_info(
         &self,
         sdk: &BreezSdk,
-        _request: GetInfoRequest,
+        request: GetInfoRequest,
     ) -> Result<GetInfoResponse, SdkError> {
+        if request.ensure_synced.unwrap_or_default() {
+            return Err(SdkError::InvalidInput(
+                "ensure_synced is not supported when background_tasks_enabled is false; call sync_wallet explicitly instead".to_string(),
+            ));
+        }
+
         let (balance_sats, token_balances) = tokio::try_join!(
             sdk.spark_wallet.get_balance(),
             sdk.spark_wallet.get_token_balances(),

--- a/crates/breez-sdk/core/src/sdk/runtime/server.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/server.rs
@@ -3,7 +3,7 @@ use tokio::sync::watch;
 use crate::{GetInfoRequest, GetInfoResponse, error::SdkError};
 
 use super::RuntimeProfile;
-use crate::sdk::{BreezSdk, SyncRequest, SyncType};
+use crate::sdk::{BreezSdk, SyncType};
 
 pub(super) struct ServerRuntime;
 
@@ -27,8 +27,7 @@ impl RuntimeProfile for ServerRuntime {
         sync_type: SyncType,
         force: bool,
     ) -> Result<(), SdkError> {
-        let request = SyncRequest::fire_and_forget(sync_type, force);
-        sdk.sync_wallet_internal(&request).await
+        sdk.sync_wallet_internal(sync_type, force).await
     }
 
     async fn get_info(

--- a/crates/breez-sdk/core/src/sdk/runtime/server.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/server.rs
@@ -1,0 +1,54 @@
+use tokio::sync::watch;
+
+use crate::{GetInfoRequest, GetInfoResponse, error::SdkError};
+
+use super::RuntimeProfile;
+use crate::sdk::{BreezSdk, SyncRequest, SyncType};
+
+pub(super) struct ServerRuntime;
+
+#[macros::async_trait]
+impl RuntimeProfile for ServerRuntime {
+    fn starts_background_services(&self) -> bool {
+        false
+    }
+
+    fn start_sdk_services(&self, sdk: &BreezSdk, _initial_synced_sender: watch::Sender<bool>) {
+        sdk.spawn_jwt_init();
+    }
+
+    async fn run_user_sync(
+        &self,
+        sdk: &BreezSdk,
+        sync_type: SyncType,
+        force: bool,
+    ) -> Result<(), SdkError> {
+        let request = SyncRequest::fire_and_forget(sync_type, force);
+        sdk.sync_wallet_internal(&request).await
+    }
+
+    async fn get_info(
+        &self,
+        sdk: &BreezSdk,
+        _request: GetInfoRequest,
+    ) -> Result<GetInfoResponse, SdkError> {
+        let balance_sats = sdk.spark_wallet.get_balance().await?;
+        let token_balances = sdk
+            .spark_wallet
+            .get_token_balances()
+            .await?
+            .into_iter()
+            .map(|(k, v)| (k, v.into()))
+            .collect();
+
+        Ok(GetInfoResponse {
+            identity_pubkey: sdk.spark_wallet.get_identity_public_key().to_string(),
+            balance_sats,
+            token_balances,
+        })
+    }
+
+    async fn ensure_spark_private_mode_initialized(&self, _sdk: &BreezSdk) -> Result<(), SdkError> {
+        Ok(())
+    }
+}

--- a/crates/breez-sdk/core/src/sdk/runtime/server.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/server.rs
@@ -13,7 +13,11 @@ impl RuntimeProfile for ServerRuntime {
         false
     }
 
-    fn start_sdk_services(&self, sdk: &BreezSdk, _initial_synced_sender: watch::Sender<bool>) {
+    async fn start_sdk_services(
+        &self,
+        sdk: &BreezSdk,
+        _initial_synced_sender: watch::Sender<bool>,
+    ) {
         sdk.spawn_jwt_init();
     }
 
@@ -32,11 +36,12 @@ impl RuntimeProfile for ServerRuntime {
         sdk: &BreezSdk,
         _request: GetInfoRequest,
     ) -> Result<GetInfoResponse, SdkError> {
-        let balance_sats = sdk.spark_wallet.get_balance().await?;
-        let token_balances = sdk
-            .spark_wallet
-            .get_token_balances()
-            .await?
+        let (balance_sats, token_balances) = tokio::try_join!(
+            sdk.spark_wallet.get_balance(),
+            sdk.spark_wallet.get_token_balances(),
+        )?;
+
+        let token_balances = token_balances
             .into_iter()
             .map(|(k, v)| (k, v.into()))
             .collect();

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -1,14 +1,11 @@
-use platform_utils::time::{Duration, Instant, SystemTime};
+use platform_utils::time::{Instant, SystemTime};
 use platform_utils::tokio;
-use spark_wallet::WalletEvent;
 use std::sync::Arc;
-use tokio::sync::watch;
-use tracing::{Instrument, debug, error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use super::{
     BreezSdk, CLAIM_TX_SIZE_VBYTES, SYNC_PAGING_LIMIT, SyncRequest, SyncType,
-    helpers::{BalanceWatcher, update_balances},
-    parse_input,
+    helpers::update_balances, parse_input,
 };
 use crate::{
     DepositInfo, InputType, MaxFee, PaymentDetails, PaymentType,
@@ -20,186 +17,12 @@ use crate::{
     sync::SparkSyncService,
     utils::{
         deposit_chain_syncer::{DepositChainSyncer, TxOutput},
-        payments::get_payment_and_emit_event,
-        run_with_shutdown,
         utxo_fetcher::DetailedUtxo,
     },
 };
 
 impl BreezSdk {
-    pub(super) fn periodic_sync(&self, initial_synced_sender: watch::Sender<bool>) {
-        let sdk = self.clone();
-        let mut shutdown_receiver = sdk.shutdown_sender.subscribe();
-        let mut subscription = sdk.spark_wallet.subscribe_events();
-        let sync_coordinator = sdk.sync_coordinator.clone();
-        let mut sync_trigger_receiver = sdk.sync_coordinator.subscribe();
-        let mut last_sync_time = SystemTime::now();
-
-        let sync_interval = u64::from(self.config.sync_interval_secs);
-        let span = tracing::Span::current();
-        tokio::spawn(async move {
-            let balance_watcher =
-                BalanceWatcher::new(sdk.spark_wallet.clone(), sdk.storage.clone());
-            let balance_watcher_id = sdk.add_event_listener(Box::new(balance_watcher)).await;
-            sdk.init_jwt().await;
-            loop {
-                tokio::select! {
-                    _ = shutdown_receiver.changed() => {
-                        if !sdk.remove_event_listener(&balance_watcher_id).await {
-                            error!("Failed to remove balance watcher listener");
-                        }
-                        info!("Deposit tracking loop shutdown signal received");
-                        return;
-                    }
-                    event = subscription.recv() => {
-                        match event {
-                            Ok(event) => {
-                                info!("Received event: {event}");
-                                trace!("Received event: {:?}", event);
-                                sdk.handle_wallet_event(event).await;
-                            }
-                            Err(e) => {
-                                error!("Failed to receive event: {e:?}");
-                            }
-                        }
-                    }
-                    sync_type_res = sync_trigger_receiver.recv() => {
-                        let Ok(sync_request) = sync_type_res else {
-                            continue;
-                        };
-                        info!("Sync trigger changed: {:?}", &sync_request);
-                        let cloned_sdk = sdk.clone();
-                        let initial_synced_sender = initial_synced_sender.clone();
-                        if let Some(true) = Box::pin(run_with_shutdown(shutdown_receiver.clone(), "Sync trigger changed", async move {
-                            if let Err(e) = cloned_sdk.sync_wallet_internal(&sync_request).await {
-                                error!("Failed to sync wallet: {e:?}");
-                                let () = sync_request.reply(Some(e)).await;
-                                return false;
-                            }
-                            // Notify that the requested sync is complete
-                            let () = sync_request.reply(None).await;
-                            // If this was a full sync, notify the initial synced watcher
-                            if sync_request.sync_type.contains(SyncType::Full) {
-                                if let Err(e) = initial_synced_sender.send(true) {
-                                    error!("Failed to send initial synced signal: {e:?}");
-                                }
-                                return true;
-                            }
-
-                            false
-                        })).await {
-                            last_sync_time = SystemTime::now();
-                        }
-                    }
-
-                    // Only executes on mainnet with API key
-                    () = sdk.jwt_refresh_interval() => {
-                        let token = match sdk.new_jwt().await {
-                            Ok(token) => token,
-                            Err(err) => {
-                                warn!("Could not fetch new JWT: {err}");
-                                continue;
-                            }
-                        };
-                        sdk.set_and_save_jwt(token).await;
-                    }
-
-                    // Ensure we sync at least the configured interval
-                    () = tokio::time::sleep(Duration::from_secs(10)) => {
-                        let now = SystemTime::now();
-                        if let Ok(elapsed) = now.duration_since(last_sync_time) && elapsed.as_secs() >= sync_interval {
-                            sync_coordinator.trigger_sync_no_wait(SyncType::Full, false).await;
-                        }
-                    }
-                }
-            }
-        }.instrument(span));
-    }
-
-    pub(super) async fn handle_wallet_event(&self, event: WalletEvent) {
-        match event {
-            WalletEvent::DepositConfirmed(_) => {
-                info!("Deposit confirmed");
-            }
-            WalletEvent::StreamConnected => {
-                info!("Stream connected");
-            }
-            WalletEvent::StreamDisconnected => {
-                info!("Stream disconnected");
-            }
-            WalletEvent::Synced => {
-                info!("Synced");
-                self.sync_coordinator
-                    .trigger_sync_no_wait(super::SyncType::Full, true)
-                    .await;
-            }
-            WalletEvent::TransferClaimed(transfer) => {
-                info!("Transfer claimed");
-                // Drop any unclaimed-deposit record for this outpoint
-                // independently of payment ingestion below, so a
-                // Payment::try_from failure does not leave the record
-                // lingering.
-                if let Some((tx_id, vout)) = claim_static_deposit_outpoint(&transfer) {
-                    self.cleanup_claimed_deposit(&tx_id, vout).await;
-                }
-                if let Ok(mut payment) = Payment::try_from(transfer) {
-                    // Insert the payment into storage to make it immediately available for listing
-                    if let Err(e) = self.storage.insert_payment(payment.clone()).await {
-                        error!("Failed to insert succeeded payment: {e:?}");
-                    }
-
-                    // Ensure potential lnurl metadata is synced before emitting the event.
-                    // Note this is already synced at TransferClaimStarting, but it might not have completed yet, so that could race.
-                    self.sync_single_lnurl_metadata(&mut payment).await;
-
-                    // Update balance before emitting the event so that listeners can immediately
-                    // query the new balance.
-                    if let Err(e) =
-                        update_balances(self.spark_wallet.clone(), self.storage.clone()).await
-                    {
-                        error!("Failed to update balances before PaymentSucceeded event: {e:?}");
-                    }
-
-                    // Fetch the payment to include already stored metadata
-                    get_payment_and_emit_event(&self.storage, &self.event_emitter, payment).await;
-                }
-                self.sync_coordinator
-                    .trigger_sync_no_wait(super::SyncType::WalletState, true)
-                    .await;
-            }
-            WalletEvent::TransferClaimStarting(transfer) => {
-                info!("Transfer claim starting");
-                if let Ok(mut payment) = Payment::try_from(transfer) {
-                    // Insert the payment into storage to make it immediately available for listing
-                    if let Err(e) = self.storage.insert_payment(payment.clone()).await {
-                        error!("Failed to insert pending payment: {e:?}");
-                    }
-
-                    // Ensure potential lnurl metadata is synced before emitting the event
-                    self.sync_single_lnurl_metadata(&mut payment).await;
-
-                    // Fetch the payment to include already stored metadata
-                    get_payment_and_emit_event(&self.storage, &self.event_emitter, payment).await;
-                }
-                self.sync_coordinator
-                    .trigger_sync_no_wait(super::SyncType::WalletState, true)
-                    .await;
-            }
-            WalletEvent::Optimization(event) => {
-                info!("Optimization event: {:?}", event);
-            }
-        }
-    }
-
-    /// Removes the unclaimed-deposit storage record for `(tx_id, vout)`,
-    /// logging on failure rather than propagating the error.
-    async fn cleanup_claimed_deposit(&self, tx_id: &str, vout: u32) {
-        if let Err(e) = self.storage.delete_deposit(tx_id.to_string(), vout).await {
-            error!("Failed to delete claimed deposit {tx_id}:{vout} from storage: {e:?}");
-        }
-    }
-
-    pub(super) async fn sync_single_lnurl_metadata(&self, payment: &mut Payment) {
+    pub(in crate::sdk) async fn sync_single_lnurl_metadata(&self, payment: &mut Payment) {
         if payment.payment_type != PaymentType::Receive {
             return;
         }
@@ -650,18 +473,6 @@ impl BreezSdk {
     }
 }
 
-/// Returns the `(txid, vout)` of the on-chain UTXO claimed by this transfer,
-/// if it was produced by a static-deposit claim.
-fn claim_static_deposit_outpoint(transfer: &spark_wallet::WalletTransfer) -> Option<(String, u32)> {
-    match transfer.user_request.as_ref()? {
-        spark_wallet::SspUserRequest::ClaimStaticDeposit(info) => {
-            let vout = u32::try_from(info.output_index).ok()?;
-            Some((info.transaction_id.clone(), vout))
-        }
-        _ => None,
-    }
-}
-
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 #[allow(clippy::needless_pass_by_value)]
 impl BreezSdk {
@@ -671,9 +482,8 @@ impl BreezSdk {
         &self,
         request: SyncWalletRequest,
     ) -> Result<SyncWalletResponse, SdkError> {
-        // Use the coordinator to coalesce duplicate sync requests
-        self.sync_coordinator
-            .trigger_sync_and_wait(super::SyncType::Full, true)
+        self.runtime
+            .run_user_sync(self, super::SyncType::Full, true)
             .await?;
         Ok(SyncWalletResponse {})
     }
@@ -729,7 +539,7 @@ mod jwt {
             matches!(self.config.network, Network::Mainnet) && self.config.api_key.is_some()
         }
 
-        pub(super) async fn set_and_save_jwt(&self, token: String) {
+        pub(in crate::sdk) async fn set_and_save_jwt(&self, token: String) {
             self.partner_headers.set_token(token.clone()).await;
             if let Err(err) = self
                 .storage
@@ -740,7 +550,7 @@ mod jwt {
             }
         }
 
-        pub(super) async fn new_jwt(&self) -> Result<String, SdkError> {
+        pub(in crate::sdk) async fn new_jwt(&self) -> Result<String, SdkError> {
             let Some(api_key) = &self.config.api_key else {
                 return Err(SdkError::Generic("Missing Breez API key".to_string()));
             };
@@ -758,7 +568,7 @@ mod jwt {
             Ok(token)
         }
 
-        pub(super) async fn init_jwt(&self) {
+        pub(in crate::sdk) async fn init_jwt(&self) {
             if !self.enable_jwt() {
                 return;
             }
@@ -776,7 +586,19 @@ mod jwt {
             }
         }
 
-        pub(super) async fn jwt_refresh_interval(&self) {
+        pub(in crate::sdk) fn spawn_jwt_init(&self) {
+            use tracing::Instrument;
+            let sdk = self.clone();
+            let span = tracing::Span::current();
+            tokio::spawn(
+                async move {
+                    sdk.init_jwt().await;
+                }
+                .instrument(span),
+            );
+        }
+
+        pub(in crate::sdk) async fn jwt_refresh_interval(&self) {
             if !self.enable_jwt() {
                 return std::future::pending::<()>().await;
             }

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use tracing::{debug, error, info, trace, warn};
 
 use super::{
-    BreezSdk, CLAIM_TX_SIZE_VBYTES, SYNC_PAGING_LIMIT, SyncRequest, SyncType,
-    helpers::update_balances, parse_input,
+    BreezSdk, CLAIM_TX_SIZE_VBYTES, SYNC_PAGING_LIMIT, SyncType, helpers::update_balances,
+    parse_input,
 };
 use crate::{
     DepositInfo, InputType, MaxFee, PaymentDetails, PaymentType,
@@ -107,7 +107,11 @@ impl BreezSdk {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub(super) async fn sync_wallet_internal(&self, request: &SyncRequest) -> Result<(), SdkError> {
+    pub(super) async fn sync_wallet_internal(
+        &self,
+        sync_type: SyncType,
+        force: bool,
+    ) -> Result<(), SdkError> {
         let cache = ObjectCacheRepository::new(self.storage.clone());
         let sync_interval_secs = u64::from(self.config.sync_interval_secs);
 
@@ -116,7 +120,7 @@ impl BreezSdk {
             .map_or(0, |d| d.as_secs());
 
         // Skip if we synced recently (unless forced).
-        if !request.force
+        if !force
             && let Some(last) = cache.get_last_sync_time().await?
             && now.saturating_sub(last) < sync_interval_secs
         {
@@ -129,7 +133,7 @@ impl BreezSdk {
         }
 
         // Update last sync time if this is a full sync.
-        if request.sync_type.contains(SyncType::Full)
+        if sync_type.contains(SyncType::Full)
             && let Err(e) = cache.set_last_sync_time(now).await
         {
             error!("sync_wallet_internal: Failed to update last sync time: {e:?}");
@@ -138,7 +142,7 @@ impl BreezSdk {
         let start_time = Instant::now();
 
         let sync_wallet = async {
-            let wallet_synced = if request.sync_type.contains(SyncType::Wallet) {
+            let wallet_synced = if sync_type.contains(SyncType::Wallet) {
                 debug!("sync_wallet_internal: Starting Wallet sync");
                 let wallet_start = Instant::now();
                 match self.spark_wallet.sync().await {
@@ -162,7 +166,7 @@ impl BreezSdk {
                 false
             };
 
-            let wallet_state_synced = if request.sync_type.contains(SyncType::WalletState) {
+            let wallet_state_synced = if sync_type.contains(SyncType::WalletState) {
                 debug!("sync_wallet_internal: Starting WalletState sync");
                 let wallet_state_start = Instant::now();
                 match self.sync_wallet_state_to_storage().await {
@@ -190,7 +194,7 @@ impl BreezSdk {
         };
 
         let sync_lnurl = async {
-            if request.sync_type.contains(SyncType::LnurlMetadata) {
+            if sync_type.contains(SyncType::LnurlMetadata) {
                 debug!("sync_wallet_internal: Starting LnurlMetadata sync");
                 let lnurl_start = Instant::now();
                 match self.sync_lnurl_metadata().await {
@@ -216,7 +220,7 @@ impl BreezSdk {
         };
 
         let sync_deposits = async {
-            if request.sync_type.contains(SyncType::Deposits) {
+            if sync_type.contains(SyncType::Deposits) {
                 debug!("sync_wallet_internal: Starting Deposits sync");
                 let deposits_start = Instant::now();
                 match self.check_and_claim_static_deposits().await {

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -277,7 +277,7 @@ impl BreezSdk {
     }
 
     pub(super) async fn check_and_claim_static_deposits(&self) -> Result<(), SdkError> {
-        self.ensure_spark_private_mode_initialized().await?;
+        self.maybe_ensure_spark_private_mode_initialized().await?;
         let existing_deposits = self.storage.list_deposits().await?;
         let existing_keys: std::collections::HashSet<TxOutput> = existing_deposits
             .iter()

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -1011,9 +1011,7 @@ mod tests {
 
     #[macros::async_test_not_wasm]
     async fn server_mode_rejects_stable_balance_config() {
-        use crate::{
-            SdkError, StableBalanceConfig, StableBalanceToken, default_server_config,
-        };
+        use crate::{SdkError, StableBalanceConfig, StableBalanceToken, default_server_config};
 
         let mut config = default_server_config(Network::Regtest);
         config.stable_balance_config = Some(StableBalanceConfig {

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -952,7 +952,8 @@ impl SdkBuilder {
             stable_balance,
             sync_coordinator,
             partner_headers,
-        })?;
+        })
+        .await?;
         debug!("Initialized and started breez sdk.");
 
         Ok(sdk)

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -994,12 +994,7 @@ mod tests {
         }
     }
 
-    // tokio::test requires `rt`, which the workspace only enables on
-    // non-wasm targets. Gate this test (and its imports) accordingly so
-    // `cargo clippy --target wasm32-unknown-unknown --all-targets` stays
-    // clean.
-    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-    #[tokio::test]
+    #[macros::async_test_not_wasm]
     async fn server_mode_rejects_stable_balance_config() {
         use crate::{
             SdkError, Seed, StableBalanceConfig, StableBalanceToken, default_server_config,

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -32,7 +32,7 @@ use crate::{
     payment_observer::{PaymentObserver, SparkTransferObserver},
     persist::Storage,
     realtime_sync::{RealTimeSyncParams, init_and_start_real_time_sync},
-    sdk::{BreezSdk, BreezSdkParams, SyncCoordinator},
+    sdk::{BreezSdk, BreezSdkParams, SyncCoordinator, runtime_from_config},
     session_manager::{SessionManager, SessionManagerAdapter},
     signer::{
         breez::BreezSignerImpl, lnurl_auth::LnurlAuthSignerAdapter, rtsync::RTSyncSigner,
@@ -664,6 +664,7 @@ impl SdkBuilder {
 
         let user_agent = crate::default_user_agent();
         info!("Building sdk with user agent: {}", user_agent);
+        let runtime = runtime_from_config(&self.config);
 
         let breez_server = Arc::new(
             BreezServer::new(PRODUCTION_BREEZSERVER_URL, None, &user_agent)
@@ -688,8 +689,9 @@ impl SdkBuilder {
             .operator_pool
             .with_user_agent(Some(user_agent.clone()));
         spark_wallet_config.service_provider_config.user_agent = Some(user_agent.clone());
+        let background_services_enabled = runtime.starts_background_services();
         spark_wallet_config.leaf_auto_optimize_enabled =
-            self.config.optimization_config.auto_enabled;
+            background_services_enabled && self.config.optimization_config.auto_enabled;
         spark_wallet_config.leaf_optimization_options.multiplicity =
             self.config.optimization_config.multiplicity;
         spark_wallet_config
@@ -816,7 +818,8 @@ impl SdkBuilder {
             spark_wallet::WalletBuilder::new(spark_wallet_config, spark_signer)
                 .with_cancellation_token(shutdown_sender.subscribe())
                 .with_session_manager(inner_session_manager)
-                .with_so_extra_header_provider(partner_headers.clone());
+                .with_so_extra_header_provider(partner_headers.clone())
+                .with_background_processing(background_services_enabled);
         if let Some(observer) = self.payment_observer {
             let observer: Arc<dyn spark_wallet::TransferObserver> =
                 Arc::new(SparkTransferObserver::new(observer));
@@ -856,30 +859,31 @@ impl SdkBuilder {
             },
         };
 
-        let event_emitter = Arc::new(EventEmitter::new(
-            self.config.real_time_sync_server_url.is_some(),
-        ));
+        let real_time_sync_active =
+            background_services_enabled && self.config.real_time_sync_server_url.is_some();
+        let event_emitter = Arc::new(EventEmitter::new(real_time_sync_active));
 
-        let storage = if let Some(server_url) = &self.config.real_time_sync_server_url {
-            init_and_start_real_time_sync(RealTimeSyncParams {
-                server_url: server_url.clone(),
-                api_key: self.config.api_key.clone(),
-                user_agent,
-                signer: rtsync_signer,
-                storage: Arc::clone(&storage),
-                shutdown_receiver: shutdown_sender.subscribe(),
-                event_emitter: Arc::clone(&event_emitter),
-                lnurl_server_client: lnurl_server_client.clone(),
-            })
-            .await?
-        } else {
-            storage
+        let storage = match &self.config.real_time_sync_server_url {
+            Some(server_url) if background_services_enabled => {
+                init_and_start_real_time_sync(RealTimeSyncParams {
+                    server_url: server_url.clone(),
+                    api_key: self.config.api_key.clone(),
+                    user_agent,
+                    signer: rtsync_signer,
+                    storage: Arc::clone(&storage),
+                    shutdown_receiver: shutdown_sender.subscribe(),
+                    event_emitter: Arc::clone(&event_emitter),
+                    lnurl_server_client: lnurl_server_client.clone(),
+                })
+                .await?
+            }
+            _ => storage,
         };
 
         // Create the MoonPay provider for buying Bitcoin
         let buy_bitcoin_provider = Arc::new(MoonpayProvider::new(breez_server.clone()));
 
-        // Create the FlashnetTokenConverter (spawns its own refunder background task)
+        // Create the FlashnetTokenConverter. Client runtime starts its refunder.
         let flashnet_config = FlashnetConfig::default_config(
             self.config.network.into(),
             DEFAULT_INTEGRATOR_PUBKEY
@@ -890,33 +894,31 @@ impl SdkBuilder {
                     fee_bps: DEFAULT_INTEGRATOR_FEE_BPS,
                 }),
         );
-        let token_converter: Arc<dyn TokenConverter> = Arc::new(FlashnetTokenConverter::new(
+        let flashnet_converter = Arc::new(FlashnetTokenConverter::new(
             flashnet_config,
             Arc::clone(&storage),
             Arc::clone(&spark_wallet),
             self.config.network,
-            shutdown_sender.subscribe(),
         ));
+        let token_converter: Arc<dyn TokenConverter> = flashnet_converter;
 
-        // Create sync coordinator early so StableBalance can trigger syncs after conversions
+        // Create sync coordinator for the client runtime's sync loop
         let sync_coordinator = SyncCoordinator::new();
-
-        // Create StableBalance if configured. It spawns its own background tasks
-        // and registers itself as event middleware (must be before TokenConversionMiddleware
+        // Create StableBalance if configured. Client runtime starts its worker.
+        // It registers itself as event middleware (must be before TokenConversionMiddleware
         // so it can see conversion child payment events for deferred task resolution)
         let stable_balance = if let Some(config) = &self.config.stable_balance_config {
-            Some(Arc::new(
+            let stable_balance = Arc::new(
                 StableBalance::new(
                     config.clone(),
                     Arc::clone(&token_converter),
                     Arc::clone(&spark_wallet),
                     Arc::clone(&storage),
-                    shutdown_sender.subscribe(),
                     Arc::clone(&event_emitter),
-                    sync_coordinator.clone(),
                 )
                 .await,
-            ))
+            );
+            Some(stable_balance)
         } else {
             None
         };
@@ -937,6 +939,7 @@ impl SdkBuilder {
             lnurl_server_client,
             lnurl_auth_signer,
             shutdown_sender,
+            runtime,
             spark_wallet,
             event_emitter,
             buy_bitcoin_provider,

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -472,6 +472,12 @@ impl SdkBuilder {
     pub async fn build(self) -> Result<BreezSdk, SdkError> {
         // Validate configuration
         self.config.validate()?;
+        let runtime = runtime_from_config(&self.config);
+        if !runtime.starts_background_services() && self.config.stable_balance_config.is_some() {
+            return Err(SdkError::InvalidInput(
+                "Stable Balance is not supported in server mode".to_string(),
+            ));
+        }
 
         // Create the base signer based on the signer source
         let signer: Arc<dyn crate::signer::BreezSigner> = match self.signer_source {
@@ -664,7 +670,6 @@ impl SdkBuilder {
 
         let user_agent = crate::default_user_agent();
         info!("Building sdk with user agent: {}", user_agent);
-        let runtime = runtime_from_config(&self.config);
 
         let breez_server = Arc::new(
             BreezServer::new(PRODUCTION_BREEZSERVER_URL, None, &user_agent)
@@ -968,7 +973,10 @@ fn default_storage(
 #[cfg(test)]
 mod tests {
     use super::SdkBuilder;
-    use crate::{Network, default_config};
+    use crate::{
+        Network, SdkError, Seed, StableBalanceConfig, StableBalanceToken, default_config,
+        default_server_config,
+    };
 
     #[test]
     fn default_config_spark_config_builds_valid_wallet_config() {
@@ -985,6 +993,34 @@ mod tests {
                     )
                 },
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn server_mode_rejects_stable_balance_config() {
+        let mut config = default_server_config(Network::Regtest);
+        config.stable_balance_config = Some(StableBalanceConfig {
+            tokens: vec![StableBalanceToken {
+                label: "USDB".to_string(),
+                token_identifier: "btkn1test".to_string(),
+            }],
+            default_active_label: None,
+            threshold_sats: None,
+            max_slippage_bps: None,
+        });
+
+        let seed = Seed::Mnemonic {
+            mnemonic: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".to_string(),
+            passphrase: None,
+        };
+
+        let result = SdkBuilder::new(config, seed).build().await;
+        match result {
+            Err(SdkError::InvalidInput(message)) => {
+                assert!(message.contains("Stable Balance is not supported in server mode"));
+            }
+            Err(err) => panic!("expected InvalidInput error, got {err:?}"),
+            Ok(_) => panic!("expected server mode with Stable Balance config to fail"),
         }
     }
 }

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -973,10 +973,7 @@ fn default_storage(
 #[cfg(test)]
 mod tests {
     use super::SdkBuilder;
-    use crate::{
-        Network, SdkError, Seed, StableBalanceConfig, StableBalanceToken, default_config,
-        default_server_config,
-    };
+    use crate::{Network, default_config};
 
     #[test]
     fn default_config_spark_config_builds_valid_wallet_config() {
@@ -996,8 +993,17 @@ mod tests {
         }
     }
 
+    // tokio::test requires `rt`, which the workspace only enables on
+    // non-wasm targets. Gate this test (and its imports) accordingly so
+    // `cargo clippy --target wasm32-unknown-unknown --all-targets` stays
+    // clean.
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     #[tokio::test]
     async fn server_mode_rejects_stable_balance_config() {
+        use crate::{
+            SdkError, Seed, StableBalanceConfig, StableBalanceToken, default_server_config,
+        };
+
         let mut config = default_server_config(Network::Regtest);
         config.stable_balance_config = Some(StableBalanceConfig {
             tokens: vec![StableBalanceToken {

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -987,6 +987,7 @@ fn default_storage(
 }
 
 #[cfg(test)]
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 mod tests {
     use super::SdkBuilder;
     use crate::{Network, default_config};
@@ -1009,7 +1010,7 @@ mod tests {
         }
     }
 
-    #[macros::async_test_not_wasm]
+    #[tokio::test]
     async fn server_mode_rejects_stable_balance_config() {
         use crate::{SdkError, StableBalanceConfig, StableBalanceToken, default_server_config};
 
@@ -1035,7 +1036,7 @@ mod tests {
         }
     }
 
-    #[macros::async_test_not_wasm]
+    #[tokio::test]
     async fn server_mode_rejects_real_time_sync_server_url() {
         use crate::{SdkError, default_server_config};
 
@@ -1053,7 +1054,7 @@ mod tests {
         }
     }
 
-    #[macros::async_test_not_wasm]
+    #[tokio::test]
     async fn server_mode_rejects_optimization_auto_enabled() {
         use crate::{SdkError, default_server_config};
 

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -473,10 +473,25 @@ impl SdkBuilder {
         // Validate configuration
         self.config.validate()?;
         let runtime = runtime_from_config(&self.config);
-        if !runtime.starts_background_services() && self.config.stable_balance_config.is_some() {
-            return Err(SdkError::InvalidInput(
-                "Stable Balance is not supported in server mode".to_string(),
-            ));
+        if !runtime.starts_background_services() {
+            if self.config.stable_balance_config.is_some() {
+                return Err(SdkError::InvalidInput(
+                    "stable_balance_config is not supported when background_tasks_enabled is false"
+                        .to_string(),
+                ));
+            }
+            if self.config.real_time_sync_server_url.is_some() {
+                return Err(SdkError::InvalidInput(
+                    "real_time_sync_server_url must be None when background_tasks_enabled is false"
+                        .to_string(),
+                ));
+            }
+            if self.config.optimization_config.auto_enabled {
+                return Err(SdkError::InvalidInput(
+                    "optimization_config.auto_enabled must be false when background_tasks_enabled is false"
+                        .to_string(),
+                ));
+            }
         }
 
         // Create the base signer based on the signer source
@@ -997,7 +1012,7 @@ mod tests {
     #[macros::async_test_not_wasm]
     async fn server_mode_rejects_stable_balance_config() {
         use crate::{
-            SdkError, Seed, StableBalanceConfig, StableBalanceToken, default_server_config,
+            SdkError, StableBalanceConfig, StableBalanceToken, default_server_config,
         };
 
         let mut config = default_server_config(Network::Regtest);
@@ -1011,18 +1026,57 @@ mod tests {
             max_slippage_bps: None,
         });
 
-        let seed = Seed::Mnemonic {
-            mnemonic: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".to_string(),
-            passphrase: None,
-        };
-
+        let seed = test_seed();
         let result = SdkBuilder::new(config, seed).build().await;
         match result {
             Err(SdkError::InvalidInput(message)) => {
-                assert!(message.contains("Stable Balance is not supported in server mode"));
+                assert!(message.contains("stable_balance_config"));
             }
             Err(err) => panic!("expected InvalidInput error, got {err:?}"),
             Ok(_) => panic!("expected server mode with Stable Balance config to fail"),
+        }
+    }
+
+    #[macros::async_test_not_wasm]
+    async fn server_mode_rejects_real_time_sync_server_url() {
+        use crate::{SdkError, default_server_config};
+
+        let mut config = default_server_config(Network::Regtest);
+        config.real_time_sync_server_url = Some("https://example.com".to_string());
+
+        let seed = test_seed();
+        let result = SdkBuilder::new(config, seed).build().await;
+        match result {
+            Err(SdkError::InvalidInput(message)) => {
+                assert!(message.contains("real_time_sync_server_url"));
+            }
+            Err(err) => panic!("expected InvalidInput error, got {err:?}"),
+            Ok(_) => panic!("expected server mode with real_time_sync_server_url to fail"),
+        }
+    }
+
+    #[macros::async_test_not_wasm]
+    async fn server_mode_rejects_optimization_auto_enabled() {
+        use crate::{SdkError, default_server_config};
+
+        let mut config = default_server_config(Network::Regtest);
+        config.optimization_config.auto_enabled = true;
+
+        let seed = test_seed();
+        let result = SdkBuilder::new(config, seed).build().await;
+        match result {
+            Err(SdkError::InvalidInput(message)) => {
+                assert!(message.contains("optimization_config.auto_enabled"));
+            }
+            Err(err) => panic!("expected InvalidInput error, got {err:?}"),
+            Ok(_) => panic!("expected server mode with optimization auto_enabled to fail"),
+        }
+    }
+
+    fn test_seed() -> crate::Seed {
+        crate::Seed::Mnemonic {
+            mnemonic: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".to_string(),
+            passphrase: None,
         }
     }
 }

--- a/crates/breez-sdk/core/src/stable_balance/mod.rs
+++ b/crates/breez-sdk/core/src/stable_balance/mod.rs
@@ -573,9 +573,10 @@ impl StableBalance {
     }
 
     /// Emits the fact that a conversion changed balances and payments.
-    pub(super) fn emit_conversion_completed(&self) {
+    pub(super) async fn emit_conversion_completed(&self) {
         self.event_emitter
-            .emit_runtime_event(RuntimeEvent::StableBalanceConversionCompleted);
+            .emit_runtime_event(RuntimeEvent::StableBalanceConversionCompleted)
+            .await;
     }
 }
 

--- a/crates/breez-sdk/core/src/stable_balance/mod.rs
+++ b/crates/breez-sdk/core/src/stable_balance/mod.rs
@@ -143,7 +143,8 @@ use tracing::{debug, info, warn};
 use self::queue::ConversionQueue;
 pub(crate) use self::queue::PendingConversion;
 
-use crate::events::{EventEmitter, EventMiddleware, RuntimeEvent, SdkEvent};
+use crate::events::{EventEmitter, EventMiddleware, SdkEvent};
+use crate::sdk::RuntimeEvent;
 use crate::models::{
     ConversionDetails, ConversionStatus, Payment, PaymentMethod, PaymentType, StableBalanceToken,
 };

--- a/crates/breez-sdk/core/src/stable_balance/mod.rs
+++ b/crates/breez-sdk/core/src/stable_balance/mod.rs
@@ -144,11 +144,11 @@ use self::queue::ConversionQueue;
 pub(crate) use self::queue::PendingConversion;
 
 use crate::events::{EventEmitter, EventMiddleware, SdkEvent};
-use crate::sdk::RuntimeEvent;
 use crate::models::{
     ConversionDetails, ConversionStatus, Payment, PaymentMethod, PaymentType, StableBalanceToken,
 };
 use crate::persist::{ObjectCacheRepository, PaymentMetadata, Storage};
+use crate::sdk::RuntimeEvent;
 use crate::{
     SdkError,
     models::StableBalanceConfig,

--- a/crates/breez-sdk/core/src/stable_balance/mod.rs
+++ b/crates/breez-sdk/core/src/stable_balance/mod.rs
@@ -58,7 +58,7 @@
 //! │    │  • BTC → Token conversion (amount = payment amount)     │      │
 //! │    │  • On failure → Defer (wait for other instance or       │      │
 //! │    │    timeout after 120s)                                  │      │
-//! │    │  • On success → mark Completed, trigger sync            │      │
+//! │    │  • On success → mark Completed, emit completion event   │      │
 //! │    └─────────────────────────────────────────────────────────┘      │
 //! │                                                                     │
 //! │    ┌─────────────────────────────────────────────────────────┐      │
@@ -68,7 +68,7 @@
 //! │    │  • Check for token dust (would balance be below         │      │
 //! │    │    ToBitcoin min limit?)                                │      │
 //! │    │  • BTC → Token conversion (amount = full BTC balance)   │      │
-//! │    │  • On success → trigger sync                            │      │
+//! │    │  • On success → emit completion event                   │      │
 //! │    └─────────────────────────────────────────────────────────┘      │
 //! │                                                                     │
 //! │    ┌─────────────────────────────────────────────────────────┐      │
@@ -76,7 +76,7 @@
 //! │    │  • Get token balance, check min conversion limit        │      │
 //! │    │  • Acquire exclusive auto_conversion lock               │      │
 //! │    │  • Token → BTC conversion (amount = full token balance) │      │
-//! │    │  • On success → trigger sync                            │      │
+//! │    │  • On success → emit completion event                   │      │
 //! │    └─────────────────────────────────────────────────────────┘      │
 //! │                                                                     │
 //! └─────────────────────────────────────────────────────────────────────┘
@@ -137,13 +137,13 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use platform_utils::tokio;
 use spark_wallet::{SparkWallet, TransferId};
-use tokio::sync::{Mutex, Notify, RwLock, watch};
+use tokio::sync::{Mutex, Notify, RwLock};
 use tracing::{debug, info, warn};
 
 use self::queue::ConversionQueue;
 pub(crate) use self::queue::PendingConversion;
 
-use crate::events::{EventEmitter, EventMiddleware, SdkEvent};
+use crate::events::{EventEmitter, EventMiddleware, RuntimeEvent, SdkEvent};
 use crate::models::{
     ConversionDetails, ConversionStatus, Payment, PaymentMethod, PaymentType, StableBalanceToken,
 };
@@ -151,7 +151,6 @@ use crate::persist::{ObjectCacheRepository, PaymentMetadata, Storage};
 use crate::{
     SdkError,
     models::StableBalanceConfig,
-    sdk::SyncCoordinator,
     token_conversion::{
         ConversionError, ConversionOptions, ConversionType, FetchConversionLimitsRequest,
         TokenConverter,
@@ -226,8 +225,8 @@ pub(crate) struct StableBalance {
     /// Notify to signal first sync completion (startup gate for the conversion worker).
     pub(super) synced_notify: Arc<Notify>,
 
-    /// Sync coordinator for triggering wallet syncs after conversions complete.
-    pub(super) sync_coordinator: SyncCoordinator,
+    /// Event emitter used to publish conversion outcomes to the active runtime.
+    pub(super) event_emitter: Arc<EventEmitter>,
 
     /// Number of in-flight send-with-conversion payments.
     /// Auto-convert is suppressed while this is > 0.
@@ -240,7 +239,7 @@ pub(crate) struct StableBalance {
 }
 
 impl StableBalance {
-    /// Creates a new `StableBalance` instance and spawns background tasks.
+    /// Creates a new `StableBalance` instance.
     ///
     /// Resolves the initial active token from the local cache and config,
     /// and registers itself as an event listener on the provided emitter.
@@ -249,9 +248,7 @@ impl StableBalance {
         token_converter: Arc<dyn TokenConverter>,
         spark_wallet: Arc<SparkWallet>,
         storage: Arc<dyn Storage>,
-        shutdown_receiver: watch::Receiver<()>,
         event_emitter: Arc<EventEmitter>,
-        sync_coordinator: SyncCoordinator,
     ) -> Self {
         let initial_active_token = Self::resolve_initial_token(&config, &storage).await;
 
@@ -273,10 +270,10 @@ impl StableBalance {
             token_converter,
             spark_wallet,
             storage,
+            event_emitter: Arc::clone(&event_emitter),
             effective_values: Arc::new(ExpiringCell::new()),
             queue,
             synced_notify,
-            sync_coordinator,
             payment_counter: Arc::new(AtomicUsize::new(0)),
             payment_lock: Arc::new(Mutex::new(())),
         };
@@ -285,9 +282,6 @@ impl StableBalance {
         event_emitter
             .add_middleware(Box::new(stable_balance.clone()))
             .await;
-
-        // Spawn the unified conversion worker
-        stable_balance.spawn_conversion_worker(shutdown_receiver);
 
         stable_balance
     }
@@ -577,12 +571,10 @@ impl StableBalance {
         true
     }
 
-    /// Triggers a full wallet sync so conversion payments and balance are updated.
-    pub(super) async fn trigger_sync(&self) {
-        use crate::sdk::SyncType;
-        self.sync_coordinator
-            .trigger_sync_no_wait(SyncType::Full, true)
-            .await;
+    /// Emits the fact that a conversion changed balances and payments.
+    pub(super) fn emit_conversion_completed(&self) {
+        self.event_emitter
+            .emit_runtime_event(RuntimeEvent::StableBalanceConversionCompleted);
     }
 }
 

--- a/crates/breez-sdk/core/src/stable_balance/queue.rs
+++ b/crates/breez-sdk/core/src/stable_balance/queue.rs
@@ -330,7 +330,7 @@ impl StableBalance {
                                             // is stale until sync completes. The next Synced event
                                             // will re-queue auto-convert if there's still excess.
                                             stable_balance.queue.clear_pending_auto_convert().await;
-                                            stable_balance.emit_conversion_completed();
+                                            stable_balance.emit_conversion_completed().await;
                                         }
                                     }
                                     PerReceiveResult::Retry => {
@@ -352,7 +352,7 @@ impl StableBalance {
                                 debug!("Conversion worker: auto-convert done (converted={converted})");
                                 stable_balance.queue.complete_task(&task).await;
                                 if converted {
-                                    stable_balance.emit_conversion_completed();
+                                    stable_balance.emit_conversion_completed().await;
                                 }
                             }
                             ConversionTask::Deactivation(token_id) => {
@@ -367,7 +367,7 @@ impl StableBalance {
                                 debug!("Conversion worker: completed task {task:?} (converted={converted})");
                                 stable_balance.queue.complete_task(&task).await;
                                 if converted {
-                                    stable_balance.emit_conversion_completed();
+                                    stable_balance.emit_conversion_completed().await;
                                 }
                             }
                         }

--- a/crates/breez-sdk/core/src/stable_balance/queue.rs
+++ b/crates/breez-sdk/core/src/stable_balance/queue.rs
@@ -276,7 +276,7 @@ impl StableBalance {
     /// 2. Recovers any pending conversions from a previous session
     /// 3. Queues a cold-start auto-convert
     /// 4. Processes tasks serially (per-receive first, then auto-convert)
-    pub(super) fn spawn_conversion_worker(&self, mut shutdown_receiver: watch::Receiver<()>) {
+    pub(crate) fn spawn_conversion_worker(&self, mut shutdown_receiver: watch::Receiver<()>) {
         let stable_balance = self.clone();
         let span = tracing::Span::current();
 
@@ -330,7 +330,7 @@ impl StableBalance {
                                             // is stale until sync completes. The next Synced event
                                             // will re-queue auto-convert if there's still excess.
                                             stable_balance.queue.clear_pending_auto_convert().await;
-                                            stable_balance.trigger_sync().await;
+                                            stable_balance.emit_conversion_completed();
                                         }
                                     }
                                     PerReceiveResult::Retry => {
@@ -352,7 +352,7 @@ impl StableBalance {
                                 debug!("Conversion worker: auto-convert done (converted={converted})");
                                 stable_balance.queue.complete_task(&task).await;
                                 if converted {
-                                    stable_balance.trigger_sync().await;
+                                    stable_balance.emit_conversion_completed();
                                 }
                             }
                             ConversionTask::Deactivation(token_id) => {
@@ -367,7 +367,7 @@ impl StableBalance {
                                 debug!("Conversion worker: completed task {task:?} (converted={converted})");
                                 stable_balance.queue.complete_task(&task).await;
                                 if converted {
-                                    stable_balance.trigger_sync().await;
+                                    stable_balance.emit_conversion_completed();
                                 }
                             }
                         }

--- a/crates/breez-sdk/core/src/token_conversion/flashnet.rs
+++ b/crates/breez-sdk/core/src/token_conversion/flashnet.rs
@@ -6,14 +6,9 @@ use flashnet::{
     FlashnetClient, FlashnetConfig, FlashnetError, GetMinAmountsRequest, ListPoolsRequest,
     PoolSortOrder, SimulateSwapRequest,
 };
-use platform_utils::time::Duration;
-use platform_utils::tokio;
 use spark_wallet::{SparkWallet, TransferId};
-use tokio::{
-    select,
-    sync::{broadcast, watch},
-};
-use tracing::{Instrument, debug, error, info, warn};
+use tokio::sync::broadcast;
+use tracing::{debug, error, info, warn};
 
 use crate::{
     AmountAdjustmentReason, Network, Payment, PaymentDetails, PaymentMetadata, Storage,
@@ -44,19 +39,15 @@ pub(crate) struct FlashnetTokenConverter {
 impl FlashnetTokenConverter {
     /// Creates a new `FlashnetTokenConverter` instance.
     ///
-    /// Spawns a background task to periodically process failed conversion refunds.
-    ///
     /// # Arguments
     /// * `storage` - Storage for payment lookups and metadata updates
     /// * `spark_wallet` - Spark wallet for transfer/transaction lookups
     /// * `network` - The network configuration
-    /// * `shutdown_receiver` - Watch receiver to signal shutdown of the refunder task
     pub fn new(
         flashnet_config: FlashnetConfig,
         storage: Arc<dyn Storage>,
         spark_wallet: Arc<SparkWallet>,
         network: Network,
-        shutdown_receiver: watch::Receiver<()>,
     ) -> Self {
         let integrator_fee_bps = flashnet_config
             .integrator_config
@@ -71,56 +62,14 @@ impl FlashnetTokenConverter {
 
         let (refund_trigger, _) = broadcast::channel(10);
 
-        let converter = Self {
+        Self {
             flashnet_client,
             storage,
             spark_wallet,
             network,
-            refund_trigger: refund_trigger.clone(),
+            refund_trigger,
             integrator_fee_bps,
-        };
-
-        // Spawn the background refunder task
-        converter.spawn_refunder(shutdown_receiver, &refund_trigger);
-
-        converter
-    }
-
-    /// Spawns a background task that periodically checks for failed conversions
-    /// and initiates refunds. Triggered on startup, by the refund trigger, and every 150 seconds.
-    fn spawn_refunder(
-        &self,
-        mut shutdown_receiver: watch::Receiver<()>,
-        refund_trigger: &broadcast::Sender<()>,
-    ) {
-        let storage = Arc::clone(&self.storage);
-        let flashnet_client = Arc::clone(&self.flashnet_client);
-        let mut trigger_receiver = refund_trigger.subscribe();
-        let span = tracing::Span::current();
-
-        tokio::spawn(
-            async move {
-                loop {
-                    if let Err(e) =
-                        Self::refund_failed_conversions(&storage, &flashnet_client).await
-                    {
-                        error!("Failed to refund failed conversions: {e:?}");
-                    }
-
-                    select! {
-                        _ = shutdown_receiver.changed() => {
-                            info!("Conversion refunder shutdown signal received");
-                            return;
-                        }
-                        _ = trigger_receiver.recv() => {
-                            debug!("Conversion refunder triggered");
-                        }
-                        () = tokio::time::sleep(Duration::from_secs(150)) => {}
-                    }
-                }
-            }
-            .instrument(span),
-        );
+        }
     }
 
     /// Process all failed conversions needing refunds.
@@ -851,5 +800,13 @@ impl TokenConverter for FlashnetTokenConverter {
             min_from_amount: min_amounts.asset_in_min,
             min_to_amount: min_amounts.asset_out_min,
         })
+    }
+
+    async fn refund_pending(&self) -> Result<(), ConversionError> {
+        Self::refund_failed_conversions(&self.storage, &self.flashnet_client).await
+    }
+
+    fn subscribe_refund_requests(&self) -> Option<broadcast::Receiver<()>> {
+        Some(self.refund_trigger.subscribe())
     }
 }

--- a/crates/breez-sdk/core/src/token_conversion/mod.rs
+++ b/crates/breez-sdk/core/src/token_conversion/mod.rs
@@ -9,6 +9,7 @@ pub(crate) use middleware::TokenConversionMiddleware;
 pub use models::*;
 
 use spark_wallet::TransferId;
+use tokio::sync::broadcast;
 
 /// Trait for conversion implementations.
 ///
@@ -62,4 +63,18 @@ pub(crate) trait TokenConverter: Send + Sync {
         &self,
         request: &FetchConversionLimitsRequest,
     ) -> Result<FetchConversionLimitsResponse, ConversionError>;
+
+    /// Process any conversions whose pending refunds need to be issued.
+    ///
+    /// Iterates over payments marked as needing a refund and attempts to
+    /// refund each one. Surfaced through `BreezSdk::refund_pending_conversions`
+    /// so partners can drive this explicitly — required in server mode (where
+    /// no periodic refunder runs) and available in client mode as a way to
+    /// force an immediate refund pass instead of waiting for the next tick.
+    async fn refund_pending(&self) -> Result<(), ConversionError>;
+
+    /// Optional signal that wakes the client-mode periodic refunder.
+    fn subscribe_refund_requests(&self) -> Option<broadcast::Receiver<()>> {
+        None
+    }
 }

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -642,6 +642,7 @@ pub struct Config {
     /// payment volume to improve throughput.
     pub max_concurrent_claims: u32,
     pub spark_config: Option<SparkConfig>,
+    pub background_tasks_enabled: bool,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::SparkConfig)]

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -347,6 +347,11 @@ impl BreezSdk {
             .into())
     }
 
+    #[wasm_bindgen(js_name = "refundPendingConversions")]
+    pub async fn refund_pending_conversions(&self) -> WasmResult<()> {
+        Ok(self.sdk.refund_pending_conversions().await?)
+    }
+
     #[wasm_bindgen(js_name = "buyBitcoin")]
     pub async fn buy_bitcoin(&self, request: BuyBitcoinRequest) -> WasmResult<BuyBitcoinResponse> {
         Ok(self.sdk.buy_bitcoin(request.into()).await?.into())

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -60,6 +60,11 @@ pub fn default_config(network: Network) -> Config {
     breez_sdk_spark::default_config(network.into()).into()
 }
 
+#[wasm_bindgen(js_name = "defaultServerConfig")]
+pub fn default_server_config(network: Network) -> Config {
+    breez_sdk_spark::default_server_config(network.into()).into()
+}
+
 /// Creates a default external signer from a mnemonic phrase.
 ///
 /// This creates a signer that can be used with `connectWithSigner` or `SdkBuilder.newWithSigner`.

--- a/docs/breez-sdk/snippets/csharp/Config.cs
+++ b/docs/breez-sdk/snippets/csharp/Config.cs
@@ -109,5 +109,18 @@ namespace BreezSdkSnippets
             };
             // ANCHOR_END: spark-config
         }
+
+        void ConfigureBackgroundTasks()
+        {
+            // ANCHOR: config-background-tasks
+            // Server-mode profile: equivalent to DefaultServerConfig(Network.Mainnet).
+            // Recommended when you build the SDK per request in a multi-tenant
+            // server deployment. See the "Server mode" page for the full profile.
+            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            {
+                backgroundTasksEnabled = false
+            };
+            // ANCHOR_END: config-background-tasks
+        }
     }
 }

--- a/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
+++ b/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
@@ -158,5 +158,80 @@ namespace BreezSdkSnippets
             var sdk = await builder.Build();
             // ANCHOR_END: init-sdk-mysql
         }
+
+        async Task InitSdkServer()
+        {
+            // ANCHOR: init-sdk-server
+            // Construct the seed using a mnemonic, entropy or passkey
+            var mnemonic = "<mnemonic words>";
+            var seed = new Seed.Mnemonic(mnemonic: mnemonic, passphrase: null);
+
+            // Build a server-mode config: same as DefaultConfig(network) with
+            // backgroundTasksEnabled = false. No periodic sync, no real-time
+            // sync client, no leaf/token optimizer, no flashnet refunder, no
+            // lightning-address recovery, no spark private-mode init.
+            var config = BreezSdkSparkMethods.DefaultServerConfig(Network.Mainnet) with
+            {
+                apiKey = "<breez api key>"
+            };
+
+            // Typically server-mode SDKs are built per request and share
+            // infrastructure (DB pool, REST chain service, SSP/Connection
+            // Manager) across instances. Pass the shared resources via the
+            // builder.
+            var builder = new SdkBuilder(config: config, seed: seed);
+            await builder.WithDefaultStorage(storageDir: "./.data");
+            var sdk = await builder.Build();
+            // ANCHOR_END: init-sdk-server
+        }
+
+        async Task ServerModeRequestHandler(BreezSdk sdk)
+        {
+            // ANCHOR: server-mode-request-handler
+            // User-facing request handler: do not call SyncWallet here.
+            // Operations that read from local storage (GetInfo, ListPayments,
+            // etc.) do not need a defensive sync. Call SyncWallet only from
+            // webhook handlers or reconciliation jobs that need to observe
+            // an external state change.
+            var paymentMethod = new ReceivePaymentMethod.Bolt11Invoice(
+                description: "<invoice description>",
+                amountSats: 5_000UL,
+                expirySecs: 3600U,
+                paymentHash: null
+            );
+            var response = await sdk.ReceivePayment(
+                request: new ReceivePaymentRequest(paymentMethod: paymentMethod)
+            );
+
+            // Always disconnect at the end of the request lifecycle to flush
+            // outstanding storage writes.
+            await sdk.Disconnect();
+            // ANCHOR_END: server-mode-request-handler
+        }
+
+        async Task ServerModeProvisioning(BreezSdk sdk)
+        {
+            // ANCHOR: server-mode-provisioning
+            // One-time setup when a wallet is first registered. The
+            // client-mode SDK would normally apply the private-mode preset
+            // itself on first startup; server-mode SDKs do not, so opt in
+            // once here via UpdateUserSettings.
+            await sdk.UpdateUserSettings(
+                request: new UpdateUserSettingsRequest(sparkPrivateModeEnabled: true)
+            );
+
+            await sdk.Disconnect();
+            // ANCHOR_END: server-mode-provisioning
+        }
+
+        async Task RefundPendingConversions(BreezSdk sdk)
+        {
+            // ANCHOR: refund-pending-conversions
+            // The flashnet conversion refunder doesn't run in the background in
+            // server mode. Call this from your own scheduler (e.g. once per
+            // minute) to issue pending refunds for failed conversions.
+            await sdk.RefundPendingConversions();
+            // ANCHOR_END: refund-pending-conversions
+        }
     }
 }

--- a/docs/breez-sdk/snippets/flutter/lib/config.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/config.dart
@@ -101,3 +101,14 @@ Future<void> configureSparkConfig() async {
   // ANCHOR_END: spark-config
   print(config);
 }
+
+void configureBackgroundTasks() {
+  // ANCHOR: config-background-tasks
+  // Server-mode profile: equivalent to defaultServerConfig(network: Network.mainnet).
+  // Recommended when you build the SDK per request in a multi-tenant server
+  // deployment. See the "Server mode" page for the full profile.
+  final config = defaultConfig(network: Network.mainnet)
+      .copyWith(backgroundTasksEnabled: false);
+  // ANCHOR_END: config-background-tasks
+  print(config);
+}

--- a/docs/breez-sdk/snippets/flutter/lib/sdk_building.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/sdk_building.dart
@@ -58,3 +58,72 @@ Future<void> withKeySet(SdkBuilder builder) async {
 
 // ANCHOR: with-payment-observer
 // ANCHOR_END: with-payment-observer
+
+Future<BreezSdk> initSdkServer() async {
+  // ANCHOR: init-sdk-server
+  // Construct the seed using a mnemonic, entropy or passkey
+  String mnemonic = "<mnemonic words>";
+  final seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: null);
+
+  // Build a server-mode config: same as defaultConfig(network) with
+  // backgroundTasksEnabled = false. No periodic sync, no real-time sync
+  // client, no leaf/token optimizer, no flashnet refunder, no lightning-
+  // address recovery, no spark private-mode init.
+  final config = defaultServerConfig(network: Network.mainnet)
+      .copyWith(apiKey: "<breez api key>");
+
+  // Typically server-mode SDKs are built per request and share infrastructure
+  // (DB pool, REST chain service, SSP/Connection Manager) across instances.
+  // Pass the shared resources via the builder.
+  final builder = SdkBuilder(config: config, seed: seed);
+  builder.withDefaultStorage(storageDir: "./.data");
+  final sdk = await builder.build();
+  // ANCHOR_END: init-sdk-server
+  return sdk;
+}
+
+Future<String> serverModeRequestHandler(BreezSdk sdk) async {
+  // ANCHOR: server-mode-request-handler
+  // User-facing request handler: do not call syncWallet here. Operations
+  // that read from local storage (getInfo, listPayments, etc.) do not need
+  // a defensive sync. Call syncWallet only from webhook handlers or
+  // reconciliation jobs that need to observe an external state change.
+  final response = await sdk.receivePayment(
+    request: ReceivePaymentRequest(
+      paymentMethod: ReceivePaymentMethod.bolt11Invoice(
+        description: "<invoice description>",
+        amountSats: BigInt.from(5000),
+        expirySecs: 3600,
+        paymentHash: null,
+      ),
+    ),
+  );
+
+  // Always disconnect at the end of the request lifecycle to flush
+  // outstanding storage writes.
+  await sdk.disconnect();
+  // ANCHOR_END: server-mode-request-handler
+  return response.paymentRequest;
+}
+
+Future<void> serverModeProvisioning(BreezSdk sdk) async {
+  // ANCHOR: server-mode-provisioning
+  // One-time setup when a wallet is first registered. The client-mode SDK
+  // would normally apply the private-mode preset itself on first startup;
+  // server-mode SDKs do not, so opt in once here via updateUserSettings.
+  await sdk.updateUserSettings(
+    request: UpdateUserSettingsRequest(sparkPrivateModeEnabled: true),
+  );
+
+  await sdk.disconnect();
+  // ANCHOR_END: server-mode-provisioning
+}
+
+Future<void> refundPendingConversions(BreezSdk sdk) async {
+  // ANCHOR: refund-pending-conversions
+  // The flashnet conversion refunder doesn't run in the background in server
+  // mode. Call this from your own scheduler (e.g. once per minute) to issue
+  // pending refunds for failed conversions.
+  await sdk.refundPendingConversions();
+  // ANCHOR_END: refund-pending-conversions
+}

--- a/docs/breez-sdk/snippets/go/config.go
+++ b/docs/breez-sdk/snippets/go/config.go
@@ -107,3 +107,14 @@ func ConfigureSparkConfig() {
 	// ANCHOR_END: spark-config
 	log.Printf("Config: %+v", config)
 }
+
+func ConfigureBackgroundTasks() {
+	// ANCHOR: config-background-tasks
+	// Server-mode profile: equivalent to DefaultServerConfig(NetworkMainnet).
+	// Recommended when you build the SDK per request in a multi-tenant server
+	// deployment. See the "Server mode" page for the full profile.
+	config := breez_sdk_spark.DefaultConfig(breez_sdk_spark.NetworkMainnet)
+	config.BackgroundTasksEnabled = false
+	// ANCHOR_END: config-background-tasks
+	log.Printf("Config: %+v", config)
+}

--- a/docs/breez-sdk/snippets/go/sdk_building.go
+++ b/docs/breez-sdk/snippets/go/sdk_building.go
@@ -170,3 +170,88 @@ func InitSdkMysql() (*breez_sdk_spark.BreezSdk, error) {
 
 	return sdk, nil
 }
+
+func InitSdkServer() (*breez_sdk_spark.BreezSdk, error) {
+	// ANCHOR: init-sdk-server
+	// Construct the seed using a mnemonic, entropy or passkey
+	mnemonic := "<mnemonic words>"
+	var seed breez_sdk_spark.Seed = breez_sdk_spark.SeedMnemonic{
+		Mnemonic:   mnemonic,
+		Passphrase: nil,
+	}
+
+	// Build a server-mode config: same as DefaultConfig(network) with
+	// BackgroundTasksEnabled = false. No periodic sync, no real-time sync
+	// client, no leaf/token optimizer, no flashnet refunder, no lightning-
+	// address recovery, no spark private-mode init.
+	apiKey := "<breez api key>"
+	config := breez_sdk_spark.DefaultServerConfig(breez_sdk_spark.NetworkMainnet)
+	config.ApiKey = &apiKey
+
+	// Typically server-mode SDKs are built per request and share infrastructure
+	// (DB pool, REST chain service, SSP/Connection Manager) across instances.
+	// Pass the shared resources via the builder.
+	builder := breez_sdk_spark.NewSdkBuilder(config, seed)
+	builder.WithDefaultStorage("./.data")
+	sdk, err := builder.Build()
+	if err != nil {
+		return nil, err
+	}
+	// ANCHOR_END: init-sdk-server
+
+	return sdk, nil
+}
+
+func ServerModeRequestHandler(sdk *breez_sdk_spark.BreezSdk) (string, error) {
+	// ANCHOR: server-mode-request-handler
+	// User-facing request handler: do not call SyncWallet here. Operations
+	// that read from local storage (GetInfo, ListPayments, etc.) do not need
+	// a defensive sync. Call SyncWallet only from webhook handlers or
+	// reconciliation jobs that need to observe an external state change.
+	amountSats := uint64(5_000)
+	expirySecs := uint32(3600)
+	response, err := sdk.ReceivePayment(breez_sdk_spark.ReceivePaymentRequest{
+		PaymentMethod: breez_sdk_spark.ReceivePaymentMethodBolt11Invoice{
+			Description: "<invoice description>",
+			AmountSats:  &amountSats,
+			ExpirySecs:  &expirySecs,
+			PaymentHash: nil,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Always disconnect at the end of the request lifecycle to flush
+	// outstanding storage writes.
+	if err := sdk.Disconnect(); err != nil {
+		return "", err
+	}
+	// ANCHOR_END: server-mode-request-handler
+	return response.PaymentRequest, nil
+}
+
+func ServerModeProvisioning(sdk *breez_sdk_spark.BreezSdk) error {
+	// ANCHOR: server-mode-provisioning
+	// One-time setup when a wallet is first registered. The client-mode SDK
+	// would normally apply the private-mode preset itself on first startup;
+	// server-mode SDKs do not, so opt in once here via UpdateUserSettings.
+	sparkPrivateModeEnabled := true
+	if err := sdk.UpdateUserSettings(breez_sdk_spark.UpdateUserSettingsRequest{
+		SparkPrivateModeEnabled: &sparkPrivateModeEnabled,
+	}); err != nil {
+		return err
+	}
+
+	return sdk.Disconnect()
+	// ANCHOR_END: server-mode-provisioning
+}
+
+func RefundPendingConversions(sdk *breez_sdk_spark.BreezSdk) error {
+	// ANCHOR: refund-pending-conversions
+	// The flashnet conversion refunder doesn't run in the background in server
+	// mode. Call this from your own scheduler (e.g. once per minute) to issue
+	// pending refunds for failed conversions.
+	return sdk.RefundPendingConversions()
+	// ANCHOR_END: refund-pending-conversions
+}

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
@@ -97,4 +97,15 @@ class Config {
         // ANCHOR_END: spark-config
         println("Config: $config")
     }
+
+    fun configureBackgroundTasks() {
+        // ANCHOR: config-background-tasks
+        // Server-mode profile: equivalent to defaultServerConfig(Network.MAINNET).
+        // Recommended when you build the SDK per request in a multi-tenant
+        // server deployment. See the "Server mode" page for the full profile.
+        val config = defaultConfig(Network.MAINNET)
+        config.backgroundTasksEnabled = false
+        // ANCHOR_END: config-background-tasks
+        println("Config: $config")
+    }
 }

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
@@ -145,4 +145,76 @@ class SdkBuilding {
         }
         // ANCHOR_END: init-sdk-mysql
     }
+
+    suspend fun initSdkServer() {
+        // ANCHOR: init-sdk-server
+        // Construct the seed using a mnemonic, entropy or passkey
+        val mnemonic = "<mnemonic words>"
+        val seed = Seed.Mnemonic(mnemonic, null)
+
+        // Build a server-mode config: same as defaultConfig(network) with
+        // backgroundTasksEnabled = false. No periodic sync, no real-time sync
+        // client, no leaf/token optimizer, no flashnet refunder, no lightning-
+        // address recovery, no spark private-mode init.
+        val config = defaultServerConfig(Network.MAINNET)
+        config.apiKey = "<breez api key>"
+
+        try {
+            // Typically server-mode SDKs are built per request and share
+            // infrastructure (DB pool, REST chain service, SSP/Connection
+            // Manager) across instances. Pass the shared resources via the
+            // builder.
+            val builder = SdkBuilder(config, seed)
+            builder.withDefaultStorage("./.data")
+            val sdk = builder.build()
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: init-sdk-server
+    }
+
+    suspend fun serverModeRequestHandler(sdk: BreezSdk) {
+        // ANCHOR: server-mode-request-handler
+        // User-facing request handler: do not call syncWallet here.
+        // Operations that read from local storage (getInfo, listPayments,
+        // etc.) do not need a defensive sync. Call syncWallet only from
+        // webhook handlers or reconciliation jobs that need to observe an
+        // external state change.
+        val response = sdk.receivePayment(
+            ReceivePaymentRequest(
+                ReceivePaymentMethod.Bolt11Invoice(
+                    "<invoice description>",
+                    5_000.toULong(),
+                    3600.toUInt(),
+                    null,
+                )
+            )
+        )
+
+        // Always disconnect at the end of the request lifecycle to flush
+        // outstanding storage writes.
+        sdk.disconnect()
+        // ANCHOR_END: server-mode-request-handler
+    }
+
+    suspend fun serverModeProvisioning(sdk: BreezSdk) {
+        // ANCHOR: server-mode-provisioning
+        // One-time setup when a wallet is first registered. The client-mode
+        // SDK would normally apply the private-mode preset itself on first
+        // startup; server-mode SDKs do not, so opt in once here via
+        // updateUserSettings.
+        sdk.updateUserSettings(UpdateUserSettingsRequest(sparkPrivateModeEnabled = true))
+
+        sdk.disconnect()
+        // ANCHOR_END: server-mode-provisioning
+    }
+
+    suspend fun refundPendingConversions(sdk: BreezSdk) {
+        // ANCHOR: refund-pending-conversions
+        // The flashnet conversion refunder doesn't run in the background in
+        // server mode. Call this from your own scheduler (e.g. once per
+        // minute) to issue pending refunds for failed conversions.
+        sdk.refundPendingConversions()
+        // ANCHOR_END: refund-pending-conversions
+    }
 }

--- a/docs/breez-sdk/snippets/python/src/config.py
+++ b/docs/breez-sdk/snippets/python/src/config.py
@@ -111,3 +111,13 @@ async def configure_spark_config():
     )
     # ANCHOR_END: spark-config
     logging.info(f"Config: {config}")
+
+async def configure_background_tasks():
+    # ANCHOR: config-background-tasks
+    # Server-mode profile: equivalent to default_server_config(network=Network.MAINNET).
+    # Recommended when you build the SDK per request in a multi-tenant server
+    # deployment. See the "Server mode" page for the full profile.
+    config = default_config(network=Network.MAINNET)
+    config.background_tasks_enabled = False
+    # ANCHOR_END: config-background-tasks
+    logging.info(f"Config: {config}")

--- a/docs/breez-sdk/snippets/python/src/sdk_building.py
+++ b/docs/breez-sdk/snippets/python/src/sdk_building.py
@@ -1,13 +1,17 @@
 import logging
 import typing
 from breez_sdk_spark import (
+    BreezSdk,
     default_config,
+    default_server_config,
     default_postgres_storage_config,
     create_postgres_connection_pool,
     default_mysql_storage_config,
     create_mysql_connection_pool,
     Network,
     ProvisionalPayment,
+    ReceivePaymentMethod,
+    ReceivePaymentRequest,
     SdkBuilder,
     Seed,
     PaymentObserver,
@@ -15,6 +19,7 @@ from breez_sdk_spark import (
     Credentials,
     KeySetType,
     KeySetConfig,
+    UpdateUserSettingsRequest,
 )
 
 
@@ -165,3 +170,75 @@ async def init_sdk_mysql():
         logging.error(error)
         raise
 # ANCHOR_END: init-sdk-mysql
+
+
+async def init_sdk_server():
+    # ANCHOR: init-sdk-server
+    # Construct the seed using a mnemonic, entropy or passkey
+    mnemonic = "<mnemonic words>"
+    seed = Seed.MNEMONIC(mnemonic=mnemonic, passphrase=None)
+
+    # Build a server-mode config: same as default_config(network) with
+    # background_tasks_enabled = False. No periodic sync, no real-time sync
+    # client, no leaf/token optimizer, no flashnet refunder, no lightning-
+    # address recovery, no spark private-mode init.
+    config = default_server_config(network=Network.MAINNET)
+    config.api_key = "<breez api key>"
+
+    try:
+        # Typically server-mode SDKs are built per request and share
+        # infrastructure (DB pool, REST chain service, SSP/Connection Manager)
+        # across instances. Pass the shared resources via the builder.
+        builder = SdkBuilder(config=config, seed=seed)
+        await builder.with_default_storage(storage_dir="./.data")
+        sdk = await builder.build()
+        return sdk
+    except Exception as error:
+        logging.error(error)
+        raise
+    # ANCHOR_END: init-sdk-server
+
+
+async def server_mode_request_handler(sdk: BreezSdk):
+    # ANCHOR: server-mode-request-handler
+    # User-facing request handler: do not call sync_wallet here. Operations
+    # that read from local storage (get_info, list_payments, etc.) do not
+    # need a defensive sync. Call sync_wallet only from webhook handlers or
+    # reconciliation jobs that need to observe an external state change.
+    payment_method = ReceivePaymentMethod.BOLT11_INVOICE(
+        description="<invoice description>",
+        amount_sats=5_000,
+        expiry_secs=3600,
+        payment_hash=None,
+    )
+    response = await sdk.receive_payment(
+        request=ReceivePaymentRequest(payment_method=payment_method)
+    )
+
+    # Always disconnect at the end of the request lifecycle to flush
+    # outstanding storage writes.
+    await sdk.disconnect()
+    # ANCHOR_END: server-mode-request-handler
+    return response.payment_request
+
+
+async def server_mode_provisioning(sdk: BreezSdk):
+    # ANCHOR: server-mode-provisioning
+    # One-time setup when a wallet is first registered. The client-mode SDK
+    # would normally apply the private-mode preset itself on first startup;
+    # server-mode SDKs do not, so opt in once here via update_user_settings.
+    await sdk.update_user_settings(
+        request=UpdateUserSettingsRequest(spark_private_mode_enabled=True)
+    )
+
+    await sdk.disconnect()
+    # ANCHOR_END: server-mode-provisioning
+
+
+async def refund_pending_conversions(sdk: BreezSdk):
+    # ANCHOR: refund-pending-conversions
+    # The flashnet conversion refunder doesn't run in the background in server
+    # mode. Call this from your own scheduler (e.g. once per minute) to issue
+    # pending refunds for failed conversions.
+    await sdk.refund_pending_conversions()
+    # ANCHOR_END: refund-pending-conversions

--- a/docs/breez-sdk/snippets/react-native/config.ts
+++ b/docs/breez-sdk/snippets/react-native/config.ts
@@ -103,10 +103,22 @@ const exampleConfigureSparkConfig = () => {
   console.log('Config:', config)
 }
 
+const exampleConfigureBackgroundTasks = () => {
+  // ANCHOR: config-background-tasks
+  // Server-mode profile: equivalent to defaultServerConfig(Network.Mainnet).
+  // Recommended when you build the SDK per request in a multi-tenant server
+  // deployment. See the "Server mode" page for the full profile.
+  const config = defaultConfig(Network.Mainnet)
+  config.backgroundTasksEnabled = false
+  // ANCHOR_END: config-background-tasks
+  console.log('Config:', config)
+}
+
 export {
   exampleConfigureSdk,
   exampleConfigurePrivateEnabledDefault,
   exampleConfigureOptimizationConfiguration,
   exampleConfigureStableBalance,
-  exampleConfigureSparkConfig
+  exampleConfigureSparkConfig,
+  exampleConfigureBackgroundTasks
 }

--- a/docs/breez-sdk/snippets/react-native/sdk_building.ts
+++ b/docs/breez-sdk/snippets/react-native/sdk_building.ts
@@ -1,13 +1,16 @@
 import {
+  type BreezSdk,
   SdkBuilder,
   Seed,
   defaultConfig,
+  defaultServerConfig,
   Network,
   ChainApiType,
   KeySetType,
   type KeySetConfig,
   type ProvisionalPayment,
-  type Credentials
+  type Credentials,
+  ReceivePaymentMethod
 } from '@breeztech/breez-sdk-spark-react-native'
 import RNFS from 'react-native-fs'
 
@@ -71,3 +74,71 @@ const exampleWithPaymentObserver = async (builder: SdkBuilder) => {
   await builder.withPaymentObserver(paymentObserver)
 }
 // ANCHOR_END: with-payment-observer
+
+const exampleInitSdkServer = async () => {
+  // ANCHOR: init-sdk-server
+  // Construct the seed using a mnemonic, entropy or passkey
+  const mnemonic = '<mnemonics words>'
+  const seed = new Seed.Mnemonic({ mnemonic, passphrase: undefined })
+
+  // Build a server-mode config: same as defaultConfig(network) with
+  // backgroundTasksEnabled = false. No periodic sync, no real-time sync
+  // client, no leaf/token optimizer, no flashnet refunder, no lightning-
+  // address recovery, no spark private-mode init.
+  const config = defaultServerConfig(Network.Mainnet)
+  config.apiKey = '<breez api key>'
+
+  // Typically server-mode SDKs are built per request and share infrastructure
+  // (DB pool, REST chain service, SSP/Connection Manager) across instances.
+  // Pass the shared resources via the builder.
+  const builder = new SdkBuilder(config, seed)
+  await builder.withDefaultStorage(`${RNFS.DocumentDirectoryPath}/data`)
+  const sdk = await builder.build()
+  // ANCHOR_END: init-sdk-server
+  return sdk
+}
+
+const exampleServerModeRequestHandler = async (sdk: BreezSdk) => {
+  // ANCHOR: server-mode-request-handler
+  // User-facing request handler: do not call syncWallet here. Operations
+  // that read from local storage (getInfo, listPayments, etc.) do not need
+  // a defensive sync. Call syncWallet only from webhook handlers or
+  // reconciliation jobs that need to observe an external state change.
+  const response = await sdk.receivePayment({
+    paymentMethod: new ReceivePaymentMethod.Bolt11Invoice({
+      description: '<invoice description>',
+      amountSats: BigInt(5_000),
+      expirySecs: 3600,
+      paymentHash: undefined
+    })
+  })
+
+  // Always disconnect at the end of the request lifecycle to flush
+  // outstanding storage writes.
+  await sdk.disconnect()
+  // ANCHOR_END: server-mode-request-handler
+  return response.paymentRequest
+}
+
+const exampleServerModeProvisioning = async (sdk: BreezSdk) => {
+  // ANCHOR: server-mode-provisioning
+  // One-time setup when a wallet is first registered. The client-mode SDK
+  // would normally apply the private-mode preset itself on first startup;
+  // server-mode SDKs do not, so opt in once here via updateUserSettings.
+  await sdk.updateUserSettings({
+    sparkPrivateModeEnabled: true,
+    stableBalanceActiveLabel: undefined
+  })
+
+  await sdk.disconnect()
+  // ANCHOR_END: server-mode-provisioning
+}
+
+const exampleRefundPendingConversions = async (sdk: BreezSdk) => {
+  // ANCHOR: refund-pending-conversions
+  // The flashnet conversion refunder doesn't run in the background in server
+  // mode. Call this from your own scheduler (e.g. once per minute) to issue
+  // pending refunds for failed conversions.
+  await sdk.refundPendingConversions()
+  // ANCHOR_END: refund-pending-conversions
+}

--- a/docs/breez-sdk/snippets/rust/Cargo.lock
+++ b/docs/breez-sdk/snippets/rust/Cargo.lock
@@ -247,12 +247,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -268,24 +262,6 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
 
 [[package]]
 name = "bip39"
@@ -383,7 +359,7 @@ dependencies = [
  "aes",
  "anyhow",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bech32",
  "bitcoin",
  "cbc",
@@ -417,7 +393,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bip39",
  "bitcoin",
  "bitflags",
@@ -520,15 +496,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,26 +554,6 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -689,47 +636,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-queue"
@@ -1084,7 +990,7 @@ checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 name = "flashnet"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bitcoin",
  "getrandom 0.2.16",
  "hex",
@@ -1120,9 +1026,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1144,7 +1050,7 @@ dependencies = [
  "derive-getters",
  "document-features",
  "hex",
- "itertools 0.14.0",
+ "itertools",
  "postcard",
  "rand_core 0.6.4",
  "serde",
@@ -1319,12 +1225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,20 +1355,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
@@ -1648,7 +1542,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1863,15 +1757,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1950,16 +1835,6 @@ dependencies = [
  "libc",
  "libz-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
 ]
 
 [[package]]
@@ -2080,18 +1955,12 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2146,12 +2015,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,65 +2043,61 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mysql_async"
-version = "0.34.2"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b66e411c31265e879d9814d03721f2daa7ad07337b6308cb4bb0cde7e6fd47"
+checksum = "d1d9585dc9058886ff3a1f48a23024dd1d054264dee7c5ae0e4bd640c953bee5"
 dependencies = [
  "bytes",
- "crossbeam",
+ "crossbeam-queue",
  "flate2",
  "futures-core",
  "futures-sink",
  "futures-util",
  "keyed_priority_queue",
- "lru 0.12.5",
+ "lru",
  "mysql_common",
  "pem",
  "percent-encoding",
- "pin-project",
- "rand 0.8.5",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "socket2 0.5.10",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "twox-hash",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "mysql_common"
-version = "0.32.4"
+version = "0.35.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
+checksum = "fbb9f371618ce723f095c61fbcdc36e8936956d2b62832f9c7648689b338e052"
 dependencies = [
- "base64 0.21.7",
- "bindgen",
+ "base64",
  "bitflags",
  "btoi",
  "byteorder",
  "bytes",
- "cc",
  "chrono",
- "cmake",
  "crc32fast",
  "flate2",
- "lazy_static",
+ "getrandom 0.3.4",
  "num-bigint",
  "num-traits",
- "rand 0.8.5",
  "regex",
  "saturating",
  "serde",
  "serde_json",
  "sha1",
  "sha2",
- "smallvec",
- "subprocess",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "uuid",
- "zstd",
 ]
 
 [[package]]
@@ -2248,22 +2107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "nostr"
 version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62a97d745f1bd8d5e05a978632bbb87b0614567d5142906fe7c86fb2440faac6"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bech32",
  "bip39",
  "bitcoin_hashes",
@@ -2286,7 +2135,7 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
 dependencies = [
- "lru 0.16.3",
+ "lru",
  "nostr",
  "tokio",
 ]
@@ -2300,7 +2149,7 @@ dependencies = [
  "async-utility",
  "async-wsocket",
  "atomic-destructor",
- "lru 0.16.3",
+ "lru",
  "negentropy",
  "nostr",
  "nostr-database",
@@ -2442,7 +2291,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -2534,7 +2383,7 @@ name = "platform-utils"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "macros",
  "reqwest",
  "serde",
@@ -2597,7 +2446,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
@@ -2683,7 +2532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -2703,7 +2552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -2917,7 +2766,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3288,7 +3137,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3438,7 +3287,7 @@ name = "spark"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bitcoin",
  "built",
  "bytes",
@@ -3458,7 +3307,6 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.8.5",
- "rustls",
  "serde",
  "serde_json",
  "serde_with",
@@ -3563,12 +3411,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3584,16 +3426,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "subprocess"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c56e8662b206b9892d7a5a3f2ecdbcb455d3d6b259111373b7e08b8055158a8"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "subtle"
@@ -3974,7 +3806,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "h2",
  "http",
@@ -4019,7 +3851,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8957be1a1c7aa12d4c9d67882060dd57aed816bbc553fa60949312e839f4a8ea"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "byteorder",
  "bytes",
  "futures-util",
@@ -4191,14 +4023,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "rand 0.8.5",
- "static_assertions",
-]
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -4490,28 +4317,6 @@ dependencies = [
  "wasite",
  "web-sys",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4885,31 +4690,3 @@ name = "zmij"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/docs/breez-sdk/snippets/rust/src/config.rs
+++ b/docs/breez-sdk/snippets/rust/src/config.rs
@@ -124,3 +124,15 @@ pub(crate) fn configure_spark_config() -> Result<()> {
     info!("Config: {:?}", config);
     Ok(())
 }
+
+pub(crate) fn configure_background_tasks() -> Result<()> {
+    // ANCHOR: config-background-tasks
+    // Server-mode profile: equivalent to default_server_config(Network::Mainnet).
+    // Recommended when you build the SDK per request in a multi-tenant server
+    // deployment. See the "Server mode" page for the full profile.
+    let mut config = default_config(Network::Mainnet);
+    config.background_tasks_enabled = false;
+    // ANCHOR_END: config-background-tasks
+    info!("Config: {:?}", config);
+    Ok(())
+}

--- a/docs/breez-sdk/snippets/rust/src/sdk_building.rs
+++ b/docs/breez-sdk/snippets/rust/src/sdk_building.rs
@@ -160,3 +160,82 @@ pub(crate) async fn init_sdk_mysql() -> Result<BreezSdk> {
 
     Ok(sdk)
 }
+
+pub(crate) async fn init_sdk_server() -> Result<BreezSdk> {
+    // ANCHOR: init-sdk-server
+    // Construct the seed using a mnemonic, entropy or passkey
+    let mnemonic = "<mnemonic words>".to_string();
+    let seed = Seed::Mnemonic {
+        mnemonic,
+        passphrase: None,
+    };
+
+    // Build a server-mode config: same as default_config(network) with
+    // background_tasks_enabled = false. No periodic sync, no real-time sync
+    // client, no leaf/token optimizer, no flashnet refunder, no lightning-
+    // address recovery, no spark private-mode init.
+    let mut config = default_server_config(Network::Mainnet);
+    config.api_key = Some("<breez api key>".to_string());
+
+    // Typically server-mode SDKs are built per request and share infrastructure
+    // (DB pool, REST chain service, SSP/Connection Manager) across instances.
+    // Pass the shared resources via the builder; see the "Customizing the SDK"
+    // page for each component.
+    let sdk = SdkBuilder::new(config, seed)
+        .with_default_storage("./.data".to_string())
+        .build()
+        .await?;
+    // ANCHOR_END: init-sdk-server
+
+    Ok(sdk)
+}
+
+pub(crate) async fn server_mode_request_handler(sdk: &BreezSdk) -> Result<String> {
+    // ANCHOR: server-mode-request-handler
+    // User-facing request handler: do not call sync_wallet here. Operations
+    // that read from local storage (get_info, list_payments, etc.) do not
+    // need a defensive sync. Call sync_wallet only from webhook handlers or
+    // reconciliation jobs that need to observe an external state change.
+    let response = sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::Bolt11Invoice {
+                description: "<invoice description>".to_string(),
+                amount_sats: Some(5_000),
+                expiry_secs: Some(3600),
+                payment_hash: None,
+            },
+        })
+        .await?;
+
+    // Always disconnect at the end of the request lifecycle to flush
+    // outstanding storage writes. See [Disconnecting](initializing.md).
+    sdk.disconnect().await?;
+    // ANCHOR_END: server-mode-request-handler
+    Ok(response.payment_request)
+}
+
+pub(crate) async fn server_mode_provisioning(sdk: &BreezSdk) -> Result<()> {
+    // ANCHOR: server-mode-provisioning
+    // One-time setup when a wallet is first registered. The client-mode SDK
+    // would normally apply the private-mode preset itself on first startup;
+    // server-mode SDKs do not, so opt in once here via update_user_settings.
+    sdk.update_user_settings(UpdateUserSettingsRequest {
+        spark_private_mode_enabled: Some(true),
+        stable_balance_active_label: None,
+    })
+    .await?;
+
+    sdk.disconnect().await?;
+    // ANCHOR_END: server-mode-provisioning
+    Ok(())
+}
+
+pub(crate) async fn refund_pending_conversions(sdk: &BreezSdk) -> Result<()> {
+    // ANCHOR: refund-pending-conversions
+    // The flashnet conversion refunder doesn't run in the background in server
+    // mode. Call this from your own scheduler (e.g. once per minute) to issue
+    // pending refunds for failed conversions.
+    sdk.refund_pending_conversions().await?;
+    // ANCHOR_END: refund-pending-conversions
+    Ok(())
+}

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Config.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Config.swift
@@ -54,3 +54,14 @@ func configureStableBalance() async throws {
     // ANCHOR_END: stable-balance-config
     print("Config: \(config)")
 }
+
+func configureBackgroundTasks() {
+    // ANCHOR: config-background-tasks
+    // Server-mode profile: equivalent to defaultServerConfig(network: .mainnet).
+    // Recommended when you build the SDK per request in a multi-tenant server
+    // deployment. See the "Server mode" page for the full profile.
+    var config = defaultConfig(network: Network.mainnet)
+    config.backgroundTasksEnabled = false
+    // ANCHOR_END: config-background-tasks
+    print("Config: \(config)")
+}

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
@@ -143,3 +143,71 @@ func initSdkMysql() async throws -> BreezSdk {
 
     return sdk
 }
+
+func initSdkServer() async throws -> BreezSdk {
+    // ANCHOR: init-sdk-server
+    // Construct the seed using a mnemonic, entropy or passkey
+    let mnemonic = "<mnemonic words>"
+    let seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: nil)
+
+    // Build a server-mode config: same as defaultConfig(network) with
+    // backgroundTasksEnabled = false. No periodic sync, no real-time sync
+    // client, no leaf/token optimizer, no flashnet refunder, no lightning-
+    // address recovery, no spark private-mode init.
+    var config = defaultServerConfig(network: Network.mainnet)
+    config.apiKey = "<breez api key>"
+
+    // Typically server-mode SDKs are built per request and share infrastructure
+    // (DB pool, REST chain service, SSP/Connection Manager) across instances.
+    // Pass the shared resources via the builder.
+    let builder = SdkBuilder(config: config, seed: seed)
+    await builder.withDefaultStorage(storageDir: "./.data")
+    let sdk = try await builder.build()
+    // ANCHOR_END: init-sdk-server
+
+    return sdk
+}
+
+func serverModeRequestHandler(sdk: BreezSdk) async throws -> String {
+    // ANCHOR: server-mode-request-handler
+    // User-facing request handler: do not call syncWallet here. Operations
+    // that read from local storage (getInfo, listPayments, etc.) do not need
+    // a defensive sync. Call syncWallet only from webhook handlers or
+    // reconciliation jobs that need to observe an external state change.
+    let response = try await sdk.receivePayment(
+        request: ReceivePaymentRequest(
+            paymentMethod: ReceivePaymentMethod.bolt11Invoice(
+                description: "<invoice description>",
+                amountSats: 5_000,
+                expirySecs: 3600,
+                paymentHash: nil
+            )
+        ))
+
+    // Always disconnect at the end of the request lifecycle to flush
+    // outstanding storage writes.
+    try await sdk.disconnect()
+    // ANCHOR_END: server-mode-request-handler
+    return response.paymentRequest
+}
+
+func serverModeProvisioning(sdk: BreezSdk) async throws {
+    // ANCHOR: server-mode-provisioning
+    // One-time setup when a wallet is first registered. The client-mode SDK
+    // would normally apply the private-mode preset itself on first startup;
+    // server-mode SDKs do not, so opt in once here via updateUserSettings.
+    try await sdk.updateUserSettings(
+        request: UpdateUserSettingsRequest(sparkPrivateModeEnabled: true))
+
+    try await sdk.disconnect()
+    // ANCHOR_END: server-mode-provisioning
+}
+
+func refundPendingConversions(sdk: BreezSdk) async throws {
+    // ANCHOR: refund-pending-conversions
+    // The flashnet conversion refunder doesn't run in the background in server
+    // mode. Call this from your own scheduler (e.g. once per minute) to issue
+    // pending refunds for failed conversions.
+    try await sdk.refundPendingConversions()
+    // ANCHOR_END: refund-pending-conversions
+}

--- a/docs/breez-sdk/snippets/wasm/config.ts
+++ b/docs/breez-sdk/snippets/wasm/config.ts
@@ -95,10 +95,22 @@ const exampleConfigureSparkConfig = async () => {
   console.log('Config:', config)
 }
 
+const exampleConfigureBackgroundTasks = async () => {
+  // ANCHOR: config-background-tasks
+  // Server-mode profile: equivalent to defaultServerConfig('mainnet').
+  // Recommended when you build the SDK per request in a multi-tenant server
+  // deployment. See the "Server mode" page for the full profile.
+  const config = defaultConfig('mainnet')
+  config.backgroundTasksEnabled = false
+  // ANCHOR_END: config-background-tasks
+  console.log('Config:', config)
+}
+
 export {
   exampleConfigureSdk,
   exampleConfigurePrivateEnabledDefault,
   exampleConfigureOptimizationConfiguration,
   exampleConfigureStableBalance,
-  exampleConfigureSparkConfig
+  exampleConfigureSparkConfig,
+  exampleConfigureBackgroundTasks
 }

--- a/docs/breez-sdk/snippets/wasm/sdk_building.ts
+++ b/docs/breez-sdk/snippets/wasm/sdk_building.ts
@@ -1,12 +1,14 @@
 import {
   SdkBuilder,
   defaultConfig,
+  defaultServerConfig,
   defaultPostgresStorageConfig,
   createPostgresConnectionPool,
   defaultMysqlStorageConfig,
   createMysqlConnectionPool
 } from '@breeztech/breez-sdk-spark'
 import type {
+  BreezSdk,
   ProvisionalPayment,
   Seed,
   TxStatus,
@@ -140,6 +142,76 @@ const exampleWithKeySet = async (builder: SdkBuilder) => {
     accountNumber: 21
   })
   // ANCHOR_END: with-key-set
+}
+
+const exampleInitSdkServer = async () => {
+  // ANCHOR: init-sdk-server
+  // Construct the seed using a mnemonic, entropy or passkey
+  const mnemonic = '<mnemonic words>'
+  const seed: Seed = { type: 'mnemonic', mnemonic, passphrase: undefined }
+
+  // Build a server-mode config: same as defaultConfig(network) with
+  // backgroundTasksEnabled = false. No periodic sync, no real-time sync
+  // client, no leaf/token optimizer, no flashnet refunder, no lightning-
+  // address recovery, no spark private-mode init.
+  const config = defaultServerConfig('mainnet')
+  config.apiKey = '<breez api key>'
+
+  // Typically server-mode SDKs are built per request and share infrastructure
+  // (DB pool, REST chain service, SSP/Connection Manager) across instances.
+  // Pass the shared resources via the builder; see the "Customizing the SDK"
+  // page for each component.
+  let builder = SdkBuilder.new(config, seed)
+  builder = await builder.withDefaultStorage('./.data')
+  const sdk = await builder.build()
+  // ANCHOR_END: init-sdk-server
+  return sdk
+}
+
+const exampleServerModeRequestHandler = async (sdk: BreezSdk): Promise<string> => {
+  // ANCHOR: server-mode-request-handler
+  // User-facing request handler: do not call syncWallet here. Operations
+  // that read from local storage (getInfo, listPayments, etc.) do not need
+  // a defensive sync. Call syncWallet only from webhook handlers or
+  // reconciliation jobs that need to observe an external state change.
+  const response = await sdk.receivePayment({
+    paymentMethod: {
+      type: 'bolt11Invoice',
+      description: '<invoice description>',
+      amountSats: 5_000,
+      expirySecs: 3600,
+      paymentHash: undefined
+    }
+  })
+
+  // Always disconnect at the end of the request lifecycle to flush
+  // outstanding storage writes.
+  await sdk.disconnect()
+  // ANCHOR_END: server-mode-request-handler
+  return response.paymentRequest
+}
+
+const exampleServerModeProvisioning = async (sdk: BreezSdk) => {
+  // ANCHOR: server-mode-provisioning
+  // One-time setup when a wallet is first registered. The client-mode SDK
+  // would normally apply the private-mode preset itself on first startup;
+  // server-mode SDKs do not, so opt in once here via updateUserSettings.
+  await sdk.updateUserSettings({
+    sparkPrivateModeEnabled: true,
+    stableBalanceActiveLabel: undefined
+  })
+
+  await sdk.disconnect()
+  // ANCHOR_END: server-mode-provisioning
+}
+
+const exampleRefundPendingConversions = async (sdk: BreezSdk) => {
+  // ANCHOR: refund-pending-conversions
+  // The flashnet conversion refunder doesn't run in the background in server
+  // mode. Call this from your own scheduler (e.g. once per minute) to issue
+  // pending refunds for failed conversions.
+  await sdk.refundPendingConversions()
+  // ANCHOR_END: refund-pending-conversions
 }
 
 // ANCHOR: with-payment-observer

--- a/docs/breez-sdk/src/SUMMARY.md
+++ b/docs/breez-sdk/src/SUMMARY.md
@@ -52,6 +52,7 @@
   - [Conditional Payments](guide/htlcs.md)
   - [Using an External Signer](guide/external_signer.md)
   - [Managing webhooks](guide/webhooks.md)
+  - [Server mode](guide/server_mode.md)
 - [Moving to production](guide/moving_to_production.md)
 
 ---

--- a/docs/breez-sdk/src/guide/advanced.md
+++ b/docs/breez-sdk/src/guide/advanced.md
@@ -6,3 +6,4 @@ The SDK supports advanced features that may be useful in specific use cases:
 - **[Custom leaf optimization](optimize.md)** allows defining the leaf optimization policy and controlling when it occurs in order to minimize payment latency
 - **[Conditional payments](htlcs.md)** are useful for implementing atomic cross-chain swaps
 - **[Using an External Signer](external_signer.md)** provides custom signing logic and enables integrating with hardware wallets, MPC protocols, or existing wallet infrastructure
+- **[Server mode](server_mode.md)** is the SDK profile for multi-tenant server deployments where each request builds an ephemeral SDK and the host orchestrates sync, claiming, and event delivery explicitly

--- a/docs/breez-sdk/src/guide/config.md
+++ b/docs/breez-sdk/src/guide/config.md
@@ -29,6 +29,23 @@ The synchronization process is used to detect some payment status updates that a
 
 A shorter synchronization interval provides more responsive detection of payment updates but increases resource usage and may trigger API rate limits. The default interval balances responsiveness with resource efficiency for most use cases.
 
+## Background tasks enabled
+
+Master switch for all per-instance background tasks. Defaults to `true`, which is the right choice for mobile and single-instance deployments — the SDK runs its periodic sync, real-time sync client, lightning-address recovery, spark private-mode init, leaf and token-output optimizers, the spark-wallet background processor, and the flashnet conversion refunder.
+
+Set to `false` for multi-tenant server deployments where the SDK is built per request and the host orchestrates sync, claiming, and event delivery (typically via webhooks) explicitly. No background work is started; manual operations (`sync_wallet`, `claim_deposits`, `claim_transfers`, `refund_pending_conversions`, etc.) continue to work and are the intended entry points in this mode.
+
+The recommended way to opt into server mode is via {{#name default_server_config}}, which returns the same `Config` as {{#name default_config}} with this flag flipped off. See [Server mode](./server_mode.md) for the full profile, lifecycle pattern, and shared-infrastructure wiring. Configuring this field directly is supported if you build your `Config` another way:
+
+{{#tabs config:config-background-tasks}}
+
+<div class="warning">
+<h4>Developer note</h4>
+
+When this flag is `false`, related per-field options such as [`real_time_sync_server_url`](#real-time-sync-server-url) and [`optimization_config.auto_enabled`](#optimization-configuration) retain their configured values but the corresponding background services are not started. Their values stay visible on the `Config` so your code reads what it set, but they have no runtime effect in server mode.
+
+</div>
+
 ## LNURL Domain
 
 The LNURL domain to be used for receiving LNURL and Lightning address payments. By default, the [Breez LNURL server](https://github.com/breez/spark-sdk/tree/main/crates/breez-sdk/lnurl) instance will be used. You may configure a different domain, or set no domain to disable receiving payments using LNURL. For more information, see [Receiving payments using LNURL-Pay](./receive_lnurl_pay.md).

--- a/docs/breez-sdk/src/guide/config.md
+++ b/docs/breez-sdk/src/guide/config.md
@@ -33,7 +33,7 @@ A shorter synchronization interval provides more responsive detection of payment
 
 Master switch for all per-instance background tasks. Defaults to `true`, which is the right choice for mobile and single-instance deployments — the SDK runs its periodic sync, real-time sync client, lightning-address recovery, spark private-mode init, leaf and token-output optimizers, the spark-wallet background processor, and the flashnet conversion refunder.
 
-Set to `false` for multi-tenant server deployments where the SDK is built per request and the host orchestrates sync, claiming, and event delivery (typically via webhooks) explicitly. No background work is started; manual operations (`sync_wallet`, `claim_deposits`, `claim_transfers`, `refund_pending_conversions`, etc.) continue to work and are the intended entry points in this mode.
+Set to `false` for multi-tenant server deployments where the SDK is built per request and the host orchestrates sync, claiming, and event delivery (typically via webhooks) explicitly. No background work is started; explicit operations such as `sync_wallet`, `claim_deposit`, `list_unclaimed_deposits`, `refund_deposit`, and `refund_pending_conversions` continue to work and are the intended entry points in this mode.
 
 The recommended way to opt into server mode is via {{#name default_server_config}}, which returns the same `Config` as {{#name default_config}} with this flag flipped off. See [Server mode](./server_mode.md) for the full profile, lifecycle pattern, and shared-infrastructure wiring. Configuring this field directly is supported if you build your `Config` another way:
 

--- a/docs/breez-sdk/src/guide/config.md
+++ b/docs/breez-sdk/src/guide/config.md
@@ -33,7 +33,7 @@ A shorter synchronization interval provides more responsive detection of payment
 
 Master switch for all per-instance background tasks. Defaults to `true`, which is the right choice for mobile and single-instance deployments — the SDK runs its periodic sync, real-time sync client, lightning-address recovery, spark private-mode init, leaf and token-output optimizers, the spark-wallet background processor, and the flashnet conversion refunder.
 
-Set to `false` for multi-tenant server deployments where the SDK is built per request and the host orchestrates sync, claiming, and event delivery (typically via webhooks) explicitly. No background work is started; explicit operations such as `sync_wallet`, `claim_deposit`, `list_unclaimed_deposits`, `refund_deposit`, and `refund_pending_conversions` continue to work and are the intended entry points in this mode.
+Set to `false` for multi-tenant server deployments where the SDK is built per request and the host orchestrates sync, claiming, and event delivery (typically via webhooks) explicitly. No background work is started; explicit operations such as {{#name sync_wallet}}, {{#name claim_deposit}}, {{#name list_unclaimed_deposits}}, {{#name refund_deposit}}, and {{#name refund_pending_conversions}} continue to work and are the intended entry points in this mode.
 
 The recommended way to opt into server mode is via {{#name default_server_config}}, which returns the same `Config` as {{#name default_config}} with this flag flipped off. See [Server mode](./server_mode.md) for the full profile, lifecycle pattern, and shared-infrastructure wiring. Configuring this field directly is supported if you build your `Config` another way:
 
@@ -42,7 +42,7 @@ The recommended way to opt into server mode is via {{#name default_server_config
 <div class="warning">
 <h4>Developer note</h4>
 
-When this flag is `false`, related per-field options such as [`real_time_sync_server_url`](#real-time-sync-server-url) and [`optimization_config.auto_enabled`](#optimization-configuration) retain their configured values but the corresponding background services are not started. Their values stay visible on the `Config` so your code reads what it set, but they have no runtime effect in server mode.
+When this flag is `false`, related per-field options such as [{{#name real_time_sync_server_url}}](#real-time-sync-server-url) and [{{#name optimization_config.auto_enabled}}](#optimization-configuration) retain their configured values but the corresponding background services are not started. Their values stay visible on the `Config` so your code reads what it set, but they have no runtime effect in server mode.
 
 </div>
 

--- a/docs/breez-sdk/src/guide/config.md
+++ b/docs/breez-sdk/src/guide/config.md
@@ -42,7 +42,7 @@ The recommended way to opt into server mode is via {{#name default_server_config
 <div class="warning">
 <h4>Developer note</h4>
 
-When this flag is `false`, related per-field options such as [{{#name real_time_sync_server_url}}](#real-time-sync-server-url) and [{{#name optimization_config.auto_enabled}}](#optimization-configuration) retain their configured values but the corresponding background services are not started. Their values stay visible on the `Config` so your code reads what it set, but they have no runtime effect in server mode.
+When this flag is `false`, related per-field options whose backing service is gated off must be in their inactive shape — [{{#name real_time_sync_server_url}}](#real-time-sync-server-url) must be `None` and [{{#name optimization_config.auto_enabled}}](#optimization-configuration) must be `false`. The SDK rejects builds that leave them in their active shape with an invalid-input error. {{#name default_server_config}} sets these compatible values automatically.
 
 </div>
 

--- a/docs/breez-sdk/src/guide/customizing.md
+++ b/docs/breez-sdk/src/guide/customizing.md
@@ -1,6 +1,8 @@
 # Customizing the SDK
 
-Using the SDK Builder gives you more control over the initialization and modular components used when the SDK is running. Below you can find examples of initializing the SDK using the SDK Builder and implementing modular components:
+Using the SDK Builder gives you more control over the initialization and modular components used when the SDK is running. Below you can find examples of initializing the SDK using the SDK Builder and implementing modular components.
+
+The shared-pool, shared-chain-service, and shared-connection-manager components on this page are designed for multi-tenant server deployments — they're most useful in combination with the [Server mode](server_mode.md) SDK profile.
 
 - [Storage](#with-storage) to manage stored data
 - [PostgreSQL Connection Pool](#with-postgres-connection-pool) as an alternative storage backend

--- a/docs/breez-sdk/src/guide/get_info.md
+++ b/docs/breez-sdk/src/guide/get_info.md
@@ -37,5 +37,5 @@ The recommended pattern is:
 
 When the SDK is built with [Server mode](server_mode.md), {{#name get_info}} reads the balance live from the spark wallet's local tree store rather than from the background-maintained cache. As a result:
 
-- {{#name ensure_synced}} = **true** is a **no-op**. The SDK has no initial-sync watcher to await.
+- {{#name ensure_synced}} = **true** is rejected with an invalid-input error. The SDK has no initial-sync watcher to await; call {{#name sync_wallet}} explicitly if you need to refresh state first.
 - The returned balance reflects whatever is currently in the local tree store. If you need the freshest possible balance after an external state change (an incoming Spark transfer claimed elsewhere, an on-chain deposit confirmed, etc.), call {{#name sync_wallet}} first.

--- a/docs/breez-sdk/src/guide/get_info.md
+++ b/docs/breez-sdk/src/guide/get_info.md
@@ -30,3 +30,12 @@ The recommended pattern is:
 {{#name ensure_synced}} = **true** blocks until the SDK's **initial** sync after {{#name connect}} completes. This is useful for short-lived scripts that connect, read the balance once, and disconnect. It is **not** a "force a fresh sync now" call. In long-running applications, prefer {{#name ensure_synced}} = **false** combined with the {{#enum SdkEvent::Synced}} event listener pattern above.
 
 </div>
+
+<h2 id="server-mode">
+    <a class="header" href="#server-mode">Server mode</a>
+</h2>
+
+When the SDK is built with [Server mode](server_mode.md), {{#name get_info}} reads the balance live from the spark wallet's local tree store rather than from the background-maintained cache. As a result:
+
+- {{#name ensure_synced}} = **true** is a **no-op**. The SDK has no initial-sync watcher to await.
+- The returned balance reflects whatever is currently in the local tree store. If you need the freshest possible balance after an external state change (an incoming Spark transfer claimed elsewhere, an on-chain deposit confirmed, etc.), call {{#name sync_wallet}} first.

--- a/docs/breez-sdk/src/guide/initializing.md
+++ b/docs/breez-sdk/src/guide/initializing.md
@@ -36,6 +36,8 @@ See [Connecting with a Passkey](passkey.md) for the full setup guide including P
 
 ## Advanced Initialization
 
+If you're building a multi-tenant server deployment, start with [Server mode](server_mode.md) for the recommended profile, lifecycle pattern, and shared-infrastructure wiring.
+
 For advanced use cases where you need more control, you can configure the SDK using the Builder pattern. With the SDK Builder you can define:
 
 - [Storage](customizing.md#with-storage) to manage stored data

--- a/docs/breez-sdk/src/guide/moving_to_production.md
+++ b/docs/breez-sdk/src/guide/moving_to_production.md
@@ -12,3 +12,5 @@ Before moving to production, we strongly recommend verifying that these use case
 - **Claiming on-chain deposits**: Make sure you handle the case where an on-chain deposit is unclaimed. For more information see [Claiming on-chain deposits](onchain_claims.md).
 
 - **Check Spark status**: Use the Spark status check to monitor the operational status of the Spark network and display a warning to users when services are degraded or experiencing issues. For more information see [Spark status](spark_status.md).
+
+- **Server-side deployments**: If you're running the SDK in a multi-tenant server hosting many wallets at once, review [Server mode](server_mode.md) for the recommended profile, explicit sync/claim patterns, and shared-infrastructure wiring.

--- a/docs/breez-sdk/src/guide/server_mode.md
+++ b/docs/breez-sdk/src/guide/server_mode.md
@@ -19,7 +19,7 @@ Build the config with {{#name default_server_config}} instead of {{#name default
 
 {{#tabs sdk_building:init-sdk-server}}
 
-{{#name default_server_config}} returns the same `Config` as {{#name default_config}} with [{{#name background_tasks_enabled}}](./config.md#background-tasks-enabled) set to `false`. All other fields are unchanged; the runtime profile prevents the background services from being started even when their per-field configuration (e.g. [{{#name real_time_sync_server_url}}](./config.md#real-time-sync-server-url), [{{#name optimization_config.auto_enabled}}](./config.md#optimization-configuration)) is left at its default.
+{{#name default_server_config}} returns the same `Config` as {{#name default_config}} with [{{#name background_tasks_enabled}}](./config.md#background-tasks-enabled) set to `false` and the fields whose background services are gated off — [{{#name real_time_sync_server_url}}](./config.md#real-time-sync-server-url) and [{{#name optimization_config.auto_enabled}}](./config.md#optimization-configuration) — reset to their inactive shape. The SDK rejects builds that leave those fields in their active shape while `background_tasks_enabled` is `false`, so prefer this preset over flipping the flag by hand.
 
 Server mode usually pairs with **shared infrastructure** across SDK instances. See [Customizing the SDK](customizing.md) and the [Shared infrastructure](#shared-infrastructure) section below for the exact wiring.
 

--- a/docs/breez-sdk/src/guide/server_mode.md
+++ b/docs/breez-sdk/src/guide/server_mode.md
@@ -1,0 +1,153 @@
+<h1 id="server-mode">
+    <a class="header" href="#server-mode">Server mode</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/fn.default_server_config.html">API docs</a>
+</h1>
+
+Server mode is the SDK profile for **multi-tenant server deployments** where a single process hosts many wallets and builds an ephemeral SDK instance per request. The SDK is treated as a library: the host orchestrates sync, claiming, and event delivery (typically via webhooks) explicitly, so each per-request SDK stays cheap, predictable, and returns fresh state.
+
+Use server mode when:
+
+- You run the SDK behind an HTTP/gRPC service that handles many wallets in the same process.
+- Each request builds the SDK, performs one operation, and disconnects.
+- Background work that makes sense for a long-lived mobile client (periodic sync, real-time sync, leaf optimization, lightning-address recovery) would be wasted on a per-request lifecycle.
+
+If you're building a mobile or desktop wallet, stay on the default ([client mode](initializing.md)) — server mode disables features your app relies on.
+
+## Selecting server mode
+
+Build the config with {{#name default_server_config}} instead of {{#name default_config}}:
+
+{{#tabs sdk_building:init-sdk-server}}
+
+`default_server_config` returns the same `Config` as `default_config` with [`background_tasks_enabled`](./config.md#background-tasks-enabled) set to `false`. All other fields are unchanged; the runtime profile prevents the background services from being started even when their per-field configuration (e.g. [`real_time_sync_server_url`](./config.md#real-time-sync-server-url), [`optimization_config.auto_enabled`](./config.md#optimization-configuration)) is left at its default.
+
+Server mode usually pairs with **shared infrastructure** across SDK instances. See [Customizing the SDK](customizing.md) and the [Shared infrastructure](#shared-infrastructure) section below for the exact wiring.
+
+## What server mode turns off
+
+None of the following per-instance background work is started when `background_tasks_enabled` is `false`:
+
+- **Periodic sync loop** — the SDK does not auto-sync with the Spark network.
+- **Real-time sync client** — no WebSocket subscription to the [real-time sync server](./config.md#real-time-sync-server-url).
+- **Spark wallet background processor** — no operator-event subscription, leaf optimizer, or token-output optimizer.
+- **Lightning-address recovery** — the SDK does not refresh the registered lightning address on startup.
+- **Spark private-mode init** — the [`private_enabled_default`](./config.md#private-mode-enabled-by-default) preset is **not** applied automatically on first startup; you must opt in once via {{#name update_user_settings}} (see [User settings](user_settings.md)).
+- **Flashnet conversion refunder** — no periodic refund pass for failed token conversions.
+
+Manual operations (`sync_wallet`, `claim_deposits`, `claim_transfers`, `recover_lightning_address`, `refund_pending_conversions`, etc.) continue to work and are the intended entry points in this mode.
+
+## Driving the SDK explicitly
+
+Because nothing runs in the background, the user is responsible for calling the operations that the SDK would otherwise schedule itself. In practice there are only three things to drive, plus one one-time setup per wallet:
+
+### Sync
+
+Call {{#name sync_wallet}} **only when an external event tells you the wallet state has changed**. The two common cases:
+
+1. **A webhook fires for an incoming payment** — a Lightning receive completes, an on-chain deposit confirms, an incoming Spark transfer lands. Run `sync_wallet()` from the webhook handler so the wallet picks up the new state before downstream consumers (balance reads, payment lists, etc.) need it.
+2. **You explicitly need to reconcile state** — e.g. a periodic reconciliation job for a specific wallet, or a manual admin action. This is rare in practice; the webhook path covers the steady state.
+
+**Do not** call `sync_wallet` from user-facing request handlers (e.g. a `GET /balance` endpoint) as a precaution — it's a network round-trip to operators and is not needed if your webhooks are wired up. {{#name get_info}} reads from the local tree store directly and is the right primitive for read paths.
+
+The {{#enum SdkEvent::Synced}} event pattern documented in [Listening to events](events.md) is **not available** in server mode — the SDK has no background subscriber to emit it. Treat `sync_wallet` as the synchronous primitive instead.
+
+### Claiming on-chain deposits
+
+Call {{#name claim_deposits}} from your on-chain deposit webhook (or chain watcher) after you observe a confirmed deposit. The standard claim flow documented in [Claiming on-chain deposits](onchain_claims.md) applies; the only difference is that server-mode SDKs do not run the periodic claim sweep that the mobile profile uses.
+
+### Token conversion refunds
+
+**Only relevant if your deployment uses [token conversions](token_conversion.md).** If you don't issue or convert tokens, skip this section.
+
+The flashnet conversion refunder doesn't run in the background in server mode. If you do use tokens, run {{#name refund_pending_conversions}} from your own periodic scheduler (once per minute is a reasonable default) so failed conversions are refunded promptly.
+
+### One-time setup: Spark private mode
+
+The client-mode SDK applies [`private_enabled_default`](./config.md#private-mode-enabled-by-default) on first startup. Server-mode SDKs do not — each per-request SDK would otherwise pay a redundant storage read to check the flag. At provisioning time (when a new wallet is first registered), call {{#name update_user_settings}} with `spark_private_mode_enabled: true`. See [User settings](user_settings.md).
+
+## Event delivery via webhooks
+
+Without the background processor, the SDK doesn't emit `PaymentSucceeded` / `PaymentPending` / `ClaimedDeposits` events from operator activity. Deliver those signals through webhooks at your own infrastructure instead:
+
+- [Managing webhooks](webhooks.md) describes the supported event types and registration flow.
+- [Lightning Address payment notifications](lnurl_webhooks.md) covers the LNURL server's webhook for incoming LNURL payments.
+
+A typical pipeline: webhook arrives → webhook handler builds a per-request SDK, calls `sync_wallet()` + the relevant operation (e.g. `claim_deposits`), disconnects.
+
+## Lifecycle pattern
+
+There are three distinct shapes for a server-mode interaction, depending on what triggered it.
+
+### User-facing request handlers
+
+Generate an invoice, send a payment, list history, etc. **Do not call `sync_wallet()` here** — operations that read from local storage (`get_info`, `list_payments`, etc.) do not need a defensive sync, and a network round-trip to operators on every request adds latency without changing the answer.
+
+```text
+    request in
+      ↓
+    build SDK (default_server_config + shared infra)
+      ↓
+    do work (receive_payment / send_payment / list_payments / …)
+      ↓
+    disconnect()
+      ↓
+    response out
+```
+
+{{#tabs sdk_building:server-mode-request-handler}}
+
+### Webhook handlers and reconciliation jobs
+
+Anything driven by an external signal that the wallet state changed. The exact operation depends on the trigger — they're not chained together in the same handler.
+
+- **Incoming Lightning / Spark transfer webhook** — call `sync_wallet()` so downstream reads see the new payment:
+
+```text
+    webhook in  →  build SDK  →  sync_wallet()  →  disconnect()
+```
+
+- **On-chain deposit webhook** (or chain watcher) — call `claim_deposits` to finalize the claim:
+
+```text
+    webhook in  →  build SDK  →  claim_deposits()  →  disconnect()
+```
+
+### One-time provisioning
+
+When a wallet is first registered, run a one-time setup pass to apply the configuration the client-mode SDK would otherwise apply itself on first startup — currently the [private mode preset](./config.md#private-mode-enabled-by-default):
+
+```text
+    new wallet registered
+      ↓
+    build SDK (default_server_config + shared infra)
+      ↓
+    update_user_settings({ spark_private_mode_enabled: true })
+      ↓
+    disconnect()
+```
+
+{{#tabs sdk_building:server-mode-provisioning}}
+
+### A few notes
+
+- **Building is cheap when infrastructure is shared.** With the shared chain service, MySQL/Postgres pool, and SSP/Connection Managers configured ([see below](#shared-infrastructure)), each per-request SDK reuses HTTP/2 connections, DB pool slots, and gRPC channels — there's no per-request handshake to operators.
+- **Always disconnect.** Even though no background loops are running, `disconnect()` flushes outstanding storage writes and is the documented lifecycle exit. See [Disconnecting](initializing.md#disconnecting).
+- **One SDK per request, not one SDK pinned to a worker thread.** The per-request build is fast enough and avoids cross-tenant state leaks.
+
+<h2 id="shared-infrastructure">
+    <a class="header" href="#shared-infrastructure">Shared infrastructure</a>
+</h2>
+
+A server-mode deployment normally pairs the profile with shared resources across every per-request SDK. Each of the following is documented in [Customizing the SDK](customizing.md):
+
+- [PostgreSQL Connection Pool](customizing.md#with-postgres-connection-pool) — shared DB pool for storage, tree, and token stores.
+- [MySQL Connection Pool](customizing.md#with-mysql-connection-pool) — same for MySQL.
+- [Shared REST Chain Service](customizing.md#with-shared-rest-chain-service) — one pooled HTTP client instead of one per SDK.
+- [SSP Connection Manager](customizing.md#with-ssp-connection-manager) — share the SSP HTTP client across SDKs.
+- [Connection Manager](customizing.md#with-connection-manager) — share gRPC channels to the Spark operators across SDKs.
+
+Pair `default_server_config` with all of these shared resources — sharing the DB pool, chain service, SSP HTTP client, and gRPC channels across SDKs is the intended deployment shape.
+
+## Driving the `background_tasks_enabled` field directly
+
+`default_server_config` is the recommended entry point. If you need to flip the flag on an existing config built another way, see [Background tasks enabled](./config.md#background-tasks-enabled).

--- a/docs/breez-sdk/src/guide/server_mode.md
+++ b/docs/breez-sdk/src/guide/server_mode.md
@@ -33,8 +33,9 @@ None of the following per-instance background work is started when `background_t
 - **Lightning-address recovery** — the SDK does not refresh the registered lightning address on startup.
 - **Spark private-mode init** — the [`private_enabled_default`](./config.md#private-mode-enabled-by-default) preset is **not** applied automatically on first startup; you must opt in once via {{#name update_user_settings}} (see [User settings](user_settings.md)).
 - **Flashnet conversion refunder** — no periodic refund pass for failed token conversions.
+- **Stable Balance** — Stable Balance is not supported in server mode because its conversion worker is a background service. Do not rely on automatic Bitcoin-to-token conversion on receive, activation/deactivation conversion, or other Stable Balance background behavior in this profile.
 
-Manual operations (`sync_wallet`, `claim_deposits`, `claim_transfers`, `recover_lightning_address`, `refund_pending_conversions`, etc.) continue to work and are the intended entry points in this mode.
+Explicit operations such as `sync_wallet`, `claim_deposit`, `list_unclaimed_deposits`, `refund_deposit`, and `refund_pending_conversions` continue to work and are the intended entry points in this mode.
 
 ## Driving the SDK explicitly
 
@@ -53,7 +54,18 @@ The {{#enum SdkEvent::Synced}} event pattern documented in [Listening to events]
 
 ### Claiming on-chain deposits
 
-Call {{#name claim_deposits}} from your on-chain deposit webhook (or chain watcher) after you observe a confirmed deposit. The standard claim flow documented in [Claiming on-chain deposits](onchain_claims.md) applies; the only difference is that server-mode SDKs do not run the periodic claim sweep that the mobile profile uses.
+Server-mode SDKs do not run the periodic deposit detection and claim sweep that the mobile profile uses. When your webhook or chain watcher observes a relevant on-chain deposit, handle it explicitly:
+
+- Call {{#name sync_wallet}} to run the SDK's deposit sync and automatic claim logic using your configured [`max_deposit_claim_fee`](./config.md#max-deposit-claim-fee).
+- If your backend already knows the deposit outpoint and wants to drive a specific claim, call {{#name claim_deposit}} for that `txid`/`vout`.
+
+The standard claim flow documented in [Claiming on-chain deposits](onchain_claims.md) applies.
+
+### Stable Balance
+
+Stable Balance is not available in server mode. The feature depends on the client runtime's background conversion worker, so server-mode SDKs will not automatically convert received Bitcoin to the active stable token and will not process Stable Balance activation/deactivation conversions in the background.
+
+Explicit token conversion flows used by payment APIs can still be used, but do not configure Stable Balance for a server-mode deployment unless a dedicated server-side driver is added.
 
 ### Token conversion refunds
 
@@ -72,7 +84,7 @@ Without the background processor, the SDK doesn't emit `PaymentSucceeded` / `Pay
 - [Managing webhooks](webhooks.md) describes the supported event types and registration flow.
 - [Lightning Address payment notifications](lnurl_webhooks.md) covers the LNURL server's webhook for incoming LNURL payments.
 
-A typical pipeline: webhook arrives → webhook handler builds a per-request SDK, calls `sync_wallet()` + the relevant operation (e.g. `claim_deposits`), disconnects.
+A typical pipeline: webhook arrives → webhook handler builds a per-request SDK, calls `sync_wallet()` or the relevant explicit operation (e.g. `claim_deposit`), disconnects.
 
 ## Lifecycle pattern
 
@@ -106,10 +118,10 @@ Anything driven by an external signal that the wallet state changed. The exact o
     webhook in  →  build SDK  →  sync_wallet()  →  disconnect()
 ```
 
-- **On-chain deposit webhook** (or chain watcher) — call `claim_deposits` to finalize the claim:
+- **On-chain deposit webhook** (or chain watcher) — call `sync_wallet()` to run the deposit sync and automatic claim sweep, or call `claim_deposit` if you want to claim a known outpoint explicitly:
 
 ```text
-    webhook in  →  build SDK  →  claim_deposits()  →  disconnect()
+    webhook in  →  build SDK  →  sync_wallet() / claim_deposit()  →  disconnect()
 ```
 
 ### One-time provisioning

--- a/docs/breez-sdk/src/guide/server_mode.md
+++ b/docs/breez-sdk/src/guide/server_mode.md
@@ -19,23 +19,23 @@ Build the config with {{#name default_server_config}} instead of {{#name default
 
 {{#tabs sdk_building:init-sdk-server}}
 
-`default_server_config` returns the same `Config` as `default_config` with [`background_tasks_enabled`](./config.md#background-tasks-enabled) set to `false`. All other fields are unchanged; the runtime profile prevents the background services from being started even when their per-field configuration (e.g. [`real_time_sync_server_url`](./config.md#real-time-sync-server-url), [`optimization_config.auto_enabled`](./config.md#optimization-configuration)) is left at its default.
+{{#name default_server_config}} returns the same `Config` as {{#name default_config}} with [{{#name background_tasks_enabled}}](./config.md#background-tasks-enabled) set to `false`. All other fields are unchanged; the runtime profile prevents the background services from being started even when their per-field configuration (e.g. [{{#name real_time_sync_server_url}}](./config.md#real-time-sync-server-url), [{{#name optimization_config.auto_enabled}}](./config.md#optimization-configuration)) is left at its default.
 
 Server mode usually pairs with **shared infrastructure** across SDK instances. See [Customizing the SDK](customizing.md) and the [Shared infrastructure](#shared-infrastructure) section below for the exact wiring.
 
 ## What server mode turns off
 
-None of the following per-instance background work is started when `background_tasks_enabled` is `false`:
+None of the following per-instance background work is started when {{#name background_tasks_enabled}} is `false`:
 
 - **Periodic sync loop** — the SDK does not auto-sync with the Spark network.
 - **Real-time sync client** — no WebSocket subscription to the [real-time sync server](./config.md#real-time-sync-server-url).
 - **Spark wallet background processor** — no operator-event subscription, leaf optimizer, or token-output optimizer.
 - **Lightning-address recovery** — the SDK does not refresh the registered lightning address on startup.
-- **Spark private-mode init** — the [`private_enabled_default`](./config.md#private-mode-enabled-by-default) preset is **not** applied automatically on first startup; you must opt in once via {{#name update_user_settings}} (see [User settings](user_settings.md)).
+- **Spark private-mode init** — the [{{#name private_enabled_default}}](./config.md#private-mode-enabled-by-default) preset is **not** applied automatically on first startup; you must opt in once via {{#name update_user_settings}} (see [User settings](user_settings.md)).
 - **Flashnet conversion refunder** — no periodic refund pass for failed token conversions.
 - **Stable Balance** — Stable Balance is not supported in server mode because its conversion worker is a background service. Do not rely on automatic Bitcoin-to-token conversion on receive, activation/deactivation conversion, or other Stable Balance background behavior in this profile.
 
-Explicit operations such as `sync_wallet`, `claim_deposit`, `list_unclaimed_deposits`, `refund_deposit`, and `refund_pending_conversions` continue to work and are the intended entry points in this mode.
+Explicit operations such as {{#name sync_wallet}}, {{#name claim_deposit}}, {{#name list_unclaimed_deposits}}, {{#name refund_deposit}}, and {{#name refund_pending_conversions}} continue to work and are the intended entry points in this mode.
 
 ## Driving the SDK explicitly
 
@@ -48,15 +48,15 @@ Call {{#name sync_wallet}} **only when an external event tells you the wallet st
 1. **A webhook fires for an incoming payment** — a Lightning receive completes, an on-chain deposit confirms, an incoming Spark transfer lands. Run `sync_wallet()` from the webhook handler so the wallet picks up the new state before downstream consumers (balance reads, payment lists, etc.) need it.
 2. **You explicitly need to reconcile state** — e.g. a periodic reconciliation job for a specific wallet, or a manual admin action. This is rare in practice; the webhook path covers the steady state.
 
-**Do not** call `sync_wallet` from user-facing request handlers (e.g. a `GET /balance` endpoint) as a precaution — it's a network round-trip to operators and is not needed if your webhooks are wired up. {{#name get_info}} reads from the local tree store directly and is the right primitive for read paths.
+**Do not** call {{#name sync_wallet}} from user-facing request handlers (e.g. a `GET /balance` endpoint) as a precaution — it's a network round-trip to operators and is not needed if your webhooks are wired up. {{#name get_info}} reads from the local tree store directly and is the right primitive for read paths.
 
-The {{#enum SdkEvent::Synced}} event pattern documented in [Listening to events](events.md) is **not available** in server mode — the SDK has no background subscriber to emit it. Treat `sync_wallet` as the synchronous primitive instead.
+The {{#enum SdkEvent::Synced}} event pattern documented in [Listening to events](events.md) is **not available** in server mode — the SDK has no background subscriber to emit it. Treat {{#name sync_wallet}} as the synchronous primitive instead.
 
 ### Claiming on-chain deposits
 
 Server-mode SDKs do not run the periodic deposit detection and claim sweep that the mobile profile uses. When your webhook or chain watcher observes a relevant on-chain deposit, handle it explicitly:
 
-- Call {{#name sync_wallet}} to run the SDK's deposit sync and automatic claim logic using your configured [`max_deposit_claim_fee`](./config.md#max-deposit-claim-fee).
+- Call {{#name sync_wallet}} to run the SDK's deposit sync and automatic claim logic using your configured [{{#name max_deposit_claim_fee}}](./config.md#max-deposit-claim-fee).
 - If your backend already knows the deposit outpoint and wants to drive a specific claim, call {{#name claim_deposit}} for that `txid`/`vout`.
 
 The standard claim flow documented in [Claiming on-chain deposits](onchain_claims.md) applies.
@@ -65,7 +65,7 @@ The standard claim flow documented in [Claiming on-chain deposits](onchain_claim
 
 Stable Balance is not available in server mode. The feature depends on the client runtime's background conversion worker, so server-mode SDKs will not automatically convert received Bitcoin to the active stable token and will not process Stable Balance activation/deactivation conversions in the background.
 
-If [`stable_balance_config`](./config.md#stable-balance-configuration) is set while using server mode, SDK initialization fails with an invalid input error. Explicit token conversion flows used by payment APIs can still be used, but do not configure Stable Balance for a server-mode deployment.
+If [{{#name stable_balance_config}}](./config.md#stable-balance-configuration) is set while using server mode, SDK initialization fails with an invalid input error. Explicit token conversion flows used by payment APIs can still be used, but do not configure Stable Balance for a server-mode deployment.
 
 ### Token conversion refunds
 
@@ -75,7 +75,7 @@ The flashnet conversion refunder doesn't run in the background in server mode. I
 
 ### One-time setup: Spark private mode
 
-The client-mode SDK applies [`private_enabled_default`](./config.md#private-mode-enabled-by-default) on first startup. Server-mode SDKs do not — each per-request SDK would otherwise pay a redundant storage read to check the flag. At provisioning time (when a new wallet is first registered), call {{#name update_user_settings}} with `spark_private_mode_enabled: true`. See [User settings](user_settings.md).
+The client-mode SDK applies [{{#name private_enabled_default}}](./config.md#private-mode-enabled-by-default) on first startup. Server-mode SDKs do not — each per-request SDK would otherwise pay a redundant storage read to check the flag. At provisioning time (when a new wallet is first registered), call {{#name update_user_settings}} with {{#name spark_private_mode_enabled}} set to `true`. See [User settings](user_settings.md).
 
 ## Event delivery via webhooks
 
@@ -84,7 +84,7 @@ Without the background processor, the SDK doesn't emit `PaymentSucceeded` / `Pay
 - [Managing webhooks](webhooks.md) describes the supported event types and registration flow.
 - [Lightning Address payment notifications](lnurl_webhooks.md) covers the LNURL server's webhook for incoming LNURL payments.
 
-A typical pipeline: webhook arrives → webhook handler builds a per-request SDK, calls `sync_wallet()` or the relevant explicit operation (e.g. `claim_deposit`), disconnects.
+A typical pipeline: webhook arrives → webhook handler builds a per-request SDK, calls {{#name sync_wallet}} or the relevant explicit operation (e.g. {{#name claim_deposit}}), disconnects.
 
 ## Lifecycle pattern
 
@@ -92,7 +92,7 @@ There are three distinct shapes for a server-mode interaction, depending on what
 
 ### User-facing request handlers
 
-Generate an invoice, send a payment, list history, etc. **Do not call `sync_wallet()` here** — operations that read from local storage (`get_info`, `list_payments`, etc.) do not need a defensive sync, and a network round-trip to operators on every request adds latency without changing the answer.
+Generate an invoice, send a payment, list history, etc. **Do not call {{#name sync_wallet}} here** — operations that read from local storage ({{#name get_info}}, {{#name list_payments}}, etc.) do not need a defensive sync, and a network round-trip to operators on every request adds latency without changing the answer.
 
 ```text
     request in
@@ -112,13 +112,13 @@ Generate an invoice, send a payment, list history, etc. **Do not call `sync_wall
 
 Anything driven by an external signal that the wallet state changed. The exact operation depends on the trigger — they're not chained together in the same handler.
 
-- **Incoming Lightning / Spark transfer webhook** — call `sync_wallet()` so downstream reads see the new payment:
+- **Incoming Lightning / Spark transfer webhook** — call {{#name sync_wallet}} so downstream reads see the new payment:
 
 ```text
     webhook in  →  build SDK  →  sync_wallet()  →  disconnect()
 ```
 
-- **On-chain deposit webhook** (or chain watcher) — call `sync_wallet()` to run the deposit sync and automatic claim sweep, or call `claim_deposit` if you want to claim a known outpoint explicitly:
+- **On-chain deposit webhook** (or chain watcher) — call {{#name sync_wallet}} to run the deposit sync and automatic claim sweep, or call {{#name claim_deposit}} if you want to claim a known outpoint explicitly:
 
 ```text
     webhook in  →  build SDK  →  sync_wallet() / claim_deposit()  →  disconnect()
@@ -143,7 +143,7 @@ When a wallet is first registered, run a one-time setup pass to apply the config
 ### A few notes
 
 - **Building is cheap when infrastructure is shared.** With the shared chain service, MySQL/Postgres pool, and SSP/Connection Managers configured ([see below](#shared-infrastructure)), each per-request SDK reuses HTTP/2 connections, DB pool slots, and gRPC channels — there's no per-request handshake to operators.
-- **Always disconnect.** Even though no background loops are running, `disconnect()` flushes outstanding storage writes and is the documented lifecycle exit. See [Disconnecting](initializing.md#disconnecting).
+- **Always disconnect.** Even though no background loops are running, calling {{#name disconnect}} flushes outstanding storage writes and is the documented lifecycle exit. See [Disconnecting](initializing.md#disconnecting).
 - **One SDK per request, not one SDK pinned to a worker thread.** The per-request build is fast enough and avoids cross-tenant state leaks.
 
 <h2 id="shared-infrastructure">
@@ -158,8 +158,8 @@ A server-mode deployment normally pairs the profile with shared resources across
 - [SSP Connection Manager](customizing.md#with-ssp-connection-manager) — share the SSP HTTP client across SDKs.
 - [Connection Manager](customizing.md#with-connection-manager) — share gRPC channels to the Spark operators across SDKs.
 
-Pair `default_server_config` with all of these shared resources — sharing the DB pool, chain service, SSP HTTP client, and gRPC channels across SDKs is the intended deployment shape.
+Pair {{#name default_server_config}} with all of these shared resources — sharing the DB pool, chain service, SSP HTTP client, and gRPC channels across SDKs is the intended deployment shape.
 
-## Driving the `background_tasks_enabled` field directly
+## Driving the {{#name background_tasks_enabled}} field directly
 
-`default_server_config` is the recommended entry point. If you need to flip the flag on an existing config built another way, see [Background tasks enabled](./config.md#background-tasks-enabled).
+{{#name default_server_config}} is the recommended entry point. If you need to flip the flag on an existing config built another way, see [Background tasks enabled](./config.md#background-tasks-enabled).

--- a/docs/breez-sdk/src/guide/server_mode.md
+++ b/docs/breez-sdk/src/guide/server_mode.md
@@ -71,7 +71,7 @@ If [{{#name stable_balance_config}}](./config.md#stable-balance-configuration) i
 
 **Only relevant if your deployment uses [token conversions](token_conversion.md).** If you don't issue or convert tokens, skip this section.
 
-The flashnet conversion refunder doesn't run in the background in server mode. If you do use tokens, run {{#name refund_pending_conversions}} from your own periodic scheduler (once per minute is a reasonable default) so failed conversions are refunded promptly.
+The flashnet conversion refunder doesn't run in the background in server mode. If you do use tokens, your host needs to drive {{#name refund_pending_conversions}} per affected wallet so failed conversions get refunded. A practical pattern is to track which wallets have pending conversions (e.g. by recording them when a conversion fails) and to run the refund pass for just those wallets on a cadence you control — not to spin up an SDK per wallet every minute regardless.
 
 ### One-time setup: Spark private mode
 
@@ -133,7 +133,7 @@ When a wallet is first registered, run a one-time setup pass to apply the config
       ↓
     build SDK (default_server_config + shared infra)
       ↓
-    update_user_settings({ spark_private_mode_enabled: true })
+    apply one-time user settings
       ↓
     disconnect()
 ```

--- a/docs/breez-sdk/src/guide/server_mode.md
+++ b/docs/breez-sdk/src/guide/server_mode.md
@@ -65,7 +65,7 @@ The standard claim flow documented in [Claiming on-chain deposits](onchain_claim
 
 Stable Balance is not available in server mode. The feature depends on the client runtime's background conversion worker, so server-mode SDKs will not automatically convert received Bitcoin to the active stable token and will not process Stable Balance activation/deactivation conversions in the background.
 
-Explicit token conversion flows used by payment APIs can still be used, but do not configure Stable Balance for a server-mode deployment unless a dedicated server-side driver is added.
+If [`stable_balance_config`](./config.md#stable-balance-configuration) is set while using server mode, SDK initialization fails with an invalid input error. Explicit token conversion flows used by payment APIs can still be used, but do not configure Stable Balance for a server-mode deployment.
 
 ### Token conversion refunds
 

--- a/packages/flutter/lib/src/config_extensions.dart
+++ b/packages/flutter/lib/src/config_extensions.dart
@@ -21,6 +21,7 @@ extension ConfigCopyWith on Config {
     StableBalanceConfig? stableBalanceConfig,
     int? maxConcurrentClaims,
     SparkConfig? sparkConfig,
+    bool? backgroundTasksEnabled,
   }) {
     return Config(
       apiKey: apiKey ?? this.apiKey,
@@ -37,6 +38,7 @@ extension ConfigCopyWith on Config {
       stableBalanceConfig: stableBalanceConfig ?? this.stableBalanceConfig,
       maxConcurrentClaims: maxConcurrentClaims ?? this.maxConcurrentClaims,
       sparkConfig: sparkConfig ?? this.sparkConfig,
+      backgroundTasksEnabled: backgroundTasksEnabled ?? this.backgroundTasksEnabled,
     );
   }
 }

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -48,6 +48,7 @@ pub struct _Config {
     /// payment volume to improve throughput.
     pub max_concurrent_claims: u32,
     pub spark_config: Option<SparkConfig>,
+    pub background_tasks_enabled: bool,
 }
 
 #[frb(mirror(SparkConfig))]

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -24,6 +24,11 @@ pub fn default_config(network: Network) -> Config {
 }
 
 #[frb(sync)]
+pub fn default_server_config(network: Network) -> Config {
+    breez_sdk_spark::default_server_config(network)
+}
+
+#[frb(sync)]
 pub fn init_logging(
     log_dir: Option<String>,
     app_logger: StreamSink<LogEntry>,

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -279,6 +279,10 @@ impl BreezSdk {
         self.inner.list_webhooks().await
     }
 
+    pub async fn refund_pending_conversions(&self) -> Result<(), SdkError> {
+        self.inner.refund_pending_conversions().await
+    }
+
     pub async fn add_contact(&self, request: AddContactRequest) -> Result<Contact, SdkError> {
         self.inner.add_contact(request).await
     }


### PR DESCRIPTION
This PR adds a master `background_tasks_enabled` flag and a server preset that disables background work by default.
Server mode keeps SDK instances lightweight by skipping per-instance background tasks like sync loops, real-time sync, wallet processors, recovery, private-mode init, and refund handling. JWT still initializes once at startup and should be refactored out in a following PR.
Runtime behavior is now handled through RuntimeProfile implementations instead of scattered flag checks. It also allows us to put all the client logic in one place and ensure no time consuming tasks affect the server runtime. 
Existing config values remain visible, but background work is gated at startup.



Public API adjustments for the no-loop world:
- sync_wallet routes through RuntimeProfile::run_user_sync, which in server mode calls sync_wallet_internal inline (no coordinator dispatch, since the receiver isn't running).
- claim_deposit no longer fires an automatic follow-up sync; in client mode the TransferClaimed event-driven path already refreshes balances and triggers a WalletState sync.
- get_info reads balance directly from the spark wallet in server mode rather than from the cached `account_info` that no background task maintains. `ensure_synced` is a no-op in this mode.
- ensure_spark_private_mode_initialized short-circuits in server mode to avoid an indexed storage read per request on ephemeral instances; partners apply Config::private_enabled_default via update_user_settings on a one-time setup pass.
- New BreezSdk::refund_pending_conversions surfaces the refund pass explicitly via a new TokenConverter::refund_pending trait method, since the periodic refunder no longer runs in server mode.
- StableBalance signals completed conversions via a RuntimeEvent on the EventEmitter; the client runtime listens and triggers sync, while the server runtime ignores it.

In summary all background tasks and work related to client side is not routed via the runtime/client module and anything that should affect high throughput  should use the "runtime" encapsulation. 