### PR TITLE
Fix incoming payment polling: filter status and hydrate Completed transfers

### DIFF
--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -878,9 +878,7 @@ impl BreezSdk {
                     .unwrap_or(DEFAULT_CONVERSION_TIMEOUT_SECS),
             )
             .await
-            .map_err(|e| {
-                SdkError::Generic(format!("Timeout waiting for conversion to complete: {e}"))
-            })?;
+            .map_err(|e| SdkError::Generic(format!("Conversion did not complete: {e}")))?;
 
         // For self-transfers, suppress the event and return
         if *conversion_purpose == ConversionPurpose::SelfTransfer {
@@ -1496,6 +1494,12 @@ impl BreezSdk {
             }
         };
         self.finalize_payment(payment.clone()).await;
+        if payment.status != PaymentStatus::Completed {
+            return Err(SdkError::Generic(format!(
+                "Incoming payment did not complete (status: {})",
+                payment.status
+            )));
+        }
         Ok(payment)
     }
 
@@ -2069,11 +2073,16 @@ impl BreezSdk {
             wallet_transfer.status
         );
         let payment: Payment = match wallet_transfer.status {
-            // Transfer has already completed. Skip the claim.
-            TransferStatus::Completed => wallet_transfer.try_into()?,
-            // Transfer is claimable. Claim the transfer and promote the
-            // transfer status to completed.
-            TransferStatus::SenderKeyTweaked => {
+            // Claim is always run so the local tree-store gets the
+            // finalized leaves. `process_transfer` is idempotent for
+            // already-claimed transfers: `claim_transfer` falls back to
+            // fetching the finalized leaves from the coordinator. This
+            // matters in client setups where the tree-store is local
+            // (in-memory / WASM-backed) and the transfer may have been
+            // claimed by another instance or a previous lifetime of this
+            // one. Server mode uses a shared SQL tree-store, so the call
+            // is harmless but redundant there.
+            TransferStatus::Completed | TransferStatus::SenderKeyTweaked => {
                 debug!("poll_then_process_spark_transfer({transfer_id}): claiming");
                 self.spark_wallet.process_transfer(&wallet_transfer).await?;
                 let mut claimed = wallet_transfer;


### PR DESCRIPTION
## Summary

Two correctness bugs in the `wait_for_incoming_payment` polling refactor (#889):

1. **Failed conversion receives were accepted as success.** `poll_then_process_spark_transfer` returns `Some(payment)` for `Expired`/`Returned` transfers (mapped to `PaymentStatus::Failed` at `models/adaptors.rs:245`) and `poll_then_process_token_transaction` passes through any non-`Pending` status. `wait_for_incoming_payment` returned this as `Ok(payment)` with no status check on the slow path. `complete_conversion_and_send` then treated the failed receive as success — returning a `SendPaymentResponse` wrapping a `Failed` payment for self-transfers, or computing `amount_override` from a failed payment's amount and continuing with the outbound send.

   Fix: filter on `PaymentStatus::Completed` after the poll resolves, and surface non-Completed terminals as an explicit error.

2. **Local tree-store was not hydrated on `Completed` Spark transfers.** The `TransferStatus::Completed` arm of `poll_then_process_spark_transfer` skipped `process_transfer`. The transfer was already claimed by someone — but in client mode the tree-store is per instance (`InMemoryTreeStore` in native, `WasmTreeStore` in WASM), so when another instance or a previous lifetime did the claim this instance's tree-store is missing the finalized leaves and a subsequent send would not find them. In server mode the tree-store is backed by the shared SQL DB (`PostgresTreeStore` / `MysqlTreeStore`), so the leaves are already visible to every instance and this case isn't a problem there.

   Fix: merge the `Completed` and `SenderKeyTweaked` arms. `claim_transfer` (in `spark/src/services/transfer.rs:680–719`) already has the `finalized_leaves_if_already_claimed` fallback (line 737) that fetches the finalized leaves from the coordinator when a local claim attempt fails — hydration is idempotent. The extra round-trip is wasteful but harmless in server mode.

## Test plan

- [x] `cargo build -p breez-sdk-spark`
- [x] `make fmt-check`
- [x] `make clippy-check`
- [x] `cargo test -p breez-sdk-spark --lib` (221 passed)
- [ ] `conversion_send_server_mode` / `lightning_send_server_mode` itests on regtest with conversion liquidity (gated `#[ignore]`)