### PR TITLE
fix(spark-wallet): retry transfers when operators report a leaf not yet available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5025,6 +5025,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tonic",
+ "tonic-types",
  "tracing",
  "uuid",
 ]
@@ -5735,6 +5736,17 @@ dependencies = [
  "prost-types",
  "quote 1.0.45",
  "syn",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0081d8ee0847d01271392a5aebe960a4600f5d4da6c67648a6382a0940f8b367"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,7 @@ deadpool = "0.12"
 tokio-test = "0.4.4"
 tonic = { version = "0.12.3", default-features = false }
 tonic-build = { version = "0.12.3", features = ["prost"] }
+tonic-types = "0.12.3"
 tonic-web-wasm-client = "0.6"
 tower-service = "0.3.3"
 tracing = "0.1.41"

--- a/crates/breez-sdk/lnurl/Cargo.lock
+++ b/crates/breez-sdk/lnurl/Cargo.lock
@@ -3580,6 +3580,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tonic",
+ "tonic-types",
  "tracing",
  "uuid",
 ]
@@ -4215,6 +4216,17 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0081d8ee0847d01271392a5aebe960a4600f5d4da6c67648a6382a0940f8b367"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
 ]
 
 [[package]]

--- a/crates/spark-wallet/Cargo.toml
+++ b/crates/spark-wallet/Cargo.toml
@@ -18,6 +18,7 @@ spark.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time"] }
 tonic.workspace = true
+tonic-types.workspace = true
 tracing.workspace = true
 
 # Non-Wasm dependencies

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -63,14 +63,12 @@ use crate::{
 
 const SELECT_LEAVES_MAX_RETRIES: usize = 3;
 const MAX_LEAF_SPENT_RETRIES: usize = 3;
-const MAX_RATE_LIMIT_RETRIES: u32 = 5;
-const RATE_LIMIT_BASE_DELAY_MS: u64 = 100;
-const RATE_LIMIT_MAX_DELAY_MS: u64 = 3000;
-/// Retries for a leaf the operators have not finished finalizing yet. The window
-/// after a deposit claim is short, so a few hundred ms of backoff clears it.
-const MAX_LEAF_UNAVAILABLE_RETRIES: u32 = 5;
-const LEAF_UNAVAILABLE_BASE_DELAY_MS: u64 = 100;
-const LEAF_UNAVAILABLE_MAX_DELAY_MS: u64 = 3000;
+/// Backoff for transient operator errors that clear on their own: rate limiting
+/// (ResourceExhausted) and leaves the operators have not finished finalizing yet
+/// (LEAF_UNAVAILABLE).
+const MAX_BACKOFF_RETRIES: u32 = 5;
+const BACKOFF_BASE_DELAY_MS: u64 = 100;
+const BACKOFF_MAX_DELAY_MS: u64 = 3000;
 /// Grace period before claiming orphaned counter-swap transfers.
 /// Generous to absorb clock skew between the server (`created_time`) and the local clock.
 const COUNTER_SWAP_CLAIM_GRACE_PERIOD_SECS: u64 = 300;
@@ -125,6 +123,12 @@ fn is_leaf_unavailable_error(error: &OperatorRpcError) -> bool {
     operator_error_reason(error).as_deref() == Some(LEAF_UNAVAILABLE_REASON)
 }
 
+/// Checks if an error is a transient operator condition that clears on its own
+/// and should be retried after a backoff delay.
+fn is_backoff_retryable_error(error: &OperatorRpcError) -> bool {
+    is_resource_exhausted_error(error) || is_leaf_unavailable_error(error)
+}
+
 /// Macro to handle retry logic for operations that may fail due to concurrent leaf spending.
 /// This retries the operation up to MAX_LEAF_SPENT_RETRIES times.
 macro_rules! with_leafs_spent_retry {
@@ -135,8 +139,7 @@ macro_rules! with_leafs_spent_retry {
         |$leaves_reservation:ident| $operation:expr
     ) => {{
         let mut attempt = 0;
-        let mut rate_limit_attempt: u32 = 0;
-        let mut leaf_unavailable_attempt: u32 = 0;
+        let mut backoff_attempt: u32 = 0;
         loop {
             if attempt > 0 {
                 if attempt >= MAX_LEAF_SPENT_RETRIES {
@@ -165,37 +168,17 @@ macro_rules! with_leafs_spent_retry {
             match result {
                 Ok(v) => break Ok(v),
                 Err(ServiceError::ServiceConnectionError(e))
-                    if is_resource_exhausted_error(&e) =>
+                    if is_backoff_retryable_error(&e) =>
                 {
-                    rate_limit_attempt += 1;
-                    if rate_limit_attempt > MAX_RATE_LIMIT_RETRIES {
+                    backoff_attempt += 1;
+                    if backoff_attempt > MAX_BACKOFF_RETRIES {
                         break Err(ServiceError::ServiceConnectionError(e).into());
                     }
-                    let delay_ms = (RATE_LIMIT_BASE_DELAY_MS
-                        * 2u64.pow(rate_limit_attempt - 1))
-                    .min(RATE_LIMIT_MAX_DELAY_MS);
+                    let delay_ms = (BACKOFF_BASE_DELAY_MS * 2u64.pow(backoff_attempt - 1))
+                        .min(BACKOFF_MAX_DELAY_MS);
                     info!(
-                        "{} rate limited (attempt {}/{}), backing off {}ms",
-                        $operation_name, rate_limit_attempt,
-                        MAX_RATE_LIMIT_RETRIES, delay_ms,
-                    );
-                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-                    continue;
-                }
-                Err(ServiceError::ServiceConnectionError(e))
-                    if is_leaf_unavailable_error(&e) =>
-                {
-                    leaf_unavailable_attempt += 1;
-                    if leaf_unavailable_attempt > MAX_LEAF_UNAVAILABLE_RETRIES {
-                        break Err(ServiceError::ServiceConnectionError(e).into());
-                    }
-                    let delay_ms = (LEAF_UNAVAILABLE_BASE_DELAY_MS
-                        * 2u64.pow(leaf_unavailable_attempt - 1))
-                    .min(LEAF_UNAVAILABLE_MAX_DELAY_MS);
-                    info!(
-                        "{} hit a not-yet-available leaf (attempt {}/{}), backing off {}ms",
-                        $operation_name, leaf_unavailable_attempt,
-                        MAX_LEAF_UNAVAILABLE_RETRIES, delay_ms,
+                        "{} hit a transient operator error (attempt {}/{}), backing off {}ms: {:?}",
+                        $operation_name, backoff_attempt, MAX_BACKOFF_RETRIES, delay_ms, e,
                     );
                     tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
                     continue;
@@ -2520,5 +2503,24 @@ mod tests {
             "leaf is not available to transfer, status: CREATING",
         )));
         assert!(!is_leaf_unavailable_error(&err));
+    }
+
+    #[test]
+    fn backoff_retryable_covers_rate_limit_and_leaf_unavailable() {
+        let rate_limited = OperatorRpcError::Connection(Box::new(tonic::Status::new(
+            tonic::Code::ResourceExhausted,
+            "rate limited",
+        )));
+        let leaf_unavailable =
+            error_with_reason(tonic::Code::FailedPrecondition, LEAF_UNAVAILABLE_REASON);
+        assert!(is_backoff_retryable_error(&rate_limited));
+        assert!(is_backoff_retryable_error(&leaf_unavailable));
+
+        // A terminal error is not retried.
+        let terminal = OperatorRpcError::Connection(Box::new(tonic::Status::new(
+            tonic::Code::Internal,
+            "boom",
+        )));
+        assert!(!is_backoff_retryable_error(&terminal));
     }
 }

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -50,6 +50,7 @@ use spark::{
     utils::paging::{PagingFilter, PagingResult},
 };
 use tokio::sync::{broadcast, watch};
+use tonic_types::StatusExt;
 use tracing::{Instrument, debug, error, info, trace, warn};
 
 use crate::{
@@ -65,6 +66,11 @@ const MAX_LEAF_SPENT_RETRIES: usize = 3;
 const MAX_RATE_LIMIT_RETRIES: u32 = 5;
 const RATE_LIMIT_BASE_DELAY_MS: u64 = 100;
 const RATE_LIMIT_MAX_DELAY_MS: u64 = 3000;
+/// Retries for a leaf the operators have not finished finalizing yet. The window
+/// after a deposit claim is short, so a few hundred ms of backoff clears it.
+const MAX_LEAF_UNAVAILABLE_RETRIES: u32 = 5;
+const LEAF_UNAVAILABLE_BASE_DELAY_MS: u64 = 100;
+const LEAF_UNAVAILABLE_MAX_DELAY_MS: u64 = 3000;
 /// Grace period before claiming orphaned counter-swap transfers.
 /// Generous to absorb clock skew between the server (`created_time`) and the local clock.
 const COUNTER_SWAP_CLAIM_GRACE_PERIOD_SECS: u64 = 300;
@@ -94,6 +100,31 @@ fn is_resource_exhausted_error(error: &OperatorRpcError) -> bool {
     matches!(error, OperatorRpcError::Connection(status) if status.code() == tonic::Code::ResourceExhausted)
 }
 
+/// `ErrorInfo` reason the operators set when a leaf is not yet available to
+/// transfer.
+const LEAF_UNAVAILABLE_REASON: &str = "LEAF_UNAVAILABLE";
+
+/// Extracts the machine-readable `google.rpc.ErrorInfo` reason the operators
+/// attach to a gRPC status (e.g. `LEAF_UNAVAILABLE`, `INVALID_STATE`). Returns
+/// `None` for non-gRPC errors or statuses without a structured detail.
+fn operator_error_reason(error: &OperatorRpcError) -> Option<String> {
+    match error {
+        OperatorRpcError::Connection(status) => {
+            status.get_details_error_info().map(|info| info.reason)
+        }
+        _ => None,
+    }
+}
+
+/// Checks if the operators report a leaf is not yet available to transfer. This
+/// happens right after a deposit claim: the local store already counts the leaf
+/// as available (its deposit event flipped the status), but the operators'
+/// transfer-prepare validation still sees `CREATING`. Transient, clears once the
+/// operators converge, so the caller backs off and retries.
+fn is_leaf_unavailable_error(error: &OperatorRpcError) -> bool {
+    operator_error_reason(error).as_deref() == Some(LEAF_UNAVAILABLE_REASON)
+}
+
 /// Macro to handle retry logic for operations that may fail due to concurrent leaf spending.
 /// This retries the operation up to MAX_LEAF_SPENT_RETRIES times.
 macro_rules! with_leafs_spent_retry {
@@ -105,6 +136,7 @@ macro_rules! with_leafs_spent_retry {
     ) => {{
         let mut attempt = 0;
         let mut rate_limit_attempt: u32 = 0;
+        let mut leaf_unavailable_attempt: u32 = 0;
         loop {
             if attempt > 0 {
                 if attempt >= MAX_LEAF_SPENT_RETRIES {
@@ -146,6 +178,24 @@ macro_rules! with_leafs_spent_retry {
                         "{} rate limited (attempt {}/{}), backing off {}ms",
                         $operation_name, rate_limit_attempt,
                         MAX_RATE_LIMIT_RETRIES, delay_ms,
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                    continue;
+                }
+                Err(ServiceError::ServiceConnectionError(e))
+                    if is_leaf_unavailable_error(&e) =>
+                {
+                    leaf_unavailable_attempt += 1;
+                    if leaf_unavailable_attempt > MAX_LEAF_UNAVAILABLE_RETRIES {
+                        break Err(ServiceError::ServiceConnectionError(e).into());
+                    }
+                    let delay_ms = (LEAF_UNAVAILABLE_BASE_DELAY_MS
+                        * 2u64.pow(leaf_unavailable_attempt - 1))
+                    .min(LEAF_UNAVAILABLE_MAX_DELAY_MS);
+                    info!(
+                        "{} hit a not-yet-available leaf (attempt {}/{}), backing off {}ms",
+                        $operation_name, leaf_unavailable_attempt,
+                        MAX_LEAF_UNAVAILABLE_RETRIES, delay_ms,
                     );
                     tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
                     continue;
@@ -2438,5 +2488,37 @@ mod tests {
     fn execute_before_from_expiry_none_before_epoch() {
         let before_epoch = UNIX_EPOCH - Duration::from_secs(1);
         assert_eq!(execute_before_from_expiry(Some(before_epoch)), None);
+    }
+
+    /// Builds an operator error carrying a structured `ErrorInfo` reason, the
+    /// way the operators populate `grpc-status-details-bin` on the wire.
+    fn error_with_reason(code: tonic::Code, reason: &str) -> OperatorRpcError {
+        let details = tonic_types::ErrorDetails::with_error_info(reason, "spark", HashMap::new());
+        let status = tonic::Status::with_error_details(code, "operator rejected", details);
+        OperatorRpcError::Connection(Box::new(status))
+    }
+
+    #[test]
+    fn leaf_unavailable_error_matches_error_info_reason() {
+        let err = error_with_reason(tonic::Code::FailedPrecondition, LEAF_UNAVAILABLE_REASON);
+        assert!(is_leaf_unavailable_error(&err));
+    }
+
+    #[test]
+    fn leaf_unavailable_error_ignores_other_reasons() {
+        // A different ErrorInfo reason on the same status code must not match.
+        let err = error_with_reason(tonic::Code::FailedPrecondition, "INVALID_STATE");
+        assert!(!is_leaf_unavailable_error(&err));
+    }
+
+    #[test]
+    fn leaf_unavailable_error_ignores_status_without_details() {
+        // A status with no structured detail (just a message) is not a match:
+        // detection no longer depends on the human-readable message text.
+        let err = OperatorRpcError::Connection(Box::new(tonic::Status::new(
+            tonic::Code::FailedPrecondition,
+            "leaf is not available to transfer, status: CREATING",
+        )));
+        assert!(!is_leaf_unavailable_error(&err));
     }
 }

--- a/docs/breez-sdk/snippets/rust/Cargo.lock
+++ b/docs/breez-sdk/snippets/rust/Cargo.lock
@@ -3397,6 +3397,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tonic",
+ "tonic-types",
  "tracing",
  "uuid",
 ]
@@ -3859,6 +3860,17 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0081d8ee0847d01271392a5aebe960a4600f5d4da6c67648a6382a0940f8b367"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
 ]
 
 [[package]]

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -3272,6 +3272,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tonic",
+ "tonic-types",
  "tracing",
  "uuid",
 ]
@@ -3670,6 +3671,17 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0081d8ee0847d01271392a5aebe960a4600f5d4da6c67648a6382a0940f8b367"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

A transfer attempted right after a deposit claim can be rejected by the operators:

```
status: FailedPrecondition, message: "consensus send transfer failed: prepare failed:
... unable to validate leaf ...: leaf ... is not available to transfer, status: CREATING"
```

The local store already counts the leaf as available (its deposit event flipped the status, so `getInfo`/balance includes it), but the operators' transfer-prepare validation still sees the leaf as `CREATING`. There is a short eventual-consistency window after a deposit confirmation where the SDK's view is ahead of the operators'.

This error class was not retried, so the transfer failed outright. It surfaced as a flaky failure of the `test_non_static_deposit_with_faucet` integration test, but it affects any user transferring straight after a deposit confirms.

## Fix

- Detect the condition via the **structured `google.rpc.ErrorInfo` reason** the operators attach to the gRPC status (`LEAF_UNAVAILABLE`), not the human-readable message. The operators consistently set machine-readable reasons (`LEAF_UNAVAILABLE`, `INVALID_STATE`, `DUPLICATE_OPERATION`), so this is a stable contract rather than a brittle string match.
- Back off and retry in `with_leafs_spent_retry!` (200ms → 3s exponential, up to 5 attempts) until the operators converge. This covers every operation routed through the macro (transfers, lightning sends, etc.).
- The retry deliberately **skips `refresh_leaves`**: that call keeps only `Available` leaves, and if the operators' query path also lagged it would drop the leaf and turn this into a spurious insufficient-funds error. The failed attempt releases its reservation via `with_reserved_leaves`, so the next attempt re-selects the same leaf cleanly once the operators catch up.

`operator_error_reason()` is a reusable helper — the structured path the existing `is_transfer_locked_error` TODO ("we want to move to an error code") was waiting for.

## Notes

- Adds the `tonic-types` dependency (0.12.3, matching tonic 0.12.3). It is pure prost type-decoding with `tonic` default-features off (no transport); confirmed WASM-safe via `make clippy-check`.
- The integration test needs the deployed regtest operators, so its timing is not reproducible locally, but the retry now keys on the exact structured reason that failed it. The integration test itself is left untouched.

## Testing

- `make fmt-check`, `make clippy-check` (cargo + WASM) ✓
- `cargo test -p spark-wallet` — 12 passed, including new unit tests pinning the classifier to round-tripped `ErrorInfo` details (reason matches / different reason does not / detail-less status does not).