### PR TITLE
Defer wallet background start until runtime subscribes

### DIFF
--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -43,9 +43,7 @@ impl RuntimeProfile for ClientRuntime {
         // Subscribers are now attached: start the wallet's BackgroundProcessor so
         // its first `WalletEvent::Synced` (emitted after the operator stream
         // connects) lands in the runtime loop and drives the initial Full sync.
-        sdk.spark_wallet
-            .start_background_processing(sdk.shutdown_sender.subscribe())
-            .await;
+        sdk.spark_wallet.start_background_processing().await;
 
         sdk.try_recover_lightning_address();
         spawn_conversion_refunder(

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -39,6 +39,14 @@ impl RuntimeProfile for ClientRuntime {
         register_client_runtime_event_handler(sdk).await;
         sdk.spawn_spark_private_mode_initialization();
         spawn_client_runtime_loop(sdk, initial_synced_sender);
+
+        // Subscribers are now attached: start the wallet's BackgroundProcessor so
+        // its first `WalletEvent::Synced` (emitted after the operator stream
+        // connects) lands in the runtime loop and drives the initial Full sync.
+        sdk.spark_wallet
+            .start_background_processing(sdk.shutdown_sender.subscribe())
+            .await;
+
         sdk.try_recover_lightning_address();
         spawn_conversion_refunder(
             Arc::clone(&sdk.token_converter),

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -76,7 +76,6 @@ struct BuildSparkWalletParams {
     spark_signer: Arc<SparkSigner>,
     session_store: Arc<dyn SessionStore>,
     shutdown_receiver: watch::Receiver<()>,
-    background_services_enabled: bool,
     tree_store: Option<Arc<dyn spark_wallet::TreeStore>>,
     token_output_store: Option<Arc<dyn spark_wallet::TokenOutputStore>>,
     payment_observer: Option<Arc<dyn PaymentObserver>>,
@@ -419,7 +418,6 @@ impl SdkBuilder {
             spark_signer: Arc::clone(&signers.spark),
             session_store,
             shutdown_receiver: shutdown_sender.subscribe(),
-            background_services_enabled,
             tree_store: stores.tree_store.clone(),
             token_output_store: stores.token_output_store.clone(),
             payment_observer: self.payment_observer,
@@ -736,7 +734,7 @@ async fn build_spark_wallet(params: BuildSparkWalletParams) -> Result<Arc<SparkW
     let mut wallet_builder = spark_wallet::WalletBuilder::new(params.config, params.spark_signer)
         .with_cancellation_token(params.shutdown_receiver)
         .with_session_store(params.session_store)
-        .with_background_processing(params.background_services_enabled);
+        .with_background_processing(false);
     if let Some(provider) = &params.context.jwt_header_provider {
         wallet_builder = wallet_builder.with_so_extra_header_provider(
             Arc::clone(provider) as Arc<dyn spark_wallet::HeaderProvider>

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -75,7 +75,11 @@ struct BuildSparkWalletParams {
     config: SparkWalletConfig,
     spark_signer: Arc<SparkSigner>,
     session_store: Arc<dyn SessionStore>,
-    shutdown_receiver: watch::Receiver<()>,
+    /// `Some` only in client mode. Wiring it in server mode would leave the
+    /// wallet holding a stored `cancellation_token` receiver that's never
+    /// consumed (server mode never calls `start_background_processing`), which
+    /// would stall `disconnect`'s `Sender::closed()` await forever.
+    shutdown_receiver: Option<watch::Receiver<()>>,
     tree_store: Option<Arc<dyn spark_wallet::TreeStore>>,
     token_output_store: Option<Arc<dyn spark_wallet::TokenOutputStore>>,
     payment_observer: Option<Arc<dyn PaymentObserver>>,
@@ -417,7 +421,7 @@ impl SdkBuilder {
             config: spark_wallet_config,
             spark_signer: Arc::clone(&signers.spark),
             session_store,
-            shutdown_receiver: shutdown_sender.subscribe(),
+            shutdown_receiver: background_services_enabled.then(|| shutdown_sender.subscribe()),
             tree_store: stores.tree_store.clone(),
             token_output_store: stores.token_output_store.clone(),
             payment_observer: self.payment_observer,
@@ -732,9 +736,10 @@ fn wrap_session_store(
 /// Builds the [`SparkWallet`] from the assembled config, signers and stores.
 async fn build_spark_wallet(params: BuildSparkWalletParams) -> Result<Arc<SparkWallet>, SdkError> {
     let mut wallet_builder = spark_wallet::WalletBuilder::new(params.config, params.spark_signer)
-        .with_cancellation_token(params.shutdown_receiver)
-        .with_session_store(params.session_store)
-        .with_background_processing(false);
+        .with_session_store(params.session_store);
+    if let Some(receiver) = params.shutdown_receiver {
+        wallet_builder = wallet_builder.with_cancellation_token(receiver);
+    }
     if let Some(provider) = &params.context.jwt_header_provider {
         wallet_builder = wallet_builder.with_so_extra_header_provider(
             Arc::clone(provider) as Arc<dyn spark_wallet::HeaderProvider>

--- a/crates/breez-sdk/lnurl/src/main.rs
+++ b/crates/breez-sdk/lnurl/src/main.rs
@@ -243,11 +243,11 @@ where
             None,
             None,
             None,
-            true,
             None,
         )
         .await?,
     );
+    wallet.start_background_processing().await;
 
     let config_domains: Vec<String> = args
         .domains

--- a/crates/internal/src/main.rs
+++ b/crates/internal/src/main.rs
@@ -123,10 +123,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let wallet =
         Arc::new(spark_wallet::SparkWallet::connect(spark_config, Arc::new(signer)).await?);
 
-    // Spawn event listener
-    let clone = Arc::clone(&wallet);
+    let mut receiver = wallet.subscribe_events();
     tokio::spawn(async move {
-        let mut receiver = clone.subscribe_events();
         loop {
             tokio::select! {
                 Ok(event) = receiver.recv() => {
@@ -145,6 +143,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     });
+    wallet.start_background_processing().await;
 
     // Setup readline
     let rl = &mut Editor::new()?;

--- a/crates/spark-itest/src/helpers.rs
+++ b/crates/spark-itest/src/helpers.rs
@@ -28,6 +28,11 @@ use crate::fixtures::{
 /// equivalent to `SparkWallet::connect(config, signer)`; for the SQL variants
 /// all three stores share the connection string (so they live in one
 /// database) and are scoped per-wallet by the signer's identity pubkey.
+///
+/// Background processing is **not** started. Callers must `subscribe_events()`
+/// first and then call `wallet.start_background_processing()`, otherwise the
+/// wallet's first `WalletEvent::Synced` fires before any listener exists and
+/// is dropped.
 pub async fn build_test_wallet(
     config: SparkWalletConfig,
     signer: Arc<dyn Signer>,
@@ -129,6 +134,7 @@ pub async fn create_regtest_wallet() -> Result<(SparkWallet, Receiver<WalletEven
     let backend = crate::backend::resolve_backend().await?;
     let wallet = build_test_wallet(config, signer, &backend).await?;
     let mut listener = wallet.subscribe_events();
+    wallet.start_background_processing().await;
 
     // Wait for initial sync
     wait_for_event(&mut listener, 60, "Synced", |e| match e {
@@ -167,12 +173,6 @@ pub async fn wallets(#[future] test_fixtures: TestFixtures) -> WalletsFixture {
         .expect("failed to create wallet config");
     let signer = create_test_signer_alice();
 
-    // Subscribe to events BEFORE the wallet has time to emit Synced. Wallet
-    // background tasks start as soon as build_test_wallet returns, and they
-    // race against subscribe_events because the broadcast channel doesn't
-    // replay past events. With the slower SQL backends, building a second
-    // wallet takes long enough that the first wallet's Synced fires before
-    // we'd otherwise get to subscribe.
     let alice_backend = crate::backend::resolve_backend()
         .await
         .expect("failed to resolve backend for alice wallet");
@@ -180,6 +180,7 @@ pub async fn wallets(#[future] test_fixtures: TestFixtures) -> WalletsFixture {
         .await
         .expect("Failed to connect alice wallet");
     let mut alice_listener = alice_wallet.subscribe_events();
+    alice_wallet.start_background_processing().await;
 
     let bob_backend = crate::backend::resolve_backend()
         .await
@@ -188,6 +189,8 @@ pub async fn wallets(#[future] test_fixtures: TestFixtures) -> WalletsFixture {
         .await
         .expect("Failed to connect bob wallet");
     let mut bob_listener = bob_wallet.subscribe_events();
+    bob_wallet.start_background_processing().await;
+
     loop {
         let event = alice_listener
             .recv()

--- a/crates/spark-itest/tests/deployed_token_tests.rs
+++ b/crates/spark-itest/tests/deployed_token_tests.rs
@@ -30,17 +30,16 @@ async fn test_many_outputs() -> Result<()> {
     rand::thread_rng().fill(&mut bob_seed);
     let signer_bob = Arc::new(DefaultSigner::new(&bob_seed, Network::Regtest).unwrap());
 
-    // Subscribe immediately after each build so Synced (emitted once during
-    // operator connect) isn't lost to a late subscribe — the broadcast
-    // channel doesn't replay past events, and SQL-backend builds + container
-    // startup are slow enough that Alice's Synced would otherwise fire before
-    // we'd subscribe.
     let alice_backend = resolve_backend().await?;
     let alice_wallet = build_test_wallet(config.clone(), signer_alice, &alice_backend).await?;
     let mut alice_listener = alice_wallet.subscribe_events();
+    alice_wallet.start_background_processing().await;
+
     let bob_backend = resolve_backend().await?;
     let bob_wallet = build_test_wallet(config, signer_bob, &bob_backend).await?;
     let mut bob_listener = bob_wallet.subscribe_events();
+    bob_wallet.start_background_processing().await;
+
     wait_for_event(&mut alice_listener, 30, "Synced", |event| match event {
         WalletEvent::Synced => Ok(Some(event)),
         _ => Ok(None),

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -165,10 +165,23 @@ macro_rules! with_leafs_spent_retry {
 }
 
 pub struct SparkWallet {
-    /// Cancellation token sender for internal use. When dropped, background tasks will stop.
-    /// This is `Some` only when no external cancellation token was provided.
+    /// Sender held for lifetime management when no external cancellation token
+    /// was provided to the builder. Dropping it cancels the receiver clones in
+    /// background tasks, so they exit when the wallet is dropped.
     #[allow(dead_code)]
     cancel: Option<watch::Sender<()>>,
+    /// Receiver moved into the background tasks on the first call to
+    /// [`Self::start_background_processing`]. Wrapped in `Mutex<Option<_>>` so
+    /// that first call can `take()` it: keeping a permanent receiver on `self`
+    /// would prevent [`watch::Sender::closed`] (used by the SDK's `disconnect`)
+    /// from ever firing while the wallet is alive. Tied to either the external
+    /// token passed via [`WalletBuilder::with_cancellation_token`] or the
+    /// internal sender in [`Self::cancel`].
+    cancellation_token: tokio::sync::Mutex<Option<watch::Receiver<()>>>,
+    /// Single-flight guard for [`Self::start_background_processing`] so callers
+    /// can invoke it repeatedly without spawning duplicate operator
+    /// subscriptions, refresh tasks, or auto-optimizer loops.
+    background_started: tokio::sync::OnceCell<()>,
     config: SparkWalletConfig,
     deposit_service: Arc<DepositService>,
     event_manager: Arc<EventManager>,
@@ -212,7 +225,6 @@ impl SparkWallet {
             None,
             None,
             None,
-            true,
             None,
         )
         .await
@@ -230,7 +242,6 @@ impl SparkWallet {
         transfer_observer: Option<Arc<dyn TransferObserver>>,
         ssp_extra_header_provider: Option<Arc<dyn HeaderProvider>>,
         so_extra_header_provider: Option<Arc<dyn HeaderProvider>>,
-        with_background_processing: bool,
         cancellation_token: Option<watch::Receiver<()>>,
     ) -> Result<Self, SparkWalletError> {
         config.validate()?;
@@ -368,7 +379,8 @@ impl SparkWallet {
             Some(auto_optimization_event_handler),
         ));
 
-        // Use external cancellation token if provided, otherwise create an internal one
+        // Use the external cancellation token if provided, otherwise create an
+        // internal sender we hold for the wallet's lifetime.
         let (cancel, cancellation_token) = match cancellation_token {
             Some(token) => (None, token),
             None => {
@@ -377,8 +389,10 @@ impl SparkWallet {
             }
         };
 
-        let wallet = Self {
+        Ok(Self {
             cancel,
+            cancellation_token: tokio::sync::Mutex::new(Some(cancellation_token)),
+            background_started: tokio::sync::OnceCell::new(),
             config,
             deposit_service,
             event_manager,
@@ -396,11 +410,7 @@ impl SparkWallet {
             htlc_service,
             leaf_optimizer,
             select_leaves_refresh: tokio::sync::OnceCell::new(),
-        };
-        if with_background_processing {
-            wallet.start_background_processing(cancellation_token).await;
-        }
-        Ok(wallet)
+        })
     }
 }
 
@@ -1300,29 +1310,46 @@ impl SparkWallet {
     }
 
     /// Spawns the operator event stream, leaf/token refresh, and auto-optimizer.
-    /// Callers that disable `with_background_processing` on the builder are
-    /// responsible for invoking this once their event subscribers are attached;
-    /// the first `WalletEvent::Synced` is otherwise dropped if no listener is
-    /// connected yet.
-    pub async fn start_background_processing(&self, cancellation_token: watch::Receiver<()>) {
-        let reconnect_interval = Duration::from_secs(self.config.reconnect_interval_seconds);
-        let background_processor = Arc::new(BackgroundProcessor::new(
-            Arc::clone(&self.operator_pool),
-            Arc::clone(&self.event_manager),
-            self.identity_public_key,
-            reconnect_interval,
-            Arc::clone(&self.tree_service),
-            Arc::clone(&self.ssp_client),
-            Arc::clone(&self.transfer_service),
-            Arc::clone(&self.htlc_service),
-            Arc::clone(&self.leaf_optimizer),
-            self.config.leaf_auto_optimize_enabled,
-            Arc::clone(&self.token_service),
-            self.config.token_outputs_optimization_options.clone(),
-            self.config.max_concurrent_claims,
-        ));
-        background_processor
-            .run_background_tasks(cancellation_token)
+    /// Callers must invoke this once their `subscribe_events()` listener is
+    /// attached; the first `WalletEvent::Synced` is otherwise dropped because no
+    /// receiver is connected to the broadcast channel yet. Background tasks run
+    /// until the cancellation token configured via
+    /// [`WalletBuilder::with_cancellation_token`] fires (or, when none was
+    /// provided, until the wallet is dropped).
+    ///
+    /// Subsequent calls are no-ops, so it is safe to call this defensively
+    /// (e.g. before every payment) without spawning duplicate subscriptions.
+    pub async fn start_background_processing(&self) {
+        self.background_started
+            .get_or_init(|| async {
+                // `take()` moves the receiver into the background processor.
+                // Holding it on `self` instead would keep the `watch::Sender`
+                // open and stall `Sender::closed()` (used by the SDK's
+                // `disconnect`) until the wallet itself dropped.
+                let Some(cancellation_token) = self.cancellation_token.lock().await.take() else {
+                    return;
+                };
+                let reconnect_interval =
+                    Duration::from_secs(self.config.reconnect_interval_seconds);
+                let background_processor = Arc::new(BackgroundProcessor::new(
+                    Arc::clone(&self.operator_pool),
+                    Arc::clone(&self.event_manager),
+                    self.identity_public_key,
+                    reconnect_interval,
+                    Arc::clone(&self.tree_service),
+                    Arc::clone(&self.ssp_client),
+                    Arc::clone(&self.transfer_service),
+                    Arc::clone(&self.htlc_service),
+                    Arc::clone(&self.leaf_optimizer),
+                    self.config.leaf_auto_optimize_enabled,
+                    Arc::clone(&self.token_service),
+                    self.config.token_outputs_optimization_options.clone(),
+                    self.config.max_concurrent_claims,
+                ));
+                background_processor
+                    .run_background_tasks(cancellation_token)
+                    .await;
+            })
             .await;
     }
 

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -377,28 +377,7 @@ impl SparkWallet {
             }
         };
 
-        if with_background_processing {
-            let reconnect_interval = Duration::from_secs(config.reconnect_interval_seconds);
-            let background_processor = Arc::new(BackgroundProcessor::new(
-                Arc::clone(&operator_pool),
-                Arc::clone(&event_manager),
-                identity_public_key,
-                reconnect_interval,
-                Arc::clone(&tree_service),
-                Arc::clone(&service_provider),
-                Arc::clone(&transfer_service),
-                Arc::clone(&htlc_service),
-                Arc::clone(&leaf_optimizer),
-                config.leaf_auto_optimize_enabled,
-                Arc::clone(&token_service),
-                config.token_outputs_optimization_options.clone(),
-                config.max_concurrent_claims,
-            ));
-            background_processor
-                .run_background_tasks(cancellation_token.clone())
-                .await;
-        }
-        Ok(Self {
+        let wallet = Self {
             cancel,
             config,
             deposit_service,
@@ -417,7 +396,11 @@ impl SparkWallet {
             htlc_service,
             leaf_optimizer,
             select_leaves_refresh: tokio::sync::OnceCell::new(),
-        })
+        };
+        if with_background_processing {
+            wallet.start_background_processing(cancellation_token).await;
+        }
+        Ok(wallet)
     }
 }
 
@@ -1314,6 +1297,33 @@ impl SparkWallet {
 
     pub fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent> {
         self.event_manager.listen()
+    }
+
+    /// Spawns the operator event stream, leaf/token refresh, and auto-optimizer.
+    /// Callers that disable `with_background_processing` on the builder are
+    /// responsible for invoking this once their event subscribers are attached;
+    /// the first `WalletEvent::Synced` is otherwise dropped if no listener is
+    /// connected yet.
+    pub async fn start_background_processing(&self, cancellation_token: watch::Receiver<()>) {
+        let reconnect_interval = Duration::from_secs(self.config.reconnect_interval_seconds);
+        let background_processor = Arc::new(BackgroundProcessor::new(
+            Arc::clone(&self.operator_pool),
+            Arc::clone(&self.event_manager),
+            self.identity_public_key,
+            reconnect_interval,
+            Arc::clone(&self.tree_service),
+            Arc::clone(&self.ssp_client),
+            Arc::clone(&self.transfer_service),
+            Arc::clone(&self.htlc_service),
+            Arc::clone(&self.leaf_optimizer),
+            self.config.leaf_auto_optimize_enabled,
+            Arc::clone(&self.token_service),
+            self.config.token_outputs_optimization_options.clone(),
+            self.config.max_concurrent_claims,
+        ));
+        background_processor
+            .run_background_tasks(cancellation_token)
+            .await;
     }
 
     /// Returns the balances of all tokens in the wallet.

--- a/crates/spark-wallet/src/wallet_builder.rs
+++ b/crates/spark-wallet/src/wallet_builder.rs
@@ -26,7 +26,6 @@ pub struct WalletBuilder {
     transfer_observer: Option<Arc<dyn TransferObserver>>,
     ssp_extra_header_provider: Option<Arc<dyn HeaderProvider>>,
     so_extra_header_provider: Option<Arc<dyn HeaderProvider>>,
-    with_background_processing: bool,
 }
 
 impl WalletBuilder {
@@ -43,7 +42,6 @@ impl WalletBuilder {
             transfer_observer: None,
             ssp_extra_header_provider: None,
             so_extra_header_provider: None,
-            with_background_processing: true,
         }
     }
 
@@ -117,12 +115,6 @@ impl WalletBuilder {
         self
     }
 
-    #[must_use]
-    pub fn with_background_processing(mut self, with_background_processing: bool) -> Self {
-        self.with_background_processing = with_background_processing;
-        self
-    }
-
     pub async fn build(self) -> Result<SparkWallet, SparkWalletError> {
         SparkWallet::new(
             self.config,
@@ -139,7 +131,6 @@ impl WalletBuilder {
             self.transfer_observer,
             self.ssp_extra_header_provider,
             self.so_extra_header_provider,
-            self.with_background_processing,
             self.cancellation_token,
         )
         .await


### PR DESCRIPTION
Wallet restores on the [cross-chain PR](https://github.com/breez/spark-sdk/pull/799) can show balance 0 for up to 60s after `connect()` returns, even when callers use `getInfo({ ensureSynced: true })`. Identified in the cross-chain PR / Boltz initialization, a race window has been identified in the SDK startup ordering enough to make the race fire reliably in WASM sessions.

### Root cause

`SparkWallet`'s `BackgroundProcessor` is spawned inside `WalletBuilder::build()`, but the SDK runtime loop that subscribes to wallet events runs much later, at the end of `BreezSdk::init_and_start`. If the operator stream connects in that window, `EventManager::notify_listeners(WalletEvent::Synced)` fires with no subscribers and `tokio::sync::broadcast` drops the send (it does not retain messages for late subscribers). Without that first `Synced`, nothing triggers the initial sync until the 60s periodic timer, and `initial_synced_watcher` (which `ensure_synced` blocks on) stays false the whole time.

A real session log shows it firing:

```
[44.249Z] Received connected event                             ← operator stream connects
[44.488Z] Received event: Connected
[44.488Z] Failed to send wallet event, no listeners attached   ← StreamConnected lost
[44.584Z] Failed to send wallet event, no listeners attached   ← Synced lost
[44.900Z] Boltz service initialized
[44.905Z] Initialized and started breez sdk.                   ← subscriber attaches, 321ms too late
```


Both `WalletEvent::StreamConnected` and `WalletEvent::Synced` are dropped before the SDK's runtime loop reaches `spark_wallet.subscribe_events()`.

The race has existed since the SDK adopted the deferred-subscribe pattern. The gap between `build_spark_wallet` and `spawn_client_runtime_loop` was usually short enough that the runtime subscribed before the operator stream connected. The cross-chain init adds awaited HTTP work (`api.boltz.exchange/v2/chain/contracts` fetch plus WebSocket handshake) into that gap, pushing the subscription past the ~330ms operator-connect time on consistent network conditions. WASM single-threaded scheduling makes the new timing reproducible session-to-session.

### Fix

Defer the background processor start until after the runtime subscribes.

- `spark-wallet`: extract the spawn into `SparkWallet::start_background_processing(&self, cancellation_token)`. `WalletBuilder` callers using the default `with_background_processing(true)` (spark-itest) are unchanged.
- `breez-sdk-spark`: `build_spark_wallet` passes `.with_background_processing(false)`. `ClientRuntime::start_sdk_services` calls `start_background_processing` immediately after `spawn_client_runtime_loop`, by which point `wallet_events` and `sync_requests` receivers are established. `ServerRuntime` unchanged.
