### PR TITLE
Token conversion: Harden recovery against silent failures

### DIFF
--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1162,6 +1162,16 @@ pub struct BuyBitcoinResponse {
     pub url: String,
 }
 
+/// Response from refunding pending conversions.
+#[derive(Debug, Clone, Serialize, Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct RefundPendingConversionsResponse {
+    /// Pending conversions refunded.
+    pub refunded: u32,
+    /// Pending conversions skipped.
+    pub skipped: u32,
+}
+
 impl std::fmt::Display for MaxFee {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1166,10 +1166,14 @@ pub struct BuyBitcoinResponse {
 #[derive(Debug, Clone, Serialize, Default)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct RefundPendingConversionsResponse {
-    /// Pending conversions refunded.
+    /// Conversions successfully refunded this pass.
     pub refunded: u32,
-    /// Pending conversions skipped.
+    /// Conversions intentionally deferred (eligible but held back by a
+    /// safety window). The next pass will retry them.
     pub skipped: u32,
+    /// Conversions that did not refund this pass. The next pass will
+    /// retry them.
+    pub failed: u32,
 }
 
 impl std::fmt::Display for MaxFee {

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1171,8 +1171,8 @@ pub struct RefundPendingConversionsResponse {
     /// Conversions intentionally deferred (eligible but held back by a
     /// safety window). The next pass will retry them.
     pub skipped: u32,
-    /// Conversions that did not refund this pass. The next pass will
-    /// retry them.
+    /// Conversions whose clawback did not complete this pass (rejected or
+    /// errored; funds not returned). The next pass will retry them.
     pub failed: u32,
 }
 

--- a/crates/breez-sdk/core/src/sdk/payments/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/mod.rs
@@ -99,15 +99,16 @@ impl BreezSdk {
             .map_err(Into::into)
     }
 
-    /// Runs one pass of the pending-conversion refunder.
+    /// Runs one full pass of the pending-conversion refunder and returns how
+    /// many conversions were refunded, skipped (held back by a safety window),
+    /// or failed.
     ///
-    /// Iterates over payments whose conversions failed and have a refund
-    /// pending, then attempts to refund each one. This is the same logic the
-    /// SDK runs internally on a periodic schedule when
-    /// `background_tasks_enabled` is `true`. When background tasks are
-    /// disabled the periodic refunder does not run, and this method is the
-    /// explicit entry point for driving the pass; when background tasks are
-    /// enabled, it can be called to force an immediate refund pass.
+    /// The pass has two parts: refunding locally-marked failed conversions, and
+    /// reconciling against Flashnet's clawback-eligible listing to catch
+    /// conversions with no local marker (e.g. a storage write that never
+    /// landed). The SDK's periodic background schedule runs only the local
+    /// part; the reconcile runs at SDK init and on each call to this method, so
+    /// this is the explicit entry point for driving a full pass on demand.
     pub async fn refund_pending_conversions(
         &self,
     ) -> Result<RefundPendingConversionsResponse, SdkError> {

--- a/crates/breez-sdk/core/src/sdk/payments/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/mod.rs
@@ -3,7 +3,8 @@ use tracing::instrument;
 
 use crate::{
     ClaimHtlcPaymentRequest, ClaimHtlcPaymentResponse, FetchConversionLimitsRequest,
-    FetchConversionLimitsResponse, GetPaymentRequest, GetPaymentResponse, WaitForPaymentIdentifier,
+    FetchConversionLimitsResponse, GetPaymentRequest, GetPaymentResponse,
+    RefundPendingConversionsResponse, WaitForPaymentIdentifier,
     error::SdkError,
     models::{
         ListPaymentsRequest, ListPaymentsResponse, Payment, PaymentRequest,
@@ -107,7 +108,9 @@ impl BreezSdk {
     /// disabled the periodic refunder does not run, and this method is the
     /// explicit entry point for driving the pass; when background tasks are
     /// enabled, it can be called to force an immediate refund pass.
-    pub async fn refund_pending_conversions(&self) -> Result<(), SdkError> {
+    pub async fn refund_pending_conversions(
+        &self,
+    ) -> Result<RefundPendingConversionsResponse, SdkError> {
         self.token_converter
             .refund_pending()
             .await

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -467,14 +467,26 @@ fn spawn_conversion_refunder(
 
     tokio::spawn(
         async move {
-            loop {
-                if let Err(e) = token_converter.refund_pending().await {
-                    error!("Failed to refund failed conversions: {e:?}");
+            // Init pass includes the Flashnet listing reconcile; periodic
+            // ticks below are local-only.
+            select! {
+                biased;
+                _ = shutdown_receiver.changed() => {
+                    info!("Conversion refunder shutdown before init pass completed");
+                    return;
                 }
+                result = token_converter.refund_pending() => {
+                    if let Err(e) = result {
+                        error!("Init conversion-refund pass failed: {e:?}");
+                    }
+                }
+            }
 
+            loop {
                 match refund_requests.as_mut() {
                     Some(trigger_receiver) => {
                         select! {
+                            biased;
                             _ = shutdown_receiver.changed() => {
                                 info!("Conversion refunder shutdown signal received");
                                 return;
@@ -487,11 +499,25 @@ fn spawn_conversion_refunder(
                     }
                     None => {
                         select! {
+                            biased;
                             _ = shutdown_receiver.changed() => {
                                 info!("Conversion refunder shutdown signal received");
                                 return;
                             }
                             () = tokio::time::sleep(Duration::from_secs(150)) => {}
+                        }
+                    }
+                }
+
+                select! {
+                    biased;
+                    _ = shutdown_receiver.changed() => {
+                        info!("Conversion refunder shutdown during local pass");
+                        return;
+                    }
+                    result = token_converter.refund_local_pending() => {
+                        if let Err(e) = result {
+                            error!("Periodic local refund pass failed: {e:?}");
                         }
                     }
                 }

--- a/crates/breez-sdk/core/src/token_conversion/flashnet.rs
+++ b/crates/breez-sdk/core/src/token_conversion/flashnet.rs
@@ -2,21 +2,26 @@ use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 use bitcoin::secp256k1::PublicKey;
 use flashnet::{
-    AssetTransfer, BTC_ASSET_ADDRESS, CacheStore, ClawbackRequest, ClawbackResponse,
+    AssetTransfer, BTC_ASSET_ADDRESS, CacheStore, ClawbackRequest, ClawbackTransfer,
     ExecuteSwapRequest, ExecuteSwapResponse, FlashnetClient, FlashnetConfig, FlashnetError,
-    GetMinAmountsRequest, ListPoolsRequest, PoolSortOrder, SimulateSwapRequest,
+    GetMinAmountsRequest, ListClawbackTransfersRequest, ListPoolsRequest, PoolSortOrder,
+    SimulateSwapRequest,
 };
+use platform_utils::time::{SystemTime, UNIX_EPOCH};
 use spark_wallet::{SparkWallet, TransferId};
 use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
 
 use crate::{
     AmountAdjustmentReason, EventEmitter, Network, Payment, PaymentDetails, PaymentMetadata,
-    Storage,
+    RefundPendingConversionsResponse, Storage,
     persist::{StorageListPaymentsRequest, StoragePaymentDetailsFilter},
     token_conversion::{ConversionAmount, DEFAULT_CONVERSION_MAX_SLIPPAGE_BPS},
     utils::{
-        payments::{fetch_and_process_payment, insert_payment_with_metadata},
+        payments::{
+            fetch_and_process_payment, insert_payment_with_metadata,
+            resolve_and_insert_payment_metadata,
+        },
         polling::{PollSchedule, poll_until},
     },
 };
@@ -34,6 +39,27 @@ use super::{
 const RECEIVED_LEG_POLL_INITIAL_DELAY_MS: u64 = 500;
 const RECEIVED_LEG_POLL_MAX_DELAY_MS: u64 = 2000;
 const RECEIVED_LEG_POLL_TIMEOUT_SECS: u64 = 15;
+
+/// Min age before reconcile claws a transfer back — guards against racing a
+/// concurrent same-seed instance's in-flight healthy swap.
+const RECONCILE_MIN_AGE_SECS: u64 = 300;
+/// Reconcile listing page size. Not paginated — subsequent inits pick up any
+/// overflow.
+const RECONCILE_LISTING_LIMIT: u32 = 100;
+
+/// Missing/unparseable timestamps fall back to old-enough/recent respectively.
+fn transfer_is_older_than(transfer: &ClawbackTransfer, cutoff_secs: u64) -> bool {
+    let Some(created_at) = transfer.created_at.as_deref() else {
+        return true;
+    };
+    let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(created_at) else {
+        return false;
+    };
+    let Ok(secs) = u64::try_from(parsed.timestamp()) else {
+        return false;
+    };
+    secs < cutoff_secs
+}
 
 /// Flashnet-based implementation of the `TokenConverter` trait.
 ///
@@ -86,13 +112,13 @@ impl FlashnetTokenConverter {
         }
     }
 
-    /// Process all failed conversions needing refunds.
+    /// Refunds rows marked `ConversionStatus::RefundNeeded`.
     async fn refund_failed_conversions(
-        storage: &Arc<dyn Storage>,
-        flashnet_client: &Arc<FlashnetClient>,
-    ) -> Result<(), ConversionError> {
+        &self,
+    ) -> Result<RefundPendingConversionsResponse, ConversionError> {
         debug!("Checking for failed conversions needing refunds");
-        let payments = storage
+        let payments = self
+            .storage
             .list_payments(StorageListPaymentsRequest {
                 payment_details_filter: Some(vec![
                     StoragePaymentDetailsFilter::Spark {
@@ -114,111 +140,226 @@ impl FlashnetTokenConverter {
             payments.len()
         );
 
+        let mut report = RefundPendingConversionsResponse::default();
         for payment in payments {
-            if let Err(e) = Self::refund_payment(storage, flashnet_client, &payment).await {
-                error!(
-                    "Failed to refund conversion for payment {}: {e:?}",
-                    payment.id
-                );
+            match self.refund_payment(&payment).await {
+                Ok(true) => report.refunded = report.refunded.saturating_add(1),
+                Ok(false) => report.skipped = report.skipped.saturating_add(1),
+                Err(e) => {
+                    error!(
+                        "Failed to refund conversion for payment {}: {e:?}",
+                        payment.id
+                    );
+                    report.skipped = report.skipped.saturating_add(1);
+                }
             }
         }
-        Ok(())
+        Ok(report)
     }
 
-    /// Refund a single failed conversion payment.
-    async fn refund_payment(
-        storage: &Arc<dyn Storage>,
-        flashnet_client: &Arc<FlashnetClient>,
-        payment: &Payment,
-    ) -> Result<(), ConversionError> {
+    /// Refund a single locally-tracked failed conversion.
+    async fn refund_payment(&self, payment: &Payment) -> Result<bool, ConversionError> {
         let (clawback_id, conversion_info) = match &payment.details {
             Some(PaymentDetails::Spark {
                 conversion_info, ..
-            }) => (payment.id.clone(), conversion_info),
+            }) => (payment.id.clone(), conversion_info.as_ref()),
             Some(PaymentDetails::Token {
                 tx_hash,
                 conversion_info,
                 ..
-            }) => (tx_hash.clone(), conversion_info),
+            }) => (tx_hash.clone(), conversion_info.as_ref()),
             _ => {
                 return Err(ConversionError::RefundFailed(
-                    "Payment is not a Spark or Conversion".into(),
+                    "Payment is not a Spark or Token conversion".into(),
                 ));
             }
         };
-
         let Some(ConversionInfo::Amm {
             pool_id,
-            conversion_id,
             status: ConversionStatus::RefundNeeded,
-            fee,
-            purpose,
-            amount_adjustment,
+            ..
         }) = conversion_info
         else {
             return Err(ConversionError::RefundFailed(
                 "Conversion is not an AMM conversion with refund pending status".into(),
             ));
         };
-
+        let pool_id = PublicKey::from_str(pool_id).map_err(|e| {
+            ConversionError::RefundFailed(format!("Invalid pool_id {pool_id}: {e}"))
+        })?;
         debug!(
             "Conversion refund needed for payment {}: pool_id {pool_id}",
             payment.id
         );
+        // payment.id is the storage row id — pass it as the hint so the
+        // shared helper skips the operator round-trip.
+        self.clawback_and_record_refunded(&clawback_id, pool_id, Some(payment.id.clone()))
+            .await
+    }
 
-        let Ok(pool_id) = PublicKey::from_str(pool_id) else {
-            return Err(ConversionError::RefundFailed(format!(
-                "Invalid pool_id: {pool_id}"
-            )));
-        };
+    /// Refunds transfers Flashnet flags as clawback-eligible. Catches the
+    /// cases the local refunder can't see (storage write failed, process
+    /// killed before mark).
+    async fn reconcile_with_flashnet(
+        &self,
+    ) -> Result<RefundPendingConversionsResponse, ConversionError> {
+        let clawback_transfers = self
+            .flashnet_client
+            .list_clawback_transfers(ListClawbackTransfersRequest {
+                limit: Some(RECONCILE_LISTING_LIMIT),
+                offset: None,
+            })
+            .await?;
 
-        match flashnet_client
+        debug!(
+            "Reconcile: Flashnet listing returned {} clawback transfers",
+            clawback_transfers.transfers.len()
+        );
+
+        let cutoff_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs())
+            .saturating_sub(RECONCILE_MIN_AGE_SECS);
+        // Skip breakdown kept internal; public response collapses to one count.
+        let mut res = RefundPendingConversionsResponse::default();
+        for transfer in clawback_transfers.transfers {
+            if !transfer_is_older_than(&transfer, cutoff_secs) {
+                debug!("Reconcile: skipping {} (within age threshold)", transfer.id);
+                res.skipped = res.skipped.saturating_add(1);
+                continue;
+            }
+            match self
+                .clawback_and_record_refunded(&transfer.id, transfer.lp_identity_public_key, None)
+                .await
+            {
+                Ok(true) => res.refunded = res.refunded.saturating_add(1),
+                _ => res.skipped = res.skipped.saturating_add(1),
+            }
+        }
+        if res.refunded > 0 || res.skipped > 0 {
+            info!(
+                "Reconcile pass complete: refunded={}, skipped={}",
+                res.refunded, res.skipped
+            );
+        }
+        Ok(res)
+    }
+
+    /// Claws back one transfer and writes `Refunded` metadata. `Ok(false)`
+    /// also writes metadata so a prior write-failure can recover. Pass
+    /// `payment_id` when known to skip the operator resolution.
+    async fn clawback_and_record_refunded(
+        &self,
+        clawback_id: &str,
+        pool_id: PublicKey,
+        payment_id: Option<String>,
+    ) -> Result<bool, ConversionError> {
+        let outcome = match self
+            .flashnet_client
             .clawback(ClawbackRequest {
                 pool_id,
-                transfer_id: clawback_id,
+                transfer_id: clawback_id.to_string(),
             })
             .await
         {
-            Ok(ClawbackResponse {
-                accepted: true,
-                spark_status_tracking_id,
-                ..
-            }) => {
+            Ok(r) if r.accepted => {
                 debug!(
-                    "Clawback initiated for payment {}: tracking_id: {}",
-                    payment.id, spark_status_tracking_id
+                    "Clawback accepted for {clawback_id}: tracking_id={}",
+                    r.spark_status_tracking_id
                 );
-                // Update the payment metadata to reflect the refund status
-                storage
-                    .insert_payment_metadata(
-                        payment.id.clone(),
-                        PaymentMetadata {
-                            conversion_info: Some(ConversionInfo::Amm {
-                                pool_id: pool_id.to_string(),
-                                conversion_id: conversion_id.clone(),
-                                status: ConversionStatus::Refunded,
-                                fee: *fee,
-                                purpose: purpose.clone(),
-                                amount_adjustment: amount_adjustment.clone(),
-                            }),
-                            ..Default::default()
-                        },
-                    )
-                    .await?;
-                Ok(())
+                true
             }
-            Ok(ClawbackResponse {
-                accepted: false,
-                request_id,
-                error,
+            Ok(r) => {
+                warn!("Clawback for {clawback_id} not accepted: {:?}", r.error);
+                false
+            }
+            Err(e) => {
+                error!("Clawback for {clawback_id} failed: {e}");
+                return Err(e.into());
+            }
+        };
+
+        // Preserve the prior ConversionInfo::Amm fields when we can read it;
+        // fall back to a placeholder when storage has nothing (reconcile path
+        // recovering a row whose original metadata write never landed).
+        let prev_amm =
+            self.storage
+                .get_payment_by_id(
+                    payment_id
+                        .clone()
+                        .unwrap_or_else(|| clawback_id.to_string()),
+                )
+                .await
+                .ok()
+                .and_then(|p| match p.details {
+                    Some(
+                        PaymentDetails::Spark {
+                            conversion_info, ..
+                        }
+                        | PaymentDetails::Token {
+                            conversion_info, ..
+                        },
+                    ) => conversion_info,
+                    _ => None,
+                });
+        let conversion_info = match prev_amm {
+            Some(ConversionInfo::Amm {
+                pool_id: prev_pool_id,
+                conversion_id,
+                fee,
+                purpose,
+                amount_adjustment,
                 ..
-            }) => Err(ConversionError::RefundFailed(format!(
-                "Clawback not accepted: request_id: {request_id:?}, error: {error:?}"
-            ))),
-            Err(e) => Err(ConversionError::RefundFailed(format!(
-                "Failed to initiate clawback: {e}"
-            ))),
+            }) => ConversionInfo::Amm {
+                pool_id: prev_pool_id,
+                conversion_id,
+                status: ConversionStatus::Refunded,
+                fee,
+                purpose,
+                amount_adjustment,
+            },
+            _ => ConversionInfo::Amm {
+                pool_id: pool_id.to_string(),
+                conversion_id: uuid::Uuid::now_v7().to_string(),
+                status: ConversionStatus::Refunded,
+                fee: None,
+                purpose: None,
+                amount_adjustment: None,
+            },
+        };
+        let metadata = PaymentMetadata {
+            conversion_info: Some(conversion_info),
+            ..Default::default()
+        };
+
+        // With a payment_id hint, skip resolution and write directly.
+        // Without one, use the shared helper: it resolves (operator round-
+        // trip for tokens) and caches the metadata for the next sync if
+        // resolution fails. That cache fallback covers the otherwise-silent
+        // "clawback accepted server-side, local row unreachable" case.
+        match payment_id {
+            Some(id) => {
+                self.storage
+                    .insert_payment_metadata(id, metadata)
+                    .await
+                    .map_err(|e| {
+                        warn!("Metadata write failed for {clawback_id}: {e}");
+                        ConversionError::from(e)
+                    })?;
+            }
+            None => {
+                resolve_and_insert_payment_metadata(
+                    clawback_id,
+                    metadata,
+                    &self.spark_wallet,
+                    &self.storage,
+                    true,
+                )
+                .await
+                .map_err(ConversionError::Sdk)?;
+            }
         }
+        Ok(outcome)
     }
 
     /// Gets the best conversion pool for the given conversion options and amount.
@@ -354,7 +495,7 @@ impl FlashnetTokenConverter {
     ///
     /// Arguments:
     /// * `pool_id` - The pool id used for the conversion.
-    /// * `outbound_identifier` - The outbound spark transfer id or token transaction hash.
+    /// * `outbound_payment_id` - Pre-derived storage `payment_id` for the sent leg.
     /// * `inbound_identifier` - The inbound spark transfer id or token transaction hash if the conversion was successful.
     /// * `refund_identifier` - The inbound refund spark transfer id or token transaction hash if the conversion was refunded.
     /// * `fee_split` - The fee split between sent and received sides of the conversion.
@@ -785,29 +926,32 @@ impl TokenConverter for FlashnetTokenConverter {
             }
             Err(e) => {
                 error!("Convert token failed: {e:?}");
-                if let FlashnetError::Execution {
-                    outbound_asset_transfer: Some(outbound_asset_transfer),
+                let FlashnetError::Execution {
+                    outbound_asset_transfer: Some(transfer),
                     source,
                 } = &e
-                {
-                    let _ = Box::pin(self.update_payment_conversion_info(
-                        &pool_id,
-                        outbound_asset_transfer,
-                        None,
-                        None,
-                        None,
-                        purpose,
-                        amount_adjustment.clone(),
-                    ))
-                    .await;
-                    let _ = self.refund_trigger.send(());
-                    Err(ConversionError::ConversionFailed(format!(
-                        "Convert token failed, refund pending: {}",
-                        *source.clone()
-                    )))
-                } else {
-                    Err(e.into())
+                else {
+                    return Err(e.into());
+                };
+                // Best-effort RefundNeeded mark; reconcile catches anything we miss.
+                let update_res = Box::pin(self.update_payment_conversion_info(
+                    &pool_id,
+                    transfer,
+                    None,
+                    None,
+                    None,
+                    purpose,
+                    amount_adjustment.clone(),
+                ))
+                .await;
+                if let Err(err) = update_res {
+                    warn!("Could not update {} to RefundNeeded: {err}", transfer.id());
                 }
+                let _ = self.refund_trigger.send(());
+                Err(ConversionError::ConversionFailed(format!(
+                    "Convert token failed, refund pending: {}",
+                    *source.clone()
+                )))
             }
         }
     }
@@ -893,8 +1037,43 @@ impl TokenConverter for FlashnetTokenConverter {
         })
     }
 
-    async fn refund_pending(&self) -> Result<(), ConversionError> {
-        Self::refund_failed_conversions(&self.storage, &self.flashnet_client).await
+    async fn refund_pending(&self) -> Result<RefundPendingConversionsResponse, ConversionError> {
+        let local = match self.refund_failed_conversions().await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("Local refund pass failed: {e}");
+                RefundPendingConversionsResponse::default()
+            }
+        };
+        let remote = match self.reconcile_with_flashnet().await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("Reconcile with Flashnet failed: {e}");
+                RefundPendingConversionsResponse::default()
+            }
+        };
+        let combined = RefundPendingConversionsResponse {
+            refunded: local.refunded.saturating_add(remote.refunded),
+            skipped: local.skipped.saturating_add(remote.skipped),
+        };
+        if combined.refunded > 0 || combined.skipped > 0 {
+            info!(
+                "Refund-pending pass: refunded={} (local={}, remote={}), skipped={} (local={}, remote={})",
+                combined.refunded,
+                local.refunded,
+                remote.refunded,
+                combined.skipped,
+                local.skipped,
+                remote.skipped,
+            );
+        }
+        Ok(combined)
+    }
+
+    async fn refund_local_pending(
+        &self,
+    ) -> Result<RefundPendingConversionsResponse, ConversionError> {
+        self.refund_failed_conversions().await
     }
 
     fn subscribe_refund_requests(&self) -> Option<broadcast::Receiver<()>> {

--- a/crates/breez-sdk/core/src/token_conversion/flashnet.rs
+++ b/crates/breez-sdk/core/src/token_conversion/flashnet.rs
@@ -19,8 +19,8 @@ use crate::{
     token_conversion::{ConversionAmount, DEFAULT_CONVERSION_MAX_SLIPPAGE_BPS},
     utils::{
         payments::{
-            fetch_and_process_payment, insert_payment_with_metadata,
-            resolve_and_insert_payment_metadata,
+            fetch_and_process_payment, insert_payment_metadata_with_cache_fallback,
+            insert_payment_with_metadata, resolve_and_insert_payment_metadata, resolve_payment_id,
         },
         polling::{PollSchedule, poll_until},
     },
@@ -48,10 +48,9 @@ const RECONCILE_MIN_AGE_SECS: u64 = 300;
 const RECONCILE_LISTING_LIMIT: u32 = 100;
 
 /// Returns true when the transfer is older than `cutoff_secs`, i.e. eligible
-/// for clawback. Backend emits RFC 3339; missing or unparseable timestamps
-/// fall back to eligible so reconcile trusts Flashnet's clawback-eligibility
-/// verdict instead of silently no-op'ing on an unexpected format. The
-/// unparseable branch logs at `warn` so operators see format drift.
+/// for clawback. Backend emits RFC 3339; a missing or unparseable timestamp
+/// falls back to eligible, trusting Flashnet's clawback-eligibility verdict
+/// over silently skipping on an unexpected format.
 fn transfer_is_older_than(transfer: &ClawbackTransfer, cutoff_secs: u64) -> bool {
     let Some(created_at) = transfer.created_at.as_deref() else {
         return true;
@@ -67,6 +66,41 @@ fn transfer_is_older_than(transfer: &ClawbackTransfer, cutoff_secs: u64) -> bool
             transfer.id
         );
         true
+    }
+}
+
+/// Builds the `Refunded` metadata for a clawed-back conversion. Carries the
+/// prior AMM fields (`conversion_id`, `fee`, `purpose`, `amount_adjustment`)
+/// forward when present; otherwise emits a placeholder keyed on
+/// `fallback_pool_id` with a fresh `conversion_id` and unset fields.
+fn refunded_info_from_prior(
+    prev: Option<ConversionInfo>,
+    fallback_pool_id: &PublicKey,
+) -> ConversionInfo {
+    match prev {
+        Some(ConversionInfo::Amm {
+            pool_id,
+            conversion_id,
+            fee,
+            purpose,
+            amount_adjustment,
+            ..
+        }) => ConversionInfo::Amm {
+            pool_id,
+            conversion_id,
+            status: ConversionStatus::Refunded,
+            fee,
+            purpose,
+            amount_adjustment,
+        },
+        _ => ConversionInfo::Amm {
+            pool_id: fallback_pool_id.to_string(),
+            conversion_id: uuid::Uuid::now_v7().to_string(),
+            status: ConversionStatus::Refunded,
+            fee: None,
+            purpose: None,
+            amount_adjustment: None,
+        },
     }
 }
 
@@ -183,11 +217,13 @@ impl FlashnetTokenConverter {
                 ));
             }
         };
-        let Some(ConversionInfo::Amm {
-            pool_id,
-            status: ConversionStatus::RefundNeeded,
-            ..
-        }) = conversion_info
+        let Some(
+            info @ ConversionInfo::Amm {
+                pool_id,
+                status: ConversionStatus::RefundNeeded,
+                ..
+            },
+        ) = conversion_info
         else {
             return Err(ConversionError::RefundFailed(
                 "Conversion is not an AMM conversion with refund pending status".into(),
@@ -200,10 +236,15 @@ impl FlashnetTokenConverter {
             "Conversion refund needed for payment {}: pool_id {pool_id}",
             payment.id
         );
-        // payment.id is the storage row id — pass it as the hint so the
-        // shared helper skips the operator round-trip.
-        self.clawback_and_record_refunded(&clawback_id, pool_id, Some(payment.id.clone()))
-            .await
+        // payment.id is the storage row id. Pass the already-loaded conversion
+        // info so the write preserves its fields without re-reading the row.
+        self.clawback_and_record_refunded(
+            &clawback_id,
+            pool_id,
+            Some(payment.id.clone()),
+            Some(info.clone()),
+        )
+        .await
     }
 
     /// Refunds transfers Flashnet flags as clawback-eligible. Catches the
@@ -237,7 +278,12 @@ impl FlashnetTokenConverter {
                 continue;
             }
             match self
-                .clawback_and_record_refunded(&transfer.id, transfer.lp_identity_public_key, None)
+                .clawback_and_record_refunded(
+                    &transfer.id,
+                    transfer.lp_identity_public_key,
+                    None,
+                    None,
+                )
                 .await
             {
                 Ok(true) => res.refunded = res.refunded.saturating_add(1),
@@ -253,16 +299,18 @@ impl FlashnetTokenConverter {
         Ok(res)
     }
 
-    /// Claws back one transfer. `Ok(true)` = Flashnet accepted and the
-    /// local `Refunded` metadata write was attempted (the write itself
-    /// propagates as `Err` on failure; resolution misses are silent).
-    /// `Ok(false)` = Flashnet rejected, local state untouched so the next
-    /// pass retries. Pass `payment_id` when known to skip resolution.
+    /// Claws back one transfer, then records `Refunded` locally while
+    /// preserving the prior AMM fields. `Ok(true)` = Flashnet accepted (a
+    /// failed metadata write is cached for the next sync); `Ok(false)` =
+    /// rejected, local state untouched for a retry; `Err` = the clawback call
+    /// failed (funds not returned). `payment_id` skips row-id resolution;
+    /// `prior_info` skips the metadata re-read.
     async fn clawback_and_record_refunded(
         &self,
         clawback_id: &str,
         pool_id: PublicKey,
         payment_id: Option<String>,
+        prior_info: Option<ConversionInfo>,
     ) -> Result<bool, ConversionError> {
         match self
             .flashnet_client
@@ -279,7 +327,10 @@ impl FlashnetTokenConverter {
                 );
             }
             Ok(r) => {
-                warn!("Clawback for {clawback_id} not accepted: {:?}", r.error);
+                warn!(
+                    "Clawback for {clawback_id} not accepted (request_id={}): {:?}",
+                    r.request_id, r.error
+                );
                 return Ok(false);
             }
             Err(e) => {
@@ -288,65 +339,54 @@ impl FlashnetTokenConverter {
             }
         }
 
-        // Preserve the prior ConversionInfo::Amm fields when we can read it;
-        // fall back to a placeholder when storage has nothing (reconcile path
-        // recovering a row whose original metadata write never landed).
-        let prev_amm = self
-            .storage
-            .get_payment_by_id(
-                payment_id
-                    .clone()
-                    .unwrap_or_else(|| clawback_id.to_string()),
-            )
-            .await
-            .ok()
-            .and_then(|p| crate::utils::conversions::extract_conversion_info(p.details));
-        let conversion_info = match prev_amm {
-            Some(ConversionInfo::Amm {
-                pool_id: prev_pool_id,
-                conversion_id,
-                fee,
-                purpose,
-                amount_adjustment,
-                ..
-            }) => ConversionInfo::Amm {
-                pool_id: prev_pool_id,
-                conversion_id,
-                status: ConversionStatus::Refunded,
-                fee,
-                purpose,
-                amount_adjustment,
-            },
-            _ => ConversionInfo::Amm {
-                pool_id: pool_id.to_string(),
-                conversion_id: uuid::Uuid::now_v7().to_string(),
-                status: ConversionStatus::Refunded,
-                fee: None,
-                purpose: None,
-                amount_adjustment: None,
+        // Resolve the storage row id once. The local path passes it directly;
+        // reconcile resolves it from clawback_id, which for tokens is a bare
+        // tx hash rather than the {hash}:{vout} row id.
+        let resolved_id = match payment_id {
+            Some(id) => Some(id),
+            None => resolve_payment_id(clawback_id, &self.spark_wallet, &self.storage, true)
+                .await
+                .ok(),
+        };
+
+        // Preserve the prior ConversionInfo::Amm fields. Prefer the
+        // caller-supplied info (local path, definitely present); otherwise read
+        // the resolved row. Falls back to a placeholder when neither is present
+        // (reconcile recovering a row whose original metadata write never landed).
+        let prev = match prior_info {
+            Some(info) => Some(info),
+            None => match &resolved_id {
+                Some(id) => self
+                    .storage
+                    .get_payment_by_id(id.clone())
+                    .await
+                    .ok()
+                    .and_then(|p| crate::utils::conversions::extract_conversion_info(p.details)),
+                None => None,
             },
         };
         let metadata = PaymentMetadata {
-            conversion_info: Some(conversion_info),
+            conversion_info: Some(refunded_info_from_prior(prev, &pool_id)),
             ..Default::default()
         };
 
-        // With a payment_id hint, skip resolution and write directly.
-        // Without one, use the shared helper: it resolves (operator round-
-        // trip for tokens) and caches the metadata for the next sync if
-        // resolution fails. That cache fallback covers the otherwise-silent
-        // "clawback accepted server-side, local row unreachable" case.
-        match payment_id {
+        match resolved_id {
             Some(id) => {
-                self.storage
-                    .insert_payment_metadata(id, metadata)
-                    .await
-                    .map_err(|e| {
-                        warn!("Metadata write failed for {clawback_id}: {e}");
-                        ConversionError::from(e)
-                    })?;
+                // Cache the mark under clawback_id (the sync-time identifier) if
+                // the write fails: the clawback already succeeded, so surface
+                // Ok rather than counting a returned refund as failed.
+                insert_payment_metadata_with_cache_fallback(
+                    &self.storage,
+                    id,
+                    clawback_id,
+                    metadata,
+                )
+                .await
+                .map_err(ConversionError::Sdk)?;
             }
             None => {
+                // Row id didn't resolve (row not present locally): cache under
+                // the identifier so the next sync reapplies the mark.
                 resolve_and_insert_payment_metadata(
                     clawback_id,
                     metadata,
@@ -1043,26 +1083,20 @@ impl TokenConverter for FlashnetTokenConverter {
             Err(e) => {
                 warn!("Local refund pass failed: {e}");
                 local_failed = true;
-                RefundPendingConversionsResponse {
-                    failed: 1,
-                    ..Default::default()
-                }
+                RefundPendingConversionsResponse::default()
             }
         };
         let remote = match self.reconcile_with_flashnet().await {
             Ok(r) => r,
             Err(e) => {
                 warn!("Reconcile with Flashnet failed: {e}");
-                // Both passes errored: surface via Err instead of masking
-                // with Ok. Single-pass error stays Ok with `failed += 1`,
-                // since the other pass still produced counts.
+                // Both passes errored: surface via Err. A single-pass error
+                // stays Ok with the other pass's counts; the errored pass
+                // contributes none rather than a phantom per-conversion `failed`.
                 if local_failed {
                     return Err(e);
                 }
-                RefundPendingConversionsResponse {
-                    failed: 1,
-                    ..Default::default()
-                }
+                RefundPendingConversionsResponse::default()
             }
         };
 
@@ -1122,10 +1156,8 @@ mod tests {
         assert!(transfer_is_older_than(&transfer("id-1", None), 0));
     }
 
-    /// Fail-loud, not-quiet: an unrecognised timestamp must still let the
-    /// clawback proceed (with a warn log) instead of being silently bucketed
-    /// as `skipped`. That silent-skip is the exact class of failure this PR
-    /// exists to prevent.
+    /// An unrecognised timestamp must still let the clawback proceed instead
+    /// of being silently bucketed as `skipped`.
     #[test]
     fn unparseable_created_at_is_eligible() {
         assert!(transfer_is_older_than(
@@ -1146,5 +1178,68 @@ mod tests {
         let t = transfer("id-4", Some("2025-09-22T19:09:36.661269+00:00"));
         assert!(transfer_is_older_than(&t, SAMPLE_UNIX_SECS + 1));
         assert!(!transfer_is_older_than(&t, SAMPLE_UNIX_SECS - 1));
+    }
+
+    fn sample_pool_key() -> PublicKey {
+        PublicKey::from_str("02894808873b896e21d29856a6d7bb346fb13c019739adb9bf0b6a8b7e28da53da")
+            .unwrap()
+    }
+
+    /// The clawed-back mark must carry the prior conversion's fields forward,
+    /// flipping only the status. This is the reconcile/local path preserving
+    /// `fee`/`purpose`/`amount_adjustment` instead of overwriting with a placeholder.
+    #[test]
+    fn refunded_info_preserves_prior_amm_fields() {
+        let prior = ConversionInfo::Amm {
+            pool_id: "prior-pool".to_string(),
+            conversion_id: "conv-abc".to_string(),
+            status: ConversionStatus::RefundNeeded,
+            fee: Some(4200),
+            purpose: Some(ConversionPurpose::AutoConversion),
+            amount_adjustment: Some(AmountAdjustmentReason::FlooredToMinLimit),
+        };
+        let ConversionInfo::Amm {
+            pool_id,
+            conversion_id,
+            status,
+            fee,
+            purpose,
+            amount_adjustment,
+        } = refunded_info_from_prior(Some(prior), &sample_pool_key())
+        else {
+            panic!("expected Amm");
+        };
+        assert_eq!(pool_id, "prior-pool");
+        assert_eq!(conversion_id, "conv-abc");
+        assert_eq!(status, ConversionStatus::Refunded);
+        assert_eq!(fee, Some(4200));
+        assert_eq!(purpose, Some(ConversionPurpose::AutoConversion));
+        assert_eq!(
+            amount_adjustment,
+            Some(AmountAdjustmentReason::FlooredToMinLimit)
+        );
+    }
+
+    /// With no prior metadata (row's original write never landed), the mark
+    /// falls back to the placeholder keyed on the passed pool id.
+    #[test]
+    fn refunded_info_falls_back_to_placeholder_when_absent() {
+        let ConversionInfo::Amm {
+            pool_id,
+            conversion_id,
+            status,
+            fee,
+            purpose,
+            amount_adjustment,
+        } = refunded_info_from_prior(None, &sample_pool_key())
+        else {
+            panic!("expected Amm");
+        };
+        assert_eq!(pool_id, sample_pool_key().to_string());
+        assert!(!conversion_id.is_empty());
+        assert_eq!(status, ConversionStatus::Refunded);
+        assert_eq!(fee, None);
+        assert_eq!(purpose, None);
+        assert_eq!(amount_adjustment, None);
     }
 }

--- a/crates/breez-sdk/core/src/token_conversion/flashnet.rs
+++ b/crates/breez-sdk/core/src/token_conversion/flashnet.rs
@@ -47,18 +47,27 @@ const RECONCILE_MIN_AGE_SECS: u64 = 300;
 /// overflow.
 const RECONCILE_LISTING_LIMIT: u32 = 100;
 
-/// Missing/unparseable timestamps fall back to old-enough/recent respectively.
+/// Returns true when the transfer is older than `cutoff_secs`, i.e. eligible
+/// for clawback. Backend emits RFC 3339; missing or unparseable timestamps
+/// fall back to eligible so reconcile trusts Flashnet's clawback-eligibility
+/// verdict instead of silently no-op'ing on an unexpected format. The
+/// unparseable branch logs at `warn` so operators see format drift.
 fn transfer_is_older_than(transfer: &ClawbackTransfer, cutoff_secs: u64) -> bool {
     let Some(created_at) = transfer.created_at.as_deref() else {
         return true;
     };
-    let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(created_at) else {
-        return false;
-    };
-    let Ok(secs) = u64::try_from(parsed.timestamp()) else {
-        return false;
-    };
-    secs < cutoff_secs
+    if let Some(secs) = chrono::DateTime::parse_from_rfc3339(created_at)
+        .ok()
+        .and_then(|dt| u64::try_from(dt.timestamp()).ok())
+    {
+        secs < cutoff_secs
+    } else {
+        warn!(
+            "Reconcile: unparseable created_at {created_at:?} on clawback transfer {}; treating as eligible",
+            transfer.id
+        );
+        true
+    }
 }
 
 /// Flashnet-based implementation of the `TokenConverter` trait.
@@ -144,13 +153,13 @@ impl FlashnetTokenConverter {
         for payment in payments {
             match self.refund_payment(&payment).await {
                 Ok(true) => report.refunded = report.refunded.saturating_add(1),
-                Ok(false) => report.skipped = report.skipped.saturating_add(1),
+                Ok(false) => report.failed = report.failed.saturating_add(1),
                 Err(e) => {
                     error!(
                         "Failed to refund conversion for payment {}: {e:?}",
                         payment.id
                     );
-                    report.skipped = report.skipped.saturating_add(1);
+                    report.failed = report.failed.saturating_add(1);
                 }
             }
         }
@@ -220,7 +229,6 @@ impl FlashnetTokenConverter {
             .duration_since(UNIX_EPOCH)
             .map_or(0, |d| d.as_secs())
             .saturating_sub(RECONCILE_MIN_AGE_SECS);
-        // Skip breakdown kept internal; public response collapses to one count.
         let mut res = RefundPendingConversionsResponse::default();
         for transfer in clawback_transfers.transfers {
             if !transfer_is_older_than(&transfer, cutoff_secs) {
@@ -233,28 +241,30 @@ impl FlashnetTokenConverter {
                 .await
             {
                 Ok(true) => res.refunded = res.refunded.saturating_add(1),
-                _ => res.skipped = res.skipped.saturating_add(1),
+                Ok(false) | Err(_) => res.failed = res.failed.saturating_add(1),
             }
         }
-        if res.refunded > 0 || res.skipped > 0 {
+        if res.refunded > 0 || res.skipped > 0 || res.failed > 0 {
             info!(
-                "Reconcile pass complete: refunded={}, skipped={}",
-                res.refunded, res.skipped
+                "Reconcile pass complete: refunded={}, skipped={}, failed={}",
+                res.refunded, res.skipped, res.failed
             );
         }
         Ok(res)
     }
 
-    /// Claws back one transfer and writes `Refunded` metadata. `Ok(false)`
-    /// also writes metadata so a prior write-failure can recover. Pass
-    /// `payment_id` when known to skip the operator resolution.
+    /// Claws back one transfer. `Ok(true)` = Flashnet accepted and the
+    /// local `Refunded` metadata write was attempted (the write itself
+    /// propagates as `Err` on failure; resolution misses are silent).
+    /// `Ok(false)` = Flashnet rejected, local state untouched so the next
+    /// pass retries. Pass `payment_id` when known to skip resolution.
     async fn clawback_and_record_refunded(
         &self,
         clawback_id: &str,
         pool_id: PublicKey,
         payment_id: Option<String>,
     ) -> Result<bool, ConversionError> {
-        let outcome = match self
+        match self
             .flashnet_client
             .clawback(ClawbackRequest {
                 pool_id,
@@ -267,41 +277,30 @@ impl FlashnetTokenConverter {
                     "Clawback accepted for {clawback_id}: tracking_id={}",
                     r.spark_status_tracking_id
                 );
-                true
             }
             Ok(r) => {
                 warn!("Clawback for {clawback_id} not accepted: {:?}", r.error);
-                false
+                return Ok(false);
             }
             Err(e) => {
                 error!("Clawback for {clawback_id} failed: {e}");
                 return Err(e.into());
             }
-        };
+        }
 
         // Preserve the prior ConversionInfo::Amm fields when we can read it;
         // fall back to a placeholder when storage has nothing (reconcile path
         // recovering a row whose original metadata write never landed).
-        let prev_amm =
-            self.storage
-                .get_payment_by_id(
-                    payment_id
-                        .clone()
-                        .unwrap_or_else(|| clawback_id.to_string()),
-                )
-                .await
-                .ok()
-                .and_then(|p| match p.details {
-                    Some(
-                        PaymentDetails::Spark {
-                            conversion_info, ..
-                        }
-                        | PaymentDetails::Token {
-                            conversion_info, ..
-                        },
-                    ) => conversion_info,
-                    _ => None,
-                });
+        let prev_amm = self
+            .storage
+            .get_payment_by_id(
+                payment_id
+                    .clone()
+                    .unwrap_or_else(|| clawback_id.to_string()),
+            )
+            .await
+            .ok()
+            .and_then(|p| crate::utils::conversions::extract_conversion_info(p.details));
         let conversion_info = match prev_amm {
             Some(ConversionInfo::Amm {
                 pool_id: prev_pool_id,
@@ -359,7 +358,7 @@ impl FlashnetTokenConverter {
                 .map_err(ConversionError::Sdk)?;
             }
         }
-        Ok(outcome)
+        Ok(true)
     }
 
     /// Gets the best conversion pool for the given conversion options and amount.
@@ -495,7 +494,7 @@ impl FlashnetTokenConverter {
     ///
     /// Arguments:
     /// * `pool_id` - The pool id used for the conversion.
-    /// * `outbound_payment_id` - Pre-derived storage `payment_id` for the sent leg.
+    /// * `outbound_asset_transfer` - The outbound `AssetTransfer` for the sent leg.
     /// * `inbound_identifier` - The inbound spark transfer id or token transaction hash if the conversion was successful.
     /// * `refund_identifier` - The inbound refund spark transfer id or token transaction hash if the conversion was refunded.
     /// * `fee_split` - The fee split between sent and received sides of the conversion.
@@ -1038,33 +1037,52 @@ impl TokenConverter for FlashnetTokenConverter {
     }
 
     async fn refund_pending(&self) -> Result<RefundPendingConversionsResponse, ConversionError> {
+        let mut local_failed = false;
         let local = match self.refund_failed_conversions().await {
             Ok(r) => r,
             Err(e) => {
                 warn!("Local refund pass failed: {e}");
-                RefundPendingConversionsResponse::default()
+                local_failed = true;
+                RefundPendingConversionsResponse {
+                    failed: 1,
+                    ..Default::default()
+                }
             }
         };
         let remote = match self.reconcile_with_flashnet().await {
             Ok(r) => r,
             Err(e) => {
                 warn!("Reconcile with Flashnet failed: {e}");
-                RefundPendingConversionsResponse::default()
+                // Both passes errored: surface via Err instead of masking
+                // with Ok. Single-pass error stays Ok with `failed += 1`,
+                // since the other pass still produced counts.
+                if local_failed {
+                    return Err(e);
+                }
+                RefundPendingConversionsResponse {
+                    failed: 1,
+                    ..Default::default()
+                }
             }
         };
+
         let combined = RefundPendingConversionsResponse {
             refunded: local.refunded.saturating_add(remote.refunded),
             skipped: local.skipped.saturating_add(remote.skipped),
+            failed: local.failed.saturating_add(remote.failed),
         };
-        if combined.refunded > 0 || combined.skipped > 0 {
+        if combined.refunded > 0 || combined.skipped > 0 || combined.failed > 0 {
             info!(
-                "Refund-pending pass: refunded={} (local={}, remote={}), skipped={} (local={}, remote={})",
+                "Refund-pending pass: refunded={} (local={}, remote={}), skipped={} (local={}, remote={}), failed={} (local={}, remote={})",
                 combined.refunded,
                 local.refunded,
                 remote.refunded,
                 combined.skipped,
                 local.skipped,
                 remote.skipped,
+                combined.failed,
+                local.failed,
+                remote.failed,
             );
         }
         Ok(combined)
@@ -1078,5 +1096,55 @@ impl TokenConverter for FlashnetTokenConverter {
 
     fn subscribe_refund_requests(&self) -> Option<broadcast::Receiver<()>> {
         Some(self.refund_trigger.subscribe())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn transfer(id: &str, created_at: Option<&str>) -> ClawbackTransfer {
+        ClawbackTransfer {
+            id: id.to_string(),
+            lp_identity_public_key: PublicKey::from_str(
+                "02894808873b896e21d29856a6d7bb346fb13c019739adb9bf0b6a8b7e28da53da",
+            )
+            .unwrap(),
+            created_at: created_at.map(str::to_string),
+        }
+    }
+
+    /// Unix seconds for `2025-09-22T19:09:36Z`.
+    const SAMPLE_UNIX_SECS: u64 = 1_758_568_176;
+
+    #[test]
+    fn missing_created_at_is_eligible() {
+        assert!(transfer_is_older_than(&transfer("id-1", None), 0));
+    }
+
+    /// Fail-loud, not-quiet: an unrecognised timestamp must still let the
+    /// clawback proceed (with a warn log) instead of being silently bucketed
+    /// as `skipped`. That silent-skip is the exact class of failure this PR
+    /// exists to prevent.
+    #[test]
+    fn unparseable_created_at_is_eligible() {
+        assert!(transfer_is_older_than(
+            &transfer("id-2", Some("not-a-timestamp")),
+            u64::MAX,
+        ));
+    }
+
+    #[test]
+    fn rfc3339_z_respects_cutoff() {
+        let t = transfer("id-3", Some("2025-09-22T19:09:36.661269Z"));
+        assert!(transfer_is_older_than(&t, SAMPLE_UNIX_SECS + 1));
+        assert!(!transfer_is_older_than(&t, SAMPLE_UNIX_SECS - 1));
+    }
+
+    #[test]
+    fn rfc3339_offset_respects_cutoff() {
+        let t = transfer("id-4", Some("2025-09-22T19:09:36.661269+00:00"));
+        assert!(transfer_is_older_than(&t, SAMPLE_UNIX_SECS + 1));
+        assert!(!transfer_is_older_than(&t, SAMPLE_UNIX_SECS - 1));
     }
 }

--- a/crates/breez-sdk/core/src/token_conversion/mod.rs
+++ b/crates/breez-sdk/core/src/token_conversion/mod.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use spark_wallet::TransferId;
 use tokio::sync::broadcast;
 
-use crate::EventEmitter;
+use crate::{EventEmitter, RefundPendingConversionsResponse};
 
 /// Trait for conversion implementations.
 ///
@@ -74,14 +74,13 @@ pub(crate) trait TokenConverter: Send + Sync {
         request: &FetchConversionLimitsRequest,
     ) -> Result<FetchConversionLimitsResponse, ConversionError>;
 
-    /// Process any conversions whose pending refunds need to be issued.
-    ///
-    /// Iterates over payments marked as needing a refund and attempts to
-    /// refund each one. Surfaced through `BreezSdk::refund_pending_conversions`
-    /// so partners can drive this explicitly — required in server mode (where
-    /// no periodic refunder runs) and available in client mode as a way to
-    /// force an immediate refund pass instead of waiting for the next tick.
-    async fn refund_pending(&self) -> Result<(), ConversionError>;
+    /// Runs a local and a remote pass to refund any pending conversions.
+    async fn refund_pending(&self) -> Result<RefundPendingConversionsResponse, ConversionError>;
+
+    /// Runs a local pass to refund any pending conversions.
+    async fn refund_local_pending(
+        &self,
+    ) -> Result<RefundPendingConversionsResponse, ConversionError>;
 
     /// Optional signal that wakes the client-mode periodic refunder.
     fn subscribe_refund_requests(&self) -> Option<broadcast::Receiver<()>> {

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -1667,6 +1667,7 @@ pub struct BuyBitcoinResponse {
 pub struct RefundPendingConversionsResponse {
     pub refunded: u32,
     pub skipped: u32,
+    pub failed: u32,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::Contact)]

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -1663,6 +1663,12 @@ pub struct BuyBitcoinResponse {
     pub url: String,
 }
 
+#[macros::extern_wasm_bindgen(breez_sdk_spark::RefundPendingConversionsResponse)]
+pub struct RefundPendingConversionsResponse {
+    pub refunded: u32,
+    pub skipped: u32,
+}
+
 #[macros::extern_wasm_bindgen(breez_sdk_spark::Contact)]
 pub struct Contact {
     pub id: String,

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -421,8 +421,8 @@ impl BreezSdk {
     }
 
     #[wasm_bindgen(js_name = "refundPendingConversions")]
-    pub async fn refund_pending_conversions(&self) -> WasmResult<()> {
-        Ok(self.sdk.refund_pending_conversions().await?)
+    pub async fn refund_pending_conversions(&self) -> WasmResult<RefundPendingConversionsResponse> {
+        Ok(self.sdk.refund_pending_conversions().await?.into())
     }
 
     #[wasm_bindgen(js_name = "buyBitcoin")]

--- a/crates/flashnet/src/amm/api.rs
+++ b/crates/flashnet/src/amm/api.rs
@@ -9,8 +9,9 @@ use tracing::debug;
 use super::models::{
     ClawbackIntent, ClawbackRequest, ClawbackResponse, ExecuteSwapIntent, ExecuteSwapRequest,
     ExecuteSwapResponse, FeatureName, FeatureStatus, FlashnetExecuteSwapResponse,
-    GetMinAmountsRequest, GetMinAmountsResponse, ListPoolsRequest, ListPoolsResponse,
-    ListUserSwapsRequest, ListUserSwapsResponse, MinAmount, PingResponse, SignedClawbackRequest,
+    GetMinAmountsRequest, GetMinAmountsResponse, ListClawbackTransfersRequest,
+    ListClawbackTransfersResponse, ListPoolsRequest, ListPoolsResponse, ListUserSwapsRequest,
+    ListUserSwapsResponse, MinAmount, PingResponse, SignedClawbackRequest,
     SignedExecuteSwapRequest, SignedExecuteSwapResponse, SimulateSwapRequest, SimulateSwapResponse,
 };
 use super::utils::generate_nonce;
@@ -66,6 +67,15 @@ impl FlashnetClient {
         self.ensure_ping_ok().await?;
 
         self.sign_clawback(request).await
+    }
+
+    pub async fn list_clawback_transfers(
+        &self,
+        request: ListClawbackTransfersRequest,
+    ) -> Result<ListClawbackTransfersResponse, FlashnetError> {
+        debug!("List clawback transfers request: {request:?}");
+        self.get_request("v1/clawback-transfers/list", Some(request))
+            .await
     }
 
     pub async fn get_min_amounts(

--- a/crates/flashnet/src/amm/models.rs
+++ b/crates/flashnet/src/amm/models.rs
@@ -96,7 +96,7 @@ pub struct ClawbackTransfer {
     pub id: String,
     #[serde_as(as = "DisplayFromStr")]
     pub lp_identity_public_key: PublicKey,
-    /// RFC3339 timestamp; absent for some older rows.
+    /// Optional RFC 3339 timestamp emitted by the Flashnet backend.
     pub created_at: Option<String>,
 }
 
@@ -456,7 +456,9 @@ pub struct Pool {
     pub bonding_progress_percent: Option<f64>,
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub graduation_threshold_amount: Option<u64>,
+    /// RFC 3339 timestamp emitted by the Flashnet backend.
     pub created_at: String,
+    /// RFC 3339 timestamp emitted by the Flashnet backend.
     pub updated_at: String,
 }
 
@@ -840,8 +842,8 @@ mod test {
             initial_reserve_a: None,
             bonding_progress_percent: None,
             graduation_threshold_amount: None,
-            created_at: "2025-09-22 19:09:36.661269 +00:00:00".to_string(),
-            updated_at: "2025-12-03 12:43:53.903531 +00:00:00".to_string(),
+            created_at: "2025-09-22T19:09:36.661269Z".to_string(),
+            updated_at: "2025-12-03T12:43:53.903531Z".to_string(),
         }
     }
 

--- a/crates/flashnet/src/amm/models.rs
+++ b/crates/flashnet/src/amm/models.rs
@@ -73,6 +73,33 @@ pub struct ClawbackResponse {
     pub error: Option<String>,
 }
 
+#[derive(Serialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ListClawbackTransfersRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u32>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ListClawbackTransfersResponse {
+    pub transfers: Vec<ClawbackTransfer>,
+}
+
+#[serde_as]
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ClawbackTransfer {
+    /// Spark `transfer_id` for BTC swaps, or token transaction hash for token swaps.
+    pub id: String,
+    #[serde_as(as = "DisplayFromStr")]
+    pub lp_identity_public_key: PublicKey,
+    /// RFC3339 timestamp; absent for some older rows.
+    pub created_at: Option<String>,
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum CurveType {

--- a/crates/flashnet/src/amm/pool_selection.rs
+++ b/crates/flashnet/src/amm/pool_selection.rs
@@ -278,8 +278,8 @@ mod tests {
             initial_reserve_a: None,
             bonding_progress_percent: None,
             graduation_threshold_amount: None,
-            created_at: "2024-01-01".to_string(),
-            updated_at: "2024-01-01".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
         }
     }
 
@@ -308,8 +308,8 @@ mod tests {
             initial_reserve_a: None,
             bonding_progress_percent: None,
             graduation_threshold_amount: None,
-            created_at: "2024-01-01".to_string(),
-            updated_at: "2024-01-01".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
         };
 
         let score = score_pool(&pool, 1_000, 1_000, 1_000, Some(1_000_000));
@@ -346,8 +346,8 @@ mod tests {
             initial_reserve_a: None,
             bonding_progress_percent: None,
             graduation_threshold_amount: None,
-            created_at: "2024-01-01".to_string(),
-            updated_at: "2024-01-01".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
         };
 
         // Pool requires 1_500 when min is 1_000 and max is 2_000
@@ -381,8 +381,8 @@ mod tests {
             initial_reserve_a: None,
             bonding_progress_percent: None,
             graduation_threshold_amount: None,
-            created_at: "2024-01-01".to_string(),
-            updated_at: "2024-01-01".to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
         };
 
         let score = score_pool(&pool, 1_000, 1_000, 2_000, None);

--- a/docs/breez-sdk/snippets/go/sdk_building.go
+++ b/docs/breez-sdk/snippets/go/sdk_building.go
@@ -251,6 +251,7 @@ func RefundPendingConversions(sdk *breez_sdk_spark.BreezSdk) error {
 	// The flashnet conversion refunder doesn't run in the background in server
 	// mode. Call this from your own scheduler (e.g. once per minute) to issue
 	// pending refunds for failed conversions.
-	return sdk.RefundPendingConversions()
+	_, err := sdk.RefundPendingConversions()
+	return err
 	// ANCHOR_END: refund-pending-conversions
 }

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1420,6 +1420,12 @@ pub struct _BuyBitcoinResponse {
     pub url: String,
 }
 
+#[frb(mirror(RefundPendingConversionsResponse))]
+pub struct _RefundPendingConversionsResponse {
+    pub refunded: u32,
+    pub skipped: u32,
+}
+
 #[frb(mirror(ServiceStatus))]
 pub enum _ServiceStatus {
     Operational,

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1424,6 +1424,7 @@ pub struct _BuyBitcoinResponse {
 pub struct _RefundPendingConversionsResponse {
     pub refunded: u32,
     pub skipped: u32,
+    pub failed: u32,
 }
 
 #[frb(mirror(ServiceStatus))]

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -298,7 +298,9 @@ impl BreezSdk {
         self.inner.list_webhooks().await
     }
 
-    pub async fn refund_pending_conversions(&self) -> Result<(), SdkError> {
+    pub async fn refund_pending_conversions(
+        &self,
+    ) -> Result<RefundPendingConversionsResponse, SdkError> {
         self.inner.refund_pending_conversions().await
     }
 


### PR DESCRIPTION
Recovery from a failed token conversions was gated on DB writes between `transfer_asset` and `clawback`. If that write failed (storage glitch, app backgrounded, process killed) the refunder never saw the row and the funds stayed locked at the pool indefinitely.

The error path also threw away the rich `AssetTransfer` returned from `execute_swap`, leaving `convert()`'s error branch to re-derive the local `payment_id` via an operator round-trip — the same network outage that caused the swap to fail would also fail that derivation, skipping the local `RefundNeeded` mark entirely.

### Fix

Two layers of recovery:

#### Recovery via local payment metadata

`FlashnetError::Execution` now carries the `AssetTransfer`. `convert()`'s error branch derives the storage `payment_id` locally — no operator round-trip. The existing `RefundNeeded` marker path is unchanged from there on.

#### Flashnet listing as a catch-all

New `list_clawback_transfers` binding + `reconcile_with_flashnet` pass picks up transfers Flashnet still considers clawback-eligible but that don't have a local marker (storage write failed, process killed). A 5-minute age threshold guards against racing a concurrent same-seed instance's in-flight healthy swap.

- **Client mode**: runs once per SDK init, after the local refunder pass.
- **Server mode**: runs per call inside `refund_pending_conversions`.
