### PR TITLE
Set sane DB TCP liveness params

### DIFF
--- a/crates/spark-mysql/src/pool.rs
+++ b/crates/spark-mysql/src/pool.rs
@@ -39,7 +39,7 @@ pub fn create_pool(config: &MysqlStorageConfig) -> Result<Pool, MysqlError> {
     let opts: Opts = Opts::from_url(&connection_string)
         .map_err(|e| MysqlError::Initialization(format!("Invalid connection string: {e}")))?;
 
-    let mut builder = OptsBuilder::from_opts(opts);
+    let mut builder = with_tcp_keepalive_default(opts);
 
     if let Some(ssl_opts) = build_ssl_opts(ssl_mode, config.root_ca_pem.as_deref()) {
         builder = builder.ssl_opts(ssl_opts);
@@ -57,6 +57,22 @@ pub fn create_pool(config: &MysqlStorageConfig) -> Result<Pool, MysqlError> {
     builder = builder.pool_opts(pool_opts);
 
     Ok(Pool::new(builder))
+}
+
+/// Sets a 60s TCP keepalive unless the connection string already specified one.
+///
+/// Without keepalives a managed-`MySQL` NAT/load balancer silently reaps an idle
+/// connection; the pool hands the half-open socket back (it pings only in tests,
+/// not on checkout) and the next query hangs ~15 min on the dead socket. Probing
+/// every 60s keeps the NAT mapping warm. `mysql_async` exposes no probe
+/// interval/retries or `tcp_user_timeout`, so idle time is the only knob here.
+fn with_tcp_keepalive_default(opts: Opts) -> OptsBuilder {
+    let keepalive_set = opts.tcp_keepalive().is_some();
+    let mut builder = OptsBuilder::from_opts(opts);
+    if !keepalive_set {
+        builder = builder.tcp_keepalive(Some(60_000u32));
+    }
+    builder
 }
 
 /// Parses an `ssl-mode` value from a `MySQL` URL connection string and constructs
@@ -178,6 +194,20 @@ impl From<mysql_async::Error> for MysqlError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn keepalive_default_applied_when_url_silent() {
+        let opts = Opts::from_url("mysql://u:p@h:3306/db").expect("valid");
+        let built = Opts::from(with_tcp_keepalive_default(opts));
+        assert_eq!(built.tcp_keepalive(), Some(60_000));
+    }
+
+    #[test]
+    fn keepalive_default_respects_explicit_url_value() {
+        let opts = Opts::from_url("mysql://u:p@h:3306/db?tcp_keepalive=5000").expect("valid");
+        let built = Opts::from(with_tcp_keepalive_default(opts));
+        assert_eq!(built.tcp_keepalive(), Some(5000));
+    }
 
     #[test]
     fn extracts_ssl_mode_before_mysql_async_url_parsing() {

--- a/crates/spark-postgres/src/pool.rs
+++ b/crates/spark-postgres/src/pool.rs
@@ -288,12 +288,40 @@ fn apply_pool_config(config: &PostgresStorageConfig) -> deadpool_postgres::PoolC
     }
 }
 
+/// Applies TCP liveness defaults so a connection reaped by a managed-`PostgreSQL`
+/// NAT/load balancer fails fast instead of lingering half-open: with
+/// tokio-postgres's 2h idle keepalive a reaped socket passes deadpool's
+/// `is_closed()` recycle check, then the next query hangs ~15 min (`tcp_retries2`)
+/// before `os error 110`. Keepalives keep the NAT mapping warm and detect a dead
+/// idle peer in ~90s; `tcp_user_timeout` bounds an in-flight query on a dead socket.
+///
+/// Each value is applied only when the connection string left it unset, so any
+/// option passed in the URL wins. `keepalives_idle` is detected on the raw string:
+/// tokio-postgres exposes it as a bare `Duration` with no "is set" signal, unlike
+/// the `Option` getters backing the other three.
+fn apply_tcp_liveness_defaults(connection_string: &str, pg_config: &mut PgConfig) {
+    if !connection_string.contains("keepalives_idle") {
+        pg_config.keepalives_idle(Duration::from_mins(1));
+    }
+    if pg_config.get_keepalives_interval().is_none() {
+        pg_config.keepalives_interval(Duration::from_secs(10));
+    }
+    if pg_config.get_keepalives_retries().is_none() {
+        pg_config.keepalives_retries(3);
+    }
+    if pg_config.get_tcp_user_timeout().is_none() {
+        pg_config.tcp_user_timeout(Duration::from_secs(30));
+    }
+}
+
 /// Creates a `PostgreSQL` connection pool from the given configuration.
 pub fn create_pool(config: &PostgresStorageConfig) -> Result<Pool, PostgresError> {
-    let pg_config: PgConfig = config
+    let mut pg_config: PgConfig = config
         .connection_string
         .parse()
         .map_err(|e| PostgresError::Initialization(format!("Invalid connection string: {e}")))?;
+
+    apply_tcp_liveness_defaults(&config.connection_string, &mut pg_config);
 
     let ssl_mode = parse_sslmode_from_connection_string(&config.connection_string);
     let pool_config = apply_pool_config(config);
@@ -477,6 +505,30 @@ mod tests {
             result.is_err(),
             "Expected TLS config with invalid CA to fail"
         );
+    }
+
+    #[test]
+    fn liveness_defaults_applied_when_url_silent() {
+        let url = "postgres://u:p@h:5432/db";
+        let mut cfg: PgConfig = url.parse().expect("valid");
+        apply_tcp_liveness_defaults(url, &mut cfg);
+        assert_eq!(cfg.get_keepalives_idle(), Duration::from_mins(1));
+        assert_eq!(cfg.get_keepalives_interval(), Some(Duration::from_secs(10)));
+        assert_eq!(cfg.get_keepalives_retries(), Some(3));
+        assert_eq!(cfg.get_tcp_user_timeout(), Some(&Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn liveness_defaults_respect_explicit_url_values() {
+        let url = "postgres://u:p@h:5432/db\
+            ?keepalives_idle=600&keepalives_interval=20&keepalives_retries=9&tcp_user_timeout=5";
+        let mut cfg: PgConfig = url.parse().expect("valid");
+        apply_tcp_liveness_defaults(url, &mut cfg);
+        // Every value supplied in the URL must survive untouched.
+        assert_eq!(cfg.get_keepalives_idle(), Duration::from_mins(10));
+        assert_eq!(cfg.get_keepalives_interval(), Some(Duration::from_secs(20)));
+        assert_eq!(cfg.get_keepalives_retries(), Some(9));
+        assert_eq!(cfg.get_tcp_user_timeout(), Some(&Duration::from_secs(5)));
     }
 
     /// Regression: deadpool's `Pool::builder(...).build()` synchronously rejects


### PR DESCRIPTION
## Problem

A managed Postgres/MySQL instance behind a NAT/load balancer may silently drop
idle TCP connections (no FIN/RST). The connection lingers half-open in the
pool: the recycle check sees it as live and hands it out, and the next query
blocks on the dead socket until the kernel gives up (~15 min), surfacing as a
long hang then `os error 110`. 

## Fix

Apply TCP keepalive defaults so the NAT mapping stays warm and a dead peer is
detected promptly. Each value is applied only when the connection string left
it unset, so explicit URL params always win.

**Postgres** (`tokio-postgres`): `keepalives_idle` 60s, `keepalives_interval`
10s, `keepalives_retries` 3, `tcp_user_timeout` 30s.

**MySQL** (`mysql_async`): `tcp_keepalive` 60s. The driver's default is no
keepalive at all, and the pool doesn't ping on checkout. `mysql_async` 0.36.2
exposes no probe interval/retries or `tcp_user_timeout`, so idle time is the
only liveness knob available.
