### PR TITLE
ci: guard iOS passkey Swift against Xcode 26 refined-for-swift PRF use

### DIFF
--- a/.github/workflows/passkey-ios-prf-bridge.yml
+++ b/.github/workflows/passkey-ios-prf-bridge.yml
@@ -1,0 +1,20 @@
+name: Passkey iOS PRF Bridge
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prf-bridge-guard:
+    name: No direct refined-for-swift PRF use in iOS Swift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check passkey PRF bridge usage
+        run: scripts/check-passkey-prf-bridge.sh

--- a/scripts/check-passkey-prf-bridge.sh
+++ b/scripts/check-passkey-prf-bridge.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Guard against the Xcode 26 passkey-PRF regression. The AuthenticationServices
+# PRF types are NS_REFINED_FOR_SWIFT, so their initializers and accessors are
+# not reachable from Swift on Xcode 26. The passkey layers must build and read
+# PRF through the PasskeyPRFHelper ObjC bridge, never directly in Swift. ObjC
+# (.h/.m) is allowed to use them: that bridge is the whole point.
+#
+# This is a fast static guard, not a full compile. A complete check would build
+# the React Native pod's Swift with `pod install` + `xcodebuild` on an Xcode 26
+# runner (see the PR description); that needs an example app the repo does not
+# ship yet, so this guard covers the specific known regression in the meantime.
+set -euo pipefail
+
+dirs=(
+  packages/react-native/ios
+  packages/flutter/ios
+  crates/breez-sdk/bindings/langs/swift
+)
+
+# The refined-for-Swift PRF input/value types, plus a direct `.prf` property
+# read. `\.prf([^A-Za-z]|$)` matches a real `.prf` access but skips the
+# `.prfNotSupported` / `.prfEvaluationFailed` error enum cases.
+pattern='ASAuthorizationPublicKeyCredentialPRF(AssertionInput|RegistrationInput|Values)|\.prf([^A-Za-z]|$)'
+
+hits=""
+for d in "${dirs[@]}"; do
+  [ -d "$d" ] || continue
+  while IFS= read -r f; do
+    m="$(grep -nE "$pattern" "$f" || true)"
+    [ -n "$m" ] && hits+="$f"$'\n'"$m"$'\n'
+  done < <(find "$d" -name '*.swift')
+done
+
+if [ -n "$hits" ]; then
+  echo "ERROR: iOS Swift uses the NS_REFINED_FOR_SWIFT AuthenticationServices PRF API directly." >&2
+  echo "This does not compile on Xcode 26. Route PRF through the PasskeyPRFHelper ObjC bridge." >&2
+  echo >&2
+  printf '%s' "$hits" >&2
+  exit 1
+fi
+
+echo "check-passkey-prf-bridge: OK (no direct refined-for-swift PRF use in iOS Swift)."


### PR DESCRIPTION
## Why

On [#781](https://github.com/breez/spark-sdk/pull/781#discussion_r3333491350) dangeross flagged that `packages/react-native/ios/BreezSdkSparkPasskey.swift` constructed the AuthenticationServices PRF types directly. Those types are `NS_REFINED_FOR_SWIFT`, so their initializers and accessors are unreachable from Swift on Xcode 26, and an integrator building the RN pod on Xcode 26 would fail to compile. The Swift binding and the Flutter shim avoid this by routing PRF through the `PasskeyPRFHelper` ObjC bridge.

The code is already fixed on the passkey stack ([#909](https://github.com/breez/spark-sdk/pull/909), `52f11cd6b`): RN iOS now delegates to the shared `PasskeyAssertionCore`, which uses `PasskeyPRFHelper`. But the CI gap dangeross also noted is real and unaddressed: nothing runs `pod install` + `xcodebuild` over `ios/*.swift`, so a future regression would not be caught.

## What

A fast static guard, runnable on any runner (no Xcode needed):

- `scripts/check-passkey-prf-bridge.sh` fails if any `*.swift` under `packages/react-native/ios`, `packages/flutter/ios`, or `crates/breez-sdk/bindings/langs/swift` constructs `ASAuthorizationPublicKeyCredentialPRF{AssertionInput,RegistrationInput,Values}` or reads `.prf` directly. ObjC (`.h` / `.m`) is allowed: that bridge is the point.
- A `Passkey iOS PRF Bridge` workflow runs it on pull requests and main pushes.

Verified locally: passes on the current passkey tree, and fails on an injected `ASAuthorizationPublicKeyCredentialPRFAssertionInput(...)` / `credential.prf` line.

## Not covered (larger follow-up)

This guards the specific known regression, not general Swift compilation. A complete check would build the RN pod's Swift with `pod install` + `xcodebuild` on an Xcode 26 macOS runner. That needs a checked-in RN example app (the repo ships none) and an Xcode 26 image. Happy to do that as a separate PR if the team wants to invest in the infrastructure.

Note on timing: the passkey iOS Swift this guards reaches `main` via the #781 / #909 stack, so until then the guard is armed but idle on `main`. It can be cherry-picked onto the stack to activate sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
