### PR TITLE
refactor: make EventEmitter references top-down, remove Weak back-references

### DIFF
--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -290,9 +290,10 @@ impl EventEmitter {
     /// Middleware can transform or suppress events before they reach external listeners.
     ///
     /// Middleware is owned by the emitter for its whole lifetime, so it must
-    /// not hold a strong reference back to the emitter (directly or
-    /// transitively); use `Weak<EventEmitter>` instead, or the SDK object
-    /// graph can never be dropped.
+    /// not hold a reference back to the emitter (directly or transitively),
+    /// or the SDK object graph can never be dropped. Code that needs to emit
+    /// must receive the emitter from its caller instead (see
+    /// `RuntimeEventHandler` and `TokenConverter::convert`).
     pub async fn add_middleware(&self, middleware: Box<dyn EventMiddleware>) {
         let mut mw = self.middleware.write().await;
         mw.push(middleware);

--- a/crates/breez-sdk/core/src/realtime_sync/init.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/init.rs
@@ -5,8 +5,12 @@ use tracing::debug;
 use uuid::Uuid;
 
 use crate::{
-    EventEmitter, error::SdkError, lnurl::LnurlServerClient, persist::Storage,
-    realtime_sync::SyncedStorage, sync_storage::SyncStorageWrapper,
+    EventEmitter,
+    error::SdkError,
+    lnurl::LnurlServerClient,
+    persist::Storage,
+    realtime_sync::{SyncedRecordHandler, SyncedStorage},
+    sync_storage::SyncStorageWrapper,
 };
 
 pub struct RealTimeSyncParams {
@@ -30,12 +34,18 @@ pub async fn init_and_start_real_time_sync(
     let synced_storage = Arc::new(SyncedStorage::new(
         Arc::clone(&params.storage),
         Arc::clone(&sync_service),
-        &params.event_emitter,
-        params.lnurl_server_client,
     ));
 
     synced_storage.initial_setup();
-    let storage: Arc<dyn Storage> = synced_storage.clone();
+    let storage: Arc<dyn Storage> = synced_storage;
+
+    // The handler writes to the raw inner storage so applied records are not
+    // echoed back into the outgoing sync queue.
+    let record_handler = Arc::new(SyncedRecordHandler::new(
+        Arc::clone(&params.storage),
+        params.event_emitter,
+        params.lnurl_server_client,
+    ));
     let sync_client: Arc<dyn breez_sdk_common::sync::SyncerClient> = Arc::new(
         BreezSyncerClient::new(
             &params.server_url,
@@ -54,7 +64,7 @@ pub async fn init_and_start_real_time_sync(
     let sync_processor = Arc::new(SyncProcessor::new(
         signing_client.clone(),
         sync_service.get_sync_trigger(),
-        synced_storage,
+        record_handler,
         Arc::clone(&sync_storage),
     ));
 

--- a/crates/breez-sdk/core/src/realtime_sync/storage.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/storage.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     fmt::{Display, Formatter},
     str::FromStr,
-    sync::{Arc, Weak},
+    sync::Arc,
 };
 
 use breez_sdk_common::sync::{
@@ -86,18 +86,31 @@ struct ContactSyncData {
     pub deleted_at: Option<u64>,
 }
 
+/// Storage wrapper that mirrors local writes into the real-time sync queue.
+///
+/// This is `sdk.storage`, which is reachable from the `EventEmitter` (handlers
+/// and listeners registered on the emitter hold it), so it must not reference
+/// the emitter or the SDK graph could never be dropped. Event emission for
+/// sync outcomes lives in [`SyncedRecordHandler`] instead.
 pub struct SyncedStorage {
     inner: Arc<dyn Storage>,
     sync_service: Arc<SyncService>,
-    /// Weak: the emitter's registered handlers and listeners can reach this
-    /// storage, so a strong back-reference would form a reference cycle that
-    /// leaks the whole SDK object graph.
-    event_emitter: Weak<EventEmitter>,
+}
+
+/// Applies incoming and replayed sync records to local storage and reports
+/// sync outcomes on the event emitter.
+///
+/// Owned by the `SyncProcessor`, whose tasks stop on the shutdown signal, so
+/// the strong emitter reference is released on `disconnect()` and cannot form
+/// a cycle (the emitter never owns the processor).
+pub struct SyncedRecordHandler {
+    storage: Arc<dyn Storage>,
+    event_emitter: Arc<EventEmitter>,
     lnurl_server_client: Option<Arc<dyn LnurlServerClient>>,
 }
 
 #[macros::async_trait]
-impl NewRecordHandler for SyncedStorage {
+impl NewRecordHandler for SyncedRecordHandler {
     async fn on_incoming_change(
         &self,
         change: CommonIncomingChange,
@@ -124,36 +137,25 @@ impl NewRecordHandler for SyncedStorage {
             return Ok(());
         }
 
-        if let Some(event_emitter) = self.event_emitter.upgrade() {
-            event_emitter
-                .emit_synced(&InternalSyncedEvent {
-                    storage_incoming: incoming_count,
-                    ..Default::default()
-                })
-                .await;
-        }
+        self.event_emitter
+            .emit_synced(&InternalSyncedEvent {
+                storage_incoming: incoming_count,
+                ..Default::default()
+            })
+            .await;
         Ok(())
     }
 
     async fn on_sync_failed(&self) {
-        if let Some(event_emitter) = self.event_emitter.upgrade() {
-            event_emitter.notify_rtsync_failed().await;
-        }
+        self.event_emitter.notify_rtsync_failed().await;
     }
 }
 
 impl SyncedStorage {
-    pub fn new(
-        inner: Arc<dyn Storage>,
-        sync_service: Arc<SyncService>,
-        event_emitter: &Arc<EventEmitter>,
-        lnurl_server_client: Option<Arc<dyn LnurlServerClient>>,
-    ) -> Self {
+    pub fn new(inner: Arc<dyn Storage>, sync_service: Arc<SyncService>) -> Self {
         SyncedStorage {
             inner,
             sync_service,
-            event_emitter: Arc::downgrade(event_emitter),
-            lnurl_server_client,
         }
     }
 
@@ -238,6 +240,37 @@ impl SyncedStorage {
         self.set_cached_item(INITIAL_SYNC_CACHE_KEY.to_string(), "true".to_string())
             .await?;
         Ok(())
+    }
+
+    async fn push_lightning_address_sync(&self) {
+        if let Err(e) = self
+            .sync_service
+            .set_outgoing_record(&RecordChangeRequest {
+                id: RecordId::new(
+                    RecordType::LightningAddress.to_string(),
+                    LIGHTNING_ADDRESS_DATA_ID,
+                ),
+                schema_version: RecordType::LightningAddress.schema_version(),
+                updated_fields: HashMap::new(),
+            })
+            .await
+        {
+            error!("Failed to push lightning address sync signal: {e:?}");
+        }
+    }
+}
+
+impl SyncedRecordHandler {
+    pub fn new(
+        storage: Arc<dyn Storage>,
+        event_emitter: Arc<EventEmitter>,
+        lnurl_server_client: Option<Arc<dyn LnurlServerClient>>,
+    ) -> Self {
+        SyncedRecordHandler {
+            storage,
+            event_emitter,
+            lnurl_server_client,
+        }
     }
 
     async fn handle_incoming_change(
@@ -330,7 +363,7 @@ impl SyncedStorage {
         )
         .map_err(|e| StorageError::Serialization(e.to_string()))?;
 
-        self.inner
+        self.storage
             .insert_payment_metadata(data_id, metadata)
             .await?;
         Ok(())
@@ -343,7 +376,7 @@ impl SyncedStorage {
     ) -> anyhow::Result<()> {
         if fields.contains_key(DELETED_AT_FIELD) {
             // Ignore not-found errors when deleting
-            let _ = self.inner.delete_contact(data_id).await;
+            let _ = self.storage.delete_contact(data_id).await;
             return Ok(());
         }
 
@@ -360,26 +393,9 @@ impl SyncedStorage {
             created_at: sync_data.created_at,
             updated_at: sync_data.updated_at,
         };
-        self.inner.insert_contact(contact).await?;
+        self.storage.insert_contact(contact).await?;
 
         Ok(())
-    }
-
-    async fn push_lightning_address_sync(&self) {
-        if let Err(e) = self
-            .sync_service
-            .set_outgoing_record(&RecordChangeRequest {
-                id: RecordId::new(
-                    RecordType::LightningAddress.to_string(),
-                    LIGHTNING_ADDRESS_DATA_ID,
-                ),
-                schema_version: RecordType::LightningAddress.schema_version(),
-                updated_fields: HashMap::new(),
-            })
-            .await
-        {
-            error!("Failed to push lightning address sync signal: {e:?}");
-        }
     }
 
     fn handle_lightning_address_change(&self) -> RecordOutcome {
@@ -388,13 +404,13 @@ impl SyncedStorage {
         };
 
         let client = Arc::clone(client);
-        let inner = Arc::clone(&self.inner);
-        let event_emitter = Weak::clone(&self.event_emitter);
+        let storage = Arc::clone(&self.storage);
+        let event_emitter = Arc::clone(&self.event_emitter);
         let span = tracing::Span::current();
 
         tokio::spawn(
             async move {
-                let cache = ObjectCacheRepository::new(Arc::clone(&inner));
+                let cache = ObjectCacheRepository::new(Arc::clone(&storage));
                 let old = cache
                     .fetch_lightning_address()
                     .await
@@ -406,7 +422,7 @@ impl SyncedStorage {
                     Ok(resp) => resp,
                     Err(e) => {
                         warn!("Failed to recover lightning address after sync trigger: {e:?}");
-                        if let Err(e) = inner
+                        if let Err(e) = storage
                             .delete_cached_item(LIGHTNING_ADDRESS_KEY.to_string())
                             .await
                         {
@@ -420,7 +436,7 @@ impl SyncedStorage {
                     let address_info = resp.into();
                     if let Err(e) = cache.save_lightning_address(&address_info, true).await {
                         error!("Failed to save recovered lightning address: {e:?}");
-                        if let Err(e) = inner
+                        if let Err(e) = storage
                             .delete_cached_item(LIGHTNING_ADDRESS_KEY.to_string())
                             .await
                         {
@@ -432,7 +448,7 @@ impl SyncedStorage {
                 } else {
                     if let Err(e) = cache.delete_lightning_address(true).await {
                         error!("Failed to delete lightning address from cache: {e:?}");
-                        if let Err(e) = inner
+                        if let Err(e) = storage
                             .delete_cached_item(LIGHTNING_ADDRESS_KEY.to_string())
                             .await
                         {
@@ -443,9 +459,7 @@ impl SyncedStorage {
                     None
                 };
 
-                if old != new
-                    && let Some(event_emitter) = event_emitter.upgrade()
-                {
+                if old != new {
                     event_emitter
                         .emit(&SdkEvent::LightningAddressChanged {
                             lightning_address: new,
@@ -689,8 +703,12 @@ mod tests {
             crate::sync_storage::SyncStorageWrapper::new(Arc::clone(&storage)),
         );
         let sync_service = Arc::new(SyncService::new(sync_storage));
+        SyncedStorage::new(storage, sync_service)
+    }
+
+    fn create_test_record_handler(storage: Arc<dyn Storage>) -> SyncedRecordHandler {
         let event_emitter = Arc::new(EventEmitter::new(true));
-        SyncedStorage::new(storage, sync_service, &event_emitter, None)
+        SyncedRecordHandler::new(storage, event_emitter, None)
     }
 
     fn make_incoming_change(
@@ -758,7 +776,7 @@ mod tests {
     async fn test_incoming_unknown_type_newer_schema() {
         let temp_dir = create_temp_dir("incoming_unknown_newer");
         let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&temp_dir).unwrap());
-        let synced = create_test_synced_storage(Arc::clone(&storage));
+        let handler = create_test_record_handler(Arc::clone(&storage));
 
         let change = make_incoming_change(
             "FutureType",
@@ -766,7 +784,7 @@ mod tests {
             SchemaVersion::new(99, 0, 0),
             HashMap::new(),
         );
-        let result = synced.handle_incoming_change(change).await;
+        let result = handler.handle_incoming_change(change).await;
         assert!(result.is_ok());
 
         // Verify no payment was created as a side effect
@@ -777,7 +795,7 @@ mod tests {
     async fn test_incoming_unknown_type_compatible_schema() {
         let temp_dir = create_temp_dir("incoming_unknown_compat");
         let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&temp_dir).unwrap());
-        let synced = create_test_synced_storage(Arc::clone(&storage));
+        let handler = create_test_record_handler(Arc::clone(&storage));
 
         let change = make_incoming_change(
             "UnknownType",
@@ -785,7 +803,7 @@ mod tests {
             SchemaVersion::new(1, 0, 0),
             HashMap::new(),
         );
-        let result = synced.handle_incoming_change(change).await;
+        let result = handler.handle_incoming_change(change).await;
         assert!(result.is_ok());
 
         // Verify no payment metadata was written
@@ -796,7 +814,7 @@ mod tests {
     async fn test_incoming_known_type_newer_major_version() {
         let temp_dir = create_temp_dir("incoming_known_newer_major");
         let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&temp_dir).unwrap());
-        let synced = create_test_synced_storage(Arc::clone(&storage));
+        let handler = create_test_record_handler(Arc::clone(&storage));
 
         // Insert a payment so we can verify metadata was NOT written
         storage
@@ -816,7 +834,7 @@ mod tests {
             SchemaVersion::new(pm_version.major + 1, 0, 0),
             data,
         );
-        let result = synced.handle_incoming_change(change).await;
+        let result = handler.handle_incoming_change(change).await;
         assert!(result.is_ok());
 
         // Verify metadata was NOT applied despite known type (newer major version)
@@ -835,7 +853,7 @@ mod tests {
     async fn test_incoming_known_type_newer_minor_version_applied() {
         let temp_dir = create_temp_dir("incoming_known_newer_minor");
         let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&temp_dir).unwrap());
-        let synced = create_test_synced_storage(Arc::clone(&storage));
+        let handler = create_test_record_handler(Arc::clone(&storage));
 
         storage
             .apply_payment_update(make_test_lightning_payment("pay1"))
@@ -854,7 +872,7 @@ mod tests {
             SchemaVersion::new(pm_version.major, pm_version.minor + 1, 0),
             data,
         );
-        let result = synced.handle_incoming_change(change).await;
+        let result = handler.handle_incoming_change(change).await;
         assert!(result.is_ok());
 
         // Verify metadata WAS applied (compatible minor version bump)
@@ -873,7 +891,7 @@ mod tests {
     async fn test_outgoing_unknown_type_newer_schema() {
         let temp_dir = create_temp_dir("outgoing_unknown_newer");
         let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&temp_dir).unwrap());
-        let synced = create_test_synced_storage(Arc::clone(&storage));
+        let handler = create_test_record_handler(Arc::clone(&storage));
 
         let change = make_outgoing_change(
             "FutureType",
@@ -881,7 +899,7 @@ mod tests {
             SchemaVersion::new(99, 0, 0),
             HashMap::new(),
         );
-        let result = synced.handle_outgoing_change(change).await;
+        let result = handler.handle_outgoing_change(change).await;
         assert!(result.is_ok());
 
         // Verify no payment metadata side effect
@@ -892,7 +910,7 @@ mod tests {
     async fn test_outgoing_unknown_type_compatible_schema() {
         let temp_dir = create_temp_dir("outgoing_unknown_compat");
         let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&temp_dir).unwrap());
-        let synced = create_test_synced_storage(Arc::clone(&storage));
+        let handler = create_test_record_handler(Arc::clone(&storage));
 
         let change = make_outgoing_change(
             "UnknownType",
@@ -900,7 +918,7 @@ mod tests {
             SchemaVersion::new(1, 0, 0),
             HashMap::new(),
         );
-        let result = synced.handle_outgoing_change(change).await;
+        let result = handler.handle_outgoing_change(change).await;
         assert!(result.is_ok());
 
         // Verify no payment metadata side effect
@@ -924,12 +942,12 @@ mod tests {
     async fn test_incoming_contact_without_deleted_at_upserts() {
         let temp_dir = create_temp_dir("incoming_contact_upsert");
         let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&temp_dir).unwrap());
-        let synced = create_test_synced_storage(Arc::clone(&storage));
+        let handler = create_test_record_handler(Arc::clone(&storage));
 
         let data = make_contact_data("Alice", "alice@example.com");
         let change =
             make_incoming_change("Contact", "c1", RecordType::Contact.schema_version(), data);
-        let result = synced.handle_incoming_change(change).await;
+        let result = handler.handle_incoming_change(change).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), RecordOutcome::Completed);
 
@@ -942,7 +960,7 @@ mod tests {
     async fn test_incoming_contact_with_deleted_at_deletes() {
         let temp_dir = create_temp_dir("incoming_contact_delete");
         let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&temp_dir).unwrap());
-        let synced = create_test_synced_storage(Arc::clone(&storage));
+        let handler = create_test_record_handler(Arc::clone(&storage));
 
         // First insert a contact
         storage
@@ -961,7 +979,7 @@ mod tests {
         data.insert("deleted_at".to_string(), serde_json::json!(2000));
         let change =
             make_incoming_change("Contact", "c1", RecordType::Contact.schema_version(), data);
-        let result = synced.handle_incoming_change(change).await;
+        let result = handler.handle_incoming_change(change).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), RecordOutcome::Completed);
 
@@ -972,12 +990,12 @@ mod tests {
     async fn test_outgoing_replay_contact_without_deleted_at_upserts() {
         let temp_dir = create_temp_dir("outgoing_contact_upsert");
         let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&temp_dir).unwrap());
-        let synced = create_test_synced_storage(Arc::clone(&storage));
+        let handler = create_test_record_handler(Arc::clone(&storage));
 
         let data = make_contact_data("Bob", "bob@example.com");
         let change =
             make_outgoing_change("Contact", "c2", RecordType::Contact.schema_version(), data);
-        let result = synced.handle_outgoing_change(change).await;
+        let result = handler.handle_outgoing_change(change).await;
         assert!(result.is_ok());
 
         let contact = storage.get_contact("c2".to_string()).await.unwrap();
@@ -988,7 +1006,7 @@ mod tests {
     async fn test_outgoing_replay_contact_with_deleted_at_deletes() {
         let temp_dir = create_temp_dir("outgoing_contact_delete");
         let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&temp_dir).unwrap());
-        let synced = create_test_synced_storage(Arc::clone(&storage));
+        let handler = create_test_record_handler(Arc::clone(&storage));
 
         // First insert a contact
         storage
@@ -1007,7 +1025,7 @@ mod tests {
         data.insert("deleted_at".to_string(), serde_json::json!(2000));
         let change =
             make_outgoing_change("Contact", "c3", RecordType::Contact.schema_version(), data);
-        let result = synced.handle_outgoing_change(change).await;
+        let result = handler.handle_outgoing_change(change).await;
         assert!(result.is_ok());
 
         assert!(storage.get_contact("c3".to_string()).await.is_err());

--- a/crates/breez-sdk/core/src/sdk/payments/send/bitcoin_address.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/send/bitcoin_address.rs
@@ -111,6 +111,7 @@ pub(in crate::sdk::payments) async fn convert_token(
     let response = sdk
         .token_converter
         .convert(
+            sdk.event_emitter.clone(),
             conversion_options,
             &purpose,
             token_identifier,

--- a/crates/breez-sdk/core/src/sdk/payments/send/bolt11.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/send/bolt11.rs
@@ -320,6 +320,7 @@ pub(in crate::sdk::payments) async fn convert_token(
     let response = sdk
         .token_converter
         .convert(
+            sdk.event_emitter.clone(),
             conversion_options,
             &purpose,
             token_identifier,

--- a/crates/breez-sdk/core/src/sdk/payments/send/spark_address.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/send/spark_address.rs
@@ -151,6 +151,7 @@ pub(in crate::sdk::payments) async fn convert_token(
     let response = sdk
         .token_converter
         .convert(
+            sdk.event_emitter.clone(),
             conversion_options,
             &purpose,
             token_identifier,

--- a/crates/breez-sdk/core/src/sdk/payments/send/spark_invoice.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/send/spark_invoice.rs
@@ -63,6 +63,7 @@ pub(in crate::sdk::payments) async fn convert_token(
     let response = sdk
         .token_converter
         .convert(
+            sdk.event_emitter.clone(),
             conversion_options,
             &purpose,
             token_identifier,

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -451,13 +451,8 @@ impl SdkBuilder {
         .await?;
 
         let buy_bitcoin_provider = Arc::new(MoonpayProvider::new(context.breez_server.clone()));
-        let token_converter = build_token_converter(
-            &self.config,
-            &storage,
-            &spark_wallet,
-            &event_emitter,
-            &context,
-        );
+        let token_converter =
+            build_token_converter(&self.config, &storage, &spark_wallet, &context);
 
         let sync_coordinator = SyncCoordinator::new();
         let stable_balance = build_stable_balance(
@@ -816,7 +811,6 @@ fn build_token_converter(
     config: &Config,
     storage: &Arc<dyn crate::persist::Storage>,
     spark_wallet: &Arc<SparkWallet>,
-    event_emitter: &Arc<EventEmitter>,
     context: &SdkContext,
 ) -> Arc<dyn TokenConverter> {
     let flashnet_config = FlashnetConfig::default_config(
@@ -833,7 +827,6 @@ fn build_token_converter(
         flashnet_config,
         Arc::clone(storage),
         Arc::clone(spark_wallet),
-        event_emitter,
         config.network,
         context.http_client.clone(),
     ))
@@ -1122,6 +1115,50 @@ mod tests {
             .build()
             .await
             .expect("client-mode build should succeed");
+
+        let event_emitter = std::sync::Arc::downgrade(&sdk.event_emitter);
+        let spark_wallet = std::sync::Arc::downgrade(&sdk.spark_wallet);
+
+        tokio::time::timeout(std::time::Duration::from_secs(30), sdk.disconnect())
+            .await
+            .expect("disconnect should not hang")
+            .expect("disconnect should succeed");
+        drop(sdk);
+
+        assert_sdk_graph_freed(event_emitter, spark_wallet).await;
+    }
+
+    /// Variant of the client-mode leak regression test with real-time sync
+    /// and stable balance enabled: the sync record handler and the conversion
+    /// worker hold the emitter strongly, so their tasks must release it on
+    /// `disconnect`.
+    #[tokio::test]
+    async fn client_mode_sdk_graph_is_freed_with_real_time_sync_enabled() {
+        use crate::{StableBalanceConfig, StableBalanceToken};
+
+        let mut config = default_config(Network::Regtest);
+        // Unreachable sync server: the gRPC client connects lazily, so the
+        // build succeeds offline and the sync tasks just retry in the
+        // background until shutdown.
+        config.real_time_sync_server_url = Some("http://127.0.0.1:9".to_string());
+        config.private_enabled_default = false;
+        // No active token, so the conversion worker spawns without making
+        // network calls.
+        config.stable_balance_config = Some(StableBalanceConfig {
+            tokens: vec![StableBalanceToken {
+                label: "USDB".to_string(),
+                token_identifier: "btkn1test".to_string(),
+            }],
+            default_active_label: None,
+            threshold_sats: None,
+            max_slippage_bps: None,
+        });
+
+        let sdk = SdkBuilder::new(config, test_seed())
+            .with_default_storage(unique_storage_dir("leak-client-rtsync"))
+            .build()
+            .await
+            .expect("client-mode build with real-time sync should succeed");
 
         let event_emitter = std::sync::Arc::downgrade(&sdk.event_emitter);
         let spark_wallet = std::sync::Arc::downgrade(&sdk.spark_wallet);

--- a/crates/breez-sdk/core/src/stable_balance/conversions.rs
+++ b/crates/breez-sdk/core/src/stable_balance/conversions.rs
@@ -28,13 +28,14 @@ impl StableBalance {
         parent_payment_id: &str,
     ) -> Result<bool, ConversionError> {
         // Get the active token, skip if stable balance is inactive
-        let Some(active_token_identifier) = self.get_active_token_identifier().await else {
+        let Some(active_token_identifier) = self.core.get_active_token_identifier().await else {
             debug!("Per-receive conversion skipped: stable balance is inactive");
             return Ok(false);
         };
 
         // Fetch payment from storage to get latest metadata and amount
         let payment = self
+            .core
             .storage
             .get_payment_by_id(parent_payment_id.to_string())
             .await?;
@@ -55,6 +56,7 @@ impl StableBalance {
         // Check minimum threshold
         let amount_sats = payment.amount;
         let (_, min_from_amount) = self
+            .core
             .get_or_init_effective_values(&active_token_identifier)
             .await?;
         let amount_sats_u64 = u64::try_from(amount_sats).unwrap_or(u64::MAX);
@@ -72,6 +74,7 @@ impl StableBalance {
 
         // Check if payment with this transfer_id already exists (already converted)
         if self
+            .core
             .storage
             .get_payment_by_id(transfer_id.to_string())
             .await
@@ -91,12 +94,14 @@ impl StableBalance {
         // Perform conversion with deterministic transfer_id for idempotency
         let options = ConversionOptions {
             conversion_type: ConversionType::FromBitcoin,
-            max_slippage_bps: self.config.max_slippage_bps,
+            max_slippage_bps: self.core.config.max_slippage_bps,
             completion_timeout_secs: None,
         };
         let response = self
+            .core
             .token_converter
             .convert(
+                self.event_emitter.clone(),
                 &options,
                 &ConversionPurpose::AutoConversion,
                 Some(&active_token_identifier),
@@ -106,7 +111,8 @@ impl StableBalance {
             .await?;
 
         // Link both conversion payments to the received parent payment
-        self.storage
+        self.core
+            .storage
             .insert_payment_metadata(
                 response.sent_payment_id.clone(),
                 PaymentMetadata {
@@ -115,7 +121,8 @@ impl StableBalance {
                 },
             )
             .await?;
-        self.storage
+        self.core
+            .storage
             .insert_payment_metadata(
                 response.received_payment_id.clone(),
                 PaymentMetadata {
@@ -141,7 +148,7 @@ impl StableBalance {
     /// - Balance is below the trigger amount
     pub(super) async fn auto_convert(&self) -> Result<bool, ConversionError> {
         // Get the active token, skip if stable balance is inactive
-        let Some(active_token_identifier) = self.get_active_token_identifier().await else {
+        let Some(active_token_identifier) = self.core.get_active_token_identifier().await else {
             debug!("Auto-conversion skipped: stable balance is inactive");
             return Ok(false);
         };
@@ -161,6 +168,7 @@ impl StableBalance {
 
         // Check if balance exceeds the threshold
         let (threshold, _) = self
+            .core
             .get_or_init_effective_values(&active_token_identifier)
             .await?;
         if balance_sats < threshold {
@@ -170,7 +178,7 @@ impl StableBalance {
 
         let from_btc_options = ConversionOptions {
             conversion_type: ConversionType::FromBitcoin,
-            max_slippage_bps: self.config.max_slippage_bps,
+            max_slippage_bps: self.core.config.max_slippage_bps,
             completion_timeout_secs: None,
         };
 
@@ -187,7 +195,7 @@ impl StableBalance {
         // Per-receive converts specific payment amounts and takes priority; if we
         // proceed, we'd convert the same sats and per-receive would fail with
         // InsufficientFunds. The next Synced event will re-queue auto-convert.
-        if self.queue.has_per_receive().await {
+        if self.core.queue.has_per_receive().await {
             debug!("Auto-conversion aborted: per-receive tasks queued during preparation");
             return Ok(false);
         }
@@ -197,8 +205,10 @@ impl StableBalance {
         );
 
         let response = self
+            .core
             .token_converter
             .convert(
+                self.event_emitter.clone(),
                 &from_btc_options,
                 &ConversionPurpose::AutoConversion,
                 Some(&active_token_identifier),
@@ -208,7 +218,8 @@ impl StableBalance {
             .await?;
 
         // Link sent payment as child of received payment
-        self.storage
+        self.core
+            .storage
             .insert_payment_metadata(
                 response.sent_payment_id.clone(),
                 PaymentMetadata {
@@ -224,7 +235,8 @@ impl StableBalance {
         );
 
         // Persist Completed status for the received token payment
-        self.storage
+        self.core
+            .storage
             .insert_payment_metadata(
                 response.received_payment_id.clone(),
                 PaymentMetadata {
@@ -259,6 +271,7 @@ impl StableBalance {
 
         // Check minimum conversion limit for ToBitcoin
         let limits = self
+            .core
             .token_converter
             .fetch_limits(&FetchConversionLimitsRequest {
                 conversion_type: ConversionType::ToBitcoin {
@@ -281,7 +294,7 @@ impl StableBalance {
             conversion_type: ConversionType::ToBitcoin {
                 from_token_identifier: token_identifier.to_string(),
             },
-            max_slippage_bps: self.config.max_slippage_bps,
+            max_slippage_bps: self.core.config.max_slippage_bps,
             completion_timeout_secs: None,
         };
 
@@ -290,8 +303,10 @@ impl StableBalance {
         );
 
         let response = self
+            .core
             .token_converter
             .convert(
+                self.event_emitter.clone(),
                 &to_btc_options,
                 &ConversionPurpose::AutoConversion,
                 Some(&token_identifier.to_string()),
@@ -301,7 +316,8 @@ impl StableBalance {
             .await?;
 
         // Link sent payment as child of received payment (same pattern as auto_convert)
-        self.storage
+        self.core
+            .storage
             .insert_payment_metadata(
                 response.sent_payment_id.clone(),
                 PaymentMetadata {
@@ -312,7 +328,8 @@ impl StableBalance {
             .await?;
 
         // Persist Completed status for the received BTC payment
-        self.storage
+        self.core
+            .storage
             .insert_payment_metadata(
                 response.received_payment_id.clone(),
                 PaymentMetadata {
@@ -348,7 +365,7 @@ impl StableBalance {
             token_identifier: Some(token_id.clone()),
         };
         let (limits_res, balances_res) = tokio::join!(
-            self.token_converter.fetch_limits(&limits_request),
+            self.core.token_converter.fetch_limits(&limits_request),
             self.spark_wallet.get_token_balances(),
         );
 
@@ -367,6 +384,7 @@ impl StableBalance {
 
         // Estimate how many tokens we'd get from converting balance_sats
         let Ok(Some(est)) = self
+            .core
             .token_converter
             .validate(
                 Some(from_btc_options),

--- a/crates/breez-sdk/core/src/stable_balance/mod.rs
+++ b/crates/breez-sdk/core/src/stable_balance/mod.rs
@@ -132,8 +132,8 @@
 mod conversions;
 mod queue;
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Weak};
 
 use platform_utils::tokio;
 use spark_wallet::{SparkWallet, TransferId};
@@ -192,45 +192,65 @@ impl Drop for PaymentGuard {
     }
 }
 
+/// State and logic shared between the emitter-owned [`StableBalanceMiddleware`]
+/// and the [`StableBalance`] worker/API surface.
+///
+/// The middleware is owned by the `EventEmitter` for its whole lifetime, so
+/// nothing reachable from this struct may hold a strong reference back to the
+/// emitter, or the SDK object graph could never be dropped.
+pub(crate) struct StableBalanceCore {
+    /// Configuration for stable balance behavior (shared across all tokens)
+    pub(super) config: StableBalanceConfig,
+
+    /// The currently active token, or `None` if deactivated
+    pub(super) active_token: RwLock<Option<StableBalanceToken>>,
+
+    /// Reference to the token converter for executing conversions
+    pub(super) token_converter: Arc<dyn TokenConverter>,
+
+    /// Reference to storage for checking existing conversions
+    pub(super) storage: Arc<dyn Storage>,
+
+    /// Cached effective values for auto-conversion (expires after TTL)
+    pub(super) effective_values: ExpiringCell<EffectiveValues>,
+
+    /// Unified conversion queue for per-receive and auto-convert tasks.
+    pub(super) queue: ConversionQueue,
+
+    /// Notify to signal first sync completion (startup gate for the conversion worker).
+    pub(super) synced_notify: Notify,
+}
+
+/// Event middleware that feeds the conversion queue from payment and sync
+/// events. Owned by the `EventEmitter`; never emits and holds no emitter
+/// reference.
+pub(crate) struct StableBalanceMiddleware {
+    core: Arc<StableBalanceCore>,
+}
+
 /// Manages stable balance auto-conversion behavior.
 ///
 /// This struct handles the business logic of when and how much to convert,
 /// while delegating the actual conversion mechanics to a `TokenConverter`.
 /// It coordinates with payment conversion flows to prevent race conditions.
 ///
+/// Held by `BreezSdk` and the conversion worker task (which stops on
+/// shutdown), never by the emitter itself: the emitter owns only the
+/// [`StableBalanceMiddleware`], so the strong emitter reference here cannot
+/// form a cycle.
+///
 /// The active token can be changed at runtime via [`set_active_token`](Self::set_active_token).
 /// When no token is active, all conversion operations are skipped.
 #[derive(Clone)]
 pub(crate) struct StableBalance {
-    /// Configuration for stable balance behavior (shared across all tokens)
-    pub(super) config: StableBalanceConfig,
-
-    /// The currently active token, or `None` if deactivated
-    pub(super) active_token: Arc<RwLock<Option<StableBalanceToken>>>,
-
-    /// Reference to the token converter for executing conversions
-    pub(super) token_converter: Arc<dyn TokenConverter>,
+    /// State shared with the registered [`StableBalanceMiddleware`].
+    pub(super) core: Arc<StableBalanceCore>,
 
     /// Reference to the spark wallet for balance queries
     pub(super) spark_wallet: Arc<SparkWallet>,
 
-    /// Reference to storage for checking existing conversions
-    pub(super) storage: Arc<dyn Storage>,
-
-    /// Cached effective values for auto-conversion (expires after TTL, shared across clones)
-    pub(super) effective_values: Arc<ExpiringCell<EffectiveValues>>,
-
-    /// Unified conversion queue for per-receive and auto-convert tasks.
-    pub(super) queue: Arc<ConversionQueue>,
-
-    /// Notify to signal first sync completion (startup gate for the conversion worker).
-    pub(super) synced_notify: Arc<Notify>,
-
     /// Event emitter used to publish conversion outcomes to the active runtime.
-    /// Weak: this struct is registered as middleware on the emitter, so a
-    /// strong back-reference would form a reference cycle that leaks the
-    /// whole SDK object graph.
-    pub(super) event_emitter: Weak<EventEmitter>,
+    pub(super) event_emitter: Arc<EventEmitter>,
 
     /// Number of in-flight send-with-conversion payments.
     /// Auto-convert is suppressed while this is > 0.
@@ -246,7 +266,7 @@ impl StableBalance {
     /// Creates a new `StableBalance` instance.
     ///
     /// Resolves the initial active token from the local cache and config,
-    /// and registers itself as an event listener on the provided emitter.
+    /// and registers a [`StableBalanceMiddleware`] on the provided emitter.
     pub async fn new(
         config: StableBalanceConfig,
         token_converter: Arc<dyn TokenConverter>,
@@ -254,10 +274,8 @@ impl StableBalance {
         storage: Arc<dyn Storage>,
         event_emitter: Arc<EventEmitter>,
     ) -> Self {
-        let initial_active_token = Self::resolve_initial_token(&config, &storage).await;
-
-        let queue = Arc::new(ConversionQueue::new(storage.clone()));
-        let synced_notify = Arc::new(Notify::new());
+        let initial_active_token =
+            StableBalanceCore::resolve_initial_token(&config, &storage).await;
 
         if let Some(token) = &initial_active_token {
             info!(
@@ -268,44 +286,44 @@ impl StableBalance {
             info!("Stable balance initialized as inactive");
         }
 
-        let stable_balance = Self {
+        let core = Arc::new(StableBalanceCore {
             config,
-            active_token: Arc::new(RwLock::new(initial_active_token)),
+            active_token: RwLock::new(initial_active_token),
             token_converter,
-            spark_wallet,
-            storage,
-            event_emitter: Arc::downgrade(&event_emitter),
-            effective_values: Arc::new(ExpiringCell::new()),
-            queue,
-            synced_notify,
-            payment_counter: Arc::new(AtomicUsize::new(0)),
-            payment_lock: Arc::new(Mutex::new(())),
-        };
+            storage: Arc::clone(&storage),
+            effective_values: ExpiringCell::new(),
+            queue: ConversionQueue::new(storage),
+            synced_notify: Notify::new(),
+        });
 
-        // Register as event middleware
         event_emitter
-            .add_middleware(Box::new(stable_balance.clone()))
+            .add_middleware(Box::new(StableBalanceMiddleware {
+                core: Arc::clone(&core),
+            }))
             .await;
 
-        stable_balance
+        Self {
+            core,
+            spark_wallet,
+            event_emitter,
+            payment_counter: Arc::new(AtomicUsize::new(0)),
+            payment_lock: Arc::new(Mutex::new(())),
+        }
     }
 
     /// Returns the `token_identifier` of the currently active token, or `None` if inactive.
     pub(crate) async fn get_active_token_identifier(&self) -> Option<String> {
-        self.active_token
-            .read()
-            .await
-            .as_ref()
-            .map(|t| t.token_identifier.clone())
+        self.core.get_active_token_identifier().await
     }
 
     /// Returns the label of the currently active token, or `None` if inactive.
     pub(crate) async fn get_active_label(&self) -> Option<String> {
-        self.active_token
-            .read()
-            .await
-            .as_ref()
-            .map(|t| t.label.clone())
+        self.core.get_active_label().await
+    }
+
+    /// Sets the active token by label, or deactivates stable balance if `None`.
+    pub(crate) async fn set_active_token(&self, label: Option<String>) -> Result<(), SdkError> {
+        self.core.set_active_token(label).await
     }
 
     /// Acquires a payment guard that suppresses auto-convert while held.
@@ -320,8 +338,28 @@ impl StableBalance {
         self.payment_counter.fetch_add(1, Ordering::Relaxed);
         PaymentGuard {
             counter: self.payment_counter.clone(),
-            notify: self.queue.notify.clone(),
+            notify: self.core.queue.notify.clone(),
         }
+    }
+}
+
+impl StableBalanceCore {
+    /// Returns the `token_identifier` of the currently active token, or `None` if inactive.
+    pub(super) async fn get_active_token_identifier(&self) -> Option<String> {
+        self.active_token
+            .read()
+            .await
+            .as_ref()
+            .map(|t| t.token_identifier.clone())
+    }
+
+    /// Returns the label of the currently active token, or `None` if inactive.
+    async fn get_active_label(&self) -> Option<String> {
+        self.active_token
+            .read()
+            .await
+            .as_ref()
+            .map(|t| t.label.clone())
     }
 
     /// Sets the active token by label, or deactivates stable balance if `None`.
@@ -329,7 +367,7 @@ impl StableBalance {
     /// Validates that the label exists in the configured tokens list.
     /// Clears the conversion queue (pending conversions for the old token are no longer
     /// relevant), marks cleared per-receive tasks as Failed, and caches the choice locally.
-    pub(crate) async fn set_active_token(&self, label: Option<String>) -> Result<(), SdkError> {
+    async fn set_active_token(&self, label: Option<String>) -> Result<(), SdkError> {
         let cache = ObjectCacheRepository::new(self.storage.clone());
 
         // Clear the queue — pending conversions for the old token are no longer relevant
@@ -488,55 +526,6 @@ impl StableBalance {
         Ok((threshold, min_from_amount))
     }
 
-    /// Gets conversion options for a payment if auto-population is needed.
-    ///
-    /// Returns `Some(ConversionOptions)` if:
-    /// - Stable balance is active
-    /// - No explicit options were provided
-    /// - The payment is not a token payment (`token_identifier` is None)
-    /// - The current sats balance is insufficient for the payment amount
-    ///
-    /// In this case, returns options to convert from the active stable token to Bitcoin.
-    pub async fn get_conversion_options(
-        &self,
-        options: Option<&ConversionOptions>,
-        token_identifier: Option<&String>,
-        payment_amount: u128,
-    ) -> Result<Option<ConversionOptions>, ConversionError> {
-        // Use provided options if explicitly set
-        if options.is_some() {
-            return Ok(options.cloned());
-        }
-
-        // Don't auto-convert for token payments
-        if token_identifier.is_some() {
-            return Ok(None);
-        }
-
-        // Don't auto-convert if inactive
-        let Some(active_token_identifier) = self.get_active_token_identifier().await else {
-            return Ok(None);
-        };
-
-        let balance_sats = self.spark_wallet.get_balance().await?;
-
-        // Only auto-populate if the sats balance is insufficient for the payment.
-        if u128::from(balance_sats) >= payment_amount {
-            return Ok(None);
-        }
-
-        info!(
-            "Auto-populating conversion options: balance {balance_sats} sats < payment amount {payment_amount} sats"
-        );
-        Ok(Some(ConversionOptions {
-            conversion_type: ConversionType::ToBitcoin {
-                from_token_identifier: active_token_identifier,
-            },
-            max_slippage_bps: self.config.max_slippage_bps,
-            completion_timeout_secs: None,
-        }))
-    }
-
     /// Checks if a payment should trigger per-receive conversion.
     ///
     /// Returns true if:
@@ -574,28 +563,78 @@ impl StableBalance {
 
         true
     }
+}
+
+impl StableBalance {
+    /// Gets conversion options for a payment if auto-population is needed.
+    ///
+    /// Returns `Some(ConversionOptions)` if:
+    /// - Stable balance is active
+    /// - No explicit options were provided
+    /// - The payment is not a token payment (`token_identifier` is None)
+    /// - The current sats balance is insufficient for the payment amount
+    ///
+    /// In this case, returns options to convert from the active stable token to Bitcoin.
+    pub async fn get_conversion_options(
+        &self,
+        options: Option<&ConversionOptions>,
+        token_identifier: Option<&String>,
+        payment_amount: u128,
+    ) -> Result<Option<ConversionOptions>, ConversionError> {
+        // Use provided options if explicitly set
+        if options.is_some() {
+            return Ok(options.cloned());
+        }
+
+        // Don't auto-convert for token payments
+        if token_identifier.is_some() {
+            return Ok(None);
+        }
+
+        // Don't auto-convert if inactive
+        let Some(active_token_identifier) = self.core.get_active_token_identifier().await else {
+            return Ok(None);
+        };
+
+        let balance_sats = self.spark_wallet.get_balance().await?;
+
+        // Only auto-populate if the sats balance is insufficient for the payment.
+        if u128::from(balance_sats) >= payment_amount {
+            return Ok(None);
+        }
+
+        info!(
+            "Auto-populating conversion options: balance {balance_sats} sats < payment amount {payment_amount} sats"
+        );
+        Ok(Some(ConversionOptions {
+            conversion_type: ConversionType::ToBitcoin {
+                from_token_identifier: active_token_identifier,
+            },
+            max_slippage_bps: self.core.config.max_slippage_bps,
+            completion_timeout_secs: None,
+        }))
+    }
 
     /// Emits the fact that a conversion changed balances and payments.
     pub(super) async fn emit_conversion_completed(&self) {
-        if let Some(event_emitter) = self.event_emitter.upgrade() {
-            event_emitter
-                .emit_runtime_event(RuntimeEvent::StableBalanceConversionCompleted)
-                .await;
-        }
+        self.event_emitter
+            .emit_runtime_event(RuntimeEvent::StableBalanceConversionCompleted)
+            .await;
     }
 }
 
 #[macros::async_trait]
-impl EventMiddleware for StableBalance {
+impl EventMiddleware for StableBalanceMiddleware {
     async fn process(&self, event: SdkEvent) -> Option<SdkEvent> {
         match event {
             // Sync completed → wake the startup gate, sweep timed-out deferred tasks
             SdkEvent::Synced => {
                 // Clean up deferred tasks that have exceeded the timeout
-                let expired_payment_ids = self.queue.clear_expired_tasks().await;
+                let expired_payment_ids = self.core.queue.clear_expired_tasks().await;
                 for expired_payment_id in expired_payment_ids {
                     warn!("Per-receive conversion timed out for {expired_payment_id}");
                     if let Err(e) = self
+                        .core
                         .storage
                         .insert_payment_metadata(
                             expired_payment_id.clone(),
@@ -610,10 +649,10 @@ impl EventMiddleware for StableBalance {
                     }
                 }
 
-                self.synced_notify.notify_one();
+                self.core.synced_notify.notify_one();
 
                 // Re-assess balance after sync — may have changed due to external activity
-                self.queue.push_auto_convert().await;
+                self.core.queue.push_auto_convert().await;
 
                 Some(SdkEvent::Synced)
             }
@@ -623,7 +662,11 @@ impl EventMiddleware for StableBalance {
             SdkEvent::PaymentSucceeded { mut payment } => {
                 // Check if this payment is a conversion result from another instance
                 // that resolves a deferred per-receive task
-                if let Some(parent_id) = self.queue.resolve_by_conversion_payment(&payment.id).await
+                if let Some(parent_id) = self
+                    .core
+                    .queue
+                    .resolve_by_conversion_payment(&payment.id)
+                    .await
                 {
                     info!(
                         "Conversion payment {} resolved deferred task for {parent_id}",
@@ -632,7 +675,7 @@ impl EventMiddleware for StableBalance {
                     return Some(SdkEvent::PaymentSucceeded { payment });
                 }
 
-                if self.should_trigger_per_receive(&payment).await {
+                if self.core.should_trigger_per_receive(&payment).await {
                     debug!("Queueing per-receive conversion for payment {}", payment.id);
 
                     // Set conversion_details with Pending status so clients know conversion is coming
@@ -644,6 +687,7 @@ impl EventMiddleware for StableBalance {
 
                     // Persist the pending status so it survives restarts
                     if let Err(e) = self
+                        .core
                         .storage
                         .insert_payment_metadata(
                             payment.id.clone(),
@@ -660,11 +704,11 @@ impl EventMiddleware for StableBalance {
                         );
                     }
 
-                    self.queue.push_per_receive(payment.id.clone()).await;
+                    self.core.queue.push_per_receive(payment.id.clone()).await;
                 } else {
                     // Non-per-receive payment — queue auto-convert to handle accumulated balance
                     debug!("Queueing auto-convert after payment {}", payment.id);
-                    self.queue.push_auto_convert().await;
+                    self.core.queue.push_auto_convert().await;
                 }
                 Some(SdkEvent::PaymentSucceeded { payment })
             }

--- a/crates/breez-sdk/core/src/stable_balance/queue.rs
+++ b/crates/breez-sdk/core/src/stable_balance/queue.rs
@@ -284,7 +284,7 @@ impl StableBalance {
             async move {
                 // Pre-warm effective values cache
                 if let Some(token_id) = stable_balance.get_active_token_identifier().await
-                    && let Err(e) = stable_balance.get_or_init_effective_values(&token_id).await
+                    && let Err(e) = stable_balance.core.get_or_init_effective_values(&token_id).await
                 {
                     warn!("Failed to pre-warm effective values: {e:?}");
                 }
@@ -299,22 +299,22 @@ impl StableBalance {
                         info!("Conversion worker shutdown before initial sync");
                         return;
                     }
-                    () = stable_balance.synced_notify.notified() => {
+                    () = stable_balance.core.synced_notify.notified() => {
                         debug!("Conversion worker: initial sync completed");
                     }
                 }
 
                 // Cold-start: queue auto-convert for any existing excess balance
-                stable_balance.queue.push_auto_convert().await;
+                stable_balance.core.queue.push_auto_convert().await;
 
                 // Main processing loop
                 debug!("Conversion worker: entering main loop");
                 loop {
                     // Register notify future BEFORE checking the queue to avoid missed wakeups
-                    let notified = stable_balance.queue.notify.notified();
+                    let notified = stable_balance.core.queue.notify.notified();
 
                     // Drain all available tasks
-                    while let Some(task) = stable_balance.queue.next_task().await {
+                    while let Some(task) = stable_balance.core.queue.next_task().await {
                         debug!("Conversion worker: processing task {task:?}");
                         match &task {
                             ConversionTask::PerReceive(payment_id) => {
@@ -324,12 +324,12 @@ impl StableBalance {
                                 {
                                     PerReceiveResult::Done { converted } => {
                                         debug!("Conversion worker: completed task {task:?} (converted={converted})");
-                                        stable_balance.queue.complete_task(&task).await;
+                                        stable_balance.core.queue.complete_task(&task).await;
                                         if converted {
                                             // Clear any pending auto-convert — the local balance
                                             // is stale until sync completes. The next Synced event
                                             // will re-queue auto-convert if there's still excess.
-                                            stable_balance.queue.clear_pending_auto_convert().await;
+                                            stable_balance.core.queue.clear_pending_auto_convert().await;
                                             stable_balance.emit_conversion_completed().await;
                                         }
                                     }
@@ -337,7 +337,7 @@ impl StableBalance {
                                         // Mark as deferred so next_task skips it until
                                         // resolved by a PaymentSucceeded event or timeout
                                         debug!("Conversion worker: deferring task {task:?}");
-                                        stable_balance.queue.defer_task(payment_id).await;
+                                        stable_balance.core.queue.defer_task(payment_id).await;
                                     }
                                 }
                             }
@@ -350,7 +350,7 @@ impl StableBalance {
                                     }
                                 };
                                 debug!("Conversion worker: auto-convert done (converted={converted})");
-                                stable_balance.queue.complete_task(&task).await;
+                                stable_balance.core.queue.complete_task(&task).await;
                                 if converted {
                                     stable_balance.emit_conversion_completed().await;
                                 }
@@ -365,7 +365,7 @@ impl StableBalance {
                                         }
                                     };
                                 debug!("Conversion worker: completed task {task:?} (converted={converted})");
-                                stable_balance.queue.complete_task(&task).await;
+                                stable_balance.core.queue.complete_task(&task).await;
                                 if converted {
                                     stable_balance.emit_conversion_completed().await;
                                 }
@@ -398,6 +398,7 @@ impl StableBalance {
             Ok(converted) => {
                 if converted
                     && let Err(e) = self
+                        .core
                         .storage
                         .insert_payment_metadata(
                             payment_id.clone(),
@@ -437,7 +438,7 @@ impl StableBalance {
     /// Stale deferred tasks are cleaned up by `clear_expired_tasks()` on the
     /// first `Synced` event.
     async fn recover_pending_conversions(&self) {
-        let cache = ObjectCacheRepository::new(self.storage.clone());
+        let cache = ObjectCacheRepository::new(self.core.storage.clone());
         match cache.fetch_pending_conversions().await {
             Ok(Some(pending)) => {
                 if !pending.is_empty() {
@@ -445,7 +446,7 @@ impl StableBalance {
                         "Recovering {} pending conversion(s) from previous session",
                         pending.len()
                     );
-                    let mut state = self.queue.state.lock().await;
+                    let mut state = self.core.queue.state.lock().await;
                     for entry in pending {
                         if state
                             .per_receive
@@ -456,7 +457,7 @@ impl StableBalance {
                         }
                         state.per_receive.push(entry);
                     }
-                    self.queue.persist_pending(&state).await;
+                    self.core.queue.persist_pending(&state).await;
                 }
             }
             Ok(None) => {}

--- a/crates/breez-sdk/core/src/token_conversion/flashnet.rs
+++ b/crates/breez-sdk/core/src/token_conversion/flashnet.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::HashMap,
-    str::FromStr,
-    sync::{Arc, Weak},
-    time::Duration,
-};
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 use bitcoin::secp256k1::PublicKey;
 use flashnet::{
@@ -49,10 +44,6 @@ pub(crate) struct FlashnetTokenConverter {
     flashnet_client: Arc<FlashnetClient>,
     storage: Arc<dyn Storage>,
     spark_wallet: Arc<SparkWallet>,
-    /// Weak: this converter is reachable from the emitter (the
-    /// `StableBalance` middleware holds it), so a strong back-reference
-    /// would form a reference cycle that leaks the whole SDK object graph.
-    event_emitter: Weak<EventEmitter>,
     network: Network,
     refund_trigger: broadcast::Sender<()>,
     integrator_fee_bps: u32,
@@ -64,14 +55,11 @@ impl FlashnetTokenConverter {
     /// # Arguments
     /// * `storage` - Storage for payment lookups and metadata updates
     /// * `spark_wallet` - Spark wallet for transfer/transaction lookups
-    /// * `event_emitter` - Event emitter used when persisting conversion-leg
-    ///   payment records after a successful swap
     /// * `network` - The network configuration
     pub fn new(
         flashnet_config: FlashnetConfig,
         storage: Arc<dyn Storage>,
         spark_wallet: Arc<SparkWallet>,
-        event_emitter: &Arc<EventEmitter>,
         network: Network,
         http_client: Arc<dyn platform_utils::HttpClient>,
     ) -> Self {
@@ -93,7 +81,6 @@ impl FlashnetTokenConverter {
             flashnet_client,
             storage,
             spark_wallet,
-            event_emitter: Arc::downgrade(event_emitter),
             network,
             refund_trigger,
             integrator_fee_bps,
@@ -640,17 +627,11 @@ impl FlashnetTokenConverter {
     /// them so the resulting Payment is terminal.
     async fn process_conversion_payments(
         &self,
+        event_emitter: Arc<EventEmitter>,
         outbound_asset_transfer: AssetTransfer,
         sent_payment_id: &str,
         received_payment_id: &str,
     ) {
-        // The emitter is gone only when the SDK is being torn down; the next
-        // sync rebuilds both conversion legs from the operators.
-        let Some(event_emitter) = self.event_emitter.upgrade() else {
-            debug!("Skipping conversion payment processing: SDK is shutting down");
-            return;
-        };
-
         // Sent leg: we just produced this transfer ourselves, so the local
         // spark/token wallet state is already current — no claim needed.
         // Build the Payment directly and insert it even if the operator-side
@@ -759,6 +740,7 @@ impl TokenConverter for FlashnetTokenConverter {
     #[allow(clippy::too_many_lines)]
     async fn convert(
         &self,
+        event_emitter: Arc<EventEmitter>,
         options: &ConversionOptions,
         purpose: &ConversionPurpose,
         token_identifier: Option<&String>,
@@ -836,6 +818,7 @@ impl TokenConverter for FlashnetTokenConverter {
                     && flashnet_response.accepted
                 {
                     self.process_conversion_payments(
+                        event_emitter,
                         outbound_asset_transfer,
                         &sent_payment_id,
                         &received_payment_id,

--- a/crates/breez-sdk/core/src/token_conversion/mod.rs
+++ b/crates/breez-sdk/core/src/token_conversion/mod.rs
@@ -8,19 +8,28 @@ pub(crate) use flashnet::FlashnetTokenConverter;
 pub(crate) use middleware::TokenConversionMiddleware;
 pub use models::*;
 
+use std::sync::Arc;
+
 use spark_wallet::TransferId;
 use tokio::sync::broadcast;
+
+use crate::EventEmitter;
 
 /// Trait for conversion implementations.
 ///
 /// This trait abstracts the conversion mechanics, allowing different
 /// implementations (e.g., Flashnet) to be used interchangeably.
 /// Business logic for when/how much to convert is handled by `StableBalance`.
+///
+/// Implementations are reachable from the `EventEmitter` (the stable balance
+/// middleware holds the converter), so they must not store an emitter
+/// reference; the caller passes one into [`convert`](Self::convert) instead.
 #[macros::async_trait]
 pub(crate) trait TokenConverter: Send + Sync {
     /// Execute a conversion swap.
     ///
     /// # Arguments
+    /// * `event_emitter` - Emitter for the payment events of the swap legs
     /// * `options` - The conversion options including type and slippage
     /// * `purpose` - The purpose of the conversion
     /// * `token_identifier` - Optional token identifier for `FromBitcoin` conversions
@@ -28,6 +37,7 @@ pub(crate) trait TokenConverter: Send + Sync {
     /// * `transfer_id` - Optional transfer ID for idempotency
     async fn convert(
         &self,
+        event_emitter: Arc<EventEmitter>,
         options: &ConversionOptions,
         purpose: &ConversionPurpose,
         token_identifier: Option<&String>,


### PR DESCRIPTION
Follow-up to #950 (fixes the structural side of #947). That fix broke the client-mode reference cycle by switching emitter-reachable components to `Weak<EventEmitter>`. `Weak` works but is a convention: any future emitter-reachable struct holding a strong `Arc<EventEmitter>` recreates the leak, caught only by the regression tests. This PR removes the stored back-references entirely.

## Changes

- **`SyncedStorage`** is now a pure `Storage` wrapper (`inner` + `sync_service`, no emitter). It is the emitter-reachable piece (registered handlers hold `sdk.storage`). The record-application and emitting half moved to a new `SyncedRecordHandler`, owned by the `SyncProcessor`. The processor is never emitter-reachable and its tasks stop on shutdown, so the handler holds the emitter strongly and releases it on `disconnect()`.
- **`StableBalance`** split into:
  - `StableBalanceCore`: shared state and queue/limits logic, no emitter reference,
  - `StableBalanceMiddleware`: emitter-owned, holds only the core, never emits,
  - `StableBalance`: worker and API surface, holds the emitter strongly. Owned by `BreezSdk` and the conversion worker task (stops on shutdown), never by the emitter.

  `set_active_token` cache invalidation crosses the split through the shared core.
- **`FlashnetTokenConverter`** stores no emitter at all anymore: `TokenConverter::convert()` takes the emitter as a parameter, the same pattern as `RuntimeEventHandler::handle`. `convert()` was the only emitting method (payment events for the swap legs), and all callers (stable balance worker, send-with-conversion paths) already own the emitter. This makes the middleware -> core -> converter chain cycle-free by construction instead of relocating the stored reference.

No `Weak<EventEmitter>` remains in the crate. The invariant is now: emitter-reachable code either holds no emitter reference, or receives one per call from owners outside the emitter graph.

## Tests

- New regression test: client-mode build with real-time sync and stable balance enabled (offline, lazy gRPC connect) must release the whole object graph after `disconnect()`. This covers the path the existing client-mode test skipped (`real_time_sync_server_url = None`).
- All existing #947/#950/#951 regression tests kept and passing.
- `fmt`, `clippy` (cargo + WASM), and the full core test suite pass.

No public API changes; everything touched is crate-internal.