### PR TITLE
feat: add ca_cert_pem to SparkSigningOperator

### DIFF
--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -822,6 +822,11 @@ pub struct SparkSigningOperator {
     pub address: String,
     /// Hex-encoded compressed public key of the operator.
     pub identity_public_key: String,
+    /// Optional PEM-encoded CA certificate for TLS verification.
+    /// When set, the SDK uses this CA to verify the operator's TLS certificate
+    /// instead of the system/default roots. Useful for local development with
+    /// self-signed certificates.
+    pub ca_cert_pem: Option<String>,
 }
 
 /// Configuration for the Spark Service Provider (SSP).

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -285,6 +285,10 @@ fn default_spark_config(network: Network) -> crate::models::SparkConfig {
             identifier: hex::encode(op.identifier.serialize()),
             address: op.address.clone(),
             identity_public_key: hex::encode(op.identity_public_key.serialize()),
+            ca_cert_pem: op
+                .ca_cert
+                .as_ref()
+                .and_then(|b| String::from_utf8(b.clone()).ok()),
         })
         .collect();
 

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -352,11 +352,12 @@ impl SdkBuilder {
             .signing_operators
             .iter()
             .map(|op| {
+                let ca_cert = op.ca_cert_pem.as_ref().map(|pem| pem.as_bytes().to_vec());
                 SparkWalletConfig::create_operator_config(
                     op.id as usize,
                     &op.identifier,
                     &op.address,
-                    None,
+                    ca_cert.as_deref(),
                     &op.identity_public_key,
                 )
                 .map_err(|e| SdkError::InvalidInput(e.to_string()))

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -644,6 +644,7 @@ pub struct SparkSigningOperator {
     pub identifier: String,
     pub address: String,
     pub identity_public_key: String,
+    pub ca_cert_pem: Option<String>,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::SparkSspConfig)]

--- a/docs/breez-sdk/snippets/csharp/Config.cs
+++ b/docs/breez-sdk/snippets/csharp/Config.cs
@@ -92,21 +92,24 @@ namespace BreezSdkSnippets
                             identifier: "0000000000000000000000000000000000000000000000000000000000000001",
                             address: "https://0.spark.example.com",
                             identityPublicKey:
-                                "03acd9a5a88db102730ff83dee69d69088cc4c9d93bbee893e90fd5051b7da9651"
+                                "03acd9a5a88db102730ff83dee69d69088cc4c9d93bbee893e90fd5051b7da9651",
+                            caCertPem: null
                         ),
                         new SparkSigningOperator(
                             id: 1,
                             identifier: "0000000000000000000000000000000000000000000000000000000000000002",
                             address: "https://1.spark.example.com",
                             identityPublicKey:
-                                "02d2d103cacb1d6355efeab27637c74484e2a7459e49110c3fe885210369782e23"
+                                "02d2d103cacb1d6355efeab27637c74484e2a7459e49110c3fe885210369782e23",
+                            caCertPem: null
                         ),
                         new SparkSigningOperator(
                             id: 2,
                             identifier: "0000000000000000000000000000000000000000000000000000000000000003",
                             address: "https://2.spark.example.com",
                             identityPublicKey:
-                                "0350f07ffc21bfd59d31e0a7a600e2995273938444447cb9bc4c75b8a895dbb853"
+                                "0350f07ffc21bfd59d31e0a7a600e2995273938444447cb9bc4c75b8a895dbb853",
+                            caCertPem: null
                         )
                     },
                     sspConfig: new SparkSspConfig(

--- a/docs/breez-sdk/snippets/flutter/lib/config.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/config.dart
@@ -77,21 +77,24 @@ Future<void> configureSparkConfig() async {
                     '0000000000000000000000000000000000000000000000000000000000000001',
                 address: 'https://0.spark.example.com',
                 identityPublicKey:
-                    '03acd9a5a88db102730ff83dee69d69088cc4c9d93bbee893e90fd5051b7da9651'),
+                    '03acd9a5a88db102730ff83dee69d69088cc4c9d93bbee893e90fd5051b7da9651',
+                caCertPem: null),
             SparkSigningOperator(
                 id: 1,
                 identifier:
                     '0000000000000000000000000000000000000000000000000000000000000002',
                 address: 'https://1.spark.example.com',
                 identityPublicKey:
-                    '02d2d103cacb1d6355efeab27637c74484e2a7459e49110c3fe885210369782e23'),
+                    '02d2d103cacb1d6355efeab27637c74484e2a7459e49110c3fe885210369782e23',
+                caCertPem: null),
             SparkSigningOperator(
                 id: 2,
                 identifier:
                     '0000000000000000000000000000000000000000000000000000000000000003',
                 address: 'https://2.spark.example.com',
                 identityPublicKey:
-                    '0350f07ffc21bfd59d31e0a7a600e2995273938444447cb9bc4c75b8a895dbb853'),
+                    '0350f07ffc21bfd59d31e0a7a600e2995273938444447cb9bc4c75b8a895dbb853',
+                caCertPem: null),
           ],
           sspConfig: SparkSspConfig(
               baseUrl: 'https://api.example.com',

--- a/docs/breez-sdk/snippets/go/config.go
+++ b/docs/breez-sdk/snippets/go/config.go
@@ -94,18 +94,21 @@ func ConfigureSparkConfig() {
 				Identifier:        "0000000000000000000000000000000000000000000000000000000000000001",
 				Address:           "https://0.spark.example.com",
 				IdentityPublicKey: "03acd9a5a88db102730ff83dee69d69088cc4c9d93bbee893e90fd5051b7da9651",
+				CaCertPem:         nil,
 			},
 			{
 				Id:                1,
 				Identifier:        "0000000000000000000000000000000000000000000000000000000000000002",
 				Address:           "https://1.spark.example.com",
 				IdentityPublicKey: "02d2d103cacb1d6355efeab27637c74484e2a7459e49110c3fe885210369782e23",
+				CaCertPem:         nil,
 			},
 			{
 				Id:                2,
 				Identifier:        "0000000000000000000000000000000000000000000000000000000000000003",
 				Address:           "https://2.spark.example.com",
 				IdentityPublicKey: "0350f07ffc21bfd59d31e0a7a600e2995273938444447cb9bc4c75b8a895dbb853",
+				CaCertPem:         nil,
 			},
 		},
 		SspConfig: breez_sdk_spark.SparkSspConfig{

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
@@ -79,19 +79,22 @@ class Config {
                     id = 0u,
                     identifier = "0000000000000000000000000000000000000000000000000000000000000001",
                     address = "https://0.spark.example.com",
-                    identityPublicKey = "03acd9a5a88db102730ff83dee69d69088cc4c9d93bbee893e90fd5051b7da9651"
+                    identityPublicKey = "03acd9a5a88db102730ff83dee69d69088cc4c9d93bbee893e90fd5051b7da9651",
+                    caCertPem = null
                 ),
                 SparkSigningOperator(
                     id = 1u,
                     identifier = "0000000000000000000000000000000000000000000000000000000000000002",
                     address = "https://1.spark.example.com",
-                    identityPublicKey = "02d2d103cacb1d6355efeab27637c74484e2a7459e49110c3fe885210369782e23"
+                    identityPublicKey = "02d2d103cacb1d6355efeab27637c74484e2a7459e49110c3fe885210369782e23",
+                    caCertPem = null
                 ),
                 SparkSigningOperator(
                     id = 2u,
                     identifier = "0000000000000000000000000000000000000000000000000000000000000003",
                     address = "https://2.spark.example.com",
-                    identityPublicKey = "0350f07ffc21bfd59d31e0a7a600e2995273938444447cb9bc4c75b8a895dbb853"
+                    identityPublicKey = "0350f07ffc21bfd59d31e0a7a600e2995273938444447cb9bc4c75b8a895dbb853",
+                    caCertPem = null
                 )
             ),
             sspConfig = SparkSspConfig(

--- a/docs/breez-sdk/snippets/python/src/config.py
+++ b/docs/breez-sdk/snippets/python/src/config.py
@@ -85,6 +85,7 @@ async def configure_spark_config():
                 identity_public_key=(
                     "03acd9a5a88db102730ff83dee69d69088cc4c9d93bbee893e90fd5051b7da9651"
                 ),
+                ca_cert_pem=None,
             ),
             SparkSigningOperator(
                 id=1,
@@ -93,6 +94,7 @@ async def configure_spark_config():
                 identity_public_key=(
                     "02d2d103cacb1d6355efeab27637c74484e2a7459e49110c3fe885210369782e23"
                 ),
+                ca_cert_pem=None,
             ),
             SparkSigningOperator(
                 id=2,
@@ -101,6 +103,7 @@ async def configure_spark_config():
                 identity_public_key=(
                     "0350f07ffc21bfd59d31e0a7a600e2995273938444447cb9bc4c75b8a895dbb853"
                 ),
+                ca_cert_pem=None,
             ),
         ],
         ssp_config=SparkSspConfig(

--- a/docs/breez-sdk/snippets/react-native/config.ts
+++ b/docs/breez-sdk/snippets/react-native/config.ts
@@ -80,19 +80,22 @@ const exampleConfigureSparkConfig = () => {
         id: 0,
         identifier: '0000000000000000000000000000000000000000000000000000000000000001',
         address: 'https://0.spark.example.com',
-        identityPublicKey: '03acd9a5a88db102730ff83dee69d69088cc4c9d93bbee893e90fd5051b7da9651'
+        identityPublicKey: '03acd9a5a88db102730ff83dee69d69088cc4c9d93bbee893e90fd5051b7da9651',
+        caCertPem: undefined
       },
       {
         id: 1,
         identifier: '0000000000000000000000000000000000000000000000000000000000000002',
         address: 'https://1.spark.example.com',
-        identityPublicKey: '02d2d103cacb1d6355efeab27637c74484e2a7459e49110c3fe885210369782e23'
+        identityPublicKey: '02d2d103cacb1d6355efeab27637c74484e2a7459e49110c3fe885210369782e23',
+        caCertPem: undefined
       },
       {
         id: 2,
         identifier: '0000000000000000000000000000000000000000000000000000000000000003',
         address: 'https://2.spark.example.com',
-        identityPublicKey: '0350f07ffc21bfd59d31e0a7a600e2995273938444447cb9bc4c75b8a895dbb853'
+        identityPublicKey: '0350f07ffc21bfd59d31e0a7a600e2995273938444447cb9bc4c75b8a895dbb853',
+        caCertPem: undefined
       }
     ],
     sspConfig: {

--- a/docs/breez-sdk/snippets/rust/src/config.rs
+++ b/docs/breez-sdk/snippets/rust/src/config.rs
@@ -91,6 +91,7 @@ pub(crate) fn configure_spark_config() -> Result<()> {
                 address: "https://0.spark.example.com".to_string(),
                 identity_public_key:
                     "03acd9a5a88db102730ff83dee69d69088cc4c9d93bbee893e90fd5051b7da9651".to_string(),
+                ca_cert_pem: None,
             },
             SparkSigningOperator {
                 id: 1,
@@ -99,6 +100,7 @@ pub(crate) fn configure_spark_config() -> Result<()> {
                 address: "https://1.spark.example.com".to_string(),
                 identity_public_key:
                     "02d2d103cacb1d6355efeab27637c74484e2a7459e49110c3fe885210369782e23".to_string(),
+                ca_cert_pem: None,
             },
             SparkSigningOperator {
                 id: 2,
@@ -107,6 +109,7 @@ pub(crate) fn configure_spark_config() -> Result<()> {
                 address: "https://2.spark.example.com".to_string(),
                 identity_public_key:
                     "0350f07ffc21bfd59d31e0a7a600e2995273938444447cb9bc4c75b8a895dbb853".to_string(),
+                ca_cert_pem: None,
             },
         ],
         ssp_config: SparkSspConfig {

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -62,6 +62,7 @@ pub struct _SparkSigningOperator {
     pub identifier: String,
     pub address: String,
     pub identity_public_key: String,
+    pub ca_cert_pem: Option<String>,
 }
 
 #[frb(mirror(SparkSspConfig))]


### PR DESCRIPTION
adds an optional ca_cert_pem field to SparkSigningOperator so callers can verify a signing operator's tls certificate against a custom pem-encoded CA instead of the default webpki roots. this lets the sdk connect to local signing operators that present self-signed development certificates.

the field threads through sdk_builder into create_operator_config, and default_spark_config surfaces any ca_cert already present on the operator config so the round trip is lossless. mirrored in the wasm and flutter models and added to the config doc snippets for rust, python, go, csharp, kotlin and dart. swift, typescript, react-native and nodejs snippets have no SparkSigningOperator construction so they are unaffected.