### PR TITLE
Encrypt static deposit key share in claim_static_deposit

### DIFF
--- a/crates/spark/schema/spark.graphql
+++ b/crates/spark/schema/spark.graphql
@@ -95,7 +95,10 @@ input ClaimStaticDepositInput {
   max_fee_sats: Long
 
   """The deposit key of the user."""
-  deposit_secret_key: String!
+  deposit_secret_key: String
+
+  """The ECIES-encrypted deposit key of the user."""
+  encrypted_deposit_secret_key: String
 
   """The signature of the claim provided by the user."""
   signature: String!

--- a/crates/spark/schema/spark.graphql
+++ b/crates/spark/schema/spark.graphql
@@ -85,26 +85,30 @@ input ClaimStaticDepositInput {
   """The bitcoin network of the deposit."""
   network: BitcoinNetwork!
 
-  """The type of the claim request."""
-  request_type: ClaimStaticDepositRequestType!
-
   """The amount of sats to claim for FIXED_AMOUNT quote."""
   credit_amount_sats: Long
 
   """The amount of sats to deduct from the UTXO value for MAX_FEE quote."""
   max_fee_sats: Long
 
-  """The deposit key of the user."""
-  deposit_secret_key: String
-
-  """The ECIES-encrypted deposit key of the user."""
-  encrypted_deposit_secret_key: String
-
   """The signature of the claim provided by the user."""
   signature: String!
 
   """The signature of the quote provided by the SSP."""
   quote_signature: String!
+
+  """
+  The deposit key of the user, hex-encoded. May be omitted if encrypted_deposit_secret_key is provided, or if the SSP has a key stored from a previous claim for the same static deposit address.
+  """
+  deposit_secret_key: String = null
+
+  """The type of the claim request."""
+  request_type: ClaimStaticDepositRequestType = null @deprecated(reason: "Different types of claim requests are no longer supported.")
+
+  """
+  The deposit key of the user, ECIES-encrypted to the SSP's identity public key for the network and hex-encoded (the same encryption scheme as transfer leaf secret ciphers). Provide instead of deposit_secret_key so the raw key never leaves the user's signer.
+  """
+  encrypted_deposit_secret_key: String = null
 }
 
 type ClaimStaticDepositOutput {

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -300,6 +300,20 @@ impl DepositService {
             })
             .await?;
 
+        // The SSP co-signs the claim and so needs the static-deposit secret.
+        // Send it ECIES-encrypted to the SSP identity public key (same scheme as
+        // transfer leaf secret ciphers) instead of in cleartext over GraphQL.
+        let encrypted_deposit_secret_key = utils::ecies::encrypt(
+            &self
+                .ssp_client
+                .identity_public_key()
+                .serialize_uncompressed(),
+            &deposit_secret_key.secret_bytes(),
+        )
+        .map_err(|e| {
+            ServiceError::Generic(format!("ECIES encryption of deposit key failed: {e}"))
+        })?;
+
         // Call the service provider to claim the static deposit
         let resp = self
             .ssp_client
@@ -310,7 +324,8 @@ impl DepositService {
                 credit_amount_sats: Some(credit_amount_sats),
                 request_type: ClaimStaticDepositRequestType::FixedAmount,
                 max_fee_sats: None,
-                deposit_secret_key: hex::encode(deposit_secret_key.secret_bytes()),
+                deposit_secret_key: None,
+                encrypted_deposit_secret_key: Some(hex::encode(encrypted_deposit_secret_key)),
                 quote_signature: quote_signature.serialize_der().to_string(),
                 signature: user_signature.serialize_der().to_string(),
             })

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -321,7 +321,7 @@ impl DepositService {
                 output_index: output_index as i64,
                 network: self.network.into(),
                 credit_amount_sats: Some(credit_amount_sats),
-                request_type: ClaimStaticDepositRequestType::FixedAmount,
+                request_type: Some(ClaimStaticDepositRequestType::FixedAmount),
                 max_fee_sats: None,
                 deposit_secret_key: None,
                 encrypted_deposit_secret_key: Some(hex::encode(encrypted_deposit_secret_key)),

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -286,9 +286,8 @@ impl DepositService {
             &quote_signature.serialize_der(),
         );
 
-        // The signer exports the static-deposit secret (the SSP co-signs and
-        // needs it in the clear) and signs the user-statement with the
-        // identity key.
+        // The signer exports the static-deposit secret and signs the
+        // user-statement with the identity key.
         let PreparedStaticDepositClaim {
             deposit_secret_key,
             user_signature,


### PR DESCRIPTION
## What

`claim_static_deposit` previously sent the user's 32-byte static deposit secret key to the SSP in cleartext (hex) over GraphQL. This switches to the SSP's new backward-compatible encrypted flow: the secret is ECIES-encrypted to the SSP identity public key for the selected network (the same scheme used for transfer leaf secret ciphers) and sent in the new `encrypted_deposit_secret_key` field, with the raw `deposit_secret_key` sent as null.

## Changes

- `crates/spark/schema/spark.graphql`: relax `deposit_secret_key` to nullable and add `encrypted_deposit_secret_key` on `ClaimStaticDepositInput`. The `graphql_client` macro regenerates both as `Option<String>`.
- `crates/spark/src/services/deposit.rs`: encrypt the exported deposit secret to `ssp_client.identity_public_key()` via `utils::ecies::encrypt`, hex-encode, and send it in the encrypted field; send `deposit_secret_key: None`.

Only `claim_static_deposit` is used by the SDK, so the other static-deposit mutations are untouched.

**Verified to be working on mainnet**