### PR TITLE
Collapse leaf optimization API to blocking optimize_leaves

### DIFF
--- a/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
@@ -14,10 +14,10 @@ use breez_sdk_itest::{
     drop_mysql_database, drop_postgres_database,
 };
 use breez_sdk_spark::{
-    BreezSdk, GetInfoRequest, Network, PrepareSendPaymentRequest, ReceivePaymentMethod,
-    ReceivePaymentRequest, SdkContext, SdkContextConfig, SdkEvent, SendPaymentRequest,
-    SyncWalletRequest, default_mysql_storage_config, default_postgres_storage_config,
-    default_server_config, new_shared_sdk_context,
+    BreezSdk, GetInfoRequest, Network, OptimizeLeavesRequest, PrepareSendPaymentRequest,
+    ReceivePaymentMethod, ReceivePaymentRequest, SdkContext, SdkContextConfig, SdkEvent,
+    SendPaymentRequest, SyncWalletRequest, default_mysql_storage_config,
+    default_postgres_storage_config, default_server_config, new_shared_sdk_context,
 };
 
 use breez_bench::stats::DurationStats;
@@ -768,7 +768,9 @@ async fn build_extra_sender(
 async fn run_optimization(sdk: &BreezSdk, label: &str) -> Result<Duration> {
     info!("Starting {}...", label.to_lowercase());
     let start = Instant::now();
-    let outcome = sdk.optimize_leaves(None).await?;
+    let outcome = sdk
+        .optimize_leaves(OptimizeLeavesRequest::default())
+        .await?;
     let elapsed = start.elapsed();
     info!(
         "{} complete in {:.2}s: {:?}",

--- a/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/concurrent_perf.rs
@@ -767,28 +767,16 @@ async fn build_extra_sender(
 
 async fn run_optimization(sdk: &BreezSdk, label: &str) -> Result<Duration> {
     info!("Starting {}...", label.to_lowercase());
-    sdk.start_leaf_optimization().await;
-
     let start = Instant::now();
-    let timeout = Duration::from_secs(900);
-    let poll_interval = Duration::from_millis(500);
-
-    loop {
-        let progress = sdk.get_leaf_optimization_progress();
-        if !progress.is_running {
-            let elapsed = start.elapsed();
-            info!("{} complete in {:.2}s", label, elapsed.as_secs_f64());
-            return Ok(elapsed);
-        }
-        info!(
-            "Optimization progress: round {}/{}",
-            progress.current_round, progress.total_rounds
-        );
-        if start.elapsed() >= timeout {
-            bail!("Timeout waiting for optimization to complete");
-        }
-        tokio::time::sleep(poll_interval).await;
-    }
+    let outcome = sdk.optimize_leaves(None).await?;
+    let elapsed = start.elapsed();
+    info!(
+        "{} complete in {:.2}s: {:?}",
+        label,
+        elapsed.as_secs_f64(),
+        outcome
+    );
+    Ok(elapsed)
 }
 
 async fn fund_via_faucet(

--- a/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
@@ -662,34 +662,15 @@ async fn run_pre_optimization(sdk: &BreezSdk) -> Result<()> {
 /// Run leaf optimization with a label and wait for completion
 async fn run_optimization(sdk: &BreezSdk, label: &str) -> Result<()> {
     info!("Starting {}...", label.to_lowercase());
-    sdk.start_leaf_optimization().await;
-
-    // Poll until optimization completes
     let start = Instant::now();
-    let timeout = Duration::from_secs(300); // 5 minute timeout
-    let poll_interval = Duration::from_millis(500);
-
-    loop {
-        let progress = sdk.get_leaf_optimization_progress();
-
-        if !progress.is_running {
-            let elapsed = start.elapsed();
-            info!("{} complete in {:.2}s", label, elapsed.as_secs_f64());
-            break;
-        }
-
-        info!(
-            "Optimization progress: round {}/{}",
-            progress.current_round, progress.total_rounds
-        );
-
-        if start.elapsed() >= timeout {
-            bail!("Timeout waiting for optimization to complete");
-        }
-
-        tokio::time::sleep(poll_interval).await;
-    }
-
+    let outcome = sdk.optimize_leaves(None).await?;
+    let elapsed = start.elapsed();
+    info!(
+        "{} complete in {:.2}s: {:?}",
+        label,
+        elapsed.as_secs_f64(),
+        outcome
+    );
     Ok(())
 }
 

--- a/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
@@ -18,8 +18,9 @@ use breez_sdk_itest::{
     PostgresTreeStore, RegtestFaucet, build_sdk_with_tree_store_config, drop_postgres_database,
 };
 use breez_sdk_spark::{
-    BreezSdk, GetInfoRequest, Network, PrepareSendPaymentRequest, ReceivePaymentMethod,
-    ReceivePaymentRequest, SdkEvent, SendPaymentRequest, SyncWalletRequest, default_config,
+    BreezSdk, GetInfoRequest, Network, OptimizeLeavesRequest, PrepareSendPaymentRequest,
+    ReceivePaymentMethod, ReceivePaymentRequest, SdkEvent, SendPaymentRequest, SyncWalletRequest,
+    default_config,
 };
 
 use breez_bench::events::{wait_for_claimed_event, wait_for_synced_event};
@@ -663,7 +664,9 @@ async fn run_pre_optimization(sdk: &BreezSdk) -> Result<()> {
 async fn run_optimization(sdk: &BreezSdk, label: &str) -> Result<()> {
     info!("Starting {}...", label.to_lowercase());
     let start = Instant::now();
-    let outcome = sdk.optimize_leaves(None).await?;
+    let outcome = sdk
+        .optimize_leaves(OptimizeLeavesRequest::default())
+        .await?;
     let elapsed = start.elapsed();
     info!(
         "{} complete in {:.2}s: {:?}",

--- a/crates/breez-sdk/breez-itest/src/fixtures/mod.rs
+++ b/crates/breez-sdk/breez-itest/src/fixtures/mod.rs
@@ -3,7 +3,10 @@ pub mod docker;
 pub mod lnurl;
 
 use anyhow::Result;
-use breez_sdk_spark::{MaxFee, Network, StableBalanceConfig, StableBalanceToken, default_config};
+use breez_sdk_spark::{
+    LeafOptimizationConfig, MaxFee, Network, StableBalanceConfig, StableBalanceToken,
+    default_config, default_server_config,
+};
 use rand::RngCore;
 use rstest::fixture;
 use tracing::info;
@@ -73,6 +76,47 @@ pub async fn bob_strict_fee_sdk() -> Result<SdkInstance> {
 
     let mut cfg = default_config(Network::Regtest);
     cfg.max_deposit_claim_fee = Some(MaxFee::Fixed { amount: 0 });
+    build_sdk_with_custom_config(path, seed, cfg, Some(dir), true).await
+}
+
+/// Fixture: Alice's SDK with leaf optimization in manual-trigger mode and a
+/// high target multiplicity. Used to drive a deterministic optimization run
+/// (no background optimizer racing the test; enough work that the planner
+/// produces real swaps).
+#[fixture]
+pub async fn alice_sdk_manual_opt() -> Result<SdkInstance> {
+    let dir = tempfile::Builder::new()
+        .prefix("breez-sdk-alice-manual-opt")
+        .tempdir()?;
+    let path = dir.path().to_string_lossy().to_string();
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+
+    let mut cfg = default_config(Network::Regtest);
+    cfg.leaf_optimization_config = LeafOptimizationConfig {
+        auto_enabled: false,
+        multiplicity: 15,
+    };
+    build_sdk_with_custom_config(path, seed, cfg, Some(dir), true).await
+}
+
+/// Server-mode variant of [`alice_sdk_manual_opt`]. Same manual-trigger
+/// shape, but with `background_tasks_enabled = false` so the test exercises
+/// the manual optimization path on the server runtime.
+#[fixture]
+pub async fn alice_server_sdk_manual_opt() -> Result<SdkInstance> {
+    let dir = tempfile::Builder::new()
+        .prefix("breez-sdk-alice-server-manual-opt")
+        .tempdir()?;
+    let path = dir.path().to_string_lossy().to_string();
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+
+    let mut cfg = default_server_config(Network::Regtest);
+    cfg.leaf_optimization_config = LeafOptimizationConfig {
+        auto_enabled: false,
+        multiplicity: 15,
+    };
     build_sdk_with_custom_config(path, seed, cfg, Some(dir), true).await
 }
 

--- a/crates/breez-sdk/breez-itest/src/helpers.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers.rs
@@ -331,6 +331,7 @@ pub async fn build_sdk_with_custom_config_and_backend(
         config.lnurl_domain = None;
     }
 
+    let background_tasks_enabled = config.background_tasks_enabled;
     let seed = Seed::Entropy(seed_bytes.to_vec());
 
     let builder = SdkBuilder::new(config, seed);
@@ -345,12 +346,17 @@ pub async fn build_sdk_with_custom_config_and_backend(
     let event_listener = Box::new(ChannelEventListener { tx });
     let _listener_id = sdk.add_event_listener(event_listener).await;
 
-    // Ensure initial sync completes
-    let _ = sdk
-        .get_info(GetInfoRequest {
-            ensure_synced: Some(true),
-        })
-        .await?;
+    // Ensure initial sync completes. Server mode rejects `ensure_synced=true`
+    // (there's no background sync to await), so drive it explicitly instead.
+    if background_tasks_enabled {
+        let _ = sdk
+            .get_info(GetInfoRequest {
+                ensure_synced: Some(true),
+            })
+            .await?;
+    } else {
+        sdk.sync_wallet(SyncWalletRequest {}).await?;
+    }
 
     Ok(SdkInstance {
         sdk,

--- a/crates/breez-sdk/breez-itest/tests/optimization.rs
+++ b/crates/breez-sdk/breez-itest/tests/optimization.rs
@@ -1,0 +1,192 @@
+use anyhow::Result;
+use breez_sdk_itest::*;
+use breez_sdk_spark::{
+    OptimizationMode, OptimizationOutcome, OptimizeLeavesOptions, SdkError, SdkEvent,
+};
+use rstest::*;
+use tokio::sync::mpsc;
+use tracing::info;
+
+/// End-to-end test for `optimize_leaves` in `Full` mode (client runtime).
+///
+/// The fixture disables auto-optimization (so nothing races the test) and
+/// uses a high multiplicity so the planner produces real swaps. We expect
+/// `Completed { rounds_executed > 0 }`.
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn test_optimize_leaves_full_client_mode(
+    #[future] alice_sdk_manual_opt: Result<SdkInstance>,
+) -> Result<()> {
+    let mut alice = alice_sdk_manual_opt.await?;
+    ensure_funded(&mut alice, 50_000).await?;
+    clear_event_receiver(&mut alice.events).await;
+
+    // `None` selects the default mode (Full). Demonstrates the
+    // no-arg-style call that bindings expose to other languages.
+    let outcome = alice.sdk.optimize_leaves(None).await?;
+
+    match outcome {
+        OptimizationOutcome::Completed { rounds_executed } => {
+            assert!(
+                rounds_executed > 0,
+                "Full mode should execute at least one round on a deliberately under-optimized wallet"
+            );
+            info!("Full mode completed with {rounds_executed} rounds");
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+
+    assert_no_auto_optimization_events(&mut alice.events).await;
+    Ok(())
+}
+
+/// End-to-end test for `optimize_leaves` in `SingleRound` mode (client
+/// runtime).
+///
+/// Drives the loop manually: each call should return `InProgress` while
+/// work remains, then `Completed` exactly once.
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn test_optimize_leaves_single_round_client_mode(
+    #[future] alice_sdk_manual_opt: Result<SdkInstance>,
+) -> Result<()> {
+    let mut alice = alice_sdk_manual_opt.await?;
+    ensure_funded(&mut alice, 50_000).await?;
+    clear_event_receiver(&mut alice.events).await;
+
+    let final_rounds = drive_single_round_loop(&alice).await?;
+    assert!(
+        final_rounds > 0,
+        "SingleRound mode should execute at least one round on a deliberately under-optimized wallet"
+    );
+    info!("SingleRound mode completed after {final_rounds} rounds");
+
+    assert_no_auto_optimization_events(&mut alice.events).await;
+    Ok(())
+}
+
+/// Server-mode counterpart: in server mode there is no
+/// `BackgroundProcessor` running auto-optimization, so the only way leaves
+/// get optimized is via the manual API. Asserts the manual path works
+/// regardless of runtime profile.
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn test_optimize_leaves_full_server_mode(
+    #[future] alice_server_sdk_manual_opt: Result<SdkInstance>,
+) -> Result<()> {
+    let mut alice = alice_server_sdk_manual_opt.await?;
+    // Server mode has no ClaimedDeposits event; poll the balance instead.
+    ensure_funded_via_polling(&mut alice, 50_000).await?;
+    clear_event_receiver(&mut alice.events).await;
+
+    let outcome = alice.sdk.optimize_leaves(None).await?;
+
+    match outcome {
+        OptimizationOutcome::Completed { rounds_executed } => {
+            assert!(rounds_executed > 0);
+            info!("Server-mode Full completed with {rounds_executed} rounds");
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+
+    assert_no_auto_optimization_events(&mut alice.events).await;
+    Ok(())
+}
+
+/// Concurrent calls must reject with `OptimizationAlreadyRunning`.
+///
+/// Joins two `Full`-mode calls concurrently: whichever the runtime polls
+/// first acquires the `is_running` lock; the other observes the lock held
+/// and returns `OptimizationAlreadyRunning`. The test doesn't care which
+/// side wins — only that the loser sees the typed error.
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn test_optimize_leaves_rejects_concurrent_calls(
+    #[future] alice_sdk_manual_opt: Result<SdkInstance>,
+) -> Result<()> {
+    let mut alice = alice_sdk_manual_opt.await?;
+    ensure_funded(&mut alice, 50_000).await?;
+    clear_event_receiver(&mut alice.events).await;
+
+    let (r1, r2) = tokio::join!(
+        alice.sdk.optimize_leaves(None),
+        alice.sdk.optimize_leaves(None),
+    );
+
+    let ok_count = [&r1, &r2].iter().filter(|r| r.is_ok()).count();
+    let rejected_count = [&r1, &r2]
+        .iter()
+        .filter(|r| matches!(r, Err(SdkError::OptimizationAlreadyRunning)))
+        .count();
+
+    assert_eq!(
+        ok_count, 1,
+        "exactly one concurrent call should succeed (r1={r1:?}, r2={r2:?})"
+    );
+    assert_eq!(
+        rejected_count, 1,
+        "exactly one concurrent call should be rejected with AlreadyRunning (r1={r1:?}, r2={r2:?})"
+    );
+
+    Ok(())
+}
+
+/// Drives a `SingleRound` loop to completion, returning the cumulative
+/// round count observed. The SDK signals the final round by returning
+/// `Completed` in the same call (when the planner reports a
+/// single-swap, fully-converging plan). `Skipped` only fires when the
+/// very first call sees an already-optimal wallet.
+async fn drive_single_round_loop(alice: &SdkInstance) -> Result<u32> {
+    let mut total = 0u32;
+    let mut saw_in_progress = false;
+    // Safety bound — the wallet is deliberately small.
+    for iteration in 0..50 {
+        let outcome = alice
+            .sdk
+            .optimize_leaves(Some(OptimizeLeavesOptions {
+                mode: OptimizationMode::SingleRound,
+            }))
+            .await?;
+        match outcome {
+            OptimizationOutcome::InProgress => {
+                total += 1;
+                saw_in_progress = true;
+                info!("SingleRound iteration {iteration}: round {total} (InProgress)");
+            }
+            OptimizationOutcome::Completed { rounds_executed } => {
+                assert_eq!(
+                    rounds_executed, 1,
+                    "SingleRound mode should always execute exactly one round per call"
+                );
+                total += rounds_executed;
+                info!("SingleRound iteration {iteration}: round {total} (Completed)");
+                return Ok(total);
+            }
+            OptimizationOutcome::Skipped => {
+                if !saw_in_progress {
+                    info!("SingleRound iteration {iteration}: Skipped (wallet already optimal)");
+                    return Ok(0);
+                }
+                panic!(
+                    "Skipped after seeing InProgress — convergence hint should have caused Completed instead"
+                );
+            }
+        }
+    }
+    panic!("SingleRound loop did not terminate within 50 iterations");
+}
+
+/// Drains the event channel for a brief window and asserts no
+/// `AutoOptimization` events were emitted — they're reserved for the auto
+/// path, and manual `optimize_leaves` calls must stay silent.
+async fn assert_no_auto_optimization_events(events: &mut mpsc::Receiver<SdkEvent>) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(200);
+    while let Ok(Some(event)) =
+        tokio::time::timeout_at(tokio::time::Instant::from_std(deadline), events.recv()).await
+    {
+        assert!(
+            !matches!(event, SdkEvent::AutoOptimization { .. }),
+            "manual optimize_leaves should not emit AutoOptimization events, got: {event:?}"
+        );
+    }
+}

--- a/crates/breez-sdk/breez-itest/tests/optimization.rs
+++ b/crates/breez-sdk/breez-itest/tests/optimization.rs
@@ -134,8 +134,8 @@ async fn test_optimize_leaves_rejects_concurrent_calls(
 /// Drives a `SingleRound` loop to completion, returning the cumulative
 /// round count observed. The SDK signals the final round by returning
 /// `Completed` in the same call (when the planner reports a
-/// single-swap, fully-converging plan). `Skipped` only fires when the
-/// very first call sees an already-optimal wallet.
+/// single-swap, fully-converging plan). `Completed { rounds_executed: 0 }`
+/// only fires when the call sees an already-optimal wallet.
 async fn drive_single_round_loop(alice: &SdkInstance) -> Result<u32> {
     let mut total = 0u32;
     let mut saw_in_progress = false;
@@ -153,23 +153,22 @@ async fn drive_single_round_loop(alice: &SdkInstance) -> Result<u32> {
                 saw_in_progress = true;
                 info!("SingleRound iteration {iteration}: round {total} (InProgress)");
             }
+            OptimizationOutcome::Completed { rounds_executed: 0 } => {
+                assert!(
+                    !saw_in_progress,
+                    "Completed{{0}} after seeing InProgress — convergence hint should have caused Completed{{1}} instead"
+                );
+                info!("SingleRound iteration {iteration}: Completed (wallet already optimal)");
+                return Ok(0);
+            }
             OptimizationOutcome::Completed { rounds_executed } => {
                 assert_eq!(
                     rounds_executed, 1,
-                    "SingleRound mode should always execute exactly one round per call"
+                    "SingleRound mode should execute at most one round per call"
                 );
                 total += rounds_executed;
                 info!("SingleRound iteration {iteration}: round {total} (Completed)");
                 return Ok(total);
-            }
-            OptimizationOutcome::Skipped => {
-                if !saw_in_progress {
-                    info!("SingleRound iteration {iteration}: Skipped (wallet already optimal)");
-                    return Ok(0);
-                }
-                panic!(
-                    "Skipped after seeing InProgress — convergence hint should have caused Completed instead"
-                );
             }
         }
     }

--- a/crates/breez-sdk/breez-itest/tests/optimization.rs
+++ b/crates/breez-sdk/breez-itest/tests/optimization.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use breez_sdk_itest::*;
 use breez_sdk_spark::{
-    OptimizationMode, OptimizationOutcome, OptimizeLeavesOptions, SdkError, SdkEvent,
+    OptimizationMode, OptimizationOutcome, OptimizeLeavesRequest, SdkError, SdkEvent,
 };
 use rstest::*;
 use tokio::sync::mpsc;
@@ -21,9 +21,12 @@ async fn test_optimize_leaves_full_client_mode(
     ensure_funded(&mut alice, 50_000).await?;
     clear_event_receiver(&mut alice.events).await;
 
-    // `None` selects the default mode (Full). Demonstrates the
-    // no-arg-style call that bindings expose to other languages.
-    let outcome = alice.sdk.optimize_leaves(None).await?;
+    // The default request selects Full mode.
+    let outcome = alice
+        .sdk
+        .optimize_leaves(OptimizeLeavesRequest::default())
+        .await?
+        .outcome;
 
     match outcome {
         OptimizationOutcome::Completed { rounds_executed } => {
@@ -79,7 +82,11 @@ async fn test_optimize_leaves_full_server_mode(
     ensure_funded_via_polling(&mut alice, 50_000).await?;
     clear_event_receiver(&mut alice.events).await;
 
-    let outcome = alice.sdk.optimize_leaves(None).await?;
+    let outcome = alice
+        .sdk
+        .optimize_leaves(OptimizeLeavesRequest::default())
+        .await?
+        .outcome;
 
     match outcome {
         OptimizationOutcome::Completed { rounds_executed } => {
@@ -109,8 +116,8 @@ async fn test_optimize_leaves_rejects_concurrent_calls(
     clear_event_receiver(&mut alice.events).await;
 
     let (r1, r2) = tokio::join!(
-        alice.sdk.optimize_leaves(None),
-        alice.sdk.optimize_leaves(None),
+        alice.sdk.optimize_leaves(OptimizeLeavesRequest::default()),
+        alice.sdk.optimize_leaves(OptimizeLeavesRequest::default()),
     );
 
     let ok_count = [&r1, &r2].iter().filter(|r| r.is_ok()).count();
@@ -143,10 +150,11 @@ async fn drive_single_round_loop(alice: &SdkInstance) -> Result<u32> {
     for iteration in 0..50 {
         let outcome = alice
             .sdk
-            .optimize_leaves(Some(OptimizeLeavesOptions {
+            .optimize_leaves(OptimizeLeavesRequest {
                 mode: OptimizationMode::SingleRound,
-            }))
-            .await?;
+            })
+            .await?
+            .outcome;
         match outcome {
             OptimizationOutcome::InProgress => {
                 total += 1;

--- a/crates/breez-sdk/core/src/error.rs
+++ b/crates/breez-sdk/core/src/error.rs
@@ -60,6 +60,16 @@ pub enum SdkError {
     #[error("Signer error: {0}")]
     Signer(String),
 
+    /// `optimize_leaves` was called while another optimization run (auto or
+    /// manual) was already in flight.
+    #[error("Optimization is already in progress")]
+    OptimizationAlreadyRunning,
+
+    /// `optimize_leaves` was preempted by the SDK to free leaves for a
+    /// higher-priority operation (typically a payment).
+    #[error("Optimization was cancelled by the SDK to free leaves")]
+    OptimizationCancelled,
+
     #[error("Error: {0}")]
     Generic(String),
 }
@@ -176,6 +186,16 @@ impl From<SparkWalletError> for SdkError {
                 SdkError::InvalidInput(msg)
             }
             _ => SdkError::SparkError(e.to_string()),
+        }
+    }
+}
+
+impl From<spark_wallet::OptimizationError> for SdkError {
+    fn from(e: spark_wallet::OptimizationError) -> Self {
+        match e {
+            spark_wallet::OptimizationError::AlreadyRunning => SdkError::OptimizationAlreadyRunning,
+            spark_wallet::OptimizationError::Cancelled => SdkError::OptimizationCancelled,
+            spark_wallet::OptimizationError::Tree(inner) => SdkError::SparkError(inner.to_string()),
         }
     }
 }

--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -35,9 +35,15 @@ pub enum SdkEvent {
     PaymentFailed {
         payment: Payment,
     },
-    Optimization {
+    /// Emitted while the background auto-optimizer is running.
+    ///
+    /// Only fired from the auto path (enabled via
+    /// `LeafOptimizationConfig::auto_enabled`). Manually-triggered runs
+    /// via `BreezSdk::optimize_leaves` do not emit events — they return an
+    /// `OptimizationOutcome` instead.
+    AutoOptimization {
         // Named with `optimization` prefix to avoid collision with `event` keyword in C#
-        optimization_event: OptimizationEvent,
+        optimization_event: AutoOptimizationEvent,
     },
     LightningAddressChanged {
         lightning_address: Option<LightningAddressInfo>,
@@ -76,10 +82,10 @@ impl fmt::Display for SdkEvent {
             SdkEvent::PaymentFailed { payment } => {
                 write!(f, "PaymentFailed: {payment:?}")
             }
-            SdkEvent::Optimization {
+            SdkEvent::AutoOptimization {
                 optimization_event: event,
             } => {
-                write!(f, "Optimization: {event:?}")
+                write!(f, "AutoOptimization: {event:?}")
             }
             SdkEvent::LightningAddressChanged { lightning_address } => {
                 write!(f, "LightningAddressChanged: {lightning_address:?}")
@@ -93,7 +99,7 @@ impl fmt::Display for SdkEvent {
 
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
-pub enum OptimizationEvent {
+pub enum AutoOptimizationEvent {
     /// Optimization has started with the given number of rounds.
     Started { total_rounds: u32 },
     /// A round has completed.

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -31,7 +31,7 @@ pub use chain::{
 pub use common::rest::{RestClient, RestResponse};
 pub use common::{fiat::*, models::*, sync_storage};
 pub use error::{DepositClaimError, SdkError, SignerError};
-pub use events::{EventEmitter, EventListener, OptimizationEvent, SdkEvent};
+pub use events::{AutoOptimizationEvent, EventEmitter, EventListener, SdkEvent};
 pub use issuer::*;
 pub use models::*;
 pub use persist::{

--- a/crates/breez-sdk/core/src/models/adaptors.rs
+++ b/crates/breez-sdk/core/src/models/adaptors.rs
@@ -544,7 +544,6 @@ impl From<spark_wallet::OptimizationOutcome> for OptimizationOutcome {
                 Self::Completed { rounds_executed }
             }
             spark_wallet::OptimizationOutcome::InProgress => Self::InProgress,
-            spark_wallet::OptimizationOutcome::Skipped => Self::Skipped,
         }
     }
 }

--- a/crates/breez-sdk/core/src/models/adaptors.rs
+++ b/crates/breez-sdk/core/src/models/adaptors.rs
@@ -12,8 +12,8 @@ use platform_utils::time::UNIX_EPOCH;
 use tracing::{debug, warn};
 
 use crate::{
-    Fee, Network, OnchainConfirmationSpeed, OptimizationProgress, Payment, PaymentDetails,
-    PaymentMethod, PaymentStatus, PaymentType, SdkError, SendOnchainFeeQuote,
+    AutoOptimizationEvent, Fee, Network, OnchainConfirmationSpeed, OptimizationOutcome, Payment,
+    PaymentDetails, PaymentMethod, PaymentStatus, PaymentType, SdkError, SendOnchainFeeQuote,
     SendOnchainSpeedFeeQuote, SparkHtlcDetails, SparkHtlcStatus, SparkInvoicePaymentDetails,
     TokenBalance, TokenMetadata,
 };
@@ -516,12 +516,35 @@ impl From<PreimageRequestStatus> for SparkHtlcStatus {
     }
 }
 
-impl From<spark_wallet::OptimizationProgress> for OptimizationProgress {
-    fn from(value: spark_wallet::OptimizationProgress) -> Self {
-        Self {
-            is_running: value.is_running,
-            current_round: value.current_round,
-            total_rounds: value.total_rounds,
+impl From<spark_wallet::AutoOptimizationEvent> for AutoOptimizationEvent {
+    fn from(value: spark_wallet::AutoOptimizationEvent) -> Self {
+        match value {
+            spark_wallet::AutoOptimizationEvent::Started { total_rounds } => {
+                Self::Started { total_rounds }
+            }
+            spark_wallet::AutoOptimizationEvent::RoundCompleted {
+                current_round,
+                total_rounds,
+            } => Self::RoundCompleted {
+                current_round,
+                total_rounds,
+            },
+            spark_wallet::AutoOptimizationEvent::Completed => Self::Completed,
+            spark_wallet::AutoOptimizationEvent::Cancelled => Self::Cancelled,
+            spark_wallet::AutoOptimizationEvent::Failed { error } => Self::Failed { error },
+            spark_wallet::AutoOptimizationEvent::Skipped => Self::Skipped,
+        }
+    }
+}
+
+impl From<spark_wallet::OptimizationOutcome> for OptimizationOutcome {
+    fn from(value: spark_wallet::OptimizationOutcome) -> Self {
+        match value {
+            spark_wallet::OptimizationOutcome::Completed { rounds_executed } => {
+                Self::Completed { rounds_executed }
+            }
+            spark_wallet::OptimizationOutcome::InProgress => Self::InProgress,
+            spark_wallet::OptimizationOutcome::Skipped => Self::Skipped,
         }
     }
 }

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1851,14 +1851,21 @@ pub enum OptimizationMode {
     SingleRound,
 }
 
-/// Optional configuration for [`BreezSdk::optimize_leaves`]. Callers that
-/// want the default `Full` behavior can pass `None` (or omit the argument
-/// where the binding supports it).
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// Request for [`BreezSdk::optimize_leaves`]. Defaults to
+/// [`OptimizationMode::Full`].
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
-pub struct OptimizeLeavesOptions {
+pub struct OptimizeLeavesRequest {
     /// Controls how much work the call performs before returning.
     pub mode: OptimizationMode,
+}
+
+/// Response from a [`BreezSdk::optimize_leaves`] call.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct OptimizeLeavesResponse {
+    /// The outcome of the optimization run.
+    pub outcome: OptimizationOutcome,
 }
 
 /// Outcome of a [`BreezSdk::optimize_leaves`] call.
@@ -1877,7 +1884,8 @@ pub struct OptimizeLeavesOptions {
 ///
 /// ```ignore
 /// loop {
-///     match sdk.optimize_leaves(SingleRound).await? {
+///     let request = OptimizeLeavesRequest { mode: OptimizationMode::SingleRound };
+///     match sdk.optimize_leaves(request).await?.outcome {
 ///         OptimizationOutcome::InProgress => continue,
 ///         OptimizationOutcome::Completed { .. } => break,
 ///     }

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1867,17 +1867,19 @@ pub struct OptimizeLeavesOptions {
 /// The SDK holds no cross-call state — callers driving a `SingleRound`
 /// loop maintain their own cumulative counter if they need one.
 ///
+/// A `Completed { rounds_executed: 0 }` outcome means the wallet was
+/// already optimal at call time (no swap was needed).
+///
 /// **`SingleRound` loop pattern**: terminate on anything that isn't
-/// `InProgress` — `Completed` (the planner confirmed this swap finished
-/// optimization) or `Skipped` (the wallet was already optimal at call
-/// time).
+/// `InProgress`. `Completed` covers both the final swap of a productive
+/// run and the "already optimal" no-op case (the latter as
+/// `rounds_executed: 0`).
 ///
 /// ```ignore
 /// loop {
 ///     match sdk.optimize_leaves(SingleRound).await? {
 ///         OptimizationOutcome::InProgress => continue,
-///         OptimizationOutcome::Completed { .. }
-///         | OptimizationOutcome::Skipped => break,
+///         OptimizationOutcome::Completed { .. } => break,
 ///     }
 /// }
 /// ```
@@ -1888,14 +1890,13 @@ pub enum OptimizationOutcome {
     /// Returned by `Full` runs on success, and by `SingleRound` runs
     /// whose swap was the final one needed (the planner produced a
     /// single-swap plan with a convergence guarantee).
+    /// `rounds_executed == 0` means the wallet was already optimal —
+    /// no work was performed.
     Completed { rounds_executed: u32 },
     /// `SingleRound` only: a round ran but the planner could not
     /// guarantee it was the last. The caller should invoke
     /// `optimize_leaves` again.
     InProgress,
-    /// No optimization work was performed because the wallet was already
-    /// optimal at call time. Returned by either mode on a no-op call.
-    Skipped,
 }
 
 /// A contact entry containing a name and payment identifier.

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1840,11 +1840,62 @@ pub struct LnurlReceiveMetadata {
     pub sender_comment: Option<String>,
 }
 
+/// Mode of a manually-triggered optimization run.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum OptimizationMode {
+    /// Run until no further optimization is productive.
+    #[default]
+    Full,
+    /// Execute a single round and return so the caller can drive progress.
+    SingleRound,
+}
+
+/// Optional configuration for [`BreezSdk::optimize_leaves`]. Callers that
+/// want the default `Full` behavior can pass `None` (or omit the argument
+/// where the binding supports it).
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
-pub struct OptimizationProgress {
-    pub is_running: bool,
-    pub current_round: u32,
-    pub total_rounds: u32,
+pub struct OptimizeLeavesOptions {
+    /// Controls how much work the call performs before returning.
+    pub mode: OptimizationMode,
+}
+
+/// Outcome of a [`BreezSdk::optimize_leaves`] call.
+///
+/// `rounds_executed` on `Completed` refers to rounds run by *this call*.
+/// The SDK holds no cross-call state — callers driving a `SingleRound`
+/// loop maintain their own cumulative counter if they need one.
+///
+/// **`SingleRound` loop pattern**: terminate on anything that isn't
+/// `InProgress` — `Completed` (the planner confirmed this swap finished
+/// optimization) or `Skipped` (the wallet was already optimal at call
+/// time).
+///
+/// ```ignore
+/// loop {
+///     match sdk.optimize_leaves(SingleRound).await? {
+///         OptimizationOutcome::InProgress => continue,
+///         OptimizationOutcome::Completed { .. }
+///         | OptimizationOutcome::Skipped => break,
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum OptimizationOutcome {
+    /// All planned optimization work was executed in this call.
+    /// Returned by `Full` runs on success, and by `SingleRound` runs
+    /// whose swap was the final one needed (the planner produced a
+    /// single-swap plan with a convergence guarantee).
+    Completed { rounds_executed: u32 },
+    /// `SingleRound` only: a round ran but the planner could not
+    /// guarantee it was the last. The caller should invoke
+    /// `optimize_leaves` again.
+    InProgress,
+    /// No optimization work was performed because the wallet was already
+    /// optimal at call time. Returned by either mode on a no-op call.
+    Skipped,
 }
 
 /// A contact entry containing a name and payment identifier.

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -7,9 +7,9 @@ use breez_sdk_common::buy::cashapp::CashAppProvider;
 use crate::{
     BuyBitcoinRequest, BuyBitcoinResponse, CheckMessageRequest, CheckMessageResponse,
     GetTokensMetadataRequest, GetTokensMetadataResponse, InputType, ListFiatCurrenciesResponse,
-    ListFiatRatesResponse, Network, OptimizationProgress, RegisterWebhookRequest,
-    RegisterWebhookResponse, SignMessageRequest, SignMessageResponse, UnregisterWebhookRequest,
-    UpdateUserSettingsRequest, UserSettings, Webhook,
+    ListFiatRatesResponse, Network, OptimizationMode, OptimizationOutcome, OptimizeLeavesOptions,
+    RegisterWebhookRequest, RegisterWebhookResponse, SignMessageRequest, SignMessageResponse,
+    UnregisterWebhookRequest, UpdateUserSettingsRequest, UserSettings, Webhook,
     chain::RecommendedFees,
     error::SdkError,
     events::EventListener,
@@ -242,31 +242,34 @@ impl BreezSdk {
         TokenIssuer::new(self.spark_wallet.clone(), self.storage.clone())
     }
 
-    /// Starts leaf optimization in the background.
+    /// Manually drives leaf optimization, blocking until the requested work
+    /// is done.
     ///
-    /// This method spawns the optimization work in a background task and returns
-    /// immediately. Progress is reported via events.
-    /// If optimization is already running, no new task will be started.
-    pub async fn start_leaf_optimization(&self) {
-        self.spark_wallet.start_leaf_optimization().await;
-    }
-
-    /// Cancels the ongoing leaf optimization.
+    /// Pass `None` (or omit the argument in bindings that support it) for
+    /// the default behavior: run the entire optimization in a single call.
+    /// Pass `Some(OptimizeLeavesOptions { mode: OptimizationMode::SingleRound })`
+    /// to execute one round and return — the caller drives the loop by
+    /// inspecting the [`OptimizationOutcome`] and calling again until
+    /// `InProgress` no longer appears.
     ///
-    /// This method cancels the ongoing optimization and waits for it to fully stop.
-    /// The current round will complete before stopping. This method blocks
-    /// until the optimization has fully stopped and leaves reserved for optimization
-    /// are available again.
+    /// Returns an error if another optimization run (auto or manual) is
+    /// already in flight ([`SdkError::OptimizationAlreadyRunning`]), or if
+    /// the SDK preempted this run to free leaves for a payment
+    /// ([`SdkError::OptimizationCancelled`]).
     ///
-    /// If no optimization is running, this method returns immediately.
-    pub async fn cancel_leaf_optimization(&self) -> Result<(), SdkError> {
-        self.spark_wallet.cancel_leaf_optimization().await?;
-        Ok(())
-    }
-
-    /// Returns the current optimization progress snapshot.
-    pub fn get_leaf_optimization_progress(&self) -> OptimizationProgress {
-        self.spark_wallet.get_leaf_optimization_progress().into()
+    /// Manual runs do not emit events; events ([`SdkEvent::AutoOptimization`])
+    /// are reserved for the background auto-optimizer.
+    #[cfg_attr(feature = "uniffi", uniffi::method(default(options = None)))]
+    pub async fn optimize_leaves(
+        &self,
+        options: Option<OptimizeLeavesOptions>,
+    ) -> Result<OptimizationOutcome, SdkError> {
+        let mode = options.map(|o| o.mode).unwrap_or_default();
+        let max_rounds = match mode {
+            OptimizationMode::Full => None,
+            OptimizationMode::SingleRound => Some(1),
+        };
+        Ok(self.spark_wallet.optimize_leaves(max_rounds).await?.into())
     }
 
     /// Registers a webhook to receive notifications for wallet events.

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -7,9 +7,10 @@ use breez_sdk_common::buy::cashapp::CashAppProvider;
 use crate::{
     BuyBitcoinRequest, BuyBitcoinResponse, CheckMessageRequest, CheckMessageResponse,
     GetTokensMetadataRequest, GetTokensMetadataResponse, InputType, ListFiatCurrenciesResponse,
-    ListFiatRatesResponse, Network, OptimizationMode, OptimizationOutcome, OptimizeLeavesOptions,
-    RegisterWebhookRequest, RegisterWebhookResponse, SignMessageRequest, SignMessageResponse,
-    UnregisterWebhookRequest, UpdateUserSettingsRequest, UserSettings, Webhook,
+    ListFiatRatesResponse, Network, OptimizationMode, OptimizeLeavesRequest,
+    OptimizeLeavesResponse, RegisterWebhookRequest, RegisterWebhookResponse, SignMessageRequest,
+    SignMessageResponse, UnregisterWebhookRequest, UpdateUserSettingsRequest, UserSettings,
+    Webhook,
     chain::RecommendedFees,
     error::SdkError,
     events::EventListener,
@@ -245,11 +246,11 @@ impl BreezSdk {
     /// Manually drives leaf optimization, blocking until the requested work
     /// is done.
     ///
-    /// Pass `None` (or omit the argument in bindings that support it) for
-    /// the default behavior: run the entire optimization in a single call.
-    /// Pass `Some(OptimizeLeavesOptions { mode: OptimizationMode::SingleRound })`
-    /// to execute one round and return — the caller drives the loop by
-    /// inspecting the [`OptimizationOutcome`] and calling again until
+    /// With [`OptimizationMode::Full`] (the default) the call runs the entire
+    /// optimization in a single invocation. With
+    /// [`OptimizationMode::SingleRound`] it executes one round and returns —
+    /// the caller drives the loop by inspecting the
+    /// [`OptimizeLeavesResponse::outcome`] and calling again until
     /// `InProgress` no longer appears.
     ///
     /// Returns an error if another optimization run (auto or manual) is
@@ -259,17 +260,16 @@ impl BreezSdk {
     ///
     /// Manual runs do not emit events; events ([`SdkEvent::AutoOptimization`])
     /// are reserved for the background auto-optimizer.
-    #[cfg_attr(feature = "uniffi", uniffi::method(default(options = None)))]
     pub async fn optimize_leaves(
         &self,
-        options: Option<OptimizeLeavesOptions>,
-    ) -> Result<OptimizationOutcome, SdkError> {
-        let mode = options.map(|o| o.mode).unwrap_or_default();
-        let max_rounds = match mode {
+        request: OptimizeLeavesRequest,
+    ) -> Result<OptimizeLeavesResponse, SdkError> {
+        let max_rounds = match request.mode {
             OptimizationMode::Full => None,
             OptimizationMode::SingleRound => Some(1),
         };
-        Ok(self.spark_wallet.optimize_leaves(max_rounds).await?.into())
+        let outcome = self.spark_wallet.optimize_leaves(max_rounds).await?.into();
+        Ok(OptimizeLeavesResponse { outcome })
     }
 
     /// Registers a webhook to receive notifications for wallet events.

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -313,8 +313,16 @@ async fn handle_wallet_event(sdk: &BreezSdk, event: WalletEvent) -> bool {
                     false
                 })
         }
-        WalletEvent::Optimization(event) => {
-            info!("Optimization event: {:?}", event);
+        WalletEvent::AutoOptimization(event) => {
+            info!("AutoOptimization event: {:?}", event);
+            // Only the background auto-optimizer reaches this branch;
+            // manually-triggered optimize_leaves calls return their result
+            // directly and never produce wallet-level optimization events.
+            sdk.event_emitter
+                .emit(&SdkEvent::AutoOptimization {
+                    optimization_event: event.into(),
+                })
+                .await;
             false
         }
     }

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -1301,8 +1301,8 @@ pub enum OptimizationMode {
     SingleRound,
 }
 
-#[macros::extern_wasm_bindgen(breez_sdk_spark::OptimizeLeavesOptions)]
-pub struct OptimizeLeavesOptions {
+#[macros::extern_wasm_bindgen(breez_sdk_spark::OptimizeLeavesRequest)]
+pub struct OptimizeLeavesRequest {
     pub mode: OptimizationMode,
 }
 
@@ -1310,6 +1310,11 @@ pub struct OptimizeLeavesOptions {
 pub enum OptimizationOutcome {
     Completed { rounds_executed: u32 },
     InProgress,
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::OptimizeLeavesResponse)]
+pub struct OptimizeLeavesResponse {
+    pub outcome: OptimizationOutcome,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::ConversionEstimate)]

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -1310,7 +1310,6 @@ pub struct OptimizeLeavesOptions {
 pub enum OptimizationOutcome {
     Completed { rounds_executed: u32 },
     InProgress,
-    Skipped,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::ConversionEstimate)]

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -79,8 +79,8 @@ pub enum SdkEvent {
     PaymentFailed {
         payment: Payment,
     },
-    Optimization {
-        optimization_event: OptimizationEvent,
+    AutoOptimization {
+        optimization_event: AutoOptimizationEvent,
     },
     LightningAddressChanged {
         lightning_address: Option<LightningAddressInfo>,
@@ -90,8 +90,8 @@ pub enum SdkEvent {
     },
 }
 
-#[macros::extern_wasm_bindgen(breez_sdk_spark::OptimizationEvent)]
-pub enum OptimizationEvent {
+#[macros::extern_wasm_bindgen(breez_sdk_spark::AutoOptimizationEvent)]
+pub enum AutoOptimizationEvent {
     Started {
         total_rounds: u32,
     },
@@ -1295,11 +1295,22 @@ pub struct LnurlReceiveMetadata {
     pub sender_comment: Option<String>,
 }
 
-#[macros::extern_wasm_bindgen(breez_sdk_spark::OptimizationProgress)]
-pub struct OptimizationProgress {
-    pub is_running: bool,
-    pub current_round: u32,
-    pub total_rounds: u32,
+#[macros::extern_wasm_bindgen(breez_sdk_spark::OptimizationMode)]
+pub enum OptimizationMode {
+    Full,
+    SingleRound,
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::OptimizeLeavesOptions)]
+pub struct OptimizeLeavesOptions {
+    pub mode: OptimizationMode,
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::OptimizationOutcome)]
+pub enum OptimizationOutcome {
+    Completed { rounds_executed: u32 },
+    InProgress,
+    Skipped,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::ConversionEstimate)]

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -323,13 +323,9 @@ impl BreezSdk {
     #[wasm_bindgen(js_name = "optimizeLeaves")]
     pub async fn optimize_leaves(
         &self,
-        options: Option<OptimizeLeavesOptions>,
-    ) -> WasmResult<OptimizationOutcome> {
-        Ok(self
-            .sdk
-            .optimize_leaves(options.map(Into::into))
-            .await?
-            .into())
+        request: OptimizeLeavesRequest,
+    ) -> WasmResult<OptimizeLeavesResponse> {
+        Ok(self.sdk.optimize_leaves(request.into()).await?.into())
     }
 
     #[wasm_bindgen(js_name = "fetchConversionLimits")]

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -320,19 +320,16 @@ impl BreezSdk {
         }
     }
 
-    #[wasm_bindgen(js_name = "startLeafOptimization")]
-    pub async fn start_leaf_optimization(&self) {
-        self.sdk.start_leaf_optimization().await;
-    }
-
-    #[wasm_bindgen(js_name = "cancelLeafOptimization")]
-    pub async fn cancel_leaf_optimization(&self) -> WasmResult<()> {
-        Ok(self.sdk.cancel_leaf_optimization().await?)
-    }
-
-    #[wasm_bindgen(js_name = "getLeafOptimizationProgress")]
-    pub fn get_leaf_optimization_progress(&self) -> OptimizationProgress {
-        self.sdk.get_leaf_optimization_progress().into()
+    #[wasm_bindgen(js_name = "optimizeLeaves")]
+    pub async fn optimize_leaves(
+        &self,
+        options: Option<OptimizeLeavesOptions>,
+    ) -> WasmResult<OptimizationOutcome> {
+        Ok(self
+            .sdk
+            .optimize_leaves(options.map(Into::into))
+            .await?
+            .into())
     }
 
     #[wasm_bindgen(js_name = "fetchConversionLimits")]

--- a/crates/internal/src/main.rs
+++ b/crates/internal/src/main.rs
@@ -138,7 +138,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         spark_wallet::WalletEvent::TransferClaimed(transfer) => info!("Transfer claimed: {}", transfer.id),
                         spark_wallet::WalletEvent::TransferClaimStarting(transfer) => info!("Transfer claim starting: {}", transfer.id),
                         spark_wallet::WalletEvent::TokenTransaction(transaction) => info!("Token transaction: {}", transaction.hash),
-                        spark_wallet::WalletEvent::Optimization(event) => info!("Optimization event: {:?}", event),
+                        spark_wallet::WalletEvent::AutoOptimization(event) => info!("Auto-optimization event: {:?}", event),
                     }
                 }
                 else => warn!("Event stream closed."),

--- a/crates/spark-wallet/src/lib.rs
+++ b/crates/spark-wallet/src/lib.rs
@@ -39,11 +39,11 @@ pub use spark::{
         TokenOutputsReservationId, TokensConfig,
     },
     tree::{
-        DEFAULT_MAX_CONCURRENT_RESERVATIONS, DEFAULT_RESERVATION_TIMEOUT, InMemoryTreeStore,
-        LeafLike, LeafOptimizationOptions, Leaves, LeavesReservation, LeavesReservationId,
-        OptimizationEvent, OptimizationProgress, ReservationPurpose, ReserveResult,
-        SelectLeavesOptions, SigningKeyshare, TargetAmounts, TreeNode, TreeNodeId, TreeNodeStatus,
-        TreeServiceError, TreeStore, select_leaves_by_minimum_amount,
+        AutoOptimizationEvent, DEFAULT_MAX_CONCURRENT_RESERVATIONS, DEFAULT_RESERVATION_TIMEOUT,
+        InMemoryTreeStore, LeafLike, LeafOptimizationOptions, Leaves, LeavesReservation,
+        LeavesReservationId, OptimizationError, OptimizationOutcome, ReservationPurpose,
+        ReserveResult, SelectLeavesOptions, SigningKeyshare, TargetAmounts, TreeNode, TreeNodeId,
+        TreeNodeStatus, TreeServiceError, TreeStore, select_leaves_by_minimum_amount,
         select_leaves_by_target_amounts,
     },
     utils::{

--- a/crates/spark-wallet/src/model.rs
+++ b/crates/spark-wallet/src/model.rs
@@ -17,7 +17,7 @@ use spark::{
     ssp::{SspTransfer, SspUserRequest},
     token::TokenMetadata,
     tree::{
-        Leaves, LeavesReservation, OptimizationEvent, SigningKeyshare, TargetAmounts, TreeNode,
+        AutoOptimizationEvent, Leaves, LeavesReservation, SigningKeyshare, TargetAmounts, TreeNode,
         TreeNodeId,
     },
     utils::paging::PagingFilter,
@@ -35,8 +35,8 @@ pub enum WalletEvent {
     TransferClaimed(WalletTransfer),
     TransferClaimStarting(WalletTransfer),
     TokenTransaction(TokenTransaction),
-    /// Optimization lifecycle event.
-    Optimization(OptimizationEvent),
+    /// Auto-optimization lifecycle event.
+    AutoOptimization(AutoOptimizationEvent),
 }
 
 impl Display for WalletEvent {
@@ -51,8 +51,8 @@ impl Display for WalletEvent {
             WalletEvent::TokenTransaction(transaction) => {
                 write!(f, "TokenTransaction({})", transaction.hash)
             }
-            WalletEvent::Optimization(event) => {
-                write!(f, "Optimization({:?})", event)
+            WalletEvent::AutoOptimization(event) => {
+                write!(f, "AutoOptimization({:?})", event)
             }
             _ => write!(f, "{:?}", self),
         }

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -42,9 +42,10 @@ use spark::{
         TokenOutputService, TokenOutputStore, TokenOutputWithPrevOut, TokenService,
     },
     tree::{
-        InMemoryTreeStore, LeafOptimizer, OptimizationEvent, OptimizationEventHandler,
-        OptimizationProgress, SelectLeavesOptions, SynchronousTreeService, TargetAmounts, TreeNode,
-        TreeNodeId, TreeService, TreeStore, select_leaves_by_target_amounts, with_reserved_leaves,
+        AutoOptimizationEvent, AutoOptimizationEventHandler, InMemoryTreeStore, LeafOptimizer,
+        OptimizationError, OptimizationOutcome, SelectLeavesOptions, SynchronousTreeService,
+        TargetAmounts, TreeNode, TreeNodeId, TreeService, TreeStore,
+        select_leaves_by_target_amounts, with_reserved_leaves,
     },
     utils::paging::{PagingFilter, PagingResult},
 };
@@ -355,8 +356,8 @@ impl SparkWallet {
 
         let event_manager = Arc::new(EventManager::new());
 
-        // Create optimization event handler that bridges to WalletEvent
-        let optimization_event_handler = Arc::new(WalletOptimizationEventHandler {
+        // Create auto-optimization event handler that bridges to WalletEvent
+        let auto_optimization_event_handler = Arc::new(WalletAutoOptimizationEventHandler {
             event_manager: Arc::clone(&event_manager),
         });
 
@@ -364,7 +365,7 @@ impl SparkWallet {
             config.leaf_optimization_options.clone(),
             Arc::clone(&swap_service),
             Arc::clone(&tree_service),
-            Some(optimization_event_handler),
+            Some(auto_optimization_event_handler),
         ));
 
         // Use external cancellation token if provided, otherwise create an internal one
@@ -1642,23 +1643,23 @@ impl SparkWallet {
         Ok(())
     }
 
-    /// Starts leaf optimization in the background.
-    pub async fn start_leaf_optimization(&self) {
-        self.leaf_optimizer.start().await;
-    }
-
-    /// Cancels the ongoing leaf optimization.
+    /// Manually drives leaf optimization, blocking until the requested work
+    /// is done.
     ///
-    /// This sets a cancellation flag that is checked between rounds.
-    /// The current round will complete before stopping.
-    pub async fn cancel_leaf_optimization(&self) -> Result<(), SparkWalletError> {
-        self.leaf_optimizer.cancel().await?;
-        Ok(())
-    }
-
-    /// Returns the current optimization progress snapshot.
-    pub fn get_leaf_optimization_progress(&self) -> OptimizationProgress {
-        self.leaf_optimizer.progress()
+    /// - `max_rounds = None`: run until no further optimization is productive.
+    /// - `max_rounds = Some(n)`: execute up to `n` rounds and return.
+    ///
+    /// Manual runs do not emit `AutoOptimizationEvent`s — only the background
+    /// auto-optimizer produces events. Use the return value to track outcome.
+    ///
+    /// Returns [`OptimizationError::AlreadyRunning`] if another run (auto or
+    /// manual) is in flight, or [`OptimizationError::Cancelled`] if the run
+    /// was cancelled while in progress.
+    pub async fn optimize_leaves(
+        &self,
+        max_rounds: Option<u32>,
+    ) -> Result<OptimizationOutcome, OptimizationError> {
+        self.leaf_optimizer.run(max_rounds).await
     }
 
     /// Optimizes token outputs by consolidating them when there are more than the configured threshold.
@@ -2028,15 +2029,15 @@ async fn claim_transfer(
     Ok(result_nodes)
 }
 
-/// Event handler that bridges OptimizationEvent to WalletEvent.
-struct WalletOptimizationEventHandler {
+/// Event handler that bridges AutoOptimizationEvent to WalletEvent.
+struct WalletAutoOptimizationEventHandler {
     event_manager: Arc<EventManager>,
 }
 
-impl OptimizationEventHandler for WalletOptimizationEventHandler {
-    fn on_optimization_event(&self, event: OptimizationEvent) {
+impl AutoOptimizationEventHandler for WalletAutoOptimizationEventHandler {
+    fn on_auto_optimization_event(&self, event: AutoOptimizationEvent) {
         self.event_manager
-            .notify_listeners(WalletEvent::Optimization(event));
+            .notify_listeners(WalletEvent::AutoOptimization(event));
     }
 }
 

--- a/crates/spark/src/tree/leaf_optimizer.rs
+++ b/crates/spark/src/tree/leaf_optimizer.rs
@@ -13,6 +13,8 @@ use crate::{
     },
 };
 
+const MAX_PLANNING_ITERATIONS: u32 = 8;
+
 /// Default maximum number of leaves per swap round
 pub const DEFAULT_MAX_LEAVES_PER_SWAP: u32 = 64;
 
@@ -51,20 +53,24 @@ impl LeafOptimizationOptions {
     }
 }
 
-/// A snapshot of the current optimization progress.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
-pub struct OptimizationProgress {
-    /// Whether optimization is currently running.
-    pub is_running: bool,
-    /// The current round being executed (1-indexed when running).
-    pub current_round: u32,
-    /// The total number of rounds to execute.
-    pub total_rounds: u32,
+/// Internal flag tracking whether an optimization run is in flight.
+///
+/// Held in an `Arc<Mutex<_>>` so the public `is_running()` getter, the
+/// atomic check-and-set in `start`/`run`, and the cleanup in
+/// [`RunningGuard`]'s `Drop` all coordinate through the same lock.
+#[derive(Clone, Debug, Default)]
+struct RunState {
+    is_running: bool,
 }
 
-/// Events emitted during optimization lifecycle.
+/// Events emitted during the lifecycle of a background ("auto")
+/// optimization run.
+///
+/// Only emitted by runs spawned via [`LeafOptimizer::start`]. Synchronous
+/// runs driven by [`LeafOptimizer::run`] do not fire events — their result
+/// is returned via [`OptimizationOutcome`].
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub enum OptimizationEvent {
+pub enum AutoOptimizationEvent {
     /// Optimization has started with the given number of rounds.
     Started { total_rounds: u32 },
     /// A round has completed.
@@ -82,10 +88,44 @@ pub enum OptimizationEvent {
     Skipped,
 }
 
-/// Trait for receiving optimization events.
-/// Implemented by the wallet layer to convert to WalletEvents.
-pub trait OptimizationEventHandler: Send + Sync {
-    fn on_optimization_event(&self, event: OptimizationEvent);
+/// Handler invoked for each [`AutoOptimizationEvent`] emitted by a
+/// background optimization run.
+pub trait AutoOptimizationEventHandler: Send + Sync {
+    fn on_auto_optimization_event(&self, event: AutoOptimizationEvent);
+}
+
+/// Outcome of a [`LeafOptimizer::run`] invocation.
+///
+/// `rounds_executed` always refers to rounds executed *by this call*. The
+/// optimizer holds no cross-call state — callers driving a capped loop
+/// maintain their own cumulative counter if they want one.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub enum OptimizationOutcome {
+    /// All planned optimization work was executed. Returned by uncapped
+    /// runs on success, and by capped runs that executed what the planner
+    /// classified as the final round.
+    Completed { rounds_executed: u32 },
+    /// A round ran but more rounds remain. Only emitted by capped runs;
+    /// the caller should invoke [`LeafOptimizer::run`] again to continue.
+    InProgress,
+    /// No optimization work was performed because the wallet was already
+    /// optimal at call time.
+    Skipped,
+}
+
+/// Errors returned by [`LeafOptimizer::run`].
+#[derive(Debug, thiserror::Error)]
+pub enum OptimizationError {
+    /// Another optimization run (auto or manual) is in progress. The caller
+    /// can retry later.
+    #[error("Optimization is already in progress")]
+    AlreadyRunning,
+    /// The run was cancelled via [`LeafOptimizer::cancel`].
+    #[error("Optimization was cancelled")]
+    Cancelled,
+    /// Underlying tree-service error.
+    #[error(transparent)]
+    Tree(#[from] TreeServiceError),
 }
 
 /// Represents a single swap operation plan for the optimization process.
@@ -97,28 +137,37 @@ struct SwapPlan {
     pub leaves_to_receive: Vec<u64>,
 }
 
+/// A computed optimization plan plus a convergence hint from the planner.
+#[derive(Clone, Debug, PartialEq)]
+struct OptimizationPlan {
+    swaps: Vec<SwapPlan>,
+    /// `true` only when executing every swap in `swaps` is guaranteed to
+    /// leave the wallet fully optimal (no further planning iterations
+    /// needed). `false` is conservative — the planner sets it whenever it
+    /// had to split batches or fall back to greedy fillers, since those
+    /// emit swaps whose results are not the global optimum.
+    fully_converges: bool,
+}
+
 /// RAII guard that automatically clears the running state when dropped.
 /// Used to ensure the running state is always cleared even if the optimization fails.
 #[derive(Clone)]
 struct RunningGuard {
-    progress: Arc<std::sync::Mutex<OptimizationProgress>>,
+    state: Arc<Mutex<RunState>>,
     terminated: Arc<Notify>,
 }
 
 impl RunningGuard {
-    fn new(progress: Arc<Mutex<OptimizationProgress>>, terminated: Arc<Notify>) -> Self {
-        Self {
-            progress,
-            terminated,
-        }
+    fn new(state: Arc<Mutex<RunState>>, terminated: Arc<Notify>) -> Self {
+        Self { state, terminated }
     }
 }
 
 impl Drop for RunningGuard {
     fn drop(&mut self) {
-        let mut progress = self.progress.lock().unwrap();
-        *progress = OptimizationProgress::default();
-        drop(progress);
+        let mut state = self.state.lock().unwrap();
+        state.is_running = false;
+        drop(state);
 
         self.terminated.notify_waiters();
     }
@@ -133,11 +182,11 @@ pub struct LeafOptimizer {
     config: LeafOptimizationOptions,
     swap_service: Arc<Swap>,
     tree_service: Arc<dyn TreeService>,
-    progress: Arc<Mutex<OptimizationProgress>>,
+    state: Arc<Mutex<RunState>>,
     cancel_tx: watch::Sender<bool>,
     cancel_rx: watch::Receiver<bool>,
     terminated: Arc<Notify>,
-    event_handler: Option<Arc<dyn OptimizationEventHandler>>,
+    event_handler: Option<Arc<dyn AutoOptimizationEventHandler>>,
 }
 
 impl LeafOptimizer {
@@ -145,14 +194,14 @@ impl LeafOptimizer {
         config: LeafOptimizationOptions,
         swap_service: Arc<Swap>,
         tree_service: Arc<dyn TreeService>,
-        event_handler: Option<Arc<dyn OptimizationEventHandler>>,
+        event_handler: Option<Arc<dyn AutoOptimizationEventHandler>>,
     ) -> Self {
         let (cancel_tx, cancel_rx) = watch::channel(false);
         Self {
             config,
             swap_service,
             tree_service,
-            progress: Arc::new(Mutex::new(OptimizationProgress::default())),
+            state: Arc::new(Mutex::new(RunState::default())),
             cancel_tx,
             cancel_rx,
             terminated: Arc::new(Notify::new()),
@@ -160,25 +209,20 @@ impl LeafOptimizer {
         }
     }
 
-    /// Returns the current optimization progress snapshot.
-    pub fn progress(&self) -> OptimizationProgress {
-        self.progress.lock().unwrap().clone()
-    }
-
     /// Checks if optimization is currently running and may have leaves in use.
     /// Used to determine if optimization should be cancelled when payments fail.
     pub fn is_running(&self) -> bool {
-        self.progress.lock().unwrap().is_running
+        self.state.lock().unwrap().is_running
     }
 
     fn should_optimize(&self, leaves: &[TreeNode]) -> bool {
         if self.config.multiplicity == 0 {
             let leave_amounts = leaves.iter().map(|leaf| leaf.value).collect::<Vec<u64>>();
 
-            let swaps = maximize_unilateral_exit(&leave_amounts, self.config.max_leaves_per_swap);
+            let plan = maximize_unilateral_exit(&leave_amounts, self.config.max_leaves_per_swap);
 
-            let num_inputs: usize = swaps.iter().map(|swap| swap.leaves_to_give.len()).sum();
-            let num_outputs: usize = swaps.iter().map(|swap| swap.leaves_to_receive.len()).sum();
+            let num_inputs: usize = plan.swaps.iter().map(|s| s.leaves_to_give.len()).sum();
+            let num_outputs: usize = plan.swaps.iter().map(|s| s.leaves_to_receive.len()).sum();
 
             num_inputs > num_outputs
         } else {
@@ -186,102 +230,146 @@ impl LeafOptimizer {
         }
     }
 
-    /// Starts the optimization process in the background.
+    /// Starts the auto-optimizer in the background.
     ///
-    /// This method spawns the optimization work in a background task and returns
-    /// immediately. Progress is reported via events.
+    /// Spawns the optimization work in a background task and returns
+    /// immediately. Progress is reported via [`AutoOptimizationEvent`]s
+    /// delivered to the configured handler.
     ///
-    /// Returns early (without spawning) if:
-    /// - Optimization is already running
+    /// Returns early (without spawning) if optimization is already running.
     pub async fn start(self: &Arc<Self>) {
-        let mut progress = self.progress.lock().unwrap();
-
-        // Check if already running
-        if progress.is_running {
-            trace!("Optimization already running, skipping");
-            return;
-        }
-
-        // Set running state
-        *progress = OptimizationProgress {
-            is_running: true,
-            current_round: 0,
-            total_rounds: 0, // Will be updated when rounds are calculated
+        let running_guard = {
+            let mut state = self.state.lock().unwrap();
+            if state.is_running {
+                trace!("Optimization already running, skipping");
+                return;
+            }
+            state.is_running = true;
+            // Reset the cancel signal under the same lock that gates
+            // `is_running`. A concurrent `cancel()` call cannot interleave
+            // between these two writes, so an arriving cancel signal can't
+            // be clobbered by a stale reset.
+            let _ = self.cancel_tx.send(false);
+            RunningGuard::new(Arc::clone(&self.state), Arc::clone(&self.terminated))
         };
-        drop(progress);
 
-        // Create the running guard for cleanup via Drop
-        let running_guard =
-            RunningGuard::new(Arc::clone(&self.progress), Arc::clone(&self.terminated));
-
-        // Spawn the optimization work in the background
         let optimizer = Arc::clone(self);
         tokio::spawn(async move {
-            if let Err(e) = optimizer.run_optimization_with_guard(running_guard).await {
-                error!("Leaf optimization failed: {:?}", e);
-            }
+            // The auto path always runs to completion and emits events.
+            // Errors are logged; outcomes are reported via events.
+            let _ = optimizer.run_inner(None, true, running_guard).await;
         });
     }
 
-    /// Internal method that runs the actual optimization logic.
-    /// The guard ensures is_running is cleared and
-    /// interested parties (e.g. cancel()) are notified when this method completes.
-    async fn run_optimization_with_guard(
+    /// Manually drives leaf optimization.
+    ///
+    /// - `max_rounds = None`: run until no further optimization is productive.
+    /// - `max_rounds = Some(n)`: execute up to `n` rounds and return so the
+    ///   caller can drive progress externally.
+    ///
+    /// Returns:
+    /// - [`OptimizationOutcome::Completed`] if all planned work was done
+    ///   (uncapped run, or capped run after the final round).
+    /// - [`OptimizationOutcome::InProgress`] if a round ran but more remain.
+    /// - [`OptimizationOutcome::Skipped`] if no work was needed.
+    ///
+    /// Errors:
+    /// - [`OptimizationError::AlreadyRunning`] if another run (auto or
+    ///   manual) is in flight.
+    /// - [`OptimizationError::Cancelled`] if [`Self::cancel`] was invoked
+    ///   while the run was in progress.
+    ///
+    /// Unlike [`Self::start`], this path does not emit
+    /// [`AutoOptimizationEvent`]s — only the auto path produces events.
+    pub async fn run(
         &self,
-        _guard: RunningGuard,
-    ) -> Result<(), TreeServiceError> {
-        const MAX_PLANNING_ITERATIONS: u32 = 8;
+        max_rounds: Option<u32>,
+    ) -> Result<OptimizationOutcome, OptimizationError> {
+        // Atomically claim the running slot. If someone (auto or another
+        // manual call) already has it, reject. The cancel reset happens
+        // under the same lock so a concurrent `cancel()` can't be
+        // clobbered (see `start` for the same pattern).
+        let running_guard = {
+            let mut state = self.state.lock().unwrap();
+            if state.is_running {
+                return Err(OptimizationError::AlreadyRunning);
+            }
+            state.is_running = true;
+            let _ = self.cancel_tx.send(false);
+            RunningGuard::new(Arc::clone(&self.state), Arc::clone(&self.terminated))
+        };
 
-        let _ = self.cancel_tx.send(false);
+        self.run_inner(max_rounds, false, running_guard).await
+    }
 
-        let initial_leaves = self.tree_service.list_leaves().await?.available;
-        if initial_leaves.is_empty() {
-            debug!("No leaves available for optimization");
-            self.emit_event(OptimizationEvent::Skipped);
-            return Ok(());
-        }
-        if !self.should_optimize(&initial_leaves) {
-            debug!("Optimization not needed, skipping");
-            self.emit_event(OptimizationEvent::Skipped);
-            return Ok(());
-        }
+    /// Shared driver for both the auto path (via [`Self::start`]) and the
+    /// manual path (via [`Self::run`]).
+    ///
+    /// `emit_events = true` mirrors the legacy auto behaviour:
+    /// `Started`/`RoundCompleted`/terminal events are emitted to the
+    /// handler. `emit_events = false` runs silently and reports via the
+    /// returned [`OptimizationOutcome`].
+    ///
+    /// Terminal detection for `max_rounds`-capped runs combines the plan's
+    /// length with the planner's convergence hint: a single-swap plan
+    /// whose `fully_converges` flag is `true` means executing that swap
+    /// leaves the wallet fully optimal, so we return `Completed` in the
+    /// same call. Otherwise (multi-swap plan, or single-swap plan with
+    /// `fully_converges = false` from the give-too-big / receive-too-big
+    /// split branches), we return `InProgress` and let the caller's next
+    /// call discover the terminal state.
+    async fn run_inner(
+        &self,
+        max_rounds: Option<u32>,
+        emit_events: bool,
+        _running_guard: RunningGuard,
+    ) -> Result<OptimizationOutcome, OptimizationError> {
+        // The cancel signal was reset by `run`/`start` under the same
+        // lock that claimed `is_running`, so no reset is needed here.
 
+        let mut rounds_this_call: u32 = 0;
         let mut started_emitted = false;
-        let mut cumulative_rounds: u32 = 0;
-        let mut next_leaves = Some(initial_leaves);
 
         for iteration in 1..=MAX_PLANNING_ITERATIONS {
             if *self.cancel_rx.borrow() {
                 debug!("Optimization cancelled before iteration {iteration}");
-                self.emit_event(OptimizationEvent::Cancelled);
-                return Ok(());
+                if emit_events {
+                    self.emit_event(AutoOptimizationEvent::Cancelled);
+                }
+                return Err(OptimizationError::Cancelled);
             }
 
-            let leaves = match next_leaves.take() {
-                Some(l) => l,
-                None => self.tree_service.list_leaves().await?.available,
-            };
+            let leaves = self.tree_service.list_leaves().await?.available;
             if leaves.is_empty() {
                 break;
             }
 
-            let swaps = calculate_optimization_swaps(
+            // `should_optimize` is a quick pre-check on the very first
+            // pass when no work has happened yet; later iterations have
+            // already done real swaps, so we trust the planner.
+            if iteration == 1 && rounds_this_call == 0 && !self.should_optimize(&leaves) {
+                debug!("Optimization not needed, skipping");
+                break;
+            }
+
+            let plan = calculate_optimization_swaps(
                 &leaves.iter().map(|l| l.value).collect::<Vec<u64>>(),
                 self.config.multiplicity,
                 self.config.max_leaves_per_swap,
             );
+            let swaps = plan.swaps;
+            let plan_fully_converges = plan.fully_converges;
 
             if swaps.is_empty() {
-                if iteration == 1 {
-                    debug!("No swaps needed for optimization");
-                    self.emit_event(OptimizationEvent::Skipped);
-                    return Ok(());
-                }
                 break;
             }
 
             let rounds_in_iter = swaps.len() as u32;
-            let total_rounds_estimate = cumulative_rounds + rounds_in_iter;
+            // A single-swap, fully-converging plan means executing this
+            // swap leaves the wallet optimal — capped runs use this to
+            // return `Completed` in the same call.
+            let plan_is_terminal = rounds_in_iter == 1 && plan_fully_converges;
+            let last_total_estimate = rounds_this_call + rounds_in_iter;
 
             info!(
                 "Optimization iteration {iteration}: {} rounds, {} input leaves, {} output leaves",
@@ -293,57 +381,86 @@ impl LeafOptimizer {
                     .sum::<usize>()
             );
 
-            if !started_emitted {
-                self.emit_event(OptimizationEvent::Started {
-                    total_rounds: total_rounds_estimate,
+            if emit_events && !started_emitted {
+                self.emit_event(AutoOptimizationEvent::Started {
+                    total_rounds: last_total_estimate,
                 });
                 started_emitted = true;
             }
 
-            {
-                let mut progress = self.progress.lock().unwrap();
-                progress.current_round = cumulative_rounds;
-                progress.total_rounds = total_rounds_estimate;
-            }
+            for swap in swaps {
+                if *self.cancel_rx.borrow() {
+                    debug!("Optimization cancelled mid-iteration");
+                    if emit_events {
+                        self.emit_event(AutoOptimizationEvent::Cancelled);
+                    }
+                    return Err(OptimizationError::Cancelled);
+                }
 
-            match self
-                .execute_optimization_rounds(swaps, cumulative_rounds, total_rounds_estimate)
-                .await
-            {
-                Ok(true) => {
-                    cumulative_rounds += rounds_in_iter;
+                let round_number = rounds_this_call + 1;
+                match self
+                    .execute_one_swap(swap, round_number, last_total_estimate, emit_events)
+                    .await
+                {
+                    Ok(true) => {
+                        rounds_this_call += 1;
+                    }
+                    Ok(false) => {
+                        // Round skipped (insufficient funds / busy);
+                        // try the next planned swap.
+                        continue;
+                    }
+                    Err(e) => {
+                        if emit_events {
+                            self.emit_event(AutoOptimizationEvent::Failed {
+                                error: e.to_string(),
+                            });
+                        }
+                        return Err(OptimizationError::Tree(e));
+                    }
                 }
-                Ok(false) => {
-                    info!("Leaf optimization was cancelled");
-                    self.emit_event(OptimizationEvent::Cancelled);
-                    return Ok(());
-                }
-                Err(e) => {
-                    self.emit_event(OptimizationEvent::Failed {
-                        error: e.to_string(),
+
+                // Capped runs return after reaching `max_rounds`. A
+                // single-swap, fully-converging plan is terminal — return
+                // `Completed` in this call. Otherwise return `InProgress`
+                // and let the caller drive the loop.
+                if let Some(max) = max_rounds
+                    && rounds_this_call >= max
+                {
+                    return Ok(if plan_is_terminal {
+                        OptimizationOutcome::Completed {
+                            rounds_executed: rounds_this_call,
+                        }
+                    } else {
+                        OptimizationOutcome::InProgress
                     });
-                    return Err(e);
                 }
             }
         }
 
-        if !started_emitted {
-            self.emit_event(OptimizationEvent::Skipped);
+        if rounds_this_call == 0 {
+            if emit_events {
+                self.emit_event(AutoOptimizationEvent::Skipped);
+            }
+            Ok(OptimizationOutcome::Skipped)
         } else {
-            info!("Leaf optimization completed successfully ({cumulative_rounds} rounds executed)");
-            self.emit_event(OptimizationEvent::Completed);
+            info!("Leaf optimization completed successfully ({rounds_this_call} rounds executed)");
+            if emit_events {
+                self.emit_event(AutoOptimizationEvent::Completed);
+            }
+            Ok(OptimizationOutcome::Completed {
+                rounds_executed: rounds_this_call,
+            })
         }
-        Ok(())
     }
 
     /// Cancels the ongoing optimization and waits for it to fully stop.
     ///
-    /// This sets a cancellation flag that is checked between rounds.
-    /// The current round will complete before stopping. This method blocks
-    /// until the optimization has fully stopped and leaves are available again.
+    /// Sets a cancellation flag that is checked between rounds; the current
+    /// round will complete before stopping. Blocks until the run has fully
+    /// stopped and leaves reserved for swaps are released.
     pub async fn cancel(&self) -> Result<(), TreeServiceError> {
-        // First check if optimization is running
-        if !self.progress.lock().unwrap().is_running {
+        if !self.state.lock().unwrap().is_running {
             debug!("No optimization running to cancel");
             return Ok(());
         }
@@ -353,157 +470,132 @@ impl LeafOptimizer {
         // Create the notified future BEFORE sending cancel signal to avoid race conditions
         let notified = self.terminated.notified();
 
-        // Send cancel signal
         let _ = self.cancel_tx.send(true);
 
         // Double-check: if optimization already stopped between our first check
         // and creating the notified future, we can return early
-        if !self.progress.lock().unwrap().is_running {
+        if !self.state.lock().unwrap().is_running {
             debug!("Optimization already stopped");
             return Ok(());
         }
 
-        // Wait for the termination signal
         notified.await;
 
         debug!("Optimization cancelled and stopped");
         Ok(())
     }
 
-    /// Executes the optimization rounds.
-    /// Returns Ok(true) if completed, Ok(false) if cancelled, Err on failure.
-    async fn execute_optimization_rounds(
+    /// Executes a single planned swap. Returns `Ok(true)` if the swap was
+    /// executed, `Ok(false)` if it was skipped (insufficient funds, busy),
+    /// or `Err` on swap failure.
+    async fn execute_one_swap(
         &self,
-        swaps: Vec<SwapPlan>,
-        rounds_offset: u32,
-        cumulative_total_rounds: u32,
+        swap: SwapPlan,
+        round: u32,
+        total_rounds: u32,
+        emit_events: bool,
     ) -> Result<bool, TreeServiceError> {
-        let total_rounds = cumulative_total_rounds.max(rounds_offset + swaps.len() as u32);
-
-        for (index, swap) in swaps.into_iter().enumerate() {
-            let round = rounds_offset + (index + 1) as u32;
-
-            // Check for cancellation before each round
-            if *self.cancel_rx.borrow() {
-                debug!("Optimization cancelled before round {}", round);
+        let swap_reservation = match self
+            .tree_service
+            .select_leaves(
+                Some(&TargetAmounts::new_exact_denominations(
+                    swap.leaves_to_give.clone(),
+                )),
+                ReservationPurpose::Swap,
+                SelectLeavesOptions::no_wait(),
+            )
+            .await
+        {
+            Ok(reservation) => reservation,
+            Err(TreeServiceError::InsufficientFunds) => {
+                debug!("Optimization round {} skipped: insufficient funds", round);
                 return Ok(false);
             }
-
-            // Reserve leaves for the swap using no-wait mode to avoid blocking
-            let swap_reservation = match self
-                .tree_service
-                .select_leaves(
-                    Some(&TargetAmounts::new_exact_denominations(
-                        swap.leaves_to_give.clone(),
-                    )),
-                    ReservationPurpose::Swap,
-                    SelectLeavesOptions::no_wait(),
-                )
-                .await
-            {
-                Ok(reservation) => reservation,
-                Err(TreeServiceError::InsufficientFunds) => {
-                    // Not enough funds for this round - skip it
-                    debug!("Optimization round {} skipped: insufficient funds", round);
-                    continue;
-                }
-                Err(e) => {
-                    // Other errors (e.g., ResourceBusy) - skip round and continue
-                    debug!("Optimization round {} skipped due to error: {:?}", round, e);
-                    continue;
-                }
-            };
-
-            debug!(
-                "Executing optimization round {round}/{total_rounds}: give {} leaves {:?} ({} sats), receive {} leaves {:?} ({} sats)",
-                swap.leaves_to_give.len(),
-                swap.leaves_to_give,
-                swap.leaves_to_give.iter().sum::<u64>(),
-                swap.leaves_to_receive.len(),
-                swap.leaves_to_receive,
-                swap.leaves_to_receive.iter().sum::<u64>(),
-            );
-
-            // Update progress with current round
-            {
-                let mut progress = self.progress.lock().unwrap();
-                *progress = OptimizationProgress {
-                    is_running: true,
-                    current_round: round,
-                    total_rounds,
-                };
+            Err(e) => {
+                debug!("Optimization round {} skipped due to error: {:?}", round, e);
+                return Ok(false);
             }
+        };
 
-            // Execute the swap
-            match self
-                .swap_service
-                .swap_leaves(&swap_reservation.leaves, Some(swap.leaves_to_receive))
-                .await
-            {
-                Ok(new_leaves) => {
-                    let gave_values: Vec<u64> =
-                        swap_reservation.leaves.iter().map(|l| l.value).collect();
-                    let received_values: Vec<u64> = new_leaves.iter().map(|l| l.value).collect();
+        debug!(
+            "Executing optimization round {round}/{total_rounds}: give {} leaves {:?} ({} sats), receive {} leaves {:?} ({} sats)",
+            swap.leaves_to_give.len(),
+            swap.leaves_to_give,
+            swap.leaves_to_give.iter().sum::<u64>(),
+            swap.leaves_to_receive.len(),
+            swap.leaves_to_receive,
+            swap.leaves_to_receive.iter().sum::<u64>(),
+        );
 
-                    if let Err(e) = self
-                        .tree_service
-                        .finalize_reservation(swap_reservation.id, Some(&new_leaves))
-                        .await
-                    {
-                        error!(
-                            "Failed to finalize optimization reservation, proceeding with optimization. {:?}",
-                            e
-                        );
-                    }
+        match self
+            .swap_service
+            .swap_leaves(&swap_reservation.leaves, Some(swap.leaves_to_receive))
+            .await
+        {
+            Ok(new_leaves) => {
+                let gave_values: Vec<u64> =
+                    swap_reservation.leaves.iter().map(|l| l.value).collect();
+                let received_values: Vec<u64> = new_leaves.iter().map(|l| l.value).collect();
 
-                    self.emit_event(OptimizationEvent::RoundCompleted {
+                if let Err(e) = self
+                    .tree_service
+                    .finalize_reservation(swap_reservation.id, Some(&new_leaves))
+                    .await
+                {
+                    error!(
+                        "Failed to finalize optimization reservation, proceeding with optimization. {:?}",
+                        e
+                    );
+                }
+
+                if emit_events {
+                    self.emit_event(AutoOptimizationEvent::RoundCompleted {
                         current_round: round,
                         total_rounds,
                     });
+                }
 
-                    debug!(
-                        "Completed optimization round {}/{}: gave {} leaves {:?} ({} sats), received {} leaves {:?} ({} sats)",
-                        round,
-                        total_rounds,
-                        gave_values.len(),
-                        gave_values,
-                        gave_values.iter().sum::<u64>(),
-                        received_values.len(),
-                        received_values,
-                        received_values.iter().sum::<u64>(),
+                debug!(
+                    "Completed optimization round {}/{}: gave {} leaves {:?} ({} sats), received {} leaves {:?} ({} sats)",
+                    round,
+                    total_rounds,
+                    gave_values.len(),
+                    gave_values,
+                    gave_values.iter().sum::<u64>(),
+                    received_values.len(),
+                    received_values,
+                    received_values.iter().sum::<u64>(),
+                );
+                Ok(true)
+            }
+            Err(e) => {
+                let reserved_leaf_ids: Vec<String> = swap_reservation
+                    .leaves
+                    .iter()
+                    .map(|l| l.id.to_string())
+                    .collect();
+                warn!(
+                    "leaf_lifecycle swap_failed_in_optimize: reservation={} round={} leaf_ids={:?} error={:?}",
+                    swap_reservation.id, round, reserved_leaf_ids, e
+                );
+                if let Err(cancel_err) =
+                    self.tree_service.cancel_reservation(swap_reservation).await
+                {
+                    error!(
+                        "Failed to cancel reservation on optimization round failure: {cancel_err:?}"
                     );
                 }
-                Err(e) => {
-                    let reserved_leaf_ids: Vec<String> = swap_reservation
-                        .leaves
-                        .iter()
-                        .map(|l| l.id.to_string())
-                        .collect();
-                    warn!(
-                        "leaf_lifecycle swap_failed_in_optimize: reservation={} round={} leaf_ids={:?} error={:?}",
-                        swap_reservation.id, round, reserved_leaf_ids, e
-                    );
-                    if let Err(cancel_err) =
-                        self.tree_service.cancel_reservation(swap_reservation).await
-                    {
-                        error!(
-                            "Failed to cancel reservation on optimization round failure: {cancel_err:?}"
-                        );
-                    }
 
-                    return Err(TreeServiceError::Generic(format!(
-                        "Failed to perform swap in optimization round {round}: {e:?}"
-                    )));
-                }
+                Err(TreeServiceError::Generic(format!(
+                    "Failed to perform swap in optimization round {round}: {e:?}"
+                )))
             }
         }
-
-        Ok(true)
     }
 
-    fn emit_event(&self, event: OptimizationEvent) {
+    fn emit_event(&self, event: AutoOptimizationEvent) {
         if let Some(handler) = &self.event_handler {
-            handler.on_optimization_event(event);
+            handler.on_auto_optimization_event(event);
         }
     }
 }
@@ -512,7 +604,7 @@ fn calculate_optimization_swaps(
     input_leave_amounts: &[u64],
     multiplicity: u8,
     max_leaves_per_swap: u32,
-) -> Vec<SwapPlan> {
+) -> OptimizationPlan {
     if multiplicity == 0 {
         maximize_unilateral_exit(input_leave_amounts, max_leaves_per_swap)
     } else {
@@ -523,18 +615,26 @@ fn calculate_optimization_swaps(
 /// Calculates the swaps needed to optimize when maximizing unilateral exit.
 ///
 /// Generates swaps that will result in the unilateral exit maximizing set of leaves.
-/// Multiple iterations may be required to reach the optimal set.
+///
+/// Convergence: when all wallet leaves fit in a single batch
+/// (`wallet.len() <= max_leaves_per_swap`), the lone remainder batch is
+/// swapped to `greedy_leaves(total)` — the global optimum — so the plan
+/// fully converges. When the wallet spans multiple batches, each batch is
+/// independently swapped to `greedy_leaves(batch_sum)`, and the union of
+/// per-batch greedies is generally not equal to `greedy_leaves(total)`,
+/// so subsequent planning iterations may find more work.
 fn maximize_unilateral_exit(
     input_leave_amounts: &[u64],
     max_leaves_per_swap: u32,
-) -> Vec<SwapPlan> {
-    let max_leaves_per_swap = max_leaves_per_swap as usize;
+) -> OptimizationPlan {
+    let max_leaves_per_swap_usize = max_leaves_per_swap as usize;
     let mut swaps = Vec::new();
     let mut batch: Vec<u64> = Vec::new();
 
     // Sort leaves ascending
     let mut leaves: Vec<u64> = input_leave_amounts.to_vec();
     leaves.sort();
+    let fully_converges = leaves.len() <= max_leaves_per_swap_usize;
 
     // Process leaves in batches of up to approximately max_leaves_per_swap
     while !leaves.is_empty() {
@@ -542,7 +642,7 @@ fn maximize_unilateral_exit(
         let batch_sum: u64 = batch.iter().sum();
         let target = greedy_leaves(batch_sum);
 
-        if batch.len() >= max_leaves_per_swap || target.len() >= max_leaves_per_swap {
+        if batch.len() >= max_leaves_per_swap_usize || target.len() >= max_leaves_per_swap_usize {
             if target != batch {
                 swaps.push(SwapPlan {
                     leaves_to_give: batch.clone(),
@@ -566,18 +666,27 @@ fn maximize_unilateral_exit(
         }
     }
 
-    swaps
+    OptimizationPlan {
+        swaps,
+        fully_converges,
+    }
 }
 
 /// Calculates the swaps needed to optimize when minimizing transfer swaps.
 ///
 /// Generates swaps that will minimize the probability of needing to swap during a transfer.
-/// Multiple iterations may be required to reach the optimal set.
+///
+/// Convergence: when neither the give nor receive batch needs splitting,
+/// the plan converges (each emitted swap has the exact `optimal_leaves`
+/// shape on the receive side). When either batch is split into smaller
+/// chunks, the chunks fall back to `greedy_leaves(chunk_sum)` on the
+/// receive side, which is not the multiplicity=N optimal shape — so
+/// subsequent planning iterations may find more work.
 fn minimize_transfer_swap(
     input_leave_amounts: &[u64],
     multiplicity: u8,
     max_leaves_per_swap: u32,
-) -> Vec<SwapPlan> {
+) -> OptimizationPlan {
     let max_leaves = max_leaves_per_swap as usize;
 
     let balance: u64 = input_leave_amounts.iter().sum();
@@ -597,13 +706,17 @@ fn minimize_transfer_swap(
         error!(
             "Unexpected: Give and receive sums do not match. Give: {give:?}, Receive: {receive:?}"
         );
-        return vec![];
+        return OptimizationPlan {
+            swaps: vec![],
+            fully_converges: false,
+        };
     }
 
     // Build swaps by balancing give/receive batches
     let mut swaps = Vec::new();
     let mut to_give_batch: Vec<u64> = Vec::new();
     let mut to_receive_batch: Vec<u64> = Vec::new();
+    let mut fully_converges = true;
 
     while !give.is_empty() || !receive.is_empty() {
         let give_sum: u64 = to_give_batch.iter().sum();
@@ -629,6 +742,7 @@ fn minimize_transfer_swap(
             if to_give_batch.len() > max_leaves {
                 // Split give batch into chunks
                 // TODO: consider improving this fallback logic in order to minimize the deviation from the optimal set.
+                fully_converges = false;
                 for chunk in to_give_batch.chunks(max_leaves) {
                     let chunk_sum: u64 = chunk.iter().sum();
                     swaps.push(SwapPlan {
@@ -638,6 +752,7 @@ fn minimize_transfer_swap(
                 }
             } else if to_receive_batch.len() > max_leaves {
                 // Find a valid cutoff for receive batch
+                fully_converges = false;
                 let mut found_valid_cutoff = false;
                 for cutoff in (1..=max_leaves).rev() {
                     let sum_cut: u64 = to_receive_batch.iter().take(cutoff).sum();
@@ -674,7 +789,10 @@ fn minimize_transfer_swap(
         }
     }
 
-    swaps
+    OptimizationPlan {
+        swaps,
+        fully_converges,
+    }
 }
 
 /// Generates the optimal leaf values for a given balance that minimize transfer swaps.
@@ -795,15 +913,21 @@ mod tests {
 
     #[test_all]
     fn test_calculate_optimization_swaps() {
-        // Test optimize for unilateral exit (multiplicity = 0)
-        // These are just wrappers for calculate_optimization_swaps
+        // Test optimize for unilateral exit (multiplicity = 0). Wallet
+        // fits in one batch → fully converges.
         assert_eq!(
             calculate_optimization_swaps(&[8], 0, DEFAULT_MAX_LEAVES_PER_SWAP),
-            vec![]
+            OptimizationPlan {
+                swaps: vec![],
+                fully_converges: true,
+            }
         );
         assert_eq!(
             calculate_optimization_swaps(&[16], 0, DEFAULT_MAX_LEAVES_PER_SWAP),
-            vec![]
+            OptimizationPlan {
+                swaps: vec![],
+                fully_converges: true,
+            }
         );
         assert_eq!(
             calculate_optimization_swaps(
@@ -811,40 +935,85 @@ mod tests {
                 0,
                 DEFAULT_MAX_LEAVES_PER_SWAP
             ),
-            vec![SwapPlan {
-                leaves_to_give: vec![16, 16, 16, 16, 16, 16, 16, 16],
-                leaves_to_receive: vec![128],
-            }]
+            OptimizationPlan {
+                swaps: vec![SwapPlan {
+                    leaves_to_give: vec![16, 16, 16, 16, 16, 16, 16, 16],
+                    leaves_to_receive: vec![128],
+                }],
+                fully_converges: true,
+            }
         );
         assert_eq!(
             calculate_optimization_swaps(&[100000], 0, DEFAULT_MAX_LEAVES_PER_SWAP),
-            vec![SwapPlan {
-                leaves_to_give: vec![100000],
-                leaves_to_receive: vec![32, 128, 512, 1024, 32768, 65536],
-            }]
+            OptimizationPlan {
+                swaps: vec![SwapPlan {
+                    leaves_to_give: vec![100000],
+                    leaves_to_receive: vec![32, 128, 512, 1024, 32768, 65536],
+                }],
+                fully_converges: true,
+            }
         );
 
-        // Test optimize for swap minimization (multiplicity = 1)
+        // Test optimize for swap minimization (multiplicity = 1). All
+        // wallets here fit in one swap (no split branch) → converges.
         assert_eq!(
             calculate_optimization_swaps(&[8], 1, DEFAULT_MAX_LEAVES_PER_SWAP),
-            vec![SwapPlan {
-                leaves_to_give: vec![8],
-                leaves_to_receive: vec![1, 1, 2, 4],
-            }]
+            OptimizationPlan {
+                swaps: vec![SwapPlan {
+                    leaves_to_give: vec![8],
+                    leaves_to_receive: vec![1, 1, 2, 4],
+                }],
+                fully_converges: true,
+            }
         );
         assert_eq!(
             calculate_optimization_swaps(&[1, 4], 1, DEFAULT_MAX_LEAVES_PER_SWAP),
-            vec![SwapPlan {
-                leaves_to_give: vec![4],
-                leaves_to_receive: vec![2, 2],
-            }]
+            OptimizationPlan {
+                swaps: vec![SwapPlan {
+                    leaves_to_give: vec![4],
+                    leaves_to_receive: vec![2, 2],
+                }],
+                fully_converges: true,
+            }
         );
         assert_eq!(
             calculate_optimization_swaps(&[1, 16], 1, DEFAULT_MAX_LEAVES_PER_SWAP),
-            vec![SwapPlan {
-                leaves_to_give: vec![16],
-                leaves_to_receive: vec![2, 2, 4, 8],
-            }]
+            OptimizationPlan {
+                swaps: vec![SwapPlan {
+                    leaves_to_give: vec![16],
+                    leaves_to_receive: vec![2, 2, 4, 8],
+                }],
+                fully_converges: true,
+            }
+        );
+    }
+
+    #[test_all]
+    fn test_calculate_optimization_swaps_does_not_converge_when_split() {
+        // multiplicity=0 wallet with more leaves than fits one batch:
+        // multiple batches → no convergence guarantee from one iteration.
+        let plan = calculate_optimization_swaps(&[16, 16, 16, 16], 0, 2);
+        assert!(
+            !plan.swaps.is_empty(),
+            "expected at least one swap for non-greedy input"
+        );
+        assert!(
+            !plan.fully_converges,
+            "multi-batch unilateral-exit plans cannot guarantee convergence in one iteration"
+        );
+
+        // multiplicity=15 with a large balance forces the planner into
+        // its receive-too-big branch (optimal set far exceeds
+        // max_leaves_per_swap), so the emitted plan should NOT claim
+        // convergence.
+        let plan = calculate_optimization_swaps(&[50_000], 15, DEFAULT_MAX_LEAVES_PER_SWAP);
+        assert!(
+            !plan.swaps.is_empty(),
+            "expected at least one swap when wallet differs from optimal"
+        );
+        assert!(
+            !plan.fully_converges,
+            "receive-too-big fallback in minimize_transfer_swap must not claim convergence"
         );
     }
 
@@ -870,31 +1039,39 @@ mod tests {
     fn test_maximize_unilateral_exit() {
         assert_eq!(
             maximize_unilateral_exit(&[100, 64, 28, 1, 1], DEFAULT_MAX_LEAVES_PER_SWAP),
-            vec![SwapPlan {
-                leaves_to_give: vec![1, 1, 28, 64, 100],
-                leaves_to_receive: vec![2, 64, 128]
-            }]
+            OptimizationPlan {
+                swaps: vec![SwapPlan {
+                    leaves_to_give: vec![1, 1, 28, 64, 100],
+                    leaves_to_receive: vec![2, 64, 128]
+                }],
+                fully_converges: true,
+            }
         );
         assert_eq!(
             maximize_unilateral_exit(&[1, 1, 1, 1, 1, 1, 1, 1], 2),
-            vec![
-                SwapPlan {
-                    leaves_to_give: vec![1, 1],
-                    leaves_to_receive: vec![2]
-                },
-                SwapPlan {
-                    leaves_to_give: vec![1, 1],
-                    leaves_to_receive: vec![2]
-                },
-                SwapPlan {
-                    leaves_to_give: vec![1, 1],
-                    leaves_to_receive: vec![2]
-                },
-                SwapPlan {
-                    leaves_to_give: vec![1, 1],
-                    leaves_to_receive: vec![2]
-                }
-            ]
+            OptimizationPlan {
+                swaps: vec![
+                    SwapPlan {
+                        leaves_to_give: vec![1, 1],
+                        leaves_to_receive: vec![2]
+                    },
+                    SwapPlan {
+                        leaves_to_give: vec![1, 1],
+                        leaves_to_receive: vec![2]
+                    },
+                    SwapPlan {
+                        leaves_to_give: vec![1, 1],
+                        leaves_to_receive: vec![2]
+                    },
+                    SwapPlan {
+                        leaves_to_give: vec![1, 1],
+                        leaves_to_receive: vec![2]
+                    }
+                ],
+                // 8 leaves with max=2 = multiple batches: no single-iteration
+                // convergence guarantee.
+                fully_converges: false,
+            }
         );
     }
 
@@ -902,17 +1079,23 @@ mod tests {
     fn test_minimize_transfer_swap() {
         assert_eq!(
             minimize_transfer_swap(&[8], 1, DEFAULT_MAX_LEAVES_PER_SWAP),
-            vec![SwapPlan {
-                leaves_to_give: vec![8],
-                leaves_to_receive: vec![1, 1, 2, 4]
-            }]
+            OptimizationPlan {
+                swaps: vec![SwapPlan {
+                    leaves_to_give: vec![8],
+                    leaves_to_receive: vec![1, 1, 2, 4]
+                }],
+                fully_converges: true,
+            }
         );
         assert_eq!(
             minimize_transfer_swap(&[100], 1, DEFAULT_MAX_LEAVES_PER_SWAP),
-            vec![SwapPlan {
-                leaves_to_give: vec![100],
-                leaves_to_receive: vec![1, 1, 2, 4, 4, 8, 16, 32, 32]
-            }]
+            OptimizationPlan {
+                swaps: vec![SwapPlan {
+                    leaves_to_give: vec![100],
+                    leaves_to_receive: vec![1, 1, 2, 4, 4, 8, 16, 32, 32]
+                }],
+                fully_converges: true,
+            }
         );
     }
 
@@ -953,37 +1136,26 @@ mod tests {
 
     #[test_all]
     fn test_running_guard_drop_clears_state() {
-        let progress = Arc::new(std::sync::Mutex::new(OptimizationProgress {
-            is_running: true,
-            current_round: 4,
-            total_rounds: 10,
-        }));
+        let state = Arc::new(std::sync::Mutex::new(RunState { is_running: true }));
         let terminated = Arc::new(tokio::sync::Notify::new());
 
         {
-            let _guard = RunningGuard::new(Arc::clone(&progress), Arc::clone(&terminated));
-            assert!(progress.lock().unwrap().is_running);
+            let _guard = RunningGuard::new(Arc::clone(&state), Arc::clone(&terminated));
+            assert!(state.lock().unwrap().is_running);
         } // guard dropped here
 
         // After drop, state should be cleared
-        let progress = progress.lock().unwrap();
-        assert!(!progress.is_running);
-        assert_eq!(progress.current_round, 0);
-        assert_eq!(progress.total_rounds, 0);
+        assert!(!state.lock().unwrap().is_running);
     }
 
     #[async_test_all]
     async fn test_running_guard_notifies_on_clear() {
-        let progress = Arc::new(std::sync::Mutex::new(OptimizationProgress {
-            is_running: true,
-            current_round: 4,
-            total_rounds: 10,
-        }));
+        let state = Arc::new(std::sync::Mutex::new(RunState { is_running: true }));
         let terminated = Arc::new(tokio::sync::Notify::new());
 
         let notified = terminated.notified();
 
-        let guard = RunningGuard::new(Arc::clone(&progress), Arc::clone(&terminated));
+        let guard = RunningGuard::new(Arc::clone(&state), Arc::clone(&terminated));
 
         drop(guard);
 

--- a/crates/spark/src/tree/leaf_optimizer.rs
+++ b/crates/spark/src/tree/leaf_optimizer.rs
@@ -99,18 +99,19 @@ pub trait AutoOptimizationEventHandler: Send + Sync {
 /// `rounds_executed` always refers to rounds executed *by this call*. The
 /// optimizer holds no cross-call state — callers driving a capped loop
 /// maintain their own cumulative counter if they want one.
+///
+/// A `Completed { rounds_executed: 0 }` outcome means the wallet was
+/// already optimal at call time (no swap was needed).
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub enum OptimizationOutcome {
     /// All planned optimization work was executed. Returned by uncapped
     /// runs on success, and by capped runs that executed what the planner
-    /// classified as the final round.
+    /// classified as the final round. `rounds_executed == 0` means the
+    /// wallet was already optimal — no work was performed.
     Completed { rounds_executed: u32 },
     /// A round ran but more rounds remain. Only emitted by capped runs;
     /// the caller should invoke [`LeafOptimizer::run`] again to continue.
     InProgress,
-    /// No optimization work was performed because the wallet was already
-    /// optimal at call time.
-    Skipped,
 }
 
 /// Errors returned by [`LeafOptimizer::run`].
@@ -269,9 +270,9 @@ impl LeafOptimizer {
     ///
     /// Returns:
     /// - [`OptimizationOutcome::Completed`] if all planned work was done
-    ///   (uncapped run, or capped run after the final round).
+    ///   (uncapped run, or capped run after the final round). A
+    ///   `rounds_executed` of `0` means no work was needed.
     /// - [`OptimizationOutcome::InProgress`] if a round ran but more remain.
-    /// - [`OptimizationOutcome::Skipped`] if no work was needed.
     ///
     /// Errors:
     /// - [`OptimizationError::AlreadyRunning`] if another run (auto or
@@ -442,16 +443,15 @@ impl LeafOptimizer {
             if emit_events {
                 self.emit_event(AutoOptimizationEvent::Skipped);
             }
-            Ok(OptimizationOutcome::Skipped)
         } else {
             info!("Leaf optimization completed successfully ({rounds_this_call} rounds executed)");
             if emit_events {
                 self.emit_event(AutoOptimizationEvent::Completed);
             }
-            Ok(OptimizationOutcome::Completed {
-                rounds_executed: rounds_this_call,
-            })
         }
+        Ok(OptimizationOutcome::Completed {
+            rounds_executed: rounds_this_call,
+        })
     }
 
     /// Cancels the ongoing optimization and waits for it to fully stop.

--- a/docs/breez-sdk/snippets/csharp/GettingStarted.cs
+++ b/docs/breez-sdk/snippets/csharp/GettingStarted.cs
@@ -94,8 +94,8 @@ namespace BreezSdkSnippets
                         var failedPayment = paymentFailedEvent.payment;
                         break;
 
-                    case SdkEvent.Optimization optimizationEvent:
-                        // An optimization event occurred
+                    case SdkEvent.AutoOptimization optimizationEvent:
+                        // An auto-optimization event occurred
                         var optimization = optimizationEvent.optimizationEvent;
                         break;
 

--- a/docs/breez-sdk/snippets/csharp/Optimize.cs
+++ b/docs/breez-sdk/snippets/csharp/Optimize.cs
@@ -12,10 +12,14 @@ namespace BreezSdkSnippets
             switch (outcome)
             {
                 case OptimizationOutcome.Completed { roundsExecuted: var roundsExecuted }:
-                    Console.WriteLine($"Optimization completed in {roundsExecuted} rounds");
-                    break;
-                case OptimizationOutcome.Skipped:
-                    Console.WriteLine("Optimization skipped — wallet already optimal");
+                    if (roundsExecuted == 0)
+                    {
+                        Console.WriteLine("Optimization skipped — wallet already optimal");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Optimization completed in {roundsExecuted} rounds");
+                    }
                     break;
                 case OptimizationOutcome.InProgress:
                     // Full mode runs to completion in one call, so InProgress is
@@ -41,12 +45,14 @@ namespace BreezSdkSnippets
                 else if (outcome is OptimizationOutcome.Completed { roundsExecuted: var n })
                 {
                     roundsExecuted += n;
-                    Console.WriteLine($"Optimization done after {roundsExecuted} rounds");
-                    break;
-                }
-                else if (outcome is OptimizationOutcome.Skipped)
-                {
-                    Console.WriteLine("Optimization skipped — wallet already optimal");
+                    if (roundsExecuted == 0)
+                    {
+                        Console.WriteLine("Optimization skipped — wallet already optimal");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Optimization done after {roundsExecuted} rounds");
+                    }
                     break;
                 }
             }

--- a/docs/breez-sdk/snippets/csharp/Optimize.cs
+++ b/docs/breez-sdk/snippets/csharp/Optimize.cs
@@ -4,55 +4,80 @@ namespace BreezSdkSnippets
 {
     class Optimize
     {
-        async Task StartOptimization(BreezSdk sdk)
+        async Task RunFullOptimization(BreezSdk sdk)
         {
-            // ANCHOR: start-optimization
-            await sdk.StartLeafOptimization();
-            // ANCHOR_END: start-optimization
+            // ANCHOR: optimize-leaves-full
+            var outcome = await sdk.OptimizeLeaves(null);
+
+            switch (outcome)
+            {
+                case OptimizationOutcome.Completed { roundsExecuted: var roundsExecuted }:
+                    Console.WriteLine($"Optimization completed in {roundsExecuted} rounds");
+                    break;
+                case OptimizationOutcome.Skipped:
+                    Console.WriteLine("Optimization skipped — wallet already optimal");
+                    break;
+                case OptimizationOutcome.InProgress:
+                    // Full mode runs to completion in one call, so InProgress is
+                    // not reachable here.
+                    throw new InvalidOperationException("Full mode never returns InProgress");
+            }
+            // ANCHOR_END: optimize-leaves-full
         }
 
-        async Task CancelOptimization(BreezSdk sdk)
+        async Task RunOptimizationOneRoundAtATime(BreezSdk sdk)
         {
-            // ANCHOR: cancel-optimization
-            await sdk.CancelLeafOptimization();
-            // ANCHOR_END: cancel-optimization
+            // ANCHOR: optimize-leaves-single-round
+            uint roundsExecuted = 0;
+            while (true)
+            {
+                var outcome = await sdk.OptimizeLeaves(new OptimizeLeavesOptions(OptimizationMode.SingleRound));
+
+                if (outcome is OptimizationOutcome.InProgress)
+                {
+                    roundsExecuted += 1;
+                    Console.WriteLine($"Executed round {roundsExecuted}");
+                }
+                else if (outcome is OptimizationOutcome.Completed { roundsExecuted: var n })
+                {
+                    roundsExecuted += n;
+                    Console.WriteLine($"Optimization done after {roundsExecuted} rounds");
+                    break;
+                }
+                else if (outcome is OptimizationOutcome.Skipped)
+                {
+                    Console.WriteLine("Optimization skipped — wallet already optimal");
+                    break;
+                }
+            }
+            // ANCHOR_END: optimize-leaves-single-round
         }
 
-        void GetOptimizationProgress(BreezSdk sdk)
+        void HandleAutoOptimizationEvent(AutoOptimizationEvent optimizationEvent)
         {
-            // ANCHOR: get-optimization-progress
-            var progress = sdk.GetLeafOptimizationProgress();
-
-            Console.WriteLine($"Optimization is running: {progress.isRunning}");
-            Console.WriteLine($"Current round: {progress.currentRound}");
-            Console.WriteLine($"Total rounds: {progress.totalRounds}");
-            // ANCHOR_END: get-optimization-progress
-        }
-
-        void OptimizationEvents(OptimizationEvent optimizationEvent)
-        {
-            // ANCHOR: optimization-events
+            // ANCHOR: auto-optimization-events
             switch (optimizationEvent)
             {
-                case OptimizationEvent.Started { totalRounds: var totalRounds }:
-                    Console.WriteLine($"Optimization started with {totalRounds} rounds");
+                case AutoOptimizationEvent.Started { totalRounds: var totalRounds }:
+                    Console.WriteLine($"Auto-optimization started with {totalRounds} rounds");
                     break;
-                case OptimizationEvent.RoundCompleted { currentRound: var currentRound, totalRounds: var totalRounds }:
-                    Console.WriteLine($"Optimization round {currentRound} of {totalRounds} completed");
+                case AutoOptimizationEvent.RoundCompleted { currentRound: var currentRound, totalRounds: var totalRounds }:
+                    Console.WriteLine($"Auto-optimization round {currentRound} of {totalRounds} completed");
                     break;
-                case OptimizationEvent.Completed:
-                    Console.WriteLine("Optimization completed successfully");
+                case AutoOptimizationEvent.Completed:
+                    Console.WriteLine("Auto-optimization completed successfully");
                     break;
-                case OptimizationEvent.Cancelled:
-                    Console.WriteLine("Optimization was cancelled");
+                case AutoOptimizationEvent.Cancelled:
+                    Console.WriteLine("Auto-optimization was cancelled");
                     break;
-                case OptimizationEvent.Failed { error: var error }:
-                    Console.WriteLine($"Optimization failed: {error}");
+                case AutoOptimizationEvent.Failed { error: var error }:
+                    Console.WriteLine($"Auto-optimization failed: {error}");
                     break;
-                case OptimizationEvent.Skipped:
-                    Console.WriteLine("Optimization was skipped because leaves are already optimal");
+                case AutoOptimizationEvent.Skipped:
+                    Console.WriteLine("Auto-optimization was skipped because leaves are already optimal");
                     break;
             }
+            // ANCHOR_END: auto-optimization-events
         }
     }
 }

--- a/docs/breez-sdk/snippets/csharp/Optimize.cs
+++ b/docs/breez-sdk/snippets/csharp/Optimize.cs
@@ -7,7 +7,7 @@ namespace BreezSdkSnippets
         async Task RunFullOptimization(BreezSdk sdk)
         {
             // ANCHOR: optimize-leaves-full
-            var outcome = await sdk.OptimizeLeaves(null);
+            var outcome = (await sdk.OptimizeLeaves(new OptimizeLeavesRequest(OptimizationMode.Full))).outcome;
 
             switch (outcome)
             {
@@ -35,7 +35,7 @@ namespace BreezSdkSnippets
             uint roundsExecuted = 0;
             while (true)
             {
-                var outcome = await sdk.OptimizeLeaves(new OptimizeLeavesOptions(OptimizationMode.SingleRound));
+                var outcome = (await sdk.OptimizeLeaves(new OptimizeLeavesRequest(OptimizationMode.SingleRound))).outcome;
 
                 if (outcome is OptimizationOutcome.InProgress)
                 {

--- a/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
@@ -142,8 +142,8 @@ class BreezSdkSpark {
           // A payment failed
           final _ = payment;
           break;
-        case SdkEvent_Optimization(:final optimizationEvent):
-          // An optimization event occurred
+        case SdkEvent_AutoOptimization(:final optimizationEvent):
+          // An auto-optimization event occurred
           final _ = optimizationEvent;
           break;
         case SdkEvent_LightningAddressChanged(:final lightningAddress):

--- a/docs/breez-sdk/snippets/flutter/lib/optimize.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/optimize.dart
@@ -6,10 +6,11 @@ Future<void> runFullOptimization(BreezSdk sdk) async {
 
   switch (outcome) {
     case OptimizationOutcome_Completed(:final roundsExecuted):
-      print("Optimization completed in $roundsExecuted rounds");
-      break;
-    case OptimizationOutcome_Skipped():
-      print("Optimization skipped — wallet already optimal");
+      if (roundsExecuted == 0) {
+        print("Optimization skipped — wallet already optimal");
+      } else {
+        print("Optimization completed in $roundsExecuted rounds");
+      }
       break;
     case OptimizationOutcome_InProgress():
       // Full mode runs to completion in one call, so InProgress is
@@ -32,10 +33,11 @@ Future<void> runOptimizationOneRoundAtATime(BreezSdk sdk) async {
         break;
       case OptimizationOutcome_Completed(roundsExecuted: var n):
         roundsExecuted += n;
-        print("Optimization done after $roundsExecuted rounds");
-        return;
-      case OptimizationOutcome_Skipped():
-        print("Optimization skipped — wallet already optimal");
+        if (roundsExecuted == 0) {
+          print("Optimization skipped — wallet already optimal");
+        } else {
+          print("Optimization done after $roundsExecuted rounds");
+        }
         return;
     }
   }

--- a/docs/breez-sdk/snippets/flutter/lib/optimize.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/optimize.dart
@@ -1,47 +1,68 @@
 import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
 
-Future<void> startOptimization(BreezSdk sdk) async {
-  // ANCHOR: start-optimization
-  await sdk.startLeafOptimization();
-  // ANCHOR_END: start-optimization
+Future<void> runFullOptimization(BreezSdk sdk) async {
+  // ANCHOR: optimize-leaves-full
+  final outcome = await sdk.optimizeLeaves();
+
+  switch (outcome) {
+    case OptimizationOutcome_Completed(:final roundsExecuted):
+      print("Optimization completed in $roundsExecuted rounds");
+      break;
+    case OptimizationOutcome_Skipped():
+      print("Optimization skipped — wallet already optimal");
+      break;
+    case OptimizationOutcome_InProgress():
+      // Full mode runs to completion in one call, so InProgress is
+      // not reachable here.
+      throw StateError("Full mode never returns InProgress");
+  }
+  // ANCHOR_END: optimize-leaves-full
 }
 
-Future<void> cancelOptimization(BreezSdk sdk) async {
-  // ANCHOR: cancel-optimization
-  await sdk.cancelLeafOptimization();
-  // ANCHOR_END: cancel-optimization
+Future<void> runOptimizationOneRoundAtATime(BreezSdk sdk) async {
+  // ANCHOR: optimize-leaves-single-round
+  var roundsExecuted = 0;
+  while (true) {
+    final outcome = await sdk.optimizeLeaves(
+        options: OptimizeLeavesOptions(mode: OptimizationMode.singleRound));
+    switch (outcome) {
+      case OptimizationOutcome_InProgress():
+        roundsExecuted += 1;
+        print("Executed round $roundsExecuted");
+        break;
+      case OptimizationOutcome_Completed(roundsExecuted: var n):
+        roundsExecuted += n;
+        print("Optimization done after $roundsExecuted rounds");
+        return;
+      case OptimizationOutcome_Skipped():
+        print("Optimization skipped — wallet already optimal");
+        return;
+    }
+  }
+  // ANCHOR_END: optimize-leaves-single-round
 }
 
-Future<void> getOptimizationProgress(BreezSdk sdk) async {
-  // ANCHOR: get-optimization-progress
-  var progress = sdk.getLeafOptimizationProgress();
-
-  print("Optimization is running: ${progress.isRunning}");
-  print("Current round: ${progress.currentRound}");
-  print("Total rounds: ${progress.totalRounds}");
-  // ANCHOR_END: get-optimization-progress
-}
-
-void optimizationEvents(OptimizationEvent optimizationEvent) {
-  // ANCHOR: optimization-events
+void handleAutoOptimizationEvent(AutoOptimizationEvent optimizationEvent) {
+  // ANCHOR: auto-optimization-events
   switch (optimizationEvent) {
-    case OptimizationEvent_Started(totalRounds: var totalRounds):
-      print("Optimization started with $totalRounds rounds");
+    case AutoOptimizationEvent_Started(totalRounds: var totalRounds):
+      print("Auto-optimization started with $totalRounds rounds");
       break;
-    case OptimizationEvent_RoundCompleted(currentRound: var currentRound, totalRounds: var totalRounds):
-      print("Optimization round $currentRound of $totalRounds completed");
+    case AutoOptimizationEvent_RoundCompleted(currentRound: var currentRound, totalRounds: var totalRounds):
+      print("Auto-optimization round $currentRound of $totalRounds completed");
       break;
-    case OptimizationEvent_Completed():
-      print("Optimization completed successfully");
+    case AutoOptimizationEvent_Completed():
+      print("Auto-optimization completed successfully");
       break;
-    case OptimizationEvent_Cancelled():
-      print("Optimization was cancelled");
+    case AutoOptimizationEvent_Cancelled():
+      print("Auto-optimization was cancelled");
       break;
-    case OptimizationEvent_Failed(error: var error):
-      print("Optimization failed: $error");
+    case AutoOptimizationEvent_Failed(error: var error):
+      print("Auto-optimization failed: $error");
       break;
-    case OptimizationEvent_Skipped():
-      print("Optimization was skipped because leaves are already optimal");
+    case AutoOptimizationEvent_Skipped():
+      print("Auto-optimization was skipped because leaves are already optimal");
       break;
   }
+  // ANCHOR_END: auto-optimization-events
 }

--- a/docs/breez-sdk/snippets/flutter/lib/optimize.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/optimize.dart
@@ -2,7 +2,7 @@ import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
 
 Future<void> runFullOptimization(BreezSdk sdk) async {
   // ANCHOR: optimize-leaves-full
-  final outcome = await sdk.optimizeLeaves();
+  final outcome = (await sdk.optimizeLeaves(request: OptimizeLeavesRequest(mode: OptimizationMode.full))).outcome;
 
   switch (outcome) {
     case OptimizationOutcome_Completed(:final roundsExecuted):
@@ -24,8 +24,8 @@ Future<void> runOptimizationOneRoundAtATime(BreezSdk sdk) async {
   // ANCHOR: optimize-leaves-single-round
   var roundsExecuted = 0;
   while (true) {
-    final outcome = await sdk.optimizeLeaves(
-        options: OptimizeLeavesOptions(mode: OptimizationMode.singleRound));
+    final outcome = (await sdk.optimizeLeaves(
+        request: OptimizeLeavesRequest(mode: OptimizationMode.singleRound))).outcome;
     switch (outcome) {
       case OptimizationOutcome_InProgress():
         roundsExecuted += 1;

--- a/docs/breez-sdk/snippets/go/getting_started.go
+++ b/docs/breez-sdk/snippets/go/getting_started.go
@@ -105,8 +105,8 @@ func (SdkListener) OnEvent(e breez_sdk_spark.SdkEvent) {
 		// A payment failed
 		failedPayment := event.Payment
 		_ = failedPayment
-	case breez_sdk_spark.SdkEventOptimization:
-		// An optimization event occurred
+	case breez_sdk_spark.SdkEventAutoOptimization:
+		// An auto-optimization event occurred
 		optimizationEvent := event.OptimizationEvent
 		_ = optimizationEvent
 	case breez_sdk_spark.SdkEventLightningAddressChanged:

--- a/docs/breez-sdk/snippets/go/optimize.go
+++ b/docs/breez-sdk/snippets/go/optimize.go
@@ -9,7 +9,7 @@ import (
 
 func RunFullOptimization(sdk *breez_sdk_spark.BreezSdk) error {
 	// ANCHOR: optimize-leaves-full
-	outcome, err := sdk.OptimizeLeaves(nil)
+	response, err := sdk.OptimizeLeaves(breez_sdk_spark.OptimizeLeavesRequest{Mode: breez_sdk_spark.OptimizationModeFull})
 	if err != nil {
 		var sdkErr *breez_sdk_spark.SdkError
 		if errors.As(err, &sdkErr) {
@@ -18,7 +18,7 @@ func RunFullOptimization(sdk *breez_sdk_spark.BreezSdk) error {
 		return err
 	}
 
-	switch o := outcome.(type) {
+	switch o := response.Outcome.(type) {
 	case breez_sdk_spark.OptimizationOutcomeCompleted:
 		if o.RoundsExecuted == 0 {
 			log.Printf("Optimization skipped — wallet already optimal")
@@ -38,7 +38,7 @@ func RunOptimizationOneRoundAtATime(sdk *breez_sdk_spark.BreezSdk) error {
 	// ANCHOR: optimize-leaves-single-round
 	var roundsExecuted uint32 = 0
 	for {
-		outcome, err := sdk.OptimizeLeaves(&breez_sdk_spark.OptimizeLeavesOptions{
+		response, err := sdk.OptimizeLeaves(breez_sdk_spark.OptimizeLeavesRequest{
 			Mode: breez_sdk_spark.OptimizationModeSingleRound,
 		})
 		if err != nil {
@@ -49,7 +49,7 @@ func RunOptimizationOneRoundAtATime(sdk *breez_sdk_spark.BreezSdk) error {
 			return err
 		}
 
-		switch o := outcome.(type) {
+		switch o := response.Outcome.(type) {
 		case breez_sdk_spark.OptimizationOutcomeInProgress:
 			roundsExecuted += 1
 			log.Printf("Executed round %v", roundsExecuted)

--- a/docs/breez-sdk/snippets/go/optimize.go
+++ b/docs/breez-sdk/snippets/go/optimize.go
@@ -20,9 +20,11 @@ func RunFullOptimization(sdk *breez_sdk_spark.BreezSdk) error {
 
 	switch o := outcome.(type) {
 	case breez_sdk_spark.OptimizationOutcomeCompleted:
-		log.Printf("Optimization completed in %v rounds", o.RoundsExecuted)
-	case breez_sdk_spark.OptimizationOutcomeSkipped:
-		log.Printf("Optimization skipped — wallet already optimal")
+		if o.RoundsExecuted == 0 {
+			log.Printf("Optimization skipped — wallet already optimal")
+		} else {
+			log.Printf("Optimization completed in %v rounds", o.RoundsExecuted)
+		}
 	case breez_sdk_spark.OptimizationOutcomeInProgress:
 		// Full mode runs to completion in one call, so InProgress is
 		// not reachable here.
@@ -53,10 +55,11 @@ func RunOptimizationOneRoundAtATime(sdk *breez_sdk_spark.BreezSdk) error {
 			log.Printf("Executed round %v", roundsExecuted)
 		case breez_sdk_spark.OptimizationOutcomeCompleted:
 			roundsExecuted += o.RoundsExecuted
-			log.Printf("Optimization done after %v rounds", roundsExecuted)
-			return nil
-		case breez_sdk_spark.OptimizationOutcomeSkipped:
-			log.Printf("Optimization skipped — wallet already optimal")
+			if roundsExecuted == 0 {
+				log.Printf("Optimization skipped — wallet already optimal")
+			} else {
+				log.Printf("Optimization done after %v rounds", roundsExecuted)
+			}
 			return nil
 		}
 	}

--- a/docs/breez-sdk/snippets/go/optimize.go
+++ b/docs/breez-sdk/snippets/go/optimize.go
@@ -7,53 +7,77 @@ import (
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 )
 
-func StartOptimization(sdk *breez_sdk_spark.BreezSdk) {
-	// ANCHOR: start-optimization
-	sdk.StartLeafOptimization()
-	// ANCHOR_END: start-optimization
-}
-
-func CancelOptimization(sdk *breez_sdk_spark.BreezSdk) error {
-	// ANCHOR: cancel-optimization
-	err := sdk.CancelLeafOptimization()
+func RunFullOptimization(sdk *breez_sdk_spark.BreezSdk) error {
+	// ANCHOR: optimize-leaves-full
+	outcome, err := sdk.OptimizeLeaves(nil)
 	if err != nil {
 		var sdkErr *breez_sdk_spark.SdkError
 		if errors.As(err, &sdkErr) {
 			// Handle SdkError - can inspect specific variants if needed
-			// e.g., switch on sdkErr variant for InsufficientFunds, NetworkError, etc.
 		}
 		return err
 	}
-	// ANCHOR_END: cancel-optimization
-	return nil
-}
 
-func GetOptimizationProgress(sdk *breez_sdk_spark.BreezSdk) error {
-	// ANCHOR: get-optimization-progress
-	progress := sdk.GetLeafOptimizationProgress()
-
-	log.Printf("Optimization is running: %v\n", progress.IsRunning)
-	log.Printf("Current round: %v\n", progress.CurrentRound)
-	log.Printf("Total rounds: %v\n", progress.TotalRounds)
-	// ANCHOR_END: get-optimization-progress
-	return nil
-}
-
-func OptimizationEvents(optimizationEvent breez_sdk_spark.OptimizationEvent) {
-	// ANCHOR: optimization-events
-	switch event := optimizationEvent.(type) {
-	case breez_sdk_spark.OptimizationEventStarted:
-		log.Printf("Optimization started with %v rounds\n", event.TotalRounds)
-	case breez_sdk_spark.OptimizationEventRoundCompleted:
-		log.Printf("Optimization round %v of %v completed\n", event.CurrentRound, event.TotalRounds)
-	case breez_sdk_spark.OptimizationEventCompleted:
-		log.Printf("Optimization completed successfully\n")
-	case breez_sdk_spark.OptimizationEventCancelled:
-		log.Printf("Optimization was cancelled\n")
-	case breez_sdk_spark.OptimizationEventFailed:
-		log.Printf("Optimization failed: %v\n", event.Error)
-	case breez_sdk_spark.OptimizationEventSkipped:
-		log.Printf("Optimization was skipped because leaves are already optimal\n")
+	switch o := outcome.(type) {
+	case breez_sdk_spark.OptimizationOutcomeCompleted:
+		log.Printf("Optimization completed in %v rounds", o.RoundsExecuted)
+	case breez_sdk_spark.OptimizationOutcomeSkipped:
+		log.Printf("Optimization skipped — wallet already optimal")
+	case breez_sdk_spark.OptimizationOutcomeInProgress:
+		// Full mode runs to completion in one call, so InProgress is
+		// not reachable here.
+		log.Panicf("Full mode never returns InProgress")
 	}
-	// ANCHOR_END: optimization-events
+	// ANCHOR_END: optimize-leaves-full
+	return nil
+}
+
+func RunOptimizationOneRoundAtATime(sdk *breez_sdk_spark.BreezSdk) error {
+	// ANCHOR: optimize-leaves-single-round
+	var roundsExecuted uint32 = 0
+	for {
+		outcome, err := sdk.OptimizeLeaves(&breez_sdk_spark.OptimizeLeavesOptions{
+			Mode: breez_sdk_spark.OptimizationModeSingleRound,
+		})
+		if err != nil {
+			var sdkErr *breez_sdk_spark.SdkError
+			if errors.As(err, &sdkErr) {
+				// Handle SdkError - can inspect specific variants if needed
+			}
+			return err
+		}
+
+		switch o := outcome.(type) {
+		case breez_sdk_spark.OptimizationOutcomeInProgress:
+			roundsExecuted += 1
+			log.Printf("Executed round %v", roundsExecuted)
+		case breez_sdk_spark.OptimizationOutcomeCompleted:
+			roundsExecuted += o.RoundsExecuted
+			log.Printf("Optimization done after %v rounds", roundsExecuted)
+			return nil
+		case breez_sdk_spark.OptimizationOutcomeSkipped:
+			log.Printf("Optimization skipped — wallet already optimal")
+			return nil
+		}
+	}
+	// ANCHOR_END: optimize-leaves-single-round
+}
+
+func HandleAutoOptimizationEvent(optimizationEvent breez_sdk_spark.AutoOptimizationEvent) {
+	// ANCHOR: auto-optimization-events
+	switch event := optimizationEvent.(type) {
+	case breez_sdk_spark.AutoOptimizationEventStarted:
+		log.Printf("Auto-optimization started with %v rounds", event.TotalRounds)
+	case breez_sdk_spark.AutoOptimizationEventRoundCompleted:
+		log.Printf("Auto-optimization round %v of %v completed", event.CurrentRound, event.TotalRounds)
+	case breez_sdk_spark.AutoOptimizationEventCompleted:
+		log.Printf("Auto-optimization completed successfully")
+	case breez_sdk_spark.AutoOptimizationEventCancelled:
+		log.Printf("Auto-optimization was cancelled")
+	case breez_sdk_spark.AutoOptimizationEventFailed:
+		log.Printf("Auto-optimization failed: %v", event.Error)
+	case breez_sdk_spark.AutoOptimizationEventSkipped:
+		log.Printf("Auto-optimization was skipped because leaves are already optimal")
+	}
+	// ANCHOR_END: auto-optimization-events
 }

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
@@ -87,8 +87,8 @@ class GettingStarted {
                     // A payment failed
                     val failedPayment = e.payment
                 }
-                is SdkEvent.Optimization -> {
-                    // An optimization event occurred
+                is SdkEvent.AutoOptimization -> {
+                    // An auto-optimization event occurred
                     val optimizationEvent = e.optimizationEvent
                 }
                 is SdkEvent.LightningAddressChanged -> {

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Optimize.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Optimize.kt
@@ -5,7 +5,7 @@ import breez_sdk_spark.*
 class Optimize {
     suspend fun runFullOptimization(sdk: BreezSdk) {
         // ANCHOR: optimize-leaves-full
-        val outcome = sdk.optimizeLeaves(null)
+        val outcome = sdk.optimizeLeaves(OptimizeLeavesRequest(mode = OptimizationMode.FULL)).outcome
 
         when (outcome) {
             is OptimizationOutcome.Completed -> {
@@ -28,7 +28,7 @@ class Optimize {
         // ANCHOR: optimize-leaves-single-round
         var roundsExecuted: UInt = 0u
         while (true) {
-            val outcome = sdk.optimizeLeaves(OptimizeLeavesOptions(mode = OptimizationMode.SINGLE_ROUND))
+            val outcome = sdk.optimizeLeaves(OptimizeLeavesRequest(mode = OptimizationMode.SINGLE_ROUND)).outcome
             when (outcome) {
                 is OptimizationOutcome.InProgress -> {
                     roundsExecuted += 1u

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Optimize.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Optimize.kt
@@ -3,54 +3,72 @@ package com.example.kotlinmpplib
 import breez_sdk_spark.*
 
 class Optimize {
-    suspend fun startOptimization(sdk: BreezSdk) {
-        // ANCHOR: start-optimization
-        sdk.startLeafOptimization()
-        // ANCHOR_END: start-optimization
-    }
+    suspend fun runFullOptimization(sdk: BreezSdk) {
+        // ANCHOR: optimize-leaves-full
+        val outcome = sdk.optimizeLeaves(null)
 
-    suspend fun cancelOptimization(sdk: BreezSdk) {
-        // ANCHOR: cancel-optimization
-        try {
-            sdk.cancelLeafOptimization()
-        } catch (e: Exception) {
-            // handle error
+        when (outcome) {
+            is OptimizationOutcome.Completed -> {
+                // Log.v("Breez", "Optimization completed in ${outcome.roundsExecuted} rounds")
+            }
+            is OptimizationOutcome.Skipped -> {
+                // Log.v("Breez", "Optimization skipped — wallet already optimal")
+            }
+            is OptimizationOutcome.InProgress -> {
+                // Full mode runs to completion in one call, so InProgress is
+                // not reachable here.
+                throw IllegalStateException("Full mode never returns InProgress")
+            }
         }
-        // ANCHOR_END: cancel-optimization
+        // ANCHOR_END: optimize-leaves-full
     }
 
-    fun getOptimizationProgress(sdk: BreezSdk) {
-        // ANCHOR: get-optimization-progress
-        val progress = sdk.getLeafOptimizationProgress()
-
-        println("Optimization is running: ${progress.isRunning}")
-        println("Current round: ${progress.currentRound}")
-        println("Total rounds: ${progress.totalRounds}")
-        // ANCHOR_END: get-optimization-progress
+    suspend fun runOptimizationOneRoundAtATime(sdk: BreezSdk) {
+        // ANCHOR: optimize-leaves-single-round
+        var roundsExecuted: UInt = 0u
+        while (true) {
+            val outcome = sdk.optimizeLeaves(OptimizeLeavesOptions(mode = OptimizationMode.SINGLE_ROUND))
+            when (outcome) {
+                is OptimizationOutcome.InProgress -> {
+                    roundsExecuted += 1u
+                    // Log.v("Breez", "Executed round $roundsExecuted")
+                }
+                is OptimizationOutcome.Completed -> {
+                    roundsExecuted += outcome.roundsExecuted
+                    // Log.v("Breez", "Optimization done after $roundsExecuted rounds")
+                    break
+                }
+                is OptimizationOutcome.Skipped -> {
+                    // Log.v("Breez", "Optimization skipped — wallet already optimal")
+                    break
+                }
+            }
+        }
+        // ANCHOR_END: optimize-leaves-single-round
     }
 
-    fun optimizationEvents(optimizationEvent: OptimizationEvent) {
-        // ANCHOR: optimization-events
+    fun handleAutoOptimizationEvent(optimizationEvent: AutoOptimizationEvent) {
+        // ANCHOR: auto-optimization-events
         when (optimizationEvent) {
-            is OptimizationEvent.Started -> {
-                // Log.v("Breez", "Optimization started with ${optimizationEvent.totalRounds} rounds")
+            is AutoOptimizationEvent.Started -> {
+                // Log.v("Breez", "Auto-optimization started with ${optimizationEvent.totalRounds} rounds")
             }
-            is OptimizationEvent.RoundCompleted -> {
-                // Log.v("Breez", "Optimization round ${optimizationEvent.currentRound} of ${optimizationEvent.totalRounds} completed")
+            is AutoOptimizationEvent.RoundCompleted -> {
+                // Log.v("Breez", "Auto-optimization round ${optimizationEvent.currentRound} of ${optimizationEvent.totalRounds} completed")
             }
-            is OptimizationEvent.Completed -> {
-                // Log.v("Breez", "Optimization completed successfully")
+            is AutoOptimizationEvent.Completed -> {
+                // Log.v("Breez", "Auto-optimization completed successfully")
             }
-            is OptimizationEvent.Cancelled -> {
-                // Log.v("Breez", "Optimization was cancelled")
+            is AutoOptimizationEvent.Cancelled -> {
+                // Log.v("Breez", "Auto-optimization was cancelled")
             }
-            is OptimizationEvent.Failed -> {
-                // Log.v("Breez", "Optimization failed: ${optimizationEvent.error}")
+            is AutoOptimizationEvent.Failed -> {
+                // Log.v("Breez", "Auto-optimization failed: ${optimizationEvent.error}")
             }
-            is OptimizationEvent.Skipped -> {
-                // Log.v("Breez", "Optimization was skipped because leaves are already optimal")
+            is AutoOptimizationEvent.Skipped -> {
+                // Log.v("Breez", "Auto-optimization was skipped because leaves are already optimal")
             }
         }
-        // ANCHOR_END: optimization-events
+        // ANCHOR_END: auto-optimization-events
     }
 }

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Optimize.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Optimize.kt
@@ -9,10 +9,11 @@ class Optimize {
 
         when (outcome) {
             is OptimizationOutcome.Completed -> {
-                // Log.v("Breez", "Optimization completed in ${outcome.roundsExecuted} rounds")
-            }
-            is OptimizationOutcome.Skipped -> {
-                // Log.v("Breez", "Optimization skipped — wallet already optimal")
+                if (outcome.roundsExecuted == 0u) {
+                    // Log.v("Breez", "Optimization skipped — wallet already optimal")
+                } else {
+                    // Log.v("Breez", "Optimization completed in ${outcome.roundsExecuted} rounds")
+                }
             }
             is OptimizationOutcome.InProgress -> {
                 // Full mode runs to completion in one call, so InProgress is
@@ -35,11 +36,11 @@ class Optimize {
                 }
                 is OptimizationOutcome.Completed -> {
                     roundsExecuted += outcome.roundsExecuted
-                    // Log.v("Breez", "Optimization done after $roundsExecuted rounds")
-                    break
-                }
-                is OptimizationOutcome.Skipped -> {
-                    // Log.v("Breez", "Optimization skipped — wallet already optimal")
+                    if (roundsExecuted == 0u) {
+                        // Log.v("Breez", "Optimization skipped — wallet already optimal")
+                    } else {
+                        // Log.v("Breez", "Optimization done after $roundsExecuted rounds")
+                    }
                     break
                 }
             }

--- a/docs/breez-sdk/snippets/python/src/getting_started.py
+++ b/docs/breez-sdk/snippets/python/src/getting_started.py
@@ -93,8 +93,8 @@ class SdkListener(EventListener):
         elif isinstance(event, SdkEvent.PAYMENT_FAILED):
             # A payment failed
             failed_payment = event.payment
-        elif isinstance(event, SdkEvent.OPTIMIZATION):
-            # An optimization event occurred
+        elif isinstance(event, SdkEvent.AUTO_OPTIMIZATION):
+            # An auto-optimization event occurred
             optimization_event = event.optimization_event
         elif isinstance(event, SdkEvent.LIGHTNING_ADDRESS_CHANGED):
             # The lightning address has changed

--- a/docs/breez-sdk/snippets/python/src/optimize.py
+++ b/docs/breez-sdk/snippets/python/src/optimize.py
@@ -12,9 +12,10 @@ async def run_full_optimization(sdk: BreezSdk):
     outcome = await sdk.optimize_leaves(None)
 
     if isinstance(outcome, OptimizationOutcome.COMPLETED):
-        logging.debug(f"Optimization completed in {outcome.rounds_executed} rounds")
-    elif isinstance(outcome, OptimizationOutcome.SKIPPED):
-        logging.debug("Optimization skipped — wallet already optimal")
+        if outcome.rounds_executed == 0:
+            logging.debug("Optimization skipped — wallet already optimal")
+        else:
+            logging.debug(f"Optimization completed in {outcome.rounds_executed} rounds")
     elif isinstance(outcome, OptimizationOutcome.IN_PROGRESS):
         raise AssertionError("Full mode never returns IN_PROGRESS")
     # ANCHOR_END: optimize-leaves-full
@@ -31,10 +32,10 @@ async def run_optimization_one_round_at_a_time(sdk: BreezSdk):
             logging.debug(f"Executed round {rounds_executed}")
         elif isinstance(outcome, OptimizationOutcome.COMPLETED):
             rounds_executed += outcome.rounds_executed
-            logging.debug(f"Optimization done after {rounds_executed} rounds")
-            break
-        elif isinstance(outcome, OptimizationOutcome.SKIPPED):
-            logging.debug("Optimization skipped — wallet already optimal")
+            if rounds_executed == 0:
+                logging.debug("Optimization skipped — wallet already optimal")
+            else:
+                logging.debug(f"Optimization done after {rounds_executed} rounds")
             break
     # ANCHOR_END: optimize-leaves-single-round
 

--- a/docs/breez-sdk/snippets/python/src/optimize.py
+++ b/docs/breez-sdk/snippets/python/src/optimize.py
@@ -4,12 +4,13 @@ from breez_sdk_spark import (
     AutoOptimizationEvent,
     OptimizationMode,
     OptimizationOutcome,
-    OptimizeLeavesOptions,
+    OptimizeLeavesRequest,
 )
 
 async def run_full_optimization(sdk: BreezSdk):
     # ANCHOR: optimize-leaves-full
-    outcome = await sdk.optimize_leaves(None)
+    response = await sdk.optimize_leaves(OptimizeLeavesRequest(mode=OptimizationMode.FULL))
+    outcome = response.outcome
 
     if isinstance(outcome, OptimizationOutcome.COMPLETED):
         if outcome.rounds_executed == 0:
@@ -24,9 +25,10 @@ async def run_optimization_one_round_at_a_time(sdk: BreezSdk):
     # ANCHOR: optimize-leaves-single-round
     rounds_executed = 0
     while True:
-        outcome = await sdk.optimize_leaves(
-            OptimizeLeavesOptions(mode=OptimizationMode.SINGLE_ROUND)
+        response = await sdk.optimize_leaves(
+            OptimizeLeavesRequest(mode=OptimizationMode.SINGLE_ROUND)
         )
+        outcome = response.outcome
         if isinstance(outcome, OptimizationOutcome.IN_PROGRESS):
             rounds_executed += 1
             logging.debug(f"Executed round {rounds_executed}")

--- a/docs/breez-sdk/snippets/python/src/optimize.py
+++ b/docs/breez-sdk/snippets/python/src/optimize.py
@@ -1,38 +1,56 @@
 import logging
-from breez_sdk_spark import BreezSdk, OptimizationEvent
+from breez_sdk_spark import (
+    BreezSdk,
+    AutoOptimizationEvent,
+    OptimizationMode,
+    OptimizationOutcome,
+    OptimizeLeavesOptions,
+)
 
-async def start_optimization(sdk: BreezSdk):
-    # ANCHOR: start-optimization
-    await sdk.start_leaf_optimization()
-    # ANCHOR_END: start-optimization
+async def run_full_optimization(sdk: BreezSdk):
+    # ANCHOR: optimize-leaves-full
+    outcome = await sdk.optimize_leaves(None)
 
-async def cancel_optimization(sdk: BreezSdk):
-    # ANCHOR: cancel-optimization
-    await sdk.cancel_leaf_optimization()
-    # ANCHOR_END: cancel-optimization
+    if isinstance(outcome, OptimizationOutcome.COMPLETED):
+        logging.debug(f"Optimization completed in {outcome.rounds_executed} rounds")
+    elif isinstance(outcome, OptimizationOutcome.SKIPPED):
+        logging.debug("Optimization skipped — wallet already optimal")
+    elif isinstance(outcome, OptimizationOutcome.IN_PROGRESS):
+        raise AssertionError("Full mode never returns IN_PROGRESS")
+    # ANCHOR_END: optimize-leaves-full
 
-async def get_optimization_progress(sdk: BreezSdk):
-    # ANCHOR: get-optimization-progress
-    progress = sdk.get_leaf_optimization_progress()
+async def run_optimization_one_round_at_a_time(sdk: BreezSdk):
+    # ANCHOR: optimize-leaves-single-round
+    rounds_executed = 0
+    while True:
+        outcome = await sdk.optimize_leaves(
+            OptimizeLeavesOptions(mode=OptimizationMode.SINGLE_ROUND)
+        )
+        if isinstance(outcome, OptimizationOutcome.IN_PROGRESS):
+            rounds_executed += 1
+            logging.debug(f"Executed round {rounds_executed}")
+        elif isinstance(outcome, OptimizationOutcome.COMPLETED):
+            rounds_executed += outcome.rounds_executed
+            logging.debug(f"Optimization done after {rounds_executed} rounds")
+            break
+        elif isinstance(outcome, OptimizationOutcome.SKIPPED):
+            logging.debug("Optimization skipped — wallet already optimal")
+            break
+    # ANCHOR_END: optimize-leaves-single-round
 
-    logging.debug(f"Optimization is running: {progress.is_running}")
-    logging.debug(f"Current round: {progress.current_round}")
-    logging.debug(f"Total rounds: {progress.total_rounds}")
-    # ANCHOR_END: get-optimization-progress
-
-def optimization_events(optimization_event: OptimizationEvent):
-    # ANCHOR: optimization-events
-    if isinstance(optimization_event, OptimizationEvent.STARTED):
-        logging.debug(f"Optimization started with {optimization_event.total_rounds} rounds")
-    elif isinstance(optimization_event, OptimizationEvent.ROUND_COMPLETED):
-        logging.debug(f"Optimization round {optimization_event.current_round} of "
-            f"{optimization_event.total_rounds} completed")
-    elif isinstance(optimization_event, OptimizationEvent.COMPLETED):
-        logging.debug("Optimization completed successfully")
-    elif isinstance(optimization_event, OptimizationEvent.CANCELLED):
-        logging.debug("Optimization was cancelled")
-    elif isinstance(optimization_event, OptimizationEvent.FAILED):
-        logging.debug(f"Optimization failed: {optimization_event.error}")
-    elif isinstance(optimization_event, OptimizationEvent.SKIPPED):
-        logging.debug("Optimization was skipped because leaves are already optimal")
-    # ANCHOR_END: optimization-events
+def handle_auto_optimization_event(event: AutoOptimizationEvent):
+    # ANCHOR: auto-optimization-events
+    if isinstance(event, AutoOptimizationEvent.STARTED):
+        logging.debug(f"Auto-optimization started with {event.total_rounds} rounds")
+    elif isinstance(event, AutoOptimizationEvent.ROUND_COMPLETED):
+        logging.debug(f"Auto-optimization round {event.current_round} of "
+            f"{event.total_rounds} completed")
+    elif isinstance(event, AutoOptimizationEvent.COMPLETED):
+        logging.debug("Auto-optimization completed successfully")
+    elif isinstance(event, AutoOptimizationEvent.CANCELLED):
+        logging.debug("Auto-optimization was cancelled")
+    elif isinstance(event, AutoOptimizationEvent.FAILED):
+        logging.debug(f"Auto-optimization failed: {event.error}")
+    elif isinstance(event, AutoOptimizationEvent.SKIPPED):
+        logging.debug("Auto-optimization was skipped because leaves are already optimal")
+    # ANCHOR_END: auto-optimization-events

--- a/docs/breez-sdk/snippets/react-native/getting_started.ts
+++ b/docs/breez-sdk/snippets/react-native/getting_started.ts
@@ -82,8 +82,8 @@ const exampleAddEventListener = async (sdk: BreezSdk) => {
       } else if (event.tag === SdkEvent_Tags.PaymentFailed) {
         // A payment failed
         const failedPayment = event.inner.payment
-      } else if (event.tag === SdkEvent_Tags.Optimization) {
-        // An optimization event occurred
+      } else if (event.tag === SdkEvent_Tags.AutoOptimization) {
+        // An auto-optimization event occurred
         const optimizationEvent = event.inner.optimizationEvent
       } else if (event.tag === SdkEvent_Tags.LightningAddressChanged) {
         // The lightning address has changed

--- a/docs/breez-sdk/snippets/react-native/optimize.ts
+++ b/docs/breez-sdk/snippets/react-native/optimize.ts
@@ -2,7 +2,7 @@ import { type AutoOptimizationEvent, AutoOptimizationEvent_Tags, OptimizationMod
 
 const exampleOptimizeLeavesFull = async (sdk: BreezSdk) => {
   // ANCHOR: optimize-leaves-full
-  const outcome = await sdk.optimizeLeaves(undefined)
+  const outcome = (await sdk.optimizeLeaves({ mode: OptimizationMode.Full })).outcome
 
   if (outcome.tag === OptimizationOutcome_Tags.Completed) {
     if (outcome.inner.roundsExecuted === 0) {
@@ -21,7 +21,7 @@ const exampleOptimizeLeavesSingleRound = async (sdk: BreezSdk) => {
   // ANCHOR: optimize-leaves-single-round
   let roundsExecuted = 0
   while (true) {
-    const outcome: OptimizationOutcome = await sdk.optimizeLeaves({ mode: OptimizationMode.SingleRound })
+    const outcome: OptimizationOutcome = (await sdk.optimizeLeaves({ mode: OptimizationMode.SingleRound })).outcome
 
     if (outcome.tag === OptimizationOutcome_Tags.InProgress) {
       roundsExecuted += 1

--- a/docs/breez-sdk/snippets/react-native/optimize.ts
+++ b/docs/breez-sdk/snippets/react-native/optimize.ts
@@ -1,41 +1,55 @@
-import { type OptimizationEvent, OptimizationEvent_Tags, type BreezSdk } from '@breeztech/breez-sdk-spark-react-native'
+import { type AutoOptimizationEvent, AutoOptimizationEvent_Tags, OptimizationMode, type OptimizationOutcome, OptimizationOutcome_Tags, type BreezSdk } from '@breeztech/breez-sdk-spark-react-native'
 
-const exampleStartOptimization = async (sdk: BreezSdk) => {
-  // ANCHOR: start-optimization
-  await sdk.startLeafOptimization()
-  // ANCHOR_END: start-optimization
-}
+const exampleOptimizeLeavesFull = async (sdk: BreezSdk) => {
+  // ANCHOR: optimize-leaves-full
+  const outcome = await sdk.optimizeLeaves(undefined)
 
-const exampleCancelOptimization = async (sdk: BreezSdk) => {
-  // ANCHOR: cancel-optimization
-  await sdk.cancelLeafOptimization()
-  // ANCHOR_END: cancel-optimization
-}
-
-const exampleGetOptimizationProgress = async (sdk: BreezSdk) => {
-  // ANCHOR: get-optimization-progress
-  const progress = sdk.getLeafOptimizationProgress()
-
-  console.log(`Optimization is running: ${progress.isRunning}`)
-  console.log(`Current round: ${progress.currentRound}`)
-  console.log(`Total rounds: ${progress.totalRounds}`)
-  // ANCHOR_END: get-optimization-progress
-}
-
-const exampleOptimizationEvents = async (optimizationEvent: OptimizationEvent) => {
-  // ANCHOR: optimization-events
-  if (optimizationEvent.tag === OptimizationEvent_Tags.Started) {
-    console.log(`Optimization started with ${optimizationEvent.inner.totalRounds} rounds`)
-  } else if (optimizationEvent.tag === OptimizationEvent_Tags.RoundCompleted) {
-    console.log(`Optimization round ${optimizationEvent.inner.currentRound} of ${optimizationEvent.inner.totalRounds} completed`)
-  } else if (optimizationEvent.tag === OptimizationEvent_Tags.Completed) {
-    console.log('Optimization completed successfully')
-  } else if (optimizationEvent.tag === OptimizationEvent_Tags.Cancelled) {
-    console.log('Optimization was cancelled')
-  } else if (optimizationEvent.tag === OptimizationEvent_Tags.Failed) {
-    console.log(`Optimization failed: ${optimizationEvent.inner.error}`)
-  } else if (optimizationEvent.tag === OptimizationEvent_Tags.Skipped) {
-    console.log('Optimization was skipped because leaves are already optimal')
+  if (outcome.tag === OptimizationOutcome_Tags.Completed) {
+    console.log(`Optimization completed in ${outcome.inner.roundsExecuted} rounds`)
+  } else if (outcome.tag === OptimizationOutcome_Tags.Skipped) {
+    console.log('Optimization skipped — wallet already optimal')
+  } else if (outcome.tag === OptimizationOutcome_Tags.InProgress) {
+    // Full mode runs to completion in one call, so InProgress is
+    // not reachable here.
   }
-  // ANCHOR_END: optimization-events
+  // ANCHOR_END: optimize-leaves-full
+}
+
+const exampleOptimizeLeavesSingleRound = async (sdk: BreezSdk) => {
+  // ANCHOR: optimize-leaves-single-round
+  let roundsExecuted = 0
+  while (true) {
+    const outcome: OptimizationOutcome = await sdk.optimizeLeaves({ mode: OptimizationMode.SingleRound })
+
+    if (outcome.tag === OptimizationOutcome_Tags.InProgress) {
+      roundsExecuted += 1
+      console.log(`Executed round ${roundsExecuted}`)
+    } else if (outcome.tag === OptimizationOutcome_Tags.Completed) {
+      roundsExecuted += outcome.inner.roundsExecuted
+      console.log(`Optimization done after ${roundsExecuted} rounds`)
+      break
+    } else if (outcome.tag === OptimizationOutcome_Tags.Skipped) {
+      console.log('Optimization skipped — wallet already optimal')
+      break
+    }
+  }
+  // ANCHOR_END: optimize-leaves-single-round
+}
+
+const exampleAutoOptimizationEvents = async (optimizationEvent: AutoOptimizationEvent) => {
+  // ANCHOR: auto-optimization-events
+  if (optimizationEvent.tag === AutoOptimizationEvent_Tags.Started) {
+    console.log(`Auto-optimization started with ${optimizationEvent.inner.totalRounds} rounds`)
+  } else if (optimizationEvent.tag === AutoOptimizationEvent_Tags.RoundCompleted) {
+    console.log(`Auto-optimization round ${optimizationEvent.inner.currentRound} of ${optimizationEvent.inner.totalRounds} completed`)
+  } else if (optimizationEvent.tag === AutoOptimizationEvent_Tags.Completed) {
+    console.log('Auto-optimization completed successfully')
+  } else if (optimizationEvent.tag === AutoOptimizationEvent_Tags.Cancelled) {
+    console.log('Auto-optimization was cancelled')
+  } else if (optimizationEvent.tag === AutoOptimizationEvent_Tags.Failed) {
+    console.log(`Auto-optimization failed: ${optimizationEvent.inner.error}`)
+  } else if (optimizationEvent.tag === AutoOptimizationEvent_Tags.Skipped) {
+    console.log('Auto-optimization was skipped because leaves are already optimal')
+  }
+  // ANCHOR_END: auto-optimization-events
 }

--- a/docs/breez-sdk/snippets/react-native/optimize.ts
+++ b/docs/breez-sdk/snippets/react-native/optimize.ts
@@ -5,9 +5,11 @@ const exampleOptimizeLeavesFull = async (sdk: BreezSdk) => {
   const outcome = await sdk.optimizeLeaves(undefined)
 
   if (outcome.tag === OptimizationOutcome_Tags.Completed) {
-    console.log(`Optimization completed in ${outcome.inner.roundsExecuted} rounds`)
-  } else if (outcome.tag === OptimizationOutcome_Tags.Skipped) {
-    console.log('Optimization skipped — wallet already optimal')
+    if (outcome.inner.roundsExecuted === 0) {
+      console.log('Optimization skipped — wallet already optimal')
+    } else {
+      console.log(`Optimization completed in ${outcome.inner.roundsExecuted} rounds`)
+    }
   } else if (outcome.tag === OptimizationOutcome_Tags.InProgress) {
     // Full mode runs to completion in one call, so InProgress is
     // not reachable here.
@@ -26,10 +28,11 @@ const exampleOptimizeLeavesSingleRound = async (sdk: BreezSdk) => {
       console.log(`Executed round ${roundsExecuted}`)
     } else if (outcome.tag === OptimizationOutcome_Tags.Completed) {
       roundsExecuted += outcome.inner.roundsExecuted
-      console.log(`Optimization done after ${roundsExecuted} rounds`)
-      break
-    } else if (outcome.tag === OptimizationOutcome_Tags.Skipped) {
-      console.log('Optimization skipped — wallet already optimal')
+      if (roundsExecuted === 0) {
+        console.log('Optimization skipped — wallet already optimal')
+      } else {
+        console.log(`Optimization done after ${roundsExecuted} rounds`)
+      }
       break
     }
   }

--- a/docs/breez-sdk/snippets/rust/src/getting_started.rs
+++ b/docs/breez-sdk/snippets/rust/src/getting_started.rs
@@ -85,8 +85,8 @@ impl EventListener for SdkEventListener {
             SdkEvent::PaymentFailed { payment } => {
                 // A payment failed
             }
-            SdkEvent::Optimization { optimization_event } => {
-                // An optimization event occurred
+            SdkEvent::AutoOptimization { optimization_event } => {
+                // An auto-optimization event occurred
             }
             SdkEvent::LightningAddressChanged {
                 lightning_address,

--- a/docs/breez-sdk/snippets/rust/src/optimize.rs
+++ b/docs/breez-sdk/snippets/rust/src/optimize.rs
@@ -8,10 +8,11 @@ async fn run_full_optimization(sdk: &BreezSdk) -> Result<()> {
 
     match outcome {
         OptimizationOutcome::Completed { rounds_executed } => {
-            info!("Optimization completed in {} rounds", rounds_executed);
-        }
-        OptimizationOutcome::Skipped => {
-            info!("Optimization skipped — wallet already optimal");
+            if rounds_executed == 0 {
+                info!("Optimization skipped — wallet already optimal");
+            } else {
+                info!("Optimization completed in {} rounds", rounds_executed);
+            }
         }
         OptimizationOutcome::InProgress => {
             // Full mode runs to completion in one call, so InProgress is
@@ -39,11 +40,11 @@ async fn run_optimization_one_round_at_a_time(sdk: &BreezSdk) -> Result<()> {
                 rounds_executed: this_round,
             } => {
                 rounds_executed += this_round;
-                info!("Optimization done after {} rounds", rounds_executed);
-                break;
-            }
-            OptimizationOutcome::Skipped => {
-                info!("Optimization skipped — wallet already optimal");
+                if rounds_executed == 0 {
+                    info!("Optimization skipped — wallet already optimal");
+                } else {
+                    info!("Optimization done after {} rounds", rounds_executed);
+                }
                 break;
             }
         }

--- a/docs/breez-sdk/snippets/rust/src/optimize.rs
+++ b/docs/breez-sdk/snippets/rust/src/optimize.rs
@@ -2,56 +2,83 @@ use anyhow::Result;
 use breez_sdk_spark::*;
 use log::info;
 
-async fn start_optimization(sdk: &BreezSdk) {
-    // ANCHOR: start-optimization
-    sdk.start_leaf_optimization().await;
-    // ANCHOR_END: start-optimization
-}
+async fn run_full_optimization(sdk: &BreezSdk) -> Result<()> {
+    // ANCHOR: optimize-leaves-full
+    let outcome = sdk.optimize_leaves(None).await?;
 
-async fn cancel_optimization(sdk: &BreezSdk) -> Result<()> {
-    // ANCHOR: cancel-optimization
-    sdk.cancel_leaf_optimization().await?;
-    // ANCHOR_END: cancel-optimization
+    match outcome {
+        OptimizationOutcome::Completed { rounds_executed } => {
+            info!("Optimization completed in {} rounds", rounds_executed);
+        }
+        OptimizationOutcome::Skipped => {
+            info!("Optimization skipped — wallet already optimal");
+        }
+        OptimizationOutcome::InProgress => {
+            // Full mode runs to completion in one call, so InProgress is
+            // not reachable here.
+            unreachable!("Full mode never returns InProgress");
+        }
+    }
+    // ANCHOR_END: optimize-leaves-full
     Ok(())
 }
 
-fn get_optimization_progress(sdk: &BreezSdk) {
-    // ANCHOR: get-optimization-progress
-    let progress = sdk.get_leaf_optimization_progress();
-
-    info!("Optimization is running: {}", progress.is_running);
-    info!("Current round: {}", progress.current_round);
-    info!("Total rounds: {}", progress.total_rounds);
-    // ANCHOR_END: get-optimization-progress
+async fn run_optimization_one_round_at_a_time(sdk: &BreezSdk) -> Result<()> {
+    // ANCHOR: optimize-leaves-single-round
+    let mut rounds_executed = 0u32;
+    loop {
+        let options = OptimizeLeavesOptions {
+            mode: OptimizationMode::SingleRound,
+        };
+        match sdk.optimize_leaves(Some(options)).await? {
+            OptimizationOutcome::InProgress => {
+                rounds_executed += 1;
+                info!("Executed round {}", rounds_executed);
+            }
+            OptimizationOutcome::Completed {
+                rounds_executed: this_round,
+            } => {
+                rounds_executed += this_round;
+                info!("Optimization done after {} rounds", rounds_executed);
+                break;
+            }
+            OptimizationOutcome::Skipped => {
+                info!("Optimization skipped — wallet already optimal");
+                break;
+            }
+        }
+    }
+    // ANCHOR_END: optimize-leaves-single-round
+    Ok(())
 }
 
-fn optimization_events(event: OptimizationEvent) {
-    // ANCHOR: optimization-events
+fn handle_auto_optimization_event(event: AutoOptimizationEvent) {
+    // ANCHOR: auto-optimization-events
     match event {
-        OptimizationEvent::Started { total_rounds } => {
-            info!("Optimization started with {} rounds", total_rounds);
+        AutoOptimizationEvent::Started { total_rounds } => {
+            info!("Auto-optimization started with {} rounds", total_rounds);
         }
-        OptimizationEvent::RoundCompleted {
+        AutoOptimizationEvent::RoundCompleted {
             current_round,
             total_rounds,
         } => {
             info!(
-                "Optimization round {} of {} completed",
+                "Auto-optimization round {} of {} completed",
                 current_round, total_rounds
             );
         }
-        OptimizationEvent::Completed => {
-            info!("Optimization completed successfully");
+        AutoOptimizationEvent::Completed => {
+            info!("Auto-optimization completed successfully");
         }
-        OptimizationEvent::Cancelled => {
-            info!("Optimization was cancelled");
+        AutoOptimizationEvent::Cancelled => {
+            info!("Auto-optimization was cancelled");
         }
-        OptimizationEvent::Failed { error } => {
-            info!("Optimization failed: {}", error);
+        AutoOptimizationEvent::Failed { error } => {
+            info!("Auto-optimization failed: {}", error);
         }
-        OptimizationEvent::Skipped => {
-            info!("Optimization was skipped because leaves are already optimal");
+        AutoOptimizationEvent::Skipped => {
+            info!("Auto-optimization was skipped because leaves are already optimal");
         }
     }
-    // ANCHOR_END: optimization-events
+    // ANCHOR_END: auto-optimization-events
 }

--- a/docs/breez-sdk/snippets/rust/src/optimize.rs
+++ b/docs/breez-sdk/snippets/rust/src/optimize.rs
@@ -4,7 +4,10 @@ use log::info;
 
 async fn run_full_optimization(sdk: &BreezSdk) -> Result<()> {
     // ANCHOR: optimize-leaves-full
-    let outcome = sdk.optimize_leaves(None).await?;
+    let outcome = sdk
+        .optimize_leaves(OptimizeLeavesRequest::default())
+        .await?
+        .outcome;
 
     match outcome {
         OptimizationOutcome::Completed { rounds_executed } => {
@@ -28,10 +31,10 @@ async fn run_optimization_one_round_at_a_time(sdk: &BreezSdk) -> Result<()> {
     // ANCHOR: optimize-leaves-single-round
     let mut rounds_executed = 0u32;
     loop {
-        let options = OptimizeLeavesOptions {
+        let request = OptimizeLeavesRequest {
             mode: OptimizationMode::SingleRound,
         };
-        match sdk.optimize_leaves(Some(options)).await? {
+        match sdk.optimize_leaves(request).await?.outcome {
             OptimizationOutcome::InProgress => {
                 rounds_executed += 1;
                 info!("Executed round {}", rounds_executed);

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
@@ -74,8 +74,8 @@ class SdkEventListener: EventListener {
         case .paymentFailed(let paymentFailed):
             // A payment failed
             let _ = paymentFailed
-        case .optimization(let optimizationEvent):
-            // An optimization event occurred
+        case .autoOptimization(let optimizationEvent):
+            // An auto-optimization event occurred
             let _ = optimizationEvent
         case .lightningAddressChanged(let lightningAddress):
             // The lightning address has changed

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Optimize.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Optimize.swift
@@ -6,9 +6,11 @@ func runFullOptimization(sdk: BreezSdk) async throws {
 
     switch outcome {
     case .completed(let roundsExecuted):
-        print("Optimization completed in \(roundsExecuted) rounds")
-    case .skipped:
-        print("Optimization skipped — wallet already optimal")
+        if roundsExecuted == 0 {
+            print("Optimization skipped — wallet already optimal")
+        } else {
+            print("Optimization completed in \(roundsExecuted) rounds")
+        }
     case .inProgress:
         // Full mode runs to completion in one call, so InProgress is
         // not reachable here.
@@ -29,10 +31,11 @@ func runOptimizationOneRoundAtATime(sdk: BreezSdk) async throws {
             print("Executed round \(roundsExecuted)")
         case .completed(let thisRound):
             roundsExecuted += thisRound
-            print("Optimization done after \(roundsExecuted) rounds")
-            break loop
-        case .skipped:
-            print("Optimization skipped — wallet already optimal")
+            if roundsExecuted == 0 {
+                print("Optimization skipped — wallet already optimal")
+            } else {
+                print("Optimization done after \(roundsExecuted) rounds")
+            }
             break loop
         }
     }

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Optimize.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Optimize.swift
@@ -2,7 +2,7 @@ import BreezSdkSpark
 
 func runFullOptimization(sdk: BreezSdk) async throws {
     // ANCHOR: optimize-leaves-full
-    let outcome = try await sdk.optimizeLeaves(options: nil)
+    let outcome = try await sdk.optimizeLeaves(request: OptimizeLeavesRequest(mode: .full)).outcome
 
     switch outcome {
     case .completed(let roundsExecuted):
@@ -23,7 +23,7 @@ func runOptimizationOneRoundAtATime(sdk: BreezSdk) async throws {
     // ANCHOR: optimize-leaves-single-round
     var roundsExecuted: UInt32 = 0
     loop: while true {
-        let outcome = try await sdk.optimizeLeaves(options: OptimizeLeavesOptions(mode: .singleRound))
+        let outcome = try await sdk.optimizeLeaves(request: OptimizeLeavesRequest(mode: .singleRound)).outcome
 
         switch outcome {
         case .inProgress:

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Optimize.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Optimize.swift
@@ -1,46 +1,59 @@
 import BreezSdkSpark
 
-func startOptimization(sdk: BreezSdk) async {
-    // ANCHOR: start-optimization
-    await sdk.startLeafOptimization()
-    // ANCHOR_END: start-optimization
-}
+func runFullOptimization(sdk: BreezSdk) async throws {
+    // ANCHOR: optimize-leaves-full
+    let outcome = try await sdk.optimizeLeaves(options: nil)
 
-func cancelOptimization(sdk: BreezSdk) async throws {
-    // ANCHOR: cancel-optimization
-    do {
-        try await sdk.cancelLeafOptimization()
-    } catch {
-        print("Failed to cancel optimization: \(error)")
+    switch outcome {
+    case .completed(let roundsExecuted):
+        print("Optimization completed in \(roundsExecuted) rounds")
+    case .skipped:
+        print("Optimization skipped — wallet already optimal")
+    case .inProgress:
+        // Full mode runs to completion in one call, so InProgress is
+        // not reachable here.
+        fatalError("Full mode never returns InProgress")
     }
-    // ANCHOR_END: cancel-optimization
+    // ANCHOR_END: optimize-leaves-full
 }
 
-func getOptimizationProgress(sdk: BreezSdk) {
-    // ANCHOR: get-optimization-progress
-    let progress = sdk.getLeafOptimizationProgress()
+func runOptimizationOneRoundAtATime(sdk: BreezSdk) async throws {
+    // ANCHOR: optimize-leaves-single-round
+    var roundsExecuted: UInt32 = 0
+    loop: while true {
+        let outcome = try await sdk.optimizeLeaves(options: OptimizeLeavesOptions(mode: .singleRound))
 
-    print("Optimization is running: \(progress.isRunning)")
-    print("Current round: \(progress.currentRound)")
-    print("Total rounds: \(progress.totalRounds)")
-    // ANCHOR_END: get-optimization-progress
-}
-
-func optimizationEvents(event: OptimizationEvent) {
-    // ANCHOR: optimization-events
-    switch event {
-        case .started(let totalRounds):
-            print("Optimization started with \(totalRounds) rounds")
-        case .roundCompleted(let currentRound, let totalRounds):
-            print("Optimization round \(currentRound) of \(totalRounds) completed")
-        case .completed:
-            print("Optimization completed successfully")
-        case .cancelled:
-            print("Optimization was cancelled")
-        case .failed(let error):
-            print("Optimization failed: \(error)")
+        switch outcome {
+        case .inProgress:
+            roundsExecuted += 1
+            print("Executed round \(roundsExecuted)")
+        case .completed(let thisRound):
+            roundsExecuted += thisRound
+            print("Optimization done after \(roundsExecuted) rounds")
+            break loop
         case .skipped:
-            print("Optimization was skipped because leaves are already optimal")
+            print("Optimization skipped — wallet already optimal")
+            break loop
+        }
     }
-    // ANCHOR_END: optimization-events
+    // ANCHOR_END: optimize-leaves-single-round
+}
+
+func handleAutoOptimizationEvent(event: AutoOptimizationEvent) {
+    // ANCHOR: auto-optimization-events
+    switch event {
+    case .started(let totalRounds):
+        print("Auto-optimization started with \(totalRounds) rounds")
+    case .roundCompleted(let currentRound, let totalRounds):
+        print("Auto-optimization round \(currentRound) of \(totalRounds) completed")
+    case .completed:
+        print("Auto-optimization completed successfully")
+    case .cancelled:
+        print("Auto-optimization was cancelled")
+    case .failed(let error):
+        print("Auto-optimization failed: \(error)")
+    case .skipped:
+        print("Auto-optimization was skipped because leaves are already optimal")
+    }
+    // ANCHOR_END: auto-optimization-events
 }

--- a/docs/breez-sdk/snippets/wasm/getting_started.ts
+++ b/docs/breez-sdk/snippets/wasm/getting_started.ts
@@ -108,8 +108,8 @@ const exampleAddEventListener = async (sdk: BreezSdk) => {
           const failedPayment = event.payment
           break
         }
-        case 'optimization': {
-          // An optimization event occurred
+        case 'autoOptimization': {
+          // An auto-optimization event occurred
           const optimizationEvent = event.optimizationEvent
           break
         }

--- a/docs/breez-sdk/snippets/wasm/optimize.ts
+++ b/docs/breez-sdk/snippets/wasm/optimize.ts
@@ -1,54 +1,75 @@
-import { type OptimizationEvent, type BreezSdk } from '@breeztech/breez-sdk-spark'
+import { type AutoOptimizationEvent, type BreezSdk } from '@breeztech/breez-sdk-spark'
 
-const exampleStartOptimization = async (sdk: BreezSdk) => {
-  // ANCHOR: start-optimization
-  await sdk.startLeafOptimization()
-  // ANCHOR_END: start-optimization
-}
+const exampleOptimizeLeavesFull = async (sdk: BreezSdk) => {
+  // ANCHOR: optimize-leaves-full
+  const outcome = await sdk.optimizeLeaves()
 
-const exampleCancelOptimization = async (sdk: BreezSdk) => {
-  // ANCHOR: cancel-optimization
-  await sdk.cancelLeafOptimization()
-  // ANCHOR_END: cancel-optimization
-}
-
-const exampleGetOptimizationProgress = async (sdk: BreezSdk) => {
-  // ANCHOR: get-optimization-progress
-  const progress = sdk.getLeafOptimizationProgress()
-
-  console.log(`Optimization is running: ${progress.isRunning}`)
-  console.log(`Current round: ${progress.currentRound}`)
-  console.log(`Total rounds: ${progress.totalRounds}`)
-  // ANCHOR_END: get-optimization-progress
-}
-
-const exampleOptimizationEvents = async (event: OptimizationEvent) => {
-  // ANCHOR: optimization-events
-  switch (event.type) {
-    case 'started': {
-      console.log(`Optimization started with ${event.totalRounds} rounds`)
-      break
-    }
-    case 'roundCompleted': {
-      console.log(`Optimization round ${event.currentRound} of ${event.totalRounds} completed`)
-      break
-    }
+  switch (outcome.type) {
     case 'completed': {
-      console.log('Optimization completed successfully')
-      break
-    }
-    case 'cancelled': {
-      console.log('Optimization was cancelled')
-      break
-    }
-    case 'failed': {
-      console.log(`Optimization failed: ${event.error}`)
+      console.log(`Optimization completed in ${outcome.roundsExecuted} rounds`)
       break
     }
     case 'skipped': {
-      console.log('Optimization was skipped because leaves are already optimal')
+      console.log('Optimization skipped — wallet already optimal')
+      break
+    }
+    case 'inProgress': {
+      // Full mode runs to completion in one call, so inProgress is
+      // not reachable here.
       break
     }
   }
-  // ANCHOR_END: optimization-events
+  // ANCHOR_END: optimize-leaves-full
+}
+
+const exampleOptimizeLeavesSingleRound = async (sdk: BreezSdk) => {
+  // ANCHOR: optimize-leaves-single-round
+  let roundsExecuted = 0
+  while (true) {
+    const outcome = await sdk.optimizeLeaves({ mode: 'singleRound' })
+
+    if (outcome.type === 'inProgress') {
+      roundsExecuted += 1
+      console.log(`Executed round ${roundsExecuted}`)
+    } else if (outcome.type === 'completed') {
+      roundsExecuted += outcome.roundsExecuted
+      console.log(`Optimization done after ${roundsExecuted} rounds`)
+      break
+    } else if (outcome.type === 'skipped') {
+      console.log('Optimization skipped — wallet already optimal')
+      break
+    }
+  }
+  // ANCHOR_END: optimize-leaves-single-round
+}
+
+const exampleAutoOptimizationEvents = async (event: AutoOptimizationEvent) => {
+  // ANCHOR: auto-optimization-events
+  switch (event.type) {
+    case 'started': {
+      console.log(`Auto-optimization started with ${event.totalRounds} rounds`)
+      break
+    }
+    case 'roundCompleted': {
+      console.log(`Auto-optimization round ${event.currentRound} of ${event.totalRounds} completed`)
+      break
+    }
+    case 'completed': {
+      console.log('Auto-optimization completed successfully')
+      break
+    }
+    case 'cancelled': {
+      console.log('Auto-optimization was cancelled')
+      break
+    }
+    case 'failed': {
+      console.log(`Auto-optimization failed: ${event.error}`)
+      break
+    }
+    case 'skipped': {
+      console.log('Auto-optimization was skipped because leaves are already optimal')
+      break
+    }
+  }
+  // ANCHOR_END: auto-optimization-events
 }

--- a/docs/breez-sdk/snippets/wasm/optimize.ts
+++ b/docs/breez-sdk/snippets/wasm/optimize.ts
@@ -2,7 +2,7 @@ import { type AutoOptimizationEvent, type BreezSdk } from '@breeztech/breez-sdk-
 
 const exampleOptimizeLeavesFull = async (sdk: BreezSdk) => {
   // ANCHOR: optimize-leaves-full
-  const outcome = await sdk.optimizeLeaves()
+  const outcome = (await sdk.optimizeLeaves({ mode: 'full' })).outcome
 
   switch (outcome.type) {
     case 'completed': {
@@ -26,7 +26,7 @@ const exampleOptimizeLeavesSingleRound = async (sdk: BreezSdk) => {
   // ANCHOR: optimize-leaves-single-round
   let roundsExecuted = 0
   while (true) {
-    const outcome = await sdk.optimizeLeaves({ mode: 'singleRound' })
+    const outcome = (await sdk.optimizeLeaves({ mode: 'singleRound' })).outcome
 
     if (outcome.type === 'inProgress') {
       roundsExecuted += 1

--- a/docs/breez-sdk/snippets/wasm/optimize.ts
+++ b/docs/breez-sdk/snippets/wasm/optimize.ts
@@ -6,11 +6,11 @@ const exampleOptimizeLeavesFull = async (sdk: BreezSdk) => {
 
   switch (outcome.type) {
     case 'completed': {
-      console.log(`Optimization completed in ${outcome.roundsExecuted} rounds`)
-      break
-    }
-    case 'skipped': {
-      console.log('Optimization skipped — wallet already optimal')
+      if (outcome.roundsExecuted === 0) {
+        console.log('Optimization skipped — wallet already optimal')
+      } else {
+        console.log(`Optimization completed in ${outcome.roundsExecuted} rounds`)
+      }
       break
     }
     case 'inProgress': {
@@ -33,10 +33,11 @@ const exampleOptimizeLeavesSingleRound = async (sdk: BreezSdk) => {
       console.log(`Executed round ${roundsExecuted}`)
     } else if (outcome.type === 'completed') {
       roundsExecuted += outcome.roundsExecuted
-      console.log(`Optimization done after ${roundsExecuted} rounds`)
-      break
-    } else if (outcome.type === 'skipped') {
-      console.log('Optimization skipped — wallet already optimal')
+      if (roundsExecuted === 0) {
+        console.log('Optimization skipped — wallet already optimal')
+      } else {
+        console.log(`Optimization done after ${roundsExecuted} rounds`)
+      }
       break
     }
   }

--- a/docs/breez-sdk/src/guide/optimize.md
+++ b/docs/breez-sdk/src/guide/optimize.md
@@ -32,46 +32,37 @@ Keep multiplicity as low as possible while meeting your performance requirements
 
 ## Controlling optimization timing
 
-The optimization process runs as a background task that reorganizes leaves by swapping them to achieve optimal denominations. During this process, funds in leaves being swapped become temporarily unavailable for payments, which can delay transaction processing.
+The optimization process reorganizes leaves by swapping them to achieve optimal denominations. During this process, funds in leaves being swapped become temporarily unavailable for payments, which can delay transaction processing.
 
-By default, the SDK automatically triggers optimization after each payment (sent or received). For applications requiring more control, you can disable automatic optimization in the [configuration](./config.md#optimization-configuration) and manage it manually as described below.
+By default, the SDK automatically triggers optimization after each payment (sent or received). For applications requiring more control, you can disable automatic optimization in the [configuration](./config.md#optimization-configuration) and drive it manually using {{#name optimize_leaves}}.
 
-<h3 id="start-optimization">
-    <a class="header" href="#start-optimization">Start optimization</a>
-    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.start_leaf_optimization">API docs</a>
+<h3 id="optimize-leaves-full">
+    <a class="header" href="#optimize-leaves-full">Run optimization to completion</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.optimize_leaves">API docs</a>
 </h3>
 
-You can manually trigger the optimization task to start running in the background. If optimization is already running, no new task will be started.
+Call {{#name optimize_leaves}} with no options to run optimization until no further work is productive. The call blocks for the duration of the run and returns an {{#name OptimizationOutcome}}: {{#enum OptimizationOutcome::Completed}} with the number of rounds executed, or {{#enum OptimizationOutcome::Skipped}} if the wallet was already optimal at call time.
 
-{{#tabs optimize:start-optimization}}
+{{#tabs optimize:optimize-leaves-full}}
 
-<h3 id="cancel-optimization">
-    <a class="header" href="#cancel-optimization">Cancel optimization</a>
-    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.cancel_leaf_optimization">API docs</a>
+<h3 id="optimize-leaves-single-round">
+    <a class="header" href="#optimize-leaves-single-round">Run optimization one round at a time</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.optimize_leaves">API docs</a>
 </h3>
 
-You can cancel an ongoing optimization task and wait for it to stop completely. Optimization is done in rounds, and the current round will complete before stopping.
+To display progress or cancel between rounds, pass an {{#name OptimizeLeavesOptions}} with {{#enum OptimizationMode::SingleRound}}. Each call executes one round and returns {{#enum OptimizationOutcome::InProgress}} (more work remains), {{#enum OptimizationOutcome::Completed}} (the planner confirmed this swap finished optimization), or {{#enum OptimizationOutcome::Skipped}} (no work was needed). Cancel between rounds simply by stopping the loop.
 
-{{#tabs optimize:cancel-optimization}}
+{{#tabs optimize:optimize-leaves-single-round}}
 
 <div class="warning">
 <h4>Developer note</h4>
 
-The SDK automatically cancels optimization when it would block an immediate payment. Use manual cancellation only when anticipating upcoming payment activity, not when there is an immediate need to make a payment.
+If {{#name optimize_leaves}} is invoked while another optimization run (auto or manual) is already in flight, it returns {{#enum SdkError::OptimizationAlreadyRunning}}. The SDK may also preempt a manual run to free leaves for a higher-priority payment, in which case the call returns {{#enum SdkError::OptimizationCancelled}}.
 
 </div>
 
-<h3 id="get-optimization-progress">
-    <a class="header" href="#get-optimization-progress">Get optimization progress</a>
-    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.get_leaf_optimization_progress">API docs</a>
-</h3>
+## Auto-optimization events
 
-You can retrieve the current optimization progress to monitor the optimization task.
+When automatic optimization is enabled, the SDK emits {{#enum SdkEvent::AutoOptimization}} events so your application can track the background optimizer's progress. Manual {{#name optimize_leaves}} calls do not emit these events — inspect their return value instead. See [Listening to events](./events.md) for subscription instructions.
 
-{{#tabs optimize:get-optimization-progress}}
-
-## Optimization events
-
-The SDK emits events to keep your application informed about optimization status. See [Listening to events](./events.md) for subscription instructions.
-
-{{#tabs optimize:optimization-events}}
+{{#tabs optimize:auto-optimization-events}}

--- a/docs/breez-sdk/src/guide/optimize.md
+++ b/docs/breez-sdk/src/guide/optimize.md
@@ -41,7 +41,7 @@ By default, the SDK automatically triggers optimization after each payment (sent
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.optimize_leaves">API docs</a>
 </h3>
 
-Call {{#name optimize_leaves}} with no options to run optimization until no further work is productive. The call blocks for the duration of the run and returns an {{#name OptimizationOutcome}}: {{#enum OptimizationOutcome::Completed}} with the number of rounds executed. A `rounds_executed` of `0` means the wallet was already optimal at call time.
+Call {{#name optimize_leaves}} with an {{#name OptimizeLeavesRequest}} using the default {{#enum OptimizationMode::Full}} mode to run optimization until no further work is productive. The call blocks for the duration of the run and returns an {{#name OptimizeLeavesResponse}} whose {{#name outcome}} is {{#enum OptimizationOutcome::Completed}} with the number of rounds executed. A `rounds_executed` of `0` means the wallet was already optimal at call time.
 
 {{#tabs optimize:optimize-leaves-full}}
 
@@ -50,7 +50,7 @@ Call {{#name optimize_leaves}} with no options to run optimization until no furt
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.optimize_leaves">API docs</a>
 </h3>
 
-To display progress or cancel between rounds, pass an {{#name OptimizeLeavesOptions}} with {{#enum OptimizationMode::SingleRound}}. Each call executes one round and returns {{#enum OptimizationOutcome::InProgress}} (more work remains) or {{#enum OptimizationOutcome::Completed}} (terminal — either the planner confirmed this swap finished optimization, or `rounds_executed == 0` indicating the wallet was already optimal). Cancel between rounds simply by stopping the loop.
+To display progress or cancel between rounds, pass an {{#name OptimizeLeavesRequest}} with {{#enum OptimizationMode::SingleRound}}. Each call executes one round and the response {{#name outcome}} is {{#enum OptimizationOutcome::InProgress}} (more work remains) or {{#enum OptimizationOutcome::Completed}} (terminal — either the planner confirmed this swap finished optimization, or `rounds_executed == 0` indicating the wallet was already optimal). Cancel between rounds simply by stopping the loop.
 
 {{#tabs optimize:optimize-leaves-single-round}}
 

--- a/docs/breez-sdk/src/guide/optimize.md
+++ b/docs/breez-sdk/src/guide/optimize.md
@@ -41,7 +41,7 @@ By default, the SDK automatically triggers optimization after each payment (sent
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.optimize_leaves">API docs</a>
 </h3>
 
-Call {{#name optimize_leaves}} with no options to run optimization until no further work is productive. The call blocks for the duration of the run and returns an {{#name OptimizationOutcome}}: {{#enum OptimizationOutcome::Completed}} with the number of rounds executed, or {{#enum OptimizationOutcome::Skipped}} if the wallet was already optimal at call time.
+Call {{#name optimize_leaves}} with no options to run optimization until no further work is productive. The call blocks for the duration of the run and returns an {{#name OptimizationOutcome}}: {{#enum OptimizationOutcome::Completed}} with the number of rounds executed. A `rounds_executed` of `0` means the wallet was already optimal at call time.
 
 {{#tabs optimize:optimize-leaves-full}}
 
@@ -50,7 +50,7 @@ Call {{#name optimize_leaves}} with no options to run optimization until no furt
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.optimize_leaves">API docs</a>
 </h3>
 
-To display progress or cancel between rounds, pass an {{#name OptimizeLeavesOptions}} with {{#enum OptimizationMode::SingleRound}}. Each call executes one round and returns {{#enum OptimizationOutcome::InProgress}} (more work remains), {{#enum OptimizationOutcome::Completed}} (the planner confirmed this swap finished optimization), or {{#enum OptimizationOutcome::Skipped}} (no work was needed). Cancel between rounds simply by stopping the loop.
+To display progress or cancel between rounds, pass an {{#name OptimizeLeavesOptions}} with {{#enum OptimizationMode::SingleRound}}. Each call executes one round and returns {{#enum OptimizationOutcome::InProgress}} (more work remains) or {{#enum OptimizationOutcome::Completed}} (terminal — either the planner confirmed this swap finished optimization, or `rounds_executed == 0` indicating the wallet was already optimal). Cancel between rounds simply by stopping the loop.
 
 {{#tabs optimize:optimize-leaves-single-round}}
 

--- a/docs/breez-sdk/src/guide/optimize.md
+++ b/docs/breez-sdk/src/guide/optimize.md
@@ -41,7 +41,7 @@ By default, the SDK automatically triggers optimization after each payment (sent
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.optimize_leaves">API docs</a>
 </h3>
 
-Call {{#name optimize_leaves}} with an {{#name OptimizeLeavesRequest}} using the default {{#enum OptimizationMode::Full}} mode to run optimization until no further work is productive. The call blocks for the duration of the run and returns an {{#name OptimizeLeavesResponse}} whose {{#name outcome}} is {{#enum OptimizationOutcome::Completed}} with the number of rounds executed. A `rounds_executed` of `0` means the wallet was already optimal at call time.
+Call {{#name optimize_leaves}} with an {{#name OptimizeLeavesRequest}} using the default {{#enum OptimizationMode::Full}} mode to run optimization until no further work is productive. The call blocks for the duration of the run and returns an {{#name OptimizeLeavesResponse}} whose {{#name outcome}} is {{#enum OptimizationOutcome::Completed}} with the number of rounds executed. A {{#name rounds_executed}} of `0` means the wallet was already optimal at call time.
 
 {{#tabs optimize:optimize-leaves-full}}
 
@@ -50,7 +50,7 @@ Call {{#name optimize_leaves}} with an {{#name OptimizeLeavesRequest}} using the
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.optimize_leaves">API docs</a>
 </h3>
 
-To display progress or cancel between rounds, pass an {{#name OptimizeLeavesRequest}} with {{#enum OptimizationMode::SingleRound}}. Each call executes one round and the response {{#name outcome}} is {{#enum OptimizationOutcome::InProgress}} (more work remains) or {{#enum OptimizationOutcome::Completed}} (terminal — either the planner confirmed this swap finished optimization, or `rounds_executed == 0` indicating the wallet was already optimal). Cancel between rounds simply by stopping the loop.
+To display progress or cancel between rounds, pass an {{#name OptimizeLeavesRequest}} with {{#enum OptimizationMode::SingleRound}}. Each call executes one round and the response {{#name outcome}} is {{#enum OptimizationOutcome::InProgress}} (more work remains) or {{#enum OptimizationOutcome::Completed}} (terminal — either the planner confirmed this swap finished optimization, or a {{#name rounds_executed}} of `0` indicates the wallet was already optimal). Cancel between rounds simply by stopping the loop.
 
 {{#tabs optimize:optimize-leaves-single-round}}
 

--- a/packages/flutter/rust/src/errors.rs
+++ b/packages/flutter/rust/src/errors.rs
@@ -42,6 +42,8 @@ pub enum _SdkError {
     },
     LnurlError(String),
     Signer(String),
+    OptimizationAlreadyRunning,
+    OptimizationCancelled,
     Generic(String),
 }
 

--- a/packages/flutter/rust/src/events.rs
+++ b/packages/flutter/rust/src/events.rs
@@ -1,6 +1,6 @@
 use crate::frb_generated::StreamSink;
 use breez_sdk_spark::{DepositInfo, EventListener, LightningAddressInfo, Payment};
-pub use breez_sdk_spark::{OptimizationEvent, SdkEvent};
+pub use breez_sdk_spark::{AutoOptimizationEvent, SdkEvent};
 use flutter_rust_bridge::frb;
 
 #[frb(mirror(SdkEvent))]
@@ -21,8 +21,8 @@ pub enum _SdkEvent {
     PaymentFailed {
         payment: Payment,
     },
-    Optimization {
-        optimization_event: OptimizationEvent,
+    AutoOptimization {
+        optimization_event: AutoOptimizationEvent,
     },
     LightningAddressChanged {
         lightning_address: Option<LightningAddressInfo>,
@@ -32,8 +32,8 @@ pub enum _SdkEvent {
     },
 }
 
-#[frb(mirror(OptimizationEvent))]
-pub enum _OptimizationEvent {
+#[frb(mirror(AutoOptimizationEvent))]
+pub enum _AutoOptimizationEvent {
     Started {
         total_rounds: u32,
     },

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1151,7 +1151,6 @@ pub struct _OptimizeLeavesOptions {
 pub enum _OptimizationOutcome {
     Completed { rounds_executed: u32 },
     InProgress,
-    Skipped,
 }
 
 #[frb(mirror(ConversionEstimate))]

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1136,11 +1136,22 @@ pub struct _ClaimHtlcPaymentResponse {
     pub payment: Payment,
 }
 
-#[frb(mirror(OptimizationProgress))]
-pub struct _OptimizationProgress {
-    pub is_running: bool,
-    pub current_round: u32,
-    pub total_rounds: u32,
+#[frb(mirror(OptimizationMode))]
+pub enum _OptimizationMode {
+    Full,
+    SingleRound,
+}
+
+#[frb(mirror(OptimizeLeavesOptions))]
+pub struct _OptimizeLeavesOptions {
+    pub mode: OptimizationMode,
+}
+
+#[frb(mirror(OptimizationOutcome))]
+pub enum _OptimizationOutcome {
+    Completed { rounds_executed: u32 },
+    InProgress,
+    Skipped,
 }
 
 #[frb(mirror(ConversionEstimate))]

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1142,8 +1142,8 @@ pub enum _OptimizationMode {
     SingleRound,
 }
 
-#[frb(mirror(OptimizeLeavesOptions))]
-pub struct _OptimizeLeavesOptions {
+#[frb(mirror(OptimizeLeavesRequest))]
+pub struct _OptimizeLeavesRequest {
     pub mode: OptimizationMode,
 }
 
@@ -1151,6 +1151,11 @@ pub struct _OptimizeLeavesOptions {
 pub enum _OptimizationOutcome {
     Completed { rounds_executed: u32 },
     InProgress,
+}
+
+#[frb(mirror(OptimizeLeavesResponse))]
+pub struct _OptimizeLeavesResponse {
+    pub outcome: OptimizationOutcome,
 }
 
 #[frb(mirror(ConversionEstimate))]

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -236,9 +236,9 @@ impl BreezSdk {
 
     pub async fn optimize_leaves(
         &self,
-        options: Option<OptimizeLeavesOptions>,
-    ) -> Result<OptimizationOutcome, SdkError> {
-        self.inner.optimize_leaves(options).await
+        request: OptimizeLeavesRequest,
+    ) -> Result<OptimizeLeavesResponse, SdkError> {
+        self.inner.optimize_leaves(request).await
     }
 
 

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -234,19 +234,14 @@ impl BreezSdk {
         }
     }
 
-    pub async fn start_leaf_optimization(&self) {
-        self.inner.start_leaf_optimization().await;
+    pub async fn optimize_leaves(
+        &self,
+        options: Option<OptimizeLeavesOptions>,
+    ) -> Result<OptimizationOutcome, SdkError> {
+        self.inner.optimize_leaves(options).await
     }
 
-    pub async fn cancel_leaf_optimization(&self) -> Result<(), SdkError> {
-        self.inner.cancel_leaf_optimization().await
-    }
 
-    #[frb(sync)]
-    pub fn get_leaf_optimization_progress(&self) -> OptimizationProgress {
-        self.inner.get_leaf_optimization_progress().into()
-    }
-    
     pub async fn fetch_conversion_limits(
         &self,
         request: FetchConversionLimitsRequest,


### PR DESCRIPTION
## Summary

Replaces the polling-based optimization API (`start_leaf_optimization` /
`cancel_leaf_optimization` / `get_leaf_optimization_progress`) with a single
blocking `optimize_leaves(request)` call.

Also fixes a pre-existing wiring bug: on `main`, the SDK runtime received
`WalletEvent::Optimization` from spark-wallet but only logged it — it never
forwarded the event to `SdkEvent::Optimization` subscribers. This PR wires
that emission, so the (now-renamed) `SdkEvent::AutoOptimization` actually
reaches integrators.

## API

```rust
sdk.optimize_leaves(OptimizeLeavesRequest { mode: Full })             // Full
sdk.optimize_leaves(OptimizeLeavesRequest { mode: SingleRound })  // one round
```

`OptimizeLeavesRequest { mode }` is mandatory (consistent with the rest of
the SDK API) and `mode` defaults to `Full`, so `OptimizeLeavesRequest::default()`
runs a full optimization. The call returns `OptimizeLeavesResponse { outcome }`,
where `outcome` is `OptimizationOutcome { Completed { rounds_executed }, InProgress }`.
The result is wrapped in a response struct so fields can be added later without
a breaking change.

- **Full**: blocks until done; `outcome` is `Completed { rounds_executed }`.
  `rounds_executed == 0` indicates the wallet was already optimal at call
  time (no swap performed).
- **SingleRound**: executes at most one round per call. `outcome` is
  `InProgress` while work remains, `Completed` on the round that converges
  (or `Completed { rounds_executed: 0 }` if the very first call sees an
  already-optimal wallet). Lets callers drive a UI / cancel between rounds.

Concurrent calls reject with `SdkError::OptimizationAlreadyRunning`. Runs
preempted by the SDK to free leaves for a payment return
`SdkError::OptimizationCancelled`.

Terminal detection uses a planner-emitted `fully_converges` hint, so a
single-swap, fully-converging plan returns `Completed` in the same call
(no extra no-op iteration needed to discover the end).

## Events

`SdkEvent::Optimization` → `SdkEvent::AutoOptimization`. Events now fire
**only** for the background auto-optimizer; manual `optimize_leaves` calls
are silent — inspect the return value instead. Internally,
`OptimizationEvent` was renamed `AutoOptimizationEvent` at the spark and
spark-wallet layers to reflect this.

`AutoOptimizationEvent::Skipped` is retained — it's a distinct concept on
the background-event path, separate from the `OptimizationOutcome` return
value.

## Breaking changes

- `BreezSdk::start_leaf_optimization` / `cancel_leaf_optimization` /
  `get_leaf_optimization_progress` removed.
- `SdkEvent::Optimization` → `SdkEvent::AutoOptimization`.