### PR TITLE
Insert child payments during conversions to avoid sync

### DIFF
--- a/crates/breez-sdk/core/src/sdk/helpers.rs
+++ b/crates/breez-sdk/core/src/sdk/helpers.rs
@@ -4,7 +4,6 @@ use breez_sdk_common::lnurl::{
     error::LnurlError,
     pay::{AesSuccessActionDataResult, SuccessAction, SuccessActionProcessed},
 };
-use platform_utils::time::Instant;
 use spark_wallet::SparkWallet;
 use std::{str::FromStr, sync::Arc};
 use tokio::sync::mpsc;
@@ -17,7 +16,8 @@ use crate::{
     error::SdkError,
     events::{EventListener, SdkEvent},
     models::Payment,
-    persist::{CachedAccountInfo, ObjectCacheRepository, Storage},
+    persist::Storage,
+    utils::payments::update_balances,
 };
 
 /// Looks up the payment matching `identifier` from storage, if present.
@@ -68,50 +68,6 @@ impl EventListener for BalanceWatcher {
             _ => {}
         }
     }
-}
-
-pub(crate) async fn update_balances(
-    spark_wallet: Arc<SparkWallet>,
-    storage: Arc<dyn Storage>,
-) -> Result<(), SdkError> {
-    let total_start = Instant::now();
-
-    let t = Instant::now();
-    let balance_sats = spark_wallet.get_balance().await?;
-    let get_balance_dt = t.elapsed();
-
-    let t = Instant::now();
-    let token_balances_raw = spark_wallet.get_token_balances().await?;
-    let get_token_balances_dt = t.elapsed();
-    let token_balances_count = token_balances_raw.len();
-    let token_balances = token_balances_raw
-        .into_iter()
-        .map(|(k, v)| (k, v.into()))
-        .collect();
-
-    let object_repository = ObjectCacheRepository::new(storage.clone());
-
-    let t = Instant::now();
-    object_repository
-        .save_account_info(&CachedAccountInfo {
-            balance_sats,
-            token_balances,
-        })
-        .await?;
-    let save_dt = t.elapsed();
-
-    let identity_public_key = spark_wallet.get_identity_public_key();
-    info!(
-        "Balance updated successfully {} for identity {} (total: {:?}, get_balance: {:?}, get_token_balances[{}]: {:?}, save_account_info: {:?})",
-        balance_sats,
-        identity_public_key,
-        total_start.elapsed(),
-        get_balance_dt,
-        token_balances_count,
-        get_token_balances_dt,
-        save_dt
-    );
-    Ok(())
 }
 
 pub(crate) struct InternalEventListener {

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -3,8 +3,7 @@ use bitcoin::secp256k1::PublicKey;
 use platform_utils::time::{Duration, SystemTime};
 use platform_utils::tokio;
 use spark_wallet::{
-    ExitSpeed, LightningReceivePayment, ListTransfersRequest, SparkAddress, TransferId,
-    TransferStatus, TransferTokenOutput,
+    ExitSpeed, LightningReceivePayment, SparkAddress, TransferId, TransferTokenOutput,
 };
 use spark_wallet::{InvoiceDescription, Preimage};
 use std::str::FromStr;
@@ -26,25 +25,25 @@ use crate::{
         ReceivePaymentRequest, ReceivePaymentResponse, SendPaymentRequest, SendPaymentResponse,
         conversion_steps_from_payments,
     },
-    persist::{ObjectCacheRepository, PaymentMetadata},
+    persist::PaymentMetadata,
     token_conversion::{
         ConversionAmount, DEFAULT_CONVERSION_TIMEOUT_SECS, TokenConversionResponse,
     },
     utils::{
         payments::{
-            get_payment_and_emit_event, get_payment_with_conversion_details, record_payment_update,
+            fetch_and_process_payment, get_payment_with_conversion_details,
+            insert_payment_with_metadata, record_payment_update,
         },
         polling::{PollSchedule, poll_until},
         send_payment_validation::{get_dust_limit_sats, validate_prepare_send_payment_request},
-        token::{map_and_persist_token_transaction, token_transaction_to_payments},
+        token::map_and_persist_token_transaction,
     },
 };
 
 use super::{
     BreezSdk,
-    helpers::{get_deposit_address, maybe_get_payment_from_storage, update_balances},
+    helpers::{get_deposit_address, maybe_get_payment_from_storage},
 };
-use crate::sync::SparkSyncService;
 
 // Polling cadence for wait_for_incoming_payment.
 const WAIT_FOR_INCOMING_PAYMENT_INITIAL_DELAY_MS: u64 = 500;
@@ -1470,25 +1469,10 @@ impl BreezSdk {
 
         let payment = match identifier {
             WaitForPaymentIdentifier::PaymentId(pid) => {
-                if let Ok(transfer_id) = TransferId::from_str(&pid) {
-                    poll_until(schedule, shutdown, || {
-                        self.poll_then_process_spark_transfer(transfer_id.clone())
-                    })
-                    .await?
-                } else if let Some((hash, _vout)) = pid.split_once(':') {
-                    let tx_hash = hash.to_string();
-                    // The only `wait_for_incoming_payment(PaymentId(token))` site
-                    // today is the conversion received leg (we're the recipient).
-                    let tx_inputs_are_ours = false;
-                    poll_until(schedule, shutdown, || {
-                        self.poll_then_process_token_transaction(&pid, &tx_hash, tx_inputs_are_ours)
-                    })
-                    .await?
-                } else {
-                    return Err(SdkError::Generic(format!(
-                        "Unrecognized payment_id format: {pid}"
-                    )));
-                }
+                poll_until(schedule, shutdown, || {
+                    fetch_and_process_payment(&self.spark_wallet, self.storage.clone(), &pid, false)
+                })
+                .await?
             }
             WaitForPaymentIdentifier::LightningReceive { ssp_id, .. } => {
                 poll_until(schedule, shutdown, || {
@@ -1997,150 +1981,28 @@ impl BreezSdk {
             .map_err(Into::into)
     }
 
-    /// Records a freshly-observed terminal payment: apply any cached
-    /// metadata, run the LNURL receive-metadata sync, persist to storage,
-    /// refresh balances, and emit `PaymentSucceeded` if this is the first
-    /// time we see this status. Returns whether an event was emitted.
+    /// Wraps `insert_payment_with_metadata` with the LNURL-receive
+    /// metadata refresh, so an LNURL-receive payment lands in storage with
+    /// its sender metadata attached. Returns whether a status event was
+    /// emitted.
     pub(crate) async fn finalize_payment(&self, mut payment: Payment) -> bool {
-        let sync_service = SparkSyncService::new(
-            self.spark_wallet.clone(),
-            self.storage.clone(),
-            self.event_emitter.clone(),
-        );
-        if let Err(e) = sync_service.apply_payment_metadata(&payment).await {
-            error!(
-                "finalize_payment({}): failed to apply payment metadata: {e:?}",
-                payment.id
-            );
-        }
         // No-op for non-Lightning-receive payments; for LNURL receives
         // this pulls the LNURL metadata into the payment record.
         self.sync_single_lnurl_metadata(&mut payment).await;
 
-        let should_emit = match self.storage.apply_payment_update(payment.clone()).await {
-            Ok(should_emit) => should_emit,
-            Err(e) => {
-                error!(
-                    "finalize_payment({}): failed to apply payment update: {e:?}",
-                    payment.id
-                );
-                return false;
-            }
-        };
-
-        if let Err(e) = update_balances(self.spark_wallet.clone(), self.storage.clone()).await {
-            error!(
-                "finalize_payment({}): failed to update balances: {e:?}",
-                payment.id
-            );
-        }
-
-        if should_emit {
-            get_payment_and_emit_event(&self.storage, &self.event_emitter, payment).await;
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Polls a single Spark transfer by id and, on terminal status, claims
-    /// it locally so its leaves land in the tree-store before the caller
-    /// spends them.
-    async fn poll_then_process_spark_transfer(
-        &self,
-        transfer_id: TransferId,
-    ) -> Result<Option<Payment>, SdkError> {
-        let mut resp = self
-            .spark_wallet
-            .list_transfers(ListTransfersRequest {
-                transfer_ids: vec![transfer_id.clone()],
-                paging: None,
-            })
-            .await?;
-        let Some(wallet_transfer) = resp.items.pop() else {
-            debug!("poll_then_process_spark_transfer({transfer_id}): not yet visible on operators");
-            return Ok(None);
-        };
-        debug!(
-            "poll_then_process_spark_transfer({transfer_id}): status={}",
-            wallet_transfer.status
-        );
-        let payment: Payment = match wallet_transfer.status {
-            // Transfer has already completed. Skip the claim.
-            TransferStatus::Completed => wallet_transfer.try_into()?,
-            // Transfer is claimable. Claim the transfer and promote the
-            // transfer status to completed.
-            TransferStatus::SenderKeyTweaked => {
-                debug!("poll_then_process_spark_transfer({transfer_id}): claiming");
-                self.spark_wallet.process_transfer(&wallet_transfer).await?;
-                let mut claimed = wallet_transfer;
-                claimed.status = TransferStatus::Completed;
-                claimed.try_into()?
-            }
-            // Terminal-failed. Return the `Failed` payment without
-            // claiming.
-            TransferStatus::Expired | TransferStatus::Returned => {
-                debug!(
-                    "poll_then_process_spark_transfer({transfer_id}): terminal-failed ({})",
-                    wallet_transfer.status
-                );
-                wallet_transfer.try_into()?
-            }
-            _ => return Ok(None),
-        };
-        Ok(Some(payment))
-    }
-
-    /// Polls a single token tx by hash and, on terminal status, updates the
-    /// local token-output store.
-    async fn poll_then_process_token_transaction(
-        &self,
-        payment_id: &str,
-        tx_hash: &str,
-        tx_inputs_are_ours: bool,
-    ) -> Result<Option<Payment>, SdkError> {
-        let token_transactions = self
-            .spark_wallet
-            .get_token_transactions_by_hashes(vec![tx_hash.to_string()])
-            .await?;
-        let Some(token_transaction) = token_transactions.first() else {
-            debug!("poll_then_process_token_transaction({tx_hash}): not yet visible on operators");
-            return Ok(None);
-        };
-        debug!(
-            "poll_then_process_token_transaction({tx_hash}): operator status={:?}",
-            token_transaction.status
-        );
-        let object_repository = ObjectCacheRepository::new(self.storage.clone());
-        let payments = token_transaction_to_payments(
-            &self.spark_wallet,
-            &object_repository,
-            token_transaction,
-            tx_inputs_are_ours,
+        insert_payment_with_metadata(
+            self.spark_wallet.clone(),
+            self.storage.clone(),
+            self.event_emitter.clone(),
+            payment,
         )
-        .await?;
-        let Some(payment) = payments.into_iter().find(|p| p.id == payment_id) else {
-            debug!(
-                "poll_then_process_token_transaction({tx_hash}): no output matches payment_id {payment_id}"
-            );
-            return Ok(None);
-        };
-        if payment.status == PaymentStatus::Pending {
-            return Ok(None);
-        }
-        debug!(
-            "poll_then_process_token_transaction({tx_hash}): terminal payment status={}, updating local outputs",
-            payment.status
-        );
-        self.spark_wallet
-            .process_token_transaction(token_transaction)
-            .await?;
-        Ok(Some(payment))
+        .await
     }
 
     /// Polls an inbound Lightning payment by SSP id. The receive object
     /// only carries the transfer id once the SSP has forwarded the payment
-    /// via Spark. Once present, defers to `poll_then_process_spark_transfer`.
+    /// via Spark. Once present, defers to [`fetch_and_process_payment`] to
+    /// fetch the Spark transfer, claim it, and produce a terminal Payment.
     async fn poll_then_process_lightning_receive(
         &self,
         ssp_id: &str,
@@ -2160,6 +2022,13 @@ impl BreezSdk {
         let Some(transfer_id) = receive.transfer_id else {
             return Ok(None);
         };
-        self.poll_then_process_spark_transfer(transfer_id).await
+        // Lightning receives are spark transfers from our perspective.
+        fetch_and_process_payment(
+            &self.spark_wallet,
+            self.storage.clone(),
+            &transfer_id.to_string(),
+            false,
+        )
+        .await
     }
 }

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -16,15 +16,15 @@ use crate::{
     events::{EventListener, SdkEvent},
     persist::ObjectCacheRepository,
     token_conversion::TokenConverter,
-    utils::{payments::get_payment_and_emit_event, run_with_shutdown},
+    utils::{
+        payments::{get_payment_and_emit_event, update_balances},
+        run_with_shutdown,
+    },
 };
 use crate::{PaymentType, StorageListPaymentsRequest, StoragePaymentDetailsFilter};
 
 use super::{RuntimeEvent, RuntimeProfile};
-use crate::sdk::{
-    BreezSdk, SyncCoordinator, SyncRequest, SyncType,
-    helpers::{BalanceWatcher, update_balances},
-};
+use crate::sdk::{BreezSdk, SyncCoordinator, SyncRequest, SyncType, helpers::BalanceWatcher};
 
 pub(super) struct ClientRuntime;
 
@@ -121,7 +121,7 @@ fn spawn_client_runtime_loop(sdk: &BreezSdk, initial_synced_sender: watch::Sende
                     }
 
                     event = wallet_events.recv() => {
-                        on_wallet_event(&sdk, event).await;
+                        Box::pin(on_wallet_event(&sdk, event)).await;
                     }
 
                     sync_request = sync_requests.recv() => {
@@ -160,7 +160,7 @@ async fn on_wallet_event(sdk: &BreezSdk, event: Result<WalletEvent, broadcast::e
                 &event,
                 WalletEvent::TransferClaimed(_) | WalletEvent::TransferClaimStarting(_)
             );
-            let payment_event_emitted = handle_wallet_event(sdk, event).await;
+            let payment_event_emitted = Box::pin(handle_wallet_event(sdk, event)).await;
 
             if wallet_synced {
                 sdk.sync_coordinator

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -3,10 +3,7 @@ use platform_utils::tokio;
 use std::sync::Arc;
 use tracing::{debug, error, info, trace, warn};
 
-use super::{
-    BreezSdk, CLAIM_TX_SIZE_VBYTES, SYNC_PAGING_LIMIT, SyncType, helpers::update_balances,
-    parse_input,
-};
+use super::{BreezSdk, CLAIM_TX_SIZE_VBYTES, SYNC_PAGING_LIMIT, SyncType, parse_input};
 use crate::{
     DepositInfo, InputType, MaxFee, PaymentDetails, PaymentType,
     error::SdkError,
@@ -17,6 +14,7 @@ use crate::{
     sync::SparkSyncService,
     utils::{
         deposit_chain_syncer::{DepositChainSyncer, TxOutput},
+        payments::update_balances,
         utxo_fetcher::DetailedUtxo,
     },
 };

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -972,6 +972,7 @@ impl SdkBuilder {
             flashnet_config,
             Arc::clone(&storage),
             Arc::clone(&spark_wallet),
+            Arc::clone(&event_emitter),
             self.config.network,
             context.http_client.clone(),
         ));

--- a/crates/breez-sdk/core/src/token_conversion/flashnet.rs
+++ b/crates/breez-sdk/core/src/token_conversion/flashnet.rs
@@ -1,20 +1,25 @@
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 use bitcoin::secp256k1::PublicKey;
 use flashnet::{
-    BTC_ASSET_ADDRESS, CacheStore, ClawbackRequest, ClawbackResponse, ExecuteSwapRequest,
-    FlashnetClient, FlashnetConfig, FlashnetError, GetMinAmountsRequest, ListPoolsRequest,
-    PoolSortOrder, SimulateSwapRequest,
+    AssetTransfer, BTC_ASSET_ADDRESS, CacheStore, ClawbackRequest, ClawbackResponse,
+    ExecuteSwapRequest, ExecuteSwapResponse, FlashnetClient, FlashnetConfig, FlashnetError,
+    GetMinAmountsRequest, ListPoolsRequest, PoolSortOrder, SimulateSwapRequest,
 };
 use spark_wallet::{SparkWallet, TransferId};
 use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    AmountAdjustmentReason, Network, Payment, PaymentDetails, PaymentMetadata, Storage,
+    AmountAdjustmentReason, EventEmitter, Network, Payment, PaymentDetails, PaymentMetadata,
+    Storage,
     persist::{ObjectCacheRepository, StorageListPaymentsRequest, StoragePaymentDetailsFilter},
     token_conversion::{ConversionAmount, DEFAULT_CONVERSION_MAX_SLIPPAGE_BPS},
-    utils::token::token_transaction_to_payments,
+    utils::{
+        payments::{fetch_and_process_payment, insert_payment_with_metadata},
+        polling::{PollSchedule, poll_until},
+        token::token_transaction_to_payments,
+    },
 };
 
 use super::{
@@ -22,6 +27,14 @@ use super::{
     ConversionStatus, ConversionType, FeeSplit, FetchConversionLimitsRequest,
     FetchConversionLimitsResponse, TokenConversionPool, TokenConversionResponse, TokenConverter,
 };
+
+// Polling cadence for the received leg of a freshly-completed conversion.
+// The pool typically takes 1-3 seconds to advance its outbound transfer to
+// the claimable state, so we keep the timeout modest — beyond that, the
+// host's next sync_wallet picks up the leg.
+const RECEIVED_LEG_POLL_INITIAL_DELAY_MS: u64 = 500;
+const RECEIVED_LEG_POLL_MAX_DELAY_MS: u64 = 2000;
+const RECEIVED_LEG_POLL_TIMEOUT_SECS: u64 = 15;
 
 /// Flashnet-based implementation of the `TokenConverter` trait.
 ///
@@ -31,6 +44,7 @@ pub(crate) struct FlashnetTokenConverter {
     flashnet_client: Arc<FlashnetClient>,
     storage: Arc<dyn Storage>,
     spark_wallet: Arc<SparkWallet>,
+    event_emitter: Arc<EventEmitter>,
     network: Network,
     refund_trigger: broadcast::Sender<()>,
     integrator_fee_bps: u32,
@@ -42,11 +56,14 @@ impl FlashnetTokenConverter {
     /// # Arguments
     /// * `storage` - Storage for payment lookups and metadata updates
     /// * `spark_wallet` - Spark wallet for transfer/transaction lookups
+    /// * `event_emitter` - Event emitter used when persisting conversion-leg
+    ///   payment records after a successful swap
     /// * `network` - The network configuration
     pub fn new(
         flashnet_config: FlashnetConfig,
         storage: Arc<dyn Storage>,
         spark_wallet: Arc<SparkWallet>,
+        event_emitter: Arc<EventEmitter>,
         network: Network,
         http_client: Arc<dyn platform_utils::HttpClient>,
     ) -> Self {
@@ -68,6 +85,7 @@ impl FlashnetTokenConverter {
             flashnet_client,
             storage,
             spark_wallet,
+            event_emitter,
             network,
             refund_trigger,
             integrator_fee_bps,
@@ -602,6 +620,123 @@ impl FlashnetTokenConverter {
             estimate.amount_adjustment,
         ))
     }
+
+    /// Insert local `Payment` records for both legs of a completed swap so
+    /// the conversion's `from`/`to` are immediately visible to callers
+    /// without waiting for the next `sync_wallet`.
+    ///
+    /// The sent leg uses the rich `AssetTransfer` that
+    /// [`FlashnetClient::execute_swap`] hands back — no extra RPC. The
+    /// received leg is fetched by id (the pool created it server-side, so
+    /// we don't yet have it locally); for spark transfers we also claim
+    /// them so the resulting Payment is terminal.
+    async fn process_conversion_payments(
+        &self,
+        outbound_asset_transfer: AssetTransfer,
+        sent_payment_id: &str,
+        received_payment_id: &str,
+    ) {
+        // Sent leg: we just produced this transfer ourselves, so the local
+        // spark/token wallet state is already current — no claim needed.
+        // Build the Payment directly and insert it even if the operator-side
+        // status hasn't reached terminal yet; the next sync will promote it
+        // to Completed.
+        let sent_payment = self
+            .build_sent_conversion_payment(outbound_asset_transfer, sent_payment_id)
+            .await;
+        if let Some(payment) = sent_payment {
+            insert_payment_with_metadata(
+                self.spark_wallet.clone(),
+                self.storage.clone(),
+                self.event_emitter.clone(),
+                payment,
+            )
+            .await;
+        }
+
+        // Received leg: look up by id (the pool created it server-side).
+        let received_payment = self
+            .fetch_received_conversion_payment(received_payment_id)
+            .await;
+        if let Some(payment) = received_payment {
+            insert_payment_with_metadata(
+                self.spark_wallet.clone(),
+                self.storage.clone(),
+                self.event_emitter.clone(),
+                payment,
+            )
+            .await;
+        }
+    }
+
+    /// Builds the `Payment` record for the sent leg of a conversion
+    /// using the response we already have from `execute_swap`.
+    async fn build_sent_conversion_payment(
+        &self,
+        outbound_asset_transfer: AssetTransfer,
+        sent_payment_id: &str,
+    ) -> Option<Payment> {
+        match outbound_asset_transfer {
+            AssetTransfer::Spark(transfer) => match Payment::try_from(transfer) {
+                Ok(payment) => Some(payment),
+                Err(e) => {
+                    warn!(
+                        "Failed to build Payment from sent spark transfer for conversion {sent_payment_id}: {e:?}"
+                    );
+                    None
+                }
+            },
+            AssetTransfer::Token(token_tx) => {
+                let object_repository = ObjectCacheRepository::new(self.storage.clone());
+                match token_transaction_to_payments(
+                    &self.spark_wallet,
+                    &object_repository,
+                    &token_tx,
+                    true,
+                )
+                .await
+                {
+                    Ok(payments) => payments.into_iter().find(|p| p.id == sent_payment_id),
+                    Err(e) => {
+                        warn!(
+                            "Failed to convert sent token tx to payments for conversion {sent_payment_id}: {e:?}"
+                        );
+                        None
+                    }
+                }
+            }
+        }
+    }
+
+    /// Fetches the received leg of a conversion by its payment id and processes
+    /// the transfer/token. Spark transfers are claimed locally before
+    /// being returned; token outputs are already terminal once the
+    /// tx is visible on operators.
+    ///
+    /// Polls briefly because the pool's outbound transfer typically arrives
+    /// in `SenderInitiated`/`SenderKeyTweakPending` and only becomes
+    /// claimable a moment later. If we're not able to fetch and process the
+    /// payment, it will be done so downstream or in the next `sync_wallet` call.
+    async fn fetch_received_conversion_payment(&self, payment_id: &str) -> Option<Payment> {
+        let schedule = PollSchedule {
+            initial_delay: Duration::from_millis(RECEIVED_LEG_POLL_INITIAL_DELAY_MS),
+            max_delay: Duration::from_millis(RECEIVED_LEG_POLL_MAX_DELAY_MS),
+            timeout: Duration::from_secs(RECEIVED_LEG_POLL_TIMEOUT_SECS),
+        };
+        let result = poll_until(schedule, None, || {
+            fetch_and_process_payment(&self.spark_wallet, self.storage.clone(), payment_id, false)
+        })
+        .await;
+        match result {
+            Ok(payment) => Some(payment),
+            Err(e) => {
+                warn!(
+                    "Failed to fetch received conversion payment {payment_id} within timeout: {e:?}"
+                );
+                None
+            }
+        }
+    }
 }
 
 #[macros::async_trait]
@@ -649,15 +784,20 @@ impl TokenConverter for FlashnetTokenConverter {
             .await;
 
         match response_res {
-            Ok(response) => {
+            Ok(ExecuteSwapResponse {
+                flashnet_response,
+                outbound_asset_transfer,
+            }) => {
                 debug!(
                     "Conversion executed: accepted {}, error {:?}, fee_amount: {:?}",
-                    response.accepted, response.error, response.fee_amount,
+                    flashnet_response.accepted,
+                    flashnet_response.error,
+                    flashnet_response.fee_amount,
                 );
-                // Fee from ExecuteSwapResponse is denominated in the non-BTC asset (token units).
-                // Route to the token-side payment: sent if asset_in is the token, received if
-                // asset_in is BTC (meaning the token is on the received side).
-                let fee_split = response.fee_amount.map(|fee| {
+                // Fee from FlashnetExecuteSwapResponse is denominated in the non-BTC asset
+                // (token units). Route to the token-side payment: sent if asset_in is the token,
+                // received if asset_in is BTC (meaning the token is on the received side).
+                let fee_split = flashnet_response.fee_amount.map(|fee| {
                     if conversion_pool.asset_in_address == BTC_ASSET_ADDRESS {
                         FeeSplit::Received(fee)
                     } else {
@@ -668,9 +808,9 @@ impl TokenConverter for FlashnetTokenConverter {
                 let (sent_payment_id, received_payment_id) = self
                     .update_payment_conversion_info(
                         &pool_id,
-                        response.transfer_id,
-                        response.outbound_transfer_id,
-                        response.refund_transfer_id,
+                        flashnet_response.transfer_id,
+                        flashnet_response.outbound_transfer_id,
+                        flashnet_response.refund_transfer_id,
                         fee_split,
                         purpose,
                         amount_adjustment.clone(),
@@ -678,14 +818,20 @@ impl TokenConverter for FlashnetTokenConverter {
                     .await?;
 
                 if let Some(received_payment_id) = received_payment_id
-                    && response.accepted
+                    && flashnet_response.accepted
                 {
+                    self.process_conversion_payments(
+                        outbound_asset_transfer,
+                        &sent_payment_id,
+                        &received_payment_id,
+                    )
+                    .await;
                     Ok(TokenConversionResponse {
                         sent_payment_id,
                         received_payment_id,
                     })
                 } else {
-                    let error_message = response
+                    let error_message = flashnet_response
                         .error
                         .unwrap_or("Conversion not accepted".to_string());
                     Err(ConversionError::ConversionFailed(format!(

--- a/crates/breez-sdk/core/src/utils/payments.rs
+++ b/crates/breez-sdk/core/src/utils/payments.rs
@@ -1,10 +1,20 @@
+use std::str::FromStr;
 use std::sync::Arc;
 
-use tracing::{error, info, warn};
+use platform_utils::time::Instant;
+use spark_wallet::{
+    ListTransfersRequest, SparkWallet, TokenTransaction, TransferId, TransferStatus, WalletTransfer,
+};
+use tracing::{debug, error, info, warn};
 
 use crate::{
-    EventEmitter, Payment, Storage, error::SdkError, events::SdkEvent,
+    EventEmitter, Payment, PaymentStatus, Storage,
+    error::SdkError,
+    events::SdkEvent,
     models::conversion_steps_from_payments,
+    persist::{CachedAccountInfo, ObjectCacheRepository},
+    sync::SparkSyncService,
+    utils::token::token_transaction_to_payments,
 };
 
 /// Insert a payment through the storage status guard and emit when requested
@@ -49,6 +59,210 @@ pub(crate) async fn get_payment_and_emit_event(
         };
     info!("Emitting payment event: {payment:?}");
     event_emitter.emit(&SdkEvent::from_payment(payment)).await;
+}
+
+/// Process an already-fetched Spark transfer, claiming it locally if
+/// it is awaiting our key tweak.
+///
+/// Returns `None` when the transfer is at a status we cannot yet finalise
+/// from (e.g. still pending on the operator) — callers can then choose to
+/// poll again, or to skip.
+async fn process_spark_transfer_to_payment(
+    spark_wallet: &SparkWallet,
+    wallet_transfer: WalletTransfer,
+) -> Result<Option<Payment>, SdkError> {
+    let payment: Payment = match wallet_transfer.status {
+        // Already terminal — convert as-is.
+        TransferStatus::Completed => wallet_transfer.try_into()?,
+        // Claimable — pull the leaves into the local tree-store and promote
+        // the status before converting.
+        TransferStatus::SenderKeyTweaked => {
+            debug!(
+                "process_spark_transfer_to_payment({}): claiming",
+                wallet_transfer.id
+            );
+            spark_wallet.process_transfer(&wallet_transfer).await?;
+            let mut claimed = wallet_transfer;
+            claimed.status = TransferStatus::Completed;
+            claimed.try_into()?
+        }
+        // Terminal-failed — convert without claiming so callers see the
+        // `Failed` payment.
+        TransferStatus::Expired | TransferStatus::Returned => {
+            debug!(
+                "process_spark_transfer_to_payment({}): terminal-failed ({})",
+                wallet_transfer.id, wallet_transfer.status
+            );
+            wallet_transfer.try_into()?
+        }
+        _ => return Ok(None),
+    };
+    Ok(Some(payment))
+}
+
+/// Process an already-fetched token transaction, updating the local token-output
+/// store on terminal status.
+///
+/// Returns `None` when the matching payment isn't found in the transaction's
+/// outputs or is still pending.
+async fn process_token_transaction_to_payment(
+    spark_wallet: &SparkWallet,
+    storage: Arc<dyn Storage>,
+    token_transaction: &TokenTransaction,
+    tx_inputs_are_ours: bool,
+    payment_id: &str,
+) -> Result<Option<Payment>, SdkError> {
+    let object_repository = ObjectCacheRepository::new(storage);
+    let payments = token_transaction_to_payments(
+        spark_wallet,
+        &object_repository,
+        token_transaction,
+        tx_inputs_are_ours,
+    )
+    .await?;
+    let Some(payment) = payments.into_iter().find(|p| p.id == payment_id) else {
+        debug!(
+            "process_token_transaction_to_payment({}): no output matches payment_id {payment_id}",
+            token_transaction.hash
+        );
+        return Ok(None);
+    };
+    if payment.status == PaymentStatus::Pending {
+        return Ok(None);
+    }
+    spark_wallet
+        .process_token_transaction(token_transaction)
+        .await?;
+    Ok(Some(payment))
+}
+
+/// Fetch a payment by its id (Spark `transfer_id` or token `{hash}:{vout}`)
+/// and process it.
+///
+/// Returns `Ok(None)` if the underlying transfer/token transaction isn't
+/// yet visible on operators, or isn't at a status we can produce a terminal
+/// `Payment` for.
+pub(crate) async fn fetch_and_process_payment(
+    spark_wallet: &SparkWallet,
+    storage: Arc<dyn Storage>,
+    payment_id: &str,
+    tx_inputs_are_ours: bool,
+) -> Result<Option<Payment>, SdkError> {
+    if let Ok(transfer_id) = TransferId::from_str(payment_id) {
+        let mut resp = spark_wallet
+            .list_transfers(ListTransfersRequest {
+                transfer_ids: vec![transfer_id],
+                paging: None,
+            })
+            .await?;
+        let Some(wallet_transfer) = resp.items.pop() else {
+            debug!("fetch_and_process_payment({payment_id}): not yet visible on operators");
+            return Ok(None);
+        };
+        debug!(
+            "fetch_and_process_payment({payment_id}): spark transfer status={}",
+            wallet_transfer.status
+        );
+        return process_spark_transfer_to_payment(spark_wallet, wallet_transfer).await;
+    }
+
+    let Some((tx_hash, _vout)) = payment_id.split_once(':') else {
+        return Err(SdkError::Generic(format!(
+            "Unrecognized payment_id format: {payment_id}"
+        )));
+    };
+    let token_transactions = spark_wallet
+        .get_token_transactions_by_hashes(vec![tx_hash.to_string()])
+        .await?;
+    let Some(token_transaction) = token_transactions.first() else {
+        debug!("fetch_and_process_payment({payment_id}): not yet visible on operators");
+        return Ok(None);
+    };
+    debug!(
+        "fetch_and_process_payment({payment_id}): token tx status={:?}",
+        token_transaction.status
+    );
+    process_token_transaction_to_payment(
+        spark_wallet,
+        storage,
+        token_transaction,
+        tx_inputs_are_ours,
+        payment_id,
+    )
+    .await
+}
+
+/// Apply any cached metadata, refresh balances, then persist the payment
+/// through the storage status guard (`record_payment_update`) and emit a
+/// status event if storage reports the persisted status advanced. Balances
+/// are refreshed before emitting so clients querying state in response to
+/// the event observe the new balance. Returns whether an event was emitted.
+pub(crate) async fn insert_payment_with_metadata(
+    spark_wallet: Arc<SparkWallet>,
+    storage: Arc<dyn Storage>,
+    event_emitter: Arc<EventEmitter>,
+    payment: Payment,
+) -> bool {
+    let sync_service =
+        SparkSyncService::new(spark_wallet.clone(), storage.clone(), event_emitter.clone());
+    if let Err(e) = sync_service.apply_payment_metadata(&payment).await {
+        error!(
+            "insert_payment_with_metadata({}): failed to apply payment metadata: {e:?}",
+            payment.id
+        );
+    }
+
+    if let Err(e) = update_balances(spark_wallet, storage.clone()).await {
+        error!("insert_payment_with_metadata: failed to update balances: {e:?}");
+    }
+
+    record_payment_update(&storage, event_emitter.as_ref(), payment, true).await
+}
+
+/// Refresh the locally-cached balance snapshot (sats + token balances) from
+/// the wallet and persist it to storage.
+pub(crate) async fn update_balances(
+    spark_wallet: Arc<SparkWallet>,
+    storage: Arc<dyn Storage>,
+) -> Result<(), SdkError> {
+    let total_start = Instant::now();
+
+    let t = Instant::now();
+    let balance_sats = spark_wallet.get_balance().await?;
+    let get_balance_dt = t.elapsed();
+
+    let t = Instant::now();
+    let token_balances_raw = spark_wallet.get_token_balances().await?;
+    let get_token_balances_dt = t.elapsed();
+    let token_balances_count = token_balances_raw.len();
+    let token_balances = token_balances_raw
+        .into_iter()
+        .map(|(k, v)| (k, v.into()))
+        .collect();
+
+    let object_repository = ObjectCacheRepository::new(storage.clone());
+
+    let t = Instant::now();
+    object_repository
+        .save_account_info(&CachedAccountInfo {
+            balance_sats,
+            token_balances,
+        })
+        .await?;
+    let save_dt = t.elapsed();
+
+    let identity_public_key = spark_wallet.get_identity_public_key();
+    info!(
+        "Balance updated successfully {} for identity {} (total: {:?}, get_balance: {:?}, get_token_balances[{}]: {:?}, save_account_info: {:?})",
+        balance_sats,
+        identity_public_key,
+        total_start.elapsed(),
+        get_balance_dt,
+        token_balances_count,
+        get_token_balances_dt,
+        save_dt
+    );
+    Ok(())
 }
 
 /// Gets a payment from storage by ID to include already stored payment metadata

--- a/crates/flashnet/src/api.rs
+++ b/crates/flashnet/src/api.rs
@@ -8,9 +8,9 @@ use tracing::debug;
 
 use crate::utils::generate_nonce;
 use crate::{
-    ClawbackIntent, ClawbackRequest, ClawbackResponse, ExecuteSwapIntent, ExecuteSwapResponse,
-    GetMinAmountsRequest, GetMinAmountsResponse, ListUserSwapsRequest, ListUserSwapsResponse,
-    SignedClawbackRequest, SignedExecuteSwapResponse,
+    AssetTransfer, ClawbackIntent, ClawbackRequest, ClawbackResponse, ExecuteSwapIntent,
+    ExecuteSwapResponse, FlashnetExecuteSwapResponse, GetMinAmountsRequest, GetMinAmountsResponse,
+    ListUserSwapsRequest, ListUserSwapsResponse, SignedClawbackRequest, SignedExecuteSwapResponse,
 };
 use crate::{
     ExecuteSwapRequest, FeatureName, FeatureStatus, FlashnetError, MinAmount, PingResponse,
@@ -181,8 +181,10 @@ impl FlashnetClient {
         )
         .await?;
 
-        // Transfer the asset in to the pool
-        let transaction_identifier = self
+        // Transfer the asset in to the pool. We keep the rich wallet-side
+        // object so callers can record a `Payment` for the sent leg
+        // without re-fetching it from the operator.
+        let outbound_asset_transfer = self
             .transfer_asset(
                 request.amount_in,
                 &request.asset_in_address,
@@ -190,6 +192,7 @@ impl FlashnetClient {
                 request.transfer_id.clone(),
             )
             .await?;
+        let transaction_identifier = outbound_asset_transfer.id();
         debug!("Signing swap execution for: {transaction_identifier}");
 
         // Sign and send the execute swap request
@@ -197,10 +200,13 @@ impl FlashnetClient {
             .sign_execute_swap(request, &transaction_identifier)
             .await;
         match swap_response_res {
-            Ok(response) => Ok(ExecuteSwapResponse::from_signed_execute_swap_response(
-                response,
-                transaction_identifier,
-            )),
+            Ok(response) => Ok(ExecuteSwapResponse {
+                flashnet_response: FlashnetExecuteSwapResponse::from_signed_execute_swap_response(
+                    response,
+                    transaction_identifier,
+                ),
+                outbound_asset_transfer,
+            }),
             Err(e) => Err(FlashnetError::execution(e, Some(transaction_identifier))),
         }
     }
@@ -428,11 +434,12 @@ impl FlashnetClient {
         asset_address: &str,
         receiver_public_key: &PublicKey,
         transfer_id: Option<TransferId>,
-    ) -> Result<String, FlashnetError> {
+    ) -> Result<AssetTransfer, FlashnetError> {
         let receiver_address = SparkAddress::new(*receiver_public_key, self.config.network, None);
-        let id = if asset_address == BTC_ASSET_ADDRESS {
+        if asset_address == BTC_ASSET_ADDRESS {
             // Send a spark transfer
-            self.spark_wallet
+            let transfer = self
+                .spark_wallet
                 .transfer(
                     u64::try_from(amount).map_err(|e| {
                         FlashnetError::Generic(format!("Failed to convert amount to u64: {e}"))
@@ -440,9 +447,8 @@ impl FlashnetClient {
                     &receiver_address,
                     transfer_id,
                 )
-                .await?
-                .id
-                .to_string()
+                .await?;
+            Ok(AssetTransfer::Spark(transfer))
         } else {
             // Send a token transfer
             let asset_address_hex = hex::decode(asset_address).map_err(|e| {
@@ -450,7 +456,8 @@ impl FlashnetClient {
             })?;
             let token_id = bech32m_encode_token_id(&asset_address_hex, self.config.network)
                 .map_err(|e| FlashnetError::Generic(format!("Failed to encode token id: {e}")))?;
-            self.spark_wallet
+            let token_tx = self
+                .spark_wallet
                 .transfer_tokens(
                     vec![TransferTokenOutput {
                         token_id,
@@ -461,9 +468,8 @@ impl FlashnetClient {
                     None,
                     None,
                 )
-                .await?
-                .hash
-        };
-        Ok(id)
+                .await?;
+            Ok(AssetTransfer::Token(token_tx))
+        }
     }
 }

--- a/crates/flashnet/src/models.rs
+++ b/crates/flashnet/src/models.rs
@@ -5,10 +5,46 @@ use serde::{Deserialize, Serialize};
 use serde_with::DisplayFromStr;
 use serde_with::serde_as;
 use spark::Network;
-use spark_wallet::{PublicKey, TransferId};
+use spark_wallet::{PublicKey, TokenTransaction, TransferId, WalletTransfer};
 
 use crate::utils::decode_token_identifier;
 use crate::{BTC_ASSET_ADDRESS, FlashnetError};
+
+/// The asset transfer produced when we send the swap's "in" asset to the
+/// pool. Carries the rich wallet-side object so callers can record a
+/// `Payment` for the sent leg without re-fetching it from the operator.
+///
+/// `Spark` is the larger variant; we don't box it because instances are
+/// short-lived (constructed once per swap, consumed by the caller almost
+/// immediately) and adding indirection would only complicate consumers.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum AssetTransfer {
+    Spark(WalletTransfer),
+    Token(TokenTransaction),
+}
+
+impl AssetTransfer {
+    /// Returns the operator-side identifier for this transfer — a Spark
+    /// `transfer_id` or a token transaction hash, matching what the swap
+    /// signing flow uses.
+    #[must_use]
+    pub fn id(&self) -> String {
+        match self {
+            AssetTransfer::Spark(t) => t.id.to_string(),
+            AssetTransfer::Token(t) => t.hash.clone(),
+        }
+    }
+}
+
+/// Response returned by [`FlashnetClient::execute_swap`](crate::FlashnetClient::execute_swap):
+/// the wire-shaped fields from Flashnet plus the rich `AssetTransfer` we
+/// produced locally when sending the asset into the pool.
+#[derive(Debug, Clone)]
+pub struct ExecuteSwapResponse {
+    pub flashnet_response: FlashnetExecuteSwapResponse,
+    pub outbound_asset_transfer: AssetTransfer,
+}
 
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -131,7 +167,7 @@ pub(crate) struct ExecuteSwapIntent {
 #[serde_as]
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct ExecuteSwapResponse {
+pub struct FlashnetExecuteSwapResponse {
     pub transfer_id: String,
     pub request_id: String,
     pub accepted: bool,
@@ -151,7 +187,7 @@ pub struct ExecuteSwapResponse {
     pub refund_transfer_id: Option<String>,
 }
 
-impl ExecuteSwapResponse {
+impl FlashnetExecuteSwapResponse {
     pub(crate) fn from_signed_execute_swap_response(
         response: SignedExecuteSwapResponse,
         transfer_id: String,


### PR DESCRIPTION
Conversion-leg `Payment` records previously only landed in storage on the
next `sync_wallet`, so `conversion_details.from`/`to` on the parent payment
showed `null` until a sync filled them in. Now both legs are inserted as
soon as the conversion completes.

`FlashnetClient::execute_swap` returns directly the `WalletTransfer`/`TokenTransaction` it
already produced for the outbound asset (no extra RPC). The sent leg is
built from that and inserted as-is; the received leg is polled by id and claimed
before insertion. On timeout, the next sync remains the fallback.