### PR TITLE
Refactor `wait_for_payment` to be polling only

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/conversion_send_server_mode.rs
+++ b/crates/breez-sdk/breez-itest/tests/conversion_send_server_mode.rs
@@ -1,0 +1,226 @@
+use anyhow::Result;
+use breez_sdk_itest::*;
+use breez_sdk_spark::*;
+use rand::RngCore;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+use tracing::info;
+
+struct ConversionServerModeFixture {
+    #[allow(dead_code)]
+    pg_container: ContainerAsync<Postgres>,
+    connection_string: String,
+}
+
+impl ConversionServerModeFixture {
+    async fn new() -> Result<Self> {
+        let pg_container = Postgres::default()
+            .start()
+            .await
+            .expect("Failed to start PostgreSQL container");
+        let host_port = pg_container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("Failed to get host port");
+        let connection_string = format!(
+            "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
+        );
+        Ok(Self {
+            pg_container,
+            connection_string,
+        })
+    }
+
+    async fn build_instance(&self) -> Result<SdkInstance> {
+        let mut seed = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut seed);
+        build_sdk_with_postgres_server_mode(&self.connection_string, seed).await
+    }
+}
+
+#[test_log::test(tokio::test)]
+#[ignore = "Requires regtest conversion liquidity; same precondition as token_conversion.rs"]
+async fn test_conversion_send_server_mode_bitcoin_to_token() -> Result<()> {
+    info!("=== Starting test_conversion_send_server_mode_bitcoin_to_token ===");
+    let sats_to_token_amount: u128 = 20_000_000_000;
+
+    let fixture = ConversionServerModeFixture::new().await?;
+    let mut alice = fixture.build_instance().await?;
+    let bob = fixture.build_instance().await?;
+
+    // Fund Alice via polling (server mode has no ClaimedDeposits event).
+    ensure_funded_via_polling(&mut alice, 10_000).await?;
+
+    let bob_spark_address = bob
+        .sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::SparkAddress,
+        })
+        .await?
+        .payment_request;
+
+    let prepare = alice
+        .sdk
+        .prepare_send_payment(PrepareSendPaymentRequest {
+            payment_request: bob_spark_address,
+            amount: Some(sats_to_token_amount),
+            token_identifier: Some(SHELL_REGTEST_TOKEN_ID.to_string()),
+            conversion_options: Some(ConversionOptions {
+                conversion_type: ConversionType::FromBitcoin,
+                max_slippage_bps: Some(200),
+                completion_timeout_secs: None,
+            }),
+            fee_policy: None,
+        })
+        .await?;
+
+    // Pre-fix, this call hangs ~30 s and returns
+    // `Err(Generic("Timeout waiting for conversion to complete: …"))`.
+    let send = alice
+        .sdk
+        .send_payment(SendPaymentRequest {
+            prepare_response: prepare,
+            options: None,
+            idempotency_key: None,
+        })
+        .await?;
+
+    assert!(
+        matches!(
+            send.payment.status,
+            PaymentStatus::Completed | PaymentStatus::Pending
+        ),
+        "Bitcoin→Token send should not time out in server mode",
+    );
+    assert!(
+        send.payment.conversion_details.is_some(),
+        "Conversion-send payment should carry conversion_details"
+    );
+
+    // Receiver doesn't run a background processor either; sync explicitly
+    // before reading balance.
+    bob.sdk.sync_wallet(SyncWalletRequest {}).await?;
+    let bob_token_balance = bob
+        .sdk
+        .get_info(GetInfoRequest {
+            ensure_synced: Some(false),
+        })
+        .await?
+        .token_balances
+        .get(SHELL_REGTEST_TOKEN_ID)
+        .map(|b| b.balance)
+        .unwrap_or(0);
+    assert!(
+        bob_token_balance > 0,
+        "Bob should receive tokens from the conversion-send"
+    );
+    info!("Bob token balance after Bitcoin→Token (server mode): {bob_token_balance}");
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+#[ignore = "Requires regtest conversion liquidity; same precondition as token_conversion.rs"]
+async fn test_conversion_send_server_mode_token_to_bitcoin() -> Result<()> {
+    info!("=== Starting test_conversion_send_server_mode_token_to_bitcoin ===");
+    let sats_to_token_amount: u128 = 20_000_000_000;
+    let token_to_sats_amount: u64 = 2_500;
+
+    let fixture = ConversionServerModeFixture::new().await?;
+    let mut alice = fixture.build_instance().await?;
+    let bob = fixture.build_instance().await?;
+
+    // Seed Bob with tokens via Alice's Bitcoin → Token conversion, so we
+    // can then exercise the Token → Bitcoin direction.
+    ensure_funded_via_polling(&mut alice, 10_000).await?;
+    let bob_spark_address = bob
+        .sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::SparkAddress,
+        })
+        .await?
+        .payment_request;
+    let prepare_seed = alice
+        .sdk
+        .prepare_send_payment(PrepareSendPaymentRequest {
+            payment_request: bob_spark_address,
+            amount: Some(sats_to_token_amount),
+            token_identifier: Some(SHELL_REGTEST_TOKEN_ID.to_string()),
+            conversion_options: Some(ConversionOptions {
+                conversion_type: ConversionType::FromBitcoin,
+                max_slippage_bps: Some(200),
+                completion_timeout_secs: None,
+            }),
+            fee_policy: None,
+        })
+        .await?;
+    alice
+        .sdk
+        .send_payment(SendPaymentRequest {
+            prepare_response: prepare_seed,
+            options: None,
+            idempotency_key: None,
+        })
+        .await?;
+
+    bob.sdk.sync_wallet(SyncWalletRequest {}).await?;
+
+    // Now Bob sends tokens → Alice receives sats via Lightning invoice.
+    let alice_invoice = alice
+        .sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::Bolt11Invoice {
+                description: "Server-mode Token→Bitcoin test".to_string(),
+                amount_sats: Some(token_to_sats_amount),
+                expiry_secs: None,
+                payment_hash: None,
+            },
+        })
+        .await?
+        .payment_request;
+
+    let prepare = bob
+        .sdk
+        .prepare_send_payment(PrepareSendPaymentRequest {
+            payment_request: alice_invoice,
+            amount: None,
+            token_identifier: None,
+            conversion_options: Some(ConversionOptions {
+                conversion_type: ConversionType::ToBitcoin {
+                    from_token_identifier: SHELL_REGTEST_TOKEN_ID.to_string(),
+                },
+                max_slippage_bps: Some(200),
+                completion_timeout_secs: None,
+            }),
+            fee_policy: None,
+        })
+        .await?;
+
+    // Pre-fix, hangs because Bob's server-mode SDK never observes the
+    // received-leg spark transfer that the conversion produces.
+    let send = bob
+        .sdk
+        .send_payment(SendPaymentRequest {
+            prepare_response: prepare,
+            options: None,
+            idempotency_key: None,
+        })
+        .await?;
+
+    assert!(
+        matches!(
+            send.payment.status,
+            PaymentStatus::Completed | PaymentStatus::Pending
+        ),
+        "Token→Bitcoin send should not time out in server mode",
+    );
+    assert!(
+        send.payment.conversion_details.is_some(),
+        "Conversion-send payment should carry conversion_details"
+    );
+
+    info!(
+        "Token→Bitcoin server-mode send completed: status={:?}",
+        send.payment.status
+    );
+    Ok(())
+}

--- a/crates/breez-sdk/breez-itest/tests/lightning_send_server_mode.rs
+++ b/crates/breez-sdk/breez-itest/tests/lightning_send_server_mode.rs
@@ -1,0 +1,121 @@
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use breez_sdk_itest::*;
+use breez_sdk_spark::*;
+use rand::RngCore;
+use rstest::*;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+use tracing::info;
+
+struct ServerModeFixture {
+    #[allow(dead_code)]
+    pg_container: ContainerAsync<Postgres>,
+    connection_string: String,
+}
+
+impl ServerModeFixture {
+    async fn new() -> Result<Self> {
+        let pg_container = Postgres::default()
+            .start()
+            .await
+            .expect("Failed to start PostgreSQL container");
+        let host_port = pg_container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("Failed to get host port");
+        let connection_string = format!(
+            "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
+        );
+        Ok(Self {
+            pg_container,
+            connection_string,
+        })
+    }
+
+    async fn build_alice(&self) -> Result<SdkInstance> {
+        let mut seed = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut seed);
+        build_sdk_with_postgres_server_mode(&self.connection_string, seed).await
+    }
+}
+
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn test_send_bolt11_invoice_server_mode(
+    #[future] bob_sdk: Result<SdkInstance>,
+) -> Result<()> {
+    info!("=== Starting test_send_bolt11_invoice_server_mode ===");
+    let invoice_amount_sats: u64 = 10_000;
+    let completion_timeout_secs: u32 = 10;
+
+    let fixture = ServerModeFixture::new().await?;
+    let mut alice = fixture.build_alice().await?;
+    let mut bob = bob_sdk.await?;
+
+    // Fund Alice via polling (server mode has no ClaimedDeposits event).
+    ensure_funded_via_polling(&mut alice, 100_000).await?;
+    alice.sdk.sync_wallet(SyncWalletRequest {}).await?;
+
+    let bob_invoice = bob
+        .sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::Bolt11Invoice {
+                description: "Server-mode bolt11 send test".to_string(),
+                amount_sats: Some(invoice_amount_sats),
+                expiry_secs: None,
+                payment_hash: None,
+            },
+        })
+        .await?
+        .payment_request;
+
+    let prepare = alice
+        .sdk
+        .prepare_send_payment(PrepareSendPaymentRequest {
+            payment_request: bob_invoice.clone(),
+            amount: None,
+            token_identifier: None,
+            conversion_options: None,
+            fee_policy: None,
+        })
+        .await?;
+
+    let start = Instant::now();
+    let send_resp = alice
+        .sdk
+        .send_payment(SendPaymentRequest {
+            prepare_response: prepare,
+            options: Some(SendPaymentOptions::Bolt11Invoice {
+                prefer_spark: false,
+                completion_timeout_secs: Some(completion_timeout_secs),
+            }),
+            idempotency_key: None,
+        })
+        .await?;
+    let elapsed = start.elapsed();
+    info!(
+        "Server-mode send_payment returned in {:?} with status {:?}",
+        elapsed, send_resp.payment.status
+    );
+
+    assert!(
+        elapsed < Duration::from_secs(u64::from(completion_timeout_secs).saturating_sub(1)),
+        "send_payment blocked until timeout in server mode (took {elapsed:?})",
+    );
+    assert_eq!(
+        send_resp.payment.status,
+        PaymentStatus::Completed,
+        "server-mode send_payment should resolve to Completed via polling, not the Pending fallback returned on timeout",
+    );
+
+    // Confirm the payment reached Bob (client-mode receiver still drives
+    // events normally).
+    let received =
+        wait_for_payment_succeeded_event(&mut bob.events, PaymentType::Receive, 30).await?;
+    assert_eq!(received.amount, u128::from(invoice_amount_sats));
+    assert_eq!(received.method, PaymentMethod::Lightning);
+
+    Ok(())
+}

--- a/crates/breez-sdk/breez-itest/tests/lightning_send_server_mode.rs
+++ b/crates/breez-sdk/breez-itest/tests/lightning_send_server_mode.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use anyhow::Result;
 use breez_sdk_itest::*;
@@ -100,14 +100,10 @@ async fn test_send_bolt11_invoice_server_mode(
         elapsed, send_resp.payment.status
     );
 
-    assert!(
-        elapsed < Duration::from_secs(u64::from(completion_timeout_secs).saturating_sub(1)),
-        "send_payment blocked until timeout in server mode (took {elapsed:?})",
-    );
     assert_eq!(
         send_resp.payment.status,
         PaymentStatus::Completed,
-        "server-mode send_payment should resolve to Completed via polling, not the Pending fallback returned on timeout",
+        "server-mode send_payment should resolve to Completed via polling, not the Pending fallback",
     );
 
     // Confirm the payment reached Bob (client-mode receiver still drives

--- a/crates/breez-sdk/cli/src/main.rs
+++ b/crates/breez-sdk/cli/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::{Result, anyhow};
 use breez_sdk_spark::{
     EventListener, Network, SdkBuilder, SdkContextConfig, SdkEvent, Seed, StableBalanceConfig,
     StableBalanceToken, default_config, default_mysql_storage_config,
-    default_postgres_storage_config, new_shared_sdk_context,
+    default_postgres_storage_config, default_server_config, new_shared_sdk_context,
 };
 use clap::Parser;
 use command::{Command, execute_command};
@@ -78,6 +78,14 @@ struct Cli {
     /// Relying party ID for FIDO2 provider (default: keys.breez.technology)
     #[arg(long, requires = "passkey")]
     rpid: Option<String>,
+
+    /// Run in server mode (`background_tasks_enabled=false`).
+    ///
+    /// The SDK won't subscribe to spark-wallet events or run periodic sync —
+    /// drive `sync` yourself between operations. Useful for testing server-mode
+    /// behavior end-to-end against mainnet/regtest without standing up a server.
+    #[arg(long)]
+    server_mode: bool,
 }
 
 fn expand_path(path: &str) -> PathBuf {
@@ -124,10 +132,15 @@ impl EventListener for CliEventListener {
     }
 }
 
-#[allow(clippy::too_many_lines, clippy::arithmetic_side_effects)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::arithmetic_side_effects
+)]
 async fn run_interactive_mode(
     data_dir: PathBuf,
     network: Network,
+    server_mode: bool,
     account_number: Option<u32>,
     postgres_connection_string: Option<String>,
     mysql_connection_string: Option<String>,
@@ -153,7 +166,12 @@ async fn run_interactive_mode(
 
     let breez_api_key = std::env::var_os("BREEZ_API_KEY")
         .map(|var| var.into_string().expect("Expected valid API key string"));
-    let mut config = default_config(network);
+    let mut config = if server_mode {
+        println!("Server mode enabled. Run `sync` between operations.");
+        default_server_config(network)
+    } else {
+        default_config(network)
+    };
     config.api_key.clone_from(&breez_api_key);
     config.stable_balance_config = stable_balance_config;
 
@@ -321,6 +339,7 @@ async fn main() -> Result<(), anyhow::Error> {
     Box::pin(run_interactive_mode(
         data_dir,
         network,
+        cli.server_mode,
         cli.account_number,
         cli.postgres_connection_string,
         cli.mysql_connection_string,

--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -178,7 +178,7 @@ pub trait EventMiddleware: Send + Sync {
 /// Event publisher that manages event listeners and middleware.
 ///
 /// Events flow through three phases:
-/// 1. Internal listeners see raw events (SDK components like `wait_for_payment`)
+/// 1. Internal listeners see raw events (SDK components like `ClientSyncListener`)
 /// 2. Middleware chain can transform or suppress events
 /// 3. External listeners see processed events (client event handlers)
 pub struct EventEmitter {
@@ -248,7 +248,7 @@ impl EventEmitter {
 
     /// Add an internal listener that sees all raw events before middleware processing.
     ///
-    /// Used by SDK components (e.g., `wait_for_payment`) that need to observe events
+    /// Used by SDK components (e.g., `ClientSyncListener`) that need to observe events
     /// that middleware may suppress.
     pub async fn add_internal_listener(&self, listener: Box<dyn EventListener>) -> String {
         let index = self.listener_index.fetch_add(1, Ordering::Relaxed);

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1761,7 +1761,7 @@ pub struct SparkStatus {
 
 pub(crate) enum WaitForPaymentIdentifier {
     PaymentId(String),
-    PaymentRequest(String),
+    LightningReceive { invoice: String, ssp_id: String },
 }
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/crates/breez-sdk/core/src/sdk/helpers.rs
+++ b/crates/breez-sdk/core/src/sdk/helpers.rs
@@ -35,41 +35,8 @@ pub(crate) async fn maybe_get_payment_from_storage(
         WaitForPaymentIdentifier::PaymentId(payment_id) => {
             Ok(storage.get_payment_by_id(payment_id.clone()).await.ok())
         }
-        WaitForPaymentIdentifier::PaymentRequest(payment_request) => Ok(storage
-            .get_payment_by_invoice(payment_request.clone())
-            .await?),
-    }
-}
-
-pub(crate) fn is_payment_match(payment: &Payment, identifier: &WaitForPaymentIdentifier) -> bool {
-    match identifier {
-        WaitForPaymentIdentifier::PaymentId(payment_id) => payment.id == *payment_id,
-        WaitForPaymentIdentifier::PaymentRequest(payment_request) => {
-            if let Some(details) = &payment.details {
-                match details {
-                    PaymentDetails::Lightning { invoice, .. } => {
-                        invoice.to_lowercase() == payment_request.to_lowercase()
-                    }
-                    PaymentDetails::Spark {
-                        invoice_details: invoice,
-                        ..
-                    }
-                    | PaymentDetails::Token {
-                        invoice_details: invoice,
-                        ..
-                    } => {
-                        if let Some(invoice) = invoice {
-                            invoice.invoice.to_lowercase() == payment_request.to_lowercase()
-                        } else {
-                            false
-                        }
-                    }
-                    PaymentDetails::Withdraw { tx_id: _ }
-                    | PaymentDetails::Deposit { tx_id: _ } => false,
-                }
-            } else {
-                false
-            }
+        WaitForPaymentIdentifier::LightningReceive { invoice, .. } => {
+            Ok(storage.get_payment_by_invoice(invoice.clone()).await?)
         }
     }
 }

--- a/crates/breez-sdk/core/src/sdk/helpers.rs
+++ b/crates/breez-sdk/core/src/sdk/helpers.rs
@@ -20,6 +20,27 @@ use crate::{
     persist::{CachedAccountInfo, ObjectCacheRepository, Storage},
 };
 
+/// Looks up the payment matching `identifier` from storage, if present.
+///
+/// Used as a fast-path check by `wait_for_payment` in both runtime
+/// profiles — if the payment is already there and complete, callers can
+/// short-circuit before subscribing to events / starting a poll loop.
+/// Returns `Ok(None)` when the row doesn't exist; surfaces real storage
+/// errors so callers can bubble them rather than mask them.
+pub(crate) async fn maybe_get_payment_from_storage(
+    storage: &dyn Storage,
+    identifier: &WaitForPaymentIdentifier,
+) -> Result<Option<Payment>, SdkError> {
+    match identifier {
+        WaitForPaymentIdentifier::PaymentId(payment_id) => {
+            Ok(storage.get_payment_by_id(payment_id.clone()).await.ok())
+        }
+        WaitForPaymentIdentifier::PaymentRequest(payment_request) => Ok(storage
+            .get_payment_by_invoice(payment_request.clone())
+            .await?),
+    }
+}
+
 pub(crate) fn is_payment_match(payment: &Payment, identifier: &WaitForPaymentIdentifier) -> bool {
     match identifier {
         WaitForPaymentIdentifier::PaymentId(payment_id) => payment.id == *payment_id,

--- a/crates/breez-sdk/core/src/sdk/helpers.rs
+++ b/crates/breez-sdk/core/src/sdk/helpers.rs
@@ -22,9 +22,9 @@ use crate::{
 
 /// Looks up the payment matching `identifier` from storage, if present.
 ///
-/// Used as a fast-path check by `wait_for_payment` in both runtime
-/// profiles — if the payment is already there and complete, callers can
-/// short-circuit before subscribing to events / starting a poll loop.
+/// Used as a fast-path check by `wait_for_incoming_payment` — if the
+/// payment is already there and complete, callers can short-circuit
+/// before starting a poll loop.
 /// Returns `Ok(None)` when the row doesn't exist; surfaces real storage
 /// errors so callers can bubble them rather than mask them.
 pub(crate) async fn maybe_get_payment_from_storage(

--- a/crates/breez-sdk/core/src/sdk/lnurl.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl.rs
@@ -387,7 +387,7 @@ impl BreezSdk {
 
         // Wait for the LNURL service to pay the invoice
         let payment = self
-            .wait_for_payment(
+            .wait_for_incoming_payment(
                 WaitForPaymentIdentifier::LightningReceive {
                     invoice: payment_request.clone(),
                     ssp_id: ssp_receive_id,

--- a/crates/breez-sdk/core/src/sdk/lnurl.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl.rs
@@ -8,9 +8,7 @@ use crate::{
     WaitForPaymentIdentifier,
     error::SdkError,
     events::SdkEvent,
-    models::{
-        PrepareSendPaymentResponse, ReceivePaymentMethod, ReceivePaymentRequest, SendPaymentRequest,
-    },
+    models::{PrepareSendPaymentResponse, SendPaymentRequest},
     persist::{ObjectCacheRepository, PaymentMetadata},
 };
 use breez_sdk_common::lnurl::withdraw::execute_lnurl_withdraw;
@@ -336,18 +334,18 @@ impl BreezSdk {
             ));
         }
 
-        // Generate a Lightning invoice for the withdraw
-        let payment_request = self
-            .receive_payment(ReceivePaymentRequest {
-                payment_method: ReceivePaymentMethod::Bolt11Invoice {
-                    description: withdraw_request.default_description.clone(),
-                    amount_sats: Some(amount_sats),
-                    expiry_secs: None,
-                    payment_hash: None,
-                },
-            })
-            .await?
-            .payment_request;
+        // Generate a Lightning invoice for the withdraw, keeping the SSP-side
+        // receive id for the targeted wait below.
+        let receive = self
+            .receive_bolt11_invoice_inner(
+                withdraw_request.default_description.clone(),
+                Some(amount_sats),
+                None,
+                None,
+            )
+            .await?;
+        let payment_request = receive.invoice.clone();
+        let ssp_receive_id = receive.id;
 
         // Store the LNURL withdraw metadata before executing the withdraw
         let cache = ObjectCacheRepository::new(self.storage.clone());
@@ -387,12 +385,13 @@ impl BreezSdk {
             }
         };
 
-        // Wait for the payment to be completed
+        // Wait for the LNURL service to pay the invoice
         let payment = self
-            .runtime
             .wait_for_payment(
-                self,
-                WaitForPaymentIdentifier::PaymentRequest(payment_request.clone()),
+                WaitForPaymentIdentifier::LightningReceive {
+                    invoice: payment_request.clone(),
+                    ssp_id: ssp_receive_id,
+                },
                 completion_timeout_secs,
             )
             .await

--- a/crates/breez-sdk/core/src/sdk/lnurl.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl.rs
@@ -389,7 +389,9 @@ impl BreezSdk {
 
         // Wait for the payment to be completed
         let payment = self
+            .runtime
             .wait_for_payment(
+                self,
                 WaitForPaymentIdentifier::PaymentRequest(payment_request.clone()),
                 completion_timeout_secs,
             )

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -5,8 +5,7 @@ use platform_utils::tokio;
 use spark_wallet::{ExitSpeed, SparkAddress, TransferId, TransferTokenOutput};
 use spark_wallet::{InvoiceDescription, Preimage};
 use std::str::FromStr;
-use tokio::sync::{mpsc, oneshot};
-use tokio::time::timeout;
+use tokio::sync::oneshot;
 use tracing::{Instrument, error, info, warn};
 
 use crate::{
@@ -35,10 +34,7 @@ use crate::{
     },
 };
 
-use super::{
-    BreezSdk,
-    helpers::{InternalEventListener, get_deposit_address, is_payment_match},
-};
+use super::{BreezSdk, helpers::get_deposit_address};
 
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 #[allow(clippy::needless_pass_by_value)]
@@ -837,7 +833,9 @@ impl BreezSdk {
     ) -> Result<SendPaymentResponse, SdkError> {
         // Wait for the received conversion payment to complete
         let payment = self
+            .runtime
             .wait_for_payment(
+                self,
                 WaitForPaymentIdentifier::PaymentId(
                     conversion_response.received_payment_id.clone(),
                 ),
@@ -1412,66 +1410,6 @@ impl BreezSdk {
         self.storage.insert_payment(payment.clone()).await?;
 
         Ok(SendPaymentResponse { payment })
-    }
-
-    pub(super) async fn wait_for_payment(
-        &self,
-        identifier: WaitForPaymentIdentifier,
-        completion_timeout_secs: u32,
-    ) -> Result<Payment, SdkError> {
-        let (tx, mut rx) = mpsc::channel(20);
-        // Use internal listener to see raw events before middleware processing.
-        // This is critical because TokenConversionMiddleware suppresses conversion
-        // child events, but wait_for_payment needs to see them.
-        let id = self
-            .event_emitter
-            .add_internal_listener(Box::new(InternalEventListener::new(tx)))
-            .await;
-
-        // Run the main logic in a closure so cleanup always happens,
-        // even if an early `?` exits (e.g. get_payment_by_invoice failure).
-        let result = async {
-            // First check if we already have the completed payment in storage
-            let payment = match &identifier {
-                WaitForPaymentIdentifier::PaymentId(payment_id) => self
-                    .storage
-                    .get_payment_by_id(payment_id.clone())
-                    .await
-                    .ok(),
-                WaitForPaymentIdentifier::PaymentRequest(payment_request) => {
-                    self.storage
-                        .get_payment_by_invoice(payment_request.clone())
-                        .await?
-                }
-            };
-            if let Some(payment) = payment
-                && payment.status == PaymentStatus::Completed
-            {
-                return Ok(payment);
-            }
-
-            timeout(Duration::from_secs(completion_timeout_secs.into()), async {
-                loop {
-                    let Some(event) = rx.recv().await else {
-                        return Err(SdkError::Generic("Event channel closed".to_string()));
-                    };
-
-                    let SdkEvent::PaymentSucceeded { payment } = event else {
-                        continue;
-                    };
-
-                    if is_payment_match(&payment, &identifier) {
-                        return Ok(payment);
-                    }
-                }
-            })
-            .await
-            .map_err(|_| SdkError::Generic("Timeout waiting for payment".to_string()))?
-        }
-        .await;
-
-        self.event_emitter.remove_internal_listener(&id).await;
-        result
     }
 
     /// Spawns the background poll that watches an outgoing Lightning send to

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -44,9 +44,9 @@ use super::{
 };
 use crate::sync::SparkSyncService;
 
-// Polling cadence for wait_for_payment.
-const WAIT_FOR_PAYMENT_INITIAL_DELAY_MS: u64 = 500;
-const WAIT_FOR_PAYMENT_MAX_DELAY_MS: u64 = 2000;
+// Polling cadence for wait_for_incoming_payment.
+const WAIT_FOR_INCOMING_PAYMENT_INITIAL_DELAY_MS: u64 = 500;
+const WAIT_FOR_INCOMING_PAYMENT_MAX_DELAY_MS: u64 = 2000;
 
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 #[allow(clippy::needless_pass_by_value)]
@@ -860,7 +860,7 @@ impl BreezSdk {
     ) -> Result<SendPaymentResponse, SdkError> {
         // Wait for the received conversion payment to complete
         let payment = self
-            .wait_for_payment(
+            .wait_for_incoming_payment(
                 WaitForPaymentIdentifier::PaymentId(
                     conversion_response.received_payment_id.clone(),
                 ),
@@ -1437,7 +1437,7 @@ impl BreezSdk {
         Ok(SendPaymentResponse { payment })
     }
 
-    pub(crate) async fn wait_for_payment(
+    pub(crate) async fn wait_for_incoming_payment(
         &self,
         identifier: WaitForPaymentIdentifier,
         completion_timeout_secs: u32,
@@ -1451,8 +1451,8 @@ impl BreezSdk {
         }
 
         let schedule = PollSchedule {
-            initial_delay: Duration::from_millis(WAIT_FOR_PAYMENT_INITIAL_DELAY_MS),
-            max_delay: Duration::from_millis(WAIT_FOR_PAYMENT_MAX_DELAY_MS),
+            initial_delay: Duration::from_millis(WAIT_FOR_INCOMING_PAYMENT_INITIAL_DELAY_MS),
+            max_delay: Duration::from_millis(WAIT_FOR_INCOMING_PAYMENT_MAX_DELAY_MS),
             timeout: Duration::from_secs(completion_timeout_secs.into()),
         };
         let shutdown = Some(self.shutdown_sender.subscribe());
@@ -1466,8 +1466,8 @@ impl BreezSdk {
                     .await?
                 } else if let Some((hash, _vout)) = pid.split_once(':') {
                     let tx_hash = hash.to_string();
-                    // The only `wait_for_payment(PaymentId(token))` site today is
-                    // the conversion received leg (we're the recipient).
+                    // The only `wait_for_incoming_payment(PaymentId(token))` site
+                    // today is the conversion received leg (we're the recipient).
                     let tx_inputs_are_ours = false;
                     poll_until(schedule, shutdown, || {
                         self.poll_then_process_token_transaction(&pid, &tx_hash, tx_inputs_are_ours)

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -2,11 +2,14 @@ use bitcoin::hashes::sha256;
 use bitcoin::secp256k1::PublicKey;
 use platform_utils::time::{Duration, SystemTime};
 use platform_utils::tokio;
-use spark_wallet::{ExitSpeed, SparkAddress, TransferId, TransferTokenOutput};
+use spark_wallet::{
+    ExitSpeed, LightningReceivePayment, ListTransfersRequest, SparkAddress, TransferId,
+    TransferStatus, TransferTokenOutput,
+};
 use spark_wallet::{InvoiceDescription, Preimage};
 use std::str::FromStr;
 use tokio::sync::oneshot;
-use tracing::{Instrument, error, info, warn};
+use tracing::{Instrument, debug, error, info, warn};
 
 use crate::{
     BitcoinAddressDetails, Bolt11InvoiceDetails, ClaimHtlcPaymentRequest, ClaimHtlcPaymentResponse,
@@ -23,18 +26,27 @@ use crate::{
         ReceivePaymentRequest, ReceivePaymentResponse, SendPaymentRequest, SendPaymentResponse,
         conversion_steps_from_payments,
     },
-    persist::PaymentMetadata,
+    persist::{ObjectCacheRepository, PaymentMetadata},
     token_conversion::{
         ConversionAmount, DEFAULT_CONVERSION_TIMEOUT_SECS, TokenConversionResponse,
     },
     utils::{
         payments::{get_payment_and_emit_event, get_payment_with_conversion_details},
+        polling::{PollSchedule, poll_until},
         send_payment_validation::{get_dust_limit_sats, validate_prepare_send_payment_request},
-        token::map_and_persist_token_transaction,
+        token::{map_and_persist_token_transaction, token_transaction_to_payments},
     },
 };
 
-use super::{BreezSdk, helpers::get_deposit_address};
+use super::{
+    BreezSdk,
+    helpers::{get_deposit_address, maybe_get_payment_from_storage, update_balances},
+};
+use crate::sync::SparkSyncService;
+
+// Polling cadence for wait_for_payment.
+const WAIT_FOR_PAYMENT_INITIAL_DELAY_MS: u64 = 500;
+const WAIT_FOR_PAYMENT_MAX_DELAY_MS: u64 = 2000;
 
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 #[allow(clippy::needless_pass_by_value)]
@@ -506,7 +518,27 @@ impl BreezSdk {
         expiry_secs: Option<u32>,
         payment_hash: Option<String>,
     ) -> Result<ReceivePaymentResponse, SdkError> {
-        let invoice = if let Some(payment_hash_hex) = payment_hash {
+        let receive = self
+            .receive_bolt11_invoice_inner(description, amount_sats, expiry_secs, payment_hash)
+            .await?;
+        Ok(ReceivePaymentResponse {
+            payment_request: receive.invoice,
+            fee: 0,
+        })
+    }
+
+    /// Internal variant of [`Self::receive_bolt11_invoice`] that keeps the
+    /// full SSP receive object (id + invoice + status + …). Used by
+    /// `lnurl_withdraw` to get the SSP id for the synchronous wait via
+    /// `WaitForPaymentIdentifier::LightningReceive`.
+    pub(crate) async fn receive_bolt11_invoice_inner(
+        &self,
+        description: String,
+        amount_sats: Option<u64>,
+        expiry_secs: Option<u32>,
+        payment_hash: Option<String>,
+    ) -> Result<LightningReceivePayment, SdkError> {
+        let receive = if let Some(payment_hash_hex) = payment_hash {
             let hash = sha256::Hash::from_str(&payment_hash_hex)
                 .map_err(|e| SdkError::InvalidInput(format!("Invalid payment hash: {e}")))?;
             self.spark_wallet
@@ -518,7 +550,6 @@ impl BreezSdk {
                     expiry_secs,
                 )
                 .await?
-                .invoice
         } else {
             self.spark_wallet
                 .create_lightning_invoice(
@@ -529,12 +560,8 @@ impl BreezSdk {
                     self.config.prefer_spark_over_lightning,
                 )
                 .await?
-                .invoice
         };
-        Ok(ReceivePaymentResponse {
-            payment_request: invoice,
-            fee: 0,
-        })
+        Ok(receive)
     }
 
     pub(super) async fn maybe_convert_token_send_payment(
@@ -833,9 +860,7 @@ impl BreezSdk {
     ) -> Result<SendPaymentResponse, SdkError> {
         // Wait for the received conversion payment to complete
         let payment = self
-            .runtime
             .wait_for_payment(
-                self,
                 WaitForPaymentIdentifier::PaymentId(
                     conversion_response.received_payment_id.clone(),
                 ),
@@ -1412,6 +1437,59 @@ impl BreezSdk {
         Ok(SendPaymentResponse { payment })
     }
 
+    pub(crate) async fn wait_for_payment(
+        &self,
+        identifier: WaitForPaymentIdentifier,
+        completion_timeout_secs: u32,
+    ) -> Result<Payment, SdkError> {
+        // Fast path: completed payment already in storage.
+        if let Some(payment) =
+            maybe_get_payment_from_storage(self.storage.as_ref(), &identifier).await?
+            && payment.status == PaymentStatus::Completed
+        {
+            return Ok(payment);
+        }
+
+        let schedule = PollSchedule {
+            initial_delay: Duration::from_millis(WAIT_FOR_PAYMENT_INITIAL_DELAY_MS),
+            max_delay: Duration::from_millis(WAIT_FOR_PAYMENT_MAX_DELAY_MS),
+            timeout: Duration::from_secs(completion_timeout_secs.into()),
+        };
+        let shutdown = Some(self.shutdown_sender.subscribe());
+
+        let payment = match identifier {
+            WaitForPaymentIdentifier::PaymentId(pid) => {
+                if let Ok(transfer_id) = TransferId::from_str(&pid) {
+                    poll_until(schedule, shutdown, || {
+                        self.poll_then_process_spark_transfer(transfer_id.clone())
+                    })
+                    .await?
+                } else if let Some((hash, _vout)) = pid.split_once(':') {
+                    let tx_hash = hash.to_string();
+                    // The only `wait_for_payment(PaymentId(token))` site today is
+                    // the conversion received leg (we're the recipient).
+                    let tx_inputs_are_ours = false;
+                    poll_until(schedule, shutdown, || {
+                        self.poll_then_process_token_transaction(&pid, &tx_hash, tx_inputs_are_ours)
+                    })
+                    .await?
+                } else {
+                    return Err(SdkError::Generic(format!(
+                        "Unrecognized payment_id format: {pid}"
+                    )));
+                }
+            }
+            WaitForPaymentIdentifier::LightningReceive { ssp_id, .. } => {
+                poll_until(schedule, shutdown, || {
+                    self.poll_then_process_lightning_receive(&ssp_id)
+                })
+                .await?
+            }
+        };
+        self.finalize_payment(payment.clone()).await;
+        Ok(payment)
+    }
+
     /// Spawns the background poll that watches an outgoing Lightning send to
     /// completion. Returns a receiver that resolves to the terminal `Payment`
     /// when the SSP reports a non-`Pending` status, so callers can `await`
@@ -1909,5 +1987,173 @@ impl BreezSdk {
             )
             .await
             .map_err(Into::into)
+    }
+
+    /// Records a freshly-observed terminal payment: apply any cached
+    /// metadata, run the LNURL receive-metadata sync, persist to storage,
+    /// refresh balances, and emit `PaymentSucceeded` if this is the first
+    /// time we see this status. Returns whether an event was emitted.
+    pub(crate) async fn finalize_payment(&self, mut payment: Payment) -> bool {
+        let existing_status = self
+            .storage
+            .get_payment_by_id(payment.id.clone())
+            .await
+            .ok()
+            .map(|p| p.status);
+        let status_changed = existing_status.is_none_or(|s| s != payment.status);
+
+        let sync_service = SparkSyncService::new(
+            self.spark_wallet.clone(),
+            self.storage.clone(),
+            self.event_emitter.clone(),
+        );
+        if let Err(e) = sync_service.apply_payment_metadata(&payment).await {
+            error!(
+                "finalize_payment({}): failed to apply payment metadata: {e:?}",
+                payment.id
+            );
+        }
+        // No-op for non-Lightning-receive payments; for LNURL receives
+        // this pulls the LNURL metadata into the payment record.
+        self.sync_single_lnurl_metadata(&mut payment).await;
+
+        if let Err(e) = self.storage.insert_payment(payment.clone()).await {
+            error!(
+                "finalize_payment({}): failed to insert payment: {e:?}",
+                payment.id
+            );
+        }
+
+        if let Err(e) = update_balances(self.spark_wallet.clone(), self.storage.clone()).await {
+            error!(
+                "finalize_payment({}): failed to update balances: {e:?}",
+                payment.id
+            );
+        }
+
+        if status_changed {
+            get_payment_and_emit_event(&self.storage, &self.event_emitter, payment).await;
+        }
+        status_changed
+    }
+
+    /// Polls a single Spark transfer by id and, on terminal status, claims
+    /// it locally so its leaves land in the tree-store before the caller
+    /// spends them.
+    async fn poll_then_process_spark_transfer(
+        &self,
+        transfer_id: TransferId,
+    ) -> Result<Option<Payment>, SdkError> {
+        let mut resp = self
+            .spark_wallet
+            .list_transfers(ListTransfersRequest {
+                transfer_ids: vec![transfer_id.clone()],
+                paging: None,
+            })
+            .await?;
+        let Some(wallet_transfer) = resp.items.pop() else {
+            debug!("poll_then_process_spark_transfer({transfer_id}): not yet visible on operators");
+            return Ok(None);
+        };
+        debug!(
+            "poll_then_process_spark_transfer({transfer_id}): status={}",
+            wallet_transfer.status
+        );
+        let payment: Payment = match wallet_transfer.status {
+            // Transfer has already completed. Skip the claim.
+            TransferStatus::Completed => wallet_transfer.try_into()?,
+            // Transfer is claimable. Claim the transfer and promote the
+            // transfer status to completed.
+            TransferStatus::SenderKeyTweaked => {
+                debug!("poll_then_process_spark_transfer({transfer_id}): claiming");
+                self.spark_wallet.process_transfer(&wallet_transfer).await?;
+                let mut claimed = wallet_transfer;
+                claimed.status = TransferStatus::Completed;
+                claimed.try_into()?
+            }
+            // Terminal-failed. Return the `Failed` payment without
+            // claiming.
+            TransferStatus::Expired | TransferStatus::Returned => {
+                debug!(
+                    "poll_then_process_spark_transfer({transfer_id}): terminal-failed ({})",
+                    wallet_transfer.status
+                );
+                wallet_transfer.try_into()?
+            }
+            _ => return Ok(None),
+        };
+        Ok(Some(payment))
+    }
+
+    /// Polls a single token tx by hash and, on terminal status, updates the
+    /// local token-output store.
+    async fn poll_then_process_token_transaction(
+        &self,
+        payment_id: &str,
+        tx_hash: &str,
+        tx_inputs_are_ours: bool,
+    ) -> Result<Option<Payment>, SdkError> {
+        let token_transactions = self
+            .spark_wallet
+            .get_token_transactions_by_hashes(vec![tx_hash.to_string()])
+            .await?;
+        let Some(token_transaction) = token_transactions.first() else {
+            debug!("poll_then_process_token_transaction({tx_hash}): not yet visible on operators");
+            return Ok(None);
+        };
+        debug!(
+            "poll_then_process_token_transaction({tx_hash}): operator status={:?}",
+            token_transaction.status
+        );
+        let object_repository = ObjectCacheRepository::new(self.storage.clone());
+        let payments = token_transaction_to_payments(
+            &self.spark_wallet,
+            &object_repository,
+            token_transaction,
+            tx_inputs_are_ours,
+        )
+        .await?;
+        let Some(payment) = payments.into_iter().find(|p| p.id == payment_id) else {
+            debug!(
+                "poll_then_process_token_transaction({tx_hash}): no output matches payment_id {payment_id}"
+            );
+            return Ok(None);
+        };
+        if payment.status == PaymentStatus::Pending {
+            return Ok(None);
+        }
+        debug!(
+            "poll_then_process_token_transaction({tx_hash}): terminal payment status={}, updating local outputs",
+            payment.status
+        );
+        self.spark_wallet
+            .process_token_transaction(token_transaction)
+            .await?;
+        Ok(Some(payment))
+    }
+
+    /// Polls an inbound Lightning payment by SSP id. The receive object
+    /// only carries the transfer id once the SSP has forwarded the payment
+    /// via Spark. Once present, defers to `poll_then_process_spark_transfer`.
+    async fn poll_then_process_lightning_receive(
+        &self,
+        ssp_id: &str,
+    ) -> Result<Option<Payment>, SdkError> {
+        let Some(receive) = self
+            .spark_wallet
+            .fetch_lightning_receive_payment(ssp_id)
+            .await?
+        else {
+            debug!("poll_then_process_lightning_receive({ssp_id}): SSP returned no receive yet");
+            return Ok(None);
+        };
+        debug!(
+            "poll_then_process_lightning_receive({ssp_id}): SSP status={:?}, transfer_id={:?}",
+            receive.status, receive.transfer_id
+        );
+        let Some(transfer_id) = receive.transfer_id else {
+            return Ok(None);
+        };
+        self.poll_then_process_spark_transfer(transfer_id).await
     }
 }

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -5,14 +5,15 @@ use platform_utils::tokio;
 use spark_wallet::{WalletEvent, WalletTransfer};
 use tokio::{
     select,
-    sync::{broadcast, watch},
+    sync::{broadcast, mpsc, watch},
+    time::timeout,
 };
 use tracing::{Instrument, debug, error, info, trace};
 
 use crate::sync::SparkSyncService;
 use crate::utils::token::{token_transaction_to_payments, token_tx_inputs_are_ours};
 use crate::{
-    GetInfoRequest, GetInfoResponse, Payment,
+    GetInfoRequest, GetInfoResponse, Payment, PaymentStatus, WaitForPaymentIdentifier,
     error::SdkError,
     events::{EventListener, SdkEvent},
     persist::ObjectCacheRepository,
@@ -24,7 +25,10 @@ use crate::{PaymentType, StorageListPaymentsRequest, StoragePaymentDetailsFilter
 use super::{RuntimeEvent, RuntimeProfile};
 use crate::sdk::{
     BreezSdk, SyncCoordinator, SyncRequest, SyncType,
-    helpers::{BalanceWatcher, update_balances},
+    helpers::{
+        BalanceWatcher, InternalEventListener, is_payment_match, maybe_get_payment_from_storage,
+        update_balances,
+    },
 };
 
 pub(super) struct ClientRuntime;
@@ -93,6 +97,56 @@ impl RuntimeProfile for ClientRuntime {
         sdk: &BreezSdk,
     ) -> Result<(), SdkError> {
         sdk.ensure_spark_private_mode_initialized_inner().await
+    }
+
+    async fn wait_for_payment(
+        &self,
+        sdk: &BreezSdk,
+        identifier: WaitForPaymentIdentifier,
+        completion_timeout_secs: u32,
+    ) -> Result<Payment, SdkError> {
+        let (tx, mut rx) = mpsc::channel(20);
+        // Use internal listener to see raw events before middleware processing.
+        // This is critical because TokenConversionMiddleware suppresses
+        // conversion child events, but wait_for_payment needs to see them.
+        let id = sdk
+            .event_emitter
+            .add_internal_listener(Box::new(InternalEventListener::new(tx)))
+            .await;
+
+        // Run the main logic in a closure so cleanup always happens,
+        // even if an early `?` exits (e.g. get_payment_by_invoice failure).
+        let result = async {
+            // First check if we already have the completed payment in storage.
+            if let Some(payment) =
+                maybe_get_payment_from_storage(sdk.storage.as_ref(), &identifier).await?
+                && payment.status == PaymentStatus::Completed
+            {
+                return Ok(payment);
+            }
+
+            timeout(Duration::from_secs(completion_timeout_secs.into()), async {
+                loop {
+                    let Some(event) = rx.recv().await else {
+                        return Err(SdkError::Generic("Event channel closed".to_string()));
+                    };
+
+                    let SdkEvent::PaymentSucceeded { payment } = event else {
+                        continue;
+                    };
+
+                    if is_payment_match(&payment, &identifier) {
+                        return Ok(payment);
+                    }
+                }
+            })
+            .await
+            .map_err(|_| SdkError::Generic("Timeout waiting for payment".to_string()))?
+        }
+        .await;
+
+        sdk.event_emitter.remove_internal_listener(&id).await;
+        result
     }
 }
 

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -5,15 +5,13 @@ use platform_utils::tokio;
 use spark_wallet::{WalletEvent, WalletTransfer};
 use tokio::{
     select,
-    sync::{broadcast, mpsc, watch},
-    time::timeout,
+    sync::{broadcast, watch},
 };
 use tracing::{Instrument, debug, error, info, trace};
 
-use crate::sync::SparkSyncService;
 use crate::utils::token::{token_transaction_to_payments, token_tx_inputs_are_ours};
 use crate::{
-    GetInfoRequest, GetInfoResponse, Payment, PaymentStatus, WaitForPaymentIdentifier,
+    GetInfoRequest, GetInfoResponse, Payment,
     error::SdkError,
     events::{EventListener, SdkEvent},
     persist::ObjectCacheRepository,
@@ -25,10 +23,7 @@ use crate::{PaymentType, StorageListPaymentsRequest, StoragePaymentDetailsFilter
 use super::{RuntimeEvent, RuntimeProfile};
 use crate::sdk::{
     BreezSdk, SyncCoordinator, SyncRequest, SyncType,
-    helpers::{
-        BalanceWatcher, InternalEventListener, is_payment_match, maybe_get_payment_from_storage,
-        update_balances,
-    },
+    helpers::{BalanceWatcher, update_balances},
 };
 
 pub(super) struct ClientRuntime;
@@ -97,56 +92,6 @@ impl RuntimeProfile for ClientRuntime {
         sdk: &BreezSdk,
     ) -> Result<(), SdkError> {
         sdk.ensure_spark_private_mode_initialized_inner().await
-    }
-
-    async fn wait_for_payment(
-        &self,
-        sdk: &BreezSdk,
-        identifier: WaitForPaymentIdentifier,
-        completion_timeout_secs: u32,
-    ) -> Result<Payment, SdkError> {
-        let (tx, mut rx) = mpsc::channel(20);
-        // Use internal listener to see raw events before middleware processing.
-        // This is critical because TokenConversionMiddleware suppresses
-        // conversion child events, but wait_for_payment needs to see them.
-        let id = sdk
-            .event_emitter
-            .add_internal_listener(Box::new(InternalEventListener::new(tx)))
-            .await;
-
-        // Run the main logic in a closure so cleanup always happens,
-        // even if an early `?` exits (e.g. get_payment_by_invoice failure).
-        let result = async {
-            // First check if we already have the completed payment in storage.
-            if let Some(payment) =
-                maybe_get_payment_from_storage(sdk.storage.as_ref(), &identifier).await?
-                && payment.status == PaymentStatus::Completed
-            {
-                return Ok(payment);
-            }
-
-            timeout(Duration::from_secs(completion_timeout_secs.into()), async {
-                loop {
-                    let Some(event) = rx.recv().await else {
-                        return Err(SdkError::Generic("Event channel closed".to_string()));
-                    };
-
-                    let SdkEvent::PaymentSucceeded { payment } = event else {
-                        continue;
-                    };
-
-                    if is_payment_match(&payment, &identifier) {
-                        return Ok(payment);
-                    }
-                }
-            })
-            .await
-            .map_err(|_| SdkError::Generic("Timeout waiting for payment".to_string()))?
-        }
-        .await;
-
-        sdk.event_emitter.remove_internal_listener(&id).await;
-        result
     }
 }
 
@@ -324,30 +269,17 @@ async fn handle_wallet_event(sdk: &BreezSdk, event: WalletEvent) -> bool {
         }
         WalletEvent::TransferClaimed(transfer) => {
             info!("Transfer claimed");
-            let mut payment_emitted = false;
             // Drop any unclaimed-deposit record for this outpoint independently
             // of payment ingestion, so conversion failures do not leave it stale.
             if let Some((tx_id, vout)) = claim_static_deposit_outpoint(&transfer) {
                 cleanup_claimed_deposit(sdk, &tx_id, vout).await;
             }
-            if let Ok(mut payment) = Payment::try_from(transfer) {
-                if let Err(e) = sdk.storage.insert_payment(payment.clone()).await {
-                    error!("Failed to insert succeeded payment: {e:?}");
-                }
-
-                // This was already requested at TransferClaimStarting, but it
-                // might still be racing, so ensure metadata before emitting.
-                sdk.sync_single_lnurl_metadata(&mut payment).await;
-
-                if let Err(e) = update_balances(sdk.spark_wallet.clone(), sdk.storage.clone()).await
-                {
-                    error!("Failed to update balances before PaymentSucceeded event: {e:?}");
-                }
-
-                get_payment_and_emit_event(&sdk.storage, &sdk.event_emitter, payment).await;
-                payment_emitted = true;
+            if let Ok(payment) = Payment::try_from(transfer) {
+                sdk.finalize_payment(payment).await;
+                true
+            } else {
+                false
             }
-            payment_emitted
         }
         WalletEvent::TransferClaimStarting(transfer) => {
             info!("Transfer claim starting");
@@ -397,38 +329,9 @@ async fn process_token_transaction_event(
         return Ok(false);
     }
 
-    // Update balances before emitting events so listeners can immediately
-    // query the new balance.
-    if let Err(e) = update_balances(sdk.spark_wallet.clone(), sdk.storage.clone()).await {
-        error!("Failed to update balances before token transaction event: {e:?}");
-    }
-
-    let sync_service = SparkSyncService::new(
-        sdk.spark_wallet.clone(),
-        sdk.storage.clone(),
-        sdk.event_emitter.clone(),
-    );
     let mut payment_emitted = false;
     for payment in payments {
-        let existing_status = sdk
-            .storage
-            .get_payment_by_id(payment.id.clone())
-            .await
-            .ok()
-            .map(|p| p.status);
-        let status_changed = existing_status.is_none_or(|s| s != payment.status);
-
-        if let Err(e) = sync_service.apply_payment_metadata(&payment).await {
-            error!("Failed to apply payment metadata for token payment: {e:?}");
-        }
-
-        if let Err(e) = sdk.storage.insert_payment(payment.clone()).await {
-            error!("Failed to insert token payment: {e:?}");
-            continue;
-        }
-
-        if status_changed {
-            get_payment_and_emit_event(&sdk.storage, &sdk.event_emitter, payment).await;
+        if sdk.finalize_payment(payment).await {
             payment_emitted = true;
         }
     }

--- a/crates/breez-sdk/core/src/sdk/runtime/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/mod.rs
@@ -2,11 +2,7 @@ use std::sync::Arc;
 
 use tokio::sync::watch;
 
-use crate::{
-    GetInfoRequest, GetInfoResponse,
-    error::SdkError,
-    models::{Config, Payment, WaitForPaymentIdentifier},
-};
+use crate::{GetInfoRequest, GetInfoResponse, error::SdkError, models::Config};
 
 use super::{BreezSdk, SyncType};
 
@@ -61,18 +57,6 @@ pub(crate) trait RuntimeProfile: Send + Sync {
         &self,
         sdk: &BreezSdk,
     ) -> Result<(), SdkError>;
-
-    /// Waits for a payment to reach a terminal state.
-    ///
-    /// `ClientRuntime` listens for `SdkEvent::PaymentSucceeded` from the
-    /// wallet event stream. `ServerRuntime` polls Spark / SSP / storage
-    /// directly because no event stream is subscribed in server mode.
-    async fn wait_for_payment(
-        &self,
-        sdk: &BreezSdk,
-        identifier: WaitForPaymentIdentifier,
-        completion_timeout_secs: u32,
-    ) -> Result<Payment, SdkError>;
 }
 
 #[cfg(test)]

--- a/crates/breez-sdk/core/src/sdk/runtime/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/mod.rs
@@ -2,7 +2,11 @@ use std::sync::Arc;
 
 use tokio::sync::watch;
 
-use crate::{GetInfoRequest, GetInfoResponse, error::SdkError, models::Config};
+use crate::{
+    GetInfoRequest, GetInfoResponse,
+    error::SdkError,
+    models::{Config, Payment, WaitForPaymentIdentifier},
+};
 
 use super::{BreezSdk, SyncType};
 
@@ -57,6 +61,18 @@ pub(crate) trait RuntimeProfile: Send + Sync {
         &self,
         sdk: &BreezSdk,
     ) -> Result<(), SdkError>;
+
+    /// Waits for a payment to reach a terminal state.
+    ///
+    /// `ClientRuntime` listens for `SdkEvent::PaymentSucceeded` from the
+    /// wallet event stream. `ServerRuntime` polls Spark / SSP / storage
+    /// directly because no event stream is subscribed in server mode.
+    async fn wait_for_payment(
+        &self,
+        sdk: &BreezSdk,
+        identifier: WaitForPaymentIdentifier,
+        completion_timeout_secs: u32,
+    ) -> Result<Payment, SdkError>;
 }
 
 #[cfg(test)]

--- a/crates/breez-sdk/core/src/sdk/runtime/server.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/server.rs
@@ -1,11 +1,27 @@
-use tokio::sync::watch;
-use tracing::error;
+use std::{str::FromStr, time::Duration};
 
-use crate::{GetInfoRequest, GetInfoResponse, error::SdkError};
+use spark_wallet::{ListTransfersRequest, TransferId};
+use tokio::sync::watch;
+use tracing::{error, trace};
+
+use crate::{
+    GetInfoRequest, GetInfoResponse,
+    error::SdkError,
+    models::{Payment, PaymentStatus, WaitForPaymentIdentifier},
+    persist::ObjectCacheRepository,
+    utils::{
+        polling::{PollSchedule, poll_until},
+        token::token_transaction_to_payments,
+    },
+};
 
 use super::{RuntimeEvent, RuntimeProfile};
-use crate::sdk::{BreezSdk, SyncType};
+use crate::sdk::{BreezSdk, SyncType, helpers::maybe_get_payment_from_storage};
 use crate::utils::payments::get_payment_and_emit_event;
+
+// Polling cadence for server-mode wait_for_payment.
+const POLL_INITIAL_DELAY_MS: u64 = 500;
+const POLL_MAX_DELAY_MS: u64 = 2000;
 
 pub(super) struct ServerRuntime;
 
@@ -67,6 +83,153 @@ impl RuntimeProfile for ServerRuntime {
         _sdk: &BreezSdk,
     ) -> Result<(), SdkError> {
         Ok(())
+    }
+
+    async fn wait_for_payment(
+        &self,
+        sdk: &BreezSdk,
+        identifier: WaitForPaymentIdentifier,
+        completion_timeout_secs: u32,
+    ) -> Result<Payment, SdkError> {
+        // Fast path: completed payment already in storage.
+        if let Some(payment) =
+            maybe_get_payment_from_storage(sdk.storage.as_ref(), &identifier).await?
+            && payment.status == PaymentStatus::Completed
+        {
+            return Ok(payment);
+        }
+
+        let schedule = PollSchedule {
+            initial_delay: Duration::from_millis(POLL_INITIAL_DELAY_MS),
+            max_delay: Duration::from_millis(POLL_MAX_DELAY_MS),
+            timeout: Duration::from_secs(completion_timeout_secs.into()),
+        };
+        let shutdown = Some(sdk.shutdown_sender.subscribe());
+
+        let payment = match identifier {
+            WaitForPaymentIdentifier::PaymentId(pid) => {
+                // Mirrors fetch_payment_id_by_identifier (flashnet.rs:341):
+                // a TransferId-shaped payment_id is a Spark transfer;
+                // otherwise it's `{token_tx_hash}:{vout}`.
+                if let Ok(transfer_id) = TransferId::from_str(&pid) {
+                    poll_until(schedule, shutdown, || {
+                        probe_spark_transfer(sdk, transfer_id.clone())
+                    })
+                    .await?
+                } else if let Some((hash, _vout)) = pid.split_once(':') {
+                    let tx_hash = hash.to_string();
+                    poll_until(schedule, shutdown, || {
+                        probe_token_transaction(sdk, &pid, &tx_hash)
+                    })
+                    .await?
+                } else {
+                    return Err(SdkError::Generic(format!(
+                        "Unrecognized payment_id format: {pid}"
+                    )));
+                }
+            }
+            WaitForPaymentIdentifier::PaymentRequest(invoice) => {
+                // Invoice probe runs sync_wallet_internal on each iteration;
+                // the sync claims pending transfers and refreshes local
+                // stores as a side effect, so no post-poll sync is needed.
+                return poll_until(schedule, shutdown, || probe_invoice_via_sync(sdk, &invoice))
+                    .await;
+            }
+        };
+
+        // PaymentId probes only confirm operator-side status; trigger a
+        // local sync so claim_pending_transfers runs and the new
+        // leaves/outputs land in the tree-store / token-output store
+        // before downstream callers (e.g. the send leg of a
+        // conversion-and-send) try to use them.
+        self.run_user_sync(sdk, SyncType::Wallet, true).await?;
+        Ok(payment)
+    }
+}
+
+async fn probe_spark_transfer(
+    sdk: &BreezSdk,
+    transfer_id: TransferId,
+) -> Result<Option<Payment>, SdkError> {
+    let mut resp = sdk
+        .spark_wallet
+        .list_transfers(ListTransfersRequest {
+            transfer_ids: vec![transfer_id],
+            paging: None,
+        })
+        .await?;
+    let Some(transfer) = resp.items.pop() else {
+        return Ok(None);
+    };
+    let payment: Payment = transfer.try_into()?;
+    if payment.status == PaymentStatus::Pending {
+        Ok(None)
+    } else {
+        Ok(Some(payment))
+    }
+}
+
+async fn probe_token_transaction(
+    sdk: &BreezSdk,
+    payment_id: &str,
+    tx_hash: &str,
+) -> Result<Option<Payment>, SdkError> {
+    let token_transactions = sdk
+        .spark_wallet
+        .get_token_transactions_by_hashes(vec![tx_hash.to_string()])
+        .await?;
+    let Some(token_transaction) = token_transactions.first() else {
+        return Ok(None);
+    };
+    let object_repository = ObjectCacheRepository::new(sdk.storage.clone());
+    // `tx_inputs_are_ours: false` is correct for the only current caller
+    // (conversion received-leg, where we are the recipient). A future
+    // caller waiting on a token tx where we are the sender would need to
+    // pass `true` to get the right PaymentType / amount mapping.
+    let payments = token_transaction_to_payments(
+        &sdk.spark_wallet,
+        &object_repository,
+        token_transaction,
+        false,
+    )
+    .await?;
+    let Some(payment) = payments.into_iter().find(|p| p.id == payment_id) else {
+        return Ok(None);
+    };
+    if payment.status == PaymentStatus::Pending {
+        Ok(None)
+    } else {
+        Ok(Some(payment))
+    }
+}
+
+async fn probe_invoice_via_sync(
+    sdk: &BreezSdk,
+    invoice: &str,
+) -> Result<Option<Payment>, SdkError> {
+    // `force=true` bypasses the "synced recently" skip in
+    // sync_wallet_internal — without it, every probe after the first
+    // becomes a no-op inside the cache window and we re-read stale
+    // storage. `Wallet | WalletState` is the minimal scope that runs
+    // claim_pending_transfers and writes Payment records to storage so
+    // get_payment_by_invoice can see the incoming send.
+    sdk.sync_wallet_internal(SyncType::Wallet | SyncType::WalletState, true)
+        .await?;
+    let payment = sdk
+        .storage
+        .get_payment_by_invoice(invoice.to_string())
+        .await?;
+    let Some(payment) = payment else {
+        return Ok(None);
+    };
+    if payment.status == PaymentStatus::Completed {
+        Ok(Some(payment))
+    } else {
+        trace!(
+            "probe_invoice_via_sync: payment status {} not yet completed",
+            payment.status
+        );
+        Ok(None)
     }
 }
 

--- a/crates/breez-sdk/core/src/sdk/runtime/server.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/server.rs
@@ -1,27 +1,11 @@
-use std::{str::FromStr, time::Duration};
-
-use spark_wallet::{ListTransfersRequest, TransferId};
 use tokio::sync::watch;
-use tracing::{error, trace};
+use tracing::error;
 
-use crate::{
-    GetInfoRequest, GetInfoResponse,
-    error::SdkError,
-    models::{Payment, PaymentStatus, WaitForPaymentIdentifier},
-    persist::ObjectCacheRepository,
-    utils::{
-        polling::{PollSchedule, poll_until},
-        token::token_transaction_to_payments,
-    },
-};
+use crate::{GetInfoRequest, GetInfoResponse, error::SdkError};
 
 use super::{RuntimeEvent, RuntimeProfile};
-use crate::sdk::{BreezSdk, SyncType, helpers::maybe_get_payment_from_storage};
+use crate::sdk::{BreezSdk, SyncType};
 use crate::utils::payments::get_payment_and_emit_event;
-
-// Polling cadence for server-mode wait_for_payment.
-const POLL_INITIAL_DELAY_MS: u64 = 500;
-const POLL_MAX_DELAY_MS: u64 = 2000;
 
 pub(super) struct ServerRuntime;
 
@@ -83,153 +67,6 @@ impl RuntimeProfile for ServerRuntime {
         _sdk: &BreezSdk,
     ) -> Result<(), SdkError> {
         Ok(())
-    }
-
-    async fn wait_for_payment(
-        &self,
-        sdk: &BreezSdk,
-        identifier: WaitForPaymentIdentifier,
-        completion_timeout_secs: u32,
-    ) -> Result<Payment, SdkError> {
-        // Fast path: completed payment already in storage.
-        if let Some(payment) =
-            maybe_get_payment_from_storage(sdk.storage.as_ref(), &identifier).await?
-            && payment.status == PaymentStatus::Completed
-        {
-            return Ok(payment);
-        }
-
-        let schedule = PollSchedule {
-            initial_delay: Duration::from_millis(POLL_INITIAL_DELAY_MS),
-            max_delay: Duration::from_millis(POLL_MAX_DELAY_MS),
-            timeout: Duration::from_secs(completion_timeout_secs.into()),
-        };
-        let shutdown = Some(sdk.shutdown_sender.subscribe());
-
-        let payment = match identifier {
-            WaitForPaymentIdentifier::PaymentId(pid) => {
-                // Mirrors fetch_payment_id_by_identifier (flashnet.rs:341):
-                // a TransferId-shaped payment_id is a Spark transfer;
-                // otherwise it's `{token_tx_hash}:{vout}`.
-                if let Ok(transfer_id) = TransferId::from_str(&pid) {
-                    poll_until(schedule, shutdown, || {
-                        probe_spark_transfer(sdk, transfer_id.clone())
-                    })
-                    .await?
-                } else if let Some((hash, _vout)) = pid.split_once(':') {
-                    let tx_hash = hash.to_string();
-                    poll_until(schedule, shutdown, || {
-                        probe_token_transaction(sdk, &pid, &tx_hash)
-                    })
-                    .await?
-                } else {
-                    return Err(SdkError::Generic(format!(
-                        "Unrecognized payment_id format: {pid}"
-                    )));
-                }
-            }
-            WaitForPaymentIdentifier::PaymentRequest(invoice) => {
-                // Invoice probe runs sync_wallet_internal on each iteration;
-                // the sync claims pending transfers and refreshes local
-                // stores as a side effect, so no post-poll sync is needed.
-                return poll_until(schedule, shutdown, || probe_invoice_via_sync(sdk, &invoice))
-                    .await;
-            }
-        };
-
-        // PaymentId probes only confirm operator-side status; trigger a
-        // local sync so claim_pending_transfers runs and the new
-        // leaves/outputs land in the tree-store / token-output store
-        // before downstream callers (e.g. the send leg of a
-        // conversion-and-send) try to use them.
-        self.run_user_sync(sdk, SyncType::Wallet, true).await?;
-        Ok(payment)
-    }
-}
-
-async fn probe_spark_transfer(
-    sdk: &BreezSdk,
-    transfer_id: TransferId,
-) -> Result<Option<Payment>, SdkError> {
-    let mut resp = sdk
-        .spark_wallet
-        .list_transfers(ListTransfersRequest {
-            transfer_ids: vec![transfer_id],
-            paging: None,
-        })
-        .await?;
-    let Some(transfer) = resp.items.pop() else {
-        return Ok(None);
-    };
-    let payment: Payment = transfer.try_into()?;
-    if payment.status == PaymentStatus::Pending {
-        Ok(None)
-    } else {
-        Ok(Some(payment))
-    }
-}
-
-async fn probe_token_transaction(
-    sdk: &BreezSdk,
-    payment_id: &str,
-    tx_hash: &str,
-) -> Result<Option<Payment>, SdkError> {
-    let token_transactions = sdk
-        .spark_wallet
-        .get_token_transactions_by_hashes(vec![tx_hash.to_string()])
-        .await?;
-    let Some(token_transaction) = token_transactions.first() else {
-        return Ok(None);
-    };
-    let object_repository = ObjectCacheRepository::new(sdk.storage.clone());
-    // `tx_inputs_are_ours: false` is correct for the only current caller
-    // (conversion received-leg, where we are the recipient). A future
-    // caller waiting on a token tx where we are the sender would need to
-    // pass `true` to get the right PaymentType / amount mapping.
-    let payments = token_transaction_to_payments(
-        &sdk.spark_wallet,
-        &object_repository,
-        token_transaction,
-        false,
-    )
-    .await?;
-    let Some(payment) = payments.into_iter().find(|p| p.id == payment_id) else {
-        return Ok(None);
-    };
-    if payment.status == PaymentStatus::Pending {
-        Ok(None)
-    } else {
-        Ok(Some(payment))
-    }
-}
-
-async fn probe_invoice_via_sync(
-    sdk: &BreezSdk,
-    invoice: &str,
-) -> Result<Option<Payment>, SdkError> {
-    // `force=true` bypasses the "synced recently" skip in
-    // sync_wallet_internal — without it, every probe after the first
-    // becomes a no-op inside the cache window and we re-read stale
-    // storage. `Wallet | WalletState` is the minimal scope that runs
-    // claim_pending_transfers and writes Payment records to storage so
-    // get_payment_by_invoice can see the incoming send.
-    sdk.sync_wallet_internal(SyncType::Wallet | SyncType::WalletState, true)
-        .await?;
-    let payment = sdk
-        .storage
-        .get_payment_by_invoice(invoice.to_string())
-        .await?;
-    let Some(payment) = payment else {
-        return Ok(None);
-    };
-    if payment.status == PaymentStatus::Completed {
-        Ok(Some(payment))
-    } else {
-        trace!(
-            "probe_invoice_via_sync: payment status {} not yet completed",
-            payment.status
-        );
-        Ok(None)
     }
 }
 

--- a/crates/breez-sdk/core/src/token_conversion/middleware.rs
+++ b/crates/breez-sdk/core/src/token_conversion/middleware.rs
@@ -2,8 +2,8 @@
 //!
 //! Conversion operations (stable balance, ongoing sends) create child payments
 //! (send sats→Flashnet, receive tokens). These child events are internal plumbing
-//! and should not reach external listeners. Internal listeners (like `wait_for_payment`)
-//! bypass middleware and still see them.
+//! and should not reach external listeners. Internal listeners (like
+//! `ClientSyncListener`) bypass middleware and still see them.
 
 use tracing::info;
 

--- a/crates/breez-sdk/core/src/utils/mod.rs
+++ b/crates/breez-sdk/core/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod contacts_validation;
 pub(crate) mod deposit_chain_syncer;
 pub(crate) mod expiring_cell;
 pub(crate) mod payments;
+pub(crate) mod polling;
 pub(crate) mod send_payment_validation;
 pub(crate) mod token;
 pub(crate) mod utxo_fetcher;

--- a/crates/breez-sdk/core/src/utils/polling.rs
+++ b/crates/breez-sdk/core/src/utils/polling.rs
@@ -58,13 +58,7 @@ where
             Err(e) => last_error = Some(e),
         }
 
-        let elapsed = started.elapsed();
-        if elapsed >= schedule.timeout {
-            return Err(last_error
-                .unwrap_or_else(|| SdkError::Generic("Timeout while polling".to_string())));
-        }
-
-        let remaining = schedule.timeout.saturating_sub(elapsed);
+        let remaining = schedule.timeout.saturating_sub(started.elapsed());
         let sleep_for = delay.min(remaining);
         match shutdown.as_mut() {
             Some(rx) => tokio::select! {
@@ -77,6 +71,11 @@ where
                 () = sleep(sleep_for) => {},
             },
             None => sleep(sleep_for).await,
+        }
+
+        if started.elapsed() >= schedule.timeout {
+            return Err(last_error
+                .unwrap_or_else(|| SdkError::Generic("Timeout while polling".to_string())));
         }
 
         delay = delay.saturating_mul(2).min(schedule.max_delay);

--- a/crates/breez-sdk/core/src/utils/polling.rs
+++ b/crates/breez-sdk/core/src/utils/polling.rs
@@ -1,0 +1,84 @@
+use std::{future::Future, time::Duration};
+
+use platform_utils::{
+    time::Instant,
+    tokio::{self, sync::watch, time::sleep},
+};
+
+use crate::error::SdkError;
+
+pub(crate) struct PollSchedule {
+    pub initial_delay: Duration,
+    pub max_delay: Duration,
+    pub timeout: Duration,
+}
+
+/// Probes `f` until it returns `Ok(Some(T))` or the timeout elapses.
+///
+/// Errors from `f` are treated like `Ok(None)` — the helper keeps probing
+/// and surfaces the last error on timeout, or a generic "Timeout while
+/// polling" if every probe returned `Ok(None)`. Between probes, sleeps
+/// `initial_delay`, doubling each iteration up to `max_delay`. If
+/// `shutdown` is provided and fires, aborts immediately.
+pub(crate) async fn poll_until<T, F, Fut>(
+    schedule: PollSchedule,
+    mut shutdown: Option<watch::Receiver<()>>,
+    mut f: F,
+) -> Result<T, SdkError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<Option<T>, SdkError>>,
+{
+    let started = Instant::now();
+    let mut delay = schedule.initial_delay;
+    let mut last_error: Option<SdkError>;
+
+    loop {
+        let probe = f();
+        // `biased;` polls the shutdown branch first on each iteration, so a
+        // shutdown signal racing with a ready probe always wins. Without it,
+        // tokio's randomised select could let the probe finish a final
+        // round-trip after we've been asked to stop.
+        let outcome = match shutdown.as_mut() {
+            Some(rx) => tokio::select! {
+                biased;
+                _ = rx.changed() => {
+                    return Err(SdkError::Generic(
+                        "Shutdown received while polling".to_string(),
+                    ));
+                }
+                r = probe => r,
+            },
+            None => probe.await,
+        };
+
+        match outcome {
+            Ok(Some(value)) => return Ok(value),
+            Ok(None) => last_error = None,
+            Err(e) => last_error = Some(e),
+        }
+
+        let elapsed = started.elapsed();
+        if elapsed >= schedule.timeout {
+            return Err(last_error
+                .unwrap_or_else(|| SdkError::Generic("Timeout while polling".to_string())));
+        }
+
+        let remaining = schedule.timeout.saturating_sub(elapsed);
+        let sleep_for = delay.min(remaining);
+        match shutdown.as_mut() {
+            Some(rx) => tokio::select! {
+                biased;
+                _ = rx.changed() => {
+                    return Err(SdkError::Generic(
+                        "Shutdown received while polling".to_string(),
+                    ));
+                }
+                () = sleep(sleep_for) => {},
+            },
+            None => sleep(sleep_for).await,
+        }
+
+        delay = delay.saturating_mul(2).min(schedule.max_delay);
+    }
+}

--- a/crates/internal/src/command/htlc.rs
+++ b/crates/internal/src/command/htlc.rs
@@ -44,7 +44,7 @@ pub async fn handle_command(
             let htlcs = wallet
                 .list_claimable_htlc_transfers(Some(PagingFilter::new(limit, offset, None)))
                 .await?;
-            println!("HTLC transfers: {}", serde_json::to_string_pretty(&htlcs)?);
+            println!("HTLC transfers: {htlcs:#?}");
         }
         HtlcCommand::Create {
             amount_sat,
@@ -80,12 +80,12 @@ pub async fn handle_command(
                     None,
                 )
                 .await?;
-            println!("Transfer: {}", serde_json::to_string_pretty(&transfer)?);
+            println!("Transfer: {transfer:#?}");
         }
         HtlcCommand::Claim { preimage } => {
             let preimage = Preimage::from_hex(&preimage)?;
             let transfer = wallet.claim_htlc(&preimage).await?;
-            println!("Transfer: {}", serde_json::to_string_pretty(&transfer)?);
+            println!("Transfer: {transfer:#?}");
         }
     }
     Ok(())

--- a/crates/internal/src/command/invoices.rs
+++ b/crates/internal/src/command/invoices.rs
@@ -73,10 +73,7 @@ pub async fn handle_command(
         }
         InvoicesCommand::Fulfill { invoice, amount } => {
             let result = wallet.fulfill_spark_invoice(&invoice, amount, None).await?;
-            println!(
-                "Fulfillment result: {}",
-                serde_json::to_string_pretty(&result)?
-            );
+            println!("Fulfillment result: {result:#?}");
         }
         InvoicesCommand::Query { invoices } => {
             let results = wallet.query_spark_invoices(invoices).await?;

--- a/crates/internal/src/command/lightning.rs
+++ b/crates/internal/src/command/lightning.rs
@@ -128,7 +128,7 @@ pub async fn handle_command(
             let payment = wallet
                 .pay_lightning_invoice(&invoice, max_fee_sat, amount_to_send, prefer_spark, None)
                 .await?;
-            println!("{}", serde_json::to_string_pretty(&payment)?);
+            println!("{payment:#?}");
         }
     }
 

--- a/crates/internal/src/command/transfer.rs
+++ b/crates/internal/src/command/transfer.rs
@@ -43,10 +43,7 @@ pub async fn handle_command(
     match command {
         TransferCommand::ClaimPending => {
             let transfers = wallet.claim_pending_transfers().await?;
-            println!(
-                "Claimed transfers: {}",
-                serde_json::to_string_pretty(&transfers)?
-            );
+            println!("Claimed transfers: {transfers:#?}");
         }
         TransferCommand::List { limit, offset } => {
             let paging = if limit.is_some() || offset.is_some() {
@@ -61,10 +58,8 @@ pub async fn handle_command(
                     ..Default::default()
                 })
                 .await?;
-            println!(
-                "Transfers: {}",
-                serde_json::to_string_pretty(&transfers.items)?
-            );
+            let items = &transfers.items;
+            println!("Transfers: {items:#?}");
         }
         TransferCommand::ListPending { limit, offset } => {
             let paging = if limit.is_some() || offset.is_some() {
@@ -74,17 +69,15 @@ pub async fn handle_command(
             };
 
             let transfers = wallet.list_pending_transfers(paging).await?;
-            println!(
-                "Pending transfers: {}",
-                serde_json::to_string_pretty(&transfers.items)?
-            );
+            let items = &transfers.items;
+            println!("Pending transfers: {items:#?}");
         }
         TransferCommand::Transfer {
             amount_sat,
             receiver_address,
         } => {
             let result = wallet.transfer(amount_sat, &receiver_address, None).await?;
-            println!("{}", serde_json::to_string_pretty(&result)?);
+            println!("{result:#?}");
         }
     }
 

--- a/crates/internal/src/command/withdraw.rs
+++ b/crates/internal/src/command/withdraw.rs
@@ -121,7 +121,7 @@ pub async fn handle_command(
                     None,
                 )
                 .await?;
-            println!("{}", serde_json::to_string_pretty(&result)?);
+            println!("{result:#?}");
         }
         WithdrawCommand::UnilateralExit {
             fee_rate,

--- a/crates/spark-wallet/src/lib.rs
+++ b/crates/spark-wallet/src/lib.rs
@@ -17,12 +17,12 @@ pub use spark::{
     operator::rpc::{BalancedConnectionManager, ConnectionManager, DefaultConnectionManager},
     services::{
         CoopExitFeeQuote, CoopExitSpeedFeeQuote, CpfpUtxo, ExitSpeed, Fee,
-        FreezeIssuerTokenResponse, InvoiceDescription, LightningSendPayment, LightningSendStatus,
-        Preimage, PreimageRequestStatus, ReceiverTokenOutput, ServiceError,
-        SingleUseDepositAddress, StaticDepositAddress, TokenInputs, TokenMintInput,
-        TokenOutputToSpend, TokenTransaction, TokenTransactionStatus, TokenTransferInput,
-        TransferId, TransferObserver, TransferObserverError, TransferStatus, TransferTokenOutput,
-        TransferType, Utxo,
+        FreezeIssuerTokenResponse, InvoiceDescription, LightningReceivePayment,
+        LightningSendPayment, LightningSendStatus, Preimage, PreimageRequestStatus,
+        ReceiverTokenOutput, ServiceError, SingleUseDepositAddress, StaticDepositAddress,
+        TokenInputs, TokenMintInput, TokenOutputToSpend, TokenTransaction, TokenTransactionStatus,
+        TokenTransferInput, TransferId, TransferObserver, TransferObserverError, TransferStatus,
+        TransferTokenOutput, TransferType, Utxo,
     },
     session_store::*,
     signer::{

--- a/crates/spark-wallet/src/model.rs
+++ b/crates/spark-wallet/src/model.rs
@@ -26,7 +26,7 @@ use spark::{
 use crate::SparkWalletError;
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub enum WalletEvent {
     DepositConfirmed(TreeNodeId),
     StreamConnected,
@@ -65,7 +65,7 @@ pub struct WalletInfo {
     pub network: Network,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct WalletTransfer {
     pub id: TransferId,
     pub sender_id: PublicKey,
@@ -82,6 +82,12 @@ pub struct WalletTransfer {
     pub spark_invoice: Option<String>,
     pub htlc_preimage_request: Option<PreimageRequest>,
     pub is_ssp_transfer: bool,
+    /// The underlying `Transfer` this projection was built from. Held in-memory
+    /// so callers can re-claim the transfer via `SparkWallet::process_transfer`
+    /// without an extra operator round-trip. Boxed to keep `WalletTransfer`'s
+    /// stack footprint small (it's carried inside `WalletEvent` variants on
+    /// the broadcast channel hot-path).
+    pub(crate) raw: Box<Transfer>,
 }
 
 impl WalletTransfer {
@@ -92,6 +98,7 @@ impl WalletTransfer {
         our_public_key: PublicKey,
         ssp_public_key: PublicKey,
     ) -> Self {
+        let raw = Box::new(value.clone());
         let direction = if value.sender_identity_public_key == our_public_key {
             TransferDirection::Outgoing
         } else {
@@ -121,7 +128,12 @@ impl WalletTransfer {
             spark_invoice: value.spark_invoice,
             htlc_preimage_request,
             is_ssp_transfer,
+            raw,
         }
+    }
+
+    pub(crate) fn raw(&self) -> &Transfer {
+        &self.raw
     }
 
     pub fn from_preimage_request_with_transfer(
@@ -164,7 +176,7 @@ impl From<PreimageRequestWithTransfer> for PreimageRequest {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct PayLightningInvoiceResult {
     // The transfer associated with this lightinng payment.
     pub transfer: WalletTransfer,
@@ -172,7 +184,7 @@ pub struct PayLightningInvoiceResult {
     pub lightning_payment: Option<LightningSendPayment>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WalletTransferLeaf {
     pub leaf: WalletLeaf,
     pub secret_cipher: String,
@@ -297,7 +309,7 @@ pub struct ListTransfersRequest {
     pub transfer_ids: Vec<TransferId>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub enum FulfillSparkInvoiceResult {
     Transfer(Box<WalletTransfer>),
     TokenTransaction(Box<TokenTransaction>),

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1099,6 +1099,14 @@ impl SparkWallet {
         .await
     }
 
+    /// Claims a transfer and performs a tree-store insert.
+    pub async fn process_transfer(
+        &self,
+        transfer: &WalletTransfer,
+    ) -> Result<Vec<TreeNode>, SparkWalletError> {
+        claim_transfer(transfer.raw(), &self.transfer_service, &self.tree_service).await
+    }
+
     /// Queries the SSP for user requests by their associated transfer IDs
     /// and returns a map of transfer IDs to user requests
     pub async fn query_ssp_user_requests(
@@ -1390,6 +1398,17 @@ impl SparkWallet {
             .query_token_transactions_by_hashes(hashes)
             .await
             .map_err(Into::into)
+    }
+
+    /// Reconciles the local token-output store for a single token tx.
+    pub async fn process_token_transaction(
+        &self,
+        transaction: &TokenTransaction,
+    ) -> Result<(), SparkWalletError> {
+        self.token_service
+            .update_token_outputs_for_transaction(transaction, &self.identity_public_key)
+            .await?;
+        Ok(())
     }
 
     pub fn get_token_l1_address(&self) -> Result<String, SparkWalletError> {


### PR DESCRIPTION
In server mode (`background_tasks_enabled=false`), `wait_for_payment` blocked for its full timeout because no spark-wallet event subscription exists to fire `PaymentSucceeded`. This broke:

- `complete_conversion_and_send` — errored with "Timeout waiting for conversion to complete"
- `lnurl_withdraw` — returned `payment: None` after a full timeout

### What this PR does

Replaces the event-listener `wait_for_payment` with a single polling `wait_for_incoming_payment` implementation that works in both modes — operator/SSP query loop with targeted local-store updates on terminal status:

- Spark transfer (`PaymentId` as `TransferId`) → `list_transfers` poll → `SparkWallet::process_transfer` claims the leaves into the tree-store.
- Token tx (`PaymentId` as `{hash}:{vout}`) → `get_token_transactions_by_hashes` poll → `SparkWallet::process_token_transaction` updates the local output store.
- Inbound Lightning (new `LightningReceive { invoice, ssp_id }` variant) → `fetch_lightning_receive_payment` poll → once the SSP populates `transfer_id`, claims the resulting Spark transfer.

Two new `pub` methods on `SparkWallet` (`process_transfer`, `process_token_transaction`) wrap the same non-emitting claim/process layer the background processor already uses, so the polled path and the event-driven path are idempotent under concurrency.

Extracted `BreezSdk::finalize_payment` for the shared post-claim work: apply cached payment metadata, sync LNURL metadata, persist, refresh balances, emit `PaymentSucceeded` on first observation. Called from `wait_for_payment`, `handle_wallet_event::TransferClaimed`, and `process_token_transaction_event`.

`lnurl_withdraw` SSP id is plumbed via an inner `receive_bolt11_invoice` fn and the new `LightningReceive` variant.

Added `--server-mode` to the CLI for manual mainnet validation.

Follow-up to #885 (timeout flagged by @danielgranhao).

### Test plan

- New regtest itest `lightning_send_server_mode.rs` covers the polling path end-to-end.
- New `conversion_send_server_mode.rs` (ignored — needs regtest token liquidity).
- Manual mainnet via `cargo run -p cli -- --server-mode --network mainnet`:
  - sats → token ✓
  - token → sats ✓
  - lnurl-withdraw ✓
