### PR TITLE
Cross chain: helpers, tests, error types and validation

### DIFF
--- a/crates/breez-sdk/core/src/cross_chain/boltz.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz.rs
@@ -14,6 +14,7 @@ use boltz_client::{
     config::{BoltzConfig as BoltzClientConfig, MAX_SLIPPAGE_BPS},
     models::{Asset, PreparedSwap},
 };
+use platform_utils::time::{SystemTime, UNIX_EPOCH};
 use spark_wallet::SparkWallet;
 use tracing::{debug, error, info};
 
@@ -156,12 +157,11 @@ impl BoltzService {
         let real_invoice_sats = fees_included_real_invoice_sats(total_sats, ln_fee_probe_sats)?;
 
         // Phase 2: real invoice sized to leave room for the probed fee.
-        // Translate `AmountOutOfRange` here (rather than in `boltz_err_to_sdk`)
-        // so the message names the user's `total_sats` and the probed fee —
-        // the raw boltz error references `real_invoice_sats`, a number the
-        // caller never chose. The phase-2 prepare validates against the Boltz
-        // pair limits before `create_reverse_swap` is called, so a failure
-        // here commits no state.
+        // Override `AmountOutOfRange` with a message that names the user's
+        // `total_sats` and the probed fee — the raw Boltz error references
+        // `real_invoice_sats`, a number the caller never chose. The phase-2
+        // prepare validates against the Boltz pair limits before
+        // `create_reverse_swap` is called, so a failure here commits no state.
         let prepared = self
             .client
             .prepare_reverse_swap_from_sats(
@@ -178,13 +178,9 @@ impl BoltzService {
                     after subtracting LN fee ({ln_fee_probe_sats} sats), the remaining \
                     invoice ({real_invoice_sats} sats) is below Boltz minimum ({min} sats)."
                 )),
-                _ => boltz_err_to_sdk(&e),
+                _ => e.into(),
             })?;
-        let created = self
-            .client
-            .create_reverse_swap(&prepared)
-            .await
-            .map_err(|e| boltz_err_to_sdk(&e))?;
+        let created = self.client.create_reverse_swap(&prepared).await?;
         let ln_fee_final_sats = self.fetch_ln_fee(&created.invoice).await?;
 
         // Mirrors LNURL's guard: if fee moved between queries, fail so caller retries.
@@ -224,18 +220,13 @@ impl BoltzService {
                 invoice_amount_sats,
                 max_slippage_bps,
             )
-            .await
-            .map_err(|e| boltz_err_to_sdk(&e))?;
+            .await?;
 
         // `create_reverse_swap` commits a HD key index, POSTs to Boltz to
         // create the swap on the server, and writes a `BoltzSwap` row into
         // the adapter cache KV. After this call Boltz is holding the swap
         // state, so the only path back to a clean state is a timeout.
-        let created = self
-            .client
-            .create_reverse_swap(&prepared)
-            .await
-            .map_err(|e| boltz_err_to_sdk(&e))?;
+        let created = self.client.create_reverse_swap(&prepared).await?;
 
         Ok((prepared, created))
     }
@@ -268,13 +259,12 @@ impl BoltzService {
                 invoice_amount_sats,
                 max_slippage_bps,
             )
-            .await
-            .map_err(|e| boltz_err_to_sdk(&e))?;
+            .await?;
 
         self.client
             .create_probe_invoice(&prepared)
             .await
-            .map_err(|e| boltz_err_to_sdk(&e))
+            .map_err(Into::into)
     }
 
     async fn fetch_ln_fee(&self, invoice: &str) -> Result<u64, SdkError> {
@@ -365,7 +355,7 @@ impl CrossChainService for BoltzService {
         route: &CrossChainRoutePair,
         amount: u128,
         token_identifier: Option<String>,
-        max_slippage_bps: Option<u32>,
+        max_slippage_bps: u32,
         fee_mode: CrossChainFeeMode,
     ) -> Result<CrossChainPrepared, SdkError> {
         // v1 Boltz is BTC-only. Tokens must be rejected before we commit any
@@ -392,14 +382,13 @@ impl CrossChainService for BoltzService {
             ))
         })?;
 
-        if let Some(bps) = max_slippage_bps
-            && bps > MAX_SLIPPAGE_BPS
-        {
+        if max_slippage_bps > MAX_SLIPPAGE_BPS {
             return Err(SdkError::InvalidInput(format!(
-                "max_slippage_bps {bps} exceeds Boltz maximum {MAX_SLIPPAGE_BPS}"
+                "max_slippage_bps {max_slippage_bps} exceeds Boltz maximum {MAX_SLIPPAGE_BPS}"
             )));
         }
 
+        let slippage = Some(max_slippage_bps);
         match fee_mode {
             CrossChainFeeMode::FeesExcluded => {
                 self.prepare_fees_excluded(
@@ -408,7 +397,7 @@ impl CrossChainService for BoltzService {
                     &route.chain,
                     asset,
                     total_sats,
-                    max_slippage_bps,
+                    slippage,
                 )
                 .await
             }
@@ -419,7 +408,7 @@ impl CrossChainService for BoltzService {
                     &route.chain,
                     asset,
                     total_sats,
-                    max_slippage_bps,
+                    slippage,
                 )
                 .await
             }
@@ -438,6 +427,8 @@ impl CrossChainService for BoltzService {
                 "Boltz send called with non-Boltz provider context".to_string(),
             ));
         };
+
+        validate_quote_expiry(&prepared.expires_at)?;
 
         let invoice_amount_sats = u64::try_from(prepared.amount_in)
             .map_err(|e| SdkError::Generic(format!("Boltz invoice amount exceeds u64: {e}")))?;
@@ -549,38 +540,70 @@ impl CrossChainService for BoltzService {
             max_delay: Duration::from_millis(SEND_POLL_MAX_DELAY_MS),
             timeout: Duration::from_secs(SEND_POLL_TIMEOUT_SECS),
         };
-        let storage = Arc::clone(&self.storage);
-        let poll_payment_id = payment_id.clone();
-        let polled = poll_until(schedule, None, || {
-            let storage = Arc::clone(&storage);
-            let payment_id = poll_payment_id.clone();
-            async move {
-                match storage.get_payment_by_id(payment_id.clone()).await {
-                    Ok(payment) if payment.status != PaymentStatus::Pending => Ok(Some(payment)),
-                    Ok(_) => Ok(None),
-                    Err(e) => Err(SdkError::Generic(format!(
-                        "Failed to fetch Boltz payment {payment_id}: {e}"
-                    ))),
-                }
-            }
-        })
-        .await;
+        Ok(poll_to_terminal_or_fallback(
+            Arc::clone(&self.storage),
+            payment_id,
+            sdk_payment,
+            schedule,
+        )
+        .await)
+    }
+}
 
-        match polled {
-            Ok(payment) => Ok(payment),
-            Err(e) => {
-                debug!(
-                    "Boltz: terminal status not reached within timeout for swap {swap_id}: {e}; \
-                     returning pending payment"
-                );
-                Ok(sdk_payment)
+/// Polls storage for a terminal status on `payment_id`. Returns the terminal
+/// `Payment` on success; on timeout or storage error returns `fallback` (the
+/// pending payment we already have in hand). The background SSP poll continues
+/// after we return.
+async fn poll_to_terminal_or_fallback(
+    storage: Arc<dyn Storage>,
+    payment_id: String,
+    fallback: crate::Payment,
+    schedule: PollSchedule,
+) -> crate::Payment {
+    let polled = poll_until(schedule, None, || {
+        let storage = Arc::clone(&storage);
+        let payment_id = payment_id.clone();
+        async move {
+            match storage.get_payment_by_id(payment_id.clone()).await {
+                Ok(payment) if payment.status != PaymentStatus::Pending => Ok(Some(payment)),
+                Ok(_) => Ok(None),
+                Err(e) => Err(SdkError::Generic(format!(
+                    "Failed to fetch Boltz payment {payment_id}: {e}"
+                ))),
             }
+        }
+    })
+    .await;
+
+    match polled {
+        Ok(payment) => payment,
+        Err(e) => {
+            debug!(
+                "Boltz: terminal status not reached within timeout: {e}; returning pending payment"
+            );
+            fallback
         }
     }
 }
 
-fn boltz_err_to_sdk(err: &BoltzError) -> SdkError {
-    SdkError::Generic(format!("Boltz: {err}"))
+/// Boltz quotes carry `expires_at` as a Unix epoch seconds string. Reject
+/// at send time if the wall clock has passed it so the user sees a clean
+/// "quote expired, re-prepare" rather than a server-side error after the LN
+/// pay attempt.
+fn validate_quote_expiry(expires_at: &str) -> Result<(), SdkError> {
+    let exp_secs: u64 = expires_at
+        .parse()
+        .map_err(|e| SdkError::Generic(format!("Boltz: invalid expires_at {expires_at:?}: {e}")))?;
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| SdkError::Generic("Failed to read current time".to_string()))?
+        .as_secs();
+    if now_secs >= exp_secs {
+        return Err(SdkError::InvalidInput(
+            "Cross-chain quote has expired. Please re-prepare.".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 /// Phase-1 check for the `FeesIncluded` path: returns the size to use for the
@@ -626,6 +649,10 @@ fn destination_to_route_pair(
 mod tests {
     use super::*;
     use boltz_client::models::{Asset, BridgeKind, DestinationOption, NetworkTransport};
+    use macros::test_all;
+
+    #[cfg(feature = "browser-tests")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     fn test_destination(
         chain_label: &str,
@@ -645,7 +672,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[test_all]
     fn destination_to_pair_maps_evm_chain_id_to_decimal_string() {
         let dest = test_destination(
             "Polygon PoS",
@@ -670,7 +697,7 @@ mod tests {
         assert!(!pair.exact_out_eligible);
     }
 
-    #[test]
+    #[test_all]
     fn destination_to_pair_surfaces_usdc_asset() {
         let dest = test_destination(
             "Base",
@@ -687,7 +714,7 @@ mod tests {
         assert_eq!(pair.chain_id, Some("8453".to_string()));
     }
 
-    #[test]
+    #[test_all]
     fn destination_to_pair_preserves_none_for_non_evm_transports() {
         let dest = test_destination(
             "Solana",
@@ -705,7 +732,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test_all]
     fn fees_included_real_invoice_sats_subtracts_probe_fee() {
         let real = fees_included_real_invoice_sats(10_000, 250).expect("fits within budget");
         assert_eq!(
@@ -714,7 +741,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test_all]
     fn fees_included_real_invoice_sats_rejects_when_fee_eats_budget() {
         // Fee exactly equals total: no room for any invoice → reject.
         let err = fees_included_real_invoice_sats(500, 500)
@@ -731,5 +758,157 @@ mod tests {
         let err =
             fees_included_real_invoice_sats(100, 250).expect_err("probe fee greater than total");
         assert!(matches!(err, SdkError::InvalidInput(_)));
+    }
+
+    // ---- poll_to_terminal_or_fallback ----
+
+    #[cfg(feature = "sqlite")]
+    mod poll_to_terminal_tests {
+        use super::*;
+
+        fn create_temp_dir(name: &str) -> std::path::PathBuf {
+            let mut path = std::env::temp_dir();
+            path.push(format!(
+                "breez-test-boltz-{}-{}",
+                name,
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            path
+        }
+
+        fn make_pending_payment(id: &str) -> crate::Payment {
+            crate::Payment {
+                id: id.to_string(),
+                payment_type: crate::PaymentType::Send,
+                status: PaymentStatus::Pending,
+                amount: 1_000,
+                fees: 10,
+                timestamp: 1,
+                method: crate::PaymentMethod::Lightning,
+                details: None,
+                conversion_details: None,
+            }
+        }
+
+        fn fast_schedule() -> PollSchedule {
+            PollSchedule {
+                initial_delay: Duration::from_millis(10),
+                max_delay: Duration::from_millis(20),
+                timeout: Duration::from_millis(100),
+            }
+        }
+
+        #[tokio::test]
+        async fn poll_to_terminal_returns_terminal_when_status_settles() {
+            let dir = create_temp_dir("poll_settles");
+            let storage: Arc<dyn Storage> =
+                Arc::new(crate::persist::sqlite::SqliteStorage::new(&dir).unwrap());
+
+            let pending = make_pending_payment("pay_settles");
+            storage.apply_payment_update(pending.clone()).await.unwrap();
+
+            let mut completed = pending.clone();
+            completed.status = PaymentStatus::Completed;
+
+            // Settle the payment mid-poll.
+            let storage_w = Arc::clone(&storage);
+            let completed_w = completed.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                storage_w.apply_payment_update(completed_w).await.unwrap();
+            });
+
+            let fallback = pending.clone();
+            let result = poll_to_terminal_or_fallback(
+                Arc::clone(&storage),
+                "pay_settles".to_string(),
+                fallback,
+                fast_schedule(),
+            )
+            .await;
+
+            assert_eq!(result.status, PaymentStatus::Completed);
+        }
+
+        #[tokio::test]
+        async fn poll_to_terminal_returns_fallback_on_timeout() {
+            let dir = create_temp_dir("poll_timeout");
+            let storage: Arc<dyn Storage> =
+                Arc::new(crate::persist::sqlite::SqliteStorage::new(&dir).unwrap());
+
+            let pending = make_pending_payment("pay_timeout");
+            storage.apply_payment_update(pending.clone()).await.unwrap();
+
+            let mut fallback = pending.clone();
+            // Sentinel field on the fallback to prove the returned value is the
+            // fallback we passed in, not a fresh read from storage.
+            fallback.timestamp = 99_999;
+
+            let result = poll_to_terminal_or_fallback(
+                Arc::clone(&storage),
+                "pay_timeout".to_string(),
+                fallback,
+                fast_schedule(),
+            )
+            .await;
+
+            assert_eq!(
+                result.timestamp, 99_999,
+                "timeout should surface the supplied fallback payment as-is"
+            );
+            assert_eq!(result.status, PaymentStatus::Pending);
+        }
+
+        #[tokio::test]
+        async fn poll_to_terminal_returns_fallback_on_storage_error() {
+            // `get_payment_by_id` returns an error when the row is missing.
+            let dir = create_temp_dir("poll_missing");
+            let storage: Arc<dyn Storage> =
+                Arc::new(crate::persist::sqlite::SqliteStorage::new(&dir).unwrap());
+
+            // No payment inserted — get_payment_by_id will error every probe,
+            // poll_until propagates the last error, and we fall back.
+            let mut fallback = make_pending_payment("pay_missing");
+            fallback.timestamp = 42_424;
+
+            let result = poll_to_terminal_or_fallback(
+                Arc::clone(&storage),
+                "pay_missing".to_string(),
+                fallback,
+                fast_schedule(),
+            )
+            .await;
+
+            assert_eq!(
+                result.timestamp, 42_424,
+                "storage errors must fall through to the fallback"
+            );
+        }
+    }
+
+    // ---- validate_quote_expiry ----
+
+    #[test_all]
+    fn validate_quote_expiry_accepts_future_unix_secs() {
+        use platform_utils::time::{SystemTime, UNIX_EPOCH};
+        let future = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .saturating_add(600);
+        assert!(validate_quote_expiry(&future.to_string()).is_ok());
+    }
+
+    #[test_all]
+    fn validate_quote_expiry_rejects_past_unix_secs() {
+        let err = validate_quote_expiry("1000000000").unwrap_err();
+        assert!(matches!(err, SdkError::InvalidInput(ref m) if m.contains("expired")));
+    }
+
+    #[test_all]
+    fn validate_quote_expiry_rejects_malformed() {
+        let err = validate_quote_expiry("not-a-number").unwrap_err();
+        assert!(matches!(err, SdkError::Generic(ref m) if m.contains("invalid expires_at")));
     }
 }

--- a/crates/breez-sdk/core/src/cross_chain/boltz_event_listener.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz_event_listener.rs
@@ -228,53 +228,16 @@ fn map_boltz_status_to_conversion(status: &BoltzSwapStatus) -> ConversionStatus 
 }
 
 #[cfg(test)]
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 mod tests {
-    use std::path::PathBuf;
-
-    use boltz_client::models::{Asset, BoltzSwap, BoltzSwapStatus, BridgeKind};
+    use boltz_client::models::BoltzSwapStatus;
 
     use super::*;
-    use crate::persist::sqlite::SqliteStorage;
+    use macros::test_all;
 
-    fn create_temp_dir(name: &str) -> PathBuf {
-        let mut path = std::env::temp_dir();
-        path.push(format!("breez-test-{}-{}", name, uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&path).unwrap();
-        path
-    }
+    #[cfg(feature = "browser-tests")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-    fn make_swap(id: &str, status: BoltzSwapStatus) -> BoltzSwap {
-        BoltzSwap {
-            id: id.to_string(),
-            status,
-            bridge_kind: BridgeKind::Oft,
-            claim_key_index: 0,
-            chain_id: 42161,
-            claim_address: "0xclaim".to_string(),
-            destination_address: "0xdest".to_string(),
-            destination_chain: "Arbitrum One".to_string(),
-            asset: Asset::Usdt,
-            refund_address: "0xrefund".to_string(),
-            erc20swap_address: "0xswap".to_string(),
-            router_address: "0xrouter".to_string(),
-            invoice: "lnbc1000n".to_string(),
-            invoice_amount_sats: 100_000,
-            onchain_amount: 99_500,
-            expected_output_amount: 70_900_000,
-            slippage_bps: 100,
-            timeout_block_height: 123_456,
-            lockup_tx_id: None,
-            claim_tx_hash: None,
-            pending_call_id: None,
-            delivered_amount: None,
-            bridge_ref: None,
-            created_at: 1_700_000_000,
-            updated_at: 1_700_000_000,
-        }
-    }
-
-    #[test]
+    #[test_all]
     fn status_mapping_covers_all_variants() {
         assert_eq!(
             map_boltz_status_to_conversion(&BoltzSwapStatus::Created),
@@ -312,15 +275,63 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn missing_payment_is_silent_noop() {
-        let dir = create_temp_dir("boltz_event_missing_payment");
-        let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&dir).unwrap());
-        let listener = BoltzSdkEventListener::new(Arc::clone(&storage));
+    #[cfg(feature = "sqlite")]
+    mod storage_tests {
+        use std::path::PathBuf;
+        use std::sync::Arc;
 
-        // No payment row carrying this invoice — the listener should
-        // short-circuit without erroring.
-        let swap = make_swap("orphan_swap", BoltzSwapStatus::InvoicePaid);
-        listener.handle_swap_updated(&swap).await.unwrap();
+        use boltz_client::models::{Asset, BoltzSwap, BoltzSwapStatus, BridgeKind};
+
+        use super::super::*;
+        use crate::persist::sqlite::SqliteStorage;
+
+        fn create_temp_dir(name: &str) -> PathBuf {
+            let mut path = std::env::temp_dir();
+            path.push(format!("breez-test-{}-{}", name, uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&path).unwrap();
+            path
+        }
+
+        fn make_swap(id: &str, status: BoltzSwapStatus) -> BoltzSwap {
+            BoltzSwap {
+                id: id.to_string(),
+                status,
+                bridge_kind: BridgeKind::Oft,
+                claim_key_index: 0,
+                chain_id: 42161,
+                claim_address: "0xclaim".to_string(),
+                destination_address: "0xdest".to_string(),
+                destination_chain: "Arbitrum One".to_string(),
+                asset: Asset::Usdt,
+                refund_address: "0xrefund".to_string(),
+                erc20swap_address: "0xswap".to_string(),
+                router_address: "0xrouter".to_string(),
+                invoice: "lnbc1000n".to_string(),
+                invoice_amount_sats: 100_000,
+                onchain_amount: 99_500,
+                expected_output_amount: 70_900_000,
+                slippage_bps: 100,
+                timeout_block_height: 123_456,
+                lockup_tx_id: None,
+                claim_tx_hash: None,
+                pending_call_id: None,
+                delivered_amount: None,
+                bridge_ref: None,
+                created_at: 1_700_000_000,
+                updated_at: 1_700_000_000,
+            }
+        }
+
+        #[tokio::test]
+        async fn missing_payment_is_silent_noop() {
+            let dir = create_temp_dir("boltz_event_missing_payment");
+            let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&dir).unwrap());
+            let listener = BoltzSdkEventListener::new(Arc::clone(&storage));
+
+            // No payment row carrying this invoice — the listener should
+            // short-circuit without erroring.
+            let swap = make_swap("orphan_swap", BoltzSwapStatus::InvoicePaid);
+            listener.handle_swap_updated(&swap).await.unwrap();
+        }
     }
 }

--- a/crates/breez-sdk/core/src/cross_chain/boltz_storage_adapter.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz_storage_adapter.rs
@@ -178,8 +178,7 @@ impl BoltzStorage for BoltzStorageAdapter {
     }
 }
 
-#[cfg(test)]
-#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+#[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;

--- a/crates/breez-sdk/core/src/cross_chain/mod.rs
+++ b/crates/breez-sdk/core/src/cross_chain/mod.rs
@@ -118,7 +118,9 @@ impl CrossChainProviders {
         provider: CrossChainProvider,
     ) -> Result<&Arc<dyn CrossChainService>, SdkError> {
         self.0.get(&provider).ok_or_else(|| {
-            SdkError::Generic(format!("Cross-chain provider {provider:?} not available"))
+            SdkError::InvalidInput(format!(
+                "Cross-chain provider {provider:?} is not available."
+            ))
         })
     }
 
@@ -209,7 +211,7 @@ pub(crate) trait CrossChainService: Send + Sync {
         route: &CrossChainRoutePair,
         amount: u128,
         source_token_identifier: Option<String>,
-        max_slippage_bps: Option<u32>,
+        max_slippage_bps: u32,
         fee_mode: CrossChainFeeMode,
     ) -> Result<CrossChainPrepared, SdkError>;
 

--- a/crates/breez-sdk/core/src/cross_chain/orchestra.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra.rs
@@ -37,11 +37,11 @@ use crate::utils::{
     polling::{PollSchedule, poll_until},
 };
 
+const DEFAULT_AFFILIATE_ID: &str = "breez_sdk";
 // Polling cadence for the outbound Spark transfer leg.
 const SEND_POLL_INITIAL_DELAY_MS: u64 = 500;
 const SEND_POLL_MAX_DELAY_MS: u64 = 2000;
 const SEND_POLL_TIMEOUT_SECS: u64 = 30;
-
 /// The canonical Spark source chain string used by Orchestra.
 const SPARK_SOURCE_CHAIN: &str = "spark";
 
@@ -366,7 +366,7 @@ impl CrossChainService for OrchestraService {
             slippage_bps: Some(max_slippage_bps),
             zeroconf_enabled: None,
             app_fees: Vec::new(),
-            affiliate_id: None,
+            affiliate_id: Some(DEFAULT_AFFILIATE_ID.to_string()),
         };
 
         debug!(
@@ -428,7 +428,7 @@ impl CrossChainService for OrchestraService {
         validate_quote_expiry(&prepared.expires_at)?;
 
         // Step 1: Spark transfer to the Orchestra deposit address.
-        let spark_tx_hash = self
+        let asset_transfer = self
             .client
             .transfer_to_deposit(
                 deposit_address,
@@ -436,6 +436,7 @@ impl CrossChainService for OrchestraService {
                 prepared.token_identifier.as_deref(),
             )
             .await?;
+        let spark_tx_hash = asset_transfer.id();
         debug!("Orchestra: deposit transfer {spark_tx_hash} sent for quote {quote_id}");
 
         // Step 2: Submit the deposit to Orchestra.
@@ -476,22 +477,23 @@ impl CrossChainService for OrchestraService {
             }
         };
 
+        let conversion_info = ConversionInfo::Orchestra {
+            order_id: order_id.clone(),
+            quote_id: quote_id.clone(),
+            chain: prepared.pair.chain.clone(),
+            chain_id: prepared.pair.chain_id.clone(),
+            asset: prepared.pair.asset.clone(),
+            recipient_address: prepared.recipient_address.clone(),
+            estimated_out: prepared.estimated_out,
+            delivered_amount: None,
+            status,
+            fee: Some(prepared.fee_amount),
+            read_token,
+            asset_decimals: u32::from(prepared.pair.decimals),
+            asset_contract: prepared.pair.contract_address.clone(),
+        };
         let metadata = crate::PaymentMetadata {
-            conversion_info: Some(ConversionInfo::Orchestra {
-                order_id: order_id.clone(),
-                quote_id: quote_id.clone(),
-                chain: prepared.pair.chain.clone(),
-                chain_id: prepared.pair.chain_id.clone(),
-                asset: prepared.pair.asset.clone(),
-                recipient_address: prepared.recipient_address.clone(),
-                estimated_out: prepared.estimated_out,
-                delivered_amount: None,
-                status,
-                fee: Some(prepared.fee_amount),
-                read_token,
-                asset_decimals: u32::from(prepared.pair.decimals),
-                asset_contract: prepared.pair.contract_address.clone(),
-            }),
+            conversion_info: Some(conversion_info.clone()),
             ..Default::default()
         };
 
@@ -523,7 +525,7 @@ impl CrossChainService for OrchestraService {
         let storage = Arc::clone(&self.storage);
         let spark_wallet = self.spark_wallet.clone();
         let payment_id_for_poll = payment_id.clone();
-        poll_until(schedule, None, || {
+        let polled = poll_until(schedule, None, || {
             fetch_and_process_payment(
                 spark_wallet.as_ref(),
                 Arc::clone(&storage),
@@ -531,12 +533,35 @@ impl CrossChainService for OrchestraService {
                 false,
             )
         })
-        .await
-        .map_err(|e| {
-            SdkError::Generic(format!(
-                "Cross-chain send submitted (order {order_id}), but payment row not yet synced: {e}"
-            ))
-        })
+        .await;
+
+        match polled {
+            Ok(payment) => Ok(payment),
+            Err(e) => {
+                // Operator sync still in flight — the metadata is already
+                // cached, and `poll_in_flight_orders` will reconcile the
+                // payment row as soon as it lands. Surface a payment built
+                // from the deposit transfer (with the Orchestra
+                // `ConversionInfo` attached) so callers see the send as
+                // submitted rather than failed.
+                debug!(
+                    "Orchestra: payment row not yet visible (order {order_id}): {e}; returning fallback payment built from the deposit transfer"
+                );
+                let payment = crate::utils::conversions::payment_from_asset_transfer(
+                    asset_transfer,
+                    &self.spark_wallet,
+                    &self.storage,
+                    &payment_id,
+                )
+                .await?
+                .ok_or_else(|| {
+                    SdkError::Generic(format!(
+                        "Orchestra transfer produced no outgoing payment for {payment_id}"
+                    ))
+                })?;
+                Ok(payment_with_orchestra_info(payment, Some(conversion_info)))
+            }
+        }
     }
 }
 
@@ -544,6 +569,44 @@ impl CrossChainService for OrchestraService {
 /// source for receives.
 fn non_spark_side(r: &Route, is_send: bool) -> &RouteAsset {
     if is_send { &r.destination } else { &r.source }
+}
+
+/// Attaches the Orchestra [`ConversionInfo`] to a freshly-converted
+/// [`Payment`]. The payment's top-level `status` is left as-is — it reflects
+/// the local Spark/Token transfer settlement, while the cross-chain pending
+/// state lives inside `conversion_info.status`. Lightning / Withdraw /
+/// Deposit details pass through unchanged (they shouldn't occur on the
+/// Orchestra send path; this is defensive).
+fn payment_with_orchestra_info(
+    mut payment: crate::Payment,
+    conversion_info: Option<ConversionInfo>,
+) -> crate::Payment {
+    payment.details = match payment.details {
+        Some(PaymentDetails::Spark {
+            invoice_details,
+            htlc_details,
+            ..
+        }) => Some(PaymentDetails::Spark {
+            invoice_details,
+            htlc_details,
+            conversion_info,
+        }),
+        Some(PaymentDetails::Token {
+            metadata,
+            tx_hash,
+            tx_type,
+            invoice_details,
+            ..
+        }) => Some(PaymentDetails::Token {
+            metadata,
+            tx_hash,
+            tx_type,
+            invoice_details,
+            conversion_info,
+        }),
+        other => other,
+    };
+    payment
 }
 
 /// Whether a raw Orchestra route should appear in the deduplicated list,
@@ -975,6 +1038,118 @@ mod tests {
             Some(CrossChainAddressFamily::Evm),
             Some("0x1234567890123456789012345678901234567890")
         ));
+    }
+
+    // ---- with_orchestra_info ----
+
+    fn dummy_payment(method: crate::PaymentMethod, details: PaymentDetails) -> crate::Payment {
+        crate::Payment {
+            id: "p1".to_string(),
+            payment_type: crate::PaymentType::Send,
+            status: crate::PaymentStatus::Completed,
+            amount: 1_000,
+            fees: 0,
+            timestamp: 100,
+            method,
+            details: Some(details),
+            conversion_details: None,
+        }
+    }
+
+    #[test_all]
+    fn with_orchestra_info_injects_into_spark_details_and_preserves_status() {
+        let original_details = PaymentDetails::Spark {
+            invoice_details: None,
+            htlc_details: None,
+            conversion_info: None,
+        };
+        let payment = dummy_payment(crate::PaymentMethod::Spark, original_details);
+        let info = orchestra_info("ord1", "q1");
+
+        let out = payment_with_orchestra_info(payment, Some(info));
+
+        // Status reflects the local Spark transfer (already settled by the
+        // time we reach the fallback); cross-chain pending lives in
+        // conversion_info.status.
+        assert_eq!(out.status, crate::PaymentStatus::Completed);
+        assert!(matches!(
+            out.details,
+            Some(PaymentDetails::Spark {
+                conversion_info: Some(ConversionInfo::Orchestra { .. }),
+                ..
+            })
+        ));
+    }
+
+    #[test_all]
+    fn with_orchestra_info_preserves_spark_invoice_and_htlc_details() {
+        // Defensive: invoice_details / htlc_details on Spark payments must
+        // not be wiped by the override.
+        let original_details = PaymentDetails::Spark {
+            invoice_details: Some(crate::SparkInvoicePaymentDetails {
+                description: Some("preserved".to_string()),
+                invoice: "inv".to_string(),
+            }),
+            htlc_details: None,
+            conversion_info: None,
+        };
+        let payment = dummy_payment(crate::PaymentMethod::Spark, original_details);
+
+        let out = payment_with_orchestra_info(payment, None);
+
+        if let Some(PaymentDetails::Spark {
+            invoice_details, ..
+        }) = out.details
+        {
+            assert_eq!(
+                invoice_details.and_then(|d| d.description).as_deref(),
+                Some("preserved")
+            );
+        } else {
+            panic!("expected Spark details");
+        }
+    }
+
+    #[test_all]
+    fn with_orchestra_info_injects_into_token_details_and_preserves_metadata() {
+        let original_details = PaymentDetails::Token {
+            metadata: crate::TokenMetadata {
+                identifier: "btkn1usdb".to_string(),
+                issuer_public_key: "issuer".to_string(),
+                name: "Bitcoin USD".to_string(),
+                ticker: "USDB".to_string(),
+                decimals: 6,
+                max_supply: 0,
+                is_freezable: true,
+            },
+            tx_hash: "hash".to_string(),
+            tx_type: crate::TokenTransactionType::Transfer,
+            invoice_details: None,
+            conversion_info: None,
+        };
+        let payment = dummy_payment(crate::PaymentMethod::Token, original_details);
+        let info = orchestra_info("ord1", "q1");
+
+        let out = payment_with_orchestra_info(payment, Some(info));
+
+        // Top-level status reflects the local Token transfer.
+        assert_eq!(out.status, crate::PaymentStatus::Completed);
+        if let Some(PaymentDetails::Token {
+            metadata,
+            conversion_info,
+            ..
+        }) = out.details
+        {
+            // Real metadata fetched via the shared helper is preserved.
+            assert_eq!(metadata.ticker, "USDB");
+            assert_eq!(metadata.decimals, 6);
+            assert!(matches!(
+                conversion_info,
+                Some(ConversionInfo::Orchestra { .. })
+            ));
+        } else {
+            panic!("expected Token details");
+        }
     }
 
     // ---- apply_terminal_status ----

--- a/crates/breez-sdk/core/src/cross_chain/orchestra.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra.rs
@@ -4,17 +4,17 @@
 //! Handles quoting, sending (deposit + submit), and background monitoring
 //! of in-flight orders.
 
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use breez_sdk_common::input::CrossChainAddressFamily;
+use chrono::DateTime;
 use flashnet::OrchestraClient;
 use flashnet::orchestra::{
-    AmountMode, OrderStatus, QuoteRequest, QuoteResponse, Route, RouteAsset, SubmitResponse,
+    AmountMode, OrderStatus, QuoteRequest, QuoteResponse, Route, RouteAsset, StatusResponse,
+    SubmitResponse,
 };
-use platform_utils::time::Duration;
+use platform_utils::time::{Duration, SystemTime, UNIX_EPOCH};
 use platform_utils::tokio;
 use spark_wallet::SparkWallet;
 use tokio::{
@@ -50,8 +50,6 @@ fn parse_amount(value: &str, field: &str) -> Result<u128, SdkError> {
         .parse::<u128>()
         .map_err(|e| SdkError::Generic(format!("Orchestra returned invalid {field}: {e}")))
 }
-
-const DEFAULT_SLIPPAGE_BPS: u32 = 50;
 
 /// How often the background monitor polls in-flight orders.
 const MONITOR_INTERVAL: Duration = Duration::from_secs(30);
@@ -149,14 +147,10 @@ impl OrchestraService {
                 ]),
                 ..Default::default()
             })
-            .await
-            .map_err(|e| {
-                SdkError::Generic(format!("Failed to list pending Orchestra orders: {e}"))
-            })?;
+            .await?;
 
         debug!("Orchestra monitor: found {} pending orders", pending.len());
         for payment in &pending {
-            // Extract all Orchestra metadata fields in one destructure.
             let Some(
                 PaymentDetails::Spark {
                     conversion_info: Some(conversion_info),
@@ -169,7 +163,7 @@ impl OrchestraService {
             ) = &payment.details
             else {
                 debug!(
-                    "Orchestra monitor: payment {} has no Orchestra conversion_info, skipping",
+                    "Orchestra monitor: payment {} has no conversion_info, skipping",
                     payment.id
                 );
                 continue;
@@ -178,17 +172,11 @@ impl OrchestraService {
             let ConversionInfo::Orchestra {
                 order_id,
                 quote_id,
-                chain,
-                chain_id,
-                asset,
-                recipient_address,
-                estimated_out,
-                fee,
                 read_token,
-                asset_decimals,
-                asset_contract,
+                chain,
+                asset,
                 ..
-            } = conversion_info.clone()
+            } = conversion_info
             else {
                 debug!(
                     "Orchestra monitor: payment {} conversion_info is not Orchestra variant, skipping",
@@ -198,9 +186,9 @@ impl OrchestraService {
             };
 
             let lookup_id = if order_id.is_empty() {
-                &quote_id
+                quote_id
             } else {
-                &order_id
+                order_id
             };
             debug!(
                 "Orchestra monitor: checking payment {} (order={order_id}, quote={quote_id}, dest={chain}/{asset})",
@@ -211,9 +199,9 @@ impl OrchestraService {
             // (can happen if /submit failed but we still want to track).
             let rt = read_token.as_deref();
             let status_response = if order_id.is_empty() {
-                client.status_by_quote_id(&quote_id, rt).await
+                client.status_by_quote_id(quote_id, rt).await
             } else {
-                client.status_by_id(&order_id, rt).await
+                client.status_by_id(order_id, rt).await
             };
 
             let status_response = match status_response {
@@ -224,57 +212,24 @@ impl OrchestraService {
                 }
             };
 
-            let order_status = status_response.order.status;
             debug!(
-                "Orchestra monitor: payment {} order status: {order_status:?} (amount_out={:?})",
-                payment.id, status_response.order.amount_out,
+                "Orchestra monitor: payment {} order status: {:?} (amount_out={:?})",
+                payment.id, status_response.order.status, status_response.order.amount_out,
             );
 
-            if !order_status.is_terminal() {
+            let Some(updated_metadata) = apply_terminal_status(conversion_info, &status_response)
+            else {
                 debug!(
                     "Orchestra monitor: payment {} still in progress",
                     payment.id
                 );
                 continue;
-            }
-
-            let new_status = match order_status {
-                OrderStatus::Completed => ConversionStatus::Completed,
-                OrderStatus::Refunded => ConversionStatus::Refunded,
-                _ => ConversionStatus::Failed,
             };
-
-            // Use the real amounts from Orchestra status if available.
-            // Keep estimated_out frozen; set delivered_amount with the actual.
-            let delivered_amount = status_response
-                .order
-                .amount_out
-                .as_deref()
-                .and_then(|s| s.parse::<u128>().ok());
 
             debug!(
-                "Orchestra monitor: payment {} terminal → {new_status:?}, delivered={delivered_amount:?} (estimated was {estimated_out})",
+                "Orchestra monitor: payment {} terminal update built",
                 payment.id
             );
-
-            let updated_metadata = crate::PaymentMetadata {
-                conversion_info: Some(ConversionInfo::Orchestra {
-                    order_id,
-                    quote_id,
-                    chain,
-                    chain_id,
-                    asset,
-                    recipient_address,
-                    estimated_out,
-                    delivered_amount,
-                    status: new_status.clone(),
-                    fee,
-                    read_token,
-                    asset_decimals,
-                    asset_contract,
-                }),
-                ..Default::default()
-            };
 
             if let Err(e) = storage
                 .insert_payment_metadata(payment.id.clone(), updated_metadata)
@@ -286,7 +241,7 @@ impl OrchestraService {
                 );
             } else {
                 info!(
-                    "Orchestra order for payment {} reached terminal state: {new_status:?}",
+                    "Orchestra order for payment {} reached terminal state",
                     payment.id
                 );
             }
@@ -311,21 +266,8 @@ impl OrchestraService {
         dest: &CrossChainRoutePair,
         token_identifier: Option<&str>,
     ) -> Result<String, SdkError> {
-        let raw_routes =
-            self.client.spark_routes(true).await.map_err(|e| {
-                SdkError::Generic(format!("Failed to fetch cross-chain routes: {e}"))
-            })?;
-        let matched = raw_routes.iter().find(|r| {
-            let dest_matches = r.destination.chain == dest.chain
-                && r.destination.asset == dest.asset
-                && r.destination.contract_address == dest.contract_address;
-            let source_matches = match token_identifier {
-                None => r.source.asset.eq_ignore_ascii_case("BTC"),
-                Some(tid) => r.source.contract_address.as_deref() == Some(tid),
-            };
-            dest_matches && source_matches
-        });
-        matched.map(|r| r.source.asset.clone()).ok_or_else(|| {
+        let raw_routes = self.client.spark_routes(true).await?;
+        find_source_asset(&raw_routes, dest, token_identifier).ok_or_else(|| {
             SdkError::InvalidInput(format!(
                 "Orchestra does not offer a route for source {} → {}/{}",
                 token_identifier.unwrap_or("BTC"),
@@ -336,8 +278,40 @@ impl OrchestraService {
     }
 }
 
+/// Finds the Orchestra-side source asset wire symbol for the given
+/// `(dest, source)` pair.
+///
+/// Match semantics:
+/// - destination matches by `(chain, asset, contract_address)` exactly.
+/// - source matches by **case-insensitive** asset symbol when
+///   `token_identifier` is `None` (BTC source); otherwise by the source's
+///   `contract_address` (which on the Spark side is the bech32m token
+///   identifier) equalling `token_identifier`.
+///
+/// Returns the matched route's `source.asset` string (e.g. `"BTC"`,
+/// `"USDB"`). `None` if no route matches.
+fn find_source_asset(
+    routes: &[Route],
+    dest: &CrossChainRoutePair,
+    token_identifier: Option<&str>,
+) -> Option<String> {
+    routes
+        .iter()
+        .find(|r| {
+            let dest_matches = r.destination.chain == dest.chain
+                && r.destination.asset == dest.asset
+                && r.destination.contract_address == dest.contract_address;
+            let source_matches = match token_identifier {
+                None => r.source.asset.eq_ignore_ascii_case("BTC"),
+                Some(tid) => r.source.contract_address.as_deref() == Some(tid),
+            };
+            dest_matches && source_matches
+        })
+        .map(|r| r.source.asset.clone())
+}
+
 #[macros::async_trait]
-#[allow(clippy::too_many_lines, clippy::items_after_statements)]
+#[allow(clippy::too_many_lines)]
 impl CrossChainService for OrchestraService {
     async fn get_routes(
         &self,
@@ -357,71 +331,14 @@ impl CrossChainService for OrchestraService {
             }
         };
 
-        let routes =
-            self.client.spark_routes(is_send).await.map_err(|e| {
-                SdkError::Generic(format!("Failed to fetch cross-chain routes: {e}"))
-            })?;
+        let routes = self.client.spark_routes(is_send).await?;
 
-        // The non-Spark side of the route: for send it's the destination,
-        // for receive it's the source (the chain the user sends from).
-        fn non_spark_side(r: &Route, is_send: bool) -> &RouteAsset {
-            if is_send { &r.destination } else { &r.source }
-        }
-
-        // Multiple raw routes may exist for the same external chain (e.g.
-        // BTC→USDT-on-tron and USDB→USDT-on-tron). Dedup by (chain, asset,
-        // contract_address) so the caller only sees one route per external
-        // endpoint, but accumulate the Spark-side source variants into
-        // `supported_sources`.
-        type Key = (String, String, Option<String>);
-        let mut order: Vec<Key> = Vec::new();
-        let mut grouped: HashMap<Key, CrossChainRoutePair> = HashMap::new();
-
-        for r in routes.iter().filter(|r| {
-            let side = non_spark_side(r, is_send);
-            let ca = side.contract_address.as_deref();
-            family_filter.is_none_or(|f| f.matches_chain(&side.chain, ca))
-                && contract_filter.is_none_or(|filter_ca| ca.is_some_and(|c| c == filter_ca))
-        }) {
-            let side = non_spark_side(r, is_send);
-            let key: Key = (
-                side.chain.clone(),
-                side.asset.clone(),
-                side.contract_address.clone(),
-            );
-
-            // On send, the Spark side is `source`; on receive, it's `destination`.
-            let spark_side = if is_send { &r.source } else { &r.destination };
-            let source_variant = if spark_side.asset.eq_ignore_ascii_case("BTC") {
-                Some(SourceAsset::Bitcoin)
-            } else {
-                // Non-BTC Spark source without contract_address: defensive
-                // skip. Shouldn't happen per current Orchestra behavior.
-                spark_side
-                    .contract_address
-                    .as_ref()
-                    .map(|ca| SourceAsset::Token {
-                        token_identifier: ca.clone(),
-                    })
-            };
-
-            let entry = grouped.entry(key.clone()).or_insert_with(|| {
-                order.push(key.clone());
-                side_to_route_pair(side, r.exact_out_eligible)
-            });
-
-            if let Some(variant) = source_variant
-                && !entry.supported_sources.contains(&variant)
-            {
-                entry.supported_sources.push(variant);
-            }
-        }
-
-        let pairs: Vec<CrossChainRoutePair> = order
-            .into_iter()
-            .filter_map(|k| grouped.remove(&k))
-            .collect();
-        Ok(pairs)
+        Ok(dedupe_routes(
+            &routes,
+            is_send,
+            family_filter,
+            contract_filter,
+        ))
     }
 
     async fn prepare(
@@ -430,7 +347,7 @@ impl CrossChainService for OrchestraService {
         route: &CrossChainRoutePair,
         amount: u128,
         token_identifier: Option<String>,
-        max_slippage_bps: Option<u32>,
+        max_slippage_bps: u32,
         fee_mode: CrossChainFeeMode,
     ) -> Result<CrossChainPrepared, SdkError> {
         let source_asset = self
@@ -446,7 +363,7 @@ impl CrossChainService for OrchestraService {
             recipient_address: recipient_address.to_string(),
             amount_mode: Some(AmountMode::ExactIn),
             refund_address: None,
-            slippage_bps: Some(max_slippage_bps.unwrap_or(DEFAULT_SLIPPAGE_BPS)),
+            slippage_bps: Some(max_slippage_bps),
             zeroconf_enabled: None,
             app_fees: Vec::new(),
             affiliate_id: None,
@@ -460,11 +377,7 @@ impl CrossChainService for OrchestraService {
             request.destination_asset,
             request.amount
         );
-        let quote: QuoteResponse = self
-            .client
-            .quote(request)
-            .await
-            .map_err(|e| SdkError::Generic(format!("Orchestra: {e}")))?;
+        let quote: QuoteResponse = self.client.quote(request).await?;
         debug!("Orchestra: quote response: {:?}", quote);
 
         let amount_in = parse_amount(&quote.amount_in, "amountIn")?;
@@ -512,6 +425,8 @@ impl CrossChainService for OrchestraService {
             ));
         };
 
+        validate_quote_expiry(&prepared.expires_at)?;
+
         // Step 1: Spark transfer to the Orchestra deposit address.
         let spark_tx_hash = self
             .client
@@ -520,8 +435,7 @@ impl CrossChainService for OrchestraService {
                 prepared.amount_in,
                 prepared.token_identifier.as_deref(),
             )
-            .await
-            .map_err(|e| SdkError::Generic(format!("Orchestra deposit transfer failed: {e}")))?;
+            .await?;
         debug!("Orchestra: deposit transfer {spark_tx_hash} sent for quote {quote_id}");
 
         // Step 2: Submit the deposit to Orchestra.
@@ -597,8 +511,7 @@ impl CrossChainService for OrchestraService {
         self.trigger_monitor();
 
         // Surface a submit error before kicking off polling.
-        let submit_response =
-            submit_res.map_err(|e| SdkError::Generic(format!("Orchestra submit failed: {e}")))?;
+        let submit_response = submit_res?;
         let order_id = submit_response.order_id;
 
         // Poll the outbound Spark transfer until it settles to terminal status.
@@ -627,6 +540,189 @@ impl CrossChainService for OrchestraService {
     }
 }
 
+/// Returns the route side opposite the Spark wallet — destination for sends,
+/// source for receives.
+fn non_spark_side(r: &Route, is_send: bool) -> &RouteAsset {
+    if is_send { &r.destination } else { &r.source }
+}
+
+/// Whether a raw Orchestra route should appear in the deduplicated list,
+/// given the caller's address-family and contract-address filters.
+///
+/// Both filters operate on the non-Spark side of the route:
+/// - `family_filter` restricts to routes whose chain/contract matches the
+///   address family (e.g. EVM, Solana).
+/// - `contract_filter` restricts to routes whose contract address equals
+///   the supplied value.
+///
+/// `None` for either filter is a pass-through.
+fn route_passes_filters(
+    r: &Route,
+    is_send: bool,
+    family_filter: Option<CrossChainAddressFamily>,
+    contract_filter: Option<&str>,
+) -> bool {
+    let side = non_spark_side(r, is_send);
+    let contract = side.contract_address.as_deref();
+    let family_ok = family_filter.is_none_or(|f| f.matches_chain(&side.chain, contract));
+    let contract_ok = contract_filter.is_none_or(|wanted| contract == Some(wanted));
+    family_ok && contract_ok
+}
+
+/// Given the current Orchestra [`ConversionInfo`] on a payment plus a fresh
+/// [`StatusResponse`], computes the [`PaymentMetadata`] to write back if the
+/// order has reached terminal state, otherwise `None`.
+///
+/// Status mapping:
+/// - `Completed` → `ConversionStatus::Completed`
+/// - `Refunded`  → `ConversionStatus::Refunded`
+/// - any other terminal status → `ConversionStatus::Failed`
+/// - non-terminal → `None` (caller skips)
+///
+/// `delivered_amount` is parsed from `status_response.order.amount_out` when
+/// the field is present and parses as `u128`; `estimated_out` is frozen at
+/// prepare-time and preserved verbatim.
+fn apply_terminal_status(
+    info: &ConversionInfo,
+    status_response: &StatusResponse,
+) -> Option<crate::PaymentMetadata> {
+    let ConversionInfo::Orchestra {
+        order_id,
+        quote_id,
+        chain,
+        chain_id,
+        asset,
+        recipient_address,
+        estimated_out,
+        fee,
+        read_token,
+        asset_decimals,
+        asset_contract,
+        ..
+    } = info
+    else {
+        return None;
+    };
+
+    let order_status = status_response.order.status;
+    if !order_status.is_terminal() {
+        return None;
+    }
+    let new_status = match order_status {
+        OrderStatus::Completed => ConversionStatus::Completed,
+        OrderStatus::Refunded => ConversionStatus::Refunded,
+        _ => ConversionStatus::Failed,
+    };
+
+    let delivered_amount = status_response
+        .order
+        .amount_out
+        .as_deref()
+        .and_then(|s| s.parse::<u128>().ok());
+
+    Some(crate::PaymentMetadata {
+        conversion_info: Some(ConversionInfo::Orchestra {
+            order_id: order_id.clone(),
+            quote_id: quote_id.clone(),
+            chain: chain.clone(),
+            chain_id: chain_id.clone(),
+            asset: asset.clone(),
+            recipient_address: recipient_address.clone(),
+            estimated_out: *estimated_out,
+            delivered_amount,
+            status: new_status,
+            fee: *fee,
+            read_token: read_token.clone(),
+            asset_decimals: *asset_decimals,
+            asset_contract: asset_contract.clone(),
+        }),
+        ..Default::default()
+    })
+}
+
+/// Orchestra quotes carry `expires_at` as an RFC3339 timestamp. Reject at
+/// send time if the wall clock has passed it so the user sees a clean
+/// "quote expired, re-prepare" rather than the API rejecting the submit.
+fn validate_quote_expiry(expires_at: &str) -> Result<(), SdkError> {
+    let exp = DateTime::parse_from_rfc3339(expires_at).map_err(|e| {
+        SdkError::Generic(format!("Orchestra: invalid expires_at {expires_at:?}: {e}"))
+    })?;
+    let exp_secs = u64::try_from(exp.timestamp()).unwrap_or(0);
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| SdkError::Generic("Failed to read current time".to_string()))?
+        .as_secs();
+    if now_secs >= exp_secs {
+        return Err(SdkError::InvalidInput(
+            "Cross-chain quote has expired. Please re-prepare.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Dedupes Orchestra's raw `Route` list into the SDK's [`CrossChainRoutePair`]
+/// shape — one pair per `(chain, asset, contract_address)` endpoint with the
+/// supported Spark-side source variants accumulated into `supported_sources`.
+///
+/// Multiple raw routes can exist for the same external chain (e.g.
+/// `BTC→USDT-on-tron` and `USDB→USDT-on-tron`); the caller wants to see one
+/// `USDT-on-tron` route advertising both source variants.
+fn dedupe_routes(
+    routes: &[Route],
+    is_send: bool,
+    family_filter: Option<CrossChainAddressFamily>,
+    contract_filter: Option<&str>,
+) -> Vec<CrossChainRoutePair> {
+    type Key = (String, String, Option<String>);
+    let mut order: Vec<Key> = Vec::new();
+    let mut grouped: HashMap<Key, CrossChainRoutePair> = HashMap::new();
+
+    for r in routes
+        .iter()
+        .filter(|r| route_passes_filters(r, is_send, family_filter, contract_filter))
+    {
+        let side = non_spark_side(r, is_send);
+        let key: Key = (
+            side.chain.clone(),
+            side.asset.clone(),
+            side.contract_address.clone(),
+        );
+
+        // On send, the Spark side is `source`; on receive, it's `destination`.
+        // Orchestra's `contract_address` on the Spark side is the bech32m
+        // token identifier (`btkn1...`).
+        let spark_side = if is_send { &r.source } else { &r.destination };
+        let source_variant = if spark_side.asset.eq_ignore_ascii_case("BTC") {
+            Some(SourceAsset::Bitcoin)
+        } else {
+            // Non-BTC Spark source without a token identifier: defensive skip.
+            // Shouldn't happen per current Orchestra behavior.
+            spark_side
+                .contract_address
+                .as_ref()
+                .map(|tid| SourceAsset::Token {
+                    token_identifier: tid.clone(),
+                })
+        };
+
+        let entry = grouped.entry(key.clone()).or_insert_with(|| {
+            order.push(key.clone());
+            side_to_route_pair(side, r.exact_out_eligible)
+        });
+
+        if let Some(variant) = source_variant
+            && !entry.supported_sources.contains(&variant)
+        {
+            entry.supported_sources.push(variant);
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|k| grouped.remove(&k))
+        .collect()
+}
+
 /// Build a [`CrossChainRoutePair`] from one side of an Orchestra [`Route`].
 ///
 /// Chain/asset/identifier/decimals pass through verbatim from the route's
@@ -648,6 +744,10 @@ fn side_to_route_pair(side: &RouteAsset, exact_out_eligible: bool) -> CrossChain
 #[cfg(test)]
 mod tests {
     use super::*;
+    use macros::test_all;
+
+    #[cfg(feature = "browser-tests")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     fn test_route_asset(chain: &str, chain_id: Option<&str>) -> RouteAsset {
         RouteAsset {
@@ -659,7 +759,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[test_all]
     fn side_to_pair_passes_through_chain_id() {
         let side = test_route_asset("base", Some("8453"));
         let pair = side_to_route_pair(&side, true);
@@ -680,7 +780,7 @@ mod tests {
         assert!(pair.exact_out_eligible);
     }
 
-    #[test]
+    #[test_all]
     fn side_to_pair_preserves_missing_chain_id() {
         let side = test_route_asset("solana", None);
         let pair = side_to_route_pair(&side, false);
@@ -690,5 +790,453 @@ mod tests {
             "chain_id stays None when the route asset doesn't expose one"
         );
         assert!(!pair.exact_out_eligible);
+    }
+
+    // ---- dedupe_routes ----
+
+    fn ra(chain: &str, asset: &str, contract: Option<&str>) -> RouteAsset {
+        RouteAsset {
+            chain: chain.to_string(),
+            asset: asset.to_string(),
+            contract_address: contract.map(str::to_string),
+            decimals: 6,
+            chain_id: None,
+        }
+    }
+
+    fn route(source: RouteAsset, destination: RouteAsset) -> Route {
+        Route {
+            source_chain: source.chain.clone(),
+            source_asset: source.asset.clone(),
+            destination_chain: destination.chain.clone(),
+            destination_asset: destination.asset.clone(),
+            exact_out_eligible: false,
+            source,
+            destination,
+        }
+    }
+
+    #[test_all]
+    fn dedupe_routes_accumulates_source_variants() {
+        // Same external endpoint (tron/USDT) fronted by two Spark sources
+        // (BTC and a USDB token). Caller should see one pair with both
+        // variants in `supported_sources`.
+        let usdb_contract = "btkn1usdb_contract";
+        let routes = vec![
+            route(
+                ra("spark", "BTC", None),
+                ra("tron", "USDT", Some("TXYZtronUsdt")),
+            ),
+            route(
+                ra("spark", "USDB", Some(usdb_contract)),
+                ra("tron", "USDT", Some("TXYZtronUsdt")),
+            ),
+        ];
+
+        let pairs = dedupe_routes(&routes, true, None, None);
+
+        assert_eq!(
+            pairs.len(),
+            1,
+            "same external endpoint must dedup to one pair"
+        );
+        let p = &pairs[0];
+        assert_eq!(p.chain, "tron");
+        assert_eq!(p.asset, "USDT");
+        assert!(p.supported_sources.contains(&SourceAsset::Bitcoin));
+        assert!(p.supported_sources.contains(&SourceAsset::Token {
+            token_identifier: usdb_contract.to_string(),
+        }));
+    }
+
+    #[test_all]
+    fn dedupe_routes_separates_different_endpoints() {
+        let routes = vec![
+            route(ra("spark", "BTC", None), ra("tron", "USDT", Some("TXYZ1"))),
+            route(ra("spark", "BTC", None), ra("base", "USDC", Some("0xABC"))),
+        ];
+
+        let pairs = dedupe_routes(&routes, true, None, None);
+
+        assert_eq!(pairs.len(), 2);
+        // Insertion order preserved.
+        assert_eq!(pairs[0].chain, "tron");
+        assert_eq!(pairs[0].asset, "USDT");
+        assert_eq!(pairs[1].chain, "base");
+        assert_eq!(pairs[1].asset, "USDC");
+    }
+
+    #[test_all]
+    fn dedupe_routes_applies_contract_filter() {
+        let routes = vec![
+            route(ra("spark", "BTC", None), ra("base", "USDC", Some("0xAAA"))),
+            route(ra("spark", "BTC", None), ra("base", "USDC", Some("0xBBB"))),
+        ];
+
+        let pairs = dedupe_routes(&routes, true, None, Some("0xBBB"));
+
+        assert_eq!(pairs.len(), 1, "contract filter narrows the result set");
+        assert_eq!(pairs[0].contract_address.as_deref(), Some("0xBBB"));
+    }
+
+    #[test_all]
+    fn dedupe_routes_receive_swaps_spark_side() {
+        // For receives, the non-Spark side is the *source* and the Spark
+        // side is the *destination*. The same dedup logic should group
+        // by the source side.
+        let routes = vec![
+            route(ra("base", "USDC", Some("0xABC")), ra("spark", "BTC", None)),
+            route(
+                ra("base", "USDC", Some("0xABC")),
+                ra("spark", "USDB", Some("btkn1usdb")),
+            ),
+        ];
+
+        let pairs = dedupe_routes(&routes, false, None, None);
+
+        assert_eq!(pairs.len(), 1, "receive dedup groups by source side");
+        assert_eq!(pairs[0].chain, "base");
+        assert!(pairs[0].supported_sources.contains(&SourceAsset::Bitcoin));
+        assert!(pairs[0].supported_sources.contains(&SourceAsset::Token {
+            token_identifier: "btkn1usdb".to_string(),
+        }));
+    }
+
+    // ---- route_passes_filters ----
+
+    #[test_all]
+    fn route_passes_filters_accepts_when_both_filters_none() {
+        let r = route(ra("spark", "BTC", None), ra("base", "USDC", Some("0xAAA")));
+        assert!(route_passes_filters(&r, true, None, None));
+    }
+
+    #[test_all]
+    fn route_passes_filters_contract_filter_rejects_mismatch() {
+        let r = route(ra("spark", "BTC", None), ra("base", "USDC", Some("0xAAA")));
+        assert!(!route_passes_filters(&r, true, None, Some("0xBBB")));
+        assert!(route_passes_filters(&r, true, None, Some("0xAAA")));
+    }
+
+    #[test_all]
+    fn route_passes_filters_family_filter_evm_matches_via_contract_address() {
+        // EVM family matches when the contract_address parses as EVM hex.
+        let r = route(
+            ra("spark", "BTC", None),
+            ra(
+                "arbitrum",
+                "USDT",
+                Some("0x1234567890123456789012345678901234567890"),
+            ),
+        );
+        assert!(route_passes_filters(
+            &r,
+            true,
+            Some(CrossChainAddressFamily::Evm),
+            None
+        ));
+    }
+
+    #[test_all]
+    fn route_passes_filters_family_filter_rejects_wrong_family() {
+        // Tron chain shouldn't match Solana family.
+        let r = route(
+            ra("spark", "BTC", None),
+            ra("tron", "USDT", Some("TXYZtronUsdt")),
+        );
+        assert!(!route_passes_filters(
+            &r,
+            true,
+            Some(CrossChainAddressFamily::Solana),
+            None
+        ));
+    }
+
+    #[test_all]
+    fn route_passes_filters_both_filters_must_match() {
+        let r = route(
+            ra("spark", "BTC", None),
+            ra(
+                "arbitrum",
+                "USDT",
+                Some("0x1234567890123456789012345678901234567890"),
+            ),
+        );
+        // Family matches but contract doesn't → reject.
+        assert!(!route_passes_filters(
+            &r,
+            true,
+            Some(CrossChainAddressFamily::Evm),
+            Some("0xdeadbeef")
+        ));
+        // Both match → accept.
+        assert!(route_passes_filters(
+            &r,
+            true,
+            Some(CrossChainAddressFamily::Evm),
+            Some("0x1234567890123456789012345678901234567890")
+        ));
+    }
+
+    // ---- apply_terminal_status ----
+
+    fn orchestra_info(order_id: &str, quote_id: &str) -> ConversionInfo {
+        ConversionInfo::Orchestra {
+            order_id: order_id.to_string(),
+            quote_id: quote_id.to_string(),
+            chain: "base".to_string(),
+            chain_id: Some("8453".to_string()),
+            asset: "USDC".to_string(),
+            recipient_address: "0xabc".to_string(),
+            estimated_out: 1_000_000,
+            delivered_amount: None,
+            status: ConversionStatus::Pending,
+            fee: Some(50),
+            read_token: Some("rt_token".to_string()),
+            asset_decimals: 6,
+            asset_contract: Some("0xUSDC".to_string()),
+        }
+    }
+
+    fn status_response(status: OrderStatus, amount_out: Option<&str>) -> StatusResponse {
+        StatusResponse {
+            order: flashnet::orchestra::Order {
+                id: "ord1".to_string(),
+                status,
+                quote_id: "q1".to_string(),
+                source_chain: "spark".to_string(),
+                source_asset: "BTC".to_string(),
+                source_address: None,
+                source_tx_hash: "txh".to_string(),
+                source_tx_vout: None,
+                deposit_address: "dep".to_string(),
+                destination_chain: "base".to_string(),
+                destination_asset: "USDC".to_string(),
+                recipient_address: "0xabc".to_string(),
+                amount_in: "1000".to_string(),
+                amount_out: amount_out.map(str::to_string),
+                fee_bps: 50,
+                fee_amount: "50".to_string(),
+                slippage_bps: 100,
+                error_code: None,
+                error_message: None,
+                created_at: "0".to_string(),
+                updated_at: "0".to_string(),
+                completed_at: None,
+            },
+            stages: Vec::new(),
+        }
+    }
+
+    fn assert_orchestra_status(metadata: &crate::PaymentMetadata, expected: &ConversionStatus) {
+        let info = metadata
+            .conversion_info
+            .as_ref()
+            .expect("metadata should have conversion_info");
+        match info {
+            ConversionInfo::Orchestra { status, .. } => assert_eq!(status, expected),
+            other => panic!("expected Orchestra variant, got {other:?}"),
+        }
+    }
+
+    #[test_all]
+    fn apply_terminal_status_skips_pending() {
+        let info = orchestra_info("ord1", "q1");
+        let resp = status_response(OrderStatus::Processing, Some("999000"));
+        assert!(apply_terminal_status(&info, &resp).is_none());
+    }
+
+    #[test_all]
+    fn apply_terminal_status_skips_non_orchestra_variant() {
+        let amm_info = ConversionInfo::Amm {
+            pool_id: "pool".to_string(),
+            conversion_id: "cid".to_string(),
+            status: ConversionStatus::Pending,
+            fee: None,
+            purpose: None,
+            amount_adjustment: None,
+        };
+        let resp = status_response(OrderStatus::Completed, Some("999000"));
+        assert!(apply_terminal_status(&amm_info, &resp).is_none());
+    }
+
+    #[test_all]
+    fn apply_terminal_status_maps_completed() {
+        let info = orchestra_info("ord1", "q1");
+        let resp = status_response(OrderStatus::Completed, Some("999000"));
+        let updated = apply_terminal_status(&info, &resp).expect("terminal");
+        assert_orchestra_status(&updated, &ConversionStatus::Completed);
+        if let Some(ConversionInfo::Orchestra {
+            delivered_amount,
+            estimated_out,
+            ..
+        }) = &updated.conversion_info
+        {
+            assert_eq!(*delivered_amount, Some(999_000));
+            assert_eq!(*estimated_out, 1_000_000, "estimated_out stays frozen");
+        }
+    }
+
+    #[test_all]
+    fn apply_terminal_status_maps_refunded() {
+        let info = orchestra_info("ord1", "q1");
+        let resp = status_response(OrderStatus::Refunded, None);
+        let updated = apply_terminal_status(&info, &resp).expect("terminal");
+        assert_orchestra_status(&updated, &ConversionStatus::Refunded);
+        if let Some(ConversionInfo::Orchestra {
+            delivered_amount, ..
+        }) = &updated.conversion_info
+        {
+            assert_eq!(*delivered_amount, None, "no amount_out → None");
+        }
+    }
+
+    #[test_all]
+    fn apply_terminal_status_maps_failed() {
+        let info = orchestra_info("ord1", "q1");
+        let resp = status_response(OrderStatus::Failed, None);
+        let updated = apply_terminal_status(&info, &resp).expect("terminal");
+        assert_orchestra_status(&updated, &ConversionStatus::Failed);
+    }
+
+    #[test_all]
+    fn apply_terminal_status_ignores_unparseable_amount_out() {
+        let info = orchestra_info("ord1", "q1");
+        let resp = status_response(OrderStatus::Completed, Some("not-a-number"));
+        let updated = apply_terminal_status(&info, &resp).expect("terminal");
+        if let Some(ConversionInfo::Orchestra {
+            delivered_amount, ..
+        }) = &updated.conversion_info
+        {
+            assert_eq!(*delivered_amount, None, "unparseable amount_out → None");
+        }
+    }
+
+    // ---- find_source_asset ----
+
+    fn dest_pair(chain: &str, asset: &str, contract: Option<&str>) -> CrossChainRoutePair {
+        CrossChainRoutePair {
+            provider: CrossChainProvider::Orchestra,
+            chain: chain.to_string(),
+            chain_id: None,
+            asset: asset.to_string(),
+            contract_address: contract.map(str::to_string),
+            decimals: 6,
+            exact_out_eligible: false,
+            supported_sources: Vec::new(),
+        }
+    }
+
+    #[test_all]
+    fn find_source_asset_matches_btc_source_case_insensitively() {
+        // Source side asset is "btc" lowercase; lookup should still match.
+        let routes = vec![route(
+            ra("spark", "btc", None),
+            ra("base", "USDC", Some("0xUSDC")),
+        )];
+        let dest = dest_pair("base", "USDC", Some("0xUSDC"));
+        assert_eq!(
+            find_source_asset(&routes, &dest, None).as_deref(),
+            Some("btc")
+        );
+    }
+
+    #[test_all]
+    fn find_source_asset_matches_token_source_by_contract_address() {
+        let routes = vec![
+            route(ra("spark", "BTC", None), ra("base", "USDC", Some("0xUSDC"))),
+            route(
+                ra("spark", "USDB", Some("btkn1usdb_contract")),
+                ra("base", "USDC", Some("0xUSDC")),
+            ),
+        ];
+        let dest = dest_pair("base", "USDC", Some("0xUSDC"));
+        assert_eq!(
+            find_source_asset(&routes, &dest, Some("btkn1usdb_contract")).as_deref(),
+            Some("USDB")
+        );
+    }
+
+    #[test_all]
+    fn find_source_asset_returns_none_when_destination_mismatch() {
+        let routes = vec![route(
+            ra("spark", "BTC", None),
+            ra("base", "USDC", Some("0xUSDC")),
+        )];
+        // Different destination chain.
+        let dest = dest_pair("tron", "USDC", Some("0xUSDC"));
+        assert!(find_source_asset(&routes, &dest, None).is_none());
+    }
+
+    #[test_all]
+    fn find_source_asset_returns_none_when_token_identifier_mismatch() {
+        let routes = vec![route(
+            ra("spark", "USDB", Some("btkn1usdb")),
+            ra("base", "USDC", Some("0xUSDC")),
+        )];
+        let dest = dest_pair("base", "USDC", Some("0xUSDC"));
+        assert!(find_source_asset(&routes, &dest, Some("btkn1other")).is_none());
+    }
+
+    #[test_all]
+    fn find_source_asset_distinguishes_contract_address_when_chain_repeats() {
+        // Two routes to the same chain/asset but different destination contracts.
+        let routes = vec![
+            route(ra("spark", "BTC", None), ra("base", "USDC", Some("0xAAA"))),
+            route(ra("spark", "BTC", None), ra("base", "USDC", Some("0xBBB"))),
+        ];
+        let dest = dest_pair("base", "USDC", Some("0xBBB"));
+        // The match logic uses contract_address as part of the destination
+        // identity, so this picks the second route.
+        assert_eq!(
+            find_source_asset(&routes, &dest, None).as_deref(),
+            Some("BTC")
+        );
+    }
+
+    // ---- validate_quote_expiry ----
+
+    #[test_all]
+    fn validate_quote_expiry_accepts_future_rfc3339() {
+        use platform_utils::time::{SystemTime, UNIX_EPOCH};
+        let future_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .saturating_add(600);
+        let dt =
+            chrono::DateTime::<chrono::Utc>::from_timestamp(future_secs.cast_signed(), 0).unwrap();
+        let s = dt.to_rfc3339();
+        assert!(validate_quote_expiry(&s).is_ok());
+    }
+
+    #[test_all]
+    fn validate_quote_expiry_rejects_past_rfc3339() {
+        // 2001-09-09 — well in the past.
+        let err = validate_quote_expiry("2001-09-09T01:46:40Z").unwrap_err();
+        assert!(matches!(err, SdkError::InvalidInput(ref m) if m.contains("expired")));
+    }
+
+    #[test_all]
+    fn validate_quote_expiry_rejects_malformed() {
+        let err = validate_quote_expiry("not-a-timestamp").unwrap_err();
+        assert!(matches!(err, SdkError::Generic(ref m) if m.contains("invalid expires_at")));
+    }
+
+    #[test_all]
+    fn dedupe_routes_skips_non_btc_spark_source_without_contract() {
+        // Defensive: a non-BTC Spark side missing `contract_address` would
+        // be silently dropped as a source variant. This shouldn't happen
+        // in practice but the path is exercised here.
+        let routes = vec![route(
+            ra("spark", "MYSTERY", None),
+            ra("base", "USDC", Some("0xABC")),
+        )];
+
+        let pairs = dedupe_routes(&routes, true, None, None);
+
+        // The route still produces a pair (the destination still matters),
+        // but `supported_sources` is empty.
+        assert_eq!(pairs.len(), 1);
+        assert!(pairs[0].supported_sources.is_empty());
     }
 }

--- a/crates/breez-sdk/core/src/error.rs
+++ b/crates/breez-sdk/core/src/error.rs
@@ -113,6 +113,29 @@ impl From<flashnet::FlashnetError> for SdkError {
     }
 }
 
+impl From<boltz_client::BoltzError> for SdkError {
+    fn from(e: boltz_client::BoltzError) -> Self {
+        use boltz_client::BoltzError;
+        match e {
+            BoltzError::Api { reason, code } => {
+                let code = match code {
+                    Some(c) => format!(" (code: {c})"),
+                    None => String::new(),
+                };
+                SdkError::NetworkError(format!("Boltz API: {reason}{code}"))
+            }
+            BoltzError::WebSocket(s) => SdkError::NetworkError(format!("Boltz WebSocket: {s}")),
+            BoltzError::Store(s) => SdkError::StorageError(format!("Boltz store: {s}")),
+            BoltzError::AmountOutOfRange { .. }
+            | BoltzError::QuoteExpired
+            | BoltzError::InvalidQuote(_)
+            | BoltzError::QuoteDegradedBeyondSlippage { .. }
+            | BoltzError::DuplicatePreimage => SdkError::InvalidInput(e.to_string()),
+            _ => SdkError::Generic(format!("Boltz: {e}")),
+        }
+    }
+}
+
 impl From<crate::token_conversion::ConversionError> for SdkError {
     fn from(e: crate::token_conversion::ConversionError) -> Self {
         use crate::token_conversion::ConversionError;

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -941,17 +941,24 @@ impl Config {
             ));
         }
 
-        if let Some(cc) = &self.cross_chain_config
-            && let Some(bps) = cc.default_slippage_bps
-            && !(crate::cross_chain::MIN_CROSS_CHAIN_SLIPPAGE_BPS
-                ..=crate::cross_chain::MAX_CROSS_CHAIN_SLIPPAGE_BPS)
-                .contains(&bps)
-        {
-            return Err(SdkError::InvalidInput(format!(
-                "cross_chain_config.default_slippage_bps {bps} must be in {}..={}",
-                crate::cross_chain::MIN_CROSS_CHAIN_SLIPPAGE_BPS,
-                crate::cross_chain::MAX_CROSS_CHAIN_SLIPPAGE_BPS,
-            )));
+        if let Some(cc) = &self.cross_chain_config {
+            if self.network != Network::Mainnet {
+                return Err(SdkError::InvalidInput(format!(
+                    "Cross-chain sends are only available on Mainnet, not on {}.",
+                    self.network,
+                )));
+            }
+            if let Some(bps) = cc.default_slippage_bps
+                && !(crate::cross_chain::MIN_CROSS_CHAIN_SLIPPAGE_BPS
+                    ..=crate::cross_chain::MAX_CROSS_CHAIN_SLIPPAGE_BPS)
+                    .contains(&bps)
+            {
+                return Err(SdkError::InvalidInput(format!(
+                    "Default cross-chain slippage must be between {} and {} basis points, but got {bps}.",
+                    crate::cross_chain::MIN_CROSS_CHAIN_SLIPPAGE_BPS,
+                    crate::cross_chain::MAX_CROSS_CHAIN_SLIPPAGE_BPS,
+                )));
+            }
         }
 
         Ok(())

--- a/crates/breez-sdk/core/src/sdk/payments/prepare/cross_chain.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/prepare/cross_chain.rs
@@ -203,8 +203,8 @@ pub(crate) async fn prepare(
         effective_conversion_options.as_ref(),
     )?;
 
-    let is_conversion = effective_conversion_options.is_some();
-    let effective_fee_policy = effective_fee_policy(is_conversion, fee_policy);
+    let effective_fee_policy =
+        effective_fee_policy(effective_conversion_options.is_some(), fee_policy);
 
     let fee_mode = match effective_fee_policy {
         FeePolicy::FeesExcluded => CrossChainFeeMode::FeesExcluded,
@@ -216,22 +216,21 @@ pub(crate) async fn prepare(
     // `source_token_identifier` is `None` on the conversion path because the
     // converted output is sats — both the provider leg and the response use
     // it directly without a token denomination.
-    let (provider_amount, conversion_estimate, source_token_identifier) = if is_conversion {
-        let opts = effective_conversion_options
-            .as_ref()
-            .expect("is_conversion implies effective_conversion_options is_some");
-        let (sats, estimate) = estimate_and_validate_conversion(
-            sdk,
-            opts,
-            token_identifier.as_ref(),
-            amount,
-            effective_fee_policy,
-        )
-        .await?;
-        (sats, estimate, None)
-    } else {
-        (amount, None, token_identifier.clone())
-    };
+    let (provider_amount, conversion_estimate, source_token_identifier) =
+        match effective_conversion_options.as_ref() {
+            Some(opts) => {
+                let (sats, estimate) = estimate_and_validate_conversion(
+                    sdk,
+                    opts,
+                    token_identifier.as_ref(),
+                    amount,
+                    effective_fee_policy,
+                )
+                .await?;
+                (sats, estimate, None)
+            }
+            None => (amount, None, token_identifier.clone()),
+        };
 
     let service = sdk.cross_chain_providers.get(route.provider)?;
     let prepared = service
@@ -240,7 +239,7 @@ pub(crate) async fn prepare(
             route,
             provider_amount,
             source_token_identifier.clone(),
-            Some(provider_slippage_bps),
+            provider_slippage_bps,
             fee_mode,
         )
         .await?;

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -388,7 +388,7 @@ impl SdkBuilder {
             }
             if self.config.cross_chain_config.is_some() {
                 return Err(SdkError::InvalidInput(
-                    "cross_chain_config must be None when background_tasks_enabled is false"
+                    "Cross-chain config must be unset when background tasks are disabled"
                         .to_string(),
                 ));
             }
@@ -896,21 +896,27 @@ mod tests {
         }
     }
 
+    /// Regtest + `cross_chain_config` trips the Mainnet-only gate in
+    /// `Config::validate` before reaching the server-mode reject in
+    /// `build`. The server-mode gate is still in place (verified by the
+    /// inline check in `build`); this test pins the more specific failure.
     #[tokio::test]
-    async fn server_mode_rejects_cross_chain_config() {
-        use crate::{CrossChainConfig, SdkError, default_server_config};
-
-        let mut config = default_server_config(Network::Regtest);
+    async fn build_rejects_cross_chain_config_on_regtest() {
+        use crate::{CrossChainConfig, SdkError, default_config};
+        let mut config = default_config(Network::Regtest);
         config.cross_chain_config = Some(CrossChainConfig::default());
 
         let seed = test_seed();
         let result = SdkBuilder::new(config, seed).build().await;
         match result {
-            Err(SdkError::InvalidInput(message)) => {
-                assert!(message.contains("cross_chain_config"));
+            Err(SdkError::InvalidInput(m)) => {
+                assert!(
+                    m.contains("only available on Mainnet"),
+                    "expected mainnet-only rejection, got: {m}"
+                );
             }
             Err(err) => panic!("expected InvalidInput error, got {err:?}"),
-            Ok(_) => panic!("expected server mode with cross_chain_config to fail"),
+            Ok(_) => panic!("expected regtest with cross_chain_config to fail"),
         }
     }
 

--- a/crates/breez-sdk/core/src/token_conversion/flashnet.rs
+++ b/crates/breez-sdk/core/src/token_conversion/flashnet.rs
@@ -13,12 +13,11 @@ use tracing::{debug, error, info, warn};
 use crate::{
     AmountAdjustmentReason, EventEmitter, Network, Payment, PaymentDetails, PaymentMetadata,
     Storage,
-    persist::{ObjectCacheRepository, StorageListPaymentsRequest, StoragePaymentDetailsFilter},
+    persist::{StorageListPaymentsRequest, StoragePaymentDetailsFilter},
     token_conversion::{ConversionAmount, DEFAULT_CONVERSION_MAX_SLIPPAGE_BPS},
     utils::{
         payments::{fetch_and_process_payment, insert_payment_with_metadata},
         polling::{PollSchedule, poll_until},
-        token::token_transaction_to_payments,
     },
 };
 
@@ -632,34 +631,20 @@ impl FlashnetTokenConverter {
         outbound_asset_transfer: AssetTransfer,
         sent_payment_id: &str,
     ) -> Option<Payment> {
-        match outbound_asset_transfer {
-            AssetTransfer::Spark(transfer) => match Payment::try_from(transfer) {
-                Ok(payment) => Some(payment),
-                Err(e) => {
-                    warn!(
-                        "Failed to build Payment from sent spark transfer for conversion {sent_payment_id}: {e:?}"
-                    );
-                    None
-                }
-            },
-            AssetTransfer::Token(token_tx) => {
-                let object_repository = ObjectCacheRepository::new(self.storage.clone());
-                match token_transaction_to_payments(
-                    &self.spark_wallet,
-                    &object_repository,
-                    &token_tx,
-                    true,
-                )
-                .await
-                {
-                    Ok(payments) => payments.into_iter().find(|p| p.id == sent_payment_id),
-                    Err(e) => {
-                        warn!(
-                            "Failed to convert sent token tx to payments for conversion {sent_payment_id}: {e:?}"
-                        );
-                        None
-                    }
-                }
+        match crate::utils::conversions::payment_from_asset_transfer(
+            outbound_asset_transfer,
+            &self.spark_wallet,
+            &self.storage,
+            sent_payment_id,
+        )
+        .await
+        {
+            Ok(payment) => payment,
+            Err(e) => {
+                warn!(
+                    "Failed to build Payment from sent asset transfer for conversion {sent_payment_id}: {e:?}"
+                );
+                None
             }
         }
     }

--- a/crates/breez-sdk/core/src/utils/conversions.rs
+++ b/crates/breez-sdk/core/src/utils/conversions.rs
@@ -15,6 +15,8 @@
 
 use std::sync::Arc;
 
+use flashnet::AssetTransfer;
+use spark_wallet::SparkWallet;
 use tracing::warn;
 
 use crate::{
@@ -24,7 +26,36 @@ use crate::{
         Conversion, ConversionAsset, ConversionChain, ConversionDetails, ConversionProvider,
         ConversionSide,
     },
+    persist::ObjectCacheRepository,
+    utils::token::token_transaction_to_payments,
 };
+
+/// Converts a freshly-produced [`AssetTransfer`] into the [`Payment`] row the
+/// SDK would surface once operator-side sync catches up.
+///
+/// - `AssetTransfer::Spark` → uses the [`Payment::try_from`] adapter on
+///   the wallet transfer (no network IO).
+/// - `AssetTransfer::Token` → calls [`token_transaction_to_payments`] (cache-
+///   backed metadata lookup) and filters to the output matching
+///   `payment_id`. Returns `Ok(None)` when no output matches (e.g. token
+///   transactions with only a change output, or a `payment_id` mismatch).
+pub(crate) async fn payment_from_asset_transfer(
+    transfer: AssetTransfer,
+    spark_wallet: &SparkWallet,
+    storage: &Arc<dyn Storage>,
+    payment_id: &str,
+) -> Result<Option<Payment>, SdkError> {
+    match transfer {
+        AssetTransfer::Spark(wallet_transfer) => Ok(Some(Payment::try_from(wallet_transfer)?)),
+        AssetTransfer::Token(token_tx) => {
+            let object_repository = ObjectCacheRepository::new(Arc::clone(storage));
+            let payments =
+                token_transaction_to_payments(spark_wallet, &object_repository, &token_tx, true)
+                    .await?;
+            Ok(payments.into_iter().find(|p| p.id == payment_id))
+        }
+    }
+}
 
 /// Extract `ConversionInfo` from whichever [`PaymentDetails`] variant carries
 /// it. Cross-chain conversion info can sit on `Lightning` (Boltz hold-invoice

--- a/crates/flashnet/src/amm/api.rs
+++ b/crates/flashnet/src/amm/api.rs
@@ -7,17 +7,17 @@ use tokio::sync::Mutex;
 use tracing::debug;
 
 use super::models::{
-    AssetTransfer, ClawbackIntent, ClawbackRequest, ClawbackResponse, ExecuteSwapIntent,
-    ExecuteSwapRequest, ExecuteSwapResponse, FeatureName, FeatureStatus,
-    FlashnetExecuteSwapResponse, GetMinAmountsRequest, GetMinAmountsResponse, ListPoolsRequest,
-    ListPoolsResponse, ListUserSwapsRequest, ListUserSwapsResponse, MinAmount, PingResponse,
-    SignedClawbackRequest, SignedExecuteSwapRequest, SignedExecuteSwapResponse,
-    SimulateSwapRequest, SimulateSwapResponse,
+    ClawbackIntent, ClawbackRequest, ClawbackResponse, ExecuteSwapIntent, ExecuteSwapRequest,
+    ExecuteSwapResponse, FeatureName, FeatureStatus, FlashnetExecuteSwapResponse,
+    GetMinAmountsRequest, GetMinAmountsResponse, ListPoolsRequest, ListPoolsResponse,
+    ListUserSwapsRequest, ListUserSwapsResponse, MinAmount, PingResponse, SignedClawbackRequest,
+    SignedExecuteSwapRequest, SignedExecuteSwapResponse, SimulateSwapRequest, SimulateSwapResponse,
 };
 use super::utils::generate_nonce;
 use crate::cache::CacheStore;
 use crate::config::FlashnetConfig;
 use crate::error::FlashnetError;
+use crate::models::AssetTransfer;
 
 pub const BTC_ASSET_ADDRESS: &str =
     "020202020202020202020202020202020202020202020202020202020202020202";

--- a/crates/flashnet/src/amm/models.rs
+++ b/crates/flashnet/src/amm/models.rs
@@ -5,38 +5,12 @@ use serde::{Deserialize, Serialize};
 use serde_with::DisplayFromStr;
 use serde_with::serde_as;
 use spark::Network;
-use spark_wallet::{PublicKey, TokenTransaction, TransferId, WalletTransfer};
+use spark_wallet::{PublicKey, TransferId};
 
 use super::api::BTC_ASSET_ADDRESS;
 use super::utils::decode_token_identifier;
 use crate::error::FlashnetError;
-
-/// The asset transfer produced when we send the swap's "in" asset to the
-/// pool. Carries the rich wallet-side object so callers can record a
-/// `Payment` for the sent leg without re-fetching it from the operator.
-///
-/// `Spark` is the larger variant; we don't box it because instances are
-/// short-lived (constructed once per swap, consumed by the caller almost
-/// immediately) and adding indirection would only complicate consumers.
-#[derive(Debug, Clone)]
-#[allow(clippy::large_enum_variant)]
-pub enum AssetTransfer {
-    Spark(WalletTransfer),
-    Token(TokenTransaction),
-}
-
-impl AssetTransfer {
-    /// Returns the operator-side identifier for this transfer — a Spark
-    /// `transfer_id` or a token transaction hash, matching what the swap
-    /// signing flow uses.
-    #[must_use]
-    pub fn id(&self) -> String {
-        match self {
-            AssetTransfer::Spark(t) => t.id.to_string(),
-            AssetTransfer::Token(t) => t.hash.clone(),
-        }
-    }
-}
+use crate::models::AssetTransfer;
 
 /// Response returned by [`FlashnetClient::execute_swap`](crate::FlashnetClient::execute_swap):
 /// the wire-shaped fields from Flashnet plus the rich `AssetTransfer` we

--- a/crates/flashnet/src/lib.rs
+++ b/crates/flashnet/src/lib.rs
@@ -2,6 +2,7 @@ pub mod amm;
 mod cache;
 mod config;
 mod error;
+pub mod models;
 pub mod orchestra;
 
 pub use amm::api::{BTC_ASSET_ADDRESS, FlashnetClient};
@@ -10,4 +11,5 @@ pub use amm::pool_selection::select_best_pool;
 pub use cache::CacheStore;
 pub use config::*;
 pub use error::FlashnetError;
+pub use models::*;
 pub use orchestra::OrchestraClient;

--- a/crates/flashnet/src/models.rs
+++ b/crates/flashnet/src/models.rs
@@ -1,0 +1,31 @@
+//! Cross-cutting types shared between the AMM and Orchestra modules.
+
+use spark_wallet::{TokenTransaction, WalletTransfer};
+
+/// The asset transfer produced when sending the source-leg asset on a
+/// Spark-side operation (an AMM swap-in or an Orchestra deposit). Carries the
+/// rich wallet-side object so callers can record a `Payment` for the sent leg
+/// without re-fetching it from the operator.
+///
+/// `Spark` is the larger variant; we don't box it because instances are
+/// short-lived (constructed once, consumed by the caller almost
+/// immediately) and adding indirection would only complicate consumers.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum AssetTransfer {
+    Spark(WalletTransfer),
+    Token(TokenTransaction),
+}
+
+impl AssetTransfer {
+    /// Returns the operator-side identifier for this transfer — a Spark
+    /// `transfer_id` or a token transaction hash, matching what the swap
+    /// signing flow uses.
+    #[must_use]
+    pub fn id(&self) -> String {
+        match self {
+            AssetTransfer::Spark(t) => t.id.to_string(),
+            AssetTransfer::Token(t) => t.hash.clone(),
+        }
+    }
+}

--- a/crates/flashnet/src/orchestra/client.rs
+++ b/crates/flashnet/src/orchestra/client.rs
@@ -1,5 +1,3 @@
-//! HTTP client for the Flashnet Orchestra cross-chain API.
-
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -16,6 +14,7 @@ use super::models::{
 use crate::cache::CacheStore;
 use crate::config::OrchestraConfig;
 use crate::error::FlashnetError;
+use crate::models::AssetTransfer;
 
 const ROUTES_CACHE_KEY: &str = "orchestra_routes";
 /// One hour — Orchestra routes are effectively static between deployments.
@@ -130,37 +129,36 @@ impl OrchestraClient {
             .await
     }
 
-    /// Send `amount_in` sats (or tokens) to the Orchestra-provided
-    /// `deposit_address` via the Spark wallet. Returns the resulting Spark
-    /// transfer id / token tx hash, which `/submit` expects as
-    /// `sparkTxHash`.
+    /// Send `amount_in` sats (or tokens) to the Orchestra-provided `deposit_address`
+    /// via the Spark wallet. Returns the full [`AssetTransfer`].
     pub async fn transfer_to_deposit(
         &self,
         deposit_address: &str,
         amount_in: u128,
         token_identifier: Option<&str>,
-    ) -> Result<String, FlashnetError> {
+    ) -> Result<AssetTransfer, FlashnetError> {
         let receiver_address = SparkAddress::from_str(deposit_address).map_err(|e| {
             FlashnetError::Generic(format!(
                 "Failed to parse Orchestra deposit address '{deposit_address}': {e}"
             ))
         })?;
 
-        let id = match token_identifier {
+        match token_identifier {
             None => {
                 // BTC sats — plain Spark transfer.
                 let amount_sats = u64::try_from(amount_in)
                     .map_err(|e| FlashnetError::Generic(format!("amount_in exceeds u64: {e}")))?;
-                self.spark_wallet
+                let transfer = self
+                    .spark_wallet
                     .transfer(amount_sats, &receiver_address, None)
-                    .await?
-                    .id
-                    .to_string()
+                    .await?;
+                Ok(AssetTransfer::Spark(transfer))
             }
             Some(token_identifier) => {
                 // USDB (or other Spark token) — token transfer.
                 // `token_identifier` is already a bech32m-encoded token id (e.g. btkn1x...).
-                self.spark_wallet
+                let token_tx = self
+                    .spark_wallet
                     .transfer_tokens(
                         vec![TransferTokenOutput {
                             token_id: token_identifier.to_string(),
@@ -171,11 +169,10 @@ impl OrchestraClient {
                         None,
                         None,
                     )
-                    .await?
-                    .hash
+                    .await?;
+                Ok(AssetTransfer::Token(token_tx))
             }
-        };
-        Ok(id)
+        }
     }
 
     /// Look up an order by its id.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -388,15 +388,7 @@ fn wasm_test_cmd(
     }
 
     // Prefer cargo test with wasm-bindgen-test runner. Allow browser or node mode.
-    //
-    // Raise the per-test timeout above the 20s wasm-bindgen default: the heaviest
-    // crypto tests (passkey wallet derivation) run unoptimized in the browser and
-    // can exceed 20s on slower CI, which the runner reports as a hang and kills
-    // the driver (SIGKILL). 120s leaves ample headroom without masking real hangs.
-    let mut envs = vec![
-        ("RUSTFLAGS".to_string(), String::new()),
-        ("WASM_BINDGEN_TEST_TIMEOUT".to_string(), "120".to_string()),
-    ];
+    let mut envs = vec![("RUSTFLAGS".to_string(), String::new())];
     if node {
         // Node is default for wasm-bindgen-test when browser env not set
     } else {


### PR DESCRIPTION
Built on top of #930

- **Extract pure helpers** from Orchestra and Boltz cross-chain paths for testability: route dedup + filter (`dedupe_routes`, `route_passes_filters`), route matching (`find_source_asset`), terminal-status mapping (`apply_terminal_status`), expiry validation (`validate_quote_expiry`), and Boltz's poll-or-fallback (`poll_to_terminal_or_fallback`). Inlined the previously-`unreachable!`'d post-extract destructure in `poll_in_flight_orders`.
- **Validation**: mainnet-only `cross_chain_config` gate in `Config::validate`, server-mode rejection, slippage range bounds (`MIN/MAX_CROSS_CHAIN_SLIPPAGE_BPS`), and per-provider quote-expiry check at send time.
- **Trait tightening**: `CrossChainService::prepare::max_slippage_bps` is now `u32` (was `Option<u32>`) — the SDK always resolves a value before dispatch.
- **Error types**: new `From<BoltzError> for SdkError` classifying variants into `NetworkError` / `StorageError` / `InvalidInput` / `Generic`. Drops the local `boltz_err_to_sdk` wrapper; consolidates flashnet + boltz call sites to `?`. Cross-chain provider lookup miss → `InvalidInput` (was `Generic`).
- **De-Rusty-fied error messages**: no Rust field names or debug formatting in user-facing strings (e.g. `cross_chain_config is only supported on mainnet (got Regtest)` → `Cross-chain sends are only available on Mainnet, not on Regtest.`).
- **Orchestra send resilience**: when the local payment row hasn't synced within the 30 s poll, return a `Payment` built from the deposit `AssetTransfer` (with the Orchestra `ConversionInfo` attached) instead of erroring. The local Spark/Token transfer is settled by then — the cross-chain pending state lives on `conversion_info.status`, not the top-level payment status.
- **Hoist `AssetTransfer`** from `flashnet::amm::models` to `flashnet::models` — it's not AMM-specific. `flashnet::OrchestraClient::transfer_to_deposit` now returns the full `AssetTransfer` instead of stringifying to a hash, matching the AMM `transfer_asset` shape.
- **Share `AssetTransfer → Payment` conversion**: new `payment_from_asset_transfer` in `utils::conversions`, consumed by both the AMM swap path (`build_sent_conversion_payment`) and the Orchestra send fallback.
- **Tests**: Adds 50 new unit tests across `cross_chain/{orchestra,boltz,boltz_event_listener}.rs` and `sdk/payments/prepare/cross_chain.rs`.
