### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -243,6 +243,7 @@ public static class Commands
         Console.WriteLine($"  {"issuer <subcommand>",-40} Token issuer commands (use 'issuer help' for details)");
         Console.WriteLine($"  {"contacts <subcommand>",-40} Contact commands (use 'contacts help' for details)");
         Console.WriteLine($"  {"webhooks <subcommand>",-40} Webhook commands (use 'webhooks help' for details)");
+        Console.WriteLine($"  {"stable-balance <subcommand>",-40} Stable balance commands (use 'stable-balance help' for details)");
         Console.WriteLine($"  {"exit / quit",-40} Exit the CLI");
         Console.WriteLine($"  {"help",-40} Show this help message");
         Console.WriteLine();
@@ -275,7 +276,7 @@ public static class Commands
     private static readonly HashSet<string> BooleanFlags = new()
     {
         "--fees-included", "--from-bitcoin", "--hodl", "-f", "--freezable",
-        "--from-bitcoin"
+        "--new-address"
     };
 
     private static string[] GetPositionalArgs(string[] args)
@@ -636,6 +637,7 @@ public static class Commands
         var comment = GetFlag(args, "-c", "--comment");
         var validateStr = GetFlag(args, "-v", "--validate");
         var idempotencyKey = GetFlag(args, "-i", "--idempotency-key");
+        var tokenIdentifier = GetFlag(args, "-t", "--token-identifier");
         var fromTokenId = GetFlag(args, "--from-token");
         var maxSlippageStr = GetFlag(args, "-s", "--convert-max-slippage-bps");
         var feesIncluded = HasFlag(args, "--fees-included");
@@ -680,7 +682,9 @@ public static class Commands
 
         var minSendable = (payRequest.minSendable + 999) / 1000; // div_ceil(1000)
         var maxSendable = payRequest.maxSendable / 1000;
-        var prompt = $"Amount to pay (min {minSendable} sat, max {maxSendable} sat): ";
+        var prompt = tokenIdentifier == null
+            ? $"Amount to pay (min {minSendable} sat, max {maxSendable} sat): "
+            : $"Amount to pay (min {minSendable} sat, max {maxSendable} sat) in token base units: ";
         var amountLine = readline(prompt);
         if (amountLine == null) return;
         var amountSats = ulong.Parse(amountLine.Trim());
@@ -692,7 +696,7 @@ public static class Commands
             payRequest: payRequest,
             comment: comment,
             validateSuccessActionUrl: validateSuccessUrl,
-            tokenIdentifier: null,
+            tokenIdentifier: tokenIdentifier,
             conversionOptions: conversionOptions,
             feePolicy: feePolicy
         ));

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
@@ -9,7 +9,9 @@ string dataDir = "./.data";
 string network = "regtest";
 uint? accountNumber = null;
 string? postgresConnectionString = null;
-string? stableBalanceTokenIdentifier = null;
+string? mysqlConnectionString = null;
+var stableBalanceTokens = new List<string>();
+string? stableBalanceDefaultActiveLabel = null;
 ulong? stableBalanceThreshold = null;
 string? passkeyProviderStr = null;
 string? label = null;
@@ -34,8 +36,14 @@ for (int i = 0; i < args.Length; i++)
         case "--postgres-connection-string":
             if (i + 1 < args.Length) postgresConnectionString = args[++i];
             break;
-        case "--stable-balance-token-identifier":
-            if (i + 1 < args.Length) stableBalanceTokenIdentifier = args[++i];
+        case "--mysql-connection-string":
+            if (i + 1 < args.Length) mysqlConnectionString = args[++i];
+            break;
+        case "--stable-balance-token":
+            if (i + 1 < args.Length) stableBalanceTokens.Add(args[++i]);
+            break;
+        case "--stable-balance-default-active-label":
+            if (i + 1 < args.Length) stableBalanceDefaultActiveLabel = args[++i];
             break;
         case "--stable-balance-threshold":
             if (i + 1 < args.Length) stableBalanceThreshold = ulong.Parse(args[++i]);
@@ -65,6 +73,12 @@ for (int i = 0; i < args.Length; i++)
 // ---------------------------------------------------------------------------
 // Validate passkey flag combinations
 // ---------------------------------------------------------------------------
+
+if (postgresConnectionString != null && mysqlConnectionString != null)
+{
+    Console.Error.WriteLine("Error: --mysql-connection-string conflicts with --postgres-connection-string");
+    return;
+}
 
 if (listLabels && passkeyProviderStr == null)
 {
@@ -125,16 +139,21 @@ Network networkEnum = network.ToLower() switch
 // ---------------------------------------------------------------------------
 
 StableBalanceConfig? stableBalanceConfig = null;
-if (stableBalanceTokenIdentifier != null)
+if (stableBalanceTokens.Count > 0)
 {
+    var tokens = stableBalanceTokens.Select(s =>
+    {
+        var parts = s.Split(':', 2);
+        if (parts.Length != 2)
+        {
+            throw new ArgumentException($"Invalid token format '{s}', expected LABEL:token_identifier");
+        }
+        return new StableBalanceToken(label: parts[0], tokenIdentifier: parts[1]);
+    }).ToArray();
+
     stableBalanceConfig = new StableBalanceConfig(
-        tokens: new StableBalanceToken[] {
-            new StableBalanceToken(
-                label: "USDB",
-                tokenIdentifier: stableBalanceTokenIdentifier
-            )
-        },
-        defaultActiveLabel: "USDB",
+        tokens: tokens,
+        defaultActiveLabel: stableBalanceDefaultActiveLabel,
         thresholdSats: stableBalanceThreshold,
         maxSlippageBps: null
     );
@@ -166,6 +185,7 @@ await RunInteractiveMode(
     networkEnum,
     accountNumber,
     postgresConnectionString,
+    mysqlConnectionString,
     stableBalanceConfig,
     passkeyConfig
 );
@@ -197,7 +217,9 @@ static void PrintUsage()
     Console.WriteLine("  --network <NETWORK>                         Network: regtest or mainnet (default: regtest)");
     Console.WriteLine("  --account-number <N>                        Account number for the Spark signer");
     Console.WriteLine("  --postgres-connection-string <CONN>         PostgreSQL connection string (SQLite by default)");
-    Console.WriteLine("  --stable-balance-token-identifier <TOKEN>   Stable balance token identifier");
+    Console.WriteLine("  --mysql-connection-string <CONN>            MySQL connection string (SQLite by default)");
+    Console.WriteLine("  --stable-balance-token <LABEL:TOKEN_ID>    Stable balance token (repeatable)");
+    Console.WriteLine("  --stable-balance-default-active-label <L>  Default active label for stable balance");
     Console.WriteLine("  --stable-balance-threshold <SATS>           Stable balance threshold in sats");
     Console.WriteLine("  --passkey <PROVIDER>                        Use passkey with file, yubikey, or fido2 provider");
     Console.WriteLine("  --label <NAME>                              Label for seed derivation (requires --passkey)");
@@ -212,6 +234,7 @@ static async Task RunInteractiveMode(
     Network network,
     uint? accountNumber,
     string? postgresConnectionString,
+    string? mysqlConnectionString,
     StableBalanceConfig? stableBalanceConfig,
     PasskeyConfig? passkeyConfig)
 {
@@ -266,9 +289,25 @@ static async Task RunInteractiveMode(
     var builder = new SdkBuilder(config: config, seed: seed);
     if (postgresConnectionString != null)
     {
-        var pgConfig = BreezSdkSparkMethods.DefaultPostgresStorageConfig(postgresConnectionString);
-        var pool = BreezSdkSparkMethods.CreatePostgresConnectionPool(config: pgConfig);
-        await builder.WithPostgresConnectionPool(pool: pool);
+        var context = BreezSdkSparkMethods.NewSharedSdkContext(config: new SdkContextConfig(
+            network: network,
+            apiKey: apiKey,
+            connectionsPerOperator: null,
+            postgresConfig: BreezSdkSparkMethods.DefaultPostgresStorageConfig(postgresConnectionString),
+            mysqlConfig: null
+        ));
+        await builder.WithSharedContext(context: context);
+    }
+    else if (mysqlConnectionString != null)
+    {
+        var context = BreezSdkSparkMethods.NewSharedSdkContext(config: new SdkContextConfig(
+            network: network,
+            apiKey: apiKey,
+            connectionsPerOperator: null,
+            postgresConfig: null,
+            mysqlConfig: BreezSdkSparkMethods.DefaultMysqlStorageConfig(mysqlConnectionString)
+        ));
+        await builder.WithSharedContext(context: context);
     }
     else
     {
@@ -302,6 +341,7 @@ static async Task RunInteractiveMode(
     allCommands.AddRange(IssuerCommandNames.All);
     allCommands.AddRange(ContactCommandNames.All);
     allCommands.AddRange(WebhookCommandNames.All);
+    allCommands.AddRange(StableBalanceCommandNames.All);
     allCommands.Add("exit");
     allCommands.Add("quit");
     allCommands.Add("help");
@@ -395,6 +435,10 @@ static async Task RunInteractiveMode(
             else if (cmdName == "webhooks")
             {
                 await WebhookCommands.DispatchCommand(cmdArgs, sdk, Readline);
+            }
+            else if (cmdName == "stable-balance")
+            {
+                await StableBalanceCommands.DispatchCommand(cmdArgs, sdk, Readline);
             }
             else if (registry.TryGetValue(cmdName, out var cmd))
             {

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/README.md
@@ -35,7 +35,9 @@ dotnet run --project BreezCli.csproj -- [OPTIONS]
 | `--network` | `regtest` | Network to use (`regtest` or `mainnet`) |
 | `--account-number` | - | Account number for the Spark signer |
 | `--postgres-connection-string` | - | PostgreSQL connection string (uses SQLite by default) |
-| `--stable-balance-token-identifier` | - | Stable balance token identifier |
+| `--mysql-connection-string` | - | MySQL connection string (uses SQLite by default) |
+| `--stable-balance-token` | - | Stable balance token in `LABEL:token_identifier` format (repeatable) |
+| `--stable-balance-default-active-label` | - | Default active label for stable balance |
 | `--stable-balance-threshold` | - | Stable balance threshold in sats |
 | `--passkey` | - | Use passkey with PRF provider (`file`, `yubikey`, or `fido2`) |
 | `--label` | - | Label for seed derivation (requires `--passkey`) |
@@ -88,6 +90,8 @@ Once inside the REPL, type `help` for all commands:
 **Contacts**: `contacts <subcommand>`
 
 **Webhooks**: `webhooks <subcommand>`
+
+**Stable Balance**: `stable-balance <subcommand>`
 
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/StableBalance.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/StableBalance.cs
@@ -1,0 +1,133 @@
+using Breez.Sdk.Spark;
+
+namespace BreezCli;
+
+/// <summary>
+/// Represents a single stable-balance subcommand.
+/// </summary>
+public class StableBalanceCliCommand
+{
+    public required string Name { get; init; }
+    public required string Description { get; init; }
+    public required Func<BreezSdk, Func<string, string?>, string[], Task> Run { get; init; }
+}
+
+/// <summary>
+/// Stable balance subcommand names (used for REPL completion).
+/// </summary>
+public static class StableBalanceCommandNames
+{
+    public static readonly string[] All =
+    {
+        "stable-balance get",
+        "stable-balance set",
+        "stable-balance unset",
+    };
+}
+
+/// <summary>
+/// Stable balance subcommand handlers.
+/// </summary>
+public static class StableBalanceCommands
+{
+    /// <summary>
+    /// Builds the stable-balance subcommand registry.
+    /// </summary>
+    public static Dictionary<string, StableBalanceCliCommand> BuildRegistry()
+    {
+        return new Dictionary<string, StableBalanceCliCommand>
+        {
+            ["get"] = new()
+            {
+                Name = "get",
+                Description = "Get the stable balance active label",
+                Run = HandleGet
+            },
+            ["set"] = new()
+            {
+                Name = "set",
+                Description = "Set the stable balance active label",
+                Run = HandleSet
+            },
+            ["unset"] = new()
+            {
+                Name = "unset",
+                Description = "Unset stable balance",
+                Run = HandleUnset
+            },
+        };
+    }
+
+    /// <summary>
+    /// Dispatches a stable-balance subcommand.
+    /// </summary>
+    public static async Task DispatchCommand(
+        string[] args,
+        BreezSdk sdk,
+        Func<string, string?> readline)
+    {
+        var registry = BuildRegistry();
+
+        if (args.Length == 0 || args[0] == "help")
+        {
+            Console.WriteLine();
+            Console.WriteLine("Stable balance subcommands:");
+            var names = registry.Keys.OrderBy(k => k).ToList();
+            foreach (var name in names)
+            {
+                Console.WriteLine($"  stable-balance {name,-24} {registry[name].Description}");
+            }
+            Console.WriteLine();
+            return;
+        }
+
+        var subName = args[0];
+        var subArgs = args.Skip(1).ToArray();
+
+        if (!registry.TryGetValue(subName, out var cmd))
+        {
+            Console.WriteLine($"Unknown stable-balance subcommand: {subName}. Use 'stable-balance help' for available commands.");
+            return;
+        }
+
+        await cmd.Run(sdk, readline, subArgs);
+    }
+
+    // --- get ---
+
+    private static async Task HandleGet(BreezSdk sdk, Func<string, string?> readline, string[] args)
+    {
+        var settings = await sdk.GetUserSettings();
+        Serialization.PrintValue(settings.stableBalanceActiveLabel);
+    }
+
+    // --- set ---
+
+    private static async Task HandleSet(BreezSdk sdk, Func<string, string?> readline, string[] args)
+    {
+        if (args.Length < 1)
+        {
+            Console.WriteLine("Usage: stable-balance set <label>");
+            return;
+        }
+
+        await sdk.UpdateUserSettings(new UpdateUserSettingsRequest(
+            sparkPrivateModeEnabled: null,
+            stableBalanceActiveLabel: new StableBalanceActiveLabel.Set(label: args[0])
+        ));
+        var settings = await sdk.GetUserSettings();
+        Serialization.PrintValue(settings);
+    }
+
+    // --- unset ---
+
+    private static async Task HandleUnset(BreezSdk sdk, Func<string, string?> readline, string[] args)
+    {
+        await sdk.UpdateUserSettings(new UpdateUserSettingsRequest(
+            sparkPrivateModeEnabled: null,
+            stableBalanceActiveLabel: new StableBalanceActiveLabel.Unset()
+        ));
+        var settings = await sdk.GetUserSettings();
+        Serialization.PrintValue(settings);
+    }
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/README.md
@@ -56,6 +56,7 @@ make clean            Remove build artifacts
 | `--network` | `regtest` | Network to use (`regtest` or `mainnet`) |
 | `--account-number` | | Account number for the Spark signer |
 | `--postgres-connection-string` | | PostgreSQL connection string (uses SQLite by default) |
+| `--mysql-connection-string` | | MySQL connection string (mutually exclusive with `--postgres-connection-string`) |
 | `--stable-balance-token-identifier` | | Stable balance token identifier |
 | `--stable-balance-threshold` | | Stable balance threshold in sats |
 | `--passkey` | | Use passkey with PRF provider (`file`, `yubikey`, or `fido2`) |

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Main.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Main.kt
@@ -61,6 +61,7 @@ fun main(args: Array<String>) {
     var network = "regtest"
     var accountNumber: String? = null
     var postgresConnectionString: String? = null
+    var mysqlConnectionString: String? = null
     var stableBalanceTokenIdentifier: String? = null
     var stableBalanceThreshold: ULong? = null
     var passkeyProviderStr: String? = null
@@ -88,6 +89,10 @@ fun main(args: Array<String>) {
             "--postgres-connection-string" -> {
                 i++
                 if (i < args.size) postgresConnectionString = args[i]
+            }
+            "--mysql-connection-string" -> {
+                i++
+                if (i < args.size) mysqlConnectionString = args[i]
             }
             "--stable-balance-token-identifier" -> {
                 i++
@@ -123,6 +128,7 @@ fun main(args: Array<String>) {
                 println("  --network <NETWORK>                          Network to use: regtest, mainnet (default: regtest)")
                 println("  --account-number <NUM>                       Account number for the Spark signer")
                 println("  --postgres-connection-string <CONN>          PostgreSQL connection string (uses SQLite by default)")
+                println("  --mysql-connection-string <CONN>             MySQL connection string (mutually exclusive with --postgres-connection-string)")
                 println("  --stable-balance-token-identifier <ID>       Stable balance token identifier")
                 println("  --stable-balance-threshold <SATS>            Stable balance threshold in sats")
                 println("  --passkey <PROVIDER>                         Use passkey with PRF provider (file, yubikey, or fido2)")
@@ -154,6 +160,10 @@ fun main(args: Array<String>) {
     }
     if (listLabels && (label != null || storeLabel)) {
         System.err.println("Error: --list-labels conflicts with --label and --store-label")
+        return
+    }
+    if (postgresConnectionString != null && mysqlConnectionString != null) {
+        System.err.println("Error: --postgres-connection-string and --mysql-connection-string are mutually exclusive")
         return
     }
 
@@ -205,6 +215,7 @@ fun main(args: Array<String>) {
             networkEnum,
             accountNumber,
             postgresConnectionString,
+            mysqlConnectionString,
             stableBalanceConfig,
             passkeyConfig,
         )
@@ -216,6 +227,7 @@ suspend fun runInteractiveMode(
     network: Network,
     accountNumber: String?,
     postgresConnectionString: String?,
+    mysqlConnectionString: String?,
     stableBalanceConfig: StableBalanceConfig?,
     passkeyConfig: PasskeyConfig?,
 ) {
@@ -255,9 +267,19 @@ suspend fun runInteractiveMode(
     // Build SDK
     val builder = SdkBuilder(config, seed)
     if (postgresConnectionString != null) {
-        val pgConfig = defaultPostgresStorageConfig(postgresConnectionString)
-        val pool = createPostgresConnectionPool(pgConfig)
-        builder.withPostgresConnectionPool(pool)
+        val context = newSharedSdkContext(SdkContextConfig(
+            network = network,
+            apiKey = if (!apiKey.isNullOrEmpty()) apiKey else null,
+            postgresConfig = defaultPostgresStorageConfig(postgresConnectionString),
+        ))
+        builder.withSharedContext(context)
+    } else if (mysqlConnectionString != null) {
+        val context = newSharedSdkContext(SdkContextConfig(
+            network = network,
+            apiKey = if (!apiKey.isNullOrEmpty()) apiKey else null,
+            mysqlConfig = defaultMysqlStorageConfig(mysqlConnectionString),
+        ))
+        builder.withSharedContext(context)
     } else {
         builder.withDefaultStorage(dataDir)
     }

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
@@ -48,6 +48,7 @@ make clean            Remove venv and build artifacts
 | `--network` | `regtest` | Network to use (`regtest` or `mainnet`) |
 | `--account-number` | - | Account number for the Spark signer |
 | `--postgres-connection-string` | - | PostgreSQL connection string (uses SQLite by default) |
+| `--mysql-connection-string` | - | MySQL connection string (mutually exclusive with `--postgres-connection-string`) |
 | `--stable-balance-token` | - | Stable balance tokens in `LABEL:token_identifier` format (repeatable) |
 | `--stable-balance-default-active-label` | - | Default active label for stable balance (must match a token label) |
 | `--stable-balance-threshold` | - | Stable balance threshold in sats |

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
@@ -15,14 +15,16 @@ from breez_sdk_spark import (
     KeySetType,
     Network,
     SdkBuilder,
+    SdkContextConfig,
     SdkEvent,
     Seed,
     StableBalanceConfig,
     StableBalanceToken,
-    create_postgres_connection_pool,
     default_config,
+    default_mysql_storage_config,
     default_postgres_storage_config,
     init_logging,
+    new_shared_sdk_context,
 )
 
 from breez_cli.commands import COMMAND_NAMES, build_command_registry
@@ -61,6 +63,7 @@ def expand_path(path: str) -> Path:
 )
 @click.option("--account-number", type=int, default=None, help="Account number for the Spark signer")
 @click.option("--postgres-connection-string", default=None, help="PostgreSQL connection string")
+@click.option("--mysql-connection-string", default=None, help="MySQL connection string")
 @click.option("--stable-balance-token", "stable_balance_tokens", multiple=True,
               help='Stable balance tokens in "LABEL:token_identifier" format (repeatable)')
 @click.option("--stable-balance-default-active-label", default=None,
@@ -72,12 +75,16 @@ def expand_path(path: str) -> Path:
 @click.option("--store-label", is_flag=True, default=False, help="Publish the label to Nostr (requires --passkey and --label)")
 @click.option("--rpid", default=None, help="Relying party ID for FIDO2 provider (requires --passkey)")
 async def main(data_dir, network, account_number, postgres_connection_string,
+               mysql_connection_string,
                stable_balance_tokens, stable_balance_default_active_label,
                stable_balance_threshold,
                passkey_provider, label, list_labels, store_label, rpid):
     """CLI client for Breez SDK with Spark."""
     data_dir = expand_path(data_dir)
     data_dir.mkdir(parents=True, exist_ok=True)
+
+    if postgres_connection_string and mysql_connection_string:
+        raise click.UsageError("--postgres-connection-string and --mysql-connection-string are mutually exclusive")
 
     # Validate passkey flag combinations
     if label and not passkey_provider:
@@ -129,9 +136,19 @@ async def main(data_dir, network, account_number, postgres_connection_string,
     builder = SdkBuilder(config=config, seed=seed)
 
     if postgres_connection_string:
-        pg_config = default_postgres_storage_config(connection_string=postgres_connection_string)
-        pool = create_postgres_connection_pool(config=pg_config)
-        await builder.with_postgres_connection_pool(pool=pool)
+        context = new_shared_sdk_context(config=SdkContextConfig(
+            network=network_enum,
+            api_key=breez_api_key,
+            postgres_config=default_postgres_storage_config(connection_string=postgres_connection_string),
+        ))
+        await builder.with_shared_context(context=context)
+    elif mysql_connection_string:
+        context = new_shared_sdk_context(config=SdkContextConfig(
+            network=network_enum,
+            api_key=breez_api_key,
+            mysql_config=default_mysql_storage_config(connection_string=mysql_connection_string),
+        ))
+        await builder.with_shared_context(context=context)
     else:
         await builder.with_default_storage(storage_dir=str(data_dir))
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
@@ -54,7 +54,9 @@ make clean            Remove build artifacts
 | `--network` | `regtest` | Network to use (`regtest` or `mainnet`) |
 | `--account-number` | - | Account number for the Spark signer |
 | `--postgres-connection-string` | - | PostgreSQL connection string (uses SQLite by default) |
-| `--stable-balance-token-identifier` | - | Stable balance token identifier |
+| `--mysql-connection-string` | - | MySQL connection string (mutually exclusive with `--postgres-connection-string`) |
+| `--stable-balance-token` | - | Stable balance token in `LABEL:token_identifier` format (repeatable) |
+| `--stable-balance-default-active-label` | - | Default active label for stable balance |
 | `--stable-balance-threshold` | - | Stable balance threshold in sats |
 | `--passkey` | - | Use Passkey with PRF provider (`file`, `yubikey` or `fido2`) |
 | `--label` | `Default` | Requires `--passkey`. The label to use |

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
@@ -9,7 +9,9 @@ struct CliOptions {
     var network: String = "regtest"
     var accountNumber: UInt32?
     var postgresConnectionString: String?
-    var stableBalanceTokenIdentifier: String?
+    var mysqlConnectionString: String?
+    var stableBalanceTokens: [String] = []
+    var stableBalanceDefaultActiveLabel: String?
     var stableBalanceThreshold: UInt64?
     var passkey: String?
     var label: String?
@@ -36,9 +38,15 @@ func parseCliFlags() -> CliOptions {
         case "--postgres-connection-string":
             i += 1
             if i < args.count { opts.postgresConnectionString = args[i] }
-        case "--stable-balance-token-identifier":
+        case "--mysql-connection-string":
             i += 1
-            if i < args.count { opts.stableBalanceTokenIdentifier = args[i] }
+            if i < args.count { opts.mysqlConnectionString = args[i] }
+        case "--stable-balance-token":
+            i += 1
+            if i < args.count { opts.stableBalanceTokens.append(args[i]) }
+        case "--stable-balance-default-active-label":
+            i += 1
+            if i < args.count { opts.stableBalanceDefaultActiveLabel = args[i] }
         case "--stable-balance-threshold":
             i += 1
             if i < args.count { opts.stableBalanceThreshold = UInt64(args[i]) }
@@ -204,13 +212,20 @@ let breezApiKey: String? = {
     return nil
 }()
 config.apiKey = breezApiKey
-if let tokenIdentifier = opts.stableBalanceTokenIdentifier {
+if !opts.stableBalanceTokens.isEmpty {
+    let tokens: [StableBalanceToken] = opts.stableBalanceTokens.map { s in
+        let parts = s.split(separator: ":", maxSplits: 1)
+        guard parts.count == 2 else {
+            fatalError("Invalid token format '\(s)', expected LABEL:token_identifier")
+        }
+        return StableBalanceToken(
+            label: String(parts[0]),
+            tokenIdentifier: String(parts[1])
+        )
+    }
     config.stableBalanceConfig = StableBalanceConfig(
-        tokens: [StableBalanceToken(
-            label: "USDB",
-            tokenIdentifier: tokenIdentifier
-        )],
-        defaultActiveLabel: "USDB",
+        tokens: tokens,
+        defaultActiveLabel: opts.stableBalanceDefaultActiveLabel,
         thresholdSats: opts.stableBalanceThreshold,
         maxSlippageBps: nil
     )
@@ -239,8 +254,19 @@ if let passkeyStr = opts.passkey {
 // Build SDK
 let builder = SdkBuilder(config: config, seed: seed)
 if let connectionString = opts.postgresConnectionString {
-    let pool = try createPostgresConnectionPool(config: defaultPostgresStorageConfig(connectionString: connectionString))
-    await builder.withPostgresConnectionPool(pool: pool)
+    let context = try newSharedSdkContext(config: SdkContextConfig(
+        network: network,
+        apiKey: breezApiKey,
+        postgresConfig: defaultPostgresStorageConfig(connectionString: connectionString)
+    ))
+    await builder.withSharedContext(context: context)
+} else if let connectionString = opts.mysqlConnectionString {
+    let context = try newSharedSdkContext(config: SdkContextConfig(
+        network: network,
+        apiKey: breezApiKey,
+        mysqlConfig: defaultMysqlStorageConfig(connectionString: connectionString)
+    ))
+    await builder.withSharedContext(context: context)
 } else {
     await builder.withDefaultStorage(storageDir: resolvedDir)
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
@@ -10,11 +10,10 @@ const { parse: parseShell } = require('shell-quote')
 
 const {
   SdkBuilder,
-  createMysqlConnectionPool,
-  createPostgresConnectionPool,
   defaultConfig,
   defaultMysqlStorageConfig,
   defaultPostgresStorageConfig,
+  newSharedSdkContext,
   initLogging,
   getSparkStatus
 } = require('@breeztech/breez-sdk-spark/nodejs')
@@ -270,15 +269,19 @@ async function main() {
   let sdkBuilder = SdkBuilder.new(config, seed)
 
   if (opts.postgresConnectionString) {
-    const pool = createPostgresConnectionPool(
-      defaultPostgresStorageConfig(opts.postgresConnectionString)
-    )
-    sdkBuilder = sdkBuilder.withPostgresConnectionPool(pool)
+    const context = newSharedSdkContext({
+      network,
+      apiKey: breezApiKey,
+      postgresConfig: defaultPostgresStorageConfig(opts.postgresConnectionString)
+    })
+    sdkBuilder = sdkBuilder.withSharedContext(context)
   } else if (opts.mysqlConnectionString) {
-    const pool = createMysqlConnectionPool(
-      defaultMysqlStorageConfig(opts.mysqlConnectionString)
-    )
-    sdkBuilder = sdkBuilder.withMysqlConnectionPool(pool)
+    const context = newSharedSdkContext({
+      network,
+      apiKey: breezApiKey,
+      mysqlConfig: defaultMysqlStorageConfig(opts.mysqlConnectionString)
+    })
+    sdkBuilder = sdkBuilder.withSharedContext(context)
   } else {
     sdkBuilder = await sdkBuilder.withDefaultStorage(dataDir)
   }


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`0d45c6e`](https://github.com/breez/spark-sdk/commit/0d45c6e1d463bcdc098fd7bc3b01705e2de87113)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/26089710193)

**Language status:**
- :white_check_mark: C#
- :next_track_button: Dart (no changes needed)
- :x: Go (patch failed to apply)
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :next_track_button: React Native (no changes needed)
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- Postgres storage used old pattern (CreatePostgresConnectionPool + WithPostgresConnectionPool) instead of new NewSharedSdkContext + SdkContextConfig + WithSharedContext pattern
- Missing `--mysql-connection-string` CLI flag and MySQL storage backend support
- Stable balance token format used single `--stable-balance-token-identifier` with hardcoded "USDB" label instead of repeatable `--stable-balance-token LABEL:token_identifier` format
- Missing `--stable-balance-default-active-label` CLI flag
- Missing `stable-balance` subcommand group (get, set, unset)
- Missing `--token-identifier` flag in lnurl-pay command handler
- `--new-address` missing from BooleanFlags set (replaced duplicate `--from-bitcoin` entry)

## Applied
- Program.cs: Replaced postgres storage setup with NewSharedSdkContext + SdkContextConfig + WithSharedContext pattern
- Program.cs: Added `--mysql-connection-string` flag with conflict validation against `--postgres-connection-string`
- Program.cs: Added MySQL storage backend using NewSharedSdkContext + SdkContextConfig + WithSharedContext pattern
- Program.cs: Changed `--stable-balance-token-identifier` to repeatable `--stable-balance-token LABEL:token_identifier` format
- Program.cs: Added `--stable-balance-default-active-label` flag
- Program.cs: Added `stable-balance` subcommand dispatch and tab-completion
- Program.cs: Updated help text for new/changed flags
- Commands.cs: Added `--token-identifier` (`-t`) flag to lnurl-pay handler with prompt text that adapts based on presence
- Commands.cs: Fixed BooleanFlags: removed duplicate `--from-bitcoin`, added `--new-address`
- Commands.cs: Added `stable-balance <subcommand>` to help output
- StableBalance.cs: Created new file with get, set, unset subcommands matching Rust stable_balance.rs
- README.md: Updated CLI Options table with MySQL, stable balance token format, and default active label
- README.md: Added "Stable Balance" section to Available Commands

## Skipped
- None

### Dart
## Divergences
- Rust CLI changed postgres/mysql storage setup from `create_postgres_connection_pool` + `with_postgres_connection_pool` to `new_shared_sdk_context(SdkContextConfig { postgres_config: ... })` + `with_shared_context(context)` (and similarly for MySQL). The Dart CLI still warns that postgres/mysql is unsupported and falls back to SQLite.

## Applied
- (none)

## Skipped
- Postgres/MySQL shared context pattern: The FRB mirror of `SdkContextConfig` (in `packages/flutter/rust/src/models.rs`) only exposes `network`, `api_key`, and `connections_per_operator` — the `postgres_config` and `mysql_config` fields are behind Rust feature gates and not mirrored to Dart. The Dart CLI cannot replicate the `new_shared_sdk_context` + `with_shared_context` pattern with database config, so the existing warning + SQLite fallback remains correct. When the FRB mirror adds these fields, the Dart CLI should be updated to use `newSharedSdkContext` + `withSharedContext`.

### Go
## Divergences
- Go CLI missing `--mysql-connection-string` flag (Rust has MySQL support via `create_mysql_connection_pool` + `with_mysql_connection_pool`)
- Go CLI stable balance used single `--stable-balance-token-identifier` with hardcoded "USDB" label; Rust uses repeatable `--stable-balance-token` (LABEL:id format) + `--stable-balance-default-active-label`
- Go CLI missing `webhooks` subcommand group (register, unregister, list) present in Rust
- Go CLI missing `stable-balance` subcommand group (get, set, unset) present in Rust
- Go CLI `lnurl-pay` missing `--token-identifier` / `-t` flag for token-denominated amounts
- Go CLI `buy-bitcoin` missing `--provider` flag and CashApp support; used `--amount` instead of `--amount-sat`
- Go CLI README missing MySQL, webhooks, and stable-balance documentation
- Rust CLI uses new `new_shared_sdk_context` + `with_shared_context` API for Postgres/MySQL; Go SDK does not yet expose this API

## Applied
- Added `--mysql-connection-string` flag with `CreateMysqlConnectionPool` + `WithMysqlConnectionPool` in `main.go`
- Changed stable balance flags to repeatable `--stable-balance-token` (LABEL:id format) + `--stable-balance-default-active-label` in `main.go`
- Created `webhooks.go` with register, unregister, list commands and webhook event type parsing
- Created `stable_balance.go` with get, set, unset commands using `StableBalanceActiveLabelSet`/`Unset`
- Added `--token-identifier` / `-t` flag to `lnurl-pay` in `commands.go`, used in prompt and `PrepareLnurlPayRequest`
- Added `--provider` flag (default "moonpay") and CashApp support to `buy-bitcoin` in `commands.go`; renamed `--amount` to `--amount-sat` to match Rust
- Updated description of `buy-bitcoin` from "Buy Bitcoin via MoonPay" to "Buy Bitcoin using an external provider"
- Added webhooks and stable-balance dispatch in REPL, completion list, and help text in `main.go` and `commands.go`
- Updated `README.md` with MySQL, stable-balance-token, stable-balance-default-active-label, webhooks, and stable-balance documentation
- Added `WebhookEventType` and `StableBalanceActiveLabel` prefixes to `serialization.go` for proper JSON display

## Skipped
- Rust CLI's migration from `create_postgres_connection_pool` + `with_postgres_connection_pool` to `new_shared_sdk_context` + `with_shared_context`: Go SDK does not expose `NewSharedSdkContext`, `WithSharedContext`, or `SdkContextConfig` (verified by grep and snippets). Go CLI continues using the working `CreatePostgresConnectionPool` + `WithPostgresConnectionPool` pattern demonstrated in Go SDK snippets.

### Kotlin
## Divergences
- Kotlin CLI used old `createPostgresConnectionPool()` + `withPostgresConnectionPool()` API; Rust CLI now uses `newSharedSdkContext(SdkContextConfig { ... })` + `withSharedContext()`
- Kotlin CLI was missing `--mysql-connection-string` flag and MySQL storage support (present in Rust CLI)
- Kotlin CLI stable balance config uses a single `--stable-balance-token-identifier` flag with hardcoded "USDB" label; Rust CLI uses repeatable `--stable-balance-token LABEL:id` format with `--stable-balance-default-active-label` (pre-existing, not in diff)
- Kotlin CLI is missing `webhooks` subcommand group: register, unregister, list (pre-existing, not in diff)
- Kotlin CLI is missing `stable-balance` subcommand group: get, set, unset (pre-existing, not in diff)
- Kotlin CLI `buy-bitcoin` only supports MoonPay provider; Rust CLI also supports CashApp (pre-existing, not in diff)
- Kotlin CLI `lnurl-pay` is missing `--token-identifier` flag (pre-existing, not in diff)

## Applied
- Updated `Main.kt`: replaced `createPostgresConnectionPool()` + `withPostgresConnectionPool()` with `newSharedSdkContext(SdkContextConfig(...))` + `withSharedContext()` for PostgreSQL storage
- Updated `Main.kt`: added `--mysql-connection-string` CLI flag with argument parsing, help text, and mutual exclusivity validation against `--postgres-connection-string`
- Updated `Main.kt`: added MySQL storage path using `newSharedSdkContext(SdkContextConfig(...))` + `withSharedContext()` with `defaultMysqlStorageConfig()`
- Updated `Main.kt`: added `mysqlConnectionString` parameter to `runInteractiveMode()` function signature and call site
- Updated `README.md`: added `--mysql-connection-string` to CLI Options table

## Skipped
- Stable balance config format divergence (repeatable tokens with labels vs single token identifier): pre-existing difference not related to the current diff
- Webhooks subcommand group (register, unregister, list): pre-existing missing feature not related to the current diff
- StableBalance subcommand group (get, set, unset): pre-existing missing feature not related to the current diff
- BuyBitcoin CashApp provider support: pre-existing missing feature not related to the current diff
- LnurlPay `--token-identifier` flag: pre-existing missing feature not related to the current diff

### Python
## Divergences
- Python CLI used old `create_postgres_connection_pool` + `with_postgres_connection_pool` pattern; Rust CLI now uses `new_shared_sdk_context(SdkContextConfig{...})` + `with_shared_context`
- Python CLI was missing `--mysql-connection-string` flag and MySQL storage support (Rust CLI had it before this diff, now using new shared context pattern)

## Applied
- Updated `main.py` imports: replaced `create_postgres_connection_pool` with `SdkContextConfig`, `new_shared_sdk_context`, `default_mysql_storage_config`
- Updated `main.py` PostgreSQL storage init to use `new_shared_sdk_context` + `with_shared_context` pattern
- Added `--mysql-connection-string` CLI flag with mutual exclusivity validation against `--postgres-connection-string`
- Added MySQL storage init path using `new_shared_sdk_context` + `with_shared_context` pattern
- Updated `README.md` CLI options table to document `--mysql-connection-string`

## Skipped
- (none)

### React Native
## Divergences
- Rust CLI changed Postgres/MySQL storage init from `create_postgres_connection_pool`/`create_mysql_connection_pool` + `with_postgres_connection_pool`/`with_mysql_connection_pool` to `new_shared_sdk_context(SdkContextConfig)` + `with_shared_context()` — React Native CLI does not implement Postgres/MySQL storage (uses `withDefaultStorage` only), so no divergence applies

## Applied
- (none — no changes needed)

## Skipped
- Postgres/MySQL shared context migration: React Native CLI only uses SQLite via `withDefaultStorage`, so the Rust change from connection-pool-based init to shared-SDK-context-based init has no React Native counterpart to update

### Swift
## Divergences
- Postgres storage setup used old `createPostgresConnectionPool` + `withPostgresConnectionPool` pattern instead of new `newSharedSdkContext(SdkContextConfig)` + `withSharedContext`
- Missing `--mysql-connection-string` CLI flag and MySQL storage support
- `--stable-balance-token-identifier` (single value, hardcoded "USDB" label) instead of repeatable `--stable-balance-token LABEL:token_identifier` format
- Missing `--stable-balance-default-active-label` CLI flag
- Swift README CLI options table was outdated (missing MySQL, old stable balance flag names)

## Applied
- Updated postgres storage to use `newSharedSdkContext` + `withSharedContext` pattern in `main.swift`
- Added MySQL storage support via `newSharedSdkContext` + `withSharedContext` pattern with `--mysql-connection-string` flag in `main.swift`
- Replaced `--stable-balance-token-identifier` with repeatable `--stable-balance-token LABEL:token_identifier` format in `main.swift`
- Added `--stable-balance-default-active-label` flag in `main.swift`
- Updated Swift README CLI options table with new/changed flags

## Skipped
- (none)

### TypeScript
## Divergences
- `main.js` used `createPostgresConnectionPool` + `withPostgresConnectionPool` and `createMysqlConnectionPool` + `withMysqlConnectionPool`, while Rust CLI now uses `new_shared_sdk_context(SdkContextConfig { api_key, postgres_config/mysql_config, ..SdkContextConfig::new(network) })` + `with_shared_context`

## Applied
- Updated `main.js` imports: replaced `createMysqlConnectionPool` and `createPostgresConnectionPool` with `newSharedSdkContext`
- Updated `main.js` Postgres storage path: now calls `newSharedSdkContext({ network, apiKey, postgresConfig })` + `withSharedContext(context)` instead of `createPostgresConnectionPool` + `withPostgresConnectionPool`
- Updated `main.js` MySQL storage path: now calls `newSharedSdkContext({ network, apiKey, mysqlConfig })` + `withSharedContext(context)` instead of `createMysqlConnectionPool` + `withMysqlConnectionPool`

## Skipped
- (none)

</details>

> [!WARNING]
> Some patches failed to apply. The target files may have changed since the sync ran.
> Failed languages: golang
> Consider re-running the sync for these languages.