### PR TITLE
Use poll fn to signal terminal payment

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/breez_sdk_tests.rs
+++ b/crates/breez-sdk/breez-itest/tests/breez_sdk_tests.rs
@@ -1,4 +1,4 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
 use breez_sdk_itest::*;
@@ -1301,5 +1301,83 @@ async fn test_09_bolt11_send_all_with_fee_overpayment(
         expected_fee1 - expected_fee2
     );
     info!("=== Test test_09_bolt11_send_all_with_fee_overpayment PASSED ===");
+    Ok(())
+}
+
+/// Test 10: Bolt11 send resolves to `Completed` via the synchronous
+/// completion signal from `poll_lightning_send_payment`, not via the
+/// `Pending` timeout fallback.
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn test_10_lightning_completion_timeout_resolves_to_completed(
+    #[future] alice_sdk: Result<SdkInstance>,
+    #[future] bob_sdk: Result<SdkInstance>,
+) -> Result<()> {
+    info!("=== Starting test_10_lightning_completion_timeout_resolves_to_completed ===");
+
+    let mut alice = alice_sdk.await?;
+    let mut bob = bob_sdk.await?;
+    ensure_funded(&mut alice, 60_000).await?;
+
+    let invoice_amount_sats = 10_000u64;
+    let completion_timeout_secs = 30u32;
+
+    let bob_invoice = bob
+        .sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::Bolt11Invoice {
+                description: "Completion-timeout regression".to_string(),
+                amount_sats: Some(invoice_amount_sats),
+                expiry_secs: None,
+                payment_hash: None,
+            },
+        })
+        .await?
+        .payment_request;
+
+    let prepare = alice
+        .sdk
+        .prepare_send_payment(PrepareSendPaymentRequest {
+            payment_request: bob_invoice,
+            amount: None,
+            token_identifier: None,
+            conversion_options: None,
+            fee_policy: None,
+        })
+        .await?;
+
+    let start = Instant::now();
+    let send_resp = alice
+        .sdk
+        .send_payment(SendPaymentRequest {
+            prepare_response: prepare,
+            options: Some(SendPaymentOptions::Bolt11Invoice {
+                prefer_spark: false,
+                completion_timeout_secs: Some(completion_timeout_secs),
+            }),
+            idempotency_key: None,
+        })
+        .await?;
+    let elapsed = start.elapsed();
+    info!(
+        "send_payment returned in {:?} with status {:?}",
+        elapsed, send_resp.payment.status
+    );
+
+    assert_eq!(
+        send_resp.payment.status,
+        PaymentStatus::Completed,
+        "send_payment should resolve to Completed, not the Pending timeout fallback",
+    );
+    assert!(
+        elapsed < Duration::from_secs(u64::from(completion_timeout_secs).saturating_sub(1)),
+        "send_payment blocked until timeout ({elapsed:?}); the wait isn't being woken by the completion signal",
+    );
+
+    // Confirm the receiver side completed normally.
+    let _received =
+        wait_for_payment_succeeded_event(&mut bob.events, PaymentType::Receive, 30).await?;
+
+    info!("=== Test test_10_lightning_completion_timeout_resolves_to_completed PASSED ===");
     Ok(())
 }

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -1,9 +1,11 @@
 use bitcoin::hashes::sha256;
-use platform_utils::time::Duration;
+use bitcoin::secp256k1::PublicKey;
+use platform_utils::time::{Duration, SystemTime};
+use platform_utils::tokio;
 use spark_wallet::{ExitSpeed, SparkAddress, TransferId, TransferTokenOutput};
+use spark_wallet::{InvoiceDescription, Preimage};
 use std::str::FromStr;
-use tokio::select;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
 use tracing::{Instrument, error, info, warn};
 
@@ -32,10 +34,6 @@ use crate::{
         token::map_and_persist_token_transaction,
     },
 };
-use bitcoin::secp256k1::PublicKey;
-use platform_utils::time::SystemTime;
-use platform_utils::tokio;
-use spark_wallet::{InvoiceDescription, Preimage};
 
 use super::{
     BreezSdk,
@@ -1292,6 +1290,7 @@ impl BreezSdk {
             ),
         )
         .await?;
+        let completion_timeout_secs = completion_timeout_secs.unwrap_or(0);
         let payment = match payment_response.lightning_payment {
             Some(lightning_payment) => {
                 let ssp_id = lightning_payment.id.clone();
@@ -1310,28 +1309,34 @@ impl BreezSdk {
                     payment_response.transfer.id.to_string(),
                     htlc_details,
                 )?;
-                self.poll_lightning_send_payment(&payment, ssp_id);
-                payment
+                let completion_rx = self.poll_lightning_send_payment(&payment, ssp_id);
+                if completion_timeout_secs == 0 {
+                    payment
+                } else {
+                    // Wait up to the caller's timeout for the background
+                    // poll to signal completion. The poll keeps running in
+                    // either branch — it still emits `PaymentSucceeded`
+                    // when terminal — so dropping the receiver on timeout
+                    // is harmless. We fall back to the pre-confirmation
+                    // payment if the wait times out or the channel closes
+                    // (e.g. missing HTLC details).
+                    tokio::time::timeout(
+                        Duration::from_secs(completion_timeout_secs.into()),
+                        completion_rx,
+                    )
+                    .await
+                    .ok()
+                    .and_then(Result::ok)
+                    .unwrap_or(payment)
+                }
             }
+            // Spark-routed Lightning sends complete synchronously inside
+            // `pay_lightning_invoice` — there is no SSP-side state to poll,
+            // so `completion_timeout_secs` is ignored for this branch and
+            // the payment is returned with whatever status the transfer
+            // already has.
             None => payment_response.transfer.try_into()?,
         };
-
-        let completion_timeout_secs = completion_timeout_secs.unwrap_or(0);
-
-        if completion_timeout_secs == 0 {
-            // Insert the payment into storage to make it immediately available for listing
-            self.storage.insert_payment(payment.clone()).await?;
-
-            return Ok(SendPaymentResponse { payment });
-        }
-
-        let payment = self
-            .wait_for_payment(
-                WaitForPaymentIdentifier::PaymentId(payment.id.clone()),
-                completion_timeout_secs,
-            )
-            .await
-            .unwrap_or(payment);
 
         // Insert the payment into storage to make it immediately available for listing
         self.storage.insert_payment(payment.clone()).await?;
@@ -1469,10 +1474,18 @@ impl BreezSdk {
         result
     }
 
-    // Pools the lightning send payment until it is in completed state.
-    fn poll_lightning_send_payment(&self, payment: &Payment, ssp_id: String) {
+    /// Spawns the background poll that watches an outgoing Lightning send to
+    /// completion. Returns a receiver that resolves to the terminal `Payment`
+    /// when the SSP reports a non-`Pending` status, so callers can `await`
+    /// completion synchronously with their own timeout.
+    fn poll_lightning_send_payment(
+        &self,
+        payment: &Payment,
+        ssp_id: String,
+    ) -> oneshot::Receiver<Payment> {
         const MAX_POLL_ATTEMPTS: u32 = 20;
         let payment_id = payment.id.clone();
+        let (tx, rx) = oneshot::channel();
         info!("Polling lightning send payment {}", payment_id);
 
         let Some(htlc_details) = payment.details.as_ref().and_then(|d| match d {
@@ -1482,7 +1495,7 @@ impl BreezSdk {
             error!(
                 "Missing HTLC details for lightning send payment {payment_id}, skipping polling"
             );
-            return;
+            return rx;
         };
         let spark_wallet = self.spark_wallet.clone();
         let storage = self.storage.clone();
@@ -1493,42 +1506,52 @@ impl BreezSdk {
         let span = tracing::Span::current();
 
         tokio::spawn(async move {
-            for i in 0..MAX_POLL_ATTEMPTS {
-                info!(
-                    "Polling lightning send payment {} attempt {}",
-                    payment_id, i
-                );
-                select! {
-                    _ = shutdown.changed() => {
-                        info!("Shutdown signal received");
-                        return;
-                    },
-                    p = spark_wallet.fetch_lightning_send_payment(&ssp_id) => {
-                        if let Ok(Some(p)) = p && let Ok(payment) = Payment::from_lightning(p.clone(), payment.amount, payment.id.clone(), htlc_details.clone()) {
-                            info!("Polling payment status = {} {:?}", payment.status, p.status);
-                            if payment.status != PaymentStatus::Pending {
-                                info!("Polling payment completed status = {}", payment.status);
-                                // Update storage before emitting event so that
-                                // get_payment returns the correct status immediately.
-                                if let Err(e) = storage.insert_payment(payment.clone()).await {
-                                    error!("Failed to update payment in storage: {e:?}");
+            // Drive the poll loop until we either reach a terminal status,
+            // hit the attempt cap, or get a shutdown signal.
+            let terminal_payment: Option<Payment> = 'poll: {
+                for i in 0..MAX_POLL_ATTEMPTS {
+                    info!(
+                        "Polling lightning send payment {} attempt {}",
+                        payment_id, i
+                    );
+                    tokio::select! {
+                        _ = shutdown.changed() => {
+                            info!("Shutdown signal received");
+                            break 'poll None;
+                        },
+                        p = spark_wallet.fetch_lightning_send_payment(&ssp_id) => {
+                            if let Ok(Some(p)) = p && let Ok(payment) = Payment::from_lightning(p.clone(), payment.amount, payment.id.clone(), htlc_details.clone()) {
+                                info!("Polling payment status = {} {:?}", payment.status, p.status);
+                                if payment.status != PaymentStatus::Pending {
+                                    info!("Polling payment completed status = {}", payment.status);
+                                    break 'poll Some(payment);
                                 }
-                                // Fetch the payment to include already stored metadata
-                                get_payment_and_emit_event(&storage, &event_emitter, payment.clone()).await;
-                                return;
                             }
-                        }
 
-                        let sleep_time = if i < 5 {
-                            Duration::from_secs(1)
-                        } else {
-                            Duration::from_secs(i.into())
-                        };
-                        tokio::time::sleep(sleep_time).await;
+                            let sleep_time = if i < 5 {
+                                Duration::from_secs(1)
+                            } else {
+                                Duration::from_secs(i.into())
+                            };
+                            tokio::time::sleep(sleep_time).await;
+                        }
                     }
                 }
+                None
+            };
+
+            let Some(payment) = terminal_payment else {
+                return;
+            };
+
+            let _ = tx.send(payment.clone());
+            if let Err(e) = storage.insert_payment(payment.clone()).await {
+                error!("Failed to update payment in storage: {e:?}");
             }
+            get_payment_and_emit_event(&storage, &event_emitter, payment).await;
         }.instrument(span));
+
+        rx
     }
 
     #[expect(clippy::too_many_arguments)]


### PR DESCRIPTION
Refactor `poll_lightning_send_payment` to return `oneshot::Receiver<Payment>`. `send_bolt11_invoice` now awaits that receiver with `tokio::time::timeout` instead of going through `wait_for_payment`.

- Same code path in client and server modes (the background poll already polls `fetch_lightning_send_payment(ssp_id)` to terminal status in both).
- Spark-routed Lightning sends (`lightning_payment == None`) return synchronously with whatever status the transfer has at send time — `completion_timeout_secs` is ignored for that branch.
- External listeners and storage writes are unchanged.

### Test plan

- New `test_10_lightning_completion_timeout_resolves_to_completed` asserts `status == Completed` and `elapsed < timeout - 1s`, catching both the timeout-fallback regression and a late-signal regression.
- `cargo test -p breez-sdk-itest --test breez_sdk_tests test_10_…` passes (55s).
