### PR TITLE
cli: await new_shared_sdk_context in language CLIs

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
@@ -289,7 +289,7 @@ static async Task RunInteractiveMode(
     var builder = new SdkBuilder(config: config, seed: seed);
     if (postgresConnectionString != null)
     {
-        var context = BreezSdkSparkMethods.NewSharedSdkContext(config: new SdkContextConfig(
+        var context = await BreezSdkSparkMethods.NewSharedSdkContext(config: new SdkContextConfig(
             network: network,
             apiKey: apiKey,
             connectionsPerOperator: null,
@@ -300,7 +300,7 @@ static async Task RunInteractiveMode(
     }
     else if (mysqlConnectionString != null)
     {
-        var context = BreezSdkSparkMethods.NewSharedSdkContext(config: new SdkContextConfig(
+        var context = await BreezSdkSparkMethods.NewSharedSdkContext(config: new SdkContextConfig(
             network: network,
             apiKey: apiKey,
             connectionsPerOperator: null,

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
@@ -136,14 +136,14 @@ async def main(data_dir, network, account_number, postgres_connection_string,
     builder = SdkBuilder(config=config, seed=seed)
 
     if postgres_connection_string:
-        context = new_shared_sdk_context(config=SdkContextConfig(
+        context = await new_shared_sdk_context(config=SdkContextConfig(
             network=network_enum,
             api_key=breez_api_key,
             postgres_config=default_postgres_storage_config(connection_string=postgres_connection_string),
         ))
         await builder.with_shared_context(context=context)
     elif mysql_connection_string:
-        context = new_shared_sdk_context(config=SdkContextConfig(
+        context = await new_shared_sdk_context(config=SdkContextConfig(
             network=network_enum,
             api_key=breez_api_key,
             mysql_config=default_mysql_storage_config(connection_string=mysql_connection_string),

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
@@ -254,14 +254,14 @@ if let passkeyStr = opts.passkey {
 // Build SDK
 let builder = SdkBuilder(config: config, seed: seed)
 if let connectionString = opts.postgresConnectionString {
-    let context = try newSharedSdkContext(config: SdkContextConfig(
+    let context = try await newSharedSdkContext(config: SdkContextConfig(
         network: network,
         apiKey: breezApiKey,
         postgresConfig: defaultPostgresStorageConfig(connectionString: connectionString)
     ))
     await builder.withSharedContext(context: context)
 } else if let connectionString = opts.mysqlConnectionString {
-    let context = try newSharedSdkContext(config: SdkContextConfig(
+    let context = try await newSharedSdkContext(config: SdkContextConfig(
         network: network,
         apiKey: breezApiKey,
         mysqlConfig: defaultMysqlStorageConfig(connectionString: connectionString)

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
@@ -269,14 +269,14 @@ async function main() {
   let sdkBuilder = SdkBuilder.new(config, seed)
 
   if (opts.postgresConnectionString) {
-    const context = newSharedSdkContext({
+    const context = await newSharedSdkContext({
       network,
       apiKey: breezApiKey,
       postgresConfig: defaultPostgresStorageConfig(opts.postgresConnectionString)
     })
     sdkBuilder = sdkBuilder.withSharedContext(context)
   } else if (opts.mysqlConnectionString) {
-    const context = newSharedSdkContext({
+    const context = await newSharedSdkContext({
       network,
       apiKey: breezApiKey,
       mysqlConfig: defaultMysqlStorageConfig(opts.mysqlConnectionString)


### PR DESCRIPTION
After #890 made `new_shared_sdk_context` async, the C# and Swift CLIs broke (build errors) and the Python/JS CLIs silently assigned a coroutine/Promise to `context`. This adds the missing `await` in all four CLIs. Kotlin already worked since uniffi-kotlin exposes the call as a suspend function.