### PR TITLE
Cross-chain: docs

### DIFF
--- a/docs/breez-sdk/snippets-processor/src/main.rs
+++ b/docs/breez-sdk/snippets-processor/src/main.rs
@@ -110,9 +110,14 @@ impl SnippetsProcessor {
         }
     }
 
-    /// Expand {{#name identifier}} to language-aware HTML
+    /// Expand {{#name identifier}} to language-aware HTML.
+    ///
+    /// Supports two dotted shapes:
+    /// - `Type.method` — prefix starts uppercase, treated as a type/class
+    ///   name and emitted verbatim across all languages.
+    /// - `field.subfield` — prefix starts lowercase, treated as a snake_case
+    ///   field path and case-converted alongside the trailing segment.
     fn expand_name(identifier: &str) -> String {
-        // Handle Type.method syntax
         let (type_prefix, method) = identifier
             .split_once('.')
             .map(|(t, m)| (Some(t), m))
@@ -122,24 +127,43 @@ impl SnippetsProcessor {
         let camel = Self::to_camel_case(method);
         let pascal = capitalize_first(method);
 
-        // Generate spans for each language group
-        let variants = [
-            ("rust", &snake),
-            ("python", &snake),
-            ("swift", &camel),
-            ("kotlin", &camel),
-            ("javascript", &camel),
-            ("react-native", &camel),
-            ("flutter", &camel),
-            ("go", &pascal),
-            ("csharp", &pascal),
+        // Pre-compute prefix in each casing flavor. For a Type prefix
+        // (starts uppercase), all three are identical to the original. For a
+        // field prefix (starts lowercase), they follow the method's casing
+        // per language.
+        let prefix_cases = type_prefix.map(|t| {
+            let is_type = t.starts_with(|c: char| c.is_uppercase());
+            if is_type {
+                (t.to_string(), t.to_string(), t.to_string())
+            } else {
+                (
+                    t.to_string(),                     // snake (rust, python)
+                    Self::to_camel_case(t),            // camel (swift, kotlin, js, rn, flutter)
+                    capitalize_first(t),               // pascal (go, csharp)
+                )
+            }
+        });
+
+        // (language tag, method-casing, prefix-casing)
+        let variants: [(&str, &String, Option<&String>); 9] = [
+            ("rust", &snake, prefix_cases.as_ref().map(|p| &p.0)),
+            ("python", &snake, prefix_cases.as_ref().map(|p| &p.0)),
+            ("swift", &camel, prefix_cases.as_ref().map(|p| &p.1)),
+            ("kotlin", &camel, prefix_cases.as_ref().map(|p| &p.1)),
+            ("javascript", &camel, prefix_cases.as_ref().map(|p| &p.1)),
+            ("react-native", &camel, prefix_cases.as_ref().map(|p| &p.1)),
+            ("flutter", &camel, prefix_cases.as_ref().map(|p| &p.1)),
+            ("go", &pascal, prefix_cases.as_ref().map(|p| &p.2)),
+            ("csharp", &pascal, prefix_cases.as_ref().map(|p| &p.2)),
         ];
 
         let spans: String = variants
             .iter()
-            .map(|(lang, variant_name)| {
-                let display =
-                    type_prefix.map_or_else(|| (*variant_name).to_string(), |t| format!("{}.{}", t, variant_name));
+            .map(|(lang, method_name, prefix)| {
+                let display = match prefix {
+                    Some(p) => format!("{}.{}", p, method_name),
+                    None => (*method_name).clone(),
+                };
                 format!("<span class=\"fn-{}\">{}</span>", lang, display)
             })
             .collect();

--- a/docs/breez-sdk/snippets/csharp/Config.cs
+++ b/docs/breez-sdk/snippets/csharp/Config.cs
@@ -137,8 +137,7 @@ namespace BreezSdkSnippets
         void ConfigureCrossChain()
         {
             // ANCHOR: cross-chain-config
-            // Override the default slippage tolerance (basis points; 10 to 500).
-            // Set crossChainConfig to null to disable the feature.
+            // Set to enable cross-chain payments. Slippage override is optional (10 to 500 bps).
             var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
             {
                 apiKey = "<breez api key>",

--- a/docs/breez-sdk/snippets/csharp/Config.cs
+++ b/docs/breez-sdk/snippets/csharp/Config.cs
@@ -133,5 +133,21 @@ namespace BreezSdkSnippets
             };
             // ANCHOR_END: config-background-tasks
         }
+
+        void ConfigureCrossChain()
+        {
+            // ANCHOR: cross-chain-config
+            // Override the default slippage tolerance (basis points; 10 to 500).
+            // Set crossChainConfig to null to disable the feature.
+            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            {
+                apiKey = "<breez api key>",
+                crossChainConfig = new CrossChainConfig(
+                    defaultSlippageBps: 50,
+                    defaultTargetOverpayBps: null)
+            };
+            // ANCHOR_END: cross-chain-config
+            Console.WriteLine($"Config: {config}");
+        }
     }
 }

--- a/docs/breez-sdk/snippets/csharp/CrossChain.cs
+++ b/docs/breez-sdk/snippets/csharp/CrossChain.cs
@@ -61,6 +61,7 @@ namespace BreezSdkSnippets
         async Task SendPaymentCrossChain(BreezSdk sdk, PrepareSendPaymentResponse prepareResponse)
         {
             // ANCHOR: cross-chain-send
+            // Only valid for sends with no token leg (see Retry safety).
             var optionalIdempotencyKey = "<idempotency key uuid>";
             var request = new SendPaymentRequest(
                 prepareResponse: prepareResponse,

--- a/docs/breez-sdk/snippets/csharp/CrossChain.cs
+++ b/docs/breez-sdk/snippets/csharp/CrossChain.cs
@@ -1,0 +1,75 @@
+using Breez.Sdk.Spark;
+
+namespace BreezSdkSnippets
+{
+    class CrossChain
+    {
+        async Task GetCrossChainRoutes(BreezSdk sdk)
+        {
+            // ANCHOR: cross-chain-get-routes
+            var inputStr = "<recipient address>";
+            var parsed = await sdk.Parse(input: inputStr);
+            if (parsed is not InputType.CrossChainAddress crossChain)
+            {
+                throw new InvalidOperationException("Not a cross-chain address");
+            }
+            var addressDetails = crossChain.v1;
+
+            var filter = new CrossChainRouteFilter.Send(addressDetails: addressDetails);
+            var routes = await sdk.GetCrossChainRoutes(filter: filter);
+
+            foreach (var route in routes)
+            {
+                Console.WriteLine($"Route via {route.provider}: {route.chain}/{route.asset}");
+            }
+            // ANCHOR_END: cross-chain-get-routes
+        }
+
+        async Task PrepareSendPaymentCrossChain(
+            BreezSdk sdk,
+            CrossChainAddressDetails addressDetails,
+            CrossChainRoutePair route)
+        {
+            // ANCHOR: cross-chain-prepare
+            // Optionally set the maximum slippage in basis points (10 to 500)
+            uint? optionalMaxSlippageBps = 100;
+
+            var request = new PrepareSendPaymentRequest(
+                paymentRequest: new PaymentRequest.CrossChain(
+                    address: addressDetails.address,
+                    route: route,
+                    maxSlippageBps: optionalMaxSlippageBps,
+                    targetOverpayBps: null
+                ),
+                amount: 50_000UL,
+                tokenIdentifier: null,
+                conversionOptions: null,
+                feePolicy: null
+            );
+            var prepareResponse = await sdk.PrepareSendPayment(request: request);
+
+            if (prepareResponse.paymentMethod is SendPaymentMethod.CrossChainAddress method)
+            {
+                Console.WriteLine($"Amount in: {method.amountIn}");
+                Console.WriteLine($"Estimated out: {method.estimatedOut}");
+                Console.WriteLine($"Provider fee: {method.feeAmount}");
+                Console.WriteLine($"Quote expires at: {method.expiresAt}");
+            }
+            // ANCHOR_END: cross-chain-prepare
+        }
+
+        async Task SendPaymentCrossChain(BreezSdk sdk, PrepareSendPaymentResponse prepareResponse)
+        {
+            // ANCHOR: cross-chain-send
+            var optionalIdempotencyKey = "<idempotency key uuid>";
+            var request = new SendPaymentRequest(
+                prepareResponse: prepareResponse,
+                options: null,
+                idempotencyKey: optionalIdempotencyKey
+            );
+            var sendResponse = await sdk.SendPayment(request: request);
+            Console.WriteLine($"Payment: {sendResponse.payment}");
+            // ANCHOR_END: cross-chain-send
+        }
+    }
+}

--- a/docs/breez-sdk/snippets/csharp/ParsingInputs.cs
+++ b/docs/breez-sdk/snippets/csharp/ParsingInputs.cs
@@ -73,6 +73,12 @@ namespace BreezSdkSnippets
                     }
                     break;
 
+                case InputType.CrossChainAddress crossChainAddress:
+                    var crossChainDetails = crossChainAddress.v1;
+                    Console.WriteLine($"Input is cross-chain address {crossChainDetails.address} " +
+                                    $"({crossChainDetails.addressFamily})");
+                    break;
+
                     // Other input types are available
             }
             // ANCHOR_END: parse-inputs

--- a/docs/breez-sdk/snippets/flutter/lib/config.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/config.dart
@@ -117,8 +117,7 @@ void configureBackgroundTasks() {
 
 void configureCrossChain() {
   // ANCHOR: cross-chain-config
-  // Override the default slippage tolerance (basis points; 10 to 500).
-  // Set crossChainConfig to null to disable the feature.
+  // Set to enable cross-chain payments. Slippage override is optional (10 to 500 bps).
   final config = defaultConfig(network: Network.mainnet).copyWith(
     apiKey: "<breez api key>",
     crossChainConfig: const CrossChainConfig(

--- a/docs/breez-sdk/snippets/flutter/lib/config.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/config.dart
@@ -114,3 +114,18 @@ void configureBackgroundTasks() {
   // ANCHOR_END: config-background-tasks
   print(config);
 }
+
+void configureCrossChain() {
+  // ANCHOR: cross-chain-config
+  // Override the default slippage tolerance (basis points; 10 to 500).
+  // Set crossChainConfig to null to disable the feature.
+  final config = defaultConfig(network: Network.mainnet).copyWith(
+    apiKey: "<breez api key>",
+    crossChainConfig: const CrossChainConfig(
+      defaultSlippageBps: 50,
+      defaultTargetOverpayBps: null,
+    ),
+  );
+  // ANCHOR_END: cross-chain-config
+  print("Config: $config");
+}

--- a/docs/breez-sdk/snippets/flutter/lib/cross_chain.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/cross_chain.dart
@@ -59,6 +59,7 @@ Future<SendPaymentResponse> sendPaymentCrossChain(
   PrepareSendPaymentResponse prepareResponse,
 ) async {
   // ANCHOR: cross-chain-send
+  // Only valid for sends with no token leg (see Retry safety).
   String? optionalIdempotencyKey = "<idempotency key uuid>";
   final request = SendPaymentRequest(
     prepareResponse: prepareResponse,

--- a/docs/breez-sdk/snippets/flutter/lib/cross_chain.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/cross_chain.dart
@@ -1,0 +1,72 @@
+import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
+
+Future<List<CrossChainRoutePair>> getCrossChainRoutes(BreezSdk sdk) async {
+  // ANCHOR: cross-chain-get-routes
+  String input = "<recipient address>";
+  InputType parsed = await sdk.parse(input: input);
+  if (parsed is! InputType_CrossChainAddress) {
+    throw Exception("Not a cross-chain address");
+  }
+  CrossChainAddressDetails addressDetails = parsed.field0;
+
+  List<CrossChainRoutePair> routes = await sdk.getCrossChainRoutes(
+    filter: CrossChainRouteFilter.send(addressDetails: addressDetails),
+  );
+
+  for (var route in routes) {
+    print("Route via ${route.provider}: ${route.chain}/${route.asset}");
+  }
+  // ANCHOR_END: cross-chain-get-routes
+  return routes;
+}
+
+Future<PrepareSendPaymentResponse> prepareSendPaymentCrossChain(
+  BreezSdk sdk,
+  CrossChainAddressDetails addressDetails,
+  CrossChainRoutePair route,
+) async {
+  // ANCHOR: cross-chain-prepare
+  // Optionally set the maximum slippage in basis points (10 to 500)
+  int? optionalMaxSlippageBps = 100;
+
+  final request = PrepareSendPaymentRequest(
+    paymentRequest: PaymentRequest.crossChain(
+      address: addressDetails.address,
+      route: route,
+      maxSlippageBps: optionalMaxSlippageBps,
+      targetOverpayBps: null,
+    ),
+    amount: BigInt.from(50000),
+    tokenIdentifier: null,
+    conversionOptions: null,
+    feePolicy: null,
+  );
+  final response = await sdk.prepareSendPayment(request: request);
+
+  final paymentMethod = response.paymentMethod;
+  if (paymentMethod is SendPaymentMethod_CrossChainAddress) {
+    print("Amount in: ${paymentMethod.amountIn}");
+    print("Estimated out: ${paymentMethod.estimatedOut}");
+    print("Provider fee: ${paymentMethod.feeAmount}");
+    print("Quote expires at: ${paymentMethod.expiresAt}");
+  }
+  // ANCHOR_END: cross-chain-prepare
+  return response;
+}
+
+Future<SendPaymentResponse> sendPaymentCrossChain(
+  BreezSdk sdk,
+  PrepareSendPaymentResponse prepareResponse,
+) async {
+  // ANCHOR: cross-chain-send
+  String? optionalIdempotencyKey = "<idempotency key uuid>";
+  final request = SendPaymentRequest(
+    prepareResponse: prepareResponse,
+    options: null,
+    idempotencyKey: optionalIdempotencyKey,
+  );
+  final response = await sdk.sendPayment(request: request);
+  print("Payment: ${response.payment}");
+  // ANCHOR_END: cross-chain-send
+  return response;
+}

--- a/docs/breez-sdk/snippets/flutter/lib/parsing_inputs.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/parsing_inputs.dart
@@ -28,19 +28,22 @@ Future<void> parseInput(BreezSdk sdk) async {
     } else {
       print("  Amount: ${invoice.amount} sats");
     }
-    
+
     if (invoice.description != null) {
       print("  Description: ${invoice.description}");
     }
-    
+
     if (invoice.expiryTime != null) {
       print("  Expiry time: "
           "${DateTime.fromMillisecondsSinceEpoch(invoice.expiryTime!.toInt() * 1000)}");
     }
-    
+
     if (invoice.senderPublicKey != null) {
       print("  Sender public key: ${invoice.senderPublicKey}");
     }
+  } else if (inputType is InputType_CrossChainAddress) {
+    var details = inputType.field0;
+    print("Input is cross-chain address ${details.address} (${details.addressFamily})");
   } else {
     // Other input types are available
   }

--- a/docs/breez-sdk/snippets/go/config.go
+++ b/docs/breez-sdk/snippets/go/config.go
@@ -131,3 +131,20 @@ func ConfigureBackgroundTasks() {
 	// ANCHOR_END: config-background-tasks
 	log.Printf("Config: %+v", config)
 }
+
+func ConfigureCrossChain() {
+	// ANCHOR: cross-chain-config
+	config := breez_sdk_spark.DefaultConfig(breez_sdk_spark.NetworkMainnet)
+	apiKey := "<breez api key>"
+	config.ApiKey = &apiKey
+
+	// Override the default slippage tolerance (basis points; 10 to 500).
+	// Set CrossChainConfig to nil to disable the feature.
+	defaultSlippageBps := uint32(50)
+	config.CrossChainConfig = &breez_sdk_spark.CrossChainConfig{
+		DefaultSlippageBps:       &defaultSlippageBps,
+		DefaultTargetOverpayBps:  nil,
+	}
+	// ANCHOR_END: cross-chain-config
+	log.Printf("Config: %v", config)
+}

--- a/docs/breez-sdk/snippets/go/config.go
+++ b/docs/breez-sdk/snippets/go/config.go
@@ -138,8 +138,7 @@ func ConfigureCrossChain() {
 	apiKey := "<breez api key>"
 	config.ApiKey = &apiKey
 
-	// Override the default slippage tolerance (basis points; 10 to 500).
-	// Set CrossChainConfig to nil to disable the feature.
+	// Set to enable cross-chain payments. Slippage override is optional (10 to 500 bps).
 	defaultSlippageBps := uint32(50)
 	config.CrossChainConfig = &breez_sdk_spark.CrossChainConfig{
 		DefaultSlippageBps:       &defaultSlippageBps,

--- a/docs/breez-sdk/snippets/go/cross_chain.go
+++ b/docs/breez-sdk/snippets/go/cross_chain.go
@@ -82,6 +82,7 @@ func SendPaymentCrossChain(
 	prepareResponse breez_sdk_spark.PrepareSendPaymentResponse,
 ) (*breez_sdk_spark.SendPaymentResponse, error) {
 	// ANCHOR: cross-chain-send
+	// Only valid for sends with no token leg (see Retry safety).
 	optionalIdempotencyKey := "<idempotency key uuid>"
 	request := breez_sdk_spark.SendPaymentRequest{
 		PrepareResponse: prepareResponse,

--- a/docs/breez-sdk/snippets/go/cross_chain.go
+++ b/docs/breez-sdk/snippets/go/cross_chain.go
@@ -1,0 +1,98 @@
+package example
+
+import (
+	"errors"
+	"log"
+	"math/big"
+
+	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
+)
+
+func GetCrossChainRoutes(sdk *breez_sdk_spark.BreezSdk) ([]breez_sdk_spark.CrossChainRoutePair, error) {
+	// ANCHOR: cross-chain-get-routes
+	inputStr := "<recipient address>"
+	input, err := sdk.Parse(inputStr)
+	if err != nil {
+		var sdkErr *breez_sdk_spark.SdkError
+		if errors.As(err, &sdkErr) {
+			// Handle SdkError
+		}
+		return nil, err
+	}
+
+	addressInput, ok := input.(breez_sdk_spark.InputTypeCrossChainAddress)
+	if !ok {
+		return nil, errors.New("not a cross-chain address")
+	}
+	addressDetails := addressInput.Field0
+
+	filter := breez_sdk_spark.CrossChainRouteFilterSend{AddressDetails: addressDetails}
+	routes, err := sdk.GetCrossChainRoutes(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, route := range routes {
+		log.Printf("Route via %v: %s/%s", route.Provider, route.Chain, route.Asset)
+	}
+	// ANCHOR_END: cross-chain-get-routes
+	return routes, nil
+}
+
+func PrepareSendPaymentCrossChain(
+	sdk *breez_sdk_spark.BreezSdk,
+	addressDetails breez_sdk_spark.CrossChainAddressDetails,
+	route breez_sdk_spark.CrossChainRoutePair,
+) (*breez_sdk_spark.PrepareSendPaymentResponse, error) {
+	// ANCHOR: cross-chain-prepare
+	// Optionally set the maximum slippage in basis points (10 to 500)
+	optionalMaxSlippageBps := uint32(100)
+	amount := new(big.Int).SetInt64(50_000)
+
+	request := breez_sdk_spark.PrepareSendPaymentRequest{
+		PaymentRequest: breez_sdk_spark.PaymentRequestCrossChain{
+			Address:           addressDetails.Address,
+			Route:             route,
+			MaxSlippageBps:    &optionalMaxSlippageBps,
+			TargetOverpayBps:  nil,
+		},
+		Amount:            &amount,
+		TokenIdentifier:   nil,
+		ConversionOptions: nil,
+		FeePolicy:         nil,
+	}
+	response, err := sdk.PrepareSendPayment(request)
+	if err != nil {
+		return nil, err
+	}
+
+	switch paymentMethod := response.PaymentMethod.(type) {
+	case breez_sdk_spark.SendPaymentMethodCrossChainAddress:
+		log.Printf("Amount in: %v", paymentMethod.AmountIn)
+		log.Printf("Estimated out: %v", paymentMethod.EstimatedOut)
+		log.Printf("Provider fee: %v", paymentMethod.FeeAmount)
+		log.Printf("Quote expires at: %s", paymentMethod.ExpiresAt)
+	}
+	// ANCHOR_END: cross-chain-prepare
+	return &response, nil
+}
+
+func SendPaymentCrossChain(
+	sdk *breez_sdk_spark.BreezSdk,
+	prepareResponse breez_sdk_spark.PrepareSendPaymentResponse,
+) (*breez_sdk_spark.SendPaymentResponse, error) {
+	// ANCHOR: cross-chain-send
+	optionalIdempotencyKey := "<idempotency key uuid>"
+	request := breez_sdk_spark.SendPaymentRequest{
+		PrepareResponse: prepareResponse,
+		Options:         nil,
+		IdempotencyKey:  &optionalIdempotencyKey,
+	}
+	response, err := sdk.SendPayment(request)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Payment: %v", response.Payment)
+	// ANCHOR_END: cross-chain-send
+	return &response, nil
+}

--- a/docs/breez-sdk/snippets/go/parsing_inputs.go
+++ b/docs/breez-sdk/snippets/go/parsing_inputs.go
@@ -70,6 +70,14 @@ func ParseInput(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.InputType, erro
 			log.Printf("  Sender public key: %s", *invoice.SenderPublicKey)
 		}
 
+	case breez_sdk_spark.InputTypeCrossChainAddress:
+		details := inputType.Field0
+		log.Printf(
+			"Input is cross-chain address %s (%v)",
+			details.Address,
+			details.AddressFamily,
+		)
+
 	default:
 		// Other input types are available
 	}

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
@@ -122,8 +122,7 @@ class Config {
         val config = defaultConfig(Network.MAINNET)
         config.apiKey = "<breez api key>"
 
-        // Override the default slippage tolerance (basis points; 10 to 500).
-        // Set crossChainConfig to null to disable the feature.
+        // Set to enable cross-chain payments. Slippage override is optional (10 to 500 bps).
         config.crossChainConfig = CrossChainConfig(
             defaultSlippageBps = 50u,
             defaultTargetOverpayBps = null,

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
@@ -116,4 +116,19 @@ class Config {
         // ANCHOR_END: config-background-tasks
         println("Config: $config")
     }
+
+    fun configureCrossChain() {
+        // ANCHOR: cross-chain-config
+        val config = defaultConfig(Network.MAINNET)
+        config.apiKey = "<breez api key>"
+
+        // Override the default slippage tolerance (basis points; 10 to 500).
+        // Set crossChainConfig to null to disable the feature.
+        config.crossChainConfig = CrossChainConfig(
+            defaultSlippageBps = 50u,
+            defaultTargetOverpayBps = null,
+        )
+        // ANCHOR_END: cross-chain-config
+        println("Config: $config")
+    }
 }

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/CrossChain.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/CrossChain.kt
@@ -74,6 +74,7 @@ class CrossChain {
         prepareResponse: PrepareSendPaymentResponse,
     ) {
         // ANCHOR: cross-chain-send
+        // Only valid for sends with no token leg (see Retry safety).
         val optionalIdempotencyKey = "<idempotency key uuid>"
         try {
             val req = SendPaymentRequest(

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/CrossChain.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/CrossChain.kt
@@ -1,0 +1,92 @@
+package com.example.kotlinmpplib
+
+import breez_sdk_spark.*
+import com.ionspin.kotlin.bignum.integer.BigInteger
+
+class CrossChain {
+    suspend fun getCrossChainRoutes(sdk: BreezSdk) {
+        // ANCHOR: cross-chain-get-routes
+        val input = "<recipient address>"
+
+        try {
+            val parsed = sdk.parse(input)
+            if (parsed !is InputType.CrossChainAddress) {
+                throw IllegalArgumentException("Not a cross-chain address")
+            }
+            val addressDetails = parsed.v1
+
+            val routes = sdk.getCrossChainRoutes(
+                CrossChainRouteFilter.Send(addressDetails = addressDetails)
+            )
+
+            for (route in routes) {
+                // Log.v("Breez", "Route via ${route.provider}: ${route.chain}/${route.asset}")
+            }
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: cross-chain-get-routes
+    }
+
+    suspend fun prepareSendPaymentCrossChain(
+        sdk: BreezSdk,
+        addressDetails: CrossChainAddressDetails,
+        route: CrossChainRoutePair,
+    ) {
+        // ANCHOR: cross-chain-prepare
+        // Optionally set the maximum slippage in basis points (10 to 500)
+        val optionalMaxSlippageBps: UInt? = 100u
+
+        try {
+            val req = PrepareSendPaymentRequest(
+                paymentRequest = PaymentRequest.CrossChain(
+                    address = addressDetails.address,
+                    route = route,
+                    maxSlippageBps = optionalMaxSlippageBps,
+                    targetOverpayBps = null,
+                ),
+                amount = BigInteger.fromLong(50_000L),
+                tokenIdentifier = null,
+                conversionOptions = null,
+                feePolicy = null,
+            )
+            val prepareResponse = sdk.prepareSendPayment(req)
+
+            val paymentMethod = prepareResponse.paymentMethod
+            if (paymentMethod is SendPaymentMethod.CrossChainAddress) {
+                val amountIn = paymentMethod.amountIn
+                val estimatedOut = paymentMethod.estimatedOut
+                val feeAmount = paymentMethod.feeAmount
+                val expiresAt = paymentMethod.expiresAt
+                // Log.v("Breez", "Amount in: $amountIn")
+                // Log.v("Breez", "Estimated out: $estimatedOut")
+                // Log.v("Breez", "Provider fee: $feeAmount")
+                // Log.v("Breez", "Quote expires at: $expiresAt")
+            }
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: cross-chain-prepare
+    }
+
+    suspend fun sendPaymentCrossChain(
+        sdk: BreezSdk,
+        prepareResponse: PrepareSendPaymentResponse,
+    ) {
+        // ANCHOR: cross-chain-send
+        val optionalIdempotencyKey = "<idempotency key uuid>"
+        try {
+            val req = SendPaymentRequest(
+                prepareResponse = prepareResponse,
+                options = null,
+                idempotencyKey = optionalIdempotencyKey,
+            )
+            val sendResponse = sdk.sendPayment(req)
+            val payment = sendResponse.payment
+            // Log.v("Breez", "Payment: $payment")
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: cross-chain-send
+    }
+}

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ParsingInputs.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ParsingInputs.kt
@@ -56,6 +56,13 @@ class ParsingInputs {
                         println("  Sender public key: ${invoice.senderPublicKey}")
                     }
                 }
+                is InputType.CrossChainAddress -> {
+                    val details = inputType.v1
+                    println(
+                            "Input is cross-chain address ${details.address} " +
+                                    "(${details.addressFamily})"
+                    )
+                }
                 else -> {
                     // Handle other input types
                 }

--- a/docs/breez-sdk/snippets/python/src/config.py
+++ b/docs/breez-sdk/snippets/python/src/config.py
@@ -133,8 +133,7 @@ async def configure_cross_chain():
     config = default_config(network=Network.MAINNET)
     config.api_key = "<breez api key>"
 
-    # Override the default slippage tolerance (basis points; 10 to 500).
-    # Set cross_chain_config to None to disable the feature.
+    # Set to enable cross-chain payments. Slippage override is optional (10 to 500 bps).
     config.cross_chain_config = CrossChainConfig(
         default_slippage_bps=50,
         default_target_overpay_bps=None,

--- a/docs/breez-sdk/snippets/python/src/config.py
+++ b/docs/breez-sdk/snippets/python/src/config.py
@@ -1,6 +1,7 @@
 import logging
 from breez_sdk_spark import (
     default_config,
+    CrossChainConfig,
     Network,
     LeafOptimizationConfig,
     MaxFee,
@@ -124,4 +125,19 @@ async def configure_background_tasks():
     config = default_config(network=Network.MAINNET)
     config.background_tasks_enabled = False
     # ANCHOR_END: config-background-tasks
+    logging.info(f"Config: {config}")
+
+
+async def configure_cross_chain():
+    # ANCHOR: cross-chain-config
+    config = default_config(network=Network.MAINNET)
+    config.api_key = "<breez api key>"
+
+    # Override the default slippage tolerance (basis points; 10 to 500).
+    # Set cross_chain_config to None to disable the feature.
+    config.cross_chain_config = CrossChainConfig(
+        default_slippage_bps=50,
+        default_target_overpay_bps=None,
+    )
+    # ANCHOR_END: cross-chain-config
     logging.info(f"Config: {config}")

--- a/docs/breez-sdk/snippets/python/src/cross_chain.py
+++ b/docs/breez-sdk/snippets/python/src/cross_chain.py
@@ -1,0 +1,94 @@
+import logging
+from breez_sdk_spark import (
+    BreezSdk,
+    CrossChainAddressDetails,
+    CrossChainRouteFilter,
+    CrossChainRoutePair,
+    InputType,
+    PaymentRequest,
+    PrepareSendPaymentRequest,
+    PrepareSendPaymentResponse,
+    SendPaymentMethod,
+    SendPaymentRequest,
+)
+
+
+async def get_cross_chain_routes(sdk: BreezSdk):
+    # ANCHOR: cross-chain-get-routes
+    input_str = "<recipient address>"
+    try:
+        parsed = await sdk.parse(input=input_str)
+        if not isinstance(parsed, InputType.CROSS_CHAIN_ADDRESS):
+            raise ValueError("Not a cross-chain address")
+        address_details = parsed[0]
+
+        routes = await sdk.get_cross_chain_routes(
+            filter=CrossChainRouteFilter.SEND(address_details=address_details)
+        )
+
+        for route in routes:
+            logging.debug(
+                f"Route via {route.provider}: {route.chain}/{route.asset}"
+            )
+    except Exception as error:
+        logging.error(error)
+        raise
+    # ANCHOR_END: cross-chain-get-routes
+
+
+async def prepare_send_payment_cross_chain(
+    sdk: BreezSdk,
+    address_details: CrossChainAddressDetails,
+    route: CrossChainRoutePair,
+):
+    # ANCHOR: cross-chain-prepare
+    # Optionally set the maximum slippage in basis points (10 to 500)
+    optional_max_slippage_bps = 100
+    try:
+        request = PrepareSendPaymentRequest(
+            payment_request=PaymentRequest.CROSS_CHAIN(
+                address=address_details.address,
+                route=route,
+                max_slippage_bps=optional_max_slippage_bps,
+                target_overpay_bps=None,
+            ),
+            amount=50_000,
+            token_identifier=None,
+            conversion_options=None,
+            fee_policy=None,
+        )
+        prepare_response = await sdk.prepare_send_payment(request=request)
+
+        if isinstance(
+            prepare_response.payment_method, SendPaymentMethod.CROSS_CHAIN_ADDRESS
+        ):
+            method = prepare_response.payment_method
+            logging.debug(f"Amount in: {method.amount_in}")
+            logging.debug(f"Estimated out: {method.estimated_out}")
+            logging.debug(f"Provider fee: {method.fee_amount}")
+            logging.debug(f"Quote expires at: {method.expires_at}")
+    except Exception as error:
+        logging.error(error)
+        raise
+    # ANCHOR_END: cross-chain-prepare
+
+
+async def send_payment_cross_chain(
+    sdk: BreezSdk,
+    prepare_response: PrepareSendPaymentResponse,
+):
+    # ANCHOR: cross-chain-send
+    optional_idempotency_key = "<idempotency key uuid>"
+    try:
+        request = SendPaymentRequest(
+            prepare_response=prepare_response,
+            options=None,
+            idempotency_key=optional_idempotency_key,
+        )
+        send_response = await sdk.send_payment(request=request)
+        payment = send_response.payment
+        logging.debug(f"Payment: {payment}")
+    except Exception as error:
+        logging.error(error)
+        raise
+    # ANCHOR_END: cross-chain-send

--- a/docs/breez-sdk/snippets/python/src/cross_chain.py
+++ b/docs/breez-sdk/snippets/python/src/cross_chain.py
@@ -78,6 +78,7 @@ async def send_payment_cross_chain(
     prepare_response: PrepareSendPaymentResponse,
 ):
     # ANCHOR: cross-chain-send
+    # Only valid for sends with no token leg (see Retry safety).
     optional_idempotency_key = "<idempotency key uuid>"
     try:
         request = SendPaymentRequest(

--- a/docs/breez-sdk/snippets/python/src/parsing_inputs.py
+++ b/docs/breez-sdk/snippets/python/src/parsing_inputs.py
@@ -50,6 +50,11 @@ async def parse_input(sdk: BreezSdk):
 
             if invoice.sender_public_key:
                 logging.debug(f"  Sender public key: {invoice.sender_public_key}")
+        elif isinstance(parsed_input, InputType.CROSS_CHAIN_ADDRESS):
+            details = parsed_input[0]
+            logging.debug(
+                f"Input is cross-chain address {details.address} ({details.address_family})"
+            )
         # Other input types are available
     except Exception as error:
         logging.error(error)

--- a/docs/breez-sdk/snippets/react-native/config.ts
+++ b/docs/breez-sdk/snippets/react-native/config.ts
@@ -118,11 +118,27 @@ const exampleConfigureBackgroundTasks = () => {
   console.log('Config:', config)
 }
 
+const exampleConfigureCrossChain = async () => {
+  // ANCHOR: cross-chain-config
+  const config = defaultConfig(Network.Mainnet)
+  config.apiKey = '<breez api key>'
+
+  // Override the default slippage tolerance (basis points; 10 to 500).
+  // Set crossChainConfig to undefined to disable the feature.
+  config.crossChainConfig = {
+    defaultSlippageBps: 50,
+    defaultTargetOverpayBps: undefined
+  }
+  // ANCHOR_END: cross-chain-config
+  console.debug('Config:', config)
+}
+
 export {
   exampleConfigureSdk,
   exampleConfigurePrivateEnabledDefault,
   exampleConfigureOptimizationConfiguration,
   exampleConfigureStableBalance,
   exampleConfigureSparkConfig,
-  exampleConfigureBackgroundTasks
+  exampleConfigureBackgroundTasks,
+  exampleConfigureCrossChain
 }

--- a/docs/breez-sdk/snippets/react-native/config.ts
+++ b/docs/breez-sdk/snippets/react-native/config.ts
@@ -123,8 +123,7 @@ const exampleConfigureCrossChain = async () => {
   const config = defaultConfig(Network.Mainnet)
   config.apiKey = '<breez api key>'
 
-  // Override the default slippage tolerance (basis points; 10 to 500).
-  // Set crossChainConfig to undefined to disable the feature.
+  // Set to enable cross-chain payments. Slippage override is optional (10 to 500 bps).
   config.crossChainConfig = {
     defaultSlippageBps: 50,
     defaultTargetOverpayBps: undefined

--- a/docs/breez-sdk/snippets/react-native/cross_chain.ts
+++ b/docs/breez-sdk/snippets/react-native/cross_chain.ts
@@ -65,6 +65,7 @@ const exampleSendPaymentCrossChain = async (
   prepareResponse: PrepareSendPaymentResponse
 ) => {
   // ANCHOR: cross-chain-send
+  // Only valid for sends with no token leg (see Retry safety).
   const optionalIdempotencyKey = '<idempotency key uuid>'
   const sendResponse = await sdk.sendPayment({
     prepareResponse,

--- a/docs/breez-sdk/snippets/react-native/cross_chain.ts
+++ b/docs/breez-sdk/snippets/react-native/cross_chain.ts
@@ -1,0 +1,76 @@
+import {
+  CrossChainRouteFilter,
+  InputType_Tags,
+  PaymentRequest,
+  SendPaymentMethod_Tags,
+  type BreezSdk,
+  type CrossChainAddressDetails,
+  type CrossChainRoutePair,
+  type PrepareSendPaymentResponse
+} from '@breeztech/breez-sdk-spark-react-native'
+
+const exampleGetCrossChainRoutes = async (sdk: BreezSdk) => {
+  // ANCHOR: cross-chain-get-routes
+  const input = '<recipient address>'
+  const parsed = await sdk.parse(input)
+  if (parsed.tag !== InputType_Tags.CrossChainAddress) {
+    throw new Error('Not a cross-chain address')
+  }
+  const addressDetails = parsed.inner[0]
+
+  const routes = await sdk.getCrossChainRoutes(
+    new CrossChainRouteFilter.Send({ addressDetails })
+  )
+
+  for (const route of routes) {
+    console.debug(`Route via ${route.provider}: ${route.chain}/${route.asset}`)
+  }
+  // ANCHOR_END: cross-chain-get-routes
+}
+
+const examplePrepareSendPaymentCrossChain = async (
+  sdk: BreezSdk,
+  addressDetails: CrossChainAddressDetails,
+  route: CrossChainRoutePair
+) => {
+  // ANCHOR: cross-chain-prepare
+  // Optionally set the maximum slippage in basis points (10 to 500)
+  const optionalMaxSlippageBps = 100
+
+  const prepareResponse = await sdk.prepareSendPayment({
+    paymentRequest: new PaymentRequest.CrossChain({
+      address: addressDetails.address,
+      route,
+      maxSlippageBps: optionalMaxSlippageBps,
+      targetOverpayBps: undefined
+    }),
+    amount: BigInt(50_000),
+    tokenIdentifier: undefined,
+    conversionOptions: undefined,
+    feePolicy: undefined
+  })
+
+  if (prepareResponse.paymentMethod?.tag === SendPaymentMethod_Tags.CrossChainAddress) {
+    const inner = prepareResponse.paymentMethod.inner
+    console.debug(`Amount in: ${inner.amountIn}`)
+    console.debug(`Estimated out: ${inner.estimatedOut}`)
+    console.debug(`Provider fee: ${inner.feeAmount}`)
+    console.debug(`Quote expires at: ${inner.expiresAt}`)
+  }
+  // ANCHOR_END: cross-chain-prepare
+}
+
+const exampleSendPaymentCrossChain = async (
+  sdk: BreezSdk,
+  prepareResponse: PrepareSendPaymentResponse
+) => {
+  // ANCHOR: cross-chain-send
+  const optionalIdempotencyKey = '<idempotency key uuid>'
+  const sendResponse = await sdk.sendPayment({
+    prepareResponse,
+    options: undefined,
+    idempotencyKey: optionalIdempotencyKey
+  })
+  console.debug('Payment:', sendResponse.payment)
+  // ANCHOR_END: cross-chain-send
+}

--- a/docs/breez-sdk/snippets/react-native/parsing_inputs.ts
+++ b/docs/breez-sdk/snippets/react-native/parsing_inputs.ts
@@ -53,6 +53,9 @@ const parseInputs = async (sdk: BreezSdk) => {
     if (invoice.senderPublicKey != null) {
       console.log(`  Sender public key: ${invoice.senderPublicKey}`)
     }
+  } else if (input.tag === InputType_Tags.CrossChainAddress) {
+    const details = input.inner[0]
+    console.log(`Input is cross-chain address ${details.address} (${details.addressFamily})`)
   } else {
     // Other input types are available
   }

--- a/docs/breez-sdk/snippets/rust/Cargo.lock
+++ b/docs/breez-sdk/snippets/rust/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -71,6 +71,429 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy-consensus"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "alloy-tx-macros",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.5",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "derive_more",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "foldhash",
+ "hashbrown 0.17.1",
+ "indexmap 2.13.0",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.2",
+ "rapidhash",
+ "ruint",
+ "rustc-hash",
+ "secp256k1 0.31.1",
+ "serde",
+ "sha3",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand 0.8.5",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
+dependencies = [
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck",
+ "indexmap 2.13.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "sha3",
+ "syn 2.0.114",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "serde",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +507,195 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "arrayvec"
@@ -110,7 +722,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -121,7 +733,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -149,7 +761,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-socks",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "url",
  "wasm-bindgen",
  "web-sys",
@@ -175,6 +787,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "autocfg"
@@ -264,6 +887,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
+name = "bip32"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db40d3dfbeab4e031d78c844642fa0caa0b0db11ce1607ac9d2986dff1405c69"
+dependencies = [
+ "bs58",
+ "hmac",
+ "k256",
+ "once_cell",
+ "pbkdf2",
+ "rand_core 0.6.4",
+ "ripemd",
+ "secp256k1 0.27.0",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bip39"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +915,21 @@ dependencies = [
  "serde",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin"
@@ -288,7 +945,7 @@ dependencies = [
  "bitcoin_hashes",
  "hex-conservative",
  "hex_lit",
- "secp256k1",
+ "secp256k1 0.29.1",
  "serde",
 ]
 
@@ -335,6 +992,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bitreq"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65c2e1ab98050c93cc9ada070d5070e014329c65196d03f6f8f1f75c2666f37"
+dependencies = [
+ "rustls",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-rustls",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,12 +1028,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "boltz-client"
+version = "0.1.0"
+source = "git+https://github.com/breez/boltz-client?rev=7367b5361124c61dfdd71f282ecb23914d981cfb#7367b5361124c61dfdd71f282ecb23914d981cfb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-sol-types",
+ "async-trait",
+ "bip32",
+ "bs58",
+ "curve25519-dalek",
+ "futures",
+ "getrandom 0.2.16",
+ "hex",
+ "k256",
+ "lightning-invoice 0.34.0",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=7367b5361124c61dfdd71f282ecb23914d981cfb)",
+ "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=7367b5361124c61dfdd71f282ecb23914d981cfb)",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.17",
+ "tiny-keccak",
+ "tokio",
+ "tokio-tungstenite-wasm",
+ "tracing",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -368,8 +1127,8 @@ dependencies = [
  "hex",
  "http",
  "lightning",
- "macros",
- "platform-utils",
+ "macros 0.1.0",
+ "platform-utils 0.1.0",
  "prost",
  "regex-lite",
  "reqwest",
@@ -397,6 +1156,7 @@ dependencies = [
  "bip39",
  "bitcoin",
  "bitflags",
+ "boltz-client",
  "breez-sdk-common",
  "built",
  "chrono",
@@ -405,10 +1165,10 @@ dependencies = [
  "hex",
  "k256",
  "lnurl-models",
- "macros",
+ "macros 0.1.0",
  "nostr",
  "nostr-sdk",
- "platform-utils",
+ "platform-utils 0.1.0",
  "rusqlite",
  "rusqlite_migration",
  "serde",
@@ -439,6 +1199,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "sha2",
+ "tinyvec",
+]
+
+[[package]]
 name = "btoi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +1233,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +1249,24 @@ name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "2.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
+]
 
 [[package]]
 name = "cbc"
@@ -515,7 +1309,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -551,7 +1345,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -582,10 +1376,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -623,6 +1459,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +1513,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +1542,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,13 +1560,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -705,7 +1616,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "strsim",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -714,9 +1639,20 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -786,7 +1722,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -800,6 +1736,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive-getters"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,7 +1754,39 @@ checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.114",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -816,10 +1795,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -830,7 +1819,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -853,6 +1842,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,11 +1860,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -877,6 +1885,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -886,13 +1897,14 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -916,6 +1928,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -959,6 +1991,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,10 +2023,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -994,8 +2066,8 @@ dependencies = [
  "bitcoin",
  "getrandom 0.2.16",
  "hex",
- "macros",
- "platform-utils",
+ "macros 0.1.0",
+ "platform-utils 0.1.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -1006,6 +2078,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1050,7 +2123,7 @@ dependencies = [
  "derive-getters",
  "document-features",
  "hex",
- "itertools",
+ "itertools 0.14.0",
  "postcard",
  "rand_core 0.6.4",
  "serde",
@@ -1085,6 +2158,12 @@ dependencies = [
  "rand_core 0.6.4",
  "sha2",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1130,7 +2209,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1162,6 +2241,12 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
+
+[[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "generic-array"
@@ -1225,6 +2310,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,7 +2370,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1290,7 +2381,7 @@ checksum = "e16ecf9bb87a6760cf5227f66cbe48bad7b89505aeb002aa9439ea090e6038a3"
 dependencies = [
  "graphql_client_codegen",
  "proc-macro2",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1365,6 +2456,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,7 +2483,7 @@ checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
- "rustc_version",
+ "rustc_version 0.4.1",
  "serde",
  "spin",
  "stable_deref_trait",
@@ -1435,7 +2537,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1482,6 +2584,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1695,6 +2806,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +2888,24 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1800,8 +2949,29 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "serdect",
  "sha2",
  "signature",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1766b89733097006f3a1388a02849865d6bc98c89273cb622e29fdd209922183"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -1812,6 +2982,21 @@ checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
 dependencies = [
  "indexmap 2.13.0",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1887,8 +3072,8 @@ dependencies = [
  "dnssec-prover",
  "hashbrown 0.13.2",
  "libm",
- "lightning-invoice",
- "lightning-types",
+ "lightning-invoice 0.33.2",
+ "lightning-types 0.2.0",
  "possiblyrandom",
 ]
 
@@ -1900,7 +3085,18 @@ checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
 dependencies = [
  "bech32",
  "bitcoin",
- "lightning-types",
+ "lightning-types 0.2.0",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b85e5e14bcdb30d746e9785b04f27938292e8944f78f26517e01e91691f6b3f2"
+dependencies = [
+ "bech32",
+ "bitcoin",
+ "lightning-types 0.3.1",
 ]
 
 [[package]]
@@ -1908,6 +3104,15 @@ name = "lightning-types"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
+dependencies = [
+ "bitcoin",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb1aac93f22f2c2eac8a0ee83bb1a1ea58673caa2c82847302710b83364d04e6"
 dependencies = [
  "bitcoin",
 ]
@@ -1969,12 +3174,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "macro-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "macros"
 version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "macros"
+version = "0.1.0"
+source = "git+https://github.com/breez/boltz-client?rev=7367b5361124c61dfdd71f282ecb23914d981cfb#7367b5361124c61dfdd71f282ecb23914d981cfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1999,7 +3225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2122,7 +3348,7 @@ dependencies = [
  "getrandom 0.2.16",
  "instant",
  "scrypt",
- "secp256k1",
+ "secp256k1 0.29.1",
  "serde",
  "serde_json",
  "unicode-normalization",
@@ -2211,6 +3437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2221,6 +3448,20 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
+dependencies = [
+ "alloy-rlp",
+ "cfg-if",
+ "proptest",
+ "ruint",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -2240,6 +3481,34 @@ name = "openssl-probe"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2276,12 +3545,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -2300,6 +3575,16 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
 
 [[package]]
 name = "petgraph"
@@ -2347,7 +3632,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2384,7 +3669,26 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",
- "macros",
+ "macros 0.1.0",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio_with_wasm",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "platform-utils"
+version = "0.1.0"
+source = "git+https://github.com/breez/boltz-client?rev=7367b5361124c61dfdd71f282ecb23914d981cfb#7367b5361124c61dfdd71f282ecb23914d981cfb"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bitreq",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=7367b5361124c61dfdd71f282ecb23914d981cfb)",
  "reqwest",
  "serde",
  "serde_json",
@@ -2401,7 +3705,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2413,7 +3717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2503,7 +3807,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2513,6 +3859,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -2532,7 +3897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -2541,7 +3906,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.114",
  "tempfile",
 ]
 
@@ -2552,10 +3917,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2566,6 +3931,12 @@ checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2638,6 +4009,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +4023,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -2656,6 +4034,7 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+ "serde",
 ]
 
 [[package]]
@@ -2694,6 +4073,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+ "serde",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2722,7 +4120,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2826,6 +4224,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
+name = "ruint"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.5",
+ "rand 0.9.2",
+ "rlp",
+ "ruint-macro",
+ "serde_core",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,12 +4307,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -2939,6 +4405,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3022,8 +4500,18 @@ dependencies = [
  "der",
  "generic-array",
  "pkcs8",
+ "serdect",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "secp256k1-sys 0.8.2",
 ]
 
 [[package]]
@@ -3034,8 +4522,40 @@ checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "secp256k1-sys 0.10.1",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.2",
+ "secp256k1-sys 0.11.0",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3043,6 +4563,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -3072,9 +4601,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -3103,7 +4650,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3156,10 +4703,10 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3179,8 +4726,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3196,8 +4743,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3211,6 +4758,26 @@ dependencies = [
  "hex",
  "sha2",
  "tokio",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3f15d4e239ebe08413eed880e0f9b5af4b40ee0472543320efa91d488e96a7"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -3234,7 +4801,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3261,6 +4828,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -3301,9 +4871,9 @@ dependencies = [
  "http-body",
  "http-body-util",
  "k256",
- "lightning-invoice",
- "macros",
- "platform-utils",
+ "lightning-invoice 0.33.2",
+ "macros 0.1.0",
+ "platform-utils 0.1.0",
  "prost",
  "prost-types",
  "rand 0.8.5",
@@ -3331,9 +4901,9 @@ dependencies = [
  "bitcoin",
  "chrono",
  "hex",
- "macros",
+ "macros 0.1.0",
  "mysql_async",
- "platform-utils",
+ "platform-utils 0.1.0",
  "serde",
  "serde_json",
  "spark-wallet",
@@ -3353,8 +4923,8 @@ dependencies = [
  "deadpool",
  "deadpool-postgres",
  "hex",
- "macros",
- "platform-utils",
+ "macros 0.1.0",
+ "platform-utils 0.1.0",
  "rustls",
  "serde",
  "serde_json",
@@ -3391,7 +4961,7 @@ dependencies = [
  "frost-secp256k1-tr",
  "futures",
  "hex",
- "platform-utils",
+ "platform-utils 0.1.0",
  "serde",
  "spark",
  "thiserror 2.0.17",
@@ -3427,6 +4997,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3451,6 +5027,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
@@ -3458,6 +5045,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3477,7 +5076,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3500,6 +5099,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3540,7 +5145,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3551,7 +5156,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3571,7 +5176,7 @@ checksum = "585e5ef40a784ce60b49c67d762110688d211d395d39e096be204535cf64590e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3581,6 +5186,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -3612,6 +5226,15 @@ checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3657,7 +5280,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3683,7 +5306,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3772,8 +5395,44 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.26.2",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.28.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite-wasm"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee909c02b8863f9bda87253127eb4da0e7e1342330b2583fbc4d1795c2f8"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "httparse",
+ "js-sys",
+ "rustls",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3810,7 +5469,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e04c1865c281139e5ccf633cb9f76ffdaabeebfe53b703984cf82878e2aabb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -3858,7 +5547,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3970,7 +5659,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4038,6 +5727,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.17",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4048,6 +5756,30 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
@@ -4077,12 +5809,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -4125,7 +5869,7 @@ dependencies = [
  "getrandom 0.2.16",
  "hkdf",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.29.1",
  "sha2",
  "thiserror 2.0.17",
 ]
@@ -4168,7 +5912,16 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4258,7 +6011,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -4355,7 +6108,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4366,7 +6119,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4561,6 +6314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4571,6 +6333,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x509-cert"
@@ -4603,7 +6374,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -4624,7 +6395,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4644,7 +6415,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -4665,7 +6436,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4698,7 +6469,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/docs/breez-sdk/snippets/rust/src/config.rs
+++ b/docs/breez-sdk/snippets/rust/src/config.rs
@@ -134,3 +134,19 @@ pub(crate) fn configure_background_tasks() -> Result<()> {
     info!("Config: {:?}", config);
     Ok(())
 }
+
+pub(crate) fn configure_cross_chain() -> Result<()> {
+    // ANCHOR: cross-chain-config
+    let mut config = default_config(Network::Mainnet);
+    config.api_key = Some("<breez api key>".to_string());
+
+    // Override the default slippage tolerance (basis points; 10 to 500).
+    // Set cross_chain_config to None to disable the feature.
+    config.cross_chain_config = Some(CrossChainConfig {
+        default_slippage_bps: Some(50),
+        default_target_overpay_bps: None,
+    });
+    // ANCHOR_END: cross-chain-config
+    info!("Config: {config:?}");
+    Ok(())
+}

--- a/docs/breez-sdk/snippets/rust/src/config.rs
+++ b/docs/breez-sdk/snippets/rust/src/config.rs
@@ -140,8 +140,7 @@ pub(crate) fn configure_cross_chain() -> Result<()> {
     let mut config = default_config(Network::Mainnet);
     config.api_key = Some("<breez api key>".to_string());
 
-    // Override the default slippage tolerance (basis points; 10 to 500).
-    // Set cross_chain_config to None to disable the feature.
+    // Set to enable cross-chain payments. Slippage override is optional (10 to 500 bps).
     config.cross_chain_config = Some(CrossChainConfig {
         default_slippage_bps: Some(50),
         default_target_overpay_bps: None,

--- a/docs/breez-sdk/snippets/rust/src/cross_chain.rs
+++ b/docs/breez-sdk/snippets/rust/src/cross_chain.rs
@@ -71,6 +71,7 @@ async fn send_payment_cross_chain(
     prepare_response: PrepareSendPaymentResponse,
 ) -> Result<()> {
     // ANCHOR: cross-chain-send
+    // Only valid for sends with no token leg (see Retry safety).
     let optional_idempotency_key = Some("<idempotency key uuid>".to_string());
     let send_response = sdk
         .send_payment(SendPaymentRequest {

--- a/docs/breez-sdk/snippets/rust/src/cross_chain.rs
+++ b/docs/breez-sdk/snippets/rust/src/cross_chain.rs
@@ -1,0 +1,86 @@
+use anyhow::Result;
+use breez_sdk_spark::*;
+use log::info;
+
+async fn get_cross_chain_routes(sdk: &BreezSdk) -> Result<()> {
+    // ANCHOR: cross-chain-get-routes
+    let input = "<recipient address>";
+    let InputType::CrossChainAddress(address_details) = sdk.parse(input).await? else {
+        anyhow::bail!("Not a cross-chain address");
+    };
+
+    let routes = sdk
+        .get_cross_chain_routes(&CrossChainRouteFilter::Send {
+            address_details: address_details.clone(),
+        })
+        .await?;
+
+    for route in &routes {
+        info!(
+            "Route via {:?}: {}/{}",
+            route.provider, route.chain, route.asset
+        );
+    }
+    // ANCHOR_END: cross-chain-get-routes
+    Ok(())
+}
+
+async fn prepare_send_payment_cross_chain(
+    sdk: &BreezSdk,
+    address_details: CrossChainAddressDetails,
+    route: CrossChainRoutePair,
+) -> Result<()> {
+    // ANCHOR: cross-chain-prepare
+    // Optionally set the maximum slippage in basis points (10 to 500)
+    let optional_max_slippage_bps = Some(100);
+
+    let prepare_response = sdk
+        .prepare_send_payment(PrepareSendPaymentRequest {
+            payment_request: PaymentRequest::CrossChain {
+                address: address_details.address.clone(),
+                route,
+                max_slippage_bps: optional_max_slippage_bps,
+                target_overpay_bps: None,
+            },
+            amount: Some(50_000),
+            token_identifier: None,
+            conversion_options: None,
+            fee_policy: None,
+        })
+        .await?;
+
+    if let SendPaymentMethod::CrossChainAddress {
+        amount_in,
+        estimated_out,
+        fee_amount,
+        expires_at,
+        ..
+    } = &prepare_response.payment_method
+    {
+        info!("Amount in: {amount_in}");
+        info!("Estimated out: {estimated_out}");
+        info!("Provider fee: {fee_amount}");
+        info!("Quote expires at: {expires_at}");
+    }
+    // ANCHOR_END: cross-chain-prepare
+    Ok(())
+}
+
+async fn send_payment_cross_chain(
+    sdk: &BreezSdk,
+    prepare_response: PrepareSendPaymentResponse,
+) -> Result<()> {
+    // ANCHOR: cross-chain-send
+    let optional_idempotency_key = Some("<idempotency key uuid>".to_string());
+    let send_response = sdk
+        .send_payment(SendPaymentRequest {
+            prepare_response,
+            options: None,
+            idempotency_key: optional_idempotency_key,
+        })
+        .await?;
+    let payment = send_response.payment;
+    info!("Payment: {payment:?}");
+    // ANCHOR_END: cross-chain-send
+    Ok(())
+}

--- a/docs/breez-sdk/snippets/rust/src/main.rs
+++ b/docs/breez-sdk/snippets/rust/src/main.rs
@@ -1,6 +1,7 @@
 mod buying_bitcoin;
 mod config;
 mod contacts;
+mod cross_chain;
 mod external_signer;
 mod fiat_currencies;
 mod getting_started;

--- a/docs/breez-sdk/snippets/rust/src/parsing_inputs.rs
+++ b/docs/breez-sdk/snippets/rust/src/parsing_inputs.rs
@@ -55,6 +55,12 @@ async fn parse_input(sdk: &BreezSdk) -> Result<()> {
                 println!("  Sender public key: {}", sender_public_key);
             }
         }
+        InputType::CrossChainAddress(details) => {
+            println!(
+                "Input is cross-chain address {} ({:?})",
+                details.address, details.address_family
+            );
+        }
         // Other input types are available
         _ => {}
     }

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Config.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Config.swift
@@ -70,3 +70,18 @@ func configureBackgroundTasks() {
     // ANCHOR_END: config-background-tasks
     print("Config: \(config)")
 }
+
+func configureCrossChain() {
+    // ANCHOR: cross-chain-config
+    var config = defaultConfig(network: Network.mainnet)
+    config.apiKey = "<breez api key>"
+
+    // Override the default slippage tolerance (basis points; 10 to 500).
+    // Set crossChainConfig to nil to disable the feature.
+    config.crossChainConfig = CrossChainConfig(
+        defaultSlippageBps: 50,
+        defaultTargetOverpayBps: nil
+    )
+    // ANCHOR_END: cross-chain-config
+    print("Config: \(config)")
+}

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Config.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Config.swift
@@ -76,8 +76,7 @@ func configureCrossChain() {
     var config = defaultConfig(network: Network.mainnet)
     config.apiKey = "<breez api key>"
 
-    // Override the default slippage tolerance (basis points; 10 to 500).
-    // Set crossChainConfig to nil to disable the feature.
+    // Set to enable cross-chain payments. Slippage override is optional (10 to 500 bps).
     config.crossChainConfig = CrossChainConfig(
         defaultSlippageBps: 50,
         defaultTargetOverpayBps: nil

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/CrossChain.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/CrossChain.swift
@@ -1,0 +1,69 @@
+import BigNumber
+import BreezSdkSpark
+import Foundation
+
+func getCrossChainRoutes(sdk: BreezSdk) async throws {
+    // ANCHOR: cross-chain-get-routes
+    let input = "<recipient address>"
+    let parsed = try await sdk.parse(input: input)
+    guard case let .crossChainAddress(v1: addressDetails) = parsed else {
+        throw NSError(domain: "CrossChain", code: 1)
+    }
+
+    let routes = try await sdk.getCrossChainRoutes(
+        filter: .send(addressDetails: addressDetails))
+
+    for route in routes {
+        print("Route via \(route.provider): \(route.chain)/\(route.asset)")
+    }
+    // ANCHOR_END: cross-chain-get-routes
+}
+
+func prepareSendPaymentCrossChain(
+    sdk: BreezSdk,
+    addressDetails: CrossChainAddressDetails,
+    route: CrossChainRoutePair
+) async throws {
+    // ANCHOR: cross-chain-prepare
+    // Optionally set the maximum slippage in basis points (10 to 500)
+    let optionalMaxSlippageBps: UInt32? = 100
+
+    let prepareResponse = try await sdk.prepareSendPayment(
+        request: PrepareSendPaymentRequest(
+            paymentRequest: .crossChain(
+                address: addressDetails.address,
+                route: route,
+                maxSlippageBps: optionalMaxSlippageBps,
+                targetOverpayBps: nil
+            ),
+            amount: BInt(50_000),
+            tokenIdentifier: nil,
+            conversionOptions: nil,
+            feePolicy: nil
+        ))
+
+    if case let .crossChainAddress(
+        _, _, amountIn, _, estimatedOut, feeAmount, _, _, _, _, expiresAt, _
+    ) = prepareResponse.paymentMethod {
+        print("Amount in: \(amountIn)")
+        print("Estimated out: \(estimatedOut)")
+        print("Provider fee: \(feeAmount)")
+        print("Quote expires at: \(expiresAt)")
+    }
+    // ANCHOR_END: cross-chain-prepare
+}
+
+func sendPaymentCrossChain(sdk: BreezSdk, prepareResponse: PrepareSendPaymentResponse) async throws
+{
+    // ANCHOR: cross-chain-send
+    let optionalIdempotencyKey = "<idempotency key uuid>"
+    let sendResponse = try await sdk.sendPayment(
+        request: SendPaymentRequest(
+            prepareResponse: prepareResponse,
+            options: nil,
+            idempotencyKey: optionalIdempotencyKey
+        ))
+    let payment = sendResponse.payment
+    print(payment)
+    // ANCHOR_END: cross-chain-send
+}

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/CrossChain.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/CrossChain.swift
@@ -56,6 +56,7 @@ func prepareSendPaymentCrossChain(
 func sendPaymentCrossChain(sdk: BreezSdk, prepareResponse: PrepareSendPaymentResponse) async throws
 {
     // ANCHOR: cross-chain-send
+    // Only valid for sends with no token leg (see Retry safety).
     let optionalIdempotencyKey = "<idempotency key uuid>"
     let sendResponse = try await sdk.sendPayment(
         request: SendPaymentRequest(

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ParsingInputs.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ParsingInputs.swift
@@ -49,6 +49,9 @@ func parseInput(sdk: BreezSdk) async throws {
                 print("  Sender public key: \(senderPublicKey)")
             }
 
+        case .crossChainAddress(v1: let details):
+            print("Input is cross-chain address \(details.address) (\(details.addressFamily))")
+
         default:
             break  // Other input types are available
         }

--- a/docs/breez-sdk/snippets/wasm/config.ts
+++ b/docs/breez-sdk/snippets/wasm/config.ts
@@ -111,11 +111,24 @@ const exampleConfigureBackgroundTasks = async () => {
   console.log('Config:', config)
 }
 
+const exampleConfigureCrossChain = async () => {
+  // ANCHOR: cross-chain-config
+  const config = defaultConfig('mainnet')
+  config.apiKey = '<breez api key>'
+
+  // Override the default slippage tolerance (basis points; 10 to 500).
+  // Set crossChainConfig to undefined to disable the feature.
+  config.crossChainConfig = { defaultSlippageBps: 50 }
+  // ANCHOR_END: cross-chain-config
+  console.debug('Config:', config)
+}
+
 export {
   exampleConfigureSdk,
   exampleConfigurePrivateEnabledDefault,
   exampleConfigureOptimizationConfiguration,
   exampleConfigureStableBalance,
   exampleConfigureSparkConfig,
-  exampleConfigureBackgroundTasks
+  exampleConfigureBackgroundTasks,
+  exampleConfigureCrossChain
 }

--- a/docs/breez-sdk/snippets/wasm/config.ts
+++ b/docs/breez-sdk/snippets/wasm/config.ts
@@ -116,8 +116,7 @@ const exampleConfigureCrossChain = async () => {
   const config = defaultConfig('mainnet')
   config.apiKey = '<breez api key>'
 
-  // Override the default slippage tolerance (basis points; 10 to 500).
-  // Set crossChainConfig to undefined to disable the feature.
+  // Set to enable cross-chain payments. Slippage override is optional (10 to 500 bps).
   config.crossChainConfig = { defaultSlippageBps: 50 }
   // ANCHOR_END: cross-chain-config
   console.debug('Config:', config)

--- a/docs/breez-sdk/snippets/wasm/cross_chain.ts
+++ b/docs/breez-sdk/snippets/wasm/cross_chain.ts
@@ -61,6 +61,7 @@ const exampleSendPaymentCrossChain = async (
   prepareResponse: PrepareSendPaymentResponse
 ) => {
   // ANCHOR: cross-chain-send
+  // Only valid for sends with no token leg (see Retry safety).
   const optionalIdempotencyKey = '<idempotency key uuid>'
   const sendResponse = await sdk.sendPayment({
     prepareResponse,

--- a/docs/breez-sdk/snippets/wasm/cross_chain.ts
+++ b/docs/breez-sdk/snippets/wasm/cross_chain.ts
@@ -1,0 +1,73 @@
+import {
+  type BreezSdk,
+  type CrossChainAddressDetails,
+  type CrossChainRoutePair,
+  type PrepareSendPaymentResponse
+} from '@breeztech/breez-sdk-spark'
+
+const exampleGetCrossChainRoutes = async (sdk: BreezSdk) => {
+  // ANCHOR: cross-chain-get-routes
+  const input = '<recipient address>'
+  const parsed = await sdk.parse(input)
+  if (parsed.type !== 'crossChainAddress') {
+    throw new Error('Not a cross-chain address')
+  }
+
+  const routes = await sdk.getCrossChainRoutes({
+    type: 'send',
+    addressDetails: parsed
+  })
+
+  for (const route of routes) {
+    console.debug(`Route via ${route.provider}: ${route.chain}/${route.asset}`)
+  }
+  // ANCHOR_END: cross-chain-get-routes
+}
+
+const examplePrepareSendPaymentCrossChain = async (
+  sdk: BreezSdk,
+  addressDetails: CrossChainAddressDetails,
+  route: CrossChainRoutePair
+) => {
+  // ANCHOR: cross-chain-prepare
+  // Optionally set the maximum slippage in basis points (10 to 500)
+  const optionalMaxSlippageBps = 100
+
+  const prepareResponse = await sdk.prepareSendPayment({
+    paymentRequest: {
+      type: 'crossChain',
+      address: addressDetails.address,
+      route,
+      maxSlippageBps: optionalMaxSlippageBps
+    },
+    amount: BigInt(50_000),
+    tokenIdentifier: undefined,
+    conversionOptions: undefined,
+    feePolicy: undefined
+  })
+
+  if (prepareResponse.paymentMethod.type === 'crossChainAddress') {
+    const { amountIn, estimatedOut, feeAmount, expiresAt } = prepareResponse.paymentMethod
+    console.debug(`Amount in: ${amountIn}`)
+    console.debug(`Estimated out: ${estimatedOut}`)
+    console.debug(`Provider fee: ${feeAmount}`)
+    console.debug(`Quote expires at: ${expiresAt}`)
+  }
+  // ANCHOR_END: cross-chain-prepare
+}
+
+const exampleSendPaymentCrossChain = async (
+  sdk: BreezSdk,
+  prepareResponse: PrepareSendPaymentResponse
+) => {
+  // ANCHOR: cross-chain-send
+  const optionalIdempotencyKey = '<idempotency key uuid>'
+  const sendResponse = await sdk.sendPayment({
+    prepareResponse,
+    options: undefined,
+    idempotencyKey: optionalIdempotencyKey
+  })
+  const payment = sendResponse.payment
+  console.debug('Payment:', payment)
+  // ANCHOR_END: cross-chain-send
+}

--- a/docs/breez-sdk/snippets/wasm/parsing_inputs.ts
+++ b/docs/breez-sdk/snippets/wasm/parsing_inputs.ts
@@ -60,6 +60,10 @@ const parseInputs = async (sdk: BreezSdk) => {
       }
       break
 
+    case 'crossChainAddress':
+      console.log(`Input is cross-chain address ${parsed.address} (${parsed.addressFamily})`)
+      break
+
     default:
       // Other input types are available
       break

--- a/docs/breez-sdk/src/SUMMARY.md
+++ b/docs/breez-sdk/src/SUMMARY.md
@@ -58,7 +58,7 @@
   - [Using an External Signer](guide/external_signer.md)
   - [Managing webhooks](guide/webhooks.md)
   - [Server mode](guide/server_mode.md)
-  - [USD stablecoin payments](guide/cross_chain.md)
+  - [Send USDC/USDT](guide/cross_chain.md)
 - [Moving to production](guide/moving_to_production.md)
 
 ---

--- a/docs/breez-sdk/src/SUMMARY.md
+++ b/docs/breez-sdk/src/SUMMARY.md
@@ -58,6 +58,7 @@
   - [Using an External Signer](guide/external_signer.md)
   - [Managing webhooks](guide/webhooks.md)
   - [Server mode](guide/server_mode.md)
+  - [USD stablecoin payments](guide/cross_chain.md)
 - [Moving to production](guide/moving_to_production.md)
 
 ---

--- a/docs/breez-sdk/src/guide/advanced.md
+++ b/docs/breez-sdk/src/guide/advanced.md
@@ -7,3 +7,4 @@ The SDK supports advanced features that may be useful in specific use cases:
 - **[Conditional payments](htlcs.md)** are useful for implementing atomic cross-chain swaps
 - **[Using an External Signer](external_signer.md)** provides custom signing logic and enables integrating with hardware wallets, MPC protocols, or existing wallet infrastructure
 - **[Server mode](server_mode.md)** is the SDK profile for multi-tenant server deployments where each request builds an ephemeral SDK and the host orchestrates sync, claiming, and event delivery explicitly
+- **[USD stablecoin payments](cross_chain.md)** to an external chain

--- a/docs/breez-sdk/src/guide/advanced.md
+++ b/docs/breez-sdk/src/guide/advanced.md
@@ -7,4 +7,4 @@ The SDK supports advanced features that may be useful in specific use cases:
 - **[Conditional payments](htlcs.md)** are useful for implementing atomic cross-chain swaps
 - **[Using an External Signer](external_signer.md)** provides custom signing logic and enables integrating with hardware wallets, MPC protocols, or existing wallet infrastructure
 - **[Server mode](server_mode.md)** is the SDK profile for multi-tenant server deployments where each request builds an ephemeral SDK and the host orchestrates sync, claiming, and event delivery explicitly
-- **[USD stablecoin payments](cross_chain.md)** to an external chain
+- **[Send USDC/USDT](cross_chain.md)** to a recipient on an external chain

--- a/docs/breez-sdk/src/guide/config.md
+++ b/docs/breez-sdk/src/guide/config.md
@@ -148,3 +148,18 @@ For server environments or applications that receive a high volume of incoming p
 The SDK can convert Bitcoin to a stable token on receive and vice versa on send, protecting against price volatility. Configure the available tokens, default behavior, conversion threshold, and slippage tolerance. See the [Stable balance](./stable_balance.md) guide for full details.
 
 {{#tabs config:stable-balance-config}}
+
+## Cross-chain payments
+
+Cross-chain USD sends require explicit opt-in: {{#name default_config}} leaves {{#name cross_chain_config}} unset. Set it to a default {{#name CrossChainConfig}} to enable the feature, or to your own to override the slippage default. The SDK only returns routes whose destination is a USD-pegged stablecoin (USDC, USDT, USDT0) on a supported chain.
+
+Constraints:
+
+- **Mainnet only**: {{#name validate}} rejects a set {{#name cross_chain_config}} on any network other than mainnet.
+- **Background tasks required**: both providers run background monitors that reconcile delivery status onto the local payment row, so {{#name cross_chain_config}} is incompatible with {{#name background_tasks_enabled}} disabled. {{#name default_server_config}} leaves the field unset for this reason.
+
+{{#tabs config:cross-chain-config}}
+
+The {{#name default_slippage_bps}} field sets the per-instance slippage default applied when the per-request {{#name max_slippage_bps}} is unset. It must be in the 10 to 500 basis-point range; when {{#name default_slippage_bps}} itself is unset, the SDK falls back to a built-in default of 100 bps (1%).
+
+See [USD payments](./cross_chain.md) for the provider lineup, status lifecycle, retry-safety semantics, and limitations.

--- a/docs/breez-sdk/src/guide/config.md
+++ b/docs/breez-sdk/src/guide/config.md
@@ -149,7 +149,10 @@ The SDK can convert Bitcoin to a stable token on receive and vice versa on send,
 
 {{#tabs config:stable-balance-config}}
 
-## Cross-chain payments
+<h2 id="send-usdc-usdt">
+    <a class="header" href="#send-usdc-usdt">Send USDC/USDT</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.CrossChainConfig.html">API docs</a>
+</h2>
 
 USDC/USDT sends require explicit opt-in: {{#name default_config}} leaves {{#name cross_chain_config}} unset. Set it to a default {{#name CrossChainConfig}} to enable the feature, or to your own to override the slippage default. The SDK only returns routes whose destination is USDC or USDT on a supported chain.
 

--- a/docs/breez-sdk/src/guide/config.md
+++ b/docs/breez-sdk/src/guide/config.md
@@ -151,7 +151,7 @@ The SDK can convert Bitcoin to a stable token on receive and vice versa on send,
 
 ## Cross-chain payments
 
-Cross-chain USD sends require explicit opt-in: {{#name default_config}} leaves {{#name cross_chain_config}} unset. Set it to a default {{#name CrossChainConfig}} to enable the feature, or to your own to override the slippage default. The SDK only returns routes whose destination is a USD-pegged stablecoin (USDC, USDT, USDT0) on a supported chain.
+USDC/USDT sends require explicit opt-in: {{#name default_config}} leaves {{#name cross_chain_config}} unset. Set it to a default {{#name CrossChainConfig}} to enable the feature, or to your own to override the slippage default. The SDK only returns routes whose destination is USDC or USDT on a supported chain.
 
 Constraints:
 
@@ -162,4 +162,4 @@ Constraints:
 
 The {{#name default_slippage_bps}} field sets the per-instance slippage default applied when the per-request {{#name max_slippage_bps}} is unset. It must be in the 10 to 500 basis-point range; when {{#name default_slippage_bps}} itself is unset, the SDK falls back to a built-in default of 100 bps (1%).
 
-See [USD payments](./cross_chain.md) for the provider lineup, status lifecycle, retry-safety semantics, and limitations.
+See [Send USDC/USDT](./cross_chain.md) for the provider lineup, status lifecycle, retry-safety semantics, and limitations.

--- a/docs/breez-sdk/src/guide/cross_chain.md
+++ b/docs/breez-sdk/src/guide/cross_chain.md
@@ -2,7 +2,7 @@
 
 The SDK can send USDC or USDT from a Spark wallet to a recipient on any of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The source on the Spark side is either BTC sats or USDB. The SDK orchestrates two legs — a Spark-side transfer to a provider-controlled deposit and the provider-driven delivery of the destination asset — and reconciles both onto a single {{#name Payment}} row.
 
-The send flow itself lives in the [Sending payments](./send_payment.md#send-usdc-usdt) page. This page covers how it works under the hood: the providers, the lifecycle, retry semantics, and limitations.
+The send flow itself lives in the [Sending payments](./send_payment.md#usdc-usdt) page. This page covers how it works under the hood: the providers, the lifecycle, retry semantics, and limitations.
 
 ## Supported address formats
 
@@ -63,7 +63,7 @@ Cross-chain slippage protects the recipient from price movement between quote an
 Resolution at prepare time:
 
 1. The per-request {{#name max_slippage_bps}} on {{#enum PaymentRequest::CrossChain}} wins if set.
-2. Otherwise, the SDK falls back to {{#name default_slippage_bps}} on {{#name CrossChainConfig}} from [the SDK configuration](./config.md#cross-chain-payments).
+2. Otherwise, the SDK falls back to {{#name default_slippage_bps}} on {{#name CrossChainConfig}} from [the SDK configuration](./config.md#send-usdc-usdt).
 3. Otherwise, the built-in default of 100 bps (1%) is used.
 
 Values outside 10 to 500 are rejected at both config validation and per-request validation.
@@ -94,28 +94,33 @@ A background monitor runs while the SDK is active and reconciles {{#enum Convers
 
 <h2 id="retry-safety">Retry safety</h2>
 
-Calling {{#name send_payment}} is safe to retry on transient errors, **with one caveat that depends on the source asset.**
+Calling {{#name send_payment}} is safe to retry on transient errors **only when the send has no token-transfer leg.** Whether the source asset displayed on the route is BTC or USDB is not the determinant — what matters is the actual first leg the SDK executes.
 
-### BTC-source sends
+### Sends with no token leg
 
-For sends where the source is BTC sats (Boltz reverse swap, or Orchestra with BTC source), the SDK threads a deterministic transfer id through to the underlying Spark transfer. Retrying with the same {{#name PrepareSendPaymentResponse}} produces the same transfer id, and the Spark protocol returns the original transfer instead of firing a new one — no double-deposit.
+When the first leg is a Spark sats transfer (Orchestra with BTC source, or Boltz funded directly from the sats balance), the SDK threads a deterministic transfer id through to the underlying Spark transfer. Retrying with the same {{#name PrepareSendPaymentResponse}} produces the same transfer id, and the Spark protocol returns the original transfer instead of firing a new one — no double-deposit.
 
 Two ways to drive idempotency:
 
 1. **Pass a caller-supplied {{#name idempotency_key}}** on {{#name SendPaymentRequest}}. The top-level dispatcher first looks for an existing payment with that id and short-circuits the retry if found; otherwise the key is used as the Spark transfer id.
 2. **Omit {{#name idempotency_key}}** — the SDK derives a deterministic UUIDv5 from the provider's quote/swap id. Re-sending the same prepared shape produces the same id and dedupes at the Spark protocol layer even if the first attempt's persistence step never completed.
 
-### USDB-source sends
+### Sends with a token leg
 
-For sends where the source is USDB (Orchestra), the underlying token transfer does not accept an idempotency token at the Spark protocol layer. There is no upstream dedup. Callers that retry on transient errors can fire a second deposit and overpay.
+When the first leg is a token transfer at the Spark protocol layer, there is no upstream idempotency hook. The dispatcher rejects a caller-supplied {{#name idempotency_key}} with {{#enum SdkError::InvalidInput}}, and a retry can fire a second token transfer and overpay.
+
+This arises in two ways for a cross-chain send:
+
+- **Direct token send** — USDB source on Orchestra. The first leg is a USDB transfer to the provider deposit address.
+- **Token conversion** — USDB balance routed through a sats-only provider (e.g. Boltz). The SDK auto-converts USDB → BTC via the [stable-balance](./stable_balance.md) flow before the provider leg; that conversion is itself a token transfer.
 
 This matches the existing contract for direct token sends.
 
-If you need at-most-once semantics for a USDB-source cross-chain send, debounce retries at the application layer until the SDK either returns a payment or a terminal error.
+If you need at-most-once semantics in either of these cases, debounce retries at the application layer until the SDK either returns a payment or a terminal error.
 
 ## Limitations
 
 - **Mainnet only.** Cross-chain providers operate against live external networks; there is no testnet equivalent in the SDK today.
 - **Background tasks required.** Both providers depend on background monitors to reconcile delivery status. {{#name cross_chain_config}} is incompatible with {{#name background_tasks_enabled}} disabled.
-- **USDB-source retries have no idempotency guarantee.** See [Retry safety](#retry-safety) above.
+- **Token-leg sends have no idempotency guarantee.** Applies to a direct USDB send and to any USDB-funded send that auto-converts through bitcoin. See [Retry safety](#retry-safety) above.
 

--- a/docs/breez-sdk/src/guide/cross_chain.md
+++ b/docs/breez-sdk/src/guide/cross_chain.md
@@ -1,8 +1,8 @@
-# USD payments
+# Send USDC/USDT
 
-The SDK can send USD-denominated value from a Spark wallet to a USD-pegged stablecoin (USDC, USDT, or USDT0) on any of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The source on the Spark side is either BTC sats or USDB; the destination is always one of the supported USD stablecoins on a supported chain. The SDK orchestrates two legs — a Spark-side transfer to a provider-controlled deposit and the provider-driven delivery of the destination asset — and reconciles both onto a single {{#name Payment}} row.
+The SDK can send USDC or USDT from a Spark wallet to a recipient on any of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The source on the Spark side is either BTC sats or USDB. The SDK orchestrates two legs — a Spark-side transfer to a provider-controlled deposit and the provider-driven delivery of the destination asset — and reconciles both onto a single {{#name Payment}} row.
 
-The send flow itself lives in the [Sending payments](./send_payment.md#usd-stablecoins) page. This page covers how it works under the hood: the providers, the lifecycle, retry semantics, and limitations.
+The send flow itself lives in the [Sending payments](./send_payment.md#send-usdc-usdt) page. This page covers how it works under the hood: the providers, the lifecycle, retry semantics, and limitations.
 
 ## Supported address formats
 
@@ -51,7 +51,7 @@ The SDK ships with two cross-chain providers. {{#name get_cross_chain_routes}} r
 
 | Provider     | Source assets    | Destinations                                                | Mechanism                            |
 | ------------ | ---------------- | ----------------------------------------------------------- | ------------------------------------ |
-| **Orchestra** (Flashnet) | BTC sats + USDB | USDC / USDT / USDT0 on Ethereum chains (Arbitrum, Base), Solana, Tron | Spark transfer to a deposit address, then provider bridges to the destination chain |
+| **Orchestra** (Flashnet) | BTC sats + USDB | USDC / USDT on Ethereum chains (Arbitrum, Base), Solana, Tron | Spark transfer to a deposit address, then provider bridges to the destination chain |
 | **Boltz**    | BTC sats only    | USDC / USDT on Ethereum chains (Arbitrum, Base), Solana, Tron                 | Lightning reverse swap: SDK pays a hold invoice, provider claims the on-chain leg |
 
 The provider tag on each {{#name CrossChainRoutePair}} is the source of truth. When the same destination is offered by multiple providers, both routes are returned; the caller picks one based on supported source assets, fees, or other preferences.

--- a/docs/breez-sdk/src/guide/cross_chain.md
+++ b/docs/breez-sdk/src/guide/cross_chain.md
@@ -1,0 +1,121 @@
+# USD payments
+
+The SDK can send USD-denominated value from a Spark wallet to a USD-pegged stablecoin (USDC, USDT, or USDT0) on any of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The source on the Spark side is either BTC sats or USDB; the destination is always one of the supported USD stablecoins on a supported chain. The SDK orchestrates two legs — a Spark-side transfer to a provider-controlled deposit and the provider-driven delivery of the destination asset — and reconciles both onto a single {{#name Payment}} row.
+
+The send flow itself lives in the [Sending payments](./send_payment.md#usd-stablecoins) page. This page covers how it works under the hood: the providers, the lifecycle, retry semantics, and limitations.
+
+## Supported address formats
+
+{{#name parse}} recognizes cross-chain destinations in the following forms, returning {{#enum InputType::CrossChainAddress}} with the parsed {{#name CrossChainAddressDetails}} — address family, bare address, and optional token contract address, chain id, and amount.
+
+### Bare addresses
+
+The SDK detects three address families from format alone. A bare address parses with no `contract_address`, `chain_id`, or `amount` — the caller selects the destination chain and asset via {{#name get_cross_chain_routes}}.
+
+- **EVM** — `0x` + 40 hex characters (lowercase or checksummed):
+  ```
+  0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+  ```
+- **Solana** — base58 encoding of a 32-byte public key:
+  ```
+  EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+  ```
+- **Tron** — base58check with a `T` prefix (34 characters total):
+  ```
+  TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t
+  ```
+
+### Canonical URIs
+
+URIs let the recipient encode chain, token contract, and amount alongside the address. Unknown query parameters are ignored.
+
+- **EVM** — [EIP-681](https://eips.ethereum.org/EIPS/eip-681). Native send or ERC-20 transfer; the optional `@<chain_id>` suffix is the EIP-681 chain identifier (e.g. `8453` for Base):
+  ```
+  ethereum:<addr>[@<chain_id>]?value=<wei>
+  ethereum:<contract>[@<chain_id>]/transfer?address=<to>&uint256=<amount>
+  ```
+- **Solana** — Solana Pay-style. `spl-token=` carries the SPL mint when the destination is an SPL token rather than native SOL:
+  ```
+  solana:<addr>?amount=<amount>&spl-token=<mint>
+  ```
+- **Tron** — TRC-20 destinations carry the contract on `token=`:
+  ```
+  tron:<addr>?amount=<amount>&token=<contract>
+  ```
+
+URIs whose recipient address doesn't match the scheme's address family (e.g. a `solana:` URI carrying an EVM address) are not recognized as cross-chain. Unknown schemes are not recognized as cross-chain either — they may still be classified by another input type if the format matches.
+
+## Providers
+
+The SDK ships with two cross-chain providers. {{#name get_cross_chain_routes}} returns the union of routes offered by each, tagged with {{#name CrossChainRoutePair.provider}}.
+
+| Provider     | Source assets    | Destinations                                                | Mechanism                            |
+| ------------ | ---------------- | ----------------------------------------------------------- | ------------------------------------ |
+| **Orchestra** (Flashnet) | BTC sats + USDB | USDC / USDT / USDT0 on Ethereum chains (Arbitrum, Base), Solana, Tron | Spark transfer to a deposit address, then provider bridges to the destination chain |
+| **Boltz**    | BTC sats only    | USDC / USDT on Ethereum chains (Arbitrum, Base), Solana, Tron                 | Lightning reverse swap: SDK pays a hold invoice, provider claims the on-chain leg |
+
+The provider tag on each {{#name CrossChainRoutePair}} is the source of truth. When the same destination is offered by multiple providers, both routes are returned; the caller picks one based on supported source assets, fees, or other preferences.
+
+## Slippage
+
+Cross-chain slippage protects the recipient from price movement between quote and delivery. Values are expressed in basis points (1 bps = 0.01%).
+
+Resolution at prepare time:
+
+1. The per-request {{#name max_slippage_bps}} on {{#enum PaymentRequest::CrossChain}} wins if set.
+2. Otherwise, the SDK falls back to {{#name default_slippage_bps}} on {{#name CrossChainConfig}} from [the SDK configuration](./config.md#cross-chain-payments).
+3. Otherwise, the built-in default of 100 bps (1%) is used.
+
+Values outside 10 to 500 are rejected at both config validation and per-request validation.
+
+## Quote expiry
+
+Each cross-chain prepare response carries an {{#name expires_at}} quote-expiry timestamp on {{#enum SendPaymentMethod::CrossChainAddress}}. If the quote has expired by the time you call {{#name send_payment}}, you must re-prepare to obtain a fresh quote (with a new {{#name expires_at}}) and try again.
+
+## Status lifecycle
+
+The Spark/USDB token transfer and the cross-chain delivery have distinct status fields. They are tracked separately on the persisted {{#name Payment}} row so each can settle independently.
+
+| Field                                                 | Reflects                                                       |
+| ----------------------------------------------------- | -------------------------------------------------------------- |
+| {{#name status}}                                      | The Spark or USDB token transfer (sender-side settlement)      |
+| {{#name conversion_info.status}}                      | The provider-driven cross-chain leg                            |
+| {{#name conversion_info.delivered_amount}}            | Final amount delivered to the recipient, set when terminal     |
+
+The cross-chain status walks one of:
+
+- **{{#enum ConversionStatus::Pending}}** — deposit transfer submitted, provider working on the cross-chain leg.
+- **{{#enum ConversionStatus::Completed}}** — provider reports the order terminal-successful; {{#name delivered_amount}} is set.
+- **{{#enum ConversionStatus::RefundNeeded}}** — provider rejected the submit or order failed before delivery; the local Spark transfer is settled and the deposit is sitting at the provider awaiting refund.
+- **{{#enum ConversionStatus::Refunded}}** — the funds have been refunded back to the wallet.
+- **{{#enum ConversionStatus::Failed}}** — terminal failure with no refund pending.
+
+A background monitor runs while the SDK is active and reconciles {{#enum ConversionStatus::RefundNeeded}} and {{#enum ConversionStatus::Pending}} rows onto their terminal state by polling the provider.
+
+<h2 id="retry-safety">Retry safety</h2>
+
+Calling {{#name send_payment}} is safe to retry on transient errors, **with one caveat that depends on the source asset.**
+
+### BTC-source sends
+
+For sends where the source is BTC sats (Boltz reverse swap, or Orchestra with BTC source), the SDK threads a deterministic transfer id through to the underlying Spark transfer. Retrying with the same {{#name PrepareSendPaymentResponse}} produces the same transfer id, and the Spark protocol returns the original transfer instead of firing a new one — no double-deposit.
+
+Two ways to drive idempotency:
+
+1. **Pass a caller-supplied {{#name idempotency_key}}** on {{#name SendPaymentRequest}}. The top-level dispatcher first looks for an existing payment with that id and short-circuits the retry if found; otherwise the key is used as the Spark transfer id.
+2. **Omit {{#name idempotency_key}}** — the SDK derives a deterministic UUIDv5 from the provider's quote/swap id. Re-sending the same prepared shape produces the same id and dedupes at the Spark protocol layer even if the first attempt's persistence step never completed.
+
+### USDB-source sends
+
+For sends where the source is USDB (Orchestra), the underlying token transfer does not accept an idempotency token at the Spark protocol layer. There is no upstream dedup. Callers that retry on transient errors can fire a second deposit and overpay.
+
+This matches the existing contract for direct token sends.
+
+If you need at-most-once semantics for a USDB-source cross-chain send, debounce retries at the application layer until the SDK either returns a payment or a terminal error.
+
+## Limitations
+
+- **Mainnet only.** Cross-chain providers operate against live external networks; there is no testnet equivalent in the SDK today.
+- **Background tasks required.** Both providers depend on background monitors to reconcile delivery status. {{#name cross_chain_config}} is incompatible with {{#name background_tasks_enabled}} disabled.
+- **USDB-source retries have no idempotency guarantee.** See [Retry safety](#retry-safety) above.
+

--- a/docs/breez-sdk/src/guide/parse.md
+++ b/docs/breez-sdk/src/guide/parse.md
@@ -4,6 +4,8 @@ The SDK provides a versatile and extensible parsing module designed to process a
 
 Natively supported formats include: BOLT11 invoices, LNURLs of different types, Bitcoin addresses, Spark addresses, and others. For the complete list, consult the [API documentation](https://breez.github.io/spark-sdk/breez_sdk_spark/enum.InputType.html).
 
+Cross-chain destinations on EVM, Solana, and Tron — bare addresses or chain-prefixed URIs — parse to {{#enum InputType::CrossChainAddress}}, carrying the parsed address family along with any token contract address and amount embedded in the URI. Use the resulting {{#name CrossChainAddressDetails}} to discover available routes; see [USD stablecoins](./send_payment.md#usd-stablecoins) for the send flow.
+
 <div class="warning">
 <h4>Developer note</h4>
 The amounts returned from calling parse on Lightning based inputs (BOLT11, LNURL) are denominated in millisatoshi.

--- a/docs/breez-sdk/src/guide/parse.md
+++ b/docs/breez-sdk/src/guide/parse.md
@@ -4,7 +4,7 @@ The SDK provides a versatile and extensible parsing module designed to process a
 
 Natively supported formats include: BOLT11 invoices, LNURLs of different types, Bitcoin addresses, Spark addresses, and others. For the complete list, consult the [API documentation](https://breez.github.io/spark-sdk/breez_sdk_spark/enum.InputType.html).
 
-Cross-chain destinations on EVM, Solana, and Tron — bare addresses or chain-prefixed URIs — parse to {{#enum InputType::CrossChainAddress}}, carrying the parsed address family along with any token contract address and amount embedded in the URI. Use the resulting {{#name CrossChainAddressDetails}} to discover available routes; see [Send USDC/USDT](./send_payment.md#send-usdc-usdt) for the send flow.
+Cross-chain destinations on EVM, Solana, and Tron — bare addresses or chain-prefixed URIs — parse to {{#enum InputType::CrossChainAddress}}, carrying the parsed address family along with any token contract address and amount embedded in the URI. Use the resulting {{#name CrossChainAddressDetails}} to discover available routes; see [Send USDC/USDT](./send_payment.md#usdc-usdt) for the send flow.
 
 <div class="warning">
 <h4>Developer note</h4>

--- a/docs/breez-sdk/src/guide/parse.md
+++ b/docs/breez-sdk/src/guide/parse.md
@@ -4,7 +4,7 @@ The SDK provides a versatile and extensible parsing module designed to process a
 
 Natively supported formats include: BOLT11 invoices, LNURLs of different types, Bitcoin addresses, Spark addresses, and others. For the complete list, consult the [API documentation](https://breez.github.io/spark-sdk/breez_sdk_spark/enum.InputType.html).
 
-Cross-chain destinations on EVM, Solana, and Tron — bare addresses or chain-prefixed URIs — parse to {{#enum InputType::CrossChainAddress}}, carrying the parsed address family along with any token contract address and amount embedded in the URI. Use the resulting {{#name CrossChainAddressDetails}} to discover available routes; see [USD stablecoins](./send_payment.md#usd-stablecoins) for the send flow.
+Cross-chain destinations on EVM, Solana, and Tron — bare addresses or chain-prefixed URIs — parse to {{#enum InputType::CrossChainAddress}}, carrying the parsed address family along with any token contract address and amount embedded in the URI. Use the resulting {{#name CrossChainAddressDetails}} to discover available routes; see [Send USDC/USDT](./send_payment.md#send-usdc-usdt) for the send flow.
 
 <div class="warning">
 <h4>Developer note</h4>

--- a/docs/breez-sdk/src/guide/send_payment.md
+++ b/docs/breez-sdk/src/guide/send_payment.md
@@ -57,9 +57,11 @@ Spark invoices may require a token (non-Bitcoin) as the payment asset. To determ
 
 {{#tabs send_payment:prepare-send-payment-spark-invoice}}
 
-## USD stablecoins
+<h2 id="send-usdc-usdt">
+    <a class="header" href="#send-usdc-usdt">Send USDC/USDT</a>
+</h2>
 
-Send USD-denominated value from a Spark wallet to a USD-pegged stablecoin (USDC, USDT, USDT0) on one of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The source on the Spark side is BTC sats or USDB; the destination is always one of the supported USD stablecoins on a supported chain. This feature must be enabled in [the SDK configuration](./config.md#cross-chain-payments) before using. See [USD payments](./cross_chain.md) for provider details and the status lifecycle.
+Send USDC or USDT from a Spark wallet to a recipient on one of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The source on the Spark side is BTC sats or USDB. This feature must be enabled in [the SDK configuration](./config.md#cross-chain-payments) before using. See [Send USDC/USDT](./cross_chain.md) for provider details and the status lifecycle.
 
 After [parsing](./parse.md) the recipient address into {{#enum InputType::CrossChainAddress}}, call {{#name get_cross_chain_routes}} with {{#enum CrossChainRouteFilter::Send}} carrying the parsed {{#name CrossChainAddressDetails}}. The returned {{#name CrossChainRoutePair}}s name the provider, destination chain and asset, decimals, optional token contract address, and which source assets (BTC sats or USDB) each route accepts.
 

--- a/docs/breez-sdk/src/guide/send_payment.md
+++ b/docs/breez-sdk/src/guide/send_payment.md
@@ -22,7 +22,7 @@ The payment request field supports Lightning invoices, Bitcoin addresses, Spark 
 Payments can be sent without holding Bitcoin by converting on-the-fly as a step before sending a payment. See <a href="./token_conversion.md">Converting tokens</a> for more information.
 </div>
 
-## Lightning
+### Lightning
 
 #### BOLT11 invoice
 
@@ -32,13 +32,13 @@ If the invoice also contains a Spark address, the payment can be sent directly v
 
 {{#tabs send_payment:prepare-send-payment-lightning-bolt11}}
 
-## Bitcoin
+### Bitcoin
 
 For Bitcoin addresses, the amount must be set in the request. The prepare response includes fee quotes for three payment speeds: Slow, Medium, and Fast.
 
 {{#tabs send_payment:prepare-send-payment-onchain}}
 
-## Spark
+### Spark
 
 #### Spark address
 
@@ -57,11 +57,11 @@ Spark invoices may require a token (non-Bitcoin) as the payment asset. To determ
 
 {{#tabs send_payment:prepare-send-payment-spark-invoice}}
 
-<h2 id="send-usdc-usdt">
-    <a class="header" href="#send-usdc-usdt">Send USDC/USDT</a>
-</h2>
+<h3 id="usdc-usdt">
+    <a class="header" href="#usdc-usdt">USDC/USDT</a>
+</h3>
 
-Send USDC or USDT from a Spark wallet to a recipient on one of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The source on the Spark side is BTC sats or USDB. This feature must be enabled in [the SDK configuration](./config.md#cross-chain-payments) before using. See [Send USDC/USDT](./cross_chain.md) for provider details and the status lifecycle.
+Send USDC or USDT from a Spark wallet to a recipient on one of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The source on the Spark side is BTC sats or USDB. This feature must be enabled in [the SDK configuration](./config.md#send-usdc-usdt) before using. See [Send USDC/USDT](./cross_chain.md) for provider details and the status lifecycle.
 
 After [parsing](./parse.md) the recipient address into {{#enum InputType::CrossChainAddress}}, call {{#name get_cross_chain_routes}} with {{#enum CrossChainRouteFilter::Send}} carrying the parsed {{#name CrossChainAddressDetails}}. The returned {{#name CrossChainRoutePair}}s name the provider, destination chain and asset, decimals, optional token contract address, and which source assets (BTC sats or USDB) each route accepts.
 
@@ -96,7 +96,7 @@ Once the payment has been prepared and the fees are accepted, the payment can be
 - **Options** - Any payment method specific options for the payment (see below).
 - **Idempotency Key** - An optional UUID that identifies the payment. If set, providing the same idempotency key for multiple requests will ensure that only one payment is made.
 
-## Lightning
+### Lightning
 
 In the optional send payment options for BOLT11 invoices, you can set:
 
@@ -105,7 +105,7 @@ In the optional send payment options for BOLT11 invoices, you can set:
 
 {{#tabs send_payment:send-payment-lightning-bolt11}}
 
-## Bitcoin
+### Bitcoin
 
 In the optional send payment options for Bitcoin addresses, you can set:
 
@@ -113,7 +113,7 @@ In the optional send payment options for Bitcoin addresses, you can set:
 
 {{#tabs send_payment:send-payment-onchain}}
 
-## Spark
+### Spark
 
 In the optional send payment options for Spark addresses, you can set:
 
@@ -121,9 +121,11 @@ In the optional send payment options for Spark addresses, you can set:
 
 {{#tabs send_payment:send-payment-spark}}
 
-## Cross-chain
+<h3 id="usdc-usdt-1">
+    <a class="header" href="#usdc-usdt-1">USDC/USDT</a>
+</h3>
 
-Cross-chain has no additional send payment options.
+Send USDC/USDT has no additional send payment options.
 
 {{#tabs cross_chain:cross-chain-send}}
 
@@ -154,7 +156,9 @@ The {{#enum SdkEvent::Synced}} event is also emitted as the SDK syncs in the bac
 | -------------------- | ------------------------------- | ------------------------------------------------ |
 | **PaymentSucceeded** | The Spark transfer is complete. | Show the payment as complete and call {{#name get_info}} to read the updated balance. The SDK refreshes the cached balance before emitting this event. See [fetching the balance](/guide/get_info.md). |
 
-#### Cross-chain
+<h4 id="usdc-usdt-2">
+    <a class="header" href="#usdc-usdt-2">USDC/USDT</a>
+</h4>
 
 | Event                | Description                                                                                              | UX Suggestion                                    |
 | -------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |

--- a/docs/breez-sdk/src/guide/send_payment.md
+++ b/docs/breez-sdk/src/guide/send_payment.md
@@ -57,6 +57,20 @@ Spark invoices may require a token (non-Bitcoin) as the payment asset. To determ
 
 {{#tabs send_payment:prepare-send-payment-spark-invoice}}
 
+## USD stablecoins
+
+Send USD-denominated value from a Spark wallet to a USD-pegged stablecoin (USDC, USDT, USDT0) on one of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The source on the Spark side is BTC sats or USDB; the destination is always one of the supported USD stablecoins on a supported chain. This feature must be enabled in [the SDK configuration](./config.md#cross-chain-payments) before using. See [USD payments](./cross_chain.md) for provider details and the status lifecycle.
+
+After [parsing](./parse.md) the recipient address into {{#enum InputType::CrossChainAddress}}, call {{#name get_cross_chain_routes}} with {{#enum CrossChainRouteFilter::Send}} carrying the parsed {{#name CrossChainAddressDetails}}. The returned {{#name CrossChainRoutePair}}s name the provider, destination chain and asset, decimals, optional token contract address, and which source assets (BTC sats or USDB) each route accepts.
+
+{{#tabs cross_chain:cross-chain-get-routes}}
+
+Build {{#enum PaymentRequest::CrossChain}} with the recipient address, the chosen route, and an optional {{#name max_slippage_bps}} (10 to 500 basis points). The amount on the prepare request is denominated in the source asset's base units: sats for a BTC source, USDB base units for a USDB source.
+
+The prepare response carries a quote {{#name expires_at}} timestamp. Re-prepare and pick a fresh route if it lapses before send.
+
+{{#tabs cross_chain:cross-chain-prepare}}
+
 ## Fee Policy
 
 By default, fees are added on top of the amount ({{#enum FeePolicy::FeesExcluded}}). Use {{#enum FeePolicy::FeesIncluded}} to deduct fees from the amount instead—the receiver gets the amount minus fees.
@@ -105,6 +119,12 @@ In the optional send payment options for Spark addresses, you can set:
 
 {{#tabs send_payment:send-payment-spark}}
 
+## Cross-chain
+
+Cross-chain has no additional send payment options.
+
+{{#tabs cross_chain:cross-chain-send}}
+
 ## Event Flows
 
 Once a send payment is initiated, you can follow and react to the different payment events using the guide below for each payment method. See [listening to events](/guide/events.html) for how to subscribe to events. 
@@ -131,3 +151,10 @@ The {{#enum SdkEvent::Synced}} event is also emitted as the SDK syncs in the bac
 | Event                | Description                     | UX Suggestion                                    |
 | -------------------- | ------------------------------- | ------------------------------------------------ |
 | **PaymentSucceeded** | The Spark transfer is complete. | Show the payment as complete and call {{#name get_info}} to read the updated balance. The SDK refreshes the cached balance before emitting this event. See [fetching the balance](/guide/get_info.md). |
+
+#### Cross-chain
+
+| Event                | Description                                                                                              | UX Suggestion                                    |
+| -------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **PaymentPending**   | The deposit transfer has been submitted to the provider. The cross-chain leg is awaiting settlement.     | Show payment as pending; the bridge leg may take several minutes depending on the provider and destination chain. |
+| **PaymentSucceeded** | The provider reports the cross-chain order terminal. The amount actually delivered to the recipient is carried on the conversion info. | Show the payment as complete and call {{#name get_info}} to read the updated balance. The SDK refreshes the cached balance before emitting this event. See [fetching the balance](/guide/get_info.md). |

--- a/docs/breez-sdk/src/guide/stable_balance.md
+++ b/docs/breez-sdk/src/guide/stable_balance.md
@@ -65,6 +65,8 @@ When you [prepare to send a payment](./send_payment.md#preparing-payments) witho
 1. If you have enough bitcoin balance, no conversion is needed
 2. If your bitcoin balance is insufficient, the SDK configures conversion options using your Stable Balance settings (token identifier and slippage)
 
+The same flow extends to [USD stablecoins](./send_payment.md#usd-stablecoins): when paying a recipient on USDC, USDT, or USDT0, the SDK can spend the user's USDB balance directly (Orchestra routes that accept USDB as source) or auto-convert it through bitcoin if the chosen route only accepts sats.
+
 <div class="warning">
 <h4>Developer note</h4>
 

--- a/docs/breez-sdk/src/guide/stable_balance.md
+++ b/docs/breez-sdk/src/guide/stable_balance.md
@@ -65,7 +65,7 @@ When you [prepare to send a payment](./send_payment.md#preparing-payments) witho
 1. If you have enough bitcoin balance, no conversion is needed
 2. If your bitcoin balance is insufficient, the SDK configures conversion options using your Stable Balance settings (token identifier and slippage)
 
-The same flow extends to [USD stablecoins](./send_payment.md#usd-stablecoins): when paying a recipient on USDC, USDT, or USDT0, the SDK can spend the user's USDB balance directly (Orchestra routes that accept USDB as source) or auto-convert it through bitcoin if the chosen route only accepts sats.
+The same flow extends to [USDC/USDT](./send_payment.md#send-usdc-usdt): when paying a recipient on USDC or USDT, the SDK can spend the user's USDB balance directly (Orchestra routes that accept USDB as source) or auto-convert it through bitcoin if the chosen route only accepts sats.
 
 <div class="warning">
 <h4>Developer note</h4>

--- a/docs/breez-sdk/src/guide/stable_balance.md
+++ b/docs/breez-sdk/src/guide/stable_balance.md
@@ -65,7 +65,7 @@ When you [prepare to send a payment](./send_payment.md#preparing-payments) witho
 1. If you have enough bitcoin balance, no conversion is needed
 2. If your bitcoin balance is insufficient, the SDK configures conversion options using your Stable Balance settings (token identifier and slippage)
 
-The same flow extends to [USDC/USDT](./send_payment.md#send-usdc-usdt): when paying a recipient on USDC or USDT, the SDK can spend the user's USDB balance directly (Orchestra routes that accept USDB as source) or auto-convert it through bitcoin if the chosen route only accepts sats.
+The same flow extends to [USDC/USDT](./send_payment.md#usdc-usdt): when paying a recipient on USDC or USDT, the SDK can spend the user's USDB balance directly (Orchestra routes that accept USDB as source) or auto-convert it through bitcoin if the chosen route only accepts sats.
 
 <div class="warning">
 <h4>Developer note</h4>


### PR DESCRIPTION
Document the USD stablecoin payment flow (Orchestra + Boltz): the opt-in `cross_chain_config`, parsing recipient addresses into `InputType::CrossChainAddress`, discovering routes, preparing and sending. Tight integration into the existing `config.md`, `parse.md`, and `send_payment.md` pages, plus a new `cross_chain.md` deep-dive (providers, supported address formats, slippage, quote expiry, status lifecycle, retry safety, limitations). New snippet anchors across all 9 languages.

### snippets-processor

Fix the `{{#name}}` macro for dotted identifiers with a lowercase prefix. `{{#name conversion_info.delivered_amount}}` was rendering as `conversion_info.deliveredAmount` for camelCase / PascalCase languages; only the trailing segment was case-converted while the prefix stayed snake_case. The processor now detects the prefix shape — uppercase = type name (emitted verbatim), lowercase = snake_case field (case-converted per language) — so it renders as `conversionInfo.deliveredAmount` for Swift/Kotlin/JS, `ConversionInfo.DeliveredAmount` for Go/C#, and unchanged `conversion_info.delivered_amount` for Rust/Python. Also fixes pre-existing references like `leaf_optimization_config.auto_enabled` in `config.md` / `server_mode.md`.
