### PR TITLE
update protocol

### DIFF
--- a/crates/spark/protos/spark/spark.proto
+++ b/crates/spark/protos/spark/spark.proto
@@ -820,6 +820,21 @@ enum TransferStatus {
     TRANSFER_STATUS_APPLYING_SENDER_KEY_TWEAK = 11;
 }
 
+// Per-receiver status on the receiver edge of a Transfer. For single-receiver
+// (V2) transfers this is always lock-step with Transfer.status. For
+// multi-receiver (V3) transfers each receiver advances independently.
+// This is the authoritative per-receiver state.
+enum TransferReceiverStatus {
+    TRANSFER_RECEIVER_STATUS_INITIATED = 0;
+    TRANSFER_RECEIVER_STATUS_CLAIM_PENDING = 1;
+    TRANSFER_RECEIVER_STATUS_KEY_TWEAKED = 2;
+    TRANSFER_RECEIVER_STATUS_KEY_TWEAK_LOCKED = 3;
+    TRANSFER_RECEIVER_STATUS_KEY_TWEAK_APPLIED = 4;
+    TRANSFER_RECEIVER_STATUS_REFUND_SIGNED = 5;
+    TRANSFER_RECEIVER_STATUS_COMPLETED = 6;
+    TRANSFER_RECEIVER_STATUS_CANCELLED = 7;
+}
+
 enum TransferType {
     PREIMAGE_SWAP = 0;
     COOPERATIVE_EXIT = 1;
@@ -840,6 +855,15 @@ enum Order {
 message TransferReceiver {
     bytes identity_public_key = 1;
     uint64 amount_sats = 2;
+    TransferReceiverStatus status = 3;
+    string id = 4;
+    google.protobuf.Timestamp completion_time = 5;
+}
+
+// Per-sender summary within a Transfer response.
+message TransferSender {
+    string id = 1;
+    bytes identity_public_key = 2;
 }
 
 message Transfer {
@@ -855,8 +879,8 @@ message Transfer {
     TransferType type = 10;
     string spark_invoice = 11;
     Network network = 12;
-    // For V3 multi-receiver transfers. Empty for single-receiver (V2) transfers.
     repeated TransferReceiver receivers = 13;
+    repeated TransferSender senders = 14;
 }
 
 message TransferLeaf {
@@ -867,6 +891,8 @@ message TransferLeaf {
     bytes intermediate_direct_refund_tx = 5;
     bytes intermediate_direct_from_cpfp_refund_tx = 6;
     bytes pending_key_tweak_public_key = 7;
+    string transfer_receiver_id = 8;
+    string transfer_sender_id = 9;
 }
 
 

--- a/crates/spark/src/bitcoin/error.rs
+++ b/crates/spark/src/bitcoin/error.rs
@@ -9,4 +9,6 @@ pub enum BitcoinError {
     Taproot(#[from] TaprootError),
     #[error("invalid transaction: {0}")]
     InvalidTransaction(String),
+    #[error("invalid signature: {0}")]
+    InvalidSignature(String),
 }

--- a/crates/spark/src/bitcoin/service.rs
+++ b/crates/spark/src/bitcoin/service.rs
@@ -120,3 +120,39 @@ pub fn sighash_from_multi_input_tx(
         )?,
     )
 }
+
+/// Verifies the aggregated Schnorr key-path signature attached to a
+/// finalized taproot transaction (e.g. one returned by an operator after
+/// server-side FROST aggregation). Our flows use `TapSighashType::Default`,
+/// so the witness signature must be exactly 64 bytes;
+/// `schnorr::Signature::from_slice` rejects anything else.
+pub fn verify_finalized_taproot_signature(
+    bitcoin_service: &BitcoinService,
+    signed_tx_bytes: &[u8],
+    sighash_bytes: &[u8; 32],
+    verifying_public_key: &PublicKey,
+) -> Result<(), BitcoinError> {
+    let tx: Transaction = bitcoin::consensus::deserialize(signed_tx_bytes).map_err(|e| {
+        BitcoinError::InvalidTransaction(format!("failed to decode signed tx: {e}"))
+    })?;
+    let witness_sig = tx
+        .input
+        .first()
+        .ok_or_else(|| BitcoinError::InvalidTransaction("signed tx has no inputs".to_string()))?
+        .witness
+        .nth(0)
+        .ok_or_else(|| {
+            BitcoinError::InvalidTransaction("signed tx input has empty witness".to_string())
+        })?;
+    let signature = schnorr::Signature::from_slice(witness_sig).map_err(|e| {
+        BitcoinError::InvalidSignature(format!("witness is not a 64-byte BIP-340 signature: {e}"))
+    })?;
+    let msg = Message::from_digest(*sighash_bytes);
+    let (xonly, _) = verifying_public_key.x_only_public_key();
+    if !bitcoin_service.is_valid_schnorr_signature(&signature, &msg, &xonly) {
+        return Err(BitcoinError::InvalidSignature(
+            "operator-aggregated signature does not verify against expected sighash".to_string(),
+        ));
+    }
+    Ok(())
+}

--- a/crates/spark/src/bitcoin/service.rs
+++ b/crates/spark/src/bitcoin/service.rs
@@ -126,6 +126,9 @@ pub fn sighash_from_multi_input_tx(
 /// server-side FROST aggregation). Our flows use `TapSighashType::Default`,
 /// so the witness signature must be exactly 64 bytes;
 /// `schnorr::Signature::from_slice` rejects anything else.
+///
+/// `verifying_public_key` is the untweaked FROST group key; the signature
+/// verifies against the BIP-341 taproot output key with an empty script tree.
 pub fn verify_finalized_taproot_signature(
     bitcoin_service: &BitcoinService,
     signed_tx_bytes: &[u8],
@@ -148,8 +151,8 @@ pub fn verify_finalized_taproot_signature(
         BitcoinError::InvalidSignature(format!("witness is not a 64-byte BIP-340 signature: {e}"))
     })?;
     let msg = Message::from_digest(*sighash_bytes);
-    let (xonly, _) = verifying_public_key.x_only_public_key();
-    if !bitcoin_service.is_valid_schnorr_signature(&signature, &msg, &xonly) {
+    let taproot_output_key = bitcoin_service.compute_taproot_key_no_script(verifying_public_key);
+    if !bitcoin_service.is_valid_schnorr_signature(&signature, &msg, &taproot_output_key) {
         return Err(BitcoinError::InvalidSignature(
             "operator-aggregated signature does not verify against expected sighash".to_string(),
         ));

--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -126,23 +126,6 @@ impl SparkRpcClient {
     }
 
     #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
-    pub async fn finalize_transfer_with_transfer_package(
-        &self,
-        req: FinalizeTransferWithTransferPackageRequest,
-    ) -> Result<FinalizeTransferResponse> {
-        debug!(
-            "Calling finalize_transfer_with_transfer_package with request: {:?}",
-            req
-        );
-        Ok(self
-            .spark_service_client()
-            .await?
-            .finalize_transfer_with_transfer_package(req)
-            .await?
-            .into_inner())
-    }
-
-    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn claim_transfer(
         &self,
         req: ClaimTransferRequest,
@@ -179,17 +162,6 @@ impl SparkRpcClient {
             .query_all_transfers(req)
             .await?
             .into_inner())
-    }
-
-    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
-    pub async fn store_preimage_share(&self, req: StorePreimageShareRequest) -> Result<()> {
-        debug!("Calling store_preimage_share with request: {:?}", req);
-        self.spark_service_client()
-            .await?
-            .store_preimage_share(req)
-            .await?
-            .into_inner();
-        Ok(())
     }
 
     #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
@@ -255,20 +227,6 @@ impl SparkRpcClient {
             .spark_service_client()
             .await?
             .provide_preimage(req)
-            .await?
-            .into_inner())
-    }
-
-    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
-    pub async fn start_leaf_swap_v2(
-        &self,
-        req: StartTransferRequest,
-    ) -> Result<StartTransferResponse> {
-        debug!("Calling start_leaf_swap_v2 with request: {:?}", req);
-        Ok(self
-            .spark_service_client()
-            .await?
-            .start_leaf_swap_v2(req)
             .await?
             .into_inner())
     }

--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -64,23 +64,6 @@ impl SparkRpcClient {
     }
 
     #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
-    pub async fn finalize_node_signatures_v2(
-        &self,
-        req: FinalizeNodeSignaturesRequest,
-    ) -> Result<FinalizeNodeSignaturesResponse> {
-        debug!(
-            "Calling finalize_node_signatures_v2 with request: {:?}",
-            req
-        );
-        Ok(self
-            .spark_service_client()
-            .await?
-            .finalize_node_signatures_v2(req)
-            .await?
-            .into_inner())
-    }
-
-    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn generate_deposit_address(
         &self,
         req: GenerateDepositAddressRequest,
@@ -107,23 +90,6 @@ impl SparkRpcClient {
             .spark_service_client()
             .await?
             .query_unused_deposit_addresses(req)
-            .await?
-            .into_inner())
-    }
-
-    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
-    pub async fn start_deposit_tree_creation(
-        &self,
-        req: StartDepositTreeCreationRequest,
-    ) -> Result<StartDepositTreeCreationResponse> {
-        debug!(
-            "Calling start_deposit_tree_creation with request: {:?}",
-            req
-        );
-        Ok(self
-            .spark_service_client()
-            .await?
-            .start_deposit_tree_creation(req)
             .await?
             .into_inner())
     }
@@ -211,37 +177,6 @@ impl SparkRpcClient {
             .spark_service_client()
             .await?
             .query_all_transfers(req)
-            .await?
-            .into_inner())
-    }
-
-    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
-    pub async fn claim_transfer_tweak_keys(
-        &self,
-        req: ClaimTransferTweakKeysRequest,
-    ) -> Result<()> {
-        debug!("Calling claim_transfer_tweak_keys with request: {:?}", req);
-        self.spark_service_client()
-            .await?
-            .claim_transfer_tweak_keys(req)
-            .await?
-            .into_inner();
-        Ok(())
-    }
-
-    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
-    pub async fn claim_transfer_sign_refunds_v2(
-        &self,
-        req: ClaimTransferSignRefundsRequest,
-    ) -> Result<ClaimTransferSignRefundsResponse> {
-        debug!(
-            "Calling claim_transfer_sign_refunds_v2 with request: {:?}",
-            req
-        );
-        Ok(self
-            .spark_service_client()
-            .await?
-            .claim_transfer_sign_refunds_v2(req)
             .await?
             .into_inner())
     }

--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -177,6 +177,20 @@ impl SparkRpcClient {
     }
 
     #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
+    pub async fn claim_transfer(
+        &self,
+        req: ClaimTransferRequest,
+    ) -> Result<ClaimTransferResponse> {
+        debug!("Calling claim_transfer with request: {:?}", req);
+        Ok(self
+            .spark_service_client()
+            .await?
+            .claim_transfer(req)
+            .await?
+            .into_inner())
+    }
+
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_pending_transfers(
         &self,
         req: TransferFilter,

--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -266,17 +266,6 @@ impl SparkRpcClient {
     }
 
     #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
-    pub async fn get_signing_operator_list(&self) -> Result<GetSigningOperatorListResponse> {
-        debug!("Calling get_signing_operator_list");
-        Ok(self
-            .spark_service_client()
-            .await?
-            .get_signing_operator_list(())
-            .await?
-            .into_inner())
-    }
-
-    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn query_nodes(&self, req: QueryNodesRequest) -> Result<QueryNodesResponse> {
         debug!("Calling query_nodes with request: {:?}", req);
         Ok(self
@@ -333,31 +322,6 @@ impl SparkRpcClient {
             items,
             next: if has_next { Some(pf.next()) } else { None },
         })
-    }
-
-    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
-    pub async fn query_balance(&self, req: QueryBalanceRequest) -> Result<QueryBalanceResponse> {
-        debug!("Calling query_balance with request: {:?}", req);
-        Ok(self
-            .spark_service_client()
-            .await?
-            .query_balance(req)
-            .await?
-            .into_inner())
-    }
-
-    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
-    pub async fn query_user_signed_refunds(
-        &self,
-        req: QueryUserSignedRefundsRequest,
-    ) -> Result<QueryUserSignedRefundsResponse> {
-        debug!("Calling query_user_signed_refunds with request: {:?}", req);
-        Ok(self
-            .spark_service_client()
-            .await?
-            .query_user_signed_refunds(req)
-            .await?
-            .into_inner())
     }
 
     #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]

--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -129,6 +129,23 @@ impl SparkRpcClient {
     }
 
     #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
+    pub async fn finalize_deposit_tree_creation(
+        &self,
+        req: FinalizeDepositTreeCreationRequest,
+    ) -> Result<FinalizeDepositTreeCreationResponse> {
+        debug!(
+            "Calling finalize_deposit_tree_creation with request: {:?}",
+            req
+        );
+        Ok(self
+            .spark_service_client()
+            .await?
+            .finalize_deposit_tree_creation(req)
+            .await?
+            .into_inner())
+    }
+
+    #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
     pub async fn start_transfer_v2(
         &self,
         req: StartTransferRequest,

--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -126,10 +126,7 @@ impl SparkRpcClient {
     }
 
     #[instrument(level = "info", target = "spark::operator_rpc", skip_all, fields(operator_id = self.operator_id))]
-    pub async fn claim_transfer(
-        &self,
-        req: ClaimTransferRequest,
-    ) -> Result<ClaimTransferResponse> {
+    pub async fn claim_transfer(&self, req: ClaimTransferRequest) -> Result<ClaimTransferResponse> {
         debug!("Calling claim_transfer with request: {:?}", req);
         Ok(self
             .spark_service_client()

--- a/crates/spark/src/services/coop_exit.rs
+++ b/crates/spark/src/services/coop_exit.rs
@@ -14,7 +14,9 @@ use crate::bitcoin::{sighash_from_multi_input_tx, sighash_from_tx};
 use crate::core::Network;
 use crate::operator::OperatorPool;
 use crate::operator::rpc as operator_rpc;
-use crate::services::models::{SignedTx, map_signing_nonce_commitments};
+use crate::services::models::{
+    SignedTx, map_signing_nonce_commitments, split_signing_commitments_by_variant,
+};
 use crate::services::{
     ExitSpeed, LeafKeyTweak, LeafRefundSigningData, Transfer, TransferId, TransferService,
 };
@@ -252,6 +254,11 @@ impl CoopExitService {
         debug!(
             "Submitting cooperative exit transfer for connector_txid: {connector_txid}, exit_txid: {exit_txid}",
         );
+        if leaf_key_tweaks.is_empty() {
+            return Err(ServiceError::InvalidInput(
+                "submit_coop_exit_transfer requires at least one leaf".to_string(),
+            ));
+        }
         let receiver_public_key = self.ssp_client.identity_public_key();
 
         // 1. Prepare key tweaks (empty signature maps; the SO hasn't signed yet).
@@ -293,14 +300,8 @@ impl CoopExitService {
             .map(|sc| map_signing_nonce_commitments(&sc.signing_nonce_commitments))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let chunks = signing_commitments
-            .chunks(leaf_key_tweaks.len())
-            .collect::<Vec<_>>();
-        if chunks.len() != 3 {
-            return Err(ServiceError::Generic(
-                "Not enough signing commitments returned".to_string(),
-            ));
-        }
+        let [cpfp_chunk, direct_chunk, direct_from_cpfp_chunk] =
+            split_signing_commitments_by_variant(&signing_commitments, leaf_key_tweaks.len())?;
 
         // 4. Sign coop-exit refunds (connector refunds, decremented timelock)
         //    operator-commits-first into UserSignedTxSigningJob's.
@@ -314,9 +315,9 @@ impl CoopExitService {
                 &receiver_public_key,
                 connector_txid,
                 &connector_tx_parsed,
-                chunks[0],
-                chunks[1],
-                chunks[2],
+                cpfp_chunk,
+                direct_chunk,
+                direct_from_cpfp_chunk,
             )
             .await?;
 

--- a/crates/spark/src/services/coop_exit.rs
+++ b/crates/spark/src/services/coop_exit.rs
@@ -3,25 +3,30 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bitcoin::hashes::Hash;
+use bitcoin::secp256k1::PublicKey;
 use bitcoin::{Address, OutPoint, Transaction, Txid};
+use frost_secp256k1_tr::Identifier;
 use platform_utils::time::SystemTime;
 use serde::Serialize;
 use tracing::{debug, trace};
 
+use crate::bitcoin::{sighash_from_multi_input_tx, sighash_from_tx};
 use crate::core::Network;
 use crate::operator::OperatorPool;
 use crate::operator::rpc as operator_rpc;
+use crate::services::models::{SignedTx, map_signing_nonce_commitments};
 use crate::services::{
     ExitSpeed, LeafKeyTweak, LeafRefundSigningData, Transfer, TransferId, TransferService,
 };
 use crate::services::{ServiceError, TransferObserver};
+use crate::signer::{FrostSigningCommitmentsWithNonces, SecretSource, SignFrostRequest};
 use crate::ssp::RequestCoopExitInput;
 use crate::ssp::ServiceProvider;
 use crate::tree::TreeNodeId;
 use crate::utils::leaf_key_tweak::prepare_leaf_key_tweaks_to_send;
 use crate::utils::refund::{
-    RefundSignatures, map_refund_signatures, prepare_leaf_refund_signing_data,
-    prepare_refund_so_signing_jobs_with_tx_constructor, sign_aggregate_refunds,
+    RefundSignatures, prepare_leaf_refund_signing_data,
+    prepare_refund_so_signing_jobs_with_tx_constructor,
 };
 use crate::utils::time::web_time_to_prost_timestamp;
 use crate::utils::transactions::{ConnectorRefundTxsParams, create_connector_refund_txs};
@@ -34,12 +39,6 @@ const COOP_EXIT_EXPIRY_DURATION: Duration = Duration::from_secs(35 * 60); // 35 
 pub struct CoopExitSpeedFeeQuote {
     pub user_fee_sat: u64,
     pub l1_broadcast_fee_sat: u64,
-}
-
-#[derive(Debug)]
-struct CoopExitRefundSignatures {
-    pub transfer: Transfer,
-    pub refund_signatures: RefundSignatures,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -209,7 +208,7 @@ impl CoopExitService {
         let coop_exit_input = connector_tx.input[0].previous_output.txid;
 
         let res = self
-            .get_connector_refund_signatures(
+            .submit_coop_exit_transfer(
                 leaf_key_tweaks,
                 connector_txid,
                 coop_exit_input,
@@ -217,8 +216,8 @@ impl CoopExitService {
                 raw_connector_transaction_bytes.clone(),
             )
             .await;
-        let coop_exit_refund_signatures = match (&transfer_id, res) {
-            (_, Ok(s)) => s,
+        let transfer = match (&transfer_id, res) {
+            (_, Ok(t)) => t,
             (Some(transfer_id), Err(e)) => {
                 return self
                     .transfer_service
@@ -227,8 +226,7 @@ impl CoopExitService {
             }
             (None, Err(e)) => return Err(e),
         };
-        trace!("Got connector refund signatures: {coop_exit_refund_signatures:?}",);
-        let transfer = coop_exit_refund_signatures.transfer;
+        trace!("Submitted cooperative exit transfer: {transfer:?}");
 
         let complete_response = self
             .ssp_client
@@ -239,82 +237,102 @@ impl CoopExitService {
         Ok(transfer)
     }
 
-    async fn get_connector_refund_signatures(
+    /// Submits the cooperative-exit transfer to the coordinator as a single
+    /// `cooperative_exit_v2` call, packaging encrypted key tweaks and
+    /// user-signed connector refunds together (operators aggregate and
+    /// finalize server-side).
+    async fn submit_coop_exit_transfer(
         &self,
         leaf_key_tweaks: Vec<LeafKeyTweak>,
         connector_txid: Txid,
         exit_txid: Txid,
         transfer_id: TransferId,
         connector_tx: Vec<u8>,
-    ) -> Result<CoopExitRefundSignatures, ServiceError> {
+    ) -> Result<Transfer, ServiceError> {
         debug!(
-            "Getting connector refund signatures for connector_txid: {connector_txid}, exit_txid: {exit_txid}",
+            "Submitting cooperative exit transfer for connector_txid: {connector_txid}, exit_txid: {exit_txid}",
         );
-        let coop_exit_refund_signatures = self
-            .sign_coop_exit_refunds(
-                &leaf_key_tweaks,
-                connector_txid,
-                exit_txid,
-                transfer_id,
-                connector_tx,
-            )
-            .await?;
+        let receiver_public_key = self.ssp_client.identity_public_key();
 
-        trace!("Delivering transfer package for cooperative exit refund signatures");
-        let transfer_tweaked = self
+        // 1. Prepare key tweaks (empty signature maps; the SO hasn't signed yet).
+        let key_tweak_input_map = self
             .transfer_service
-            .deliver_transfer_package(
-                &coop_exit_refund_signatures.transfer,
+            .prepare_send_transfer_key_tweaks(
+                &transfer_id,
+                &receiver_public_key,
                 &leaf_key_tweaks,
-                coop_exit_refund_signatures.refund_signatures.clone(),
+                RefundSignatures::default(),
             )
             .await?;
 
-        Ok(CoopExitRefundSignatures {
-            transfer: transfer_tweaked,
-            refund_signatures: coop_exit_refund_signatures.refund_signatures,
-        })
-    }
+        // 2. ECIES-encrypt the key tweaks per operator.
+        let encrypted_key_tweaks = self
+            .transfer_service
+            .encrypt_key_tweaks(&key_tweak_input_map)?;
+        let key_tweak_package: HashMap<String, Vec<u8>> = encrypted_key_tweaks
+            .into_iter()
+            .map(|(k, v)| (hex::encode(k.serialize()), v))
+            .collect();
 
-    async fn sign_coop_exit_refunds(
-        &self,
-        leaf_key_tweaks: &[LeafKeyTweak],
-        connector_txid: Txid,
-        exit_txid: Txid,
-        transfer_id: TransferId,
-        connector_tx: Vec<u8>,
-    ) -> Result<CoopExitRefundSignatures, ServiceError> {
-        debug!(
-            "Signing cooperative exit refunds for connector_txid: {connector_txid}, exit_txid: {exit_txid}",
-        );
-        // Prepare leaf data map with refund signing information
-        let receiving_public_key = self.ssp_client.identity_public_key();
-        let mut leaf_data_map =
-            prepare_leaf_refund_signing_data(&self.signer, leaf_key_tweaks, receiving_public_key)
-                .await?;
+        // 3. Fetch operator signing commitments (3 per leaf: cpfp, direct, direct-from-cpfp).
+        let signing_commitments = self
+            .operator_pool
+            .get_coordinator()
+            .client
+            .get_signing_commitments(operator_rpc::spark::GetSigningCommitmentsRequest {
+                node_ids: leaf_key_tweaks
+                    .iter()
+                    .map(|l| l.node.id.to_string())
+                    .collect(),
+                count: 3,
+                node_id_count: 0,
+            })
+            .await?
+            .signing_commitments
+            .iter()
+            .map(|sc| map_signing_nonce_commitments(&sc.signing_nonce_commitments))
+            .collect::<Result<Vec<_>, _>>()?;
 
-        // Parse connector tx to get outputs for signing
+        let chunks = signing_commitments
+            .chunks(leaf_key_tweaks.len())
+            .collect::<Vec<_>>();
+        if chunks.len() != 3 {
+            return Err(ServiceError::Generic(
+                "Not enough signing commitments returned".to_string(),
+            ));
+        }
+
+        // 4. Sign coop-exit refunds (connector refunds, decremented timelock)
+        //    operator-commits-first into UserSignedTxSigningJob's.
         let connector_tx_parsed: Transaction = bitcoin::consensus::deserialize(&connector_tx)
             .map_err(|_| {
                 ServiceError::Generic("Failed to deserialize connector transaction".to_string())
             })?;
+        let (cpfp_jobs, direct_jobs, direct_from_cpfp_jobs) = self
+            .sign_coop_exit_refunds_into_jobs(
+                &leaf_key_tweaks,
+                &receiver_public_key,
+                connector_txid,
+                &connector_tx_parsed,
+                chunks[0],
+                chunks[1],
+                chunks[2],
+            )
+            .await?;
 
-        // Update leaf_data_map with connector prev_out for coop exit signing
-        for (i, leaf_key) in leaf_key_tweaks.iter().enumerate() {
-            if let Some(leaf_data) = leaf_data_map.get_mut(&leaf_key.node.id)
-                && i < connector_tx_parsed.output.len()
-            {
-                leaf_data.connector_prev_out = Some(connector_tx_parsed.output[i].clone());
-            }
-        }
-
-        // Prepare refund signing jobs for the coordinator
-        trace!("Preparing refund signing jobs for cooperative exit");
-        let signing_jobs = self.prepare_refund_so_signing_jobs(
-            leaf_key_tweaks,
-            connector_txid,
-            &mut leaf_data_map,
-        )?;
+        // 5. Assemble + sign the transfer package.
+        let unsigned_package = operator_rpc::spark::TransferPackage {
+            leaves_to_send: cpfp_jobs,
+            direct_leaves_to_send: direct_jobs,
+            direct_from_cpfp_leaves_to_send: direct_from_cpfp_jobs,
+            key_tweak_package,
+            user_signature: Vec::new(),
+            hash_variant: operator_rpc::spark::HashVariant::V2.into(),
+        };
+        let signed_package = self
+            .transfer_service
+            .sign_transfer_package(&transfer_id, unsigned_package)
+            .await?;
 
         let expiry_time = SystemTime::now()
             + if self.network == Network::Mainnet {
@@ -323,9 +341,7 @@ impl CoopExitService {
                 COOP_EXIT_EXPIRY_DURATION
             };
 
-        // Call the coordinator to get signing results
-        // TODO: Use `transfer_package` as `leaves_to_send` is deprecated
-        trace!("Calling coordinator for cooperative exit signing results");
+        // 6. Single cooperative_exit_v2 call with the full transfer_package.
         let response =
             self.operator_pool
                 .get_coordinator()
@@ -333,23 +349,17 @@ impl CoopExitService {
                 .cooperative_exit_v2(operator_rpc::spark::CooperativeExitRequest {
                     transfer: Some(operator_rpc::spark::StartTransferRequest {
                         transfer_id: transfer_id.to_string(),
-                        #[allow(deprecated)]
-                        leaves_to_send: signing_jobs,
                         owner_identity_public_key: self
                             .signer
                             .get_identity_public_key()
                             .await?
                             .serialize()
                             .to_vec(),
-                        receiver_identity_public_key: self
-                            .ssp_client
-                            .identity_public_key()
-                            .serialize()
-                            .to_vec(),
+                        receiver_identity_public_key: receiver_public_key.serialize().to_vec(),
                         expiry_time: Some(web_time_to_prost_timestamp(&expiry_time).map_err(
                             |_| ServiceError::Generic("Invalid expiry time".to_string()),
                         )?),
-                        transfer_package: None,
+                        transfer_package: Some(signed_package),
                         ..Default::default()
                     }),
                     exit_id: uuid::Uuid::now_v7().to_string(),
@@ -357,56 +367,223 @@ impl CoopExitService {
                     connector_tx,
                 })
                 .await?;
-        let transfer = response
+
+        response
             .transfer
             .ok_or(ServiceError::Generic("No transfer in response".to_string()))?
-            .try_into()?;
-
-        // Sign the refunds using FROST
-        trace!("Signing aggregate refunds for cooperative exit");
-        let signed_refunds = sign_aggregate_refunds(
-            &self.signer,
-            &leaf_data_map,
-            &response.signing_results,
-            None,
-            None,
-            None,
-        )
-        .await?;
-
-        trace!("Converting signed refunds to map");
-        let refund_signatures = map_refund_signatures(signed_refunds)?;
-
-        Ok(CoopExitRefundSignatures {
-            transfer,
-            refund_signatures,
-        })
+            .try_into()
     }
 
-    fn prepare_refund_so_signing_jobs(
+    /// Signs the coop-exit connector refund transactions operator-commits-first.
+    /// The operators aggregate server-side during `cooperative_exit_v2`.
+    #[allow(clippy::too_many_arguments)]
+    async fn sign_coop_exit_refunds_into_jobs(
         &self,
-        leaf_key_tweaks: &[LeafKeyTweak],
+        leaves: &[LeafKeyTweak],
+        receiving_public_key: &PublicKey,
         connector_txid: Txid,
-        leaf_data_map: &mut HashMap<TreeNodeId, LeafRefundSigningData>,
-    ) -> Result<Vec<operator_rpc::spark::LeafRefundTxSigningJob>, ServiceError> {
+        connector_tx_parsed: &Transaction,
+        cpfp_commitments: &[std::collections::BTreeMap<
+            Identifier,
+            frost_secp256k1_tr::round1::SigningCommitments,
+        >],
+        direct_commitments: &[std::collections::BTreeMap<
+            Identifier,
+            frost_secp256k1_tr::round1::SigningCommitments,
+        >],
+        direct_from_cpfp_commitments: &[std::collections::BTreeMap<
+            Identifier,
+            frost_secp256k1_tr::round1::SigningCommitments,
+        >],
+    ) -> Result<
+        (
+            Vec<operator_rpc::spark::UserSignedTxSigningJob>,
+            Vec<operator_rpc::spark::UserSignedTxSigningJob>,
+            Vec<operator_rpc::spark::UserSignedTxSigningJob>,
+        ),
+        ServiceError,
+    > {
+        // Build leaf data map (with the single SSP receiver) + connector prev_out
+        // per leaf.
+        let mut leaf_data_map =
+            prepare_leaf_refund_signing_data(&self.signer, leaves, *receiving_public_key).await?;
+        for (i, leaf) in leaves.iter().enumerate() {
+            if let Some(leaf_data) = leaf_data_map.get_mut(&leaf.node.id)
+                && i < connector_tx_parsed.output.len()
+            {
+                leaf_data.connector_prev_out = Some(connector_tx_parsed.output[i].clone());
+            }
+        }
+
+        // Build the connector refund transactions (decremented timelock) into
+        // `leaf_data_map`. The (fused-form) signing jobs returned here are
+        // discarded — we sign operator-commits-first below.
         prepare_refund_so_signing_jobs_with_tx_constructor(
-            leaf_key_tweaks,
-            leaf_data_map,
+            leaves,
+            &mut leaf_data_map,
             false,
-            |refund_tx_constructor| {
+            |c| {
                 create_connector_refund_txs(ConnectorRefundTxsParams {
-                    cpfp_sequence: refund_tx_constructor.cpfp_sequence,
-                    direct_sequence: refund_tx_constructor.direct_sequence,
-                    node_tx: &refund_tx_constructor.node.node_tx,
-                    direct_tx: refund_tx_constructor.node.direct_refund_tx(),
+                    cpfp_sequence: c.cpfp_sequence,
+                    direct_sequence: c.direct_sequence,
+                    node_tx: &c.node.node_tx,
+                    direct_tx: c.node.direct_refund_tx(),
                     connector_outpoint: OutPoint {
                         txid: connector_txid,
-                        vout: refund_tx_constructor.vout,
+                        vout: c.vout,
                     },
-                    receiving_pubkey: refund_tx_constructor.receiving_pubkey,
+                    receiving_pubkey: c.receiving_pubkey,
                     network: self.network,
                 })
             },
-        )
+        )?;
+
+        let mut cpfp_jobs = Vec::new();
+        let mut direct_jobs = Vec::new();
+        let mut direct_from_cpfp_jobs = Vec::new();
+        for (i, leaf) in leaves.iter().enumerate() {
+            let data = leaf_data_map.remove(&leaf.node.id).ok_or_else(|| {
+                ServiceError::Generic(format!("Leaf data not found for leaf {}", leaf.node.id))
+            })?;
+            let verifying_key = leaf.node.verifying_public_key;
+            let signing_private_key = leaf.signing_key.clone();
+
+            let LeafRefundSigningData {
+                signing_public_key,
+                tx: node_tx,
+                direct_tx,
+                refund_tx,
+                direct_refund_tx,
+                direct_from_cpfp_refund_tx,
+                signing_nonce_commitment,
+                direct_signing_nonce_commitment,
+                direct_from_cpfp_signing_nonce_commitment,
+                connector_prev_out,
+                ..
+            } = data;
+
+            // Coop-exit refunds spend multiple inputs (node_tx + connector); BIP-341
+            // sighash requires all prev outs.
+            let node_all_prev_outs = connector_prev_out
+                .as_ref()
+                .map(|c| vec![node_tx.output[0].clone(), c.clone()]);
+
+            let cpfp_refund_tx = refund_tx
+                .ok_or_else(|| ServiceError::Generic("Missing cpfp refund tx".to_string()))?;
+            let cpfp_sighash = if let Some(prev_outs) = node_all_prev_outs
+                .as_ref()
+                .filter(|_| cpfp_refund_tx.input.len() > 1)
+            {
+                sighash_from_multi_input_tx(&cpfp_refund_tx, 0, prev_outs)
+            } else {
+                sighash_from_tx(&cpfp_refund_tx, 0, &node_tx.output[0])
+            }?;
+            cpfp_jobs.push(
+                self.sign_coop_exit_refund_job(
+                    &leaf.node.id,
+                    cpfp_refund_tx,
+                    cpfp_sighash.as_byte_array(),
+                    &signing_public_key,
+                    &signing_private_key,
+                    signing_nonce_commitment,
+                    cpfp_commitments[i].clone(),
+                    &verifying_key,
+                )
+                .await?,
+            );
+
+            if let (Some(direct_tx), Some(direct_refund_tx)) = (direct_tx, direct_refund_tx) {
+                let direct_all_prev_outs = connector_prev_out
+                    .as_ref()
+                    .map(|c| vec![direct_tx.output[0].clone(), c.clone()]);
+                let sighash = if let Some(prev_outs) = direct_all_prev_outs
+                    .as_ref()
+                    .filter(|_| direct_refund_tx.input.len() > 1)
+                {
+                    sighash_from_multi_input_tx(&direct_refund_tx, 0, prev_outs)
+                } else {
+                    sighash_from_tx(&direct_refund_tx, 0, &direct_tx.output[0])
+                }?;
+                direct_jobs.push(
+                    self.sign_coop_exit_refund_job(
+                        &leaf.node.id,
+                        direct_refund_tx,
+                        sighash.as_byte_array(),
+                        &signing_public_key,
+                        &signing_private_key,
+                        direct_signing_nonce_commitment,
+                        direct_commitments[i].clone(),
+                        &verifying_key,
+                    )
+                    .await?,
+                );
+            }
+
+            if let Some(dfc_refund_tx) = direct_from_cpfp_refund_tx {
+                let sighash = if let Some(prev_outs) = node_all_prev_outs
+                    .as_ref()
+                    .filter(|_| dfc_refund_tx.input.len() > 1)
+                {
+                    sighash_from_multi_input_tx(&dfc_refund_tx, 0, prev_outs)
+                } else {
+                    sighash_from_tx(&dfc_refund_tx, 0, &node_tx.output[0])
+                }?;
+                direct_from_cpfp_jobs.push(
+                    self.sign_coop_exit_refund_job(
+                        &leaf.node.id,
+                        dfc_refund_tx,
+                        sighash.as_byte_array(),
+                        &signing_public_key,
+                        &signing_private_key,
+                        direct_from_cpfp_signing_nonce_commitment,
+                        direct_from_cpfp_commitments[i].clone(),
+                        &verifying_key,
+                    )
+                    .await?,
+                );
+            }
+        }
+
+        Ok((cpfp_jobs, direct_jobs, direct_from_cpfp_jobs))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn sign_coop_exit_refund_job(
+        &self,
+        node_id: &TreeNodeId,
+        refund_tx: Transaction,
+        sighash_bytes: &[u8],
+        signing_public_key: &PublicKey,
+        signing_private_key: &SecretSource,
+        self_nonce_commitment: FrostSigningCommitmentsWithNonces,
+        operator_commitments: std::collections::BTreeMap<
+            Identifier,
+            frost_secp256k1_tr::round1::SigningCommitments,
+        >,
+        verifying_key: &PublicKey,
+    ) -> Result<operator_rpc::spark::UserSignedTxSigningJob, ServiceError> {
+        let user_signature = self
+            .signer
+            .sign_frost(SignFrostRequest {
+                message: sighash_bytes,
+                public_key: signing_public_key,
+                private_key: signing_private_key,
+                verifying_key,
+                self_nonce_commitment: &self_nonce_commitment,
+                statechain_commitments: operator_commitments.clone(),
+                adaptor_public_key: None,
+            })
+            .await?;
+
+        let signed_tx = SignedTx {
+            node_id: node_id.clone(),
+            signing_public_key: *signing_public_key,
+            tx: refund_tx,
+            user_signature,
+            signing_commitments: operator_commitments,
+            self_nonce_commitment,
+            network: self.network,
+        };
+        (&signed_tx).try_into()
     }
 }

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, str::FromStr, sync::Arc};
 use bitcoin::{
     Address, Amount, OutPoint, Transaction, TxOut, Txid, Witness,
     address::NetworkUnchecked,
-    consensus::{deserialize, serialize},
+    consensus::serialize,
     hashes::{Hash, sha256},
     params::Params,
     secp256k1::{Message, PublicKey, ecdsa::Signature, schnorr},
@@ -18,10 +18,10 @@ use crate::{
         OperatorPool,
         rpc::{self as operator_rpc, spark::HashVariant},
     },
-    services::Utxo,
-    signer::{SecretSource, Signer},
+    services::{Utxo, models::map_signing_nonce_commitments},
+    signer::{SecretSource, SignFrostRequest, Signer},
     ssp::{ClaimStaticDepositInput, ClaimStaticDepositRequestType, ServiceProvider},
-    tree::{TreeNode, TreeNodeId, TreeNodeStatus},
+    tree::{TreeNode, TreeNodeId},
     utils::{
         frost::{SignAggregateFrostParams, sign_aggregate_frost},
         paging::{PagingFilter, PagingResult, pager},
@@ -584,78 +584,31 @@ impl DepositService {
         let direct_from_cpfp_refund_nonce_commitment =
             self.signer.generate_random_signing_commitment().await?;
 
-        let tree_resp = self
+        // Fetch operator signing commitments. The tree node does not exist yet,
+        // so request commitments by count rather than by node id.
+        let signing_commitments = self
             .operator_pool
             .get_coordinator()
             .client
-            .start_deposit_tree_creation(operator_rpc::spark::StartDepositTreeCreationRequest {
-                identity_public_key: self.identity_public_key.serialize().to_vec(),
-                on_chain_utxo: Some(operator_rpc::spark::Utxo {
-                    raw_tx: serialize(&deposit_tx),
-                    vout,
-                    network: self.network.to_proto_network() as i32,
-                    txid: deposit_txid.as_byte_array().to_vec(),
-                }),
-                root_tx_signing_job: Some(operator_rpc::spark::SigningJob {
-                    signing_public_key: signing_public_key.serialize().to_vec(),
-                    raw_tx: serialize(&cpfp_root_tx),
-                    signing_nonce_commitment: Some(
-                        cpfp_node_nonce_commitment.commitments.try_into()?,
-                    ),
-                }),
-                refund_tx_signing_job: Some(operator_rpc::spark::SigningJob {
-                    signing_public_key: signing_public_key.serialize().to_vec(),
-                    raw_tx: serialize(&cpfp_refund_tx),
-                    signing_nonce_commitment: Some(
-                        cpfp_refund_nonce_commitment.commitments.try_into()?,
-                    ),
-                }),
-                #[allow(deprecated)]
-                direct_root_tx_signing_job: None,
-                #[allow(deprecated)]
-                direct_refund_tx_signing_job: None,
-                direct_from_cpfp_refund_tx_signing_job: Some(operator_rpc::spark::SigningJob {
-                    signing_public_key: signing_public_key.serialize().to_vec(),
-                    raw_tx: serialize(&direct_from_cpfp_refund_tx),
-                    signing_nonce_commitment: Some(
-                        direct_from_cpfp_refund_nonce_commitment
-                            .commitments
-                            .try_into()?,
-                    ),
-                }),
+            .get_signing_commitments(operator_rpc::spark::GetSigningCommitmentsRequest {
+                node_ids: Vec::new(),
+                count: 3,
+                node_id_count: 1,
             })
-            .await?;
+            .await?
+            .signing_commitments;
 
-        let root_node_signature_shares = tree_resp
-            .root_node_signature_shares
-            .ok_or(ServiceError::MissingTreeSignatures)?;
-
-        let cpfp_node_signing_result = root_node_signature_shares
-            .node_tx_signing_result
-            .as_ref()
-            .map(|sr| sr.try_into())
-            .transpose()?
-            .ok_or(ServiceError::MissingTreeSignatures)?;
-        let cpfp_refund_signing_result = root_node_signature_shares
-            .refund_tx_signing_result
-            .as_ref()
-            .map(|sr| sr.try_into())
-            .transpose()?
-            .ok_or(ServiceError::MissingTreeSignatures)?;
-        let direct_from_cpfp_refund_signing_result = root_node_signature_shares
-            .direct_from_cpfp_refund_tx_signing_result
-            .as_ref()
-            .map(|sr| sr.try_into())
-            .transpose()?
-            .ok_or(ServiceError::MissingTreeSignatures)?;
-
-        let tree_resp_verifying_key =
-            PublicKey::from_slice(&root_node_signature_shares.verifying_key)
-                .map_err(|_| ServiceError::InvalidVerifyingKey)?;
-
-        if &tree_resp_verifying_key != verifying_public_key {
-            return Err(ServiceError::InvalidVerifyingKey);
-        }
+        let [
+            cpfp_root_commitments,
+            cpfp_refund_commitments,
+            direct_from_cpfp_refund_commitments,
+        ] = signing_commitments.as_slice()
+        else {
+            return Err(ServiceError::Generic(format!(
+                "Expected 3 signing commitments, got {}",
+                signing_commitments.len()
+            )));
+        };
 
         // Compute sighashes for all transactions
         let cpfp_root_sighash = sighash_from_tx(&cpfp_root_tx, 0, deposit_tx_out)?;
@@ -663,122 +616,129 @@ impl DepositService {
         let direct_from_cpfp_refund_sighash =
             sighash_from_tx(&direct_from_cpfp_refund_tx, 0, &cpfp_root_tx.output[0])?;
 
-        let cpfp_root_signature = sign_aggregate_frost(SignAggregateFrostParams {
-            signer: &self.signer,
-            sighash: &cpfp_root_sighash,
-            signing_public_key: &signing_public_key,
-            aggregating_public_key: &signing_public_key,
-            signing_private_key: &signing_private_key,
-            self_nonce_commitment: &cpfp_node_nonce_commitment,
-            adaptor_public_key: None,
-            verifying_key: verifying_public_key,
-            signing_result: cpfp_node_signing_result,
-        })
-        .await?;
+        // The user produces a FROST signature share for each transaction; the
+        // operators aggregate server-side during finalization.
+        let cpfp_root_user_signature = self
+            .signer
+            .sign_frost(SignFrostRequest {
+                message: cpfp_root_sighash.as_byte_array(),
+                public_key: &signing_public_key,
+                private_key: &signing_private_key,
+                verifying_key: verifying_public_key,
+                self_nonce_commitment: &cpfp_node_nonce_commitment,
+                statechain_commitments: map_signing_nonce_commitments(
+                    &cpfp_root_commitments.signing_nonce_commitments,
+                )?,
+                adaptor_public_key: None,
+            })
+            .await?;
 
-        let cpfp_refund_signature = sign_aggregate_frost(SignAggregateFrostParams {
-            signer: &self.signer,
-            sighash: &cpfp_refund_sighash,
-            signing_public_key: &signing_public_key,
-            aggregating_public_key: &signing_public_key,
-            signing_private_key: &signing_private_key,
-            self_nonce_commitment: &cpfp_refund_nonce_commitment,
-            adaptor_public_key: None,
-            verifying_key: verifying_public_key,
-            signing_result: cpfp_refund_signing_result,
-        })
-        .await?;
+        let cpfp_refund_user_signature = self
+            .signer
+            .sign_frost(SignFrostRequest {
+                message: cpfp_refund_sighash.as_byte_array(),
+                public_key: &signing_public_key,
+                private_key: &signing_private_key,
+                verifying_key: verifying_public_key,
+                self_nonce_commitment: &cpfp_refund_nonce_commitment,
+                statechain_commitments: map_signing_nonce_commitments(
+                    &cpfp_refund_commitments.signing_nonce_commitments,
+                )?,
+                adaptor_public_key: None,
+            })
+            .await?;
 
-        let direct_from_cpfp_refund_signature = sign_aggregate_frost(SignAggregateFrostParams {
-            signer: &self.signer,
-            sighash: &direct_from_cpfp_refund_sighash,
-            signing_public_key: &signing_public_key,
-            aggregating_public_key: &signing_public_key,
-            signing_private_key: &signing_private_key,
-            self_nonce_commitment: &direct_from_cpfp_refund_nonce_commitment,
-            adaptor_public_key: None,
-            verifying_key: verifying_public_key,
-            signing_result: direct_from_cpfp_refund_signing_result,
-        })
-        .await?;
+        let direct_from_cpfp_refund_user_signature = self
+            .signer
+            .sign_frost(SignFrostRequest {
+                message: direct_from_cpfp_refund_sighash.as_byte_array(),
+                public_key: &signing_public_key,
+                private_key: &signing_private_key,
+                verifying_key: verifying_public_key,
+                self_nonce_commitment: &direct_from_cpfp_refund_nonce_commitment,
+                statechain_commitments: map_signing_nonce_commitments(
+                    &direct_from_cpfp_refund_commitments.signing_nonce_commitments,
+                )?,
+                adaptor_public_key: None,
+            })
+            .await?;
 
         let finalize_resp = self
             .operator_pool
             .get_coordinator()
             .client
-            .finalize_node_signatures_v2(operator_rpc::spark::FinalizeNodeSignaturesRequest {
-                intent: operator_rpc::common::SignatureIntent::Creation as i32,
-                node_signatures: vec![operator_rpc::spark::NodeSignatures {
-                    node_id: root_node_signature_shares.node_id,
-                    node_tx_signature: cpfp_root_signature
-                        .serialize()
-                        .map_err(|_| ServiceError::InvalidSignatureShare)?
-                        .to_vec(),
-                    refund_tx_signature: cpfp_refund_signature
-                        .serialize()
-                        .map_err(|_| ServiceError::InvalidSignatureShare)?
-                        .to_vec(),
-                    direct_node_tx_signature: Vec::new(),
-                    direct_refund_tx_signature: Vec::new(),
-                    direct_from_cpfp_refund_tx_signature: direct_from_cpfp_refund_signature
-                        .serialize()
-                        .map_err(|_| ServiceError::InvalidSignatureShare)?
-                        .to_vec(),
-                }],
-            })
+            .finalize_deposit_tree_creation(
+                operator_rpc::spark::FinalizeDepositTreeCreationRequest {
+                    identity_public_key: self.identity_public_key.serialize().to_vec(),
+                    on_chain_utxo: Some(operator_rpc::spark::Utxo {
+                        raw_tx: serialize(&deposit_tx),
+                        vout,
+                        network: self.network.to_proto_network() as i32,
+                        txid: deposit_txid.as_byte_array().to_vec(),
+                    }),
+                    root_tx_signing_job: Some(operator_rpc::spark::UserSignedTxSigningJob {
+                        leaf_id: String::new(),
+                        signing_public_key: signing_public_key.serialize().to_vec(),
+                        raw_tx: serialize(&cpfp_root_tx),
+                        signing_nonce_commitment: Some(
+                            cpfp_node_nonce_commitment.commitments.try_into()?,
+                        ),
+                        user_signature: cpfp_root_user_signature.serialize().to_vec(),
+                        signing_commitments: Some(operator_rpc::spark::SigningCommitments {
+                            signing_commitments: cpfp_root_commitments
+                                .signing_nonce_commitments
+                                .clone(),
+                        }),
+                        additional_inputs: Vec::new(),
+                    }),
+                    refund_tx_signing_job: Some(operator_rpc::spark::UserSignedTxSigningJob {
+                        leaf_id: String::new(),
+                        signing_public_key: signing_public_key.serialize().to_vec(),
+                        raw_tx: serialize(&cpfp_refund_tx),
+                        signing_nonce_commitment: Some(
+                            cpfp_refund_nonce_commitment.commitments.try_into()?,
+                        ),
+                        user_signature: cpfp_refund_user_signature.serialize().to_vec(),
+                        signing_commitments: Some(operator_rpc::spark::SigningCommitments {
+                            signing_commitments: cpfp_refund_commitments
+                                .signing_nonce_commitments
+                                .clone(),
+                        }),
+                        additional_inputs: Vec::new(),
+                    }),
+                    direct_from_cpfp_refund_tx_signing_job: Some(
+                        operator_rpc::spark::UserSignedTxSigningJob {
+                            leaf_id: String::new(),
+                            signing_public_key: signing_public_key.serialize().to_vec(),
+                            raw_tx: serialize(&direct_from_cpfp_refund_tx),
+                            signing_nonce_commitment: Some(
+                                direct_from_cpfp_refund_nonce_commitment
+                                    .commitments
+                                    .try_into()?,
+                            ),
+                            user_signature: direct_from_cpfp_refund_user_signature
+                                .serialize()
+                                .to_vec(),
+                            signing_commitments: Some(operator_rpc::spark::SigningCommitments {
+                                signing_commitments: direct_from_cpfp_refund_commitments
+                                    .signing_nonce_commitments
+                                    .clone(),
+                            }),
+                            additional_inputs: Vec::new(),
+                        },
+                    ),
+                    additional_on_chain_utxos: Vec::new(),
+                },
+            )
             .await?;
 
-        // TODO: Verify the returned tx signatures
+        let root_node = finalize_resp.root_node.ok_or_else(|| {
+            ServiceError::Generic(
+                "finalize_deposit_tree_creation returned no root node".to_string(),
+            )
+        })?;
 
-        let nodes = finalize_resp
-            .nodes
-            .into_iter()
-            .map(|node| {
-                let signing_keyshare = node
-                    .signing_keyshare
-                    .ok_or(ServiceError::MissingSigningKeyshare)?;
-
-                Ok(TreeNode {
-                    id: node
-                        .id
-                        .parse()
-                        .map_err(|_| ServiceError::InvalidNodeId(node.id))?,
-                    tree_id: node.tree_id,
-                    value: node.value,
-                    parent_node_id: match node.parent_node_id {
-                        Some(id) => Some(id.parse().map_err(|_| ServiceError::InvalidNodeId(id))?),
-                        None => None,
-                    },
-                    node_tx: deserialize(&node.node_tx)
-                        .map_err(|_| ServiceError::InvalidTransaction)?,
-                    refund_tx: Some(
-                        deserialize(&node.refund_tx)
-                            .map_err(|_| ServiceError::InvalidTransaction)?,
-                    ),
-                    direct_tx: None,
-                    direct_refund_tx: None,
-                    direct_from_cpfp_refund_tx: Some(
-                        deserialize(&node.direct_from_cpfp_refund_tx)
-                            .map_err(|_| ServiceError::InvalidTransaction)?,
-                    ),
-                    vout: node.vout,
-                    verifying_public_key: PublicKey::from_slice(&node.verifying_public_key)
-                        .map_err(|_| ServiceError::InvalidVerifyingKey)?,
-                    owner_identity_public_key: if node.owner_identity_public_key.is_empty() {
-                        None
-                    } else {
-                        Some(
-                            PublicKey::from_slice(&node.owner_identity_public_key)
-                                .map_err(|_| ServiceError::InvalidPublicKey)?,
-                        )
-                    },
-                    signing_keyshare: signing_keyshare.try_into()?,
-                    status: TreeNodeStatus::from(node.status.as_str()),
-                })
-            })
-            .collect::<Result<Vec<_>, ServiceError>>()?;
-
-        Ok(nodes)
+        Ok(vec![root_node.try_into()?])
     }
 
     pub async fn generate_deposit_address(

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -13,7 +13,7 @@ use tracing::{error, trace};
 
 use crate::{
     Network,
-    bitcoin::{BitcoinService, sighash_from_tx},
+    bitcoin::{BitcoinService, sighash_from_tx, verify_finalized_taproot_signature},
     operator::{
         OperatorPool,
         rpc::{self as operator_rpc, spark::HashVariant},
@@ -737,6 +737,37 @@ impl DepositService {
                 "finalize_deposit_tree_creation returned no root node".to_string(),
             )
         })?;
+
+        // Verify the operator-returned root node matches what we signed for.
+        // The fused `start_deposit_tree_creation` flow returned signature shares
+        // that we aggregated locally; the package flow aggregates server-side,
+        // so we re-derive the same security guarantees here:
+        //  1) the verifying key we used really is the tree's verifying key,
+        //  2) each returned transaction carries a valid Schnorr signature
+        //     under that key for the sighashes we computed.
+        let returned_verifying_key = PublicKey::from_slice(&root_node.verifying_public_key)
+            .map_err(|_| ServiceError::InvalidVerifyingKey)?;
+        if &returned_verifying_key != verifying_public_key {
+            return Err(ServiceError::InvalidVerifyingKey);
+        }
+        verify_finalized_taproot_signature(
+            &self.bitcoin_service,
+            &root_node.node_tx,
+            cpfp_root_sighash.as_byte_array(),
+            verifying_public_key,
+        )?;
+        verify_finalized_taproot_signature(
+            &self.bitcoin_service,
+            &root_node.refund_tx,
+            cpfp_refund_sighash.as_byte_array(),
+            verifying_public_key,
+        )?;
+        verify_finalized_taproot_signature(
+            &self.bitcoin_service,
+            &root_node.direct_from_cpfp_refund_tx,
+            direct_from_cpfp_refund_sighash.as_byte_array(),
+            verifying_public_key,
+        )?;
 
         Ok(vec![root_node.try_into()?])
     }

--- a/crates/spark/src/services/error.rs
+++ b/crates/spark/src/services/error.rs
@@ -20,8 +20,6 @@ pub enum ServiceError {
     MissingUtxo,
     #[error("missing deposit address proof")]
     MissingDepositAddressProof,
-    #[error("missing signing keyshare")]
-    MissingSigningKeyshare,
     #[error("missing tree signatures")]
     MissingTreeSignatures,
     #[error("missing leaf id")]

--- a/crates/spark/src/services/error.rs
+++ b/crates/spark/src/services/error.rs
@@ -50,20 +50,12 @@ pub enum ServiceError {
     SSPswapError(String),
     #[error("preimage share store failed: {0}")]
     PreimageShareStoreFailed(String),
-    #[error("payment not found")]
-    PaymentNotFound,
 
     // Transfer related errors
-    #[error("Failed to extend time lock: {0}")]
-    ExtendTimeLockError(String),
-    #[error("Transfer verification failed: {0}")]
-    TransferVerificationError(String),
     #[error("Max retries exceeded")]
     MaxRetriesExceeded,
     #[error("No leaves to claim")]
     NoLeavesToClaim,
-    #[error("Claim transfer failed: {0}")]
-    ClaimTransferError(String),
     #[error("Signature verification failed: {0}")]
     SignatureVerificationFailed(String),
 

--- a/crates/spark/src/services/models.rs
+++ b/crates/spark/src/services/models.rs
@@ -222,6 +222,40 @@ pub(crate) fn map_signing_nonce_commitments(
     Ok(nonce_commitments)
 }
 
+/// Splits a flat list of signing commitments returned by
+/// `get_signing_commitments` into the three refund-transaction variants
+/// (CPFP, direct, direct-from-CPFP).
+///
+/// `get_signing_commitments` lays out commitments as
+/// `[A1, B1, A2, B2, A3, B3]` for `node_ids = [A, B], count = 3`, i.e.
+/// `node_id_count` entries per variant, three variants in a row.
+///
+/// Returns `InvalidInput` if `node_id_count == 0` (which would otherwise
+/// cause `Vec::chunks(0)` to panic) and a generic error if the total
+/// length doesn't match `3 * node_id_count`.
+pub(crate) fn split_signing_commitments_by_variant<T>(
+    commitments: &[T],
+    node_id_count: usize,
+) -> Result<[&[T]; 3], ServiceError> {
+    if node_id_count == 0 {
+        return Err(ServiceError::InvalidInput(
+            "cannot request signing commitments for zero nodes".to_string(),
+        ));
+    }
+    let expected = node_id_count.checked_mul(3).ok_or_else(|| {
+        ServiceError::InvalidInput("node count overflow computing commitment total".to_string())
+    })?;
+    if commitments.len() != expected {
+        return Err(ServiceError::Generic(format!(
+            "expected {expected} signing commitments, got {}",
+            commitments.len()
+        )));
+    }
+    let (cpfp, rest) = commitments.split_at(node_id_count);
+    let (direct, direct_from_cpfp) = rest.split_at(node_id_count);
+    Ok([cpfp, direct, direct_from_cpfp])
+}
+
 #[derive(Debug)]
 pub struct LeafKeyTweak {
     pub node: TreeNode,

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -10,13 +10,14 @@ use crate::operator::rpc::{self as operator_rpc, OperatorRpcError};
 use crate::services::models::{LeafKeyTweak, Transfer, map_signing_nonce_commitments};
 use crate::services::{ProofMap, TransferId, TransferObserver, TransferStatus};
 use crate::signer::{
-    FrostSigningCommitmentsWithNonces, SecretSource, SecretToSplit, VerifiableSecretShare,
+    FrostSigningCommitmentsWithNonces, SecretSource, SecretToSplit, SignFrostRequest,
+    VerifiableSecretShare,
 };
 use crate::utils::leaf_key_tweak::prepare_leaf_key_tweaks_to_send;
 use crate::utils::paging::{PagingFilter, PagingResult, pager};
 use crate::utils::refund::{
     RefundSignatures, SignRefundsParams, SignedRefundTransactions, prepare_refund_so_signing_jobs,
-    sign_aggregate_refunds, sign_refunds,
+    sign_refunds,
 };
 use crate::utils::tagged_hasher::TaggedHasher;
 use crate::utils::time::web_time_to_prost_timestamp;
@@ -34,6 +35,7 @@ use prost::Message as ProstMessage;
 use tracing::{debug, error, trace, warn};
 
 use crate::{
+    bitcoin::sighash_from_tx,
     signer::Signer,
     tree::{TreeNode, TreeNodeId},
 };
@@ -803,134 +805,143 @@ impl TransferService {
         leaves_to_claim: Vec<LeafKeyTweak>,
     ) -> Result<Vec<TreeNode>, ServiceError> {
         trace!("Claiming transfer with leaves: {:?}", leaves_to_claim);
-        // Check if we need to apply key tweaks first
-        let proof_map = if transfer.status == TransferStatus::SenderKeyTweaked {
-            Some(
-                self.claim_transfer_tweak_keys(transfer, &leaves_to_claim)
-                    .await
-                    .map_err(|e| {
-                        debug!("Failed to claim transfer tweak keys: {}", e);
-                        e
-                    })?,
-            )
-        } else {
-            None
-        };
 
-        debug!("Claim transfer tweak keys successful.");
-        let node_signatures = self
-            .claim_transfer_sign_refunds(transfer, &leaves_to_claim, proof_map.as_ref())
+        let claim_package = self
+            .prepare_claim_package(transfer, &leaves_to_claim)
             .await?;
-        debug!("Claim transfer sign refunds successful.");
-        let finalized_nodes = self.finalize_node_signatures(&node_signatures).await?;
-        debug!("Finalize node signatures successful.");
-        Ok(finalized_nodes)
+
+        let response = self
+            .operator_pool
+            .get_coordinator()
+            .client
+            .claim_transfer(operator_rpc::spark::ClaimTransferRequest {
+                transfer_id: transfer.id.to_string(),
+                owner_identity_public_key: self
+                    .signer
+                    .get_identity_public_key()
+                    .await?
+                    .serialize()
+                    .to_vec(),
+                claim_package: Some(claim_package),
+            })
+            .await?;
+
+        let claimed_transfer: Transfer = response
+            .transfer
+            .ok_or_else(|| {
+                ServiceError::Generic("claim_transfer returned no transfer".to_string())
+            })?
+            .try_into()?;
+
+        Ok(claimed_transfer
+            .leaves
+            .into_iter()
+            .map(|l| l.leaf)
+            .collect())
     }
 
-    /// Claims transfer by applying key tweaks across all operators
-    async fn claim_transfer_tweak_keys(
+    /// Assembles a signed `ClaimPackage` for the coordinator: per-operator
+    /// ECIES-encrypted key tweaks, user-signed refund jobs, and an
+    /// identity-key signature over the package payload.
+    async fn prepare_claim_package(
         &self,
         transfer: &Transfer,
         leaves: &[LeafKeyTweak],
-    ) -> Result<ProofMap, ServiceError> {
-        let (leaves_tweaks_map, proof_map) = self.prepare_claim_leaves_key_tweaks(leaves).await?;
+    ) -> Result<operator_rpc::spark::ClaimPackage, ServiceError> {
+        let (leaves_tweaks_map, _proof_map) =
+            self.prepare_claim_leaves_key_tweaks(leaves).await?;
 
-        // Send claim transfer tweak keys to all signing operators in parallel
-        let mut tasks = Vec::new();
-
-        let identity_public_key = self
-            .signer
-            .get_identity_public_key()
-            .await?
-            .serialize()
-            .to_vec();
-
-        for operator in self.operator_pool.get_all_operators() {
-            let Some(leaves_to_receive) = leaves_tweaks_map.get(&operator.identifier) else {
-                continue;
-            };
-
-            let identity_public_key = identity_public_key.clone();
-            let leaves_to_receive = leaves_to_receive.clone();
-
-            let task = async move {
-                let result = operator
-                    .client
-                    .claim_transfer_tweak_keys(operator_rpc::spark::ClaimTransferTweakKeysRequest {
-                        transfer_id: transfer.id.to_string(),
-                        owner_identity_public_key: identity_public_key,
-                        leaves_to_receive,
-                    })
-                    .await;
-
-                let err = match result {
-                    Ok(()) => {
-                        trace!(
-                            "Operator {} successfully applied key tweaks for transfer {}",
-                            operator.identity_public_key, transfer.id
-                        );
-                        return Ok::<_, ServiceError>(());
-                    }
-                    Err(e) => e,
-                };
-
-                let OperatorRpcError::Connection(status) = err else {
-                    return Err(err.into());
-                };
-
-                debug!(
-                    "Operator {} returned connection error: {:?}",
-                    operator.identity_public_key, status
-                );
-
-                // There was an error tweaking the keys. It's likely the transfer was not in state SenderKeyTweaked after all.
-                // Let's find out what state we're in.
-                // Fetch the leaf remotely from the operator. Determine its state, and return info about it to the caller.
-                let operator_transfers = operator
-                    .client
-                    .query_all_transfers(TransferFilter {
-                        transfer_ids: vec![transfer.id.to_string()],
-                        network: self.network.to_proto_network() as i32,
-                        participant: Some(Participant::ReceiverIdentityPublicKey(
-                            self.signer
-                                .get_identity_public_key()
-                                .await?
-                                .serialize()
-                                .to_vec(),
-                        )),
-                        ..Default::default()
-                    })
-                    .await?;
-                let Some(operator_transfer) = operator_transfers.transfers.into_iter().nth(0)
-                else {
-                    debug!(
-                        "Attempting to recover from operator error, but operator doesn't know transfer {}",
-                        transfer.id
-                    );
-                    return Err(ServiceError::ClaimTransferError(status.to_string()));
-                };
-
-                let operator_transfer: Transfer = operator_transfer.try_into()?;
-                debug!(
-                    "Operator {} reports transfer {} is now in {} state (expected SenderKeyTweaked)",
-                    operator.identity_public_key, operator_transfer.id, operator_transfer.status
-                );
-                match operator_transfer.status {
-                    TransferStatus::ReceiverKeyTweaked
-                    | TransferStatus::ReceiverKeyTweakApplied
-                    | TransferStatus::ReceiverKeyTweakLocked
-                    | TransferStatus::ReceiverRefundSigned
-                    | TransferStatus::Completed => Ok(()),
-                    _ => Err(ServiceError::ClaimTransferError(status.to_string())),
-                }
-            };
-
-            tasks.push(task);
+        // ECIES-encrypt the per-operator claim leaf key tweaks.
+        let mut key_tweak_package: HashMap<String, Vec<u8>> = HashMap::new();
+        for (identifier, leaves_to_receive) in leaves_tweaks_map {
+            let proto = operator_rpc::spark::ClaimLeafKeyTweaks { leaves_to_receive };
+            let operator = self
+                .operator_pool
+                .get_operator_by_identifier(&identifier)
+                .ok_or_else(|| ServiceError::Generic("Operator not found".to_string()))?;
+            let encrypted = self
+                .encrypt_with_public_key(&operator.identity_public_key, &proto.encode_to_vec())?;
+            key_tweak_package.insert(hex::encode(identifier.serialize()), encrypted);
         }
 
-        futures::future::try_join_all(tasks).await?;
+        // Fetch operator signing commitments. The receiver does not yet own the
+        // leaves, so request commitments by count rather than by node id.
+        let signing_commitments = self
+            .operator_pool
+            .get_coordinator()
+            .client
+            .get_signing_commitments(operator_rpc::spark::GetSigningCommitmentsRequest {
+                node_ids: Vec::new(),
+                count: 3,
+                node_id_count: leaves.len() as u32,
+            })
+            .await?
+            .signing_commitments
+            .iter()
+            .map(|sc| map_signing_nonce_commitments(&sc.signing_nonce_commitments))
+            .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(proof_map)
+        let chunks = signing_commitments
+            .chunks(leaves.len())
+            .collect::<Vec<_>>();
+        if chunks.len() != 3 {
+            return Err(ServiceError::Generic(
+                "Not enough signing commitments returned".to_string(),
+            ));
+        }
+
+        // Sign the claim refunds (current timelock) operator-commits-first;
+        // the operators aggregate server-side during `claim_transfer`.
+        let (cpfp_jobs, direct_jobs, direct_from_cpfp_jobs) = self
+            .sign_claim_refunds(leaves, chunks[0], chunks[1], chunks[2])
+            .await?;
+
+        let mut claim_package = operator_rpc::spark::ClaimPackage {
+            leaves_to_claim: cpfp_jobs,
+            direct_leaves_to_claim: direct_jobs,
+            direct_from_cpfp_leaves_to_claim: direct_from_cpfp_jobs,
+            key_tweak_package,
+            user_signature: Vec::new(),
+            hash_variant: HashVariant::V2.into(),
+        };
+
+        let signing_payload =
+            self.get_claim_package_signing_payload(&transfer.id, &claim_package)?;
+        let signature = self
+            .signer
+            .sign_message_ecdsa_with_identity_key(&signing_payload)
+            .await
+            .map_err(ServiceError::SignerError)?;
+        claim_package.user_signature = signature.serialize_der().to_vec();
+
+        Ok(claim_package)
+    }
+
+    /// Creates the signing payload for a claim package using tagged hashing.
+    /// Uses V2 structured hashing with domain tag for collision resistance.
+    fn get_claim_package_signing_payload(
+        &self,
+        transfer_id: &TransferId,
+        claim_package: &operator_rpc::spark::ClaimPackage,
+    ) -> Result<Vec<u8>, ServiceError> {
+        let transfer_id_bytes =
+            hex::decode(transfer_id.to_string().replace('-', "")).map_err(|e| {
+                ServiceError::ValidationError(format!("Failed to decode transfer ID: {e}"))
+            })?;
+
+        // Convert HashMap to BTreeMap for deterministic ordering
+        let key_tweak_package: std::collections::BTreeMap<String, Vec<u8>> = claim_package
+            .key_tweak_package
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
+        let signable_message = TaggedHasher::new(&["spark", "claim", "signing payload"])
+            .add_bytes(&transfer_id_bytes)
+            .add_map_string_to_bytes(&key_tweak_package)
+            .signable_message();
+
+        Ok(signable_message)
     }
 
     /// Prepares claim leaves key tweaks for all operators
@@ -1040,108 +1051,191 @@ impl TransferService {
         Ok((leaf_tweaks_map, *proof))
     }
 
-    /// Claims transfer by signing refunds with the coordinator.
-    async fn claim_transfer_sign_refunds(
+    /// Signs claim refund transactions operator-commits-first. The operator
+    /// aggregates server-side during `claim_transfer`.
+    async fn sign_claim_refunds(
         &self,
-        transfer: &Transfer,
-        leaf_keys: &[LeafKeyTweak],
-        // TODO: do something with proofs? Currently not used in js implementation
-        _proof_map: Option<&ProofMap>,
-    ) -> Result<Vec<operator_rpc::spark::NodeSignatures>, ServiceError> {
-        // Prepare leaf data map with refund signing information
-        let mut leaf_data_map = HashMap::new();
-        for leaf_key in leaf_keys {
-            let signing_nonce_commitment = self.signer.generate_random_signing_commitment().await?;
-            let direct_signing_nonce_commitment =
-                self.signer.generate_random_signing_commitment().await?;
-            let direct_from_cpfp_signing_nonce_commitment =
-                self.signer.generate_random_signing_commitment().await?;
-
+        leaves: &[LeafKeyTweak],
+        cpfp_commitments: &[std::collections::BTreeMap<
+            Identifier,
+            frost_secp256k1_tr::round1::SigningCommitments,
+        >],
+        direct_commitments: &[std::collections::BTreeMap<
+            Identifier,
+            frost_secp256k1_tr::round1::SigningCommitments,
+        >],
+        direct_from_cpfp_commitments: &[std::collections::BTreeMap<
+            Identifier,
+            frost_secp256k1_tr::round1::SigningCommitments,
+        >],
+    ) -> Result<
+        (
+            Vec<operator_rpc::spark::UserSignedTxSigningJob>,
+            Vec<operator_rpc::spark::UserSignedTxSigningJob>,
+            Vec<operator_rpc::spark::UserSignedTxSigningJob>,
+        ),
+        ServiceError,
+    > {
+        // Build per-leaf signing data using the receiver's new signing key.
+        let mut leaf_data_map: HashMap<TreeNodeId, LeafRefundSigningData> = HashMap::new();
+        for leaf in leaves {
             let signing_public_key = self
                 .signer
-                .public_key_from_secret(&leaf_key.new_signing_key)
+                .public_key_from_secret(&leaf.new_signing_key)
                 .await?;
-
             leaf_data_map.insert(
-                leaf_key.node.id.clone(),
+                leaf.node.id.clone(),
                 LeafRefundSigningData {
-                    signing_private_key: leaf_key.new_signing_key.clone(),
+                    signing_private_key: leaf.new_signing_key.clone(),
                     signing_public_key,
                     receiving_public_key: signing_public_key,
-                    tx: leaf_key.node.node_tx.clone(),
-                    direct_tx: leaf_key.node.direct_tx.clone(),
+                    tx: leaf.node.node_tx.clone(),
+                    direct_tx: leaf.node.direct_tx.clone(),
                     refund_tx: None,
                     direct_refund_tx: None,
                     direct_from_cpfp_refund_tx: None,
-                    signing_nonce_commitment,
-                    direct_signing_nonce_commitment,
-                    direct_from_cpfp_signing_nonce_commitment,
-                    vout: leaf_key.node.vout,
+                    signing_nonce_commitment: self
+                        .signer
+                        .generate_random_signing_commitment()
+                        .await?,
+                    direct_signing_nonce_commitment: self
+                        .signer
+                        .generate_random_signing_commitment()
+                        .await?,
+                    direct_from_cpfp_signing_nonce_commitment: self
+                        .signer
+                        .generate_random_signing_commitment()
+                        .await?,
+                    vout: leaf.node.vout,
                     connector_prev_out: None,
                 },
             );
         }
 
-        // Prepare refund signing jobs for the coordinator
-        let signing_jobs =
-            prepare_refund_so_signing_jobs(self.network, leaf_keys, &mut leaf_data_map, true)?;
+        // Build the claim refund transactions (current timelock) into
+        // `leaf_data_map`. The (fused-form) signing jobs returned here are
+        // discarded — we sign operator-commits-first below.
+        prepare_refund_so_signing_jobs(self.network, leaves, &mut leaf_data_map, true)?;
 
-        // Call the coordinator to get signing results
-        let response = self
-            .operator_pool
-            .get_coordinator()
-            .client
-            .claim_transfer_sign_refunds_v2(operator_rpc::spark::ClaimTransferSignRefundsRequest {
-                transfer_id: transfer.id.to_string(),
-                owner_identity_public_key: self
-                    .signer
-                    .get_identity_public_key()
-                    .await?
-                    .serialize()
-                    .to_vec(),
-                signing_jobs,
-            })
-            .await?;
+        let mut cpfp_jobs = Vec::new();
+        let mut direct_jobs = Vec::new();
+        let mut direct_from_cpfp_jobs = Vec::new();
+        for (i, leaf) in leaves.iter().enumerate() {
+            let data = leaf_data_map.remove(&leaf.node.id).ok_or_else(|| {
+                ServiceError::Generic(format!("Leaf data not found for leaf {}", leaf.node.id))
+            })?;
+            let verifying_key = leaf.node.verifying_public_key;
 
-        // Sign the refunds using FROST
-        let node_signatures = sign_aggregate_refunds(
-            &self.signer,
-            &leaf_data_map.into_iter().collect(),
-            &response.signing_results,
-            None,
-            None,
-            None,
-        )
-        .await?;
+            let LeafRefundSigningData {
+                signing_private_key,
+                signing_public_key,
+                tx: node_tx,
+                direct_tx,
+                refund_tx,
+                direct_refund_tx,
+                direct_from_cpfp_refund_tx,
+                signing_nonce_commitment,
+                direct_signing_nonce_commitment,
+                direct_from_cpfp_signing_nonce_commitment,
+                ..
+            } = data;
 
-        Ok(node_signatures)
+            let cpfp_refund_tx = refund_tx
+                .ok_or_else(|| ServiceError::Generic("Missing cpfp refund tx".to_string()))?;
+            let cpfp_sighash = sighash_from_tx(&cpfp_refund_tx, 0, &node_tx.output[0])?;
+            cpfp_jobs.push(
+                self.sign_claim_refund_job(
+                    &leaf.node.id,
+                    cpfp_refund_tx,
+                    cpfp_sighash.as_byte_array(),
+                    &signing_public_key,
+                    &signing_private_key,
+                    signing_nonce_commitment,
+                    cpfp_commitments[i].clone(),
+                    &verifying_key,
+                )
+                .await?,
+            );
+
+            if let (Some(direct_tx), Some(direct_refund_tx)) = (direct_tx, direct_refund_tx) {
+                let sighash = sighash_from_tx(&direct_refund_tx, 0, &direct_tx.output[0])?;
+                direct_jobs.push(
+                    self.sign_claim_refund_job(
+                        &leaf.node.id,
+                        direct_refund_tx,
+                        sighash.as_byte_array(),
+                        &signing_public_key,
+                        &signing_private_key,
+                        direct_signing_nonce_commitment,
+                        direct_commitments[i].clone(),
+                        &verifying_key,
+                    )
+                    .await?,
+                );
+            }
+
+            if let Some(dfc_refund_tx) = direct_from_cpfp_refund_tx {
+                let sighash = sighash_from_tx(&dfc_refund_tx, 0, &node_tx.output[0])?;
+                direct_from_cpfp_jobs.push(
+                    self.sign_claim_refund_job(
+                        &leaf.node.id,
+                        dfc_refund_tx,
+                        sighash.as_byte_array(),
+                        &signing_public_key,
+                        &signing_private_key,
+                        direct_from_cpfp_signing_nonce_commitment,
+                        direct_from_cpfp_commitments[i].clone(),
+                        &verifying_key,
+                    )
+                    .await?,
+                );
+            }
+        }
+
+        Ok((cpfp_jobs, direct_jobs, direct_from_cpfp_jobs))
     }
 
-    /// Finalizes node signatures with the coordinator.
-    async fn finalize_node_signatures(
+    #[allow(clippy::too_many_arguments)]
+    async fn sign_claim_refund_job(
         &self,
-        node_signatures: &[operator_rpc::spark::NodeSignatures],
-    ) -> Result<Vec<TreeNode>, ServiceError> {
-        let response = self
-            .operator_pool
-            .get_coordinator()
-            .client
-            .finalize_node_signatures_v2(operator_rpc::spark::FinalizeNodeSignaturesRequest {
-                intent: operator_rpc::common::SignatureIntent::Transfer as i32,
-                node_signatures: node_signatures.to_vec(),
+        node_id: &TreeNodeId,
+        refund_tx: Transaction,
+        sighash_bytes: &[u8],
+        signing_public_key: &PublicKey,
+        signing_private_key: &SecretSource,
+        self_nonce_commitment: FrostSigningCommitmentsWithNonces,
+        operator_commitments: std::collections::BTreeMap<
+            Identifier,
+            frost_secp256k1_tr::round1::SigningCommitments,
+        >,
+        verifying_key: &PublicKey,
+    ) -> Result<operator_rpc::spark::UserSignedTxSigningJob, ServiceError> {
+        let user_signature = self
+            .signer
+            .sign_frost(SignFrostRequest {
+                message: sighash_bytes,
+                public_key: signing_public_key,
+                private_key: signing_private_key,
+                verifying_key,
+                self_nonce_commitment: &self_nonce_commitment,
+                statechain_commitments: operator_commitments.clone(),
+                adaptor_public_key: None,
             })
             .await?;
 
-        let nodes = response
-            .nodes
-            .into_iter()
-            .map(|node| node.try_into())
-            .collect::<Result<Vec<TreeNode>, _>>()?;
-
-        Ok(nodes)
+        let signed_tx = SignedTx {
+            node_id: node_id.clone(),
+            signing_public_key: *signing_public_key,
+            tx: refund_tx,
+            user_signature,
+            signing_commitments: operator_commitments,
+            self_nonce_commitment,
+            network: self.network,
+        };
+        (&signed_tx).try_into()
     }
 
-    pub async fn verify_pending_transfer(
+pub async fn verify_pending_transfer(
         &self,
         transfer: &Transfer,
     ) -> Result<HashMap<TreeNodeId, SecretSource>, ServiceError> {

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -848,8 +848,7 @@ impl TransferService {
         transfer: &Transfer,
         leaves: &[LeafKeyTweak],
     ) -> Result<operator_rpc::spark::ClaimPackage, ServiceError> {
-        let (leaves_tweaks_map, _proof_map) =
-            self.prepare_claim_leaves_key_tweaks(leaves).await?;
+        let (leaves_tweaks_map, _proof_map) = self.prepare_claim_leaves_key_tweaks(leaves).await?;
 
         // ECIES-encrypt the per-operator claim leaf key tweaks.
         let mut key_tweak_package: HashMap<String, Vec<u8>> = HashMap::new();
@@ -881,9 +880,7 @@ impl TransferService {
             .map(|sc| map_signing_nonce_commitments(&sc.signing_nonce_commitments))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let chunks = signing_commitments
-            .chunks(leaves.len())
-            .collect::<Vec<_>>();
+        let chunks = signing_commitments.chunks(leaves.len()).collect::<Vec<_>>();
         if chunks.len() != 3 {
             return Err(ServiceError::Generic(
                 "Not enough signing commitments returned".to_string(),
@@ -1235,7 +1232,7 @@ impl TransferService {
         (&signed_tx).try_into()
     }
 
-pub async fn verify_pending_transfer(
+    pub async fn verify_pending_transfer(
         &self,
         transfer: &Transfer,
     ) -> Result<HashMap<TreeNodeId, SecretSource>, ServiceError> {

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -7,7 +7,9 @@ use crate::operator::OperatorPool;
 use crate::operator::rpc::spark::transfer_filter::Participant;
 use crate::operator::rpc::spark::{HashVariant, StartTransferRequest, TransferFilter};
 use crate::operator::rpc::{self as operator_rpc, OperatorRpcError};
-use crate::services::models::{LeafKeyTweak, Transfer, map_signing_nonce_commitments};
+use crate::services::models::{
+    LeafKeyTweak, Transfer, map_signing_nonce_commitments, split_signing_commitments_by_variant,
+};
 use crate::services::{ProofMap, TransferId, TransferObserver, TransferStatus};
 use crate::signer::{
     FrostSigningCommitmentsWithNonces, SecretSource, SecretToSplit, SignFrostRequest,
@@ -445,6 +447,12 @@ impl TransferService {
         payment_hash: Option<&sha256::Hash>,
         cpfp_adaptor_public_key: Option<&PublicKey>,
     ) -> Result<PreparedTransferPackage, ServiceError> {
+        if leaf_key_tweaks.is_empty() {
+            return Err(ServiceError::InvalidInput(
+                "prepare_transfer_package requires at least one leaf".to_string(),
+            ));
+        }
+
         let signing_commitments = self
             .operator_pool
             .get_coordinator()
@@ -463,19 +471,11 @@ impl TransferService {
             .map(|sc| map_signing_nonce_commitments(&sc.signing_nonce_commitments))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let chunked_signing_commitments = signing_commitments
-            .chunks(leaf_key_tweaks.len())
-            .collect::<Vec<_>>();
-
-        if chunked_signing_commitments.len() != 3 {
-            return Err(ServiceError::SSPswapError(
-                "Not enough signing commitments returned".to_string(),
-            ));
-        }
-
-        let cpfp_signing_commitments = chunked_signing_commitments[0].to_vec();
-        let direct_signing_commitments = chunked_signing_commitments[1].to_vec();
-        let direct_from_cpfp_signing_commitments = chunked_signing_commitments[2].to_vec();
+        let [cpfp_chunk, direct_chunk, direct_from_cpfp_chunk] =
+            split_signing_commitments_by_variant(&signing_commitments, leaf_key_tweaks.len())?;
+        let cpfp_signing_commitments = cpfp_chunk.to_vec();
+        let direct_signing_commitments = direct_chunk.to_vec();
+        let direct_from_cpfp_signing_commitments = direct_from_cpfp_chunk.to_vec();
 
         let SignedRefundTransactions {
             cpfp_signed_tx,
@@ -848,6 +848,14 @@ impl TransferService {
         transfer: &Transfer,
         leaves: &[LeafKeyTweak],
     ) -> Result<operator_rpc::spark::ClaimPackage, ServiceError> {
+        if leaves.is_empty() {
+            return Err(ServiceError::NoLeavesToClaim);
+        }
+        let node_id_count: u32 = leaves
+            .len()
+            .try_into()
+            .map_err(|_| ServiceError::InvalidInput("too many leaves to claim".to_string()))?;
+
         let (leaves_tweaks_map, _proof_map) = self.prepare_claim_leaves_key_tweaks(leaves).await?;
 
         // ECIES-encrypt the per-operator claim leaf key tweaks.
@@ -872,7 +880,7 @@ impl TransferService {
             .get_signing_commitments(operator_rpc::spark::GetSigningCommitmentsRequest {
                 node_ids: Vec::new(),
                 count: 3,
-                node_id_count: leaves.len() as u32,
+                node_id_count,
             })
             .await?
             .signing_commitments
@@ -880,17 +888,13 @@ impl TransferService {
             .map(|sc| map_signing_nonce_commitments(&sc.signing_nonce_commitments))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let chunks = signing_commitments.chunks(leaves.len()).collect::<Vec<_>>();
-        if chunks.len() != 3 {
-            return Err(ServiceError::Generic(
-                "Not enough signing commitments returned".to_string(),
-            ));
-        }
+        let [cpfp_chunk, direct_chunk, direct_from_cpfp_chunk] =
+            split_signing_commitments_by_variant(&signing_commitments, leaves.len())?;
 
         // Sign the claim refunds (current timelock) operator-commits-first;
         // the operators aggregate server-side during `claim_transfer`.
         let (cpfp_jobs, direct_jobs, direct_from_cpfp_jobs) = self
-            .sign_claim_refunds(leaves, chunks[0], chunks[1], chunks[2])
+            .sign_claim_refunds(leaves, cpfp_chunk, direct_chunk, direct_from_cpfp_chunk)
             .await?;
 
         let mut claim_package = operator_rpc::spark::ClaimPackage {

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -1485,47 +1485,6 @@ impl TransferService {
             None => Ok(None),
         }
     }
-
-    pub async fn deliver_transfer_package(
-        &self,
-        transfer: &Transfer,
-        leaves: &[LeafKeyTweak],
-        refund_signatures: RefundSignatures,
-    ) -> Result<Transfer, ServiceError> {
-        let prepared_transfer_request = self
-            .prepare_transfer_request(
-                &transfer.id,
-                leaves,
-                &transfer.receiver_identity_public_key,
-                refund_signatures,
-                None,
-                None,
-                None, // No adaptor public key for regular transfers
-            )
-            .await?;
-
-        let response = self
-            .operator_pool
-            .get_coordinator()
-            .client
-            .finalize_transfer_with_transfer_package(
-                operator_rpc::spark::FinalizeTransferWithTransferPackageRequest {
-                    transfer_id: prepared_transfer_request.transfer_request.transfer_id,
-                    owner_identity_public_key: prepared_transfer_request
-                        .transfer_request
-                        .owner_identity_public_key,
-                    transfer_package: prepared_transfer_request.transfer_request.transfer_package,
-                },
-            )
-            .await?;
-
-        match response.transfer {
-            Some(transfer) => Ok(transfer.try_into()?),
-            None => Err(ServiceError::Generic(
-                "No transfer response from operator".to_string(),
-            )),
-        }
-    }
 }
 
 fn find_share(

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashMap};
-use std::str::FromStr;
 use std::sync::Arc;
 
 use bitcoin::hashes::{Hash, sha256};
@@ -7,23 +6,17 @@ use bitcoin::secp256k1::{PublicKey, ecdsa::Signature};
 use bitcoin::{Sequence, Transaction};
 use frost_secp256k1_tr::Identifier;
 use frost_secp256k1_tr::round1::SigningCommitments;
-use tracing::{info, trace};
+use tracing::info;
 
 use crate::core::{current_sequence, enforce_timelock, next_lightning_htlc_sequence};
 use crate::services::{LeafRefundSigningData, ServiceError, SignedTx};
 use crate::signer::{SignFrostRequest, Signer, SignerError};
 use crate::tree::{TreeNode, TreeNodeId};
-use crate::utils::frost::{SignAggregateFrostParams, sign_aggregate_frost};
 use crate::utils::htlc_transactions::{
     CreateLightningHtlcRefundTxsParams, create_lightning_htlc_refund_txs,
 };
 use crate::utils::transactions::{RefundTransactions, create_refund_txs};
-use crate::{
-    Network,
-    bitcoin::{sighash_from_multi_input_tx, sighash_from_tx},
-    core::next_sequence,
-    services::LeafKeyTweak,
-};
+use crate::{Network, bitcoin::sighash_from_tx, core::next_sequence, services::LeafKeyTweak};
 
 #[derive(Clone, Debug, Default)]
 pub struct RefundSignatures {
@@ -290,186 +283,6 @@ async fn sign_refund(
     })
 }
 
-/// Signs refund transactions using FROST threshold signatures
-pub async fn sign_aggregate_refunds(
-    signer: &Arc<dyn Signer>,
-    leaf_data_map: &HashMap<TreeNodeId, LeafRefundSigningData>,
-    operator_signing_results: &[crate::operator::rpc::spark::LeafRefundTxSigningResult],
-    cpfp_adaptor_pubkey: Option<&PublicKey>,
-    direct_adaptor_pubkey: Option<&PublicKey>,
-    direct_from_cpfp_adaptor_pubkey: Option<&PublicKey>,
-) -> Result<Vec<crate::operator::rpc::spark::NodeSignatures>, ServiceError> {
-    let mut node_signatures = Vec::new();
-
-    for operator_signing_result in operator_signing_results {
-        let leaf_id = TreeNodeId::from_str(&operator_signing_result.leaf_id)
-            .map_err(ServiceError::ValidationError)?;
-
-        let leaf_data = leaf_data_map.get(&leaf_id).ok_or_else(|| {
-            ServiceError::Generic(format!(
-                "Leaf data not found for leaf {}",
-                operator_signing_result.leaf_id
-            ))
-        })?;
-
-        let tx = &leaf_data.tx;
-        let refund_tx = leaf_data
-            .refund_tx
-            .as_ref()
-            .ok_or_else(|| ServiceError::Generic("Missing refund transaction".to_string()))?;
-
-        let verifying_key = PublicKey::from_slice(&operator_signing_result.verifying_key)
-            .map_err(|_| ServiceError::ValidationError("Invalid verifying key".to_string()))?;
-
-        let refund_tx_signing_result = operator_signing_result
-            .refund_tx_signing_result
-            .as_ref()
-            .map(|sr| sr.try_into())
-            .transpose()?
-            .ok_or(ServiceError::ValidationError(
-                "Missing refund tx signing result".to_string(),
-            ))?;
-
-        // For coop exit (multi-input refunds), build all_prev_outs with both node and connector outputs
-        let all_prev_outs = leaf_data
-            .connector_prev_out
-            .as_ref()
-            .map(|connector_out| vec![tx.output[0].clone(), connector_out.clone()]);
-
-        tracing::debug!(
-            "sign_aggregate_refunds: leaf={}, connector_prev_out={}, refund_tx_inputs={}, node_tx_out0_value={}, connector_out_value={:?}",
-            leaf_id,
-            leaf_data.connector_prev_out.is_some(),
-            refund_tx.input.len(),
-            tx.output[0].value,
-            leaf_data.connector_prev_out.as_ref().map(|c| c.value)
-        );
-
-        // Compute sighash for refund tx
-        // For multi-input transactions (coop exit), use all_prev_outs for BIP 341 sighash
-        let refund_sighash =
-            if let Some(prev_outs) = all_prev_outs.as_ref().filter(|_| refund_tx.input.len() > 1) {
-                sighash_from_multi_input_tx(refund_tx, 0, prev_outs)
-            } else {
-                sighash_from_tx(refund_tx, 0, &tx.output[0])
-            }
-            .map_err(|e| ServiceError::Generic(e.to_string()))?;
-
-        let refund_tx_signature = sign_aggregate_frost(SignAggregateFrostParams {
-            signer,
-            sighash: &refund_sighash,
-            signing_public_key: &leaf_data.signing_public_key,
-            aggregating_public_key: &leaf_data.signing_public_key,
-            signing_private_key: &leaf_data.signing_private_key,
-            self_nonce_commitment: &leaf_data.signing_nonce_commitment,
-            adaptor_public_key: cpfp_adaptor_pubkey,
-            verifying_key: &verifying_key,
-            signing_result: refund_tx_signing_result,
-        })
-        .await?;
-
-        let mut direct_refund_tx_signature = Vec::new();
-        let mut direct_from_cpfp_refund_tx_signature = Vec::new();
-
-        if let Some(direct_tx) = &leaf_data.direct_tx
-            && let Some(direct_refund_tx) = &leaf_data.direct_refund_tx
-        {
-            trace!("Signing direct refund tx for leaf");
-            let direct_refund_tx_signing_result = operator_signing_result
-                .direct_refund_tx_signing_result
-                .as_ref()
-                .map(|sr| sr.try_into())
-                .transpose()?
-                .ok_or(ServiceError::ValidationError(
-                    "Missing direct refund tx signing result".to_string(),
-                ))?;
-
-            // Build all_prev_outs for direct refund (direct_tx + connector)
-            // BIP 341 Taproot sighash requires ALL inputs' prevouts
-            let direct_all_prev_outs = leaf_data
-                .connector_prev_out
-                .as_ref()
-                .map(|connector_out| vec![direct_tx.output[0].clone(), connector_out.clone()]);
-
-            // Compute sighash for direct refund tx
-            let direct_refund_sighash = if let Some(prev_outs) = direct_all_prev_outs
-                .as_ref()
-                .filter(|_| direct_refund_tx.input.len() > 1)
-            {
-                sighash_from_multi_input_tx(direct_refund_tx, 0, prev_outs)
-            } else {
-                sighash_from_tx(direct_refund_tx, 0, &direct_tx.output[0])
-            }
-            .map_err(|e| ServiceError::Generic(e.to_string()))?;
-
-            let signature = sign_aggregate_frost(SignAggregateFrostParams {
-                signer,
-                sighash: &direct_refund_sighash,
-                signing_public_key: &leaf_data.signing_public_key,
-                aggregating_public_key: &leaf_data.signing_public_key,
-                signing_private_key: &leaf_data.signing_private_key,
-                self_nonce_commitment: &leaf_data.direct_signing_nonce_commitment,
-                adaptor_public_key: direct_adaptor_pubkey,
-                verifying_key: &verifying_key,
-                signing_result: direct_refund_tx_signing_result,
-            })
-            .await?;
-            direct_refund_tx_signature = signature.serialize()?.to_vec();
-        }
-
-        // direct_from_cpfp_refund_tx spends from the CPFP (node_tx) output, not from
-        // direct_tx, so it must be signed regardless of whether direct_tx exists.
-        if let Some(direct_from_cpfp_refund_tx) = &leaf_data.direct_from_cpfp_refund_tx {
-            trace!("Signing direct from CPFP refund tx for leaf");
-            let direct_from_cpfp_refund_tx_signing_result = operator_signing_result
-                .direct_from_cpfp_refund_tx_signing_result
-                .as_ref()
-                .map(|sr| sr.try_into())
-                .transpose()?
-                .ok_or(ServiceError::ValidationError(
-                    "Missing direct from CPFP refund tx signing result".to_string(),
-                ))?;
-
-            // Compute sighash for direct from CPFP refund tx
-            // Reuse all_prev_outs from CPFP refund (same inputs: node_tx + connector)
-            let direct_from_cpfp_sighash = if let Some(prev_outs) = all_prev_outs
-                .as_ref()
-                .filter(|_| direct_from_cpfp_refund_tx.input.len() > 1)
-            {
-                sighash_from_multi_input_tx(direct_from_cpfp_refund_tx, 0, prev_outs)
-            } else {
-                sighash_from_tx(direct_from_cpfp_refund_tx, 0, &tx.output[0])
-            }
-            .map_err(|e| ServiceError::Generic(e.to_string()))?;
-
-            let signature = sign_aggregate_frost(SignAggregateFrostParams {
-                signer,
-                sighash: &direct_from_cpfp_sighash,
-                signing_public_key: &leaf_data.signing_public_key,
-                aggregating_public_key: &leaf_data.signing_public_key,
-                signing_private_key: &leaf_data.signing_private_key,
-                self_nonce_commitment: &leaf_data.direct_from_cpfp_signing_nonce_commitment,
-                adaptor_public_key: direct_from_cpfp_adaptor_pubkey,
-                verifying_key: &verifying_key,
-                signing_result: direct_from_cpfp_refund_tx_signing_result,
-            })
-            .await?;
-            direct_from_cpfp_refund_tx_signature = signature.serialize()?.to_vec();
-        }
-
-        node_signatures.push(crate::operator::rpc::spark::NodeSignatures {
-            node_id: operator_signing_result.leaf_id.clone(),
-            node_tx_signature: Vec::new(),
-            refund_tx_signature: refund_tx_signature.serialize()?.to_vec(),
-            direct_node_tx_signature: Vec::new(),
-            direct_refund_tx_signature,
-            direct_from_cpfp_refund_tx_signature,
-        });
-    }
-
-    Ok(node_signatures)
-}
-
 /// Prepares refund signing jobs for claim operations
 pub fn prepare_refund_so_signing_jobs(
     network: Network,
@@ -605,72 +418,4 @@ where
     }
 
     Ok(signing_jobs)
-}
-
-/// Converts operator-provided node signatures into a structured `RefundSignatures` object.
-///
-/// This function processes an array of `NodeSignatures` (typically from operators) and maps them
-/// into HashMaps keyed by `TreeNodeId` for easier access. It handles three types of signatures:
-///
-/// 1. CPFP refund transaction signatures (always present)
-/// 2. Direct refund transaction signatures (optional)
-/// 3. Direct-from-CPFP refund transaction signatures (optional)
-///
-/// The function validates each signature by attempting to parse it from its compact representation.
-///
-/// # Arguments
-///
-/// * `node_signatures` - A vector of `NodeSignatures` from operators containing serialized signatures
-///
-/// # Returns
-///
-/// * `Ok(RefundSignatures)` - A structured object containing HashMaps of signatures organized by type and node ID
-/// * `Err(ServiceError)` - If any node ID or signature fails validation
-pub fn map_refund_signatures(
-    node_signatures: Vec<crate::operator::rpc::spark::NodeSignatures>,
-) -> Result<RefundSignatures, ServiceError> {
-    let mut cpfp_signatures = HashMap::new();
-    let mut direct_signatures = HashMap::new();
-    let mut direct_from_cpfp_signatures = HashMap::new();
-
-    for ns in node_signatures {
-        let node_id: TreeNodeId = match ns.node_id.parse() {
-            Ok(id) => id,
-            Err(_) => return Err(ServiceError::Generic("invalid node_id".to_string())),
-        };
-
-        cpfp_signatures.insert(
-            node_id.clone(),
-            Signature::from_compact(&ns.refund_tx_signature)
-                .map_err(|_| ServiceError::Generic("invalid refund tx signature".to_string()))?,
-        );
-
-        if !ns.direct_refund_tx_signature.is_empty() {
-            direct_signatures.insert(
-                node_id.clone(),
-                Signature::from_compact(&ns.direct_refund_tx_signature).map_err(|_| {
-                    ServiceError::Generic("invalid direct refund tx signature".to_string())
-                })?,
-            );
-        }
-
-        if !ns.direct_from_cpfp_refund_tx_signature.is_empty() {
-            direct_from_cpfp_signatures.insert(
-                node_id,
-                Signature::from_compact(&ns.direct_from_cpfp_refund_tx_signature).map_err(
-                    |_| {
-                        ServiceError::Generic(
-                            "invalid direct from CPFP refund tx signature".to_string(),
-                        )
-                    },
-                )?,
-            );
-        }
-    }
-
-    Ok(RefundSignatures {
-        cpfp_signatures,
-        direct_signatures,
-        direct_from_cpfp_signatures,
-    })
 }


### PR DESCRIPTION
This change updates how the Breez SDK talks to the Spark network for three core
operations: depositing Bitcoin into Spark, receiving a transfer from another user,
and cooperatively withdrawing back to Bitcoin. Each previously took two network
round-trips with the Spark operators; we collapse them into one, matching what the
reference Spark JS SDK already uses.