### PR TITLE
Avoid per-build migration contention

### DIFF
--- a/crates/breez-sdk/core/src/persist/backend/mysql.rs
+++ b/crates/breez-sdk/core/src/persist/backend/mysql.rs
@@ -105,3 +105,107 @@ impl StorageBackend for MysqlBackend {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persist::StorageListPaymentsRequest;
+    use crate::persist::mysql::{MysqlStorageConfig, create_pool};
+    use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use spark_wallet::SessionStoreError;
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::mysql::Mysql;
+
+    /// Two distinct 33-byte tenant identities sharing one pool / database.
+    const TENANT_A: [u8; 33] = [
+        0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+        0x1e, 0x1f, 0x20,
+    ];
+    const TENANT_B: [u8; 33] = [
+        0x03, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae,
+        0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd,
+        0xbe, 0xbf, 0xc0,
+    ];
+
+    fn dummy_pubkey() -> PublicKey {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret key");
+        PublicKey::from_secret_key(&secp, &sk)
+    }
+
+    /// Asserts every store in `stores` is present and backed by a fully migrated
+    /// schema by issuing a trivial read against each of the four tables. This is
+    /// what guards the fix: per-tenant stores are built migration-free, so each
+    /// of these reads only succeeds if `ensure_migrated` already created that
+    /// store's schema.
+    async fn assert_all_stores_usable(stores: &ResolvedStores) {
+        stores
+            .storage
+            .list_payments(StorageListPaymentsRequest::default())
+            .await
+            .expect("main storage schema migrated");
+
+        let tree = stores.tree_store.as_ref().expect("tree store present");
+        tree.get_leaves().await.expect("tree store schema migrated");
+
+        let tokens = stores
+            .token_output_store
+            .as_ref()
+            .expect("token store present");
+        tokens
+            .list_tokens_outputs()
+            .await
+            .expect("token store schema migrated");
+
+        let sessions = stores
+            .session_store
+            .as_ref()
+            .expect("session store present");
+        // No session has been written, so a *migrated* (but empty) schema returns
+        // `NotFound` because the query ran and matched no row. A missing table
+        // would surface as a different error, failing this assertion.
+        match sessions.get_session(&dummy_pubkey()).await {
+            Err(SessionStoreError::NotFound) => {}
+            Err(e) => {
+                panic!("expected NotFound from migrated empty session store, got error {e:?}")
+            }
+            Ok(_) => panic!("unexpected session returned from empty session store"),
+        }
+    }
+
+    /// With `run_migration = true`, the backend migrates the shared database once
+    /// via `ensure_migrated`, then builds each tenant's stores migration-free.
+    /// This exercises that path end-to-end: concurrent first-callers race into
+    /// the `OnceCell`, all four stores' migrations must be covered (so the
+    /// migration-free per-tenant builds see a complete schema), and two tenants
+    /// are provisioned over the same pool.
+    #[tokio::test]
+    async fn test_create_stores_migrates_once_for_all_tenants() {
+        let container = Mysql::default()
+            .start()
+            .await
+            .expect("Failed to start MySQL container");
+        let host_port = container
+            .get_host_port_ipv4(3306)
+            .await
+            .expect("Failed to get host port");
+        let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
+        let pool = create_pool(&MysqlStorageConfig::with_defaults(connection_string))
+            .expect("Failed to create pool");
+
+        let backend = MysqlBackend::new(pool, true, MysqlForeignKeyMode::Enforced);
+
+        // Provision both tenants concurrently: the first to reach `ensure_migrated`
+        // runs the migrations while the other awaits the same `OnceCell`.
+        let (a, b) = tokio::join!(
+            backend.create_stores(Network::Regtest, TENANT_A.to_vec()),
+            backend.create_stores(Network::Regtest, TENANT_B.to_vec()),
+        );
+        let a = a.expect("tenant A stores created");
+        let b = b.expect("tenant B stores created");
+
+        assert_all_stores_usable(&a).await;
+        assert_all_stores_usable(&b).await;
+    }
+}

--- a/crates/breez-sdk/core/src/persist/backend/mysql.rs
+++ b/crates/breez-sdk/core/src/persist/backend/mysql.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use macros::async_trait;
 use spark_mysql::mysql_async;
+use tokio::sync::OnceCell;
 
 use crate::{
     Network, SdkError,
@@ -22,6 +23,18 @@ pub(super) struct MysqlBackend {
     pool: mysql_async::Pool,
     run_migration: bool,
     foreign_key_mode: MysqlForeignKeyMode,
+    /// Ensures the schema migrations run at most once per pool.
+    ///
+    /// The migrations are global to the database: schema-level, version-tracked
+    /// `brz_*` tables, not per-tenant data. Each `run_migrations` call also
+    /// takes a *global* `GET_LOCK` named lock while holding a pooled
+    /// connection. With a fresh store set built per request (as a multi-tenant
+    /// server does), running them on every `create_stores` serializes every
+    /// build across every tenant behind that lock and starves the pool under
+    /// load. Gating behind a `OnceCell` runs them once per process; the global
+    /// lock still serializes the first run across processes, so two instances
+    /// booting together can't double-migrate.
+    migrated: OnceCell<()>,
 }
 
 impl MysqlBackend {
@@ -34,7 +47,31 @@ impl MysqlBackend {
             pool,
             run_migration,
             foreign_key_mode,
+            migrated: OnceCell::new(),
         }
+    }
+
+    /// Runs every store's migrations exactly once per pool. Concurrent
+    /// first-callers await the same run; a failure is not cached, so a later
+    /// build retries.
+    async fn ensure_migrated(&self, identity: &[u8]) -> Result<(), SdkError> {
+        self.migrated
+            .get_or_try_init(|| async {
+                // Construct each store once with migrations enabled, then drop
+                // it — we only want the migration side effect here. `identity`
+                // feeds only the one-shot single-tenant backfill migration,
+                // which is version-gated and runs once per database regardless
+                // of which tenant happens to trigger it first.
+                MysqlStorage::new_with_pool(self.pool.clone(), identity, true).await?;
+                create_mysql_tree_store(self.pool.clone(), identity, true, self.foreign_key_mode)
+                    .await?;
+                create_mysql_token_store(self.pool.clone(), identity, true, self.foreign_key_mode)
+                    .await?;
+                create_mysql_session_store(self.pool.clone(), identity, true).await?;
+                Ok::<(), SdkError>(())
+            })
+            .await
+            .copied()
     }
 }
 
@@ -45,25 +82,21 @@ impl StorageBackend for MysqlBackend {
         _network: Network,
         identity: Vec<u8>,
     ) -> Result<Arc<ResolvedStores>, SdkError> {
-        let storage = Arc::new(
-            MysqlStorage::new_with_pool(self.pool.clone(), &identity, self.run_migration).await?,
-        );
-        let tree_store = create_mysql_tree_store(
-            self.pool.clone(),
-            &identity,
-            self.run_migration,
-            self.foreign_key_mode,
-        )
-        .await?;
-        let token_output_store = create_mysql_token_store(
-            self.pool.clone(),
-            &identity,
-            self.run_migration,
-            self.foreign_key_mode,
-        )
-        .await?;
-        let session_store =
-            create_mysql_session_store(self.pool.clone(), &identity, self.run_migration).await?;
+        if self.run_migration {
+            self.ensure_migrated(&identity).await?;
+        }
+        // Migrations are handled once per pool by `ensure_migrated`; the stores
+        // themselves are built migration-free so a per-request build never
+        // re-runs (and re-locks) them.
+        let storage =
+            Arc::new(MysqlStorage::new_with_pool(self.pool.clone(), &identity, false).await?);
+        let tree_store =
+            create_mysql_tree_store(self.pool.clone(), &identity, false, self.foreign_key_mode)
+                .await?;
+        let token_output_store =
+            create_mysql_token_store(self.pool.clone(), &identity, false, self.foreign_key_mode)
+                .await?;
+        let session_store = create_mysql_session_store(self.pool.clone(), &identity, false).await?;
         Ok(Arc::new(ResolvedStores {
             storage,
             tree_store: Some(tree_store),

--- a/crates/breez-sdk/core/src/persist/backend/postgres.rs
+++ b/crates/breez-sdk/core/src/persist/backend/postgres.rs
@@ -95,3 +95,111 @@ impl StorageBackend for PostgresBackend {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persist::{
+        StorageListPaymentsRequest,
+        postgres::{PostgresStorageConfig, create_pool},
+    };
+    use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use spark_wallet::SessionStoreError;
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::postgres::Postgres;
+
+    /// Two distinct 33-byte tenant identities sharing one pool / database.
+    const TENANT_A: [u8; 33] = [
+        0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+        0x1e, 0x1f, 0x20,
+    ];
+    const TENANT_B: [u8; 33] = [
+        0x03, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae,
+        0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd,
+        0xbe, 0xbf, 0xc0,
+    ];
+
+    fn dummy_pubkey() -> PublicKey {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[0x11; 32]).expect("valid secret key");
+        PublicKey::from_secret_key(&secp, &sk)
+    }
+
+    /// Asserts every store in `stores` is present and backed by a fully migrated
+    /// schema by issuing a trivial read against each of the four tables. This is
+    /// what guards the fix: per-tenant stores are built migration-free, so each
+    /// of these reads only succeeds if `ensure_migrated` already created that
+    /// store's schema.
+    async fn assert_all_stores_usable(stores: &ResolvedStores) {
+        stores
+            .storage
+            .list_payments(StorageListPaymentsRequest::default())
+            .await
+            .expect("main storage schema migrated");
+
+        let tree = stores.tree_store.as_ref().expect("tree store present");
+        tree.get_leaves().await.expect("tree store schema migrated");
+
+        let tokens = stores
+            .token_output_store
+            .as_ref()
+            .expect("token store present");
+        tokens
+            .list_tokens_outputs()
+            .await
+            .expect("token store schema migrated");
+
+        let sessions = stores
+            .session_store
+            .as_ref()
+            .expect("session store present");
+        // No session has been written, so a *migrated* (but empty) schema returns
+        // `NotFound` because the query ran and matched no row. A missing table
+        // would surface as a different error, failing this assertion.
+        match sessions.get_session(&dummy_pubkey()).await {
+            Err(SessionStoreError::NotFound) => {}
+            Err(e) => {
+                panic!("expected NotFound from migrated empty session store, got error {e:?}")
+            }
+            Ok(_) => panic!("unexpected session returned from empty session store"),
+        }
+    }
+
+    /// With `run_migration = true`, the backend migrates the shared database once
+    /// via `ensure_migrated`, then builds each tenant's stores migration-free.
+    /// This exercises that path end-to-end: concurrent first-callers race into
+    /// the `OnceCell`, all four stores' migrations must be covered (so the
+    /// migration-free per-tenant builds see a complete schema), and two tenants
+    /// are provisioned over the same pool.
+    #[tokio::test]
+    async fn test_create_stores_migrates_once_for_all_tenants() {
+        let container = Postgres::default()
+            .start()
+            .await
+            .expect("Failed to start PostgreSQL container");
+        let host_port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("Failed to get host port");
+        let connection_string = format!(
+            "host=127.0.0.1 port={host_port} user=postgres password=postgres dbname=postgres"
+        );
+        let pool = create_pool(&PostgresStorageConfig::with_defaults(connection_string))
+            .expect("Failed to create pool");
+
+        let backend = PostgresBackend::new(pool, true);
+
+        // Provision both tenants concurrently: the first to reach `ensure_migrated`
+        // runs the migrations while the other awaits the same `OnceCell`.
+        let (a, b) = tokio::join!(
+            backend.create_stores(Network::Regtest, TENANT_A.to_vec()),
+            backend.create_stores(Network::Regtest, TENANT_B.to_vec()),
+        );
+        let a = a.expect("tenant A stores created");
+        let b = b.expect("tenant B stores created");
+
+        assert_all_stores_usable(&a).await;
+        assert_all_stores_usable(&b).await;
+    }
+}

--- a/crates/breez-sdk/core/src/persist/backend/postgres.rs
+++ b/crates/breez-sdk/core/src/persist/backend/postgres.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use macros::async_trait;
 use spark_postgres::deadpool_postgres;
+use tokio::sync::OnceCell;
 
 use crate::{
     Network, SdkError,
@@ -21,6 +22,18 @@ use super::{ResolvedStores, StorageBackend};
 pub(super) struct PostgresBackend {
     pool: deadpool_postgres::Pool,
     run_migration: bool,
+    /// Ensures the schema migrations run at most once per pool.
+    ///
+    /// The migrations are global to the database: schema-level, version-tracked
+    /// `brz_*` tables, not per-tenant data. Each `run_migrations` call also
+    /// takes a *global* `pg_advisory_xact_lock` while holding a pooled
+    /// connection. With a fresh store set built per request (as a multi-tenant
+    /// server does), running them on every `create_stores` serializes every
+    /// build across every tenant behind that lock and starves the pool under
+    /// load. Gating behind a `OnceCell` runs them once per process; the global
+    /// lock still serializes the first run across processes, so two instances
+    /// booting together can't double-migrate.
+    migrated: OnceCell<()>,
 }
 
 impl PostgresBackend {
@@ -28,7 +41,29 @@ impl PostgresBackend {
         Self {
             pool,
             run_migration,
+            migrated: OnceCell::new(),
         }
+    }
+
+    /// Runs every store's migrations exactly once per pool. Concurrent
+    /// first-callers await the same run; a failure is not cached, so a later
+    /// build retries.
+    async fn ensure_migrated(&self, identity: &[u8]) -> Result<(), SdkError> {
+        self.migrated
+            .get_or_try_init(|| async {
+                // Construct each store once with migrations enabled, then drop
+                // it — we only want the migration side effect here. `identity`
+                // feeds only the one-shot single-tenant backfill migration,
+                // which is version-gated and runs once per database regardless
+                // of which tenant happens to trigger it first.
+                PostgresStorage::new_with_pool(self.pool.clone(), identity, true).await?;
+                create_postgres_tree_store(self.pool.clone(), identity, true).await?;
+                create_postgres_token_store(self.pool.clone(), identity, true).await?;
+                create_postgres_session_store(self.pool.clone(), identity, true).await?;
+                Ok::<(), SdkError>(())
+            })
+            .await
+            .copied()
     }
 }
 
@@ -39,16 +74,19 @@ impl StorageBackend for PostgresBackend {
         _network: Network,
         identity: Vec<u8>,
     ) -> Result<Arc<ResolvedStores>, SdkError> {
-        let storage = Arc::new(
-            PostgresStorage::new_with_pool(self.pool.clone(), &identity, self.run_migration)
-                .await?,
-        );
-        let tree_store =
-            create_postgres_tree_store(self.pool.clone(), &identity, self.run_migration).await?;
+        if self.run_migration {
+            self.ensure_migrated(&identity).await?;
+        }
+        // Migrations are handled once per pool by `ensure_migrated`; the stores
+        // themselves are built migration-free so a per-request build never
+        // re-runs (and re-locks) them.
+        let storage =
+            Arc::new(PostgresStorage::new_with_pool(self.pool.clone(), &identity, false).await?);
+        let tree_store = create_postgres_tree_store(self.pool.clone(), &identity, false).await?;
         let token_output_store =
-            create_postgres_token_store(self.pool.clone(), &identity, self.run_migration).await?;
+            create_postgres_token_store(self.pool.clone(), &identity, false).await?;
         let session_store =
-            create_postgres_session_store(self.pool.clone(), &identity, self.run_migration).await?;
+            create_postgres_session_store(self.pool.clone(), &identity, false).await?;
         Ok(Arc::new(ResolvedStores {
             storage,
             tree_store: Some(tree_store),

--- a/crates/breez-sdk/wasm/src/sdk_builder.rs
+++ b/crates/breez-sdk/wasm/src/sdk_builder.rs
@@ -22,12 +22,13 @@ use crate::{
         },
     },
     sdk::BreezSdk,
-    sdk_context::WasmSdkContext,
+    sdk_context::{SharedMysqlPool, SharedPostgresPool, WasmSdkContext},
     token_store::WasmTokenStore,
     tree_store::WasmTreeStore,
 };
 use bitcoin::secp256k1::PublicKey;
 use breez_sdk_spark::{KeySet, PrebuiltBackend, SessionStoreAdapter, StorageBackend};
+use platform_utils::tokio::sync::OnceCell;
 use wasm_bindgen::prelude::*;
 
 /// Configuration for PostgreSQL storage connection pool.
@@ -195,9 +196,9 @@ pub struct SdkBuilder {
     storage_config: Option<WasmStorageConfig>,
     storage: Option<Storage>,
     /// JS Postgres pool supplied via `withSharedContext(ctx_with_pool)`.
-    context_postgres_pool: Option<(Rc<JsPool>, bool)>,
+    context_postgres_pool: Option<SharedPostgresPool>,
     /// JS MySQL pool supplied via `withSharedContext(ctx_with_pool)`.
-    context_mysql_pool: Option<(Rc<JsPool>, bool, MysqlForeignKeyMode)>,
+    context_mysql_pool: Option<SharedMysqlPool>,
     key_set_type: breez_sdk_spark::KeySetType,
     use_address_index: bool,
     account_number: Option<u32>,
@@ -390,12 +391,19 @@ impl SdkBuilder {
                 None,
                 None,
             )),
-            (None, None, Some((pool_rc, run_migration)), None) => {
-                build_postgres_storage(&pool_rc, &identity_bytes, run_migration).await?
-            }
-            (None, None, None, Some((pool_rc, run_migration, foreign_key_mode))) => {
-                build_mysql_storage(&pool_rc, &identity_bytes, foreign_key_mode, run_migration)
+            (None, None, Some((pool_rc, run_migration, migrated)), None) => {
+                build_postgres_storage_shared(&pool_rc, &identity_bytes, run_migration, &migrated)
                     .await?
+            }
+            (None, None, None, Some((pool_rc, run_migration, foreign_key_mode, migrated))) => {
+                build_mysql_storage_shared(
+                    &pool_rc,
+                    &identity_bytes,
+                    foreign_key_mode,
+                    run_migration,
+                    &migrated,
+                )
+                .await?
             }
             _ => {
                 return Err(WasmError::new(
@@ -437,6 +445,53 @@ async fn resolve_storage_config(
             build_mysql_storage(&pool, identity, foreign_key_mode, run_migration).await
         }
     }
+}
+
+/// Builds the Postgres stores over a context-shared `pool`, running schema
+/// migrations at most once for that pool. Mirrors the native `PostgresBackend`:
+/// migrations are global per database (not per tenant) and take a global lock,
+/// so running them on every per-tenant build serializes builds and starves the
+/// pool. The `OnceCell` runs them once; concurrent first-callers await the same
+/// run, and a failure isn't cached so a later build retries.
+async fn build_postgres_storage_shared(
+    pool: &Rc<JsPool>,
+    identity: &[u8],
+    run_migration: bool,
+    migrated: &Rc<OnceCell<()>>,
+) -> WasmResult<Arc<dyn StorageBackend>> {
+    if run_migration {
+        migrated
+            .get_or_try_init(|| async {
+                build_postgres_storage(pool, identity, true)
+                    .await
+                    .map(|_| ())
+            })
+            .await?;
+    }
+    // Migrations handled once above; build the per-tenant stores migration-free.
+    build_postgres_storage(pool, identity, false).await
+}
+
+/// Builds the MySQL stores over a context-shared `pool`, running schema
+/// migrations at most once for that pool. See [`build_postgres_storage_shared`].
+async fn build_mysql_storage_shared(
+    pool: &Rc<JsPool>,
+    identity: &[u8],
+    foreign_key_mode: MysqlForeignKeyMode,
+    run_migration: bool,
+    migrated: &Rc<OnceCell<()>>,
+) -> WasmResult<Arc<dyn StorageBackend>> {
+    if run_migration {
+        migrated
+            .get_or_try_init(|| async {
+                build_mysql_storage(pool, identity, foreign_key_mode, true)
+                    .await
+                    .map(|_| ())
+            })
+            .await?;
+    }
+    // Migrations handled once above; build the per-tenant stores migration-free.
+    build_mysql_storage(pool, identity, foreign_key_mode, false).await
 }
 
 /// Builds the four PostgreSQL-backed JS stores over `pool`.

--- a/crates/breez-sdk/wasm/src/sdk_context.rs
+++ b/crates/breez-sdk/wasm/src/sdk_context.rs
@@ -4,6 +4,7 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
+use platform_utils::tokio::sync::OnceCell;
 use wasm_bindgen::prelude::*;
 
 use crate::{
@@ -13,6 +14,21 @@ use crate::{
     sdk_builder::{MysqlForeignKeyMode, MysqlStorageConfig, PostgresStorageConfig},
 };
 
+/// A context-shared Postgres pool: the JS pool, its `run_migration` flag, and a
+/// once-guard that limits schema migrations to a single run per pool.
+///
+/// The guard exists because every SDK built from the context reuses the same
+/// pool and (pre-fix) re-ran the four stores' migrations on each build, each
+/// taking a *global* migration lock while holding a connection — serializing
+/// every build across every tenant. Shared via `Rc` so it stays the same guard
+/// after the context's pool is cloned into each `SdkBuilder`. Mirrors the
+/// native `PostgresBackend`/`MysqlBackend` fix.
+pub(crate) type SharedPostgresPool = (Rc<JsPool>, bool, Rc<OnceCell<()>>);
+
+/// A context-shared MySQL pool: like [`SharedPostgresPool`] plus the
+/// foreign-key mode the stores were configured with.
+pub(crate) type SharedMysqlPool = (Rc<JsPool>, bool, MysqlForeignKeyMode, Rc<OnceCell<()>>);
+
 /// Process-shared resources backing one or more `BreezSdk` instances on WASM.
 ///
 /// Construct once via `newSharedSdkContext` and pass the handle to every
@@ -21,8 +37,8 @@ use crate::{
 #[wasm_bindgen]
 pub struct WasmSdkContext {
     pub(crate) inner: Arc<breez_sdk_spark::SdkContext>,
-    pub(crate) postgres_pool: Option<(Rc<JsPool>, bool)>,
-    pub(crate) mysql_pool: Option<(Rc<JsPool>, bool, MysqlForeignKeyMode)>,
+    pub(crate) postgres_pool: Option<SharedPostgresPool>,
+    pub(crate) mysql_pool: Option<SharedMysqlPool>,
 }
 
 /// Settings for `newSharedSdkContext`. `network` is required; all other
@@ -74,7 +90,11 @@ pub async fn new_shared_sdk_context(config: WasmSdkContextConfig) -> WasmResult<
     let postgres_pool = match config.postgres_config {
         Some(cfg) => {
             let run_migration = cfg.run_migration;
-            Some((Rc::new(create_postgres_pool(cfg)?), run_migration))
+            Some((
+                Rc::new(create_postgres_pool(cfg)?),
+                run_migration,
+                Rc::new(OnceCell::new()),
+            ))
         }
         None => None,
     };
@@ -87,6 +107,7 @@ pub async fn new_shared_sdk_context(config: WasmSdkContextConfig) -> WasmResult<
                 Rc::new(create_mysql_pool(cfg)?),
                 run_migration,
                 foreign_key_mode,
+                Rc::new(OnceCell::new()),
             ))
         }
         None => None,


### PR DESCRIPTION
When there is latency between the server and the DB, a multi-tenant deployment can easily run into contention issues because every instance build competes for the same global DB locks. 