### PR TITLE
feat(passkey): group provider config into PasskeyProviderOptions + guide readability

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Passkey.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Passkey.swift
@@ -160,8 +160,7 @@ func createPrfProvider(type: PasskeyProviderType, dataDir: String, rpId: String?
     case .platform:
         if #available(iOS 18.0, macOS 15.0, *) {
             return PasskeyProvider(
-                rpId: rpId ?? "keys.breez.technology",
-                rpName: "Breez SDK"
+                options: PasskeyProviderOptions(rpId: rpId ?? "keys.breez.technology", rpName: "Breez SDK")
             )
         } else {
             throw PrfProviderError.Generic(

--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyClientBuilder.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyClientBuilder.kt
@@ -9,7 +9,7 @@ import breez_sdk_spark.PrfProvider
 /**
  * Zero-config [PasskeyClient] wired to the built-in [PasskeyProvider].
  * Defaults to the Breez shared RP (`keys.breez.technology`), so a
- * Breez-registered app needs only its relay key; set `rpId` / `rpName`
+ * Breez-registered app needs only its relay key; set `providerOptions`
  * on [config] to use your own RP.
  *
  * Takes an [activityProvider] because the platform Credential Manager
@@ -21,7 +21,7 @@ import breez_sdk_spark.PrfProvider
  *   storage. Pass `null` for public relays only.
  * @param activityProvider Called lazily on every ceremony to obtain the
  *   foreground [Activity] that drives Credential Manager.
- * @param config Passkey client config (`rpId` / `rpName` / `defaultLabel`).
+ * @param config Passkey client config (`providerOptions` / `defaultLabel`).
  */
 public fun PasskeyClient(
     breezApiKey: String? = null,
@@ -37,15 +37,14 @@ public fun PasskeyClient(
 
 /**
  * Builder for a [PasskeyClient] backed by a caller-supplied
- * [PrfProvider]. Use this when you need a [PasskeyProvider] configured
- * beyond `rpId` / `rpName` (rotating `userName`) or a custom PRF
- * backend. For the zero-config case use the
+ * [PrfProvider]. Use this for a custom PRF backend (hardware key,
+ * FIDO2, file-backed). For the zero-config case use the
  * [PasskeyClient] factory above, which takes the `activityProvider`.
  *
  * @param breezApiKey Breez relay key for authenticated (NIP-42) label
  *   storage. Pass `null` for public relays only.
  * @param config Passkey client config. `defaultLabel` applies as the
- *   label-store default; `rpId` / `rpName` are owned by the injected
+ *   label-store default; `providerOptions` is owned by the injected
  *   provider.
  */
 class PasskeyClientBuilder(

--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyClientBuilder.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyClientBuilder.kt
@@ -3,6 +3,7 @@ package technology.breez.spark.passkey
 import android.app.Activity
 import breez_sdk_spark.PasskeyClient
 import breez_sdk_spark.PasskeyConfig
+import breez_sdk_spark.PasskeyProviderOptions
 import breez_sdk_spark.PrfProvider
 
 /**
@@ -29,8 +30,7 @@ public fun PasskeyClient(
 ): PasskeyClient {
     val provider = PasskeyProvider(
         activityProvider = activityProvider,
-        rpId = config?.rpId ?: PasskeyProvider.BREEZ_RP_ID,
-        rpName = config?.rpName ?: PasskeyProvider.DEFAULT_RP_NAME,
+        options = config?.providerOptions ?: PasskeyProviderOptions(),
     )
     return PasskeyClient(provider, breezApiKey, config)
 }

--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyProvider.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyProvider.kt
@@ -5,6 +5,7 @@ import breez_sdk_spark.DeriveSeedsOutput
 import breez_sdk_spark.DeriveSeedsRequest
 import breez_sdk_spark.DomainAssociation
 import breez_sdk_spark.PasskeyCredential
+import breez_sdk_spark.PasskeyProviderOptions
 import breez_sdk_spark.PrfProvider
 import breez_sdk_spark.PrfProviderException
 import technology.breez.spark.passkey.core.CredentialManagerPrfCore
@@ -30,24 +31,15 @@ import technology.breez.spark.passkey.core.DomainAssociationResult
  *   the foreground, RESUMED, non-finishing Activity (a stale or background
  *   instance surfaces as opaque Credential Manager failures). A lambda
  *   avoids holding a stale reference across configuration changes.
- * @param rpId Relying Party ID (your app's domain), or [BREEZ_RP_ID] to opt
- *   into Breez's shared RP. Changing it after users register makes their
- *   existing credentials undiscoverable.
- * @param rpName WebAuthn `rp.name`, shown in some credential-manager UIs.
- *   Deprecated in L3 but still required by current prompts. Used only at
- *   registration.
- * @param userName WebAuthn `user.name`, shown in the sign-in picker. Pass a
- *   stable per-user value if each registration should be a distinct entry.
- *   Defaults to [rpName]. Used only at registration.
- * @param userDisplayName WebAuthn `user.displayName`, a label the picker MAY
- *   show (varies by backend). Defaults to [userName]. Used only at registration.
+ * @param options Relying Party and user identity (`rpId`, `rpName`,
+ *   `userName`, `userDisplayName`). Unset `rpId` / `rpName` default to
+ *   [BREEZ_RP_ID] / [DEFAULT_RP_NAME]; `userName` defaults to `rpName` and
+ *   `userDisplayName` to `userName`. The same [PasskeyProviderOptions] is
+ *   settable on `PasskeyConfig` for the zero-config client.
  */
 public class PasskeyProvider(
     private val activityProvider: () -> Activity,
-    private val rpId: String,
-    private val rpName: String,
-    userName: String? = null,
-    userDisplayName: String? = null,
+    options: PasskeyProviderOptions = PasskeyProviderOptions(),
 ) : PrfProvider {
 
     public companion object {
@@ -68,8 +60,10 @@ public class PasskeyProvider(
         public const val DEFAULT_RP_NAME: String = "Breez"
     }
 
-    private val resolvedUserName: String = userName ?: rpName
-    private val resolvedUserDisplayName: String = userDisplayName ?: resolvedUserName
+    private val rpId: String = options.rpId ?: BREEZ_RP_ID
+    private val rpName: String = options.rpName ?: DEFAULT_RP_NAME
+    private val resolvedUserName: String = options.userName ?: rpName
+    private val resolvedUserDisplayName: String = options.userDisplayName ?: resolvedUserName
 
     /** The configured PRF engine; holds the rp identity. */
     private val core = CredentialManagerPrfCore(

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyClientBuilder.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyClientBuilder.swift
@@ -4,11 +4,10 @@ import Foundation
 /// ``PrfProvider``.
 ///
 /// Use this when you need a fully custom PRF backend or a
-/// ``PasskeyProvider`` configured beyond `rpId` / `rpName` (rotating
-/// `userName`, timeout overrides). For the
-/// zero-config or RP-only case, use
-/// ``PasskeyClient/init(breezApiKey:config:)`` and set `rpId` / `rpName`
-/// on the ``PasskeyConfig``.
+/// ``PasskeyProvider`` configured with platform-specific options
+/// (`URLSession`, presentation anchor). For the zero-config or
+/// RP-only case, use ``PasskeyClient/init(breezApiKey:config:)`` and
+/// set `providerOptions` on the ``PasskeyConfig``.
 @available(iOS 18.0, macOS 15.0, *)
 public class PasskeyClientBuilder {
     private let breezApiKey: String?
@@ -18,7 +17,7 @@ public class PasskeyClientBuilder {
     /// - Parameters:
     ///   - breezApiKey: Breez relay key for authenticated (NIP-42) label
     ///     storage. Pass `nil` for public relays only.
-    ///   - config: Passkey client config. `rpId` / `rpName` configure the
+    ///   - config: Passkey client config. `providerOptions` configures the
     ///     default provider (ignored when one is injected via
     ///     ``withPrfProvider(_:)``); `defaultLabel` is the label-store
     ///     default.
@@ -29,7 +28,7 @@ public class PasskeyClientBuilder {
 
     /// Inject the ``PrfProvider`` the client derives seeds through. The
     /// built-in ``PasskeyProvider`` or any custom implementation is
-    /// accepted. Supersedes the config's `rpId` / `rpName` (the injected
+    /// accepted. Supersedes the config's `providerOptions` (the injected
     /// provider owns its RP).
     @discardableResult
     public func withPrfProvider(_ provider: any PrfProvider) -> PasskeyClientBuilder {
@@ -38,7 +37,7 @@ public class PasskeyClientBuilder {
     }
 
     /// Construct the client. Falls back to a default ``PasskeyProvider``
-    /// on the config's `rpId` / `rpName` (default: the Breez RP) when no
+    /// on the config's `providerOptions` (default: the Breez RP) when no
     /// provider was injected.
     public func build() -> PasskeyClient {
         let resolved = provider ?? PasskeyProvider(options: config?.providerOptions ?? PasskeyProviderOptions())
@@ -49,7 +48,7 @@ public class PasskeyClientBuilder {
 public extension PasskeyClient {
     /// Client wired to the built-in ``PasskeyProvider``. Defaults to the
     /// Breez shared RP (`keys.breez.technology`), so a Breez-registered
-    /// app needs only its relay key; set `rpId` / `rpName` on the
+    /// app needs only its relay key; set `providerOptions` on the
     /// ``PasskeyConfig`` to use your own RP.
     ///
     /// Apps that need a credential registry or a custom PRF backend build
@@ -59,7 +58,7 @@ public extension PasskeyClient {
     /// - Parameters:
     ///   - breezApiKey: Breez relay key for authenticated (NIP-42) label
     ///     storage. Pass `nil` for public relays only.
-    ///   - config: Passkey client config (`rpId` / `rpName` / `defaultLabel`).
+    ///   - config: Passkey client config (`providerOptions` / `defaultLabel`).
     @available(iOS 18.0, macOS 15.0, *)
     convenience init(breezApiKey: String?, config: PasskeyConfig? = nil) {
         self.init(

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyClientBuilder.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyClientBuilder.swift
@@ -41,10 +41,7 @@ public class PasskeyClientBuilder {
     /// on the config's `rpId` / `rpName` (default: the Breez RP) when no
     /// provider was injected.
     public func build() -> PasskeyClient {
-        let resolved = provider ?? PasskeyProvider(
-            rpId: config?.rpId ?? PasskeyProvider.BREEZ_RP_ID,
-            rpName: config?.rpName ?? PasskeyProvider.defaultRpName
-        )
+        let resolved = provider ?? PasskeyProvider(options: config?.providerOptions ?? PasskeyProviderOptions())
         return PasskeyClient(prfProvider: resolved, breezApiKey: breezApiKey, config: config)
     }
 }
@@ -66,10 +63,7 @@ public extension PasskeyClient {
     @available(iOS 18.0, macOS 15.0, *)
     convenience init(breezApiKey: String?, config: PasskeyConfig? = nil) {
         self.init(
-            prfProvider: PasskeyProvider(
-                rpId: config?.rpId ?? PasskeyProvider.BREEZ_RP_ID,
-                rpName: config?.rpName ?? PasskeyProvider.defaultRpName
-            ),
+            prfProvider: PasskeyProvider(options: config?.providerOptions ?? PasskeyProviderOptions()),
             breezApiKey: breezApiKey,
             config: config
         )

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyProvider.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyProvider.swift
@@ -70,35 +70,27 @@ public class PasskeyProvider: PrfProvider {
     /// Create a new platform passkey PRF provider.
     ///
     /// - Parameters:
-    ///   - rpId: **Required.** Relying Party ID (your app's domain), or
-    ///     `PasskeyProvider.BREEZ_RP_ID` to opt into Breez's shared RP
-    ///     (Breez-registered apps only). Changing it after users register
-    ///     makes their existing credentials undiscoverable.
-    ///   - rpName: **Required.** WebAuthn `rp.name`, shown in some
-    ///     credential-manager UIs. Deprecated in L3 but still required by
-    ///     current prompts. Used only at registration.
-    ///   - userName: WebAuthn `user.name`, shown in the sign-in picker.
-    ///     Pass a stable per-user value if each registration should be a
-    ///     distinct entry (iCloud Keychain dedupes by `(rpId, user.name)`).
-    ///     Defaults to `rpName`. Used only at registration.
-    ///   - userDisplayName: WebAuthn `user.displayName`. Defaults to
-    ///     `userName`. Silently dropped at registration on current iOS SDKs
-    ///     (the create overload omits it); kept for cross-platform parity.
+    ///   - options: Relying Party and user identity (`rpId`, `rpName`,
+    ///     `userName`, `userDisplayName`). Unset `rpId` / `rpName` default to
+    ///     `PasskeyProvider.BREEZ_RP_ID` / `"Breez"`; `userName` defaults to
+    ///     `rpName` and `userDisplayName` to `userName`. The same
+    ///     `PasskeyProviderOptions` is settable on `PasskeyConfig` for the
+    ///     zero-config client.
     ///   - iosOptions: iOS / macOS-specific knobs (team ID, URLSession,
     ///     presentation anchor). Defaults work for any signed build.
     public init(
-        rpId: String,
-        rpName: String,
-        userName: String? = nil,
-        userDisplayName: String? = nil,
+        options: PasskeyProviderOptions = PasskeyProviderOptions(),
         iosOptions: IOSOptions? = nil
     ) {
+        let rpId = options.rpId ?? PasskeyProvider.BREEZ_RP_ID
+        let rpName = options.rpName ?? PasskeyProvider.defaultRpName
+        let userName = options.userName ?? rpName
         self.rpId = rpId
         self.core = PasskeyAssertionCore(
             rpId: rpId,
             rpName: rpName,
-            userName: userName ?? rpName,
-            userDisplayName: userDisplayName ?? (userName ?? rpName),
+            userName: userName,
+            userDisplayName: options.userDisplayName ?? userName,
             explicitTeamId: iosOptions?.teamId,
             urlSession: iosOptions?.urlSession ?? .shared,
             anchorProvider: iosOptions?.anchorProvider

--- a/crates/breez-sdk/core/src/passkey/mod.rs
+++ b/crates/breez-sdk/core/src/passkey/mod.rs
@@ -56,7 +56,8 @@ pub use derivation::ACCOUNT_MASTER_SALT;
 use derivation::prf_to_mnemonic;
 pub use error::{ErrorKind, PasskeyError, PrfProviderError};
 pub use models::{
-    DeriveSeedsOutput, PasskeyConfig, PasskeyCredential, SetupWalletRequest, Wallet, WalletSetup,
+    DeriveSeedsOutput, PasskeyConfig, PasskeyCredential, PasskeyProviderOptions,
+    SetupWalletRequest, Wallet, WalletSetup,
 };
 pub use passkey_client::{
     ConnectWithPasskeyRequest, ConnectWithPasskeyResponse, PasskeyAvailability, PasskeyClient,

--- a/crates/breez-sdk/core/src/passkey/models.rs
+++ b/crates/breez-sdk/core/src/passkey/models.rs
@@ -85,17 +85,13 @@ impl PasskeyCredential {
     }
 }
 
-/// Configuration for the passkey client. The Relying Party fields apply
-/// only when a binding builds the built-in provider for you; a provider
-/// you construct yourself owns its own RP and ignores them.
+/// Relying Party and user identity for the built-in passkey provider.
+/// Applies only when a binding builds the provider for you (the
+/// zero-config path); a provider you construct yourself owns these and
+/// ignores them.
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
-pub struct PasskeyConfig {
-    /// Default wallet label when a call provides none. Unset uses
-    /// `"Default"`.
-    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
-    pub default_label: Option<String>,
-
+pub struct PasskeyProviderOptions {
     /// Relying Party ID. Unset uses the Breez shared RP
     /// (`keys.breez.technology`).
     #[cfg_attr(feature = "uniffi", uniffi(default = None))]
@@ -104,4 +100,34 @@ pub struct PasskeyConfig {
     /// Relying Party name. Unset uses `"Breez"`.
     #[cfg_attr(feature = "uniffi", uniffi(default = None))]
     pub rp_name: Option<String>,
+
+    /// `WebAuthn` `user.name`: the account identifier the OS sign-in
+    /// picker shows beneath the display name, typically an email or
+    /// handle (e.g. `john@doe.com`). Set a stable per-user
+    /// value to keep each registration a distinct entry. Unset uses
+    /// `rp_name`.
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub user_name: Option<String>,
+
+    /// `WebAuthn` `user.display_name`: the human-friendly name the
+    /// picker shows most prominently (e.g. `John Doe`). Unset uses
+    /// `user_name`.
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub user_display_name: Option<String>,
+}
+
+/// Configuration for the passkey client.
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct PasskeyConfig {
+    /// Default wallet label when a call provides none. Unset uses
+    /// `"Default"`.
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub default_label: Option<String>,
+
+    /// Relying Party and user identity for the built-in provider, used
+    /// on the zero-config path. Ignored when you inject your own
+    /// provider.
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub provider_options: Option<PasskeyProviderOptions>,
 }

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.d.ts
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.d.ts
@@ -1,13 +1,14 @@
-import { PasskeyClient as SdkPasskeyClient } from '../breez_sdk_spark_wasm';
+import { PasskeyClient as SdkPasskeyClient } from '../breez_sdk_spark_wasm.js';
 import type {
     PasskeyConfig,
+    PasskeyProviderOptions,
     PrfProvider,
     PasskeyCredential,
     DeriveSeedsResult,
     DeriveSeedOptions
-} from '../breez_sdk_spark_wasm';
+} from '../breez_sdk_spark_wasm.js';
 
-export type { PasskeyCredential, DeriveSeedsResult, DeriveSeedOptions };
+export type { PasskeyCredential, DeriveSeedsResult, DeriveSeedOptions, PasskeyProviderOptions };
 
 /**
  * Outcome of a domain-association check: whether `rpId` is a valid
@@ -54,42 +55,12 @@ export declare class PasskeyUserCancelledError extends Error {
 }
 
 /**
- * Options for constructing a PasskeyProvider. `rpId` is required: pass
- * {@link PasskeyProvider.BREEZ_RP_ID} to opt into Breez's shared RP.
+ * Web-only options for the built-in {@link PasskeyProvider}, passed as the
+ * second constructor argument. The cross-platform Relying Party / user
+ * fields live on {@link PasskeyProviderOptions} (the first argument), and
+ * are also settable on `PasskeyConfig` for the zero-config client.
  */
-export interface PasskeyProviderOptions {
-    /**
-     * Relying Party ID, the domain hosting your passkeys. On web it must
-     * be a registrable suffix of `window.location.hostname` or equal to
-     * it. Changing it after users register makes existing credentials
-     * undiscoverable. Pass {@link PasskeyProvider.BREEZ_RP_ID} to use
-     * Breez's shared RP (Breez-registered apps only).
-     */
-    rpId: string;
-
-    /**
-     * WebAuthn `rp.name`, shown in some credential-manager UIs (iCloud
-     * Keychain, Google Password Manager). Deprecated in L3 but still
-     * required by current browsers, so an empty string is rejected at
-     * construction. Used only at registration.
-     */
-    rpName: string;
-
-    /**
-     * WebAuthn `user.name`, shown in the sign-in account picker. Apple's
-     * Passwords app dedupes by `(rpId, user.name)`, so pass a stable
-     * per-user value if each registration should be a distinct entry.
-     * Defaults to `rpName`. Used only at registration.
-     */
-    userName?: string;
-
-    /**
-     * WebAuthn `user.displayName`, a user-friendly label the browser may
-     * show in the picker (behavior varies by platform). Defaults to
-     * `userName`. Used only at registration.
-     */
-    userDisplayName?: string;
-
+export interface PasskeyProviderWebOptions {
     /**
      * Narrows the create-time chooser to one authenticator class.
      * `'platform'` allows only the local authenticator (Touch ID, Face
@@ -144,7 +115,7 @@ export declare class PasskeyProvider {
      */
     static readonly DEFAULT_RP_NAME: string;
 
-    constructor(options: PasskeyProviderOptions);
+    constructor(options?: PasskeyProviderOptions, webOptions?: PasskeyProviderWebOptions);
 
     /**
      * Derive one 32-byte PRF output per salt (in input order), pairing

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
@@ -136,62 +136,45 @@ export class PasskeyProvider {
     static get DEFAULT_RP_NAME() { return DEFAULT_RP_NAME; }
 
     /**
-     * @param {object} options
-     * @param {string} options.rpId - **Required.** Relying Party ID, the
-     *   domain hosting your passkeys; on web a registrable suffix of
-     *   `window.location.hostname` or equal to it. Pass
-     *   `PasskeyProvider.BREEZ_RP_ID` to use Breez's shared RP
-     *   (Breez-registered apps only).
-     * @param {string} options.rpName - **Required.** WebAuthn `rp.name`,
-     *   shown in some credential-manager UIs (iCloud Keychain, Google
-     *   Password Manager). Deprecated in L3 but still required by current
-     *   browsers, so empty is rejected. Used only at registration.
-     * @param {string} [options.userName] - WebAuthn `user.name`, shown in
-     *   the sign-in picker. Apple's Passwords app dedupes by
-     *   `(rpId, user.name)`, so pass a stable per-user value for distinct
-     *   entries. Defaults to `rpName`. Used only at registration.
-     * @param {string} [options.userDisplayName] - WebAuthn
-     *   `user.displayName`, a label the browser may show in the picker
-     *   (behavior varies). Defaults to `userName`. Used only at
-     *   registration.
-     * @param {'platform'|'cross-platform'} [options.authenticatorAttachment]
+     * @param {import('../breez_sdk_spark_wasm.js').PasskeyProviderOptions} [options]
+     *   Relying Party and user identity. `rpId` defaults to
+     *   `PasskeyProvider.BREEZ_RP_ID`, `rpName` to `"Breez"`, `userName` to
+     *   `rpName`, `userDisplayName` to `userName`. The same
+     *   `PasskeyProviderOptions` is settable on `PasskeyConfig` for the
+     *   zero-config client.
+     * @param {object} [webOptions] - Web-only knobs.
+     * @param {'platform'|'cross-platform'} [webOptions.authenticatorAttachment]
      *   Narrows the create-time chooser to one authenticator class.
      *   `'platform'` allows only the local authenticator (Touch ID, Face
      *   ID, Windows Hello, iCloud Keychain); `'cross-platform'` only
      *   roaming keys (USB, NFC, BLE, hybrid). Unset shows all.
-     * @param {Array<'client-device'|'security-key'|'hybrid'>} [options.hints]
+     * @param {Array<'client-device'|'security-key'|'hybrid'>} [webOptions.hints]
      *   WebAuthn L3 priority hints applied to both create and get,
      *   ordering the classes a supporting browser offers first (ignored
      *   otherwise). Pass `['client-device']` to favor the platform
      *   authenticator. Only standards-track lever for the sign-in picker,
      *   where `authenticatorAttachment` is not allowed.
+     * @param {number} [webOptions.defaultTimeoutMs] - Default WebAuthn
+     *   `timeout` (ms) for create and get. A hint only: platforms cap
+     *   around 60s. Set it 5 to 10s under the cap so a host-side timeout
+     *   heuristic can fire first.
      */
-    constructor(options) {
-        if (!options || typeof options.rpId !== 'string' || options.rpId.length === 0) {
-            throw new Error(
-                'PasskeyProvider: rpId is required. Pass your app\'s RP domain, '
-                + 'or PasskeyProvider.BREEZ_RP_ID if you registered with Breez.'
-            );
+    constructor(options = {}, webOptions = {}) {
+        const rpId = options.rpId ?? BREEZ_RP_ID;
+        const rpName = options.rpName ?? DEFAULT_RP_NAME;
+        if (typeof rpId !== 'string' || rpId.length === 0) {
+            throw new Error('PasskeyProvider: rpId must be a non-empty string.');
         }
-        if (typeof options.rpName !== 'string' || options.rpName.length === 0) {
-            throw new Error(
-                'PasskeyProvider: rpName is required. Pass your app name; it is '
-                + 'shown to the user in the OS passkey picker.'
-            );
+        if (typeof rpName !== 'string' || rpName.length === 0) {
+            throw new Error('PasskeyProvider: rpName must be a non-empty string.');
         }
-        this.rpId = options.rpId;
-        this.rpName = options.rpName;
+        this.rpId = rpId;
+        this.rpName = rpName;
         this.userName = options.userName || this.rpName;
         this.userDisplayName = options.userDisplayName || this.userName;
-        this.authenticatorAttachment = options.authenticatorAttachment;
-        this.hints = options.hints;
-        /**
-         * Default WebAuthn `timeout` (ms) for create and get. A hint
-         * only: platforms cap around 60s. Set it 5 to 10s under the cap
-         * so a host-side timeout heuristic can fire first.
-         * @type {number | undefined}
-         */
-        this.defaultTimeoutMs = options.defaultTimeoutMs;
+        this.authenticatorAttachment = webOptions.authenticatorAttachment;
+        this.hints = webOptions.hints;
+        this.defaultTimeoutMs = webOptions.defaultTimeoutMs;
 
         /**
          * Credential ID asserted in the most recent ceremony. Reset at
@@ -712,10 +695,7 @@ export class PasskeyClientBuilder {
     build() {
         const provider =
             this._provider ??
-            new PasskeyProvider({
-                rpId: this._config.rpId ?? BREEZ_RP_ID,
-                rpName: this._config.rpName ?? DEFAULT_RP_NAME,
-            });
+            new PasskeyProvider(this._config.providerOptions ?? {});
         return new SdkPasskeyClient(provider, this._breezApiKey, this._config);
     }
 }

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
@@ -648,7 +648,8 @@ export class PasskeyProvider {
 /**
  * Builder for a {@link PasskeyClient} with a caller-supplied
  * `PrfProvider`. Use it when you need a configured {@link PasskeyProvider}
- * (custom `rpId`/`rpName`, timeout overrides) or a custom PRF backend.
+ * (web-specific options like `authenticatorAttachment` or timeout overrides)
+ * or a custom PRF backend.
  * For the zero-config Breez-RP case, use the {@link PasskeyClient}
  * constructor directly.
  *
@@ -665,7 +666,7 @@ export class PasskeyClientBuilder {
      * @param {string} [breezApiKey] - Breez relay key for authenticated
      *   (NIP-42) label storage. Omit for public relays only.
      * @param {import('../breez_sdk_spark_wasm.js').PasskeyConfig} [config] -
-     *   `rpId` / `rpName` configure the built-in provider (ignored when
+     *   `providerOptions` configures the built-in provider (ignored when
      *   one is injected via {@link withPrfProvider}); `defaultLabel` is
      *   the label-store default.
      */
@@ -677,7 +678,7 @@ export class PasskeyClientBuilder {
 
     /**
      * Inject the `PrfProvider` the client derives seeds through,
-     * superseding the config's `rpId` / `rpName`.
+     * superseding the config's `providerOptions`.
      * @param {PrfProvider} provider
      * @returns {PasskeyClientBuilder} this, for chaining.
      */
@@ -688,7 +689,7 @@ export class PasskeyClientBuilder {
 
     /**
      * Build the client, defaulting to a browser {@link PasskeyProvider}
-     * on the config's `rpId` / `rpName` (default: the Breez RP) when no
+     * on the config's `providerOptions` (default: the Breez RP) when no
      * provider was injected.
      * @returns {import('../breez_sdk_spark_wasm.js').PasskeyClient}
      */
@@ -720,7 +721,7 @@ export class PasskeyClient {
      * @param {string} [breezApiKey] - Breez relay key for authenticated
      *   (NIP-42) label storage. Omit for public relays only.
      * @param {import('../breez_sdk_spark_wasm.js').PasskeyConfig} [config] -
-     *   Optional `rpId` / `rpName` for the built-in provider (default: the
+     *   Optional `providerOptions` for the built-in provider (default: the
      *   Breez shared RP) plus `defaultLabel`.
      * @returns {import('../breez_sdk_spark_wasm.js').PasskeyClient}
      */

--- a/crates/breez-sdk/wasm/src/passkey.rs
+++ b/crates/breez-sdk/wasm/src/passkey.rs
@@ -10,20 +10,31 @@ use crate::{
     },
 };
 
-/// Configuration for `PasskeyClient`. `rpId` / `rpName` configure the
-/// built-in provider on the zero-config path (ignored when you inject
-/// your own provider, which owns its RP).
+/// Relying Party and user identity for the built-in provider on the
+/// zero-config path (ignored when you inject your own provider).
+#[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::PasskeyProviderOptions)]
+pub struct PasskeyProviderOptions {
+    /// Relying Party ID. Unset uses the Breez shared RP.
+    pub rp_id: Option<String>,
+    /// Relying Party name. Unset uses the SDK default (`"Breez"`).
+    pub rp_name: Option<String>,
+    /// `user.name`: the account identifier the picker shows beneath the
+    /// display name (e.g. `john@doe.com`). Unset uses `rpName`.
+    pub user_name: Option<String>,
+    /// `user.displayName`: the human-friendly name shown most
+    /// prominently (e.g. `John Doe`). Unset uses `userName`.
+    pub user_display_name: Option<String>,
+}
+
+/// Configuration for `PasskeyClient`.
 #[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::PasskeyConfig)]
 pub struct PasskeyConfig {
     /// Wallet label for `register` / `signIn` when no label is given.
     /// Unset falls back to the internal default `"Default"`.
     pub default_label: Option<String>,
-    /// Relying Party ID for the built-in provider. Unset uses the Breez
-    /// shared RP.
-    pub rp_id: Option<String>,
-    /// Relying Party name for the built-in provider. Unset uses the SDK
-    /// default (`"Breez"`).
-    pub rp_name: Option<String>,
+    /// Relying Party and user identity for the built-in provider on the
+    /// zero-config path.
+    pub provider_options: Option<PasskeyProviderOptions>,
 }
 
 /// One-shot capability + configuration probe returned by

--- a/docs/breez-sdk/snippets/csharp/Passkey.cs
+++ b/docs/breez-sdk/snippets/csharp/Passkey.cs
@@ -3,14 +3,13 @@ using Breez.Sdk.Spark;
 namespace BreezSdkSnippets
 {
     // ANCHOR: implement-prf-provider
-    // Implement the PrfProvider interface for custom logic if no built-in
-    // PasskeyProvider ships for your target. Three required methods:
-    // DeriveSeeds for derivation, IsSupported for the capability probe;
-    // CreatePasskey for registration is optional.
+    // Implement PrfProvider for a custom authenticator (hardware key, FIDO2,
+    // file-backed). Only DeriveSeeds and IsSupported are required.
     class CustomPrfProvider : PrfProvider
     {
         public async Task<DeriveSeedsOutput> DeriveSeeds(DeriveSeedsRequest request)
         {
+            // Return one 32-byte PRF output per salt, in input order.
             throw new NotImplementedException("Implement using WebAuthn or native passkey APIs");
         }
 
@@ -21,9 +20,7 @@ namespace BreezSdkSnippets
 
         public async Task<PasskeyCredential> CreatePasskey(byte[][] excludeCredentials)
         {
-            // Register a new credential and return its ID, the WebAuthn
-            // user.id the platform recorded (returned for host-side
-            // correlation, never host-supplied), AAGUID, and BE flag.
+            // Register a credential and return its ID plus attestation.
             throw new NotImplementedException("Implement registration via native passkey API");
         }
 
@@ -76,22 +73,10 @@ namespace BreezSdkSnippets
             var passkey = new PasskeyClient(prfProvider, null, null);
 
             // ANCHOR: connect-with-passkey
-            // Single-CTA onboarding: silent sign-in for a returning user,
-            // fall-through to register on a fresh device. Internally pins
-            // `preferImmediatelyAvailableCredentials = true` so the silent
-            // attempt fast-fails (no UI) when no local credential exists;
-            // only `CredentialNotFound` flips to register, all other errors
-            // (cancel / timeout / configuration) propagate unchanged.
+            // Single-CTA onboarding: silent sign-in for a returning user, fall-through to register on a fresh device.
             var response = await passkey.ConnectWithPasskey(
                 new ConnectWithPasskeyRequest(label: "personal")
             );
-
-            // The credential is surfaced on both paths when the provider
-            // exposes it. Persist credentialId for future excludeCredentials.
-            if (response.credential is not null)
-            {
-                var persistedId = response.credential.credentialId;
-            }
 
             var config = BreezSdkSparkMethods.DefaultConfig(network: Network.Mainnet);
             var sdk = await BreezSdkSparkMethods.Connect(new ConnectRequest(
@@ -111,15 +96,6 @@ namespace BreezSdkSnippets
             // ANCHOR: register-passkey
             var response = await passkey.Register(new RegisterRequest(label: "personal"));
 
-            // Persist credential.credentialId (for excludeCredentials bookkeeping)
-            // and credential.userId (for server-side correlation). The SDK
-            // generates userId; it is never host-supplied.
-            if (response.credential is not null)
-            {
-                var _persistedCredentialId = response.credential.credentialId;
-                var _persistedUserId = response.credential.userId;
-            }
-
             var config = BreezSdkSparkMethods.DefaultConfig(network: Network.Mainnet);
             var sdk = await BreezSdkSparkMethods.Connect(new ConnectRequest(
                 config: config,
@@ -138,26 +114,25 @@ namespace BreezSdkSnippets
             // ANCHOR: credential-metadata
             var response = await passkey.Register(new RegisterRequest(label: "personal"));
 
-            // Persist these in synced storage (iCloud Keychain / Block Store) so
-            // they survive reinstall and reach the user's other devices. aaguid
-            // and backupEligible are only available here, on registration.
             if (response.credential is not null)
             {
-                var _persistedCredentialId = response.credential.credentialId;
-                var _persistedAaguid = response.credential.aaguid;
-                var _persistedBackupEligible = response.credential.backupEligible;
+                Console.WriteLine(response.credential.credentialId); // Persist to reopen the same wallet on sign-in
+                Console.WriteLine(response.credential.aaguid); // Authenticator model (display hint, unverified)
+                Console.WriteLine(response.credential.backupEligible); // Whether the passkey syncs across devices
             }
 
-            // On a later sign-in, pin the stored credential ID via
-            // allowCredentials so the OS cannot substitute a sibling credential,
-            // which would derive a different wallet seed.
-            await passkey.SignIn(new SignInRequest(
+            // Pin the stored credential ID so the OS can't substitute a sibling credential, which would derive a different wallet.
+            var signInResponse = await passkey.SignIn(new SignInRequest(
                 label: "personal",
                 allowCredentials: new byte[][]
                 {
                     // stored credentialId bytes
                 }
             ));
+            Console.WriteLine(signInResponse.wallet.seed); // Pass to connect() to open the wallet
+            Console.WriteLine(signInResponse.wallet.label); // Label this wallet was derived from
+            Console.WriteLine(signInResponse.labels); // This passkey's labels (populated on discovery sign-in)
+            Console.WriteLine(signInResponse.credential); // Credential signed in with (credential_id only)
             // ANCHOR_END: credential-metadata
         }
 

--- a/docs/breez-sdk/snippets/flutter/lib/passkey.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/passkey.dart
@@ -6,30 +6,21 @@ import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
 // fit your needs. Pass them to PasskeyClient.fromCallbacks instead
 // of going through PasskeyClientBuilder.withPrfProvider.
 Future<DeriveSeedsOutput> deriveSeeds(DeriveSeedsRequest request) async {
-  // Call platform passkey API with PRF extension. Use the dual-salt
-  // ceremony when the authenticator supports it (one OS prompt for N
-  // salts) and fall back to per-salt assertions otherwise. Returns
-  // one 32-byte PRF output per salt in input order.
+  // Return one 32-byte PRF output per salt, in input order.
   throw UnimplementedError('Implement using platform passkey APIs');
 }
 
 Future<PasskeyCredential> createPasskey(List<Uint8List> excludeCredentials) async {
-  // Register a new credential and return its ID, the WebAuthn user.id
-  // the native plugin minted for it (returned for host-side
-  // correlation, never host-supplied), AAGUID, and BE flag.
+  // Register a credential and return its ID plus attestation.
   throw UnimplementedError('Implement registration via native passkey API');
 }
 
 Future<bool> isSupported() async {
-  // Check if a PRF-capable authenticator is reachable from this
-  // platform / device.
   throw UnimplementedError('Check platform passkey availability');
 }
 // ANCHOR_END: implement-prf-provider
 
 Future<void> checkAvailability() async {
-  // Pass `PasskeyProvider.breezRpId` instead of \'<your-rp-domain>\' if your
-  // app is Breez-registered (shares credentials with other Breez apps).
   final prfProvider = PasskeyProvider(PasskeyProviderOptions(
     rpId: '<your-rp-domain>',
     rpName: 'Your App',
@@ -54,13 +45,10 @@ Future<void> checkAvailability() async {
 
 PasskeyClient setupPasskeyClient() {
   // ANCHOR: setup-client
-  final prfProvider = PasskeyProvider(PasskeyProviderOptions(
-    rpId: '<your-rp-domain>',
-    rpName: 'Your App',
-  ));
-  final passkey = PasskeyClientBuilder(breezApiKey: '<breez api key>')
-      .withPrfProvider(prfProvider)
-      .build();
+  final passkey = PasskeyClient(
+    breezApiKey: '<breez api key>',
+    config: PasskeyConfig(providerOptions: PasskeyProviderOptions(rpId: '<your-rp-domain>', rpName: 'Your App')),
+  );
   // ANCHOR_END: setup-client
   return passkey;
 }
@@ -82,12 +70,6 @@ Future<BreezSdk> connectWithPasskey() async {
     request: ConnectWithPasskeyRequest(label: 'personal'),
   );
 
-  // `credential` is the path discriminator (null on sign-in).
-  final credential = response.credential;
-  if (credential != null) {
-    final _ = credential.credentialId;
-  }
-
   final sdk = await connect(
       request: ConnectRequest(
           config: config, seed: response.wallet.seed, storageDir: "./.data"));
@@ -105,8 +87,7 @@ Future<SignInResponse> signInExistingUser() async {
       .build();
 
   // ANCHOR: sign-in
-  // Returning-user-only sign-in. No fall-through to register: use
-  // `connectWithPasskey` when you also want the new-user path.
+  // Returning-user sign-in. No fall-through to register.
   return await passkey.signIn(request: SignInRequest(label: 'personal'));
   // ANCHOR_END: sign-in
 }
@@ -126,11 +107,6 @@ Future<BreezSdk> registerNewPasskey() async {
   final response = await passkey.register(
     request: RegisterRequest(label: 'personal'),
   );
-
-  // Persist credentialId + userId for future excludeCredentials / host-side
-  // correlation. Replace the prints with your own persistence call.
-  print('credentialId: ${response.credential?.credentialId}');
-  print('userId: ${response.credential?.userId}');
 
   final sdk = await connect(
       request: ConnectRequest(
@@ -153,24 +129,23 @@ Future<void> credentialMetadata() async {
     request: RegisterRequest(label: 'personal'),
   );
 
-  // Persist these in synced storage (iCloud Keychain / Block Store) so they
-  // survive reinstall and reach the user's other devices. aaguid and
-  // backupEligible are only available here, on registration.
   final credential = response.credential;
   if (credential != null) {
-    print('credentialId: ${credential.credentialId}');
-    print('aaguid: ${credential.aaguid}');
-    print('backupEligible: ${credential.backupEligible}');
+    print(credential.credentialId); // Persist to reopen the same wallet on sign-in
+    print(credential.aaguid); // Authenticator model (display hint, unverified)
+    print(credential.backupEligible); // Whether the passkey syncs across devices
   }
 
-  // On a later sign-in, pin the stored credential ID via allowCredentials so
-  // the OS cannot substitute a sibling credential, which would derive a
-  // different wallet seed.
-  await passkey.signIn(
+  // Pin the stored credential ID so the OS can't substitute a sibling.
+  final signInResponse = await passkey.signIn(
     request: SignInRequest(label: 'personal', allowCredentials: const [
       // stored credentialId bytes
     ]),
   );
+  print(signInResponse.wallet.seed); // Pass to connect() to open the wallet
+  print(signInResponse.wallet.label); // Label this wallet was derived from
+  print(signInResponse.labels); // This passkey's labels (populated on discovery sign-in)
+  print(signInResponse.credential); // Credential signed in with (credential_id only)
   // ANCHOR_END: credential-metadata
 }
 
@@ -206,7 +181,7 @@ Future<void> storeLabel() async {
 
 Future<void> checkDomain() async {
   // ANCHOR: domain-association
-  // Lower-level provider call. Most hosts use `checkAvailability` instead.
+  // Diagnostic only: never blocks the ceremony.
   final prfProvider = PasskeyProvider(PasskeyProviderOptions(rpId: '<your-rp-domain>', rpName: 'Your App'));
   final result = await prfProvider.checkDomainAssociation();
 
@@ -231,7 +206,6 @@ Future<Wallet?> recoverFromAlreadyExists() async {
       .build();
 
   // ANCHOR: recover-already-exists
-  // Recovery: flip to sign-in so the OS picker surfaces the existing credential.
   try {
     final response = await passkey.register(
       request: RegisterRequest(
@@ -244,6 +218,7 @@ Future<Wallet?> recoverFromAlreadyExists() async {
     return response.wallet;
   } on PasskeyPrfException catch (e) {
     if (e.code != 'credentialAlreadyExists') rethrow;
+    // A matching credential already exists; sign in instead.
     final response = await passkey.signIn(
       request: SignInRequest(label: 'personal'),
     );
@@ -269,6 +244,7 @@ Future<SignInResponse> handleTimeout() async {
     );
   } on PasskeyPrfException catch (e) {
     if (e.code == 'userTimedOut') {
+      // Show a retry UI. Do NOT auto-retry without user input.
       print("Sign-in timed out: show \"Try Again\" UI.");
     }
     rethrow;

--- a/docs/breez-sdk/snippets/go/passkey.go
+++ b/docs/breez-sdk/snippets/go/passkey.go
@@ -8,38 +8,25 @@ import (
 )
 
 // ANCHOR: implement-prf-provider
-// Implement the PrfProvider interface for custom logic if no built-in
-// PasskeyProvider ships for your target. Three required methods:
-// DeriveSeeds for derivation, IsSupported for the capability probe;
-// CreatePasskey for registration is optional.
+// Implement the PrfProvider interface for a custom authenticator (hardware
+// key, FIDO2, file-backed). Only DeriveSeeds and IsSupported are required.
 type CustomPrfProvider struct{}
 
 func (p *CustomPrfProvider) DeriveSeeds(request breez_sdk_spark.DeriveSeedsRequest) (breez_sdk_spark.DeriveSeedsOutput, error) {
-	// Call platform passkey API with PRF extension. Use the dual-salt
-	// ceremony when the authenticator supports it (one OS prompt for
-	// N salts) and fall back to per-salt assertions otherwise.
-	// Returns one 32-byte PRF output per salt in input order.
+	// Return one 32-byte PRF output per salt, in input order.
 	panic("Implement using WebAuthn or native passkey APIs")
 }
 
 func (p *CustomPrfProvider) IsSupported() (bool, error) {
-	// Check if a PRF-capable authenticator is reachable from this
-	// platform / device.
 	panic("Check platform passkey availability")
 }
 
 func (p *CustomPrfProvider) CreatePasskey(excludeCredentials [][]byte) (breez_sdk_spark.PasskeyCredential, error) {
-	// Register a new credential and return its ID, the WebAuthn user.id
-	// the platform recorded (returned for host-side correlation, never
-	// host-supplied), AAGUID, and BE flag.
+	// Register a credential and return its ID plus attestation.
 	panic("Implement registration via native passkey API")
 }
 
 func (p *CustomPrfProvider) CheckDomainAssociation() (breez_sdk_spark.DomainAssociation, error) {
-	// Optional: verify the app's identity against the platform's domain
-	// verification source (e.g., Apple AASA CDN, Google Digital Asset
-	// Links). Custom providers without a verification source return
-	// Skipped, which tells callers "proceed with WebAuthn as normal".
 	return breez_sdk_spark.DomainAssociationSkipped{
 		Reason: "CustomPrfProvider does not verify domain association",
 	}, nil
@@ -52,8 +39,6 @@ func CheckAvailability() {
 	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
 
 	// ANCHOR: check-availability
-	// CheckAvailability collapses IsSupported + CheckDomainAssociation
-	// into a single tagged value. Branch on the variant the host needs.
 	availability, err := passkey.CheckAvailability()
 	if err != nil {
 		return
@@ -84,24 +69,13 @@ func ConnectWithPasskey() (*breez_sdk_spark.BreezSdk, error) {
 	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
 
 	// ANCHOR: connect-with-passkey
-	// Single-CTA onboarding: silent sign-in for a returning user,
-	// fall-through to register on a fresh device. Internally pins
-	// `PreferImmediatelyAvailableCredentials = true` so the silent
-	// attempt fast-fails (no UI) when no local credential exists; only
-	// `CredentialNotFound` flips to register, all other errors (cancel
-	// / timeout / configuration) propagate unchanged.
+	// Silent sign-in for a returning user, fall-through to register on a fresh device.
 	label := "personal"
 	response, err := passkey.ConnectWithPasskey(breez_sdk_spark.ConnectWithPasskeyRequest{
 		Label: &label,
 	})
 	if err != nil {
 		return nil, err
-	}
-
-	// The credential is surfaced on both paths when the provider exposes
-	// it. Persist CredentialId for future ExcludeCredentials / AllowCredentials.
-	if response.Credential != nil {
-		_ = response.Credential.CredentialId
 	}
 
 	config := breez_sdk_spark.DefaultConfig(breez_sdk_spark.NetworkMainnet)
@@ -122,22 +96,10 @@ func RegisterNewPasskey() (*breez_sdk_spark.BreezSdk, error) {
 	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
 
 	// ANCHOR: register-passkey
-	// For a brand-new user with no existing passkey: Register() creates
-	// the credential AND derives the seed in one orchestrated
-	// call. On iOS+Android this is 2 OS prompts total (1 create + 1
-	// dual-salt assert) thanks to the SDK's bulk-PRF path.
 	label := "personal"
 	response, err := passkey.Register(breez_sdk_spark.RegisterRequest{Label: &label})
 	if err != nil {
 		return nil, err
-	}
-
-	// Persist Credential.CredentialId (for ExcludeCredentials bookkeeping)
-	// and Credential.UserId (for server-side correlation). The SDK
-	// generates UserId; it is never host-supplied.
-	if response.Credential != nil {
-		_ = response.Credential.CredentialId
-		_ = response.Credential.UserId
 	}
 
 	config := breez_sdk_spark.DefaultConfig(breez_sdk_spark.NetworkMainnet)
@@ -164,19 +126,15 @@ func CredentialMetadata() error {
 		return err
 	}
 
-	// Persist these in synced storage (iCloud Keychain / Block Store) so they
-	// survive reinstall and reach the user's other devices. Aaguid and
-	// BackupEligible are only available here, on registration.
 	if response.Credential != nil {
-		_ = response.Credential.CredentialId
-		_ = response.Credential.Aaguid
-		_ = response.Credential.BackupEligible
+		log.Println(response.Credential.CredentialId)   // Persist to reopen the same wallet on sign-in
+		log.Println(response.Credential.Aaguid)         // Authenticator model (display hint, unverified)
+		log.Println(response.Credential.BackupEligible) // Whether the passkey syncs across devices
 	}
 
-	// On a later sign-in, pin the stored credential ID via AllowCredentials so
-	// the OS cannot substitute a sibling credential, which would derive a
-	// different wallet seed.
-	_, err = passkey.SignIn(breez_sdk_spark.SignInRequest{
+	// Pin the stored credential ID so the OS can't substitute a sibling
+	// credential, which would derive a different wallet.
+	signInResponse, err := passkey.SignIn(breez_sdk_spark.SignInRequest{
 		Label:            &label,
 		AllowCredentials: &[][]byte{
 			// stored CredentialId bytes
@@ -185,6 +143,10 @@ func CredentialMetadata() error {
 	if err != nil {
 		return err
 	}
+	log.Println(signInResponse.Wallet.Seed)  // Pass to connect() to open the wallet
+	log.Println(signInResponse.Wallet.Label) // Label this wallet was derived from
+	log.Println(signInResponse.Labels)       // This passkey's labels (populated on discovery sign-in)
+	log.Println(signInResponse.Credential)   // Credential signed in with (credential_id only)
 	// ANCHOR_END: credential-metadata
 	return nil
 }
@@ -220,8 +182,7 @@ func StoreLabel() error {
 
 func CheckDomain() error {
 	// ANCHOR: domain-association
-	// Verify Apple AASA / Android Asset Links / Web Related Origins
-	// before the first WebAuthn ceremony. Diagnostic only: never blocks.
+	// Diagnostic only: never blocks the ceremony.
 	prfProvider := &CustomPrfProvider{}
 	result, err := prfProvider.CheckDomainAssociation()
 	if err != nil {
@@ -246,11 +207,6 @@ func RecoverFromAlreadyExists() (*breez_sdk_spark.Wallet, error) {
 	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
 
 	// ANCHOR: recover-already-exists
-	// The OS rejected Register because the user's password manager
-	// already holds a credential matching `ExcludeCredentials`.
-	// Route the user to the sign-in path: the OS picker will surface
-	// the existing credential and the SDK's identity cache will warm
-	// up on the assertion.
 	label := "personal"
 	registerResponse, err := passkey.Register(breez_sdk_spark.RegisterRequest{
 		Label: &label,
@@ -266,6 +222,7 @@ func RecoverFromAlreadyExists() (*breez_sdk_spark.Wallet, error) {
 		return nil, err
 	}
 
+	// A matching credential already exists; sign in to it instead.
 	signInResponse, err := passkey.SignIn(breez_sdk_spark.SignInRequest{Label: &label})
 	if err != nil {
 		return nil, err
@@ -279,15 +236,12 @@ func HandleTimeout() (*breez_sdk_spark.SignInResponse, error) {
 	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
 
 	// ANCHOR: handle-timeout
-	// The OS biometric inactivity timeout (~55s+) tore down the prompt
-	// without user intent. Distinct from a real cancel: hosts may
-	// surface a re-prompt UI without treating it as the user opting
-	// out. The SDK fires PrfProviderErrorUserTimedOut when assertion or
-	// register elapsed time crosses 55_000 ms.
+	// Biometric inactivity timeout, distinct from a user cancel.
 	label := "personal"
 	response, err := passkey.SignIn(breez_sdk_spark.SignInRequest{Label: &label})
 	if err != nil {
 		if errors.Is(err, breez_sdk_spark.ErrPrfProviderErrorUserTimedOut) {
+			// Show a retry UI. Do NOT auto-retry without user input.
 			log.Print("Sign-in timed out: show \"Try Again\" UI.")
 		}
 		return nil, err

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
@@ -2,19 +2,15 @@ package com.example.kotlinmpplib
 
 import android.app.Activity
 import breez_sdk_spark.*
+import technology.breez.spark.passkey.PasskeyClient
 import technology.breez.spark.passkey.PasskeyProvider
 
 // ANCHOR: implement-prf-provider
-// Implement the PrfProvider interface for custom logic if the built-in
-// PasskeyProvider doesn't fit your needs. Three required methods:
-// deriveSeeds for derivation, isSupported for the capability probe;
-// createPasskey for registration is optional.
+// Implement PrfProvider for a custom authenticator. Only deriveSeeds and
+// isSupported are required.
 class CustomPrfProvider : PrfProvider {
     override suspend fun deriveSeeds(request: DeriveSeedsRequest): DeriveSeedsOutput {
-        // Call platform passkey API with PRF extension. Use the dual-salt
-        // ceremony when the authenticator supports it (one OS prompt for
-        // N salts) and fall back to per-salt assertions otherwise.
-        // Returns one 32-byte PRF output per salt in input order.
+        // Return one 32-byte PRF output per salt, in input order.
         TODO("Implement using WebAuthn or native passkey APIs")
     }
 
@@ -23,9 +19,7 @@ class CustomPrfProvider : PrfProvider {
     }
 
     override suspend fun createPasskey(excludeCredentials: List<ByteArray>): PasskeyCredential {
-        // Register a new credential and return its ID, the WebAuthn
-        // user.id the platform recorded (returned for host-side
-        // correlation, never host-supplied), AAGUID, and BE flag.
+        // Register a credential and return its ID plus attestation.
         TODO("Implement registration via native passkey API")
     }
 
@@ -37,12 +31,9 @@ class CustomPrfProvider : PrfProvider {
 
 class PasskeySnippets(private val activity: Activity) {
     suspend fun checkAvailability() {
-        // Pass `PasskeyProvider.BREEZ_RP_ID` instead of "<your-rp-domain>" if your
-        // app is Breez-registered (shares credentials with other Breez apps).
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            rpId = "<your-rp-domain>",
-            rpName = "Your App",
+            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
@@ -60,12 +51,11 @@ class PasskeySnippets(private val activity: Activity) {
 
     fun setupPasskeyClient(): PasskeyClient {
         // ANCHOR: setup-client
-        val prfProvider = PasskeyProvider(
+        val passkey = PasskeyClient(
+            breezApiKey = "<breez api key>",
             activityProvider = { activity },
-            rpId = "<your-rp-domain>",
-            rpName = "Your App",
+            config = PasskeyConfig(providerOptions = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App")),
         )
-        val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
         // ANCHOR_END: setup-client
         return passkey
     }
@@ -73,8 +63,7 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun connectWithPasskey(): BreezSdk {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            rpId = "<your-rp-domain>",
-            rpName = "Your App",
+            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
@@ -85,11 +74,6 @@ class PasskeySnippets(private val activity: Activity) {
             ConnectWithPasskeyRequest(label = "personal")
         )
 
-        // The credential is surfaced on both paths when the provider exposes it.
-        response.credential?.let { credential ->
-            val persistedId = credential.credentialId
-        }
-
         val sdk = connect(ConnectRequest(config, response.wallet.seed, "./.data"))
         // ANCHOR_END: connect-with-passkey
         return sdk
@@ -98,14 +82,12 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun signInExistingUser(): SignInResponse {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            rpId = "<your-rp-domain>",
-            rpName = "Your App",
+            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
         // ANCHOR: sign-in
-        // Returning-user-only sign-in. No fall-through to register: use
-        // `connectWithPasskey` when you also want the new-user path.
+        // Returning-user sign-in. No fall-through to register.
         return passkey.signIn(SignInRequest(label = "personal"))
         // ANCHOR_END: sign-in
     }
@@ -113,20 +95,13 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun registerNewPasskey(): BreezSdk {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            rpId = "<your-rp-domain>",
-            rpName = "Your App",
+            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
         // ANCHOR: register-passkey
         val config = defaultConfig(Network.MAINNET).apply { apiKey = "<breez api key>" }
         val response = passkey.register(RegisterRequest(label = "personal"))
-
-        // Persist credentialId for future excludeCredentials.
-        response.credential?.let { credential ->
-            val persistedCredentialId = credential.credentialId
-            val persistedUserId = credential.userId
-        }
 
         val sdk = connect(ConnectRequest(config, response.wallet.seed, "./.data"))
         // ANCHOR_END: register-passkey
@@ -136,40 +111,38 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun credentialMetadata() {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            rpId = "<your-rp-domain>",
-            rpName = "Your App",
+            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
         // ANCHOR: credential-metadata
         val response = passkey.register(RegisterRequest(label = "personal"))
 
-        // Persist these in synced storage (Block Store / iCloud Keychain) so
-        // they survive reinstall and reach the user's other devices. aaguid
-        // and backupEligible are only available here, on registration.
         response.credential?.let { credential ->
-            val persistedCredentialId = credential.credentialId
-            val persistedAaguid = credential.aaguid
-            val persistedBackupEligible = credential.backupEligible
+            // Log.v("Breez", "${credential.credentialId}") // Persist to reopen the same wallet on sign-in
+            // Log.v("Breez", "${credential.aaguid}") // Authenticator model (display hint, unverified)
+            // Log.v("Breez", "${credential.backupEligible}") // Whether the passkey syncs across devices
         }
 
-        // On a later sign-in, pin the stored credential ID via allowCredentials
-        // so the OS cannot substitute a sibling credential, which would derive
-        // a different wallet seed.
-        passkey.signIn(
+        // Pin the stored credential ID so the OS can't substitute a sibling
+        // credential, which would derive a different wallet.
+        val signInResponse = passkey.signIn(
             SignInRequest(
                 label = "personal",
                 allowCredentials = emptyList(), // stored credentialId bytes
             )
         )
+        // Log.v("Breez", "${signInResponse.wallet.seed}") // Pass to connect() to open the wallet
+        // Log.v("Breez", "${signInResponse.wallet.label}") // Label this wallet was derived from
+        // Log.v("Breez", "${signInResponse.labels}") // This passkey's labels (populated on discovery sign-in)
+        // Log.v("Breez", "${signInResponse.credential}") // Credential signed in with (credential_id only)
         // ANCHOR_END: credential-metadata
     }
 
     suspend fun listLabels(): List<String> {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            rpId = "<your-rp-domain>",
-            rpName = "Your App",
+            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
         // ANCHOR: list-labels
@@ -184,8 +157,7 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun storeLabel() {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            rpId = "<your-rp-domain>",
-            rpName = "Your App",
+            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
         // ANCHOR: store-label
@@ -195,14 +167,10 @@ class PasskeySnippets(private val activity: Activity) {
 
     suspend fun checkDomain() {
         // ANCHOR: domain-association
-        // Lower-level diagnostic on the provider itself. Most hosts
-        // can reach this through `passkey.checkAvailability()`, which
-        // folds PRF support and domain association into a single call
-        // (see the `check-availability` snippet above).
+        // Diagnostic only: never blocks the ceremony.
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            rpId = "<your-rp-domain>",
-            rpName = "Your App",
+            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
         )
         val result = prfProvider.checkDomainAssociation()
 
@@ -219,8 +187,7 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun recoverFromAlreadyExists(): Wallet {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            rpId = "<your-rp-domain>",
-            rpName = "Your App",
+            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
@@ -234,6 +201,7 @@ class PasskeySnippets(private val activity: Activity) {
             )
             response.wallet
         } catch (e: PrfProviderException.CredentialAlreadyExists) {
+            // A matching credential already exists; sign in to it instead.
             val response = passkey.signIn(SignInRequest(label = "personal"))
             response.wallet
         }
@@ -243,8 +211,7 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun handleTimeout(): SignInResponse {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            rpId = "<your-rp-domain>",
-            rpName = "Your App",
+            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
@@ -252,6 +219,7 @@ class PasskeySnippets(private val activity: Activity) {
         return try {
             passkey.signIn(SignInRequest(label = "personal"))
         } catch (e: PrfProviderException.UserTimedOut) {
+            // Show a retry UI. Do NOT auto-retry without user input.
             // Log.v("Breez", "Sign-in timed out: show \"Try Again\" UI.")
             throw e
         }

--- a/docs/breez-sdk/snippets/python/src/passkey.py
+++ b/docs/breez-sdk/snippets/python/src/passkey.py
@@ -27,21 +27,14 @@ from breez_sdk_spark import (
 # create_passkey for registration is optional.
 class CustomPrfProvider(PrfProvider):
     async def derive_seeds(self, request: DeriveSeedsRequest) -> DeriveSeedsOutput:
-        # Call platform passkey API with PRF extension. Use the dual-salt
-        # ceremony when the authenticator supports it (one OS prompt for
-        # N salts) and fall back to per-salt assertions otherwise.
-        # Returns one 32-byte PRF output per salt in input order.
+        # Return one 32-byte PRF output per salt, in input order.
         raise NotImplementedError("Implement using WebAuthn or native passkey APIs")
 
     async def is_supported(self) -> bool:
-        # Check if a PRF-capable authenticator is reachable from this
-        # platform / device.
         raise NotImplementedError("Check platform passkey availability")
 
     async def create_passkey(self, exclude_credentials: list[bytes]) -> PasskeyCredential:
-        # Register a new credential and return its ID, the WebAuthn
-        # user.id the platform recorded (returned for host-side
-        # correlation, never host-supplied), AAGUID, and BE flag.
+        # Register a credential and return its ID plus attestation.
         raise NotImplementedError("Implement registration via native passkey API")
 
     async def check_domain_association(self) -> DomainAssociation:
@@ -65,8 +58,6 @@ async def check_availability():
     passkey = PasskeyClient(prf_provider, None, None)
 
     # ANCHOR: check-availability
-    # check_availability collapses is_supported + check_domain_association
-    # into a single tagged value. Branch on the variant the host needs.
     availability = await passkey.check_availability()
     if isinstance(availability, PasskeyAvailability.AVAILABLE):
         pass  # Show passkey as primary option.
@@ -92,20 +83,10 @@ async def connect_with_passkey():
     passkey = PasskeyClient(prf_provider, None, None)
 
     # ANCHOR: connect-with-passkey
-    # Single-CTA onboarding: silent sign-in for a returning user,
-    # fall-through to register on a fresh device. Internally pins
-    # `prefer_immediately_available_credentials = True` so the silent
-    # attempt fast-fails (no UI) when no local credential exists; only
-    # `CredentialNotFound` flips to register, all other errors (cancel
-    # / timeout / configuration) propagate unchanged.
+    # Silent sign-in for a returning user, fall-through to register on a fresh device.
     response = await passkey.connect_with_passkey(
         ConnectWithPasskeyRequest(label="personal")
     )
-
-    # The credential is surfaced on both paths when the provider exposes
-    # it. Persist credential_id for future exclude_credentials.
-    if response.credential is not None:
-        _persist = response.credential.credential_id
 
     config = default_config(network=Network.MAINNET)
     sdk = await connect(
@@ -120,18 +101,7 @@ async def register_new_passkey():
     passkey = PasskeyClient(prf_provider, None, None)
 
     # ANCHOR: register-passkey
-    # For a brand-new user with no existing passkey: register() creates
-    # the credential AND derives the seed in one orchestrated
-    # call. On iOS+Android this is 2 OS prompts total (1 create + 1
-    # dual-salt assert) thanks to the SDK's bulk-PRF path.
     response = await passkey.register(RegisterRequest(label="personal"))
-
-    # Persist credential.credential_id (for exclude_credentials bookkeeping)
-    # and credential.user_id (for server-side correlation). The SDK
-    # generates user_id; it is never host-supplied.
-    if response.credential is not None:
-        _persisted_credential_id = response.credential.credential_id
-        _persisted_user_id = response.credential.user_id
 
     config = default_config(network=Network.MAINNET)
     sdk = await connect(
@@ -148,18 +118,14 @@ async def credential_metadata():
     # ANCHOR: credential-metadata
     response = await passkey.register(RegisterRequest(label="personal"))
 
-    # Persist these in synced storage (iCloud Keychain / Block Store) so they
-    # survive reinstall and reach the user's other devices. aaguid and
-    # backup_eligible are only available here, on registration.
     if response.credential is not None:
-        _persisted_credential_id = response.credential.credential_id
-        _persisted_aaguid = response.credential.aaguid
-        _persisted_backup_eligible = response.credential.backup_eligible
+        print(response.credential.credential_id)  # Persist to reopen the same wallet on sign-in
+        print(response.credential.aaguid)  # Authenticator model (display hint, unverified)
+        print(response.credential.backup_eligible)  # Whether the passkey syncs across devices
 
-    # On a later sign-in, pin the stored credential ID via allow_credentials so
-    # the OS cannot substitute a sibling credential, which would derive a
-    # different wallet seed.
-    await passkey.sign_in(
+    # Pin the stored credential ID so the OS can't substitute a sibling
+    # credential, which would derive a different wallet.
+    sign_in_response = await passkey.sign_in(
         SignInRequest(
             label="personal",
             allow_credentials=[
@@ -167,6 +133,10 @@ async def credential_metadata():
             ],
         )
     )
+    print(sign_in_response.wallet.seed)  # Pass to connect() to open the wallet
+    print(sign_in_response.wallet.label)  # Label this wallet was derived from
+    print(sign_in_response.labels)  # This passkey's labels (populated on discovery sign-in)
+    print(sign_in_response.credential)  # Credential signed in with (credential_id only)
     # ANCHOR_END: credential-metadata
 
 
@@ -193,8 +163,7 @@ async def store_label():
 
 async def check_domain():
     # ANCHOR: domain-association
-    # Verify Apple AASA / Android Asset Links / Web Related Origins
-    # before the first WebAuthn ceremony. Diagnostic only: never blocks.
+    # Diagnostic only: never blocks the ceremony.
     prf_provider = CustomPrfProvider()
     result = await prf_provider.check_domain_association()
 
@@ -213,11 +182,6 @@ async def recover_from_already_exists():
     passkey = PasskeyClient(prf_provider, None, None)
 
     # ANCHOR: recover-already-exists
-    # The OS rejected register because the user's password manager
-    # already holds a credential matching `exclude_credentials`.
-    # Route the user to the sign-in path: the OS picker will surface
-    # the existing credential and the SDK's identity cache will warm
-    # up on the assertion.
     try:
         await passkey.register(
             RegisterRequest(
@@ -228,8 +192,7 @@ async def recover_from_already_exists():
             )
         )
     except PrfProviderError.CredentialAlreadyExists:
-        # Flip to sign-in. The existing credential's PRF output is
-        # the same seed the host would have minted on register.
+        # A matching credential already exists; sign in to it instead.
         response = await passkey.sign_in(SignInRequest(label="personal"))
         return response.wallet
     # ANCHOR_END: recover-already-exists
@@ -240,14 +203,11 @@ async def handle_timeout():
     passkey = PasskeyClient(prf_provider, None, None)
 
     # ANCHOR: handle-timeout
-    # The OS biometric inactivity timeout (~55s+) tore down the prompt
-    # without user intent. Distinct from a real cancel: hosts may
-    # surface a re-prompt UI without treating it as the user opting
-    # out. The SDK fires PrfProviderError.UserTimedOut when assertion
-    # or register elapsed time crosses 55_000 ms.
+    # Biometric inactivity timeout, distinct from a user cancel.
     try:
         return await passkey.sign_in(SignInRequest(label="personal"))
     except PrfProviderError.UserTimedOut:
+        # Show a retry UI. Do NOT auto-retry without user input.
         print("Sign-in timed out: show \"Try Again\" UI.")
         raise
     # ANCHOR_END: handle-timeout

--- a/docs/breez-sdk/snippets/react-native/passkey.ts
+++ b/docs/breez-sdk/snippets/react-native/passkey.ts
@@ -3,34 +3,31 @@ import type {
 } from '@breeztech/breez-sdk-spark-react-native'
 import {
   PasskeyAvailability_Tags,
-  PasskeyClient,
+  PasskeyConfig,
+  PasskeyProviderOptions,
   connect,
   defaultConfig,
   Network
 } from '@breeztech/breez-sdk-spark-react-native'
 import {
+  PasskeyClient,
   PasskeyPrfException,
   PasskeyProvider
 } from '@breeztech/breez-sdk-spark-react-native/passkey-prf-provider'
 
 // ANCHOR: implement-prf-provider
-// Implement the PrfProvider interface for custom logic if the built-in
-// PasskeyProvider doesn't fit your needs. Three required methods:
-// deriveSeeds for derivation, isSupported for the capability probe;
-// createPasskey for registration is optional.
+// Implement PrfProvider for a custom authenticator (hardware key, FIDO2,
+// file-backed). Only deriveSeeds and isSupported are required.
 class CustomPrfProvider {
   deriveSeeds = async (_request: { salts: string[] }): Promise<{ seeds: Uint8Array[], credentialId?: Uint8Array }> => {
-    // Call platform passkey API with PRF extension. Returns one 32-byte
-    // output per salt in input order.
+    // Return one 32-byte PRF output per salt, in input order.
     throw new Error('Implement using WebAuthn or native passkey APIs')
   }
 
   createPasskey = async (
     _excludeCredentials: Uint8Array[]
   ): Promise<PasskeyCredential> => {
-    // Register a new credential and return its ID, the WebAuthn user.id
-    // the native plugin minted for it (returned for host-side
-    // correlation, never host-supplied), AAGUID, and BE flag.
+    // Register a credential and return its ID plus attestation.
     throw new Error('Implement registration via native passkey API')
   }
 
@@ -41,10 +38,7 @@ class CustomPrfProvider {
 // ANCHOR_END: implement-prf-provider
 
 const checkAvailability = async () => {
-  // Pass `PasskeyProvider.BREEZ_RP_ID` instead of \'<your-rp-domain>\' if your
-  // app is Breez-registered (shares credentials with other Breez apps).
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, '<breez api key>', undefined)
+  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
 
   // ANCHOR: check-availability
   const availability = await passkey.checkAvailability()
@@ -69,25 +63,18 @@ const checkAvailability = async () => {
 
 const setupPasskeyClient = () => {
   // ANCHOR: setup-client
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, '<breez api key>', undefined)
+  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
   // ANCHOR_END: setup-client
   return passkey
 }
 
 const connectWithPasskey = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, '<breez api key>', undefined)
+  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
 
   // ANCHOR: connect-with-passkey
-  // Single-CTA onboarding: silent sign-in, fall through to register.
+  // Silent sign-in, fall through to register.
   const config = { ...defaultConfig(Network.Mainnet), apiKey: '<breez api key>' }
   const response = await passkey.connectWithPasskey({ label: 'personal', allowCredentials: undefined, excludeCredentials: undefined })
-
-  // `credential` is the path discriminator (undefined on sign-in).
-  if (response.credential !== undefined) {
-    const _persist = response.credential.credentialId
-  }
 
   const sdk = await connect({ config, seed: response.wallet.seed, storageDir: './.data' })
   // ANCHOR_END: connect-with-passkey
@@ -95,29 +82,20 @@ const connectWithPasskey = async () => {
 }
 
 const signInExistingUser = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, '<breez api key>', undefined)
+  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
 
   // ANCHOR: sign-in
-  // Returning-user-only sign-in. No fall-through to register: use
-  // `connectWithPasskey` when you also want the new-user path.
+  // Returning-user sign-in. No fall-through to register.
   return await passkey.signIn({ label: 'personal', allowCredentials: undefined, preferImmediatelyAvailableCredentials: undefined })
   // ANCHOR_END: sign-in
 }
 
 const registerNewPasskey = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, '<breez api key>', undefined)
+  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
 
   // ANCHOR: register-passkey
   const config = { ...defaultConfig(Network.Mainnet), apiKey: '<breez api key>' }
   const response = await passkey.register({ label: 'personal', excludeCredentials: undefined })
-
-  // Persist credentialId for future excludeCredentials.
-  const _persist = {
-    credentialId: response.credential?.credentialId,
-    userId: response.credential?.userId
-  }
 
   const sdk = await connect({ config, seed: response.wallet.seed, storageDir: './.data' })
   // ANCHOR_END: register-passkey
@@ -125,38 +103,33 @@ const registerNewPasskey = async () => {
 }
 
 const credentialMetadata = async () => {
-  const config = { ...defaultConfig(Network.Mainnet), apiKey: '<breez api key>' }
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, config.apiKey, undefined)
+  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
 
   // ANCHOR: credential-metadata
   const response = await passkey.register({ label: 'personal', excludeCredentials: undefined })
 
-  // Persist these in synced storage (iCloud Keychain / Block Store) so they
-  // survive reinstall and reach the user's other devices. aaguid and
-  // backupEligible are only available here, on registration.
   if (response.credential !== undefined) {
-    const _meta = {
-      credentialId: response.credential.credentialId,
-      aaguid: response.credential.aaguid,
-      backupEligible: response.credential.backupEligible
-    }
+    console.log(response.credential.credentialId) // Persist to reopen the same wallet on sign-in
+    console.log(response.credential.aaguid) // Authenticator model (display hint, unverified)
+    console.log(response.credential.backupEligible) // Whether the passkey syncs across devices
   }
 
-  // On a later sign-in, pin the stored credential ID via allowCredentials so
-  // the OS cannot substitute a sibling credential, which would derive a
-  // different wallet seed.
-  const _signedIn = await passkey.signIn({
+  // Pin the stored credential ID so the OS can't substitute a sibling
+  // credential, which would derive a different wallet.
+  const signInResponse = await passkey.signIn({
     label: 'personal',
     allowCredentials: [/* stored credentialId bytes */],
     preferImmediatelyAvailableCredentials: undefined
   })
+  console.log(signInResponse.wallet.seed) // Pass to connect() to open the wallet
+  console.log(signInResponse.wallet.label) // Label this wallet was derived from
+  console.log(signInResponse.labels) // This passkey's labels (populated on discovery sign-in)
+  console.log(signInResponse.credential) // Credential signed in with (credential_id only)
   // ANCHOR_END: credential-metadata
 }
 
 const listLabels = async (): Promise<string[]> => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, '<breez api key>', undefined)
+  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
   // ANCHOR: list-labels
   const labels = await passkey.labels().list()
   for (const label of labels) {
@@ -167,8 +140,7 @@ const listLabels = async (): Promise<string[]> => {
 }
 
 const storeLabel = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, '<breez api key>', undefined)
+  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
   // ANCHOR: store-label
   await passkey.labels().store('personal')
   // ANCHOR_END: store-label
@@ -176,8 +148,8 @@ const storeLabel = async () => {
 
 const checkDomain = async () => {
   // ANCHOR: domain-association
-  // Lower-level provider call. Most hosts use `checkAvailability` instead.
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
+  // Diagnostic only: never blocks the ceremony.
+  const prfProvider = new PasskeyProvider(PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }))
   const result = await prfProvider.checkDomainAssociation()
 
   switch (result.kind) {
@@ -185,26 +157,22 @@ const checkDomain = async () => {
       // Safe to proceed.
       break
     case 'NotAssociated':
-      // Configuration is wrong (entitlement missing, AASA stale,
-      // assetlinks malformed). Surface a developer-facing error.
+      // Misconfigured (entitlement, AASA, or assetlinks). Surface a dev error.
       console.error(
         `Domain association failed (source=${result.source}): ${result.reason}`
       )
       break
     case 'Skipped':
-      // Verification could not be performed (offline, endpoint timeout).
-      // Proceed normally: this is NOT a negative signal.
+      // Could not verify (offline, no public-suffix match). Not a failure.
       break
   }
   // ANCHOR_END: domain-association
 }
 
 const recoverFromAlreadyExists = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, '<breez api key>', undefined)
+  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
 
   // ANCHOR: recover-already-exists
-  // Recovery: flip to sign-in so the OS picker surfaces the existing credential.
   try {
     const response = await passkey.register({
       label: 'personal',
@@ -215,8 +183,7 @@ const recoverFromAlreadyExists = async () => {
     return response.wallet
   } catch (error) {
     if (error instanceof PasskeyPrfException && error.code === 'credentialAlreadyExists') {
-      // Flip to sign-in. The existing credential's PRF output is
-      // the same seed the host would have minted on register.
+      // A matching credential already exists; sign in to it instead.
       const response = await passkey.signIn({ label: 'personal', allowCredentials: undefined, preferImmediatelyAvailableCredentials: undefined })
       return response.wallet
     }
@@ -226,18 +193,16 @@ const recoverFromAlreadyExists = async () => {
 }
 
 const handleTimeout = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider as any, '<breez api key>', undefined)
+  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
 
   // ANCHOR: handle-timeout
-  // Timeout is distinct from a cancel: surface a re-prompt UI.
+  // Biometric inactivity timeout, distinct from a user cancel.
   try {
     const response = await passkey.signIn({ label: 'personal', allowCredentials: undefined, preferImmediatelyAvailableCredentials: undefined })
     return response
   } catch (error) {
     if (error instanceof PasskeyPrfException && error.code === 'userTimedOut') {
-      // Show a sticky retry screen with timeout-specific copy.
-      // Do NOT auto-retry without user input.
+      // Show a retry UI. Do NOT auto-retry without user input.
       console.log('Sign-in timed out: show "Try Again" UI.')
     }
     throw error

--- a/docs/breez-sdk/snippets/rust/src/passkey.rs
+++ b/docs/breez-sdk/snippets/rust/src/passkey.rs
@@ -8,11 +8,8 @@ use breez_sdk_spark::{connect, default_config, ConnectRequest, Network};
 use std::sync::Arc;
 
 // ANCHOR: implement-prf-provider
-/// Implement the PrfProvider trait for custom logic if the built-in
-/// PasskeyProvider doesn't fit your needs (hardware key, FIDO2 transport,
-/// air-gapped backup file, etc.). Three required methods: derive_seeds
-/// for derivation, is_supported for the capability probe; create_passkey
-/// for registration is optional (defaults to PrfNotSupported).
+/// Implement PrfProvider for a custom authenticator (hardware key, FIDO2,
+/// file-backed). Only derive_seeds and is_supported are required.
 struct CustomPrfProvider;
 
 #[async_trait::async_trait]
@@ -21,16 +18,11 @@ impl PrfProvider for CustomPrfProvider {
         &self,
         _request: DeriveSeedsRequest,
     ) -> Result<DeriveSeedsOutput, PrfProviderError> {
-        // Call platform passkey API with PRF extension. Use the dual-salt
-        // ceremony when the authenticator supports it (one OS prompt for
-        // N salts) and fall back to per-salt assertions otherwise.
-        // Returns one 32-byte PRF output per salt in input order.
+        // Return one 32-byte PRF output per salt, in input order.
         todo!("Implement using WebAuthn or native passkey APIs")
     }
 
     async fn is_supported(&self) -> Result<bool, PrfProviderError> {
-        // Check if a PRF-capable authenticator is reachable from this
-        // platform / device.
         todo!("Check platform passkey availability")
     }
 
@@ -38,17 +30,12 @@ impl PrfProvider for CustomPrfProvider {
         &self,
         _exclude_credentials: Vec<Vec<u8>>,
     ) -> Result<PasskeyCredential, PrfProviderError> {
-        // Register a new credential and return its ID, the WebAuthn
-        // user.id the platform recorded (returned for host-side
-        // correlation, never host-supplied), AAGUID, and BE flag.
+        // Register a credential and return its ID plus attestation.
         todo!("Implement registration via WebAuthn create() / native API")
     }
 
     async fn check_domain_association(&self) -> Result<DomainAssociation, PrfProviderError> {
-        // Optional: verify the app's identity against the platform's
-        // domain verification source. Custom providers without a
-        // verification source return Skipped, which tells callers
-        // "proceed with WebAuthn as normal".
+        // Custom providers without a verification source return Skipped.
         Ok(DomainAssociation::Skipped {
             reason: "CustomPrfProvider does not verify domain association".to_string(),
         })
@@ -99,11 +86,6 @@ async fn connect_with_passkey_unified() -> Result<breez_sdk_spark::BreezSdk> {
         })
         .await?;
 
-    // The credential is surfaced on both paths when the provider exposes it.
-    if let Some(credential) = &response.credential {
-        let _persist = credential.credential_id.clone();
-    }
-
     let config = default_config(Network::Mainnet);
     let sdk = connect(ConnectRequest {
         config,
@@ -142,11 +124,6 @@ async fn register_new_passkey() -> Result<breez_sdk_spark::BreezSdk> {
         })
         .await?;
 
-    // Persist credential_id for future exclude_credentials.
-    if let Some(credential) = &response.credential {
-        let _persist = (credential.credential_id.clone(), credential.user_id.clone());
-    }
-
     let config = default_config(Network::Mainnet);
     let sdk = connect(ConnectRequest {
         config,
@@ -170,27 +147,25 @@ async fn credential_metadata() -> Result<()> {
         })
         .await?;
 
-    // Persist these in synced storage (iCloud Keychain / Block Store) so they
-    // survive reinstall and reach the user's other devices. aaguid and
-    // backup_eligible are only available here, on registration.
     if let Some(credential) = &response.credential {
-        let _meta = (
-            credential.credential_id.clone(),
-            credential.aaguid.clone(),
-            credential.backup_eligible,
-        );
+        println!("{:?}", credential.credential_id); // Persist to reopen the same wallet on sign-in
+        println!("{:?}", credential.aaguid); // Authenticator model (display hint, unverified)
+        println!("{:?}", credential.backup_eligible); // Whether the passkey syncs across devices
     }
 
-    // On a later sign-in, pin the stored credential ID via allow_credentials so
-    // the OS cannot substitute a sibling credential, which would derive a
-    // different wallet seed.
-    let _signed_in = passkey
+    // Pin the stored credential ID so the OS can't substitute a sibling,
+    // which would derive a different wallet.
+    let sign_in_response = passkey
         .sign_in(SignInRequest {
             label: Some("personal".to_string()),
             allow_credentials: Some(vec![/* stored credential_id bytes */]),
             ..Default::default()
         })
         .await?;
+    println!("{:?}", sign_in_response.wallet.seed); // Pass to connect() to open the wallet
+    println!("{}", sign_in_response.wallet.label); // Label this wallet was derived from
+    println!("{:?}", sign_in_response.labels); // This passkey's labels (populated on discovery sign-in)
+    println!("{:?}", sign_in_response.credential); // Credential signed in with (credential_id only)
     // ANCHOR_END: credential-metadata
     Ok(())
 }
@@ -218,8 +193,7 @@ async fn store_label() -> Result<()> {
 
 async fn check_domain() -> Result<()> {
     // ANCHOR: domain-association
-    // Verify Apple AASA / Android Asset Links / Web Related Origins
-    // before the first WebAuthn ceremony. Diagnostic only: never blocks.
+    // Diagnostic only: never blocks the ceremony.
     let prf_provider = Arc::new(CustomPrfProvider);
     let result = prf_provider.check_domain_association().await?;
 
@@ -228,15 +202,12 @@ async fn check_domain() -> Result<()> {
             // Safe to proceed.
         }
         DomainAssociation::NotAssociated { source, reason } => {
-            // Configuration is wrong (entitlement missing, AASA stale,
-            // assetlinks malformed). Surface a developer-facing error.
+            // Misconfigured (entitlement, AASA, or assetlinks). Surface a dev error.
             eprintln!("Domain association failed (source={source}): {reason}");
             return Ok(());
         }
         DomainAssociation::Skipped { reason: _ } => {
-            // Verification could not be performed (offline, endpoint
-            // timeout, no public-suffix match). Proceed normally: this
-            // is NOT a negative signal.
+            // Could not verify (offline, no public-suffix match). Not a failure.
         }
     }
     // ANCHOR_END: domain-association
@@ -248,11 +219,6 @@ async fn recover_from_already_exists() -> Result<Wallet> {
     let passkey = PasskeyClient::new(prf_provider, None, None);
 
     // ANCHOR: recover-already-exists
-    // The OS rejected register because the user's password manager
-    // already holds a credential matching `exclude_credentials`.
-    // Route the user to the sign-in path: the OS picker will surface
-    // the existing credential and the SDK's identity cache will warm
-    // up on the assertion.
     match passkey
         .register(RegisterRequest {
             label: Some("personal".to_string()),
@@ -264,8 +230,7 @@ async fn recover_from_already_exists() -> Result<Wallet> {
     {
         Ok(response) => Ok(response.wallet),
         Err(e) if e.kind() == ErrorKind::AlreadyExists => {
-            // Flip to sign-in. The existing credential's PRF output is
-            // the same seed the host would have minted on register.
+            // A matching credential already exists; sign in to it instead.
             let response = passkey
                 .sign_in(SignInRequest {
                     label: Some("personal".to_string()),
@@ -284,7 +249,7 @@ async fn handle_timeout() -> Result<SignInResponse> {
     let passkey = PasskeyClient::new(prf_provider, None, None);
 
     // ANCHOR: handle-timeout
-    // Timeout is distinct from a cancel: surface a re-prompt UI.
+    // Biometric inactivity timeout, distinct from a user cancel.
     match passkey
         .sign_in(SignInRequest {
             label: Some("personal".to_string()),
@@ -294,8 +259,7 @@ async fn handle_timeout() -> Result<SignInResponse> {
     {
         Ok(response) => Ok(response),
         Err(e) if e.kind() == ErrorKind::Timeout => {
-            // Show a sticky retry screen with timeout-specific copy.
-            // Do NOT auto-retry without user input.
+            // Show a retry UI. Do NOT auto-retry without user input.
             println!("Sign-in timed out: show \"Try Again\" UI.");
             Err(e.into())
         }

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
@@ -2,48 +2,31 @@ import BreezSdkSpark
 import Foundation
 
 // ANCHOR: implement-prf-provider
-// Implement the PrfProvider interface for custom logic if the built-in
-// PasskeyProvider doesn't fit your needs (hardware key, FIDO2 transport,
-// air-gapped backup file, etc.). Three required methods: deriveSeeds for
-// derivation, isSupported for the capability probe; createPasskey for
-// registration is optional.
+// Implement PrfProvider for a custom authenticator (hardware key, FIDO2,
+// file-backed). Only deriveSeeds and isSupported are required.
 class CustomPrfProvider: PrfProvider {
     func deriveSeeds(request: DeriveSeedsRequest) async throws -> DeriveSeedsOutput {
-        // Call platform passkey API with PRF extension. Use the dual-salt
-        // ceremony when the authenticator supports it (one OS prompt for
-        // N salts) and fall back to per-salt assertions otherwise.
-        // Returns one 32-byte PRF output per salt in input order.
+        // Return one 32-byte PRF output per salt, in input order.
         fatalError("Implement using WebAuthn or native passkey APIs")
     }
 
     func isSupported() async throws -> Bool {
-        // Check if a PRF-capable authenticator is reachable from this
-        // platform / device.
         fatalError("Check platform passkey availability")
     }
 
     func createPasskey(excludeCredentials: [Data]) async throws -> PasskeyCredential {
-        // Register a new credential and return its ID, the WebAuthn
-        // user.id the platform recorded (returned for host-side
-        // correlation, never host-supplied), AAGUID, and BE flag.
+        // Register a credential and return its ID plus attestation.
         fatalError("Implement registration via WebAuthn create() / native API")
     }
 
     func checkDomainAssociation() async throws -> DomainAssociation {
-        // Optional: verify the app's identity against the platform's
-        // domain verification source (e.g., iOS AASA CDN, Android
-        // assetlinks). Custom providers without a verification source
-        // return `.skipped`, which tells callers "proceed with WebAuthn
-        // as normal".
         return .skipped(reason: "CustomPrfProvider does not verify domain association")
     }
 }
 // ANCHOR_END: implement-prf-provider
 
 func checkAvailability() async throws {
-    // Pass `PasskeyProvider.BREEZ_RP_ID` instead of "<your-rp-domain>" if your
-    // app is Breez-registered (shares credentials with other Breez apps).
-    let prfProvider = PasskeyProvider(rpId: "<your-rp-domain>", rpName: "Your App")
+    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: check-availability
@@ -62,14 +45,16 @@ func checkAvailability() async throws {
 
 func setupPasskeyClient() -> PasskeyClient {
     // ANCHOR: setup-client
-    let prfProvider = PasskeyProvider(rpId: "<your-rp-domain>", rpName: "Your App")
-    let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
+    let passkey = PasskeyClient(
+        breezApiKey: "<breez api key>",
+        config: PasskeyConfig(providerOptions: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
+    )
     // ANCHOR_END: setup-client
     return passkey
 }
 
 func connectWithPasskey() async throws -> BreezSdk {
-    let prfProvider = PasskeyProvider(rpId: "<your-rp-domain>", rpName: "Your App")
+    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: connect-with-passkey
@@ -80,11 +65,6 @@ func connectWithPasskey() async throws -> BreezSdk {
     let response = try await passkey.connectWithPasskey(
         request: ConnectWithPasskeyRequest(label: "personal")
     )
-
-    // `credential` is the path discriminator (nil on sign-in).
-    if let credential = response.credential {
-        let _ = credential.credentialId
-    }
 
     let sdk = try await connect(
         request: ConnectRequest(
@@ -97,18 +77,17 @@ func connectWithPasskey() async throws -> BreezSdk {
 }
 
 func signInExistingUser() async throws -> SignInResponse {
-    let prfProvider = PasskeyProvider(rpId: "<your-rp-domain>", rpName: "Your App")
+    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: sign-in
-    // Returning-user-only sign-in. No fall-through to register: use
-    // `connectWithPasskey` when you also want the new-user path.
+    // Returning-user sign-in. No fall-through to register.
     return try await passkey.signIn(request: SignInRequest(label: "personal"))
     // ANCHOR_END: sign-in
 }
 
 func registerNewPasskey() async throws -> BreezSdk {
-    let prfProvider = PasskeyProvider(rpId: "<your-rp-domain>", rpName: "Your App")
+    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: register-passkey
@@ -118,9 +97,6 @@ func registerNewPasskey() async throws -> BreezSdk {
     let response = try await passkey.register(
         request: RegisterRequest(label: "personal")
     )
-
-    // Persist credentialId for future excludeCredentials.
-    let _ = (response.credential?.credentialId, response.credential?.userId)
 
     let sdk = try await connect(
         request: ConnectRequest(
@@ -133,7 +109,7 @@ func registerNewPasskey() async throws -> BreezSdk {
 }
 
 func credentialMetadata() async throws {
-    let prfProvider = PasskeyProvider(rpId: "<your-rp-domain>", rpName: "Your App")
+    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: nil, config: nil)
 
     // ANCHOR: credential-metadata
@@ -141,17 +117,15 @@ func credentialMetadata() async throws {
         request: RegisterRequest(label: "personal")
     )
 
-    // Persist these in synced storage (iCloud Keychain) so they survive
-    // reinstall and reach the user's other devices. aaguid and backupEligible
-    // are only available here, on registration.
     if let credential = response.credential {
-        let _ = (credential.credentialId, credential.aaguid, credential.backupEligible)
+        print(credential.credentialId) // Persist to reopen the same wallet on sign-in
+        print(credential.aaguid) // Authenticator model (display hint, unverified)
+        print(credential.backupEligible) // Whether the passkey syncs across devices
     }
 
-    // On a later sign-in, pin the stored credential ID via allowCredentials so
-    // the OS cannot substitute a sibling credential, which would derive a
-    // different wallet seed.
-    let _ = try await passkey.signIn(
+    // Pin the stored credential ID so the OS can't substitute a sibling
+    // credential, which would derive a different wallet.
+    let signInResponse = try await passkey.signIn(
         request: SignInRequest(
             label: "personal",
             allowCredentials: [
@@ -159,11 +133,15 @@ func credentialMetadata() async throws {
             ]
         )
     )
+    print(signInResponse.wallet.seed) // Pass to connect() to open the wallet
+    print(signInResponse.wallet.label) // Label this wallet was derived from
+    print(signInResponse.labels) // This passkey's labels (populated on discovery sign-in)
+    print(signInResponse.credential) // Credential signed in with (credential_id only)
     // ANCHOR_END: credential-metadata
 }
 
 func listLabels() async throws -> [String] {
-    let prfProvider = PasskeyProvider(rpId: "<your-rp-domain>", rpName: "Your App")
+    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
     // ANCHOR: list-labels
     let labels = try await passkey.labels().list()
@@ -175,7 +153,7 @@ func listLabels() async throws -> [String] {
 }
 
 func storeLabel() async throws {
-    let prfProvider = PasskeyProvider(rpId: "<your-rp-domain>", rpName: "Your App")
+    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
     // ANCHOR: store-label
     try await passkey.labels().store(label: "personal")
@@ -185,7 +163,7 @@ func storeLabel() async throws {
 func checkDomain() async throws {
     // ANCHOR: domain-association
     // Lower-level provider call. Most hosts use `checkAvailability` instead.
-    let prfProvider = PasskeyProvider(rpId: "<your-rp-domain>", rpName: "Your App")
+    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
     let result = try await prfProvider.checkDomainAssociation()
 
     switch result {
@@ -201,7 +179,7 @@ func checkDomain() async throws {
 }
 
 func recoverFromAlreadyExists() async throws -> Wallet {
-    let prfProvider = PasskeyProvider(rpId: "<your-rp-domain>", rpName: "Your App")
+    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: recover-already-exists
@@ -216,6 +194,7 @@ func recoverFromAlreadyExists() async throws -> Wallet {
         )
         return response.wallet
     } catch PrfProviderError.CredentialAlreadyExists {
+        // A matching credential already exists; sign in instead.
         let response = try await passkey.signIn(
             request: SignInRequest(label: "personal")
         )
@@ -225,7 +204,7 @@ func recoverFromAlreadyExists() async throws -> Wallet {
 }
 
 func handleTimeout() async throws -> SignInResponse {
-    let prfProvider = PasskeyProvider(rpId: "<your-rp-domain>", rpName: "Your App")
+    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: handle-timeout
@@ -234,6 +213,7 @@ func handleTimeout() async throws -> SignInResponse {
             request: SignInRequest(label: "personal")
         )
     } catch PrfProviderError.UserTimedOut {
+        // Show a retry UI. Do NOT auto-retry without user input.
         print("Sign-in timed out: show \"Try Again\" UI.")
         throw PrfProviderError.UserTimedOut
     }

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -1,54 +1,40 @@
 import type {
   PasskeyCredential
 } from '@breeztech/breez-sdk-spark'
-import { PasskeyClient, connect, defaultConfig } from '@breeztech/breez-sdk-spark'
+import { connect, defaultConfig } from '@breeztech/breez-sdk-spark'
 import {
   PasskeyAlreadyExistsError,
+  PasskeyClient,
   PasskeyProvider,
   PasskeyTimedOutError
 } from '@breeztech/breez-sdk-spark/passkey-prf-provider'
 
 // ANCHOR: implement-prf-provider
-// Implement the PrfProvider interface for custom logic if the built-in
-// PasskeyProvider doesn't fit your needs (hardware key, FIDO2 transport,
-// air-gapped backup file, etc.). Three required methods: deriveSeeds for
-// derivation, isSupported for the capability probe; createPasskey for
-// registration is optional.
+// Implement PrfProvider for a custom authenticator (hardware key, FIDO2,
+// file-backed). Only deriveSeeds and isSupported are required.
 class CustomPrfProvider {
   deriveSeeds = async (salts: string[]): Promise<{ seeds: Uint8Array[], credentialId: Uint8Array | null }> => {
-    // Call platform passkey API with PRF extension. Use the dual-salt
-    // ceremony when the authenticator supports it (one OS prompt for N
-    // salts) and fall back to per-salt assertions otherwise. Returns
-    // one 32-byte PRF output per salt in input order.
+    // Return one 32-byte PRF output per salt, in input order.
     throw new Error('Implement using WebAuthn or native passkey APIs')
   }
 
   createPasskey = async (
     _excludeCredentials: Uint8Array[]
   ): Promise<PasskeyCredential> => {
-    // Register a new credential and return its ID, the WebAuthn
-    // user.id the provider minted for it (returned for host-side
-    // correlation, never host-supplied), AAGUID, and BE flag.
+    // Register a credential and return its ID plus attestation.
     throw new Error('Implement registration via WebAuthn create() / native API')
   }
 
   isSupported = async (): Promise<boolean> => {
-    // Check if a PRF-capable authenticator is reachable from this
-    // platform / browser / device.
     throw new Error('Check platform passkey availability')
   }
 }
 // ANCHOR_END: implement-prf-provider
 
 const checkAvailability = async () => {
-  // `rpId` is required. Pass your app's domain, or
-  // `PasskeyProvider.BREEZ_RP_ID` if your app is Breez-registered.
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
+  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
 
   // ANCHOR: check-availability
-  // checkAvailability collapses isSupported + checkDomainAssociation
-  // into a single tagged value. Branch on the variant the host needs.
   const availability = await passkey.checkAvailability()
   switch (availability.type) {
     case 'available':
@@ -71,21 +57,16 @@ const checkAvailability = async () => {
 
 const setupPasskeyClient = () => {
   // ANCHOR: setup-client
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider, '<breez api key>', undefined)
+  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
   // ANCHOR_END: setup-client
   return passkey
 }
 
 const connectWithPasskey = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
+  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
 
   // ANCHOR: connect-with-passkey
-  // connectWithPasskey is not surfaced on web: WebAuthn can't hand the
-  // SDK a silent "no credential" signal to fall through on. On web, wire
-  // two buttons instead (Sign In -> signIn, Create Account -> register);
-  // see "Sign in and register". The returning-user path is a plain signIn:
+  // Not available on web; use two buttons (signIn / register) instead.
   const response = await passkey.signIn({ label: 'personal' })
 
   const config = defaultConfig('mainnet')
@@ -95,33 +76,19 @@ const connectWithPasskey = async () => {
 }
 
 const signInExistingUser = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
+  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
 
   // ANCHOR: sign-in
-  // Returning-user-only sign-in. No fall-through to register.
+  // Returning-user sign-in. No fall-through to register.
   return await passkey.signIn({ label: 'personal' })
   // ANCHOR_END: sign-in
 }
 
 const registerNewPasskey = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
+  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
 
   // ANCHOR: register-passkey
-  // For a brand-new user with no existing passkey: register() creates
-  // the credential AND derives the seed in one orchestrated call.
-  // On iOS+Android this is 2 OS prompts total (1 create + 1 dual-salt
-  // assert) thanks to the SDK's bulk-PRF path.
   const response = await passkey.register({ label: 'personal' })
-
-  // Hosts SHOULD persist credentialId (for excludeCredentials
-  // bookkeeping) and userId (for server-side correlation).
-  // The SDK generates userId; it is never host-supplied.
-  const _persist = {
-    credentialId: response.credential?.credentialId,
-    userId: response.credential?.userId
-  }
 
   const config = defaultConfig('mainnet')
   const sdk = await connect({ config, seed: response.wallet.seed, storageDir: './.data' })
@@ -130,36 +97,32 @@ const registerNewPasskey = async () => {
 }
 
 const credentialMetadata = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
+  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
 
   // ANCHOR: credential-metadata
   const response = await passkey.register({ label: 'personal' })
 
-  // Persist these in synced storage (iCloud Keychain / Block Store) so they
-  // survive reinstall and reach the user's other devices. aaguid and
-  // backupEligible are only available here, on registration.
   if (response.credential != null) {
-    const _meta = {
-      credentialId: response.credential.credentialId,
-      aaguid: response.credential.aaguid,
-      backupEligible: response.credential.backupEligible
-    }
+    console.log(response.credential.credentialId) // Persist to reopen the same wallet on sign-in
+    console.log(response.credential.aaguid) // Authenticator model (display hint, unverified)
+    console.log(response.credential.backupEligible) // Whether the passkey syncs across devices
   }
 
-  // On a later sign-in, pin the stored credential ID via allowCredentials so
-  // the OS cannot substitute a sibling credential, which would derive a
-  // different wallet seed.
-  const _signedIn = await passkey.signIn({
+  // Pin the stored credential ID so the OS can't substitute a sibling
+  // credential, which would derive a different wallet.
+  const signInResponse = await passkey.signIn({
     label: 'personal',
     allowCredentials: [/* stored credentialId bytes */]
   })
+  console.log(signInResponse.wallet.seed) // Pass to connect() to open the wallet
+  console.log(signInResponse.wallet.label) // Label this wallet was derived from
+  console.log(signInResponse.labels) // This passkey's labels (populated on discovery sign-in)
+  console.log(signInResponse.credential) // Credential signed in with (credential_id only)
   // ANCHOR_END: credential-metadata
 }
 
 const listLabels = async (): Promise<string[]> => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider, '<breez api key>', undefined)
+  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
   // ANCHOR: list-labels
   const labels = await passkey.labels().list()
   for (const label of labels) {
@@ -170,8 +133,7 @@ const listLabels = async (): Promise<string[]> => {
 }
 
 const storeLabel = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider, '<breez api key>', undefined)
+  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
   // ANCHOR: store-label
   await passkey.labels().store('personal')
   // ANCHOR_END: store-label
@@ -179,8 +141,7 @@ const storeLabel = async () => {
 
 const checkDomain = async () => {
   // ANCHOR: domain-association
-  // Verify Apple AASA / Android Asset Links / Web Related Origins
-  // before the first WebAuthn ceremony. Diagnostic only: never blocks.
+  // Diagnostic only: never blocks the ceremony.
   const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
   const result = await prfProvider.checkDomainAssociation()
 
@@ -189,31 +150,22 @@ const checkDomain = async () => {
       // Safe to proceed.
       break
     case 'NotAssociated':
-      // Configuration is wrong (entitlement missing, AASA stale,
-      // assetlinks malformed). Surface a developer-facing error.
+      // Misconfigured (entitlement, AASA, or assetlinks). Surface a dev error.
       console.error(
         `Domain association failed (source=${result.source}): ${result.reason}`
       )
       break
     case 'Skipped':
-      // Verification could not be performed (offline, endpoint
-      // timeout, no public-suffix match). Proceed normally: this
-      // is NOT a negative signal.
+      // Could not verify (offline, no public-suffix match). Not a failure.
       break
   }
   // ANCHOR_END: domain-association
 }
 
 const recoverFromAlreadyExists = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
+  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
 
   // ANCHOR: recover-already-exists
-  // The OS rejected register because the user's password manager
-  // already holds a credential matching `excludeCredentials`.
-  // Route the user to the sign-in path: the OS picker will surface
-  // the existing credential and the SDK's identity cache will warm
-  // up on the assertion.
   try {
     const response = await passkey.register({
       label: 'personal',
@@ -224,8 +176,7 @@ const recoverFromAlreadyExists = async () => {
     return response.wallet
   } catch (error) {
     if (error instanceof PasskeyAlreadyExistsError) {
-      // Flip to sign-in. The existing credential's PRF output is
-      // the same seed the host would have minted on register.
+      // A matching credential already exists; sign in to it instead.
       const response = await passkey.signIn({ label: 'personal' })
       return response.wallet
     }
@@ -235,22 +186,16 @@ const recoverFromAlreadyExists = async () => {
 }
 
 const handleTimeout = async () => {
-  const prfProvider = new PasskeyProvider({ rpId: '<your-rp-domain>', rpName: 'Your App' })
-  const passkey = new PasskeyClient(prfProvider, undefined, undefined)
+  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
 
   // ANCHOR: handle-timeout
-  // The OS biometric inactivity timeout (~55s+) tore down the prompt
-  // without user intent. Distinct from a real cancel: hosts may
-  // surface a re-prompt UI without treating it as the user opting
-  // out. The SDK fires PasskeyTimedOutError when assertion or
-  // register elapsed time crosses 55_000ms.
+  // Biometric inactivity timeout, distinct from a user cancel.
   try {
     const response = await passkey.signIn({ label: 'personal' })
     return response
   } catch (error) {
     if (error instanceof PasskeyTimedOutError) {
-      // Show a sticky retry screen with timeout-specific copy.
-      // Do NOT auto-retry without user input.
+      // Show a retry UI. Do NOT auto-retry without user input.
       console.log('Sign-in timed out: show "Try Again" UI.')
     }
     throw error

--- a/docs/breez-sdk/src/guide/passkey.md
+++ b/docs/breez-sdk/src/guide/passkey.md
@@ -1,15 +1,19 @@
 # Passkey login
 
-Passkey Login lets users access their wallet with biometrics (fingerprint, face scan, or device PIN) instead of writing down and safeguarding a seed phrase. The SDK uses the <a target="_blank" href="https://w3c.github.io/webauthn/#prf-extension">WebAuthn PRF extension</a> to deterministically derive wallet keys from a passkey. Keys are never stored; they're regenerated on demand each time the user authenticates. The protocol also supports multiple wallets, each derived from a different label, with labels discoverable via Nostr relays.
+Passkey login lets users access their wallet using biometrics (fingerprint or face recognition) or a device PIN, eliminating the need to write down and safeguard a seed phrase.
 
-- **[Setup](passkey_setup.md)** - host the Web / Android / iOS configuration files that tie passkeys to your app
-- **[Onboarding](passkey_onboarding.md)** - initialize the client and wire up the register / sign-in / unified onboarding flows
-- **[Credential metadata](passkey_credential_metadata.md)** - pin a returning user, prevent duplicate registrations, and show the authenticator and sync status
-- **[Managing labels](passkey_labels.md)** - derive multiple wallets from a single passkey and discover them through Nostr
-- **[PRF providers](passkey_prf_providers.md)** - use the built-in platform provider, or implement a custom one (hardware key, FIDO2, file-backed)
+No keys or seed phrases are stored. The SDK uses the <a target="_blank" href="https://w3c.github.io/webauthn/#prf-extension">WebAuthn PRF extension</a> to deterministically derive a seed phrase from the user's passkey on-demand, and regenerates it on each sign-in.
+
+One passkey can be associated with multiple wallets, each under its own label, discoverable across the user's devices through Nostr relays.
+
+- **[Setup](passkey_setup.md)** - host the Web / Android / iOS configuration files that tie passkeys to your app.
+- **[Onboarding](passkey_onboarding.md)** - initialize the client and wire up the sign-in, register, and unified onboarding flows.
+- **[Credential metadata](passkey_credential_metadata.md)** - pin a returning user, prevent duplicate registrations, and show the authenticator and sync status.
+- **[Managing labels](passkey_labels.md)** - derive multiple wallets from one passkey and discover them through Nostr.
+- **[PRF providers](passkey_prf_providers.md)** - use the built-in platform provider, or implement a custom one (hardware key, FIDO2, file-backed).
 
 ## Further reading
 
-- **[UX guidelines](uxguide_passkey.md)** - recommended onboarding UX, prompt counts, and error-recovery patterns
+- **[UX guidelines](uxguide_passkey.md)** - recommended onboarding UX, prompt counts, and error-recovery patterns.
 
 For the full technical specification, see the <a target="_blank" href="https://github.com/breez/passkey-login/blob/main/spec.md">Passkey Login spec</a>.

--- a/docs/breez-sdk/src/guide/passkey_credential_metadata.md
+++ b/docs/breez-sdk/src/guide/passkey_credential_metadata.md
@@ -39,7 +39,7 @@ If your backend ties passkeys to your own user accounts, {{#name user_id}} is a 
 
 This enables account-level controls the passkey layer can't enforce on its own:
 
-- Cap how many passkeys (and wallet) one account may register.
+- Cap how many passkeys (and wallets) one account may register.
 - Revoke a lost credential server-side.
 - List a user's registered devices in their settings.
 
@@ -51,6 +51,6 @@ This enables account-level controls the passkey layer can't enforce on its own:
 
 ## Persisting the values
 
-The use cases above require these values to be persisted across app launches. {{#name credential_id}} is returned on every authentication response, while {{#name aaguid}},{{#name backup_eligible}}, and {{#name user_id}} are only returned during registration and should be stored at that time.
+The use cases above require these values to be persisted across app launches. {{#name credential_id}} is returned on every authentication response, while {{#name aaguid}}, {{#name backup_eligible}}, and {{#name user_id}} are only returned during registration and should be stored at that time.
 
 Use synced storage such as iCloud Keychain (iOS), Block Store (Android), or your own synced backend. Local-only storage is insufficient because it is lost on app reinstall and cannot be accessed from another device.

--- a/docs/breez-sdk/src/guide/passkey_credential_metadata.md
+++ b/docs/breez-sdk/src/guide/passkey_credential_metadata.md
@@ -1,8 +1,8 @@
 # Credential metadata
 
-Every passkey flow returns the credential it used or created. Its IDs and attestation hints let you keep a returning user on the same wallet, prevent duplicate registrations on one device, correlate the credential with your backend, and show which authenticator holds the passkey.
+Every passkey flow returns the credential it created or signed in with. Its IDs and attestation hints let you pin a returning user to the same wallet, prevent duplicate registrations, correlate with your backend, and show which authenticator holds the passkey.
 
-{{#name register}}, {{#name sign_in}}, and {{#name connect_with_passkey}} each return a {{#name credential}} field. It is unset only for PRF backends that do not surface one (CLI / file-backed / hardware providers); the built-in platform providers always populate it.
+{{#name register}}, {{#name sign_in}}, and {{#name connect_with_passkey}} each return a {{#name credential}} field. The built-in platform providers always populate it; only PRF backends that don't surface one (CLI / file-backed / hardware) leave it unset.
 
 ## Fields
 
@@ -15,36 +15,42 @@ Every passkey flow returns the credential it used or created. Its IDs and attest
 | {{#name aaguid}} | registration | [Showing the authenticator](#show-the-authenticator-and-sync-status). Unverified. |
 | {{#name backup_eligible}} | registration | [Showing the sync status](#show-the-authenticator-and-sync-status). |
 
-The attestation fields ({{#name user_id}}, {{#name aaguid}}, {{#name backup_eligible}}) come from the registration ceremony only. A sign-in assertion carries no attestation, so they are unset on the sign-in path; {{#name credential_id}} is always present.
-
 ## Using the fields
 
-Each of these is optional. The basic register and sign-in flows need none of them: reach for one only when your app wants that specific behavior.
+Each of these is optional. The basic register and sign-in flows need none of them: reach for one only when your app wants that behavior.
 
 ### Pin a returning user to the same wallet
 
-Each credential derives its own wallet seed, so a returning user must sign in with the same credential to re-open the same wallet. Persist {{#name credential_id}} after registration and pass it as {{#name allow_credentials}} on {{#name sign_in}}: the OS then offers only that credential and the user lands on the same wallet. {{#name allow_credentials}} is optional; omit it and the OS picks any matching credential for your RP.
+Each credential derives its own wallet seed, so a returning user must sign in with the same credential to re-open the same wallet.
+
+Persist {{#name credential_id}} after registration and pass it as {{#name allow_credentials}} on {{#name sign_in}}. The OS then offers only that credential. Omit {{#name allow_credentials}} and the OS picks any matching credential for your RP.
 
 {{#tabs passkey:credential-metadata}}
 
 ### Prevent duplicate registrations
 
-Pass the credential IDs already registered for this user as {{#name exclude_credentials}} on {{#name register}}. When one matches a credential already on the device, the OS refuses to create a second and raises {{#enum PrfProviderError::CredentialAlreadyExists}}; route that to {{#name sign_in}} so the OS picker surfaces the existing credential. {{#name exclude_credentials}} is optional; omit it for the simple path.
+Pass the user's already-registered credential IDs as {{#name exclude_credentials}} on {{#name register}}. When one is already on the device, the OS refuses to create a second and raises {{#enum PrfProviderError::CredentialAlreadyExists}}: route that to {{#name sign_in}} so the picker surfaces the existing credential.
 
 {{#tabs passkey:recover-already-exists}}
 
 ### Correlate the credential with your backend
 
-Most wallets don't need this, but if your backend ties wallets to your own user accounts, {{#name user_id}} is the stable identifier that links the two. The SDK mints this WebAuthn user handle at registration and surfaces it here (it never transmits the value). Persist it with your user record, then match it against the handle a later assertion carries to tell which of your users is signing in.
+If your backend ties passkeys to your own user accounts, {{#name user_id}} is a stable identifier set at registration that links the two. The SDK surfaces it locally and never transmits it. Persist it with your user record, then match it on later sign-ins to tell which user is signing in.
 
-Tying credentials to accounts this way unlocks controls the passkey layer can't enforce on its own: capping how many passkeys (and therefore wallets) one account may register, revoking a lost credential server-side, or listing a user's registered devices in their account settings.
+This enables account-level controls the passkey layer can't enforce on its own:
+
+- Cap how many passkeys (and wallet) one account may register.
+- Revoke a lost credential server-side.
+- List a user's registered devices in their settings.
 
 ### Show the authenticator and sync status
 
-{{#name aaguid}} identifies the authenticator that created the passkey (Apple Passwords, Google Password Manager, a hardware key, and so on). Look it up in the community [AAGUID database](https://github.com/passkeydeveloper/passkey-authenticator-aaguids) for a display name and icon. {{#name backup_eligible}} tells you whether the passkey syncs across the user's devices or stays on this one.
+{{#name aaguid}} identifies the authenticator that created the passkey (Apple Passwords, Google Password Manager, a hardware key). Look it up in the community [AAGUID database](https://github.com/passkeydeveloper/passkey-authenticator-aaguids) for a name and icon. {{#name backup_eligible}} tells you whether the passkey syncs across the user's devices.
 
-Both are unverified attestation, self-reported by the authenticator: use them as display hints only, never as a trust or security signal.
+> **Note:** {{#name aaguid}} and {{#name backup_eligible}} are unverified and self-reported by the authenticator. Use them as display hints, never as a trust signal.
 
 ## Persisting the values
 
-The use cases above need the values kept across app launches. {{#name credential_id}} comes back on every response; {{#name aaguid}}, {{#name backup_eligible}}, and {{#name user_id}} arrive only at registration, so capture them there. For cross-device continuity, back the store with synced storage: iCloud Keychain (`kSecAttrSynchronizable`) on iOS, Block Store on Android, or your own synced backend. Plain local storage does not survive reinstall or replicate to a second device.
+The use cases above require these values to be persisted across app launches. {{#name credential_id}} is returned on every authentication response, while {{#name aaguid}},{{#name backup_eligible}}, and {{#name user_id}} are only returned during registration and should be stored at that time.
+
+Use synced storage such as iCloud Keychain (iOS), Block Store (Android), or your own synced backend. Local-only storage is insufficient because it is lost on app reinstall and cannot be accessed from another device.

--- a/docs/breez-sdk/src/guide/passkey_onboarding.md
+++ b/docs/breez-sdk/src/guide/passkey_onboarding.md
@@ -4,9 +4,9 @@ Initialize the {{#name PasskeyClient}}, then run the onboarding flow that fits y
 
 ## Initialization
 
-{{#name PasskeyClient}} is the entry point for every passkey-derived wallet operation. It composes a {{#name PrfProvider}} (the platform-specific bridge to WebAuthn / Credential Manager / AuthenticationServices) with the SDK's internal Nostr-backed label store, then exposes register / sign-in / connect / labels to your app code. Construct one per app session and reuse it.
+{{#name PasskeyClient}} is the entry point for every passkey wallet operation. Construct one per app session and reuse it.
 
-Build the platform's {{#name PasskeyProvider}}, then pass it to {{#name PasskeyClient}} along with your Breez API key:
+On web, iOS, Android, Flutter, and React Native it wires the built-in {{#name PasskeyProvider}} for you, defaulting to the Breez shared RP (`keys.breez.technology`): a Breez-registered app needs only its Breez API key. Set {{#name provider_options}} on the config to use your own RP or customize the picker identity. On other platforms, or for a custom PRF backend (hardware key, file-backed), implement {{#name PrfProvider}} and inject it:
 
 {{#tabs passkey:setup-client}}
 
@@ -14,44 +14,52 @@ Build the platform's {{#name PasskeyProvider}}, then pass it to {{#name PasskeyC
 
 | Parameter | Default | Description |
 |---|---|---|
-| {{#name breez_api_key}} | **required** | Your Breez API key, used to authenticate to the Breez relay (<a target="_blank" href="https://github.com/nostr-protocol/nips/blob/master/42.md">NIP-42</a>) for label storage. |
-| {{#name rp_id}} | **required** | Relying Party ID. Pass your app's domain, or `PasskeyProvider.BREEZ_RP_ID` if your app is Breez-registered. Changing it later strands existing credentials. |
-| {{#name rp_name}} | **required** | Maps to the WebAuthn `rp.name`, which current OS prompts still mandate (deprecated in WebAuthn L3 but enforced everywhere). Surfaces in some authenticators' management UIs (Apple Passwords, Google Password Manager); platform UIs increasingly ignore it. Set at registration only; changing it does not affect existing credentials. |
-| {{#name user_name}} | {{#name rp_name}} | Maps to the WebAuthn `user.name`. Treated as the user's unique identifier for the credential and shown in the OS account picker during sign-in. Pass a stable per-user value if each registration should surface as a distinct entry (Apple's Passwords app, in particular, dedupes credentials by `(rpId, user.name)`). Registration-only. |
-| {{#name user_display_name}} | {{#name user_name}} | Maps to the WebAuthn `user.displayName`. The user-friendly label the OS / browser MAY (but is not required to) show in the picker; behavior varies by platform. Registration-only. |
-| {{#name passkey_config}} | none | Carries {{#name default_label}}, the label used when {{#name PasskeyClient.register}} / {{#name PasskeyClient.sign_in}} receive no label. Falls back to the SDK's internal `"Default"` when unset. |
+| {{#name breez_api_key}} | **required** | Your Breez API key, used to authenticate to the Breez relay for label storage. |
+| {{#name default_label}} | `"Default"` | Wallet label used when {{#name PasskeyClient.register}} / {{#name PasskeyClient.sign_in}} receive none. Set on {{#name passkey_config}}. |
 
-The SDK also implements <a target="_blank" href="https://github.com/nostr-protocol/nips/blob/master/65.md">NIP-65</a> to discover and publish to additional public relays for redundancy.
+Configure the built-in provider through {{#name provider_options}} on {{#name passkey_config}} (a {{#name PasskeyProviderOptions}}):
 
-For custom PRF providers (CLI YubiKey, FIDO2, file-backed) or non-default {{#name PasskeyProvider}} options, see [PRF providers](./passkey_prf_providers.md).
+| Field | Default | Description |
+|---|---|---|
+| {{#name rp_id}} | Breez shared RP | Relying Party ID: your app's domain, or unset for the Breez shared RP (`keys.breez.technology`) if your app is Breez-registered. Changing it later strands existing credentials. |
+| {{#name rp_name}} | `"Breez"` | Display name for your app, shown in some authenticator UIs. |
+| {{#name user_name}} | {{#name rp_name}} | Account identifier the OS sign-in picker shows beneath the display name, e.g. `john@doe.com`. Set a stable per-user value to keep each registration a distinct entry. |
+| {{#name user_display_name}} | {{#name user_name}} | Human-friendly name the picker shows most prominently, e.g. `John Doe`. |
+
+For platform-specific provider options (iOS `URLSession` / presentation anchor, Android `Activity`, web `authenticatorAttachment`) or a custom PRF backend, build the provider yourself and inject it. See [PRF providers](./passkey_prf_providers.md).
 
 ### Checking passkey availability
 
-Call {{#name PasskeyClient.check_availability}} before surfacing the passkey button. It probes OS support, PRF capability, and your domain association in one shot, so you can hide the option on incompatible devices (older Android / iOS) or surface a configuration error (missing entitlement, undeployed AASA) before the user runs into an opaque WebAuthn failure:
+Call {{#name PasskeyClient.check_availability}} before showing the passkey button. One call covers device support and your domain config, so you can hide the option on unsupported devices (older Android / iOS) or surface a configuration error (missing entitlement, undeployed AASA) before the user runs into an opaque WebAuthn failure.
 
 {{#tabs passkey:check-availability}}
 
 ## Choosing a flow
 
-The recommended flow depends on the platform. iOS and Android use a single-call unified flow backed by {{#name PasskeyClient.connect_with_passkey}}. Web (browser) uses two buttons (Sign In and Create Account) and lets the user pick. For explicit control over each path, call {{#name PasskeyClient.sign_in}} and {{#name PasskeyClient.register}} directly.
+The right flow depends on the platform:
+
+- **iOS / Android** use a single-call unified flow backed by {{#name PasskeyClient.connect_with_passkey}}.
+- **Web** uses two buttons ("Create a new passkey" and "Sign in with a passkey") and lets the user pick.
+
+For explicit control over each path, call {{#name PasskeyClient.sign_in}} and {{#name PasskeyClient.register}} directly.
 
 ### Unified flow (iOS / Android)
 
-One "Use Passkey" button backed by {{#name PasskeyClient.connect_with_passkey}}: silent sign-in for a returning user, automatic fall-through to registration on a fresh device. The response's {{#name credential}} field carries whichever credential signed in or was registered; the register path also fills the attestation fields ({{#name aaguid}}, {{#name backup_eligible}}). See [Credential metadata](./passkey_credential_metadata.md) for using these.
+One "Use Passkey" button: a silent sign-in for returning users, with automatic fall-through to registration on a fresh device.
 
-Internally the silent attempt pins {{#name prefer_immediately_available_credentials}} to true so the OS fast-fails (no UI, sub-300ms on iOS / Android) when no local credential exists; only {{#enum PrfProviderError::CredentialNotFound}} flips to register, all other errors (`Cancel`, `Timeout`, `Configuration`) propagate unchanged.
+The response's {{#name credential}} field carries whichever credential signed in or was registered. See [Credential metadata](./passkey_credential_metadata.md) for using it.
 
 {{#tabs passkey:connect-with-passkey}}
 
 ### Two-button flow (Web)
 
-`connectWithPasskey` is not surfaced on the WASM target. The unified flow needs a silent "no credential here" signal so it can fall through to register, and WebAuthn deliberately collapses that case into the same `NotAllowedError` as a user cancel for privacy reasons. There is no reliable way on web for the SDK to tell the two apart.
+On web, present two buttons: **Create a new passkey** (calls {{#name PasskeyClient.register}}) and **Sign in with a passkey** (calls {{#name PasskeyClient.sign_in}}).
 
-The recommended UX on web is two buttons: a **Sign In** button calling `signIn` and a separate **Create Account** button calling `register`. Let the user pick the right one instead of trying to auto-detect. See [Sign in and register](#sign-in-and-register) for the call shapes.
+{{#name PasskeyClient.connect_with_passkey}} is not available on the WASM target. WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect the flow. Let the user choose.
 
 ### Sign in and register
 
-For finer control, call {{#name PasskeyClient.sign_in}} and {{#name PasskeyClient.register}} directly: on web (the two buttons above), when separating Sign-In and Create-Account flows, or when adding a new label on a returning user without going through {{#name PasskeyClient.connect_with_passkey}}. Pass `wallet.seed` to {{#name connect}} in either case.
+Call {{#name PasskeyClient.sign_in}} and {{#name PasskeyClient.register}} directly for explicit control: the two web buttons, separate create-a-passkey and sign-in screens, or adding a new label for a returning user. Pass `wallet.seed` to {{#name connect}} in either case.
 
 #### Sign in
 
@@ -71,31 +79,31 @@ Every passkey failure normalizes to a {{#name PrfProviderError}} variant. Match 
 
 | Variant | What it means | Recommended action |
 |---|---|---|
-| {{#enum PrfProviderError::UserCancelled}} | User dismissed the OS prompt (≥ 300ms, < 55s) | Sticky retry UI with "Try Again" |
-| {{#enum PrfProviderError::CredentialNotFound}} | No matching credential on this device (includes iOS sub-300ms fast-fail) | Fall through to {{#name PasskeyClient.register}} |
-| {{#enum PrfProviderError::CredentialAlreadyExists}} | Register hit a credential in {{#name exclude_credentials}} | Flip to {{#name PasskeyClient.sign_in}}; the OS picker surfaces the existing credential |
-| {{#enum PrfProviderError::UserTimedOut}} | OS biometric inactivity timeout (≥ 55s): distinct from a user-cancel | Sticky retry with timeout-specific copy. **Do not** auto-retry |
-| {{#enum PrfProviderError::PrfNotSupported}} | Authenticator doesn't implement the PRF extension | Fall back to mnemonic onboarding |
-| {{#enum PrfProviderError::Configuration}} | Entitlement missing, AASA stale, or assetlinks malformed | Developer-facing error; surface {{#name check_domain_association}}'s {{#enum PasskeyAvailability::NotAssociated}} reason |
-| {{#enum PrfProviderError::Generic}} | Network / library / generic failure | Generic "try again later" UI |
+| {{#enum PrfProviderError::UserCancelled}} | User dismissed the OS prompt | Sticky retry UI with "Try Again". |
+| {{#enum PrfProviderError::CredentialNotFound}} | No matching credential on this device | Fall through to {{#name PasskeyClient.register}}. |
+| {{#enum PrfProviderError::CredentialAlreadyExists}} | Register hit a credential in {{#name exclude_credentials}} | Flip to {{#name PasskeyClient.sign_in}}; the OS picker surfaces the existing credential. |
+| {{#enum PrfProviderError::UserTimedOut}} | OS biometric inactivity timeout, distinct from a cancel | Sticky retry with timeout-specific copy. **Do not** auto-retry. |
+| {{#enum PrfProviderError::PrfNotSupported}} | Authenticator lacks the PRF extension | Fall back to mnemonic onboarding. |
+| {{#enum PrfProviderError::Configuration}} | Entitlement missing, AASA stale, or assetlinks malformed | Developer-facing error; surface the {{#enum PasskeyAvailability::NotAssociated}} reason. |
+| {{#enum PrfProviderError::Generic}} | Network or generic failure | Generic "try again later" UI. |
 
-Rust callers can branch on the collapsed `error.kind()` / [`ErrorKind`](https://breez.github.io/spark-sdk/breez_sdk_spark/passkey/enum.ErrorKind.html) instead of matching every variant; `kind()` is Rust-only. Web exposes typed exception classes (`PasskeyAlreadyExistsError`, `PasskeyTimedOutError`, `PasskeyCredentialNotFoundError`) for `instanceof` matching.
+Web exposes typed exception classes (`PasskeyAlreadyExistsError`, `PasskeyTimedOutError`, `PasskeyCredentialNotFoundError`) for `instanceof` matching. Rust callers can branch on the collapsed `error.kind()` instead of every variant.
 
-Two recovery paths are common enough to warrant runnable examples.
+Two recovery paths are common enough to show in full.
 
-Flip to sign-in when register hits an existing credential (`AlreadyExists`):
+Flip to sign-in when register hits an existing credential:
 
 {{#tabs passkey:recover-already-exists}}
 
-Show a sticky retry UI when the OS biometric timeout fires (`Timeout`):
+Show a sticky retry when the biometric timeout fires:
 
 {{#tabs passkey:handle-timeout}}
 
-For the full mapping (including the iOS sub-300ms fast-fail nuance that bundles "no-credential" under `UserCancelled`), see the [UX guide](./uxguide_passkey.md).
+See the [UX guide](./uxguide_passkey.md) for the recommended recovery UX.
 
 ## Supported specs
 
-- [Seedless Restore](https://github.com/breez/seedless-restore): Passkey-based wallet derivation and discovery
-- [Nostr](https://github.com/nostr-protocol/nostr): Relay-based event protocol for label storage
-- [NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md): Authentication of clients to relays
-- [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md): Relay List Metadata
+- [Seedless Restore](https://github.com/breez/seedless-restore): passkey-based wallet derivation and discovery
+- [Nostr](https://github.com/nostr-protocol/nostr): relay-based event protocol for label storage
+- [NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md): authentication of clients to relays
+- [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md): relay list metadata

--- a/docs/breez-sdk/src/guide/passkey_prf_providers.md
+++ b/docs/breez-sdk/src/guide/passkey_prf_providers.md
@@ -2,29 +2,31 @@
 
 The built-in {{#name PasskeyProvider}} covers the common case. Reach for this page when:
 
-- You need fine-grained {{#name PasskeyProvider}} options (custom {{#name user_name}}, {{#name user_display_name}}, etc.).
+- You need platform-specific provider options (iOS `URLSession` / presentation anchor, Android `Activity` wiring, web `authenticatorAttachment`).
 - You're integrating Python, Go, or C# (no built-in {{#name PasskeyProvider}} ships for those bindings).
 - You need a custom {{#name PrfProvider}} (CLI YubiKey, FIDO2, air-gapped backup file, hardware module).
 
 ## Built-in PasskeyProvider options
 
-In addition to {{#name rp_id}} and {{#name rp_name}}, the {{#name PasskeyProvider}} constructor accepts:
+The built-in {{#name PasskeyProvider}} takes a {{#name PasskeyProviderOptions}}:
 
-| Option | Default | Description |
+| Field | Default | Description |
 |--------|---------|-------------|
-| {{#name rp_id}} | **required** | Relying Party ID. Pass your app's domain, or `PasskeyProvider.BREEZ_RP_ID` (= `keys.breez.technology`) if your app is Breez-registered. Changing this means existing passkeys produce a different seed; see [migration considerations](https://github.com/breez/passkey-login/blob/main/SDK%20implementation.md#passkey-migration-considerations). |
-| {{#name rp_name}} | **required** | Maps to the WebAuthn `rp.name`. Required by current OS prompts (deprecated in WebAuthn L3 but still enforced everywhere). Surfaces in some authenticators' management UIs (Apple Passwords, Google Password Manager); platform UIs increasingly ignore it. Set at registration only; changing it does not affect existing credentials. |
-| {{#name user_name}} | {{#name rp_name}} | Maps to the WebAuthn `user.name`. Treated as the user's unique identifier for the credential and shown in the OS account picker during sign-in. Pass a stable per-user value if each registration should surface as a distinct entry (Apple's Passwords app, in particular, dedupes credentials by `(rpId, user.name)`; iOS additionally treats this as the only label exposed by `ASAuthorizationPlatformPublicKeyCredentialProvider`). Registration-only. |
-| {{#name user_display_name}} | {{#name user_name}} | Maps to the WebAuthn `user.displayName`. The user-friendly label the OS / browser MAY (but is not required to) show in the picker; Android Credential Manager and the WebAuthn L3 picker surface it, iOS ignores. Registration-only. |
+| {{#name rp_id}} | Breez shared RP | Relying Party ID. Your app's domain, or `PasskeyProvider.BREEZ_RP_ID` (`keys.breez.technology`) if Breez-registered. Changing it makes existing passkeys derive a different seed (see [migration considerations](https://github.com/breez/passkey-login/blob/main/SDK%20implementation.md#passkey-migration-considerations)). |
+| {{#name rp_name}} | `"Breez"` | Display name for your app, shown in some authenticator UIs. Registration-only. |
+| {{#name user_name}} | {{#name rp_name}} | Account identifier shown beneath the display name in the OS picker, e.g. `john@doe.com`. Pass a stable per-user value so each registration is a distinct entry (Apple Passwords dedupes by `(rpId, user.name)`). Registration-only. |
+| {{#name user_display_name}} | {{#name user_name}} | Human-friendly name shown most prominently, e.g. `John Doe`. Registration-only. |
+
+The same {{#name PasskeyProviderOptions}} is settable on {{#name passkey_config}} via {{#name provider_options}}, which builds the provider for you (see [Initialization](./passkey_onboarding.md#initialization)). Construct {{#name PasskeyProvider}} directly only for platform-specific options (iOS `URLSession`, web `authenticatorAttachment`) or a custom backend.
 
 <div class="warning">
 <h4>C# / Go / Python limitation</h4>
 
-The SDK does not ship a built-in {{#name PasskeyProvider}} for C#, Go, or Python (no native passkey API to wrap on those targets). Integrators on those bindings implement their own {{#name PrfProvider}} and pass it to {{#name PasskeyClient}} directly.
+The SDK does not ship a built-in {{#name PasskeyProvider}} for C#, Go, or Python (no native passkey API to wrap). On those bindings, implement your own {{#name PrfProvider}} and pass it to {{#name PasskeyClient}}.
 </div>
 
 ## Custom PrfProvider
 
-If the built-in {{#name PasskeyProvider}} does not satisfy your requirements (e.g., you need a hardware security key, a FIDO2/CTAP2 transport, an air-gapped backup file, or a custom authenticator), implement the {{#name PrfProvider}} interface directly. The Breez CLI ships [YubiKey](https://github.com/breez/spark-sdk/blob/main/crates/breez-sdk/cli/src/passkey/yubikey_prf.rs), [FIDO2](https://github.com/breez/spark-sdk/blob/main/crates/breez-sdk/cli/src/passkey/fido2_prf.rs), and [file-based](https://github.com/breez/spark-sdk/blob/main/crates/breez-sdk/cli/src/passkey/file_prf.rs) implementations as references.
+To support a custom authenticator (hardware security key, FIDO2/CTAP2 transport, air-gapped backup file), implement the {{#name PrfProvider}} interface directly. The Breez CLI ships [YubiKey](https://github.com/breez/spark-sdk/blob/main/crates/breez-sdk/cli/src/passkey/yubikey_prf.rs), [FIDO2](https://github.com/breez/spark-sdk/blob/main/crates/breez-sdk/cli/src/passkey/fido2_prf.rs), and [file-based](https://github.com/breez/spark-sdk/blob/main/crates/breez-sdk/cli/src/passkey/file_prf.rs) implementations as references.
 
 {{#tabs passkey:implement-prf-provider}}

--- a/docs/breez-sdk/src/guide/passkey_setup.md
+++ b/docs/breez-sdk/src/guide/passkey_setup.md
@@ -29,11 +29,11 @@ Same code paths in either case; only the `rpId` value and who hosts the JSON dif
 <div class="warning">
 <h4>Related Origins: developer notes</h4>
 
-**Firefox does not implement Related Origins.** Users on Firefox can only use credentials whose RP ID matches their current origin's eTLD+1. If you need Firefox support across multiple domains, host your own RP ID per domain or accept that Firefox users register fresh on each origin.
+**Firefox does not implement Related Origins.** Its users register fresh on each origin. For multi-domain support, host a separate RP ID per domain.
 
-**Chrome and Edge cap the number of distinct labels** in `related_origins` (around 5 distinct eTLD+1 labels per RP). For larger app families, partition into multiple RP IDs.
+**Chrome and Edge cap the number of distinct origins** in `related_origins` (around 5 per RP). For larger app families, partition into multiple RP IDs.
 
-**Browsers cache the `.well-known/webauthn` file aggressively.** Adding or removing an origin won't propagate immediately; expect a delay until the cache TTL expires.
+**Browsers cache `.well-known/webauthn` aggressively.** Adding or removing an origin takes effect only after the cache TTL expires.
 </div>
 
 ## Android: Asset Links
@@ -80,7 +80,7 @@ Replace `TEAMID` with your Apple Developer Team ID and `com.example.yourapp` wit
 
 <div class="warning">
 <h4>iOS / macOS: Associated Domains entitlement required</h4>
-Without the Associated Domains entitlement declared in Xcode, passkey operations on iOS / macOS will fail with a configuration error even though {{#name PasskeyClient.check_availability}} returns {{#enum PasskeyAvailability::Available}} (the OS-level check can't verify entitlements at runtime).
+Without the Associated Domains entitlement declared in Xcode, passkey operations on iOS / macOS fail with a configuration error, even when {{#name PasskeyClient.check_availability}} returns {{#enum PasskeyAvailability::Available}}.
 </div>
 
 <div class="warning">

--- a/docs/breez-sdk/src/guide/uxguide_passkey.md
+++ b/docs/breez-sdk/src/guide/uxguide_passkey.md
@@ -7,13 +7,14 @@
 
 ### Guidelines
 
-1. **Gate passkey UI on availability.** Call {{#name PasskeyClient.check_availability}} at startup and fall back to mnemonic onboarding on unsupported devices (Android < 9, iOS < 18, browsers without WebAuthn PRF). The same call surfaces domain-association failures, so a single check covers both "device can't" and "config is broken".
-2. **Match the CTA layout to the platform.** On iOS and Android, the recommended UX is a single primary CTA backed by {{#name PasskeyClient.connect_with_passkey}}: silent sign-in for returning users, automatic fall-through to register for new ones. On web, present two CTAs ("Sign In" and "Create Account") and let the user pick: WebAuthn's privacy-preserving error collapse makes auto-detection unreliable. Don't gate registration behind a separate "I understand" review screen on either platform: the OS already shows its own consent UI.
-3. **Cache the derived seed within a session.** A sign-in / register call primes the Nostr identity cache on the {{#name PasskeyClient}} instance, so subsequent {{#name PasskeyLabels.list}} / {{#name PasskeyLabels.store}} calls (via {{#name PasskeyClient.labels}}) reuse it without re-prompting. For longer-lived caching (e.g. across a router rebuild on app launch), store the seed in your own in-memory cache and pass it to {{#name connect}} when reconnecting; do not persist to disk.
-4. **Never persist the derived mnemonic.** Re-derive from the passkey and label on each session. Persisting the mnemonic would bypass the OS authentication prompt.
-5. **Allow manual mnemonic backup.** Offer a user-initiated "Show recovery phrase" path that derives the mnemonic on demand via {{#name PasskeyClient.sign_in}}. This gives users a recovery option if they lose access to their passkey.
-6. **Match on {{#name PrfProviderError}} variants.** They are the cross-language error surface. Rust callers can branch on the collapsed `error.kind()` / `ErrorKind` instead; `kind()` is Rust-only.
-7. **Don't auto-retry on dismissed prompts.** The SDK never re-fires the OS prompt without an explicit retry from the host. Build your state machine the same way: a dismissed prompt leads to a sticky error screen with a Try Again button, and only a user tap retries.
+1. **Gate passkey UI on availability.** Call {{#name PasskeyClient.check_availability}} at startup and fall back to mnemonic onboarding on unsupported devices. The same call surfaces domain-association failures, so one check covers both "device can't" and "config is broken".
+2. **Match the CTA layout to the platform.** iOS and Android: a single primary CTA backed by {{#name PasskeyClient.connect_with_passkey}} (silent sign-in for returning users, fall-through to register for new ones). Web: two CTAs, "Create a new passkey" and "Sign in with a passkey", since WebAuthn can't tell "no credential" from "cancel" for auto-detection.
+3. **Don't add your own consent screen.** The OS shows its own consent UI, so don't gate registration behind a separate "I understand" review step.
+4. **Cache the derived seed within a session.** A sign-in or register call avoids re-prompting for later {{#name PasskeyLabels.list}} / {{#name PasskeyLabels.store}} calls in the same session. For reuse across an app relaunch, keep the seed in your own in-memory cache and pass it to {{#name connect}}; never persist it to disk.
+5. **Never persist the derived mnemonic.** Re-derive it from the passkey and label on each session. Persisting it would bypass the OS authentication prompt.
+6. **Allow manual mnemonic backup.** Offer a user-initiated "Show recovery phrase" path that derives the mnemonic on demand via {{#name PasskeyClient.sign_in}}, so users keep a recovery option if they lose the passkey.
+7. **Match on {{#name PrfProviderError}} variants.** They are the cross-language error surface. Rust callers can branch on the collapsed `error.kind()` instead.
+8. **Don't auto-retry on dismissed prompts.** The SDK never re-fires the OS prompt on its own. A dismissed prompt should lead to a sticky error screen with a "Try Again" button; only a user tap retries.
 
 ### Onboarding flow
 
@@ -26,7 +27,7 @@ Browsers and native authenticators expose different error semantics, so the reco
 | Returning user | **1** (one assertion derives master + label) |
 | New user | **2** (1 create, 1 assertion) |
 
-**Web:** two buttons, "Sign In" and "Create Account". WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect which the user wants; let them choose. {{#name PasskeyClient.connect_with_passkey}} is not surfaced on the WASM target.
+**Web:** two buttons, "Create a new passkey" and "Sign in with a passkey". WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect which the user wants. {{#name PasskeyClient.connect_with_passkey}} is not surfaced on the WASM target.
 
 See [Onboarding](./passkey_onboarding.md) for the call shapes.
 
@@ -34,29 +35,19 @@ See [Onboarding](./passkey_onboarding.md) for the call shapes.
 
 For a user who already has a passkey and wants another wallet:
 
-1. {{#name PasskeyClient.sign_in}} with the new label. One assertion derives the master and new-label seeds and primes the identity cache.
-2. {{#name PasskeyLabels.store}} (via {{#name PasskeyClient.labels}}) to publish the label to Nostr. This reuses the cached identity, so it adds no prompt.
+1. {{#name PasskeyClient.sign_in}} with the new label. One assertion derives the master and new-label seeds.
+2. {{#name PasskeyLabels.store}} to publish the label to Nostr. This reuses the cached identity, so it adds no prompt.
 
-Total: **1** OS prompt. Storing the label first would cost 2, because each call would derive the master salt independently.
+Total: **1** OS prompt. Storing the label first would cost 2, since each call would derive the master salt independently.
 
 ### Credential metadata
 
-Every flow returns a {{#name PasskeyCredential}}: the credential ID on every path, plus the user handle, AAGUID, and backup flag on registration. Persist them so you can keep a returning user on the same wallet, block duplicate registrations on one device, and show which authenticator holds the passkey and whether it syncs. AAGUID and the backup flag are unverified attestation: treat them as display hints, never as trust signals.
+Every flow returns a {{#name PasskeyCredential}}: the credential ID on every path, plus the user handle, AAGUID, and backup flag on registration. Persist them to keep a returning user on the same wallet, block duplicate registrations on one device, and show which authenticator holds the passkey and whether it syncs. AAGUID and the backup flag are unverified: treat them as display hints, never trust signals.
 
 See [Credential metadata](./passkey_credential_metadata.md) for the fields, where to store them, and the per-use-case code.
 
 ### Recovery paths
 
-Every passkey failure normalizes to a {{#name PrfProviderError}} variant. Match on the variant to choose the UX:
+Every passkey failure normalizes to a {{#name PrfProviderError}} variant. See [Onboarding error recovery](./passkey_onboarding.md#error-recovery) for the variant-to-action table; the guidelines above cover the UX rules.
 
-| Variant | What it means | Recommended UX |
-|---|---|---|
-| {{#enum PrfProviderError::CredentialNotFound}} | No matching passkey on this device | Fall through to {{#name PasskeyClient.register}} automatically |
-| {{#enum PrfProviderError::UserCancelled}} | User dismissed the prompt | Sticky screen with "Try Again" and "Go Back". **Do not** auto-retry |
-| {{#enum PrfProviderError::CredentialAlreadyExists}} | Create hit a credential already on the device | Switch to {{#name PasskeyClient.sign_in}} so the OS picker surfaces it |
-| {{#enum PrfProviderError::Configuration}} | Entitlement or AASA misconfigured | Developer-facing error; surface {{#name check_domain_association}}'s {{#enum PasskeyAvailability::NotAssociated}} reason |
-| {{#enum PrfProviderError::PrfNotSupported}} | Device or authenticator lacks the PRF extension | Fall back to mnemonic onboarding |
-| {{#enum PrfProviderError::UserTimedOut}} | OS biometric inactivity timeout | Sticky retry with timeout-specific copy |
-| {{#enum PrfProviderError::Generic}} | Network / library / generic failure | Generic "try again later"; log for diagnostics |
-
-On iOS the SDK resolves the platform's wall-clock ambiguity (a generic failure could be a missing credential, a cancel, or a timeout) into these variants for you, so you don't need a host-side stopwatch.
+On iOS, the SDK disambiguates the platform's generic failure (missing credential, cancel, or timeout) into these variants for you, so you don't need a host-side timer.

--- a/packages/flutter/lib/src/passkey_client.dart
+++ b/packages/flutter/lib/src/passkey_client.dart
@@ -10,12 +10,13 @@ import 'rust/models.dart'
         PasskeyAvailability,
         PasskeyConfig,
         PasskeyCredential,
+        PasskeyProviderOptions,
         RegisterRequest,
         RegisterResponse,
         SignInRequest,
         SignInResponse;
 import 'rust/passkey.dart' as rust;
-import 'passkey_prf_provider.dart' show PasskeyProvider, PasskeyProviderOptions, PrfProvider;
+import 'passkey_prf_provider.dart' show PasskeyProvider, PrfProvider;
 
 /// Passkey-based wallet client. The default constructor wires the built-in
 /// [PasskeyProvider] on the Breez shared RP, so a Breez-registered app needs
@@ -27,12 +28,7 @@ class PasskeyClient {
   /// `rpId` / `rpName` on the [config] to use your own RP.
   PasskeyClient({String? breezApiKey, PasskeyConfig? config})
     : this._fromProvider(
-        PasskeyProvider(
-          PasskeyProviderOptions(
-            rpId: config?.rpId ?? PasskeyProvider.breezRpId,
-            rpName: config?.rpName ?? PasskeyProvider.defaultRpName,
-          ),
-        ),
+        PasskeyProvider(config?.providerOptions ?? const PasskeyProviderOptions()),
         breezApiKey: breezApiKey,
         config: config,
       );
@@ -107,14 +103,7 @@ class PasskeyClientBuilder {
   /// the config's `rpId` / `rpName` (default: the Breez RP) when no
   /// provider was injected.
   PasskeyClient build() {
-    final provider =
-        _provider ??
-        PasskeyProvider(
-          PasskeyProviderOptions(
-            rpId: config?.rpId ?? PasskeyProvider.breezRpId,
-            rpName: config?.rpName ?? PasskeyProvider.defaultRpName,
-          ),
-        );
+    final provider = _provider ?? PasskeyProvider(config?.providerOptions ?? const PasskeyProviderOptions());
     return PasskeyClient._fromProvider(provider, breezApiKey: breezApiKey, config: config);
   }
 }

--- a/packages/flutter/lib/src/passkey_client.dart
+++ b/packages/flutter/lib/src/passkey_client.dart
@@ -25,7 +25,7 @@ class PasskeyClient {
   final rust.PasskeyClient _inner;
 
   /// Zero-config client on the Breez shared RP (`keys.breez.technology`); set
-  /// `rpId` / `rpName` on the [config] to use your own RP.
+  /// `providerOptions` on the [config] to use your own RP.
   PasskeyClient({String? breezApiKey, PasskeyConfig? config})
     : this._fromProvider(
         PasskeyProvider(config?.providerOptions ?? const PasskeyProviderOptions()),
@@ -75,8 +75,8 @@ class PasskeyClient {
 }
 
 /// Builds a [PasskeyClient] backed by a caller-supplied [PrfProvider]. Use
-/// this when you need a configured provider (custom `rpId` / `rpName`,
-/// rotating `userName`).
+/// this for a custom PRF backend (hardware key, FIDO2, file-backed); set
+/// `providerOptions` on the [config] for the built-in provider instead.
 class PasskeyClientBuilder {
   PasskeyClientBuilder({this.breezApiKey, this.config});
 
@@ -84,7 +84,7 @@ class PasskeyClientBuilder {
   /// `null` for public relays only.
   final String? breezApiKey;
 
-  /// Passkey client config. `rpId` / `rpName` configure the default
+  /// Passkey client config. `providerOptions` configures the default
   /// provider (ignored when a provider is injected via [withPrfProvider]);
   /// `defaultLabel` is the label-store default.
   final PasskeyConfig? config;
@@ -93,14 +93,14 @@ class PasskeyClientBuilder {
 
   /// Inject the [PrfProvider] the client derives seeds through: the
   /// built-in [PasskeyProvider] or any custom PRF backend. Supersedes the
-  /// config's `rpId` / `rpName`.
+  /// config's `providerOptions`.
   PasskeyClientBuilder withPrfProvider(PrfProvider provider) {
     _provider = provider;
     return this;
   }
 
   /// Construct the client. Falls back to a default [PasskeyProvider] on
-  /// the config's `rpId` / `rpName` (default: the Breez RP) when no
+  /// the config's `providerOptions` (default: the Breez RP) when no
   /// provider was injected.
   PasskeyClient build() {
     final provider = _provider ?? PasskeyProvider(config?.providerOptions ?? const PasskeyProviderOptions());

--- a/packages/flutter/lib/src/passkey_prf_provider.dart
+++ b/packages/flutter/lib/src/passkey_prf_provider.dart
@@ -2,7 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 
-import 'rust/models.dart' show DeriveSeedsOutput, DeriveSeedsRequest, PasskeyCredential;
+import 'rust/models.dart'
+    show DeriveSeedsOutput, DeriveSeedsRequest, PasskeyCredential, PasskeyProviderOptions;
 
 /// Result of verifying that the app is associated with its RP domain.
 /// Switch on the subtype to handle each outcome.
@@ -31,36 +32,6 @@ class DomainAssociationSkipped extends DomainAssociation {
   final String reason;
 
   const DomainAssociationSkipped({required this.reason});
-}
-
-/// Options for constructing a [PasskeyProvider]. `rpId` is required: pass
-/// [PasskeyProvider.breezRpId] to opt into Breez's shared RP.
-class PasskeyProviderOptions {
-  /// Relying Party ID: the domain configured for credential sharing.
-  /// Changing it after users register passkeys makes their existing
-  /// credentials undiscoverable. Pass [PasskeyProvider.breezRpId] for the
-  /// Breez-managed RP (only valid for Breez-registered apps).
-  final String rpId;
-
-  /// Display name shown in the OS passkey picker and credential-manager
-  /// UIs. Only used at registration; changing it does not affect existing
-  /// credentials.
-  final String rpName;
-
-  /// Secondary label shown in some passkey managers. Defaults to [rpName].
-  /// Only used at registration.
-  final String? userName;
-
-  /// Primary label shown in the passkey picker. Defaults to [userName].
-  /// Only used at registration.
-  final String? userDisplayName;
-
-  const PasskeyProviderOptions({
-    required this.rpId,
-    required this.rpName,
-    this.userName,
-    this.userDisplayName,
-  });
 }
 
 /// Error thrown by [PasskeyProvider] when a passkey operation fails.
@@ -121,10 +92,10 @@ class PasskeyProvider implements PrfProvider {
   final String _userDisplayName;
 
   PasskeyProvider(PasskeyProviderOptions options)
-    : _rpId = options.rpId,
-      _rpName = options.rpName,
-      _userName = options.userName ?? options.rpName,
-      _userDisplayName = options.userDisplayName ?? (options.userName ?? options.rpName);
+    : _rpId = options.rpId ?? breezRpId,
+      _rpName = options.rpName ?? defaultRpName,
+      _userName = options.userName ?? options.rpName ?? defaultRpName,
+      _userDisplayName = options.userDisplayName ?? options.userName ?? options.rpName ?? defaultRpName;
 
   /// Derive one 32-byte seed per salt from passkey PRF, in as few OS prompts
   /// as the platform supports. Returns the seeds plus the credential ID

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1334,11 +1334,18 @@ pub struct _UnregisterWebhookRequest {
     pub webhook_id: String,
 }
 
+#[frb(mirror(PasskeyProviderOptions))]
+pub struct _PasskeyProviderOptions {
+    pub rp_id: Option<String>,
+    pub rp_name: Option<String>,
+    pub user_name: Option<String>,
+    pub user_display_name: Option<String>,
+}
+
 #[frb(mirror(PasskeyConfig))]
 pub struct _PasskeyConfig {
     pub default_label: Option<String>,
-    pub rp_id: Option<String>,
-    pub rp_name: Option<String>,
+    pub provider_options: Option<PasskeyProviderOptions>,
 }
 
 #[frb(mirror(PasskeyAvailability))]

--- a/packages/react-native/src/passkey-prf-provider.ts
+++ b/packages/react-native/src/passkey-prf-provider.ts
@@ -303,9 +303,8 @@ function uint8ArrayToBase64(bytes: Uint8Array): string {
 
 /**
  * Builds a `PasskeyClient` backed by a caller-supplied provider. Use this
- * when you need a configured {@link PasskeyProvider} (custom `rpId` /
- * `rpName`) or a custom PRF backend; omit the provider for the zero-config
- * Breez-RP default.
+ * for a custom PRF backend; omit the provider for the zero-config Breez-RP
+ * default and set `providerOptions` on the config to use your own RP.
  */
 export class PasskeyClientBuilder {
   private provider?: PrfProvider;
@@ -313,7 +312,7 @@ export class PasskeyClientBuilder {
   /**
    * @param breezApiKey Breez relay key for authenticated (NIP-42) label
    *   storage. Omit for public relays only.
-   * @param config Passkey client config. `rpId` / `rpName` configure the
+   * @param config Passkey client config. `providerOptions` configures the
    *   default provider (ignored when a provider is injected via
    *   {@link withPrfProvider}, which owns its RP); `defaultLabel` is the
    *   label-store default.
@@ -326,7 +325,7 @@ export class PasskeyClientBuilder {
   /**
    * Inject the provider the client derives seeds through: the built-in
    * {@link PasskeyProvider} or any custom `PrfProvider` implementation.
-   * Supersedes the config's `rpId` / `rpName` (the injected provider owns
+   * Supersedes the config's `providerOptions` (the injected provider owns
    * its RP).
    */
   withPrfProvider(provider: PrfProvider): this {
@@ -336,7 +335,7 @@ export class PasskeyClientBuilder {
 
   /**
    * Construct the client. Falls back to a default {@link PasskeyProvider}
-   * on the config's `rpId` / `rpName` (default: the Breez RP) when no
+   * on the config's `providerOptions` (default: the Breez RP) when no
    * provider was injected.
    */
   build(): SdkPasskeyClient {
@@ -361,7 +360,7 @@ function buildPasskeyClient(
 
 /**
  * Zero-config passkey client on the Breez shared RP (`keys.breez.technology`),
- * so a Breez-registered app needs only its relay key; set `rpId` / `rpName` on
+ * so a Breez-registered app needs only its relay key; set `providerOptions` on
  * the config to use your own RP. For a custom PRF backend, build the provider
  * and inject it via {@link PasskeyClientBuilder}.
  */

--- a/packages/react-native/src/passkey-prf-provider.ts
+++ b/packages/react-native/src/passkey-prf-provider.ts
@@ -1,6 +1,7 @@
 import { NativeModules, Platform } from 'react-native';
 import {
   PasskeyClient as SdkPasskeyClient,
+  PasskeyProviderOptions,
   type PasskeyConfig,
   type PrfProvider,
 } from './generated/breez_sdk_spark';
@@ -66,40 +67,6 @@ export type DomainAssociation =
   | { kind: 'Associated' }
   | { kind: 'NotAssociated'; source: string; reason: string }
   | { kind: 'Skipped'; reason: string };
-
-/**
- * Options for constructing a PasskeyProvider.
- */
-export interface PasskeyProviderOptions {
-  /**
-   * Relying Party ID: the domain configured for credential sharing.
-   * Changing it after users register passkeys makes their existing
-   * credentials undiscoverable. Pass {@link PasskeyProvider.BREEZ_RP_ID} for
-   * the Breez-managed RP (only valid for Breez-registered apps).
-   */
-  rpId: string;
-
-  /**
-   * Display name shown in the OS passkey picker and credential-manager
-   * UIs. Only used at registration; changing it does not affect existing
-   * credentials.
-   */
-  rpName: string;
-
-  /**
-   * Per-credential identifier shown in the account picker during sign-in.
-   * Pass a stable per-user value to surface each registration distinctly
-   * (Apple's Passwords app dedupes by `(rpId, userName)`). Defaults to
-   * `rpName`. Only used at registration.
-   */
-  userName?: string;
-
-  /**
-   * User-friendly label some platforms show in the picker. Defaults to
-   * `userName`. Only used at registration.
-   */
-  userDisplayName?: string;
-}
 
 /**
  * Error thrown when a passkey operation fails, with a structured `code` for
@@ -171,20 +138,8 @@ export class PasskeyProvider {
   private userDisplayName: string;
 
   constructor(options: PasskeyProviderOptions) {
-    if (!options?.rpId || options.rpId.length === 0) {
-      throw new Error(
-        "PasskeyProvider: rpId is required. Pass your app's RP domain, " +
-          'or PasskeyProvider.BREEZ_RP_ID if you registered with Breez.'
-      );
-    }
-    if (!options.rpName || options.rpName.length === 0) {
-      throw new Error(
-        'PasskeyProvider: rpName is required. Pass your app name; it is ' +
-          'shown to the user in the OS passkey picker.'
-      );
-    }
-    this.rpId = options.rpId;
-    this.rpName = options.rpName;
+    this.rpId = options.rpId ?? PasskeyProvider.BREEZ_RP_ID;
+    this.rpName = options.rpName ?? PasskeyProvider.DEFAULT_RP_NAME;
     this.userName = options.userName ?? this.rpName;
     this.userDisplayName = options.userDisplayName ?? this.userName;
   }
@@ -389,10 +344,9 @@ export class PasskeyClientBuilder {
     // generated PrfProvider foreign interface.
     const provider: PrfProvider =
       this.provider ??
-      (new PasskeyProvider({
-        rpId: this.config?.rpId ?? PasskeyProvider.BREEZ_RP_ID,
-        rpName: this.config?.rpName ?? PasskeyProvider.DEFAULT_RP_NAME,
-      }) as unknown as PrfProvider);
+      (new PasskeyProvider(
+        this.config?.providerOptions ?? PasskeyProviderOptions.create({})
+      ) as unknown as PrfProvider);
     return new SdkPasskeyClient(provider, this.breezApiKey, this.config);
   }
 }


### PR DESCRIPTION
## Changes

### SDK (breaking)
- **`PasskeyProviderOptions`**: a cross-language `PasskeyProviderOptions { rp_id, rp_name, user_name, user_display_name }`, nested on `PasskeyConfig` as `provider_options` (replacing the four flat fields). Every platform's built-in `PasskeyProvider` now takes this one type. Platform-specific knobs (iOS `URLSession` / presentation anchor, Android `activityProvider`, web `authenticatorAttachment` / `hints` / `defaultTimeoutMs`) stay on the provider as a separate argument. Breaking: the `PasskeyProvider(...)` constructors and the `PasskeyConfig` fields change shape.
- **WASM node16 type fix**: the `passkey-prf-provider` `.d.ts` imported its base via an extensionless relative path, which dropped the inherited `PasskeyClient` methods under `moduleResolution: node16`. Fixed by adding the `.js` extension.

### Docs
- **Guide readability rewrite** (`docs/breez-sdk/src/guide/passkey*.md`, `uxguide_passkey.md`): restructure toward the payments / LNURL house style: short single-purpose paragraphs, mechanism pushed into snippets, tables, callouts, and cross-links. De-duplicate the provider-options table (now only in PRF providers) and the error-recovery table (now only in Onboarding).
- **Zero-config initialization**: document that the built-in provider is wired by default (the Breez shared RP), so a Breez-registered app needs only its API key; set `provider_options` for your own RP. Onboarding / PRF tables split into `PasskeyConfig` vs `PasskeyProviderOptions`.
- **Field clarity**: `user_name` is the account identifier the OS picker shows (e.g. `john@doe.com`); `user_display_name` is the display name (e.g. `John Doe`).
- **CTA wording**: "Create a new passkey" / "Sign in with a passkey" instead of "Create Account" / "Sign In".
- **Snippets** (9 language bindings): per-field credential-metadata comments and the full `SignInResponse` output (wallet seed, label, labels, credential), plus the comment cleanup (trim multi-line comments to single intent-level lines, drop unused scratch objects, examine responses directly).

### Follow-ups
- The `PasskeyProvider(...)` constructor change is breaking: the CLI examples are left to the sync-cli workflow, and the glow apps need the `options:` migration.
