### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
@@ -62,6 +62,9 @@ declare module '@breeztech/breez-sdk-spark-react-native' {
   export const StableBalanceActiveLabel: any;
   export type StableBalanceActiveLabel = any;
 
+  export const Passkey: any;
+  export type Passkey = any;
+
   // --- values only ---
   export const defaultConfig: any;
   export const SdkEvent_Tags: any;
@@ -76,4 +79,5 @@ declare module '@breeztech/breez-sdk-spark-react-native' {
   export type BreezSdkInterface = any;
   export type TokenIssuerInterface = any;
   export type SdkEvent = any;
+  export type NostrRelayConfig = any;
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -923,6 +923,9 @@ async function handleBuyBitcoin(sdk: BreezSdkInterface, _tokenIssuer: TokenIssue
     case 'cashapp':
     case 'cash_app':
     case 'cash-app':
+      if (amountSat === undefined) {
+        return 'Error: --amount-sat is required when --provider is cashapp'
+      }
       request = new BuyBitcoinRequest.CashApp({
         amountSats: amountSat,
       })

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/passkey.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/passkey.ts
@@ -12,8 +12,9 @@
  */
 
 import {
-  Seed,
+  Passkey,
   type Seed as SeedType,
+  type NostrRelayConfig,
 } from '@breeztech/breez-sdk-spark-react-native'
 import RNFS from 'react-native-fs'
 import { generateRandomBytes, hmacSha256 } from './crypto_utils'
@@ -239,32 +240,47 @@ export async function buildPrfProvider(
 /**
  * Resolve a wallet seed using the given PRF provider.
  *
- * Note: Full passkey functionality (Nostr label listing/storing) is not
- * yet supported in the React Native SDK. This stub derives a seed from the
- * PRF provider and returns it as a Seed.Entropy variant.
+ * Uses the SDK's Passkey class for proper seed derivation with Nostr label
+ * management, matching the Rust CLI's resolve_passkey_seed function.
  *
  * @param provider - The PRF provider to use
- * @param _breezApiKey - Optional Breez API key (unused - Nostr not yet supported)
+ * @param breezApiKey - Optional Breez API key (for Nostr relay access)
  * @param label - Optional label for seed derivation
- * @param _listLabels - Whether to list labels (not yet supported)
- * @param _storeLabel - Whether to publish the label (not yet supported)
+ * @param listLabels - Whether to list labels from Nostr
+ * @param storeLabel - Whether to publish the label to Nostr
  * @returns Object with { seed, labels? } - seed is the derived Seed,
  *          labels is populated when listLabels is true
  */
 export async function resolvePasskeySeed(
   provider: { derivePrfSeed: (salt: string) => Promise<ArrayBuffer>; isPrfAvailable: () => Promise<boolean> },
-  _breezApiKey: string | undefined,
+  breezApiKey: string | undefined,
   label: string | undefined,
-  _listLabels: boolean,
-  _storeLabel: boolean,
+  listLabels: boolean,
+  storeLabel: boolean,
 ): Promise<{ seed: SeedType; labels?: string[] }> {
-  // Derive seed bytes from the PRF provider
-  const seedBytes = await provider.derivePrfSeed(label ?? 'Default')
+  const relayConfig: NostrRelayConfig = {
+    breezApiKey,
+    timeoutSecs: undefined,
+  }
+  const passkey = new Passkey(provider, relayConfig)
 
-  // Note: Passkey label listing/storing via Nostr is not yet supported
-  // in React Native. Only basic seed derivation is available.
+  if (storeLabel && label) {
+    await passkey.storeLabel(label)
+  }
 
-  // Use Entropy variant since we have raw bytes
-  const seed = new Seed.Entropy(seedBytes)
-  return { seed }
+  let labels: string[] | undefined
+  let selectedLabel = label
+  if (listLabels) {
+    const fetchedLabels = (await passkey.listLabels()) as string[]
+    if (fetchedLabels.length === 0) {
+      throw new Error('No labels found on Nostr for this identity')
+    }
+    // In the Rust CLI this prompts the user to select; pick the first label
+    // since the React Native CLI cannot prompt interactively during init.
+    selectedLabel = fetchedLabels[0]
+    labels = fetchedLabels
+  }
+
+  const wallet = await passkey.getWallet(selectedLabel)
+  return { seed: wallet.seed, labels }
 }


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`995f792`](https://github.com/breez/spark-sdk/commit/995f7920c62e3c6eac8c00249a306be548b6cd92)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/26150924172)
**Approved from:** [dry-run #26105005138](https://github.com/breez/spark-sdk/actions/runs/26105005138)

**Language status:**
- :x: C# (patch failed to apply)
- :next_track_button: Dart (no changes needed)
- :x: Go (patch failed to apply)
- :x: Kotlin (patch failed to apply)
- :x: Python (patch failed to apply)
- :white_check_mark: React Native
- :next_track_button: Swift (no changes needed)
- :next_track_button: TypeScript (no changes needed)

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- Missing `--mysql-connection-string` CLI flag; Rust supports MySQL storage via `new_shared_sdk_context` with `mysql_config`, C# had no MySQL path
- `--stable-balance-token-identifier` (single, hardcoded "USDB" label) vs Rust's `--stable-balance-token` (repeatable, `LABEL:token_identifier` format) with `--stable-balance-default-active-label`
- Missing `stable-balance` subcommand group (get/set/unset) present in Rust CLI
- Missing `--token-identifier` (`-t`) flag for `lnurl-pay` command; C# always passed `null`
- Help output and README did not mention `stable-balance` subcommands or MySQL option
- Rust `new_shared_sdk_context` is now async (`.await`); C# uses `CreatePostgresConnectionPool`/`CreateMysqlConnectionPool` which is the correct C# SDK pattern per snippets

## Applied
- Added `--mysql-connection-string` flag with mutual exclusivity validation and `CreateMysqlConnectionPool` + `WithMysqlConnectionPool` builder path in `Program.cs`
- Updated stable balance flags to `--stable-balance-token` (repeatable, `LABEL:token_identifier` format) and added `--stable-balance-default-active-label` in `Program.cs`
- Created `StableBalance.cs` with get/set/unset subcommands using `StableBalanceActiveLabel.Set`/`Unset` SDK types
- Added `stable-balance` dispatch in REPL loop and tab-completion list in `Program.cs`
- Added `--token-identifier` (`-t`) flag to `lnurl-pay` handler and pass through to `PrepareLnurlPayRequest` in `Commands.cs`
- Added `stable-balance <subcommand>` entry to help output in `Commands.cs`
- Updated `PrintUsage()` in `Program.cs` to document `--mysql-connection-string`, `--stable-balance-token`, and `--stable-balance-default-active-label`
- Updated `README.md` CLI options table and Available Commands section to include MySQL and stable-balance

## Skipped
- Rust `new_shared_sdk_context` + `with_shared_context` pattern not available in C# SDK; used equivalent `CreatePostgresConnectionPool`/`CreateMysqlConnectionPool` + `WithPostgresConnectionPool`/`WithMysqlConnectionPool` per C# snippets (SdkBuilding.cs)
- C# CLI extra UX touches (success messages on delete, "No lightning address registered" message) kept as-is; these are suggestions for the Rust CLI

### Dart
## Divergences
- `new_shared_sdk_context` is now async in Rust CLI (requires `.await`), but the Dart CLI does not call this function — it prints a warning that postgres/mysql are not yet supported and uses default SQLite storage instead.

## Applied
- (none — no Dart CLI changes needed)

## Skipped
- The `new_shared_sdk_context` async change does not affect the Dart CLI since it does not use shared SDK contexts (postgres/mysql storage). The Dart CLI already correctly falls back to SQLite with a user-facing warning.

### Go
## Divergences
- MySQL storage support (`--mysql-connection-string` flag and `CreateMysqlConnectionPool` + `WithMysqlConnectionPool`) missing from Go CLI
- Stable balance token format: Rust uses repeatable `--stable-balance-token LABEL:token_identifier`, Go used single `--stable-balance-token-identifier` with hardcoded "USDB" label
- `--stable-balance-default-active-label` flag missing from Go CLI
- Webhooks subcommand group (`webhooks register/unregister/list`) missing from Go CLI
- Stable balance subcommand group (`stable-balance get/set/unset`) missing from Go CLI
- `--token-identifier` (`-t`) flag missing from `lnurl-pay` command in Go CLI
- `buy-bitcoin` missing `--provider` flag and CashApp support (only MoonPay was supported)
- `buy-bitcoin` used `--amount` instead of `--amount-sat` to match Rust flag name
- Conversion estimate display in `pay` command used same unit string for in/out/fee instead of separate in_units and out_units
- Conversion estimate display in `lnurl-pay` command had same issue
- Serialization variant type detection missing `StableBalanceActiveLabel` and `WebhookEventType` prefixes
- README missing MySQL, updated stable balance flags, webhooks, and stable-balance command documentation

## Applied
- Added `--mysql-connection-string` flag and MySQL storage via `CreateMysqlConnectionPool` + `WithMysqlConnectionPool` in `main.go`
- Changed stable balance from `--stable-balance-token-identifier` (single) to `--stable-balance-token` (repeatable `LABEL:token_identifier` format) in `main.go`
- Added `--stable-balance-default-active-label` flag in `main.go`
- Created `webhooks.go` with `register`, `unregister`, `list` subcommands and REPL dispatch
- Created `stable_balance.go` with `get`, `set`, `unset` subcommands and REPL dispatch
- Added `--token-identifier` (`-t`) flag to `lnurl-pay` in `commands.go`, with token-aware prompt text
- Added `--provider` flag and CashApp support to `buy-bitcoin` in `commands.go`, renamed `--amount` to `--amount-sat`
- Fixed conversion estimate display in `handlePay` and `handleLnurlPay` in `commands.go` to use separate in/out units matching Rust format
- Added webhook and stable-balance dispatch to REPL loop and completion list in `main.go`
- Added `StableBalanceActiveLabel` and `WebhookEventType` to serialization variant prefixes in `serialization.go`
- Updated `README.md` with MySQL option, new stable balance flag format, and webhooks/stable-balance command sections

## Skipped
- `set-user-settings` flag naming: Go uses `--spark-private-mode` (more descriptive) vs Rust `--private` — kept Go's naming as a UX improvement
- Go CLI's extra success messages (e.g., "Lightning address deleted", "User settings updated") — kept as UX additions, noted as suggestions for Rust CLI

### Kotlin
## Divergences
- Missing `--mysql-connection-string` CLI flag (Rust supports MySQL storage via `defaultMysqlStorageConfig` + `createMysqlConnectionPool`)
- Stable balance token flags use incompatible format: Rust has repeatable `--stable-balance-token LABEL:id` + `--stable-balance-default-active-label`; Kotlin had single `--stable-balance-token-identifier` with hardcoded "USDB" label
- Missing `webhooks` subcommand group (register, unregister, list) — SDK types `RegisterWebhookRequest`, `UnregisterWebhookRequest`, `WebhookEventType` all available in Kotlin
- Missing `stable-balance` subcommand group (get, set, unset) — SDK types `StableBalanceActiveLabel.Set`/`Unset` available in Kotlin
- `buy-bitcoin` only supported MoonPay; Rust also supports CashApp provider (`BuyBitcoinRequest.CashApp` available in Kotlin SDK)
- `lnurl-pay` missing `--token-identifier` flag for token-denominated amounts (Rust passes it to `PrepareLnurlPayRequest.token_identifier`)
- `set-user-settings` did not explicitly pass `stableBalanceActiveLabel = null` (Rust passes `stable_balance_active_label: None`)

## Applied
- Added `--mysql-connection-string` flag and MySQL storage initialization in `Main.kt`
- Updated stable balance flags to repeatable `--stable-balance-token LABEL:id` format with `--stable-balance-default-active-label` in `Main.kt`
- Added mutual exclusion validation between `--postgres-connection-string` and `--mysql-connection-string` in `Main.kt`
- Created `Webhooks.kt` with register, unregister, list subcommands matching Rust `webhooks.rs`
- Created `StableBalance.kt` with get, set, unset subcommands matching Rust `stable_balance.rs`
- Added `--provider` and `--amount-sat` flags to `buy-bitcoin` with CashApp support in `Commands.kt`
- Added `--token-identifier` flag to `lnurl-pay` with token-aware prompt in `Commands.kt`
- Added explicit `stableBalanceActiveLabel = null` to `set-user-settings` handler in `Commands.kt`
- Registered webhooks and stable-balance subcommand groups in REPL dispatch, help, and tab completion in `Main.kt`
- Updated `README.md` with MySQL option, new stable balance token flags, webhooks and stable-balance command sections

## Skipped
- Nothing skipped; all Rust CLI features have equivalent Kotlin SDK APIs

### Python
## Divergences
- Python CLI missing `--mysql-connection-string` flag and MySQL storage backend support (Rust CLI has it with `conflicts_with = "postgres_connection_string"`)

## Applied
- Added `--mysql-connection-string` CLI option with mutual exclusion validation against `--postgres-connection-string` (`main.py`)
- Added MySQL storage builder logic using `default_mysql_storage_config` + `create_mysql_connection_pool` + `with_mysql_connection_pool` (`main.py`)
- Added `create_mysql_connection_pool` and `default_mysql_storage_config` imports (`main.py`)
- Added `--mysql-connection-string` to Python README CLI Options table (`README.md`)

## Skipped
- Rust CLI uses `new_shared_sdk_context` + `with_shared_context` pattern for Postgres/MySQL; Python CLI uses `create_*_connection_pool` + `with_*_connection_pool` pattern. Both are valid — Python snippets (`sdk_building.py`) demonstrate the pool-based pattern as the recommended approach for Python bindings. No change needed.

### React Native
## Divergences
- passkey.ts: resolvePasskeySeed() used raw PRF derivation (derivePrfSeed + Seed.Entropy) instead of the SDK's Passkey class (getWallet, listLabels, storeLabel), producing different seeds than the Rust CLI
- commands.ts: handleBuyBitcoin did not validate that --amount-sat is required for CashApp provider (Rust CLI returns explicit error)
- main.rs diff: new_shared_sdk_context() changed from sync to async — not applicable to React Native CLI (does not use Postgres/MySQL shared context)

## Applied
- passkey.ts: Updated resolvePasskeySeed() to use SDK Passkey class with NostrRelayConfig, getWallet(), listLabels(), and storeLabel(), matching the Rust CLI's resolve_passkey_seed function
- commands.ts: Added CashApp amount validation in handleBuyBitcoin to return error when --amount-sat is missing

## Skipped
- new_shared_sdk_context() async change: React Native CLI uses withDefaultStorage() for storage, not Postgres/MySQL shared context, so the async change has no counterpart to sync

### Swift
## Divergences
- Rust `main.rs` changed `new_shared_sdk_context()` from sync to async (`.await`), but the Swift SDK does not expose `newSharedSdkContext` or `SdkContextConfig` — the Swift CLI correctly uses `createPostgresConnectionPool` + `withPostgresConnectionPool` per the Swift SDK snippets

## Applied
- (none — no changes required)

## Skipped
- (none)

### TypeScript
## Divergences
- None. The Rust CLI change (making `new_shared_sdk_context()` async) does not affect the TypeScript CLI, which uses the equivalent WASM SDK APIs (`createPostgresConnectionPool` + `withPostgresConnectionPool` / `createMysqlConnectionPool` + `withMysqlConnectionPool`).

## Applied
- No changes applied — CLIs are in sync.

## Skipped
- No items skipped.

</details>

> [!WARNING]
> Some patches failed to apply. The target files may have changed since the sync ran.
> Failed languages: csharp,golang,kotlin-multiplatform,python
> Consider re-running the sync for these languages.