### PR TITLE
Skip the reqwest User-Agent on WASM to keep requests CORS-simple

### DIFF
--- a/crates/platform-utils/src/http/client.rs
+++ b/crates/platform-utils/src/http/client.rs
@@ -30,10 +30,20 @@ impl ReqwestHttpClient {
     /// Native targets layer HTTP/2 and TCP keepalives on top of reqwest's
     /// defaults (uncapped idle pool, 90s idle timeout, `TCP_NODELAY`) so a
     /// long-lived shared client survives intermediaries that reap idle HTTP/2
-    /// flows, and apply the caller's user agent. On WASM the browser owns
-    /// connection management and the `User-Agent` header: a script-set user
-    /// agent trips a CORS preflight on an otherwise simple request, so both
-    /// the keepalive knobs and the user agent are skipped.
+    /// flows, and apply the caller's user agent.
+    ///
+    /// On WASM both are skipped. The browser owns connection management, and a
+    /// script-set `User-Agent` is not CORS-safelisted, so it turns an otherwise
+    /// simple request into a preflighted one: Chrome silently drops the header
+    /// (crbug.com/571722) while Firefox/Safari send it and then fail the
+    /// preflight against an endpoint that doesn't allow it. The browser sends
+    /// its own `User-Agent` regardless, so omitting it loses nothing.
+    // `user_agent` is intentionally unused on WASM (see above); the signature
+    // stays uniform across targets.
+    #[cfg_attr(
+        all(target_family = "wasm", target_os = "unknown"),
+        expect(clippy::needless_pass_by_value, unused_variables)
+    )]
     pub fn new(user_agent: Option<String>) -> Self {
         let builder = reqwest::Client::builder();
         #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
@@ -48,8 +58,6 @@ impl ReqwestHttpClient {
                 .http2_keep_alive_timeout(Duration::from_secs(10))
                 .http2_keep_alive_while_idle(true)
         };
-        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
-        drop(user_agent);
         let client = match builder.build() {
             Ok(client) => client,
             Err(e) => {

--- a/crates/platform-utils/src/http/client.rs
+++ b/crates/platform-utils/src/http/client.rs
@@ -30,21 +30,26 @@ impl ReqwestHttpClient {
     /// Native targets layer HTTP/2 and TCP keepalives on top of reqwest's
     /// defaults (uncapped idle pool, 90s idle timeout, `TCP_NODELAY`) so a
     /// long-lived shared client survives intermediaries that reap idle HTTP/2
-    /// flows. On WASM the browser owns connection management and these knobs
-    /// aren't exposed.
+    /// flows, and apply the caller's user agent. On WASM the browser owns
+    /// connection management and the `User-Agent` header: a script-set user
+    /// agent trips a CORS preflight on an otherwise simple request, so both
+    /// the keepalive knobs and the user agent are skipped.
     pub fn new(user_agent: Option<String>) -> Self {
-        let mut builder = reqwest::Client::builder();
-        if let Some(ua) = user_agent {
-            builder = builder.user_agent(ua);
-        }
+        let builder = reqwest::Client::builder();
         #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-        {
-            builder = builder
+        let builder = {
+            let mut builder = builder;
+            if let Some(ua) = user_agent {
+                builder = builder.user_agent(ua);
+            }
+            builder
                 .tcp_keepalive(Some(Duration::from_mins(1)))
                 .http2_keep_alive_interval(Duration::from_secs(30))
                 .http2_keep_alive_timeout(Duration::from_secs(10))
-                .http2_keep_alive_while_idle(true);
-        }
+                .http2_keep_alive_while_idle(true)
+        };
+        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+        drop(user_agent);
         let client = match builder.build() {
             Ok(client) => client,
             Err(e) => {


### PR DESCRIPTION
## What

`ReqwestHttpClient::new` (the SDK's only reqwest client) applied the caller's user agent on **every** target, including WASM. On WASM a script-set `User-Agent` is not a CORS-safelisted request header, so it turns an otherwise *simple* cross-origin request into one that requires a preflight (`OPTIONS`). When the target server doesn't answer the preflight with the right CORS headers, the request fails in the browser.

This gates the `.user_agent(...)` call to native targets, alongside the existing keepalive knobs. On WASM the client is built from the base builder, so requests stay CORS-simple.

## Why this is the right layer

Our reference app previously worked around this by stripping the SDK User-Agent in the WebView ([glow-web #224](https://github.com/breez/glow-web/pull/224)). Doing it at the SDK reqwest layer fixes it for every WASM consumer, not just that app's WebView.

## Scope / not touched

The gRPC WASM transport (`crates/breez-sdk/common/src/grpc/transport_wasm.rs`) deliberately sets its own `User-Agent` + `X-User-Agent` (with a documented Chrome `crbug.com/571722` workaround) and is intentionally left untouched: this change is scoped to the reqwest path only.

## Verification

- `cargo clippy -p platform-utils -- -D warnings` (native) ✅
- `cargo clippy -p platform-utils --target wasm32-unknown-unknown -- -D warnings` ✅
- `cargo fmt -p platform-utils -- --check` ✅

Public API is unchanged (`ReqwestHttpClient::new(Option<String>)`, `create_http_client(Option<&str>)`), so no callers are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Related: boltz-client already ships this

boltz-client made the identical native-only User-Agent gating in its forked `platform-utils` ([boltz-client@e747a3e](https://github.com/breez/boltz-client/commit/e747a3e80c06fba90224622505995e8ecb0ffa4d), 2026-06-15), where its commit and `docs/decisions.md` document it as **a deliberate divergence from the upstream spark-sdk client** ("...which keeps the UA because it only talks to servers it controls"). This PR converges spark-sdk with that fix, so the divergence goes away. (boltz-client's own comment + decisions-doc entry then want a follow-up update in that repo.)

One spark-sdk-specific note: this changes only the **reqwest** path. The gRPC WASM transport (`transport_wasm.rs`) still sends `User-Agent` + `X-User-Agent` to Breez-controlled servers, intentionally; unlike boltz (whose only HTTP path is reqwest), this is not a full removal of the UA on WASM.

