### PR TITLE
fix: unregister event listeners on disconnect

### DIFF
--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -252,6 +252,16 @@ impl EventEmitter {
         listeners.remove(id).is_some()
     }
 
+    /// Remove all external listeners.
+    ///
+    /// Listeners are owned by the emitter, so a listener that references the
+    /// SDK pins the whole instance; dropping them here on disconnect makes
+    /// the instance releasable regardless of what listeners capture.
+    pub async fn clear_external_listeners(&self) {
+        let mut listeners = self.external_listeners.write().await;
+        listeners.clear();
+    }
+
     /// Add an internal listener that sees all raw events before middleware processing.
     ///
     /// Used by SDK components (e.g., `ClientSyncListener`) that need to observe events
@@ -499,6 +509,36 @@ mod tests {
 
         // Try to remove a non-existent listener
         assert!(!emitter.remove_external_listener("non-existent-id").await);
+    }
+
+    #[async_test_all]
+    async fn test_clear_external_listeners() {
+        let emitter = EventEmitter::new(false);
+
+        let received1 = Arc::new(AtomicBool::new(false));
+        let received2 = Arc::new(AtomicBool::new(false));
+
+        let id1 = emitter
+            .add_external_listener(Box::new(TestListener {
+                received: received1.clone(),
+            }))
+            .await;
+        let id2 = emitter
+            .add_external_listener(Box::new(TestListener {
+                received: received2.clone(),
+            }))
+            .await;
+
+        emitter.clear_external_listeners().await;
+
+        emitter.emit(&SdkEvent::Synced).await;
+
+        assert!(!received1.load(Ordering::Relaxed));
+        assert!(!received2.load(Ordering::Relaxed));
+
+        // Already cleared, so individual removal finds nothing
+        assert!(!emitter.remove_external_listener(&id1).await);
+        assert!(!emitter.remove_external_listener(&id2).await);
     }
 
     #[async_test_all]

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -27,6 +27,11 @@ use super::{BreezSdk, helpers::get_deposit_address, parse_input};
 impl BreezSdk {
     /// Registers a listener to receive SDK events
     ///
+    /// The SDK holds the listener until it is removed with
+    /// `remove_event_listener` or until `disconnect` unregisters all
+    /// listeners. A held listener that references the SDK instance keeps
+    /// that instance alive.
+    ///
     /// # Arguments
     ///
     /// * `listener` - An implementation of the `EventListener` trait
@@ -56,11 +61,15 @@ impl BreezSdk {
     /// This method stops the background tasks started by the `start()` method.
     /// It should be called before your application terminates to ensure proper cleanup.
     ///
+    /// It also unregisters all event listeners, so listeners that reference
+    /// the SDK no longer keep it alive after this call.
+    ///
     /// # Returns
     ///
     /// Result containing either success or an `SdkError` if the background task couldn't be stopped
     pub async fn disconnect(&self) -> Result<(), SdkError> {
         info!("Disconnecting Breez SDK");
+        self.event_emitter.clear_external_listeners().await;
         if self.shutdown_sender.send(()).is_err() {
             // A `watch::Sender::send` error means every receiver has been
             // dropped, i.e. no background task is listening. This is the

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -1029,6 +1029,42 @@ mod tests {
         }
     }
 
+    /// `disconnect` must unregister event listeners, so a listener that
+    /// references the SDK instance cannot keep it alive afterwards.
+    #[tokio::test]
+    async fn disconnect_unregisters_event_listeners() {
+        use crate::{SdkEvent, default_server_config, events::EventListener};
+
+        struct NoopListener;
+
+        #[macros::async_trait]
+        impl EventListener for NoopListener {
+            async fn on_event(&self, _event: SdkEvent) {}
+        }
+
+        let storage_dir = std::env::temp_dir()
+            .join(format!(
+                "breez-sdk-test-listener-clear-{}",
+                uuid::Uuid::new_v4()
+            ))
+            .to_string_lossy()
+            .into_owned();
+        let sdk = SdkBuilder::new(default_server_config(Network::Regtest), test_seed())
+            .with_default_storage(storage_dir)
+            .build()
+            .await
+            .expect("server-mode build should succeed");
+
+        let id = sdk.add_event_listener(Box::new(NoopListener)).await;
+
+        sdk.disconnect().await.expect("disconnect should succeed");
+
+        assert!(
+            !sdk.remove_event_listener(&id).await,
+            "listener should already be unregistered by disconnect"
+        );
+    }
+
     fn test_spark_signer() -> std::sync::Arc<crate::signer::spark::SparkSigner> {
         use crate::KeySetType;
         use crate::signer::breez::BreezSignerImpl;


### PR DESCRIPTION
Follow-up to the listener-lifecycle discussion on #950 (not a blocker for it; this is independent and based on main).

## Problem

A registered `EventListener` is held by the SDK until removed. A listener that references the SDK instance therefore pins the whole instance: the SDK holds the listener, and the listener holds the SDK back. In the bindings, garbage collection alone can never reclaim this, because the foreign listener object is rooted on the Rust side for callback dispatch. Teardown required either `remove_event_listener` for every listener or an explicit `close()`/`destroy()`.

## Fix

`disconnect()` now unregisters all external event listeners (before the server-mode early return, which previously skipped any cleanup). After `disconnect`, the SDK holds no references to application objects, so listeners that capture the SDK no longer keep it alive and the instance is always releasable.

Docs updated on `add_event_listener` (listener is held until removed or until `disconnect`) and `disconnect` (also unregisters listeners).

## Tests

- `events::tests::test_clear_external_listeners`: cleared listeners receive no further events and are no longer individually removable.
- `sdk_builder::tests::disconnect_unregisters_event_listeners`: end-to-end via the public API; after `disconnect`, `remove_event_listener` reports the listener already gone.