### PR TITLE
spark: wait 5ms before transport-error retry to let Reconnect swap connections

### DIFF
--- a/crates/spark/src/operator/rpc/transport/retry_channel.rs
+++ b/crates/spark/src/operator/rpc/transport/retry_channel.rs
@@ -7,6 +7,7 @@ use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 use tonic::{Status, body::BoxBody};
 use tower_service::Service;
@@ -19,6 +20,15 @@ pub enum RetryChannelError {
     #[error("transport error: {0}")]
     Transport(#[from] tonic::transport::Error),
 }
+
+/// Pause between the initial transport failure and the retry, so that
+/// tonic's `Reconnect` middleware has time to drop the dying connection
+/// and start a fresh one before the retry's `poll_ready`. Without it
+/// the retry tends to hit the same teardown window — e.g. when an L7
+/// proxy sends a graceful `GoAway` to recycle the HTTP/2 connection,
+/// the original call and an immediate retry on the same `inner.clone()`
+/// both fail with the same `hyper::Error(Canceled)`.
+const RETRY_DELAY: Duration = Duration::from_millis(5);
 
 /// A channel that retries a gRPC call once if a transport error occurs
 #[derive(Debug, Clone)]
@@ -79,9 +89,10 @@ where
             };
 
             debug!(
-                "RetryChannel: transport error detected: {:?}, retrying...",
-                err
+                "RetryChannel: transport error detected: {:?}, retrying after {:?}",
+                err, RETRY_DELAY
             );
+            tokio::time::sleep(RETRY_DELAY).await;
 
             // Wait for the retry clone to be ready and make the call
             poll_fn(|cx| inner_clone.poll_ready(cx)).await?;


### PR DESCRIPTION
## Problem

The Kotlin server-mode bench (`crates/breez-sdk/breez-bench/kotlin`) had
been producing a small but persistent stream of
`Status::Cancelled("operation was canceled")` errors (~7 per 3-min 40 RPS
`send` run) that always clustered in bursts at ~50 s intervals. Same error
shape, same period regardless of `CONNS_PER_OPERATOR` (N=1 → 7 errors,
N=4 → 10 errors — equivalent within noise).

## Root cause

An L7 proxy in front of the Spark operators sends a graceful
`GoAway { error_code: NO_ERROR, last_stream_id: StreamId(19999) }` after
every 10 000 client streams on the HTTP/2 connection — standard
connection-rebalancing behaviour (e.g. AWS ALB, Envoy
`max_requests_per_connection`).

When hyper-1.x's client task processes the GOAWAY it tears down the
connection. In-flight requests on the dying connection surface as
`hyper::Error(Canceled, "connection closed")` via
`client/dispatch.rs::Envelope::Drop`; tonic 0.12's
`Status::from_hyper_error` maps them to `Status::Cancelled("operation
was canceled")` with empty metadata — the exact failure shape callers
were seeing.

The existing single retry in `RetryChannel` reused the same
`inner.clone()` and fired microseconds after the failure, hitting the
same dying connection before tonic's internal `Reconnect` middleware
had a chance to swap in a fresh one. In the Kotlin server bench at
3-min, 40 RPS, this reproduced as 88 transport failures with 32
retry-also-failed → 7 user-visible Cancelled.

## Fix

Insert a 5 ms `tokio::time::sleep` between the failure and the retry's
`poll_ready`. That's enough for `Reconnect` to start a fresh connection,
so the retry lands on it. +13 / −2 lines, no structural changes.

## Verification

Same workload after the change (Kotlin server bench, N=1, 3-min, 40 RPS,
send=100%):

| | before | after |
|---|---|---|
| Cancelled errors | 7 | **0** |
| GOAWAY frames (NO_ERROR, stream 19999) | 3 | 3 |
| Transport failures caught by RetryChannel | 88 | 102 |
| Retry-also-failed | 32 | **0** |