### PR TITLE
Add ENV-based spark-itest backend switch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,8 +42,16 @@ jobs:
         run: make fmt-check
 
   itest:
-    name: Integration test
+    name: Integration test (${{ matrix.backend.name }})
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.backend.allow-failure }}
+    strategy:
+      fail-fast: false
+      matrix:
+        backend:
+          - { name: in-memory, target: itest,             allow-failure: false }
+          - { name: postgres,  target: spark-itest-pg,    allow-failure: true }
+          - { name: mysql,     target: spark-itest-mysql, allow-failure: true }
     env:
       FAUCET_USERNAME: ${{ secrets.FAUCET_USERNAME }}
       FAUCET_PASSWORD: ${{ secrets.FAUCET_PASSWORD }}
@@ -56,7 +64,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Tests
-        run: make itest
+        run: make ${{ matrix.backend.target }}
 
   test:
     name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4918,6 +4918,8 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "spark-mysql",
+ "spark-postgres",
  "spark-wallet",
  "test-log",
  "testcontainers",

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,12 @@ flutter-check:
 itest:
 	cargo xtask itest
 
+spark-itest-pg:
+	USE_POSTGRES_BACKEND=true cargo xtask itest
+
+spark-itest-mysql:
+	USE_MYSQL_BACKEND=true cargo xtask itest
+
 breez-itest:
 	cargo xtask test --package breez-sdk-itest -- --test-threads=8
 

--- a/crates/spark-itest/Cargo.toml
+++ b/crates/spark-itest/Cargo.toml
@@ -16,10 +16,12 @@ base64.workspace = true
 rstest.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+spark-mysql.workspace = true
+spark-postgres.workspace = true
 spark-wallet.workspace = true
 test-log = { workspace = true, features = ["trace"] }
 testcontainers.workspace = true
-testcontainers-modules = { workspace = true, features = ["postgres"] }
+testcontainers-modules = { workspace = true, features = ["postgres", "mysql"] }
 testdir.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/crates/spark-itest/src/backend.rs
+++ b/crates/spark-itest/src/backend.rs
@@ -1,0 +1,207 @@
+//! Selects which backend to use for spark-wallet's session / tree / token
+//! output stores in integration tests, driven by `USE_POSTGRES_BACKEND` /
+//! `USE_MYSQL_BACKEND` env vars. Patterned on `breez-itest`'s tree-store
+//! switch, but generalized: one env var, every SQL-eligible spark-wallet store.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use testcontainers::{ContainerAsync, runners::AsyncRunner};
+use testcontainers_modules::mysql::Mysql;
+use testcontainers_modules::postgres::Postgres;
+use tokio::sync::OnceCell;
+use tracing::info;
+
+/// Process-lifetime PostgreSQL container shared across every test in the run.
+struct SharedPgContainer {
+    _container: ContainerAsync<Postgres>,
+    base_conn_str: String,
+}
+
+static PG_CONTAINER: OnceCell<SharedPgContainer> = OnceCell::const_new();
+static PG_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Process-lifetime MySQL container shared across every test in the run.
+struct SharedMysqlContainer {
+    _container: ContainerAsync<Mysql>,
+    /// Connection URL up to (but not including) the path. Callers append `/<dbname>`.
+    base_url: String,
+}
+
+static MYSQL_CONTAINER: OnceCell<SharedMysqlContainer> = OnceCell::const_new();
+static MYSQL_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// A resolved backend selection. SQL variants carry the connection string for
+/// the freshly-allocated database so all three spark-wallet stores can share
+/// one connection (and one database) per wallet.
+#[derive(Clone, Debug)]
+pub enum Backend {
+    InMemory,
+    Postgres(String),
+    Mysql(String),
+}
+
+async fn get_postgres_base_url() -> Option<&'static str> {
+    if std::env::var("USE_POSTGRES_BACKEND").is_err() {
+        return None;
+    }
+    let shared = PG_CONTAINER
+        .get_or_init(|| async {
+            info!("Starting shared PostgreSQL container for spark-itest...");
+            let container = Postgres::default()
+                .start()
+                .await
+                .expect("Failed to start PostgreSQL container for spark-itest");
+            let port = container
+                .get_host_port_ipv4(5432)
+                .await
+                .expect("Failed to get PostgreSQL container port");
+            info!("Shared PostgreSQL container for spark-itest started on port {port}");
+            SharedPgContainer {
+                _container: container,
+                base_conn_str: format!(
+                    "host=127.0.0.1 port={port} user=postgres password=postgres"
+                ),
+            }
+        })
+        .await;
+    Some(&shared.base_conn_str)
+}
+
+async fn get_mysql_base_url() -> Option<&'static str> {
+    if std::env::var("USE_MYSQL_BACKEND").is_err() {
+        return None;
+    }
+    let shared = MYSQL_CONTAINER
+        .get_or_init(|| async {
+            info!("Starting shared MySQL container for spark-itest...");
+            let container = Mysql::default()
+                .start()
+                .await
+                .expect("Failed to start MySQL container for spark-itest");
+            let port = container
+                .get_host_port_ipv4(3306)
+                .await
+                .expect("Failed to get MySQL container port");
+            info!("Shared MySQL container for spark-itest started on port {port}");
+            SharedMysqlContainer {
+                _container: container,
+                base_url: format!("mysql://root@127.0.0.1:{port}"),
+            }
+        })
+        .await;
+    Some(&shared.base_url)
+}
+
+/// Resolves which backend to use for the next wallet build. Allocates a fresh
+/// database per call when a SQL backend is selected — two wallets in the same
+/// test should each call this so they get isolated databases.
+///
+/// If both env vars are set, Postgres wins.
+pub async fn resolve_backend() -> Result<Backend> {
+    if let Some(base_url) = get_postgres_base_url().await {
+        let counter = PG_DB_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let conn_str = format!("{base_url} dbname=spark_itest_{counter}");
+        ensure_postgres_database_exists(&conn_str).await?;
+        return Ok(Backend::Postgres(conn_str));
+    }
+    if let Some(base_url) = get_mysql_base_url().await {
+        let counter = MYSQL_DB_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let db_name = format!("spark_itest_{counter}");
+        let conn_str = format!("{base_url}/{db_name}");
+        ensure_mysql_database_exists(base_url, &db_name).await?;
+        return Ok(Backend::Mysql(conn_str));
+    }
+    Ok(Backend::InMemory)
+}
+
+fn extract_dbname(conn_str: &str) -> Option<String> {
+    for part in conn_str.split_whitespace() {
+        if let Some((key, value)) = part.split_once('=')
+            && key == "dbname"
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn postgres_admin_conn_str(conn_str: &str) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    let mut saw_dbname = false;
+    for part in conn_str.split_whitespace() {
+        if let Some((key, value)) = part.split_once('=') {
+            if key == "dbname" {
+                parts.push("dbname=postgres".to_string());
+                saw_dbname = true;
+            } else {
+                parts.push(format!("{key}={value}"));
+            }
+        }
+    }
+    if !saw_dbname {
+        parts.push("dbname=postgres".to_string());
+    }
+    parts.join(" ")
+}
+
+async fn ensure_postgres_database_exists(conn_str: &str) -> Result<()> {
+    let db_name = extract_dbname(conn_str).unwrap_or_else(|| "postgres".to_string());
+    let admin_conn_str = postgres_admin_conn_str(conn_str);
+
+    info!("Ensuring postgres database '{}' exists...", db_name);
+
+    let (client, connection) = tokio_postgres::connect(&admin_conn_str, tokio_postgres::NoTls)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to connect to postgres admin database: {e}"))?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            tracing::error!("Postgres connection error: {}", e);
+        }
+    });
+
+    let row = client
+        .query_one(
+            "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)",
+            &[&db_name],
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to check if database exists: {e}"))?;
+    let exists: bool = row.get(0);
+    if !exists {
+        client
+            .simple_query(&format!("CREATE DATABASE {db_name}"))
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to create database '{}': {e}", db_name))?;
+    }
+    Ok(())
+}
+
+async fn ensure_mysql_database_exists(admin_url: &str, db_name: &str) -> Result<()> {
+    use spark_mysql::mysql_async::{Pool, prelude::*};
+
+    info!("Ensuring MySQL database '{}' exists...", db_name);
+
+    let admin_conn_str = format!("{admin_url}/mysql");
+    let pool = Pool::from_url(admin_conn_str.as_str())
+        .map_err(|e| anyhow::anyhow!("Failed to parse MySQL admin URL: {e}"))?;
+    let mut conn = pool
+        .get_conn()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to connect to MySQL admin database: {e}"))?;
+
+    // db_name is internally generated (`spark_itest_<u64>`), so identifier
+    // interpolation is safe. CREATE DATABASE IF NOT EXISTS is idempotent.
+    let stmt = format!("CREATE DATABASE IF NOT EXISTS `{db_name}`");
+    conn.query_drop(stmt)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to create MySQL database '{}': {e}", db_name))?;
+
+    drop(conn);
+    pool.disconnect()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to disconnect MySQL admin pool: {e}"))?;
+
+    Ok(())
+}

--- a/crates/spark-itest/src/helpers.rs
+++ b/crates/spark-itest/src/helpers.rs
@@ -5,14 +5,62 @@ use anyhow::Result;
 use bitcoin::Amount;
 use rand::Rng;
 use rstest::*;
-use spark_wallet::{DefaultSigner, Network, SparkWallet, SparkWalletConfig, WalletEvent};
+use spark_mysql::{
+    MysqlSessionStore, MysqlTokenStore, MysqlTreeStore, default_mysql_storage_config,
+};
+use spark_postgres::{
+    PostgresSessionStore, PostgresTokenStore, PostgresTreeStore, default_postgres_storage_config,
+};
+use spark_wallet::{
+    DefaultSigner, Network, Signer, SparkWallet, SparkWalletConfig, WalletBuilder, WalletEvent,
+};
 use tokio::sync::broadcast::Receiver;
 use tracing::{debug, info};
 
+use crate::backend::Backend;
 use crate::fixtures::{
     bitcoind::BitcoindFixture,
     setup::{TestFixtures, create_test_signer_alice, create_test_signer_bob},
 };
+
+/// Builds a `SparkWallet` whose session, tree, and token-output stores are
+/// backed by the resolved `Backend`. For `Backend::InMemory` this is
+/// equivalent to `SparkWallet::connect(config, signer)`; for the SQL variants
+/// all three stores share the connection string (so they live in one
+/// database) and are scoped per-wallet by the signer's identity pubkey.
+pub async fn build_test_wallet(
+    config: SparkWalletConfig,
+    signer: Arc<dyn Signer>,
+    backend: &Backend,
+) -> Result<SparkWallet> {
+    let mut builder = WalletBuilder::new(config, signer.clone());
+    match backend {
+        Backend::InMemory => {}
+        Backend::Postgres(conn_str) => {
+            let identity = signer.get_identity_public_key().await?.serialize();
+            let pg_config = default_postgres_storage_config(conn_str.clone());
+            let session = PostgresSessionStore::from_config(pg_config.clone(), &identity).await?;
+            let tree = PostgresTreeStore::from_config(pg_config.clone(), &identity).await?;
+            let token = PostgresTokenStore::from_config(pg_config, &identity).await?;
+            builder = builder
+                .with_session_store(Arc::new(session))
+                .with_tree_store(Arc::new(tree))
+                .with_token_output_store(Arc::new(token));
+        }
+        Backend::Mysql(conn_str) => {
+            let identity = signer.get_identity_public_key().await?.serialize();
+            let my_config = default_mysql_storage_config(conn_str.clone());
+            let session = MysqlSessionStore::from_config(my_config.clone(), &identity).await?;
+            let tree = MysqlTreeStore::from_config(my_config.clone(), &identity).await?;
+            let token = MysqlTokenStore::from_config(my_config, &identity).await?;
+            builder = builder
+                .with_session_store(Arc::new(session))
+                .with_tree_store(Arc::new(tree))
+                .with_token_output_store(Arc::new(token));
+        }
+    }
+    Ok(builder.build().await?)
+}
 
 pub async fn wait_for_event<F>(
     event_rx: &mut Receiver<WalletEvent>,
@@ -78,7 +126,8 @@ pub async fn create_regtest_wallet() -> Result<(SparkWallet, Receiver<WalletEven
     let signer = Arc::new(DefaultSigner::new(&seed, Network::Regtest)?);
 
     info!("Connecting wallet to deployed regtest operators...");
-    let wallet = SparkWallet::connect(config, signer).await?;
+    let backend = crate::backend::resolve_backend().await?;
+    let wallet = build_test_wallet(config, signer, &backend).await?;
     let mut listener = wallet.subscribe_events();
 
     // Wait for initial sync
@@ -118,15 +167,26 @@ pub async fn wallets(#[future] test_fixtures: TestFixtures) -> WalletsFixture {
         .expect("failed to create wallet config");
     let signer = create_test_signer_alice();
 
-    let alice_wallet = SparkWallet::connect(config.clone(), Arc::new(signer))
+    // Subscribe to events BEFORE the wallet has time to emit Synced. Wallet
+    // background tasks start as soon as build_test_wallet returns, and they
+    // race against subscribe_events because the broadcast channel doesn't
+    // replay past events. With the slower SQL backends, building a second
+    // wallet takes long enough that the first wallet's Synced fires before
+    // we'd otherwise get to subscribe.
+    let alice_backend = crate::backend::resolve_backend()
+        .await
+        .expect("failed to resolve backend for alice wallet");
+    let alice_wallet = build_test_wallet(config.clone(), Arc::new(signer), &alice_backend)
         .await
         .expect("Failed to connect alice wallet");
+    let mut alice_listener = alice_wallet.subscribe_events();
 
-    let bob_wallet = SparkWallet::connect(config, Arc::new(create_test_signer_bob()))
+    let bob_backend = crate::backend::resolve_backend()
+        .await
+        .expect("failed to resolve backend for bob wallet");
+    let bob_wallet = build_test_wallet(config, Arc::new(create_test_signer_bob()), &bob_backend)
         .await
         .expect("Failed to connect bob wallet");
-
-    let mut alice_listener = alice_wallet.subscribe_events();
     let mut bob_listener = bob_wallet.subscribe_events();
     loop {
         let event = alice_listener

--- a/crates/spark-itest/src/lib.rs
+++ b/crates/spark-itest/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod backend;
 pub mod faucet;
 pub mod fixtures;
 pub mod helpers;

--- a/crates/spark-itest/tests/deployed_token_tests.rs
+++ b/crates/spark-itest/tests/deployed_token_tests.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 use anyhow::Result;
 use rand::Rng;
 use rstest::*;
-use spark_itest::helpers::wait_for_event;
+use spark_itest::backend::resolve_backend;
+use spark_itest::helpers::{build_test_wallet, wait_for_event};
 use spark_wallet::{
-    DefaultSigner, Network, SelectionStrategy, SparkWallet, SparkWalletConfig, TransferTokenOutput,
-    WalletEvent,
+    DefaultSigner, Network, SelectionStrategy, SparkWalletConfig, TransferTokenOutput, WalletEvent,
 };
 use tracing::info;
 
@@ -30,11 +30,16 @@ async fn test_many_outputs() -> Result<()> {
     rand::thread_rng().fill(&mut bob_seed);
     let signer_bob = Arc::new(DefaultSigner::new(&bob_seed, Network::Regtest).unwrap());
 
-    let alice_wallet = SparkWallet::connect(config.clone(), signer_alice).await?;
-    let bob_wallet = SparkWallet::connect(config, signer_bob).await?;
-
-    // Wait for wallets to sync
+    // Subscribe immediately after each build so Synced (emitted once during
+    // operator connect) isn't lost to a late subscribe — the broadcast
+    // channel doesn't replay past events, and SQL-backend builds + container
+    // startup are slow enough that Alice's Synced would otherwise fire before
+    // we'd subscribe.
+    let alice_backend = resolve_backend().await?;
+    let alice_wallet = build_test_wallet(config.clone(), signer_alice, &alice_backend).await?;
     let mut alice_listener = alice_wallet.subscribe_events();
+    let bob_backend = resolve_backend().await?;
+    let bob_wallet = build_test_wallet(config, signer_bob, &bob_backend).await?;
     let mut bob_listener = bob_wallet.subscribe_events();
     wait_for_event(&mut alice_listener, 30, "Synced", |event| match event {
         WalletEvent::Synced => Ok(Some(event)),


### PR DESCRIPTION
Adds an env-var-driven backend switch to `spark-itest`: setting `USE_POSTGRES_BACKEND=true` or `USE_MYSQL_BACKEND=true` swaps every wallet's `SessionStore`, `TreeStore`, and `TokenOutputStore` to the corresponding SQL implementation, with per-test fresh databases backed by testcontainers. Pattern copied from `breez-itest`'s tree-store switch but generalized: one env var covers every SQL-eligible spark-wallet store.

`make itest` is unchanged (in-memory); `make spark-itest-pg` and `make spark-itest-mysql` exercise the SQL backends. CI's `itest` job is now a 3-way matrix.

### Why

PR #861's V3 dedup-by-id fix (commit `794d3c3f`, "key token output pool by `(prev_tx_hash, vout)` instead of server id") landed **only in the in-memory store**. The four SQL backends still have the bug, but it slips past CI today because `spark-itest`'s only token reproducer (`test_many_outputs`) always builds wallets via `SparkWallet::connect`, which hardcodes `InMemoryTokenOutputStore::default()`. So the canonical end-to-end test never exercises the SQL paths.

This change lets `test_many_outputs` and the rest of `spark-itest` run against the SQL backends, closing that coverage gap and giving a fixture-ready home for the SQL-side fix.

### Bonus fix

The `wallets` rstest fixture had a latent race: it built Alice + Bob before subscribing to either, so the first wallet's `Synced` could fire before `subscribe_events()` ran. In-memory was fast enough to hide it; SQL wallet construction (~500ms with migrations) was slow enough to lose the race deterministically. Fixed by subscribing immediately after each `build_test_wallet`.

### Test plan

- [x] `make itest` — 9/9 pass
- [x] `USE_POSTGRES_BACKEND=true make itest` — 9/9 pass (within ~5% of in-memory time)
- [x] `USE_MYSQL_BACKEND=true make itest` — 9/9 pass (within ~15% of in-memory time)
