### PR TITLE
wire execute_before through token transfers and fulfill_spark_invoice

### DIFF
--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1366,7 +1366,7 @@ impl SparkWallet {
 
         let tx = self
             .token_service
-            .transfer_tokens(outputs, selected_outputs, selection_strategy)
+            .transfer_tokens(outputs, selected_outputs, selection_strategy, None)
             .await?;
         Ok(tx)
     }
@@ -1571,6 +1571,9 @@ impl SparkWallet {
                     "Amount is required when invoice does not include an amount".to_string(),
                 ))?;
 
+                let execute_before_unix_micros =
+                    execute_before_from_expiry(invoice_fields.expiry_time);
+
                 let tx = self
                     .token_service
                     .transfer_tokens(
@@ -1582,6 +1585,7 @@ impl SparkWallet {
                         }],
                         None,
                         None,
+                        execute_before_unix_micros,
                     )
                     .await?;
 
@@ -2399,5 +2403,40 @@ impl BackgroundProcessor {
                 }
             }
         }
+    }
+}
+
+/// `None` when there is no expiry or the instant is out of `i64` micros range, leaving the transfer unbounded.
+fn execute_before_from_expiry(expiry_time: Option<SystemTime>) -> Option<i64> {
+    expiry_time.and_then(|t| {
+        t.duration_since(UNIX_EPOCH)
+            .ok()
+            .and_then(|d| i64::try_from(d.as_micros()).ok())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn execute_before_from_expiry_none_when_absent() {
+        assert_eq!(execute_before_from_expiry(None), None);
+    }
+
+    #[test]
+    fn execute_before_from_expiry_converts_to_micros() {
+        let expiry = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        assert_eq!(
+            execute_before_from_expiry(Some(expiry)),
+            Some(1_700_000_000_000_000)
+        );
+    }
+
+    #[test]
+    fn execute_before_from_expiry_none_before_epoch() {
+        let before_epoch = UNIX_EPOCH - Duration::from_secs(1);
+        assert_eq!(execute_before_from_expiry(Some(before_epoch)), None);
     }
 }

--- a/crates/spark/src/token/token_service.rs
+++ b/crates/spark/src/token/token_service.rs
@@ -496,8 +496,13 @@ impl TokenService {
             receiver_address: burn_spark_address,
             spark_invoice: None,
         }];
-        self.transfer_tokens(receiver_outputs, preferred_outputs, selection_strategy)
-            .await
+        self.transfer_tokens(
+            receiver_outputs,
+            preferred_outputs,
+            selection_strategy,
+            None,
+        )
+        .await
     }
 
     pub async fn freeze_issuer_token(
@@ -566,6 +571,7 @@ impl TokenService {
         receiver_outputs: Vec<TransferTokenOutput>,
         preferred_outputs: Option<Vec<TokenOutputWithPrevOut>>,
         selection_strategy: Option<SelectionStrategy>,
+        execute_before_unix_micros: Option<i64>,
     ) -> Result<TokenTransaction, ServiceError> {
         if receiver_outputs.is_empty() {
             return Err(ServiceError::Generic(
@@ -609,6 +615,7 @@ impl TokenService {
                     &token_id,
                     reservation.token_outputs.outputs.clone(),
                     receiver_outputs.clone(),
+                    execute_before_unix_micros,
                 ),
                 &reservation,
             )
@@ -672,6 +679,7 @@ impl TokenService {
         token_id: &str,
         inputs: Vec<TokenOutputWithPrevOut>,
         receiver_outputs: Vec<TransferTokenOutput>,
+        execute_before_unix_micros: Option<i64>,
     ) -> Result<TokenTransaction, ServiceError> {
         if inputs.len() > MAX_TOKEN_TX_INPUTS {
             return Err(ServiceError::NeededTooManyOutputs);
@@ -769,7 +777,7 @@ impl TokenService {
                 withdraw_relative_block_locktime: self
                     .tokens_config
                     .expected_withdraw_relative_block_locktime,
-                execute_before_unix_micros: None,
+                execute_before_unix_micros,
             },
         )
         .map_err(|e| ServiceError::Generic(e.to_string()))?;
@@ -1056,6 +1064,7 @@ impl TokenService {
                     &output.metadata.identifier,
                     reservation.token_outputs.outputs.clone(),
                     receiver_outputs,
+                    None,
                 ),
                 &reservation,
             )


### PR DESCRIPTION
threads execute_before_unix_micros through TokenService::transfer_tokens and its inner builder into the spark_token_primitives::TransferBuildRequest, replacing the hardcoded None. fulfill_spark_invoice reads the token invoice's expiry_time and sets execute_before on the resulting token transaction, so the SO rejects the transfer once the deadline lapses.

this lets a receiver issue a spark token invoice with an expiry_time and have the payer's wallet fulfill it with a signed deadline, allowing longer quote windows while keeping output locking bounded per fulfillment attempt.

the public SparkWallet::transfer_tokens signature is unchanged. non invoice callers (burn, consolidation, the send pipeline, flashnet, the internal cli, itests) pass None, so the deadline is opt in and scoped to invoice fulfillment. the expiry to micros conversion is factored into execute_before_from_expiry with unit tests for the absent, in range, and pre epoch cases.

the deadline itself is enforced operator side once execute_before_unix_micros is set on the transaction, so there is no rust side rejection path to unit test beyond the conversion.