### PR TITLE
core: treat disconnect() as a no-op when no shutdown receivers

### DIFF
--- a/crates/breez-sdk/breez-itest/src/concurrent_scenarios.rs
+++ b/crates/breez-sdk/breez-itest/src/concurrent_scenarios.rs
@@ -470,6 +470,13 @@ where
         final_payments_0.payments.len(),
         current_balance
     );
+
+    let [instance_0, instance_1, instance_2] = instances;
+    instance_0.sdk.disconnect().await?;
+    instance_1.sdk.disconnect().await?;
+    instance_2.sdk.disconnect().await?;
+    counterparty.sdk.disconnect().await?;
+
     Ok(())
 }
 

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -1,6 +1,6 @@
 use bitcoin::secp256k1::{PublicKey, ecdsa::Signature};
 use std::str::FromStr;
-use tracing::info;
+use tracing::{debug, info};
 
 use breez_sdk_common::buy::cashapp::CashAppProvider;
 
@@ -60,9 +60,15 @@ impl BreezSdk {
     /// Result containing either success or an `SdkError` if the background task couldn't be stopped
     pub async fn disconnect(&self) -> Result<(), SdkError> {
         info!("Disconnecting Breez SDK");
-        self.shutdown_sender
-            .send(())
-            .map_err(|_| SdkError::Generic("Failed to send shutdown signal".to_string()))?;
+        if self.shutdown_sender.send(()).is_err() {
+            // A `watch::Sender::send` error means every receiver has been
+            // dropped, i.e. no background task is listening. This is the
+            // expected steady state for a server-mode SDK
+            // (`background_tasks_enabled = false`): there is nothing to
+            // stop, so disconnecting is a successful no-op.
+            debug!("No shutdown receivers; SDK has no background tasks to stop");
+            return Ok(());
+        }
 
         self.shutdown_sender.closed().await;
         info!("Breez SDK disconnected");


### PR DESCRIPTION
Server mode (`background_tasks_enabled = false`) has no listener on the shutdown watch channel — `watch::Sender::send` returns Err and `disconnect()` reports "Failed to send shutdown signal" even though there is nothing to stop. Match that case explicitly: log at debug and return Ok(()).