### PR TITLE
docs: move trailing comments above statements for readability

### DIFF
--- a/docs/breez-sdk/snippets/csharp/Passkey.cs
+++ b/docs/breez-sdk/snippets/csharp/Passkey.cs
@@ -116,9 +116,12 @@ namespace BreezSdkSnippets
 
             if (response.credential is not null)
             {
-                Console.WriteLine(response.credential.credentialId); // Persist to reopen the same wallet on sign-in
-                Console.WriteLine(response.credential.aaguid); // Authenticator model (display hint, unverified)
-                Console.WriteLine(response.credential.backupEligible); // Whether the passkey syncs across devices
+                // Persist to reopen the same wallet on sign-in
+                Console.WriteLine(response.credential.credentialId);
+                // Authenticator model (display hint, unverified)
+                Console.WriteLine(response.credential.aaguid);
+                // Whether the passkey syncs across devices
+                Console.WriteLine(response.credential.backupEligible);
             }
 
             // Pin the stored credential ID so the OS can't substitute a sibling credential, which would derive a different wallet.
@@ -129,10 +132,14 @@ namespace BreezSdkSnippets
                     // stored credentialId bytes
                 }
             ));
-            Console.WriteLine(signInResponse.wallet.seed); // Pass to connect() to open the wallet
-            Console.WriteLine(signInResponse.wallet.label); // Label this wallet was derived from
-            Console.WriteLine(signInResponse.labels); // This passkey's labels (populated on discovery sign-in)
-            Console.WriteLine(signInResponse.credential); // Credential signed in with (credential_id only)
+            // Pass to connect() to open the wallet
+            Console.WriteLine(signInResponse.wallet.seed);
+            // Label this wallet was derived from
+            Console.WriteLine(signInResponse.wallet.label);
+            // This passkey's labels (populated on discovery sign-in)
+            Console.WriteLine(signInResponse.labels);
+            // Credential signed in with (credential_id only)
+            Console.WriteLine(signInResponse.credential);
             // ANCHOR_END: credential-metadata
         }
 

--- a/docs/breez-sdk/snippets/flutter/lib/passkey.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/passkey.dart
@@ -47,7 +47,9 @@ PasskeyClient setupPasskeyClient() {
   // ANCHOR: setup-client
   final passkey = PasskeyClient(
     breezApiKey: '<breez api key>',
-    config: PasskeyConfig(providerOptions: PasskeyProviderOptions(rpId: '<your-rp-domain>', rpName: 'Your App')),
+    config: PasskeyConfig(
+      providerOptions: PasskeyProviderOptions(rpId: '<your-rp-domain>', rpName: 'Your App'),
+    ),
   );
   // ANCHOR_END: setup-client
   return passkey;
@@ -182,7 +184,10 @@ Future<void> storeLabel() async {
 Future<void> checkDomain() async {
   // ANCHOR: domain-association
   // Diagnostic only: never blocks the ceremony.
-  final prfProvider = PasskeyProvider(PasskeyProviderOptions(rpId: '<your-rp-domain>', rpName: 'Your App'));
+  final prfProvider = PasskeyProvider(PasskeyProviderOptions(
+    rpId: '<your-rp-domain>',
+    rpName: 'Your App',
+  ));
   final result = await prfProvider.checkDomainAssociation();
 
   if (result is DomainAssociationAssociated) {

--- a/docs/breez-sdk/snippets/flutter/lib/passkey.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/passkey.dart
@@ -133,9 +133,12 @@ Future<void> credentialMetadata() async {
 
   final credential = response.credential;
   if (credential != null) {
-    print(credential.credentialId); // Persist to reopen the same wallet on sign-in
-    print(credential.aaguid); // Authenticator model (display hint, unverified)
-    print(credential.backupEligible); // Whether the passkey syncs across devices
+    // Persist to reopen the same wallet on sign-in
+    print(credential.credentialId);
+    // Authenticator model (display hint, unverified)
+    print(credential.aaguid);
+    // Whether the passkey syncs across devices
+    print(credential.backupEligible);
   }
 
   // Pin the stored credential ID so the OS can't substitute a sibling.
@@ -144,10 +147,14 @@ Future<void> credentialMetadata() async {
       // stored credentialId bytes
     ]),
   );
-  print(signInResponse.wallet.seed); // Pass to connect() to open the wallet
-  print(signInResponse.wallet.label); // Label this wallet was derived from
-  print(signInResponse.labels); // This passkey's labels (populated on discovery sign-in)
-  print(signInResponse.credential); // Credential signed in with (credential_id only)
+  // Pass to connect() to open the wallet
+  print(signInResponse.wallet.seed);
+  // Label this wallet was derived from
+  print(signInResponse.wallet.label);
+  // This passkey's labels (populated on discovery sign-in)
+  print(signInResponse.labels);
+  // Credential signed in with (credential_id only)
+  print(signInResponse.credential);
   // ANCHOR_END: credential-metadata
 }
 

--- a/docs/breez-sdk/snippets/go/passkey.go
+++ b/docs/breez-sdk/snippets/go/passkey.go
@@ -45,13 +45,16 @@ func CheckAvailability() {
 	}
 	switch r := availability.(type) {
 	case breez_sdk_spark.PasskeyAvailabilityAvailable:
-		_ = r // Show passkey as primary option.
+		// Show passkey as primary option.
+		_ = r
 	case breez_sdk_spark.PasskeyAvailabilityPrfUnsupported:
-		_ = r // Fall back to mnemonic flow.
+		// Fall back to mnemonic flow.
+		_ = r
 	case breez_sdk_spark.PasskeyAvailabilityNotAssociated:
 		log.Printf("Domain association failed (source=%s): %s", r.Source, r.Reason)
 	case breez_sdk_spark.PasskeyAvailabilitySkipped:
-		_ = r // No verification source on this platform; proceed normally.
+		// No verification source on this platform; proceed normally.
+		_ = r
 	}
 	// ANCHOR_END: check-availability
 }
@@ -198,12 +201,14 @@ func CheckDomain() error {
 
 	switch r := result.(type) {
 	case breez_sdk_spark.DomainAssociationAssociated:
-		_ = r // Safe to proceed.
+		// Safe to proceed.
+		_ = r
 	case breez_sdk_spark.DomainAssociationNotAssociated:
 		log.Printf("Domain association failed (source=%s): %s", r.Source, r.Reason)
 		return nil
 	case breez_sdk_spark.DomainAssociationSkipped:
-		_ = r // Verification could not be performed; proceed normally.
+		// Verification could not be performed; proceed normally.
+		_ = r
 	}
 	// ANCHOR_END: domain-association
 	return nil

--- a/docs/breez-sdk/snippets/go/passkey.go
+++ b/docs/breez-sdk/snippets/go/passkey.go
@@ -127,9 +127,12 @@ func CredentialMetadata() error {
 	}
 
 	if response.Credential != nil {
-		log.Println(response.Credential.CredentialId)   // Persist to reopen the same wallet on sign-in
-		log.Println(response.Credential.Aaguid)         // Authenticator model (display hint, unverified)
-		log.Println(response.Credential.BackupEligible) // Whether the passkey syncs across devices
+		// Persist to reopen the same wallet on sign-in
+		log.Println(response.Credential.CredentialId)
+		// Authenticator model (display hint, unverified)
+		log.Println(response.Credential.Aaguid)
+		// Whether the passkey syncs across devices
+		log.Println(response.Credential.BackupEligible)
 	}
 
 	// Pin the stored credential ID so the OS can't substitute a sibling
@@ -143,10 +146,14 @@ func CredentialMetadata() error {
 	if err != nil {
 		return err
 	}
-	log.Println(signInResponse.Wallet.Seed)  // Pass to connect() to open the wallet
-	log.Println(signInResponse.Wallet.Label) // Label this wallet was derived from
-	log.Println(signInResponse.Labels)       // This passkey's labels (populated on discovery sign-in)
-	log.Println(signInResponse.Credential)   // Credential signed in with (credential_id only)
+	// Pass to connect() to open the wallet
+	log.Println(signInResponse.Wallet.Seed)
+	// Label this wallet was derived from
+	log.Println(signInResponse.Wallet.Label)
+	// This passkey's labels (populated on discovery sign-in)
+	log.Println(signInResponse.Labels)
+	// Credential signed in with (credential_id only)
+	log.Println(signInResponse.Credential)
 	// ANCHOR_END: credential-metadata
 	return nil
 }

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
@@ -33,7 +33,10 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun checkAvailability() {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
+            options = PasskeyProviderOptions(
+                rpId = "<your-rp-domain>",
+                rpName = "Your App",
+            ),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
@@ -54,7 +57,9 @@ class PasskeySnippets(private val activity: Activity) {
         val passkey = PasskeyClient(
             breezApiKey = "<breez api key>",
             activityProvider = { activity },
-            config = PasskeyConfig(providerOptions = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App")),
+            config = PasskeyConfig(
+                providerOptions = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
+            ),
         )
         // ANCHOR_END: setup-client
         return passkey
@@ -63,7 +68,10 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun connectWithPasskey(): BreezSdk {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
+            options = PasskeyProviderOptions(
+                rpId = "<your-rp-domain>",
+                rpName = "Your App",
+            ),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
@@ -82,7 +90,10 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun signInExistingUser(): SignInResponse {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
+            options = PasskeyProviderOptions(
+                rpId = "<your-rp-domain>",
+                rpName = "Your App",
+            ),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
@@ -95,7 +106,10 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun registerNewPasskey(): BreezSdk {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
+            options = PasskeyProviderOptions(
+                rpId = "<your-rp-domain>",
+                rpName = "Your App",
+            ),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
@@ -111,7 +125,10 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun credentialMetadata() {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
+            options = PasskeyProviderOptions(
+                rpId = "<your-rp-domain>",
+                rpName = "Your App",
+            ),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
@@ -142,7 +159,10 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun listLabels(): List<String> {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
+            options = PasskeyProviderOptions(
+                rpId = "<your-rp-domain>",
+                rpName = "Your App",
+            ),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
         // ANCHOR: list-labels
@@ -157,7 +177,10 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun storeLabel() {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
+            options = PasskeyProviderOptions(
+                rpId = "<your-rp-domain>",
+                rpName = "Your App",
+            ),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
         // ANCHOR: store-label
@@ -170,7 +193,10 @@ class PasskeySnippets(private val activity: Activity) {
         // Diagnostic only: never blocks the ceremony.
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
+            options = PasskeyProviderOptions(
+                rpId = "<your-rp-domain>",
+                rpName = "Your App",
+            ),
         )
         val result = prfProvider.checkDomainAssociation()
 
@@ -187,7 +213,10 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun recoverFromAlreadyExists(): Wallet {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
+            options = PasskeyProviderOptions(
+                rpId = "<your-rp-domain>",
+                rpName = "Your App",
+            ),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 
@@ -211,7 +240,10 @@ class PasskeySnippets(private val activity: Activity) {
     suspend fun handleTimeout(): SignInResponse {
         val prfProvider = PasskeyProvider(
             activityProvider = { activity },
-            options = PasskeyProviderOptions(rpId = "<your-rp-domain>", rpName = "Your App"),
+            options = PasskeyProviderOptions(
+                rpId = "<your-rp-domain>",
+                rpName = "Your App",
+            ),
         )
         val passkey = PasskeyClient(prfProvider, "<breez api key>", null)
 

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
@@ -146,7 +146,8 @@ class PasskeySnippets(private val activity: Activity) {
         val signInResponse = passkey.signIn(
             SignInRequest(
                 label = "personal",
-                allowCredentials = emptyList(), // stored credentialId bytes
+                // stored credentialId bytes
+                allowCredentials = emptyList(),
             )
         )
         // Log.v("Breez", "${signInResponse.wallet.seed}") // Pass to connect() to open the wallet
@@ -225,7 +226,8 @@ class PasskeySnippets(private val activity: Activity) {
             val response = passkey.register(
                 RegisterRequest(
                     label = "personal",
-                    excludeCredentials = emptyList(), // app-persisted credential IDs from prior registrations
+                    // app-persisted credential IDs from prior registrations
+                    excludeCredentials = emptyList(),
                 )
             )
             response.wallet

--- a/docs/breez-sdk/snippets/python/src/passkey.py
+++ b/docs/breez-sdk/snippets/python/src/passkey.py
@@ -60,13 +60,16 @@ async def check_availability():
     # ANCHOR: check-availability
     availability = await passkey.check_availability()
     if isinstance(availability, PasskeyAvailability.AVAILABLE):
-        pass  # Show passkey as primary option.
+        # Show passkey as primary option.
+        pass
     elif isinstance(availability, PasskeyAvailability.PRF_UNSUPPORTED):
-        pass  # Fall back to mnemonic flow.
+        # Fall back to mnemonic flow.
+        pass
     elif isinstance(availability, PasskeyAvailability.NOT_ASSOCIATED):
         print(f"Domain association failed (source={availability.source}): {availability.reason}")
     elif isinstance(availability, PasskeyAvailability.SKIPPED):
-        pass  # No verification source on this platform; proceed normally.
+        # No verification source on this platform; proceed normally.
+        pass
     # ANCHOR_END: check-availability
 
 
@@ -175,12 +178,14 @@ async def check_domain():
     result = await prf_provider.check_domain_association()
 
     if isinstance(result, DomainAssociation.ASSOCIATED):
-        pass  # Safe to proceed.
+        # Safe to proceed.
+        pass
     elif isinstance(result, DomainAssociation.NOT_ASSOCIATED):
         print(f"Domain association failed (source={result.source}): {result.reason}")
         return
     elif isinstance(result, DomainAssociation.SKIPPED):
-        pass  # Verification could not be performed; proceed normally.
+        # Verification could not be performed; proceed normally.
+        pass
     # ANCHOR_END: domain-association
 
 

--- a/docs/breez-sdk/snippets/python/src/passkey.py
+++ b/docs/breez-sdk/snippets/python/src/passkey.py
@@ -119,9 +119,12 @@ async def credential_metadata():
     response = await passkey.register(RegisterRequest(label="personal"))
 
     if response.credential is not None:
-        print(response.credential.credential_id)  # Persist to reopen the same wallet on sign-in
-        print(response.credential.aaguid)  # Authenticator model (display hint, unverified)
-        print(response.credential.backup_eligible)  # Whether the passkey syncs across devices
+        # Persist to reopen the same wallet on sign-in
+        print(response.credential.credential_id)
+        # Authenticator model (display hint, unverified)
+        print(response.credential.aaguid)
+        # Whether the passkey syncs across devices
+        print(response.credential.backup_eligible)
 
     # Pin the stored credential ID so the OS can't substitute a sibling
     # credential, which would derive a different wallet.
@@ -133,10 +136,14 @@ async def credential_metadata():
             ],
         )
     )
-    print(sign_in_response.wallet.seed)  # Pass to connect() to open the wallet
-    print(sign_in_response.wallet.label)  # Label this wallet was derived from
-    print(sign_in_response.labels)  # This passkey's labels (populated on discovery sign-in)
-    print(sign_in_response.credential)  # Credential signed in with (credential_id only)
+    # Pass to connect() to open the wallet
+    print(sign_in_response.wallet.seed)
+    # Label this wallet was derived from
+    print(sign_in_response.wallet.label)
+    # This passkey's labels (populated on discovery sign-in)
+    print(sign_in_response.labels)
+    # Credential signed in with (credential_id only)
+    print(sign_in_response.credential)
     # ANCHOR_END: credential-metadata
 
 

--- a/docs/breez-sdk/snippets/react-native/passkey.ts
+++ b/docs/breez-sdk/snippets/react-native/passkey.ts
@@ -139,9 +139,12 @@ const credentialMetadata = async () => {
   const response = await passkey.register({ label: 'personal', excludeCredentials: undefined })
 
   if (response.credential !== undefined) {
-    console.log(response.credential.credentialId) // Persist to reopen the same wallet on sign-in
-    console.log(response.credential.aaguid) // Authenticator model (display hint, unverified)
-    console.log(response.credential.backupEligible) // Whether the passkey syncs across devices
+    // Persist to reopen the same wallet on sign-in
+    console.log(response.credential.credentialId)
+    // Authenticator model (display hint, unverified)
+    console.log(response.credential.aaguid)
+    // Whether the passkey syncs across devices
+    console.log(response.credential.backupEligible)
   }
 
   // Pin the stored credential ID so the OS can't substitute a sibling
@@ -151,10 +154,14 @@ const credentialMetadata = async () => {
     allowCredentials: [/* stored credentialId bytes */],
     preferImmediatelyAvailableCredentials: undefined
   })
-  console.log(signInResponse.wallet.seed) // Pass to connect() to open the wallet
-  console.log(signInResponse.wallet.label) // Label this wallet was derived from
-  console.log(signInResponse.labels) // This passkey's labels (populated on discovery sign-in)
-  console.log(signInResponse.credential) // Credential signed in with (credential_id only)
+  // Pass to connect() to open the wallet
+  console.log(signInResponse.wallet.seed)
+  // Label this wallet was derived from
+  console.log(signInResponse.wallet.label)
+  // This passkey's labels (populated on discovery sign-in)
+  console.log(signInResponse.labels)
+  // Credential signed in with (credential_id only)
+  console.log(signInResponse.credential)
   // ANCHOR_END: credential-metadata
 }
 

--- a/docs/breez-sdk/snippets/react-native/passkey.ts
+++ b/docs/breez-sdk/snippets/react-native/passkey.ts
@@ -38,7 +38,12 @@ class CustomPrfProvider {
 // ANCHOR_END: implement-prf-provider
 
 const checkAvailability = async () => {
-  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
+  const passkey = new PasskeyClient(
+    '<breez api key>',
+    PasskeyConfig.create({
+      providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' })
+    })
+  )
 
   // ANCHOR: check-availability
   const availability = await passkey.checkAvailability()
@@ -63,13 +68,23 @@ const checkAvailability = async () => {
 
 const setupPasskeyClient = () => {
   // ANCHOR: setup-client
-  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
+  const passkey = new PasskeyClient(
+    '<breez api key>',
+    PasskeyConfig.create({
+      providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' })
+    })
+  )
   // ANCHOR_END: setup-client
   return passkey
 }
 
 const connectWithPasskey = async () => {
-  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
+  const passkey = new PasskeyClient(
+    '<breez api key>',
+    PasskeyConfig.create({
+      providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' })
+    })
+  )
 
   // ANCHOR: connect-with-passkey
   // Silent sign-in, fall through to register.
@@ -82,7 +97,12 @@ const connectWithPasskey = async () => {
 }
 
 const signInExistingUser = async () => {
-  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
+  const passkey = new PasskeyClient(
+    '<breez api key>',
+    PasskeyConfig.create({
+      providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' })
+    })
+  )
 
   // ANCHOR: sign-in
   // Returning-user sign-in. No fall-through to register.
@@ -91,7 +111,12 @@ const signInExistingUser = async () => {
 }
 
 const registerNewPasskey = async () => {
-  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
+  const passkey = new PasskeyClient(
+    '<breez api key>',
+    PasskeyConfig.create({
+      providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' })
+    })
+  )
 
   // ANCHOR: register-passkey
   const config = { ...defaultConfig(Network.Mainnet), apiKey: '<breez api key>' }
@@ -103,7 +128,12 @@ const registerNewPasskey = async () => {
 }
 
 const credentialMetadata = async () => {
-  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
+  const passkey = new PasskeyClient(
+    '<breez api key>',
+    PasskeyConfig.create({
+      providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' })
+    })
+  )
 
   // ANCHOR: credential-metadata
   const response = await passkey.register({ label: 'personal', excludeCredentials: undefined })
@@ -129,7 +159,12 @@ const credentialMetadata = async () => {
 }
 
 const listLabels = async (): Promise<string[]> => {
-  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
+  const passkey = new PasskeyClient(
+    '<breez api key>',
+    PasskeyConfig.create({
+      providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' })
+    })
+  )
   // ANCHOR: list-labels
   const labels = await passkey.labels().list()
   for (const label of labels) {
@@ -140,7 +175,12 @@ const listLabels = async (): Promise<string[]> => {
 }
 
 const storeLabel = async () => {
-  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
+  const passkey = new PasskeyClient(
+    '<breez api key>',
+    PasskeyConfig.create({
+      providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' })
+    })
+  )
   // ANCHOR: store-label
   await passkey.labels().store('personal')
   // ANCHOR_END: store-label
@@ -170,7 +210,12 @@ const checkDomain = async () => {
 }
 
 const recoverFromAlreadyExists = async () => {
-  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
+  const passkey = new PasskeyClient(
+    '<breez api key>',
+    PasskeyConfig.create({
+      providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' })
+    })
+  )
 
   // ANCHOR: recover-already-exists
   try {
@@ -193,7 +238,12 @@ const recoverFromAlreadyExists = async () => {
 }
 
 const handleTimeout = async () => {
-  const passkey = new PasskeyClient('<breez api key>', PasskeyConfig.create({ providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' }) }))
+  const passkey = new PasskeyClient(
+    '<breez api key>',
+    PasskeyConfig.create({
+      providerOptions: PasskeyProviderOptions.create({ rpId: '<your-rp-domain>', rpName: 'Your App' })
+    })
+  )
 
   // ANCHOR: handle-timeout
   // Biometric inactivity timeout, distinct from a user cancel.

--- a/docs/breez-sdk/snippets/rust/src/passkey.rs
+++ b/docs/breez-sdk/snippets/rust/src/passkey.rs
@@ -148,9 +148,12 @@ async fn credential_metadata() -> Result<()> {
         .await?;
 
     if let Some(credential) = &response.credential {
-        println!("{:?}", credential.credential_id); // Persist to reopen the same wallet on sign-in
-        println!("{:?}", credential.aaguid); // Authenticator model (display hint, unverified)
-        println!("{:?}", credential.backup_eligible); // Whether the passkey syncs across devices
+        // Persist to reopen the same wallet on sign-in
+        println!("{:?}", credential.credential_id);
+        // Authenticator model (display hint, unverified)
+        println!("{:?}", credential.aaguid);
+        // Whether the passkey syncs across devices
+        println!("{:?}", credential.backup_eligible);
     }
 
     // Pin the stored credential ID so the OS can't substitute a sibling,
@@ -162,10 +165,14 @@ async fn credential_metadata() -> Result<()> {
             ..Default::default()
         })
         .await?;
-    println!("{:?}", sign_in_response.wallet.seed); // Pass to connect() to open the wallet
-    println!("{}", sign_in_response.wallet.label); // Label this wallet was derived from
-    println!("{:?}", sign_in_response.labels); // This passkey's labels (populated on discovery sign-in)
-    println!("{:?}", sign_in_response.credential); // Credential signed in with (credential_id only)
+    // Pass to connect() to open the wallet
+    println!("{:?}", sign_in_response.wallet.seed);
+    // Label this wallet was derived from
+    println!("{}", sign_in_response.wallet.label);
+    // This passkey's labels (populated on discovery sign-in)
+    println!("{:?}", sign_in_response.labels);
+    // Credential signed in with (credential_id only)
+    println!("{:?}", sign_in_response.credential);
     // ANCHOR_END: credential-metadata
     Ok(())
 }

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
@@ -34,13 +34,16 @@ func checkAvailability() async throws {
     // ANCHOR: check-availability
     switch try await passkey.checkAvailability() {
     case .available:
-        break // Show passkey as primary option.
+        // Show passkey as primary option.
+        break
     case .prfUnsupported:
-        break // Fall back to mnemonic flow.
+        // Fall back to mnemonic flow.
+        break
     case .notAssociated(let source, let reason):
         print("Domain association failed (source=\(source)): \(reason)")
     case .skipped:
-        break // No verification source on this platform; proceed normally.
+        // No verification source on this platform; proceed normally.
+        break
     }
     // ANCHOR_END: check-availability
 }

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
@@ -26,7 +26,9 @@ class CustomPrfProvider: PrfProvider {
 // ANCHOR_END: implement-prf-provider
 
 func checkAvailability() async throws {
-    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
+    let prfProvider = PasskeyProvider(
+        options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
+    )
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: check-availability
@@ -47,14 +49,18 @@ func setupPasskeyClient() -> PasskeyClient {
     // ANCHOR: setup-client
     let passkey = PasskeyClient(
         breezApiKey: "<breez api key>",
-        config: PasskeyConfig(providerOptions: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
+        config: PasskeyConfig(
+            providerOptions: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
+        )
     )
     // ANCHOR_END: setup-client
     return passkey
 }
 
 func connectWithPasskey() async throws -> BreezSdk {
-    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
+    let prfProvider = PasskeyProvider(
+        options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
+    )
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: connect-with-passkey
@@ -77,7 +83,9 @@ func connectWithPasskey() async throws -> BreezSdk {
 }
 
 func signInExistingUser() async throws -> SignInResponse {
-    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
+    let prfProvider = PasskeyProvider(
+        options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
+    )
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: sign-in
@@ -87,7 +95,9 @@ func signInExistingUser() async throws -> SignInResponse {
 }
 
 func registerNewPasskey() async throws -> BreezSdk {
-    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
+    let prfProvider = PasskeyProvider(
+        options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
+    )
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: register-passkey
@@ -109,7 +119,9 @@ func registerNewPasskey() async throws -> BreezSdk {
 }
 
 func credentialMetadata() async throws {
-    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
+    let prfProvider = PasskeyProvider(
+        options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
+    )
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: nil, config: nil)
 
     // ANCHOR: credential-metadata
@@ -141,7 +153,9 @@ func credentialMetadata() async throws {
 }
 
 func listLabels() async throws -> [String] {
-    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
+    let prfProvider = PasskeyProvider(
+        options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
+    )
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
     // ANCHOR: list-labels
     let labels = try await passkey.labels().list()
@@ -153,7 +167,9 @@ func listLabels() async throws -> [String] {
 }
 
 func storeLabel() async throws {
-    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
+    let prfProvider = PasskeyProvider(
+        options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
+    )
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
     // ANCHOR: store-label
     try await passkey.labels().store(label: "personal")
@@ -163,7 +179,9 @@ func storeLabel() async throws {
 func checkDomain() async throws {
     // ANCHOR: domain-association
     // Lower-level provider call. Most hosts use `checkAvailability` instead.
-    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
+    let prfProvider = PasskeyProvider(
+        options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
+    )
     let result = try await prfProvider.checkDomainAssociation()
 
     switch result {
@@ -179,7 +197,9 @@ func checkDomain() async throws {
 }
 
 func recoverFromAlreadyExists() async throws -> Wallet {
-    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
+    let prfProvider = PasskeyProvider(
+        options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
+    )
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: recover-already-exists
@@ -204,7 +224,9 @@ func recoverFromAlreadyExists() async throws -> Wallet {
 }
 
 func handleTimeout() async throws -> SignInResponse {
-    let prfProvider = PasskeyProvider(options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App"))
+    let prfProvider = PasskeyProvider(
+        options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
+    )
     let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: handle-timeout

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
@@ -130,9 +130,12 @@ func credentialMetadata() async throws {
     )
 
     if let credential = response.credential {
-        print(credential.credentialId) // Persist to reopen the same wallet on sign-in
-        print(credential.aaguid) // Authenticator model (display hint, unverified)
-        print(credential.backupEligible) // Whether the passkey syncs across devices
+        // Persist to reopen the same wallet on sign-in
+        print(credential.credentialId)
+        // Authenticator model (display hint, unverified)
+        print(credential.aaguid)
+        // Whether the passkey syncs across devices
+        print(credential.backupEligible)
     }
 
     // Pin the stored credential ID so the OS can't substitute a sibling
@@ -145,10 +148,14 @@ func credentialMetadata() async throws {
             ]
         )
     )
-    print(signInResponse.wallet.seed) // Pass to connect() to open the wallet
-    print(signInResponse.wallet.label) // Label this wallet was derived from
-    print(signInResponse.labels) // This passkey's labels (populated on discovery sign-in)
-    print(signInResponse.credential) // Credential signed in with (credential_id only)
+    // Pass to connect() to open the wallet
+    print(signInResponse.wallet.seed)
+    // Label this wallet was derived from
+    print(signInResponse.wallet.label)
+    // This passkey's labels (populated on discovery sign-in)
+    print(signInResponse.labels)
+    // Credential signed in with (credential_id only)
+    print(signInResponse.credential)
     // ANCHOR_END: credential-metadata
 }
 

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -32,7 +32,9 @@ class CustomPrfProvider {
 // ANCHOR_END: implement-prf-provider
 
 const checkAvailability = async () => {
-  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
+  const passkey = new PasskeyClient('<breez api key>', {
+    providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' }
+  })
 
   // ANCHOR: check-availability
   const availability = await passkey.checkAvailability()
@@ -57,13 +59,17 @@ const checkAvailability = async () => {
 
 const setupPasskeyClient = () => {
   // ANCHOR: setup-client
-  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
+  const passkey = new PasskeyClient('<breez api key>', {
+    providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' }
+  })
   // ANCHOR_END: setup-client
   return passkey
 }
 
 const connectWithPasskey = async () => {
-  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
+  const passkey = new PasskeyClient('<breez api key>', {
+    providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' }
+  })
 
   // ANCHOR: connect-with-passkey
   // Not available on web; use two buttons (signIn / register) instead.
@@ -76,7 +82,9 @@ const connectWithPasskey = async () => {
 }
 
 const signInExistingUser = async () => {
-  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
+  const passkey = new PasskeyClient('<breez api key>', {
+    providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' }
+  })
 
   // ANCHOR: sign-in
   // Returning-user sign-in. No fall-through to register.
@@ -85,7 +93,9 @@ const signInExistingUser = async () => {
 }
 
 const registerNewPasskey = async () => {
-  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
+  const passkey = new PasskeyClient('<breez api key>', {
+    providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' }
+  })
 
   // ANCHOR: register-passkey
   const response = await passkey.register({ label: 'personal' })
@@ -97,7 +107,9 @@ const registerNewPasskey = async () => {
 }
 
 const credentialMetadata = async () => {
-  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
+  const passkey = new PasskeyClient('<breez api key>', {
+    providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' }
+  })
 
   // ANCHOR: credential-metadata
   const response = await passkey.register({ label: 'personal' })
@@ -122,7 +134,9 @@ const credentialMetadata = async () => {
 }
 
 const listLabels = async (): Promise<string[]> => {
-  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
+  const passkey = new PasskeyClient('<breez api key>', {
+    providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' }
+  })
   // ANCHOR: list-labels
   const labels = await passkey.labels().list()
   for (const label of labels) {
@@ -133,7 +147,9 @@ const listLabels = async (): Promise<string[]> => {
 }
 
 const storeLabel = async () => {
-  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
+  const passkey = new PasskeyClient('<breez api key>', {
+    providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' }
+  })
   // ANCHOR: store-label
   await passkey.labels().store('personal')
   // ANCHOR_END: store-label
@@ -163,7 +179,9 @@ const checkDomain = async () => {
 }
 
 const recoverFromAlreadyExists = async () => {
-  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
+  const passkey = new PasskeyClient('<breez api key>', {
+    providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' }
+  })
 
   // ANCHOR: recover-already-exists
   try {
@@ -186,7 +204,9 @@ const recoverFromAlreadyExists = async () => {
 }
 
 const handleTimeout = async () => {
-  const passkey = new PasskeyClient('<breez api key>', { providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' } })
+  const passkey = new PasskeyClient('<breez api key>', {
+    providerOptions: { rpId: '<your-rp-domain>', rpName: 'Your App' }
+  })
 
   // ANCHOR: handle-timeout
   // Biometric inactivity timeout, distinct from a user cancel.

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -115,9 +115,12 @@ const credentialMetadata = async () => {
   const response = await passkey.register({ label: 'personal' })
 
   if (response.credential != null) {
-    console.log(response.credential.credentialId) // Persist to reopen the same wallet on sign-in
-    console.log(response.credential.aaguid) // Authenticator model (display hint, unverified)
-    console.log(response.credential.backupEligible) // Whether the passkey syncs across devices
+    // Persist to reopen the same wallet on sign-in
+    console.log(response.credential.credentialId)
+    // Authenticator model (display hint, unverified)
+    console.log(response.credential.aaguid)
+    // Whether the passkey syncs across devices
+    console.log(response.credential.backupEligible)
   }
 
   // Pin the stored credential ID so the OS can't substitute a sibling
@@ -126,10 +129,14 @@ const credentialMetadata = async () => {
     label: 'personal',
     allowCredentials: [/* stored credentialId bytes */]
   })
-  console.log(signInResponse.wallet.seed) // Pass to connect() to open the wallet
-  console.log(signInResponse.wallet.label) // Label this wallet was derived from
-  console.log(signInResponse.labels) // This passkey's labels (populated on discovery sign-in)
-  console.log(signInResponse.credential) // Credential signed in with (credential_id only)
+  // Pass to connect() to open the wallet
+  console.log(signInResponse.wallet.seed)
+  // Label this wallet was derived from
+  console.log(signInResponse.wallet.label)
+  // This passkey's labels (populated on discovery sign-in)
+  console.log(signInResponse.labels)
+  // Credential signed in with (credential_id only)
+  console.log(signInResponse.credential)
   // ANCHOR_END: credential-metadata
 }
 


### PR DESCRIPTION
This PR moves trailing comments above statements in doc snippets to improve readability.