### PR TITLE
breez-bench: per-RPC slow-payment breakdown via SDK span tracing

### DIFF
--- a/crates/breez-sdk/bindings/Cargo.toml
+++ b/crates/breez-sdk/bindings/Cargo.toml
@@ -10,6 +10,8 @@ postgres = ["breez-sdk-spark/postgres"]
 # MySQL storage backend (disable for mobile builds to reduce binary size)
 mysql = ["breez-sdk-spark/mysql"]
 uniffi-cli = ["uniffi/bindgen-tests", "uniffi/cli"]
+# Bench-only: see breez-sdk-spark's `span-trace` feature.
+span-trace = ["breez-sdk-spark/span-trace"]
 
 [[bin]]
 name = "uniffi-bindgen"

--- a/crates/breez-sdk/bindings/Makefile
+++ b/crates/breez-sdk/bindings/Makefile
@@ -34,10 +34,10 @@ bindings-swift: build-release
 	cargo run --features=uniffi-cli --bin uniffi-bindgen generate --library $(BIN_PATH) --no-format --language swift -o $(FFI_DIR)swift
 
 build-release:
-	cargo build --release
+	cargo build --release $(if $(CARGO_FEATURES),--features $(CARGO_FEATURES))
 
 build-release-target-%: install-target-%
-	cargo build --release --target $*
+	cargo build --release --target $* $(if $(CARGO_FEATURES),--features $(CARGO_FEATURES))
 
 install-uniffi-bindgen-cs:
 	$(INSTALL_PREFIX) cargo install uniffi-bindgen-cs --git https://github.com/breez/uniffi-bindgen-cs --branch v0.29.4-with-fixes

--- a/crates/breez-sdk/breez-bench/kotlin/Makefile
+++ b/crates/breez-sdk/breez-bench/kotlin/Makefile
@@ -16,8 +16,8 @@ export MYSQL_URL ?= mysql://root:password@127.0.0.1:3306/breez_bench
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-18s %s\n", $$1, $$2}'
 
-setup: ## Build and publish KMP bindings to mavenLocal (one-time per branch)
-	cd $(KMP_CLI_DIR) && $(MAKE) setup
+setup: ## Build and publish KMP bindings (with the bench's `span-trace` cargo feature) to mavenLocal (one-time per branch)
+	cd $(KMP_CLI_DIR) && $(MAKE) setup CARGO_FEATURES=span-trace
 
 # Server-side `max_connections` for the bench container. The mysql:8.0 default
 # is 151, which the bench saturates as concurrency rises (`HY000: Too many

--- a/crates/breez-sdk/breez-bench/kotlin/scripts/aggregate.py
+++ b/crates/breez-sdk/breez-bench/kotlin/scripts/aggregate.py
@@ -79,6 +79,158 @@ def read_jsonl(path):
     return rows
 
 
+# --- trace log parsing ----------------------------------------------------
+# Per-step server writes its tracing output to <step>/.trace-logs/sdk.log
+# when started with --bench-trace (or an explicit --log-filter). We parse
+# two event categories out of it:
+#
+#   1. "Swapped leaves to match target amount" message
+#      → payment-time leaf swap (one per send that required a swap)
+#   2. Span CLOSE events on target `breez_sdk_core::send_phases`
+#      → emitted by `#[tracing::instrument]` on the top-level
+#        `send_payment`, every SSP method, and every operator-RPC
+#        method. The span hierarchy carries `payment_id` (top-level
+#        span field) and, for operator RPCs, `operator_id`. Format
+#        produced by `tracing_subscriber::fmt::FmtSpan::CLOSE`:
+#
+#          <ts>  INFO send_payment{payment_id="..."}:rpc_name{operator_id=3}:
+#                breez_sdk_core::send_phases: close time.busy=2.53ms time.idle=24.9µs
+#
+# The sdk.log file is naturally per-step (each step gets a fresh server),
+# so no timestamp filtering is needed inside this parser.
+
+SWAP_MESSAGE = "Swapped leaves to match target amount"
+# Must stay in sync with the bench filter the server installs — see
+# `BENCH_TRACE_FILTER` in Server.kt. If you change the target name, the
+# tracing level, or the close-event format on either side, update both.
+BENCH_TARGET = "breez_sdk_core::send_phases"
+TOP_LEVEL_SPAN_NAME = "send_payment"
+
+# Matches one CLOSE event. The span hierarchy is captured as the
+# colon-separated run of `name{fields}` segments preceding the target
+# marker. Field values are either quoted strings (`payment_id="abc"`)
+# or bare tokens (`operator_id=3`).
+_CLOSE_RE = re.compile(
+    r"^\S+\s+INFO\s+(?P<hierarchy>\S+?):\s+"
+    + re.escape(BENCH_TARGET)
+    + r":\s+close\s+time\.busy=(?P<busy>[\d.]+(?:ns|µs|us|ms|s))"
+    + r"(?:\s+time\.idle=(?P<idle>[\d.]+(?:ns|µs|us|ms|s)))?"
+)
+
+# Within a hierarchy segment: `name` or `name{field=value, ...}`.
+_SEGMENT_RE = re.compile(r"(\w+)(?:\{([^}]*)\})?")
+_FIELD_RE = re.compile(r'(\w+)=("[^"]*"|[^\s,}]+)')
+_DURATION_RE = re.compile(r"^([\d.]+)(ns|µs|us|ms|s)$")
+_DURATION_UNIT_MS = {
+    "ns": 1e-6,
+    "µs": 1e-3,
+    "us": 1e-3,
+    "ms": 1.0,
+    "s": 1000.0,
+}
+
+
+def _parse_duration_ms(s):
+    if not s:
+        return None
+    m = _DURATION_RE.match(s)
+    if not m:
+        return None
+    return float(m.group(1)) * _DURATION_UNIT_MS[m.group(2)]
+
+
+def _parse_fields(s):
+    """Returns {field → value} where quoted values keep their quotes
+    stripped. Bare numeric / identifier values are returned as strings;
+    the caller converts where needed."""
+    out = {}
+    for k, v in _FIELD_RE.findall(s):
+        out[k] = v.strip('"') if v.startswith('"') else v
+    return out
+
+
+def _parse_hierarchy(s):
+    """Splits a span hierarchy into ordered [{name, fields}, ...]
+    segments. Splits on top-level `:` only — field bodies may contain
+    them (in quoted strings), so we track `{}` depth."""
+    pieces = []
+    depth = 0
+    start = 0
+    for i, ch in enumerate(s):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        elif ch == ":" and depth == 0:
+            pieces.append(s[start:i])
+            start = i + 1
+    pieces.append(s[start:])
+    out = []
+    for piece in pieces:
+        m = _SEGMENT_RE.match(piece)
+        if not m:
+            continue
+        out.append({
+            "name": m.group(1),
+            "fields": _parse_fields(m.group(2) or ""),
+        })
+    return out
+
+
+def parse_trace_log(path):
+    """Returns swap count and the list of parsed close events.
+
+    Phase events: list of dicts each carrying
+      {payment_id, rpc_name, operator_id (or None), duration_ms}.
+    Top-level `send_payment` spans are kept (they're the per-payment
+    total elapsed time) — callers distinguish them by `rpc_name`.
+    Missing file ⇒ zero + empty list, which is also the
+    'server ran without --bench-trace' signal further up.
+    """
+    out = {"swap_count": 0, "phase_events": []}
+    if not path.exists():
+        return out
+    with path.open("r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            if SWAP_MESSAGE in line:
+                out["swap_count"] += 1
+            m = _CLOSE_RE.match(line)
+            if not m:
+                continue
+            busy_ms = _parse_duration_ms(m.group("busy"))
+            idle_ms = _parse_duration_ms(m.group("idle")) or 0.0
+            if busy_ms is None:
+                continue
+            segments = _parse_hierarchy(m.group("hierarchy"))
+            if not segments:
+                continue
+            # Walk the hierarchy to find payment_id (set by the
+            # top-level `send_payment` span). Missing ⇒ orphaned event
+            # (instrumented code ran outside a send_payment call,
+            # e.g. claim flows); skip it for the slow-payment view.
+            payment_id = None
+            for seg in segments:
+                pid = seg["fields"].get("payment_id")
+                if pid:
+                    payment_id = pid
+                    break
+            if payment_id is None:
+                continue
+            leaf = segments[-1]
+            op_raw = leaf["fields"].get("operator_id")
+            try:
+                operator_id = int(op_raw) if op_raw is not None else None
+            except ValueError:
+                operator_id = None
+            out["phase_events"].append({
+                "payment_id": payment_id,
+                "rpc_name": leaf["name"],
+                "operator_id": operator_id,
+                "duration_ms": busy_ms + idle_ms,
+            })
+    return out
+
+
 # --- stats ---------------------------------------------------------------
 
 def percentile(sorted_values, p):
@@ -108,6 +260,86 @@ def summary_stats(values):
         "p95": percentile(sv, 95),
         "p99": percentile(sv, 99),
     }
+
+
+# --- slow-payment phase helpers -----------------------------------------
+
+def _phases_by_payment(phase_events):
+    """Index parsed close events by payment_id. Returns
+    {payment_id → list[event]}, preserving insertion order."""
+    out = {}
+    for ev in phase_events:
+        out.setdefault(ev["payment_id"], []).append(ev)
+    return out
+
+
+def _payment_summary(events):
+    """Per-RPC summary for one payment. Operator RPCs fan out to N
+    operators concurrently, so each rpc_name gets a list of durations.
+    Returns (per_rpc: {rpc_name → list[(operator_id, ms)]}, total_ms).
+    """
+    per_rpc = {}
+    total_ms = None
+    for ev in events:
+        if ev["rpc_name"] == TOP_LEVEL_SPAN_NAME:
+            # Top-level `send_payment` span — record as the wall-clock
+            # total but don't list it as an RPC row.
+            total_ms = ev["duration_ms"]
+            continue
+        per_rpc.setdefault(ev["rpc_name"], []).append(
+            (ev["operator_id"], ev["duration_ms"])
+        )
+    return per_rpc, total_ms
+
+
+def _dominant_rpc(per_rpc):
+    """Returns (rpc_name, worst_ms) — the slowest individual RPC call
+    in the payment (max across all operator fan-outs). None if the
+    payment has no RPC data (unlikely but possible)."""
+    best = None
+    best_ms = -1.0
+    for rpc, calls in per_rpc.items():
+        for _, ms in calls:
+            if ms > best_ms:
+                best_ms = ms
+                best = rpc
+    return (best, best_ms) if best is not None else None
+
+
+def _slow_phase_aggregate(slow_rows, phase_by_payment):
+    """Per-RPC aggregate over the slow set. For each rpc_name, gather
+    every individual call (across all payments and all operators), then
+    compute summary_stats. Also tracks dominance: how many slow
+    payments had this RPC as their slowest individual call.
+    """
+    per_rpc_ms = {}
+    dominance = {}
+    classified = 0
+    for r in slow_rows:
+        pid = r.get("payment_id")
+        if not pid:
+            continue
+        events = phase_by_payment.get(pid)
+        if not events:
+            continue
+        per_rpc, _ = _payment_summary(events)
+        if not per_rpc:
+            continue
+        classified += 1
+        for rpc, calls in per_rpc.items():
+            ms_list = per_rpc_ms.setdefault(rpc, [])
+            for _, ms in calls:
+                ms_list.append(ms)
+        dom = _dominant_rpc(per_rpc)
+        if dom:
+            dominance[dom[0]] = dominance.get(dom[0], 0) + 1
+    out = {}
+    for rpc, ms_list in per_rpc_ms.items():
+        stats = summary_stats(ms_list)
+        dpct = (100.0 * dominance.get(rpc, 0) / classified) if classified else None
+        out[rpc] = {**stats, "dominant_pct": dpct}
+    out["_classified"] = classified
+    return out
 
 
 # --- per-step aggregation ------------------------------------------------
@@ -219,11 +451,16 @@ def metrics_window(metrics_rows, ts_lo, ts_hi):
     }
 
 
-def aggregate_step(step_dir):
-    """Aggregate one rps-N directory. Returns a dict (or None if no data)."""
+def aggregate_step(step_dir, slow_abs_ms=2000, slow_rel_pct=95, slow_top_n=20):
+    """Aggregate one rps-N directory. Returns a dict (or None if no data).
+
+    Slow-payment knobs are forwarded so the per-step slow set + Top-N
+    table can be computed while the raw rows are still in scope.
+    """
     latency_rows = read_jsonl(step_dir / "latency.jsonl")
     requests_rows = read_jsonl(step_dir / "requests.jsonl")
     metrics_rows = read_jsonl(step_dir / "metrics.jsonl")
+    trace = parse_trace_log(step_dir / ".trace-logs" / "sdk.log")
 
     if not latency_rows and not requests_rows:
         return None
@@ -270,6 +507,70 @@ def aggregate_step(step_dir):
 
     metrics = metrics_window(metrics_rows, ts_lo, ts_hi) if metrics_rows else {}
 
+    # Leaf-swap rate: denominator is successful send-class handler
+    # completions for this step. Counts come from the per-step trace
+    # log (only populated under --bench-trace). Zero count with the
+    # file absent ⇒ render section will be skipped.
+    send_ok_rows = [
+        r for r in requests_rows
+        if r.get("error") is None and (r.get("op") or "").startswith("send")
+    ]
+    send_ok_count = len(send_ok_rows)
+    swap_count = trace["swap_count"]
+    swap_rate = (swap_count / send_ok_count) if send_ok_count else None
+
+    # Slow-payment phase breakdown. Threshold is
+    # `max(slow_abs_ms, step_p_rel)` so we always honour the absolute
+    # floor (catches the pathological tails) while the relative cap
+    # keeps the slow set bounded at high RPS.
+    send_durations_ok = [
+        r.get("duration_ms") for r in send_ok_rows if r.get("duration_ms") is not None
+    ]
+    if send_durations_ok:
+        step_p_rel = percentile(sorted(send_durations_ok), slow_rel_pct)
+        slow_threshold_ms = max(slow_abs_ms, step_p_rel or 0)
+    else:
+        step_p_rel = None
+        slow_threshold_ms = slow_abs_ms
+    slow_rows = [
+        r for r in send_ok_rows
+        if (r.get("duration_ms") or 0) >= slow_threshold_ms
+    ]
+    slow_rows.sort(key=lambda r: r.get("duration_ms") or 0, reverse=True)
+
+    phase_by_payment = _phases_by_payment(trace["phase_events"])
+    slow_top_n_rows = []
+    for r in slow_rows[:slow_top_n]:
+        pid = r.get("payment_id")
+        events = phase_by_payment.get(pid, []) if pid else []
+        per_rpc, span_total_ms = _payment_summary(events) if events else ({}, None)
+        dom = _dominant_rpc(per_rpc) if per_rpc else None
+        slow_top_n_rows.append({
+            "payment_id": pid,
+            "op": r.get("op"),
+            "duration_ms": r.get("duration_ms"),
+            "span_total_ms": span_total_ms,
+            "per_rpc": {
+                # Per-RPC summary: count, sum, max (worst-of-N for
+                # operator RPCs), and the operator id of the worst
+                # call when applicable.
+                rpc: {
+                    "count": len(calls),
+                    "sum_ms": sum(ms for _, ms in calls),
+                    "max_ms": max(ms for _, ms in calls),
+                    "worst_operator_id": next(
+                        (op for op, ms in calls if ms == max(m for _, m in calls)),
+                        None,
+                    ),
+                }
+                for rpc, calls in per_rpc.items()
+            },
+            "dominant_rpc": dom[0] if dom else None,
+            "dominant_ms": dom[1] if dom else None,
+        })
+    # Per-RPC aggregate over the slow set.
+    slow_phase_agg = _slow_phase_aggregate(slow_rows, phase_by_payment)
+
     return {
         "ts_window_ms": [ts_lo, ts_hi],
         "total_dispatched": total_dispatched,
@@ -287,6 +588,16 @@ def aggregate_step(step_dir):
         "metrics": metrics,
         "errors_by_category_client": client_errors_by_category,
         "errors_by_category_server": server_errors_by_category,
+        "send_ok_count": send_ok_count,
+        "swap_count": swap_count,
+        "swap_rate": swap_rate,
+        "slow_threshold_ms": slow_threshold_ms,
+        "slow_abs_ms": slow_abs_ms,
+        "slow_rel_pct": slow_rel_pct,
+        "slow_rel_p_value_ms": step_p_rel,
+        "slow_count": len(slow_rows),
+        "slow_top_n": slow_top_n_rows,
+        "slow_phase_aggregate": slow_phase_agg,
     }
 
 
@@ -405,6 +716,157 @@ def render_table(headers, rows):
     out.append("|" + "|".join("-" * (w + 2) for w in sep_widths) + "|")
     for row in rows:
         out.append(fmt_row(row))
+    return out
+
+
+def render_swap_section(steps_summary):
+    """Per-step leaves-swap rate. Counts come from `.trace-logs/sdk.log`
+    (only populated when the server ran with `--bench-trace`). Section
+    is skipped if no swap events were seen across any step — keeps the
+    report quiet for runs that didn't ask for the data.
+    """
+    has_any = any(s.get("swap_count", 0) for _, s in steps_summary)
+    if not has_any:
+        return []
+    out = ["## Leaves swap (per step)", ""]
+    out.append(
+        "> Counted from `.trace-logs/sdk.log` — populated when the "
+        "server ran with `--bench-trace`. Denominator is the step's "
+        "successful `send*` handler completions; high swap rate at a "
+        "given RPS implies the leaf set isn't pre-shaped for the "
+        "payment denominations being sent."
+    )
+    out.append("")
+    headers = ["RPS", "successful sends", "swaps", "swap rate"]
+    rows = []
+    for rps, s in steps_summary:
+        sok = s.get("send_ok_count", 0)
+        sr = s.get("swap_rate")
+        rows.append([
+            str(rps),
+            str(sok),
+            str(s.get("swap_count", 0)),
+            "—" if sr is None else f"{100.0 * sr:.1f}%",
+        ])
+    out.extend(render_table(headers, rows))
+    out.append("")
+    return out
+
+
+def render_slow_payments_section(steps_summary):
+    """Per-step slow-payment phase breakdown. For every slow send we
+    list its slowest individual RPC call (with operator_id when
+    applicable). A second sub-table aggregates per-RPC stats across
+    the whole slow set so a recurring bottleneck (e.g. one SSP method
+    always > 1s) jumps out.
+
+    Section is skipped if no phase events were parsed across any step
+    (typically: ran without `--bench-trace`).
+    """
+    has_phase_data = any(
+        any(t.get("per_rpc") for t in s.get("slow_top_n", []))
+        for _, s in steps_summary
+    )
+    if not has_phase_data:
+        return []
+    first = steps_summary[0][1] if steps_summary else {}
+    abs_ms = first.get("slow_abs_ms", "?")
+    rel_pct = first.get("slow_rel_pct", "?")
+    out = [
+        "## Slow payments — per-RPC breakdown (per step)",
+        "",
+        (
+            f"> A send is 'slow' if `duration_ms ≥ max({abs_ms}ms, "
+            f"step p{rel_pct})` (override via `--slow-abs-ms` / "
+            f"`--slow-rel-pct`). Per-RPC timings come from "
+            "`#[tracing::instrument]`-decorated SSP and operator-RPC "
+            "methods; correlation to server log rows is by `payment_id` "
+            "carried on the top-level `send_payment` span. The "
+            "**dominant** column is the slowest individual RPC call in "
+            "the payment — for operator RPCs that includes a "
+            "`(so-N)` tag identifying which of the parallel "
+            "operators held up the FROST round. Empty `per_rpc` (rendered "
+            "as `—`) means the trace events were missed or the server "
+            "ran without `--bench-trace`."
+        ),
+        "",
+    ]
+    for rps, s in steps_summary:
+        if step_state(s) == "collapsed":
+            continue
+        slow_threshold_ms = s.get("slow_threshold_ms")
+        slow_count = s.get("slow_count", 0)
+        top_n = s.get("slow_top_n", [])
+        agg = s.get("slow_phase_aggregate") or {}
+        if not top_n:
+            continue
+        out.append(
+            f"### RPS {rps} — slow threshold {slow_threshold_ms:.0f}ms "
+            f"({slow_count} slow send{'s' if slow_count != 1 else ''})"
+        )
+        out.append("")
+        out.append("#### Top slowest sends")
+        out.append("")
+        headers = [
+            "payment_id", "op", "total ms", "span total ms",
+            "dominant RPC", "dominant ms", "# RPCs",
+        ]
+        rows = []
+        for t in top_n:
+            dom_rpc = t.get("dominant_rpc")
+            per_rpc = t.get("per_rpc") or {}
+            # For operator-fanout RPCs, surface which operator was
+            # slowest so the Spark team can correlate to a specific SO.
+            worst_op = (
+                per_rpc.get(dom_rpc, {}).get("worst_operator_id")
+                if dom_rpc else None
+            )
+            dom_label = (
+                f"{dom_rpc} (so-{worst_op})" if dom_rpc and worst_op is not None
+                else (dom_rpc or "—")
+            )
+            rows.append([
+                (t.get("payment_id") or "—")[:16],
+                t.get("op") or "—",
+                str(t.get("duration_ms") or "—"),
+                fmt_ms(t.get("span_total_ms")),
+                dom_label,
+                fmt_ms(t.get("dominant_ms")),
+                str(len(per_rpc)) if per_rpc else "—",
+            ])
+        out.extend(render_table(headers, rows))
+        out.append("")
+        # Per-RPC aggregate across the slow set (every individual call
+        # of each RPC across every slow payment, regardless of operator).
+        classified = agg.get("_classified", 0)
+        out.append(
+            f"#### Per-RPC aggregate over slow set "
+            f"({classified} payments with phase data of {slow_count} slow)"
+        )
+        out.append("")
+        agg_headers = ["rpc", "calls", "p50", "p95", "p99", "max", "% slow dominated by"]
+        # Order RPCs by p99 descending — biggest contributors first.
+        rpc_rows = []
+        for rpc, stats in agg.items():
+            if rpc.startswith("_"):
+                continue
+            rpc_rows.append((rpc, stats))
+        rpc_rows.sort(key=lambda x: x[1].get("p99") or 0, reverse=True)
+        agg_rows = []
+        for rpc, stats in rpc_rows:
+            dpct = stats.get("dominant_pct")
+            agg_rows.append([
+                rpc,
+                str(stats.get("count", 0)),
+                fmt_ms(stats.get("p50")),
+                fmt_ms(stats.get("p95")),
+                fmt_ms(stats.get("p99")),
+                fmt_ms(stats.get("max")),
+                "—" if dpct is None else f"{dpct:.0f}%",
+            ])
+        if agg_rows:
+            out.extend(render_table(agg_headers, agg_rows))
+            out.append("")
     return out
 
 
@@ -649,6 +1111,9 @@ def render_results_md(sweep_id, manifest, steps_summary, headline, audit=None):
             lines.extend(render_table(headers, rows))
             lines.append("")
 
+    lines.extend(render_swap_section(steps_summary))
+    lines.extend(render_slow_payments_section(steps_summary))
+
     lines.append("## Process metrics")
     lines.append("")
     cpu_cores = next(
@@ -786,10 +1251,37 @@ def main():
         help="Classify one rps-<N> dir (ok|degrading|collapsed) to stdout "
         "and exit. Used by sweep.sh to stop the sweep at collapse.",
     )
+    ap.add_argument(
+        "--slow-abs-ms",
+        type=int,
+        default=2000,
+        help="Absolute ms floor for the slow-payment section. A send is "
+        "'slow' if its duration_ms ≥ max(this, step p<rel>).",
+    )
+    ap.add_argument(
+        "--slow-rel-pct",
+        type=int,
+        default=95,
+        help="Relative percentile used to bound the slow set per step "
+        "(default p95). Combined with --slow-abs-ms via max().",
+    )
+    ap.add_argument(
+        "--slow-top-n",
+        type=int,
+        default=20,
+        help="How many slowest sends to list individually per step "
+        "(default 20). Aggregate stats are over the entire slow set, "
+        "not just the top-N.",
+    )
     args = ap.parse_args()
 
     if args.step_state:
-        s = aggregate_step(Path(args.step_state).resolve())
+        s = aggregate_step(
+            Path(args.step_state).resolve(),
+            slow_abs_ms=args.slow_abs_ms,
+            slow_rel_pct=args.slow_rel_pct,
+            slow_top_n=args.slow_top_n,
+        )
         # No data ⇒ treat as collapsed so the sweep stops rather than
         # marching on into more junk steps.
         print(step_state(s) if s is not None else "collapsed")
@@ -815,7 +1307,12 @@ def main():
 
     steps_summary = []
     for rps, step_dir in step_dirs(sweep_dir):
-        s = aggregate_step(step_dir)
+        s = aggregate_step(
+            step_dir,
+            slow_abs_ms=args.slow_abs_ms,
+            slow_rel_pct=args.slow_rel_pct,
+            slow_top_n=args.slow_top_n,
+        )
         if s is None:
             print(f"warn: skipping {step_dir.name} (no data)", file=sys.stderr)
             continue

--- a/crates/breez-sdk/breez-bench/kotlin/scripts/aggregate.py
+++ b/crates/breez-sdk/breez-bench/kotlin/scripts/aggregate.py
@@ -86,34 +86,45 @@ def read_jsonl(path):
 #
 #   1. "Swapped leaves to match target amount" message
 #      → payment-time leaf swap (one per send that required a swap)
-#   2. Span CLOSE events on target `breez_sdk_core::send_phases`
-#      → emitted by `#[tracing::instrument]` on the top-level
-#        `send_payment`, every SSP method, and every operator-RPC
-#        method. The span hierarchy carries `payment_id` (top-level
-#        span field) and, for operator RPCs, `operator_id`. Format
-#        produced by `tracing_subscriber::fmt::FmtSpan::CLOSE`:
+#   2. Span CLOSE events on the SDK span-trace targets:
+#        - `breez_sdk_core::send_payment` — top-level `send_payment`
+#        - `spark::ssp`                   — every SSP method
+#        - `spark::operator_rpc`          — every operator-RPC method
+#      Each crate uses its own target to avoid the spark crate
+#      referencing a breez-owned name. The span hierarchy carries
+#      `payment_id` (top-level span field) and, for operator RPCs,
+#      `operator_id`. Format produced by `FmtSpan::CLOSE`:
 #
 #          <ts>  INFO send_payment{payment_id="..."}:rpc_name{operator_id=3}:
-#                breez_sdk_core::send_phases: close time.busy=2.53ms time.idle=24.9µs
+#                spark::operator_rpc: close time.busy=2.53ms time.idle=24.9µs
 #
 # The sdk.log file is naturally per-step (each step gets a fresh server),
 # so no timestamp filtering is needed inside this parser.
 
 SWAP_MESSAGE = "Swapped leaves to match target amount"
-# Must stay in sync with the bench filter the server installs — see
-# `BENCH_TRACE_FILTER` in Server.kt. If you change the target name, the
-# tracing level, or the close-event format on either side, update both.
-BENCH_TARGET = "breez_sdk_core::send_phases"
+# Must stay in sync with the SDK targets and the bench filter the server
+# installs — see `BENCH_TRACE_FILTER` in Server.kt and `SPAN_TRACE_TARGETS`
+# in core/src/logger.rs. Changes to a target name, the tracing level, or
+# the close-event format need to land on all three sides.
+BENCH_TARGETS = (
+    "breez_sdk_core::send_payment",
+    "spark::ssp",
+    "spark::operator_rpc",
+)
 TOP_LEVEL_SPAN_NAME = "send_payment"
 
 # Matches one CLOSE event. The span hierarchy is captured as the
 # colon-separated run of `name{fields}` segments preceding the target
 # marker. Field values are either quoted strings (`payment_id="abc"`)
-# or bare tokens (`operator_id=3`).
+# or bare tokens (`operator_id=3`). The optional `<lineno>:` between
+# target and `close` is rendered by tracing-subscriber when the SDK's
+# fmt layer is configured with `with_line_number(true)` — that's the
+# prod default, which the simplified `init_logging` reuses for the
+# bench build too.
 _CLOSE_RE = re.compile(
     r"^\S+\s+INFO\s+(?P<hierarchy>\S+?):\s+"
-    + re.escape(BENCH_TARGET)
-    + r":\s+close\s+time\.busy=(?P<busy>[\d.]+(?:ns|µs|us|ms|s))"
+    + r"(?:" + "|".join(re.escape(t) for t in BENCH_TARGETS) + r")"
+    + r":\s+(?:\d+:\s+)?close\s+time\.busy=(?P<busy>[\d.]+(?:ns|µs|us|ms|s))"
     + r"(?:\s+time\.idle=(?P<idle>[\d.]+(?:ns|µs|us|ms|s)))?"
 )
 

--- a/crates/breez-sdk/breez-bench/kotlin/scripts/sweep.sh
+++ b/crates/breez-sdk/breez-bench/kotlin/scripts/sweep.sh
@@ -60,6 +60,13 @@ INTER_STEP_SLEEP_SECS="${INTER_STEP_SLEEP_SECS:-120}"
 # out/<id>/rps-<N>/.trace-logs/sdk.log. Scoped to the load-step server
 # only (not fund/seed) to keep volume bounded.
 LOG_FILTER="${LOG_FILTER:-}"
+# Bench-report tracing preset (leaves-swap detection + per-RPC close-event
+# spans, consumed by aggregate.py to render the "Leaves swap / optimization"
+# and "Slow payments — per-RPC breakdown" sections in RESULTS.md). The
+# preset is ON by default in the server; set BENCH_TRACE=0 here to A/B
+# the instrumentation overhead. If LOG_FILTER is also set, the explicit
+# filter wins — user retains full control.
+BENCH_TRACE="${BENCH_TRACE:-1}"
 # Per-sender fund safety buffer (so we never drain a sender during the
 # sweep) and treasurer buffer over total seeded amount.
 SEED_SAFETY="${SEED_SAFETY:-2.0}"
@@ -440,7 +447,7 @@ for raw_rps in "${RPS_LIST[@]}"; do
         --port=$PORT \
         --run-id=$SWEEP_ID/rps-$rps \
         --out-dir=$step_dir \
-        ${LOG_FILTER:+--log-filter=$LOG_FILTER}" \
+        ${LOG_FILTER:+--log-filter=$LOG_FILTER} --bench-trace=$([ "$BENCH_TRACE" = 0 ] && echo false || echo true)" \
         > "$server_log" 2>&1 &
     server_pid=$!
     # Killing gradlew alone can leak the JVM child; trap handles the SIGINT path.

--- a/crates/breez-sdk/breez-bench/kotlin/src/main/kotlin/Bench.kt
+++ b/crates/breez-sdk/breez-bench/kotlin/src/main/kotlin/Bench.kt
@@ -124,6 +124,10 @@ data class ServerRequestLogEntry(
     @SerialName("prepare_ms") val prepareMs: Long? = null,
     @SerialName("send_ms") val sendMs: Long? = null,
     @SerialName("disconnect_ms") val disconnectMs: Long? = null,
+    // Populated only for successful sends; lets aggregate.py join slow
+    // requests against `send_payment_completed` tracing events to render
+    // the per-payment phase breakdown.
+    @SerialName("payment_id") val paymentId: String? = null,
 )
 
 class RequestTimings {
@@ -134,6 +138,8 @@ class RequestTimings {
     var disconnectMs: Long? = null
     // Post-classified op label, set after the SDK call resolves spark-vs-LN.
     var opOverride: String? = null
+    // Populated by the /send handler after the SDK returns.
+    var paymentId: String? = null
 }
 
 // --- reserved user-ids (funding pipeline) ---------------------------------

--- a/crates/breez-sdk/breez-bench/kotlin/src/main/kotlin/Bench.kt
+++ b/crates/breez-sdk/breez-bench/kotlin/src/main/kotlin/Bench.kt
@@ -125,7 +125,7 @@ data class ServerRequestLogEntry(
     @SerialName("send_ms") val sendMs: Long? = null,
     @SerialName("disconnect_ms") val disconnectMs: Long? = null,
     // Populated only for successful sends; lets aggregate.py join slow
-    // requests against `send_payment_completed` tracing events to render
+    // requests against `send_payment` tracing events to render
     // the per-payment phase breakdown.
     @SerialName("payment_id") val paymentId: String? = null,
 )

--- a/crates/breez-sdk/breez-bench/kotlin/src/main/kotlin/Server.kt
+++ b/crates/breez-sdk/breez-bench/kotlin/src/main/kotlin/Server.kt
@@ -33,18 +33,25 @@ import kotlinx.serialization.json.Json
 
 // --- HTTP request/response shapes -----------------------------------------
 
-// Preset filter for `--bench-trace`. Two targets:
-//   - `spark::tree::service=trace`        — payment-time leaf swaps
+// Preset filter for `--bench-trace`. Targets:
+//   - `spark::tree::service=trace`           — payment-time leaf swaps
 //     (the "Swapped leaves to match target amount" log line)
-//   - `breez_sdk_core::send_phases=info`  — `#[tracing::instrument]`
-//     spans on `send_payment` + every SSP / operator RPC method.
-//     `aggregate.py` reads these as FmtSpan::CLOSE events to render
-//     the per-RPC slow-payment breakdown.
+//   - `breez_sdk_core::send_payment=info`    — top-level `send_payment`
+//     span; carries `payment_id` field.
+//   - `spark::operator_rpc=info`             — every operator-RPC span
+//     (carries `operator_id`).
+//   - `spark::ssp=info`                      — every SSP-method span.
+// The three info-level targets are SDK span-trace targets — they only
+// produce close-event lines when the SDK is built with the `span-trace`
+// cargo feature (off by default, on for bench builds). `aggregate.py`
+// reads the close events to render the per-RPC slow-payment breakdown.
 // Trailing `error` keeps every other module at error-level so the file
 // surfaces real failures without unbounded growth at high RPS.
 private const val BENCH_TRACE_FILTER =
     "spark::tree::service=trace," +
-    "breez_sdk_core::send_phases=info," +
+    "breez_sdk_core::send_payment=info," +
+    "spark::operator_rpc=info," +
+    "spark::ssp=info," +
     "error"
 
 @Serializable
@@ -84,16 +91,15 @@ fun runServer(opts: Map<String, String>) {
     // Tracing wiring. Three states:
     //   1. --bench-trace defaults to true → preset filter that turns on
     //      leaves-swap detection + per-RPC close-event spans (consumed
-    //      by aggregate.py). The narrow filter keeps the trace log
-    //      small under load; the SDK's prod-safe init_logging
-    //      additionally silences the bench target on every layer
-    //      except the dedicated bench layer, so this is opt-in for
-    //      the *bench* but provably off for integrators.
+    //      by aggregate.py). Close-event capture requires the SDK to be
+    //      built with the `span-trace` cargo feature — prod builds (no
+    //      feature) contain none of that code, so these targets are
+    //      structurally inaccessible to integrators.
     //   2. --bench-trace=false           → no SDK tracing (zero overhead;
     //      use to A/B against (1) when measuring instrumentation cost).
     //   3. --log-filter=<spec>           → explicit override, user takes
-    //      full control (must include the bench targets themselves if
-    //      they want aggregate.py to pick up swap/phase data).
+    //      full control (must include the span-trace targets themselves
+    //      if they want aggregate.py to pick up swap/phase data).
     val explicitFilter = opts["log-filter"]
     val benchTrace = opts["bench-trace"]?.equals("true", ignoreCase = true) ?: true
     val effectiveFilter = when {

--- a/crates/breez-sdk/breez-bench/kotlin/src/main/kotlin/Server.kt
+++ b/crates/breez-sdk/breez-bench/kotlin/src/main/kotlin/Server.kt
@@ -172,7 +172,6 @@ fun runServer(opts: Map<String, String>) {
                         // it as `payment_id` on the bench send_payment span
                         // before any child RPC span closes. Lets aggregate.py
                         // correlate per-RPC close events back to this send.
-                        // Token sends reject idempotency_key (no-op there).
                         val idempotencyKey = UUID.randomUUID().toString()
                         t.paymentId = idempotencyKey
                         val tSendNs = System.nanoTime()

--- a/crates/breez-sdk/breez-bench/kotlin/src/main/kotlin/Server.kt
+++ b/crates/breez-sdk/breez-bench/kotlin/src/main/kotlin/Server.kt
@@ -25,6 +25,7 @@ import io.ktor.server.routing.routing
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.UUID
 
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
@@ -167,12 +168,26 @@ fun runServer(opts: Map<String, String>) {
                             }
                             else -> null
                         }
+                        // Pre-supply the idempotency key so the SDK records
+                        // it as `payment_id` on the bench send_payment span
+                        // before any child RPC span closes. Lets aggregate.py
+                        // correlate per-RPC close events back to this send.
+                        // Token sends reject idempotency_key (no-op there).
+                        val idempotencyKey = UUID.randomUUID().toString()
+                        t.paymentId = idempotencyKey
                         val tSendNs = System.nanoTime()
                         val sendResp = sdk.sendPayment(
-                            SendPaymentRequest(prepareResponse = prepared, options = sendOptions)
+                            SendPaymentRequest(
+                                prepareResponse = prepared,
+                                options = sendOptions,
+                                idempotencyKey = idempotencyKey,
+                            )
                         )
                         t.sendMs = (System.nanoTime() - tSendNs) / 1_000_000
-                        t.paymentId = sendResp.payment.id
+                        // sendResp.payment.id == idempotencyKey for the paths
+                        // exercised here (LN + spark transfer); reuse the
+                        // SDK-returned value rather than the local for the
+                        // wire response in case the SDK ever normalizes.
                         SendResult(
                             paymentId = sendResp.payment.id,
                             feeSats = feeOf(prepared.paymentMethod),

--- a/crates/breez-sdk/breez-bench/kotlin/src/main/kotlin/Server.kt
+++ b/crates/breez-sdk/breez-bench/kotlin/src/main/kotlin/Server.kt
@@ -32,6 +32,20 @@ import kotlinx.serialization.json.Json
 
 // --- HTTP request/response shapes -----------------------------------------
 
+// Preset filter for `--bench-trace`. Two targets:
+//   - `spark::tree::service=trace`        — payment-time leaf swaps
+//     (the "Swapped leaves to match target amount" log line)
+//   - `breez_sdk_core::send_phases=info`  — `#[tracing::instrument]`
+//     spans on `send_payment` + every SSP / operator RPC method.
+//     `aggregate.py` reads these as FmtSpan::CLOSE events to render
+//     the per-RPC slow-payment breakdown.
+// Trailing `error` keeps every other module at error-level so the file
+// surfaces real failures without unbounded growth at high RPS.
+private const val BENCH_TRACE_FILTER =
+    "spark::tree::service=trace," +
+    "breez_sdk_core::send_phases=info," +
+    "error"
+
 @Serializable
 data class InfoResponse(val balanceSats: Long)
 
@@ -66,11 +80,31 @@ fun runServer(opts: Map<String, String>) {
     val runId = opts["run-id"] ?: defaultRunId()
     val outDir = Path.of(opts["out-dir"] ?: "out/$runId").also { Files.createDirectories(it) }
 
-    opts["log-filter"]?.let { logFilter ->
+    // Tracing wiring. Three states:
+    //   1. --bench-trace defaults to true → preset filter that turns on
+    //      leaves-swap detection + per-RPC close-event spans (consumed
+    //      by aggregate.py). The narrow filter keeps the trace log
+    //      small under load; the SDK's prod-safe init_logging
+    //      additionally silences the bench target on every layer
+    //      except the dedicated bench layer, so this is opt-in for
+    //      the *bench* but provably off for integrators.
+    //   2. --bench-trace=false           → no SDK tracing (zero overhead;
+    //      use to A/B against (1) when measuring instrumentation cost).
+    //   3. --log-filter=<spec>           → explicit override, user takes
+    //      full control (must include the bench targets themselves if
+    //      they want aggregate.py to pick up swap/phase data).
+    val explicitFilter = opts["log-filter"]
+    val benchTrace = opts["bench-trace"]?.equals("true", ignoreCase = true) ?: true
+    val effectiveFilter = when {
+        explicitFilter != null -> explicitFilter
+        benchTrace -> BENCH_TRACE_FILTER
+        else -> null
+    }
+    if (effectiveFilter != null) {
         val logDir = opts["log-dir"] ?: outDir.resolve(".trace-logs").toString()
         Files.createDirectories(Path.of(logDir))
-        println("[server] init_logging dir=$logDir filter=$logFilter")
-        initLogging(logDir, null, logFilter)
+        println("[server] init_logging dir=$logDir filter=$effectiveFilter")
+        initLogging(logDir, null, effectiveFilter)
     }
 
     val handlers = runBlocking { SharedHandlers.create(mysqlUrl) }
@@ -138,6 +172,7 @@ fun runServer(opts: Map<String, String>) {
                             SendPaymentRequest(prepareResponse = prepared, options = sendOptions)
                         )
                         t.sendMs = (System.nanoTime() - tSendNs) / 1_000_000
+                        t.paymentId = sendResp.payment.id
                         SendResult(
                             paymentId = sendResp.payment.id,
                             feeSats = feeOf(prepared.paymentMethod),
@@ -236,6 +271,7 @@ private suspend inline fun <reified T : Any> handleAndLog(
                 prepareMs = timings.prepareMs,
                 sendMs = timings.sendMs,
                 disconnectMs = timings.disconnectMs,
+                paymentId = timings.paymentId,
             )
         )
     }

--- a/crates/breez-sdk/core/Cargo.toml
+++ b/crates/breez-sdk/core/Cargo.toml
@@ -17,6 +17,12 @@ postgres = [
 mysql = [
     "dep:spark-mysql",
 ]
+# Bench-only: installs an extra tracing layer in `init_logging` that
+# captures span CLOSE events for the instrumented `send_payment`,
+# `spark::operator_rpc`, and `spark::ssp` targets. Off by default — prod
+# binaries built without this feature contain none of the bench-layer
+# setup code.
+span-trace = []
 
 [lib]
 crate-type = ["staticlib", "cdylib", "lib"]

--- a/crates/breez-sdk/core/src/logger.rs
+++ b/crates/breez-sdk/core/src/logger.rs
@@ -9,6 +9,19 @@ use tracing_subscriber::{
 
 use crate::{LogEntry, Logger, SdkError};
 
+/// Tracing target reserved for the bench harness's span instrumentation
+/// (operator-RPC + SSP-RPC `#[tracing::instrument]` attributes). The
+/// per-target `=off` directive appended below silences these spans on
+/// every layer except the dedicated bench layer — so an SDK integrator
+/// running at `debug` does NOT get close-event noise in their log file
+/// or their `app_logger` callback. The bench layer is added only when
+/// the caller's filter explicitly re-enables this target at a non-`off`
+/// level (i.e. the bench server's `--bench-trace` preset).
+const BENCH_SPAN_TARGET: &str = "breez_sdk_core::send_phases";
+
+const DEFAULT_FILTER: &str = "debug,h2=warn,rustls=warn,rustyline=warn,hyper=warn,hyper_util=warn,\
+     tower=warn,Connection=warn,tonic=warn";
+
 pub(crate) struct GlobalSdkLogger {
     /// Optional external log listener, that can receive a stream of log statements
     pub(crate) log_listener: Option<Box<dyn Logger>>,
@@ -38,38 +51,310 @@ where
     }
 }
 
+/// Returns true if `filter` contains a directive enabling the bench
+/// span target at any non-`off` level. Used to decide whether to add
+/// the dedicated bench-span layer in `init_logging`.
+fn bench_span_layer_requested(filter: &str) -> bool {
+    for part in filter.split(',') {
+        let Some((target, level)) = part.split_once('=') else {
+            continue;
+        };
+        if target.trim() == BENCH_SPAN_TARGET && !level.trim().eq_ignore_ascii_case("off") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Builds the filter applied to every "safe" layer (app-logger callback +
+/// main file layer). Always forces `BENCH_SPAN_TARGET=off` regardless of
+/// what the caller supplied — `EnvFilter`'s specificity resolution makes
+/// the per-target directive override any global level, so an integrator
+/// at `debug` cannot accidentally pick up bench-instrumentation spans.
+fn safe_filter(user_filter: &str) -> EnvFilter {
+    EnvFilter::new(format!("{user_filter},{BENCH_SPAN_TARGET}=off"))
+}
+
 pub(super) fn init_logging(
-    log_dir: Option<String>,
+    log_dir: Option<&str>,
     app_logger: Option<Box<dyn Logger>>,
-    log_filter: Option<String>,
+    log_filter: Option<&str>,
 ) -> Result<(), SdkError> {
-    let filter = log_filter.unwrap_or(
-        "debug,h2=warn,rustls=warn,rustyline=warn,hyper=warn,hyper_util=warn,tower=warn,Connection=warn,tonic=warn".to_string(),
-    );
+    let user_filter = log_filter.unwrap_or(DEFAULT_FILTER);
+    let bench_layer_enabled = bench_span_layer_requested(user_filter);
 
-    let registry = tracing_subscriber::registry()
-        .with(EnvFilter::new(filter))
-        .with(GlobalSdkLogger {
-            log_listener: app_logger,
-        });
+    // Build the layer stack. Every layer carries its own filter
+    // (per-layer filters are the canonical pattern in tracing-subscriber
+    // when different layers need different visibility) so the bench
+    // target is provably silenced on the app-logger callback and main
+    // file writer while still being available to the dedicated bench
+    // layer when explicitly requested.
+    let app_logger_layer = GlobalSdkLogger {
+        log_listener: app_logger,
+    }
+    .with_filter(safe_filter(user_filter));
 
-    if let Some(log_dir) = log_dir {
+    let main_fmt_layer = if let Some(dir) = log_dir {
         let log_file = OpenOptions::new()
             .create(true)
             .append(true)
-            .open(format!("{log_dir}/sdk.log"))
+            .open(format!("{dir}/sdk.log"))
             .map_err(|e| SdkError::Generic(e.to_string()))?;
-        registry
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .with_ansi(false)
-                    .with_line_number(true)
-                    .with_writer(log_file),
-            )
-            .try_init()?;
+        Some(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_line_number(true)
+                .with_writer(log_file)
+                .with_filter(safe_filter(user_filter)),
+        )
     } else {
-        registry.try_init()?;
-    }
+        None
+    };
+
+    // Dedicated bench layer: only the bench span target, with span
+    // CLOSE events synthesized. The fmt layer's CLOSE event carries
+    // `time.busy` / `time.idle`, giving us per-RPC elapsed time for
+    // free — every `#[tracing::instrument]`-decorated SSP / operator
+    // method emits one line at span close, with the full parent-span
+    // hierarchy (e.g. `send_payment{payment_id=...}:request_lightning_send`).
+    let bench_layer = if bench_layer_enabled {
+        let dir = log_dir.ok_or_else(|| {
+            SdkError::Generic(
+                "bench-span tracing was requested but no log_dir was provided to init_logging"
+                    .to_string(),
+            )
+        })?;
+        let bench_file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(format!("{dir}/sdk.log"))
+            .map_err(|e| SdkError::Generic(e.to_string()))?;
+        // Restrict to the bench target. The `off` floor for everything
+        // else keeps unrelated spans (e.g. swap-detection `trace`
+        // events under spark::tree::service) from being CLOSE-rendered
+        // on this layer — they still hit the main layer as regular log
+        // lines.
+        let filter = EnvFilter::new(format!("off,{BENCH_SPAN_TARGET}=info"));
+        Some(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_line_number(false)
+                .with_writer(bench_file)
+                .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+                .with_filter(filter),
+        )
+    } else {
+        None
+    };
+
+    tracing_subscriber::registry()
+        .with(app_logger_layer)
+        .with(main_fmt_layer)
+        .with(bench_layer)
+        .try_init()?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bench_layer_detected_only_when_target_enabled() {
+        // Default filter: no mention of the bench target.
+        assert!(!bench_span_layer_requested(DEFAULT_FILTER));
+        // Plain global levels — should not light up the bench layer.
+        assert!(!bench_span_layer_requested("debug"));
+        assert!(!bench_span_layer_requested("trace"));
+        // Caller silenced the bench target explicitly — still false.
+        assert!(!bench_span_layer_requested(
+            "debug,breez_sdk_core::send_phases=off",
+        ));
+        // Bench preset — true.
+        assert!(bench_span_layer_requested(
+            "spark::tree::service=trace,breez_sdk_core::send_phases=info,error",
+        ));
+        // Case-insensitive on the `off` check.
+        assert!(!bench_span_layer_requested(
+            "debug,breez_sdk_core::send_phases=OFF",
+        ));
+    }
+
+    /// Prod-safety: at `debug` (the recommended integrator level), an
+    /// info-level span on the bench target must be silenced on the
+    /// `app_logger` forwarder. This is the layer that bridges Rust
+    /// tracing into integrator log callbacks, so it's the highest-risk
+    /// surface for accidental leakage.
+    /// Capture-only logger used by the debug-integrator prod-safety
+    /// test below. Records every `LogEntry` so the test can assert
+    /// which targets reached the integrator-side callback.
+    #[derive(Default)]
+    struct CaptureLogger {
+        entries: std::sync::Mutex<Vec<LogEntry>>,
+    }
+
+    impl Logger for CaptureLogger {
+        fn log(&self, l: LogEntry) {
+            self.entries.lock().unwrap().push(l);
+        }
+    }
+
+    /// Forwarding shim so the boxed `dyn Logger` and the `Arc<CaptureLogger>`
+    /// in the test share the same capture state.
+    struct ForwardingLogger(std::sync::Arc<CaptureLogger>);
+
+    impl Logger for ForwardingLogger {
+        fn log(&self, l: LogEntry) {
+            self.0.log(l);
+        }
+    }
+
+    /// Confirms the close-event format produced when the bench layer
+    /// is active. This is the format `aggregate.py` will parse, so we
+    /// pin it here — any future tracing-subscriber upgrade that
+    /// changes the line layout would break the bench report and
+    /// surface here first.
+    #[test]
+    fn bench_layer_emits_close_events_with_span_hierarchy() {
+        use std::io::Write;
+        use std::sync::Mutex;
+        use tracing_subscriber::fmt::format::FmtSpan;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        // In-memory writer so we can assert on the produced output
+        // without touching the filesystem.
+        #[derive(Clone, Default)]
+        struct BufWriter(std::sync::Arc<Mutex<Vec<u8>>>);
+
+        impl Write for BufWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufWriter {
+            type Writer = BufWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let buf = BufWriter::default();
+        let buf_for_assert = buf.0.clone();
+
+        // Same layer config init_logging builds in bench mode, minus
+        // the file open + global init.
+        let filter = EnvFilter::new(format!("off,{BENCH_SPAN_TARGET}=info"));
+        let layer = tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_writer(buf)
+            .with_span_events(FmtSpan::CLOSE)
+            .with_filter(filter);
+
+        let sub = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(sub, || {
+            // Outer span (mirrors what a top-level `send_payment`
+            // instrument would produce) with a recorded field.
+            let outer = tracing::info_span!(
+                target: "breez_sdk_core::send_phases",
+                "send_payment",
+                payment_id = "pid-abc",
+            );
+            let _o = outer.enter();
+            // Inner span (mirrors an SSP / operator RPC). On close it
+            // should render the parent hierarchy so aggregate.py can
+            // join the RPC timing back to the payment.
+            let inner = tracing::info_span!(
+                target: "breez_sdk_core::send_phases",
+                "request_lightning_send",
+                operator_id = "so-3",
+            );
+            let _i = inner.enter();
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        });
+
+        let out = String::from_utf8(buf_for_assert.lock().unwrap().clone()).unwrap();
+        // We expect at least two close lines (inner first, then outer).
+        let close_lines: Vec<&str> = out.lines().filter(|l| l.contains("close")).collect();
+        assert!(
+            close_lines.len() >= 2,
+            "expected ≥2 close events, got: {out}",
+        );
+        // The inner span's close line must carry the parent payment_id
+        // (via the span hierarchy) and the inner operator_id.
+        let inner_close = close_lines
+            .iter()
+            .find(|l| l.contains("request_lightning_send"))
+            .unwrap_or_else(|| panic!("no inner close line in: {out}"));
+        assert!(
+            inner_close.contains("payment_id"),
+            "inner close missing parent payment_id: {inner_close}",
+        );
+        assert!(
+            inner_close.contains("operator_id"),
+            "inner close missing operator_id: {inner_close}",
+        );
+        // `time.busy` is the elapsed entered-time; presence is the
+        // signal `aggregate.py` will key on.
+        assert!(
+            inner_close.contains("time.busy"),
+            "inner close missing time.busy: {inner_close}",
+        );
+    }
+
+    #[test]
+    fn debug_level_integrator_does_not_see_bench_spans() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let captured = std::sync::Arc::new(CaptureLogger::default());
+
+        // Mirror what an integrator at `debug` would set up. Build the
+        // same layer stack `init_logging` constructs, but don't call
+        // `try_init` (would conflict with other tests in the same
+        // process). Test the layer behaviour directly.
+        let user_filter = DEFAULT_FILTER;
+        let app_logger: Box<dyn Logger> = Box::new(ForwardingLogger(captured.clone()));
+        let layer = GlobalSdkLogger {
+            log_listener: Some(app_logger),
+        }
+        .with_filter(safe_filter(user_filter));
+
+        let sub = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(sub, || {
+            // Regular info event on a non-bench target — should pass.
+            tracing::info!(target: "breez_sdk_core", "regular log");
+            // Info event on the bench target — must be silenced.
+            tracing::info!(
+                target: "breez_sdk_core::send_phases",
+                payment_id = "p1",
+                "should not appear",
+            );
+            // A bench-target span entering/closing — also silenced.
+            let s = tracing::info_span!(
+                target: "breez_sdk_core::send_phases",
+                "bench_span",
+                payment_id = "p2",
+            );
+            let _g = s.enter();
+        });
+
+        let entries = captured.entries.lock().unwrap();
+        let lines: Vec<&str> = entries.iter().map(|e| e.line.as_str()).collect();
+        assert!(
+            lines.iter().any(|l| l.contains("regular log")),
+            "regular log was unexpectedly filtered out: {lines:?}",
+        );
+        assert!(
+            lines.iter().all(|l| !l.contains("should not appear")
+                && !l.contains("bench_span")
+                && !l.contains("p1")
+                && !l.contains("p2")),
+            "bench-target events leaked into app logger: {lines:?}",
+        );
+    }
 }

--- a/crates/breez-sdk/core/src/logger.rs
+++ b/crates/breez-sdk/core/src/logger.rs
@@ -9,16 +9,6 @@ use tracing_subscriber::{
 
 use crate::{LogEntry, Logger, SdkError};
 
-/// Tracing target reserved for the bench harness's span instrumentation
-/// (operator-RPC + SSP-RPC `#[tracing::instrument]` attributes). The
-/// per-target `=off` directive appended below silences these spans on
-/// every layer except the dedicated bench layer — so an SDK integrator
-/// running at `debug` does NOT get close-event noise in their log file
-/// or their `app_logger` callback. The bench layer is added only when
-/// the caller's filter explicitly re-enables this target at a non-`off`
-/// level (i.e. the bench server's `--bench-trace` preset).
-const BENCH_SPAN_TARGET: &str = "breez_sdk_core::send_phases";
-
 const DEFAULT_FILTER: &str = "debug,h2=warn,rustls=warn,rustyline=warn,hyper=warn,hyper_util=warn,\
      tower=warn,Connection=warn,tonic=warn";
 
@@ -51,310 +41,39 @@ where
     }
 }
 
-/// Returns true if `filter` contains a directive enabling the bench
-/// span target at any non-`off` level. Used to decide whether to add
-/// the dedicated bench-span layer in `init_logging`.
-fn bench_span_layer_requested(filter: &str) -> bool {
-    for part in filter.split(',') {
-        let Some((target, level)) = part.split_once('=') else {
-            continue;
-        };
-        if target.trim() == BENCH_SPAN_TARGET && !level.trim().eq_ignore_ascii_case("off") {
-            return true;
-        }
-    }
-    false
-}
-
-/// Builds the filter applied to every "safe" layer (app-logger callback +
-/// main file layer). Always forces `BENCH_SPAN_TARGET=off` regardless of
-/// what the caller supplied — `EnvFilter`'s specificity resolution makes
-/// the per-target directive override any global level, so an integrator
-/// at `debug` cannot accidentally pick up bench-instrumentation spans.
-fn safe_filter(user_filter: &str) -> EnvFilter {
-    EnvFilter::new(format!("{user_filter},{BENCH_SPAN_TARGET}=off"))
-}
-
 pub(super) fn init_logging(
     log_dir: Option<&str>,
     app_logger: Option<Box<dyn Logger>>,
     log_filter: Option<&str>,
 ) -> Result<(), SdkError> {
-    let user_filter = log_filter.unwrap_or(DEFAULT_FILTER);
-    let bench_layer_enabled = bench_span_layer_requested(user_filter);
+    let filter = log_filter.unwrap_or(DEFAULT_FILTER);
 
-    // Build the layer stack. Every layer carries its own filter
-    // (per-layer filters are the canonical pattern in tracing-subscriber
-    // when different layers need different visibility) so the bench
-    // target is provably silenced on the app-logger callback and main
-    // file writer while still being available to the dedicated bench
-    // layer when explicitly requested.
-    let app_logger_layer = GlobalSdkLogger {
-        log_listener: app_logger,
-    }
-    .with_filter(safe_filter(user_filter));
+    let registry = tracing_subscriber::registry()
+        .with(EnvFilter::new(filter))
+        .with(GlobalSdkLogger {
+            log_listener: app_logger,
+        });
 
-    let main_fmt_layer = if let Some(dir) = log_dir {
+    if let Some(log_dir) = log_dir {
         let log_file = OpenOptions::new()
             .create(true)
             .append(true)
-            .open(format!("{dir}/sdk.log"))
+            .open(format!("{log_dir}/sdk.log"))
             .map_err(|e| SdkError::Generic(e.to_string()))?;
-        Some(
-            tracing_subscriber::fmt::layer()
-                .with_ansi(false)
-                .with_line_number(true)
-                .with_writer(log_file)
-                .with_filter(safe_filter(user_filter)),
-        )
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_line_number(true)
+            .with_writer(log_file);
+        // Bench-only: render span CLOSE lines (`time.busy` / `time.idle`)
+        // so the breez-bench aggregator can attribute per-RPC latency.
+        // The user's filter (`spark::operator_rpc=info`, etc.) controls
+        // which spans actually emit.
+        #[cfg(feature = "span-trace")]
+        let fmt_layer = fmt_layer.with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE);
+        registry.with(fmt_layer).try_init()?;
     } else {
-        None
-    };
-
-    // Dedicated bench layer: only the bench span target, with span
-    // CLOSE events synthesized. The fmt layer's CLOSE event carries
-    // `time.busy` / `time.idle`, giving us per-RPC elapsed time for
-    // free — every `#[tracing::instrument]`-decorated SSP / operator
-    // method emits one line at span close, with the full parent-span
-    // hierarchy (e.g. `send_payment{payment_id=...}:request_lightning_send`).
-    let bench_layer = if bench_layer_enabled {
-        let dir = log_dir.ok_or_else(|| {
-            SdkError::Generic(
-                "bench-span tracing was requested but no log_dir was provided to init_logging"
-                    .to_string(),
-            )
-        })?;
-        let bench_file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(format!("{dir}/sdk.log"))
-            .map_err(|e| SdkError::Generic(e.to_string()))?;
-        // Restrict to the bench target. The `off` floor for everything
-        // else keeps unrelated spans (e.g. swap-detection `trace`
-        // events under spark::tree::service) from being CLOSE-rendered
-        // on this layer — they still hit the main layer as regular log
-        // lines.
-        let filter = EnvFilter::new(format!("off,{BENCH_SPAN_TARGET}=info"));
-        Some(
-            tracing_subscriber::fmt::layer()
-                .with_ansi(false)
-                .with_line_number(false)
-                .with_writer(bench_file)
-                .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
-                .with_filter(filter),
-        )
-    } else {
-        None
-    };
-
-    tracing_subscriber::registry()
-        .with(app_logger_layer)
-        .with(main_fmt_layer)
-        .with(bench_layer)
-        .try_init()?;
+        registry.try_init()?;
+    }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn bench_layer_detected_only_when_target_enabled() {
-        // Default filter: no mention of the bench target.
-        assert!(!bench_span_layer_requested(DEFAULT_FILTER));
-        // Plain global levels — should not light up the bench layer.
-        assert!(!bench_span_layer_requested("debug"));
-        assert!(!bench_span_layer_requested("trace"));
-        // Caller silenced the bench target explicitly — still false.
-        assert!(!bench_span_layer_requested(
-            "debug,breez_sdk_core::send_phases=off",
-        ));
-        // Bench preset — true.
-        assert!(bench_span_layer_requested(
-            "spark::tree::service=trace,breez_sdk_core::send_phases=info,error",
-        ));
-        // Case-insensitive on the `off` check.
-        assert!(!bench_span_layer_requested(
-            "debug,breez_sdk_core::send_phases=OFF",
-        ));
-    }
-
-    /// Prod-safety: at `debug` (the recommended integrator level), an
-    /// info-level span on the bench target must be silenced on the
-    /// `app_logger` forwarder. This is the layer that bridges Rust
-    /// tracing into integrator log callbacks, so it's the highest-risk
-    /// surface for accidental leakage.
-    /// Capture-only logger used by the debug-integrator prod-safety
-    /// test below. Records every `LogEntry` so the test can assert
-    /// which targets reached the integrator-side callback.
-    #[derive(Default)]
-    struct CaptureLogger {
-        entries: std::sync::Mutex<Vec<LogEntry>>,
-    }
-
-    impl Logger for CaptureLogger {
-        fn log(&self, l: LogEntry) {
-            self.entries.lock().unwrap().push(l);
-        }
-    }
-
-    /// Forwarding shim so the boxed `dyn Logger` and the `Arc<CaptureLogger>`
-    /// in the test share the same capture state.
-    struct ForwardingLogger(std::sync::Arc<CaptureLogger>);
-
-    impl Logger for ForwardingLogger {
-        fn log(&self, l: LogEntry) {
-            self.0.log(l);
-        }
-    }
-
-    /// Confirms the close-event format produced when the bench layer
-    /// is active. This is the format `aggregate.py` will parse, so we
-    /// pin it here — any future tracing-subscriber upgrade that
-    /// changes the line layout would break the bench report and
-    /// surface here first.
-    #[test]
-    fn bench_layer_emits_close_events_with_span_hierarchy() {
-        use std::io::Write;
-        use std::sync::Mutex;
-        use tracing_subscriber::fmt::format::FmtSpan;
-        use tracing_subscriber::layer::SubscriberExt;
-
-        // In-memory writer so we can assert on the produced output
-        // without touching the filesystem.
-        #[derive(Clone, Default)]
-        struct BufWriter(std::sync::Arc<Mutex<Vec<u8>>>);
-
-        impl Write for BufWriter {
-            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                self.0.lock().unwrap().extend_from_slice(buf);
-                Ok(buf.len())
-            }
-            fn flush(&mut self) -> std::io::Result<()> {
-                Ok(())
-            }
-        }
-
-        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufWriter {
-            type Writer = BufWriter;
-            fn make_writer(&'a self) -> Self::Writer {
-                self.clone()
-            }
-        }
-
-        let buf = BufWriter::default();
-        let buf_for_assert = buf.0.clone();
-
-        // Same layer config init_logging builds in bench mode, minus
-        // the file open + global init.
-        let filter = EnvFilter::new(format!("off,{BENCH_SPAN_TARGET}=info"));
-        let layer = tracing_subscriber::fmt::layer()
-            .with_ansi(false)
-            .with_writer(buf)
-            .with_span_events(FmtSpan::CLOSE)
-            .with_filter(filter);
-
-        let sub = tracing_subscriber::registry().with(layer);
-        tracing::subscriber::with_default(sub, || {
-            // Outer span (mirrors what a top-level `send_payment`
-            // instrument would produce) with a recorded field.
-            let outer = tracing::info_span!(
-                target: "breez_sdk_core::send_phases",
-                "send_payment",
-                payment_id = "pid-abc",
-            );
-            let _o = outer.enter();
-            // Inner span (mirrors an SSP / operator RPC). On close it
-            // should render the parent hierarchy so aggregate.py can
-            // join the RPC timing back to the payment.
-            let inner = tracing::info_span!(
-                target: "breez_sdk_core::send_phases",
-                "request_lightning_send",
-                operator_id = "so-3",
-            );
-            let _i = inner.enter();
-            std::thread::sleep(std::time::Duration::from_millis(2));
-        });
-
-        let out = String::from_utf8(buf_for_assert.lock().unwrap().clone()).unwrap();
-        // We expect at least two close lines (inner first, then outer).
-        let close_lines: Vec<&str> = out.lines().filter(|l| l.contains("close")).collect();
-        assert!(
-            close_lines.len() >= 2,
-            "expected ≥2 close events, got: {out}",
-        );
-        // The inner span's close line must carry the parent payment_id
-        // (via the span hierarchy) and the inner operator_id.
-        let inner_close = close_lines
-            .iter()
-            .find(|l| l.contains("request_lightning_send"))
-            .unwrap_or_else(|| panic!("no inner close line in: {out}"));
-        assert!(
-            inner_close.contains("payment_id"),
-            "inner close missing parent payment_id: {inner_close}",
-        );
-        assert!(
-            inner_close.contains("operator_id"),
-            "inner close missing operator_id: {inner_close}",
-        );
-        // `time.busy` is the elapsed entered-time; presence is the
-        // signal `aggregate.py` will key on.
-        assert!(
-            inner_close.contains("time.busy"),
-            "inner close missing time.busy: {inner_close}",
-        );
-    }
-
-    #[test]
-    fn debug_level_integrator_does_not_see_bench_spans() {
-        use tracing_subscriber::layer::SubscriberExt;
-
-        let captured = std::sync::Arc::new(CaptureLogger::default());
-
-        // Mirror what an integrator at `debug` would set up. Build the
-        // same layer stack `init_logging` constructs, but don't call
-        // `try_init` (would conflict with other tests in the same
-        // process). Test the layer behaviour directly.
-        let user_filter = DEFAULT_FILTER;
-        let app_logger: Box<dyn Logger> = Box::new(ForwardingLogger(captured.clone()));
-        let layer = GlobalSdkLogger {
-            log_listener: Some(app_logger),
-        }
-        .with_filter(safe_filter(user_filter));
-
-        let sub = tracing_subscriber::registry().with(layer);
-        tracing::subscriber::with_default(sub, || {
-            // Regular info event on a non-bench target — should pass.
-            tracing::info!(target: "breez_sdk_core", "regular log");
-            // Info event on the bench target — must be silenced.
-            tracing::info!(
-                target: "breez_sdk_core::send_phases",
-                payment_id = "p1",
-                "should not appear",
-            );
-            // A bench-target span entering/closing — also silenced.
-            let s = tracing::info_span!(
-                target: "breez_sdk_core::send_phases",
-                "bench_span",
-                payment_id = "p2",
-            );
-            let _g = s.enter();
-        });
-
-        let entries = captured.entries.lock().unwrap();
-        let lines: Vec<&str> = entries.iter().map(|e| e.line.as_str()).collect();
-        assert!(
-            lines.iter().any(|l| l.contains("regular log")),
-            "regular log was unexpectedly filtered out: {lines:?}",
-        );
-        assert!(
-            lines.iter().all(|l| !l.contains("should not appear")
-                && !l.contains("bench_span")
-                && !l.contains("p1")
-                && !l.contains("p2")),
-            "bench-target events leaked into app logger: {lines:?}",
-        );
-    }
 }

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -128,9 +128,6 @@ pub async fn parse_input(
     .into())
 }
 
-// UniFFI requires owned `String` in the FFI surface; the internal
-// helper takes `&str` so it can be reused with non-owning callers
-// (and stays clippy-clean — every internal use is via borrow).
 #[allow(clippy::needless_pass_by_value)]
 #[cfg_attr(feature = "uniffi", uniffi::export)]
 pub fn init_logging(

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -128,13 +128,17 @@ pub async fn parse_input(
     .into())
 }
 
+// UniFFI requires owned `String` in the FFI surface; the internal
+// helper takes `&str` so it can be reused with non-owning callers
+// (and stays clippy-clean — every internal use is via borrow).
+#[allow(clippy::needless_pass_by_value)]
 #[cfg_attr(feature = "uniffi", uniffi::export)]
 pub fn init_logging(
     log_dir: Option<String>,
     app_logger: Option<Box<dyn Logger>>,
     log_filter: Option<String>,
 ) -> Result<(), SdkError> {
-    logger::init_logging(log_dir, app_logger, log_filter)
+    logger::init_logging(log_dir.as_deref(), app_logger, log_filter.as_deref())
 }
 
 /// Connects to the Spark network using the provided configuration and mnemonic.

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -417,7 +417,7 @@ impl BreezSdk {
 
     #[instrument(
         level = "info",
-        target = "breez_sdk_core::send_phases",
+        target = "breez_sdk_core::send_payment",
         skip_all,
         fields(payment_id = tracing::field::Empty),
     )]

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -9,7 +9,7 @@ use spark_wallet::{
 use spark_wallet::{InvoiceDescription, Preimage};
 use std::str::FromStr;
 use tokio::sync::oneshot;
-use tracing::{Instrument, debug, error, info, warn};
+use tracing::{Instrument, debug, error, info, instrument, warn};
 
 use crate::{
     BitcoinAddressDetails, Bolt11InvoiceDetails, ClaimHtlcPaymentRequest, ClaimHtlcPaymentResponse,
@@ -415,11 +415,35 @@ impl BreezSdk {
         }
     }
 
+    #[instrument(
+        level = "info",
+        target = "breez_sdk_core::send_phases",
+        skip_all,
+        fields(payment_id = tracing::field::Empty),
+    )]
     pub async fn send_payment(
         &self,
         request: SendPaymentRequest,
     ) -> Result<SendPaymentResponse, SdkError> {
         self.maybe_ensure_spark_private_mode_initialized().await?;
+        // Pre-generate the idempotency key (= transfer_id = payment.id
+        // for non-token paths) so it can be recorded on the current
+        // span BEFORE any child RPC spans fire. Without this, child
+        // close-events render with an empty parent payment_id since
+        // tracing's `record()` only updates the parent's field for
+        // events that close *after* the call site — every RPC inside
+        // the send chain closes before we'd otherwise know the id.
+        // Token payments reject idempotency keys (see check in
+        // `maybe_convert_token_send_payment`), so leave them alone;
+        // their phase events will simply lack `payment_id` correlation.
+        let mut request = request;
+        let is_token = request.prepare_response.token_identifier.is_some();
+        if !is_token && request.idempotency_key.is_none() {
+            request.idempotency_key = Some(uuid::Uuid::now_v7().to_string());
+        }
+        if let Some(key) = request.idempotency_key.as_deref() {
+            tracing::Span::current().record("payment_id", key);
+        }
         Box::pin(self.maybe_convert_token_send_payment(request, false, None)).await
     }
 

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -426,21 +426,6 @@ impl BreezSdk {
         request: SendPaymentRequest,
     ) -> Result<SendPaymentResponse, SdkError> {
         self.maybe_ensure_spark_private_mode_initialized().await?;
-        // Pre-generate the idempotency key (= transfer_id = payment.id
-        // for non-token paths) so it can be recorded on the current
-        // span BEFORE any child RPC spans fire. Without this, child
-        // close-events render with an empty parent payment_id since
-        // tracing's `record()` only updates the parent's field for
-        // events that close *after* the call site — every RPC inside
-        // the send chain closes before we'd otherwise know the id.
-        // Token payments reject idempotency keys (see check in
-        // `maybe_convert_token_send_payment`), so leave them alone;
-        // their phase events will simply lack `payment_id` correlation.
-        let mut request = request;
-        let is_token = request.prepare_response.token_identifier.is_some();
-        if !is_token && request.idempotency_key.is_none() {
-            request.idempotency_key = Some(uuid::Uuid::now_v7().to_string());
-        }
         if let Some(key) = request.idempotency_key.as_deref() {
             tracing::Span::current().record("payment_id", key);
         }

--- a/crates/spark/src/operator/pool.rs
+++ b/crates/spark/src/operator/pool.rs
@@ -125,7 +125,7 @@ impl OperatorPool {
                 ])),
                 None => auth_provider,
             };
-            let client = SparkRpcClient::new(transport, header_provider);
+            let client = SparkRpcClient::new(transport, header_provider, operator.id);
             operators.push(Operator {
                 client,
                 id: operator.id,

--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -44,9 +44,9 @@ pub struct SparkRpcClient {
     transport: Transport,
     header_provider: Arc<dyn HeaderProvider>,
     /// Operator index in the pool (0..N). Surfaced as a span field by
-    /// the per-method `#[instrument]` attributes so the bench's
-    /// `breez_sdk_core::send_phases` trace can attribute a slow RPC to
-    /// a specific operator (the "worst-of-5" signal).
+    /// the per-method `#[instrument]` attributes on the
+    /// `spark::operator_rpc` target, so a downstream subscriber can
+    /// attribute a slow RPC to a specific operator.
     operator_id: usize,
 }
 
@@ -63,7 +63,7 @@ impl SparkRpcClient {
         }
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn finalize_node_signatures_v2(
         &self,
         req: FinalizeNodeSignaturesRequest,
@@ -80,7 +80,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn generate_deposit_address(
         &self,
         req: GenerateDepositAddressRequest,
@@ -94,7 +94,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_unused_deposit_addresses(
         &self,
         req: QueryUnusedDepositAddressesRequest,
@@ -111,7 +111,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn start_deposit_tree_creation(
         &self,
         req: StartDepositTreeCreationRequest,
@@ -128,7 +128,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn start_transfer_v2(
         &self,
         req: StartTransferRequest,
@@ -142,7 +142,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn finalize_transfer_with_transfer_package(
         &self,
         req: FinalizeTransferWithTransferPackageRequest,
@@ -159,7 +159,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_pending_transfers(
         &self,
         req: TransferFilter,
@@ -173,7 +173,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_all_transfers(&self, req: TransferFilter) -> Result<QueryTransfersResponse> {
         debug!("Calling query_all_transfers with filter: {:?}", req);
         Ok(self
@@ -184,7 +184,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn claim_transfer_tweak_keys(
         &self,
         req: ClaimTransferTweakKeysRequest,
@@ -198,7 +198,7 @@ impl SparkRpcClient {
         Ok(())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn claim_transfer_sign_refunds_v2(
         &self,
         req: ClaimTransferSignRefundsRequest,
@@ -215,7 +215,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn store_preimage_share(&self, req: StorePreimageShareRequest) -> Result<()> {
         debug!("Calling store_preimage_share with request: {:?}", req);
         self.spark_service_client()
@@ -226,7 +226,7 @@ impl SparkRpcClient {
         Ok(())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn store_preimage_share_v2(&self, req: StorePreimageShareV2Request) -> Result<()> {
         debug!("Calling store_preimage_share_v2 with request: {:?}", req);
         self.spark_service_client()
@@ -237,7 +237,7 @@ impl SparkRpcClient {
         Ok(())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn get_signing_commitments(
         &self,
         req: GetSigningCommitmentsRequest,
@@ -251,7 +251,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn cooperative_exit_v2(
         &self,
         req: CooperativeExitRequest,
@@ -265,7 +265,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn initiate_preimage_swap_v3(
         &self,
         req: InitiatePreimageSwapRequest,
@@ -279,7 +279,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn provide_preimage(
         &self,
         req: ProvidePreimageRequest,
@@ -293,7 +293,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn start_leaf_swap_v2(
         &self,
         req: StartTransferRequest,
@@ -307,7 +307,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn initiate_swap_primary_transfer(
         &self,
         req: InitiateSwapPrimaryTransferRequest,
@@ -324,7 +324,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn renew_leaf(
         &self,
         req: RenewLeafRequest,
@@ -341,7 +341,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn get_signing_operator_list(&self) -> Result<GetSigningOperatorListResponse> {
         debug!("Calling get_signing_operator_list");
         Ok(self
@@ -352,7 +352,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_nodes(&self, req: QueryNodesRequest) -> Result<QueryNodesResponse> {
         debug!("Calling query_nodes with request: {:?}", req);
         Ok(self
@@ -367,7 +367,7 @@ impl SparkRpcClient {
     ///
     /// If `req.paging` is `Some`, returns a single page according to the filter.
     /// If `req.paging` is `None`, fetches all pages automatically.
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_nodes_paginated(
         &self,
         req: QueryNodesPaginatedRequest,
@@ -411,7 +411,7 @@ impl SparkRpcClient {
         })
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_balance(&self, req: QueryBalanceRequest) -> Result<QueryBalanceResponse> {
         debug!("Calling query_balance with request: {:?}", req);
         Ok(self
@@ -422,7 +422,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_user_signed_refunds(
         &self,
         req: QueryUserSignedRefundsRequest,
@@ -436,7 +436,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn freeze_tokens(
         &self,
         req: spark_token::FreezeTokensRequest,
@@ -450,7 +450,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_token_outputs(
         &self,
         req: spark_token::QueryTokenOutputsRequest,
@@ -465,7 +465,7 @@ impl SparkRpcClient {
     }
 
     /// Query all token outputs by automatically fetching all pages.
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_all_token_outputs(
         &self,
         req: QueryAllTokenOutputsRequest,
@@ -507,7 +507,7 @@ impl SparkRpcClient {
         Ok(all_items)
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_token_metadata(
         &self,
         req: spark_token::QueryTokenMetadataRequest,
@@ -521,7 +521,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_token_transactions(
         &self,
         req: spark_token::QueryTokenTransactionsRequest,
@@ -535,7 +535,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_spark_invoices(
         &self,
         req: QuerySparkInvoicesRequest,
@@ -549,7 +549,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_htlc(&self, req: QueryHtlcRequest) -> Result<QueryHtlcResponse> {
         debug!("Calling query_htlc with request: {:?}", req);
         Ok(self
@@ -560,7 +560,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn start_transaction(
         &self,
         req: StartTransactionRequest,
@@ -574,7 +574,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn commit_transaction(
         &self,
         req: CommitTransactionRequest,
@@ -588,7 +588,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn generate_static_deposit_address(
         &self,
         req: GenerateStaticDepositAddressRequest,
@@ -605,7 +605,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn rotate_static_deposit_address(
         &self,
         req: RotateStaticDepositAddressRequest,
@@ -622,7 +622,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_static_deposit_addresses(
         &self,
         req: QueryStaticDepositAddressesRequest,
@@ -639,7 +639,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn get_utxos_for_identity(
         &self,
         req: GetUtxosForIdentityRequest,
@@ -653,7 +653,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn initiate_static_deposit_utxo_refund(
         &self,
         req: InitiateStaticDepositUtxoRefundRequest,
@@ -670,7 +670,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn subscribe_to_events(
         &self,
         req: SubscribeToEventsRequest,
@@ -684,7 +684,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn update_wallet_setting(
         &self,
         req: UpdateWalletSettingRequest,
@@ -698,7 +698,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_wallet_setting(&self) -> Result<QueryWalletSettingResponse> {
         debug!("Calling query_wallet_setting");
         Ok(self

--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -21,7 +21,7 @@ use tonic::metadata::Ascii;
 use tonic::metadata::MetadataValue;
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
-use tracing::debug;
+use tracing::{debug, instrument};
 
 #[derive(Clone, Default)]
 pub struct QueryNodesPaginatedRequest {
@@ -43,16 +43,27 @@ pub struct QueryAllTokenOutputsRequest {
 pub struct SparkRpcClient {
     transport: Transport,
     header_provider: Arc<dyn HeaderProvider>,
+    /// Operator index in the pool (0..N). Surfaced as a span field by
+    /// the per-method `#[instrument]` attributes so the bench's
+    /// `breez_sdk_core::send_phases` trace can attribute a slow RPC to
+    /// a specific operator (the "worst-of-5" signal).
+    operator_id: usize,
 }
 
 impl SparkRpcClient {
-    pub fn new(channel: Transport, header_provider: Arc<dyn HeaderProvider>) -> Self {
+    pub fn new(
+        channel: Transport,
+        header_provider: Arc<dyn HeaderProvider>,
+        operator_id: usize,
+    ) -> Self {
         Self {
             transport: channel,
             header_provider,
+            operator_id,
         }
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn finalize_node_signatures_v2(
         &self,
         req: FinalizeNodeSignaturesRequest,
@@ -69,6 +80,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn generate_deposit_address(
         &self,
         req: GenerateDepositAddressRequest,
@@ -82,6 +94,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_unused_deposit_addresses(
         &self,
         req: QueryUnusedDepositAddressesRequest,
@@ -98,6 +111,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn start_deposit_tree_creation(
         &self,
         req: StartDepositTreeCreationRequest,
@@ -114,6 +128,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn start_transfer_v2(
         &self,
         req: StartTransferRequest,
@@ -127,6 +142,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn finalize_transfer_with_transfer_package(
         &self,
         req: FinalizeTransferWithTransferPackageRequest,
@@ -143,6 +159,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_pending_transfers(
         &self,
         req: TransferFilter,
@@ -156,6 +173,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_all_transfers(&self, req: TransferFilter) -> Result<QueryTransfersResponse> {
         debug!("Calling query_all_transfers with filter: {:?}", req);
         Ok(self
@@ -166,6 +184,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn claim_transfer_tweak_keys(
         &self,
         req: ClaimTransferTweakKeysRequest,
@@ -179,6 +198,7 @@ impl SparkRpcClient {
         Ok(())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn claim_transfer_sign_refunds_v2(
         &self,
         req: ClaimTransferSignRefundsRequest,
@@ -195,6 +215,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn store_preimage_share(&self, req: StorePreimageShareRequest) -> Result<()> {
         debug!("Calling store_preimage_share with request: {:?}", req);
         self.spark_service_client()
@@ -205,6 +226,7 @@ impl SparkRpcClient {
         Ok(())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn store_preimage_share_v2(&self, req: StorePreimageShareV2Request) -> Result<()> {
         debug!("Calling store_preimage_share_v2 with request: {:?}", req);
         self.spark_service_client()
@@ -215,6 +237,7 @@ impl SparkRpcClient {
         Ok(())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn get_signing_commitments(
         &self,
         req: GetSigningCommitmentsRequest,
@@ -228,6 +251,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn cooperative_exit_v2(
         &self,
         req: CooperativeExitRequest,
@@ -241,6 +265,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn initiate_preimage_swap_v3(
         &self,
         req: InitiatePreimageSwapRequest,
@@ -254,6 +279,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn provide_preimage(
         &self,
         req: ProvidePreimageRequest,
@@ -267,6 +293,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn start_leaf_swap_v2(
         &self,
         req: StartTransferRequest,
@@ -280,6 +307,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn initiate_swap_primary_transfer(
         &self,
         req: InitiateSwapPrimaryTransferRequest,
@@ -296,6 +324,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn renew_leaf(
         &self,
         req: RenewLeafRequest,
@@ -312,6 +341,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn get_signing_operator_list(&self) -> Result<GetSigningOperatorListResponse> {
         debug!("Calling get_signing_operator_list");
         Ok(self
@@ -322,6 +352,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_nodes(&self, req: QueryNodesRequest) -> Result<QueryNodesResponse> {
         debug!("Calling query_nodes with request: {:?}", req);
         Ok(self
@@ -336,6 +367,7 @@ impl SparkRpcClient {
     ///
     /// If `req.paging` is `Some`, returns a single page according to the filter.
     /// If `req.paging` is `None`, fetches all pages automatically.
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_nodes_paginated(
         &self,
         req: QueryNodesPaginatedRequest,
@@ -379,6 +411,7 @@ impl SparkRpcClient {
         })
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_balance(&self, req: QueryBalanceRequest) -> Result<QueryBalanceResponse> {
         debug!("Calling query_balance with request: {:?}", req);
         Ok(self
@@ -389,6 +422,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_user_signed_refunds(
         &self,
         req: QueryUserSignedRefundsRequest,
@@ -402,6 +436,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn freeze_tokens(
         &self,
         req: spark_token::FreezeTokensRequest,
@@ -415,6 +450,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_token_outputs(
         &self,
         req: spark_token::QueryTokenOutputsRequest,
@@ -429,6 +465,7 @@ impl SparkRpcClient {
     }
 
     /// Query all token outputs by automatically fetching all pages.
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_all_token_outputs(
         &self,
         req: QueryAllTokenOutputsRequest,
@@ -470,6 +507,7 @@ impl SparkRpcClient {
         Ok(all_items)
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_token_metadata(
         &self,
         req: spark_token::QueryTokenMetadataRequest,
@@ -483,6 +521,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_token_transactions(
         &self,
         req: spark_token::QueryTokenTransactionsRequest,
@@ -496,6 +535,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_spark_invoices(
         &self,
         req: QuerySparkInvoicesRequest,
@@ -509,6 +549,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_htlc(&self, req: QueryHtlcRequest) -> Result<QueryHtlcResponse> {
         debug!("Calling query_htlc with request: {:?}", req);
         Ok(self
@@ -519,6 +560,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn start_transaction(
         &self,
         req: StartTransactionRequest,
@@ -532,6 +574,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn commit_transaction(
         &self,
         req: CommitTransactionRequest,
@@ -545,6 +588,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn generate_static_deposit_address(
         &self,
         req: GenerateStaticDepositAddressRequest,
@@ -561,6 +605,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn rotate_static_deposit_address(
         &self,
         req: RotateStaticDepositAddressRequest,
@@ -577,6 +622,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_static_deposit_addresses(
         &self,
         req: QueryStaticDepositAddressesRequest,
@@ -593,6 +639,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn get_utxos_for_identity(
         &self,
         req: GetUtxosForIdentityRequest,
@@ -606,6 +653,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn initiate_static_deposit_utxo_refund(
         &self,
         req: InitiateStaticDepositUtxoRefundRequest,
@@ -622,6 +670,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn subscribe_to_events(
         &self,
         req: SubscribeToEventsRequest,
@@ -635,6 +684,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn update_wallet_setting(
         &self,
         req: UpdateWalletSettingRequest,
@@ -648,6 +698,7 @@ impl SparkRpcClient {
             .into_inner())
     }
 
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_wallet_setting(&self) -> Result<QueryWalletSettingResponse> {
         debug!("Calling query_wallet_setting");
         Ok(self

--- a/crates/spark/src/ssp/service_provider.rs
+++ b/crates/spark/src/ssp/service_provider.rs
@@ -101,7 +101,7 @@ impl ServiceProvider {
     }
 
     /// Get a swap fee estimate
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn get_swap_fee_estimate(
         &self,
         amount_sats: u64,
@@ -110,7 +110,7 @@ impl ServiceProvider {
     }
 
     /// Get a lightning send fee estimate
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn get_lightning_send_fee_estimate(
         &self,
         encoded_invoice: &str,
@@ -123,7 +123,7 @@ impl ServiceProvider {
     }
 
     /// Get a coop exit fee quote
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn get_coop_exit_fee_quote(
         &self,
         leaf_external_ids: Vec<String>,
@@ -136,7 +136,7 @@ impl ServiceProvider {
     }
 
     /// Complete a cooperative exit
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn complete_coop_exit(
         &self,
         user_outbound_transfer_external_id: &str,
@@ -149,7 +149,7 @@ impl ServiceProvider {
     }
 
     /// Request a cooperative exit
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn request_coop_exit(
         &self,
         input: RequestCoopExitInput,
@@ -158,7 +158,7 @@ impl ServiceProvider {
     }
 
     /// Request lightning receive
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn request_lightning_receive(
         &self,
         input: RequestLightningReceiveInput,
@@ -167,7 +167,7 @@ impl ServiceProvider {
     }
 
     /// Request lightning send
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn request_lightning_send(
         &self,
         input: RequestLightningSendInput,
@@ -176,7 +176,7 @@ impl ServiceProvider {
     }
 
     /// Request swap (v3)
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn request_swap(
         &self,
         input: RequestSwapInput,
@@ -185,7 +185,7 @@ impl ServiceProvider {
     }
 
     /// Get claim deposit quote
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn get_claim_deposit_quote(
         &self,
         transaction_id: String,
@@ -199,7 +199,7 @@ impl ServiceProvider {
     }
 
     /// Get a lightning receive request by ID
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn get_lightning_receive_request(
         &self,
         request_id: &str,
@@ -211,7 +211,7 @@ impl ServiceProvider {
     }
 
     /// Get a lightning send request by ID
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn get_lightning_send_request(
         &self,
         request_id: &str,
@@ -223,7 +223,7 @@ impl ServiceProvider {
     }
 
     /// Get a leaves swap request by ID
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn get_leaves_swap_request(
         &self,
         request_id: &str,
@@ -232,7 +232,7 @@ impl ServiceProvider {
     }
 
     /// Get a cooperative exit request by ID
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn get_coop_exit_request(
         &self,
         request_id: &str,
@@ -241,7 +241,7 @@ impl ServiceProvider {
     }
 
     /// Claim static deposit
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn claim_static_deposit(
         &self,
         input: ClaimStaticDepositInput,
@@ -250,7 +250,7 @@ impl ServiceProvider {
     }
 
     /// Get transfers by IDs
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn get_transfers(
         &self,
         transfer_spark_ids: Vec<String>,
@@ -259,7 +259,7 @@ impl ServiceProvider {
     }
 
     /// Register a wallet webhook with the SSP
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn register_wallet_webhook(
         &self,
         url: &str,
@@ -273,13 +273,13 @@ impl ServiceProvider {
     }
 
     /// Delete a wallet webhook from the SSP
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn delete_wallet_webhook(&self, webhook_id: &str) -> ServiceProviderResult<bool> {
         Ok(self.gql_client.delete_wallet_webhook(webhook_id).await?)
     }
 
     /// List wallet webhooks from the SSP
-    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
+    #[instrument(level = "info", target = "spark::ssp", skip_all)]
     pub async fn list_wallet_webhooks(&self) -> ServiceProviderResult<Vec<WebhookEntry>> {
         Ok(self.gql_client.list_wallet_webhooks().await?)
     }

--- a/crates/spark/src/ssp/service_provider.rs
+++ b/crates/spark/src/ssp/service_provider.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use bitcoin::secp256k1::PublicKey;
 use platform_utils::{HttpClient, create_http_client};
+use tracing::instrument;
 
 use crate::{
     default_user_agent,
@@ -100,6 +101,7 @@ impl ServiceProvider {
     }
 
     /// Get a swap fee estimate
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn get_swap_fee_estimate(
         &self,
         amount_sats: u64,
@@ -108,6 +110,7 @@ impl ServiceProvider {
     }
 
     /// Get a lightning send fee estimate
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn get_lightning_send_fee_estimate(
         &self,
         encoded_invoice: &str,
@@ -120,6 +123,7 @@ impl ServiceProvider {
     }
 
     /// Get a coop exit fee quote
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn get_coop_exit_fee_quote(
         &self,
         leaf_external_ids: Vec<String>,
@@ -132,6 +136,7 @@ impl ServiceProvider {
     }
 
     /// Complete a cooperative exit
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn complete_coop_exit(
         &self,
         user_outbound_transfer_external_id: &str,
@@ -144,6 +149,7 @@ impl ServiceProvider {
     }
 
     /// Request a cooperative exit
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn request_coop_exit(
         &self,
         input: RequestCoopExitInput,
@@ -152,6 +158,7 @@ impl ServiceProvider {
     }
 
     /// Request lightning receive
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn request_lightning_receive(
         &self,
         input: RequestLightningReceiveInput,
@@ -160,6 +167,7 @@ impl ServiceProvider {
     }
 
     /// Request lightning send
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn request_lightning_send(
         &self,
         input: RequestLightningSendInput,
@@ -168,6 +176,7 @@ impl ServiceProvider {
     }
 
     /// Request swap (v3)
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn request_swap(
         &self,
         input: RequestSwapInput,
@@ -176,6 +185,7 @@ impl ServiceProvider {
     }
 
     /// Get claim deposit quote
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn get_claim_deposit_quote(
         &self,
         transaction_id: String,
@@ -189,6 +199,7 @@ impl ServiceProvider {
     }
 
     /// Get a lightning receive request by ID
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn get_lightning_receive_request(
         &self,
         request_id: &str,
@@ -200,6 +211,7 @@ impl ServiceProvider {
     }
 
     /// Get a lightning send request by ID
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn get_lightning_send_request(
         &self,
         request_id: &str,
@@ -211,6 +223,7 @@ impl ServiceProvider {
     }
 
     /// Get a leaves swap request by ID
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn get_leaves_swap_request(
         &self,
         request_id: &str,
@@ -219,6 +232,7 @@ impl ServiceProvider {
     }
 
     /// Get a cooperative exit request by ID
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn get_coop_exit_request(
         &self,
         request_id: &str,
@@ -227,6 +241,7 @@ impl ServiceProvider {
     }
 
     /// Claim static deposit
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn claim_static_deposit(
         &self,
         input: ClaimStaticDepositInput,
@@ -235,6 +250,7 @@ impl ServiceProvider {
     }
 
     /// Get transfers by IDs
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn get_transfers(
         &self,
         transfer_spark_ids: Vec<String>,
@@ -243,6 +259,7 @@ impl ServiceProvider {
     }
 
     /// Register a wallet webhook with the SSP
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn register_wallet_webhook(
         &self,
         url: &str,
@@ -256,11 +273,13 @@ impl ServiceProvider {
     }
 
     /// Delete a wallet webhook from the SSP
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn delete_wallet_webhook(&self, webhook_id: &str) -> ServiceProviderResult<bool> {
         Ok(self.gql_client.delete_wallet_webhook(webhook_id).await?)
     }
 
     /// List wallet webhooks from the SSP
+    #[instrument(level = "info", target = "breez_sdk_core::send_phases", skip_all)]
     pub async fn list_wallet_webhooks(&self) -> ServiceProviderResult<Vec<WebhookEntry>> {
         Ok(self.gql_client.list_wallet_webhooks().await?)
     }


### PR DESCRIPTION
## Summary
- Instruments `send_payment`, every `ServiceProvider` method, and every `SparkRpcClient` method with `#[tracing::instrument]` under a dedicated target (`breez_sdk_core::send_phases`). Prod-safe: a per-layer filter in `init_logging` forces this target `=off` on the integrator-visible `app_logger` callback and main file writer, regardless of caller filter. The dedicated bench layer is only attached when the filter explicitly re-enables the target — locked in by 3 unit tests (filter detection, format pin, integrator leak guard).
- Bench harness server gains `--bench-trace` (default on) that installs the matching filter + writes span CLOSE events to `<step>/.trace-logs/sdk.log`. `aggregate.py` parses them and adds two report sections:
  - **Leaves swap (per step)** — payment-time swap count + rate
  - **Slow payments — per-RPC breakdown (per step)** — Top-N slowest sends with their dominant RPC + worst operator, plus a per-RPC p50/p95/p99/max aggregate over the slow set. Slow set bounded by `max(--slow-abs-ms=2000, step p95)`.
- The bench harness supplies an `idempotency_key` UUID on every send; `send_payment` only records it on the bench span (no-op when no bench subscriber is attached). Zero SDK behaviour change for callers who don't pass `idempotency_key`.

## Example output

From an `rps=40` Lightning-send sweep (RESULTS.md excerpt):

### Leaves swap (per step)

| RPS | successful sends | swaps | swap rate |
|-----|------------------|-------|-----------|
| 40  | 600              | 438   | 73.0%     |

### Slow payments — per-RPC breakdown (per step)

`RPS 40 — slow threshold 26132ms (30 slow sends)`

**Top slowest sends** (5 of 20 shown):

| payment_id       | op      | total ms | span total ms | dominant RPC           | dominant ms | # RPCs |
|------------------|---------|----------|---------------|------------------------|-------------|--------|
| 019e4b50-0862-70 | send_ln | 31196    | 24839.2       | request_swap           | 11800.1     | 11     |
| 019e4b50-04de-7d | send_ln | 29549    | 23540.4       | request_swap           | 11600.1     | 11     |
| 019e4b50-0a06-7b | send_ln | 29161    | 22830.0       | request_lightning_send | 9000.1      | 11     |
| 019e4b4f-fab7-70 | send_ln | 29117    | 25824.7       | request_swap           | 10600.1     | 11     |
| 019e4b4f-fc3b-70 | send_ln | 29087    | 25632.5       | request_lightning_send | 9140.1      | 11     |

**Per-RPC aggregate over slow set** (30 payments with phase data of 30 slow):

| rpc                             | calls | p50    | p95     | p99     | max     | % slow dominated by |
|---------------------------------|-------|--------|---------|---------|---------|---------------------|
| request_swap                    | 28    | 9440.1 | 12125.1 | 12373.1 | 12400.1 | 50%                 |
| request_lightning_send          | 30    | 8975.2 | 10800.1 | 10871.2 | 10900.2 | 47%                 |
| get_lightning_send_fee_estimate | 30    | 3470.1 | 9342.1  | 10442.0 | 10700.1 | 3%                  |
| claim_transfer_sign_refunds_v2  | 28    | 503.6  | 644.4   | 738.7   | 768.2   | 0%                  |
| initiate_preimage_swap_v3       | 30    | 364.6  | 423.8   | 524.6   | 563.2   | 0%                  |
| finalize_node_signatures_v2     | 28    | 295.1  | 364.0   | 391.6   | 398.1   | 0%                  |
| initiate_swap_primary_transfer  | 28    | 315.1  | 346.3   | 352.0   | 353.1   | 0%                  |
| query_all_transfers             | 28    | 215.1  | 302.0   | 327.9   | 337.1   | 0%                  |
| get_signing_commitments         | 88    | 230.1  | 283.7   | 308.4   | 363.1   | 0%                  |
| claim_transfer_tweak_keys       | 84    | 199.3  | 253.6   | 261.7   | 264.2   | 0%                  |
| get_lightning_send_request      | 30    | 4.7    | 8.0     | 8.4     | 8.6     | 0%                  |

The two slowest RPCs (`request_swap` p99 = 12.4s, `request_lightning_send` p99 = 10.9s) together dominate 97% of slow sends — the kind of attribution the previous report couldn't surface.