### PR TITLE
tree/token tests: source refresh_start from the store clock

### DIFF
--- a/crates/spark-mysql/src/token_store.rs
+++ b/crates/spark-mysql/src/token_store.rs
@@ -2020,7 +2020,10 @@ mod tests {
         let token_outputs = shared_tests::create_token_outputs(1, vec![100, 200]);
         fixture
             .store
-            .set_tokens_outputs(&[token_outputs], shared_tests::future_refresh_start())
+            .set_tokens_outputs(
+                &[token_outputs],
+                shared_tests::future_refresh_start(&fixture.store).await,
+            )
             .await
             .unwrap();
         let reservation = fixture
@@ -2084,7 +2087,7 @@ mod tests {
             .store
             .set_tokens_outputs(
                 std::slice::from_ref(&token1),
-                shared_tests::future_refresh_start(),
+                shared_tests::future_refresh_start(&fixture.store).await,
             )
             .await
             .unwrap();
@@ -2127,7 +2130,7 @@ mod tests {
             .store
             .set_tokens_outputs(
                 std::slice::from_ref(&token1_refresh),
-                shared_tests::future_refresh_start(),
+                shared_tests::future_refresh_start(&fixture.store).await,
             )
             .await
             .unwrap();
@@ -2227,13 +2230,13 @@ mod tests {
 
         fx.a.set_tokens_outputs(
             std::slice::from_ref(&a_token1),
-            shared_tests::future_refresh_start(),
+            shared_tests::future_refresh_start(&fx.a).await,
         )
         .await
         .unwrap();
         fx.b.set_tokens_outputs(
             &[b_token1, b_only_token2],
-            shared_tests::future_refresh_start(),
+            shared_tests::future_refresh_start(&fx.b).await,
         )
         .await
         .unwrap();

--- a/crates/spark-postgres/src/token_store.rs
+++ b/crates/spark-postgres/src/token_store.rs
@@ -1690,7 +1690,7 @@ mod tests {
             .store
             .set_tokens_outputs(
                 std::slice::from_ref(&token1),
-                shared_tests::future_refresh_start(),
+                shared_tests::future_refresh_start(&fixture.store).await,
             )
             .await
             .unwrap();
@@ -1733,7 +1733,7 @@ mod tests {
             .store
             .set_tokens_outputs(
                 std::slice::from_ref(&token1_refresh),
-                shared_tests::future_refresh_start(),
+                shared_tests::future_refresh_start(&fixture.store).await,
             )
             .await
             .unwrap();
@@ -1773,7 +1773,10 @@ mod tests {
         let token_outputs = shared_tests::create_token_outputs(1, vec![100, 200]);
         fixture
             .store
-            .set_tokens_outputs(&[token_outputs], shared_tests::future_refresh_start())
+            .set_tokens_outputs(
+                &[token_outputs],
+                shared_tests::future_refresh_start(&fixture.store).await,
+            )
             .await
             .unwrap();
         let reservation = fixture
@@ -1892,13 +1895,13 @@ mod tests {
 
         fx.a.set_tokens_outputs(
             std::slice::from_ref(&a_token1),
-            shared_tests::future_refresh_start(),
+            shared_tests::future_refresh_start(&fx.a).await,
         )
         .await
         .unwrap();
         fx.b.set_tokens_outputs(
             &[b_token1, b_only_token2],
-            shared_tests::future_refresh_start(),
+            shared_tests::future_refresh_start(&fx.b).await,
         )
         .await
         .unwrap();

--- a/crates/spark/src/token/store/tests.rs
+++ b/crates/spark/src/token/store/tests.rs
@@ -1,4 +1,5 @@
 use std::slice;
+use std::time::Duration;
 
 use super::*;
 use macros::async_test_all;
@@ -12,8 +13,11 @@ fn create_token_outputs(identifier_no: u8, output_amounts: Vec<u128>) -> TokenOu
     shared_tests::create_token_outputs(identifier_no, output_amounts)
 }
 
+// The in-memory store has no DB clock — its `now()` is just `SystemTime::now()`
+// — so there is no host/DB clock skew to guard against and we can build the
+// refresh boundary from the host clock directly.
 fn future_refresh_start() -> SystemTime {
-    shared_tests::future_refresh_start()
+    SystemTime::now() + Duration::from_secs(10)
 }
 
 // ==================== InMemory-specific tests ====================

--- a/crates/spark/src/token/tests.rs
+++ b/crates/spark/src/token/tests.rs
@@ -65,10 +65,21 @@ pub fn create_token_outputs(identifier_no: u8, output_amounts: Vec<u128>) -> Tok
     TokenOutputs { metadata, outputs }
 }
 
-/// Returns a future `SystemTime`, ensuring that outputs added "now" are
-/// treated as old relative to this refresh start.
-pub fn future_refresh_start() -> SystemTime {
-    SystemTime::now() + Duration::from_secs(10)
+/// Returns a refresh start 10s in the future relative to the store's clock,
+/// ensuring that outputs added "now" are treated as old relative to it.
+///
+/// Sourced from `store.now()` rather than `SystemTime::now()` so the boundary
+/// shares a clock with the DB-stamped timestamps it is compared against (the
+/// application and DB-server clocks can differ, e.g. a Docker VM clock).
+pub async fn future_refresh_start(store: &dyn TokenOutputStore) -> SystemTime {
+    store.now().await.unwrap() + Duration::from_secs(10)
+}
+
+/// Returns a refresh start 60s in the past relative to the store's clock,
+/// ensuring that outputs/spends recorded "now" are treated as new relative to
+/// it. See [`future_refresh_start`] for why this uses `store.now()`.
+pub async fn past_refresh_start(store: &dyn TokenOutputStore) -> SystemTime {
+    store.now().await.unwrap() - Duration::from_secs(60)
 }
 
 pub async fn test_set_tokens_outputs(store: &dyn TokenOutputStore) {
@@ -76,7 +87,10 @@ pub async fn test_set_tokens_outputs(store: &dyn TokenOutputStore) {
     let token2 = create_token_outputs(2, vec![500, 1000]);
 
     let result = store
-        .set_tokens_outputs(&[token1.clone(), token2.clone()], future_refresh_start())
+        .set_tokens_outputs(
+            &[token1.clone(), token2.clone()],
+            future_refresh_start(store).await,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -89,7 +103,10 @@ pub async fn test_get_token_outputs(store: &dyn TokenOutputStore) {
     let token2 = create_token_outputs(2, vec![500, 1000]);
 
     let result = store
-        .set_tokens_outputs(&[token1.clone(), token2.clone()], future_refresh_start())
+        .set_tokens_outputs(
+            &[token1.clone(), token2.clone()],
+            future_refresh_start(store).await,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -131,7 +148,10 @@ pub async fn test_set_tokens_outputs_with_update(store: &dyn TokenOutputStore) {
     let token2 = create_token_outputs(2, vec![500, 1000]);
 
     let result = store
-        .set_tokens_outputs(&[token1.clone(), token2.clone()], future_refresh_start())
+        .set_tokens_outputs(
+            &[token1.clone(), token2.clone()],
+            future_refresh_start(store).await,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -141,7 +161,10 @@ pub async fn test_set_tokens_outputs_with_update(store: &dyn TokenOutputStore) {
     // Update with new token outputs (overwrite)
     let token1_updated = create_token_outputs(1, vec![150, 250]);
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1_updated), future_refresh_start())
+        .set_tokens_outputs(
+            slice::from_ref(&token1_updated),
+            future_refresh_start(store).await,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -168,7 +191,7 @@ pub async fn test_insert_token_outputs(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100, 200, 300]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -215,7 +238,10 @@ pub async fn test_reserve_token_outputs(store: &dyn TokenOutputStore) {
     let token2 = create_token_outputs(2, vec![500, 1000]);
 
     let result = store
-        .set_tokens_outputs(&[token1.clone(), token2.clone()], future_refresh_start())
+        .set_tokens_outputs(
+            &[token1.clone(), token2.clone()],
+            future_refresh_start(store).await,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -246,7 +272,10 @@ pub async fn test_reserve_token_outputs_and_cancel(store: &dyn TokenOutputStore)
     let token2 = create_token_outputs(2, vec![500, 1000]);
 
     let result = store
-        .set_tokens_outputs(&[token1.clone(), token2.clone()], future_refresh_start())
+        .set_tokens_outputs(
+            &[token1.clone(), token2.clone()],
+            future_refresh_start(store).await,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -286,7 +315,10 @@ pub async fn test_reserve_token_outputs_and_finalize(store: &dyn TokenOutputStor
     let token2 = create_token_outputs(2, vec![500, 1000]);
 
     let result = store
-        .set_tokens_outputs(&[token1.clone(), token2.clone()], future_refresh_start())
+        .set_tokens_outputs(
+            &[token1.clone(), token2.clone()],
+            future_refresh_start(store).await,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -326,7 +358,10 @@ pub async fn test_reserve_token_outputs_and_set_add_output(store: &dyn TokenOutp
     let token2 = create_token_outputs(2, vec![500, 1000]);
 
     let result = store
-        .set_tokens_outputs(&[token1.clone(), token2.clone()], future_refresh_start())
+        .set_tokens_outputs(
+            &[token1.clone(), token2.clone()],
+            future_refresh_start(store).await,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -351,7 +386,10 @@ pub async fn test_reserve_token_outputs_and_set_add_output(store: &dyn TokenOutp
     // Set new token outputs, simulating an external update
     let token1_updated = create_token_outputs(1, vec![100, 200, 300, 400]);
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1_updated), future_refresh_start())
+        .set_tokens_outputs(
+            slice::from_ref(&token1_updated),
+            future_refresh_start(store).await,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -371,7 +409,10 @@ pub async fn test_reserve_token_outputs_and_set_remove_reserved_output(
     let token2 = create_token_outputs(2, vec![500, 1000]);
 
     let result = store
-        .set_tokens_outputs(&[token1.clone(), token2.clone()], future_refresh_start())
+        .set_tokens_outputs(
+            &[token1.clone(), token2.clone()],
+            future_refresh_start(store).await,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -396,7 +437,10 @@ pub async fn test_reserve_token_outputs_and_set_remove_reserved_output(
     // Set new token outputs without the reserved output
     let token1_updated = create_token_outputs(1, vec![100, 200, 400]);
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1_updated), future_refresh_start())
+        .set_tokens_outputs(
+            slice::from_ref(&token1_updated),
+            future_refresh_start(store).await,
+        )
         .await;
     assert!(result.is_ok());
 
@@ -413,7 +457,7 @@ pub async fn test_multiple_parallel_reservations(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100, 200, 300, 400, 500]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -498,7 +542,7 @@ pub async fn test_reserve_with_preferred_outputs(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100, 200, 300, 400, 500]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -553,7 +597,7 @@ pub async fn test_reserve_insufficient_outputs(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100, 200]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -577,7 +621,7 @@ pub async fn test_reserve_nonexistent_token(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100, 200]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -601,7 +645,7 @@ pub async fn test_reserve_exact_amount_match(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![50, 100, 150, 200, 250]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -633,7 +677,7 @@ pub async fn test_reserve_multiple_outputs_combination(store: &dyn TokenOutputSt
     let token1 = create_token_outputs(1, vec![10, 20, 30, 40, 50]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -662,7 +706,7 @@ pub async fn test_reserve_all_available_outputs(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100, 200, 300]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -690,7 +734,7 @@ pub async fn test_reserve_with_preferred_outputs_insufficient(store: &dyn TokenO
     let token1 = create_token_outputs(1, vec![100, 200, 300, 400, 500]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -731,7 +775,7 @@ pub async fn test_reserve_zero_amount(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100, 200]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -751,7 +795,7 @@ pub async fn test_cancel_nonexistent_reservation(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100, 200]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -765,7 +809,7 @@ pub async fn test_finalize_nonexistent_reservation(store: &dyn TokenOutputStore)
     let token1 = create_token_outputs(1, vec![100, 200]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -780,11 +824,16 @@ pub async fn test_set_removes_all_tokens(store: &dyn TokenOutputStore) {
     let token2 = create_token_outputs(2, vec![300, 400]);
 
     let result = store
-        .set_tokens_outputs(&[token1.clone(), token2.clone()], future_refresh_start())
+        .set_tokens_outputs(
+            &[token1.clone(), token2.clone()],
+            future_refresh_start(store).await,
+        )
         .await;
     assert!(result.is_ok());
 
-    let result = store.set_tokens_outputs(&[], future_refresh_start()).await;
+    let result = store
+        .set_tokens_outputs(&[], future_refresh_start(store).await)
+        .await;
     assert!(result.is_ok());
 
     let stored_outputs = store.list_tokens_outputs().await.unwrap();
@@ -795,7 +844,7 @@ pub async fn test_reserve_single_large_output(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![10, 20, 1000]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -817,7 +866,7 @@ pub async fn test_get_token_outputs_none_found(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -837,7 +886,7 @@ pub async fn test_set_reconciles_reservation_with_empty_outputs(store: &dyn Toke
     let token1 = create_token_outputs(1, vec![100, 200, 300]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -853,7 +902,9 @@ pub async fn test_set_reconciles_reservation_with_empty_outputs(store: &dyn Toke
         .unwrap();
 
     // Set token outputs to empty list (all outputs removed)
-    let result = store.set_tokens_outputs(&[], future_refresh_start()).await;
+    let result = store
+        .set_tokens_outputs(&[], future_refresh_start(store).await)
+        .await;
     assert!(result.is_ok());
 
     // Verify no outputs remain
@@ -867,7 +918,7 @@ pub async fn test_reserve_token_outputs_selection_strategy_smallest_first(
     let token1 = create_token_outputs(1, vec![50, 100, 150, 200, 500]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -913,7 +964,7 @@ pub async fn test_reserve_token_outputs_selection_strategy_largest_first(
     let token1 = create_token_outputs(1, vec![50, 100, 150, 200, 500]);
 
     let result = store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await;
     assert!(result.is_ok());
 
@@ -953,7 +1004,7 @@ pub async fn test_reserve_token_outputs_selection_strategy_largest_first(
 pub async fn test_reserve_max_output_count_smallest_first(store: &dyn TokenOutputStore) {
     let token_outputs = create_token_outputs(1, vec![50, 100, 150, 200, 500]);
     store
-        .set_tokens_outputs(&[token_outputs], future_refresh_start())
+        .set_tokens_outputs(&[token_outputs], future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -994,7 +1045,7 @@ pub async fn test_reserve_max_output_count_smallest_first(store: &dyn TokenOutpu
 pub async fn test_reserve_max_output_count_largest_first(store: &dyn TokenOutputStore) {
     let token_outputs = create_token_outputs(1, vec![50, 100, 150, 200, 500]);
     store
-        .set_tokens_outputs(&[token_outputs], future_refresh_start())
+        .set_tokens_outputs(&[token_outputs], future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1035,7 +1086,7 @@ pub async fn test_reserve_max_output_count_largest_first(store: &dyn TokenOutput
 pub async fn test_reserve_max_output_count_more_than_available(store: &dyn TokenOutputStore) {
     let token_outputs = create_token_outputs(1, vec![50, 100, 150]);
     store
-        .set_tokens_outputs(&[token_outputs], future_refresh_start())
+        .set_tokens_outputs(&[token_outputs], future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1069,7 +1120,7 @@ pub async fn test_reserve_max_output_count_more_than_available(store: &dyn Token
 pub async fn test_reserve_max_output_count_zero_rejected(store: &dyn TokenOutputStore) {
     let token_outputs = create_token_outputs(1, vec![100, 200]);
     store
-        .set_tokens_outputs(&[token_outputs], future_refresh_start())
+        .set_tokens_outputs(&[token_outputs], future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1091,7 +1142,7 @@ pub async fn test_reserve_max_output_count_zero_rejected(store: &dyn TokenOutput
 pub async fn test_reserve_for_payment_affects_balance(store: &dyn TokenOutputStore) {
     let token_outputs = create_token_outputs(1, vec![100, 200, 300]);
     store
-        .set_tokens_outputs(&[token_outputs], future_refresh_start())
+        .set_tokens_outputs(&[token_outputs], future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1145,7 +1196,7 @@ pub async fn test_get_token_balances_includes_zero_spendable(store: &dyn TokenOu
     // balance 0.
     let token_outputs = create_token_outputs(1, vec![100, 200]);
     store
-        .set_tokens_outputs(&[token_outputs], future_refresh_start())
+        .set_tokens_outputs(&[token_outputs], future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1171,7 +1222,7 @@ pub async fn test_get_token_balances_includes_zero_spendable(store: &dyn TokenOu
 pub async fn test_reserve_for_swap_does_not_affect_balance(store: &dyn TokenOutputStore) {
     let token_outputs = create_token_outputs(1, vec![100, 200, 300]);
     store
-        .set_tokens_outputs(&[token_outputs], future_refresh_start())
+        .set_tokens_outputs(&[token_outputs], future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1217,7 +1268,7 @@ pub async fn test_reserve_for_swap_does_not_affect_balance(store: &dyn TokenOutp
 pub async fn test_mixed_reservation_purposes_balance(store: &dyn TokenOutputStore) {
     let token_outputs = create_token_outputs(1, vec![100, 200, 300, 400, 500]);
     store
-        .set_tokens_outputs(&[token_outputs], future_refresh_start())
+        .set_tokens_outputs(&[token_outputs], future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1285,7 +1336,7 @@ pub async fn test_mixed_reservation_purposes_balance(store: &dyn TokenOutputStor
 pub async fn test_set_tokens_outputs_skipped_during_active_swap(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100, 200]);
     store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1304,7 +1355,10 @@ pub async fn test_set_tokens_outputs_skipped_during_active_swap(store: &dyn Toke
     // Try to set new outputs while swap is active - should be skipped
     let token1_updated = create_token_outputs(1, vec![500]);
     store
-        .set_tokens_outputs(slice::from_ref(&token1_updated), future_refresh_start())
+        .set_tokens_outputs(
+            slice::from_ref(&token1_updated),
+            future_refresh_start(store).await,
+        )
         .await
         .unwrap();
 
@@ -1322,7 +1376,7 @@ pub async fn test_set_tokens_outputs_skipped_after_swap_completes_during_refresh
 ) {
     let token1 = create_token_outputs(1, vec![100, 200]);
     store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1374,7 +1428,7 @@ pub async fn test_insert_outputs_preserved_by_set_tokens_outputs(store: &dyn Tok
     // Add initial outputs
     let token1 = create_token_outputs(1, vec![100]);
     store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1419,7 +1473,7 @@ pub async fn test_insert_outputs_preserved_by_set_tokens_outputs(store: &dyn Tok
 pub async fn test_spent_outputs_not_restored_by_set_tokens_outputs(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100, 200]);
     store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1447,7 +1501,7 @@ pub async fn test_spent_outputs_not_restored_by_set_tokens_outputs(store: &dyn T
     assert_eq!(stored.available[0].output.token_amount, 200);
 
     // Simulate a stale refresh that tries to bring back the spent output
-    let refresh_start = SystemTime::now() - Duration::from_secs(60);
+    let refresh_start = past_refresh_start(store).await;
     let token1_stale = create_token_outputs(1, vec![100, 200, 300]);
     store
         .set_tokens_outputs(slice::from_ref(&token1_stale), refresh_start)
@@ -1476,7 +1530,7 @@ pub async fn test_spent_outputs_not_restored_by_set_tokens_outputs(store: &dyn T
 pub async fn test_finalize_swap_marks_spent_and_tracks_completion(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100, 200, 300]);
     store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1511,7 +1565,7 @@ pub async fn test_finalize_swap_marks_spent_and_tracks_completion(store: &dyn To
     assert_eq!(stored.available[0].output.token_amount, 600);
 
     // A refresh that started before the swap should be skipped
-    let old_refresh = SystemTime::now() - Duration::from_secs(60);
+    let old_refresh = past_refresh_start(store).await;
     let token1_stale = create_token_outputs(1, vec![100, 200, 300]);
     store
         .set_tokens_outputs(slice::from_ref(&token1_stale), old_refresh)
@@ -1530,7 +1584,7 @@ pub async fn test_finalize_swap_marks_spent_and_tracks_completion(store: &dyn To
 pub async fn test_insert_outputs_clears_spent_status(store: &dyn TokenOutputStore) {
     let token1 = create_token_outputs(1, vec![100]);
     store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1563,7 +1617,7 @@ pub async fn test_insert_outputs_clears_spent_status(store: &dyn TokenOutputStor
     assert_eq!(stored.available[0].output.token_amount, 100);
 
     // Now a stale refresh should not remove it (spent status was cleared)
-    let old_refresh = SystemTime::now() - Duration::from_secs(60);
+    let old_refresh = past_refresh_start(store).await;
     let token1_refresh = create_token_outputs(1, vec![100, 200]);
     store
         .set_tokens_outputs(slice::from_ref(&token1_refresh), old_refresh)
@@ -1581,7 +1635,7 @@ pub async fn test_remove_token_outputs_by_prev_tx_ref(store: &dyn TokenOutputSto
     // Insert outputs: token-1 has outputs at (tx-hash-0, 0), (tx-hash-1, 1), (tx-hash-2, 2)
     let token1 = create_token_outputs(1, vec![100, 200, 300]);
     store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1610,7 +1664,7 @@ pub async fn test_remove_token_outputs_prevents_refresh_re_add(store: &dyn Token
     // Insert outputs
     let token1 = create_token_outputs(1, vec![100, 200]);
     store
-        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start())
+        .set_tokens_outputs(slice::from_ref(&token1), future_refresh_start(store).await)
         .await
         .unwrap();
 
@@ -1622,7 +1676,7 @@ pub async fn test_remove_token_outputs_prevents_refresh_re_add(store: &dyn Token
 
     // A refresh whose start time is before the removal should not re-add it,
     // because the spent marker is newer than the refresh start.
-    let old_refresh = SystemTime::now() - Duration::from_secs(60);
+    let old_refresh = past_refresh_start(store).await;
     let token1_refresh = create_token_outputs(1, vec![100, 200]);
     store
         .set_tokens_outputs(slice::from_ref(&token1_refresh), old_refresh)

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -76,10 +76,21 @@ pub async fn reserve_leaves(
     }
 }
 
-/// Returns a future `SystemTime`, ensuring that leaves added "now" are
-/// treated as old relative to this refresh start.
-fn future_refresh_start() -> SystemTime {
-    SystemTime::now() + Duration::from_secs(10)
+/// Returns a refresh start 10s in the future relative to the store's clock,
+/// ensuring that leaves added "now" are treated as old relative to it.
+///
+/// Sourced from `store.now()` rather than `SystemTime::now()` so the boundary
+/// shares a clock with the DB-stamped `added_at` values it is compared against
+/// (the application and DB-server clocks can differ, e.g. a Docker VM clock).
+async fn future_refresh_start(store: &dyn TreeStore) -> SystemTime {
+    store.now().await.unwrap() + Duration::from_secs(10)
+}
+
+/// Returns a refresh start 60s in the past relative to the store's clock,
+/// ensuring that leaves/spends recorded "now" are treated as new relative to
+/// it. See [`future_refresh_start`] for why this uses `store.now()`.
+async fn past_refresh_start(store: &dyn TreeStore) -> SystemTime {
+    store.now().await.unwrap() - Duration::from_secs(60)
 }
 
 /// Asserts that `get_leaves()` returns `expected` available leaves.
@@ -143,7 +154,7 @@ pub async fn test_set_leaves(store: &dyn TreeStore) {
     let initial = vec![create_test_tree_node("node1", 100)];
     store.add_leaves(&initial).await.unwrap();
 
-    let refresh_start = future_refresh_start();
+    let refresh_start = future_refresh_start(store).await;
     let new_leaves = vec![
         create_test_tree_node("node2", 200),
         create_test_tree_node("node3", 300),
@@ -178,7 +189,7 @@ pub async fn test_set_leaves_with_reservations(store: &dyn TreeStore) {
     .await
     .unwrap();
 
-    let refresh_start = future_refresh_start();
+    let refresh_start = future_refresh_start(store).await;
 
     // Update leaves with new data (including updated versions of reserved leaves)
     let non_existing_operator_leaf = create_test_tree_node("node7", 1000);
@@ -221,7 +232,7 @@ pub async fn test_set_leaves_preserves_reservations_for_in_flight_swaps(store: &
     .await
     .unwrap();
 
-    let refresh_start = future_refresh_start();
+    let refresh_start = future_refresh_start(store).await;
 
     // Set new leaves that don't include the reserved ones
     let new_leaves = vec![create_test_tree_node("node3", 300)];
@@ -951,7 +962,7 @@ pub async fn test_spent_leaves_not_restored_by_set_leaves(store: &dyn TreeStore)
     assert!(!available.iter().any(|l| l.id.to_string() == "node1"));
 
     // Simulate a refresh that started BEFORE the finalize completed.
-    let refresh_start = SystemTime::now() - Duration::from_secs(60);
+    let refresh_start = past_refresh_start(store).await;
     let stale_leaves = vec![
         create_test_tree_node("node1", 100), // This was spent!
         create_test_tree_node("node2", 200),
@@ -992,7 +1003,7 @@ pub async fn test_spent_ids_cleaned_up_when_no_longer_in_refresh(store: &dyn Tre
         .unwrap();
 
     // First refresh with refresh_start BEFORE spent_at
-    let refresh_start = SystemTime::now() - Duration::from_secs(60);
+    let refresh_start = past_refresh_start(store).await;
     let stale_leaves = vec![create_test_tree_node("node1", 100)];
     store
         .set_leaves(&stale_leaves, &[], refresh_start)
@@ -1002,7 +1013,7 @@ pub async fn test_spent_ids_cleaned_up_when_no_longer_in_refresh(store: &dyn Tre
     assert!(get_available(store).await.is_empty());
 
     // Second refresh with refresh_start AFTER spent_at
-    let refresh_start2 = future_refresh_start();
+    let refresh_start2 = future_refresh_start(store).await;
     let fresh_leaves = vec![create_test_tree_node("node2", 200)];
     store
         .set_leaves(&fresh_leaves, &[], refresh_start2)
@@ -1020,7 +1031,7 @@ pub async fn test_add_leaves_not_deleted_by_set_leaves(store: &dyn TreeStore) {
     store.add_leaves(&initial).await.unwrap();
 
     // Refresh starts at T1
-    let refresh_start = SystemTime::now();
+    let refresh_start = store.now().await.unwrap();
 
     // Small delay to ensure the new leaf is added AFTER refresh_start
     platform_utils::tokio::time::sleep(Duration::from_millis(10)).await;
@@ -1055,7 +1066,7 @@ pub async fn test_old_leaves_deleted_by_set_leaves(store: &dyn TreeStore) {
     store.add_leaves(&initial).await.unwrap();
 
     // Use a future refresh_start so existing leaves are considered "old"
-    let refresh_start = future_refresh_start();
+    let refresh_start = future_refresh_start(store).await;
 
     // Refresh completes without node2
     let refresh_data = vec![create_test_tree_node("node1", 100)];
@@ -1090,7 +1101,7 @@ pub async fn test_change_leaves_from_swap_protected(store: &dyn TreeStore) {
     .unwrap();
 
     // Refresh starts
-    let refresh_start = SystemTime::now();
+    let refresh_start = store.now().await.unwrap();
 
     // Small delay
     platform_utils::tokio::time::sleep(Duration::from_millis(10)).await;
@@ -1134,7 +1145,7 @@ pub async fn test_finalize_with_new_leaves_protected(store: &dyn TreeStore) {
     .unwrap();
 
     // Refresh starts
-    let refresh_start = SystemTime::now();
+    let refresh_start = store.now().await.unwrap();
 
     // Small delay
     platform_utils::tokio::time::sleep(Duration::from_millis(10)).await;
@@ -1228,7 +1239,7 @@ pub async fn test_set_leaves_skipped_during_active_swap(store: &dyn TreeStore) {
     .unwrap();
 
     // Simulate refresh starting while swap is in progress
-    let refresh_start = SystemTime::now();
+    let refresh_start = store.now().await.unwrap();
 
     platform_utils::tokio::time::sleep(Duration::from_millis(10)).await;
 
@@ -1264,7 +1275,7 @@ pub async fn test_set_leaves_skipped_after_swap_completes_during_refresh(store: 
     .unwrap();
 
     // Refresh starts at T0
-    let refresh_start = SystemTime::now();
+    let refresh_start = store.now().await.unwrap();
 
     // Small delay to ensure swap completes AFTER refresh started
     platform_utils::tokio::time::sleep(Duration::from_millis(10)).await;
@@ -1326,7 +1337,7 @@ pub async fn test_set_leaves_proceeds_after_swap_when_refresh_starts_later(store
     platform_utils::tokio::time::sleep(Duration::from_millis(10)).await;
 
     // Refresh starts AFTER swap completed
-    let refresh_start = future_refresh_start();
+    let refresh_start = future_refresh_start(store).await;
 
     // set_leaves with fresh data
     let fresh_refresh_data = vec![
@@ -1368,7 +1379,7 @@ pub async fn test_payment_reservation_does_not_block_set_leaves(store: &dyn Tree
     .await
     .unwrap();
 
-    let refresh_start = future_refresh_start();
+    let refresh_start = future_refresh_start(store).await;
 
     // set_leaves should proceed (payment reservation doesn't block)
     let new_leaves = vec![
@@ -1573,7 +1584,7 @@ pub async fn test_get_leaves_missing_operators_filters_spent(store: &dyn TreeSto
         .unwrap();
 
     // Call set_leaves with refresh_start BEFORE the spend, so spent marker is preserved
-    let refresh_start = SystemTime::now() - Duration::from_secs(60);
+    let refresh_start = past_refresh_start(store).await;
     let missing = vec![
         create_test_tree_node("node1", 100), // was spent
         create_test_tree_node("node3", 300), // new
@@ -1600,7 +1611,7 @@ pub async fn test_get_leaves_missing_operators_filters_spent(store: &dyn TreeSto
 }
 
 pub async fn test_missing_operators_replaced_on_set_leaves(store: &dyn TreeStore) {
-    let refresh_start1 = future_refresh_start();
+    let refresh_start1 = future_refresh_start(store).await;
     let missing1 = vec![create_test_tree_node("missing1", 100)];
     store
         .set_leaves(&[], &missing1, refresh_start1)
@@ -1617,7 +1628,7 @@ pub async fn test_missing_operators_replaced_on_set_leaves(store: &dyn TreeStore
     );
 
     // Second set_leaves replaces with missing2
-    let refresh_start2 = future_refresh_start();
+    let refresh_start2 = future_refresh_start(store).await;
     let missing2 = vec![create_test_tree_node("missing2", 200)];
     store
         .set_leaves(&[], &missing2, refresh_start2)
@@ -1757,7 +1768,7 @@ pub async fn test_full_payment_cycle(store: &dyn TreeStore) {
 }
 
 pub async fn test_set_leaves_replaces_fully(store: &dyn TreeStore) {
-    let refresh_start1 = future_refresh_start();
+    let refresh_start1 = future_refresh_start(store).await;
     let initial = vec![
         create_test_tree_node("node1", 100),
         create_test_tree_node("node2", 200),
@@ -1769,7 +1780,7 @@ pub async fn test_set_leaves_replaces_fully(store: &dyn TreeStore) {
     assert_available_count(store, 2).await;
 
     // Second set_leaves with only node3
-    let refresh_start2 = future_refresh_start();
+    let refresh_start2 = future_refresh_start(store).await;
     let replacement = vec![create_test_tree_node("node3", 300)];
     store
         .set_leaves(&replacement, &[], refresh_start2)


### PR DESCRIPTION
Four tree-store tests flaked on macOS but not CI: they took `refresh_start`
from the host clock (`SystemTime::now()`) but compared it against `added_at`
timestamps stamped by the DB clock. Under load, Docker's Linux VM
clock can lag the host past the tests' 10ms buffer, so a just-written row
lands before the boundary and is wrongly culled. CI shares the host/container
clock, so it never reproduced there.

Fix: source `refresh_start` from `store.now()` (the DB clock for DB-backed
stores) so the boundary and row timestamps share a clock.

What actually flaked: the four tight-margin (10ms-sleep) tree tests. The
bigger-margin (+10s / -60s) helpers in both suites are switched too purely
for consistency — they never flaked, since their margins dwarf the skew. The
token tests never flaked at all: their tight cases already used `store.now()`,
so only their buffered helpers changed. In-memory callers keep the host clock
(their `store.now()` is just `SystemTime::now()`).