### PR TITLE
make new_shared_sdk_context async to run on the tokio runtime

### DIFF
--- a/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
@@ -633,7 +633,8 @@ async fn build_sender_postgres_context(conn_str: &str) -> Result<Arc<SdkContext>
     Ok(new_shared_sdk_context(SdkContextConfig {
         postgres_config: Some(pg_config),
         ..SdkContextConfig::new(Network::Regtest)
-    })?)
+    })
+    .await?)
 }
 
 /// Builds an `SdkContext` backed by a MySQL pool for the sender side, sized
@@ -646,7 +647,8 @@ async fn build_sender_mysql_context(conn_str: &str) -> Result<Arc<SdkContext>> {
     Ok(new_shared_sdk_context(SdkContextConfig {
         mysql_config: Some(my_config),
         ..SdkContextConfig::new(Network::Regtest)
-    })?)
+    })
+    .await?)
 }
 
 async fn initialize_sdk_pair(

--- a/crates/breez-sdk/breez-bench/src/bin/pool_share_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/pool_share_perf.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<()> {
 
     // Build one shared SdkContext up-front (or None for the per-instance path).
     let shared_context: Option<Arc<SdkContext>> = match args.mode {
-        Mode::Shared => Some(make_context(&args.postgres, args.max_pool_size)?),
+        Mode::Shared => Some(make_context(&args.postgres, args.max_pool_size).await?),
         Mode::Separate => None,
     };
 
@@ -123,7 +123,7 @@ async fn main() -> Result<()> {
         builder = match (&shared_context, args.mode) {
             (Some(ctx), _) => builder.with_shared_context(Arc::clone(ctx)),
             (None, Mode::Separate) => {
-                let ctx = make_context(&args.postgres, args.max_pool_size)?;
+                let ctx = make_context(&args.postgres, args.max_pool_size).await?;
                 builder.with_shared_context(ctx)
             }
             (None, Mode::Shared) => unreachable!(),
@@ -191,13 +191,14 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn make_context(conn_str: &str, max_pool_size: u32) -> Result<Arc<SdkContext>> {
+async fn make_context(conn_str: &str, max_pool_size: u32) -> Result<Arc<SdkContext>> {
     let mut cfg = default_postgres_storage_config(conn_str.to_string());
     cfg.max_pool_size = max_pool_size;
     Ok(new_shared_sdk_context(SdkContextConfig {
         postgres_config: Some(cfg),
         ..SdkContextConfig::new(Network::Regtest)
-    })?)
+    })
+    .await?)
 }
 
 struct Snapshots {

--- a/crates/breez-sdk/breez-itest/src/helpers.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers.rs
@@ -128,7 +128,7 @@ pub async fn resolve_backend_choice() -> Result<BackendChoice> {
 }
 
 /// Attaches a previously-resolved [`BackendChoice`] to the builder.
-fn apply_backend_choice(
+async fn apply_backend_choice(
     builder: SdkBuilder,
     storage_dir: String,
     choice: &BackendChoice,
@@ -140,7 +140,8 @@ fn apply_backend_choice(
             let ctx = breez_sdk_spark::new_shared_sdk_context(breez_sdk_spark::SdkContextConfig {
                 postgres_config: Some(pg_config),
                 ..breez_sdk_spark::SdkContextConfig::new(breez_sdk_spark::Network::Regtest)
-            })?;
+            })
+            .await?;
             Ok(builder.with_shared_context(ctx))
         }
         BackendChoice::Mysql(conn_str) => {
@@ -148,7 +149,8 @@ fn apply_backend_choice(
             let ctx = breez_sdk_spark::new_shared_sdk_context(breez_sdk_spark::SdkContextConfig {
                 mysql_config: Some(my_config),
                 ..breez_sdk_spark::SdkContextConfig::new(breez_sdk_spark::Network::Regtest)
-            })?;
+            })
+            .await?;
             Ok(builder.with_shared_context(ctx))
         }
     }
@@ -160,7 +162,7 @@ fn apply_backend_choice(
 /// configuration is applied; if both env vars are set, postgres wins.
 async fn apply_storage(builder: SdkBuilder, storage_dir: String) -> Result<SdkBuilder> {
     let choice = resolve_backend_choice().await?;
-    apply_backend_choice(builder, storage_dir, &choice)
+    apply_backend_choice(builder, storage_dir, &choice).await
 }
 
 /// Event listener that forwards events to a channel
@@ -334,7 +336,7 @@ pub async fn build_sdk_with_custom_config_and_backend(
 
     let builder = SdkBuilder::new(config, seed);
     let builder = match backend {
-        Some(choice) => apply_backend_choice(builder, storage_dir, &choice)?,
+        Some(choice) => apply_backend_choice(builder, storage_dir, &choice).await?,
         None => apply_storage(builder, storage_dir).await?,
     };
     let sdk = builder.build().await?;
@@ -685,7 +687,8 @@ pub async fn build_sdk_with_tree_store_config(
             let ctx = breez_sdk_spark::new_shared_sdk_context(breez_sdk_spark::SdkContextConfig {
                 postgres_config: Some(pg_config),
                 ..breez_sdk_spark::SdkContextConfig::new(breez_sdk_spark::Network::Regtest)
-            })?;
+            })
+            .await?;
             builder = builder.with_shared_context(ctx);
         }
         (Some(PostgresTreeStore::SharedContext(ctx)), None) => {
@@ -699,7 +702,8 @@ pub async fn build_sdk_with_tree_store_config(
             let ctx = breez_sdk_spark::new_shared_sdk_context(breez_sdk_spark::SdkContextConfig {
                 mysql_config: Some(my_config),
                 ..breez_sdk_spark::SdkContextConfig::new(breez_sdk_spark::Network::Regtest)
-            })?;
+            })
+            .await?;
             builder = builder.with_shared_context(ctx);
         }
         (None, Some(MysqlTreeStore::SharedContext(ctx))) => {
@@ -1652,7 +1656,8 @@ pub async fn build_sdk_with_postgres(
     let ctx = breez_sdk_spark::new_shared_sdk_context(breez_sdk_spark::SdkContextConfig {
         postgres_config: Some(postgres_config),
         ..breez_sdk_spark::SdkContextConfig::new(breez_sdk_spark::Network::Regtest)
-    })?;
+    })
+    .await?;
 
     let sdk = breez_sdk_spark::SdkBuilder::new(config, seed)
         .with_shared_context(ctx)
@@ -1710,7 +1715,8 @@ pub async fn build_sdk_with_mysql(
     let ctx = breez_sdk_spark::new_shared_sdk_context(breez_sdk_spark::SdkContextConfig {
         mysql_config: Some(mysql_config),
         ..breez_sdk_spark::SdkContextConfig::new(breez_sdk_spark::Network::Regtest)
-    })?;
+    })
+    .await?;
 
     let sdk = breez_sdk_spark::SdkBuilder::new(config, seed)
         .with_shared_context(ctx)

--- a/crates/breez-sdk/breez-itest/tests/connection_manager.rs
+++ b/crates/breez-sdk/breez-itest/tests/connection_manager.rs
@@ -24,7 +24,8 @@ async fn test_shared_connection_manager_spark_transfer(
     let context = new_shared_sdk_context(SdkContextConfig {
         connections_per_operator,
         ..SdkContextConfig::new(Network::Regtest)
-    })?;
+    })
+    .await?;
 
     let alice_dir = Builder::new()
         .prefix("breez-sdk-shared-cm-alice")

--- a/crates/breez-sdk/breez-itest/tests/ssp_connection_manager.rs
+++ b/crates/breez-sdk/breez-itest/tests/ssp_connection_manager.rs
@@ -16,7 +16,7 @@ use tracing::info;
 #[rstest]
 #[test_log::test(tokio::test)]
 async fn test_shared_ssp_connection_manager_spark_transfer() -> Result<()> {
-    let context = new_shared_sdk_context(SdkContextConfig::new(Network::Regtest))?;
+    let context = new_shared_sdk_context(SdkContextConfig::new(Network::Regtest)).await?;
 
     let alice_dir = Builder::new()
         .prefix("breez-sdk-shared-ssp-cm-alice")

--- a/crates/breez-sdk/cli/src/main.rs
+++ b/crates/breez-sdk/cli/src/main.rs
@@ -184,14 +184,16 @@ async fn run_interactive_mode(
             api_key: breez_api_key.clone(),
             postgres_config: Some(default_postgres_storage_config(connection_string)),
             ..SdkContextConfig::new(network)
-        })?;
+        })
+        .await?;
         sdk_builder = sdk_builder.with_shared_context(context);
     } else if let Some(connection_string) = mysql_connection_string {
         let context = new_shared_sdk_context(SdkContextConfig {
             api_key: breez_api_key.clone(),
             mysql_config: Some(default_mysql_storage_config(connection_string)),
             ..SdkContextConfig::new(network)
-        })?;
+        })
+        .await?;
         sdk_builder = sdk_builder.with_shared_context(context);
     } else {
         sdk_builder = sdk_builder.with_default_storage(data_dir.to_string_lossy().to_string());

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -515,10 +515,13 @@ impl SdkBuilder {
         // wiring reads from `context` for connection managers.
         let context = match self.context {
             Some(ctx) => ctx,
-            None => new_shared_sdk_context(SdkContextConfig {
-                api_key: self.config.api_key.clone(),
-                ..SdkContextConfig::new(self.config.network)
-            })?,
+            None => {
+                new_shared_sdk_context(SdkContextConfig {
+                    api_key: self.config.api_key.clone(),
+                    ..SdkContextConfig::new(self.config.network)
+                })
+                .await?
+            }
         };
 
         // Ensure the context's parameters are the same as the config parameters.
@@ -1123,6 +1126,7 @@ mod tests {
             api_key: Some("partner-key".to_string()),
             ..SdkContextConfig::new(Network::Regtest)
         })
+        .await
         .expect("regtest context");
         let err = SdkBuilder::new(config, test_seed())
             .with_shared_context(ctx)
@@ -1150,6 +1154,7 @@ mod tests {
             api_key: Some("wrong-key".to_string()),
             ..SdkContextConfig::new(Network::Mainnet)
         })
+        .await
         .expect("mainnet context");
         let err = SdkBuilder::new(config, test_seed())
             .with_shared_context(ctx)

--- a/crates/breez-sdk/core/src/sdk_context.rs
+++ b/crates/breez-sdk/core/src/sdk_context.rs
@@ -117,9 +117,11 @@ impl SdkContextConfig {
 /// `SdkContextConfig::new(network)` yields an in-memory, single-tenant setup;
 /// supply a DB config to back the SDKs with a shared `PostgreSQL` or `MySQL`
 /// pool.
-#[cfg_attr(feature = "uniffi", uniffi::export)]
-#[allow(clippy::needless_pass_by_value)]
-pub fn new_shared_sdk_context(config: SdkContextConfig) -> Result<Arc<SdkContext>, SdkError> {
+// Async-on-tokio so UniFFI runs it on the managed runtime: building the
+// shared resources `tokio::spawn`s internally (gRPC channel; mainnet JWT
+// task) and aborts off-runtime, despite no `.await` here.
+#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+pub async fn new_shared_sdk_context(config: SdkContextConfig) -> Result<Arc<SdkContext>, SdkError> {
     // Mirror the storage-config conflict check in `SdkBuilder::build()` —
     // fail before opening either pool rather than after.
     #[cfg(all(feature = "postgres", feature = "mysql"))]
@@ -193,6 +195,7 @@ mod tests {
     #[tokio::test]
     async fn default_config_yields_context_with_shared_clients_and_no_db() {
         let ctx = new_shared_sdk_context(SdkContextConfig::new(Network::Regtest))
+            .await
             .expect("default context");
         // Just confirming the Arcs are non-null.
         let _http = Arc::clone(&ctx.http_client);
@@ -215,6 +218,7 @@ mod tests {
             api_key: Some("test-key".to_string()),
             ..SdkContextConfig::new(Network::Mainnet)
         })
+        .await
         .expect("mainnet context");
         assert!(ctx.jwt_header_provider.is_some());
         assert_eq!(ctx.network, Network::Mainnet);
@@ -227,6 +231,7 @@ mod tests {
             api_key: Some("test-key".to_string()),
             ..SdkContextConfig::new(Network::Regtest)
         })
+        .await
         .expect("regtest context");
         // Regtest never gets a JWT provider — there's no Breez endpoint to
         // mint a token. But the inputs are still stored so the builder

--- a/crates/breez-sdk/wasm/src/sdk_context.rs
+++ b/crates/breez-sdk/wasm/src/sdk_context.rs
@@ -60,12 +60,13 @@ pub struct WasmSdkContextConfig {
 
 /// Constructs a [`WasmSdkContext`] from a `WasmSdkContextConfig`.
 #[wasm_bindgen(js_name = "newSharedSdkContext")]
-pub fn new_shared_sdk_context(config: WasmSdkContextConfig) -> WasmResult<WasmSdkContext> {
+pub async fn new_shared_sdk_context(config: WasmSdkContextConfig) -> WasmResult<WasmSdkContext> {
     let inner = breez_sdk_spark::new_shared_sdk_context(breez_sdk_spark::SdkContextConfig {
         network: config.network.into(),
         api_key: config.api_key,
         connections_per_operator: config.connections_per_operator,
-    })?;
+    })
+    .await?;
 
     let postgres_pool = match config.postgres_config {
         Some(cfg) => {

--- a/packages/flutter/rust/src/sdk_context.rs
+++ b/packages/flutter/rust/src/sdk_context.rs
@@ -9,8 +9,6 @@
 
 use std::sync::Arc;
 
-use flutter_rust_bridge::frb;
-
 use breez_sdk_spark::{SdkContextConfig, SdkError};
 
 pub struct SdkContext {
@@ -18,8 +16,7 @@ pub struct SdkContext {
 }
 
 /// Process-shared SDK resources for Flutter integrations.
-#[frb(sync)]
-pub fn new_shared_sdk_context(config: SdkContextConfig) -> Result<SdkContext, SdkError> {
-    let inner = breez_sdk_spark::new_shared_sdk_context(config)?;
+pub async fn new_shared_sdk_context(config: SdkContextConfig) -> Result<SdkContext, SdkError> {
+    let inner = breez_sdk_spark::new_shared_sdk_context(config).await?;
     Ok(SdkContext { inner })
 }


### PR DESCRIPTION
Building the shared resources transitively tokio::spawns at construction with no .await of our own: BreezServer::new -> Endpoint::connect_lazy() spawns tonic's channel buffer-worker (unconditional), and on mainnet+api_key BreezJwtHeaderProvider::new spawns its refresh task. tokio::spawn aborts outside a runtime, which is exactly the case for a sync UniFFI export called on a foreign thread.

Export it async with async_runtime = "tokio" so UniFFI polls it on the managed runtime, and propagate .await to all callers (builder, cli, itest helpers, bench bins, wasm and flutter bindings). The flutter binding drops #[frb(sync)] accordingly.