### PR TITLE
Add SplitLocked to accepted unilateral exit node statuses

### DIFF
--- a/crates/internal/src/command/withdraw.rs
+++ b/crates/internal/src/command/withdraw.rs
@@ -12,7 +12,8 @@ use bitcoin::{
 };
 use clap::Subcommand;
 use spark_wallet::{
-    Network, SparkWallet, SparkWalletError, TreeNodeId, is_ephemeral_anchor_output,
+    ExitChainTermination, Network, SparkWallet, SparkWalletError, TreeNodeId,
+    is_ephemeral_anchor_output,
 };
 
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -140,9 +141,52 @@ pub async fn handle_command(
                 .collect::<Result<_, _>>()?;
             let all_leaf_tx_cpfp_psbts = wallet.unilateral_exit(fee_rate, leaf_ids, utxos).await?;
 
+            let mut incomplete_leaves: Vec<&TreeNodeId> = Vec::new();
             for leaf_tx_cpfp_psbts in &all_leaf_tx_cpfp_psbts {
                 println!();
                 println!("Leaf ID: {}", leaf_tx_cpfp_psbts.leaf_id);
+                match &leaf_tx_cpfp_psbts.termination {
+                    ExitChainTermination::ReachedRoot => {
+                        println!("Exit chain: complete (reached root).");
+                    }
+                    ExitChainTermination::ParentStatusNonExitable {
+                        parent_id,
+                        parent_status,
+                        parent_tx,
+                        parent_parent_id,
+                    } => {
+                        incomplete_leaves.push(&leaf_tx_cpfp_psbts.leaf_id);
+                        let parent_txid = parent_tx.compute_txid();
+                        let parent_tx_hex = serialize_hex(parent_tx);
+                        println!(
+                            "Exit chain: STOPPED at parent {parent_id} with status {parent_status:?}. The Leaf TX below will not be broadcastable until this parent's node_tx is on chain."
+                        );
+                        println!("  Parent node ID:  {parent_id}");
+                        println!("  Parent status:   {parent_status:?}");
+                        println!("  Parent TX ID:    {parent_txid}");
+                        println!("  Parent TX:       {parent_tx_hex}");
+                        match parent_parent_id {
+                            Some(grand) => println!("  Parent's parent: {grand}"),
+                            None => println!("  Parent's parent: <none> (parent is the root)"),
+                        }
+                    }
+                    ExitChainTermination::CurrentStatusNonExitable {
+                        node_id,
+                        node_status,
+                        node_tx,
+                    } => {
+                        incomplete_leaves.push(&leaf_tx_cpfp_psbts.leaf_id);
+                        let node_txid = node_tx.compute_txid();
+                        let node_tx_hex = serialize_hex(node_tx);
+                        println!(
+                            "Exit chain: rejected current node {node_id} with status {node_status:?}. No package produced."
+                        );
+                        println!("  Node ID:     {node_id}");
+                        println!("  Node status: {node_status:?}");
+                        println!("  Node TX ID:  {node_txid}");
+                        println!("  Node TX:     {node_tx_hex}");
+                    }
+                }
                 println!();
 
                 let total_txs = leaf_tx_cpfp_psbts.tx_cpfp_psbts.len();
@@ -221,6 +265,16 @@ pub async fn handle_command(
             println!(
                 "Use the taproot descriptor shown for each refund TX to sweep funds into any Bitcoin wallet."
             );
+            if !incomplete_leaves.is_empty() {
+                println!();
+                println!(
+                    "WARNING: {} leaf(s) have an incomplete exit chain (see \"STOPPED at parent\" / \"rejected current node\" above):",
+                    incomplete_leaves.len()
+                );
+                for leaf_id in incomplete_leaves {
+                    println!("  - {leaf_id}");
+                }
+            }
         }
     }
 

--- a/crates/spark-wallet/src/lib.rs
+++ b/crates/spark-wallet/src/lib.rs
@@ -16,7 +16,7 @@ pub use spark::{
     header_provider::*,
     operator::rpc::{BalancedConnectionManager, ConnectionManager, DefaultConnectionManager},
     services::{
-        CoopExitFeeQuote, CoopExitSpeedFeeQuote, CpfpUtxo, ExitSpeed, Fee,
+        CoopExitFeeQuote, CoopExitSpeedFeeQuote, CpfpUtxo, ExitChainTermination, ExitSpeed, Fee,
         FreezeIssuerTokenResponse, InvoiceDescription, LightningReceivePayment,
         LightningSendPayment, LightningSendStatus, Preimage, PreimageRequestStatus,
         ReceiverTokenOutput, ServiceError, SingleUseDepositAddress, StaticDepositAddress,

--- a/crates/spark/src/services/unilateral_exit.rs
+++ b/crates/spark/src/services/unilateral_exit.rs
@@ -7,7 +7,7 @@ use bitcoin::{
     Address, Amount, CompressedPublicKey, OutPoint, Psbt, Transaction, TxIn, TxOut, Txid,
     absolute::LockTime, psbt, secp256k1::PublicKey, transaction::Version,
 };
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 use crate::{
     Network,
@@ -50,6 +50,41 @@ pub struct TxCpfpPsbt {
 pub struct LeafTxCpfpPsbts {
     pub leaf_id: TreeNodeId,
     pub tx_cpfp_psbts: Vec<TxCpfpPsbt>,
+    /// Why the ancestor walk that produced `tx_cpfp_psbts` stopped. A value
+    /// other than `ReachedRoot` means the package is incomplete: the Leaf TX
+    /// spends an output of an ancestor whose `node_tx` is not in the package.
+    pub termination: ExitChainTermination,
+}
+
+/// Diagnostic record of why `build_exit_chain` stopped walking from a leaf up
+/// toward the root. Only `ReachedRoot` indicates a complete exit package.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExitChainTermination {
+    /// Walked all the way to the root (`parent_node_id` was `None`).
+    ReachedRoot,
+    /// An ancestor's status was outside [`EXIT_CHAIN_STATUSES`] and the walk
+    /// stopped before pushing it. The descendant's `node_tx` spends an output
+    /// of `parent_tx`, which is not in the package.
+    ParentStatusNonExitable {
+        parent_id: TreeNodeId,
+        parent_status: TreeNodeStatus,
+        /// The parent's `node_tx`. Surfacing this lets the caller inspect or
+        /// hand-broadcast the missing tx even though the SDK refused to
+        /// include it in the package.
+        parent_tx: Transaction,
+        /// The parent's own `parent_node_id`, if any. Lets the caller see
+        /// whether the chain would have continued further up.
+        parent_parent_id: Option<TreeNodeId>,
+    },
+    /// The leaf itself had a status outside [`EXIT_CHAIN_STATUSES`] on the
+    /// first iteration, so no nodes were pushed at all.
+    CurrentStatusNonExitable {
+        node_id: TreeNodeId,
+        node_status: TreeNodeStatus,
+        /// The rejected node's `node_tx`, surfaced for the same inspection
+        /// reason as `ParentStatusNonExitable::parent_tx`.
+        node_tx: Transaction,
+    },
 }
 
 pub struct UnilateralExitService {
@@ -109,7 +144,7 @@ impl UnilateralExitService {
 
             // Walk the leaf's ancestors up to the root, re-fetching any parent
             // missing from the initial response by its node ID.
-            let nodes = build_exit_chain(leaf, &mut tree_nodes, async |ids| {
+            let (nodes, termination) = build_exit_chain(leaf, &mut tree_nodes, async |ids| {
                 self.fetch_leaves_parents(ids).await
             })
             .await?;
@@ -149,6 +184,7 @@ impl UnilateralExitService {
             all_leaf_tx_cpfp_psbts.push(LeafTxCpfpPsbts {
                 leaf_id,
                 tx_cpfp_psbts,
+                termination,
             });
         }
 
@@ -211,7 +247,8 @@ impl UnilateralExitService {
 }
 
 /// Walks a leaf's ancestor chain up to the root, returning the nodes ordered
-/// root → leaf.
+/// root → leaf alongside an [`ExitChainTermination`] that records why the walk
+/// stopped.
 ///
 /// `node_map` is seeded with nodes already known to the caller (the leaves and
 /// whatever ancestors the initial `query_nodes(include_parents=true)` returned).
@@ -221,27 +258,55 @@ impl UnilateralExitService {
 ///
 /// The walk stops gracefully when it reaches a node whose status is outside
 /// [`EXIT_CHAIN_STATUSES`] (e.g. an already-exited ancestor), rather than
-/// treating it as an error.
+/// treating it as an error. The returned [`ExitChainTermination`] tells the
+/// caller which case applied: a non-`ReachedRoot` value means the resulting
+/// chain is incomplete and the descendant's `node_tx` cannot be broadcast on
+/// its own.
 async fn build_exit_chain<F>(
     leaf: TreeNode,
     node_map: &mut HashMap<TreeNodeId, TreeNode>,
     mut fetch_by_ids: F,
-) -> Result<Vec<TreeNode>, ServiceError>
+) -> Result<(Vec<TreeNode>, ExitChainTermination), ServiceError>
 where
     F: AsyncFnMut(&[TreeNodeId]) -> Result<Vec<TreeNode>, ServiceError>,
 {
-    let mut chain = Vec::new();
+    let mut chain: Vec<TreeNode> = Vec::new();
     let mut current = leaf;
-    loop {
+    let termination = loop {
         if !EXIT_CHAIN_STATUSES.contains(&current.status) {
-            break;
+            let node_id = current.id.clone();
+            let node_status = current.status;
+            let node_tx = current.node_tx.clone();
+            let parent_parent_id = current.parent_node_id.clone();
+            if chain.is_empty() {
+                warn!(
+                    %node_id, ?node_status, node_txid = %node_tx.compute_txid(),
+                    "Unilateral exit: leaf status outside EXIT_CHAIN_STATUSES; no chain produced"
+                );
+                break ExitChainTermination::CurrentStatusNonExitable {
+                    node_id,
+                    node_status,
+                    node_tx,
+                };
+            }
+            warn!(
+                parent_id = %node_id, parent_status = ?node_status,
+                parent_txid = %node_tx.compute_txid(),
+                "Unilateral exit: ancestor status outside EXIT_CHAIN_STATUSES; chain stops before this parent"
+            );
+            break ExitChainTermination::ParentStatusNonExitable {
+                parent_id: node_id,
+                parent_status: node_status,
+                parent_tx: node_tx,
+                parent_parent_id,
+            };
         }
 
         let parent_node_id = current.parent_node_id.clone();
         chain.insert(0, current);
 
         let Some(parent_node_id) = parent_node_id else {
-            break;
+            break ExitChainTermination::ReachedRoot;
         };
 
         if !node_map.contains_key(&parent_node_id) {
@@ -264,8 +329,8 @@ where
             parent.node_tx.compute_txid()
         );
         current = parent.clone();
-    }
-    Ok(chain)
+    };
+    Ok((chain, termination))
 }
 
 /// Creates a Partially Signed Bitcoin Transaction (PSBT) to CPFP a parent transaction.
@@ -685,18 +750,20 @@ mod tests {
                 .collect();
 
             let mut fetched = false;
-            let chain = super::super::build_exit_chain(leaf, &mut map, async |_ids| {
-                fetched = true;
-                Ok(Vec::new())
-            })
-            .await
-            .unwrap();
+            let (chain, termination) =
+                super::super::build_exit_chain(leaf, &mut map, async |_ids| {
+                    fetched = true;
+                    Ok(Vec::new())
+                })
+                .await
+                .unwrap();
 
             assert!(
                 !fetched,
                 "fetcher must not be called when chain is complete"
             );
             assert_eq!(chain_ids(&chain), vec![ROOT, MID, LEAF]);
+            assert_eq!(termination, ExitChainTermination::ReachedRoot);
         }
 
         // The bug scenario: the SO omits the root from the bulk response, so it
@@ -718,7 +785,7 @@ mod tests {
                 [(root.id.clone(), root.clone())].into_iter().collect();
             let mut requested: Vec<TreeNodeId> = Vec::new();
 
-            let chain =
+            let (chain, termination) =
                 super::super::build_exit_chain(leaf, &mut map, async |ids: &[TreeNodeId]| {
                     requested.extend_from_slice(ids);
                     Ok(ids.iter().filter_map(|i| server.get(i).cloned()).collect())
@@ -728,9 +795,11 @@ mod tests {
 
             assert_eq!(requested, vec![root.id.clone()]);
             assert_eq!(chain_ids(&chain), vec![ROOT, MID, LEAF]);
+            assert_eq!(termination, ExitChainTermination::ReachedRoot);
         }
 
-        // An ancestor outside the exitable set ends the walk gracefully.
+        // An ancestor outside the exitable set ends the walk gracefully and
+        // surfaces the offending ancestor in the termination value.
         #[macros::async_test_all]
         async fn stops_on_non_exit_status() {
             let root = node(ROOT, None, TreeNodeStatus::Available);
@@ -742,11 +811,49 @@ mod tests {
                 .map(|n| (n.id.clone(), n.clone()))
                 .collect();
 
-            let chain = super::super::build_exit_chain(leaf, &mut map, async |_ids| Ok(Vec::new()))
-                .await
-                .unwrap();
+            let (chain, termination) =
+                super::super::build_exit_chain(leaf, &mut map, async |_ids| Ok(Vec::new()))
+                    .await
+                    .unwrap();
 
             assert_eq!(chain_ids(&chain), vec![LEAF]);
+            assert_eq!(
+                termination,
+                ExitChainTermination::ParentStatusNonExitable {
+                    parent_id: TreeNodeId::from_str(MID).unwrap(),
+                    parent_status: TreeNodeStatus::Exited,
+                    parent_tx: mid.node_tx.clone(),
+                    parent_parent_id: Some(TreeNodeId::from_str(ROOT).unwrap()),
+                }
+            );
+        }
+
+        // The leaf itself having a non-exitable status produces an empty chain
+        // and a `CurrentStatusNonExitable` termination.
+        #[macros::async_test_all]
+        async fn stops_on_non_exit_status_at_leaf() {
+            let leaf = node(LEAF, Some(MID), TreeNodeStatus::Exited);
+
+            let mut map: HashMap<TreeNodeId, TreeNode> = [&leaf]
+                .into_iter()
+                .map(|n| (n.id.clone(), n.clone()))
+                .collect();
+
+            let leaf_node_tx = leaf.node_tx.clone();
+            let (chain, termination) =
+                super::super::build_exit_chain(leaf, &mut map, async |_ids| Ok(Vec::new()))
+                    .await
+                    .unwrap();
+
+            assert!(chain.is_empty());
+            assert_eq!(
+                termination,
+                ExitChainTermination::CurrentStatusNonExitable {
+                    node_id: TreeNodeId::from_str(LEAF).unwrap(),
+                    node_status: TreeNodeStatus::Exited,
+                    node_tx: leaf_node_tx,
+                }
+            );
         }
 
         // A parent that cannot be fetched by ID is a genuine error.

--- a/crates/spark/src/services/unilateral_exit.rs
+++ b/crates/spark/src/services/unilateral_exit.rs
@@ -26,12 +26,21 @@ use crate::{
     },
 };
 
-/// Statuses where a node can still contribute to an exit chain. `OnChain` is
-/// included because the SO marks a node `ON_CHAIN` once its raw or direct tx
-/// confirms, which is a normal in-progress state for an exit.
-const EXIT_CHAIN_STATUSES: [TreeNodeStatus; 3] = [
+/// Statuses where a node can still contribute to an exit chain.
+///
+/// `OnChain` is included because the SO marks a node `ON_CHAIN` once its raw
+/// or direct tx confirms, which is a normal in-progress state for an exit.
+///
+/// `SplitLocked` is included because the SO sets it permanently on the
+/// zero-timelock intermediate node introduced by a timelock renewal (see
+/// the SO's `finalizeRenewNodeTimelockDB` / `finalizeRenewNodeZeroTimelockDB`).
+/// Without it, any leaf that has been renewed has a `SplitLocked` parent that
+/// silently terminates the walk, leaving the Leaf TX referencing an input
+/// that is not in the exit package.
+const EXIT_CHAIN_STATUSES: [TreeNodeStatus; 4] = [
     TreeNodeStatus::Available,
     TreeNodeStatus::Splitted,
+    TreeNodeStatus::SplitLocked,
     TreeNodeStatus::OnChain,
 ];
 
@@ -794,6 +803,30 @@ mod tests {
                 .unwrap();
 
             assert_eq!(requested, vec![root.id.clone()]);
+            assert_eq!(chain_ids(&chain), vec![ROOT, MID, LEAF]);
+            assert_eq!(termination, ExitChainTermination::ReachedRoot);
+        }
+
+        // The renewal scenario: the SO inserts a SplitLocked parent above a
+        // renewed leaf and never advances it. The walk must include the
+        // SplitLocked parent and continue up to the root, otherwise the Leaf
+        // TX is unbroadcastable.
+        #[macros::async_test_all]
+        async fn walks_through_split_locked_parent() {
+            let root = node(ROOT, None, TreeNodeStatus::Available);
+            let mid = node(MID, Some(ROOT), TreeNodeStatus::SplitLocked);
+            let leaf = node(LEAF, Some(MID), TreeNodeStatus::Available);
+
+            let mut map: HashMap<TreeNodeId, TreeNode> = [&root, &mid, &leaf]
+                .into_iter()
+                .map(|n| (n.id.clone(), n.clone()))
+                .collect();
+
+            let (chain, termination) =
+                super::super::build_exit_chain(leaf, &mut map, async |_ids| Ok(Vec::new()))
+                    .await
+                    .unwrap();
+
             assert_eq!(chain_ids(&chain), vec![ROOT, MID, LEAF]);
             assert_eq!(termination, ExitChainTermination::ReachedRoot);
         }


### PR DESCRIPTION
Unilateral exit for any leaf that has been through a timelock renewal silently produced an unbroadcastable package: the Leaf TX referenced a parent input not on chain and not in the printed output.

Root cause: `EXIT_CHAIN_STATUSES = [Available, Splitted, OnChain]` excluded `SplitLocked`. The SO's renewal handlers create the zero-timelock intermediate "split node" directly in `SplitLocked` and never advance it, so every renewed leaf ends up with a `SplitLocked` parent. The exit walker hit it, silently terminated, and dropped the missing parent without any signal.
