### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -39,6 +39,8 @@ public static class CommandNames
         "check-lightning-address-available",
         "get-lightning-address",
         "register-lightning-address",
+        "authorize-lightning-address-transfer",
+        "claim-lightning-address-transfer",
         "delete-lightning-address",
         "list-fiat-currencies",
         "list-fiat-rates",
@@ -170,6 +172,18 @@ public static class Commands
                 Name = "register-lightning-address",
                 Description = "Register a lightning address",
                 Run = HandleRegisterLightningAddress
+            },
+            ["authorize-lightning-address-transfer"] = new()
+            {
+                Name = "authorize-lightning-address-transfer",
+                Description = "Authorize transferring your lightning address to another user",
+                Run = HandleAuthorizeLightningAddressTransfer
+            },
+            ["claim-lightning-address-transfer"] = new()
+            {
+                Name = "claim-lightning-address-transfer",
+                Description = "Claim a lightning address transfer authorized by the current owner",
+                Run = HandleClaimLightningAddressTransfer
             },
             ["delete-lightning-address"] = new()
             {
@@ -1015,6 +1029,49 @@ public static class Commands
         var result = await sdk.RegisterLightningAddress(new RegisterLightningAddressRequest(
             username: positional[0],
             description: description
+        ));
+        Serialization.PrintValue(result);
+    }
+
+    // --- authorize-lightning-address-transfer ---
+
+    private static async Task HandleAuthorizeLightningAddressTransfer(BreezSdk sdk, Func<string, string?> readline, string[] args)
+    {
+        var positional = GetPositionalArgs(args);
+        if (positional.Length < 1)
+        {
+            Console.WriteLine("Usage: authorize-lightning-address-transfer <transferee_pubkey>");
+            return;
+        }
+
+        var result = await sdk.AuthorizeLightningAddressTransfer(new AuthorizeTransferRequest(
+            transfereePubkey: positional[0]
+        ));
+        Serialization.PrintValue(result);
+    }
+
+    // --- claim-lightning-address-transfer ---
+
+    private static async Task HandleClaimLightningAddressTransfer(BreezSdk sdk, Func<string, string?> readline, string[] args)
+    {
+        var description = GetFlag(args, "-d", "--description");
+        var fromPubkey = GetFlag(args, "--from-pubkey");
+        var fromSignature = GetFlag(args, "--from-signature");
+        var positional = GetPositionalArgs(args);
+
+        if (positional.Length < 1 || fromPubkey == null || fromSignature == null)
+        {
+            Console.WriteLine("Usage: claim-lightning-address-transfer <username> [<description>] --from-pubkey <pk> --from-signature <sig>");
+            return;
+        }
+
+        var result = await sdk.ClaimLightningAddressTransfer(new ClaimTransferRequest(
+            authorization: new TransferAuthorization(
+                username: positional[0],
+                pubkey: fromPubkey,
+                signature: fromSignature
+            ),
+            description: description ?? (positional.Length > 1 ? positional[1] : null)
         ));
         Serialization.PrintValue(result);
     }

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -1054,7 +1054,6 @@ public static class Commands
 
     private static async Task HandleClaimLightningAddressTransfer(BreezSdk sdk, Func<string, string?> readline, string[] args)
     {
-        var description = GetFlag(args, "-d", "--description");
         var fromPubkey = GetFlag(args, "--from-pubkey");
         var fromSignature = GetFlag(args, "--from-signature");
         var positional = GetPositionalArgs(args);
@@ -1071,7 +1070,7 @@ public static class Commands
                 pubkey: fromPubkey,
                 signature: fromSignature
             ),
-            description: description ?? (positional.Length > 1 ? positional[1] : null)
+            description: positional.Length > 1 ? positional[1] : null
         ));
         Serialization.PrintValue(result);
     }

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Passkey.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Passkey.cs
@@ -199,34 +199,27 @@ public static class PasskeyResolver
     {
         var passkey = new PasskeyClient(provider, breezApiKey, config: null);
 
-        // --store-label: publish to Nostr
-        if (storeLabel && label != null)
-        {
-            Console.WriteLine($"Publishing label '{label}' to Nostr...");
-            await passkey.Labels().Store(label);
-            Console.WriteLine($"Label '{label}' published successfully.");
-        }
-
-        // --list-labels: query Nostr and prompt user to select
+        // --list-labels: discovery sign-in (null label) returns the
+        // discovered label set; prompt user to pick.
         string? resolvedName = label;
         if (listLabels)
         {
             Console.WriteLine("Querying Nostr for available labels...");
-            var labels = await passkey.Labels().List();
+            var discoveryResponse = await passkey.SignIn(new SignInRequest(label: null));
 
-            if (labels.Length == 0)
+            if (discoveryResponse.labels == null || discoveryResponse.labels.Length == 0)
             {
                 throw new InvalidOperationException(
                     "No labels found on Nostr for this identity");
             }
 
             Console.WriteLine("Available labels:");
-            for (int i = 0; i < labels.Length; i++)
+            for (int i = 0; i < discoveryResponse.labels.Length; i++)
             {
-                Console.WriteLine($"  {i + 1}: {labels[i]}");
+                Console.WriteLine($"  {i + 1}: {discoveryResponse.labels[i]}");
             }
 
-            Console.Write($"Select label (1-{labels.Length}): ");
+            Console.Write($"Select label (1-{discoveryResponse.labels.Length}): ");
             Console.Out.Flush();
             var input = Console.ReadLine();
             if (!int.TryParse(input?.Trim(), out int idx))
@@ -234,12 +227,21 @@ public static class PasskeyResolver
                 throw new InvalidOperationException("Invalid selection");
             }
 
-            if (idx < 1 || idx > labels.Length)
+            if (idx < 1 || idx > discoveryResponse.labels.Length)
             {
                 throw new InvalidOperationException("Selection out of range");
             }
 
-            resolvedName = labels[idx - 1];
+            resolvedName = discoveryResponse.labels[idx - 1];
+        }
+
+        // --store-label: publish before final sign-in so a fresh client
+        // can discover the label later.
+        if (storeLabel && resolvedName != null)
+        {
+            Console.WriteLine($"Publishing label '{resolvedName}' to Nostr...");
+            await passkey.Labels().Store(resolvedName);
+            Console.WriteLine($"Label '{resolvedName}' published successfully.");
         }
 
         var response = await passkey.SignIn(new SignInRequest(label: resolvedName));

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
@@ -13,6 +13,7 @@ string? mysqlConnectionString = null;
 var stableBalanceTokens = new List<string>();
 string? stableBalanceDefaultActiveLabel = null;
 ulong? stableBalanceThreshold = null;
+bool serverMode = false;
 string? passkeyProviderStr = null;
 string? label = null;
 bool listLabels = false;
@@ -62,6 +63,9 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--rpid":
             if (i + 1 < args.Length) rpId = args[++i];
+            break;
+        case "--server-mode":
+            serverMode = true;
             break;
         case "--help":
         case "-h":
@@ -183,6 +187,7 @@ if (passkeyProviderStr != null)
 await RunInteractiveMode(
     resolvedDir,
     networkEnum,
+    serverMode,
     accountNumber,
     postgresConnectionString,
     mysqlConnectionString,
@@ -226,12 +231,14 @@ static void PrintUsage()
     Console.WriteLine("  --list-labels                               List and select from labels on Nostr (requires --passkey)");
     Console.WriteLine("  --store-label                               Publish label to Nostr (requires --passkey and --label)");
     Console.WriteLine("  --rpid <RPID>                               Relying party ID for FIDO2 provider (requires --passkey)");
+    Console.WriteLine("  --server-mode                               Run in server mode (background tasks disabled)");
     Console.WriteLine("  -h, --help                                  Show this help");
 }
 
 static async Task RunInteractiveMode(
     string dataDir,
     Network network,
+    bool serverMode,
     uint? accountNumber,
     string? postgresConnectionString,
     string? mysqlConnectionString,
@@ -253,7 +260,16 @@ static async Task RunInteractiveMode(
     Directory.CreateDirectory(dataDir);
 
     // Config
-    var config = BreezSdkSparkMethods.DefaultConfig(network);
+    Config config;
+    if (serverMode)
+    {
+        Console.WriteLine("Server mode enabled. Run `sync` between operations.");
+        config = BreezSdkSparkMethods.DefaultServerConfig(network);
+    }
+    else
+    {
+        config = BreezSdkSparkMethods.DefaultConfig(network);
+    }
     var apiKey = Environment.GetEnvironmentVariable("BREEZ_API_KEY");
     if (!string.IsNullOrEmpty(apiKey))
     {
@@ -289,23 +305,13 @@ static async Task RunInteractiveMode(
     var builder = new SdkBuilder(config: config, seed: seed);
     if (postgresConnectionString != null)
     {
-        var context = await BreezSdkSparkMethods.NewSharedSdkContext(config: new SdkContextConfig(
-            network: network,
-            apiKey: apiKey,
-            connectionsPerOperator: null,
-            storage: BreezSdkSparkMethods.PostgresStorage(BreezSdkSparkMethods.DefaultPostgresStorageConfig(postgresConnectionString))
-        ));
-        await builder.WithSharedContext(context: context);
+        await builder.WithStorageBackend(storage: BreezSdkSparkMethods.PostgresStorage(
+            BreezSdkSparkMethods.DefaultPostgresStorageConfig(postgresConnectionString)));
     }
     else if (mysqlConnectionString != null)
     {
-        var context = await BreezSdkSparkMethods.NewSharedSdkContext(config: new SdkContextConfig(
-            network: network,
-            apiKey: apiKey,
-            connectionsPerOperator: null,
-            storage: BreezSdkSparkMethods.MysqlStorage(BreezSdkSparkMethods.DefaultMysqlStorageConfig(mysqlConnectionString))
-        ));
-        await builder.WithSharedContext(context: context);
+        await builder.WithStorageBackend(storage: BreezSdkSparkMethods.MysqlStorage(
+            BreezSdkSparkMethods.DefaultMysqlStorageConfig(mysqlConnectionString)));
     }
     else
     {

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/README.md
@@ -44,6 +44,7 @@ dotnet run --project BreezCli.csproj -- [OPTIONS]
 | `--list-labels` | - | List and select from labels published to Nostr (requires `--passkey`) |
 | `--store-label` | - | Publish the label to Nostr (requires `--passkey` and `--label`) |
 | `--rpid` | - | Relying party ID for FIDO2 provider (requires `--passkey`) |
+| `--server-mode` | - | Run in server mode (background tasks disabled; drive `sync` manually) |
 
 ### Passkey Support
 
@@ -83,7 +84,7 @@ Once inside the REPL, type `help` for all commands:
 
 **On-chain**: `claim-deposit`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
 
-**Lightning address**: `get-lightning-address`, `register-lightning-address`, `delete-lightning-address`, `check-lightning-address-available`
+**Lightning address**: `get-lightning-address`, `register-lightning-address`, `authorize-lightning-address-transfer`, `claim-lightning-address-transfer`, `delete-lightning-address`, `check-lightning-address-available`
 
 **Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`, `issuer <subcommand>`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
@@ -56,6 +56,7 @@ make run-mainnet
     --list-labels                       List and select labels from Nostr (requires --passkey)
     --store-label                       Publish label to Nostr (requires --passkey and --label)
     --rpid                              Relying party ID for FIDO2 provider (requires --passkey)
+    --server-mode                       Run in server mode (background_tasks_enabled=false)
 -h, --help                              Show usage
 ```
 
@@ -81,6 +82,8 @@ Once the CLI is running, type `help` to see all available commands:
 - `check-lightning-address-available` — Check username availability
 - `get-lightning-address` — Get registered lightning address
 - `register-lightning-address` — Register a lightning address
+- `authorize-lightning-address-transfer` — Authorize transferring your lightning address
+- `claim-lightning-address-transfer` — Claim a lightning address transfer
 - `delete-lightning-address` — Delete lightning address
 - `list-fiat-currencies` — List fiat currencies
 - `list-fiat-rates` — List fiat exchange rates

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
@@ -39,6 +39,11 @@ Future<void> main(List<String> arguments) async {
           help: 'Publish label to Nostr (requires --passkey and --label)',
         )
         ..addOption('rpid', help: 'Relying party ID for FIDO2 provider (requires --passkey)')
+        ..addFlag(
+          'server-mode',
+          negatable: false,
+          help: 'Run in server mode (background_tasks_enabled=false)',
+        )
         ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage');
 
   final ArgResults results;
@@ -135,6 +140,7 @@ Future<void> main(List<String> arguments) async {
     stableBalanceDefaultActiveLabel: stableBalanceDefaultActiveLabel,
     stableBalanceThreshold: stableBalanceThreshold,
     passkeyConfig: passkeyConfig,
+    serverMode: results.flag('server-mode'),
   );
 
   // Force exit — the native FFI library may keep background threads alive

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/cli.dart
@@ -24,6 +24,7 @@ Future<void> runCli({
   String? stableBalanceDefaultActiveLabel,
   BigInt? stableBalanceThreshold,
   CliPasskeyConfig? passkeyConfig,
+  bool serverMode = false,
 }) async {
   await BreezSdkSparkLib.init(externalLibrary: ExternalLibrary.open(_nativeLibPath()));
 
@@ -35,7 +36,13 @@ Future<void> runCli({
   final persistence = CliPersistence(dataDir);
 
   final networkEnum = network == 'mainnet' ? Network.mainnet : Network.regtest;
-  var config = defaultConfig(network: networkEnum);
+  Config config;
+  if (serverMode) {
+    stdout.writeln('Server mode enabled. Run `sync` between operations.');
+    config = defaultServerConfig(network: networkEnum);
+  } else {
+    config = defaultConfig(network: networkEnum);
+  }
   final apiKey = Platform.environment['BREEZ_API_KEY'];
   if (apiKey != null) {
     config = config.copyWith(apiKey: apiKey);

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -28,6 +28,8 @@ const commandNames = [
   'check-lightning-address-available',
   'get-lightning-address',
   'register-lightning-address',
+  'authorize-lightning-address-transfer',
+  'claim-lightning-address-transfer',
   'delete-lightning-address',
   'list-fiat-currencies',
   'list-fiat-rates',
@@ -73,6 +75,14 @@ Map<String, CommandEntry> buildCommandRegistry() {
     'register-lightning-address': CommandEntry(
       'Register a lightning address',
       _handleRegisterLightningAddress,
+    ),
+    'authorize-lightning-address-transfer': CommandEntry(
+      'Authorize transferring your lightning address to another pubkey',
+      _handleAuthorizeLightningAddressTransfer,
+    ),
+    'claim-lightning-address-transfer': CommandEntry(
+      'Claim a lightning address transfer authorized by the current owner',
+      _handleClaimLightningAddressTransfer,
     ),
     'delete-lightning-address': CommandEntry('Delete lightning address', _handleDeleteLightningAddress),
     'list-fiat-currencies': CommandEntry('List fiat currencies', _handleListFiatCurrencies),
@@ -419,9 +429,11 @@ Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args
 
   if (prepareResponse.conversionEstimate != null) {
     final est = prepareResponse.conversionEstimate!;
-    final units = est.options.conversionType is ConversionType_FromBitcoin ? 'sats' : 'token base units';
+    final inUnits = est.options.conversionType is ConversionType_FromBitcoin ? 'sats' : 'token base units';
+    final outUnits = est.options.conversionType is ConversionType_FromBitcoin ? 'token base units' : 'sats';
     print(
-      'Estimated conversion of ${est.amountIn} $units → ${est.amountOut} $units with a ${est.fee} $units fee',
+      'Estimated conversion from ${est.amountIn} $inUnits to ${est.amountOut} $outUnits '
+      'with a ${est.fee} token base units fee',
     );
     final answer = prompt('Do you want to continue (y/n): ', defaultValue: 'y');
     if (answer.toLowerCase() != 'y') {
@@ -791,6 +803,62 @@ Future<void> _handleRegisterLightningAddress(BreezSdk sdk, TokenIssuer tokenIssu
   final description = args.length > 1 ? args[1] : null;
   final result = await sdk.registerLightningAddress(
     request: RegisterLightningAddressRequest(username: username, description: description),
+  );
+  printValue(result);
+}
+
+// --- authorize-lightning-address-transfer ---
+
+Future<void> _handleAuthorizeLightningAddressTransfer(
+  BreezSdk sdk,
+  TokenIssuer tokenIssuer,
+  List<String> args,
+) async {
+  if (args.isEmpty || args.first == 'help' || args.first == '--help') {
+    print('Usage: authorize-lightning-address-transfer <transferee_pubkey>');
+    return;
+  }
+  final transfereePubkey = args.first;
+  final result = await sdk.authorizeLightningAddressTransfer(
+    request: AuthorizeTransferRequest(transfereePubkey: transfereePubkey),
+  );
+  printValue(result);
+}
+
+// --- claim-lightning-address-transfer ---
+
+Future<void> _handleClaimLightningAddressTransfer(
+  BreezSdk sdk,
+  TokenIssuer tokenIssuer,
+  List<String> args,
+) async {
+  final parser =
+      _parser('claim-lightning-address-transfer')
+        ..addOption('from-pubkey', mandatory: true, help: 'Current owner identity pubkey (hex)')
+        ..addOption('from-signature', mandatory: true, help: 'Current owner authorization signature (hex)');
+  final results = _parseArgs(
+    parser,
+    args,
+    'claim-lightning-address-transfer <username> [description] --from-pubkey <pubkey> --from-signature <sig>',
+  );
+  if (results == null) return;
+
+  if (results.rest.isEmpty) {
+    print(
+      'Usage: claim-lightning-address-transfer <username> [description] --from-pubkey <pubkey> --from-signature <sig>',
+    );
+    return;
+  }
+  final username = results.rest[0];
+  final description = results.rest.length > 1 ? results.rest[1] : null;
+  final fromPubkey = results.option('from-pubkey')!;
+  final fromSignature = results.option('from-signature')!;
+
+  final result = await sdk.claimLightningAddressTransfer(
+    request: ClaimTransferRequest(
+      authorization: TransferAuthorization(username: username, pubkey: fromPubkey, signature: fromSignature),
+      description: description,
+    ),
   );
   printValue(result);
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/passkey.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/passkey.dart
@@ -99,18 +99,13 @@ Future<Seed> resolvePasskeySeed(CliPasskeyConfig config, String dataDir, String?
   final filePrf = FilePrfProvider.create(dataDir);
   final passkey = PasskeyClientBuilder(breezApiKey: breezApiKey).withPrfProvider(filePrf).build();
 
-  // --store-label: publish the label to Nostr
-  if (config.storeLabel && config.label != null) {
-    print("Publishing label '${config.label}' to Nostr...");
-    await passkey.labels().store(label: config.label!);
-    print("Label '${config.label}' published successfully.");
-  }
-
-  // --list-labels: query Nostr and prompt user to select
+  // --list-labels: discovery sign-in (no cached label) returns the
+  // published label set; prompt the user to pick one.
   String? label;
   if (config.listLabels) {
     print('Querying Nostr for available labels...');
-    final labels = await passkey.labels().list();
+    final discovery = await passkey.signIn(request: SignInRequest(label: null, allowCredentials: const []));
+    final labels = discovery.labels;
 
     if (labels.isEmpty) {
       throw Exception('No labels found on Nostr for this identity');
@@ -129,6 +124,14 @@ Future<Seed> resolvePasskeySeed(CliPasskeyConfig config, String dataDir, String?
     label = labels[idx - 1];
   } else {
     label = config.label;
+  }
+
+  // --store-label: publish before signing in so a fresh client can
+  // discover the label later.
+  if (config.storeLabel && label != null) {
+    print("Publishing label '$label' to Nostr...");
+    await passkey.labels().store(label: label);
+    print("Label '$label' published successfully.");
   }
 
   final response = await passkey.signIn(request: SignInRequest(label: label, allowCredentials: const []));

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/.gitignore
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/.gitignore
@@ -1,0 +1,4 @@
+# Compiled CLI binaries. `make build` produces breez-cli; a bare `go build`
+# (no -o) names the binary `go` after this module's path tail (.../langs/go).
+/breez-cli
+/go

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/README.md
@@ -55,8 +55,11 @@ make clean            Remove binary
 | `--network` | `regtest` | Network to use (`regtest` or `mainnet`) |
 | `--account-number` | - | Account number for the Spark signer |
 | `--postgres-connection-string` | - | PostgreSQL connection string (uses SQLite by default) |
-| `--stable-balance-token-identifier` | - | Stable balance token identifier |
+| `--mysql-connection-string` | - | MySQL connection string (uses SQLite by default) |
+| `--stable-balance-token` | - | Stable balance token in `LABEL:token_identifier` format (repeatable) |
+| `--stable-balance-default-active-label` | - | Default active label for stable balance |
 | `--stable-balance-threshold` | - | Stable balance threshold in sats |
+| `--server-mode` | false | Run in server mode (`background_tasks_enabled=false`) |
 | `--passkey` | - | Use Passkey with PRF provider (`file`, `yubikey` or `fido2`) |
 | `--label` | `Default` | Requires `--passkey`. The label to use |
 | `--list-labels` | false | Requires `--passkey`. Select label from Nostr |
@@ -79,11 +82,15 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **On-chain**: `claim-deposit`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
 
-**Lightning address**: `get-lightning-address`, `register-lightning-address`, `delete-lightning-address`, `check-lightning-address-available`
+**Lightning address**: `get-lightning-address`, `register-lightning-address`, `authorize-lightning-address-transfer`, `claim-lightning-address-transfer`, `delete-lightning-address`, `check-lightning-address-available`
 
 **Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`, `issuer <subcommand>`
 
 **Contacts**: `contacts add`, `contacts update`, `contacts delete`, `contacts list`
+
+**Webhooks**: `webhooks register`, `webhooks unregister`, `webhooks list`
+
+**Stable Balance**: `stable-balance get`, `stable-balance set`, `stable-balance unset`
 
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -43,6 +43,8 @@ var CommandNames = []string{
 	"check-lightning-address-available",
 	"get-lightning-address",
 	"register-lightning-address",
+	"authorize-lightning-address-transfer",
+	"claim-lightning-address-transfer",
 	"delete-lightning-address",
 	"list-fiat-currencies",
 	"list-fiat-rates",
@@ -57,33 +59,35 @@ var CommandNames = []string{
 // BuildCommandRegistry returns a map of command name → Command.
 func BuildCommandRegistry() map[string]Command {
 	return map[string]Command{
-		"get-info":                          {Name: "get-info", Description: "Get balance information", Run: handleGetInfo},
-		"get-payment":                       {Name: "get-payment", Description: "Get the payment with the given ID", Run: handleGetPayment},
-		"sync":                              {Name: "sync", Description: "Sync wallet state", Run: handleSync},
-		"list-payments":                     {Name: "list-payments", Description: "List payments", Run: handleListPayments},
-		"receive":                           {Name: "receive", Description: "Receive a payment", Run: handleReceive},
-		"pay":                               {Name: "pay", Description: "Pay the given payment request", Run: handlePay},
-		"lnurl-pay":                         {Name: "lnurl-pay", Description: "Pay using LNURL", Run: handleLnurlPay},
-		"lnurl-withdraw":                    {Name: "lnurl-withdraw", Description: "Withdraw using LNURL", Run: handleLnurlWithdraw},
-		"lnurl-auth":                        {Name: "lnurl-auth", Description: "Authenticate using LNURL", Run: handleLnurlAuth},
-		"claim-htlc-payment":                {Name: "claim-htlc-payment", Description: "Claim an HTLC payment", Run: handleClaimHtlcPayment},
-		"claim-deposit":                     {Name: "claim-deposit", Description: "Claim an on-chain deposit", Run: handleClaimDeposit},
-		"parse":                             {Name: "parse", Description: "Parse an input (invoice, address, LNURL)", Run: handleParse},
-		"refund-deposit":                    {Name: "refund-deposit", Description: "Refund an on-chain deposit", Run: handleRefundDeposit},
-		"list-unclaimed-deposits":           {Name: "list-unclaimed-deposits", Description: "List unclaimed on-chain deposits", Run: handleListUnclaimedDeposits},
-		"buy-bitcoin":                       {Name: "buy-bitcoin", Description: "Buy Bitcoin via MoonPay", Run: handleBuyBitcoin},
-		"check-lightning-address-available": {Name: "check-lightning-address-available", Description: "Check if a lightning address username is available", Run: handleCheckLightningAddress},
-		"get-lightning-address":             {Name: "get-lightning-address", Description: "Get registered lightning address", Run: handleGetLightningAddress},
-		"register-lightning-address":        {Name: "register-lightning-address", Description: "Register a lightning address", Run: handleRegisterLightningAddress},
-		"delete-lightning-address":          {Name: "delete-lightning-address", Description: "Delete lightning address", Run: handleDeleteLightningAddress},
-		"list-fiat-currencies":              {Name: "list-fiat-currencies", Description: "List fiat currencies", Run: handleListFiatCurrencies},
-		"list-fiat-rates":                   {Name: "list-fiat-rates", Description: "List available fiat rates", Run: handleListFiatRates},
-		"recommended-fees":                  {Name: "recommended-fees", Description: "Get recommended BTC fees", Run: handleRecommendedFees},
-		"get-tokens-metadata":               {Name: "get-tokens-metadata", Description: "Get metadata for token(s)", Run: handleGetTokensMetadata},
-		"fetch-conversion-limits":           {Name: "fetch-conversion-limits", Description: "Fetch conversion limits for a token", Run: handleFetchConversionLimits},
-		"get-user-settings":                 {Name: "get-user-settings", Description: "Get user settings", Run: handleGetUserSettings},
-		"set-user-settings":                 {Name: "set-user-settings", Description: "Update user settings", Run: handleSetUserSettings},
-		"get-spark-status":                  {Name: "get-spark-status", Description: "Get Spark network service status", Run: handleGetSparkStatus},
+		"get-info":                             {Name: "get-info", Description: "Get balance information", Run: handleGetInfo},
+		"get-payment":                          {Name: "get-payment", Description: "Get the payment with the given ID", Run: handleGetPayment},
+		"sync":                                 {Name: "sync", Description: "Sync wallet state", Run: handleSync},
+		"list-payments":                        {Name: "list-payments", Description: "List payments", Run: handleListPayments},
+		"receive":                              {Name: "receive", Description: "Receive a payment", Run: handleReceive},
+		"pay":                                  {Name: "pay", Description: "Pay the given payment request", Run: handlePay},
+		"lnurl-pay":                            {Name: "lnurl-pay", Description: "Pay using LNURL", Run: handleLnurlPay},
+		"lnurl-withdraw":                       {Name: "lnurl-withdraw", Description: "Withdraw using LNURL", Run: handleLnurlWithdraw},
+		"lnurl-auth":                           {Name: "lnurl-auth", Description: "Authenticate using LNURL", Run: handleLnurlAuth},
+		"claim-htlc-payment":                   {Name: "claim-htlc-payment", Description: "Claim an HTLC payment", Run: handleClaimHtlcPayment},
+		"claim-deposit":                        {Name: "claim-deposit", Description: "Claim an on-chain deposit", Run: handleClaimDeposit},
+		"parse":                                {Name: "parse", Description: "Parse an input (invoice, address, LNURL)", Run: handleParse},
+		"refund-deposit":                       {Name: "refund-deposit", Description: "Refund an on-chain deposit", Run: handleRefundDeposit},
+		"list-unclaimed-deposits":              {Name: "list-unclaimed-deposits", Description: "List unclaimed on-chain deposits", Run: handleListUnclaimedDeposits},
+		"buy-bitcoin":                          {Name: "buy-bitcoin", Description: "Buy Bitcoin using an external provider", Run: handleBuyBitcoin},
+		"check-lightning-address-available":    {Name: "check-lightning-address-available", Description: "Check if a lightning address username is available", Run: handleCheckLightningAddress},
+		"get-lightning-address":                {Name: "get-lightning-address", Description: "Get registered lightning address", Run: handleGetLightningAddress},
+		"register-lightning-address":           {Name: "register-lightning-address", Description: "Register a lightning address", Run: handleRegisterLightningAddress},
+		"authorize-lightning-address-transfer": {Name: "authorize-lightning-address-transfer", Description: "Authorize transferring lightning address to a new owner", Run: handleAuthorizeLightningAddressTransfer},
+		"claim-lightning-address-transfer":     {Name: "claim-lightning-address-transfer", Description: "Claim a lightning address transfer", Run: handleClaimLightningAddressTransfer},
+		"delete-lightning-address":             {Name: "delete-lightning-address", Description: "Delete lightning address", Run: handleDeleteLightningAddress},
+		"list-fiat-currencies":                 {Name: "list-fiat-currencies", Description: "List fiat currencies", Run: handleListFiatCurrencies},
+		"list-fiat-rates":                      {Name: "list-fiat-rates", Description: "List available fiat rates", Run: handleListFiatRates},
+		"recommended-fees":                     {Name: "recommended-fees", Description: "Get recommended BTC fees", Run: handleRecommendedFees},
+		"get-tokens-metadata":                  {Name: "get-tokens-metadata", Description: "Get metadata for token(s)", Run: handleGetTokensMetadata},
+		"fetch-conversion-limits":              {Name: "fetch-conversion-limits", Description: "Fetch conversion limits for a token", Run: handleFetchConversionLimits},
+		"get-user-settings":                    {Name: "get-user-settings", Description: "Get user settings", Run: handleGetUserSettings},
+		"set-user-settings":                    {Name: "set-user-settings", Description: "Update user settings", Run: handleSetUserSettings},
+		"get-spark-status":                     {Name: "get-spark-status", Description: "Get Spark network service status", Run: handleGetSparkStatus},
 	}
 }
 
@@ -101,6 +105,8 @@ func PrintHelp(registry map[string]Command) {
 	}
 	fmt.Printf("\n  %-40s %s\n", "issuer <subcommand>", "Token issuer commands (use 'issuer help' for details)")
 	fmt.Printf("  %-40s %s\n", "contacts <subcommand>", "Contacts commands (use 'contacts help' for details)")
+	fmt.Printf("  %-40s %s\n", "webhooks <subcommand>", "Webhook commands (use 'webhooks help' for details)")
+	fmt.Printf("  %-40s %s\n", "stable-balance <subcommand>", "Stable balance commands (use 'stable-balance help' for details)")
 	fmt.Printf("  %-40s %s\n", "exit / quit", "Exit the CLI")
 	fmt.Printf("  %-40s %s\n", "help", "Show this help message")
 	fmt.Println()
@@ -454,11 +460,13 @@ func handlePay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []stri
 	// Show conversion estimate and confirm
 	if prepareResponse.ConversionEstimate != nil {
 		est := prepareResponse.ConversionEstimate
-		units := "token base units"
+		inUnits := "token base units"
+		outUnits := "sats"
 		if _, ok := est.Options.ConversionType.(breez_sdk_spark.ConversionTypeFromBitcoin); ok {
-			units = "sats"
+			inUnits = "sats"
+			outUnits = "token base units"
 		}
-		fmt.Printf("Estimated conversion of %v %s → %v %s with a %v %s fee\n", est.AmountIn, units, est.AmountOut, units, est.Fee, units)
+		fmt.Printf("Estimated conversion from %v %s to %v %s with a %v token base units fee\n", est.AmountIn, inUnits, est.AmountOut, outUnits, est.Fee)
 		line, err := readlineWithDefault(rl, "Do you want to continue (y/n): ", "y")
 		if err != nil {
 			return err
@@ -500,6 +508,8 @@ func handleLnurlPay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args [
 	fs.StringVar(validateStr, "validate", "", "Validate success URL")
 	idempotencyKey := fs.String("i", "", "Optional idempotency key")
 	fs.StringVar(idempotencyKey, "idempotency-key", "", "Optional idempotency key")
+	tokenId := fs.String("t", "", "Optional token identifier (amount in token base units)")
+	fs.StringVar(tokenId, "token-identifier", "", "Optional token identifier")
 	fromToken := fs.String("from-token", "", "Convert from token to Bitcoin to fulfill payment")
 	maxSlippage := fs.String("s", "", "Max slippage in basis points for conversion")
 	fs.StringVar(maxSlippage, "convert-max-slippage-bps", "", "Max slippage in basis points")
@@ -532,18 +542,23 @@ func handleLnurlPay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args [
 
 	minSendable := (payRequest.MinSendable + 999) / 1000
 	maxSendable := payRequest.MaxSendable / 1000
-	prompt := fmt.Sprintf("Amount to pay (min %d sat, max %d sat): ", minSendable, maxSendable)
+	var prompt string
+	if *tokenId == "" {
+		prompt = fmt.Sprintf("Amount to pay (min %d sat, max %d sat): ", minSendable, maxSendable)
+	} else {
+		prompt = fmt.Sprintf("Amount to pay (min %d sat, max %d sat) in token base units: ", minSendable, maxSendable)
+	}
 	amountLine, err := readlinePrompt(rl, prompt)
 	if err != nil {
 		return err
 	}
-	amountSats, err := strconv.ParseUint(strings.TrimSpace(amountLine), 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid amount: %w", err)
+	amount, ok := new(big.Int).SetString(strings.TrimSpace(amountLine), 10)
+	if !ok {
+		return fmt.Errorf("invalid amount: %s", strings.TrimSpace(amountLine))
 	}
 
 	prepareReq := breez_sdk_spark.PrepareLnurlPayRequest{
-		Amount: new(big.Int).SetUint64(amountSats),
+		Amount:     amount,
 		PayRequest: payRequest,
 	}
 	if *comment != "" {
@@ -552,6 +567,9 @@ func handleLnurlPay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args [
 	if *validateStr != "" {
 		val := *validateStr == "true"
 		prepareReq.ValidateSuccessActionUrl = &val
+	}
+	if *tokenId != "" {
+		prepareReq.TokenIdentifier = tokenId
 	}
 
 	// Conversion options
@@ -586,7 +604,13 @@ func handleLnurlPay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args [
 	// Show conversion estimate and confirm
 	if prepareResponse.ConversionEstimate != nil {
 		est := prepareResponse.ConversionEstimate
-		fmt.Printf("Estimated conversion of %v token base units → %v sats with a %v token base units fee\n", est.AmountIn, est.AmountOut, est.Fee)
+		inUnits := "token base units"
+		outUnits := "sats"
+		if _, ok := est.Options.ConversionType.(breez_sdk_spark.ConversionTypeFromBitcoin); ok {
+			inUnits = "sats"
+			outUnits = "token base units"
+		}
+		fmt.Printf("Estimated conversion from %v %s to %v %s with a %v token base units fee\n", est.AmountIn, inUnits, est.AmountOut, outUnits, est.Fee)
 		line, err := readlineWithDefault(rl, "Do you want to continue (y/n): ", "y")
 		if err != nil {
 			return err
@@ -865,18 +889,29 @@ func handleListUnclaimedDeposits(sdk *breez_sdk_spark.BreezSdk, _ *readline.Inst
 
 func handleBuyBitcoin(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []string) error {
 	fs := flag.NewFlagSet("buy-bitcoin", flag.ContinueOnError)
-	lockedAmount := fs.Uint64("amount", 0, "Lock purchase to this amount in sats")
-	redirectUrl := fs.String("redirect-url", "", "Redirect URL after purchase")
+	provider := fs.String("provider", "moonpay", "Provider: moonpay or cashapp")
+	amountSat := fs.Uint64("amount-sat", 0, "Amount in satoshis")
+	redirectUrl := fs.String("redirect-url", "", "Redirect URL after purchase (MoonPay only)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	req := breez_sdk_spark.BuyBitcoinRequestMoonpay{}
-	if *lockedAmount > 0 {
-		req.LockedAmountSat = lockedAmount
-	}
-	if *redirectUrl != "" {
-		req.RedirectUrl = redirectUrl
+	var req breez_sdk_spark.BuyBitcoinRequest
+	switch strings.ToLower(*provider) {
+	case "cashapp", "cash_app", "cash-app":
+		if *amountSat == 0 {
+			return fmt.Errorf("--amount-sat is required when --provider is cashapp")
+		}
+		req = breez_sdk_spark.BuyBitcoinRequestCashApp{AmountSats: *amountSat}
+	default:
+		moonpayReq := breez_sdk_spark.BuyBitcoinRequestMoonpay{}
+		if *amountSat > 0 {
+			moonpayReq.LockedAmountSat = amountSat
+		}
+		if *redirectUrl != "" {
+			moonpayReq.RedirectUrl = redirectUrl
+		}
+		req = moonpayReq
 	}
 
 	result, err := sdk.BuyBitcoin(req)
@@ -956,6 +991,60 @@ func handleRegisterLightningAddress(sdk *breez_sdk_spark.BreezSdk, _ *readline.I
 	return nil
 }
 
+// --- authorize-lightning-address-transfer ---
+
+func handleAuthorizeLightningAddressTransfer(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []string) error {
+	if len(args) < 1 {
+		fmt.Println("Usage: authorize-lightning-address-transfer <transferee_pubkey>")
+		return nil
+	}
+
+	result, err := sdk.AuthorizeLightningAddressTransfer(breez_sdk_spark.AuthorizeTransferRequest{
+		TransfereePubkey: args[0],
+	})
+	if err = liftError(err); err != nil {
+		return err
+	}
+	printValue(result)
+	return nil
+}
+
+// --- claim-lightning-address-transfer ---
+
+func handleClaimLightningAddressTransfer(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []string) error {
+	fs := flag.NewFlagSet("claim-lightning-address-transfer", flag.ContinueOnError)
+	fromPubkey := fs.String("from-pubkey", "", "Current owner's identity public key")
+	fromSignature := fs.String("from-signature", "", "Current owner's authorization signature")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	positional := fs.Args()
+	if len(positional) < 1 || *fromPubkey == "" || *fromSignature == "" {
+		fmt.Println("Usage: claim-lightning-address-transfer <username> [<description>] --from-pubkey <pubkey> --from-signature <signature>")
+		return nil
+	}
+
+	req := breez_sdk_spark.ClaimTransferRequest{
+		Authorization: breez_sdk_spark.TransferAuthorization{
+			Username:  positional[0],
+			Pubkey:    *fromPubkey,
+			Signature: *fromSignature,
+		},
+	}
+	if len(positional) > 1 {
+		description := positional[1]
+		req.Description = &description
+	}
+
+	result, err := sdk.ClaimLightningAddressTransfer(req)
+	if err = liftError(err); err != nil {
+		return err
+	}
+	printValue(result)
+	return nil
+}
+
 // --- delete-lightning-address ---
 
 func handleDeleteLightningAddress(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, _ []string) error {
@@ -1021,29 +1110,31 @@ func handleGetTokensMetadata(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance
 
 func handleFetchConversionLimits(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []string) error {
 	fs := flag.NewFlagSet("fetch-conversion-limits", flag.ContinueOnError)
-	fromBitcoin := fs.Bool("from-bitcoin", false, "Convert from bitcoin to token")
-	tokenId := fs.String("token", "", "Token identifier (required)")
+	fromBitcoin := fs.Bool("f", false, "Convert from bitcoin to token")
+	fs.BoolVar(fromBitcoin, "from-bitcoin", false, "Convert from bitcoin to token")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	if *tokenId == "" {
-		fmt.Println("Usage: fetch-conversion-limits --token <token_id> [--from-bitcoin]")
+	positional := fs.Args()
+	if len(positional) < 1 {
+		fmt.Println("Usage: fetch-conversion-limits [-f/--from-bitcoin] <token_identifier>")
 		return nil
 	}
+	tokenId := positional[0]
 
 	var convType breez_sdk_spark.ConversionType
 	if *fromBitcoin {
 		convType = breez_sdk_spark.ConversionTypeFromBitcoin{}
 	} else {
-		convType = breez_sdk_spark.ConversionTypeToBitcoin{FromTokenIdentifier: *tokenId}
+		convType = breez_sdk_spark.ConversionTypeToBitcoin{FromTokenIdentifier: tokenId}
 	}
 
 	req := breez_sdk_spark.FetchConversionLimitsRequest{
 		ConversionType: convType,
 	}
 	if *fromBitcoin {
-		req.TokenIdentifier = tokenId
+		req.TokenIdentifier = &tokenId
 	}
 
 	result, err := sdk.FetchConversionLimits(req)
@@ -1069,7 +1160,8 @@ func handleGetUserSettings(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, 
 
 func handleSetUserSettings(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []string) error {
 	fs := flag.NewFlagSet("set-user-settings", flag.ContinueOnError)
-	privateMode := fs.String("spark-private-mode", "", "Enable spark private mode (true/false)")
+	privateMode := fs.String("p", "", "Enable spark private mode (true/false)")
+	fs.StringVar(privateMode, "private", "", "Enable spark private mode (true/false)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/main.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/main.go
@@ -79,8 +79,12 @@ func main() {
 	network := flag.String("network", "regtest", "Network to use (regtest or mainnet)")
 	accountNumber := flag.String("account-number", "", "Account number for the Spark signer")
 	postgresConnectionString := flag.String("postgres-connection-string", "", "PostgreSQL connection string (uses SQLite by default)")
-	stableBalanceTokenIdentifier := flag.String("stable-balance-token-identifier", "", "Stable balance token identifier")
+	mysqlConnectionString := flag.String("mysql-connection-string", "", "MySQL connection string (uses SQLite by default)")
+	var stableBalanceTokens stringSliceFlag
+	flag.Var(&stableBalanceTokens, "stable-balance-token", "Stable balance token in LABEL:token_identifier format (repeatable)")
+	stableBalanceDefaultActiveLabel := flag.String("stable-balance-default-active-label", "", "Default active label for stable balance")
 	stableBalanceThreshold := flag.Uint64("stable-balance-threshold", 0, "Stable balance threshold in sats")
+	serverMode := flag.Bool("server-mode", false, "Run in server mode (background_tasks_enabled=false)")
 	passkeyProviderStr := flag.String("passkey", "", "Use passkey with PRF provider (file, yubikey, or fido2)")
 	label := flag.String("label", "", "Label for seed derivation (requires --passkey)")
 	listLabels := flag.Bool("list-labels", false, "List and select from labels published to Nostr (requires --passkey)")
@@ -112,19 +116,33 @@ func main() {
 
 	// Config
 	config := breez_sdk_spark.DefaultConfig(networkEnum)
+	if *serverMode {
+		fmt.Println("Server mode enabled. Run `sync` between operations.")
+		config = breez_sdk_spark.DefaultServerConfig(networkEnum)
+	}
 	apiKey := os.Getenv("BREEZ_API_KEY")
 	if apiKey != "" {
 		config.ApiKey = &apiKey
 	}
 
 	// Stable balance config
-	if *stableBalanceTokenIdentifier != "" {
-		defaultActiveLabel := "USDB"
+	if len(stableBalanceTokens) > 0 {
+		var tokens []breez_sdk_spark.StableBalanceToken
+		for _, s := range stableBalanceTokens {
+			parts := strings.SplitN(s, ":", 2)
+			if len(parts) != 2 {
+				log.Fatalf("Invalid token format '%s', expected LABEL:token_identifier", s)
+			}
+			tokens = append(tokens, breez_sdk_spark.StableBalanceToken{
+				Label:           parts[0],
+				TokenIdentifier: parts[1],
+			})
+		}
 		sbc := breez_sdk_spark.StableBalanceConfig{
-			Tokens: []breez_sdk_spark.StableBalanceToken{
-				{Label: "USDB", TokenIdentifier: *stableBalanceTokenIdentifier},
-			},
-			DefaultActiveLabel: &defaultActiveLabel,
+			Tokens: tokens,
+		}
+		if *stableBalanceDefaultActiveLabel != "" {
+			sbc.DefaultActiveLabel = stableBalanceDefaultActiveLabel
 		}
 		if *stableBalanceThreshold > 0 {
 			sbc.ThresholdSats = stableBalanceThreshold
@@ -164,12 +182,22 @@ func main() {
 	}
 
 	// Build SDK
+	if *postgresConnectionString != "" && *mysqlConnectionString != "" {
+		log.Fatalf("Cannot specify both --postgres-connection-string and --mysql-connection-string")
+	}
 	builder := breez_sdk_spark.NewSdkBuilder(config, seed)
 	if *postgresConnectionString != "" {
 		pgConfig := breez_sdk_spark.DefaultPostgresStorageConfig(*postgresConnectionString)
 		storage, err := breez_sdk_spark.PostgresStorage(pgConfig)
 		if err != nil {
 			log.Fatalf("Failed to create postgres storage: %v", err)
+		}
+		builder.WithStorageBackend(storage)
+	} else if *mysqlConnectionString != "" {
+		mysqlConfig := breez_sdk_spark.DefaultMysqlStorageConfig(*mysqlConnectionString)
+		storage, err := breez_sdk_spark.MysqlStorage(mysqlConfig)
+		if err != nil {
+			log.Fatalf("Failed to create mysql storage: %v", err)
 		}
 		builder.WithStorageBackend(storage)
 	} else {
@@ -218,6 +246,8 @@ func runRepl(sdk *breez_sdk_spark.BreezSdk, tokenIssuer *breez_sdk_spark.TokenIs
 	allCommands = append(allCommands, CommandNames...)
 	allCommands = append(allCommands, IssuerCommandNames...)
 	allCommands = append(allCommands, ContactCommandNames...)
+	allCommands = append(allCommands, WebhookCommandNames...)
+	allCommands = append(allCommands, StableBalanceCommandNames...)
 	allCommands = append(allCommands, "exit", "quit", "help")
 
 	// Build prefix completer items
@@ -287,6 +317,10 @@ func runRepl(sdk *breez_sdk_spark.BreezSdk, tokenIssuer *breez_sdk_spark.TokenIs
 			DispatchIssuerCommand(cmdArgs, tokenIssuer, rl)
 		} else if cmdName == "contacts" {
 			DispatchContactCommand(cmdArgs, sdk, rl)
+		} else if cmdName == "webhooks" {
+			DispatchWebhookCommand(cmdArgs, sdk, rl)
+		} else if cmdName == "stable-balance" {
+			DispatchStableBalanceCommand(cmdArgs, sdk, rl)
 		} else if cmd, ok := registry[cmdName]; ok {
 			if err := cmd.Run(sdk, rl, cmdArgs); err != nil {
 				fmt.Printf("Error: %v\n", err)

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/passkey.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/passkey.go
@@ -163,23 +163,16 @@ func resolvePasskeySeed(
 ) (breez_sdk_spark.Seed, error) {
 	passkey := breez_sdk_spark.NewPasskeyClient(provider, breezAPIKey, nil)
 
-	// --store-label: publish to Nostr
-	if storeLabel && label != nil {
-		fmt.Printf("Publishing label '%s' to Nostr...\n", *label)
-		if err := liftError(passkey.Labels().Store(*label)); err != nil {
-			return nil, fmt.Errorf("failed to store label: %w", err)
-		}
-		fmt.Printf("Label '%s' published successfully.\n", *label)
-	}
-
-	// --list-labels: query Nostr and prompt user to select
+	// --list-labels: discovery sign-in (no cached label) returns the
+	// published label set; prompt the user to pick one.
 	resolvedName := label
 	if listLabels {
 		fmt.Println("Querying Nostr for available labels...")
-		labels, err := passkey.Labels().List()
+		discovery, err := passkey.SignIn(breez_sdk_spark.SignInRequest{Label: nil})
 		if err = liftError(err); err != nil {
-			return nil, fmt.Errorf("failed to list labels: %w", err)
+			return nil, fmt.Errorf("failed to discover labels: %w", err)
 		}
+		labels := discovery.Labels
 
 		if len(labels) == 0 {
 			return nil, fmt.Errorf("no labels found on Nostr for this identity")
@@ -203,6 +196,15 @@ func resolvePasskeySeed(
 
 		selected := labels[idx-1]
 		resolvedName = &selected
+	}
+
+	// --store-label: publish to Nostr
+	if storeLabel && resolvedName != nil {
+		fmt.Printf("Publishing label '%s' to Nostr...\n", *resolvedName)
+		if err := liftError(passkey.Labels().Store(*resolvedName)); err != nil {
+			return nil, fmt.Errorf("failed to store label: %w", err)
+		}
+		fmt.Printf("Label '%s' published successfully.\n", *resolvedName)
 	}
 
 	response, err := passkey.SignIn(breez_sdk_spark.SignInRequest{Label: resolvedName})

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/serialization.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/serialization.go
@@ -120,6 +120,7 @@ func isVariantType(name string) bool {
 		"AssetFilter", "OnchainConfirmationSpeed", "FeePolicy",
 		"PaymentType", "PaymentStatus", "SparkHtlcStatus",
 		"TokenTransactionType", "ServiceStatus",
+		"StableBalanceActiveLabel", "BuyBitcoinRequest",
 	}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(name, prefix) && name != prefix {
@@ -139,6 +140,7 @@ func extractVariantName(name string) string {
 		"SparkHtlcStatus", "PaymentStatus", "PaymentType",
 		"ServiceStatus", "SdkEvent", "InputType",
 		"AssetFilter", "FeePolicy", "MaxFee", "Fee",
+		"StableBalanceActiveLabel", "BuyBitcoinRequest",
 	}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(name, prefix) && len(name) > len(prefix) {

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/stable_balance.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/stable_balance.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	breez_sdk_spark "github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
+	"github.com/chzyer/readline"
+)
+
+// StableBalanceCmd represents a single stable-balance subcommand.
+type StableBalanceCmd struct {
+	Name        string
+	Description string
+	Run         func(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []string) error
+}
+
+// StableBalanceCommandNames lists all stable-balance subcommand names (used for REPL completion).
+var StableBalanceCommandNames = []string{
+	"stable-balance get",
+	"stable-balance set",
+	"stable-balance unset",
+}
+
+// BuildStableBalanceRegistry returns a map of stable-balance subcommand name to StableBalanceCmd.
+func BuildStableBalanceRegistry() map[string]StableBalanceCmd {
+	return map[string]StableBalanceCmd{
+		"get": {
+			Name:        "get",
+			Description: "Get the stable balance active label",
+			Run:         handleStableBalanceGet,
+		},
+		"set": {
+			Name:        "set",
+			Description: "Set the stable balance active label",
+			Run:         handleStableBalanceSet,
+		},
+		"unset": {
+			Name:        "unset",
+			Description: "Unset stable balance",
+			Run:         handleStableBalanceUnset,
+		},
+	}
+}
+
+// DispatchStableBalanceCommand dispatches a stable-balance subcommand.
+func DispatchStableBalanceCommand(args []string, sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance) {
+	registry := BuildStableBalanceRegistry()
+
+	if len(args) == 0 || args[0] == "help" {
+		fmt.Println("\nStable balance subcommands:")
+		names := make([]string, 0, len(registry))
+		for name := range registry {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			cmd := registry[name]
+			fmt.Printf("  stable-balance %-24s %s\n", name, cmd.Description)
+		}
+		fmt.Println()
+		return
+	}
+
+	subName := args[0]
+	subArgs := args[1:]
+
+	cmd, ok := registry[subName]
+	if !ok {
+		fmt.Printf("Unknown stable-balance subcommand: %s. Use 'stable-balance help' for available commands.\n", subName)
+		return
+	}
+
+	if err := cmd.Run(sdk, rl, subArgs); err != nil {
+		fmt.Printf("Error: %v\n", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Stable balance command handlers
+// ---------------------------------------------------------------------------
+
+// --- get ---
+
+func handleStableBalanceGet(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, _ []string) error {
+	result, err := sdk.GetUserSettings()
+	if err = liftError(err); err != nil {
+		return err
+	}
+	printValue(result.StableBalanceActiveLabel)
+	return nil
+}
+
+// --- set ---
+
+func handleStableBalanceSet(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []string) error {
+	if len(args) < 1 {
+		fmt.Println("Usage: stable-balance set <label>")
+		return nil
+	}
+
+	var activeLabel breez_sdk_spark.StableBalanceActiveLabel = breez_sdk_spark.StableBalanceActiveLabelSet{
+		Label: args[0],
+	}
+	if err := liftError(sdk.UpdateUserSettings(breez_sdk_spark.UpdateUserSettingsRequest{
+		StableBalanceActiveLabel: &activeLabel,
+	})); err != nil {
+		return err
+	}
+	result, err := sdk.GetUserSettings()
+	if err = liftError(err); err != nil {
+		return err
+	}
+	printValue(result)
+	return nil
+}
+
+// --- unset ---
+
+func handleStableBalanceUnset(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, _ []string) error {
+	var activeLabel breez_sdk_spark.StableBalanceActiveLabel = breez_sdk_spark.StableBalanceActiveLabelUnset{}
+	if err := liftError(sdk.UpdateUserSettings(breez_sdk_spark.UpdateUserSettingsRequest{
+		StableBalanceActiveLabel: &activeLabel,
+	})); err != nil {
+		return err
+	}
+	result, err := sdk.GetUserSettings()
+	if err = liftError(err); err != nil {
+		return err
+	}
+	printValue(result)
+	return nil
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/webhooks.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/webhooks.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	breez_sdk_spark "github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
+	"github.com/chzyer/readline"
+)
+
+// WebhookCmd represents a single webhooks subcommand.
+type WebhookCmd struct {
+	Name        string
+	Description string
+	Run         func(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []string) error
+}
+
+// WebhookCommandNames lists all webhooks subcommand names (used for REPL completion).
+var WebhookCommandNames = []string{
+	"webhooks register",
+	"webhooks unregister",
+	"webhooks list",
+}
+
+// BuildWebhookRegistry returns a map of webhooks subcommand name to WebhookCmd.
+func BuildWebhookRegistry() map[string]WebhookCmd {
+	return map[string]WebhookCmd{
+		"register": {
+			Name:        "register",
+			Description: "Register a new webhook",
+			Run:         handleWebhookRegister,
+		},
+		"unregister": {
+			Name:        "unregister",
+			Description: "Unregister a webhook",
+			Run:         handleWebhookUnregister,
+		},
+		"list": {
+			Name:        "list",
+			Description: "List all registered webhooks",
+			Run:         handleWebhookList,
+		},
+	}
+}
+
+// DispatchWebhookCommand dispatches a webhooks subcommand.
+func DispatchWebhookCommand(args []string, sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance) {
+	registry := BuildWebhookRegistry()
+
+	if len(args) == 0 || args[0] == "help" {
+		fmt.Println("\nWebhooks subcommands:")
+		names := make([]string, 0, len(registry))
+		for name := range registry {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			cmd := registry[name]
+			fmt.Printf("  webhooks %-30s %s\n", name, cmd.Description)
+		}
+		fmt.Println()
+		return
+	}
+
+	subName := args[0]
+	subArgs := args[1:]
+
+	cmd, ok := registry[subName]
+	if !ok {
+		fmt.Printf("Unknown webhooks subcommand: %s. Use 'webhooks help' for available commands.\n", subName)
+		return
+	}
+
+	if err := cmd.Run(sdk, rl, subArgs); err != nil {
+		fmt.Printf("Error: %v\n", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Webhooks command handlers
+// ---------------------------------------------------------------------------
+
+// --- register ---
+
+func handleWebhookRegister(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []string) error {
+	if len(args) < 3 {
+		fmt.Println("Usage: webhooks register <url> <secret> <event_type> [<event_type> ...]")
+		fmt.Println("Event types: lightning-receive, lightning-send, coop-exit, static-deposit")
+		return nil
+	}
+
+	url := args[0]
+	secret := args[1]
+	eventTypes, err := parseWebhookEventTypes(args[2:])
+	if err != nil {
+		return err
+	}
+
+	result, err := sdk.RegisterWebhook(breez_sdk_spark.RegisterWebhookRequest{
+		Url:        url,
+		Secret:     secret,
+		EventTypes: eventTypes,
+	})
+	if err = liftError(err); err != nil {
+		return err
+	}
+	printValue(result)
+	return nil
+}
+
+// --- unregister ---
+
+func handleWebhookUnregister(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []string) error {
+	if len(args) < 1 {
+		fmt.Println("Usage: webhooks unregister <webhook_id>")
+		return nil
+	}
+
+	if err := liftError(sdk.UnregisterWebhook(breez_sdk_spark.UnregisterWebhookRequest{
+		WebhookId: args[0],
+	})); err != nil {
+		return err
+	}
+	fmt.Println("Webhook unregistered successfully")
+	return nil
+}
+
+// --- list ---
+
+func handleWebhookList(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, _ []string) error {
+	result, err := sdk.ListWebhooks()
+	if err = liftError(err); err != nil {
+		return err
+	}
+	printValue(result)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func parseWebhookEventTypes(values []string) ([]breez_sdk_spark.WebhookEventType, error) {
+	var types []breez_sdk_spark.WebhookEventType
+	for _, v := range values {
+		switch strings.ToLower(v) {
+		case "lightning-receive":
+			types = append(types, breez_sdk_spark.WebhookEventTypeLightningReceiveFinished{})
+		case "lightning-send":
+			types = append(types, breez_sdk_spark.WebhookEventTypeLightningSendFinished{})
+		case "coop-exit":
+			types = append(types, breez_sdk_spark.WebhookEventTypeCoopExitFinished{})
+		case "static-deposit":
+			types = append(types, breez_sdk_spark.WebhookEventTypeStaticDepositFinished{})
+		default:
+			return nil, fmt.Errorf("unknown webhook event type: %s (valid: lightning-receive, lightning-send, coop-exit, static-deposit)", v)
+		}
+	}
+	return types, nil
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/README.md
@@ -57,13 +57,15 @@ make clean            Remove build artifacts
 | `--account-number` | | Account number for the Spark signer |
 | `--postgres-connection-string` | | PostgreSQL connection string (uses SQLite by default) |
 | `--mysql-connection-string` | | MySQL connection string (mutually exclusive with `--postgres-connection-string`) |
-| `--stable-balance-token-identifier` | | Stable balance token identifier |
-| `--stable-balance-threshold` | | Stable balance threshold in sats |
+| `--stable-balance-token` | | Stable balance token in `TICKER:token_identifier` format (repeatable) |
+| `--stable-balance-default-active-label` | | Default active label for stable balance (requires `--stable-balance-token`) |
+| `--stable-balance-threshold` | | Stable balance threshold in sats (requires `--stable-balance-token`) |
 | `--passkey` | | Use passkey with PRF provider (`file`, `yubikey`, or `fido2`) |
 | `--label` | | Label for seed derivation (requires `--passkey`) |
 | `--list-labels` | | List and select from labels on Nostr (requires `--passkey`) |
 | `--store-label` | | Publish the label to Nostr (requires `--passkey` + `--label`) |
 | `--rpid` | | Relying party ID for FIDO2 provider (requires `--passkey`) |
+| `--server-mode` | | Run in server mode (no background tasks) |
 
 ## Environment Variables
 
@@ -111,19 +113,19 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **On-chain**: `claim-deposit`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
 
-**Lightning address**: `get-lightning-address`, `register-lightning-address`, `delete-lightning-address`, `check-lightning-address-available`
+**Lightning address**: `get-lightning-address`, `register-lightning-address`, `authorize-lightning-address-transfer`, `claim-lightning-address-transfer`, `delete-lightning-address`, `check-lightning-address-available`
 
-**Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`
+**Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`, `issuer <subcommand>`
 
-**Fiat**: `list-fiat-currencies`, `list-fiat-rates`
+**Webhooks**: `webhooks register`, `webhooks unregister`, `webhooks list`
 
-**Settings**: `get-user-settings`, `set-user-settings`, `get-spark-status`
+**Stable balance**: `stable-balance get`, `stable-balance set`, `stable-balance unset`
+
+**Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 
 **Token issuer**: `issuer create-token`, `issuer mint-token`, `issuer burn-token`, `issuer token-balance`, `issuer token-metadata`, `issuer freeze-token`, `issuer unfreeze-token`
 
 **Contacts**: `contacts add`, `contacts update`, `contacts delete`, `contacts list`
-
-**Input parsing**: `parse`
 
 Each command supports its own usage help.
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -33,6 +33,8 @@ val COMMAND_NAMES = listOf(
     "check-lightning-address-available",
     "get-lightning-address",
     "register-lightning-address",
+    "authorize-lightning-address-transfer",
+    "claim-lightning-address-transfer",
     "delete-lightning-address",
     "list-fiat-currencies",
     "list-fiat-rates",
@@ -63,10 +65,12 @@ fun buildCommandRegistry(): Map<String, CliCommand> {
         "parse" to CliCommand("parse", "Parse an input (invoice, address, LNURL)", ::handleParse),
         "refund-deposit" to CliCommand("refund-deposit", "Refund an on-chain deposit", ::handleRefundDeposit),
         "list-unclaimed-deposits" to CliCommand("list-unclaimed-deposits", "List unclaimed on-chain deposits", ::handleListUnclaimedDeposits),
-        "buy-bitcoin" to CliCommand("buy-bitcoin", "Buy Bitcoin via MoonPay", ::handleBuyBitcoin),
+        "buy-bitcoin" to CliCommand("buy-bitcoin", "Buy Bitcoin via an external provider", ::handleBuyBitcoin),
         "check-lightning-address-available" to CliCommand("check-lightning-address-available", "Check if a lightning address username is available", ::handleCheckLightningAddress),
         "get-lightning-address" to CliCommand("get-lightning-address", "Get registered lightning address", ::handleGetLightningAddress),
         "register-lightning-address" to CliCommand("register-lightning-address", "Register a lightning address", ::handleRegisterLightningAddress),
+        "authorize-lightning-address-transfer" to CliCommand("authorize-lightning-address-transfer", "Authorize transferring a lightning address to a new owner", ::handleAuthorizeLightningAddressTransfer),
+        "claim-lightning-address-transfer" to CliCommand("claim-lightning-address-transfer", "Claim a lightning address transfer from the current owner", ::handleClaimLightningAddressTransfer),
         "delete-lightning-address" to CliCommand("delete-lightning-address", "Delete lightning address", ::handleDeleteLightningAddress),
         "list-fiat-currencies" to CliCommand("list-fiat-currencies", "List fiat currencies", ::handleListFiatCurrencies),
         "list-fiat-rates" to CliCommand("list-fiat-rates", "List available fiat rates", ::handleListFiatRates),
@@ -475,6 +479,7 @@ suspend fun handleLnurlPay(sdk: BreezSdk, reader: LineReader, args: List<String>
     val comment = fp.getString("c", "comment")
     val validateStr = fp.getString("v", "validate")
     val idempotencyKey = fp.getString("i", "idempotency-key")
+    val tokenIdentifier = fp.getString("t", "token-identifier")
     val convertFromToken = fp.getString("from-token")
     val maxSlippageBps = fp.getUInt("s", "convert-max-slippage-bps")
     val feesIncluded = fp.hasFlag("fees-included")
@@ -485,6 +490,7 @@ suspend fun handleLnurlPay(sdk: BreezSdk, reader: LineReader, args: List<String>
         println("  -c, --comment <comment>          Comment for the invoice")
         println("  -v, --validate <true/false>      Validate success action URL")
         println("  -i, --idempotency-key <key>      Idempotency key")
+        println("  -t, --token-identifier <id>      Token identifier (amount in token base units)")
         println("  --from-token <token_id>          Convert from token to Bitcoin")
         println("  -s, --convert-max-slippage-bps   Max slippage in basis points")
         println("  --fees-included                  Deduct fees from amount")
@@ -515,7 +521,12 @@ suspend fun handleLnurlPay(sdk: BreezSdk, reader: LineReader, args: List<String>
 
     val minSendable = (payRequest.minSendable + 999u) / 1000u
     val maxSendable = payRequest.maxSendable / 1000u
-    val amountLine = readlinePrompt(reader, "Amount to pay (min $minSendable sat, max $maxSendable sat): ")
+    val prompt = if (tokenIdentifier == null) {
+        "Amount to pay (min $minSendable sat, max $maxSendable sat): "
+    } else {
+        "Amount to pay (min $minSendable sat, max $maxSendable sat) in token base units: "
+    }
+    val amountLine = readlinePrompt(reader, prompt)
     val amountSats = amountLine.toULongOrNull()
     if (amountSats == null) {
         println("Invalid amount: $amountLine")
@@ -530,7 +541,7 @@ suspend fun handleLnurlPay(sdk: BreezSdk, reader: LineReader, args: List<String>
             payRequest = payRequest,
             comment = comment,
             validateSuccessActionUrl = validateSuccessUrl,
-            tokenIdentifier = null,
+            tokenIdentifier = tokenIdentifier,
             conversionOptions = conversionOptions,
             feePolicy = feePolicy,
         )
@@ -757,15 +768,25 @@ suspend fun handleListUnclaimedDeposits(sdk: BreezSdk, reader: LineReader, args:
 
 suspend fun handleBuyBitcoin(sdk: BreezSdk, reader: LineReader, args: List<String>) {
     val fp = FlagParser(args)
-    val lockedAmount = fp.getULong("amount", "locked-amount-sat")
+    val provider = fp.getString("provider") ?: "moonpay"
+    val amountSat = fp.getULong("amount-sat")
     val redirectUrl = fp.getString("redirect-url")
 
-    val result = sdk.buyBitcoin(
-        BuyBitcoinRequest.Moonpay(
-            lockedAmountSat = lockedAmount,
+    val request = when (provider.lowercase()) {
+        "cashapp", "cash_app", "cash-app" -> {
+            if (amountSat == null) {
+                println("--amount-sat is required when --provider is cashapp")
+                return
+            }
+            BuyBitcoinRequest.CashApp(amountSats = amountSat)
+        }
+        else -> BuyBitcoinRequest.Moonpay(
+            lockedAmountSat = amountSat,
             redirectUrl = redirectUrl,
         )
-    )
+    }
+
+    val result = sdk.buyBitcoin(request)
     println("Open this URL in a browser to complete the purchase:")
     println(result.url)
 }
@@ -813,6 +834,48 @@ suspend fun handleRegisterLightningAddress(sdk: BreezSdk, reader: LineReader, ar
     val result = sdk.registerLightningAddress(
         RegisterLightningAddressRequest(
             username = fp.positional[0],
+            description = description,
+        )
+    )
+    printValue(result)
+}
+
+// --- authorize-lightning-address-transfer ---
+
+suspend fun handleAuthorizeLightningAddressTransfer(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    if (args.isEmpty()) {
+        println("Usage: authorize-lightning-address-transfer <transferee_pubkey>")
+        return
+    }
+
+    val result = sdk.authorizeLightningAddressTransfer(
+        AuthorizeTransferRequest(
+            transfereePubkey = args[0],
+        )
+    )
+    printValue(result)
+}
+
+// --- claim-lightning-address-transfer ---
+
+suspend fun handleClaimLightningAddressTransfer(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    val fp = FlagParser(args)
+    val fromPubkey = fp.getString("from-pubkey")
+    val fromSignature = fp.getString("from-signature")
+    val description = fp.getString("d", "description")
+
+    if (fp.positional.isEmpty() || fromPubkey == null || fromSignature == null) {
+        println("Usage: claim-lightning-address-transfer <username> --from-pubkey <pubkey> --from-signature <sig> [-d <description>]")
+        return
+    }
+
+    val result = sdk.claimLightningAddressTransfer(
+        ClaimTransferRequest(
+            authorization = TransferAuthorization(
+                username = fp.positional[0],
+                pubkey = fromPubkey,
+                signature = fromSignature,
+            ),
             description = description,
         )
     )

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -862,10 +862,9 @@ suspend fun handleClaimLightningAddressTransfer(sdk: BreezSdk, reader: LineReade
     val fp = FlagParser(args)
     val fromPubkey = fp.getString("from-pubkey")
     val fromSignature = fp.getString("from-signature")
-    val description = fp.getString("d", "description")
 
     if (fp.positional.isEmpty() || fromPubkey == null || fromSignature == null) {
-        println("Usage: claim-lightning-address-transfer <username> --from-pubkey <pubkey> --from-signature <sig> [-d <description>]")
+        println("Usage: claim-lightning-address-transfer <username> [<description>] --from-pubkey <pubkey> --from-signature <sig>")
         return
     }
 
@@ -876,7 +875,7 @@ suspend fun handleClaimLightningAddressTransfer(sdk: BreezSdk, reader: LineReade
                 pubkey = fromPubkey,
                 signature = fromSignature,
             ),
-            description = description,
+            description = fp.positional.getOrNull(1),
         )
     )
     printValue(result)

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Main.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Main.kt
@@ -62,13 +62,15 @@ fun main(args: Array<String>) {
     var accountNumber: String? = null
     var postgresConnectionString: String? = null
     var mysqlConnectionString: String? = null
-    var stableBalanceTokenIdentifier: String? = null
+    val stableBalanceTokens = mutableListOf<String>()
+    var stableBalanceDefaultActiveLabel: String? = null
     var stableBalanceThreshold: ULong? = null
     var passkeyProviderStr: String? = null
     var label: String? = null
     var listLabels = false
     var storeLabel = false
     var rpId: String? = null
+    var serverMode = false
 
     // Simple argument parsing
     var i = 0
@@ -94,9 +96,13 @@ fun main(args: Array<String>) {
                 i++
                 if (i < args.size) mysqlConnectionString = args[i]
             }
-            "--stable-balance-token-identifier" -> {
+            "--stable-balance-token" -> {
                 i++
-                if (i < args.size) stableBalanceTokenIdentifier = args[i]
+                if (i < args.size) stableBalanceTokens.add(args[i])
+            }
+            "--stable-balance-default-active-label" -> {
+                i++
+                if (i < args.size) stableBalanceDefaultActiveLabel = args[i]
             }
             "--stable-balance-threshold" -> {
                 i++
@@ -120,6 +126,9 @@ fun main(args: Array<String>) {
                 i++
                 if (i < args.size) rpId = args[i]
             }
+            "--server-mode" -> {
+                serverMode = true
+            }
             "--help", "-h" -> {
                 println("Usage: breez-sdk-spark-cli [OPTIONS]")
                 println()
@@ -129,13 +138,15 @@ fun main(args: Array<String>) {
                 println("  --account-number <NUM>                       Account number for the Spark signer")
                 println("  --postgres-connection-string <CONN>          PostgreSQL connection string (uses SQLite by default)")
                 println("  --mysql-connection-string <CONN>             MySQL connection string (mutually exclusive with --postgres-connection-string)")
-                println("  --stable-balance-token-identifier <ID>       Stable balance token identifier")
+                println("  --stable-balance-token <TICKER:ID>           Stable balance token in TICKER:token_identifier format (repeatable)")
+                println("  --stable-balance-default-active-label <LBL>  Default active label for stable balance")
                 println("  --stable-balance-threshold <SATS>            Stable balance threshold in sats")
                 println("  --passkey <PROVIDER>                         Use passkey with PRF provider (file, yubikey, or fido2)")
                 println("  --label <NAME>                               Label for seed derivation (requires --passkey)")
                 println("  --list-labels                                List and select from labels on Nostr (requires --passkey)")
                 println("  --store-label                                Publish the label to Nostr (requires --passkey and --label)")
                 println("  --rpid <ID>                                  Relying party ID for FIDO2 provider (requires --passkey)")
+                println("  --server-mode                                Run in server mode (no background tasks)")
                 println("  -h, --help                                   Show this help message")
                 return
             }
@@ -180,13 +191,21 @@ fun main(args: Array<String>) {
     }
 
     // Build stable balance config
-    val stableBalanceConfig = if (stableBalanceTokenIdentifier != null) {
+    val stableBalanceConfig = if (stableBalanceTokens.isNotEmpty()) {
+        val tokens = stableBalanceTokens.map { s ->
+            val parts = s.split(":", limit = 2)
+            if (parts.size != 2) {
+                System.err.println("Invalid token format '$s', expected LABEL:token_identifier")
+                return
+            }
+            StableBalanceToken(
+                label = parts[0],
+                tokenIdentifier = parts[1],
+            )
+        }
         StableBalanceConfig(
-            tokens = listOf(StableBalanceToken(
-                label = "USDB",
-                tokenIdentifier = stableBalanceTokenIdentifier,
-            )),
-            defaultActiveLabel = "USDB",
+            tokens = tokens,
+            defaultActiveLabel = stableBalanceDefaultActiveLabel,
             thresholdSats = stableBalanceThreshold,
             maxSlippageBps = null,
         )
@@ -213,6 +232,7 @@ fun main(args: Array<String>) {
         runInteractiveMode(
             resolvedDir,
             networkEnum,
+            serverMode,
             accountNumber,
             postgresConnectionString,
             mysqlConnectionString,
@@ -225,6 +245,7 @@ fun main(args: Array<String>) {
 suspend fun runInteractiveMode(
     dataDir: String,
     network: Network,
+    serverMode: Boolean,
     accountNumber: String?,
     postgresConnectionString: String?,
     mysqlConnectionString: String?,
@@ -242,7 +263,12 @@ suspend fun runInteractiveMode(
     val persistence = CliPersistence(dataDir)
 
     // Config
-    val config = defaultConfig(network)
+    val config = if (serverMode) {
+        println("Server mode enabled. Run `sync` between operations.")
+        defaultServerConfig(network)
+    } else {
+        defaultConfig(network)
+    }
     val apiKey = System.getenv("BREEZ_API_KEY")
     if (!apiKey.isNullOrEmpty()) {
         config.apiKey = apiKey
@@ -267,19 +293,9 @@ suspend fun runInteractiveMode(
     // Build SDK
     val builder = SdkBuilder(config, seed)
     if (postgresConnectionString != null) {
-        val context = newSharedSdkContext(SdkContextConfig(
-            network = network,
-            apiKey = if (!apiKey.isNullOrEmpty()) apiKey else null,
-            storage = postgresStorage(defaultPostgresStorageConfig(postgresConnectionString)),
-        ))
-        builder.withSharedContext(context)
+        builder.withStorageBackend(postgresStorage(defaultPostgresStorageConfig(postgresConnectionString)))
     } else if (mysqlConnectionString != null) {
-        val context = newSharedSdkContext(SdkContextConfig(
-            network = network,
-            apiKey = if (!apiKey.isNullOrEmpty()) apiKey else null,
-            storage = mysqlStorage(defaultMysqlStorageConfig(mysqlConnectionString)),
-        ))
-        builder.withSharedContext(context)
+        builder.withStorageBackend(mysqlStorage(defaultMysqlStorageConfig(mysqlConnectionString)))
     } else {
         builder.withDefaultStorage(dataDir)
     }
@@ -307,6 +323,8 @@ suspend fun runInteractiveMode(
     val commandRegistry = buildCommandRegistry()
     val issuerRegistry = buildIssuerRegistry()
     val contactsRegistry = buildContactsRegistry()
+    val webhooksRegistry = buildWebhooksRegistry()
+    val stableBalanceRegistry = buildStableBalanceRegistry()
 
     // Build completion list
     val allCommands = mutableListOf<String>()
@@ -315,6 +333,10 @@ suspend fun runInteractiveMode(
     allCommands.add("issuer")
     allCommands.addAll(CONTACTS_COMMAND_NAMES.map { "contacts $it" })
     allCommands.add("contacts")
+    allCommands.addAll(WEBHOOKS_COMMAND_NAMES.map { "webhooks $it" })
+    allCommands.add("webhooks")
+    allCommands.addAll(STABLE_BALANCE_COMMAND_NAMES.map { "stable-balance $it" })
+    allCommands.add("stable-balance")
     allCommands.addAll(listOf("exit", "quit", "help"))
 
     val networkLabel = when (network) {
@@ -357,7 +379,7 @@ suspend fun runInteractiveMode(
         }
 
         if (trimmed == "help") {
-            printHelp(commandRegistry, issuerRegistry, contactsRegistry)
+            printHelp(commandRegistry, issuerRegistry, contactsRegistry, webhooksRegistry, stableBalanceRegistry)
             continue
         }
 
@@ -369,6 +391,8 @@ suspend fun runInteractiveMode(
             when (cmdName) {
                 "issuer" -> dispatchIssuerCommand(cmdArgs, tokenIssuer, issuerRegistry, lineReader)
                 "contacts" -> dispatchContactsCommand(cmdArgs, sdk, contactsRegistry, lineReader)
+                "webhooks" -> dispatchWebhooksCommand(cmdArgs, sdk, webhooksRegistry, lineReader)
+                "stable-balance" -> dispatchStableBalanceCommand(cmdArgs, sdk, stableBalanceRegistry, lineReader)
                 else -> {
                     val cmd = commandRegistry[cmdName]
                     if (cmd != null) {
@@ -395,7 +419,9 @@ suspend fun runInteractiveMode(
 fun printHelp(
     commandRegistry: Map<String, CliCommand>,
     issuerRegistry: Map<String, IssuerCliCommand>,
-    contactsRegistry: Map<String, ContactsCliCommand>
+    contactsRegistry: Map<String, ContactsCliCommand>,
+    webhooksRegistry: Map<String, WebhooksCliCommand>,
+    stableBalanceRegistry: Map<String, StableBalanceCliCommand>,
 ) {
     println()
     println("Available commands:")
@@ -405,6 +431,8 @@ fun printHelp(
     }
     println("  %-40s %s".format("issuer <subcommand>", "Token issuer commands (use 'issuer help' for details)"))
     println("  %-40s %s".format("contacts <subcommand>", "Contacts commands (use 'contacts help' for details)"))
+    println("  %-40s %s".format("webhooks <subcommand>", "Webhook commands (use 'webhooks help' for details)"))
+    println("  %-40s %s".format("stable-balance <subcommand>", "Stable balance commands (use 'stable-balance help' for details)"))
     println("  %-40s %s".format("exit / quit", "Exit the CLI"))
     println("  %-40s %s".format("help", "Show this help message"))
     println()

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Passkey.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Passkey.kt
@@ -159,41 +159,43 @@ suspend fun resolvePasskeySeed(
 ): Seed {
     val passkey = PasskeyClient(prfProvider = provider, breezApiKey = breezApiKey, config = null)
 
-    // --store-label: publish the label to Nostr
-    if (storeLabel && label != null) {
-        println("Publishing label '$label' to Nostr...")
-        passkey.labels().store(label)
-        println("Label '$label' published successfully.")
-    }
-
-    // --list-labels: query Nostr and prompt user to select
-    val resolvedName: String? = if (listLabels) {
+    // --list-labels: discovery sign-in (no cached label) returns the
+    // discovered label set; prompt user to pick.
+    val resolvedLabel: String? = if (listLabels) {
         println("Querying Nostr for available labels...")
-        val labels = passkey.labels().list()
+        val response = passkey.signIn(SignInRequest(label = null))
 
-        if (labels.isEmpty()) {
+        if (response.labels.isEmpty()) {
             throw IllegalStateException("No labels found on Nostr for this identity")
         }
 
         println("Available labels:")
-        labels.forEachIndexed { i, name ->
+        response.labels.forEachIndexed { i, name ->
             println("  ${i + 1}: $name")
         }
 
-        print("Select label (1-${labels.size}): ")
+        print("Select label (1-${response.labels.size}): ")
         System.out.flush()
         val input = readlnOrNull()?.trim() ?: throw IllegalStateException("No input")
         val idx = input.toIntOrNull() ?: throw IllegalArgumentException("Invalid selection")
 
-        if (idx < 1 || idx > labels.size) {
+        if (idx < 1 || idx > response.labels.size) {
             throw IllegalArgumentException("Selection out of range")
         }
 
-        labels[idx - 1]
+        response.labels[idx - 1]
     } else {
         label
     }
 
-    val response = passkey.signIn(SignInRequest(label = resolvedName))
+    // --store-label: publish before signing in so a fresh client can
+    // discover the label later.
+    if (storeLabel && resolvedLabel != null) {
+        println("Publishing label '$resolvedLabel' to Nostr...")
+        passkey.labels().store(resolvedLabel)
+        println("Label '$resolvedLabel' published successfully.")
+    }
+
+    val response = passkey.signIn(SignInRequest(label = resolvedLabel))
     return response.wallet.seed
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/StableBalance.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/StableBalance.kt
@@ -1,0 +1,91 @@
+import breez_sdk_spark.*
+import org.jline.reader.LineReader
+
+data class StableBalanceCliCommand(
+    val name: String,
+    val description: String,
+    val run: suspend (sdk: BreezSdk, reader: LineReader, args: List<String>) -> Unit
+)
+
+val STABLE_BALANCE_COMMAND_NAMES = listOf(
+    "get",
+    "set",
+    "unset",
+)
+
+fun buildStableBalanceRegistry(): Map<String, StableBalanceCliCommand> {
+    return mapOf(
+        "get" to StableBalanceCliCommand("get", "Get the stable balance active label", ::handleStableBalanceGet),
+        "set" to StableBalanceCliCommand("set", "Set the stable balance active label", ::handleStableBalanceSet),
+        "unset" to StableBalanceCliCommand("unset", "Unset stable balance", ::handleStableBalanceUnset),
+    )
+}
+
+suspend fun dispatchStableBalanceCommand(
+    args: List<String>,
+    sdk: BreezSdk,
+    registry: Map<String, StableBalanceCliCommand>,
+    reader: LineReader,
+) {
+    if (args.isEmpty() || args[0] == "help") {
+        println()
+        println("Stable balance subcommands:")
+        registry.keys.sorted().forEach { name ->
+            val cmd = registry[name]!!
+            println("  stable-balance %-20s %s".format(name, cmd.description))
+        }
+        println()
+        return
+    }
+
+    val subName = args[0]
+    val subArgs = args.drop(1)
+
+    val cmd = registry[subName]
+    if (cmd == null) {
+        println("Unknown stable-balance subcommand: $subName. Use 'stable-balance help' for available commands.")
+        return
+    }
+
+    try {
+        cmd.run(sdk, reader, subArgs)
+    } catch (e: Exception) {
+        println("Error: ${e.message}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stable balance command handlers
+// ---------------------------------------------------------------------------
+
+suspend fun handleStableBalanceGet(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    val settings = sdk.getUserSettings()
+    printValue(settings.stableBalanceActiveLabel)
+}
+
+suspend fun handleStableBalanceSet(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    if (args.isEmpty()) {
+        println("Usage: stable-balance set <label>")
+        return
+    }
+
+    sdk.updateUserSettings(
+        UpdateUserSettingsRequest(
+            sparkPrivateModeEnabled = null,
+            stableBalanceActiveLabel = StableBalanceActiveLabel.Set(label = args[0]),
+        )
+    )
+    val settings = sdk.getUserSettings()
+    printValue(settings)
+}
+
+suspend fun handleStableBalanceUnset(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    sdk.updateUserSettings(
+        UpdateUserSettingsRequest(
+            sparkPrivateModeEnabled = null,
+            stableBalanceActiveLabel = StableBalanceActiveLabel.Unset,
+        )
+    )
+    val settings = sdk.getUserSettings()
+    printValue(settings)
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Webhooks.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Webhooks.kt
@@ -1,0 +1,109 @@
+import breez_sdk_spark.*
+import org.jline.reader.LineReader
+
+data class WebhooksCliCommand(
+    val name: String,
+    val description: String,
+    val run: suspend (sdk: BreezSdk, reader: LineReader, args: List<String>) -> Unit
+)
+
+val WEBHOOKS_COMMAND_NAMES = listOf(
+    "register",
+    "unregister",
+    "list",
+)
+
+fun buildWebhooksRegistry(): Map<String, WebhooksCliCommand> {
+    return mapOf(
+        "register" to WebhooksCliCommand("register", "Register a new webhook", ::handleRegisterWebhook),
+        "unregister" to WebhooksCliCommand("unregister", "Unregister a webhook", ::handleUnregisterWebhook),
+        "list" to WebhooksCliCommand("list", "List all registered webhooks", ::handleListWebhooks),
+    )
+}
+
+suspend fun dispatchWebhooksCommand(
+    args: List<String>,
+    sdk: BreezSdk,
+    registry: Map<String, WebhooksCliCommand>,
+    reader: LineReader,
+) {
+    if (args.isEmpty() || args[0] == "help") {
+        println()
+        println("Webhooks subcommands:")
+        registry.keys.sorted().forEach { name ->
+            val cmd = registry[name]!!
+            println("  webhooks %-26s %s".format(name, cmd.description))
+        }
+        println()
+        return
+    }
+
+    val subName = args[0]
+    val subArgs = args.drop(1)
+
+    val cmd = registry[subName]
+    if (cmd == null) {
+        println("Unknown webhooks subcommand: $subName. Use 'webhooks help' for available commands.")
+        return
+    }
+
+    try {
+        cmd.run(sdk, reader, subArgs)
+    } catch (e: Exception) {
+        println("Error: ${e.message}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Webhooks command handlers
+// ---------------------------------------------------------------------------
+
+suspend fun handleRegisterWebhook(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    val fp = FlagParser(args)
+    val url = fp.getString("url") ?: fp.positional.getOrNull(0)
+    val secret = fp.getString("secret") ?: fp.positional.getOrNull(1)
+    val eventsStr = fp.getString("events") ?: fp.positional.drop(2).joinToString(",").ifEmpty { null }
+
+    if (url == null || secret == null || eventsStr == null) {
+        println("Usage: webhooks register --url <url> --secret <secret> --events <type1,type2,...>")
+        println("Event types: lightning-receive, lightning-send, coop-exit, static-deposit")
+        return
+    }
+
+    val eventTypes = eventsStr.split(",").map { s ->
+        when (s.trim().lowercase()) {
+            "lightning-receive" -> WebhookEventType.LightningReceiveFinished
+            "lightning-send" -> WebhookEventType.LightningSendFinished
+            "coop-exit" -> WebhookEventType.CoopExitFinished
+            "static-deposit" -> WebhookEventType.StaticDepositFinished
+            else -> {
+                println("Unknown event type: ${s.trim()}")
+                return
+            }
+        }
+    }
+
+    val result = sdk.registerWebhook(
+        RegisterWebhookRequest(
+            url = url,
+            secret = secret,
+            eventTypes = eventTypes,
+        )
+    )
+    printValue(result)
+}
+
+suspend fun handleUnregisterWebhook(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    if (args.isEmpty()) {
+        println("Usage: webhooks unregister <webhook_id>")
+        return
+    }
+
+    sdk.unregisterWebhook(UnregisterWebhookRequest(webhookId = args[0]))
+    println("Webhook unregistered successfully")
+}
+
+suspend fun handleListWebhooks(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    val result = sdk.listWebhooks()
+    printValue(result)
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
@@ -52,6 +52,7 @@ make clean            Remove venv and build artifacts
 | `--stable-balance-token` | - | Stable balance tokens in `LABEL:token_identifier` format (repeatable) |
 | `--stable-balance-default-active-label` | - | Default active label for stable balance (must match a token label) |
 | `--stable-balance-threshold` | - | Stable balance threshold in sats |
+| `--server-mode` | false | Run in server mode (`background_tasks_enabled=false`) |
 | `--passkey` | - | Use Passkey with PRF provider (`file`, `yubikey` or `fido2`) |
 | `--label` | `Default` | Requires `--passkey`. The label to use |
 | `--list-labels` | false | Requires `--passkey`. Select label from NOSTR |
@@ -74,7 +75,7 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **On-chain**: `claim-deposit`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
 
-**Lightning address**: `get-lightning-address`, `register-lightning-address`, `delete-lightning-address`, `check-lightning-address-available`
+**Lightning address**: `get-lightning-address`, `register-lightning-address`, `authorize-lightning-address-transfer`, `claim-lightning-address-transfer`, `delete-lightning-address`, `check-lightning-address-available`
 
 **Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`, `issuer <subcommand>`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -7,10 +7,12 @@ import time
 import breez_sdk_spark
 from breez_sdk_spark import (
     AssetFilter,
+    AuthorizeTransferRequest,
     BuyBitcoinRequest,
     CheckLightningAddressRequest,
     ClaimDepositRequest,
     ClaimHtlcPaymentRequest,
+    ClaimTransferRequest,
     ConversionOptions,
     ConversionType,
     Fee,
@@ -42,6 +44,7 @@ from breez_sdk_spark import (
     SparkHtlcStatus,
     SyncWalletRequest,
     TokenTransactionType,
+    TransferAuthorization,
     UpdateUserSettingsRequest,
 )
 
@@ -67,6 +70,8 @@ COMMAND_NAMES = [
     "check-lightning-address-available",
     "get-lightning-address",
     "register-lightning-address",
+    "authorize-lightning-address-transfer",
+    "claim-lightning-address-transfer",
     "delete-lightning-address",
     "list-fiat-currencies",
     "list-fiat-rates",
@@ -685,6 +690,52 @@ async def _handle_register_lightning_address(sdk, _token_issuer, _session, args)
     print_value(result)
 
 
+# --- authorize-lightning-address-transfer ---
+
+def _build_authorize_lightning_address_transfer_parser():
+    p = _parser("authorize-lightning-address-transfer",
+                "Authorize transferring lightning address to another pubkey")
+    p.add_argument("transferee_pubkey",
+                   help="The new owner's identity public key (hex-encoded compressed secp256k1)")
+    return p
+
+async def _handle_authorize_lightning_address_transfer(sdk, _token_issuer, _session, args):
+    result = await sdk.authorize_lightning_address_transfer(
+        request=AuthorizeTransferRequest(
+            transferee_pubkey=args.transferee_pubkey,
+        )
+    )
+    print_value(result)
+
+
+# --- claim-lightning-address-transfer ---
+
+def _build_claim_lightning_address_transfer_parser():
+    p = _parser("claim-lightning-address-transfer",
+                "Claim a lightning address transfer authorized by the current owner")
+    p.add_argument("username", help="The username being taken over (from the authorization)")
+    p.add_argument("description", nargs="?", default=None,
+                   help="Description in the lnurl response and the invoice")
+    p.add_argument("--from-pubkey", required=True,
+                   help="The current owner's identity public key (hex-encoded compressed secp256k1)")
+    p.add_argument("--from-signature", required=True,
+                   help="The current owner's signature authorizing the transfer (hex-encoded DER ECDSA)")
+    return p
+
+async def _handle_claim_lightning_address_transfer(sdk, _token_issuer, _session, args):
+    result = await sdk.claim_lightning_address_transfer(
+        request=ClaimTransferRequest(
+            authorization=TransferAuthorization(
+                username=args.username,
+                pubkey=args.from_pubkey,
+                signature=args.from_signature,
+            ),
+            description=args.description,
+        )
+    )
+    print_value(result)
+
+
 # --- delete-lightning-address ---
 
 def _build_delete_lightning_address_parser():
@@ -784,6 +835,7 @@ async def _handle_set_user_settings(sdk, _token_issuer, _session, args):
     await sdk.update_user_settings(
         request=UpdateUserSettingsRequest(
             spark_private_mode_enabled=args.spark_private_mode_enabled,
+            stable_balance_active_label=None,
         )
     )
     print("User settings updated")
@@ -902,6 +954,8 @@ def build_command_registry():
         "check-lightning-address-available": (_build_check_lightning_address_available_parser(), _handle_check_lightning_address_available),
         "get-lightning-address": (_build_get_lightning_address_parser(), _handle_get_lightning_address),
         "register-lightning-address": (_build_register_lightning_address_parser(), _handle_register_lightning_address),
+        "authorize-lightning-address-transfer": (_build_authorize_lightning_address_transfer_parser(), _handle_authorize_lightning_address_transfer),
+        "claim-lightning-address-transfer": (_build_claim_lightning_address_transfer_parser(), _handle_claim_lightning_address_transfer),
         "delete-lightning-address": (_build_delete_lightning_address_parser(), _handle_delete_lightning_address),
         "list-fiat-currencies": (_build_list_fiat_currencies_parser(), _handle_list_fiat_currencies),
         "list-fiat-rates": (_build_list_fiat_rates_parser(), _handle_list_fiat_rates),

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
@@ -15,7 +15,6 @@ from breez_sdk_spark import (
     KeySetType,
     Network,
     SdkBuilder,
-    SdkContextConfig,
     SdkEvent,
     Seed,
     StableBalanceConfig,
@@ -23,8 +22,10 @@ from breez_sdk_spark import (
     default_config,
     default_mysql_storage_config,
     default_postgres_storage_config,
+    default_server_config,
     init_logging,
-    new_shared_sdk_context,
+    mysql_storage,
+    postgres_storage,
 )
 
 from breez_cli.commands import COMMAND_NAMES, build_command_registry
@@ -69,6 +70,8 @@ def expand_path(path: str) -> Path:
 @click.option("--stable-balance-default-active-label", default=None,
               help="Default active label for stable balance (must match a token label)")
 @click.option("--stable-balance-threshold", type=int, default=None, help="Stable balance threshold in sats")
+@click.option("--server-mode", is_flag=True, default=False,
+              help="Run in server mode (background_tasks_enabled=false)")
 @click.option("--passkey", "passkey_provider", default=None, help="Use passkey with file, yubikey, or fido2 provider")
 @click.option("--label", default=None, help="Label for seed derivation (requires --passkey)")
 @click.option("--list-labels", is_flag=True, default=False, help="List and select from labels published to Nostr (requires --passkey)")
@@ -78,6 +81,7 @@ async def main(data_dir, network, account_number, postgres_connection_string,
                mysql_connection_string,
                stable_balance_tokens, stable_balance_default_active_label,
                stable_balance_threshold,
+               server_mode,
                passkey_provider, label, list_labels, store_label, rpid):
     """CLI client for Breez SDK with Spark."""
     data_dir = expand_path(data_dir)
@@ -106,7 +110,11 @@ async def main(data_dir, network, account_number, postgres_connection_string,
 
     network_enum = Network.MAINNET if network == "mainnet" else Network.REGTEST
     breez_api_key = os.environ.get("BREEZ_API_KEY")
-    config = default_config(network=network_enum)
+    if server_mode:
+        print("Server mode enabled. Run `sync` between operations.")
+        config = default_server_config(network=network_enum)
+    else:
+        config = default_config(network=network_enum)
     config.api_key = breez_api_key
 
     if stable_balance_tokens:
@@ -136,19 +144,17 @@ async def main(data_dir, network, account_number, postgres_connection_string,
     builder = SdkBuilder(config=config, seed=seed)
 
     if postgres_connection_string:
-        context = await new_shared_sdk_context(config=SdkContextConfig(
-            network=network_enum,
-            api_key=breez_api_key,
-            postgres_config=default_postgres_storage_config(connection_string=postgres_connection_string),
-        ))
-        await builder.with_shared_context(context=context)
+        await builder.with_storage_backend(
+            storage=postgres_storage(config=default_postgres_storage_config(
+                connection_string=postgres_connection_string,
+            ))
+        )
     elif mysql_connection_string:
-        context = await new_shared_sdk_context(config=SdkContextConfig(
-            network=network_enum,
-            api_key=breez_api_key,
-            mysql_config=default_mysql_storage_config(connection_string=mysql_connection_string),
-        ))
-        await builder.with_shared_context(context=context)
+        await builder.with_storage_backend(
+            storage=mysql_storage(config=default_mysql_storage_config(
+                connection_string=mysql_connection_string,
+            ))
+        )
     else:
         await builder.with_default_storage(storage_dir=str(data_dir))
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/passkey.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/passkey.py
@@ -5,10 +5,13 @@ import sys
 from pathlib import Path
 
 from breez_sdk_spark import (
-    NostrRelayConfig,
-    Passkey,
+    DeriveSeedsOutput,
+    DeriveSeedsRequest,
+    DomainAssociation,
+    PasskeyClient,
     PrfProvider,
     Seed,
+    SignInRequest,
 )
 
 SECRET_FILE_NAME = "seedless-restore-secret"
@@ -35,11 +38,23 @@ class FilePrfProvider(PrfProvider):
             data_dir.mkdir(parents=True, exist_ok=True)
             secret_path.write_bytes(self._secret)
 
-    async def derive_prf_seed(self, salt: str):
+    def _derive_one(self, salt: str) -> bytes:
         return hmac.new(self._secret, salt.encode(), hashlib.sha256).digest()
 
-    async def is_prf_available(self):
+    async def derive_seeds(self, request: DeriveSeedsRequest) -> DeriveSeedsOutput:
+        seeds = [self._derive_one(s) for s in request.salts]
+        return DeriveSeedsOutput(seeds=seeds, credential_id=None)
+
+    async def is_supported(self) -> bool:
         return True
+
+    async def create_passkey(self, exclude_credentials):
+        raise NotImplementedError
+
+    async def check_domain_association(self) -> DomainAssociation:
+        return DomainAssociation.SKIPPED(
+            reason="File provider does not verify domain association"
+        )
 
 
 class YubiKeyPrfProvider(PrfProvider):
@@ -56,11 +71,17 @@ class YubiKeyPrfProvider(PrfProvider):
         )
         raise SystemExit(1)
 
-    async def derive_prf_seed(self, salt: str):
+    async def derive_seeds(self, request: DeriveSeedsRequest) -> DeriveSeedsOutput:
         raise NotImplementedError
 
-    async def is_prf_available(self):
+    async def is_supported(self) -> bool:
         return False
+
+    async def create_passkey(self, exclude_credentials):
+        raise NotImplementedError
+
+    async def check_domain_association(self) -> DomainAssociation:
+        raise NotImplementedError
 
 
 class Fido2PrfProvider(PrfProvider):
@@ -77,11 +98,17 @@ class Fido2PrfProvider(PrfProvider):
         )
         raise SystemExit(1)
 
-    async def derive_prf_seed(self, salt: str):
+    async def derive_seeds(self, request: DeriveSeedsRequest) -> DeriveSeedsOutput:
         raise NotImplementedError
 
-    async def is_prf_available(self):
+    async def is_supported(self) -> bool:
         return False
+
+    async def create_passkey(self, exclude_credentials):
+        raise NotImplementedError
+
+    async def check_domain_association(self) -> DomainAssociation:
+        raise NotImplementedError
 
 
 def create_provider(provider_name: str, data_dir: Path, rpid=None):
@@ -106,40 +133,37 @@ async def resolve_passkey_seed(
     store_label,
 ) -> Seed:
     """Resolve a Seed from a passkey PRF provider, with optional Nostr label operations."""
-    relay_config = NostrRelayConfig(breez_api_key=breez_api_key)
-    passkey = Passkey(provider, relay_config)
+    client = PasskeyClient(provider, breez_api_key, None)
 
-    # --store-label: publish the label to Nostr
-    if store_label and label:
-        print(f"Publishing label '{label}' to Nostr...")
-        await passkey.store_label(label=label)
-        print(f"Label '{label}' published successfully.")
-
-    # --list-labels: query Nostr and prompt user to select
     if list_labels:
         print("Querying Nostr for available labels...")
-        labels = await passkey.list_labels()
+        response = await client.sign_in(request=SignInRequest(label=None))
 
-        if not labels:
+        if not response.labels:
             print("No labels found on Nostr for this identity")
             raise SystemExit(1)
 
         print("Available labels:")
-        for i, name in enumerate(labels, 1):
+        for i, name in enumerate(response.labels, 1):
             print(f"  {i}: {name}")
 
-        selection = input(f"Select label (1-{len(labels)}): ").strip()
+        selection = input(f"Select label (1-{len(response.labels)}): ").strip()
         try:
             idx = int(selection)
         except ValueError:
             print("Invalid selection")
             raise SystemExit(1)
 
-        if idx < 1 or idx > len(labels):
+        if idx < 1 or idx > len(response.labels):
             print("Selection out of range")
             raise SystemExit(1)
 
-        label = labels[idx - 1]
+        label = response.labels[idx - 1]
 
-    wallet = await passkey.get_wallet(label)
-    return wallet.seed
+    if store_label and label:
+        print(f"Publishing label '{label}' to Nostr...")
+        await client.labels().store(label=label)
+        print(f"Label '{label}' published successfully.")
+
+    response = await client.sign_in(request=SignInRequest(label=label))
+    return response.wallet.seed

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/README.md
@@ -111,7 +111,7 @@ Transfer a lightning address to another user:
 authorize-lightning-address-transfer <transferee_pubkey>
 
 # New owner claims the transfer
-claim-lightning-address-transfer <username> --from-pubkey <pubkey> --from-signature <signature>
+claim-lightning-address-transfer <username> [<description>] --from-pubkey <pubkey> --from-signature <signature>
 ```
 
 ### HODL Invoices

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/README.md
@@ -43,9 +43,10 @@ Three PRF providers are available:
 
 | Provider | Description |
 |----------|-------------|
+| `platform` | Platform-native passkey (iOS AuthenticationServices / Android CredentialManager) |
 | `file` | File-based HMAC-SHA256 provider (for development/testing) |
-| `yubikey` | YubiKey hardware key (stub - not yet implemented) |
-| `fido2` | FIDO2/WebAuthn PRF (stub - not yet implemented) |
+| `yubikey` | YubiKey hardware key (stub, not yet implemented) |
+| `fido2` | FIDO2/WebAuthn PRF (stub, not yet implemented) |
 
 ### Configuration
 
@@ -81,9 +82,11 @@ Once the app is running, type commands in the text input at the bottom:
 
 **On-chain**: `claim-deposit`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
 
-**Lightning address**: `get-lightning-address`, `register-lightning-address`, `delete-lightning-address`, `check-lightning-address-available`
+**Lightning address**: `get-lightning-address`, `register-lightning-address`, `authorize-lightning-address-transfer`, `claim-lightning-address-transfer`, `delete-lightning-address`, `check-lightning-address-available`
 
 **Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`, `issuer <subcommand>`
+
+**Stable balance**: `stable-balance get`, `stable-balance set`, `stable-balance unset`
 
 **Contacts**: `contacts <subcommand>`
 
@@ -92,6 +95,24 @@ Once the app is running, type commands in the text input at the bottom:
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 
 Type `help` for a full list of commands. Each command mirrors the Rust CLI behavior.
+
+### Server Mode
+
+The setup screen includes a Client/Server mode toggle. Server mode uses `defaultServerConfig`
+which disables background tasks (periodic sync, real-time sync client, optimizers).
+Run `sync` manually between operations.
+
+### Lightning Address Transfers
+
+Transfer a lightning address to another user:
+
+```
+# Current owner authorizes the transfer
+authorize-lightning-address-transfer <transferee_pubkey>
+
+# New owner claims the transfer
+claim-lightning-address-transfer <username> --from-pubkey <pubkey> --from-signature <signature>
+```
 
 ### HODL Invoices
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/App.tsx
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/App.tsx
@@ -24,6 +24,7 @@ import {
 } from 'react-native'
 import {
   defaultConfig,
+  defaultServerConfig,
   Network,
   Seed,
   SdkBuilder,
@@ -61,6 +62,7 @@ function getDataDir(network: Network): string {
 
 interface SetupConfig {
   network: Network
+  serverMode: boolean
   passkeyConfig: PasskeyConfig | undefined
   /** If provided, use this mnemonic instead of generating/loading one. */
   restoreMnemonic: string | undefined
@@ -91,6 +93,7 @@ interface SetupScreenProps {
 
 const SetupScreen: React.FC<SetupScreenProps> = ({ onStart }) => {
   const [network, setNetwork] = useState<Network>(Network.Regtest as Network)
+  const [serverMode, setServerMode] = useState(false)
   const [seedMethod, setSeedMethod] = useState<'mnemonic' | 'passkey'>('mnemonic')
   const [mnemonicMode, setMnemonicMode] = useState<'new' | 'restore'>('new')
   const [mnemonicInput, setMnemonicInput] = useState('')
@@ -106,6 +109,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStart }) => {
     }
     onStart({
       network,
+      serverMode,
       passkeyConfig: seedMethod === 'passkey' ? {
         provider: passkeyProvider,
         label: 'Default',
@@ -178,6 +182,28 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStart }) => {
             </TouchableOpacity>
           ))}
         </View>
+
+        {/* Server Mode */}
+        <Text style={styles.sectionLabel}>Mode</Text>
+        <View style={styles.buttonRow}>
+          <TouchableOpacity
+            style={[styles.optionButton, !serverMode && styles.optionButtonActive]}
+            onPress={() => setServerMode(false)}
+          >
+            <Text style={[styles.optionText, !serverMode && styles.optionTextActive]}>Client</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.optionButton, serverMode && styles.optionButtonActive]}
+            onPress={() => setServerMode(true)}
+          >
+            <Text style={[styles.optionText, serverMode && styles.optionTextActive]}>Server</Text>
+          </TouchableOpacity>
+        </View>
+        {serverMode && (
+          <Text style={styles.hint}>
+            No background tasks. Run `sync` between operations.
+          </Text>
+        )}
 
         {/* Seed Method */}
         <Text style={styles.sectionLabel}>Seed Method</Text>
@@ -373,7 +399,12 @@ const CliScreen: React.FC<CliScreenProps> = ({ config, onDisconnect }) => {
         appendLog('Initializing SDK...')
 
         const persistence = persistenceRef.current
-        const sdkConfig = defaultConfig(config.network)
+        const sdkConfig = config.serverMode
+          ? defaultServerConfig(config.network)
+          : defaultConfig(config.network)
+        if (config.serverMode) {
+          appendLog('Server mode enabled. Run `sync` between operations.')
+        }
         const apiKey = getApiKey()
         if (apiKey) {
           sdkConfig.apiKey = apiKey

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
@@ -64,6 +64,7 @@ declare module '@breeztech/breez-sdk-spark-react-native' {
 
   // --- values only ---
   export const defaultConfig: any;
+  export const defaultServerConfig: any;
   export const SdkEvent_Tags: any;
   export const InputType_Tags: any;
   export const ReceivePaymentMethod: any;

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -1007,7 +1007,7 @@ async function handleClaimLightningAddressTransfer(sdk: BreezSdkInterface, _toke
   }
 
   const username = positional[0]
-  const description = positional.length > 1 ? positional[1] : parseFlag(args, '--description', '-d')
+  const description = positional.length > 1 ? positional[1] : undefined
   const fromPubkey = parseFlag(args, '--from-pubkey')
   const fromSignature = parseFlag(args, '--from-signature')
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -162,6 +162,8 @@ export const COMMAND_NAMES = [
   'check-lightning-address-available',
   'get-lightning-address',
   'register-lightning-address',
+  'authorize-lightning-address-transfer',
+  'claim-lightning-address-transfer',
   'delete-lightning-address',
   'list-fiat-currencies',
   'list-fiat-rates',
@@ -203,6 +205,8 @@ export function buildCommandRegistry(): Map<string, CommandDef> {
     { name: 'check-lightning-address-available', description: 'Check if a lightning address username is available', run: handleCheckLightningAddress },
     { name: 'get-lightning-address', description: 'Get registered lightning address', run: handleGetLightningAddress },
     { name: 'register-lightning-address', description: 'Register a lightning address', run: handleRegisterLightningAddress },
+    { name: 'authorize-lightning-address-transfer', description: 'Authorize transferring your lightning address to another pubkey', run: handleAuthorizeLightningAddressTransfer },
+    { name: 'claim-lightning-address-transfer', description: 'Claim a lightning address transfer', run: handleClaimLightningAddressTransfer },
     { name: 'delete-lightning-address', description: 'Delete lightning address', run: handleDeleteLightningAddress },
     { name: 'list-fiat-currencies', description: 'List fiat currencies', run: handleListFiatCurrencies },
     { name: 'list-fiat-rates', description: 'List available fiat rates', run: handleListFiatRates },
@@ -983,6 +987,45 @@ async function handleRegisterLightningAddress(sdk: BreezSdkInterface, _tokenIssu
   return formatValue(result)
 }
 
+// --- authorize-lightning-address-transfer ---
+
+async function handleAuthorizeLightningAddressTransfer(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
+  if (args.length < 1) {
+    return 'Usage: authorize-lightning-address-transfer <transferee_pubkey>'
+  }
+
+  const result = await sdk.authorizeLightningAddressTransfer({ transfereePubkey: args[0] })
+  return formatValue(result)
+}
+
+// --- claim-lightning-address-transfer ---
+
+async function handleClaimLightningAddressTransfer(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
+  const positional = args.filter(a => !a.startsWith('-'))
+  if (positional.length < 1) {
+    return 'Usage: claim-lightning-address-transfer <username> [<description>] --from-pubkey <pubkey> --from-signature <signature>'
+  }
+
+  const username = positional[0]
+  const description = positional.length > 1 ? positional[1] : parseFlag(args, '--description', '-d')
+  const fromPubkey = parseFlag(args, '--from-pubkey')
+  const fromSignature = parseFlag(args, '--from-signature')
+
+  if (!fromPubkey || !fromSignature) {
+    return 'Error: --from-pubkey and --from-signature are required'
+  }
+
+  const result = await sdk.claimLightningAddressTransfer({
+    authorization: {
+      username,
+      pubkey: fromPubkey,
+      signature: fromSignature,
+    },
+    description,
+  })
+  return formatValue(result)
+}
+
 // --- delete-lightning-address ---
 
 async function handleDeleteLightningAddress(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, _args: string[]): Promise<string> {
@@ -1074,6 +1117,7 @@ async function handleSetUserSettings(sdk: BreezSdkInterface, _tokenIssuer: Token
 
   await sdk.updateUserSettings({
     sparkPrivateModeEnabled,
+    stableBalanceActiveLabel: undefined,
   })
   return 'User settings updated'
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/passkey.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/passkey.ts
@@ -306,20 +306,20 @@ export async function resolvePasskeySeed(
 ): Promise<{ seed: SeedType; labels?: string[] }> {
   const passkey = new PasskeyClient(provider, breezApiKey, undefined)
 
-  // --store-label: publish to Nostr
-  if (storeLabel && label) {
-    await passkey.labels().store(label)
-  }
-
-  // --list-labels: query Nostr for all labels published by this identity.
-  // App.tsx does not prompt for selection; default to the explicit label if
-  // provided, otherwise the first discovered label.
+  // --list-labels: discovery sign-in (no cached label) returns the published
+  // label set. App.tsx does not prompt for selection; default to the explicit
+  // label if provided, otherwise the first discovered label.
   let returnedLabels: string[] | undefined
   let resolvedLabel = label
   if (listLabels) {
-    const labels = await passkey.labels().list()
+    const { labels } = await passkey.signIn({ label: undefined })
     returnedLabels = labels
     resolvedLabel = label ?? labels[0]
+  }
+
+  // --store-label: publish to Nostr
+  if (storeLabel && resolvedLabel) {
+    await passkey.labels().store(resolvedLabel)
   }
 
   const response = await passkey.connectWithPasskey({

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
@@ -58,6 +58,7 @@ make clean            Remove build artifacts
 | `--stable-balance-token` | - | Stable balance token in `LABEL:token_identifier` format (repeatable) |
 | `--stable-balance-default-active-label` | - | Default active label for stable balance |
 | `--stable-balance-threshold` | - | Stable balance threshold in sats |
+| `--server-mode` | false | Run in server mode (no background tasks, drive `sync` yourself) |
 | `--passkey` | - | Use Passkey with PRF provider (`file`, `yubikey` or `fido2`) |
 | `--label` | `Default` | Requires `--passkey`. The label to use |
 | `--list-labels` | false | Requires `--passkey`. Select label from Nostr |
@@ -76,19 +77,23 @@ Once inside the REPL, type `help` to see all commands. The REPL supports **comma
 
 The CLI supports:
 
-**Wallet**: `get-info`, `sync`, `get-payment`, `list-payments`
+**Wallet**: `get-info`, `sync`, `get-payment`, `list-payments`, `recommended-fees`
 
 **Payments**: `receive`, `pay`, `lnurl-pay`, `lnurl-withdraw`, `lnurl-auth`, `claim-htlc-payment`
 
 **On-chain**: `claim-deposit`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
 
-**Lightning address**: `get-lightning-address`, `register-lightning-address`, `delete-lightning-address`, `check-lightning-address-available`
+**Lightning address**: `get-lightning-address`, `register-lightning-address`, `delete-lightning-address`, `check-lightning-address-available`, `authorize-lightning-address-transfer`, `claim-lightning-address-transfer`
 
 **Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`, `issuer <subcommand>`
 
 **Contacts**: `contacts add`, `contacts update`, `contacts delete`, `contacts list`
 
-**Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`, `recommended-fees`
+**Webhooks**: `webhooks register`, `webhooks unregister`, `webhooks list`
+
+**Stable balance**: `stable-balance get`, `stable-balance set`, `stable-balance unset`
+
+**Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 
 ## Passkey
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -80,6 +80,8 @@ let commandNames: [String] = [
     "check-lightning-address-available",
     "get-lightning-address",
     "register-lightning-address",
+    "authorize-lightning-address-transfer",
+    "claim-lightning-address-transfer",
     "delete-lightning-address",
     "list-fiat-currencies",
     "list-fiat-rates",
@@ -113,6 +115,8 @@ func buildCommandRegistry() -> [String: CommandEntry] {
         "check-lightning-address-available": CommandEntry(name: "check-lightning-address-available", description: "Check if a lightning address username is available", run: handleCheckLightningAddress),
         "get-lightning-address":             CommandEntry(name: "get-lightning-address", description: "Get registered lightning address", run: handleGetLightningAddress),
         "register-lightning-address":        CommandEntry(name: "register-lightning-address", description: "Register a lightning address", run: handleRegisterLightningAddress),
+        "authorize-lightning-address-transfer": CommandEntry(name: "authorize-lightning-address-transfer", description: "Authorize transferring your lightning address", run: handleAuthorizeLightningAddressTransfer),
+        "claim-lightning-address-transfer":     CommandEntry(name: "claim-lightning-address-transfer", description: "Claim a lightning address transfer", run: handleClaimLightningAddressTransfer),
         "delete-lightning-address":          CommandEntry(name: "delete-lightning-address", description: "Delete lightning address", run: handleDeleteLightningAddress),
         "list-fiat-currencies":              CommandEntry(name: "list-fiat-currencies", description: "List fiat currencies", run: handleListFiatCurrencies),
         "list-fiat-rates":                   CommandEntry(name: "list-fiat-rates", description: "List available fiat rates", run: handleListFiatRates),
@@ -136,6 +140,8 @@ func printHelp(_ registry: [String: CommandEntry]) {
     }
     print("\n  \("issuer <subcommand>".padding(toLength: 40, withPad: " ", startingAt: 0))Token issuer commands (use 'issuer help' for details)")
     print("  \("contacts <subcommand>".padding(toLength: 40, withPad: " ", startingAt: 0))Contacts commands (use 'contacts help' for details)")
+    print("  \("webhooks <subcommand>".padding(toLength: 40, withPad: " ", startingAt: 0))Webhook commands (use 'webhooks help' for details)")
+    print("  \("stable-balance <subcommand>".padding(toLength: 40, withPad: " ", startingAt: 0))Stable balance commands (use 'stable-balance help' for details)")
     print("  \("exit / quit".padding(toLength: 40, withPad: " ", startingAt: 0))Exit the CLI")
     print("  \("help".padding(toLength: 40, withPad: " ", startingAt: 0))Show this help message")
     print()
@@ -487,7 +493,7 @@ func handlePay(_ sdk: BreezSdk, _ args: [String]) async throws {
 func handleLnurlPay(_ sdk: BreezSdk, _ args: [String]) async throws {
     let fp = FlagParser(args)
     guard let lnurl = fp.positional.first else {
-        print("Usage: lnurl-pay <lnurl> [-c <comment>] [-v <validate>] [-i <idempotency_key>] [--from-token <id>] [-s <slippage_bps>] [--fees-included]")
+        print("Usage: lnurl-pay <lnurl> [-c <comment>] [-v <validate>] [-i <idempotency_key>] [-t <token_identifier>] [--from-token <id>] [-s <slippage_bps>] [--fees-included]")
         return
     }
 
@@ -495,6 +501,7 @@ func handleLnurlPay(_ sdk: BreezSdk, _ args: [String]) async throws {
     let validateStr = fp.get("v", "validate")
     let validateSuccessUrl: Bool? = validateStr.map { $0 == "true" }
     let idempotencyKey = fp.get("i", "idempotency-key")
+    let tokenIdentifier = fp.get("t", "token-identifier")
     let fromTokenId = fp.get("from-token")
     let maxSlippageBps = fp.get("s", "convert-max-slippage-bps").flatMap { UInt32($0) }
     let feesIncluded = fp.has("fees-included")
@@ -523,19 +530,24 @@ func handleLnurlPay(_ sdk: BreezSdk, _ args: [String]) async throws {
 
     let minSendable = (payRequest.minSendable + 999) / 1000
     let maxSendable = payRequest.maxSendable / 1000
-    let prompt = "Amount to pay (min \(minSendable) sat, max \(maxSendable) sat): "
+    let prompt: String
+    if tokenIdentifier == nil {
+        prompt = "Amount to pay (min \(minSendable) sat, max \(maxSendable) sat): "
+    } else {
+        prompt = "Amount to pay (min \(minSendable) sat, max \(maxSendable) sat) in token base units: "
+    }
     guard let amountLine = readlinePrompt(prompt),
-          let amountSats = UInt64(amountLine.trimmingCharacters(in: .whitespaces)) else {
+          let amount = BInt(amountLine.trimmingCharacters(in: .whitespaces)) else {
         print("Invalid amount")
         return
     }
 
     let prepareResponse = try await sdk.prepareLnurlPay(request: PrepareLnurlPayRequest(
-        amount: BInt(amountSats),
+        amount: amount,
         payRequest: payRequest,
         comment: comment,
         validateSuccessActionUrl: validateSuccessUrl,
-        tokenIdentifier: nil,
+        tokenIdentifier: tokenIdentifier,
         conversionOptions: conversionOptions,
         feePolicy: feePolicy
     ))
@@ -741,13 +753,23 @@ func handleListUnclaimedDeposits(_ sdk: BreezSdk, _ args: [String]) async throws
 
 func handleBuyBitcoin(_ sdk: BreezSdk, _ args: [String]) async throws {
     let fp = FlagParser(args)
-    let lockedAmount = fp.get("locked-amount-sat").flatMap { UInt64($0) }
+    let provider = fp.get("provider") ?? "moonpay"
+    let amountSat = fp.get("amount-sat").flatMap { UInt64($0) }
     let redirectUrl = fp.get("redirect-url")
 
-    let result = try await sdk.buyBitcoin(request: .moonpay(
-        lockedAmountSat: lockedAmount,
-        redirectUrl: redirectUrl
-    ))
+    let request: BuyBitcoinRequest
+    switch provider.lowercased() {
+    case "cashapp", "cash_app", "cash-app":
+        guard let amountSats = amountSat else {
+            print("--amount-sat is required when --provider is cashapp")
+            return
+        }
+        request = .cashApp(amountSats: amountSats)
+    default:
+        request = .moonpay(lockedAmountSat: amountSat, redirectUrl: redirectUrl)
+    }
+
+    let result = try await sdk.buyBitcoin(request: request)
     print("Open this URL in a browser to complete the purchase:")
     print(result.url)
 }
@@ -794,6 +816,51 @@ func handleRegisterLightningAddress(_ sdk: BreezSdk, _ args: [String]) async thr
 
     let result = try await sdk.registerLightningAddress(request: RegisterLightningAddressRequest(
         username: username,
+        description: description
+    ))
+    printValue(result)
+}
+
+// --- authorize-lightning-address-transfer ---
+
+func handleAuthorizeLightningAddressTransfer(_ sdk: BreezSdk, _ args: [String]) async throws {
+    guard !args.isEmpty else {
+        print("Usage: authorize-lightning-address-transfer <transferee_pubkey>")
+        return
+    }
+
+    let result = try await sdk.authorizeLightningAddressTransfer(request: AuthorizeTransferRequest(
+        transfereePubkey: args[0]
+    ))
+    printValue(result)
+}
+
+// --- claim-lightning-address-transfer ---
+
+func handleClaimLightningAddressTransfer(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let fp = FlagParser(args)
+    guard let username = fp.positional.first else {
+        print("Usage: claim-lightning-address-transfer <username> [<description>] --from-pubkey <pubkey> --from-signature <signature>")
+        return
+    }
+
+    let description: String? = fp.positional.count > 1 ? fp.positional[1] : nil
+
+    guard let fromPubkey = fp.get("from-pubkey") else {
+        print("--from-pubkey is required")
+        return
+    }
+    guard let fromSignature = fp.get("from-signature") else {
+        print("--from-signature is required")
+        return
+    }
+
+    let result = try await sdk.claimLightningAddressTransfer(request: ClaimTransferRequest(
+        authorization: TransferAuthorization(
+            username: username,
+            pubkey: fromPubkey,
+            signature: fromSignature
+        ),
         description: description
     ))
     printValue(result)

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Passkey.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Passkey.swift
@@ -188,18 +188,12 @@ func resolvePasskeySeed(
 ) async throws -> Seed {
     let passkey = PasskeyClient(prfProvider: provider, breezApiKey: breezApiKey, config: nil)
 
-    // --store-label: publish the label to Nostr
-    if storeLabel, let label {
-        print("Publishing label '\(label)' to Nostr...")
-        try await passkey.labels().store(label: label)
-        print("Label '\(label)' published successfully.")
-    }
-
-    // --list-labels: query Nostr and prompt user to select
+    // --list-labels: discovery sign-in (no cached label) returns the
+    // published label set; prompt the user to pick one.
     let resolvedName: String?
     if listLabels {
         print("Querying Nostr for available labels...")
-        let labels = try await passkey.labels().list()
+        let labels = try await passkey.signIn(request: SignInRequest(label: nil)).labels
 
         if labels.isEmpty {
             throw PrfProviderError.Generic(
@@ -222,6 +216,14 @@ func resolvePasskeySeed(
         resolvedName = labels[idx - 1]
     } else {
         resolvedName = label
+    }
+
+    // --store-label: publish before signing in so a fresh client can
+    // discover the label later.
+    if storeLabel, let resolvedName {
+        print("Publishing label '\(resolvedName)' to Nostr...")
+        try await passkey.labels().store(label: resolvedName)
+        print("Label '\(resolvedName)' published successfully.")
     }
 
     let response = try await passkey.signIn(request: SignInRequest(label: resolvedName))

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/StableBalance.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/StableBalance.swift
@@ -1,0 +1,83 @@
+import Foundation
+import BreezSdkSpark
+
+// MARK: - Stable balance command names (for REPL completion)
+
+let stableBalanceCommandNames: [String] = [
+    "stable-balance get",
+    "stable-balance set",
+    "stable-balance unset",
+]
+
+// MARK: - Dispatch
+
+func dispatchStableBalanceCommand(_ args: [String], sdk: BreezSdk) async {
+    if args.isEmpty || args[0] == "help" {
+        printStableBalanceHelp()
+        return
+    }
+
+    let subName = args[0]
+    let subArgs = Array(args.dropFirst())
+
+    do {
+        switch subName {
+        case "get":
+            try await handleStableBalanceGet(sdk, subArgs)
+        case "set":
+            try await handleStableBalanceSet(sdk, subArgs)
+        case "unset":
+            try await handleStableBalanceUnset(sdk, subArgs)
+        default:
+            print("Unknown stable-balance subcommand: \(subName). Use 'stable-balance help' for available commands.")
+        }
+    } catch {
+        print("Error: \(error)")
+    }
+}
+
+// MARK: - Help
+
+private func printStableBalanceHelp() {
+    print("\nStable balance subcommands:")
+    print("  stable-balance \("get".padding(toLength: 22, withPad: " ", startingAt: 0))Get the stable balance active label")
+    print("  stable-balance \("set".padding(toLength: 22, withPad: " ", startingAt: 0))Set the stable balance active label")
+    print("  stable-balance \("unset".padding(toLength: 22, withPad: " ", startingAt: 0))Unset stable balance")
+    print()
+}
+
+// MARK: - Handlers
+
+// --- get ---
+
+private func handleStableBalanceGet(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let settings = try await sdk.getUserSettings()
+    printValue(settings.stableBalanceActiveLabel)
+}
+
+// --- set ---
+
+private func handleStableBalanceSet(_ sdk: BreezSdk, _ args: [String]) async throws {
+    guard !args.isEmpty else {
+        print("Usage: stable-balance set <label>")
+        return
+    }
+
+    try await sdk.updateUserSettings(request: UpdateUserSettingsRequest(
+        sparkPrivateModeEnabled: nil,
+        stableBalanceActiveLabel: .set(label: args[0])
+    ))
+    let settings = try await sdk.getUserSettings()
+    printValue(settings)
+}
+
+// --- unset ---
+
+private func handleStableBalanceUnset(_ sdk: BreezSdk, _ args: [String]) async throws {
+    try await sdk.updateUserSettings(request: UpdateUserSettingsRequest(
+        sparkPrivateModeEnabled: nil,
+        stableBalanceActiveLabel: .unset
+    ))
+    let settings = try await sdk.getUserSettings()
+    printValue(settings)
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Webhooks.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Webhooks.swift
@@ -1,0 +1,110 @@
+import Foundation
+import BreezSdkSpark
+
+// MARK: - Webhooks command names (for REPL completion)
+
+let webhooksCommandNames: [String] = [
+    "webhooks register",
+    "webhooks unregister",
+    "webhooks list",
+]
+
+// MARK: - Dispatch
+
+func dispatchWebhooksCommand(_ args: [String], sdk: BreezSdk) async {
+    if args.isEmpty || args[0] == "help" {
+        printWebhooksHelp()
+        return
+    }
+
+    let subName = args[0]
+    let subArgs = Array(args.dropFirst())
+
+    do {
+        switch subName {
+        case "register":
+            try await handleWebhookRegister(sdk, subArgs)
+        case "unregister":
+            try await handleWebhookUnregister(sdk, subArgs)
+        case "list":
+            try await handleWebhookList(sdk, subArgs)
+        default:
+            print("Unknown webhooks subcommand: \(subName). Use 'webhooks help' for available commands.")
+        }
+    } catch {
+        print("Error: \(error)")
+    }
+}
+
+// MARK: - Help
+
+private func printWebhooksHelp() {
+    print("\nWebhooks subcommands:")
+    print("  webhooks \("register".padding(toLength: 30, withPad: " ", startingAt: 0))Register a new webhook")
+    print("  webhooks \("unregister".padding(toLength: 30, withPad: " ", startingAt: 0))Unregister a webhook")
+    print("  webhooks \("list".padding(toLength: 30, withPad: " ", startingAt: 0))List all registered webhooks")
+    print()
+}
+
+// MARK: - Parsing helper
+
+private func parseWebhookEventType(_ raw: String) -> WebhookEventType? {
+    switch raw.lowercased().replacingOccurrences(of: "-", with: "").replacingOccurrences(of: "_", with: "") {
+    case "lightningreceive": return .lightningReceiveFinished
+    case "lightningsend": return .lightningSendFinished
+    case "coopexit": return .coopExitFinished
+    case "staticdeposit": return .staticDepositFinished
+    default: return nil
+    }
+}
+
+// MARK: - Handlers
+
+// --- register ---
+
+private func handleWebhookRegister(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let fp = FlagParser(args)
+    guard fp.positional.count >= 3 else {
+        print("Usage: webhooks register <url> <secret> <event_type> [<event_type> ...]")
+        print("Event types: lightning-receive, lightning-send, coop-exit, static-deposit")
+        return
+    }
+
+    let url = fp.positional[0]
+    let secret = fp.positional[1]
+    let eventTypes = fp.positional.dropFirst(2).compactMap { parseWebhookEventType(String($0)) }
+
+    if eventTypes.isEmpty {
+        print("No valid event types provided")
+        print("Event types: lightning-receive, lightning-send, coop-exit, static-deposit")
+        return
+    }
+
+    let result = try await sdk.registerWebhook(request: RegisterWebhookRequest(
+        url: url,
+        secret: secret,
+        eventTypes: eventTypes
+    ))
+    printValue(result)
+}
+
+// --- unregister ---
+
+private func handleWebhookUnregister(_ sdk: BreezSdk, _ args: [String]) async throws {
+    guard !args.isEmpty else {
+        print("Usage: webhooks unregister <webhook_id>")
+        return
+    }
+
+    try await sdk.unregisterWebhook(request: UnregisterWebhookRequest(
+        webhookId: args[0]
+    ))
+    print("Webhook unregistered successfully")
+}
+
+// --- list ---
+
+private func handleWebhookList(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let result = try await sdk.listWebhooks()
+    printValue(result)
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
@@ -18,6 +18,7 @@ struct CliOptions {
     var listLabels: Bool = false
     var storeLabel: Bool = false
     var rpid: String?
+    var serverMode: Bool = false
 }
 
 func parseCliFlags() -> CliOptions {
@@ -63,6 +64,8 @@ func parseCliFlags() -> CliOptions {
         case "--rpid":
             i += 1
             if i < args.count { opts.rpid = args[i] }
+        case "--server-mode":
+            opts.serverMode = true
         default:
             break
         }
@@ -204,7 +207,13 @@ try initLogging(logDir: resolvedDir, appLogger: nil, logFilter: nil)
 let persistence = CliPersistence(dataDir: resolvedDir)
 
 // Config
-var config = defaultConfig(network: network)
+var config: Config
+if opts.serverMode {
+    print("Server mode enabled. Run `sync` between operations.")
+    config = defaultServerConfig(network: network)
+} else {
+    config = defaultConfig(network: network)
+}
 let breezApiKey: String? = {
     if let key = ProcessInfo.processInfo.environment["BREEZ_API_KEY"], !key.isEmpty {
         return key
@@ -254,19 +263,13 @@ if let passkeyStr = opts.passkey {
 // Build SDK
 let builder = SdkBuilder(config: config, seed: seed)
 if let connectionString = opts.postgresConnectionString {
-    let context = try await newSharedSdkContext(config: SdkContextConfig(
-        network: network,
-        apiKey: breezApiKey,
-        storage: try postgresStorage(config: defaultPostgresStorageConfig(connectionString: connectionString))
+    await builder.withStorageBackend(storage: try postgresStorage(
+        config: defaultPostgresStorageConfig(connectionString: connectionString)
     ))
-    await builder.withSharedContext(context: context)
 } else if let connectionString = opts.mysqlConnectionString {
-    let context = try await newSharedSdkContext(config: SdkContextConfig(
-        network: network,
-        apiKey: breezApiKey,
-        storage: try mysqlStorage(config: defaultMysqlStorageConfig(connectionString: connectionString))
+    await builder.withStorageBackend(storage: try mysqlStorage(
+        config: defaultMysqlStorageConfig(connectionString: connectionString)
     ))
-    await builder.withSharedContext(context: context)
 } else {
     await builder.withDefaultStorage(storageDir: resolvedDir)
 }
@@ -290,7 +293,7 @@ let tokenIssuer = sdk.getTokenIssuer()
 let registry = buildCommandRegistry()
 
 // Set up tab completion
-allCompletionCommands = commandNames + issuerCommandNames + contactsCommandNames + ["help", "exit", "quit"]
+allCompletionCommands = commandNames + issuerCommandNames + contactsCommandNames + webhooksCommandNames + stableBalanceCommandNames + ["help", "exit", "quit"]
 rl_attempted_completion_function = attemptedCompletion
 
 // Load history
@@ -336,6 +339,10 @@ replLoop: while true {
         await dispatchIssuerCommand(cmdArgs, tokenIssuer: tokenIssuer)
     } else if cmdName == "contacts" {
         await dispatchContactsCommand(cmdArgs, sdk: sdk)
+    } else if cmdName == "webhooks" {
+        await dispatchWebhooksCommand(cmdArgs, sdk: sdk)
+    } else if cmdName == "stable-balance" {
+        await dispatchStableBalanceCommand(cmdArgs, sdk: sdk)
     } else if let cmd = registry[cmdName] {
         do {
             try await cmd.run(sdk, cmdArgs)

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
@@ -61,6 +61,7 @@ node src/main.js [OPTIONS]
 | `--list-labels` | false | Requires `--passkey`. Select label from Nostr |
 | `--store-label` | false | Requires `--passkey`. Publish label to Nostr |
 | `--rpid` | `keys.breez.technology` | Requires `--passkey`. Relying party ID for FIDO2 provider |
+| `--server-mode` | false | Run in server mode (`background_tasks_enabled=false`) |
 
 ### Examples
 
@@ -88,7 +89,7 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **On-chain**: `claim-deposit`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
 
-**Lightning address**: `get-lightning-address`, `register-lightning-address`, `delete-lightning-address`, `check-lightning-address-available`
+**Lightning address**: `get-lightning-address`, `register-lightning-address`, `authorize-lightning-address-transfer`, `claim-lightning-address-transfer`, `delete-lightning-address`, `check-lightning-address-available`
 
 **Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`, `issuer <subcommand>`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -34,6 +34,8 @@ const COMMAND_NAMES = [
   'check-lightning-address-available',
   'get-lightning-address',
   'register-lightning-address',
+  'authorize-lightning-address-transfer',
+  'claim-lightning-address-transfer',
   'delete-lightning-address',
   'list-fiat-currencies',
   'list-fiat-rates',
@@ -648,6 +650,38 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
       const sdk = getSdk()
       const res = await sdk.registerLightningAddress({
         username,
+        description
+      })
+      printValue(res)
+    })
+
+  // --- authorize-lightning-address-transfer ---
+  program
+    .command('authorize-lightning-address-transfer')
+    .description('Authorize transferring the registered lightning address to another pubkey')
+    .argument('<transferee_pubkey>', 'The new owner\'s identity public key (hex-encoded compressed secp256k1)')
+    .action(async (transfereePubkey) => {
+      const sdk = getSdk()
+      const res = await sdk.authorizeLightningAddressTransfer({ transfereePubkey })
+      printValue(res)
+    })
+
+  // --- claim-lightning-address-transfer ---
+  program
+    .command('claim-lightning-address-transfer')
+    .description('Claim a lightning address transfer authorized by the current owner')
+    .argument('<username>', 'The username being taken over')
+    .argument('[description]', 'Description in the lnurl response and the invoice')
+    .requiredOption('--from-pubkey <pubkey>', 'The current owner\'s identity public key (hex-encoded compressed secp256k1)')
+    .requiredOption('--from-signature <signature>', 'The current owner\'s signature authorizing the transfer (hex-encoded DER ECDSA)')
+    .action(async (username, description, options) => {
+      const sdk = getSdk()
+      const res = await sdk.claimLightningAddressTransfer({
+        authorization: {
+          username,
+          pubkey: options.fromPubkey,
+          signature: options.fromSignature
+        },
         description
       })
       printValue(res)

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
@@ -11,9 +11,11 @@ const { parse: parseShell } = require('shell-quote')
 const {
   SdkBuilder,
   defaultConfig,
+  defaultServerConfig,
   defaultMysqlStorageConfig,
   defaultPostgresStorageConfig,
-  newSharedSdkContext,
+  postgresStorage,
+  mysqlStorage,
   initLogging,
   getSparkStatus
 } = require('@breeztech/breez-sdk-spark/nodejs')
@@ -37,6 +39,7 @@ function parseCliArgs() {
     stableBalanceTokens: [],
     stableBalanceDefaultActiveLabel: undefined,
     stableBalanceThreshold: undefined,
+    serverMode: false,
     passkey: undefined,
     label: undefined,
     listLabels: false,
@@ -86,6 +89,9 @@ function parseCliArgs() {
       case '--rpid':
         opts.rpid = args[++i]
         break
+      case '--server-mode':
+        opts.serverMode = true
+        break
       case '-h':
       case '--help':
         console.log('Usage: node src/main.js [OPTIONS]')
@@ -104,6 +110,7 @@ function parseCliArgs() {
         console.log('  --list-labels                                List and select from labels on Nostr (requires --passkey)')
         console.log('  --store-label                                Publish the label to Nostr (requires --passkey and --label)')
         console.log('  --rpid <id>                                  Relying party ID for FIDO2 provider (requires --passkey)')
+        console.log('  --server-mode                                Run in server mode (background_tasks_enabled=false)')
         console.log('  -h, --help                                   Show this help message')
         process.exit(0)
         break
@@ -222,7 +229,13 @@ async function main() {
   const persistence = new CliPersistence(dataDir)
 
   // Config
-  const config = defaultConfig(network)
+  let config
+  if (opts.serverMode) {
+    console.log('Server mode enabled. Run `sync` between operations.')
+    config = defaultServerConfig(network)
+  } else {
+    config = defaultConfig(network)
+  }
   const breezApiKey = process.env.BREEZ_API_KEY
   if (breezApiKey) {
     config.apiKey = breezApiKey
@@ -269,19 +282,13 @@ async function main() {
   let sdkBuilder = SdkBuilder.new(config, seed)
 
   if (opts.postgresConnectionString) {
-    const context = await newSharedSdkContext({
-      network,
-      apiKey: breezApiKey,
-      postgresConfig: defaultPostgresStorageConfig(opts.postgresConnectionString)
-    })
-    sdkBuilder = sdkBuilder.withSharedContext(context)
+    sdkBuilder = sdkBuilder.withStorageBackend(
+      postgresStorage(defaultPostgresStorageConfig(opts.postgresConnectionString))
+    )
   } else if (opts.mysqlConnectionString) {
-    const context = await newSharedSdkContext({
-      network,
-      apiKey: breezApiKey,
-      mysqlConfig: defaultMysqlStorageConfig(opts.mysqlConnectionString)
-    })
-    sdkBuilder = sdkBuilder.withSharedContext(context)
+    sdkBuilder = sdkBuilder.withStorageBackend(
+      mysqlStorage(defaultMysqlStorageConfig(opts.mysqlConnectionString))
+    )
   } else {
     sdkBuilder = await sdkBuilder.withDefaultStorage(dataDir)
   }

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/passkey.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/passkey.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const readline = require('readline')
 
-const { Passkey } = require('@breeztech/breez-sdk-spark/nodejs')
+const { PasskeyClient } = require('@breeztech/breez-sdk-spark/nodejs')
 
 // ---------------------------------------------------------------------------
 // Passkey provider constants
@@ -103,15 +103,18 @@ class FilePrfProvider {
   }
 
   /**
-   * Derive a PRF seed using HMAC-SHA256(secret, salt).
+   * Derive PRF seeds using HMAC-SHA256(secret, salt) for each salt.
    *
-   * @param {string} salt - The salt string
-   * @returns {Promise<Uint8Array>} 32-byte PRF output
+   * @param {string[]} salts - The salt strings
+   * @returns {Promise<{seeds: Uint8Array[], credentialId: Uint8Array | null}>}
    */
-  derivePrfSeed = async (salt) => {
-    const hmac = crypto.createHmac('sha256', this.secret)
-    hmac.update(salt)
-    return new Uint8Array(hmac.digest())
+  deriveSeeds = async (salts) => {
+    const seeds = salts.map((salt) => {
+      const hmac = crypto.createHmac('sha256', this.secret)
+      hmac.update(salt)
+      return new Uint8Array(hmac.digest())
+    })
+    return { seeds, credentialId: null }
   }
 
   /**
@@ -119,7 +122,7 @@ class FilePrfProvider {
    *
    * @returns {Promise<boolean>}
    */
-  isPrfAvailable = async () => {
+  isSupported = async () => {
     return true
   }
 }
@@ -136,11 +139,11 @@ class NotYetSupportedProvider {
     this.name = name
   }
 
-  derivePrfSeed = async (_salt) => {
+  deriveSeeds = async (_salts) => {
     throw new Error(`${this.name} passkey provider is not yet supported in the Node.js CLI`)
   }
 
-  isPrfAvailable = async () => {
+  isSupported = async () => {
     return false
   }
 }
@@ -212,23 +215,13 @@ async function resolvePasskeySeed(
   listLabels,
   storeLabel
 ) {
-  const relayConfig = {
-    breezApiKey
-  }
-  const passkey = new Passkey(provider, relayConfig)
-
-  // --store-label: publish to Nostr
-  if (storeLabel && label) {
-    console.log(`Publishing label '${label}' to Nostr...`)
-    await passkey.storeLabel(label)
-    console.log(`Label '${label}' published successfully.`)
-  }
+  const client = new PasskeyClient(provider, breezApiKey, undefined)
 
   // --list-labels: query Nostr and prompt user to select
-  let resolvedName = label
+  let resolvedLabel = label
   if (listLabels) {
     console.log('Querying Nostr for available labels...')
-    const labels = await passkey.listLabels()
+    const labels = await client.labels().list()
 
     if (labels.length === 0) {
       throw new Error('No labels found on Nostr for this identity')
@@ -245,11 +238,18 @@ async function resolvePasskeySeed(
       throw new Error('Invalid selection')
     }
 
-    resolvedName = labels[idx - 1]
+    resolvedLabel = labels[idx - 1]
   }
 
-  const wallet = await passkey.getWallet(resolvedName)
-  return wallet.seed
+  // --store-label: publish to Nostr before signing in
+  if (storeLabel && resolvedLabel) {
+    console.log(`Publishing label '${resolvedLabel}' to Nostr...`)
+    await client.labels().store(resolvedLabel)
+    console.log(`Label '${resolvedLabel}' published successfully.`)
+  }
+
+  const response = await client.signIn({ label: resolvedLabel })
+  return response.wallet.seed
 }
 
 module.exports = {

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/passkey.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/passkey.js
@@ -217,11 +217,12 @@ async function resolvePasskeySeed(
 ) {
   const client = new PasskeyClient(provider, breezApiKey, undefined)
 
-  // --list-labels: query Nostr and prompt user to select
+  // --list-labels: discovery sign-in (no cached label) returns the
+  // published label set; prompt the user to pick one.
   let resolvedLabel = label
   if (listLabels) {
     console.log('Querying Nostr for available labels...')
-    const labels = await client.labels().list()
+    const { labels } = await client.signIn({ label: undefined })
 
     if (labels.length === 0) {
       throw new Error('No labels found on Nostr for this identity')


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`ee2e770`](https://github.com/breez/spark-sdk/commit/ee2e77086ab1018bccae77099db82025789056d2)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/27019553239)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :x: Go (patch failed to apply)
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :white_check_mark: React Native
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- Missing `--server-mode` CLI flag: Rust uses `default_server_config(network)` for server mode; C# had no equivalent
- Storage builder used `NewSharedSdkContext` + `WithSharedContext` instead of `WithStorageBackend` (diverged from both Rust CLI and C# SDK snippets)
- Missing `authorize-lightning-address-transfer` command (Rust has `AuthorizeLightningAddressTransfer`)
- Missing `claim-lightning-address-transfer` command (Rust has `ClaimLightningAddressTransfer`)
- Passkey `ResolvePasskeySeed` ran store-label before list-labels; Rust runs list-labels first, then store-label
- Passkey list-labels used `Labels().List()` for discovery; Rust uses `sign_in(label: None)` which returns labels from the sign-in response
- README missing `--server-mode` in CLI Options table
- README missing lightning address transfer commands in Available Commands section

## Applied
- Added `--server-mode` flag parsing, usage text, and `DefaultServerConfig` support to `Program.cs`
- Replaced `NewSharedSdkContext` + `WithSharedContext` with `WithStorageBackend` for Postgres/MySQL in `Program.cs`
- Added `authorize-lightning-address-transfer` command (name, registry entry, handler) to `Commands.cs`
- Added `claim-lightning-address-transfer` command (name, registry entry, handler) to `Commands.cs`
- Fixed `ResolvePasskeySeed` in `Passkey.cs`: reordered to list-labels first, store-label second; switched from `Labels().List()` to `SignIn(label: null)` for discovery
- Added `--server-mode` to CLI Options table in `README.md`
- Added transfer commands to Available Commands in `README.md`

## Skipped
- Nothing skipped. All Rust CLI features have C# equivalents.

## C# additions (suggestions for Rust CLI)
- C# `delete-lightning-address` prints "Lightning address deleted" confirmation; Rust is silent
- C# `set-user-settings` prints "User settings updated" confirmation; Rust is silent

### Dart
## Divergences
- Missing `--server-mode` CLI flag: Rust uses `default_server_config()` when enabled; Dart CLI only used `defaultConfig()`
- Missing `authorize-lightning-address-transfer` command: Rust CLI has it, Dart SDK has the API (`authorizeLightningAddressTransfer`)
- Missing `claim-lightning-address-transfer` command: Rust CLI has it, Dart SDK has the API (`claimLightningAddressTransfer`)
- Bug in `pay` conversion estimate display: Dart used the same unit label for both input and output instead of separate `inUnits`/`outUnits` like Rust

## Applied
- Added `--server-mode` flag to `bin/breez_cli.dart` and `lib/cli.dart`, using `defaultServerConfig()` when enabled
- Added `authorize-lightning-address-transfer` command to `lib/commands.dart` (handler, registry entry, commandNames)
- Added `claim-lightning-address-transfer` command to `lib/commands.dart` with `--from-pubkey` and `--from-signature` options
- Fixed conversion estimate display in `_handlePay` to use separate `inUnits`/`outUnits` matching Rust behavior
- Updated `README.md` with new commands and `--server-mode` CLI option

## Skipped
- Nothing skipped

### Go
## Divergences
- Missing `--mysql-connection-string` CLI flag (Rust supports MySQL storage alongside PostgreSQL and SQLite)
- Missing `--server-mode` CLI flag (Rust supports `default_server_config` for server-mode operation)
- `--stable-balance-token-identifier` accepts single token instead of `--stable-balance-token` with repeatable `LABEL:token_identifier` format
- Missing `--stable-balance-default-active-label` CLI flag
- Missing `authorize-lightning-address-transfer` command
- Missing `claim-lightning-address-transfer` command
- Missing `webhooks` subcommand group (register, unregister, list)
- Missing `stable-balance` subcommand group (get, set, unset)
- `buy-bitcoin` missing `--provider` flag and CashApp provider support; used `--amount` instead of `--amount-sat`
- `lnurl-pay` missing `--token-identifier` (`-t`) flag for token-denominated payments
- `set-user-settings` used `--spark-private-mode` instead of `-p`/`--private` to match Rust
- `fetch-conversion-limits` used `--token` flag instead of positional `<token_identifier>`, missing `-f` short flag for `--from-bitcoin`
- `pay` conversion estimate message used same unit for both in/out amounts (should be separate in_units/out_units)
- `lnurl-pay` conversion estimate message hardcoded "token base units to sats" instead of dynamic direction
- `passkey.go` store/list label ordering was reversed (Go: store then list; Rust: list then store)

## Applied
- Added `--mysql-connection-string` flag with `DefaultMysqlStorageConfig`/`MysqlStorage` support (main.go)
- Added `--server-mode` flag using `DefaultServerConfig` (main.go)
- Replaced `--stable-balance-token-identifier` with `--stable-balance-token` using `LABEL:token_identifier` repeatable format (main.go)
- Added `--stable-balance-default-active-label` flag (main.go)
- Added mutual exclusion check between `--postgres-connection-string` and `--mysql-connection-string` (main.go)
- Added `authorize-lightning-address-transfer` command with `AuthorizeTransferRequest` (commands.go)
- Added `claim-lightning-address-transfer` command with `ClaimTransferRequest`/`TransferAuthorization` (commands.go)
- Created `webhooks.go` with register, unregister, and list subcommands; REPL dispatch and completion (main.go, webhooks.go)
- Created `stable_balance.go` with get, set, and unset subcommands using `StableBalanceActiveLabel` (main.go, stable_balance.go)
- Updated `buy-bitcoin` with `--provider` flag (moonpay/cashapp), `--amount-sat`, and `BuyBitcoinRequestCashApp` (commands.go)
- Added `-t`/`--token-identifier` to `lnurl-pay`; changed amount parsing from uint64 to big.Int; added to prepare request (commands.go)
- Changed `set-user-settings` from `--spark-private-mode` to `-p`/`--private` (commands.go)
- Changed `fetch-conversion-limits` from `--token` flag to positional arg; added `-f` short flag (commands.go)
- Fixed `pay` conversion estimate to use separate in_units/out_units (commands.go)
- Fixed `lnurl-pay` conversion estimate to use dynamic in/out units (commands.go)
- Reordered passkey label resolution: list before store, matching Rust (passkey.go)
- Added `StableBalanceActiveLabel` and `BuyBitcoinRequest` to serialization variant prefixes (serialization.go)
- Updated buy-bitcoin registry description from "via MoonPay" to "using an external provider" (commands.go)
- Added webhooks and stable-balance entries to `PrintHelp` (commands.go)
- Updated README with new CLI options, commands, and feature sections (README.md)

## Skipped
- YubiKey passkey provider: requires YubiKey OTP challenge-response hardware. Skeleton `notYetSupportedProvider` already in place. No viable pure-Go HMAC-SHA1 challenge-response library for YubiKey OTP was found that doesn't require CGo/USB HID.
- FIDO2 passkey provider: requires CTAP2 hmac-secret extension via USB HID. Skeleton `notYetSupportedProvider` already in place. Evaluated `go-libfido2` (CGo wrapper) and `go-webauthn` (server-side only); neither provides client-side CTAP2 hmac-secret without native dependencies.

### Kotlin
## Divergences
- Main.kt: Missing `--server-mode` flag (Rust uses `defaultServerConfig()` when enabled)
- Main.kt: `--stable-balance-token-identifier` (single) vs Rust's repeatable `--stable-balance-token` in `TICKER:token_identifier` format with `--stable-balance-default-active-label`
- Main.kt: Storage backend used `withSharedContext(newSharedSdkContext(...))` instead of `withStorageBackend(postgresStorage(...))` / `withStorageBackend(mysqlStorage(...))`
- Commands.kt: Missing `authorize-lightning-address-transfer` command
- Commands.kt: Missing `claim-lightning-address-transfer` command
- Commands.kt: Missing `webhooks` subcommand group (register, unregister, list)
- Commands.kt: Missing `stable-balance` subcommand group (get, set, unset)
- Commands.kt: `lnurl-pay` missing `--token-identifier` flag (always passed `null`)
- Commands.kt: `buy-bitcoin` only supported MoonPay, missing CashApp provider
- Passkey.kt: `--list-labels` used `passkey.labels().list()` instead of `passkey.signIn(SignInRequest(label = null))` for discovery, and had `--store-label` before `--list-labels` (reversed from Rust)
- README.md: Missing `--server-mode`, `--stable-balance-default-active-label`, webhooks/stable-balance commands, authorize/claim transfer commands, CashApp provider documentation

## Applied
- Main.kt: Added `--server-mode` flag with `defaultServerConfig()` support
- Main.kt: Replaced `--stable-balance-token-identifier` with repeatable `--stable-balance-token` in `TICKER:token_identifier` format and added `--stable-balance-default-active-label`
- Main.kt: Fixed storage backend to use `builder.withStorageBackend(postgresStorage(...))` and `builder.withStorageBackend(mysqlStorage(...))` matching SDK snippets
- Main.kt: Added webhooks and stable-balance subcommand dispatching, registries, and tab completions
- Main.kt: Updated `printHelp` to include webhooks and stable-balance subcommand groups
- Commands.kt: Added `authorize-lightning-address-transfer` command with `AuthorizeTransferRequest`
- Commands.kt: Added `claim-lightning-address-transfer` command with `ClaimTransferRequest` and `TransferAuthorization`
- Commands.kt: Added `--token-identifier` (`-t`) flag to `lnurl-pay`, matching Rust's prompt and `PrepareLnurlPayRequest` usage
- Commands.kt: Updated `buy-bitcoin` to support `--provider` flag with CashApp (`BuyBitcoinRequest.CashApp`) and `--amount-sat` flag
- Webhooks.kt: Created new file with webhook subcommand group (register, unregister, list) using `RegisterWebhookRequest`, `UnregisterWebhookRequest`, `listWebhooks()`
- StableBalance.kt: Created new file with stable-balance subcommand group (get, set, unset) using `StableBalanceActiveLabel.Set` and `StableBalanceActiveLabel.Unset`
- Passkey.kt: Fixed `--list-labels` to use `passkey.signIn(SignInRequest(label = null))` for discovery (matching Rust's discovery sign-in pattern), and reordered to handle `--list-labels` before `--store-label`
- README.md: Added `--server-mode` flag, updated stable balance token documentation, added authorize/claim transfer commands, added webhooks and stable-balance command groups

## Skipped
- Nothing skipped. All Rust CLI features have Kotlin equivalents using SDK types available in the Kotlin bindings.

### Python
## Divergences
- main.py: Missing `--server-mode` CLI flag (Rust uses `default_server_config` when set)
- main.py: Wrong storage API for Postgres/MySQL (used `new_shared_sdk_context`/`SdkContextConfig`/`with_shared_context` instead of `postgres_storage`/`mysql_storage`/`with_storage_backend`)
- commands.py: Missing `authorize-lightning-address-transfer` command
- commands.py: Missing `claim-lightning-address-transfer` command
- commands.py: `set-user-settings` handler missing `stable_balance_active_label=None` parameter
- passkey.py: Used deprecated `Passkey`/`NostrRelayConfig` API instead of `PasskeyClient`
- passkey.py: `PrfProvider` implemented old `derive_prf_seed`/`is_prf_available` instead of `derive_seeds`/`is_supported`/`create_passkey`/`check_domain_association`
- passkey.py: `resolve_passkey_seed` used old `get_wallet`/`list_labels`/`store_label` methods instead of `sign_in`/`labels().list()`/`labels().store()`
- README.md: Missing `--server-mode` in CLI Options table
- README.md: Missing `authorize-lightning-address-transfer` and `claim-lightning-address-transfer` in Available Commands

## Applied
- main.py: Added `--server-mode` flag with `default_server_config` support
- main.py: Replaced `new_shared_sdk_context`/`with_shared_context` with `postgres_storage`/`mysql_storage`/`with_storage_backend` to match Rust CLI and Python SDK snippets
- main.py: Updated imports (removed `SdkContextConfig`/`new_shared_sdk_context`, added `default_server_config`/`postgres_storage`/`mysql_storage`)
- commands.py: Added `authorize-lightning-address-transfer` command with `AuthorizeTransferRequest`
- commands.py: Added `claim-lightning-address-transfer` command with `ClaimTransferRequest`/`TransferAuthorization`
- commands.py: Added `stable_balance_active_label=None` to `set-user-settings` handler
- passkey.py: Updated `FilePrfProvider` to implement new `PrfProvider` interface (`derive_seeds`, `is_supported`, `create_passkey`, `check_domain_association`)
- passkey.py: Updated `YubiKeyPrfProvider` and `Fido2PrfProvider` skeletons with new interface
- passkey.py: Updated `resolve_passkey_seed` to use `PasskeyClient` with `sign_in`/`labels().store()` API matching the Rust CLI flow
- README.md: Added `--server-mode` to CLI Options table
- README.md: Added `authorize-lightning-address-transfer` and `claim-lightning-address-transfer` to Available Commands

## Skipped
- YubiKey PRF provider: Requires `challenge-response` crate (Rust) / `yubico-manager` for HMAC-SHA1 challenge-response. Python packages `python-yubico` and `yubikey-manager` exist on PyPI but the provider skeleton is sufficient for the CLI reference implementation. The stub prints "not yet supported" and exits.
- FIDO2 PRF provider: Requires `ctap-hid-fido2` crate (Rust) for CTAP2 hmac-secret extension. Python packages `fido2` (Yubico's python-fido2) exist on PyPI and could implement this. The stub prints "not yet supported" and exits.

### React Native
## Divergences
- Missing `authorize-lightning-address-transfer` command in React Native CLI (present in Rust CLI since contacts.rs and command/mod.rs)
- Missing `claim-lightning-address-transfer` command in React Native CLI (present in Rust CLI)
- Missing server mode support: Rust CLI has `--server-mode` flag using `default_server_config()`, React Native CLI only used `defaultConfig()`
- `set-user-settings` handler did not pass `stableBalanceActiveLabel: undefined` (Rust passes `stable_balance_active_label: None`)
- README missing: server mode section, lightning address transfer commands, stable-balance in command list, Platform passkey provider in provider table
- `defaultServerConfig` not declared in ambient module type declarations

## Applied
- Added `authorize-lightning-address-transfer` command handler in `commands.ts`
- Added `claim-lightning-address-transfer` command handler with `--from-pubkey` and `--from-signature` flags in `commands.ts`
- Added both commands to `COMMAND_NAMES` and `buildCommandRegistry()` in `commands.ts`
- Added server mode toggle (Client/Server) to setup screen in `App.tsx`
- Imported and used `defaultServerConfig` for server mode initialization in `App.tsx`
- Added `serverMode` field to `SetupConfig` interface in `App.tsx`
- Added `defaultServerConfig` export to `breez-sdk-spark-react-native.d.ts`
- Fixed `set-user-settings` to pass `stableBalanceActiveLabel: undefined` in `commands.ts`
- Updated README: added server mode section, lightning address transfer section, stable-balance commands, Platform passkey provider

## Skipped
- `--postgres-connection-string` and `--mysql-connection-string` flags: not applicable for mobile (React Native uses file-based SQLite storage)
- `--account-number` / `with_key_set()` startup flag: available in React Native SDK but requires complex UI additions for a niche feature; the SDK snippet shows `builder.withKeySet()` works
- `--stable-balance-token`, `--stable-balance-default-active-label`, `--stable-balance-threshold` startup flags: available in React Native SDK but require complex setup UI for multiple token entries
- Contacts commands remain stubbed: contacts API (`addContact`, `listContacts`, etc.) is not available in the React Native SDK
- Passkey `--label`, `--list-labels`, `--store-label` flags: partially exposed via setup screen defaults; full interactive label selection would require multi-step UI flow

### Swift
## Divergences
- Swift CLI missing `--server-mode` flag (Rust uses `default_server_config()` when enabled)
- Swift CLI storage backend used `newSharedSdkContext` + `withSharedContext` instead of `withStorageBackend` (per SDK snippets and Rust CLI pattern)
- Swift CLI missing `authorize-lightning-address-transfer` command
- Swift CLI missing `claim-lightning-address-transfer` command
- Swift CLI missing `webhooks` subcommand group (register, unregister, list)
- Swift CLI missing `stable-balance` subcommand group (get, set, unset)
- Swift CLI `lnurl-pay` missing `--token-identifier` / `-t` flag (hardcoded to nil)
- Swift CLI `lnurl-pay` amount prompt did not adjust text for token payments
- Swift CLI `buy-bitcoin` missing `--provider` flag and CashApp provider support
- Swift CLI README missing `--server-mode` in CLI options table
- Swift CLI README `recommended-fees` listed under "Other" instead of "Wallet"
- Swift CLI README missing `authorize-lightning-address-transfer` and `claim-lightning-address-transfer` commands
- Swift CLI README missing `webhooks` and `stable-balance` command groups

## Applied
- Added `--server-mode` flag to `CliOptions` and `parseCliFlags()`, uses `defaultServerConfig(network:)` when enabled (main.swift)
- Replaced `newSharedSdkContext` + `withSharedContext` with `withStorageBackend(storage:)` for PostgreSQL and MySQL storage backends (main.swift)
- Added `authorize-lightning-address-transfer` command with handler using `AuthorizeTransferRequest` (Commands.swift)
- Added `claim-lightning-address-transfer` command with handler using `ClaimTransferRequest` and `TransferAuthorization` (Commands.swift)
- Created Webhooks.swift with `register`, `unregister`, `list` subcommands dispatched from REPL
- Created StableBalance.swift with `get`, `set`, `unset` subcommands using `StableBalanceActiveLabel` enum
- Added `--token-identifier` / `-t` flag to `lnurl-pay` and updated amount prompt for token payments (Commands.swift)
- Updated `buy-bitcoin` handler with `--provider` flag and CashApp provider support via `BuyBitcoinRequest.cashApp` (Commands.swift)
- Added webhook and stable-balance dispatch in REPL loop and tab completion (main.swift)
- Added webhook and stable-balance help entries to `printHelp` (Commands.swift)
- Updated README with `--server-mode` CLI option, `authorize/claim-lightning-address-transfer` commands, `webhooks` and `stable-balance` sections, and moved `recommended-fees` to Wallet category

## Skipped
- YubiKey PRF provider: requires `yubico-manager` (Rust) or YubiKit (Swift). No well-known pure-Swift HMAC-SHA1 challenge-response library for YubiKey OTP. Skeleton retained with correct `PrfProvider` interface.
- FIDO2 PRF provider: requires `ctap-hid-fido2` (Rust) or a Swift CTAP2/HID library. No established Swift package for CTAP2 hmac-secret. Skeleton retained with correct `PrfProvider` interface.
- Swift `register-lightning-address` uses flag-based `--description` while Rust uses positional arg. Kept as Swift UX improvement.
- Swift `lnurl-pay` parses amount as `BInt` (supports arbitrary precision) vs Rust `u128`. This is correct for the Swift SDK API.

### TypeScript
## Divergences
- Missing `--server-mode` CLI flag: Rust uses `default_server_config(network)` when enabled, TypeScript had no equivalent
- Outdated storage API: TypeScript used `newSharedSdkContext()` + `withSharedContext()`, Rust and SDK snippets use `withStorageBackend(postgresStorage())` / `withStorageBackend(mysqlStorage())`
- Missing `authorize-lightning-address-transfer` command in TypeScript CLI
- Missing `claim-lightning-address-transfer` command in TypeScript CLI
- Outdated passkey API: TypeScript used `Passkey` class with `storeLabel()`, `listLabels()`, `getWallet()`, Rust and SDK snippets use `PasskeyClient` with `labels().store()`, `labels().list()`, `signIn()`
- Outdated PrfProvider interface: TypeScript used `derivePrfSeed(salt)` / `isPrfAvailable()`, SDK snippets show `deriveSeeds(salts)` / `isSupported()`
- Passkey store-label ordering: Rust lists labels first then stores, TypeScript stored then listed (now fixed to match Rust ordering)
- README missing `--server-mode` option and lightning address transfer commands

## Applied
- Added `--server-mode` flag with `defaultServerConfig` support (main.js, README.md)
- Replaced `newSharedSdkContext` + `withSharedContext` storage setup with `withStorageBackend(postgresStorage())` / `withStorageBackend(mysqlStorage())` (main.js)
- Added `authorize-lightning-address-transfer` command with `transfereePubkey` argument (commands.js)
- Added `claim-lightning-address-transfer` command with `username`, `description`, `--from-pubkey`, `--from-signature` (commands.js)
- Updated passkey import from `Passkey` to `PasskeyClient` and updated `resolvePasskeySeed` to use `client.labels().list()`, `client.labels().store()`, `client.signIn()` (passkey.js)
- Updated `FilePrfProvider` interface from `derivePrfSeed(salt)` / `isPrfAvailable()` to `deriveSeeds(salts)` / `isSupported()` (passkey.js)
- Updated `NotYetSupportedProvider` interface to match new PrfProvider API (passkey.js)
- Added `--server-mode` to CLI Options table and transfer commands to Available Commands in README.md

## Skipped
- YubiKey PRF provider: requires `yubico-manager` crate with USB HID access. No viable Node.js npm package found for YubiKey OTP challenge-response. Provider skeleton retained with "not yet supported" error.
- FIDO2 PRF provider: requires `ctap-hid-fido2` crate with USB HID access. The `@aspect/webauthn-fido2` and `fido2-lib` npm packages exist but focus on server-side FIDO2 verification, not client-side CTAP2 hmac-secret evaluation. Provider skeleton retained with "not yet supported" error.

</details>

> [!WARNING]
> Some patches failed to apply. The target files may have changed since the sync ran.
> Failed languages: golang
> Consider re-running the sync for these languages.