### PR TITLE
Forward debug/trace logs to external loggers

### DIFF
--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -33,6 +33,7 @@ pub use common::{fiat::*, models::*, sync_storage};
 pub use error::{DepositClaimError, SdkError, SignerError};
 pub use events::{AutoOptimizationEvent, EventEmitter, EventListener, SdkEvent};
 pub use issuer::*;
+pub use logger::DEFAULT_FILTER;
 pub use models::*;
 pub use persist::{
     PaymentMetadata, SetLnurlMetadataItem, Storage, StorageError, StorageListPaymentsRequest,
@@ -40,7 +41,6 @@ pub use persist::{
     backend::{PrebuiltBackend, ResolvedStores, StorageBackend, custom_storage},
     path::default_storage_path,
 };
-pub use logger::DEFAULT_FILTER;
 pub use sdk::{
     BreezSdk, default_config, default_server_config, get_spark_status, init_logging, parse_input,
 };

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -40,6 +40,7 @@ pub use persist::{
     backend::{PrebuiltBackend, ResolvedStores, StorageBackend, custom_storage},
     path::default_storage_path,
 };
+pub use logger::DEFAULT_FILTER;
 pub use sdk::{
     BreezSdk, default_config, default_server_config, get_spark_status, init_logging, parse_input,
 };

--- a/crates/breez-sdk/core/src/logger.rs
+++ b/crates/breez-sdk/core/src/logger.rs
@@ -1,5 +1,5 @@
 use std::fs::OpenOptions;
-use tracing::{Event, Level, Subscriber};
+use tracing::{Event, Subscriber};
 use tracing_subscriber::{
     EnvFilter, Layer,
     fmt::{FormatFields, format::Writer},
@@ -22,9 +22,7 @@ where
     S: Subscriber,
 {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
-        if event.metadata().level() <= &Level::INFO
-            && let Some(s) = self.log_listener.as_ref()
-        {
+        if let Some(s) = self.log_listener.as_ref() {
             let mut buf = String::new();
             let writer = Writer::new(&mut buf);
 
@@ -48,11 +46,12 @@ pub(super) fn init_logging(
 ) -> Result<(), SdkError> {
     let filter = log_filter.unwrap_or(DEFAULT_FILTER);
 
-    let registry = tracing_subscriber::registry()
-        .with(EnvFilter::new(filter))
-        .with(GlobalSdkLogger {
+    let registry = tracing_subscriber::registry().with(
+        GlobalSdkLogger {
             log_listener: app_logger,
-        });
+        }
+        .with_filter(EnvFilter::new(filter)),
+    );
 
     if let Some(log_dir) = log_dir {
         let log_file = OpenOptions::new()
@@ -70,10 +69,74 @@ pub(super) fn init_logging(
         // which spans actually emit.
         #[cfg(feature = "span-trace")]
         let fmt_layer = fmt_layer.with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE);
+        let fmt_layer = fmt_layer.with_filter(EnvFilter::new(filter));
         registry.with(fmt_layer).try_init()?;
     } else {
         registry.try_init()?;
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use tracing::{debug, info, trace};
+
+    use super::{EnvFilter, GlobalSdkLogger, Layer, SubscriberExt};
+    use crate::{LogEntry, Logger};
+
+    /// External logger that records the level of every entry it receives.
+    struct CapturingLogger {
+        levels: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl Logger for CapturingLogger {
+        fn log(&self, l: LogEntry) {
+            self.levels.lock().unwrap().push(l.level);
+        }
+    }
+
+    /// Runs `emit` with a [`GlobalSdkLogger`] filtered by `filter` installed as
+    /// the thread-local default, returning the levels that reached the external
+    /// logger. `emit` must use a literal `target:` (the macros bake it into a
+    /// `static` callsite) matching a directive in `filter`.
+    fn forwarded_levels(filter: &str, emit: impl FnOnce()) -> Vec<String> {
+        let levels = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(
+            GlobalSdkLogger {
+                log_listener: Some(Box::new(CapturingLogger {
+                    levels: levels.clone(),
+                })),
+            }
+            .with_filter(EnvFilter::new(filter)),
+        );
+
+        tracing::subscriber::with_default(subscriber, emit);
+
+        levels.lock().unwrap().clone()
+    }
+
+    #[test]
+    fn external_logger_respects_filter_level() {
+        // A `debug` filter forwards debug (and above) but not trace — this is
+        // the behaviour that regressed when the layer hard-capped at INFO.
+        let levels = forwarded_levels("brz_logtest_debug=debug", || {
+            info!(target: "brz_logtest_debug", "info");
+            debug!(target: "brz_logtest_debug", "debug");
+            trace!(target: "brz_logtest_debug", "trace");
+        });
+        assert!(levels.contains(&"INFO".to_string()), "got {levels:?}");
+        assert!(levels.contains(&"DEBUG".to_string()), "got {levels:?}");
+        assert!(!levels.contains(&"TRACE".to_string()), "got {levels:?}");
+
+        // A `trace` filter forwards trace too.
+        let levels = forwarded_levels("brz_logtest_trace=trace", || {
+            debug!(target: "brz_logtest_trace", "debug");
+            trace!(target: "brz_logtest_trace", "trace");
+        });
+        assert!(levels.contains(&"DEBUG".to_string()), "got {levels:?}");
+        assert!(levels.contains(&"TRACE".to_string()), "got {levels:?}");
+    }
 }

--- a/crates/breez-sdk/core/src/logger.rs
+++ b/crates/breez-sdk/core/src/logger.rs
@@ -9,8 +9,29 @@ use tracing_subscriber::{
 
 use crate::{LogEntry, Logger, SdkError};
 
-const DEFAULT_FILTER: &str = "debug,h2=warn,rustls=warn,rustyline=warn,hyper=warn,hyper_util=warn,\
-     tower=warn,Connection=warn,tonic=warn";
+const DEFAULT_FILTER: &str = concat!(
+    "info",
+    // First-party crates: keep debug logging.
+    ",breez_sdk_spark=debug",
+    ",breez_sdk_common=debug",
+    ",breez_sdk_spark_wasm=debug",
+    ",breez_sdk_spark_bindings=debug",
+    ",spark=debug",
+    ",spark_wallet=debug",
+    ",spark_postgres=debug",
+    ",spark_mysql=debug",
+    ",flashnet=debug",
+    ",platform_utils=debug",
+    // Noisy third-party crates: silence below warn.
+    ",h2=warn",
+    ",rustls=warn",
+    ",rustyline=warn",
+    ",hyper=warn",
+    ",hyper_util=warn",
+    ",tower=warn",
+    ",Connection=warn",
+    ",tonic=warn",
+);
 
 pub(crate) struct GlobalSdkLogger {
     /// Optional external log listener, that can receive a stream of log statements

--- a/crates/breez-sdk/core/src/logger.rs
+++ b/crates/breez-sdk/core/src/logger.rs
@@ -9,7 +9,10 @@ use tracing_subscriber::{
 
 use crate::{LogEntry, Logger, SdkError};
 
-const DEFAULT_FILTER: &str = concat!(
+/// Default tracing filter: `info` globally, `debug` for first-party crates,
+/// and noisy third-party crates silenced below `warn`. Shared with the WASM
+/// bindings so both default to the same behaviour.
+pub const DEFAULT_FILTER: &str = concat!(
     "info",
     // First-party crates: keep debug logging.
     ",breez_sdk_spark=debug",

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -21,9 +21,9 @@ pub struct BreezSdk {
 pub async fn init_logging(logger: Logger, filter: Option<String>) -> WasmResult<()> {
     crate::logger::WASM_LOGGER.set(Some(logger));
 
-    let filter = EnvFilter::new(filter.unwrap_or(
-        "debug,h2=warn,rustls=warn,rustyline=warn,hyper=warn,hyper_util=warn,tower=warn,Connection=warn,tonic=warn".to_string(),
-    ));
+    let filter = EnvFilter::new(
+        filter.unwrap_or_else(|| breez_sdk_spark::DEFAULT_FILTER.to_string()),
+    );
     let subscriber = tracing_subscriber::registry()
         .with(filter)
         .with(WasmTracingLayer {});

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -21,9 +21,8 @@ pub struct BreezSdk {
 pub async fn init_logging(logger: Logger, filter: Option<String>) -> WasmResult<()> {
     crate::logger::WASM_LOGGER.set(Some(logger));
 
-    let filter = EnvFilter::new(
-        filter.unwrap_or_else(|| breez_sdk_spark::DEFAULT_FILTER.to_string()),
-    );
+    let filter =
+        EnvFilter::new(filter.unwrap_or_else(|| breez_sdk_spark::DEFAULT_FILTER.to_string()));
     let subscriber = tracing_subscriber::registry()
         .with(filter)
         .with(WasmTracingLayer {});


### PR DESCRIPTION
The external logger layer hard-capped events at INFO, so debug/trace were silently dropped regardless of the configured `log_filter` (only the file log and WASM honored it).

Removes the cap and applies the filter per-layer, matching the file layer and WASM. External loggers now honor `log_filter` (default `debug`). Adds a regression test.