### PR TITLE
Emit SdkEvent::Optimization in both client and server mode

### DIFF
--- a/crates/breez-sdk/breez-itest/src/fixtures/mod.rs
+++ b/crates/breez-sdk/breez-itest/src/fixtures/mod.rs
@@ -3,7 +3,10 @@ pub mod docker;
 pub mod lnurl;
 
 use anyhow::Result;
-use breez_sdk_spark::{MaxFee, Network, StableBalanceConfig, StableBalanceToken, default_config};
+use breez_sdk_spark::{
+    LeafOptimizationConfig, MaxFee, Network, StableBalanceConfig, StableBalanceToken,
+    default_config, default_server_config,
+};
 use rand::RngCore;
 use rstest::fixture;
 use tracing::info;
@@ -73,6 +76,49 @@ pub async fn bob_strict_fee_sdk() -> Result<SdkInstance> {
 
     let mut cfg = default_config(Network::Regtest);
     cfg.max_deposit_claim_fee = Some(MaxFee::Fixed { amount: 0 });
+    build_sdk_with_custom_config(path, seed, cfg, Some(dir), true).await
+}
+
+/// Fixture: Alice's SDK with leaf optimization in manual-trigger mode and a
+/// high target multiplicity. Used to drive a deterministic optimization run
+/// (no background optimizer racing the test; enough work to exit the
+/// `Skipped` fast path).
+#[fixture]
+pub async fn alice_sdk_manual_opt() -> Result<SdkInstance> {
+    let dir = tempfile::Builder::new()
+        .prefix("breez-sdk-alice-manual-opt")
+        .tempdir()?;
+    let path = dir.path().to_string_lossy().to_string();
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+
+    let mut cfg = default_config(Network::Regtest);
+    cfg.leaf_optimization_config = LeafOptimizationConfig {
+        auto_enabled: false,
+        multiplicity: 15,
+    };
+    build_sdk_with_custom_config(path, seed, cfg, Some(dir), true).await
+}
+
+/// Server-mode variant of [`alice_sdk_manual_opt`]. Same manual-trigger
+/// optimization shape (`auto_enabled = false`, high `multiplicity`), but on
+/// the server runtime (`background_tasks_enabled = false`) so the
+/// optimization-event bridge is exercised through the runtime-agnostic
+/// forwarder.
+#[fixture]
+pub async fn alice_server_sdk_manual_opt() -> Result<SdkInstance> {
+    let dir = tempfile::Builder::new()
+        .prefix("breez-sdk-alice-server-manual-opt")
+        .tempdir()?;
+    let path = dir.path().to_string_lossy().to_string();
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+
+    let mut cfg = default_server_config(Network::Regtest);
+    cfg.leaf_optimization_config = LeafOptimizationConfig {
+        auto_enabled: false,
+        multiplicity: 15,
+    };
     build_sdk_with_custom_config(path, seed, cfg, Some(dir), true).await
 }
 

--- a/crates/breez-sdk/breez-itest/src/helpers.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers.rs
@@ -1475,34 +1475,59 @@ pub async fn wait_for_synced_event(
     .map(|_| ())
 }
 
-/// Wait for leaf optimization to reach a terminal state.
+/// Wait for the full optimization lifecycle: `Started` followed by
+/// `Completed`. Designed for the manual-trigger fixtures where the wallet
+/// is guaranteed to have work to do.
 ///
-/// Succeeds on `Completed` and `Skipped` (both prove spark-wallet's
-/// dedicated optimization channel is being forwarded to
-/// `SdkEvent::Optimization`). Fails on `Failed`/`Cancelled` and on timeout —
-/// a timeout is the exact symptom of the bridge being missing.
+/// Fails on:
+/// - `Skipped` — the fixture was supposed to give the optimizer real work.
+/// - `Completed` without a prior `Started` — would indicate dropped
+///   progress events (a partial regression of the bridge).
+/// - `Failed`/`Cancelled` — optimization didn't run cleanly.
+/// - Timeout — the bridge is silent.
+///
+/// Both checks together catch regressions where *some* events flow but
+/// others get dropped, not just the all-or-nothing case.
 pub async fn wait_for_optimization_completed_event(
     event_rx: &mut mpsc::Receiver<SdkEvent>,
     timeout_secs: u64,
 ) -> Result<()> {
+    let mut started_seen = false;
     wait_for_event(
         event_rx,
         timeout_secs,
         "Optimization",
         |event| match event {
             SdkEvent::Optimization { optimization_event } => match optimization_event {
-                OptimizationEvent::Completed | OptimizationEvent::Skipped => {
-                    info!("Received Optimization terminal event: {optimization_event:?}");
-                    Ok(Some(EventResult::OptimizationFinished))
+                OptimizationEvent::Started { total_rounds } => {
+                    info!("Optimization Started with {total_rounds} rounds");
+                    started_seen = true;
+                    Ok(None)
                 }
+                OptimizationEvent::RoundCompleted {
+                    current_round,
+                    total_rounds,
+                } => {
+                    info!("Optimization round {current_round}/{total_rounds} completed");
+                    Ok(None)
+                }
+                OptimizationEvent::Completed => {
+                    if started_seen {
+                        info!("Received Optimization terminal event: Completed");
+                        Ok(Some(EventResult::OptimizationFinished))
+                    } else {
+                        Err(anyhow::anyhow!(
+                            "Received Completed without observing Started — Started event was dropped"
+                        ))
+                    }
+                }
+                OptimizationEvent::Skipped => Err(anyhow::anyhow!(
+                    "Optimization was Skipped — fixture should have had work to do"
+                )),
                 OptimizationEvent::Failed { error } => {
                     Err(anyhow::anyhow!("Optimization failed: {error}"))
                 }
                 OptimizationEvent::Cancelled => Err(anyhow::anyhow!("Optimization was cancelled")),
-                other => {
-                    info!("Optimization progress event: {other:?}");
-                    Ok(None)
-                }
             },
             other => {
                 info!("Ignored SDK event: {other:?}");

--- a/crates/breez-sdk/breez-itest/src/helpers.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers.rs
@@ -331,6 +331,7 @@ pub async fn build_sdk_with_custom_config_and_backend(
         config.lnurl_domain = None;
     }
 
+    let background_tasks_enabled = config.background_tasks_enabled;
     let seed = Seed::Entropy(seed_bytes.to_vec());
 
     let builder = SdkBuilder::new(config, seed);
@@ -345,12 +346,17 @@ pub async fn build_sdk_with_custom_config_and_backend(
     let event_listener = Box::new(ChannelEventListener { tx });
     let _listener_id = sdk.add_event_listener(event_listener).await;
 
-    // Ensure initial sync completes
-    let _ = sdk
-        .get_info(GetInfoRequest {
-            ensure_synced: Some(true),
-        })
-        .await?;
+    // Ensure initial sync completes. Server mode rejects `ensure_synced=true`
+    // (there's no background sync to await), so drive it explicitly instead.
+    if background_tasks_enabled {
+        let _ = sdk
+            .get_info(GetInfoRequest {
+                ensure_synced: Some(true),
+            })
+            .await?;
+    } else {
+        sdk.sync_wallet(SyncWalletRequest {}).await?;
+    }
 
     Ok(SdkInstance {
         sdk,
@@ -1201,6 +1207,8 @@ pub enum EventResult {
     Synced,
     /// Lightning address changed
     LightningAddressChanged(Option<LightningAddressInfo>),
+    /// Leaf optimization reached a terminal state (`Completed` or `Skipped`).
+    OptimizationFinished,
 }
 
 pub async fn clear_event_receiver(event_rx: &mut mpsc::Receiver<SdkEvent>) {
@@ -1463,6 +1471,45 @@ pub async fn wait_for_synced_event(
             Ok(None)
         }
     })
+    .await
+    .map(|_| ())
+}
+
+/// Wait for leaf optimization to reach a terminal state.
+///
+/// Succeeds on `Completed` and `Skipped` (both prove the
+/// `WalletEvent::Optimization` → `SdkEvent::Optimization` bridge is wired
+/// up). Fails on `Failed`/`Cancelled` and on timeout — a timeout is the
+/// exact symptom of the bridge being missing.
+pub async fn wait_for_optimization_completed_event(
+    event_rx: &mut mpsc::Receiver<SdkEvent>,
+    timeout_secs: u64,
+) -> Result<()> {
+    wait_for_event(
+        event_rx,
+        timeout_secs,
+        "Optimization",
+        |event| match event {
+            SdkEvent::Optimization { optimization_event } => match optimization_event {
+                OptimizationEvent::Completed | OptimizationEvent::Skipped => {
+                    info!("Received Optimization terminal event: {optimization_event:?}");
+                    Ok(Some(EventResult::OptimizationFinished))
+                }
+                OptimizationEvent::Failed { error } => {
+                    Err(anyhow::anyhow!("Optimization failed: {error}"))
+                }
+                OptimizationEvent::Cancelled => Err(anyhow::anyhow!("Optimization was cancelled")),
+                other => {
+                    info!("Optimization progress event: {other:?}");
+                    Ok(None)
+                }
+            },
+            other => {
+                info!("Ignored SDK event: {other:?}");
+                Ok(None)
+            }
+        },
+    )
     .await
     .map(|_| ())
 }

--- a/crates/breez-sdk/breez-itest/src/helpers.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers.rs
@@ -1477,10 +1477,10 @@ pub async fn wait_for_synced_event(
 
 /// Wait for leaf optimization to reach a terminal state.
 ///
-/// Succeeds on `Completed` and `Skipped` (both prove the
-/// `WalletEvent::Optimization` → `SdkEvent::Optimization` bridge is wired
-/// up). Fails on `Failed`/`Cancelled` and on timeout — a timeout is the
-/// exact symptom of the bridge being missing.
+/// Succeeds on `Completed` and `Skipped` (both prove spark-wallet's
+/// dedicated optimization channel is being forwarded to
+/// `SdkEvent::Optimization`). Fails on `Failed`/`Cancelled` and on timeout —
+/// a timeout is the exact symptom of the bridge being missing.
 pub async fn wait_for_optimization_completed_event(
     event_rx: &mut mpsc::Receiver<SdkEvent>,
     timeout_secs: u64,

--- a/crates/breez-sdk/breez-itest/tests/optimization.rs
+++ b/crates/breez-sdk/breez-itest/tests/optimization.rs
@@ -2,10 +2,10 @@ use anyhow::Result;
 use breez_sdk_itest::*;
 use rstest::*;
 
-/// Regression test for the missing `WalletEvent::Optimization` →
-/// `SdkEvent::Optimization` bridge: the variant existed and was exposed
-/// through the bindings, but core dropped the wallet event on the floor,
-/// so external listeners never saw any optimization events.
+/// Regression test for the missing `SdkEvent::Optimization` bridge: the
+/// variant was defined and exposed through the bindings, but core never
+/// subscribed to spark-wallet's optimization channel, so external listeners
+/// never saw any optimization events.
 ///
 /// The fixture disables auto-optimization (so nothing races us) and sets a
 /// high multiplicity (so triggering optimization on a freshly-funded

--- a/crates/breez-sdk/breez-itest/tests/optimization.rs
+++ b/crates/breez-sdk/breez-itest/tests/optimization.rs
@@ -1,0 +1,50 @@
+use anyhow::Result;
+use breez_sdk_itest::*;
+use rstest::*;
+
+/// Regression test for the missing `WalletEvent::Optimization` →
+/// `SdkEvent::Optimization` bridge: the variant existed and was exposed
+/// through the bindings, but core dropped the wallet event on the floor,
+/// so external listeners never saw any optimization events.
+///
+/// The fixture disables auto-optimization (so nothing races us) and sets a
+/// high multiplicity (so triggering optimization on a freshly-funded
+/// single-leaf wallet has real work to do, not a `Skipped` no-op). If the
+/// bridge is removed again, this test times out waiting for the terminal
+/// event.
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn test_leaf_optimization_emits_events(
+    #[future] alice_sdk_manual_opt: Result<SdkInstance>,
+) -> Result<()> {
+    let mut alice = alice_sdk_manual_opt.await?;
+    ensure_funded(&mut alice, 50_000).await?;
+    clear_event_receiver(&mut alice.events).await;
+
+    alice.sdk.start_leaf_optimization().await;
+    wait_for_optimization_completed_event(&mut alice.events, 180).await?;
+    Ok(())
+}
+
+/// Server-mode counterpart of [`test_leaf_optimization_emits_events`].
+///
+/// In server mode (`background_tasks_enabled = false`) the client runtime
+/// loop — which used to be the only subscriber of `WalletEvent` — doesn't
+/// run, so optimization events would silently disappear if the bridge lived
+/// inside that loop. This test asserts the runtime-agnostic forwarder
+/// keeps optimization events flowing to external listeners regardless of
+/// runtime profile.
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn test_leaf_optimization_emits_events_server_mode(
+    #[future] alice_server_sdk_manual_opt: Result<SdkInstance>,
+) -> Result<()> {
+    let mut alice = alice_server_sdk_manual_opt.await?;
+    // Server mode has no ClaimedDeposits event; poll for the balance instead.
+    ensure_funded_via_polling(&mut alice, 50_000).await?;
+    clear_event_receiver(&mut alice.events).await;
+
+    alice.sdk.start_leaf_optimization().await;
+    wait_for_optimization_completed_event(&mut alice.events, 180).await?;
+    Ok(())
+}

--- a/crates/breez-sdk/core/src/models/adaptors.rs
+++ b/crates/breez-sdk/core/src/models/adaptors.rs
@@ -12,8 +12,8 @@ use platform_utils::time::UNIX_EPOCH;
 use tracing::{debug, warn};
 
 use crate::{
-    Fee, Network, OnchainConfirmationSpeed, OptimizationProgress, Payment, PaymentDetails,
-    PaymentMethod, PaymentStatus, PaymentType, SdkError, SendOnchainFeeQuote,
+    Fee, Network, OnchainConfirmationSpeed, OptimizationEvent, OptimizationProgress, Payment,
+    PaymentDetails, PaymentMethod, PaymentStatus, PaymentType, SdkError, SendOnchainFeeQuote,
     SendOnchainSpeedFeeQuote, SparkHtlcDetails, SparkHtlcStatus, SparkInvoicePaymentDetails,
     TokenBalance, TokenMetadata,
 };
@@ -512,6 +512,27 @@ impl From<PreimageRequestStatus> for SparkHtlcStatus {
             PreimageRequestStatus::WaitingForPreimage => SparkHtlcStatus::WaitingForPreimage,
             PreimageRequestStatus::PreimageShared => SparkHtlcStatus::PreimageShared,
             PreimageRequestStatus::Returned => SparkHtlcStatus::Returned,
+        }
+    }
+}
+
+impl From<spark_wallet::OptimizationEvent> for OptimizationEvent {
+    fn from(value: spark_wallet::OptimizationEvent) -> Self {
+        match value {
+            spark_wallet::OptimizationEvent::Started { total_rounds } => {
+                Self::Started { total_rounds }
+            }
+            spark_wallet::OptimizationEvent::RoundCompleted {
+                current_round,
+                total_rounds,
+            } => Self::RoundCompleted {
+                current_round,
+                total_rounds,
+            },
+            spark_wallet::OptimizationEvent::Completed => Self::Completed,
+            spark_wallet::OptimizationEvent::Cancelled => Self::Cancelled,
+            spark_wallet::OptimizationEvent::Failed { error } => Self::Failed { error },
+            spark_wallet::OptimizationEvent::Skipped => Self::Skipped,
         }
     }
 }

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -248,6 +248,11 @@ impl BreezSdk {
     /// immediately. Progress is reported via events.
     /// If optimization is already running, no new task will be started.
     pub async fn start_leaf_optimization(&self) {
+        // In server mode the forwarder is spawned lazily so SDK instances
+        // that never opt into optimization carry no background task. The
+        // call is idempotent (OnceCell-gated), so it's safe to invoke on
+        // every start.
+        self.ensure_optimization_forwarder_spawned().await;
         self.spark_wallet.start_leaf_optimization().await;
     }
 

--- a/crates/breez-sdk/core/src/sdk/init.rs
+++ b/crates/breez-sdk/core/src/sdk/init.rs
@@ -52,13 +52,6 @@ impl BreezSdk {
 
     /// Starts the SDK runtime services selected during construction.
     pub(super) async fn start(&self, initial_synced_sender: watch::Sender<bool>) {
-        // Client mode runs auto-optimization in the background, so the
-        // forwarder must be live before any optimization can fire. Server
-        // mode defers the spawn to the first explicit `start_leaf_optimization`
-        // call — see [`Self::ensure_optimization_forwarder_spawned`].
-        if self.runtime.starts_background_services() {
-            self.ensure_optimization_forwarder_spawned().await;
-        }
         self.runtime
             .start_sdk_services(self, initial_synced_sender)
             .await;

--- a/crates/breez-sdk/core/src/sdk/init.rs
+++ b/crates/breez-sdk/core/src/sdk/init.rs
@@ -5,7 +5,10 @@ use tracing::{Instrument, error, info};
 
 use crate::{Network, error::SdkError, persist::ObjectCacheRepository};
 
-use super::{BreezSdk, BreezSdkParams, helpers::validate_breez_api_key};
+use super::{
+    BreezSdk, BreezSdkParams, helpers::validate_breez_api_key,
+    optimization_forwarder::spawn_optimization_forwarder,
+};
 
 impl BreezSdk {
     /// Creates a new instance of the `BreezSdk`
@@ -48,6 +51,7 @@ impl BreezSdk {
 
     /// Starts the SDK runtime services selected during construction.
     pub(super) async fn start(&self, initial_synced_sender: watch::Sender<bool>) {
+        spawn_optimization_forwarder(self);
         self.runtime
             .start_sdk_services(self, initial_synced_sender)
             .await;

--- a/crates/breez-sdk/core/src/sdk/init.rs
+++ b/crates/breez-sdk/core/src/sdk/init.rs
@@ -40,6 +40,7 @@ impl BreezSdk {
             initial_synced_watcher,
             external_input_parsers,
             spark_private_mode_initialized: Arc::new(OnceCell::new()),
+            optimization_forwarder_spawned: Arc::new(OnceCell::new()),
             token_converter: params.token_converter,
             stable_balance: params.stable_balance,
             buy_bitcoin_provider: params.buy_bitcoin_provider,
@@ -51,9 +52,26 @@ impl BreezSdk {
 
     /// Starts the SDK runtime services selected during construction.
     pub(super) async fn start(&self, initial_synced_sender: watch::Sender<bool>) {
-        spawn_optimization_forwarder(self);
+        // Client mode runs auto-optimization in the background, so the
+        // forwarder must be live before any optimization can fire. Server
+        // mode defers the spawn to the first explicit `start_leaf_optimization`
+        // call — see [`Self::ensure_optimization_forwarder_spawned`].
+        if self.runtime.starts_background_services() {
+            self.ensure_optimization_forwarder_spawned().await;
+        }
         self.runtime
             .start_sdk_services(self, initial_synced_sender)
+            .await;
+    }
+
+    /// Idempotently spawns the optimization-event forwarder. Subsequent
+    /// calls are no-ops (the `OnceCell` guarantees only one task is ever
+    /// spawned per SDK instance).
+    pub(crate) async fn ensure_optimization_forwarder_spawned(&self) {
+        self.optimization_forwarder_spawned
+            .get_or_init(|| async {
+                spawn_optimization_forwarder(self);
+            })
             .await;
     }
 

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -5,6 +5,7 @@ mod helpers;
 mod init;
 mod lightning_address;
 mod lnurl;
+mod optimization_forwarder;
 mod payments;
 mod runtime;
 mod sync;

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -94,6 +94,11 @@ pub struct BreezSdk {
     pub(crate) initial_synced_watcher: watch::Receiver<bool>,
     pub(crate) external_input_parsers: Vec<ExternalInputParser>,
     pub(crate) spark_private_mode_initialized: Arc<OnceCell<()>>,
+    /// Tracks whether the optimization-event forwarder has been spawned. In
+    /// client mode this is set at startup; in server mode it stays empty
+    /// until the first `start_leaf_optimization` call, so an SDK instance
+    /// that never opts into optimization carries no forwarder task.
+    pub(crate) optimization_forwarder_spawned: Arc<OnceCell<()>>,
     pub(crate) token_converter: Arc<dyn TokenConverter>,
     pub(crate) stable_balance: Option<Arc<StableBalance>>,
     pub(crate) buy_bitcoin_provider: Arc<MoonpayProvider>,

--- a/crates/breez-sdk/core/src/sdk/optimization_forwarder.rs
+++ b/crates/breez-sdk/core/src/sdk/optimization_forwarder.rs
@@ -1,20 +1,18 @@
-//! Runtime-agnostic bridge from `WalletEvent::Optimization` (emitted by the
-//! spark-wallet leaf optimizer) to `SdkEvent::Optimization` on the external
-//! `EventEmitter`.
+//! Runtime-agnostic bridge from spark-wallet's dedicated
+//! `OptimizationEvent` broadcast channel to `SdkEvent::Optimization` on the
+//! external `EventEmitter`.
 //!
 //! Spawned from `BreezSdk::start` so it runs in both client and server mode —
 //! the public `start_leaf_optimization` API is available in both, and listeners
-//! should see progress events in both.
+//! should see progress events in both. The dedicated channel is silent when
+//! no optimization is running, so the forwarder has no per-event cost in the
+//! common case.
 
 use platform_utils::tokio;
-use spark_wallet::WalletEvent;
 use tokio::{select, sync::broadcast};
 use tracing::{Instrument, info, warn};
 
-use crate::{
-    events::SdkEvent,
-    sdk::BreezSdk,
-};
+use crate::{events::SdkEvent, sdk::BreezSdk};
 
 pub(super) fn spawn_optimization_forwarder(sdk: &BreezSdk) {
     let sdk = sdk.clone();
@@ -22,7 +20,7 @@ pub(super) fn spawn_optimization_forwarder(sdk: &BreezSdk) {
 
     tokio::spawn(
         async move {
-            let mut wallet_events = sdk.spark_wallet.subscribe_events();
+            let mut optimization_events = sdk.spark_wallet.subscribe_optimization_events();
             let mut shutdown = sdk.shutdown_sender.subscribe();
 
             loop {
@@ -31,20 +29,19 @@ pub(super) fn spawn_optimization_forwarder(sdk: &BreezSdk) {
                         info!("Optimization forwarder shutdown signal received");
                         return;
                     }
-                    event = wallet_events.recv() => match event {
-                        Ok(WalletEvent::Optimization(e)) => {
+                    event = optimization_events.recv() => match event {
+                        Ok(e) => {
                             sdk.event_emitter
                                 .emit(&SdkEvent::Optimization {
                                     optimization_event: e.into(),
                                 })
                                 .await;
                         }
-                        Ok(_) => {}
                         Err(broadcast::error::RecvError::Lagged(n)) => {
-                            warn!("Optimization forwarder lagged by {n} wallet events");
+                            warn!("Optimization forwarder lagged by {n} events");
                         }
                         Err(broadcast::error::RecvError::Closed) => {
-                            info!("Wallet event stream closed; optimization forwarder exiting");
+                            info!("Optimization event stream closed; forwarder exiting");
                             return;
                         }
                     }

--- a/crates/breez-sdk/core/src/sdk/optimization_forwarder.rs
+++ b/crates/breez-sdk/core/src/sdk/optimization_forwarder.rs
@@ -15,12 +15,16 @@ use tracing::{Instrument, info, warn};
 use crate::{events::SdkEvent, sdk::BreezSdk};
 
 pub(super) fn spawn_optimization_forwarder(sdk: &BreezSdk) {
+    // Subscribe synchronously *before* spawning so the receiver is live by
+    // the time this function returns. Otherwise a caller that invokes
+    // `spark_wallet.start_leaf_optimization()` immediately after spawning
+    // could race the forwarder task and lose the initial `Started` event.
+    let mut optimization_events = sdk.spark_wallet.subscribe_optimization_events();
     let sdk = sdk.clone();
     let span = tracing::Span::current();
 
     tokio::spawn(
         async move {
-            let mut optimization_events = sdk.spark_wallet.subscribe_optimization_events();
             let mut shutdown = sdk.shutdown_sender.subscribe();
 
             loop {

--- a/crates/breez-sdk/core/src/sdk/optimization_forwarder.rs
+++ b/crates/breez-sdk/core/src/sdk/optimization_forwarder.rs
@@ -1,0 +1,56 @@
+//! Runtime-agnostic bridge from `WalletEvent::Optimization` (emitted by the
+//! spark-wallet leaf optimizer) to `SdkEvent::Optimization` on the external
+//! `EventEmitter`.
+//!
+//! Spawned from `BreezSdk::start` so it runs in both client and server mode —
+//! the public `start_leaf_optimization` API is available in both, and listeners
+//! should see progress events in both.
+
+use platform_utils::tokio;
+use spark_wallet::WalletEvent;
+use tokio::{select, sync::broadcast};
+use tracing::{Instrument, info, warn};
+
+use crate::{
+    events::SdkEvent,
+    sdk::BreezSdk,
+};
+
+pub(super) fn spawn_optimization_forwarder(sdk: &BreezSdk) {
+    let sdk = sdk.clone();
+    let span = tracing::Span::current();
+
+    tokio::spawn(
+        async move {
+            let mut wallet_events = sdk.spark_wallet.subscribe_events();
+            let mut shutdown = sdk.shutdown_sender.subscribe();
+
+            loop {
+                select! {
+                    _ = shutdown.changed() => {
+                        info!("Optimization forwarder shutdown signal received");
+                        return;
+                    }
+                    event = wallet_events.recv() => match event {
+                        Ok(WalletEvent::Optimization(e)) => {
+                            sdk.event_emitter
+                                .emit(&SdkEvent::Optimization {
+                                    optimization_event: e.into(),
+                                })
+                                .await;
+                        }
+                        Ok(_) => {}
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            warn!("Optimization forwarder lagged by {n} wallet events");
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            info!("Wallet event stream closed; optimization forwarder exiting");
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        .instrument(span),
+    );
+}

--- a/crates/breez-sdk/core/src/sdk/optimization_forwarder.rs
+++ b/crates/breez-sdk/core/src/sdk/optimization_forwarder.rs
@@ -2,11 +2,15 @@
 //! `OptimizationEvent` broadcast channel to `SdkEvent::Optimization` on the
 //! external `EventEmitter`.
 //!
-//! Spawned from `BreezSdk::start` so it runs in both client and server mode —
-//! the public `start_leaf_optimization` API is available in both, and listeners
-//! should see progress events in both. The dedicated channel is silent when
-//! no optimization is running, so the forwarder has no per-event cost in the
-//! common case.
+//! The forwarder is gated by `BreezSdk::ensure_optimization_forwarder_spawned`,
+//! which is `OnceCell`-backed so at most one task is ever spawned per SDK
+//! instance. It's invoked from two places:
+//!
+//! - `ClientRuntime::start_sdk_services` — eagerly at startup, because client
+//!   mode's `BackgroundProcessor` can trigger auto-optimization at any time.
+//! - `BreezSdk::start_leaf_optimization` — lazily on first call, so server-mode
+//!   SDK instances that never opt into optimization carry no forwarder task
+//!   (matching the `background_tasks_enabled = false` contract).
 
 use platform_utils::tokio;
 use tokio::{select, sync::broadcast};

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -304,13 +304,6 @@ async fn handle_wallet_event(sdk: &BreezSdk, event: WalletEvent) -> bool {
                     false
                 })
         }
-        WalletEvent::Optimization(event) => {
-            // Forwarding to `SdkEvent::Optimization` is handled by the
-            // runtime-agnostic `optimization_forwarder` so server mode sees
-            // the same events as client mode.
-            info!("Optimization event: {:?}", event);
-            false
-        }
     }
 }
 

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -35,6 +35,11 @@ impl RuntimeProfile for ClientRuntime {
     }
 
     async fn start_sdk_services(&self, sdk: &BreezSdk, initial_synced_sender: watch::Sender<bool>) {
+        // Auto-optimization can fire from `BackgroundProcessor` in client
+        // mode, so the forwarder must be live before any of the background
+        // tasks below start. Server mode defers this to the first explicit
+        // `start_leaf_optimization` call.
+        sdk.ensure_optimization_forwarder_spawned().await;
         register_client_sync_listener(sdk).await;
         register_client_runtime_event_handler(sdk).await;
         sdk.spawn_spark_private_mode_initialization();

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -305,6 +305,9 @@ async fn handle_wallet_event(sdk: &BreezSdk, event: WalletEvent) -> bool {
                 })
         }
         WalletEvent::Optimization(event) => {
+            // Forwarding to `SdkEvent::Optimization` is handled by the
+            // runtime-agnostic `optimization_forwarder` so server mode sees
+            // the same events as client mode.
             info!("Optimization event: {:?}", event);
             false
         }

--- a/crates/internal/src/main.rs
+++ b/crates/internal/src/main.rs
@@ -138,10 +138,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         spark_wallet::WalletEvent::TransferClaimed(transfer) => info!("Transfer claimed: {}", transfer.id),
                         spark_wallet::WalletEvent::TransferClaimStarting(transfer) => info!("Transfer claim starting: {}", transfer.id),
                         spark_wallet::WalletEvent::TokenTransaction(transaction) => info!("Token transaction: {}", transaction.hash),
-                        spark_wallet::WalletEvent::Optimization(event) => info!("Optimization event: {:?}", event),
                     }
                 }
                 else => warn!("Event stream closed."),
+            }
+        }
+    });
+
+    // Spawn optimization event listener (separate channel)
+    let clone = Arc::clone(&wallet);
+    tokio::spawn(async move {
+        let mut receiver = clone.subscribe_optimization_events();
+        loop {
+            tokio::select! {
+                Ok(event) = receiver.recv() => info!("Optimization event: {:?}", event),
+                else => warn!("Optimization event stream closed."),
             }
         }
     });

--- a/crates/spark-wallet/src/event.rs
+++ b/crates/spark-wallet/src/event.rs
@@ -1,3 +1,4 @@
+use spark::tree::OptimizationEvent;
 use tokio::sync::broadcast;
 use tracing::trace;
 
@@ -5,12 +6,20 @@ use crate::WalletEvent;
 
 pub(super) struct EventManager {
     channel: broadcast::Sender<WalletEvent>,
+    /// Dedicated channel for leaf-optimization lifecycle events.
+    ///
+    /// Kept separate from [`Self::channel`] so consumers (e.g. the SDK's
+    /// optimization forwarder) can subscribe without paying the clone cost
+    /// of unrelated wallet events. Only carries traffic while an
+    /// optimization run is in flight.
+    optimization_channel: broadcast::Sender<OptimizationEvent>,
 }
 
 impl EventManager {
     pub fn new() -> Self {
         Self {
             channel: broadcast::channel(100).0,
+            optimization_channel: broadcast::channel(100).0,
         }
     }
 
@@ -18,10 +27,21 @@ impl EventManager {
         self.channel.subscribe()
     }
 
+    pub fn listen_optimization(&self) -> broadcast::Receiver<OptimizationEvent> {
+        self.optimization_channel.subscribe()
+    }
+
     pub fn notify_listeners(&self, event: WalletEvent) {
         trace!("notifying listeners of event: {:?}", event);
         if self.channel.send(event).is_err() {
             tracing::debug!("Failed to send wallet event, no listeners attached");
+        }
+    }
+
+    pub fn notify_optimization_listeners(&self, event: OptimizationEvent) {
+        trace!("notifying optimization listeners of event: {:?}", event);
+        if self.optimization_channel.send(event).is_err() {
+            tracing::debug!("Failed to send optimization event, no listeners attached");
         }
     }
 }

--- a/crates/spark-wallet/src/model.rs
+++ b/crates/spark-wallet/src/model.rs
@@ -16,10 +16,7 @@ use spark::{
     },
     ssp::{SspTransfer, SspUserRequest},
     token::TokenMetadata,
-    tree::{
-        Leaves, LeavesReservation, OptimizationEvent, SigningKeyshare, TargetAmounts, TreeNode,
-        TreeNodeId,
-    },
+    tree::{Leaves, LeavesReservation, SigningKeyshare, TargetAmounts, TreeNode, TreeNodeId},
     utils::paging::PagingFilter,
 };
 
@@ -35,8 +32,6 @@ pub enum WalletEvent {
     TransferClaimed(WalletTransfer),
     TransferClaimStarting(WalletTransfer),
     TokenTransaction(TokenTransaction),
-    /// Optimization lifecycle event.
-    Optimization(OptimizationEvent),
 }
 
 impl Display for WalletEvent {
@@ -50,9 +45,6 @@ impl Display for WalletEvent {
             }
             WalletEvent::TokenTransaction(transaction) => {
                 write!(f, "TokenTransaction({})", transaction.hash)
-            }
-            WalletEvent::Optimization(event) => {
-                write!(f, "Optimization({:?})", event)
             }
             _ => write!(f, "{:?}", self),
         }

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1314,6 +1314,16 @@ impl SparkWallet {
         self.event_manager.listen()
     }
 
+    /// Subscribes to leaf-optimization lifecycle events on a dedicated
+    /// broadcast channel separate from [`Self::subscribe_events`].
+    ///
+    /// Consumers that only care about optimization should prefer this so they
+    /// don't pay the clone cost of unrelated [`WalletEvent`]s. The channel is
+    /// silent when no optimization is running.
+    pub fn subscribe_optimization_events(&self) -> broadcast::Receiver<OptimizationEvent> {
+        self.event_manager.listen_optimization()
+    }
+
     /// Returns the balances of all tokens in the wallet.
     ///
     /// Balances are returned in a map keyed by the token identifier.
@@ -2028,15 +2038,15 @@ async fn claim_transfer(
     Ok(result_nodes)
 }
 
-/// Event handler that bridges OptimizationEvent to WalletEvent.
+/// Event handler that forwards `OptimizationEvent`s onto the wallet's
+/// dedicated optimization broadcast channel.
 struct WalletOptimizationEventHandler {
     event_manager: Arc<EventManager>,
 }
 
 impl OptimizationEventHandler for WalletOptimizationEventHandler {
     fn on_optimization_event(&self, event: OptimizationEvent) {
-        self.event_manager
-            .notify_listeners(WalletEvent::Optimization(event));
+        self.event_manager.notify_optimization_listeners(event);
     }
 }
 


### PR DESCRIPTION
## Summary

`SdkEvent::Optimization` was defined and exposed through every binding, but core never emitted it: `handle_wallet_event` in the client runtime logged `WalletEvent::Optimization` and dropped it, and server mode didn't subscribe to wallet events at all. External listeners never saw any optimization progress.

This PR wires the bridge in a runtime-agnostic place and reshapes the underlying plumbing so server mode keeps its "background tasks disabled" contract:

- **Dedicated channel in spark-wallet.** Optimization moves off the omnibus `WalletEvent` broadcast onto its own `broadcast::Sender<OptimizationEvent>` exposed via `SparkWallet::subscribe_optimization_events`. The channel is silent unless an optimization run is in flight, so subscribers pay no clone cost for unrelated wallet events. `WalletEvent::Optimization` is removed (only consumer was the SDK itself).
- **Runtime-agnostic forwarder.** A small `optimization_forwarder` spawn in core subscribes to the new channel and re-emits `SdkEvent::Optimization`. The `WalletEvent::Optimization` arm in the client runtime's `handle_wallet_event` is gone.
- **Lazy spawn in server mode.** Client mode spawns the forwarder eagerly (auto-optimization can fire from `BackgroundProcessor` independently). Server mode defers the spawn to the first `start_leaf_optimization` call via an `OnceCell`, so SDK instances that never opt into optimization carry no forwarder task — matching the `background_tasks_enabled = false` promise.

Plus a regression itest (`tests/optimization.rs`) that triggers `start_leaf_optimization`, asserts `Started → Completed` (rejects `Skipped` and lone `Completed` without `Started`), and runs in both client and server mode via paired fixtures.