### PR TITLE
Auto-recover refundable conversions via Flashnet API

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -423,15 +423,13 @@ public static class Commands
                     .Select(s => Enum.Parse<SparkHtlcStatus>(s.Trim(), ignoreCase: true))
                     .ToArray();
                 paymentDetailsFilterList.Add(new PaymentDetailsFilter.Spark(
-                    htlcStatus: statuses,
-                    conversionRefundNeeded: null
+                    htlcStatus: statuses
                 ));
             }
 
             if (txHash != null)
             {
                 paymentDetailsFilterList.Add(new PaymentDetailsFilter.Token(
-                    conversionRefundNeeded: null,
                     txType: null,
                     txHash: txHash
                 ));
@@ -441,7 +439,6 @@ public static class Commands
             {
                 var txType = Enum.Parse<TokenTransactionType>(txTypeStr, ignoreCase: true);
                 paymentDetailsFilterList.Add(new PaymentDetailsFilter.Token(
-                    conversionRefundNeeded: null,
                     txType: txType,
                     txHash: null
                 ));

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -241,13 +241,11 @@ suspend fun handleListPayments(sdk: BreezSdk, reader: LineReader, args: List<Str
             SparkHtlcStatus.valueOf(s.trim().uppercase())
         }
         paymentDetailsFilter.add(PaymentDetailsFilter.Spark(
-            htlcStatus = statuses,
-            conversionRefundNeeded = null
+            htlcStatus = statuses
         ))
     }
     if (txHash != null) {
         paymentDetailsFilter.add(PaymentDetailsFilter.Token(
-            conversionRefundNeeded = null,
             txType = null,
             txHash = txHash
         ))
@@ -255,7 +253,6 @@ suspend fun handleListPayments(sdk: BreezSdk, reader: LineReader, args: List<Str
     if (txTypeStr != null) {
         val txType = TokenTransactionType.valueOf(txTypeStr.trim().uppercase())
         paymentDetailsFilter.add(PaymentDetailsFilter.Token(
-            conversionRefundNeeded = null,
             txType = txType,
             txHash = null
         ))

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -203,12 +203,12 @@ async def _handle_list_payments(sdk, _token_issuer, _session, args):
         statuses = [_parse_htlc_status(s) for s in args.spark_htlc_status_filter if _parse_htlc_status(s)]
         if statuses:
             payment_details_filter.append(
-                PaymentDetailsFilter.SPARK(htlc_status=statuses, conversion_refund_needed=None)
+                PaymentDetailsFilter.SPARK(htlc_status=statuses)
             )
     if args.tx_hash:
         payment_details_filter.append(
             PaymentDetailsFilter.TOKEN(
-                conversion_refund_needed=None, tx_type=None, tx_hash=args.tx_hash,
+                tx_type=None, tx_hash=args.tx_hash,
             )
         )
     if args.tx_type:
@@ -216,7 +216,7 @@ async def _handle_list_payments(sdk, _token_issuer, _session, args):
         if tx_type:
             payment_details_filter.append(
                 PaymentDetailsFilter.TOKEN(
-                    conversion_refund_needed=None, tx_type=tx_type, tx_hash=None,
+                    tx_type=tx_type, tx_hash=None,
                 )
             )
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -395,14 +395,12 @@ async function handleListPayments(sdk: BreezSdkInterface, _tokenIssuer: TokenIss
       }).filter((v): v is SparkHtlcStatus => v !== undefined)
       paymentDetailsFilter.push(new PaymentDetailsFilter.Spark({
         htlcStatus: htlcStatuses.length > 0 ? htlcStatuses : undefined,
-        conversionRefundNeeded: undefined,
       }))
     }
     if (txHash) {
       paymentDetailsFilter.push(new PaymentDetailsFilter.Token({
         txHash,
         txType: undefined,
-        conversionRefundNeeded: undefined,
       }))
     }
     if (txType) {
@@ -416,7 +414,6 @@ async function handleListPayments(sdk: BreezSdkInterface, _tokenIssuer: TokenIss
       paymentDetailsFilter.push(new PaymentDetailsFilter.Token({
         txType: parsedTxType,
         txHash: undefined,
-        conversionRefundNeeded: undefined,
       }))
     }
   }

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -273,13 +273,13 @@ func handleListPayments(_ sdk: BreezSdk, _ args: [String]) async throws {
     var paymentDetailsFilter: [PaymentDetailsFilter] = []
     if let htlcStatusRaw = fp.get("spark-htlc-status-filter") {
         let statuses = htlcStatusRaw.split(separator: ",").compactMap { parseSparkHtlcStatus(String($0)) }
-        paymentDetailsFilter.append(.spark(htlcStatus: statuses, conversionRefundNeeded: nil))
+        paymentDetailsFilter.append(.spark(htlcStatus: statuses))
     }
     if let txHash = fp.get("tx-hash") {
-        paymentDetailsFilter.append(.token(conversionRefundNeeded: nil, txHash: txHash, txType: nil))
+        paymentDetailsFilter.append(.token(txHash: txHash, txType: nil))
     }
     if let txTypeRaw = fp.get("tx-type"), let txType = parseTokenTransactionType(txTypeRaw) {
-        paymentDetailsFilter.append(.token(conversionRefundNeeded: nil, txHash: nil, txType: txType))
+        paymentDetailsFilter.append(.token(txHash: nil, txType: txType))
     }
 
     let result = try await sdk.listPayments(request: ListPaymentsRequest(

--- a/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
+++ b/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
@@ -63,7 +63,6 @@ async fn send_htlc_alice_to_bob(
             type_filter: Some(vec![PaymentType::Receive]),
             payment_details_filter: Some(vec![PaymentDetailsFilter::Spark {
                 htlc_status: Some(vec![SparkHtlcStatus::WaitingForPreimage]),
-                conversion_refund_needed: None,
             }]),
             ..Default::default()
         })
@@ -94,7 +93,6 @@ async fn send_htlc_alice_to_bob(
             type_filter: Some(vec![PaymentType::Send]),
             payment_details_filter: Some(vec![PaymentDetailsFilter::Spark {
                 htlc_status: Some(vec![SparkHtlcStatus::WaitingForPreimage]),
-                conversion_refund_needed: None,
             }]),
             ..Default::default()
         })
@@ -247,7 +245,6 @@ async fn test_02_htlc_refund(
             type_filter: Some(vec![PaymentType::Receive]),
             payment_details_filter: Some(vec![PaymentDetailsFilter::Spark {
                 htlc_status: Some(vec![SparkHtlcStatus::Returned]),
-                conversion_refund_needed: None,
             }]),
             ..Default::default()
         })
@@ -279,7 +276,6 @@ async fn test_02_htlc_refund(
             type_filter: Some(vec![PaymentType::Send]),
             payment_details_filter: Some(vec![PaymentDetailsFilter::Spark {
                 htlc_status: Some(vec![SparkHtlcStatus::Returned]),
-                conversion_refund_needed: None,
             }]),
             ..Default::default()
         })

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -402,19 +402,16 @@ pub(crate) async fn execute_command(
             if let Some(statuses) = spark_htlc_status_filter {
                 payment_details_filter.push(PaymentDetailsFilter::Spark {
                     htlc_status: Some(statuses),
-                    conversion_refund_needed: None,
                 });
             }
             if let Some(tx_hash) = tx_hash {
                 payment_details_filter.push(PaymentDetailsFilter::Token {
-                    conversion_refund_needed: None,
                     tx_type: None,
                     tx_hash: Some(tx_hash),
                 });
             }
             if let Some(tx_type) = tx_type {
                 payment_details_filter.push(PaymentDetailsFilter::Token {
-                    conversion_refund_needed: None,
                     tx_type: Some(tx_type),
                     tx_hash: None,
                 });

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1114,6 +1114,16 @@ pub struct GetInfoRequest {
     pub ensure_synced: Option<bool>,
 }
 
+/// Response from refunding pending conversions.
+#[derive(Debug, Clone, Serialize, Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct RefundPendingConversionsResponse {
+    /// Pending conversions refunded.
+    pub refunded: u32,
+    /// Pending conversions skipped.
+    pub skipped: u32,
+}
+
 /// Response containing the balance of the wallet
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -1499,12 +1509,8 @@ pub enum PaymentDetailsFilter {
     Spark {
         /// Filter specific Spark HTLC statuses
         htlc_status: Option<Vec<SparkHtlcStatus>>,
-        /// Filter conversion payments with refund information
-        conversion_refund_needed: Option<bool>,
     },
     Token {
-        /// Filter conversion payments with refund information
-        conversion_refund_needed: Option<bool>,
         /// Filter by transaction hash
         tx_hash: Option<String>,
         /// Filter by transaction type

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -126,10 +126,8 @@ impl From<std::num::TryFromIntError> for StorageError {
 pub enum StoragePaymentDetailsFilter {
     Spark {
         htlc_status: Option<Vec<SparkHtlcStatus>>,
-        conversion_refund_needed: Option<bool>,
     },
     Token {
-        conversion_refund_needed: Option<bool>,
         tx_hash: Option<String>,
         tx_type: Option<TokenTransactionType>,
     },
@@ -141,22 +139,12 @@ pub enum StoragePaymentDetailsFilter {
 impl From<PaymentDetailsFilter> for StoragePaymentDetailsFilter {
     fn from(filter: PaymentDetailsFilter) -> Self {
         match filter {
-            PaymentDetailsFilter::Spark {
-                htlc_status,
-                conversion_refund_needed,
-            } => StoragePaymentDetailsFilter::Spark {
-                htlc_status,
-                conversion_refund_needed,
-            },
-            PaymentDetailsFilter::Token {
-                conversion_refund_needed,
-                tx_hash,
-                tx_type,
-            } => StoragePaymentDetailsFilter::Token {
-                conversion_refund_needed,
-                tx_hash,
-                tx_type,
-            },
+            PaymentDetailsFilter::Spark { htlc_status } => {
+                StoragePaymentDetailsFilter::Spark { htlc_status }
+            }
+            PaymentDetailsFilter::Token { tx_hash, tx_type } => {
+                StoragePaymentDetailsFilter::Token { tx_hash, tx_type }
+            }
             PaymentDetailsFilter::Lightning { htlc_status } => {
                 StoragePaymentDetailsFilter::Lightning { htlc_status }
             }
@@ -167,22 +155,12 @@ impl From<PaymentDetailsFilter> for StoragePaymentDetailsFilter {
 impl From<StoragePaymentDetailsFilter> for PaymentDetailsFilter {
     fn from(filter: StoragePaymentDetailsFilter) -> Self {
         match filter {
-            StoragePaymentDetailsFilter::Spark {
-                htlc_status,
-                conversion_refund_needed,
-            } => PaymentDetailsFilter::Spark {
-                htlc_status,
-                conversion_refund_needed,
-            },
-            StoragePaymentDetailsFilter::Token {
-                conversion_refund_needed,
-                tx_hash,
-                tx_type,
-            } => PaymentDetailsFilter::Token {
-                conversion_refund_needed,
-                tx_hash,
-                tx_type,
-            },
+            StoragePaymentDetailsFilter::Spark { htlc_status } => {
+                PaymentDetailsFilter::Spark { htlc_status }
+            }
+            StoragePaymentDetailsFilter::Token { tx_hash, tx_type } => {
+                PaymentDetailsFilter::Token { tx_hash, tx_type }
+            }
             StoragePaymentDetailsFilter::Lightning { htlc_status } => {
                 PaymentDetailsFilter::Lightning { htlc_status }
             }

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -918,28 +918,6 @@ impl Storage for MysqlStorage {
                         params.push(Value::from(htlc_status.to_string()));
                     }
                 }
-                let conversion_filter = match payment_details_filter {
-                    StoragePaymentDetailsFilter::Spark {
-                        conversion_refund_needed: Some(v),
-                        ..
-                    } => Some((v, "p.spark = 1")),
-                    StoragePaymentDetailsFilter::Token {
-                        conversion_refund_needed: Some(v),
-                        ..
-                    } => Some((v, "p.spark IS NULL")),
-                    _ => None,
-                };
-                if let Some((conversion_refund_needed, type_check)) = conversion_filter {
-                    let refund_needed = if *conversion_refund_needed {
-                        "= 'RefundNeeded'"
-                    } else {
-                        "!= 'RefundNeeded'"
-                    };
-                    payment_details_clauses.push(format!(
-                        "{type_check} AND pm.conversion_info IS NOT NULL AND
-                         JSON_UNQUOTE(JSON_EXTRACT(pm.conversion_info, '$.status')) {refund_needed}"
-                    ));
-                }
                 if let StoragePaymentDetailsFilter::Token {
                     tx_hash: Some(tx_hash),
                     ..
@@ -2167,13 +2145,6 @@ mod tests {
             fixture.storage,
         ))
         .await;
-    }
-
-    #[tokio::test]
-    async fn test_conversion_refund_needed_filtering() {
-        let fixture = MysqlTestFixture::new().await;
-        crate::persist::tests::test_conversion_refund_needed_filtering(Box::new(fixture.storage))
-            .await;
     }
 
     #[tokio::test]

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -832,29 +832,6 @@ impl Storage for PostgresStorage {
                         params.push(Box::new(htlc_status.to_string()));
                     }
                 }
-                // Filter by conversion info presence
-                let conversion_filter = match payment_details_filter {
-                    StoragePaymentDetailsFilter::Spark {
-                        conversion_refund_needed: Some(v),
-                        ..
-                    } => Some((v, "p.spark = true")),
-                    StoragePaymentDetailsFilter::Token {
-                        conversion_refund_needed: Some(v),
-                        ..
-                    } => Some((v, "p.spark IS NULL")),
-                    _ => None,
-                };
-                if let Some((conversion_refund_needed, type_check)) = conversion_filter {
-                    let refund_needed = if *conversion_refund_needed {
-                        "= 'RefundNeeded'"
-                    } else {
-                        "!= 'RefundNeeded'"
-                    };
-                    payment_details_clauses.push(format!(
-                        "{type_check} AND pm.conversion_info IS NOT NULL AND
-                         pm.conversion_info::jsonb->>'status' {refund_needed}"
-                    ));
-                }
                 // Filter by token transaction hash
                 if let StoragePaymentDetailsFilter::Token {
                     tx_hash: Some(tx_hash),
@@ -2018,13 +1995,6 @@ mod tests {
             fixture.storage,
         ))
         .await;
-    }
-
-    #[tokio::test]
-    async fn test_conversion_refund_needed_filtering() {
-        let fixture = PostgresTestFixture::new().await;
-        crate::persist::tests::test_conversion_refund_needed_filtering(Box::new(fixture.storage))
-            .await;
     }
 
     #[tokio::test]

--- a/crates/breez-sdk/core/src/persist/sqlite.rs
+++ b/crates/breez-sdk/core/src/persist/sqlite.rs
@@ -606,29 +606,6 @@ impl Storage for SqliteStorage {
                         params.push(Box::new(htlc_status.to_string()));
                     }
                 }
-                // Filter by conversion info presence
-                let conversion_filter = match payment_details_filter {
-                    StoragePaymentDetailsFilter::Spark {
-                        conversion_refund_needed: Some(v),
-                        ..
-                    } => Some((v, "p.spark = 1")),
-                    StoragePaymentDetailsFilter::Token {
-                        conversion_refund_needed: Some(v),
-                        ..
-                    } => Some((v, "p.spark IS NULL")),
-                    _ => None,
-                };
-                if let Some((conversion_refund_needed, type_check)) = conversion_filter {
-                    let refund_needed = if *conversion_refund_needed {
-                        "= 'RefundNeeded'"
-                    } else {
-                        "!= 'RefundNeeded'"
-                    };
-                    payment_details_clauses.push(format!(
-                        "{type_check} AND pm.conversion_info IS NOT NULL AND
-                         json_extract(pm.conversion_info, '$.status') {refund_needed}"
-                    ));
-                }
                 // Filter by token transaction hash
                 if let StoragePaymentDetailsFilter::Token {
                     tx_hash: Some(tx_hash),
@@ -1837,14 +1814,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_conversion_refund_needed_filtering() {
-        let temp_dir = create_temp_dir("sqlite_storage_conversion_refund_needed_filter");
-        let storage = SqliteStorage::new(&temp_dir).unwrap();
-
-        crate::persist::tests::test_conversion_refund_needed_filtering(Box::new(storage)).await;
-    }
-
-    #[tokio::test]
     async fn test_token_transaction_type_filtering() {
         let temp_dir = create_temp_dir("sqlite_storage_token_transaction_type_filter");
         let storage = SqliteStorage::new(&temp_dir).unwrap();
@@ -2092,7 +2061,6 @@ mod tests {
             status_filter: None,
             asset_filter: None,
             payment_details_filter: Some(vec![StoragePaymentDetailsFilter::Token {
-                conversion_refund_needed: None,
                 tx_hash: None,
                 tx_type: Some(TokenTransactionType::Transfer),
             }]),

--- a/crates/breez-sdk/core/src/persist/tests.rs
+++ b/crates/breez-sdk/core/src/persist/tests.rs
@@ -1818,7 +1818,6 @@ pub async fn test_spark_htlc_status_filtering(storage: Box<dyn Storage>) {
         .list_payments(StorageListPaymentsRequest {
             payment_details_filter: Some(vec![crate::StoragePaymentDetailsFilter::Spark {
                 htlc_status: Some(vec![SparkHtlcStatus::WaitingForPreimage]),
-                conversion_refund_needed: None,
             }]),
             ..Default::default()
         })
@@ -1832,7 +1831,6 @@ pub async fn test_spark_htlc_status_filtering(storage: Box<dyn Storage>) {
         .list_payments(StorageListPaymentsRequest {
             payment_details_filter: Some(vec![crate::StoragePaymentDetailsFilter::Spark {
                 htlc_status: Some(vec![SparkHtlcStatus::PreimageShared]),
-                conversion_refund_needed: None,
             }]),
             ..Default::default()
         })
@@ -1846,7 +1844,6 @@ pub async fn test_spark_htlc_status_filtering(storage: Box<dyn Storage>) {
         .list_payments(StorageListPaymentsRequest {
             payment_details_filter: Some(vec![crate::StoragePaymentDetailsFilter::Spark {
                 htlc_status: Some(vec![SparkHtlcStatus::Returned]),
-                conversion_refund_needed: None,
             }]),
             ..Default::default()
         })
@@ -1863,7 +1860,6 @@ pub async fn test_spark_htlc_status_filtering(storage: Box<dyn Storage>) {
                     SparkHtlcStatus::WaitingForPreimage,
                     SparkHtlcStatus::PreimageShared,
                 ]),
-                conversion_refund_needed: None,
             }]),
             ..Default::default()
         })
@@ -1882,7 +1878,6 @@ pub async fn test_spark_htlc_status_filtering(storage: Box<dyn Storage>) {
                     SparkHtlcStatus::PreimageShared,
                     SparkHtlcStatus::Returned,
                 ]),
-                conversion_refund_needed: None,
             }]),
             ..Default::default()
         })
@@ -1890,227 +1885,6 @@ pub async fn test_spark_htlc_status_filtering(storage: Box<dyn Storage>) {
         .unwrap();
     assert_eq!(all_htlc_filter.len(), 3);
     assert!(all_htlc_filter.iter().all(|p| p.id != "non_htlc"));
-}
-
-#[allow(clippy::too_many_lines)]
-pub async fn test_conversion_refund_needed_filtering(storage: Box<dyn Storage>) {
-    // Create payments with and without conversion info
-    let payment_with_refund_metadata = PaymentMetadata {
-        conversion_info: Some(crate::ConversionInfo {
-            pool_id: "pool1".to_string(),
-            conversion_id: "with_refund".to_string(),
-            status: crate::ConversionStatus::Refunded,
-            fee: None,
-            purpose: None,
-            amount_adjustment: None,
-        }),
-        ..Default::default()
-    };
-    let payment_with_refund = Payment {
-        id: "with_refund".to_string(),
-        payment_type: PaymentType::Send,
-        status: PaymentStatus::Completed,
-        amount: 10_000_000,
-        fees: 0,
-        timestamp: 1000,
-        method: PaymentMethod::Token,
-        details: Some(PaymentDetails::Token {
-            metadata: crate::TokenMetadata {
-                identifier: "token1".to_string(),
-                issuer_public_key: "pubkey1".to_string(),
-                name: "Test Token".to_string(),
-                ticker: "TTK".to_string(),
-                decimals: 8,
-                max_supply: 1_000_000_000,
-                is_freezable: false,
-            },
-            tx_hash: "txhash1".to_string(),
-            tx_type: TokenTransactionType::Transfer,
-            invoice_details: None,
-            conversion_info: None,
-        }),
-        conversion_details: None,
-    };
-
-    let successful_conversion_metadata = PaymentMetadata {
-        conversion_info: Some(crate::ConversionInfo {
-            pool_id: "pool1".to_string(),
-            conversion_id: "successful_conversion".to_string(),
-            status: crate::ConversionStatus::Completed,
-            fee: Some(100),
-            purpose: None,
-            amount_adjustment: None,
-        }),
-        ..Default::default()
-    };
-    let successful_conversion = Payment {
-        id: "successful_conversion".to_string(),
-        payment_type: PaymentType::Send,
-        status: PaymentStatus::Completed,
-        amount: 20_000,
-        fees: 0,
-        timestamp: 2000,
-        method: PaymentMethod::Spark,
-        details: Some(PaymentDetails::Spark {
-            invoice_details: None,
-            htlc_details: None,
-            conversion_info: None,
-        }),
-        conversion_details: None,
-    };
-
-    let payment_without_refund_metadata = PaymentMetadata {
-        conversion_info: Some(crate::ConversionInfo {
-            pool_id: "pool1".to_string(),
-            conversion_id: "without_refund".to_string(),
-            status: crate::ConversionStatus::RefundNeeded,
-            fee: None,
-            purpose: None,
-            amount_adjustment: None,
-        }),
-        ..Default::default()
-    };
-    let payment_without_refund = Payment {
-        id: "without_refund".to_string(),
-        payment_type: PaymentType::Send,
-        status: PaymentStatus::Completed,
-        amount: 10_000,
-        fees: 0,
-        timestamp: 3000,
-        method: PaymentMethod::Spark,
-        details: Some(PaymentDetails::Spark {
-            invoice_details: None,
-            htlc_details: None,
-            conversion_info: None,
-        }),
-        conversion_details: None,
-    };
-
-    storage
-        .apply_payment_update(payment_with_refund)
-        .await
-        .unwrap();
-    storage
-        .apply_payment_update(successful_conversion)
-        .await
-        .unwrap();
-    storage
-        .apply_payment_update(payment_without_refund)
-        .await
-        .unwrap();
-    storage
-        .insert_payment_metadata("with_refund".to_string(), payment_with_refund_metadata)
-        .await
-        .unwrap();
-    storage
-        .insert_payment_metadata(
-            "successful_conversion".to_string(),
-            successful_conversion_metadata,
-        )
-        .await
-        .unwrap();
-    storage
-        .insert_payment_metadata(
-            "without_refund".to_string(),
-            payment_without_refund_metadata,
-        )
-        .await
-        .unwrap();
-
-    let payments = storage
-        .list_payments(StorageListPaymentsRequest::default())
-        .await
-        .unwrap();
-    assert_eq!(payments.len(), 3);
-
-    // Test filter for payments missing transfer refund info
-    let missing_refund_filter = storage
-        .list_payments(StorageListPaymentsRequest {
-            payment_details_filter: Some(vec![crate::StoragePaymentDetailsFilter::Spark {
-                htlc_status: None,
-                conversion_refund_needed: Some(true),
-            }]),
-            ..Default::default()
-        })
-        .await
-        .unwrap();
-    assert_eq!(missing_refund_filter.len(), 1);
-    assert_eq!(missing_refund_filter[0].id, "without_refund");
-
-    // Test filter for payments with transfer refund info present
-    let present_refund_filter = storage
-        .list_payments(StorageListPaymentsRequest {
-            payment_details_filter: Some(vec![crate::StoragePaymentDetailsFilter::Token {
-                conversion_refund_needed: Some(false),
-                tx_hash: None,
-                tx_type: None,
-            }]),
-            ..Default::default()
-        })
-        .await
-        .unwrap();
-    assert_eq!(present_refund_filter.len(), 1);
-    assert_eq!(present_refund_filter[0].id, "with_refund");
-
-    // Test multiple payment detail filters
-    let multiple_filters = storage
-        .list_payments(StorageListPaymentsRequest {
-            payment_details_filter: Some(vec![
-                crate::StoragePaymentDetailsFilter::Spark {
-                    htlc_status: None,
-                    conversion_refund_needed: Some(true),
-                },
-                crate::StoragePaymentDetailsFilter::Token {
-                    conversion_refund_needed: Some(false),
-                    tx_hash: None,
-                    tx_type: None,
-                },
-            ]),
-            ..Default::default()
-        })
-        .await
-        .unwrap();
-    assert_eq!(multiple_filters.len(), 2);
-
-    // Test filter for token payments missing transfer refund info
-    let token_no_refund_filter = storage
-        .list_payments(StorageListPaymentsRequest {
-            payment_details_filter: Some(vec![crate::StoragePaymentDetailsFilter::Token {
-                conversion_refund_needed: Some(true),
-                tx_hash: None,
-                tx_type: None,
-            }]),
-            ..Default::default()
-        })
-        .await
-        .unwrap();
-    assert_eq!(token_no_refund_filter.len(), 0);
-
-    // Test filter for spark payments with transfer refund info present
-    let spark_with_refund_filter = storage
-        .list_payments(StorageListPaymentsRequest {
-            payment_details_filter: Some(vec![crate::StoragePaymentDetailsFilter::Spark {
-                htlc_status: None,
-                conversion_refund_needed: Some(false),
-            }]),
-            ..Default::default()
-        })
-        .await
-        .unwrap();
-    assert_eq!(spark_with_refund_filter.len(), 1);
-
-    // Test filter for all payments regardless of transfer refund info
-    let all_payments_filter = storage
-        .list_payments(StorageListPaymentsRequest {
-            payment_details_filter: Some(vec![crate::StoragePaymentDetailsFilter::Spark {
-                htlc_status: None,
-                conversion_refund_needed: None,
-            }]),
-            ..Default::default()
-        })
-        .await
-        .unwrap();
-    assert_eq!(all_payments_filter.len(), 3);
 }
 
 #[allow(clippy::too_many_lines)]
@@ -2187,7 +1961,6 @@ pub async fn test_token_transaction_type_filtering(storage: Box<dyn Storage>) {
             payment_details_filter: Some(vec![crate::StoragePaymentDetailsFilter::Token {
                 tx_type: Some(TokenTransactionType::Transfer),
                 tx_hash: None,
-                conversion_refund_needed: None,
             }]),
             ..Default::default()
         })
@@ -2203,7 +1976,6 @@ pub async fn test_token_transaction_type_filtering(storage: Box<dyn Storage>) {
             payment_details_filter: Some(vec![crate::StoragePaymentDetailsFilter::Token {
                 tx_type: Some(TokenTransactionType::Mint),
                 tx_hash: None,
-                conversion_refund_needed: None,
             }]),
             ..Default::default()
         })
@@ -2218,7 +1990,6 @@ pub async fn test_token_transaction_type_filtering(storage: Box<dyn Storage>) {
             payment_details_filter: Some(vec![crate::StoragePaymentDetailsFilter::Token {
                 tx_type: Some(TokenTransactionType::Burn),
                 tx_hash: None,
-                conversion_refund_needed: None,
             }]),
             ..Default::default()
         })

--- a/crates/breez-sdk/core/src/sdk/payments.rs
+++ b/crates/breez-sdk/core/src/sdk/payments.rs
@@ -22,8 +22,8 @@ use crate::{
     models::{
         ConversionStatus, ListPaymentsRequest, ListPaymentsResponse, Payment, PaymentDetails,
         PrepareSendPaymentRequest, PrepareSendPaymentResponse, ReceivePaymentMethod,
-        ReceivePaymentRequest, ReceivePaymentResponse, SendPaymentRequest, SendPaymentResponse,
-        conversion_steps_from_payments,
+        ReceivePaymentRequest, ReceivePaymentResponse, RefundPendingConversionsResponse,
+        SendPaymentRequest, SendPaymentResponse, conversion_steps_from_payments,
     },
     persist::PaymentMetadata,
     token_conversion::{
@@ -452,11 +452,14 @@ impl BreezSdk {
     /// disabled the periodic refunder does not run, and this method is the
     /// explicit entry point for driving the pass; when background tasks are
     /// enabled, it can be called to force an immediate refund pass.
-    pub async fn refund_pending_conversions(&self) -> Result<(), SdkError> {
-        self.token_converter
-            .refund_pending()
-            .await
-            .map_err(Into::into)
+    pub async fn refund_pending_conversions(
+        &self,
+    ) -> Result<RefundPendingConversionsResponse, SdkError> {
+        let report = self.token_converter.refund_pending().await?;
+        Ok(RefundPendingConversionsResponse {
+            refunded: report.refunded,
+            skipped: report.skipped,
+        })
     }
 
     /// Lists payments from the storage with pagination

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -23,6 +23,10 @@ use crate::{
 };
 use crate::{PaymentType, StorageListPaymentsRequest, StoragePaymentDetailsFilter};
 
+/// Fixed retry interval for recovery operations. Both the startup `FullScan`
+/// and the per-conversion targeted recovery use this delay between attempts.
+const CONVERSION_RECOVERY_RETRY_SECS: u64 = 30;
+
 use super::{RuntimeEvent, RuntimeProfile};
 use crate::sdk::{BreezSdk, SyncCoordinator, SyncRequest, SyncType, helpers::BalanceWatcher};
 
@@ -205,6 +209,29 @@ impl crate::events::RuntimeEventHandler for ClientRuntimeEventHandler {
                     error!("Failed to refresh balances after claim_deposit: {e:?}");
                 }
             }
+            RuntimeEvent::ConversionRecoveryNeeded {
+                clawback_id,
+                pool_id,
+            } => {
+                let converter = Arc::clone(&self.sdk.token_converter);
+                let shutdown = self.sdk.shutdown_sender.subscribe();
+                tokio::spawn(async move {
+                    run_recover_conversion_with_retry(shutdown, move || {
+                        let converter = Arc::clone(&converter);
+                        let clawback_id = clawback_id.clone();
+                        async move {
+                            // Either terminal outcome (Refunded or ServerRejected) ends the
+                            // retry loop; only retryable HTTP/storage errors restart it.
+                            converter
+                                .refund_conversion(&clawback_id, pool_id)
+                                .await
+                                .map(|_| ())
+                                .map_err(Into::into)
+                        }
+                    })
+                    .await;
+                });
+            }
         }
     }
 }
@@ -360,7 +387,6 @@ async fn token_tx_inputs_are_ours_cached_or_query(
         .list_payments(StorageListPaymentsRequest {
             payment_details_filter: Some(vec![StoragePaymentDetailsFilter::Token {
                 tx_hash: Some(transaction.hash.clone()),
-                conversion_refund_needed: None,
                 tx_type: None,
             }]),
             limit: Some(1),
@@ -441,43 +467,71 @@ impl EventListener for ClientSyncListener {
 
 fn spawn_conversion_refunder(
     token_converter: Arc<dyn TokenConverter>,
-    mut shutdown_receiver: watch::Receiver<()>,
+    shutdown_receiver: watch::Receiver<()>,
 ) {
-    let mut refund_requests = token_converter.subscribe_refund_requests();
     let span = tracing::Span::current();
-
     tokio::spawn(
         async move {
-            loop {
-                if let Err(e) = token_converter.refund_pending().await {
-                    error!("Failed to refund failed conversions: {e:?}");
-                }
-
-                match refund_requests.as_mut() {
-                    Some(trigger_receiver) => {
-                        select! {
-                            _ = shutdown_receiver.changed() => {
-                                info!("Conversion refunder shutdown signal received");
-                                return;
-                            }
-                            _ = trigger_receiver.recv() => {
-                                debug!("Conversion refunder triggered");
-                            }
-                            () = tokio::time::sleep(Duration::from_secs(150)) => {}
-                        }
+            run_recover_conversion_with_retry(shutdown_receiver, move || {
+                let converter = Arc::clone(&token_converter);
+                async move {
+                    let report = converter.refund_pending().await?;
+                    if report.refunded > 0 || report.skipped > 0 {
+                        info!(
+                            "Startup recovery scan: refunded={}, skipped={}",
+                            report.refunded, report.skipped
+                        );
                     }
-                    None => {
-                        select! {
-                            _ = shutdown_receiver.changed() => {
-                                info!("Conversion refunder shutdown signal received");
-                                return;
-                            }
-                            () = tokio::time::sleep(Duration::from_secs(150)) => {}
-                        }
+                    // Mid-scan per-transfer retryable failures (HTTP 5xx /
+                    // storage glitch) surface as an Err so the retry loop runs
+                    // another pass in 30s. Without this, a Flashnet blip during
+                    // a multi-transfer scan would silently strand those
+                    // transfers until the next SDK start.
+                    if report.failed_retryable > 0 {
+                        return Err(SdkError::Generic(format!(
+                            "{} retryable per-transfer failures during startup recovery scan; retrying",
+                            report.failed_retryable
+                        )));
                     }
+                    Ok(())
                 }
-            }
+            })
+            .await;
         }
         .instrument(span),
     );
+}
+
+/// Retries every 30s until it returns `Ok(())` or shutdown fires.
+/// The shutdown receiver is the only thing that terminates the loop — there's
+/// no bounded timeout because recovery is something we want to keep attempting
+/// for as long as the SDK is alive.
+async fn run_recover_conversion_with_retry<F, Fut>(
+    mut shutdown: watch::Receiver<()>,
+    mut recover_fn: F,
+) where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<(), SdkError>>,
+{
+    loop {
+        // Bias toward shutdown so a signal racing with a finishing probe always wins.
+        let outcome = tokio::select! {
+            biased;
+            _ = shutdown.changed() => return,
+            result = recover_fn() => result,
+        };
+
+        match outcome {
+            Ok(()) => return,
+            Err(e) => {
+                debug!("Recovery failed: {e:?}; retrying in {CONVERSION_RECOVERY_RETRY_SECS}s");
+            }
+        }
+
+        tokio::select! {
+            biased;
+            _ = shutdown.changed() => return,
+            () = tokio::time::sleep(Duration::from_secs(CONVERSION_RECOVERY_RETRY_SECS)) => {}
+        }
+    }
 }

--- a/crates/breez-sdk/core/src/sdk/runtime/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use bitcoin::secp256k1::PublicKey;
 use tokio::sync::watch;
 
 use crate::{GetInfoRequest, GetInfoResponse, error::SdkError, models::Config};
@@ -24,6 +25,10 @@ pub(crate) enum RuntimeEvent {
     DepositClaimed {
         payment: Box<crate::models::Payment>,
         should_emit_event: bool,
+    },
+    ConversionRecoveryNeeded {
+        clawback_id: String,
+        pool_id: PublicKey,
     },
 }
 

--- a/crates/breez-sdk/core/src/sdk/runtime/server.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/server.rs
@@ -91,7 +91,8 @@ impl crate::events::RuntimeEventHandler for ServerRuntimeEventHandler {
                     .await;
                 }
             }
-            RuntimeEvent::StableBalanceConversionCompleted => {}
+            RuntimeEvent::StableBalanceConversionCompleted
+            | RuntimeEvent::ConversionRecoveryNeeded { .. } => {}
         }
     }
 }

--- a/crates/breez-sdk/core/src/token_conversion/flashnet.rs
+++ b/crates/breez-sdk/core/src/token_conversion/flashnet.rs
@@ -2,18 +2,20 @@ use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 use bitcoin::secp256k1::PublicKey;
 use flashnet::{
-    AssetTransfer, BTC_ASSET_ADDRESS, CacheStore, ClawbackRequest, ClawbackResponse,
-    ExecuteSwapRequest, ExecuteSwapResponse, FlashnetClient, FlashnetConfig, FlashnetError,
-    GetMinAmountsRequest, ListPoolsRequest, PoolSortOrder, SimulateSwapRequest,
+    AssetTransfer, BTC_ASSET_ADDRESS, CacheStore, ClawbackRequest, ExecuteSwapRequest,
+    ExecuteSwapResponse, FlashnetClient, FlashnetConfig, FlashnetError, GetMinAmountsRequest,
+    ListClawbackTransfersRequest, ListPoolsRequest, PoolSortOrder, SimulateSwapRequest,
 };
+use platform_utils::time::{SystemTime, UNIX_EPOCH};
 use spark_wallet::{SparkWallet, TransferId};
-use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    AmountAdjustmentReason, EventEmitter, Network, Payment, PaymentDetails, PaymentMetadata,
-    Storage,
-    persist::{ObjectCacheRepository, StorageListPaymentsRequest, StoragePaymentDetailsFilter},
+    AmountAdjustmentReason, Network, Payment, PaymentMetadata, Storage,
+    events::EventEmitter,
+    models::PaymentDetails,
+    persist::ObjectCacheRepository,
+    sdk::RuntimeEvent,
     token_conversion::{ConversionAmount, DEFAULT_CONVERSION_MAX_SLIPPAGE_BPS},
     utils::{
         payments::{fetch_and_process_payment, insert_payment_with_metadata},
@@ -25,7 +27,8 @@ use crate::{
 use super::{
     ConversionError, ConversionEstimate, ConversionInfo, ConversionOptions, ConversionPurpose,
     ConversionStatus, ConversionType, FeeSplit, FetchConversionLimitsRequest,
-    FetchConversionLimitsResponse, TokenConversionPool, TokenConversionResponse, TokenConverter,
+    FetchConversionLimitsResponse, RefundPendingConversionsResponse, TokenConversionPool,
+    TokenConversionResponse, TokenConverter,
 };
 
 // Polling cadence for the received leg of a freshly-completed conversion.
@@ -35,6 +38,8 @@ use super::{
 const RECEIVED_LEG_POLL_INITIAL_DELAY_MS: u64 = 500;
 const RECEIVED_LEG_POLL_MAX_DELAY_MS: u64 = 2000;
 const RECEIVED_LEG_POLL_TIMEOUT_SECS: u64 = 15;
+/// Skip transfers younger than this when running a `FullScan` reconciliation.
+const RECONCILE_MIN_AGE_SECS: u64 = 300;
 
 /// Flashnet-based implementation of the `TokenConverter` trait.
 ///
@@ -46,7 +51,6 @@ pub(crate) struct FlashnetTokenConverter {
     spark_wallet: Arc<SparkWallet>,
     event_emitter: Arc<EventEmitter>,
     network: Network,
-    refund_trigger: broadcast::Sender<()>,
     integrator_fee_bps: u32,
 }
 
@@ -56,8 +60,8 @@ impl FlashnetTokenConverter {
     /// # Arguments
     /// * `storage` - Storage for payment lookups and metadata updates
     /// * `spark_wallet` - Spark wallet for transfer/transaction lookups
-    /// * `event_emitter` - Event emitter used when persisting conversion-leg
-    ///   payment records after a successful swap
+    /// * `event_emitter` - Event emitter used to emit an `SdkEvent` on success
+    ///   and `RuntimeEvent::ConversionRecoveryNeeded` on failure.
     /// * `network` - The network configuration
     pub fn new(
         flashnet_config: FlashnetConfig,
@@ -79,152 +83,157 @@ impl FlashnetTokenConverter {
             http_client,
         ));
 
-        let (refund_trigger, _) = broadcast::channel(10);
-
         Self {
             flashnet_client,
             storage,
             spark_wallet,
             event_emitter,
             network,
-            refund_trigger,
             integrator_fee_bps,
         }
     }
 
-    /// Process all failed conversions needing refunds.
-    async fn refund_failed_conversions(
-        storage: &Arc<dyn Storage>,
-        flashnet_client: &Arc<FlashnetClient>,
-    ) -> Result<(), ConversionError> {
-        debug!("Checking for failed conversions needing refunds");
-        let payments = storage
-            .list_payments(StorageListPaymentsRequest {
-                payment_details_filter: Some(vec![
-                    StoragePaymentDetailsFilter::Spark {
-                        htlc_status: None,
-                        conversion_refund_needed: Some(true),
-                    },
-                    StoragePaymentDetailsFilter::Token {
-                        conversion_refund_needed: Some(true),
-                        tx_hash: None,
-                        tx_type: None,
-                    },
-                ]),
-                ..Default::default()
+    /// Query Flashnet for every clawbackable transfer for this identity,
+    /// then attempt to claw back any that are past the age threshold.
+    async fn refund_pending_conversions(
+        &self,
+    ) -> Result<RefundPendingConversionsResponse, ConversionError> {
+        debug!("Reconciling stuck conversions with Flashnet listing");
+        let resp = self
+            .flashnet_client
+            .list_clawback_transfers(ListClawbackTransfersRequest {
+                limit: Some(100),
+                offset: None,
             })
             .await?;
 
-        debug!(
-            "Found {} payments needing conversion refunds",
-            payments.len()
-        );
+        let cutoff_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(u64::MAX, |d| d.as_secs())
+            .saturating_sub(RECONCILE_MIN_AGE_SECS);
+        let mut report = RefundPendingConversionsResponse::default();
+        for t in resp.transfers {
+            let created_secs = t
+                .created_at
+                .as_deref()
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .and_then(|dt| u64::try_from(dt.timestamp()).ok());
+            if !matches!(created_secs, Some(c) if c < cutoff_secs) {
+                report.skipped = report.skipped.saturating_add(1);
+                continue;
+            }
 
-        for payment in payments {
-            if let Err(e) = Self::refund_payment(storage, flashnet_client, &payment).await {
-                error!(
-                    "Failed to refund conversion for payment {}: {e:?}",
-                    payment.id
-                );
+            match self
+                .clawback_conversion(&t.id, t.lp_identity_public_key)
+                .await
+            {
+                Ok(true) => {
+                    report.refunded = report.refunded.saturating_add(1);
+                }
+                Ok(false) => {
+                    report.failed_terminal = report.failed_terminal.saturating_add(1);
+                }
+                Err(_) => {
+                    report.failed_retryable = report.failed_retryable.saturating_add(1);
+                }
             }
         }
-        Ok(())
+        Ok(report)
     }
 
-    /// Refund a single failed conversion payment.
-    async fn refund_payment(
-        storage: &Arc<dyn Storage>,
-        flashnet_client: &Arc<FlashnetClient>,
-        payment: &Payment,
-    ) -> Result<(), ConversionError> {
-        let (clawback_id, conversion_info) = match &payment.details {
-            Some(PaymentDetails::Spark {
-                conversion_info, ..
-            }) => (payment.id.clone(), conversion_info),
-            Some(PaymentDetails::Token {
-                tx_hash,
-                conversion_info,
-                ..
-            }) => (tx_hash.clone(), conversion_info),
-            _ => {
-                return Err(ConversionError::RefundFailed(
-                    "Payment is not a Spark or Conversion".into(),
-                ));
-            }
-        };
-
-        let Some(ConversionInfo {
-            pool_id,
-            conversion_id,
-            status: ConversionStatus::RefundNeeded,
-            fee,
-            purpose,
-            amount_adjustment,
-        }) = conversion_info
-        else {
-            return Err(ConversionError::RefundFailed(
-                "Conversion does not have a refund pending status".into(),
-            ));
-        };
-
-        debug!(
-            "Conversion refund needed for payment {}: pool_id {pool_id}",
-            payment.id
-        );
-
-        let Ok(pool_id) = PublicKey::from_str(pool_id) else {
-            return Err(ConversionError::RefundFailed(format!(
-                "Invalid pool_id: {pool_id}"
-            )));
-        };
-
-        match flashnet_client
+    /// Claw back one transfer and write the `Refunded` metadata.
+    ///
+    /// `clawback_id` is whatever Flashnet uses as `transfer_id`: Spark
+    /// `TransferId` for BTC swaps, or token transaction hash for token swaps.
+    ///
+    /// Returns:
+    /// - `Ok(true)` — server accepted the clawback; metadata written.
+    /// - `Ok(false)` — server rejected (`accepted=false`, already settled or
+    ///   ineligible). Terminal — caller should not retry. Metadata still written.
+    /// - `Err(_)` — retryable failure (HTTP / storage). Caller may retry.
+    async fn clawback_conversion(
+        &self,
+        clawback_id: &str,
+        pool_id: PublicKey,
+    ) -> Result<bool, ConversionError> {
+        let clawback_res = self
+            .flashnet_client
             .clawback(ClawbackRequest {
                 pool_id,
-                transfer_id: clawback_id,
+                transfer_id: clawback_id.to_string(),
             })
-            .await
-        {
-            Ok(ClawbackResponse {
-                accepted: true,
-                spark_status_tracking_id,
-                ..
-            }) => {
+            .await;
+
+        let outcome = match clawback_res {
+            Ok(r) if r.accepted => {
                 debug!(
-                    "Clawback initiated for payment {}: tracking_id: {}",
-                    payment.id, spark_status_tracking_id
+                    "Clawback accepted for {clawback_id}: tracking_id={}",
+                    r.spark_status_tracking_id
                 );
-                // Update the payment metadata to reflect the refund status
-                storage
-                    .insert_payment_metadata(
-                        payment.id.clone(),
-                        PaymentMetadata {
-                            conversion_info: Some(ConversionInfo {
-                                pool_id: pool_id.to_string(),
-                                conversion_id: conversion_id.clone(),
-                                status: ConversionStatus::Refunded,
-                                fee: *fee,
-                                purpose: purpose.clone(),
-                                amount_adjustment: amount_adjustment.clone(),
-                            }),
-                            ..Default::default()
-                        },
-                    )
-                    .await?;
-                Ok(())
+                true
             }
-            Ok(ClawbackResponse {
-                accepted: false,
-                request_id,
-                error,
-                ..
-            }) => Err(ConversionError::RefundFailed(format!(
-                "Clawback not accepted: request_id: {request_id:?}, error: {error:?}"
-            ))),
-            Err(e) => Err(ConversionError::RefundFailed(format!(
-                "Failed to initiate clawback: {e}"
-            ))),
-        }
+            Ok(r) => {
+                warn!("Clawback for {clawback_id} not accepted: {:?}", r.error);
+                false
+            }
+            Err(e) => {
+                error!("Clawback for {clawback_id} failed: {e}");
+                return Err(e.into());
+            }
+        };
+
+        let payment_id = match self.fetch_payment_id_by_identifier(clawback_id, true).await {
+            Ok(id) => id,
+            Err(e) => {
+                error!("Could not determine payment id for {clawback_id}: {e}");
+                return Err(e);
+            }
+        };
+
+        let prev_conversion_info = match self.storage.get_payment_by_id(payment_id.clone()).await {
+            Ok(p) => match p.details {
+                Some(
+                    PaymentDetails::Spark {
+                        conversion_info, ..
+                    }
+                    | PaymentDetails::Token {
+                        conversion_info, ..
+                    },
+                ) => conversion_info,
+                _ => None,
+            },
+            Err(e) => {
+                warn!("Failed to read existing metadata for {payment_id}: {e}");
+                None
+            }
+        };
+        let conversion_info = match prev_conversion_info {
+            Some(prev) => ConversionInfo {
+                status: ConversionStatus::Refunded,
+                ..prev
+            },
+            None => ConversionInfo {
+                pool_id: pool_id.to_string(),
+                conversion_id: uuid::Uuid::now_v7().to_string(),
+                status: ConversionStatus::Refunded,
+                fee: None,
+                purpose: None,
+                amount_adjustment: None,
+            },
+        };
+
+        let metadata = PaymentMetadata {
+            conversion_info: Some(conversion_info),
+            ..Default::default()
+        };
+        self.storage
+            .insert_payment_metadata(payment_id, metadata)
+            .await
+            .map_err(|e| {
+                warn!("Metadata write failed for {clawback_id}: {e}");
+                ConversionError::from(e)
+            })?;
+        Ok(outcome)
     }
 
     /// Gets the best conversion pool for the given conversion options and amount.
@@ -435,7 +444,7 @@ impl FlashnetTokenConverter {
         let status = match (&inbound_identifier, &refund_identifier) {
             (Some(_), _) => ConversionStatus::Completed,
             (None, Some(_)) => ConversionStatus::Refunded,
-            _ => ConversionStatus::RefundNeeded,
+            _ => ConversionStatus::Failed,
         };
         let pool_id_str = pool_id.to_string();
         let conversion_id = uuid::Uuid::now_v7().to_string();
@@ -805,6 +814,9 @@ impl TokenConverter for FlashnetTokenConverter {
                     }
                 });
 
+                let outbound_transfer_id = flashnet_response.transfer_id.clone();
+                let server_refund_initiated = flashnet_response.refund_transfer_id.is_some();
+
                 let (sent_payment_id, received_payment_id) = self
                     .update_payment_conversion_info(
                         &pool_id,
@@ -831,11 +843,19 @@ impl TokenConverter for FlashnetTokenConverter {
                         received_payment_id,
                     })
                 } else {
+                    if !server_refund_initiated {
+                        self.event_emitter
+                            .emit_runtime_event(RuntimeEvent::ConversionRecoveryNeeded {
+                                clawback_id: outbound_transfer_id,
+                                pool_id,
+                            })
+                            .await;
+                    }
                     let error_message = flashnet_response
                         .error
                         .unwrap_or("Conversion not accepted".to_string());
                     Err(ConversionError::ConversionFailed(format!(
-                        "Convert token failed, refund in progress: {error_message}",
+                        "Convert token failed, refund pending: {error_message}",
                     )))
                 }
             }
@@ -846,18 +866,12 @@ impl TokenConverter for FlashnetTokenConverter {
                     source,
                 } = &e
                 {
-                    let _ = self
-                        .update_payment_conversion_info(
-                            &pool_id,
-                            transaction_identifier.clone(),
-                            None,
-                            None,
-                            None,
-                            purpose,
-                            amount_adjustment.clone(),
-                        )
+                    self.event_emitter
+                        .emit_runtime_event(RuntimeEvent::ConversionRecoveryNeeded {
+                            clawback_id: transaction_identifier.clone(),
+                            pool_id,
+                        })
                         .await;
-                    let _ = self.refund_trigger.send(());
                     Err(ConversionError::ConversionFailed(format!(
                         "Convert token failed, refund pending: {}",
                         *source.clone()
@@ -950,11 +964,15 @@ impl TokenConverter for FlashnetTokenConverter {
         })
     }
 
-    async fn refund_pending(&self) -> Result<(), ConversionError> {
-        Self::refund_failed_conversions(&self.storage, &self.flashnet_client).await
+    async fn refund_pending(&self) -> Result<RefundPendingConversionsResponse, ConversionError> {
+        self.refund_pending_conversions().await
     }
 
-    fn subscribe_refund_requests(&self) -> Option<broadcast::Receiver<()>> {
-        Some(self.refund_trigger.subscribe())
+    async fn refund_conversion(
+        &self,
+        clawback_id: &str,
+        pool_id: PublicKey,
+    ) -> Result<bool, ConversionError> {
+        self.clawback_conversion(clawback_id, pool_id).await
     }
 }

--- a/crates/breez-sdk/core/src/token_conversion/mod.rs
+++ b/crates/breez-sdk/core/src/token_conversion/mod.rs
@@ -8,8 +8,21 @@ pub(crate) use flashnet::FlashnetTokenConverter;
 pub(crate) use middleware::TokenConversionMiddleware;
 pub use models::*;
 
+use bitcoin::secp256k1::PublicKey;
 use spark_wallet::TransferId;
-use tokio::sync::broadcast;
+
+/// Counts from a single recovery pass.
+#[derive(Debug, Default, Clone)]
+pub struct RefundPendingConversionsResponse {
+    /// Transfers clawed back this pass.
+    pub refunded: u32,
+    /// Transfers skipped.
+    pub skipped: u32,
+    /// Retryable per-transfer failures.
+    pub(crate) failed_retryable: u32,
+    /// Server-rejected clawbacks.
+    pub(crate) failed_terminal: u32,
+}
 
 /// Trait for conversion implementations.
 ///
@@ -64,17 +77,15 @@ pub(crate) trait TokenConverter: Send + Sync {
         request: &FetchConversionLimitsRequest,
     ) -> Result<FetchConversionLimitsResponse, ConversionError>;
 
-    /// Process any conversions whose pending refunds need to be issued.
-    ///
-    /// Iterates over payments marked as needing a refund and attempts to
-    /// refund each one. Surfaced through `BreezSdk::refund_pending_conversions`
-    /// so partners can drive this explicitly — required in server mode (where
-    /// no periodic refunder runs) and available in client mode as a way to
-    /// force an immediate refund pass instead of waiting for the next tick.
-    async fn refund_pending(&self) -> Result<(), ConversionError>;
+    /// Lists every clawbackable transfer for this identity,
+    /// then claws back anything past the implementation's safety
+    /// threshold.
+    async fn refund_pending(&self) -> Result<RefundPendingConversionsResponse, ConversionError>;
 
-    /// Optional signal that wakes the client-mode periodic refunder.
-    fn subscribe_refund_requests(&self) -> Option<broadcast::Receiver<()>> {
-        None
-    }
+    /// Refund one specific conversion.
+    async fn refund_conversion(
+        &self,
+        clawback_id: &str,
+        pool_id: PublicKey,
+    ) -> Result<bool, ConversionError>;
 }

--- a/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
@@ -283,25 +283,6 @@ class MysqlStorage {
           }
 
           if (
-            (paymentDetailsFilter.type === "spark" ||
-              paymentDetailsFilter.type === "token") &&
-            paymentDetailsFilter.conversionRefundNeeded !== undefined
-          ) {
-            const typeCheck =
-              paymentDetailsFilter.type === "spark"
-                ? "p.spark = 1"
-                : "p.spark IS NULL";
-            const refundNeeded =
-              paymentDetailsFilter.conversionRefundNeeded === true
-                ? "= 'refundNeeded'"
-                : "!= 'refundNeeded'";
-            paymentDetailsClauses.push(
-              `${typeCheck} AND pm.conversion_info IS NOT NULL AND
-               JSON_UNQUOTE(JSON_EXTRACT(pm.conversion_info, '$.status')) ${refundNeeded}`
-            );
-          }
-
-          if (
             paymentDetailsFilter.type === "token" &&
             paymentDetailsFilter.txHash !== undefined
           ) {

--- a/crates/breez-sdk/wasm/js/node-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/node-storage/index.cjs
@@ -230,21 +230,6 @@ class SqliteStorage {
             }
             params.push(...paymentDetailsFilter.htlcStatus);
           }
-          // Filter by token conversion info presence
-          if (
-            (paymentDetailsFilter.type === "spark" || paymentDetailsFilter.type === "token") &&
-              paymentDetailsFilter.conversionRefundNeeded !== undefined
-          ) {
-            const typeCheck = paymentDetailsFilter.type === "spark" ? "p.spark = 1" : "p.spark IS NULL";
-            const refundNeeded =
-              paymentDetailsFilter.conversionRefundNeeded === true
-                ? "= 'refundNeeded'"
-                : "!= 'refundNeeded'";
-            paymentDetailsClauses.push(
-              `${typeCheck} AND pm.conversion_info IS NOT NULL AND
-              json_extract(pm.conversion_info, '$.status') ${refundNeeded}`
-            );
-          }
           // Filter by token transaction hash
           if (
             paymentDetailsFilter.type === "token" &&

--- a/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
@@ -264,26 +264,6 @@ class PostgresStorage {
             params.push(...paymentDetailsFilter.htlcStatus);
           }
 
-          // Filter by conversion refund needed
-          if (
-            (paymentDetailsFilter.type === "spark" ||
-              paymentDetailsFilter.type === "token") &&
-            paymentDetailsFilter.conversionRefundNeeded !== undefined
-          ) {
-            const typeCheck =
-              paymentDetailsFilter.type === "spark"
-                ? "p.spark = true"
-                : "p.spark IS NULL";
-            const refundNeeded =
-              paymentDetailsFilter.conversionRefundNeeded === true
-                ? "= 'refundNeeded'"
-                : "!= 'refundNeeded'";
-            paymentDetailsClauses.push(
-              `${typeCheck} AND pm.conversion_info IS NOT NULL AND
-               pm.conversion_info::jsonb->>'status' ${refundNeeded}`
-            );
-          }
-
           // Filter by token transaction hash
           if (
             paymentDetailsFilter.type === "token" &&

--- a/crates/breez-sdk/wasm/js/web-storage/index.js
+++ b/crates/breez-sdk/wasm/js/web-storage/index.js
@@ -2223,26 +2223,6 @@ class IndexedDBStorage {
             continue;
           }
         }
-        // Filter by token conversion info presence
-        if (
-          (paymentDetailsFilter.type === "spark" ||
-            paymentDetailsFilter.type === "token") &&
-          paymentDetailsFilter.conversionRefundNeeded != null
-        ) {
-          if (
-            details.type !== paymentDetailsFilter.type ||
-            !details.conversionInfo
-          ) {
-            continue;
-          }
-
-          if (
-            paymentDetailsFilter.conversionRefundNeeded ===
-            (details.conversionInfo.status !== "refundNeeded")
-          ) {
-            continue;
-          }
-        }
         // Filter by token transaction hash
         if (
           paymentDetailsFilter.type === "token" &&

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -736,6 +736,12 @@ pub struct GetInfoResponse {
     pub token_balances: HashMap<String, TokenBalance>,
 }
 
+#[macros::extern_wasm_bindgen(breez_sdk_spark::RefundPendingConversionsResponse)]
+pub struct RefundPendingConversionsResponse {
+    pub refunded: u32,
+    pub skipped: u32,
+}
+
 #[macros::extern_wasm_bindgen(breez_sdk_spark::TokenBalance)]
 pub struct TokenBalance {
     pub balance: u128,
@@ -959,10 +965,8 @@ pub struct SendPaymentResponse {
 pub enum PaymentDetailsFilter {
     Spark {
         htlc_status: Option<Vec<SparkHtlcStatus>>,
-        conversion_refund_needed: Option<bool>,
     },
     Token {
-        conversion_refund_needed: Option<bool>,
         tx_hash: Option<String>,
         tx_type: Option<TokenTransactionType>,
     },
@@ -975,10 +979,8 @@ pub enum PaymentDetailsFilter {
 pub enum StoragePaymentDetailsFilter {
     Spark {
         htlc_status: Option<Vec<SparkHtlcStatus>>,
-        conversion_refund_needed: Option<bool>,
     },
     Token {
-        conversion_refund_needed: Option<bool>,
         tx_hash: Option<String>,
         tx_type: Option<TokenTransactionType>,
     },

--- a/crates/breez-sdk/wasm/src/persist/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/mysql.rs
@@ -144,13 +144,6 @@ async fn test_lightning_htlc_details_and_status_filtering() {
 }
 
 #[wasm_bindgen_test]
-async fn test_conversion_refund_needed_filtering() {
-    let storage = create_test_storage("my_conversion_refund_needed_filtering").await;
-    breez_sdk_spark::storage_tests::test_conversion_refund_needed_filtering(Box::new(storage))
-        .await;
-}
-
-#[wasm_bindgen_test]
 async fn test_token_transaction_type_filtering() {
     let storage = create_test_storage("my_token_tx_type_filtering").await;
     breez_sdk_spark::storage_tests::test_token_transaction_type_filtering(Box::new(storage)).await;

--- a/crates/breez-sdk/wasm/src/persist/tests/node.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/node.rs
@@ -157,14 +157,6 @@ async fn test_lightning_htlc_details_and_status_filtering() {
 }
 
 #[wasm_bindgen_test]
-async fn test_conversion_refund_needed_filtering() {
-    let storage = create_test_storage("test_conversion_refund_needed_filtering").await;
-
-    breez_sdk_spark::storage_tests::test_conversion_refund_needed_filtering(Box::new(storage))
-        .await;
-}
-
-#[wasm_bindgen_test]
 async fn test_token_transaction_type_filtering() {
     let storage = create_test_storage("token_tx_type_filtering").await;
 
@@ -373,7 +365,6 @@ async fn test_migration_from_v17_to_v18() {
         status_filter: None,
         asset_filter: None,
         payment_details_filter: Some(vec![breez_sdk_spark::StoragePaymentDetailsFilter::Token {
-            conversion_refund_needed: None,
             tx_hash: None,
             tx_type: Some(breez_sdk_spark::TokenTransactionType::Transfer),
         }]),

--- a/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
@@ -144,13 +144,6 @@ async fn test_lightning_htlc_details_and_status_filtering() {
 }
 
 #[wasm_bindgen_test]
-async fn test_conversion_refund_needed_filtering() {
-    let storage = create_test_storage("pg_conversion_refund_needed_filtering").await;
-    breez_sdk_spark::storage_tests::test_conversion_refund_needed_filtering(Box::new(storage))
-        .await;
-}
-
-#[wasm_bindgen_test]
 async fn test_token_transaction_type_filtering() {
     let storage = create_test_storage("pg_token_tx_type_filtering").await;
     breez_sdk_spark::storage_tests::test_token_transaction_type_filtering(Box::new(storage)).await;

--- a/crates/breez-sdk/wasm/src/persist/tests/web.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/web.rs
@@ -147,14 +147,6 @@ async fn test_lightning_htlc_details_and_status_filtering() {
 }
 
 #[wasm_bindgen_test]
-async fn test_conversion_refund_needed_filtering() {
-    let storage = create_test_storage("test_conversion_refund_needed_filtering").await;
-
-    breez_sdk_spark::storage_tests::test_conversion_refund_needed_filtering(Box::new(storage))
-        .await;
-}
-
-#[wasm_bindgen_test]
 async fn test_token_transaction_type_filtering() {
     let storage = create_test_storage("token_tx_type_filtering").await;
 
@@ -416,7 +408,6 @@ async fn test_migration_from_v8_to_v9() {
         status_filter: None,
         asset_filter: None,
         payment_details_filter: Some(vec![breez_sdk_spark::StoragePaymentDetailsFilter::Token {
-            conversion_refund_needed: None,
             tx_hash: None,
             tx_type: Some(breez_sdk_spark::TokenTransactionType::Transfer),
         }]),

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -348,8 +348,8 @@ impl BreezSdk {
     }
 
     #[wasm_bindgen(js_name = "refundPendingConversions")]
-    pub async fn refund_pending_conversions(&self) -> WasmResult<()> {
-        Ok(self.sdk.refund_pending_conversions().await?)
+    pub async fn refund_pending_conversions(&self) -> WasmResult<RefundPendingConversionsResponse> {
+        Ok(self.sdk.refund_pending_conversions().await?.into())
     }
 
     #[wasm_bindgen(js_name = "buyBitcoin")]

--- a/crates/flashnet/src/api.rs
+++ b/crates/flashnet/src/api.rs
@@ -10,7 +10,8 @@ use crate::utils::generate_nonce;
 use crate::{
     AssetTransfer, ClawbackIntent, ClawbackRequest, ClawbackResponse, ExecuteSwapIntent,
     ExecuteSwapResponse, FlashnetExecuteSwapResponse, GetMinAmountsRequest, GetMinAmountsResponse,
-    ListUserSwapsRequest, ListUserSwapsResponse, SignedClawbackRequest, SignedExecuteSwapResponse,
+    ListClawbackTransfersRequest, ListClawbackTransfersResponse, ListUserSwapsRequest,
+    ListUserSwapsResponse, SignedClawbackRequest, SignedExecuteSwapResponse,
 };
 use crate::{
     ExecuteSwapRequest, FeatureName, FeatureStatus, FlashnetError, MinAmount, PingResponse,
@@ -67,6 +68,15 @@ impl FlashnetClient {
         self.ensure_ping_ok().await?;
 
         self.sign_clawback(request).await
+    }
+
+    pub async fn list_clawback_transfers(
+        &self,
+        request: ListClawbackTransfersRequest,
+    ) -> Result<ListClawbackTransfersResponse, FlashnetError> {
+        debug!("List clawback transfers request: {request:?}");
+        self.get_request("v1/clawback-transfers/list", Some(request))
+            .await
     }
 
     pub async fn get_min_amounts(

--- a/crates/flashnet/src/models.rs
+++ b/crates/flashnet/src/models.rs
@@ -98,6 +98,33 @@ pub struct ClawbackResponse {
     pub error: Option<String>,
 }
 
+#[derive(Serialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ListClawbackTransfersRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u32>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ListClawbackTransfersResponse {
+    pub transfers: Vec<ClawbackTransfer>,
+}
+
+#[serde_as]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ClawbackTransfer {
+    /// Spark `transfer_id` for BTC swaps, or token transaction hash for token swaps.
+    pub id: String,
+    #[serde_as(as = "DisplayFromStr")]
+    pub lp_identity_public_key: PublicKey,
+    /// RFC3339 timestamp; absent for some older rows.
+    pub created_at: Option<String>,
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum CurveType {

--- a/docs/breez-sdk/snippets/csharp/Htlcs.cs
+++ b/docs/breez-sdk/snippets/csharp/Htlcs.cs
@@ -82,8 +82,7 @@ namespace BreezSdkSnippets
                     new PaymentDetailsFilter.Spark(
                         htlcStatus: new SparkHtlcStatus[] {
                             SparkHtlcStatus.WaitingForPreimage
-                        },
-                        conversionRefundNeeded: null
+                        }
                     ),
                     new PaymentDetailsFilter.Lightning(
                         htlcStatus: new SparkHtlcStatus[] {

--- a/docs/breez-sdk/snippets/csharp/IssuingTokens.cs
+++ b/docs/breez-sdk/snippets/csharp/IssuingTokens.cs
@@ -84,18 +84,15 @@ namespace BreezSdkSnippets
             // the `paymentDetailsFilter` field when listing payments
             var paymentDefailsTransferFilter = new PaymentDetailsFilter.Token(
                 txType: TokenTransactionType.Transfer,
-                txHash: null,
-                conversionRefundNeeded: null
+                txHash: null
             );
             var paymentDefailsMintFilter = new PaymentDetailsFilter.Token(
                 txType: TokenTransactionType.Mint,
-                txHash: null,
-                conversionRefundNeeded: null
+                txHash: null
             );
             var paymentDefailsBurnFilter = new PaymentDetailsFilter.Token(
                 txType: TokenTransactionType.Burn,
-                txHash: null,
-                conversionRefundNeeded: null
+                txHash: null
             );
             // ANCHOR_END: list-mint-burn-payments
         }

--- a/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
+++ b/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
@@ -227,9 +227,8 @@ namespace BreezSdkSnippets
         async Task RefundPendingConversions(BreezSdk sdk)
         {
             // ANCHOR: refund-pending-conversions
-            // The flashnet conversion refunder doesn't run in the background in
-            // server mode. Call this from your own scheduler (e.g. once per
-            // minute) to issue pending refunds for failed conversions.
+            // The returned response reports how many were refunded and how
+            // many were skipped (too young to recover).
             await sdk.RefundPendingConversions();
             // ANCHOR_END: refund-pending-conversions
         }

--- a/docs/breez-sdk/snippets/flutter/lib/sdk_building.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/sdk_building.dart
@@ -121,9 +121,8 @@ Future<void> serverModeProvisioning(BreezSdk sdk) async {
 
 Future<void> refundPendingConversions(BreezSdk sdk) async {
   // ANCHOR: refund-pending-conversions
-  // The flashnet conversion refunder doesn't run in the background in server
-  // mode. Call this from your own scheduler (e.g. once per minute) to issue
-  // pending refunds for failed conversions.
+  // The returned response reports how many were refunded and how many were
+  // skipped (too young to recover).
   await sdk.refundPendingConversions();
   // ANCHOR_END: refund-pending-conversions
 }

--- a/docs/breez-sdk/snippets/go/sdk_building.go
+++ b/docs/breez-sdk/snippets/go/sdk_building.go
@@ -249,9 +249,9 @@ func ServerModeProvisioning(sdk *breez_sdk_spark.BreezSdk) error {
 
 func RefundPendingConversions(sdk *breez_sdk_spark.BreezSdk) error {
 	// ANCHOR: refund-pending-conversions
-	// The flashnet conversion refunder doesn't run in the background in server
-	// mode. Call this from your own scheduler (e.g. once per minute) to issue
-	// pending refunds for failed conversions.
-	return sdk.RefundPendingConversions()
+	// The returned response reports how many were refunded and how many were
+	// skipped (too young to recover).
+	_, err := sdk.RefundPendingConversions()
+	return err
 	// ANCHOR_END: refund-pending-conversions
 }

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Htlcs.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Htlcs.kt
@@ -96,8 +96,7 @@ class Htlcs {
                 statusFilter = listOf(PaymentStatus.PENDING),
                 paymentDetailsFilter = listOf(
                     PaymentDetailsFilter.Spark(
-                        htlcStatus = listOf(SparkHtlcStatus.WAITING_FOR_PREIMAGE),
-                        conversionRefundNeeded = null
+                        htlcStatus = listOf(SparkHtlcStatus.WAITING_FOR_PREIMAGE)
                     ),
                     PaymentDetailsFilter.Lightning(
                         htlcStatus = listOf(SparkHtlcStatus.WAITING_FOR_PREIMAGE)

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/IssuingTokens.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/IssuingTokens.kt
@@ -93,20 +93,17 @@ class IssuingTokens {
         val paymentDetailsTransferFilter =
                 PaymentDetailsFilter.Token(
                         txType = TokenTransactionType.TRANSFER,
-                        txHash = null,
-                        conversionRefundNeeded = null
+                        txHash = null
                 )
         val paymentDetailsMintFilter =
                 PaymentDetailsFilter.Token(
                         txType = TokenTransactionType.MINT,
-                        txHash = null,
-                        conversionRefundNeeded = null
+                        txHash = null
                 )
         val paymentDetailsBurnFilter =
                 PaymentDetailsFilter.Token(
                         txType = TokenTransactionType.BURN,
-                        txHash = null,
-                        conversionRefundNeeded = null
+                        txHash = null
                 )
         // ANCHOR_END: list-mint-burn-payments
     }

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
@@ -211,9 +211,8 @@ class SdkBuilding {
 
     suspend fun refundPendingConversions(sdk: BreezSdk) {
         // ANCHOR: refund-pending-conversions
-        // The flashnet conversion refunder doesn't run in the background in
-        // server mode. Call this from your own scheduler (e.g. once per
-        // minute) to issue pending refunds for failed conversions.
+        // The returned response reports how many were refunded and how many
+        // were skipped (too young to recover).
         sdk.refundPendingConversions()
         // ANCHOR_END: refund-pending-conversions
     }

--- a/docs/breez-sdk/snippets/python/src/htlcs.py
+++ b/docs/breez-sdk/snippets/python/src/htlcs.py
@@ -88,8 +88,7 @@ async def list_claimable_htlc_payments(sdk: BreezSdk):
         status_filter=[PaymentStatus.PENDING],
         payment_details_filter=[
             cast(PaymentDetailsFilter, PaymentDetailsFilter.SPARK(
-                htlc_status=[SparkHtlcStatus.WAITING_FOR_PREIMAGE],
-                conversion_refund_needed=None
+                htlc_status=[SparkHtlcStatus.WAITING_FOR_PREIMAGE]
             )),
             cast(PaymentDetailsFilter, PaymentDetailsFilter.LIGHTNING(
                 htlc_status=[SparkHtlcStatus.WAITING_FOR_PREIMAGE],

--- a/docs/breez-sdk/snippets/python/src/issuing_tokens.py
+++ b/docs/breez-sdk/snippets/python/src/issuing_tokens.py
@@ -101,18 +101,15 @@ async def list_mint_burn_payments():
     # the `payment_details_filter` field when listing payments
     payment_details_transfer_filter = PaymentDetailsFilter.TOKEN(
         tx_type=TokenTransactionType.TRANSFER,
-        tx_hash=None,
-        conversion_refund_needed=None
+        tx_hash=None
     )
     payment_details_mint_filter = PaymentDetailsFilter.TOKEN(
         tx_type=TokenTransactionType.MINT,
-        tx_hash=None,
-        conversion_refund_needed=None
+        tx_hash=None
     )
     payment_details_burn_filter = PaymentDetailsFilter.TOKEN(
         tx_type=TokenTransactionType.BURN,
-        tx_hash=None,
-        conversion_refund_needed=None
+        tx_hash=None
     )
     # ANCHOR_END: list-mint-burn-payments
 

--- a/docs/breez-sdk/snippets/python/src/sdk_building.py
+++ b/docs/breez-sdk/snippets/python/src/sdk_building.py
@@ -237,8 +237,7 @@ async def server_mode_provisioning(sdk: BreezSdk):
 
 async def refund_pending_conversions(sdk: BreezSdk):
     # ANCHOR: refund-pending-conversions
-    # The flashnet conversion refunder doesn't run in the background in server
-    # mode. Call this from your own scheduler (e.g. once per minute) to issue
-    # pending refunds for failed conversions.
+    # The returned response reports how many were refunded and how many were
+    # skipped (too young to recover).
     await sdk.refund_pending_conversions()
     # ANCHOR_END: refund-pending-conversions

--- a/docs/breez-sdk/snippets/react-native/htlcs.ts
+++ b/docs/breez-sdk/snippets/react-native/htlcs.ts
@@ -81,8 +81,7 @@ const exampleListClaimableHtlcPayments = async (sdk: BreezSdk): Promise<Payment[
     typeFilter: [PaymentType.Receive],
     statusFilter: [PaymentStatus.Pending],
     paymentDetailsFilter: [new PaymentDetailsFilter.Spark({
-      htlcStatus: [SparkHtlcStatus.WaitingForPreimage],
-      conversionRefundNeeded: undefined
+      htlcStatus: [SparkHtlcStatus.WaitingForPreimage]
     }), new PaymentDetailsFilter.Lightning({
       htlcStatus: [SparkHtlcStatus.WaitingForPreimage]
     })],

--- a/docs/breez-sdk/snippets/react-native/issuing_tokens.ts
+++ b/docs/breez-sdk/snippets/react-native/issuing_tokens.ts
@@ -81,18 +81,15 @@ const listMintBurnPayments = async (): Promise<void> => {
   // the `paymentDetailsFilter` field when listing payments
   const paymentDetailsTransferFilter = new PaymentDetailsFilter.Token({
     txType: TokenTransactionType.Transfer,
-    txHash: undefined,
-    conversionRefundNeeded: undefined
+    txHash: undefined
   })
   const paymentDetailsMintFilter = new PaymentDetailsFilter.Token({
     txType: TokenTransactionType.Mint,
-    txHash: undefined,
-    conversionRefundNeeded: undefined
+    txHash: undefined
   })
   const paymentDetailsBurnFilter = new PaymentDetailsFilter.Token({
     txType: TokenTransactionType.Burn,
-    txHash: undefined,
-    conversionRefundNeeded: undefined
+    txHash: undefined
   })
   // ANCHOR_END: list-mint-burn-payments
 }

--- a/docs/breez-sdk/snippets/react-native/sdk_building.ts
+++ b/docs/breez-sdk/snippets/react-native/sdk_building.ts
@@ -136,9 +136,8 @@ const exampleServerModeProvisioning = async (sdk: BreezSdk) => {
 
 const exampleRefundPendingConversions = async (sdk: BreezSdk) => {
   // ANCHOR: refund-pending-conversions
-  // The flashnet conversion refunder doesn't run in the background in server
-  // mode. Call this from your own scheduler (e.g. once per minute) to issue
-  // pending refunds for failed conversions.
+  // The returned response reports how many were refunded and how many were
+  // skipped (too young to recover).
   await sdk.refundPendingConversions()
   // ANCHOR_END: refund-pending-conversions
 }

--- a/docs/breez-sdk/snippets/rust/src/htlcs.rs
+++ b/docs/breez-sdk/snippets/rust/src/htlcs.rs
@@ -77,7 +77,6 @@ async fn list_claimable_htlc_payments(sdk: &BreezSdk) -> Result<Vec<Payment>> {
         payment_details_filter: Some(vec![
             PaymentDetailsFilter::Spark {
                 htlc_status: Some(vec![SparkHtlcStatus::WaitingForPreimage]),
-                conversion_refund_needed: None,
             },
             PaymentDetailsFilter::Lightning {
                 htlc_status: Some(vec![SparkHtlcStatus::WaitingForPreimage]),

--- a/docs/breez-sdk/snippets/rust/src/issuing_tokens.rs
+++ b/docs/breez-sdk/snippets/rust/src/issuing_tokens.rs
@@ -78,17 +78,14 @@ async fn list_mint_burn_payments() -> Result<Vec<PaymentDetailsFilter>> {
     let payment_details_transfer_filter = PaymentDetailsFilter::Token {
         tx_type: Some(TokenTransactionType::Transfer),
         tx_hash: None,
-        conversion_refund_needed: None,
     };
     let payment_details_mint_filter = PaymentDetailsFilter::Token {
         tx_type: Some(TokenTransactionType::Mint),
         tx_hash: None,
-        conversion_refund_needed: None,
     };
     let payment_details_burn_filter = PaymentDetailsFilter::Token {
         tx_type: Some(TokenTransactionType::Burn),
         tx_hash: None,
-        conversion_refund_needed: None,
     };
     // ANCHOR_END: list-mint-burn-payments
     Ok(vec![

--- a/docs/breez-sdk/snippets/rust/src/sdk_building.rs
+++ b/docs/breez-sdk/snippets/rust/src/sdk_building.rs
@@ -232,9 +232,8 @@ pub(crate) async fn server_mode_provisioning(sdk: &BreezSdk) -> Result<()> {
 
 pub(crate) async fn refund_pending_conversions(sdk: &BreezSdk) -> Result<()> {
     // ANCHOR: refund-pending-conversions
-    // The flashnet conversion refunder doesn't run in the background in server
-    // mode. Call this from your own scheduler (e.g. once per minute) to issue
-    // pending refunds for failed conversions.
+    // The returned response reports how many were refunded and how many were
+    // skipped (too young to recover).
     sdk.refund_pending_conversions().await?;
     // ANCHOR_END: refund-pending-conversions
     Ok(())

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Htlcs.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Htlcs.swift
@@ -94,8 +94,7 @@ func listClaimableHtlcPayments(sdk: BreezSdk) async throws -> [Payment] {
         statusFilter: [PaymentStatus.pending],
         paymentDetailsFilter: [
             PaymentDetailsFilter.spark(
-                htlcStatus: [SparkHtlcStatus.waitingForPreimage],
-                conversionRefundNeeded: nil
+                htlcStatus: [SparkHtlcStatus.waitingForPreimage]
             ),
             PaymentDetailsFilter.lightning(
                 htlcStatus: [SparkHtlcStatus.waitingForPreimage]

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/IssuingTokens.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/IssuingTokens.swift
@@ -72,13 +72,13 @@ func listMintBurnPayments(tokenIssuer: TokenIssuer) async throws {
     // Provide one or multiple of the following filters to
     // the `paymentDetailsFilter` field when listing payments
     let paymentDetailsTransferFilter = PaymentDetailsFilter.token(
-        conversionRefundNeeded: nil, txHash: nil,
+        txHash: nil,
         txType: TokenTransactionType.transfer)
     let paymentDetailsMintFilter = PaymentDetailsFilter.token(
-        conversionRefundNeeded: nil, txHash: nil,
+        txHash: nil,
         txType: TokenTransactionType.mint)
     let paymentDetailsBurnFilter = PaymentDetailsFilter.token(
-        conversionRefundNeeded: nil, txHash: nil,
+        txHash: nil,
         txType: TokenTransactionType.burn)
     // ANCHOR_END: list-mint-burn-payments
 }

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
@@ -205,9 +205,8 @@ func serverModeProvisioning(sdk: BreezSdk) async throws {
 
 func refundPendingConversions(sdk: BreezSdk) async throws {
     // ANCHOR: refund-pending-conversions
-    // The flashnet conversion refunder doesn't run in the background in server
-    // mode. Call this from your own scheduler (e.g. once per minute) to issue
-    // pending refunds for failed conversions.
+    // The returned response reports how many were refunded and how many were
+    // skipped (too young to recover).
     try await sdk.refundPendingConversions()
     // ANCHOR_END: refund-pending-conversions
 }

--- a/docs/breez-sdk/snippets/wasm/sdk_building.ts
+++ b/docs/breez-sdk/snippets/wasm/sdk_building.ts
@@ -207,9 +207,8 @@ const exampleServerModeProvisioning = async (sdk: BreezSdk) => {
 
 const exampleRefundPendingConversions = async (sdk: BreezSdk) => {
   // ANCHOR: refund-pending-conversions
-  // The flashnet conversion refunder doesn't run in the background in server
-  // mode. Call this from your own scheduler (e.g. once per minute) to issue
-  // pending refunds for failed conversions.
+  // The returned response reports how many were refunded and how many were
+  // skipped (too young to recover).
   await sdk.refundPendingConversions()
   // ANCHOR_END: refund-pending-conversions
 }

--- a/docs/breez-sdk/src/guide/server_mode.md
+++ b/docs/breez-sdk/src/guide/server_mode.md
@@ -73,6 +73,8 @@ If [{{#name stable_balance_config}}](./config.md#stable-balance-configuration) i
 
 The flashnet conversion refunder doesn't run in the background in server mode. If you do use tokens, your host needs to drive {{#name refund_pending_conversions}} per affected wallet so failed conversions get refunded. A practical pattern is to track which wallets have pending conversions (e.g. by recording them when a conversion fails) and to run the refund pass for just those wallets on a cadence you control — not to spin up an SDK per wallet every minute regardless.
 
+{{#tabs sdk_building:refund-pending-conversions}}
+
 ### One-time setup: Spark private mode
 
 The client-mode SDK applies [{{#name private_enabled_default}}](./config.md#private-mode-enabled-by-default) on first startup. Server-mode SDKs do not — each per-request SDK would otherwise pay a redundant storage read to check the flag. At provisioning time (when a new wallet is first registered), call {{#name update_user_settings}} with {{#name spark_private_mode_enabled}} set to `true`. See [User settings](user_settings.md).

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -194,6 +194,12 @@ pub struct _GetInfoResponse {
     pub token_balances: HashMap<String, TokenBalance>,
 }
 
+#[frb(mirror(RefundPendingConversionsResponse))]
+pub struct _RefundPendingConversionsResponse {
+    pub refunded: u32,
+    pub skipped: u32,
+}
+
 #[frb(mirror(TokenBalance))]
 pub struct _TokenBalance {
     pub balance: u128,
@@ -243,10 +249,8 @@ pub enum _InputType {
 pub enum _PaymentDetailsFilter {
     Spark {
         htlc_status: Option<Vec<SparkHtlcStatus>>,
-        conversion_refund_needed: Option<bool>,
     },
     Token {
-        conversion_refund_needed: Option<bool>,
         tx_hash: Option<String>,
         tx_type: Option<TokenTransactionType>,
     },

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -279,7 +279,9 @@ impl BreezSdk {
         self.inner.list_webhooks().await
     }
 
-    pub async fn refund_pending_conversions(&self) -> Result<(), SdkError> {
+    pub async fn refund_pending_conversions(
+        &self,
+    ) -> Result<RefundPendingConversionsResponse, SdkError> {
         self.inner.refund_pending_conversions().await
     }
 


### PR DESCRIPTION
When a BTC ↔ token conversion fails between `transfer_asset` (Phase 1) and the local-state write that drives the refunder, the BTC stays locked at the pool and the SDK's existing refunder never finds it (no local row to act on).

Root cause: recovery was gated on a single local-DB write surviving. Any disruption (Android backgrounding, process killed, storage glitch) silently stranded funds.

## Approach

Stop relying on local DB as the recovery source of truth. Treat Flashnet's `list_clawback_transfers` endpoint as authoritative; local state is a display cache only.

- **`convert()` failure paths** emit `RuntimeEvent::ConversionRecoveryNeeded { clawback_id, pool_id }` instead of writing a local "needs refund" flag.
- **Client runtime** spawns a 30s retry loop calling `recover_conversion` until success or shutdown. Startup also runs a single `FullScan` to catch orphans from prior process lifetimes.
- **Server runtime** no-ops the event. Operators drive recovery on demand via the public `BreezSdk::refund_pending_conversions` method (now returns counts).
- **5-min age threshold** on FullScan protects against racing in-flight swaps on a multi-device wallet (same seed, two devices).