### PR TITLE
fix: break EventEmitter reference cycles that leaked the SDK object graph per lifecycle

### DIFF
--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -201,9 +201,14 @@ pub struct EventEmitter {
     synced_event_buffer: Mutex<Option<InternalSyncedEvent>>,
 }
 
+/// Handlers registered here are owned by the `EventEmitter` for its whole
+/// lifetime, and the emitter is itself owned by the SDK object graph. To keep
+/// that graph droppable, a handler must not hold a strong reference back to
+/// the `EventEmitter` (directly or via a `BreezSdk` clone); the emitter is
+/// passed into `handle` instead.
 #[macros::async_trait]
 pub(crate) trait RuntimeEventHandler: Send + Sync {
-    async fn handle(&self, event: RuntimeEvent);
+    async fn handle(&self, emitter: &EventEmitter, event: RuntimeEvent);
 }
 
 impl EventEmitter {
@@ -273,6 +278,11 @@ impl EventEmitter {
     /// Add middleware to the event processing chain.
     ///
     /// Middleware can transform or suppress events before they reach external listeners.
+    ///
+    /// Middleware is owned by the emitter for its whole lifetime, so it must
+    /// not hold a strong reference back to the emitter (directly or
+    /// transitively); use `Weak<EventEmitter>` instead, or the SDK object
+    /// graph can never be dropped.
     pub async fn add_middleware(&self, middleware: Box<dyn EventMiddleware>) {
         let mut mw = self.middleware.write().await;
         mw.push(middleware);
@@ -286,7 +296,7 @@ impl EventEmitter {
     pub(crate) async fn emit_runtime_event(&self, event: RuntimeEvent) {
         let handlers = self.runtime_event_handlers.read().await;
         for handler in handlers.iter() {
-            handler.handle(event.clone()).await;
+            handler.handle(self, event.clone()).await;
         }
     }
 

--- a/crates/breez-sdk/core/src/realtime_sync/init.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/init.rs
@@ -30,7 +30,7 @@ pub async fn init_and_start_real_time_sync(
     let synced_storage = Arc::new(SyncedStorage::new(
         Arc::clone(&params.storage),
         Arc::clone(&sync_service),
-        params.event_emitter,
+        &params.event_emitter,
         params.lnurl_server_client,
     ));
 

--- a/crates/breez-sdk/core/src/realtime_sync/storage.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/storage.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     fmt::{Display, Formatter},
     str::FromStr,
-    sync::Arc,
+    sync::{Arc, Weak},
 };
 
 use breez_sdk_common::sync::{
@@ -89,7 +89,10 @@ struct ContactSyncData {
 pub struct SyncedStorage {
     inner: Arc<dyn Storage>,
     sync_service: Arc<SyncService>,
-    event_emitter: Arc<EventEmitter>,
+    /// Weak: the emitter's registered handlers and listeners can reach this
+    /// storage, so a strong back-reference would form a reference cycle that
+    /// leaks the whole SDK object graph.
+    event_emitter: Weak<EventEmitter>,
     lnurl_server_client: Option<Arc<dyn LnurlServerClient>>,
 }
 
@@ -121,17 +124,21 @@ impl NewRecordHandler for SyncedStorage {
             return Ok(());
         }
 
-        self.event_emitter
-            .emit_synced(&InternalSyncedEvent {
-                storage_incoming: incoming_count,
-                ..Default::default()
-            })
-            .await;
+        if let Some(event_emitter) = self.event_emitter.upgrade() {
+            event_emitter
+                .emit_synced(&InternalSyncedEvent {
+                    storage_incoming: incoming_count,
+                    ..Default::default()
+                })
+                .await;
+        }
         Ok(())
     }
 
     async fn on_sync_failed(&self) {
-        self.event_emitter.notify_rtsync_failed().await;
+        if let Some(event_emitter) = self.event_emitter.upgrade() {
+            event_emitter.notify_rtsync_failed().await;
+        }
     }
 }
 
@@ -139,13 +146,13 @@ impl SyncedStorage {
     pub fn new(
         inner: Arc<dyn Storage>,
         sync_service: Arc<SyncService>,
-        event_emitter: Arc<EventEmitter>,
+        event_emitter: &Arc<EventEmitter>,
         lnurl_server_client: Option<Arc<dyn LnurlServerClient>>,
     ) -> Self {
         SyncedStorage {
             inner,
             sync_service,
-            event_emitter,
+            event_emitter: Arc::downgrade(event_emitter),
             lnurl_server_client,
         }
     }
@@ -382,7 +389,7 @@ impl SyncedStorage {
 
         let client = Arc::clone(client);
         let inner = Arc::clone(&self.inner);
-        let event_emitter = Arc::clone(&self.event_emitter);
+        let event_emitter = Weak::clone(&self.event_emitter);
         let span = tracing::Span::current();
 
         tokio::spawn(
@@ -436,7 +443,9 @@ impl SyncedStorage {
                     None
                 };
 
-                if old != new {
+                if old != new
+                    && let Some(event_emitter) = event_emitter.upgrade()
+                {
                     event_emitter
                         .emit(&SdkEvent::LightningAddressChanged {
                             lightning_address: new,
@@ -681,7 +690,7 @@ mod tests {
         );
         let sync_service = Arc::new(SyncService::new(sync_storage));
         let event_emitter = Arc::new(EventEmitter::new(true));
-        SyncedStorage::new(storage, sync_service, event_emitter, None)
+        SyncedStorage::new(storage, sync_service, &event_emitter, None)
     }
 
     fn make_incoming_change(

--- a/crates/breez-sdk/core/src/sdk/runtime/client.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/client.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use platform_utils::time::{Duration, SystemTime};
 use platform_utils::tokio;
-use spark_wallet::{WalletEvent, WalletTransfer};
+use spark_wallet::{SparkWallet, WalletEvent, WalletTransfer};
 use tokio::{
     select,
     sync::{broadcast, watch},
@@ -180,27 +180,32 @@ async fn on_wallet_event(sdk: &BreezSdk, event: Result<WalletEvent, broadcast::e
 
 async fn register_client_runtime_event_handler(sdk: &BreezSdk) {
     sdk.event_emitter
-        .add_runtime_event_handler(Box::new(ClientRuntimeEventHandler { sdk: sdk.clone() }))
+        .add_runtime_event_handler(Box::new(ClientRuntimeEventHandler {
+            sync_coordinator: sdk.sync_coordinator.clone(),
+            spark_wallet: sdk.spark_wallet.clone(),
+            storage: sdk.storage.clone(),
+        }))
         .await;
 }
 
 struct ClientRuntimeEventHandler {
-    sdk: BreezSdk,
+    sync_coordinator: SyncCoordinator,
+    spark_wallet: Arc<SparkWallet>,
+    storage: Arc<dyn crate::Storage>,
 }
 
 #[macros::async_trait]
 impl crate::events::RuntimeEventHandler for ClientRuntimeEventHandler {
-    async fn handle(&self, event: RuntimeEvent) {
+    async fn handle(&self, _emitter: &crate::EventEmitter, event: RuntimeEvent) {
         match event {
             RuntimeEvent::StableBalanceConversionCompleted => {
-                self.sdk
-                    .sync_coordinator
+                self.sync_coordinator
                     .trigger_sync_no_wait(SyncType::Full, true)
                     .await;
             }
             RuntimeEvent::DepositClaimed { .. } => {
                 if let Err(e) =
-                    update_balances(self.sdk.spark_wallet.clone(), self.sdk.storage.clone()).await
+                    update_balances(self.spark_wallet.clone(), self.storage.clone()).await
                 {
                     error!("Failed to refresh balances after claim_deposit: {e:?}");
                 }

--- a/crates/breez-sdk/core/src/sdk/runtime/server.rs
+++ b/crates/breez-sdk/core/src/sdk/runtime/server.rs
@@ -1,7 +1,9 @@
+use std::sync::Arc;
+
 use tokio::sync::watch;
 use tracing::error;
 
-use crate::{GetInfoRequest, GetInfoResponse, error::SdkError};
+use crate::{EventEmitter, GetInfoRequest, GetInfoResponse, Storage, error::SdkError};
 
 use super::{RuntimeEvent, RuntimeProfile};
 use crate::sdk::{BreezSdk, SyncType};
@@ -21,7 +23,9 @@ impl RuntimeProfile for ServerRuntime {
         }
 
         sdk.event_emitter
-            .add_runtime_event_handler(Box::new(ServerRuntimeEventHandler { sdk: sdk.clone() }))
+            .add_runtime_event_handler(Box::new(ServerRuntimeEventHandler {
+                storage: sdk.storage.clone(),
+            }))
             .await;
     }
 
@@ -71,24 +75,19 @@ impl RuntimeProfile for ServerRuntime {
 }
 
 struct ServerRuntimeEventHandler {
-    sdk: BreezSdk,
+    storage: Arc<dyn Storage>,
 }
 
 #[macros::async_trait]
 impl crate::events::RuntimeEventHandler for ServerRuntimeEventHandler {
-    async fn handle(&self, event: RuntimeEvent) {
+    async fn handle(&self, emitter: &EventEmitter, event: RuntimeEvent) {
         match event {
             RuntimeEvent::DepositClaimed {
                 payment,
                 should_emit_event,
             } => {
                 if should_emit_event {
-                    get_payment_and_emit_event(
-                        &self.sdk.storage,
-                        &self.sdk.event_emitter,
-                        *payment,
-                    )
-                    .await;
+                    get_payment_and_emit_event(&self.storage, emitter, *payment).await;
                 }
             }
             RuntimeEvent::StableBalanceConversionCompleted => {}

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -833,7 +833,7 @@ fn build_token_converter(
         flashnet_config,
         Arc::clone(storage),
         Arc::clone(spark_wallet),
-        Arc::clone(event_emitter),
+        event_emitter,
         config.network,
         context.http_client.clone(),
     ))
@@ -1027,6 +1027,112 @@ mod tests {
                 .to_string(),
             passphrase: None,
         }
+    }
+
+    fn unique_storage_dir(name: &str) -> String {
+        std::env::temp_dir()
+            .join(format!("breez-sdk-test-{}-{}", name, uuid::Uuid::new_v4()))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// Waits for the SDK object graph to be released. Background tasks drop
+    /// their `BreezSdk` clones asynchronously after the shutdown signal, so
+    /// poll briefly instead of asserting immediately after `drop`.
+    async fn assert_sdk_graph_freed(
+        event_emitter: std::sync::Weak<crate::EventEmitter>,
+        spark_wallet: std::sync::Weak<spark_wallet::SparkWallet>,
+    ) {
+        for _ in 0..100 {
+            if event_emitter.upgrade().is_none() && spark_wallet.upgrade().is_none() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        panic!(
+            "SDK object graph leaked after drop (EventEmitter alive: {}, SparkWallet alive: {})",
+            event_emitter.upgrade().is_some(),
+            spark_wallet.upgrade().is_some(),
+        );
+    }
+
+    /// Regression test for <https://github.com/breez/spark-sdk/issues/947>:
+    /// each server-mode build → disconnect → drop lifecycle must release the
+    /// whole per-instance object graph.
+    #[tokio::test]
+    async fn server_mode_sdk_graph_is_freed_on_drop() {
+        use crate::default_server_config;
+
+        let config = default_server_config(Network::Regtest);
+        let sdk = SdkBuilder::new(config, test_seed())
+            .with_default_storage(unique_storage_dir("leak-server"))
+            .build()
+            .await
+            .expect("server-mode build should succeed");
+
+        let event_emitter = std::sync::Arc::downgrade(&sdk.event_emitter);
+        let spark_wallet = std::sync::Arc::downgrade(&sdk.spark_wallet);
+
+        sdk.disconnect().await.expect("disconnect should succeed");
+        drop(sdk);
+
+        assert_sdk_graph_freed(event_emitter, spark_wallet).await;
+    }
+
+    /// Network-dependent variant of `server_mode_sdk_graph_is_freed_on_drop`
+    /// that runs a real `sync_wallet` against the regtest operators before
+    /// dropping, proving the sync path retains nothing either.
+    #[tokio::test]
+    #[ignore = "requires network access to the regtest operators"]
+    async fn server_mode_sdk_graph_is_freed_on_drop_after_sync() {
+        use crate::{SyncWalletRequest, default_server_config};
+
+        let config = default_server_config(Network::Regtest);
+        let sdk = SdkBuilder::new(config, test_seed())
+            .with_default_storage(unique_storage_dir("leak-server-sync"))
+            .build()
+            .await
+            .expect("server-mode build should succeed");
+
+        let event_emitter = std::sync::Arc::downgrade(&sdk.event_emitter);
+        let spark_wallet = std::sync::Arc::downgrade(&sdk.spark_wallet);
+
+        sdk.sync_wallet(SyncWalletRequest {})
+            .await
+            .expect("sync_wallet should succeed");
+
+        sdk.disconnect().await.expect("disconnect should succeed");
+        drop(sdk);
+
+        assert_sdk_graph_freed(event_emitter, spark_wallet).await;
+    }
+
+    /// Client-mode counterpart of the issue #947 regression test: after
+    /// `disconnect`, dropping the SDK must release the whole object graph.
+    #[tokio::test]
+    async fn client_mode_sdk_graph_is_freed_after_disconnect_and_drop() {
+        let mut config = default_config(Network::Regtest);
+        // Keep the build offline: no real-time sync connection and no
+        // network-backed private-mode setup on startup.
+        config.real_time_sync_server_url = None;
+        config.private_enabled_default = false;
+
+        let sdk = SdkBuilder::new(config, test_seed())
+            .with_default_storage(unique_storage_dir("leak-client"))
+            .build()
+            .await
+            .expect("client-mode build should succeed");
+
+        let event_emitter = std::sync::Arc::downgrade(&sdk.event_emitter);
+        let spark_wallet = std::sync::Arc::downgrade(&sdk.spark_wallet);
+
+        tokio::time::timeout(std::time::Duration::from_secs(30), sdk.disconnect())
+            .await
+            .expect("disconnect should not hang")
+            .expect("disconnect should succeed");
+        drop(sdk);
+
+        assert_sdk_graph_freed(event_emitter, spark_wallet).await;
     }
 
     fn test_spark_signer() -> std::sync::Arc<crate::signer::spark::SparkSigner> {

--- a/crates/breez-sdk/core/src/stable_balance/mod.rs
+++ b/crates/breez-sdk/core/src/stable_balance/mod.rs
@@ -132,8 +132,8 @@
 mod conversions;
 mod queue;
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Weak};
 
 use platform_utils::tokio;
 use spark_wallet::{SparkWallet, TransferId};
@@ -227,7 +227,10 @@ pub(crate) struct StableBalance {
     pub(super) synced_notify: Arc<Notify>,
 
     /// Event emitter used to publish conversion outcomes to the active runtime.
-    pub(super) event_emitter: Arc<EventEmitter>,
+    /// Weak: this struct is registered as middleware on the emitter, so a
+    /// strong back-reference would form a reference cycle that leaks the
+    /// whole SDK object graph.
+    pub(super) event_emitter: Weak<EventEmitter>,
 
     /// Number of in-flight send-with-conversion payments.
     /// Auto-convert is suppressed while this is > 0.
@@ -271,7 +274,7 @@ impl StableBalance {
             token_converter,
             spark_wallet,
             storage,
-            event_emitter: Arc::clone(&event_emitter),
+            event_emitter: Arc::downgrade(&event_emitter),
             effective_values: Arc::new(ExpiringCell::new()),
             queue,
             synced_notify,
@@ -574,9 +577,11 @@ impl StableBalance {
 
     /// Emits the fact that a conversion changed balances and payments.
     pub(super) async fn emit_conversion_completed(&self) {
-        self.event_emitter
-            .emit_runtime_event(RuntimeEvent::StableBalanceConversionCompleted)
-            .await;
+        if let Some(event_emitter) = self.event_emitter.upgrade() {
+            event_emitter
+                .emit_runtime_event(RuntimeEvent::StableBalanceConversionCompleted)
+                .await;
+        }
     }
 }
 

--- a/crates/breez-sdk/core/src/token_conversion/flashnet.rs
+++ b/crates/breez-sdk/core/src/token_conversion/flashnet.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    sync::{Arc, Weak},
+    time::Duration,
+};
 
 use bitcoin::secp256k1::PublicKey;
 use flashnet::{
@@ -44,7 +49,10 @@ pub(crate) struct FlashnetTokenConverter {
     flashnet_client: Arc<FlashnetClient>,
     storage: Arc<dyn Storage>,
     spark_wallet: Arc<SparkWallet>,
-    event_emitter: Arc<EventEmitter>,
+    /// Weak: this converter is reachable from the emitter (the
+    /// `StableBalance` middleware holds it), so a strong back-reference
+    /// would form a reference cycle that leaks the whole SDK object graph.
+    event_emitter: Weak<EventEmitter>,
     network: Network,
     refund_trigger: broadcast::Sender<()>,
     integrator_fee_bps: u32,
@@ -63,7 +71,7 @@ impl FlashnetTokenConverter {
         flashnet_config: FlashnetConfig,
         storage: Arc<dyn Storage>,
         spark_wallet: Arc<SparkWallet>,
-        event_emitter: Arc<EventEmitter>,
+        event_emitter: &Arc<EventEmitter>,
         network: Network,
         http_client: Arc<dyn platform_utils::HttpClient>,
     ) -> Self {
@@ -85,7 +93,7 @@ impl FlashnetTokenConverter {
             flashnet_client,
             storage,
             spark_wallet,
-            event_emitter,
+            event_emitter: Arc::downgrade(event_emitter),
             network,
             refund_trigger,
             integrator_fee_bps,
@@ -636,6 +644,13 @@ impl FlashnetTokenConverter {
         sent_payment_id: &str,
         received_payment_id: &str,
     ) {
+        // The emitter is gone only when the SDK is being torn down; the next
+        // sync rebuilds both conversion legs from the operators.
+        let Some(event_emitter) = self.event_emitter.upgrade() else {
+            debug!("Skipping conversion payment processing: SDK is shutting down");
+            return;
+        };
+
         // Sent leg: we just produced this transfer ourselves, so the local
         // spark/token wallet state is already current — no claim needed.
         // Build the Payment directly and insert it even if the operator-side
@@ -648,7 +663,7 @@ impl FlashnetTokenConverter {
             insert_payment_with_metadata(
                 self.spark_wallet.clone(),
                 self.storage.clone(),
-                self.event_emitter.clone(),
+                event_emitter.clone(),
                 payment,
             )
             .await;
@@ -662,7 +677,7 @@ impl FlashnetTokenConverter {
             insert_payment_with_metadata(
                 self.spark_wallet.clone(),
                 self.storage.clone(),
-                self.event_emitter.clone(),
+                event_emitter,
                 payment,
             )
             .await;


### PR DESCRIPTION
Fixes #947

## Problem

Every `build()` registers a `RuntimeEventHandler` holding a full `BreezSdk` clone into the per-instance `EventEmitter`. Since `BreezSdk` owns the emitter via `Arc<EventEmitter>`, the emitter transitively owned itself: a reference cycle that kept the entire per-instance object graph (`SparkWallet`, storage wrapper, channels, the `InMemoryTreeStore` processor task) alive after `disconnect()` and drop. In server mode this leaks once per build/sync/disconnect/close cycle, growing RSS linearly until OOM, exactly as reported.

Three sibling cycles existed in client mode through the same registries:

- `StableBalance` is registered as middleware and held `Arc<EventEmitter>` directly.
- That middleware clone also holds `FlashnetTokenConverter`, which held another `Arc<EventEmitter>`.
- With real-time sync enabled, `SyncedStorage` held `Arc<EventEmitter>` while being reachable from the emitter via the handlers.

## Fix

Break the cycles structurally so plain drop releases the graph (no reliance on `disconnect()` being called):

- `RuntimeEventHandler::handle` now receives `&EventEmitter` from the emitter itself, and the server/client handlers store only the components they use (`storage` / `sync_coordinator` + `spark_wallet` + `storage`) instead of a `BreezSdk` clone.
- `SyncedStorage`, `StableBalance` and `FlashnetTokenConverter` now hold `Weak<EventEmitter>` with upgrade-or-skip at their emit sites (an upgrade only fails during teardown, when there is no listener left to notify).
- Invariant documented on the trait and on `add_middleware`: nothing reachable from the emitter's registries may strongly hold the emitter.

Once the graph drops, the `InMemoryTreeStore` command sender drops with it, so its processor task exits: the per-lifecycle task leak from the issue resolves automatically.

## Evidence

Regression tests (`sdk_builder.rs`) assert via `Weak` pointers that the `EventEmitter` and `SparkWallet` are released after disconnect + drop. They fail on `main` with `SDK object graph leaked after drop (EventEmitter alive: true, SparkWallet alive: true)` and pass with this change, in server mode, client mode, and (ignored, network-dependent) server mode after a real `sync_wallet`.

A manual reproduction harness ([attached as a PR comment](https://github.com/breez/spark-sdk/pull/950#issuecomment-4689423247)) runs the reported lifecycle (shared `SdkContext` + short-lived server-mode SDK per operation) in a loop, sampling RSS and live tokio task count:

| Run | RSS | Tokio tasks |
|---|---|---|
| `main`, 300 lifecycles | linear growth, ~115 KB per lifecycle (27.8 MB at iter 50 to 56.8 MB at iter 300), no plateau | +1 leaked task per lifecycle (304 at iter 300) |
| This branch, 300 lifecycles | flat after warmup (~25.4 MB) | constant (4) |
| This branch, 2000-lifecycle soak | byte-identical 24,432 KB across the final 230+ samples | constant (4) |
| This branch, MySQL shared backend + rotating tenant identities, 300 lifecycles | flat (28.7 MB constant) | constant (5) |
| This branch, 40 lifecycles each running a real `sync_wallet` | oscillates 78 to 91 MB with dips (memory returned), no monotone growth | constant (13) |

The pre-fix numbers match the issue report: RSS grows linearly with wallet lifecycle count while everything else stays flat.

`make check` is green (fmt, clippy cargo + WASM, full workspace tests). All changed types are crate-internal, so no binding interface updates are needed.

