### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -649,7 +649,8 @@ func handleLnurlPay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args [
 
 func handleLnurlWithdraw(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []string) error {
 	fs := flag.NewFlagSet("lnurl-withdraw", flag.ContinueOnError)
-	timeoutSecs := fs.Uint("timeout", 0, "Completion timeout in seconds")
+	timeoutSecs := fs.Uint("t", 0, "Completion timeout in seconds")
+	fs.UintVar(timeoutSecs, "timeout", 0, "Completion timeout in seconds")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -450,8 +450,12 @@ suspend fun handlePay(sdk: BreezSdk, reader: LineReader, args: List<String>) {
 
     // Show conversion estimate if applicable
     prepareResponse.conversionEstimate?.let { conversionEstimate ->
-        val units = if (conversionEstimate.options.conversionType == ConversionType.FromBitcoin) "sats" else "token base units"
-        println("Estimated conversion of ${conversionEstimate.amountIn} $units → ${conversionEstimate.amountOut} $units with a ${conversionEstimate.fee} $units fee")
+        val (inUnits, outUnits) = if (conversionEstimate.options.conversionType == ConversionType.FromBitcoin) {
+            "sats" to "token base units"
+        } else {
+            "token base units" to "sats"
+        }
+        println("Estimated conversion from ${conversionEstimate.amountIn} $inUnits to ${conversionEstimate.amountOut} $outUnits with a ${conversionEstimate.fee} token base units fee")
         val line = readlineWithDefault(reader, "Do you want to continue (y/n): ", "y").lowercase()
         if (line != "y") {
             println("Payment cancelled")

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/App.tsx
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/App.tsx
@@ -329,8 +329,8 @@ class CliEventListener {
       eventDesc = 'UnclaimedDeposits'
     } else if (event.tag === SdkEvent_Tags.NewDeposits) {
       eventDesc = 'NewDeposits'
-    } else if (event.tag === SdkEvent_Tags.Optimization) {
-      eventDesc = 'Optimization'
+    } else if (event.tag === SdkEvent_Tags.AutoOptimization) {
+      eventDesc = 'AutoOptimization'
     } else if (event.tag === SdkEvent_Tags.LightningAddressChanged) {
       eventDesc = 'LightningAddressChanged'
     }

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -610,6 +610,9 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
       const provider = (options.provider || 'moonpay').toLowerCase()
       let request
       if (provider === 'cashapp' || provider === 'cash_app' || provider === 'cash-app') {
+        if (options.amountSat == null) {
+          throw new Error('--amount-sat is required when --provider is cashapp')
+        }
         request = { type: 'cashApp', amountSats: options.amountSat }
       } else {
         request = { type: 'moonpay', lockedAmountSat: options.amountSat, redirectUrl: options.redirectUrl }


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`2c80c32`](https://github.com/breez/spark-sdk/commit/2c80c32db4489447af4c5600c39c272d6e8845d2)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/27298599192)

**Language status:**
- :next_track_button: C# (no changes needed)
- :next_track_button: Dart (no changes needed)
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :next_track_button: Python (no changes needed)
- :white_check_mark: React Native
- :next_track_button: Swift (no changes needed)
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
No differences found: CLIs are in sync.

### Dart
No differences found: CLIs are in sync.

### Go
## Divergences
- `lnurl-withdraw` command missing `-t` short flag for `--timeout` (Rust has `#[clap(short = 't', long = "timeout")]`)

## Applied
- Added `-t` short flag alias for `--timeout` in `handleLnurlWithdraw` in `commands.go`

## Skipped
- None

### Kotlin
## Divergences
- `handlePay` conversion estimate message used a single `units` variable for both input and output amounts; Rust correctly uses separate `in_units`/`out_units` since conversions swap between sats and token base units

## Applied
- Fixed conversion estimate display in `Commands.kt` `handlePay` to use separate `inUnits`/`outUnits` variables and match the Rust format string ("from X inUnits to Y outUnits with a Z token base units fee")

## Skipped
- (none)

### Python
No differences found: CLIs are in sync.

### React Native
## Divergences
- App.tsx event listener used `SdkEvent_Tags.Optimization` (non-existent tag) instead of `SdkEvent_Tags.AutoOptimization` (the correct tag per Rust SDK and React Native snippets)

## Applied
- Fixed `SdkEvent_Tags.Optimization` to `SdkEvent_Tags.AutoOptimization` in `App.tsx` event listener (line 332)

## Skipped
- No Rust CLI changes since ee2e77086ab1018bccae77099db82025789056d2 (empty diff), so no new features to sync
- Contacts commands remain stubbed as "Not yet supported in React Native" per task instructions (contacts API not available in the React Native SDK)
- YubiKey and FIDO2 passkey providers remain as `NotYetSupportedProvider` stubs (require USB HID/NFC hardware access not available on mobile)
- MySQL/PostgreSQL storage options not applicable for React Native (mobile app uses default storage)
- Stable balance config setup flags (`--stable-balance-token`, `--stable-balance-default-active-label`, `--stable-balance-threshold`) have no React Native UI equivalent (config-level setup handled via the setup screen, stable-balance commands are fully implemented)

### TypeScript
## Divergences
- `buy-bitcoin` cashapp: Rust CLI validates `--amount-sat` is present when provider is cashapp and returns a clear error; TypeScript CLI passed `undefined` to the SDK

## Applied
- Added `--amount-sat` validation for cashapp provider in `commands.js` buy-bitcoin handler, matching the Rust CLI error behavior

## Skipped
- None

</details>