### PR TITLE
Pin all MySQL timestamps to UTC to fix host-TZ mismatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,15 @@ Run a single test:
 cargo test <test_name> -p <package>
 ```
 
+**Node.js version**: `make wasm-test` (and any target depending on `wasm-test-node`)
+requires Node.js 22. `better-sqlite3`'s native bindings fail to build on Node 23+
+(uses removed `v8::AccessorGetterCallback` API). If `node --version` reports >=23,
+switch first:
+
+```bash
+nvm use 22 || nvm install 22  # then re-run the make target
+```
+
 ## Code Quality
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,21 @@ test: cargo-test wasm-test
 cargo-test:
 	cargo xtask test
 
-wasm-test: wasm-test-browser wasm-test-node
+wasm-test: wasm-test-browser wasm-test-node wasm-test-mysql-timezone
 
 wasm-test-browser:
 	cargo xtask wasm-test
 
 wasm-test-node:
 	cargo xtask wasm-test --node
+
+# Regression test for the JS mysql-token-store TZ-handling bug. Runs the
+# spent-marker scenario under several host TZs (positive and negative offsets)
+# so the bug surfaces on any CI runner regardless of system clock.
+# Depends on wasm-test-node for the upstream `npm install` of mysql-storage /
+# mysql-token-store deps that this test reuses.
+wasm-test-mysql-timezone: wasm-test-node
+	cd crates/breez-sdk/wasm/js/mysql-token-store && npm test
 
 flutter-check:
 	cargo xtask flutter-check

--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,14 @@ wasm-test-browser:
 wasm-test-node:
 	cargo xtask wasm-test --node
 
-# Regression test for the JS mysql-token-store TZ-handling bug. Runs the
-# spent-marker scenario under several host TZs (positive and negative offsets)
-# so the bug surfaces on any CI runner regardless of system clock.
-# Depends on wasm-test-node for the upstream `npm install` of mysql-storage /
-# mysql-token-store deps that this test reuses.
+# Regression test for the JS mysql-{token,tree}-store TZ-handling bug. Runs
+# the spent-marker / spent-leaf scenarios under several host TZs (positive
+# and negative offsets) so the bug surfaces on any CI runner regardless of
+# system clock. Depends on wasm-test-node for the upstream `npm install` of
+# mysql-storage / mysql-{token,tree}-store deps that these tests reuse.
 wasm-test-mysql-timezone: wasm-test-node
 	cd crates/breez-sdk/wasm/js/mysql-token-store && npm test
+	cd crates/breez-sdk/wasm/js/mysql-tree-store && npm test
 
 flutter-check:
 	cargo xtask flutter-check

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -456,6 +456,16 @@ impl MysqlStorage {
             // SQL-injection surface even though the value is concatenated
             // rather than parameter-bound.
             multi_tenant_migration(identity),
+            // Migration 17: Pin the migration-tracking table's `applied_at`
+            // default to UTC. The migration manager already writes
+            // `UTC_TIMESTAMP(6)` explicitly on INSERT, but aligning the
+            // default keeps `SHOW CREATE TABLE` output consistent with the
+            // token-store / tree-store migrations table and matches the JS
+            // mysql-storage migration of the same name.
+            vec![Migration::sql(
+                "ALTER TABLE brz_schema_migrations MODIFY COLUMN applied_at \
+                 DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
+            )],
         ]
     }
 }
@@ -2505,7 +2515,12 @@ mod tests {
             .exec_first("SELECT MAX(version) FROM brz_schema_migrations", ())
             .await
             .unwrap();
-        assert_eq!(version, Some(16), "migration version must be preserved");
+        assert_eq!(
+            version,
+            Some(17),
+            "migration version must advance to 17 (the legacy fixture starts at 16, migration 17 \
+             pins applied_at default to UTC)"
+        );
 
         let payment_count: Option<i64> = conn
             .exec_first("SELECT COUNT(*) FROM brz_payments WHERE id = 'p1'", ())
@@ -2777,7 +2792,7 @@ mod tests {
             .exec_first("SELECT MAX(version) FROM brz_schema_migrations", ())
             .await
             .unwrap();
-        assert_eq!(version, Some(16), "migration must advance to 16");
+        assert_eq!(version, Some(17), "migration must advance to 17");
 
         let payment_count: Option<i64> = conn
             .exec_first("SELECT COUNT(*) FROM brz_payments WHERE id = 'p1'", ())

--- a/crates/breez-sdk/wasm/js/mysql-session-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-session-store/index.cjs
@@ -127,7 +127,10 @@ function _decodePubkey(hex) {
 }
 
 async function createMysqlSessionStore(poolConfig, identity, logger = null) {
-  const pool = mysql.createPool(poolConfig);
+  // Serialize JS `Date` parameters as UTC strings rather than host-local
+  // time. Paired with explicit `UTC_TIMESTAMP(6)` on the server side, this
+  // keeps timestamp comparisons consistent regardless of the host TZ.
+  const pool = mysql.createPool({ ...poolConfig, timezone: "Z" });
   const manager = new MysqlSessionStore(
     pool,
     identity,

--- a/crates/breez-sdk/wasm/js/mysql-session-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-session-store/migrations.cjs
@@ -38,7 +38,7 @@ class MysqlSessionStoreMigrationManager {
         await conn.query(`
           CREATE TABLE IF NOT EXISTS \`${SESSION_MIGRATIONS_TABLE}\` (
             version INT PRIMARY KEY,
-            applied_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+            applied_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))
           )
         `);
 
@@ -61,7 +61,7 @@ class MysqlSessionStoreMigrationManager {
             await conn.query(sql);
           }
           await conn.query(
-            `INSERT INTO \`${SESSION_MIGRATIONS_TABLE}\` (version) VALUES (?)`,
+            `INSERT INTO \`${SESSION_MIGRATIONS_TABLE}\` (version, applied_at) VALUES (?, UTC_TIMESTAMP(6))`,
             [version]
           );
         }
@@ -121,6 +121,12 @@ class MysqlSessionStoreMigrationManager {
             expiration BIGINT NOT NULL,
             PRIMARY KEY (user_id, service_identity_key)
           )`,
+        ],
+      },
+      {
+        name: "Pin schema-migrations applied_at default to UTC",
+        sql: [
+          `ALTER TABLE \`${SESSION_MIGRATIONS_TABLE}\` MODIFY COLUMN applied_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
@@ -1332,6 +1332,10 @@ function createMysqlPool(config) {
     connectTimeout: (config.createTimeoutSecs || 0) * 1000 || 10000,
     idleTimeout: (config.recycleTimeoutSecs || 0) * 1000 || 10000,
     waitForConnections: true,
+    // Serialize JS `Date` parameters as UTC strings rather than host-local
+    // time. Paired with explicit `UTC_TIMESTAMP(6)` on the server side, this
+    // keeps timestamp comparisons consistent regardless of the host TZ.
+    timezone: "Z",
   });
 }
 

--- a/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
@@ -89,7 +89,7 @@ class MysqlMigrationManager {
         await conn.query(`
           CREATE TABLE IF NOT EXISTS brz_schema_migrations (
             version INT PRIMARY KEY,
-            applied_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+            applied_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))
           )
         `);
 
@@ -121,7 +121,7 @@ class MysqlMigrationManager {
           }
 
           await conn.query(
-            "INSERT INTO brz_schema_migrations (version) VALUES (?)",
+            "INSERT INTO brz_schema_migrations (version, applied_at) VALUES (?, UTC_TIMESTAMP(6))",
             [version]
           );
         }
@@ -495,6 +495,17 @@ class MysqlMigrationManager {
           `DROP INDEX brz_idx_sync_incoming_revision ON brz_sync_incoming`,
           `CREATE INDEX brz_idx_sync_incoming_user_revision
              ON brz_sync_incoming(user_id, revision)`,
+        ],
+      },
+      {
+        // Pin the migration-tracking table's `applied_at` default to UTC.
+        // The migration manager already passes `UTC_TIMESTAMP(6)` explicitly
+        // on INSERT, but aligning the default keeps `SHOW CREATE TABLE`
+        // output consistent with the token-store / tree-store migrations
+        // table and avoids future mistakes if a callsite omits the column.
+        name: "Pin schema-migrations applied_at default to UTC",
+        sql: [
+          `ALTER TABLE brz_schema_migrations MODIFY COLUMN applied_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/js/mysql-token-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/index.cjs
@@ -558,7 +558,7 @@ class MysqlTokenStore {
                 [this.identity, outputId]
               );
               await conn.query(
-                "INSERT IGNORE INTO brz_token_spent_outputs (user_id, output_id, spent_at) VALUES (?, ?, NOW())",
+                "INSERT IGNORE INTO brz_token_spent_outputs (user_id, output_id, spent_at) VALUES (?, ?, UTC_TIMESTAMP(6))",
                 [this.identity, outputId]
               );
             }
@@ -727,7 +727,7 @@ class MysqlTokenStore {
         const reservationId = this._generateId();
 
         await conn.query(
-          "INSERT INTO brz_token_reservations (user_id, id, purpose) VALUES (?, ?, ?)",
+          "INSERT INTO brz_token_reservations (user_id, id, purpose, created_at) VALUES (?, ?, ?, UTC_TIMESTAMP(6))",
           [this.identity, reservationId, purpose]
         );
 
@@ -801,7 +801,7 @@ class MysqlTokenStore {
 
         if (reservedOutputIds.length > 0) {
           const valueClauses = new Array(reservedOutputIds.length)
-            .fill("(?, ?)")
+            .fill("(?, ?, UTC_TIMESTAMP(6))")
             .join(", ");
           const params = [];
           for (const outputId of reservedOutputIds) {
@@ -809,7 +809,7 @@ class MysqlTokenStore {
           }
           // Suppress duplicate-PK errors only.
           await conn.query(
-            `INSERT INTO brz_token_spent_outputs (user_id, output_id) VALUES ${valueClauses}
+            `INSERT INTO brz_token_spent_outputs (user_id, output_id, spent_at) VALUES ${valueClauses}
              ON DUPLICATE KEY UPDATE output_id = output_id`,
             params
           );
@@ -828,7 +828,7 @@ class MysqlTokenStore {
         // (and thus has no row) gets one created lazily.
         if (isSwap) {
           await conn.query(
-            `INSERT INTO brz_token_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
+            `INSERT INTO brz_token_swap_status (user_id, last_completed_at) VALUES (?, UTC_TIMESTAMP(6))
              ON DUPLICATE KEY UPDATE last_completed_at = VALUES(last_completed_at)`,
             [this.identity]
           );
@@ -854,7 +854,7 @@ class MysqlTokenStore {
 
   async now() {
     try {
-      const [rows] = await this.pool.query("SELECT NOW(6) AS now");
+      const [rows] = await this.pool.query("SELECT UTC_TIMESTAMP(6) AS now");
       const value = rows[0].now;
       if (value instanceof Date) return value.getTime();
       return new Date(value).getTime();
@@ -892,14 +892,14 @@ class MysqlTokenStore {
            SELECT id FROM (
              SELECT id FROM brz_token_reservations
              WHERE user_id = ?
-               AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
+               AND created_at < DATE_SUB(UTC_TIMESTAMP(6), INTERVAL ? SECOND)
            ) AS stale
          )`,
       [this.identity, this.identity, RESERVATION_TIMEOUT_SECS]
     );
     await conn.query(
       `DELETE FROM brz_token_reservations
-       WHERE user_id = ? AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)`,
+       WHERE user_id = ? AND created_at < DATE_SUB(UTC_TIMESTAMP(6), INTERVAL ? SECOND)`,
       [this.identity, RESERVATION_TIMEOUT_SECS]
     );
   }
@@ -941,7 +941,7 @@ class MysqlTokenStore {
         (user_id, id, token_identifier, owner_public_key, revocation_commitment,
          withdraw_bond_sats, withdraw_relative_block_locktime,
          token_public_key, token_amount, prev_tx_hash, prev_tx_vout, added_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(6))
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))
        ON DUPLICATE KEY UPDATE id = id`,
       [
         this.identity,
@@ -999,6 +999,10 @@ function createMysqlPool(config) {
     connectTimeout: (config.createTimeoutSecs || 0) * 1000 || 10000,
     idleTimeout: (config.recycleTimeoutSecs || 0) * 1000 || 10000,
     waitForConnections: true,
+    // Serialize JS `Date` parameters as UTC strings rather than host-local
+    // time. Paired with explicit `UTC_TIMESTAMP(6)` on the server side, this
+    // keeps timestamp comparisons consistent regardless of the host TZ.
+    timezone: "Z",
   });
 }
 

--- a/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
@@ -447,6 +447,18 @@ class MysqlTokenStoreMigrationManager {
           `ALTER TABLE brz_token_swap_status ADD PRIMARY KEY (user_id)`,
         ],
       },
+      {
+        // Pin DATETIME defaults to UTC. Server-side INSERTs already pass
+        // `UTC_TIMESTAMP(6)` explicitly; this migration makes the column
+        // default match, so any future callsite that omits the column also
+        // gets a UTC value rather than a session-TZ-dependent one.
+        name: "Pin DATETIME defaults to UTC",
+        sql: [
+          `ALTER TABLE brz_token_outputs       MODIFY COLUMN added_at  DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_token_reservations  MODIFY COLUMN created_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_token_spent_outputs MODIFY COLUMN spent_at  DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+        ],
+      },
     ];
   }
 }

--- a/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs
@@ -109,7 +109,7 @@ class MysqlTokenStoreMigrationManager {
         await conn.query(`
           CREATE TABLE IF NOT EXISTS \`${TOKEN_MIGRATIONS_TABLE}\` (
             version INT PRIMARY KEY,
-            applied_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+            applied_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))
           )
         `);
 
@@ -132,7 +132,7 @@ class MysqlTokenStoreMigrationManager {
             await runMigrationStep(conn, step);
           }
           await conn.query(
-            `INSERT INTO \`${TOKEN_MIGRATIONS_TABLE}\` (version) VALUES (?)`,
+            `INSERT INTO \`${TOKEN_MIGRATIONS_TABLE}\` (version, applied_at) VALUES (?, UTC_TIMESTAMP(6))`,
             [version]
           );
         }
@@ -454,9 +454,10 @@ class MysqlTokenStoreMigrationManager {
         // gets a UTC value rather than a session-TZ-dependent one.
         name: "Pin DATETIME defaults to UTC",
         sql: [
-          `ALTER TABLE brz_token_outputs       MODIFY COLUMN added_at  DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
-          `ALTER TABLE brz_token_reservations  MODIFY COLUMN created_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
-          `ALTER TABLE brz_token_spent_outputs MODIFY COLUMN spent_at  DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_token_outputs            MODIFY COLUMN added_at   DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_token_reservations       MODIFY COLUMN created_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_token_spent_outputs      MODIFY COLUMN spent_at   DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_token_schema_migrations  MODIFY COLUMN applied_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/js/mysql-token-store/package.json
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "lint": "eslint *.cjs",
-    "lint:fix": "eslint *.cjs --fix"
+    "lint:fix": "eslint *.cjs --fix",
+    "test": "node --test tests/timezone.test.cjs"
   },
   "dependencies": {
     "mysql2": "^3.11.0"

--- a/crates/breez-sdk/wasm/js/mysql-token-store/tests/timezone-scenario.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/tests/timezone-scenario.cjs
@@ -1,0 +1,121 @@
+// Spent-marker scenario that demonstrates the timezone-mismatch bug fixed in
+// the surrounding patch. Runs in a child process so the test runner can set
+// `process.env.TZ` per invocation — Node's `Date` formatter latches the TZ at
+// startup, so this test cannot mutate it inside a single process.
+//
+// Expects `MYSQL_URI` in the environment. Exits 0 on success, 1 with a
+// printed error on failure.
+
+const { createMysqlTokenStore } = require("../index.cjs");
+
+// Same shape as the wasm-bindgen-test fixture identity; 33 bytes is required.
+const TEST_IDENTITY = Buffer.from([
+  0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+  0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+  0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+]);
+
+// 33-byte secp256k1 compressed pubkey bytes formatted as hex strings, matching
+// `create_token_outputs` in crates/spark/src/token/tests.rs. The values don't
+// need to be cryptographically valid — the store only persists/echoes them.
+function pubkeyHex(fillByte) {
+  const buf = Buffer.alloc(33, fillByte);
+  buf[0] = 2;
+  return buf.toString("hex");
+}
+
+const OWNER_PUBKEY = Buffer.from([
+  0x03, 0x17, 0xb7, 0xe1, 0xce, 0x1f, 0x9f, 0x94, 0xc3, 0x2a, 0x43, 0x73, 0x92,
+  0x29, 0xf8, 0x8c, 0x0b, 0x03, 0x33, 0x29, 0x6f, 0xb4, 0x6e, 0x8f, 0x72, 0x86,
+  0x58, 0x49, 0xc6, 0xae, 0x34, 0xb8, 0x4e,
+]).toString("hex");
+
+function buildTokenOutputs(amounts) {
+  const identifier = "token-1";
+  const ticker = "TK1";
+  const issuerPk = pubkeyHex(1);
+
+  return {
+    metadata: {
+      identifier,
+      issuerPublicKey: issuerPk,
+      name: `${ticker} Token`,
+      ticker,
+      decimals: 8,
+      maxSupply: "1000000",
+      isFreezable: false,
+      creationEntityPublicKey: null,
+    },
+    outputs: amounts.map((amount, i) => ({
+      output: {
+        id: `output-${identifier}-${amount}`,
+        ownerPublicKey: OWNER_PUBKEY,
+        revocationCommitment: `commitment-${i}`,
+        withdrawBondSats: 1000,
+        withdrawRelativeBlockLocktime: 144,
+        tokenPublicKey: issuerPk,
+        tokenIdentifier: identifier,
+        tokenAmount: String(amount),
+      },
+      prevTxHash: `tx-hash-${i}`,
+      prevTxVout: i,
+    })),
+  };
+}
+
+async function main() {
+  const connectionString = process.env.MYSQL_URI;
+  if (!connectionString) {
+    throw new Error("MYSQL_URI must be set");
+  }
+
+  const store = await createMysqlTokenStore(
+    { connectionString, maxPoolSize: 4 },
+    TEST_IDENTITY,
+    null
+  );
+
+  try {
+    const token = buildTokenOutputs([100, 200]);
+
+    // 1. Initial set with a future refresh start, so the outputs aren't
+    //    treated as stale.
+    await store.setTokensOutputs([token], Date.now() + 10_000);
+
+    // 2. Mark output 100 (at prev_tx_hash 'tx-hash-0', vout 0) as spent.
+    await store.updateTokenOutputs([["tx-hash-0", 0]], null);
+
+    // 3. Replay setTokensOutputs with a refresh start in the past (60s ago).
+    //    The spent marker should suppress re-adding output 100.
+    await store.setTokensOutputs([token], Date.now() - 60_000);
+
+    const result = await store.getTokenOutputs({
+      type: "identifier",
+      identifier: "token-1",
+    });
+
+    if (result.available.length !== 1) {
+      throw new Error(
+        `expected 1 available output, got ${result.available.length} (TZ=${
+          process.env.TZ
+        }, amounts=${result.available
+          .map((o) => o.output.tokenAmount)
+          .join(",")})`
+      );
+    }
+    if (result.available[0].output.tokenAmount !== "200") {
+      throw new Error(
+        `expected remaining output to be 200, got ${result.available[0].output.tokenAmount} (TZ=${process.env.TZ})`
+      );
+    }
+
+    console.log(`PASS (TZ=${process.env.TZ ?? "unset"})`);
+  } finally {
+    await store.close();
+  }
+}
+
+main().catch((err) => {
+  console.error("FAIL:", err.message ?? err);
+  process.exit(1);
+});

--- a/crates/breez-sdk/wasm/js/mysql-token-store/tests/timezone.test.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-token-store/tests/timezone.test.cjs
@@ -1,0 +1,58 @@
+// TZ-mismatch regression test for mysql-token-store. Runs the spent-marker
+// scenario under several host timezones to catch the JS-side timezone bug
+// that surfaced as
+// `token_store::tests::mysql::test_remove_token_outputs_prevents_refresh_re_add`
+// failing on contributors whose host TZ is positive-offset (CEST, etc).
+//
+// A regression here would otherwise pass on UTC-only CI runners; this test
+// forces a positive- and a negative-offset TZ regardless of the host's clock.
+
+const { describe, test, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const { createTestConnectionString } = require(
+  "../../mysql-test-helpers.cjs"
+);
+
+const SCENARIO_PATH = path.join(__dirname, "timezone-scenario.cjs");
+const TIMEZONES = [
+  "UTC",
+  "Pacific/Kiritimati", // UTC+14: largest positive offset.
+  "Pacific/Pago_Pago", // UTC-11: large negative offset.
+  "Europe/Berlin", // UTC+1/+2: the original repro environment.
+];
+
+describe("mysql-token-store timezone regression", () => {
+  for (const tz of TIMEZONES) {
+    test(
+      `spent marker survives setTokensOutputs replay under TZ=${tz}`,
+      { timeout: 120_000 },
+      async () => {
+        const connectionString = await createTestConnectionString(
+          `tz_${tz.replace(/[^a-zA-Z0-9]/g, "_")}`
+        );
+
+        const result = spawnSync(
+          process.execPath,
+          [SCENARIO_PATH],
+          {
+            env: {
+              ...process.env,
+              TZ: tz,
+              MYSQL_URI: connectionString,
+            },
+            stdio: "inherit",
+          }
+        );
+
+        assert.equal(
+          result.status,
+          0,
+          `scenario failed under TZ=${tz} (exit ${result.status})`
+        );
+      }
+    );
+  }
+});

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -430,7 +430,7 @@ class MysqlTreeStore {
         // (and thus has no row) gets one created lazily.
         if (isSwap && newLeaves && newLeaves.length > 0) {
           await conn.query(
-            `INSERT INTO brz_tree_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
+            `INSERT INTO brz_tree_swap_status (user_id, last_completed_at) VALUES (?, UTC_TIMESTAMP(6))
              ON DUPLICATE KEY UPDATE last_completed_at = VALUES(last_completed_at)`,
             [this.identity]
           );
@@ -581,7 +581,7 @@ class MysqlTreeStore {
 
   async now() {
     try {
-      const [rows] = await this.pool.query("SELECT NOW(6) AS now");
+      const [rows] = await this.pool.query("SELECT UTC_TIMESTAMP(6) AS now");
       const value = rows[0].now;
       // mysql2 typically returns DATETIME as a JS Date when dateStrings is false (default).
       if (value instanceof Date) return value.getTime();
@@ -809,7 +809,7 @@ class MysqlTreeStore {
 
   async _createReservation(conn, reservationId, leaves, purpose, pendingChange) {
     await conn.query(
-      "INSERT INTO brz_tree_reservations (user_id, id, purpose, pending_change_amount) VALUES (?, ?, ?, ?)",
+      "INSERT INTO brz_tree_reservations (user_id, id, purpose, pending_change_amount, created_at) VALUES (?, ?, ?, ?, UTC_TIMESTAMP(6))",
       [this.identity, reservationId, purpose, pendingChange]
     );
 
@@ -827,7 +827,7 @@ class MysqlTreeStore {
     if (filtered.length === 0) return;
 
     const valueClauses = new Array(filtered.length)
-      .fill("(?, ?, ?, ?, ?, ?, NOW(6))")
+      .fill("(?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))")
       .join(", ");
     const params = [];
     for (const leaf of filtered) {
@@ -849,7 +849,7 @@ class MysqlTreeStore {
          is_missing_from_operators = VALUES(is_missing_from_operators),
          data = VALUES(data),
          value = VALUES(value),
-         added_at = NOW(6)`,
+         added_at = UTC_TIMESTAMP(6)`,
       params
     );
   }
@@ -867,7 +867,9 @@ class MysqlTreeStore {
   async _batchInsertSpentLeaves(conn, leafIds) {
     if (leafIds.length === 0) return;
 
-    const valueClauses = new Array(leafIds.length).fill("(?, ?)").join(", ");
+    const valueClauses = new Array(leafIds.length)
+      .fill("(?, ?, UTC_TIMESTAMP(6))")
+      .join(", ");
     const params = [];
     for (const id of leafIds) {
       params.push(this.identity, id);
@@ -876,7 +878,7 @@ class MysqlTreeStore {
     // problems (FK violations, NOT NULL violations, type errors) still
     // propagate.
     await conn.query(
-      `INSERT INTO brz_tree_spent_leaves (user_id, leaf_id) VALUES ${valueClauses}
+      `INSERT INTO brz_tree_spent_leaves (user_id, leaf_id, spent_at) VALUES ${valueClauses}
        ON DUPLICATE KEY UPDATE leaf_id = leaf_id`,
       params
     );
@@ -904,14 +906,14 @@ class MysqlTreeStore {
            SELECT id FROM (
              SELECT id FROM brz_tree_reservations
              WHERE user_id = ?
-               AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
+               AND created_at < DATE_SUB(UTC_TIMESTAMP(6), INTERVAL ? SECOND)
            ) AS stale
          )`,
       [this.identity, this.identity, RESERVATION_TIMEOUT_SECS]
     );
     await conn.query(
       `DELETE FROM brz_tree_reservations
-       WHERE user_id = ? AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)`,
+       WHERE user_id = ? AND created_at < DATE_SUB(UTC_TIMESTAMP(6), INTERVAL ? SECOND)`,
       [this.identity, RESERVATION_TIMEOUT_SECS]
     );
   }
@@ -936,6 +938,10 @@ function createMysqlPool(config) {
     connectTimeout: (config.createTimeoutSecs || 0) * 1000 || 10000,
     idleTimeout: (config.recycleTimeoutSecs || 0) * 1000 || 10000,
     waitForConnections: true,
+    // Serialize JS `Date` parameters as UTC strings rather than host-local
+    // time. Paired with explicit `UTC_TIMESTAMP(6)` on the server side, this
+    // keeps timestamp comparisons consistent regardless of the host TZ.
+    timezone: "Z",
   });
 }
 

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
@@ -367,6 +367,19 @@ class MysqlTreeStoreMigrationManager {
           `ALTER TABLE brz_tree_swap_status ADD PRIMARY KEY (user_id)`,
         ],
       },
+      {
+        // Pin DATETIME defaults to UTC. Server-side INSERTs already pass
+        // `UTC_TIMESTAMP(6)` explicitly; this migration makes the column
+        // default match, so any future callsite that omits the column also
+        // gets a UTC value rather than a session-TZ-dependent one.
+        name: "Pin DATETIME defaults to UTC",
+        sql: [
+          `ALTER TABLE brz_tree_reservations MODIFY COLUMN created_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_tree_leaves       MODIFY COLUMN created_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_tree_leaves       MODIFY COLUMN added_at   DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_tree_spent_leaves MODIFY COLUMN spent_at   DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+        ],
+      },
     ];
   }
 }

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
@@ -98,7 +98,7 @@ class MysqlTreeStoreMigrationManager {
         await conn.query(`
           CREATE TABLE IF NOT EXISTS \`${TREE_MIGRATIONS_TABLE}\` (
             version INT PRIMARY KEY,
-            applied_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+            applied_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))
           )
         `);
 
@@ -121,7 +121,7 @@ class MysqlTreeStoreMigrationManager {
             await runMigrationStep(conn, step);
           }
           await conn.query(
-            `INSERT INTO \`${TREE_MIGRATIONS_TABLE}\` (version) VALUES (?)`,
+            `INSERT INTO \`${TREE_MIGRATIONS_TABLE}\` (version, applied_at) VALUES (?, UTC_TIMESTAMP(6))`,
             [version]
           );
         }
@@ -374,10 +374,11 @@ class MysqlTreeStoreMigrationManager {
         // gets a UTC value rather than a session-TZ-dependent one.
         name: "Pin DATETIME defaults to UTC",
         sql: [
-          `ALTER TABLE brz_tree_reservations MODIFY COLUMN created_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
-          `ALTER TABLE brz_tree_leaves       MODIFY COLUMN created_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
-          `ALTER TABLE brz_tree_leaves       MODIFY COLUMN added_at   DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
-          `ALTER TABLE brz_tree_spent_leaves MODIFY COLUMN spent_at   DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_tree_reservations      MODIFY COLUMN created_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_tree_leaves            MODIFY COLUMN created_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_tree_leaves            MODIFY COLUMN added_at   DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_tree_spent_leaves      MODIFY COLUMN spent_at   DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
+          `ALTER TABLE brz_tree_schema_migrations MODIFY COLUMN applied_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/package.json
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "lint": "eslint *.cjs",
-    "lint:fix": "eslint *.cjs --fix"
+    "lint:fix": "eslint *.cjs --fix",
+    "test": "node --test tests/timezone.test.cjs"
   },
   "dependencies": {
     "mysql2": "^3.11.0"

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/tests/timezone-scenario.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/tests/timezone-scenario.cjs
@@ -1,0 +1,99 @@
+// Spent-leaf scenario that demonstrates the timezone-mismatch bug fixed in
+// commit 141bcf1a ("Pin all MySQL timestamps to UTC to fix host-TZ
+// mismatch"). Runs in a child process so the test runner can set
+// `process.env.TZ` per invocation — Node's `Date` formatter latches the TZ at
+// startup, so this test cannot mutate it inside a single process.
+//
+// Mirrors mysql-token-store/tests/timezone-scenario.cjs but exercises the
+// tree-store's setLeaves/finalizeReservation spent-marker path.
+//
+// Expects `MYSQL_URI` in the environment. Exits 0 on success, 1 with a
+// printed error on failure.
+
+const { createMysqlTreeStore } = require("../index.cjs");
+
+// Same shape as the wasm-bindgen-test fixture identity; 33 bytes is required.
+const TEST_IDENTITY = Buffer.from([
+  0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+  0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+  0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+]);
+
+// The tree-store persists each leaf as JSON in the `data` column, so the
+// scenario only needs the fields touched by selection / spent-marker logic:
+// `id`, `status`, `value`. Everything else round-trips via JSON.stringify.
+function buildLeaf(id, value) {
+  return { id, status: "Available", value };
+}
+
+async function main() {
+  const connectionString = process.env.MYSQL_URI;
+  if (!connectionString) {
+    throw new Error("MYSQL_URI must be set");
+  }
+
+  const store = await createMysqlTreeStore(
+    { connectionString, maxPoolSize: 4 },
+    TEST_IDENTITY,
+    null
+  );
+
+  try {
+    const leafA = buildLeaf("leaf-100", 100);
+    const leafB = buildLeaf("leaf-200", 200);
+
+    // 1. Populate the tree under a future refresh window so neither leaf
+    //    is treated as aged out.
+    await store.setLeaves([leafA, leafB], [], Date.now() + 10_000);
+
+    // 2. Reserve leaf-100 by exact amount.
+    const reserve = await store.tryReserveLeaves(
+      { type: "amountAndFee", amountSats: 100, feeSats: null },
+      true,
+      "Payment"
+    );
+    if (reserve.type !== "success") {
+      throw new Error(
+        `expected tryReserveLeaves success, got type=${reserve.type}`
+      );
+    }
+    const reservedIds = reserve.reservation.leaves.map((l) => l.id);
+    if (reservedIds.length !== 1 || reservedIds[0] !== "leaf-100") {
+      throw new Error(
+        `expected reservation to hold leaf-100, got [${reservedIds.join(",")}]`
+      );
+    }
+
+    // 3. Finalize → spent marker for leaf-100 (no replacement leaves).
+    await store.finalizeReservation(reserve.reservation.id, null);
+
+    // 4. Replay setLeaves with a refresh start in the past. The spent
+    //    marker (timestamp ≈ now) is newer than the refresh start, so
+    //    leaf-100 must not be re-added. This is the comparison that was
+    //    silently inverted on positive-offset hosts before the fix.
+    await store.setLeaves([leafA, leafB], [], Date.now() - 60_000);
+
+    const result = await store.getLeaves();
+    if (result.available.length !== 1) {
+      throw new Error(
+        `expected 1 available leaf, got ${result.available.length} (TZ=${
+          process.env.TZ
+        }, ids=${result.available.map((l) => l.id).join(",")})`
+      );
+    }
+    if (result.available[0].id !== "leaf-200") {
+      throw new Error(
+        `expected surviving leaf to be leaf-200, got ${result.available[0].id} (TZ=${process.env.TZ})`
+      );
+    }
+
+    console.log(`PASS (TZ=${process.env.TZ ?? "unset"})`);
+  } finally {
+    await store.close();
+  }
+}
+
+main().catch((err) => {
+  console.error("FAIL:", err.message ?? err);
+  process.exit(1);
+});

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/tests/timezone.test.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/tests/timezone.test.cjs
@@ -1,0 +1,57 @@
+// TZ-mismatch regression test for mysql-tree-store. Runs the spent-leaf
+// scenario under several host timezones to catch any JS-side timezone bug
+// in the tree-store, mirroring the protection that mysql-token-store has
+// via its own timezone.test.cjs.
+//
+// A regression here would otherwise pass on UTC-only CI runners; this test
+// forces a positive- and a negative-offset TZ regardless of the host's clock.
+
+const { describe, test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const { createTestConnectionString } = require(
+  "../../mysql-test-helpers.cjs"
+);
+
+const SCENARIO_PATH = path.join(__dirname, "timezone-scenario.cjs");
+const TIMEZONES = [
+  "UTC",
+  "Pacific/Kiritimati", // UTC+14: largest positive offset.
+  "Pacific/Pago_Pago", // UTC-11: large negative offset.
+  "Europe/Berlin", // UTC+1/+2: the original repro environment.
+];
+
+describe("mysql-tree-store timezone regression", () => {
+  for (const tz of TIMEZONES) {
+    test(
+      `spent marker survives setLeaves replay under TZ=${tz}`,
+      { timeout: 120_000 },
+      async () => {
+        const connectionString = await createTestConnectionString(
+          `tz_tree_${tz.replace(/[^a-zA-Z0-9]/g, "_")}`
+        );
+
+        const result = spawnSync(
+          process.execPath,
+          [SCENARIO_PATH],
+          {
+            env: {
+              ...process.env,
+              TZ: tz,
+              MYSQL_URI: connectionString,
+            },
+            stdio: "inherit",
+          }
+        );
+
+        assert.equal(
+          result.status,
+          0,
+          `scenario failed under TZ=${tz} (exit ${result.status})`
+        );
+      }
+    );
+  }
+});

--- a/crates/breez-sdk/wasm/src/token_store/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/token_store/tests/mysql.rs
@@ -54,8 +54,8 @@ async fn test_remove_token_outputs_by_prev_tx_ref() {
 }
 
 #[wasm_bindgen_test]
-async fn test_remove_token_outputs_prevents_refresh_readd() {
+async fn test_remove_token_outputs_prevents_refresh_re_add() {
     let store = create_test_token_store("pg_token_remove_outputs_prevents_refresh").await;
-    breez_sdk_spark::token_store_tests::test_remove_token_outputs_prevents_refresh_readd(&store)
+    breez_sdk_spark::token_store_tests::test_remove_token_outputs_prevents_refresh_re_add(&store)
         .await;
 }

--- a/crates/breez-sdk/wasm/src/token_store/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/token_store/tests/postgres.rs
@@ -54,8 +54,8 @@ async fn test_remove_token_outputs_by_prev_tx_ref() {
 }
 
 #[wasm_bindgen_test]
-async fn test_remove_token_outputs_prevents_refresh_readd() {
+async fn test_remove_token_outputs_prevents_refresh_re_add() {
     let store = create_test_token_store("pg_token_remove_outputs_prevents_refresh").await;
-    breez_sdk_spark::token_store_tests::test_remove_token_outputs_prevents_refresh_readd(&store)
+    breez_sdk_spark::token_store_tests::test_remove_token_outputs_prevents_refresh_re_add(&store)
         .await;
 }

--- a/crates/spark-mysql/src/migrations.rs
+++ b/crates/spark-mysql/src/migrations.rs
@@ -344,11 +344,13 @@ async fn run_migrations_inner(
         .await
         .map_err(map_db_error)?;
 
-    // Create migrations table if it doesn't exist.
+    // Create migrations table if it doesn't exist. `applied_at` is pinned to
+    // UTC (rather than session-local) so the migration audit log is consistent
+    // regardless of MySQL session TZ.
     let create_table_sql = format!(
         "CREATE TABLE IF NOT EXISTS `{migrations_table}` (
             version INT PRIMARY KEY,
-            applied_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+            applied_at DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))
         )"
     );
     conn.query_drop(&create_table_sql)
@@ -370,7 +372,9 @@ async fn run_migrations_inner(
             for step in migration {
                 run_step(conn, version, step).await?;
             }
-            let insert_sql = format!("INSERT INTO `{migrations_table}` (version) VALUES (?)");
+            let insert_sql = format!(
+                "INSERT INTO `{migrations_table}` (version, applied_at) VALUES (?, UTC_TIMESTAMP(6))"
+            );
             conn.exec_drop(&insert_sql, (version,))
                 .await
                 .map_err(map_db_error)?;

--- a/crates/spark-mysql/src/session_store.rs
+++ b/crates/spark-mysql/src/session_store.rs
@@ -138,15 +138,21 @@ impl MysqlSessionStore {
     }
 
     fn migrations() -> Vec<Vec<Migration>> {
-        vec![vec![Migration::sql(
-            "CREATE TABLE IF NOT EXISTS brz_sessions (
-                user_id VARBINARY(33) NOT NULL,
-                service_identity_key VARBINARY(33) NOT NULL,
-                token TEXT NOT NULL,
-                expiration BIGINT NOT NULL,
-                PRIMARY KEY (user_id, service_identity_key)
-            )",
-        )]]
+        vec![
+            vec![Migration::sql(
+                "CREATE TABLE IF NOT EXISTS brz_sessions (
+                    user_id VARBINARY(33) NOT NULL,
+                    service_identity_key VARBINARY(33) NOT NULL,
+                    token TEXT NOT NULL,
+                    expiration BIGINT NOT NULL,
+                    PRIMARY KEY (user_id, service_identity_key)
+                )",
+            )],
+            vec![Migration::sql(
+                "ALTER TABLE brz_session_schema_migrations MODIFY COLUMN applied_at \
+                 DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
+            )],
+        ]
     }
 }
 

--- a/crates/spark-mysql/src/token_store.rs
+++ b/crates/spark-mysql/src/token_store.rs
@@ -804,6 +804,10 @@ impl MysqlTokenStore {
                     "ALTER TABLE brz_token_spent_outputs MODIFY COLUMN spent_at \
                      DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
                 ),
+                Migration::sql(
+                    "ALTER TABLE brz_token_schema_migrations MODIFY COLUMN applied_at \
+                     DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
+                ),
             ],
         ]
     }

--- a/crates/spark-mysql/src/token_store.rs
+++ b/crates/spark-mysql/src/token_store.rs
@@ -526,7 +526,7 @@ impl TokenOutputStore for MysqlTokenStore {
                 .map_err(map_err)?;
                 tx.exec_drop(
                     "INSERT IGNORE INTO brz_token_spent_outputs (user_id, output_id, spent_at) \
-                     VALUES (?, ?, NOW())",
+                     VALUES (?, ?, UTC_TIMESTAMP(6))",
                     (self.identity.as_slice(), output_id.as_str()),
                 )
                 .await
@@ -639,10 +639,13 @@ impl TokenOutputStore for MysqlTokenStore {
 
     async fn now(&self) -> Result<SystemTime, TokenOutputServiceError> {
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
-        let row: Option<NaiveDateTime> =
-            conn.query_first("SELECT NOW(6)").await.map_err(map_err)?;
-        let now =
-            row.ok_or_else(|| TokenOutputServiceError::Generic("NOW() returned no row".into()))?;
+        let row: Option<NaiveDateTime> = conn
+            .query_first("SELECT UTC_TIMESTAMP(6)")
+            .await
+            .map_err(map_err)?;
+        let now = row.ok_or_else(|| {
+            TokenOutputServiceError::Generic("UTC_TIMESTAMP() returned no row".into())
+        })?;
         let dt = DateTime::<Utc>::from_naive_utc_and_offset(now, Utc);
         Ok(dt.into())
     }
@@ -693,6 +696,7 @@ impl MysqlTokenStore {
         .await
     }
 
+    #[allow(clippy::too_many_lines)]
     fn migrations(identity: &[u8], foreign_key_mode: MysqlForeignKeyMode) -> Vec<Vec<Migration>> {
         let mut initial = vec![
             Migration::sql(
@@ -781,6 +785,26 @@ impl MysqlTokenStore {
             initial,
             // Migration 2: Multi-tenant scoping.
             token_store_multi_tenant_migration(identity, foreign_key_mode),
+            // Migration 3: Pin DATETIME defaults to UTC. Server-side INSERTs
+            // already pass `UTC_TIMESTAMP(6)` explicitly; this migration makes
+            // the column default match so any future callsite that omits the
+            // column also gets a UTC value rather than a session-TZ-dependent
+            // one. Mirrored in
+            // crates/breez-sdk/wasm/js/mysql-token-store/migrations.cjs.
+            vec![
+                Migration::sql(
+                    "ALTER TABLE brz_token_outputs MODIFY COLUMN added_at \
+                     DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
+                ),
+                Migration::sql(
+                    "ALTER TABLE brz_token_reservations MODIFY COLUMN created_at \
+                     DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
+                ),
+                Migration::sql(
+                    "ALTER TABLE brz_token_spent_outputs MODIFY COLUMN spent_at \
+                     DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
+                ),
+            ],
         ]
     }
 
@@ -1117,7 +1141,7 @@ impl MysqlTokenStore {
         };
 
         tx.exec_drop(
-            "INSERT INTO brz_token_reservations (user_id, id, purpose) VALUES (?, ?, ?)",
+            "INSERT INTO brz_token_reservations (user_id, id, purpose, created_at) VALUES (?, ?, ?, UTC_TIMESTAMP(6))",
             (self.identity.clone(), &reservation_id, purpose_str),
         )
         .await
@@ -1211,15 +1235,16 @@ impl MysqlTokenStore {
             .map_err(map_err)?;
 
         if !reserved_output_ids.is_empty() {
-            let mut sql =
-                String::from("INSERT INTO brz_token_spent_outputs (user_id, output_id) VALUES ");
+            let mut sql = String::from(
+                "INSERT INTO brz_token_spent_outputs (user_id, output_id, spent_at) VALUES ",
+            );
             let mut params: Vec<Value> =
                 Vec::with_capacity(reserved_output_ids.len().saturating_mul(2));
             for (i, oid) in reserved_output_ids.iter().enumerate() {
                 if i > 0 {
                     sql.push_str(", ");
                 }
-                sql.push_str("(?, ?)");
+                sql.push_str("(?, ?, UTC_TIMESTAMP(6))");
                 params.push(Value::from(self.identity.clone()));
                 params.push(Value::from(oid.clone()));
             }
@@ -1249,7 +1274,7 @@ impl MysqlTokenStore {
         // lazily.
         if is_swap {
             tx.exec_drop(
-                "INSERT INTO brz_token_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
+                "INSERT INTO brz_token_swap_status (user_id, last_completed_at) VALUES (?, UTC_TIMESTAMP(6))
                  ON DUPLICATE KEY UPDATE last_completed_at = VALUES(last_completed_at)",
                 (self.identity.clone(),),
             )
@@ -1287,7 +1312,7 @@ impl MysqlTokenStore {
                 (user_id, id, token_identifier, owner_public_key, revocation_commitment,
                  withdraw_bond_sats, withdraw_relative_block_locktime,
                  token_public_key, token_amount, prev_tx_hash, prev_tx_vout, added_at)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(6))
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))
               ON DUPLICATE KEY UPDATE id = id",
             (
                 self.identity.clone(),
@@ -1358,7 +1383,7 @@ impl MysqlTokenStore {
                     SELECT id FROM (
                         SELECT id FROM brz_token_reservations
                         WHERE user_id = ?
-                          AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
+                          AND created_at < DATE_SUB(UTC_TIMESTAMP(6), INTERVAL ? SECOND)
                     ) AS stale
                 )",
             (
@@ -1373,7 +1398,7 @@ impl MysqlTokenStore {
         let mut result = tx
             .exec_iter(
                 "DELETE FROM brz_token_reservations
-                 WHERE user_id = ? AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)",
+                 WHERE user_id = ? AND created_at < DATE_SUB(UTC_TIMESTAMP(6), INTERVAL ? SECOND)",
                 (self.identity.clone(), RESERVATION_TIMEOUT_SECS),
             )
             .await
@@ -1793,9 +1818,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_remove_token_outputs_prevents_refresh_readd() {
+    async fn test_remove_token_outputs_prevents_refresh_re_add() {
         let fixture = MysqlTokenStoreTestFixture::new().await;
-        shared_tests::test_remove_token_outputs_prevents_refresh_readd(&fixture.store).await;
+        shared_tests::test_remove_token_outputs_prevents_refresh_re_add(&fixture.store).await;
     }
 
     #[tokio::test]
@@ -2082,7 +2107,7 @@ mod tests {
         // Backdate the swap reservation past the 5-minute timeout.
         let mut conn = fixture.store.pool.get_conn().await.unwrap();
         conn.exec_drop(
-            "UPDATE brz_token_reservations SET created_at = DATE_SUB(NOW(6), INTERVAL 10 MINUTE) WHERE id = ?",
+            "UPDATE brz_token_reservations SET created_at = DATE_SUB(UTC_TIMESTAMP(6), INTERVAL 10 MINUTE) WHERE id = ?",
             (&reservation.id,),
         )
         .await

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -735,6 +735,10 @@ impl MysqlTreeStore {
                     "ALTER TABLE brz_tree_spent_leaves MODIFY COLUMN spent_at \
                      DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
                 ),
+                Migration::sql(
+                    "ALTER TABLE brz_tree_schema_migrations MODIFY COLUMN applied_at \
+                     DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
+                ),
             ],
         ]
     }

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -517,9 +517,12 @@ impl TreeStore for MysqlTreeStore {
 
     async fn now(&self) -> Result<SystemTime, TreeServiceError> {
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
-        let row: Option<NaiveDateTime> =
-            conn.query_first("SELECT NOW(6)").await.map_err(map_err)?;
-        let now = row.ok_or_else(|| TreeServiceError::Generic("NOW() returned no row".into()))?;
+        let row: Option<NaiveDateTime> = conn
+            .query_first("SELECT UTC_TIMESTAMP(6)")
+            .await
+            .map_err(map_err)?;
+        let now =
+            row.ok_or_else(|| TreeServiceError::Generic("UTC_TIMESTAMP() returned no row".into()))?;
         let dt = DateTime::<Utc>::from_naive_utc_and_offset(now, Utc);
         Ok(dt.into())
     }
@@ -603,6 +606,7 @@ impl MysqlTreeStore {
         .await
     }
 
+    #[allow(clippy::too_many_lines)]
     fn migrations(identity: &[u8], foreign_key_mode: MysqlForeignKeyMode) -> Vec<Vec<Migration>> {
         // Migration 1: Initial tree tables.
         //
@@ -708,6 +712,30 @@ impl MysqlTreeStore {
             // user_id. The `brz_tree_swap_status` singleton is restructured the
             // same way as `sync_revision` in the SDK-core storage.
             tree_store_multi_tenant_migration(identity, foreign_key_mode),
+            // Migration 5: Pin DATETIME defaults to UTC. Server-side INSERTs
+            // already pass `UTC_TIMESTAMP(6)` explicitly; this migration makes
+            // the column default match so any future callsite that omits the
+            // column also gets a UTC value rather than a session-TZ-dependent
+            // one. Mirrored in
+            // crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs.
+            vec![
+                Migration::sql(
+                    "ALTER TABLE brz_tree_reservations MODIFY COLUMN created_at \
+                     DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
+                ),
+                Migration::sql(
+                    "ALTER TABLE brz_tree_leaves MODIFY COLUMN created_at \
+                     DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
+                ),
+                Migration::sql(
+                    "ALTER TABLE brz_tree_leaves MODIFY COLUMN added_at \
+                     DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
+                ),
+                Migration::sql(
+                    "ALTER TABLE brz_tree_spent_leaves MODIFY COLUMN spent_at \
+                     DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP(6))",
+                ),
+            ],
         ]
     }
 
@@ -980,7 +1008,7 @@ impl MysqlTreeStore {
         // no row) gets one created lazily.
         if is_swap && new_leaves.is_some() {
             tx.exec_drop(
-                "INSERT INTO brz_tree_swap_status (user_id, last_completed_at) VALUES (?, NOW(6))
+                "INSERT INTO brz_tree_swap_status (user_id, last_completed_at) VALUES (?, UTC_TIMESTAMP(6))
                  ON DUPLICATE KEY UPDATE last_completed_at = VALUES(last_completed_at)",
                 (self.identity.clone(),),
             )
@@ -1323,7 +1351,7 @@ impl MysqlTreeStore {
             return Ok(());
         }
 
-        // Build VALUES (?, ?, ?, ?, ?, ?, NOW(6)), … with user_id as the first column.
+        // Build VALUES (?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6)), … with user_id as the first column.
         let mut sql = String::from(
             "INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, value, added_at) VALUES ",
         );
@@ -1332,7 +1360,7 @@ impl MysqlTreeStore {
             if i > 0 {
                 sql.push_str(", ");
             }
-            sql.push_str("(?, ?, ?, ?, ?, ?, NOW(6))");
+            sql.push_str("(?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))");
             #[allow(clippy::cast_possible_wrap)]
             let value_i64 = leaf.value as i64;
             params.push(Value::from(self.identity.clone()));
@@ -1348,7 +1376,7 @@ impl MysqlTreeStore {
                 is_missing_from_operators = VALUES(is_missing_from_operators),
                 data = VALUES(data),
                 value = VALUES(value),
-                added_at = NOW(6)",
+                added_at = UTC_TIMESTAMP(6)",
         );
 
         tx.exec_drop(&sql, Params::Positional(params))
@@ -1397,13 +1425,14 @@ impl MysqlTreeStore {
             return Ok(());
         }
 
-        let mut sql = String::from("INSERT INTO brz_tree_spent_leaves (user_id, leaf_id) VALUES ");
+        let mut sql =
+            String::from("INSERT INTO brz_tree_spent_leaves (user_id, leaf_id, spent_at) VALUES ");
         let mut params: Vec<Value> = Vec::with_capacity(leaf_ids.len().saturating_mul(2));
         for (i, id) in leaf_ids.iter().enumerate() {
             if i > 0 {
                 sql.push_str(", ");
             }
-            sql.push_str("(?, ?)");
+            sql.push_str("(?, ?, UTC_TIMESTAMP(6))");
             params.push(Value::from(self.identity.clone()));
             params.push(Value::from(id.clone()));
         }
@@ -1470,7 +1499,7 @@ impl MysqlTreeStore {
                     SELECT id FROM (
                         SELECT id FROM brz_tree_reservations
                         WHERE user_id = ?
-                          AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)
+                          AND created_at < DATE_SUB(UTC_TIMESTAMP(6), INTERVAL ? SECOND)
                     ) AS stale
                 )",
             (
@@ -1485,7 +1514,7 @@ impl MysqlTreeStore {
         let mut result = tx
             .exec_iter(
                 "DELETE FROM brz_tree_reservations
-                 WHERE user_id = ? AND created_at < DATE_SUB(NOW(6), INTERVAL ? SECOND)",
+                 WHERE user_id = ? AND created_at < DATE_SUB(UTC_TIMESTAMP(6), INTERVAL ? SECOND)",
                 (self.identity.clone(), RESERVATION_TIMEOUT_SECS),
             )
             .await
@@ -1539,7 +1568,7 @@ impl MysqlTreeStore {
         let pending_i64 = pending_change as i64;
 
         tx.exec_drop(
-            "INSERT INTO brz_tree_reservations (user_id, id, purpose, pending_change_amount) VALUES (?, ?, ?, ?)",
+            "INSERT INTO brz_tree_reservations (user_id, id, purpose, pending_change_amount, created_at) VALUES (?, ?, ?, ?, UTC_TIMESTAMP(6))",
             (self.identity.clone(), reservation_id, purpose.to_string(), pending_i64),
         )
         .await
@@ -2114,7 +2143,7 @@ mod tests {
         // Backdate the reservation past the timeout.
         let mut conn = fixture.store.pool.get_conn().await.unwrap();
         conn.exec_drop(
-            "UPDATE brz_tree_reservations SET created_at = DATE_SUB(NOW(6), INTERVAL 10 MINUTE) WHERE id = ?",
+            "UPDATE brz_tree_reservations SET created_at = DATE_SUB(UTC_TIMESTAMP(6), INTERVAL 10 MINUTE) WHERE id = ?",
             (&reservation.id,),
         )
         .await
@@ -2356,7 +2385,7 @@ mod tests {
         // Backdate the swap reservation past the 5-minute timeout.
         let mut conn = fixture.store.pool.get_conn().await.unwrap();
         conn.exec_drop(
-            "UPDATE brz_tree_reservations SET created_at = DATE_SUB(NOW(6), INTERVAL 10 MINUTE) WHERE id = ?",
+            "UPDATE brz_tree_reservations SET created_at = DATE_SUB(UTC_TIMESTAMP(6), INTERVAL 10 MINUTE) WHERE id = ?",
             (&reservation.id,),
         )
         .await

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -1674,9 +1674,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_remove_token_outputs_prevents_refresh_readd() {
+    async fn test_remove_token_outputs_prevents_refresh_re_add() {
         let fixture = PostgresTokenStoreTestFixture::new().await;
-        shared_tests::test_remove_token_outputs_prevents_refresh_readd(&fixture.store).await;
+        shared_tests::test_remove_token_outputs_prevents_refresh_re_add(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark/src/token/store/tests.rs
+++ b/crates/spark/src/token/store/tests.rs
@@ -448,7 +448,7 @@ async fn test_remove_token_outputs_by_prev_tx_ref() {
 }
 
 #[async_test_all]
-async fn test_remove_token_outputs_prevents_refresh_readd() {
+async fn test_remove_token_outputs_prevents_refresh_re_add() {
     let store = InMemoryTokenOutputStore::default();
-    shared_tests::test_remove_token_outputs_prevents_refresh_readd(&store).await;
+    shared_tests::test_remove_token_outputs_prevents_refresh_re_add(&store).await;
 }

--- a/crates/spark/src/token/tests.rs
+++ b/crates/spark/src/token/tests.rs
@@ -1606,7 +1606,7 @@ pub async fn test_remove_token_outputs_by_prev_tx_ref(store: &dyn TokenOutputSto
     assert_eq!(amounts, vec![100, 300]);
 }
 
-pub async fn test_remove_token_outputs_prevents_refresh_readd(store: &dyn TokenOutputStore) {
+pub async fn test_remove_token_outputs_prevents_refresh_re_add(store: &dyn TokenOutputStore) {
     // Insert outputs
     let token1 = create_token_outputs(1, vec![100, 200]);
     store


### PR DESCRIPTION
The wasm-bindgen test `token_store::tests::mysql::test_remove_token_outputs_prevents_refresh_re_add` (added in #846) fails on environments whose host timezone has a positive UTC offset (e.g. CEST). Output: `left: 2, right: 1` — a spent output is silently re-added by a refresh.

Root cause: `mysql2` defaults to `timezone: 'local'`, which serializes JS `Date` parameters as **host-local** datetime strings. The MySQL server stores them literally in `DATETIME(6)` columns (no TZ awareness) and compares them against `NOW()`, which returns the **session** TZ. When the host and the session disagree, the inequality `spent_at >= refresh_timestamp` flips and the spent marker is missed.

Postgres is unaffected because `TIMESTAMPTZ` carries TZ info. Rust `spark-mysql` tests pass only because the test container happens to be UTC; the same MySQL session bug affects production deployments where the server's `time_zone` isn't UTC, regardless of client.

### Fix

Pin every server-side timestamp to UTC explicitly, and fix the JS-only client-side serialization:

1. **Server-side**: replace every `NOW()` / `NOW(6)` / `DATE_SUB(NOW(6), …)` with `UTC_TIMESTAMP(…)` across JS `mysql-token-store`, `mysql-tree-store`, and Rust `spark-mysql::{token_store,tree_store}`. Make INSERTs that relied on `DEFAULT CURRENT_TIMESTAMP(6)` pass `UTC_TIMESTAMP(6)` explicitly.
2. **Schema migration**: new migration flips column defaults to `DEFAULT (UTC_TIMESTAMP(6))`.
3. **JS client**: `timezone: "Z"` on every `createMysqlPool` (token-store, tree-store, storage) so `Date` parameters are sent as UTC.

After this, every timestamp comparison is UTC↔UTC regardless of host TZ or MySQL session TZ.

### Regression test

New Node-level test in `crates/breez-sdk/wasm/js/mysql-token-store/tests/` that spawns child processes under `TZ=UTC | Pacific/Kiritimati (+14) | Pacific/Pago_Pago (-11) | Europe/Berlin (+2)` and runs the spent-marker scenario in each. Wired into `make wasm-test`, so any future TZ regression fails on standard CI runners (UTC) rather than only on contributor machines.
