### PR TITLE
fix: unify WASM byte types on Uint8Array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,7 @@ dependencies = [
  "platform-utils",
  "serde",
  "serde-wasm-bindgen",
+ "serde_bytes",
  "spark-wallet",
  "tracing",
  "tracing-subscriber",
@@ -4565,6 +4566,16 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ rusqlite_migration = { version = "1.3.1" }
 rustls = { version = "0.23.37", default-features = false, features = ["ring"] }
 rustyline = "16.0.0"
 serde = "1.0.219"
+serde_bytes = "0.11"
 serde_json = "1.0.140"
 serde-wasm-bindgen = "0.6.5"
 serde_with = "3.13.0"

--- a/crates/breez-sdk/wasm/Cargo.toml
+++ b/crates/breez-sdk/wasm/Cargo.toml
@@ -37,6 +37,7 @@ macros.workspace = true
 platform-utils.workspace = true
 serde.workspace = true
 serde-wasm-bindgen.workspace = true
+serde_bytes.workspace = true
 spark-wallet.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.d.ts
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.d.ts
@@ -1,5 +1,13 @@
 import { PasskeyClient as SdkPasskeyClient } from '../breez_sdk_spark_wasm';
-import type { PasskeyConfig, PrfProvider } from '../breez_sdk_spark_wasm';
+import type {
+    PasskeyConfig,
+    PrfProvider,
+    PasskeyCredential,
+    DeriveSeedsResult,
+    DeriveSeedOptions
+} from '../breez_sdk_spark_wasm';
+
+export type { PasskeyCredential, DeriveSeedsResult, DeriveSeedOptions };
 
 /**
  * Outcome of a domain-association check: whether `rpId` is a valid
@@ -9,32 +17,6 @@ export type DomainAssociation =
     | { kind: 'Associated' }
     | { kind: 'NotAssociated'; source: string; reason: string }
     | { kind: 'Skipped'; reason: string };
-
-/**
- * A passkey credential from a register or sign-in ceremony.
- * `credentialId` is always set. `userId` (provider-generated WebAuthn
- * user handle, never host-supplied), `aaguid` (provider identifier), and
- * `backupEligible` (can sync across devices) are populated on
- * registration and null on sign-in (an assertion carries no
- * attestation). AAGUID is unverified: a display hint only, never a trust
- * signal.
- */
-export interface PasskeyCredential {
-    credentialId: Uint8Array;
-    userId: Uint8Array | null;
-    aaguid: Uint8Array | null;
-    backupEligible: boolean | null;
-}
-
-/**
- * Result of {@link PasskeyProvider.deriveSeeds}: the 32-byte outputs in
- * input order plus the credential ID observed in the same assertion
- * (null when `salts` was empty).
- */
-export interface DeriveSeedsResult {
-    seeds: Uint8Array[];
-    credentialId: Uint8Array | null;
-}
 
 /**
  * Thrown by `createPasskey` when an entry in `excludeCredentials`
@@ -69,23 +51,6 @@ export declare class PasskeyCredentialNotFoundError extends Error {
  */
 export declare class PasskeyUserCancelledError extends Error {
     constructor(message?: string);
-}
-
-/** Per-call options for {@link PasskeyProvider.deriveSeeds}. */
-export interface DeriveSeedOptions {
-    /**
-     * Credential IDs the assertion is restricted to, for
-     * reauthenticating a known user without an account picker. Empty or
-     * unset lets the browser pick any matching credential for this RP.
-     */
-    allowCredentials?: Uint8Array[];
-
-    /**
-     * Requests fast-fail when no local credential is available. Ignored
-     * by the web provider: the WebAuthn flag it maps to is still
-     * experimental, so the standard browser picker is always shown.
-     */
-    preferImmediatelyAvailableCredentials?: boolean;
 }
 
 /**

--- a/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
+++ b/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
@@ -259,7 +259,7 @@ export interface PrfProvider {
      *   credential ID observed in the same assertion (`null` when the
      *   provider surfaces none, e.g. sources without an OS picker)
      */
-    deriveSeeds(salts: string[], options?: DeriveSeedsOptionsJSON): Promise<DeriveSeedsResultJSON>;
+    deriveSeeds(salts: string[], options?: DeriveSeedOptions): Promise<DeriveSeedsResult>;
 
     /**
      * Optional explicit registration. Platform passkey providers (browser
@@ -275,7 +275,7 @@ export interface PrfProvider {
      * @throws `PasskeyAlreadyExistsError` when an entry in
      *   `excludeCredentials` matches a credential already on the device.
      */
-    createPasskey?(excludeCredentials: Uint8Array[]): Promise<PasskeyCredentialJSON>;
+    createPasskey?(excludeCredentials: Uint8Array[]): Promise<PasskeyCredential>;
 
     /**
      * Whether this provider can produce PRF outputs on the current
@@ -285,12 +285,10 @@ export interface PrfProvider {
 }
 
 /**
- * Plain-object shape passed as the second argument of
- * {@link PrfProvider.deriveSeeds}. Mirrors the bundled
- * `PasskeyProvider`'s `DeriveSeedOptions` so JS providers can apply
- * the same shaping fields the Rust-side `DeriveSeedsRequest` carries.
+ * Per-call options passed as the second argument of
+ * {@link PrfProvider.deriveSeeds}.
  */
-export interface DeriveSeedsOptionsJSON {
+export interface DeriveSeedOptions {
     /**
      * Credential IDs the assertion is restricted to, for reauthenticating
      * a known user without an account picker. Empty or unset lets the
@@ -307,27 +305,14 @@ export interface DeriveSeedsOptionsJSON {
 }
 
 /**
- * Plain-object shape returned by {@link PrfProvider.deriveSeeds}: the
- * derived 32-byte outputs in input order plus the credential ID observed
- * in the same assertion. `credentialId` is `null` when the provider does
- * not surface one (custom deterministic sources without an OS picker).
+ * Returned by {@link PrfProvider.deriveSeeds}: the derived 32-byte outputs
+ * in input order plus the credential ID observed in the same assertion.
+ * `credentialId` is `null` when the provider does not surface one (custom
+ * deterministic sources without an OS picker).
  */
-export interface DeriveSeedsResultJSON {
+export interface DeriveSeedsResult {
     seeds: Uint8Array[];
     credentialId?: Uint8Array | null;
-}
-
-/**
- * Plain-object shape returned by {@link PrfProvider.createPasskey}: the
- * registered credential plus its attestation. `userId` is the WebAuthn
- * user handle the provider generated for this credential, always
- * returned on registration and never host-supplied.
- */
-export interface PasskeyCredentialJSON {
-    credentialId: Uint8Array;
-    userId: Uint8Array;
-    aaguid?: Uint8Array | null;
-    backupEligible?: boolean | null;
 }"#;
 
 #[wasm_bindgen]

--- a/crates/breez-sdk/wasm/src/passkey.rs
+++ b/crates/breez-sdk/wasm/src/passkey.rs
@@ -53,8 +53,14 @@ pub struct Wallet {
 /// display hint only, never a trust signal.
 #[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::PasskeyCredential)]
 pub struct PasskeyCredential {
+    #[serde(with = "serde_bytes")]
+    #[tsify(type = "Uint8Array")]
     pub credential_id: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    #[tsify(type = "Uint8Array")]
     pub user_id: Option<Vec<u8>>,
+    #[serde(with = "serde_bytes")]
+    #[tsify(type = "Uint8Array")]
     pub aaguid: Option<Vec<u8>>,
     pub backup_eligible: Option<bool>,
 }
@@ -63,6 +69,7 @@ pub struct PasskeyCredential {
 #[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::RegisterRequest)]
 pub struct RegisterRequest {
     pub label: Option<String>,
+    #[tsify(type = "Uint8Array[]")]
     pub exclude_credentials: Option<Vec<Vec<u8>>>,
 }
 
@@ -77,6 +84,7 @@ pub struct RegisterResponse {
 #[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::SignInRequest)]
 pub struct SignInRequest {
     pub label: Option<String>,
+    #[tsify(type = "Uint8Array[]")]
     pub allow_credentials: Option<Vec<Vec<u8>>>,
     pub prefer_immediately_available_credentials: Option<bool>,
 }

--- a/crates/xtask/src/package.rs
+++ b/crates/xtask/src/package.rs
@@ -133,6 +133,20 @@ fn package_wasm_cmd(wasm_package: WasmPackages) -> Result<()> {
         }
     }
 
+    // Remove tarballs from prior `yarn pack` runs before packing. `yarn
+    // pack` bundles any `*.tgz` sitting in the package dir into the new
+    // tarball, so without this the output snowballs by the size of every
+    // previous build (each one nesting all the earlier ones).
+    for entry in fs::read_dir(&pkg_dir)
+        .with_context(|| format!("failed to read package dir {:?}", &pkg_dir))?
+    {
+        let path = entry?.path();
+        if path.extension().is_some_and(|ext| ext == "tgz") {
+            fs::remove_file(&path)
+                .with_context(|| format!("failed to remove stale tarball {path:?}"))?;
+        }
+    }
+
     // Run `yarn pack` in the pkg_dir after packaging WASM targets
     let status = Command::new("yarn")
         .arg("pack")

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -44,7 +44,7 @@ const checkAvailability = async () => {
   // `rpId` is required. Pass your app's domain, or
   // `PasskeyProvider.BREEZ_RP_ID` if your app is Breez-registered.
   const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, undefined, undefined)
+  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
 
   // ANCHOR: check-availability
   // checkAvailability collapses isSupported + checkDomainAssociation
@@ -72,14 +72,14 @@ const checkAvailability = async () => {
 const setupPasskeyClient = () => {
   // ANCHOR: setup-client
   const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, '<breez api key>', undefined)
+  const passkey = new PasskeyClient(prfProvider, '<breez api key>', undefined)
   // ANCHOR_END: setup-client
   return passkey
 }
 
 const connectWithPasskey = async () => {
   const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, undefined, undefined)
+  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
 
   // ANCHOR: connect-with-passkey
   // connectWithPasskey is not surfaced on web: WebAuthn can't hand the
@@ -96,7 +96,7 @@ const connectWithPasskey = async () => {
 
 const signInExistingUser = async () => {
   const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, undefined, undefined)
+  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
 
   // ANCHOR: sign-in
   // Returning-user-only sign-in. No fall-through to register.
@@ -106,7 +106,7 @@ const signInExistingUser = async () => {
 
 const registerNewPasskey = async () => {
   const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, undefined, undefined)
+  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
 
   // ANCHOR: register-passkey
   // For a brand-new user with no existing passkey: register() creates
@@ -131,7 +131,7 @@ const registerNewPasskey = async () => {
 
 const credentialMetadata = async () => {
   const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, undefined, undefined)
+  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
 
   // ANCHOR: credential-metadata
   const response = await passkey.register({ label: 'personal' })
@@ -159,7 +159,7 @@ const credentialMetadata = async () => {
 
 const listLabels = async (): Promise<string[]> => {
   const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, '<breez api key>', undefined)
+  const passkey = new PasskeyClient(prfProvider, '<breez api key>', undefined)
   // ANCHOR: list-labels
   const labels = await passkey.labels().list()
   for (const label of labels) {
@@ -171,7 +171,7 @@ const listLabels = async (): Promise<string[]> => {
 
 const storeLabel = async () => {
   const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, '<breez api key>', undefined)
+  const passkey = new PasskeyClient(prfProvider, '<breez api key>', undefined)
   // ANCHOR: store-label
   await passkey.labels().store('personal')
   // ANCHOR_END: store-label
@@ -206,7 +206,7 @@ const checkDomain = async () => {
 
 const recoverFromAlreadyExists = async () => {
   const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, undefined, undefined)
+  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
 
   // ANCHOR: recover-already-exists
   // The OS rejected register because the user's password manager
@@ -236,7 +236,7 @@ const recoverFromAlreadyExists = async () => {
 
 const handleTimeout = async () => {
   const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, undefined, undefined)
+  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
 
   // ANCHOR: handle-timeout
   // The OS biometric inactivity timeout (~55s+) tore down the prompt


### PR DESCRIPTION
## Problem

The WASM passkey surface had two byte representations and a structural gap:

1. **Two byte shapes.** tsify-generated response/request types used `number[]`; the hand-written `PrfProvider` boundary used `Uint8Array`. This split required the duplicate boundary types `PasskeyCredentialJSON`, `DeriveSeedsResultJSON`, and `DeriveSeedsOptionsJSON`, and pushed `number[]`-to-`Uint8Array` conversions onto integrators.
2. **No-cast conformance gap.** The built-in `PasskeyProvider` did not structurally satisfy `PrfProvider`, so injecting it forced a cast (`new PasskeyClient(new PasskeyProvider(...) as any, ...)`).

## Changes

**Unify the WASM byte types on `Uint8Array`.** `PasskeyCredential`'s byte fields serialize via `serde_bytes` (serde-wasm-bindgen emits `Uint8Array`) with a tsify type override so the generated `.d.ts` matches. `RegisterRequest.excludeCredentials` / `SignInRequest.allowCredentials` take only the tsify override, since the deserializer already reads a JS `Uint8Array` into a `Vec<u8>`.

**Result**: one shape both internal and external, no `*JSON` duplicates, no app-side `number[]`/`Uint8Array` conversions, and `PasskeyProvider` satisfies `PrfProvider` with **no cast**. The WASM snippet drops its `as any`.
