### PR TITLE
Dedup payment events and don't override terminal state

### DIFF
--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -269,6 +269,13 @@ pub struct PaymentMetadata {
     pub conversion_status: Option<ConversionStatus>,
 }
 
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub(crate) fn parse_payment_status(value: &str) -> Result<PaymentStatus, StorageError> {
+    value
+        .parse()
+        .map_err(|e| StorageError::Implementation(format!("invalid payment status: {e}")))
+}
+
 /// Trait for persistent storage
 #[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
 #[async_trait]
@@ -290,16 +297,15 @@ pub trait Storage: Send + Sync {
         request: StorageListPaymentsRequest,
     ) -> Result<Vec<Payment>, StorageError>;
 
-    /// Inserts a payment into storage
+    /// Inserts or updates a payment unless it would replace a terminal status.
     ///
-    /// # Arguments
+    /// Same-status updates are still persisted so details can be enriched.
     ///
-    /// * `payment` - The payment to insert
-    ///
-    /// # Returns
-    ///
-    /// Success or a `StorageError`
-    async fn insert_payment(&self, payment: Payment) -> Result<(), StorageError>;
+    /// Returns `true` if the caller should emit a payment event (new payment was
+    /// inserted, or status transitioned). Returns `false` for redundant
+    /// same-status updates and for rejected updates against a terminal stored
+    /// status
+    async fn apply_payment_update(&self, payment: Payment) -> Result<bool, StorageError>;
 
     /// Inserts payment metadata into storage
     ///

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -669,7 +669,7 @@ impl MysqlStorage {
         engine.input(identity);
         engine.input(payment_id.as_bytes());
         let digest = sha256::Hash::from_engine(engine);
-        format!("brz_payment_{}", &digest.to_string()[..32])
+        digest.to_string()[..32].to_string()
     }
 
     async fn get_payment_status_in_tx(

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 
-use bitcoin::hashes::{Hash, sha256};
+use bitcoin::hashes::{Hash, HashEngine, sha256};
 use macros::async_trait;
 use mysql_async::prelude::*;
 use mysql_async::{Params, Pool, Row, Transaction, Value};
@@ -664,10 +664,11 @@ fn from_json_string_opt<T: serde::de::DeserializeOwned>(
 
 impl MysqlStorage {
     fn payment_update_lock_name(identity: &[u8], payment_id: &str) -> String {
-        let mut lock_key = Vec::with_capacity(identity.len().saturating_add(payment_id.len()));
-        lock_key.extend_from_slice(identity);
-        lock_key.extend_from_slice(payment_id.as_bytes());
-        let digest = sha256::Hash::hash(&lock_key);
+        let mut engine = sha256::Hash::engine();
+        engine.input(b"brz_payment_update");
+        engine.input(identity);
+        engine.input(payment_id.as_bytes());
+        let digest = sha256::Hash::from_engine(engine);
         format!("brz_payment_{}", &digest.to_string()[..32])
     }
 

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -6,20 +6,22 @@
 
 use std::collections::HashMap;
 
+use bitcoin::hashes::{Hash, sha256};
 use macros::async_trait;
 use mysql_async::prelude::*;
-use mysql_async::{Params, Pool, Row, Value};
+use mysql_async::{Params, Pool, Row, Transaction, Value};
 use spark_mysql::{mysql_async, tx_opts};
 use tracing::warn;
 
 use crate::{
     AssetFilter, Contact, ConversionDetails, ConversionInfo, ConversionStatus, DepositInfo,
     ListContactsRequest, LnurlPayInfo, LnurlReceiveMetadata, LnurlWithdrawInfo, PaymentDetails,
-    PaymentMethod, SparkHtlcDetails, SparkHtlcStatus,
+    PaymentMethod, PaymentStatus, SparkHtlcDetails, SparkHtlcStatus,
     error::DepositClaimError,
     persist::{
         Payment, PaymentMetadata, SetLnurlMetadataItem, Storage, StorageError,
         StorageListPaymentsRequest, StoragePaymentDetailsFilter, UpdateDepositPayload,
+        parse_payment_status,
     },
     sync_storage::{
         IncomingChange, OutgoingChange, Record, RecordChange, RecordId, UnversionedRecordChange,
@@ -31,6 +33,7 @@ use super::base::{Migration, SchemaRenames, map_db_error, run_migrations};
 use super::base::{MysqlStorageConfig, create_pool};
 
 const MIGRATIONS_TABLE: &str = "brz_schema_migrations";
+const PAYMENT_UPDATE_LOCK_TIMEOUT_SECS: u64 = 10;
 
 /// Pre-prefix rename map for upgrading core persist deployments.
 const SCHEMA_RENAMES: SchemaRenames<'static> = SchemaRenames {
@@ -659,6 +662,172 @@ fn from_json_string_opt<T: serde::de::DeserializeOwned>(
         .map_err(|e| StorageError::Serialization(e.to_string()))
 }
 
+impl MysqlStorage {
+    fn payment_update_lock_name(identity: &[u8], payment_id: &str) -> String {
+        let mut lock_key = Vec::with_capacity(identity.len().saturating_add(payment_id.len()));
+        lock_key.extend_from_slice(identity);
+        lock_key.extend_from_slice(payment_id.as_bytes());
+        let digest = sha256::Hash::hash(&lock_key);
+        format!("brz_payment_{}", &digest.to_string()[..32])
+    }
+
+    async fn get_payment_status_in_tx(
+        tx: &mut Transaction<'_>,
+        identity: &[u8],
+        payment_id: &str,
+    ) -> Result<Option<PaymentStatus>, StorageError> {
+        let status: Option<String> = tx
+            .exec_first(
+                "SELECT status FROM brz_payments WHERE user_id = ? AND id = ? FOR UPDATE",
+                (identity.to_vec(), payment_id),
+            )
+            .await
+            .map_err(map_db_error)?;
+
+        status
+            .map(|status| parse_payment_status(&status))
+            .transpose()
+    }
+
+    #[allow(clippy::too_many_lines)]
+    async fn insert_payment_in_tx(
+        tx: &mut Transaction<'_>,
+        identity: &[u8],
+        payment: Payment,
+    ) -> Result<(), StorageError> {
+        let (withdraw_tx_id, deposit_tx_id, spark): (Option<&str>, Option<&str>, Option<bool>) =
+            match &payment.details {
+                Some(PaymentDetails::Withdraw { tx_id }) => (Some(tx_id.as_str()), None, None),
+                Some(PaymentDetails::Deposit { tx_id }) => (None, Some(tx_id.as_str()), None),
+                Some(PaymentDetails::Spark { .. }) => (None, None, Some(true)),
+                _ => (None, None, None),
+            };
+
+        tx.exec_drop(
+            "INSERT INTO brz_payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 ON DUPLICATE KEY UPDATE
+                    payment_type = VALUES(payment_type),
+                    status = VALUES(status),
+                    amount = VALUES(amount),
+                    fees = VALUES(fees),
+                    timestamp = VALUES(timestamp),
+                    method = VALUES(method),
+                    withdraw_tx_id = VALUES(withdraw_tx_id),
+                    deposit_tx_id = VALUES(deposit_tx_id),
+                    spark = VALUES(spark)",
+            (
+                identity.to_vec(),
+                &payment.id,
+                payment.payment_type.to_string(),
+                payment.status.to_string(),
+                payment.amount.to_string(),
+                payment.fees.to_string(),
+                i64::try_from(payment.timestamp)?,
+                Some(payment.method.to_string()),
+                withdraw_tx_id.map(str::to_string),
+                deposit_tx_id.map(str::to_string),
+                spark,
+            ),
+        )
+        .await
+        .map_err(map_db_error)?;
+
+        match payment.details {
+            Some(PaymentDetails::Spark {
+                invoice_details,
+                htlc_details,
+                ..
+            }) => {
+                if invoice_details.is_some() || htlc_details.is_some() {
+                    let invoice_json = to_json_string_opt(invoice_details.as_ref())?;
+                    let htlc_json = to_json_string_opt(htlc_details.as_ref())?;
+                    tx.exec_drop(
+                        "INSERT INTO brz_payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
+                             VALUES (?, ?, ?, ?)
+                             ON DUPLICATE KEY UPDATE
+                                invoice_details = COALESCE(VALUES(invoice_details), invoice_details),
+                                htlc_details = COALESCE(VALUES(htlc_details), htlc_details)",
+                        (identity.to_vec(), &payment.id, invoice_json, htlc_json),
+                    )
+                    .await
+                    .map_err(map_db_error)?;
+                }
+            }
+            Some(PaymentDetails::Token {
+                metadata,
+                tx_hash,
+                tx_type,
+                invoice_details,
+                ..
+            }) => {
+                let metadata_json = serde_json::to_string(&metadata)
+                    .map_err(|e| StorageError::Serialization(e.to_string()))?;
+                let invoice_json = to_json_string_opt(invoice_details.as_ref())?;
+                tx.exec_drop(
+                    "INSERT INTO brz_payment_details_token (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
+                         VALUES (?, ?, ?, ?, ?, ?)
+                         ON DUPLICATE KEY UPDATE
+                            metadata = VALUES(metadata),
+                            tx_hash = VALUES(tx_hash),
+                            tx_type = VALUES(tx_type),
+                            invoice_details = COALESCE(VALUES(invoice_details), invoice_details)",
+                    (
+                        identity.to_vec(),
+                        &payment.id,
+                        metadata_json,
+                        tx_hash,
+                        tx_type.to_string(),
+                        invoice_json,
+                    ),
+                )
+                .await
+                .map_err(map_db_error)?;
+            }
+            Some(PaymentDetails::Lightning {
+                invoice,
+                destination_pubkey,
+                description,
+                htlc_details,
+                ..
+            }) => {
+                let payment_hash = htlc_details.payment_hash.clone();
+                let preimage = htlc_details.preimage.clone();
+                let htlc_status = htlc_details.status.to_string();
+                let htlc_expiry_time = i64::try_from(htlc_details.expiry_time)?;
+                tx.exec_drop(
+                    "INSERT INTO brz_payment_details_lightning (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         ON DUPLICATE KEY UPDATE
+                            invoice = VALUES(invoice),
+                            payment_hash = VALUES(payment_hash),
+                            destination_pubkey = VALUES(destination_pubkey),
+                            description = VALUES(description),
+                            preimage = COALESCE(VALUES(preimage), preimage),
+                            htlc_status = COALESCE(VALUES(htlc_status), htlc_status),
+                            htlc_expiry_time = COALESCE(VALUES(htlc_expiry_time), htlc_expiry_time)",
+                    (
+                        identity.to_vec(),
+                        &payment.id,
+                        invoice,
+                        payment_hash,
+                        destination_pubkey,
+                        description,
+                        preimage,
+                        htlc_status,
+                        htlc_expiry_time,
+                    ),
+                )
+                .await
+                .map_err(map_db_error)?;
+            }
+            Some(PaymentDetails::Withdraw { .. } | PaymentDetails::Deposit { .. }) | None => {}
+        }
+
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl Storage for MysqlStorage {
     #[allow(clippy::too_many_lines, clippy::arithmetic_side_effects)]
@@ -831,145 +1000,65 @@ impl Storage for MysqlStorage {
         Ok(payments)
     }
 
-    #[allow(clippy::too_many_lines)]
-    async fn insert_payment(&self, payment: Payment) -> Result<(), StorageError> {
+    async fn apply_payment_update(&self, payment: Payment) -> Result<bool, StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
-        let mut tx = conn
-            .start_transaction(tx_opts())
+        let lock_name = Self::payment_update_lock_name(&self.identity, &payment.id);
+        let acquired: Option<i64> = conn
+            .exec_first(
+                "SELECT GET_LOCK(?, ?)",
+                (lock_name.as_str(), PAYMENT_UPDATE_LOCK_TIMEOUT_SECS),
+            )
             .await
             .map_err(map_db_error)?;
-
-        let (withdraw_tx_id, deposit_tx_id, spark): (Option<&str>, Option<&str>, Option<bool>) =
-            match &payment.details {
-                Some(PaymentDetails::Withdraw { tx_id }) => (Some(tx_id.as_str()), None, None),
-                Some(PaymentDetails::Deposit { tx_id }) => (None, Some(tx_id.as_str()), None),
-                Some(PaymentDetails::Spark { .. }) => (None, None, Some(true)),
-                _ => (None, None, None),
-            };
-
-        tx.exec_drop(
-            "INSERT INTO brz_payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                 ON DUPLICATE KEY UPDATE
-                    payment_type = VALUES(payment_type),
-                    status = VALUES(status),
-                    amount = VALUES(amount),
-                    fees = VALUES(fees),
-                    timestamp = VALUES(timestamp),
-                    method = VALUES(method),
-                    withdraw_tx_id = VALUES(withdraw_tx_id),
-                    deposit_tx_id = VALUES(deposit_tx_id),
-                    spark = VALUES(spark)",
-            (
-                self.identity.clone(),
-                &payment.id,
-                payment.payment_type.to_string(),
-                payment.status.to_string(),
-                payment.amount.to_string(),
-                payment.fees.to_string(),
-                i64::try_from(payment.timestamp)?,
-                Some(payment.method.to_string()),
-                withdraw_tx_id.map(str::to_string),
-                deposit_tx_id.map(str::to_string),
-                spark,
-            ),
-        )
-        .await
-        .map_err(map_db_error)?;
-
-        match payment.details {
-            Some(PaymentDetails::Spark {
-                invoice_details,
-                htlc_details,
-                ..
-            }) => {
-                if invoice_details.is_some() || htlc_details.is_some() {
-                    let invoice_json = to_json_string_opt(invoice_details.as_ref())?;
-                    let htlc_json = to_json_string_opt(htlc_details.as_ref())?;
-                    tx.exec_drop(
-                        "INSERT INTO brz_payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
-                             VALUES (?, ?, ?, ?)
-                             ON DUPLICATE KEY UPDATE
-                                invoice_details = COALESCE(VALUES(invoice_details), invoice_details),
-                                htlc_details = COALESCE(VALUES(htlc_details), htlc_details)",
-                        (self.identity.clone(), &payment.id, invoice_json, htlc_json),
-                    )
-                    .await
-                    .map_err(map_db_error)?;
-                }
-            }
-            Some(PaymentDetails::Token {
-                metadata,
-                tx_hash,
-                tx_type,
-                invoice_details,
-                ..
-            }) => {
-                let metadata_json = serde_json::to_string(&metadata)
-                    .map_err(|e| StorageError::Serialization(e.to_string()))?;
-                let invoice_json = to_json_string_opt(invoice_details.as_ref())?;
-                tx.exec_drop(
-                    "INSERT INTO brz_payment_details_token (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
-                         VALUES (?, ?, ?, ?, ?, ?)
-                         ON DUPLICATE KEY UPDATE
-                            metadata = VALUES(metadata),
-                            tx_hash = VALUES(tx_hash),
-                            tx_type = VALUES(tx_type),
-                            invoice_details = COALESCE(VALUES(invoice_details), invoice_details)",
-                    (
-                        self.identity.clone(),
-                        &payment.id,
-                        metadata_json,
-                        tx_hash,
-                        tx_type.to_string(),
-                        invoice_json,
-                    ),
-                )
-                .await
-                .map_err(map_db_error)?;
-            }
-            Some(PaymentDetails::Lightning {
-                invoice,
-                destination_pubkey,
-                description,
-                htlc_details,
-                ..
-            }) => {
-                let payment_hash = htlc_details.payment_hash.clone();
-                let preimage = htlc_details.preimage.clone();
-                let htlc_status = htlc_details.status.to_string();
-                let htlc_expiry_time = i64::try_from(htlc_details.expiry_time)?;
-                tx.exec_drop(
-                    "INSERT INTO brz_payment_details_lightning (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
-                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                         ON DUPLICATE KEY UPDATE
-                            invoice = VALUES(invoice),
-                            payment_hash = VALUES(payment_hash),
-                            destination_pubkey = VALUES(destination_pubkey),
-                            description = VALUES(description),
-                            preimage = COALESCE(VALUES(preimage), preimage),
-                            htlc_status = COALESCE(VALUES(htlc_status), htlc_status),
-                            htlc_expiry_time = COALESCE(VALUES(htlc_expiry_time), htlc_expiry_time)",
-                    (
-                        self.identity.clone(),
-                        &payment.id,
-                        invoice,
-                        payment_hash,
-                        destination_pubkey,
-                        description,
-                        preimage,
-                        htlc_status,
-                        htlc_expiry_time,
-                    ),
-                )
-                .await
-                .map_err(map_db_error)?;
-            }
-            Some(PaymentDetails::Withdraw { .. } | PaymentDetails::Deposit { .. }) | None => {}
+        if acquired != Some(1) {
+            return Err(StorageError::Implementation(format!(
+                "Timed out acquiring payment update lock '{lock_name}'"
+            )));
         }
 
-        tx.commit().await.map_err(map_db_error)?;
-        Ok(())
+        let result = async {
+            let mut tx = conn
+                .start_transaction(tx_opts())
+                .await
+                .map_err(map_db_error)?;
+            let stored_status =
+                Self::get_payment_status_in_tx(&mut tx, &self.identity, &payment.id).await?;
+
+            // Guard against downgrading a terminal status.
+            if let Some(stored) = stored_status
+                && stored.is_final()
+                && stored != payment.status
+            {
+                warn!(
+                    "Skipping payment update (would replace terminal status): id={} stored={stored:?} new={:?}",
+                    payment.id, payment.status
+                );
+                tx.commit().await.map_err(map_db_error)?;
+                return Ok(false);
+            }
+
+            let same_status = stored_status == Some(payment.status);
+            if same_status {
+                tracing::debug!(
+                    "Skipping redundant payment event: id={} status={:?}",
+                    payment.id, payment.status
+                );
+            }
+            Self::insert_payment_in_tx(&mut tx, &self.identity, payment).await?;
+            tx.commit().await.map_err(map_db_error)?;
+            Ok(!same_status)
+        }
+        .await;
+
+        let release_result = conn
+            .exec_drop("SELECT RELEASE_LOCK(?)", (lock_name.as_str(),))
+            .await
+            .map_err(map_db_error);
+
+        match (result, release_result) {
+            (Ok(should_emit), Ok(())) => Ok(should_emit),
+            (Err(e), _) | (Ok(_), Err(e)) => Err(e),
+        }
     }
 
     async fn insert_payment_metadata(
@@ -2113,6 +2202,15 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_payment_terminal_status_is_not_replaced() {
+        let fixture = MysqlTestFixture::new().await;
+        crate::persist::tests::test_payment_terminal_status_is_not_replaced(Box::new(
+            fixture.storage,
+        ))
+        .await;
+    }
+
+    #[tokio::test]
     async fn test_payment_metadata_merge() {
         let fixture = MysqlTestFixture::new().await;
         crate::persist::tests::test_payment_metadata_merge(Box::new(fixture.storage)).await;
@@ -2225,8 +2323,8 @@ mod tests {
             *destination_pubkey = "pkB".to_string();
         }
 
-        fx.a.insert_payment(pmt_a.clone()).await.unwrap();
-        fx.b.insert_payment(pmt_b.clone()).await.unwrap();
+        fx.a.apply_payment_update(pmt_a.clone()).await.unwrap();
+        fx.b.apply_payment_update(pmt_b.clone()).await.unwrap();
 
         let list_a =
             fx.a.list_payments(StorageListPaymentsRequest::default())

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -5,22 +5,24 @@
 
 use std::collections::HashMap;
 
+use bitcoin::hashes::{Hash, HashEngine, sha256};
 use macros::async_trait;
 use spark_postgres::deadpool_postgres;
 use spark_postgres::tokio_postgres;
 
 use deadpool_postgres::Pool;
-use tokio_postgres::{Row, types::ToSql};
+use tokio_postgres::{Row, Transaction, types::ToSql};
 use tracing::warn;
 
 use crate::{
     AssetFilter, Contact, ConversionDetails, ConversionInfo, ConversionStatus, DepositInfo,
     ListContactsRequest, LnurlPayInfo, LnurlReceiveMetadata, LnurlWithdrawInfo, PaymentDetails,
-    PaymentMethod, SparkHtlcDetails, SparkHtlcStatus,
+    PaymentMethod, PaymentStatus, SparkHtlcDetails, SparkHtlcStatus,
     error::DepositClaimError,
     persist::{
         Payment, PaymentMetadata, SetLnurlMetadataItem, Storage, StorageError,
         StorageListPaymentsRequest, StoragePaymentDetailsFilter, UpdateDepositPayload,
+        parse_payment_status,
     },
     sync_storage::{
         IncomingChange, OutgoingChange, Record, RecordChange, RecordId, UnversionedRecordChange,
@@ -550,6 +552,163 @@ fn from_json_opt<T: serde::de::DeserializeOwned>(
         .map_err(|e| StorageError::Serialization(e.to_string()))
 }
 
+impl PostgresStorage {
+    fn payment_update_lock_key(identity: &[u8], payment_id: &str) -> i64 {
+        let mut engine = sha256::Hash::engine();
+        engine.input(b"brz_payment_update");
+        engine.input(identity);
+        engine.input(payment_id.as_bytes());
+        let digest = sha256::Hash::from_engine(engine);
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(&digest.as_byte_array()[..8]);
+        i64::from_be_bytes(buf)
+    }
+
+    async fn get_payment_status_in_tx(
+        tx: &Transaction<'_>,
+        identity: &[u8],
+        payment_id: &str,
+    ) -> Result<Option<PaymentStatus>, StorageError> {
+        let row = tx
+            .query_opt(
+                "SELECT status FROM brz_payments WHERE user_id = $1 AND id = $2 FOR UPDATE",
+                &[&identity, &payment_id],
+            )
+            .await
+            .map_err(map_db_error)?;
+
+        row.map(|row| {
+            let status: String = row.get(0);
+            parse_payment_status(&status)
+        })
+        .transpose()
+    }
+
+    #[allow(clippy::too_many_lines)]
+    async fn insert_payment_in_tx(
+        tx: &Transaction<'_>,
+        identity: &[u8],
+        payment: Payment,
+    ) -> Result<(), StorageError> {
+        // Compute detail columns for the main payments row
+        let (withdraw_tx_id, deposit_tx_id, spark): (Option<&str>, Option<&str>, Option<bool>) =
+            match &payment.details {
+                Some(PaymentDetails::Withdraw { tx_id }) => (Some(tx_id.as_str()), None, None),
+                Some(PaymentDetails::Deposit { tx_id }) => (None, Some(tx_id.as_str()), None),
+                Some(PaymentDetails::Spark { .. }) => (None, None, Some(true)),
+                _ => (None, None, None),
+            };
+
+        // Insert or update main payment record (including detail columns atomically)
+        tx.execute(
+            "INSERT INTO brz_payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                 ON CONFLICT(user_id, id) DO UPDATE SET
+                    payment_type = EXCLUDED.payment_type,
+                    status = EXCLUDED.status,
+                    amount = EXCLUDED.amount,
+                    fees = EXCLUDED.fees,
+                    timestamp = EXCLUDED.timestamp,
+                    method = EXCLUDED.method,
+                    withdraw_tx_id = EXCLUDED.withdraw_tx_id,
+                    deposit_tx_id = EXCLUDED.deposit_tx_id,
+                    spark = EXCLUDED.spark",
+            &[
+                &identity,
+                &payment.id,
+                &payment.payment_type.to_string(),
+                &payment.status.to_string(),
+                &payment.amount.to_string(),
+                &payment.fees.to_string(),
+                &i64::try_from(payment.timestamp)?,
+                &Some(payment.method.to_string()),
+                &withdraw_tx_id,
+                &deposit_tx_id,
+                &spark,
+            ],
+        )
+        .await
+        .map_err(map_db_error)?;
+
+        match payment.details {
+            Some(PaymentDetails::Spark {
+                invoice_details,
+                htlc_details,
+                ..
+            }) => {
+                if invoice_details.is_some() || htlc_details.is_some() {
+                    let invoice_json = to_json_opt(invoice_details.as_ref())?;
+                    let htlc_json = to_json_opt(htlc_details.as_ref())?;
+                    tx.execute(
+                        "INSERT INTO brz_payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
+                             VALUES ($1, $2, $3, $4)
+                             ON CONFLICT(user_id, payment_id) DO UPDATE SET
+                                invoice_details = COALESCE(EXCLUDED.invoice_details, brz_payment_details_spark.invoice_details),
+                                htlc_details = COALESCE(EXCLUDED.htlc_details, brz_payment_details_spark.htlc_details)",
+                        &[&identity, &payment.id, &invoice_json, &htlc_json],
+                    )
+                    .await
+                    .map_err(map_db_error)?;
+                }
+            }
+            Some(PaymentDetails::Token {
+                metadata,
+                tx_hash,
+                tx_type,
+                invoice_details,
+                ..
+            }) => {
+                let metadata_json = serde_json::to_value(&metadata)
+                    .map_err(|e| StorageError::Serialization(e.to_string()))?;
+                let invoice_json = to_json_opt(invoice_details.as_ref())?;
+                tx.execute(
+                    "INSERT INTO brz_payment_details_token (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
+                         VALUES ($1, $2, $3, $4, $5, $6)
+                         ON CONFLICT(user_id, payment_id) DO UPDATE SET
+                            metadata = EXCLUDED.metadata,
+                            tx_hash = EXCLUDED.tx_hash,
+                            tx_type = EXCLUDED.tx_type,
+                            invoice_details = COALESCE(EXCLUDED.invoice_details, brz_payment_details_token.invoice_details)",
+                    &[&identity, &payment.id, &metadata_json, &tx_hash, &tx_type.to_string(), &invoice_json],
+                )
+                .await
+                .map_err(map_db_error)?;
+            }
+            Some(PaymentDetails::Lightning {
+                invoice,
+                destination_pubkey,
+                description,
+                htlc_details,
+                ..
+            }) => {
+                let payment_hash = &htlc_details.payment_hash;
+                let preimage = &htlc_details.preimage;
+                let htlc_status = htlc_details.status.to_string();
+                let htlc_expiry_time = i64::try_from(htlc_details.expiry_time)?;
+                tx.execute(
+                    "INSERT INTO brz_payment_details_lightning (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
+                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                         ON CONFLICT(user_id, payment_id) DO UPDATE SET
+                            invoice = EXCLUDED.invoice,
+                            payment_hash = EXCLUDED.payment_hash,
+                            destination_pubkey = EXCLUDED.destination_pubkey,
+                            description = EXCLUDED.description,
+                            preimage = COALESCE(EXCLUDED.preimage, brz_payment_details_lightning.preimage),
+                            htlc_status = COALESCE(EXCLUDED.htlc_status, brz_payment_details_lightning.htlc_status),
+                            htlc_expiry_time = COALESCE(EXCLUDED.htlc_expiry_time, brz_payment_details_lightning.htlc_expiry_time)",
+                    &[&identity, &payment.id, &invoice, payment_hash, &destination_pubkey, &description, preimage, &htlc_status, &htlc_expiry_time],
+                )
+                .await
+                .map_err(map_db_error)?;
+            }
+            // Withdraw/Deposit detail columns are already set in the main INSERT
+            Some(PaymentDetails::Withdraw { .. } | PaymentDetails::Deposit { .. }) | None => {}
+        }
+
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl Storage for PostgresStorage {
     #[allow(clippy::too_many_lines, clippy::arithmetic_side_effects)]
@@ -769,126 +928,40 @@ impl Storage for PostgresStorage {
         Ok(payments)
     }
 
-    #[allow(clippy::too_many_lines)]
-    async fn insert_payment(&self, payment: Payment) -> Result<(), StorageError> {
+    async fn apply_payment_update(&self, payment: Payment) -> Result<bool, StorageError> {
         let mut client = self.pool.get().await.map_err(map_pool_error)?;
-
         let tx = client.transaction().await.map_err(map_db_error)?;
+        let payment_lock_key = Self::payment_update_lock_key(&self.identity, &payment.id);
+        tx.execute("SELECT pg_advisory_xact_lock($1)", &[&payment_lock_key])
+            .await
+            .map_err(map_db_error)?;
+        let stored_status =
+            Self::get_payment_status_in_tx(&tx, &self.identity, &payment.id).await?;
 
-        // Compute detail columns for the main payments row
-        let (withdraw_tx_id, deposit_tx_id, spark): (Option<&str>, Option<&str>, Option<bool>) =
-            match &payment.details {
-                Some(PaymentDetails::Withdraw { tx_id }) => (Some(tx_id.as_str()), None, None),
-                Some(PaymentDetails::Deposit { tx_id }) => (None, Some(tx_id.as_str()), None),
-                Some(PaymentDetails::Spark { .. }) => (None, None, Some(true)),
-                _ => (None, None, None),
-            };
-
-        // Insert or update main payment record (including detail columns atomically)
-        tx.execute(
-            "INSERT INTO brz_payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-                 ON CONFLICT(user_id, id) DO UPDATE SET
-                    payment_type = EXCLUDED.payment_type,
-                    status = EXCLUDED.status,
-                    amount = EXCLUDED.amount,
-                    fees = EXCLUDED.fees,
-                    timestamp = EXCLUDED.timestamp,
-                    method = EXCLUDED.method,
-                    withdraw_tx_id = EXCLUDED.withdraw_tx_id,
-                    deposit_tx_id = EXCLUDED.deposit_tx_id,
-                    spark = EXCLUDED.spark",
-            &[
-                &self.identity,
-                &payment.id,
-                &payment.payment_type.to_string(),
-                &payment.status.to_string(),
-                &payment.amount.to_string(),
-                &payment.fees.to_string(),
-                &i64::try_from(payment.timestamp)?,
-                &Some(payment.method.to_string()),
-                &withdraw_tx_id,
-                &deposit_tx_id,
-                &spark,
-            ],
-        )
-        .await?;
-
-        match payment.details {
-            Some(PaymentDetails::Spark {
-                invoice_details,
-                htlc_details,
-                ..
-            }) => {
-                if invoice_details.is_some() || htlc_details.is_some() {
-                    let invoice_json = to_json_opt(invoice_details.as_ref())?;
-                    let htlc_json = to_json_opt(htlc_details.as_ref())?;
-                    tx.execute(
-                        "INSERT INTO brz_payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
-                             VALUES ($1, $2, $3, $4)
-                             ON CONFLICT(user_id, payment_id) DO UPDATE SET
-                                invoice_details = COALESCE(EXCLUDED.invoice_details, brz_payment_details_spark.invoice_details),
-                                htlc_details = COALESCE(EXCLUDED.htlc_details, brz_payment_details_spark.htlc_details)",
-                        &[&self.identity, &payment.id, &invoice_json, &htlc_json],
-                    )
-                    .await?;
-                }
-            }
-            Some(PaymentDetails::Token {
-                metadata,
-                tx_hash,
-                tx_type,
-                invoice_details,
-                ..
-            }) => {
-                let metadata_json = serde_json::to_value(&metadata)
-                    .map_err(|e| StorageError::Serialization(e.to_string()))?;
-                let invoice_json = to_json_opt(invoice_details.as_ref())?;
-                tx.execute(
-                    "INSERT INTO brz_payment_details_token (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
-                         VALUES ($1, $2, $3, $4, $5, $6)
-                         ON CONFLICT(user_id, payment_id) DO UPDATE SET
-                            metadata = EXCLUDED.metadata,
-                            tx_hash = EXCLUDED.tx_hash,
-                            tx_type = EXCLUDED.tx_type,
-                            invoice_details = COALESCE(EXCLUDED.invoice_details, brz_payment_details_token.invoice_details)",
-                    &[&self.identity, &payment.id, &metadata_json, &tx_hash, &tx_type.to_string(), &invoice_json],
-                )
-                .await?;
-            }
-            Some(PaymentDetails::Lightning {
-                invoice,
-                destination_pubkey,
-                description,
-                htlc_details,
-                ..
-            }) => {
-                let payment_hash = &htlc_details.payment_hash;
-                let preimage = &htlc_details.preimage;
-                let htlc_status = htlc_details.status.to_string();
-                let htlc_expiry_time = i64::try_from(htlc_details.expiry_time)?;
-                tx.execute(
-                    "INSERT INTO brz_payment_details_lightning (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
-                         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-                         ON CONFLICT(user_id, payment_id) DO UPDATE SET
-                            invoice = EXCLUDED.invoice,
-                            payment_hash = EXCLUDED.payment_hash,
-                            destination_pubkey = EXCLUDED.destination_pubkey,
-                            description = EXCLUDED.description,
-                            preimage = COALESCE(EXCLUDED.preimage, brz_payment_details_lightning.preimage),
-                            htlc_status = COALESCE(EXCLUDED.htlc_status, brz_payment_details_lightning.htlc_status),
-                            htlc_expiry_time = COALESCE(EXCLUDED.htlc_expiry_time, brz_payment_details_lightning.htlc_expiry_time)",
-                    &[&self.identity, &payment.id, &invoice, payment_hash, &destination_pubkey, &description, preimage, &htlc_status, &htlc_expiry_time],
-                )
-                .await?;
-            }
-            // Withdraw/Deposit detail columns are already set in the main INSERT
-            Some(PaymentDetails::Withdraw { .. } | PaymentDetails::Deposit { .. }) | None => {}
+        // Guard against downgrading a terminal status.
+        if let Some(stored) = stored_status
+            && stored.is_final()
+            && stored != payment.status
+        {
+            warn!(
+                "Skipping payment update (would replace terminal status): id={} stored={stored:?} new={:?}",
+                payment.id, payment.status
+            );
+            tx.commit().await.map_err(map_db_error)?;
+            return Ok(false);
         }
 
+        let same_status = stored_status == Some(payment.status);
+        if same_status {
+            tracing::debug!(
+                "Skipping redundant payment event: id={} status={:?}",
+                payment.id,
+                payment.status
+            );
+        }
+        Self::insert_payment_in_tx(&tx, &self.identity, payment).await?;
         tx.commit().await.map_err(map_db_error)?;
-
-        Ok(())
+        Ok(!same_status)
     }
 
     async fn insert_payment_metadata(
@@ -1987,6 +2060,15 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_payment_terminal_status_is_not_replaced() {
+        let fixture = PostgresTestFixture::new().await;
+        crate::persist::tests::test_payment_terminal_status_is_not_replaced(Box::new(
+            fixture.storage,
+        ))
+        .await;
+    }
+
+    #[tokio::test]
     async fn test_payment_metadata_merge() {
         let fixture = PostgresTestFixture::new().await;
         crate::persist::tests::test_payment_metadata_merge(Box::new(fixture.storage)).await;
@@ -2113,8 +2195,8 @@ mod tests {
             *destination_pubkey = "pkB".to_string();
         }
 
-        fx.a.insert_payment(pmt_a.clone()).await.unwrap();
-        fx.b.insert_payment(pmt_b.clone()).await.unwrap();
+        fx.a.apply_payment_update(pmt_a.clone()).await.unwrap();
+        fx.b.apply_payment_update(pmt_b.clone()).await.unwrap();
 
         // Each tenant's list contains only its own row.
         let list_a =

--- a/crates/breez-sdk/core/src/persist/sqlite.rs
+++ b/crates/breez-sdk/core/src/persist/sqlite.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use macros::async_trait;
 use rusqlite::{
-    Connection, Row, ToSql, TransactionBehavior, params,
+    Connection, Row, ToSql, Transaction, TransactionBehavior, params,
     types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, ValueRef},
 };
 use rusqlite_migration::{M, Migrations, SchemaVersion};
@@ -10,11 +10,11 @@ use rusqlite_migration::{M, Migrations, SchemaVersion};
 use crate::{
     AssetFilter, Contact, ConversionDetails, ConversionInfo, ConversionStatus, DepositInfo,
     ListContactsRequest, LnurlPayInfo, LnurlReceiveMetadata, LnurlWithdrawInfo, PaymentDetails,
-    PaymentMethod, SparkHtlcDetails, SparkHtlcStatus, TokenTransactionType,
+    PaymentMethod, PaymentStatus, SparkHtlcDetails, SparkHtlcStatus, TokenTransactionType,
     error::DepositClaimError,
     persist::{
         PaymentMetadata, SetLnurlMetadataItem, StorageListPaymentsRequest,
-        StoragePaymentDetailsFilter, UpdateDepositPayload,
+        StoragePaymentDetailsFilter, UpdateDepositPayload, parse_payment_status,
     },
     sync_storage::{
         IncomingChange, OutgoingChange, Record, RecordChange, RecordId, UnversionedRecordChange,
@@ -360,6 +360,144 @@ impl From<rusqlite_migration::Error> for StorageError {
     }
 }
 
+impl SqliteStorage {
+    fn get_payment_status_in_tx(
+        tx: &Transaction<'_>,
+        payment_id: &str,
+    ) -> Result<Option<PaymentStatus>, StorageError> {
+        match tx.query_row(
+            "SELECT status FROM payments WHERE id = ?",
+            params![payment_id],
+            |row| row.get::<_, String>(0),
+        ) {
+            Ok(status) => Ok(Some(parse_payment_status(&status)?)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn insert_payment_in_tx(tx: &Transaction<'_>, payment: Payment) -> Result<(), StorageError> {
+        // Compute detail columns for the main payments row
+        let (withdraw_tx_id, deposit_tx_id, spark): (Option<&str>, Option<&str>, Option<bool>) =
+            match &payment.details {
+                Some(PaymentDetails::Withdraw { tx_id }) => (Some(tx_id.as_str()), None, None),
+                Some(PaymentDetails::Deposit { tx_id }) => (None, Some(tx_id.as_str()), None),
+                Some(PaymentDetails::Spark { .. }) => (None, None, Some(true)),
+                _ => (None, None, None),
+            };
+
+        // Insert or update main payment record (including detail columns atomically)
+        tx.execute(
+            "INSERT INTO payments (id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+                payment_type=excluded.payment_type,
+                status=excluded.status,
+                amount=excluded.amount,
+                fees=excluded.fees,
+                timestamp=excluded.timestamp,
+                method=excluded.method,
+                withdraw_tx_id=excluded.withdraw_tx_id,
+                deposit_tx_id=excluded.deposit_tx_id,
+                spark=excluded.spark",
+            params![
+                payment.id,
+                payment.payment_type.to_string(),
+                payment.status.to_string(),
+                U128SqlWrapper(payment.amount),
+                U128SqlWrapper(payment.fees),
+                payment.timestamp,
+                payment.method,
+                withdraw_tx_id,
+                deposit_tx_id,
+                spark,
+            ],
+        )?;
+
+        match payment.details {
+            Some(PaymentDetails::Spark {
+                invoice_details,
+                htlc_details,
+                ..
+            }) => {
+                if invoice_details.is_some() || htlc_details.is_some() {
+                    // Upsert both details together and avoid overwriting existing data with NULLs
+                    tx.execute(
+                        "INSERT INTO payment_details_spark (payment_id, invoice_details, htlc_details)
+                         VALUES (?, ?, ?)
+                         ON CONFLICT(payment_id) DO UPDATE SET
+                            invoice_details=COALESCE(excluded.invoice_details, payment_details_spark.invoice_details),
+                            htlc_details=COALESCE(excluded.htlc_details, payment_details_spark.htlc_details)",
+                        params![
+                            payment.id,
+                            invoice_details.as_ref().map(serde_json::to_string).transpose()?,
+                            htlc_details.as_ref().map(serde_json::to_string).transpose()?,
+                        ],
+                    )?;
+                }
+            }
+            Some(PaymentDetails::Token {
+                metadata,
+                tx_hash,
+                tx_type,
+                invoice_details,
+                ..
+            }) => {
+                tx.execute(
+                    "INSERT INTO payment_details_token (payment_id, metadata, tx_hash, tx_type, invoice_details)
+                     VALUES (?, ?, ?, ?, ?)
+                     ON CONFLICT(payment_id) DO UPDATE SET
+                        metadata=excluded.metadata,
+                        tx_hash=excluded.tx_hash,
+                        tx_type=excluded.tx_type,
+                        invoice_details=COALESCE(excluded.invoice_details, payment_details_token.invoice_details)",
+                    params![
+                        payment.id,
+                        serde_json::to_string(&metadata)?,
+                        tx_hash,
+                        tx_type.to_string(),
+                        invoice_details.as_ref().map(serde_json::to_string).transpose()?,
+                    ],
+                )?;
+            }
+            Some(PaymentDetails::Lightning {
+                invoice,
+                destination_pubkey,
+                description,
+                htlc_details,
+                ..
+            }) => {
+                tx.execute(
+                    "INSERT INTO payment_details_lightning (payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                     ON CONFLICT(payment_id) DO UPDATE SET
+                        invoice=excluded.invoice,
+                        payment_hash=excluded.payment_hash,
+                        destination_pubkey=excluded.destination_pubkey,
+                        description=excluded.description,
+                        preimage=COALESCE(excluded.preimage, payment_details_lightning.preimage),
+                        htlc_status=COALESCE(excluded.htlc_status, payment_details_lightning.htlc_status),
+                        htlc_expiry_time=COALESCE(excluded.htlc_expiry_time, payment_details_lightning.htlc_expiry_time)",
+                    params![
+                        payment.id,
+                        invoice,
+                        htlc_details.payment_hash,
+                        destination_pubkey,
+                        description,
+                        htlc_details.preimage,
+                        htlc_details.status.to_string(),
+                        htlc_details.expiry_time,
+                    ],
+                )?;
+            }
+            Some(PaymentDetails::Withdraw { .. } | PaymentDetails::Deposit { .. }) | None => {}
+        }
+
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl Storage for SqliteStorage {
     #[allow(clippy::too_many_lines)]
@@ -554,129 +692,35 @@ impl Storage for SqliteStorage {
         Ok(payments)
     }
 
-    #[allow(clippy::too_many_lines)]
-    async fn insert_payment(&self, payment: Payment) -> Result<(), StorageError> {
+    async fn apply_payment_update(&self, payment: Payment) -> Result<bool, StorageError> {
         let mut connection = self.get_connection()?;
         let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let stored_status = Self::get_payment_status_in_tx(&tx, &payment.id)?;
 
-        // Compute detail columns for the main payments row
-        let (withdraw_tx_id, deposit_tx_id, spark): (Option<&str>, Option<&str>, Option<bool>) =
-            match &payment.details {
-                Some(PaymentDetails::Withdraw { tx_id }) => (Some(tx_id.as_str()), None, None),
-                Some(PaymentDetails::Deposit { tx_id }) => (None, Some(tx_id.as_str()), None),
-                Some(PaymentDetails::Spark { .. }) => (None, None, Some(true)),
-                _ => (None, None, None),
-            };
-
-        // Insert or update main payment record (including detail columns atomically)
-        tx.execute(
-            "INSERT INTO payments (id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(id) DO UPDATE SET
-                payment_type=excluded.payment_type,
-                status=excluded.status,
-                amount=excluded.amount,
-                fees=excluded.fees,
-                timestamp=excluded.timestamp,
-                method=excluded.method,
-                withdraw_tx_id=excluded.withdraw_tx_id,
-                deposit_tx_id=excluded.deposit_tx_id,
-                spark=excluded.spark",
-            params![
-                payment.id,
-                payment.payment_type.to_string(),
-                payment.status.to_string(),
-                U128SqlWrapper(payment.amount),
-                U128SqlWrapper(payment.fees),
-                payment.timestamp,
-                payment.method,
-                withdraw_tx_id,
-                deposit_tx_id,
-                spark,
-            ],
-        )?;
-
-        match payment.details {
-            Some(PaymentDetails::Spark {
-                invoice_details,
-                htlc_details,
-                ..
-            }) => {
-                if invoice_details.is_some() || htlc_details.is_some() {
-                    // Upsert both details together and avoid overwriting existing data with NULLs
-                    tx.execute(
-                        "INSERT INTO payment_details_spark (payment_id, invoice_details, htlc_details)
-                         VALUES (?, ?, ?)
-                         ON CONFLICT(payment_id) DO UPDATE SET
-                            invoice_details=COALESCE(excluded.invoice_details, payment_details_spark.invoice_details),
-                            htlc_details=COALESCE(excluded.htlc_details, payment_details_spark.htlc_details)",
-                        params![
-                            payment.id,
-                            invoice_details.as_ref().map(serde_json::to_string).transpose()?,
-                            htlc_details.as_ref().map(serde_json::to_string).transpose()?,
-                        ],
-                    )?;
-                }
-            }
-            Some(PaymentDetails::Token {
-                metadata,
-                tx_hash,
-                tx_type,
-                invoice_details,
-                ..
-            }) => {
-                tx.execute(
-                    "INSERT INTO payment_details_token (payment_id, metadata, tx_hash, tx_type, invoice_details)
-                     VALUES (?, ?, ?, ?, ?)
-                     ON CONFLICT(payment_id) DO UPDATE SET 
-                        metadata=excluded.metadata,
-                        tx_hash=excluded.tx_hash,
-                        tx_type=excluded.tx_type,
-                        invoice_details=COALESCE(excluded.invoice_details, payment_details_token.invoice_details)",
-                    params![
-                        payment.id,
-                        serde_json::to_string(&metadata)?,
-                        tx_hash,
-                        tx_type.to_string(),
-                        invoice_details.as_ref().map(serde_json::to_string).transpose()?,
-                    ],
-                )?;
-            }
-            Some(PaymentDetails::Lightning {
-                invoice,
-                destination_pubkey,
-                description,
-                htlc_details,
-                ..
-            }) => {
-                tx.execute(
-                    "INSERT INTO payment_details_lightning (payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                     ON CONFLICT(payment_id) DO UPDATE SET
-                        invoice=excluded.invoice,
-                        payment_hash=excluded.payment_hash,
-                        destination_pubkey=excluded.destination_pubkey,
-                        description=excluded.description,
-                        preimage=COALESCE(excluded.preimage, payment_details_lightning.preimage),
-                        htlc_status=COALESCE(excluded.htlc_status, payment_details_lightning.htlc_status),
-                        htlc_expiry_time=COALESCE(excluded.htlc_expiry_time, payment_details_lightning.htlc_expiry_time)",
-                    params![
-                        payment.id,
-                        invoice,
-                        htlc_details.payment_hash,
-                        destination_pubkey,
-                        description,
-                        htlc_details.preimage,
-                        htlc_details.status.to_string(),
-                        htlc_details.expiry_time,
-                    ],
-                )?;
-            }
-            Some(PaymentDetails::Withdraw { .. } | PaymentDetails::Deposit { .. }) | None => {}
+        // Guard against downgrading a terminal status.
+        if let Some(stored) = stored_status
+            && stored.is_final()
+            && stored != payment.status
+        {
+            warn!(
+                "Skipping payment update (would replace terminal status): id={} stored={stored:?} new={:?}",
+                payment.id, payment.status
+            );
+            tx.commit()?;
+            return Ok(false);
         }
 
+        let same_status = stored_status == Some(payment.status);
+        if same_status {
+            tracing::debug!(
+                "Skipping redundant payment event: id={} status={:?}",
+                payment.id,
+                payment.status
+            );
+        }
+        Self::insert_payment_in_tx(&tx, payment)?;
         tx.commit()?;
-        Ok(())
+        Ok(!same_status)
     }
 
     async fn insert_payment_metadata(
@@ -1841,6 +1885,15 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_payment_terminal_status_is_not_replaced() {
+        let temp_dir = create_temp_dir("sqlite_storage_payment_terminal_guard");
+        let storage = SqliteStorage::new(&temp_dir).unwrap();
+
+        crate::persist::tests::test_payment_terminal_status_is_not_replaced(Box::new(storage))
+            .await;
+    }
+
+    #[tokio::test]
     async fn test_sync_storage() {
         let temp_dir = create_temp_dir("sqlite_sync_storage");
         let storage = SqliteStorage::new(&temp_dir).unwrap();
@@ -1991,7 +2044,7 @@ mod tests {
             conversion_details: None,
         };
 
-        storage.insert_payment(new_payment).await.unwrap();
+        storage.apply_payment_update(new_payment).await.unwrap();
 
         // Step 6: List all payments
         let request = StorageListPaymentsRequest {

--- a/crates/breez-sdk/core/src/persist/tests.rs
+++ b/crates/breez-sdk/core/src/persist/tests.rs
@@ -789,7 +789,7 @@ pub async fn test_storage(storage: Box<dyn Storage>) {
 
     // Insert all payments
     for payment in &test_payments {
-        storage.insert_payment(payment.clone()).await.unwrap();
+        storage.apply_payment_update(payment.clone()).await.unwrap();
     }
     storage
         .insert_payment_metadata(lightning_lnurl_pay_payment.id.clone(), pay_metadata)
@@ -1086,7 +1086,7 @@ pub async fn test_storage(storage: Box<dyn Storage>) {
     };
 
     storage
-        .insert_payment(lightning_zap_payment.clone())
+        .apply_payment_update(lightning_zap_payment.clone())
         .await
         .unwrap();
 
@@ -1178,11 +1178,11 @@ pub async fn test_storage(storage: Box<dyn Storage>) {
     };
 
     storage
-        .insert_payment(lightning_zap_payment2.clone())
+        .apply_payment_update(lightning_zap_payment2.clone())
         .await
         .unwrap();
     storage
-        .insert_payment(lightning_zap_payment3.clone())
+        .apply_payment_update(lightning_zap_payment3.clone())
         .await
         .unwrap();
 
@@ -1429,8 +1429,8 @@ pub async fn test_payment_type_filtering(storage: Box<dyn Storage>) {
         conversion_details: None,
     };
 
-    storage.insert_payment(send_payment).await.unwrap();
-    storage.insert_payment(receive_payment).await.unwrap();
+    storage.apply_payment_update(send_payment).await.unwrap();
+    storage.apply_payment_update(receive_payment).await.unwrap();
 
     // Test filter by Send type only
     let send_only = storage
@@ -1522,9 +1522,12 @@ pub async fn test_payment_status_filtering(storage: Box<dyn Storage>) {
         conversion_details: None,
     };
 
-    storage.insert_payment(completed_payment).await.unwrap();
-    storage.insert_payment(pending_payment).await.unwrap();
-    storage.insert_payment(failed_payment).await.unwrap();
+    storage
+        .apply_payment_update(completed_payment)
+        .await
+        .unwrap();
+    storage.apply_payment_update(pending_payment).await.unwrap();
+    storage.apply_payment_update(failed_payment).await.unwrap();
 
     // Test filter by Completed status only
     let completed_only = storage
@@ -1654,11 +1657,17 @@ pub async fn test_asset_filtering(storage: Box<dyn Storage>) {
         conversion_details: None,
     };
 
-    storage.insert_payment(spark_payment).await.unwrap();
-    storage.insert_payment(lightning_payment).await.unwrap();
-    storage.insert_payment(token_payment).await.unwrap();
-    storage.insert_payment(withdraw_payment).await.unwrap();
-    storage.insert_payment(deposit_payment).await.unwrap();
+    storage.apply_payment_update(spark_payment).await.unwrap();
+    storage
+        .apply_payment_update(lightning_payment)
+        .await
+        .unwrap();
+    storage.apply_payment_update(token_payment).await.unwrap();
+    storage
+        .apply_payment_update(withdraw_payment)
+        .await
+        .unwrap();
+    storage.apply_payment_update(deposit_payment).await.unwrap();
 
     // Test filter by Bitcoin
     let spark_only = storage
@@ -1796,10 +1805,13 @@ pub async fn test_spark_htlc_status_filtering(storage: Box<dyn Storage>) {
     };
 
     // Insert all payments
-    storage.insert_payment(htlc_waiting).await.unwrap();
-    storage.insert_payment(htlc_shared).await.unwrap();
-    storage.insert_payment(htlc_returned).await.unwrap();
-    storage.insert_payment(non_htlc_payment).await.unwrap();
+    storage.apply_payment_update(htlc_waiting).await.unwrap();
+    storage.apply_payment_update(htlc_shared).await.unwrap();
+    storage.apply_payment_update(htlc_returned).await.unwrap();
+    storage
+        .apply_payment_update(non_htlc_payment)
+        .await
+        .unwrap();
 
     // Test filter for WaitingForPreimage
     let waiting_filter = storage
@@ -1974,10 +1986,16 @@ pub async fn test_conversion_refund_needed_filtering(storage: Box<dyn Storage>) 
         conversion_details: None,
     };
 
-    storage.insert_payment(payment_with_refund).await.unwrap();
-    storage.insert_payment(successful_conversion).await.unwrap();
     storage
-        .insert_payment(payment_without_refund)
+        .apply_payment_update(payment_with_refund)
+        .await
+        .unwrap();
+    storage
+        .apply_payment_update(successful_conversion)
+        .await
+        .unwrap();
+    storage
+        .apply_payment_update(payment_without_refund)
         .await
         .unwrap();
     storage
@@ -2159,9 +2177,9 @@ pub async fn test_token_transaction_type_filtering(storage: Box<dyn Storage>) {
         }),
         conversion_details: None,
     };
-    storage.insert_payment(payment1).await.unwrap();
-    storage.insert_payment(payment2).await.unwrap();
-    storage.insert_payment(payment3).await.unwrap();
+    storage.apply_payment_update(payment1).await.unwrap();
+    storage.apply_payment_update(payment2).await.unwrap();
+    storage.apply_payment_update(payment3).await.unwrap();
 
     // Test filter by transaction type
     let transfer_filter = storage
@@ -2260,9 +2278,9 @@ pub async fn test_timestamp_filtering(storage: Box<dyn Storage>) {
         conversion_details: None,
     };
 
-    storage.insert_payment(payment1).await.unwrap();
-    storage.insert_payment(payment2).await.unwrap();
-    storage.insert_payment(payment3).await.unwrap();
+    storage.apply_payment_update(payment1).await.unwrap();
+    storage.apply_payment_update(payment2).await.unwrap();
+    storage.apply_payment_update(payment3).await.unwrap();
 
     // Test filter by from_timestamp
     let from_2000 = storage
@@ -2358,9 +2376,9 @@ pub async fn test_combined_filters(storage: Box<dyn Storage>) {
         conversion_details: None,
     };
 
-    storage.insert_payment(payment1).await.unwrap();
-    storage.insert_payment(payment2).await.unwrap();
-    storage.insert_payment(payment3).await.unwrap();
+    storage.apply_payment_update(payment1).await.unwrap();
+    storage.apply_payment_update(payment2).await.unwrap();
+    storage.apply_payment_update(payment3).await.unwrap();
 
     // Test: Send + Completed
     let send_completed = storage
@@ -2450,9 +2468,9 @@ pub async fn test_sort_order(storage: Box<dyn Storage>) {
         conversion_details: None,
     };
 
-    storage.insert_payment(payment1).await.unwrap();
-    storage.insert_payment(payment2).await.unwrap();
-    storage.insert_payment(payment3).await.unwrap();
+    storage.apply_payment_update(payment1).await.unwrap();
+    storage.apply_payment_update(payment2).await.unwrap();
+    storage.apply_payment_update(payment3).await.unwrap();
 
     // Test default sort (descending by timestamp)
     let desc_payments = storage
@@ -2578,11 +2596,11 @@ pub async fn test_payment_details_update_persistence(storage: Box<dyn Storage>) 
     };
 
     // Insert the payment into storage
-    storage.insert_payment(payment.clone()).await.unwrap();
+    storage.apply_payment_update(payment.clone()).await.unwrap();
 
     // Simulate payment completion by updating status
     payment.status = PaymentStatus::Completed;
-    storage.insert_payment(payment.clone()).await.unwrap();
+    storage.apply_payment_update(payment.clone()).await.unwrap();
 
     // Check the payment details
     let updated_payment = storage
@@ -2609,7 +2627,8 @@ pub async fn test_payment_details_update_persistence(storage: Box<dyn Storage>) 
         }),
         conversion_info: None,
     });
-    storage.insert_payment(payment.clone()).await.unwrap();
+    let should_emit = storage.apply_payment_update(payment.clone()).await.unwrap();
+    assert!(!should_emit, "redundant same-status update should not emit");
 
     // Check the updated payment details
     let updated_payment = storage
@@ -2627,6 +2646,59 @@ pub async fn test_payment_details_update_persistence(storage: Box<dyn Storage>) 
         htlc_details.as_ref().unwrap().preimage.as_ref().unwrap(),
         "preimage_123"
     );
+}
+
+pub async fn test_payment_terminal_status_is_not_replaced(storage: Box<dyn Storage>) {
+    let mut payment = Payment {
+        id: "payment_terminal_guard".to_string(),
+        payment_type: PaymentType::Receive,
+        status: PaymentStatus::Pending,
+        amount: 15_000,
+        fees: 150,
+        timestamp: 1_234_567_890,
+        method: PaymentMethod::Spark,
+        details: Some(PaymentDetails::Spark {
+            invoice_details: None,
+            htlc_details: Some(SparkHtlcDetails {
+                payment_hash: "terminal_guard_hash".to_string(),
+                preimage: None,
+                expiry_time: 1_234_567_990,
+                status: SparkHtlcStatus::WaitingForPreimage,
+            }),
+            conversion_info: None,
+        }),
+        conversion_details: None,
+    };
+
+    let should_emit = storage.apply_payment_update(payment.clone()).await.unwrap();
+    assert!(should_emit, "first insert should emit");
+
+    payment.status = PaymentStatus::Completed;
+    let should_emit = storage.apply_payment_update(payment.clone()).await.unwrap();
+    assert!(should_emit, "status transition should emit");
+
+    let mut stale_pending = payment.clone();
+    stale_pending.status = PaymentStatus::Pending;
+    stale_pending.amount = 1;
+    let should_emit = storage.apply_payment_update(stale_pending).await.unwrap();
+    assert!(
+        !should_emit,
+        "downgrade from terminal status should not emit"
+    );
+
+    let stored_payment = storage.get_payment_by_id(payment.id.clone()).await.unwrap();
+    assert_eq!(stored_payment.status, PaymentStatus::Completed);
+    assert_eq!(stored_payment.amount, 15_000);
+
+    let mut conflicting_final = payment.clone();
+    conflicting_final.status = PaymentStatus::Failed;
+    storage
+        .apply_payment_update(conflicting_final)
+        .await
+        .unwrap();
+
+    let stored_payment = storage.get_payment_by_id(payment.id).await.unwrap();
+    assert_eq!(stored_payment.status, PaymentStatus::Completed);
 }
 
 /// Tests that `insert_payment_metadata` preserves existing fields when updating with partial data.
@@ -2651,7 +2723,7 @@ pub async fn test_payment_metadata_merge(storage: Box<dyn Storage>) {
         }),
         conversion_details: None,
     };
-    storage.insert_payment(payment).await.unwrap();
+    storage.apply_payment_update(payment).await.unwrap();
 
     // Create the parent payment so get_payments_by_parent_ids works
     let parent_payment = Payment {
@@ -2665,7 +2737,7 @@ pub async fn test_payment_metadata_merge(storage: Box<dyn Storage>) {
         details: None,
         conversion_details: None,
     };
-    storage.insert_payment(parent_payment).await.unwrap();
+    storage.apply_payment_update(parent_payment).await.unwrap();
 
     // Step 1: Set metadata with only conversion_info
     let metadata1 = PaymentMetadata {
@@ -2829,13 +2901,19 @@ pub async fn test_lightning_htlc_details_and_status_filtering(storage: Box<dyn S
         conversion_details: None,
     };
 
-    storage.insert_payment(htlc_waiting.clone()).await.unwrap();
-    storage.insert_payment(htlc_claimed.clone()).await.unwrap();
     storage
-        .insert_payment(regular_lightning.clone())
+        .apply_payment_update(htlc_waiting.clone())
         .await
         .unwrap();
-    storage.insert_payment(spark_payment).await.unwrap();
+    storage
+        .apply_payment_update(htlc_claimed.clone())
+        .await
+        .unwrap();
+    storage
+        .apply_payment_update(regular_lightning.clone())
+        .await
+        .unwrap();
+    storage.apply_payment_update(spark_payment).await.unwrap();
 
     // Verify htlc_details is persisted and fetched correctly
     let fetched = storage
@@ -3063,7 +3141,7 @@ pub async fn test_conversion_status_persistence(storage: Box<dyn Storage>) {
 
     for (id, status) in &variants {
         let payment = make_payment(id);
-        storage.insert_payment(payment).await.unwrap();
+        storage.apply_payment_update(payment).await.unwrap();
 
         let metadata = PaymentMetadata {
             conversion_status: Some(status.clone()),
@@ -3091,7 +3169,10 @@ pub async fn test_conversion_status_persistence(storage: Box<dyn Storage>) {
 
     // --- Test 2: Payment without conversion_status has no conversion_details ---
     let no_status_payment = make_payment("cs_none");
-    storage.insert_payment(no_status_payment).await.unwrap();
+    storage
+        .apply_payment_update(no_status_payment)
+        .await
+        .unwrap();
 
     let fetched = storage
         .get_payment_by_id("cs_none".to_string())
@@ -3104,7 +3185,10 @@ pub async fn test_conversion_status_persistence(storage: Box<dyn Storage>) {
 
     // --- Test 3: COALESCE — conversion_status preserved across partial metadata updates ---
     let coalesce_payment = make_payment("cs_coalesce");
-    storage.insert_payment(coalesce_payment).await.unwrap();
+    storage
+        .apply_payment_update(coalesce_payment)
+        .await
+        .unwrap();
 
     // Set conversion_status
     let metadata1 = PaymentMetadata {

--- a/crates/breez-sdk/core/src/realtime_sync/storage.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/storage.rs
@@ -475,8 +475,8 @@ impl Storage for SyncedStorage {
         self.inner.list_payments(request).await
     }
 
-    async fn insert_payment(&self, payment: Payment) -> Result<(), StorageError> {
-        self.inner.insert_payment(payment).await
+    async fn apply_payment_update(&self, payment: Payment) -> Result<bool, StorageError> {
+        self.inner.apply_payment_update(payment).await
     }
 
     async fn insert_payment_metadata(
@@ -791,7 +791,7 @@ mod tests {
 
         // Insert a payment so we can verify metadata was NOT written
         storage
-            .insert_payment(make_test_lightning_payment("id1"))
+            .apply_payment_update(make_test_lightning_payment("id1"))
             .await
             .unwrap();
 
@@ -829,7 +829,7 @@ mod tests {
         let synced = create_test_synced_storage(Arc::clone(&storage));
 
         storage
-            .insert_payment(make_test_lightning_payment("pay1"))
+            .apply_payment_update(make_test_lightning_payment("pay1"))
             .await
             .unwrap();
 

--- a/crates/breez-sdk/core/src/sdk/deposits.rs
+++ b/crates/breez-sdk/core/src/sdk/deposits.rs
@@ -41,13 +41,14 @@ impl BreezSdk {
                 let payment: Payment = transfer.try_into()?;
                 // Insert the payment before returning so callers that
                 // immediately list payments see the claim.
-                self.storage.insert_payment(payment.clone()).await?;
+                let should_emit_event = self.storage.apply_payment_update(payment.clone()).await?;
                 self.storage
                     .delete_deposit(detailed_utxo.txid.to_string(), detailed_utxo.vout)
                     .await?;
                 self.event_emitter
                     .emit_runtime_event(RuntimeEvent::DepositClaimed {
                         payment: Box::new(payment.clone()),
+                        should_emit_event,
                     })
                     .await;
                 Ok(ClaimDepositResponse { payment })

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -32,7 +32,7 @@ use crate::{
     },
     utils::{
         payments::{
-            emit_payment_update, get_payment_with_conversion_details, record_payment_update,
+            get_payment_and_emit_event, get_payment_with_conversion_details, record_payment_update,
         },
         polling::{PollSchedule, poll_until},
         send_payment_validation::{get_dust_limit_sats, validate_prepare_send_payment_request},
@@ -1544,14 +1544,14 @@ impl BreezSdk {
                                     info!("Polling payment completed status = {}", payment.status);
                                     break 'poll Some(payment);
                                 }
-
-                                let sleep_time = if i < 5 {
-                                    Duration::from_secs(1)
-                                } else {
-                                    Duration::from_secs(i.into())
-                                };
-                                tokio::time::sleep(sleep_time).await;
                             }
+
+                            let sleep_time = if i < 5 {
+                                Duration::from_secs(1)
+                            } else {
+                                Duration::from_secs(i.into())
+                            };
+                            tokio::time::sleep(sleep_time).await;
                         }
                     }
                 }
@@ -2026,7 +2026,12 @@ impl BreezSdk {
             );
         }
 
-        emit_payment_update(&self.storage, &self.event_emitter, payment, should_emit).await
+        if should_emit {
+            get_payment_and_emit_event(&self.storage, &self.event_emitter, payment).await;
+            true
+        } else {
+            false
+        }
     }
 
     /// Polls a single Spark transfer by id and, on terminal status, claims

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -31,7 +31,9 @@ use crate::{
         ConversionAmount, DEFAULT_CONVERSION_TIMEOUT_SECS, TokenConversionResponse,
     },
     utils::{
-        payments::{get_payment_and_emit_event, get_payment_with_conversion_details},
+        payments::{
+            emit_payment_update, get_payment_with_conversion_details, record_payment_update,
+        },
         polling::{PollSchedule, poll_until},
         send_payment_validation::{get_dust_limit_sats, validate_prepare_send_payment_request},
         token::{map_and_persist_token_transaction, token_transaction_to_payments},
@@ -142,7 +144,7 @@ impl BreezSdk {
         let payment: Payment = transfer.try_into()?;
 
         // Insert the payment into storage to make it immediately available for listing
-        self.storage.insert_payment(payment.clone()).await?;
+        self.storage.apply_payment_update(payment.clone()).await?;
 
         Ok(ClaimHtlcPaymentResponse { payment })
     }
@@ -1079,7 +1081,7 @@ impl BreezSdk {
         };
 
         // Insert the payment into storage to make it immediately available for listing
-        self.storage.insert_payment(payment.clone()).await?;
+        self.storage.apply_payment_update(payment.clone()).await?;
 
         Ok(SendPaymentResponse { payment })
     }
@@ -1119,7 +1121,7 @@ impl BreezSdk {
         let payment: Payment = transfer.try_into()?;
 
         // Insert the payment into storage to make it immediately available for listing
-        self.storage.insert_payment(payment.clone()).await?;
+        self.storage.apply_payment_update(payment.clone()).await?;
 
         Ok(SendPaymentResponse { payment })
     }
@@ -1179,7 +1181,7 @@ impl BreezSdk {
         };
 
         // Insert the payment into storage to make it immediately available for listing
-        self.storage.insert_payment(payment.clone()).await?;
+        self.storage.apply_payment_update(payment.clone()).await?;
 
         Ok(SendPaymentResponse { payment })
     }
@@ -1362,7 +1364,7 @@ impl BreezSdk {
         };
 
         // Insert the payment into storage to make it immediately available for listing
-        self.storage.insert_payment(payment.clone()).await?;
+        self.storage.apply_payment_update(payment.clone()).await?;
 
         Ok(SendPaymentResponse { payment })
     }
@@ -1432,7 +1434,7 @@ impl BreezSdk {
 
         let payment: Payment = response.try_into()?;
 
-        self.storage.insert_payment(payment.clone()).await?;
+        self.storage.apply_payment_update(payment.clone()).await?;
 
         Ok(SendPaymentResponse { payment })
     }
@@ -1542,14 +1544,14 @@ impl BreezSdk {
                                     info!("Polling payment completed status = {}", payment.status);
                                     break 'poll Some(payment);
                                 }
-                            }
 
-                            let sleep_time = if i < 5 {
-                                Duration::from_secs(1)
-                            } else {
-                                Duration::from_secs(i.into())
-                            };
-                            tokio::time::sleep(sleep_time).await;
+                                let sleep_time = if i < 5 {
+                                    Duration::from_secs(1)
+                                } else {
+                                    Duration::from_secs(i.into())
+                                };
+                                tokio::time::sleep(sleep_time).await;
+                            }
                         }
                     }
                 }
@@ -1561,10 +1563,7 @@ impl BreezSdk {
             };
 
             let _ = tx.send(payment.clone());
-            if let Err(e) = storage.insert_payment(payment.clone()).await {
-                error!("Failed to update payment in storage: {e:?}");
-            }
-            get_payment_and_emit_event(&storage, &event_emitter, payment).await;
+            record_payment_update(&storage, &event_emitter, payment, true).await;
         }.instrument(span));
 
         rx
@@ -1994,14 +1993,6 @@ impl BreezSdk {
     /// refresh balances, and emit `PaymentSucceeded` if this is the first
     /// time we see this status. Returns whether an event was emitted.
     pub(crate) async fn finalize_payment(&self, mut payment: Payment) -> bool {
-        let existing_status = self
-            .storage
-            .get_payment_by_id(payment.id.clone())
-            .await
-            .ok()
-            .map(|p| p.status);
-        let status_changed = existing_status.is_none_or(|s| s != payment.status);
-
         let sync_service = SparkSyncService::new(
             self.spark_wallet.clone(),
             self.storage.clone(),
@@ -2017,12 +2008,16 @@ impl BreezSdk {
         // this pulls the LNURL metadata into the payment record.
         self.sync_single_lnurl_metadata(&mut payment).await;
 
-        if let Err(e) = self.storage.insert_payment(payment.clone()).await {
-            error!(
-                "finalize_payment({}): failed to insert payment: {e:?}",
-                payment.id
-            );
-        }
+        let should_emit = match self.storage.apply_payment_update(payment.clone()).await {
+            Ok(should_emit) => should_emit,
+            Err(e) => {
+                error!(
+                    "finalize_payment({}): failed to apply payment update: {e:?}",
+                    payment.id
+                );
+                return false;
+            }
+        };
 
         if let Err(e) = update_balances(self.spark_wallet.clone(), self.storage.clone()).await {
             error!(
@@ -2031,10 +2026,7 @@ impl BreezSdk {
             );
         }
 
-        if status_changed {
-            get_payment_and_emit_event(&self.storage, &self.event_emitter, payment).await;
-        }
-        status_changed
+        emit_payment_update(&self.storage, &self.event_emitter, payment, should_emit).await
     }
 
     /// Polls a single Spark transfer by id and, on terminal status, claims

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -16,7 +16,7 @@ use crate::{
     events::{EventListener, SdkEvent},
     persist::ObjectCacheRepository,
     token_conversion::TokenConverter,
-    utils::{payments::emit_payment_update, run_with_shutdown},
+    utils::{payments::get_payment_and_emit_event, run_with_shutdown},
 };
 use crate::{PaymentType, StorageListPaymentsRequest, StoragePaymentDetailsFilter};
 
@@ -297,9 +297,10 @@ async fn handle_wallet_event(sdk: &BreezSdk, event: WalletEvent) -> bool {
                 sdk.sync_single_lnurl_metadata(&mut payment).await;
 
                 // Drop this Pending event if sync already saw the transfer Completed.
-                payment_emitted =
-                    emit_payment_update(&sdk.storage, &sdk.event_emitter, payment, should_emit)
-                        .await;
+                if should_emit {
+                    get_payment_and_emit_event(&sdk.storage, &sdk.event_emitter, payment).await;
+                    payment_emitted = true;
+                }
             }
             payment_emitted
         }

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -16,7 +16,7 @@ use crate::{
     events::{EventListener, SdkEvent},
     persist::ObjectCacheRepository,
     token_conversion::TokenConverter,
-    utils::{payments::get_payment_and_emit_event, run_with_shutdown},
+    utils::{payments::emit_payment_update, run_with_shutdown},
 };
 use crate::{PaymentType, StorageListPaymentsRequest, StoragePaymentDetailsFilter};
 
@@ -275,8 +275,7 @@ async fn handle_wallet_event(sdk: &BreezSdk, event: WalletEvent) -> bool {
                 cleanup_claimed_deposit(sdk, &tx_id, vout).await;
             }
             if let Ok(payment) = Payment::try_from(transfer) {
-                sdk.finalize_payment(payment).await;
-                true
+                sdk.finalize_payment(payment).await
             } else {
                 false
             }
@@ -285,13 +284,22 @@ async fn handle_wallet_event(sdk: &BreezSdk, event: WalletEvent) -> bool {
             info!("Transfer claim starting");
             let mut payment_emitted = false;
             if let Ok(mut payment) = Payment::try_from(transfer) {
-                if let Err(e) = sdk.storage.insert_payment(payment.clone()).await {
-                    error!("Failed to insert pending payment: {e:?}");
-                }
+                // Persist before syncing metadata so the Pending payment is not
+                // delayed by the metadata fetch.
+                let should_emit = match sdk.storage.apply_payment_update(payment.clone()).await {
+                    Ok(should_emit) => should_emit,
+                    Err(e) => {
+                        error!("Failed to apply pending payment update: {e:?}");
+                        return false;
+                    }
+                };
 
                 sdk.sync_single_lnurl_metadata(&mut payment).await;
-                get_payment_and_emit_event(&sdk.storage, &sdk.event_emitter, payment).await;
-                payment_emitted = true;
+
+                // Drop this Pending event if sync already saw the transfer Completed.
+                payment_emitted =
+                    emit_payment_update(&sdk.storage, &sdk.event_emitter, payment, should_emit)
+                        .await;
             }
             payment_emitted
         }

--- a/crates/breez-sdk/core/src/sdk/runtime/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/mod.rs
@@ -23,6 +23,7 @@ pub(crate) enum RuntimeEvent {
     StableBalanceConversionCompleted,
     DepositClaimed {
         payment: Box<crate::models::Payment>,
+        should_emit_event: bool,
     },
 }
 

--- a/crates/breez-sdk/core/src/sdk/runtime/server.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/server.rs
@@ -78,9 +78,18 @@ struct ServerRuntimeEventHandler {
 impl crate::events::RuntimeEventHandler for ServerRuntimeEventHandler {
     async fn handle(&self, event: RuntimeEvent) {
         match event {
-            RuntimeEvent::DepositClaimed { payment } => {
-                get_payment_and_emit_event(&self.sdk.storage, &self.sdk.event_emitter, *payment)
+            RuntimeEvent::DepositClaimed {
+                payment,
+                should_emit_event,
+            } => {
+                if should_emit_event {
+                    get_payment_and_emit_event(
+                        &self.sdk.storage,
+                        &self.sdk.event_emitter,
+                        *payment,
+                    )
                     .await;
+                }
             }
             RuntimeEvent::StableBalanceConversionCompleted => {}
         }

--- a/crates/breez-sdk/core/src/sync.rs
+++ b/crates/breez-sdk/core/src/sync.rs
@@ -10,7 +10,7 @@ use crate::{
     EventEmitter, Payment, PaymentDetails, PaymentStatus, SdkError, Storage,
     persist::{CachedSyncInfo, ObjectCacheRepository, StorageListPaymentsRequest},
     utils::{
-        payments::get_payment_and_emit_event,
+        payments::record_payment_update,
         token::{token_transaction_to_payments, token_tx_inputs_are_ours},
     },
 };
@@ -95,33 +95,18 @@ impl SparkSyncService {
                 }
 
                 // Emit events for new payment statuses after initial sync, or even before initial sync if the payment is pending
-                let should_emit =
-                    if initial_sync_complete || payment.status == PaymentStatus::Pending {
-                        let maybe_existing_payment_status = self
-                            .storage
-                            .get_payment_by_id(payment.id.clone())
-                            .await
-                            .ok()
-                            .map(|p| p.status);
-                        maybe_existing_payment_status.is_none_or(|s| s != payment.status)
-                    } else {
-                        false
-                    };
-
-                // Insert payment into storage
-                if let Err(err) = self.storage.insert_payment(payment.clone()).await {
-                    error!("Failed to insert payment: {err:?}");
-                }
+                let should_emit = initial_sync_complete || payment.status == PaymentStatus::Pending;
+                record_payment_update(
+                    &self.storage,
+                    &self.event_emitter,
+                    payment.clone(),
+                    should_emit,
+                )
+                .await;
                 if payment.status == PaymentStatus::Pending {
                     pending_payments = pending_payments.saturating_add(1);
                 }
-                info!("Inserted payment: {payment:?}");
-
-                if should_emit {
-                    // Fetch the payment to include already stored metadata
-                    get_payment_and_emit_event(&self.storage, &self.event_emitter, payment.clone())
-                        .await;
-                }
+                info!("Synced payment: {payment:?}");
             }
 
             // Check if we have more transfers to fetch
@@ -219,15 +204,13 @@ impl SparkSyncService {
                 payment.id, payment.status
             );
 
-            if let Err(e) = self.storage.insert_payment(payment.clone()).await {
-                error!("Failed to update payment status during reconciliation: {e:?}");
-                continue;
-            }
-
-            if initial_sync_complete {
-                get_payment_and_emit_event(&self.storage, &self.event_emitter, payment.clone())
-                    .await;
-            }
+            record_payment_update(
+                &self.storage,
+                &self.event_emitter,
+                payment.clone(),
+                initial_sync_complete,
+            )
+            .await;
         }
     }
 
@@ -416,28 +399,16 @@ impl SparkSyncService {
         payments_to_sync.sort_by_key(|p| p.timestamp);
         for payment in &payments_to_sync {
             // Emit events for new payment statuses after initial sync, or even before initial sync if the payment is pending
-            let should_emit = if initial_sync_complete || payment.status == PaymentStatus::Pending {
-                let maybe_existing_payment_status = self
-                    .storage
-                    .get_payment_by_id(payment.id.clone())
-                    .await
-                    .ok()
-                    .map(|p| p.status);
-                maybe_existing_payment_status.is_none_or(|s| s != payment.status)
-            } else {
-                false
-            };
+            let should_emit = initial_sync_complete || payment.status == PaymentStatus::Pending;
 
-            info!("Inserting token payment: {payment:?}");
-            if let Err(e) = self.storage.insert_payment(payment.clone()).await {
-                error!("Failed to insert token payment: {e:?}");
-            }
-
-            if should_emit {
-                // Fetch the payment to include already stored metadata
-                get_payment_and_emit_event(&self.storage, &self.event_emitter, payment.clone())
-                    .await;
-            }
+            info!("Syncing token payment: {payment:?}");
+            record_payment_update(
+                &self.storage,
+                &self.event_emitter,
+                payment.clone(),
+                should_emit,
+            )
+            .await;
         }
 
         // We have synced all token transactions or found the last synced payment id.

--- a/crates/breez-sdk/core/src/utils/payments.rs
+++ b/crates/breez-sdk/core/src/utils/payments.rs
@@ -31,22 +31,6 @@ pub(crate) async fn record_payment_update(
     }
 }
 
-/// Emit a payment event based on whether storage indicated the update should
-/// produce one (new payment inserted or status transitioned).
-pub(crate) async fn emit_payment_update(
-    storage: &Arc<dyn Storage>,
-    event_emitter: &EventEmitter,
-    payment: Payment,
-    should_emit: bool,
-) -> bool {
-    if should_emit {
-        get_payment_and_emit_event(storage, event_emitter, payment).await;
-        true
-    } else {
-        false
-    }
-}
-
 /// Gets the payment from storage to include already stored metadata and conversion details.
 /// Emits the appropriate event based on its status. Falls back to the provided
 /// payment if the storage lookup fails.

--- a/crates/breez-sdk/core/src/utils/payments.rs
+++ b/crates/breez-sdk/core/src/utils/payments.rs
@@ -1,11 +1,51 @@
 use std::sync::Arc;
 
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::{
     EventEmitter, Payment, Storage, error::SdkError, events::SdkEvent,
     models::conversion_steps_from_payments,
 };
+
+/// Insert a payment through the storage status guard and emit when requested
+/// and when the persisted status advances.
+pub(crate) async fn record_payment_update(
+    storage: &Arc<dyn Storage>,
+    event_emitter: &EventEmitter,
+    payment: Payment,
+    emit_event: bool,
+) -> bool {
+    let should_emit = match storage.apply_payment_update(payment.clone()).await {
+        Ok(should_emit) => should_emit,
+        Err(err) => {
+            error!("Failed to apply payment update {}: {err:?}", payment.id);
+            return false;
+        }
+    };
+
+    if emit_event && should_emit {
+        get_payment_and_emit_event(storage, event_emitter, payment).await;
+        true
+    } else {
+        false
+    }
+}
+
+/// Emit a payment event based on whether storage indicated the update should
+/// produce one (new payment inserted or status transitioned).
+pub(crate) async fn emit_payment_update(
+    storage: &Arc<dyn Storage>,
+    event_emitter: &EventEmitter,
+    payment: Payment,
+    should_emit: bool,
+) -> bool {
+    if should_emit {
+        get_payment_and_emit_event(storage, event_emitter, payment).await;
+        true
+    } else {
+        false
+    }
+}
 
 /// Gets the payment from storage to include already stored metadata and conversion details.
 /// Emits the appropriate event based on its status. Falls back to the provided

--- a/crates/breez-sdk/core/src/utils/token.rs
+++ b/crates/breez-sdk/core/src/utils/token.rs
@@ -219,7 +219,7 @@ pub(crate) async fn map_and_persist_token_transaction(
         token_transaction_to_payments(spark_wallet, &object_repository, token_transaction, true)
             .await?;
     for payment in &payments {
-        storage.insert_payment(payment.clone()).await?;
+        storage.apply_payment_update(payment.clone()).await?;
     }
 
     payments

--- a/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
@@ -16,6 +16,8 @@
  *   → `conn.beginTransaction()`/`conn.commit()`/`conn.rollback()`.
  */
 
+const crypto = require("crypto");
+
 let mysql;
 try {
   const mainModule = require.main;
@@ -37,6 +39,8 @@ try {
 
 const { StorageError } = require("./errors.cjs");
 const { MysqlMigrationManager } = require("./migrations.cjs");
+
+const PAYMENT_UPDATE_LOCK_TIMEOUT_SECS = 10;
 
 /**
  * Base query for payment lookups. All columns are accessed by name in _rowToPayment.
@@ -360,129 +364,228 @@ class MysqlStorage {
     }
   }
 
-  async insertPayment(payment) {
+  async applyPaymentUpdate(payment) {
+    if (!payment) {
+      throw new StorageError("Payment cannot be null or undefined");
+    }
+
+    let conn = null;
+    const lockName = this._paymentUpdateLockName(payment.id);
+    let acquired = false;
+    let shouldEmit = false;
+    let operationError = null;
+    let releaseError = null;
+
     try {
-      if (!payment) {
-        throw new StorageError("Payment cannot be null or undefined");
+      conn = await this.pool.getConnection();
+      const [lockRows] = await conn.query("SELECT GET_LOCK(?, ?) AS acquired", [
+        lockName,
+        PAYMENT_UPDATE_LOCK_TIMEOUT_SECS,
+      ]);
+      acquired = Number(lockRows?.[0]?.acquired) === 1;
+      if (!acquired) {
+        throw new StorageError(`Timed out acquiring payment update lock '${lockName}'`);
       }
 
-      await this._withTransaction(async (conn) => {
-        const withdrawTxId =
-          payment.details?.type === "withdraw" ? payment.details.txId : null;
-        const depositTxId =
-          payment.details?.type === "deposit" ? payment.details.txId : null;
-        const spark = payment.details?.type === "spark" ? 1 : null;
-
-        await conn.query(
-          `INSERT INTO brz_payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-           ON DUPLICATE KEY UPDATE
-             payment_type=VALUES(payment_type),
-             status=VALUES(status),
-             amount=VALUES(amount),
-             fees=VALUES(fees),
-             timestamp=VALUES(timestamp),
-             method=VALUES(method),
-             withdraw_tx_id=VALUES(withdraw_tx_id),
-             deposit_tx_id=VALUES(deposit_tx_id),
-             spark=VALUES(spark)`,
-          [
-            this.identity,
-            payment.id,
-            payment.paymentType,
-            payment.status,
-            payment.amount.toString(),
-            payment.fees.toString(),
-            payment.timestamp,
-            payment.method ? JSON.stringify(payment.method) : null,
-            withdrawTxId,
-            depositTxId,
-            spark,
-          ]
+      await conn.query("SET TRANSACTION ISOLATION LEVEL READ COMMITTED");
+      await conn.beginTransaction();
+      try {
+        const [rows] = await conn.query(
+          "SELECT status FROM brz_payments WHERE user_id = ? AND id = ?",
+          [this.identity, payment.id]
         );
+        const stored = rows.length > 0
+          ? this._normalizePaymentStatus(rows[0].status)
+          : null;
+        const next = this._normalizePaymentStatus(payment.status);
 
-        if (
-          payment.details?.type === "spark" &&
-          (payment.details.invoiceDetails != null ||
-            payment.details.htlcDetails != null)
-        ) {
-          await conn.query(
-            `INSERT INTO brz_payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
-             VALUES (?, ?, ?, ?)
-             ON DUPLICATE KEY UPDATE
-               invoice_details=COALESCE(VALUES(invoice_details), invoice_details),
-               htlc_details=COALESCE(VALUES(htlc_details), htlc_details)`,
-            [
-              this.identity,
-              payment.id,
-              payment.details.invoiceDetails
-                ? JSON.stringify(payment.details.invoiceDetails)
-                : null,
-              payment.details.htlcDetails
-                ? JSON.stringify(payment.details.htlcDetails)
-                : null,
-            ]
+        if (stored == null) {
+          await this._runPaymentUpsert(conn, payment);
+          shouldEmit = true;
+        } else if (stored === next) {
+          console.debug(
+            `Skipping redundant payment event: id=${payment.id} status=${next}`
           );
+          await this._runPaymentUpsert(conn, payment);
+          shouldEmit = false;
+        } else if (this._isFinalPaymentStatus(stored)) {
+          console.warn(
+            `Skipping payment update (would replace terminal status): id=${payment.id} stored=${stored} new=${next}`
+          );
+          shouldEmit = false;
+        } else {
+          await this._runPaymentUpsert(conn, payment);
+          shouldEmit = true;
         }
 
-        if (payment.details?.type === "lightning") {
-          await conn.query(
-            `INSERT INTO brz_payment_details_lightning
-              (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-              ON DUPLICATE KEY UPDATE
-                invoice=VALUES(invoice),
-                payment_hash=VALUES(payment_hash),
-                destination_pubkey=VALUES(destination_pubkey),
-                description=VALUES(description),
-                preimage=COALESCE(VALUES(preimage), preimage),
-                htlc_status=COALESCE(VALUES(htlc_status), htlc_status),
-                htlc_expiry_time=COALESCE(VALUES(htlc_expiry_time), htlc_expiry_time)`,
-            [
-              this.identity,
-              payment.id,
-              payment.details.invoice,
-              payment.details.htlcDetails.paymentHash,
-              payment.details.destinationPubkey,
-              payment.details.description,
-              payment.details.htlcDetails?.preimage,
-              payment.details.htlcDetails?.status ?? null,
-              payment.details.htlcDetails?.expiryTime ?? 0,
-            ]
-          );
-        }
-
-        if (payment.details?.type === "token") {
-          await conn.query(
-            `INSERT INTO brz_payment_details_token
-              (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
-              VALUES (?, ?, ?, ?, ?, ?)
-              ON DUPLICATE KEY UPDATE
-                metadata=VALUES(metadata),
-                tx_hash=VALUES(tx_hash),
-                tx_type=VALUES(tx_type),
-                invoice_details=COALESCE(VALUES(invoice_details), invoice_details)`,
-            [
-              this.identity,
-              payment.id,
-              JSON.stringify(payment.details.metadata),
-              payment.details.txHash,
-              payment.details.txType,
-              payment.details.invoiceDetails
-                ? JSON.stringify(payment.details.invoiceDetails)
-                : null,
-            ]
-          );
-        }
-      });
+        await conn.commit();
+      } catch (error) {
+        await conn.rollback().catch(() => {});
+        throw error;
+      }
     } catch (error) {
-      if (error instanceof StorageError) throw error;
+      operationError = error;
+    } finally {
+      if (conn && acquired) {
+        try {
+          await conn.query("SELECT RELEASE_LOCK(?)", [lockName]);
+        } catch (error) {
+          releaseError = error;
+        }
+      }
+      if (conn) {
+        conn.release();
+      }
+    }
+
+    if (operationError) {
+      if (operationError instanceof StorageError) {
+        throw operationError;
+      }
       throw new StorageError(
-        `Failed to insert payment '${payment.id}': ${error.message}`,
-        error
+        `Failed to apply payment update '${payment.id}': ${operationError.message}`,
+        operationError
+      );
+    }
+
+    if (releaseError) {
+      throw new StorageError(
+        `Failed to release payment update lock '${lockName}': ${releaseError.message}`,
+        releaseError
+      );
+    }
+
+    return shouldEmit;
+  }
+
+  async _runPaymentUpsert(conn, payment) {
+    const withdrawTxId =
+      payment.details?.type === "withdraw" ? payment.details.txId : null;
+    const depositTxId =
+      payment.details?.type === "deposit" ? payment.details.txId : null;
+    const spark = payment.details?.type === "spark" ? 1 : null;
+
+    await conn.query(
+      `INSERT INTO brz_payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         payment_type=VALUES(payment_type),
+         status=VALUES(status),
+         amount=VALUES(amount),
+         fees=VALUES(fees),
+         timestamp=VALUES(timestamp),
+         method=VALUES(method),
+         withdraw_tx_id=VALUES(withdraw_tx_id),
+         deposit_tx_id=VALUES(deposit_tx_id),
+         spark=VALUES(spark)`,
+      [
+        this.identity,
+        payment.id,
+        payment.paymentType,
+        payment.status,
+        payment.amount.toString(),
+        payment.fees.toString(),
+        payment.timestamp,
+        payment.method ? JSON.stringify(payment.method) : null,
+        withdrawTxId,
+        depositTxId,
+        spark,
+      ]
+    );
+
+    if (
+      payment.details?.type === "spark" &&
+      (payment.details.invoiceDetails != null ||
+        payment.details.htlcDetails != null)
+    ) {
+      await conn.query(
+        `INSERT INTO brz_payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
+         VALUES (?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+           invoice_details=COALESCE(VALUES(invoice_details), invoice_details),
+           htlc_details=COALESCE(VALUES(htlc_details), htlc_details)`,
+        [
+          this.identity,
+          payment.id,
+          payment.details.invoiceDetails
+            ? JSON.stringify(payment.details.invoiceDetails)
+            : null,
+          payment.details.htlcDetails
+            ? JSON.stringify(payment.details.htlcDetails)
+            : null,
+        ]
+      );
+    }
+
+    if (payment.details?.type === "lightning") {
+      await conn.query(
+        `INSERT INTO brz_payment_details_lightning
+          (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON DUPLICATE KEY UPDATE
+            invoice=VALUES(invoice),
+            payment_hash=VALUES(payment_hash),
+            destination_pubkey=VALUES(destination_pubkey),
+            description=VALUES(description),
+            preimage=COALESCE(VALUES(preimage), preimage),
+            htlc_status=COALESCE(VALUES(htlc_status), htlc_status),
+            htlc_expiry_time=COALESCE(VALUES(htlc_expiry_time), htlc_expiry_time)`,
+        [
+          this.identity,
+          payment.id,
+          payment.details.invoice,
+          payment.details.htlcDetails.paymentHash,
+          payment.details.destinationPubkey,
+          payment.details.description,
+          payment.details.htlcDetails?.preimage,
+          payment.details.htlcDetails?.status ?? null,
+          payment.details.htlcDetails?.expiryTime ?? 0,
+        ]
+      );
+    }
+
+    if (payment.details?.type === "token") {
+      await conn.query(
+        `INSERT INTO brz_payment_details_token
+          (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON DUPLICATE KEY UPDATE
+            metadata=VALUES(metadata),
+            tx_hash=VALUES(tx_hash),
+            tx_type=VALUES(tx_type),
+            invoice_details=COALESCE(VALUES(invoice_details), invoice_details)`,
+        [
+          this.identity,
+          payment.id,
+          JSON.stringify(payment.details.metadata),
+          payment.details.txHash,
+          payment.details.txType,
+          payment.details.invoiceDetails
+            ? JSON.stringify(payment.details.invoiceDetails)
+            : null,
+        ]
       );
     }
   }
+
+  _paymentUpdateLockName(paymentId) {
+    const lockKey = Buffer.concat([this.identity, Buffer.from(paymentId)]);
+    return `brz_payment_${crypto
+      .createHash("sha256")
+      .update(lockKey)
+      .digest("hex")
+      .slice(0, 32)}`;
+  }
+
+  _normalizePaymentStatus(status) {
+    return typeof status === "string" ? status.toLowerCase() : status;
+  }
+
+  _isFinalPaymentStatus(status) {
+    const normalized = this._normalizePaymentStatus(status);
+    return normalized === "completed" || normalized === "failed";
+  }
+
 
   async getPaymentById(id) {
     try {

--- a/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
@@ -391,7 +391,7 @@ class MysqlStorage {
       await conn.beginTransaction();
       try {
         const [rows] = await conn.query(
-          "SELECT status FROM brz_payments WHERE user_id = ? AND id = ?",
+          "SELECT status FROM brz_payments WHERE user_id = ? AND id = ? FOR UPDATE",
           [this.identity, payment.id]
         );
         const stored = rows.length > 0
@@ -569,10 +569,11 @@ class MysqlStorage {
   }
 
   _paymentUpdateLockName(paymentId) {
-    const lockKey = Buffer.concat([this.identity, Buffer.from(paymentId)]);
     return `brz_payment_${crypto
       .createHash("sha256")
-      .update(lockKey)
+      .update("brz_payment_update")
+      .update(this.identity)
+      .update(Buffer.from(paymentId))
       .digest("hex")
       .slice(0, 32)}`;
   }

--- a/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
@@ -569,13 +569,13 @@ class MysqlStorage {
   }
 
   _paymentUpdateLockName(paymentId) {
-    return `brz_payment_${crypto
+    return crypto
       .createHash("sha256")
       .update("brz_payment_update")
       .update(this.identity)
       .update(Buffer.from(paymentId))
       .digest("hex")
-      .slice(0, 32)}`;
+      .slice(0, 32);
   }
 
   _normalizePaymentStatus(status) {

--- a/crates/breez-sdk/wasm/js/node-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/node-storage/index.cjs
@@ -313,128 +313,166 @@ class SqliteStorage {
     }
   }
 
-  insertPayment(payment) {
+  async applyPaymentUpdate(payment) {
+    if (!payment) {
+      throw new StorageError("Payment cannot be null or undefined");
+    }
+
     try {
-      if (!payment) {
-        return Promise.reject(
-          new StorageError("Payment cannot be null or undefined")
-        );
-      }
-
-      const paymentInsert = this.db.prepare(
-        `INSERT INTO payments (id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark) 
-         VALUES (@id, @paymentType, @status, @amount, @fees, @timestamp, @method, @withdrawTxId, @depositTxId, @spark)
-         ON CONFLICT(id) DO UPDATE SET
-           payment_type=excluded.payment_type,
-           status=excluded.status,
-           amount=excluded.amount,
-           fees=excluded.fees,
-           timestamp=excluded.timestamp,
-           method=excluded.method,
-           withdraw_tx_id=excluded.withdraw_tx_id,
-           deposit_tx_id=excluded.deposit_tx_id,
-           spark=excluded.spark`
+      const selectStatus = this.db.prepare(
+        "SELECT status FROM payments WHERE id = ?"
       );
-      const lightningInsert = this.db.prepare(
-        `INSERT INTO payment_details_lightning
-          (payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
-          VALUES (@id, @invoice, @paymentHash, @destinationPubkey, @description, @preimage, @htlcStatus, @htlcExpiryTime)
-          ON CONFLICT(payment_id) DO UPDATE SET
-            invoice=excluded.invoice,
-            payment_hash=excluded.payment_hash,
-            destination_pubkey=excluded.destination_pubkey,
-            description=excluded.description,
-            preimage=COALESCE(excluded.preimage, payment_details_lightning.preimage),
-            htlc_status=COALESCE(excluded.htlc_status, payment_details_lightning.htlc_status),
-            htlc_expiry_time=COALESCE(excluded.htlc_expiry_time, payment_details_lightning.htlc_expiry_time)`
-      );
-      const tokenInsert = this.db.prepare(
-        `INSERT INTO payment_details_token 
-          (payment_id, metadata, tx_hash, tx_type, invoice_details) 
-          VALUES (@id, @metadata, @txHash, @txType, @invoiceDetails)
-          ON CONFLICT(payment_id) DO UPDATE SET
-            metadata=excluded.metadata,
-            tx_hash=excluded.tx_hash,
-            tx_type=excluded.tx_type,
-            invoice_details=COALESCE(excluded.invoice_details, payment_details_token.invoice_details)`
-      );
-      const sparkInsert = this.db.prepare(
-        `INSERT INTO payment_details_spark 
-          (payment_id, invoice_details, htlc_details) 
-          VALUES (@id, @invoiceDetails, @htlcDetails)
-          ON CONFLICT(payment_id) DO UPDATE SET
-            invoice_details=COALESCE(excluded.invoice_details, payment_details_spark.invoice_details),
-            htlc_details=COALESCE(excluded.htlc_details, payment_details_spark.htlc_details)`
-      );
+      let shouldEmit = false;
       const transaction = this.db.transaction(() => {
-        paymentInsert.run({
-          id: payment.id,
-          paymentType: payment.paymentType,
-          status: payment.status,
-          amount: payment.amount.toString(),
-          fees: payment.fees.toString(),
-          timestamp: payment.timestamp,
-          method: payment.method ? JSON.stringify(payment.method) : null,
-          withdrawTxId:
-            payment.details?.type === "withdraw" ? payment.details.txId : null,
-          depositTxId:
-            payment.details?.type === "deposit" ? payment.details.txId : null,
-          spark: payment.details?.type === "spark" ? 1 : null,
-        });
+        const row = selectStatus.get(payment.id);
+        const stored = row
+          ? this._normalizePaymentStatus(row.status)
+          : null;
+        const next = this._normalizePaymentStatus(payment.status);
 
-        if (
-          payment.details?.type === "spark" &&
-          (payment.details.invoiceDetails != null ||
-            payment.details.htlcDetails != null)
-        ) {
-          sparkInsert.run({
-            id: payment.id,
-            invoiceDetails: payment.details.invoiceDetails
-              ? JSON.stringify(payment.details.invoiceDetails)
-              : null,
-            htlcDetails: payment.details.htlcDetails
-              ? JSON.stringify(payment.details.htlcDetails)
-              : null,
-          });
-        }
-
-        if (payment.details?.type === "lightning") {
-          lightningInsert.run({
-            id: payment.id,
-            invoice: payment.details.invoice,
-            paymentHash: payment.details.htlcDetails.paymentHash,
-            destinationPubkey: payment.details.destinationPubkey,
-            description: payment.details.description,
-            preimage: payment.details.htlcDetails?.preimage,
-            htlcStatus: payment.details.htlcDetails?.status ?? null,
-            htlcExpiryTime: payment.details.htlcDetails?.expiryTime ?? 0,
-          });
-        }
-
-        if (payment.details?.type === "token") {
-          tokenInsert.run({
-            id: payment.id,
-            metadata: JSON.stringify(payment.details.metadata),
-            txHash: payment.details.txHash,
-            txType: payment.details.txType,
-            invoiceDetails: payment.details.invoiceDetails
-              ? JSON.stringify(payment.details.invoiceDetails)
-              : null,
-          });
+        if (stored == null) {
+          this._runPaymentUpsert(payment);
+          shouldEmit = true;
+        } else if (stored === next) {
+          console.debug(
+            `Skipping redundant payment event: id=${payment.id} status=${next}`
+          );
+          this._runPaymentUpsert(payment);
+          shouldEmit = false;
+        } else if (this._isFinalPaymentStatus(stored)) {
+          console.warn(
+            `Skipping payment update (would replace terminal status): id=${payment.id} stored=${stored} new=${next}`
+          );
+          shouldEmit = false;
+        } else {
+          this._runPaymentUpsert(payment);
+          shouldEmit = true;
         }
       });
 
-      transaction();
-      return Promise.resolve();
+      transaction.immediate();
+      return shouldEmit;
     } catch (error) {
-      return Promise.reject(
-        new StorageError(
-          `Failed to insert payment '${payment.id}': ${error.message}`,
-          error
-        )
+      throw new StorageError(
+        `Failed to apply payment update '${payment.id}': ${error.message}`,
+        error
       );
     }
   }
+
+  _runPaymentUpsert(payment) {
+    const paymentInsert = this.db.prepare(
+      `INSERT INTO payments (id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+       VALUES (@id, @paymentType, @status, @amount, @fees, @timestamp, @method, @withdrawTxId, @depositTxId, @spark)
+       ON CONFLICT(id) DO UPDATE SET
+         payment_type=excluded.payment_type,
+         status=excluded.status,
+         amount=excluded.amount,
+         fees=excluded.fees,
+         timestamp=excluded.timestamp,
+         method=excluded.method,
+         withdraw_tx_id=excluded.withdraw_tx_id,
+         deposit_tx_id=excluded.deposit_tx_id,
+         spark=excluded.spark`
+    );
+    const lightningInsert = this.db.prepare(
+      `INSERT INTO payment_details_lightning
+        (payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
+        VALUES (@id, @invoice, @paymentHash, @destinationPubkey, @description, @preimage, @htlcStatus, @htlcExpiryTime)
+        ON CONFLICT(payment_id) DO UPDATE SET
+          invoice=excluded.invoice,
+          payment_hash=excluded.payment_hash,
+          destination_pubkey=excluded.destination_pubkey,
+          description=excluded.description,
+          preimage=COALESCE(excluded.preimage, payment_details_lightning.preimage),
+          htlc_status=COALESCE(excluded.htlc_status, payment_details_lightning.htlc_status),
+          htlc_expiry_time=COALESCE(excluded.htlc_expiry_time, payment_details_lightning.htlc_expiry_time)`
+    );
+    const tokenInsert = this.db.prepare(
+      `INSERT INTO payment_details_token
+        (payment_id, metadata, tx_hash, tx_type, invoice_details)
+        VALUES (@id, @metadata, @txHash, @txType, @invoiceDetails)
+        ON CONFLICT(payment_id) DO UPDATE SET
+          metadata=excluded.metadata,
+          tx_hash=excluded.tx_hash,
+          tx_type=excluded.tx_type,
+          invoice_details=COALESCE(excluded.invoice_details, payment_details_token.invoice_details)`
+    );
+    const sparkInsert = this.db.prepare(
+      `INSERT INTO payment_details_spark
+        (payment_id, invoice_details, htlc_details)
+        VALUES (@id, @invoiceDetails, @htlcDetails)
+        ON CONFLICT(payment_id) DO UPDATE SET
+          invoice_details=COALESCE(excluded.invoice_details, payment_details_spark.invoice_details),
+          htlc_details=COALESCE(excluded.htlc_details, payment_details_spark.htlc_details)`
+    );
+
+    paymentInsert.run({
+      id: payment.id,
+      paymentType: payment.paymentType,
+      status: payment.status,
+      amount: payment.amount.toString(),
+      fees: payment.fees.toString(),
+      timestamp: payment.timestamp,
+      method: payment.method ? JSON.stringify(payment.method) : null,
+      withdrawTxId:
+        payment.details?.type === "withdraw" ? payment.details.txId : null,
+      depositTxId:
+        payment.details?.type === "deposit" ? payment.details.txId : null,
+      spark: payment.details?.type === "spark" ? 1 : null,
+    });
+
+    if (
+      payment.details?.type === "spark" &&
+      (payment.details.invoiceDetails != null ||
+        payment.details.htlcDetails != null)
+    ) {
+      sparkInsert.run({
+        id: payment.id,
+        invoiceDetails: payment.details.invoiceDetails
+          ? JSON.stringify(payment.details.invoiceDetails)
+          : null,
+        htlcDetails: payment.details.htlcDetails
+          ? JSON.stringify(payment.details.htlcDetails)
+          : null,
+      });
+    }
+
+    if (payment.details?.type === "lightning") {
+      lightningInsert.run({
+        id: payment.id,
+        invoice: payment.details.invoice,
+        paymentHash: payment.details.htlcDetails.paymentHash,
+        destinationPubkey: payment.details.destinationPubkey,
+        description: payment.details.description,
+        preimage: payment.details.htlcDetails?.preimage,
+        htlcStatus: payment.details.htlcDetails?.status ?? null,
+        htlcExpiryTime: payment.details.htlcDetails?.expiryTime ?? 0,
+      });
+    }
+
+    if (payment.details?.type === "token") {
+      tokenInsert.run({
+        id: payment.id,
+        metadata: JSON.stringify(payment.details.metadata),
+        txHash: payment.details.txHash,
+        txType: payment.details.txType,
+        invoiceDetails: payment.details.invoiceDetails
+          ? JSON.stringify(payment.details.invoiceDetails)
+          : null,
+      });
+    }
+  }
+
+  _normalizePaymentStatus(status) {
+    return typeof status === "string" ? status.toLowerCase() : status;
+  }
+
+  _isFinalPaymentStatus(status) {
+    const normalized = this._normalizePaymentStatus(status);
+    return normalized === "completed" || normalized === "failed";
+  }
+
 
   getPaymentById(id) {
     try {

--- a/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
@@ -2,6 +2,8 @@
  * CommonJS implementation for Node.js PostgreSQL Storage
  */
 
+const crypto = require("crypto");
+
 let pg;
 try {
   const mainModule = require.main;
@@ -353,126 +355,172 @@ class PostgresStorage {
     }
   }
 
-  async insertPayment(payment) {
+  async applyPaymentUpdate(payment) {
+    if (!payment) {
+      throw new StorageError("Payment cannot be null or undefined");
+    }
+
     try {
-      if (!payment) {
-        throw new StorageError("Payment cannot be null or undefined");
-      }
-
-      await this._withTransaction(async (client) => {
-        const withdrawTxId =
-          payment.details?.type === "withdraw" ? payment.details.txId : null;
-        const depositTxId =
-          payment.details?.type === "deposit" ? payment.details.txId : null;
-        const spark = payment.details?.type === "spark" ? true : null;
-
+      return await this._withTransaction(async (client) => {
+        const lockKey = this._paymentUpdateLockKey(payment.id);
         await client.query(
-          `INSERT INTO brz_payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-           ON CONFLICT(user_id, id) DO UPDATE SET
-             payment_type=EXCLUDED.payment_type,
-             status=EXCLUDED.status,
-             amount=EXCLUDED.amount,
-             fees=EXCLUDED.fees,
-             timestamp=EXCLUDED.timestamp,
-             method=EXCLUDED.method,
-             withdraw_tx_id=EXCLUDED.withdraw_tx_id,
-             deposit_tx_id=EXCLUDED.deposit_tx_id,
-             spark=EXCLUDED.spark`,
-          [
-            this.identity,
-            payment.id,
-            payment.paymentType,
-            payment.status,
-            payment.amount.toString(),
-            payment.fees.toString(),
-            payment.timestamp,
-            payment.method ? JSON.stringify(payment.method) : null,
-            withdrawTxId,
-            depositTxId,
-            spark,
-          ]
+          "SELECT pg_advisory_xact_lock($1::bigint)",
+          [lockKey]
         );
 
-        if (
-          payment.details?.type === "spark" &&
-          (payment.details.invoiceDetails != null ||
-            payment.details.htlcDetails != null)
-        ) {
-          await client.query(
-            `INSERT INTO brz_payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
-             VALUES ($1, $2, $3, $4)
-             ON CONFLICT(user_id, payment_id) DO UPDATE SET
-               invoice_details=COALESCE(EXCLUDED.invoice_details, brz_payment_details_spark.invoice_details),
-               htlc_details=COALESCE(EXCLUDED.htlc_details, brz_payment_details_spark.htlc_details)`,
-            [
-              this.identity,
-              payment.id,
-              payment.details.invoiceDetails
-                ? JSON.stringify(payment.details.invoiceDetails)
-                : null,
-              payment.details.htlcDetails
-                ? JSON.stringify(payment.details.htlcDetails)
-                : null,
-            ]
+        const { rows } = await client.query(
+          "SELECT status FROM brz_payments WHERE user_id = $1 AND id = $2 FOR UPDATE",
+          [this.identity, payment.id]
+        );
+        const stored = rows.length > 0
+          ? this._normalizePaymentStatus(rows[0].status)
+          : null;
+        const next = this._normalizePaymentStatus(payment.status);
+
+        if (stored != null
+            && this._isFinalPaymentStatus(stored)
+            && stored !== next) {
+          console.warn(
+            `Skipping payment update (would replace terminal status): id=${payment.id} stored=${stored} new=${next}`
           );
+          return false;
         }
 
-        if (payment.details?.type === "lightning") {
-          await client.query(
-            `INSERT INTO brz_payment_details_lightning
-              (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
-              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-              ON CONFLICT(user_id, payment_id) DO UPDATE SET
-                invoice=EXCLUDED.invoice,
-                payment_hash=EXCLUDED.payment_hash,
-                destination_pubkey=EXCLUDED.destination_pubkey,
-                description=EXCLUDED.description,
-                preimage=COALESCE(EXCLUDED.preimage, brz_payment_details_lightning.preimage),
-                htlc_status=COALESCE(EXCLUDED.htlc_status, brz_payment_details_lightning.htlc_status),
-                htlc_expiry_time=COALESCE(EXCLUDED.htlc_expiry_time, brz_payment_details_lightning.htlc_expiry_time)`,
-            [
-              this.identity,
-              payment.id,
-              payment.details.invoice,
-              payment.details.htlcDetails.paymentHash,
-              payment.details.destinationPubkey,
-              payment.details.description,
-              payment.details.htlcDetails?.preimage,
-              payment.details.htlcDetails?.status ?? null,
-              payment.details.htlcDetails?.expiryTime ?? 0,
-            ]
+        const sameStatus = stored === next;
+        if (sameStatus) {
+          console.debug(
+            `Skipping redundant payment event: id=${payment.id} status=${next}`
           );
         }
-
-        if (payment.details?.type === "token") {
-          await client.query(
-            `INSERT INTO brz_payment_details_token
-              (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
-              VALUES ($1, $2, $3, $4, $5, $6)
-              ON CONFLICT(user_id, payment_id) DO UPDATE SET
-                metadata=EXCLUDED.metadata,
-                tx_hash=EXCLUDED.tx_hash,
-                tx_type=EXCLUDED.tx_type,
-                invoice_details=COALESCE(EXCLUDED.invoice_details, brz_payment_details_token.invoice_details)`,
-            [
-              this.identity,
-              payment.id,
-              JSON.stringify(payment.details.metadata),
-              payment.details.txHash,
-              payment.details.txType,
-              payment.details.invoiceDetails
-                ? JSON.stringify(payment.details.invoiceDetails)
-                : null,
-            ]
-          );
-        }
+        await this._runPaymentUpsert(client, payment);
+        return !sameStatus;
       });
     } catch (error) {
       if (error instanceof StorageError) throw error;
       throw new StorageError(
-        `Failed to insert payment '${payment.id}': ${error.message}`,
+        `Failed to apply payment update '${payment.id}': ${error.message}`,
         error
+      );
+    }
+  }
+
+  _paymentUpdateLockKey(paymentId) {
+    return crypto
+      .createHash("sha256")
+      .update("brz_payment_update")
+      .update(this.identity)
+      .update(Buffer.from(paymentId))
+      .digest()
+      .readBigInt64BE(0)
+      .toString();
+  }
+
+  async _runPaymentUpsert(client, payment) {
+    const withdrawTxId =
+      payment.details?.type === "withdraw" ? payment.details.txId : null;
+    const depositTxId =
+      payment.details?.type === "deposit" ? payment.details.txId : null;
+    const spark = payment.details?.type === "spark" ? true : null;
+
+    await client.query(
+      `INSERT INTO brz_payments (user_id, id, payment_type, status, amount, fees, timestamp, method, withdraw_tx_id, deposit_tx_id, spark)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       ON CONFLICT(user_id, id) DO UPDATE SET
+         payment_type=EXCLUDED.payment_type,
+         status=EXCLUDED.status,
+         amount=EXCLUDED.amount,
+         fees=EXCLUDED.fees,
+         timestamp=EXCLUDED.timestamp,
+         method=EXCLUDED.method,
+         withdraw_tx_id=EXCLUDED.withdraw_tx_id,
+         deposit_tx_id=EXCLUDED.deposit_tx_id,
+         spark=EXCLUDED.spark`,
+      [
+        this.identity,
+        payment.id,
+        payment.paymentType,
+        payment.status,
+        payment.amount.toString(),
+        payment.fees.toString(),
+        payment.timestamp,
+        payment.method ? JSON.stringify(payment.method) : null,
+        withdrawTxId,
+        depositTxId,
+        spark,
+      ]
+    );
+
+    if (
+      payment.details?.type === "spark" &&
+      (payment.details.invoiceDetails != null ||
+        payment.details.htlcDetails != null)
+    ) {
+      await client.query(
+        `INSERT INTO brz_payment_details_spark (user_id, payment_id, invoice_details, htlc_details)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT(user_id, payment_id) DO UPDATE SET
+           invoice_details=COALESCE(EXCLUDED.invoice_details, brz_payment_details_spark.invoice_details),
+           htlc_details=COALESCE(EXCLUDED.htlc_details, brz_payment_details_spark.htlc_details)`,
+        [
+          this.identity,
+          payment.id,
+          payment.details.invoiceDetails
+            ? JSON.stringify(payment.details.invoiceDetails)
+            : null,
+          payment.details.htlcDetails
+            ? JSON.stringify(payment.details.htlcDetails)
+            : null,
+        ]
+      );
+    }
+
+    if (payment.details?.type === "lightning") {
+      await client.query(
+        `INSERT INTO brz_payment_details_lightning
+          (user_id, payment_id, invoice, payment_hash, destination_pubkey, description, preimage, htlc_status, htlc_expiry_time)
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+          ON CONFLICT(user_id, payment_id) DO UPDATE SET
+            invoice=EXCLUDED.invoice,
+            payment_hash=EXCLUDED.payment_hash,
+            destination_pubkey=EXCLUDED.destination_pubkey,
+            description=EXCLUDED.description,
+            preimage=COALESCE(EXCLUDED.preimage, brz_payment_details_lightning.preimage),
+            htlc_status=COALESCE(EXCLUDED.htlc_status, brz_payment_details_lightning.htlc_status),
+            htlc_expiry_time=COALESCE(EXCLUDED.htlc_expiry_time, brz_payment_details_lightning.htlc_expiry_time)`,
+        [
+          this.identity,
+          payment.id,
+          payment.details.invoice,
+          payment.details.htlcDetails.paymentHash,
+          payment.details.destinationPubkey,
+          payment.details.description,
+          payment.details.htlcDetails?.preimage,
+          payment.details.htlcDetails?.status ?? null,
+          payment.details.htlcDetails?.expiryTime ?? 0,
+        ]
+      );
+    }
+
+    if (payment.details?.type === "token") {
+      await client.query(
+        `INSERT INTO brz_payment_details_token
+          (user_id, payment_id, metadata, tx_hash, tx_type, invoice_details)
+          VALUES ($1, $2, $3, $4, $5, $6)
+          ON CONFLICT(user_id, payment_id) DO UPDATE SET
+            metadata=EXCLUDED.metadata,
+            tx_hash=EXCLUDED.tx_hash,
+            tx_type=EXCLUDED.tx_type,
+            invoice_details=COALESCE(EXCLUDED.invoice_details, brz_payment_details_token.invoice_details)`,
+        [
+          this.identity,
+          payment.id,
+          JSON.stringify(payment.details.metadata),
+          payment.details.txHash,
+          payment.details.txType,
+          payment.details.invoiceDetails
+            ? JSON.stringify(payment.details.invoiceDetails)
+            : null,
+        ]
       );
     }
   }

--- a/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
@@ -525,6 +525,15 @@ class PostgresStorage {
     }
   }
 
+  _normalizePaymentStatus(status) {
+    return typeof status === "string" ? status.toLowerCase() : status;
+  }
+
+  _isFinalPaymentStatus(status) {
+    const normalized = this._normalizePaymentStatus(status);
+    return normalized === "completed" || normalized === "failed";
+  }
+
   async getPaymentById(id) {
     try {
       if (!id) {

--- a/crates/breez-sdk/wasm/js/web-storage/index.js
+++ b/crates/breez-sdk/wasm/js/web-storage/index.js
@@ -847,31 +847,98 @@ class IndexedDBStorage {
     });
   }
 
-  async insertPayment(payment) {
+  async applyPaymentUpdate(payment) {
     if (!this.db) {
       throw new StorageError("Database not initialized");
     }
 
     return new Promise((resolve, reject) => {
+      let shouldEmit = false;
+      let settled = false;
       const transaction = this.db.transaction("payments", "readwrite");
       const store = transaction.objectStore("payments");
 
-      // Ensure details and method are serialized properly
-      const paymentToStore = {
-        ...payment,
-        details: payment.details ? JSON.stringify(payment.details) : null,
-        method: payment.method ? JSON.stringify(payment.method) : null,
+      const rejectOnce = (message, error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        reject(new StorageError(message, error));
       };
 
-      const request = store.put(paymentToStore);
-      request.onsuccess = () => resolve();
-      request.onerror = () => {
-        reject(
-          new StorageError(
-            `Failed to insert payment '${payment.id}': ${request.error?.message || "Unknown error"
+      transaction.oncomplete = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve(shouldEmit);
+      };
+
+      transaction.onerror = () => {
+        rejectOnce(
+          `Failed to apply payment update '${payment.id}': ${transaction.error?.message || "Unknown error"
+          }`,
+          transaction.error
+        );
+      };
+
+      transaction.onabort = () => {
+        rejectOnce(
+          `Payment update transaction aborted for '${payment.id}': ${transaction.error?.message || "Unknown error"
+          }`,
+          transaction.error
+        );
+      };
+
+      const getRequest = store.get(payment.id);
+
+      getRequest.onsuccess = () => {
+        const storedPayment = getRequest.result;
+        const stored = storedPayment
+          ? this._normalizePaymentStatus(storedPayment.status)
+          : null;
+        const next = this._normalizePaymentStatus(payment.status);
+
+        let shouldPersist;
+        if (stored == null) {
+          shouldPersist = true;
+          shouldEmit = true;
+        } else if (stored === next) {
+          console.debug(
+            `Skipping redundant payment event: id=${payment.id} status=${next}`
+          );
+          shouldPersist = true;
+          shouldEmit = false;
+        } else if (this._isFinalPaymentStatus(stored)) {
+          console.warn(
+            `Skipping payment update (would replace terminal status): id=${payment.id} stored=${stored} new=${next}`
+          );
+          shouldPersist = false;
+          shouldEmit = false;
+        } else {
+          shouldPersist = true;
+          shouldEmit = true;
+        }
+
+        if (!shouldPersist) {
+          return;
+        }
+
+        const putRequest = store.put(this._paymentToStore(payment));
+        putRequest.onerror = () => {
+          rejectOnce(
+            `Failed to persist payment update '${payment.id}': ${putRequest.error?.message || "Unknown error"
             }`,
-            request.error
-          )
+            putRequest.error
+          );
+        };
+      };
+
+      getRequest.onerror = () => {
+        rejectOnce(
+          `Failed to read payment '${payment.id}' before update: ${getRequest.error?.message || "Unknown error"
+          }`,
+          getRequest.error
         );
       };
     });
@@ -2065,6 +2132,25 @@ class IndexedDBStorage {
   }
 
   // ===== Private Helper Methods =====
+
+  _paymentToStore(payment) {
+    // Ensure details and method are serialized properly
+    return {
+      ...payment,
+      details: payment.details ? JSON.stringify(payment.details) : null,
+      method: payment.method ? JSON.stringify(payment.method) : null,
+    };
+  }
+
+  _normalizePaymentStatus(status) {
+    return typeof status === "string" ? status.toLowerCase() : status;
+  }
+
+  _isFinalPaymentStatus(status) {
+    const normalized = this._normalizePaymentStatus(status);
+    return normalized === "completed" || normalized === "failed";
+  }
+
 
   _matchesFilters(payment, request) {
     // Filter by payment type

--- a/crates/breez-sdk/wasm/src/persist/mod.rs
+++ b/crates/breez-sdk/wasm/src/persist/mod.rs
@@ -5,6 +5,7 @@ mod tests;
 
 use breez_sdk_spark::StorageError;
 use macros::async_trait;
+use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_futures::js_sys::Promise;
@@ -74,6 +75,15 @@ fn get_detailed_js_error(js_error: &JsValue) -> String {
     "JavaScript storage operation failed (Unknown error type)".to_string()
 }
 
+fn should_emit_from_js(value: &JsValue) -> Result<bool, StorageError> {
+    value.as_bool().ok_or_else(|| {
+        StorageError::Implementation(
+            "applyPaymentUpdate must return a boolean indicating whether to emit an event"
+                .to_string(),
+        )
+    })
+}
+
 // This assumes that we'll always be running in a single thread (true for Wasm environments)
 unsafe impl Send for WasmStorage {}
 unsafe impl Sync for WasmStorage {}
@@ -131,14 +141,17 @@ impl breez_sdk_spark::Storage for WasmStorage {
         Ok(payments.into_iter().map(|p| p.into()).collect())
     }
 
-    async fn insert_payment(&self, payment: breez_sdk_spark::Payment) -> Result<(), StorageError> {
+    async fn apply_payment_update(
+        &self,
+        payment: breez_sdk_spark::Payment,
+    ) -> Result<bool, StorageError> {
         let promise = self
             .storage
-            .insert_payment(payment.into())
+            .apply_payment_update(payment.into())
             .map_err(js_error_to_storage_error)?;
         let future = JsFuture::from(promise);
-        future.await.map_err(js_error_to_storage_error)?;
-        Ok(())
+        let result = future.await.map_err(js_error_to_storage_error)?;
+        should_emit_from_js(&result)
     }
 
     async fn insert_payment_metadata(
@@ -478,7 +491,15 @@ const STORAGE_INTERFACE: &'static str = r#"export interface Storage {
     setCachedItem: (key: string, value: string) => Promise<void>;
     deleteCachedItem: (key: string) => Promise<void>;
     listPayments: (request: StorageListPaymentsRequest) => Promise<Payment[]>;
-    insertPayment: (payment: Payment) => Promise<void>;
+    /**
+     * Insert or update a payment, applying a terminal-status guard.
+     *
+     * Returns `true` when the caller should emit a payment event (the row was
+     * newly inserted, or its status transitioned). Returns `false` for
+     * redundant same-status updates and for rejected updates that would
+     * replace an already-terminal status.
+     */
+    applyPaymentUpdate: (payment: Payment) => Promise<boolean>;
     insertPaymentMetadata: (paymentId: string, metadata: PaymentMetadata) => Promise<void>;
     getPaymentById: (id: string) => Promise<Payment>;
     getPaymentByInvoice: (invoice: string) => Promise<Payment>;
@@ -523,8 +544,8 @@ extern "C" {
         request: StorageListPaymentsRequest,
     ) -> Result<Promise, JsValue>;
 
-    #[wasm_bindgen(structural, method, js_name = insertPayment, catch)]
-    pub fn insert_payment(this: &Storage, payment: Payment) -> Result<Promise, JsValue>;
+    #[wasm_bindgen(structural, method, js_name = applyPaymentUpdate, catch)]
+    pub fn apply_payment_update(this: &Storage, payment: Payment) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, js_name = insertPaymentMetadata, catch)]
     pub fn insert_payment_metadata(

--- a/crates/breez-sdk/wasm/src/persist/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/mysql.rs
@@ -122,6 +122,13 @@ async fn test_payment_details_update_persistence() {
 }
 
 #[wasm_bindgen_test]
+async fn test_payment_terminal_status_is_not_replaced() {
+    let storage = create_test_storage("my_payment_terminal_guard").await;
+    breez_sdk_spark::storage_tests::test_payment_terminal_status_is_not_replaced(Box::new(storage))
+        .await;
+}
+
+#[wasm_bindgen_test]
 async fn test_spark_htlc_status_filtering() {
     let storage = create_test_storage("my_spark_htlc_status_filtering").await;
     breez_sdk_spark::storage_tests::test_spark_htlc_status_filtering(Box::new(storage)).await;

--- a/crates/breez-sdk/wasm/src/persist/tests/node.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/node.rs
@@ -132,6 +132,14 @@ async fn test_payment_details_update_persistence() {
 }
 
 #[wasm_bindgen_test]
+async fn test_payment_terminal_status_is_not_replaced() {
+    let storage = create_test_storage("payment_terminal_guard").await;
+
+    breez_sdk_spark::storage_tests::test_payment_terminal_status_is_not_replaced(Box::new(storage))
+        .await;
+}
+
+#[wasm_bindgen_test]
 async fn test_spark_htlc_status_filtering() {
     let storage = create_test_storage("spark_htlc_status_filtering").await;
 
@@ -308,7 +316,7 @@ async fn test_migration_from_v17_to_v18() {
         conversion_details: None,
     };
 
-    breez_sdk_spark::Storage::insert_payment(&storage, new_payment.clone())
+    breez_sdk_spark::Storage::apply_payment_update(&storage, new_payment.clone())
         .await
         .expect("Failed to insert new token payment");
 

--- a/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
@@ -122,6 +122,13 @@ async fn test_payment_details_update_persistence() {
 }
 
 #[wasm_bindgen_test]
+async fn test_payment_terminal_status_is_not_replaced() {
+    let storage = create_test_storage("pg_payment_terminal_guard").await;
+    breez_sdk_spark::storage_tests::test_payment_terminal_status_is_not_replaced(Box::new(storage))
+        .await;
+}
+
+#[wasm_bindgen_test]
 async fn test_spark_htlc_status_filtering() {
     let storage = create_test_storage("pg_spark_htlc_status_filtering").await;
     breez_sdk_spark::storage_tests::test_spark_htlc_status_filtering(Box::new(storage)).await;

--- a/crates/breez-sdk/wasm/src/persist/tests/web.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/web.rs
@@ -122,6 +122,14 @@ async fn test_payment_details_update_persistence() {
 }
 
 #[wasm_bindgen_test]
+async fn test_payment_terminal_status_is_not_replaced() {
+    let storage = create_test_storage("payment_terminal_guard").await;
+
+    breez_sdk_spark::storage_tests::test_payment_terminal_status_is_not_replaced(Box::new(storage))
+        .await;
+}
+
+#[wasm_bindgen_test]
 async fn test_spark_htlc_status_filtering() {
     let storage = create_test_storage("spark_htlc_status_filtering").await;
 
@@ -219,7 +227,7 @@ async fn test_migration_from_v2_to_v3() {
         conversion_details: None,
     };
 
-    breez_sdk_spark::Storage::insert_payment(&storage, new_payment.clone())
+    breez_sdk_spark::Storage::apply_payment_update(&storage, new_payment.clone())
         .await
         .expect("Failed to insert new payment");
 
@@ -351,7 +359,7 @@ async fn test_migration_from_v8_to_v9() {
         conversion_details: None,
     };
 
-    breez_sdk_spark::Storage::insert_payment(&storage, new_payment.clone())
+    breez_sdk_spark::Storage::apply_payment_update(&storage, new_payment.clone())
         .await
         .expect("Failed to insert new token payment");
 


### PR DESCRIPTION
We are emitting events from various sources (sync, spark events, ssp).
These are not always in sync so we have to ensure:
1. We don't emit duplicate events (enforced by the storage for atomicity).
2. We don't override completed/failed payments with payments that are not in terminal state (final state).

I believe this also solve a flakiness in our integration tests such as:  https://github.com/breez/spark-sdk/actions/runs/26083908033/job/76692046270