### PR TITLE
Boltz cross-chain: sync swap rows for cross-instance recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=6906a0d84fb2252df827665a52b0356aca64ed2d#6906a0d84fb2252df827665a52b0356aca64ed2d"
+source = "git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730#809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -1326,8 +1326,8 @@ dependencies = [
  "hex",
  "k256",
  "lightning-invoice 0.34.0",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=6906a0d84fb2252df827665a52b0356aca64ed2d)",
- "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=6906a0d84fb2252df827665a52b0356aca64ed2d)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730)",
+ "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730)",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4165,7 +4165,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=6906a0d84fb2252df827665a52b0356aca64ed2d#6906a0d84fb2252df827665a52b0356aca64ed2d"
+source = "git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730#809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -4896,11 +4896,11 @@ dependencies = [
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=6906a0d84fb2252df827665a52b0356aca64ed2d#6906a0d84fb2252df827665a52b0356aca64ed2d"
+source = "git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730#809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=6906a0d84fb2252df827665a52b0356aca64ed2d)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730)",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ bech32 = "0.11.0"
 bip39 = "2.2.0"
 bitcoin = { version = "0.32.6", features = ["serde"] }
 bitflags = "2.10.0"
-boltz-client = { git = "https://github.com/breez/boltz-client", rev = "6906a0d84fb2252df827665a52b0356aca64ed2d" }
+boltz-client = { git = "https://github.com/breez/boltz-client", rev = "809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730" }
 breez-sdk-common = { path = "crates/breez-sdk/common", default-features = false }
 breez-sdk-spark = { path = "crates/breez-sdk/core" }
 built = { version = "0.8.0", features = ["git2"] }

--- a/crates/breez-sdk/core/src/cross_chain/boltz.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz.rs
@@ -87,15 +87,12 @@ impl BoltzService {
         }
     }
 
-    /// Initializes the Boltz reverse-swap cross-chain provider: constructs the
-    /// inner seedless [`BoltzClient`], registers the event listener, resumes any
-    /// active swaps, and returns an SDK-side wrapper ready to be inserted into
-    /// the provider registry. Returns `None` when the network has no default
-    /// configuration.
+    /// Builds the Boltz reverse-swap cross-chain provider, or `None` when the
+    /// network has no default configuration.
     ///
-    /// Seedless: each swap carries its own random secrets, persisted (encrypted)
-    /// and synced by the adapter, so a swap is recoverable on any instance of the
-    /// same wallet without a shared seed.
+    /// Runs boltz-client in seedless mode: each swap carries its own secrets,
+    /// persisted and synced by the storage adapter, so it is recoverable on any
+    /// instance of the same wallet without a shared seed.
     pub(crate) async fn build(
         network: Network,
         spark_wallet: Arc<SparkWallet>,

--- a/crates/breez-sdk/core/src/cross_chain/boltz.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz.rs
@@ -43,107 +43,6 @@ const SEND_POLL_INITIAL_DELAY_MS: u64 = 500;
 const SEND_POLL_MAX_DELAY_MS: u64 = 2000;
 const SEND_POLL_TIMEOUT_SECS: u64 = 60;
 
-/// Hardened derivation index reserved for encrypting the Boltz instance handle
-/// at rest. `1112493140` == ASCII "BOLT", distinct from the session store's
-/// "SESN" path, `RTSyncSigner`'s indices, and the `KeySet` master keys, so this
-/// scope can never collide with another subsystem deriving from the same
-/// identity master key. Never change it: this index derives the at-rest
-/// encryption key, so altering it makes every existing encrypted handle
-/// undecryptable (we then discard and regenerate, dropping any swap in flight
-/// on that device). No per-network variant is needed: the signer's
-/// `identity_master_key` is already derived under a network-specific account
-/// number, so mainnet and regtest yield distinct encryption keys regardless.
-const BOLTZ_INSTANCE_ENCRYPTION_PATH: &str = "m/1112493140'/0'/0'/0/0";
-
-#[derive(serde::Serialize, serde::Deserialize)]
-struct BoltzInstanceHandle {
-    instance_id: String,
-    seed_hex: String,
-}
-
-/// Loads or generates the device-local Boltz instance handle (random 32-byte
-/// seed + instance id). The seed is a long-lived secret that derives the Boltz
-/// swap claim/refund keys, so the serialized handle is encrypted at rest via
-/// the signer (ECIES under a dedicated derivation path): an attacker with
-/// read-only storage access never sees the seed in cleartext.
-///
-/// The seed is random rather than derived from the wallet identity so two
-/// devices restored from the same mnemonic never share a Boltz instance seed.
-///
-/// In v1 this is kept local only. Cross-device recovery of swaps lands with
-/// the v2 submarine-swap feature.
-///
-/// Cross-device consequence in v1: a user who restores from mnemonic on a
-/// second device cannot claim destination-chain payouts for reverse swaps
-/// initiated on the first device. Funds are not at risk (Boltz's hold-invoice
-/// timeout refunds the lightning leg), but the second device is blind to the
-/// in-flight swap until it terminates on Boltz's side. v2 is expected to
-/// retroactively publish the existing local seed on first boot so new devices
-/// can bootstrap from rtsync.
-async fn load_or_create_boltz_instance(
-    storage: &Arc<dyn Storage>,
-    signer: &Arc<dyn crate::signer::BreezSigner>,
-) -> Result<BoltzInstanceHandle, SdkError> {
-    use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
-    use bitcoin::bip32::DerivationPath;
-    use bitcoin::secp256k1::rand::{RngCore, thread_rng};
-
-    const BOLTZ_INSTANCE_KEY: &str = "boltz_instance_current";
-
-    let encryption_path: DerivationPath = BOLTZ_INSTANCE_ENCRYPTION_PATH
-        .parse()
-        .map_err(|e| SdkError::Generic(format!("Invalid Boltz instance encryption path: {e}")))?;
-
-    if let Some(raw) = storage
-        .get_cached_item(BOLTZ_INSTANCE_KEY.to_string())
-        .await
-        .map_err(|e| SdkError::Generic(format!("Failed to read Boltz instance: {e}")))?
-    {
-        // A decrypt or parse failure here means the stored blob predates
-        // encryption-at-rest (or is otherwise unreadable). The seed is
-        // device-local and regenerable, so we fall through and mint a fresh
-        // one rather than failing connect; the only cost is abandoning any
-        // swap in flight on this device.
-        match decrypt_boltz_instance(&raw, signer, &encryption_path).await {
-            Ok(handle) => return Ok(handle),
-            Err(e) => debug!("Discarding unreadable Boltz instance handle, regenerating: {e}"),
-        }
-    }
-
-    let mut seed = [0u8; 32];
-    thread_rng().fill_bytes(&mut seed);
-    let handle = BoltzInstanceHandle {
-        instance_id: uuid::Uuid::new_v4().to_string(),
-        seed_hex: hex::encode(seed),
-    };
-    let serialized = serde_json::to_vec(&handle)
-        .map_err(|e| SdkError::Generic(format!("Failed to serialize Boltz instance: {e}")))?;
-    let ciphertext = signer
-        .encrypt_ecies(&serialized, &encryption_path)
-        .await
-        .map_err(|e| SdkError::Generic(format!("Failed to encrypt Boltz instance: {e}")))?;
-    storage
-        .set_cached_item(BOLTZ_INSTANCE_KEY.to_string(), BASE64.encode(ciphertext))
-        .await
-        .map_err(|e| SdkError::Generic(format!("Failed to persist Boltz instance: {e}")))?;
-    Ok(handle)
-}
-
-async fn decrypt_boltz_instance(
-    raw: &str,
-    signer: &Arc<dyn crate::signer::BreezSigner>,
-    encryption_path: &bitcoin::bip32::DerivationPath,
-) -> Result<BoltzInstanceHandle, SdkError> {
-    use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
-
-    let ciphertext = BASE64
-        .decode(raw.as_bytes())
-        .map_err(|e| SdkError::Generic(format!("Invalid base64 Boltz instance: {e}")))?;
-    let plaintext = signer.decrypt_ecies(&ciphertext, encryption_path).await?;
-    serde_json::from_slice(&plaintext)
-        .map_err(|e| SdkError::Generic(format!("Corrupted Boltz instance handle: {e}")))
-}
-
 pub(crate) struct BoltzService {
     client: Arc<BoltzClient>,
     spark_wallet: Arc<SparkWallet>,
@@ -188,11 +87,15 @@ impl BoltzService {
         }
     }
 
-    /// Initializes the Boltz reverse-swap cross-chain provider: loads or creates
-    /// the local instance seed, constructs the inner [`BoltzClient`], registers
-    /// the event listener, resumes any active swaps, and returns an SDK-side
-    /// wrapper ready to be inserted into the provider registry. Returns `None`
-    /// when the network has no default configuration.
+    /// Initializes the Boltz reverse-swap cross-chain provider: constructs the
+    /// inner seedless [`BoltzClient`], registers the event listener, resumes any
+    /// active swaps, and returns an SDK-side wrapper ready to be inserted into
+    /// the provider registry. Returns `None` when the network has no default
+    /// configuration.
+    ///
+    /// Seedless: each swap carries its own random secrets, persisted (encrypted)
+    /// and synced by the adapter, so a swap is recoverable on any instance of the
+    /// same wallet without a shared seed.
     pub(crate) async fn build(
         network: Network,
         spark_wallet: Arc<SparkWallet>,
@@ -205,17 +108,18 @@ impl BoltzService {
             return Ok(None);
         };
 
-        let handle = load_or_create_boltz_instance(&storage, &signer).await?;
-        let seed = hex::decode(&handle.seed_hex)
-            .map_err(|e| SdkError::Generic(format!("Invalid Boltz instance seed hex: {e}")))?;
-
-        let adapter = Arc::new(super::boltz_storage_adapter::BoltzStorageAdapter::new(
-            Arc::clone(&storage),
-            handle.instance_id.clone(),
-        ));
+        let adapter = Arc::new(
+            super::boltz_storage_adapter::BoltzStorageAdapter::new(
+                Arc::clone(&storage),
+                Arc::clone(&signer),
+            )
+            .map_err(|e| {
+                SdkError::Generic(format!("Failed to build Boltz storage adapter: {e}"))
+            })?,
+        );
 
         let client = Arc::new(
-            BoltzClient::new(client_config, &seed, adapter)
+            BoltzClient::new_seedless(client_config, adapter)
                 .await
                 .map_err(|e| SdkError::Generic(format!("Failed to construct Boltz client: {e}")))?,
         );

--- a/crates/breez-sdk/core/src/cross_chain/boltz_event_listener.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz_event_listener.rs
@@ -363,7 +363,7 @@ pub(crate) async fn reconcile_pending_boltz_conversions(
 
 #[cfg(test)]
 mod tests {
-    use boltz_client::models::{Asset, BoltzSwap, BoltzSwapStatus, BridgeKind};
+    use boltz_client::models::{Asset, BoltzSwap, BoltzSwapStatus, BridgeKind, SwapKeySource};
 
     use super::*;
     use macros::test_all;
@@ -376,7 +376,7 @@ mod tests {
             id: id.to_string(),
             status,
             bridge_kind: BridgeKind::Direct,
-            claim_key_index: 0,
+            key_source: SwapKeySource::Derived { claim_key_index: 0 },
             chain_id: 42161,
             claim_address: "0xclaim".to_string(),
             destination_address: "0xdest".to_string(),
@@ -526,7 +526,7 @@ mod tests {
         use std::path::PathBuf;
         use std::sync::Arc;
 
-        use boltz_client::models::{Asset, BoltzSwap, BoltzSwapStatus, BridgeKind};
+        use boltz_client::models::{Asset, BoltzSwap, BoltzSwapStatus, BridgeKind, SwapKeySource};
 
         use super::super::*;
         use crate::persist::sqlite::SqliteStorage;
@@ -543,7 +543,7 @@ mod tests {
                 id: id.to_string(),
                 status,
                 bridge_kind: BridgeKind::Oft,
-                claim_key_index: 0,
+                key_source: SwapKeySource::Derived { claim_key_index: 0 },
                 chain_id: 42161,
                 claim_address: "0xclaim".to_string(),
                 destination_address: "0xdest".to_string(),

--- a/crates/breez-sdk/core/src/cross_chain/boltz_storage_adapter.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz_storage_adapter.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use bitcoin::bip32::DerivationPath;
 use boltz_client::{BoltzError, BoltzStorage, models::BoltzSwap};
+use tracing::warn;
 
 use crate::{Storage, persist::StoredBoltzSwap, signer::BreezSigner};
 
@@ -144,7 +145,12 @@ impl BoltzStorage for BoltzStorageAdapter {
             .map_err(|e| BoltzError::Store(format!("Failed to list active swaps: {e}")))?;
         let mut swaps = Vec::with_capacity(rows.len());
         for stored in rows {
-            swaps.push(self.swap_from_stored(stored).await?);
+            let id = stored.id.clone();
+            // Skip row on error (bad base64/json, decryption).
+            match self.swap_from_stored(stored).await {
+                Ok(swap) => swaps.push(swap),
+                Err(e) => warn!("Skipping Boltz swap '{id}': failed to load from storage: {e}"),
+            }
         }
         Ok(swaps)
     }

--- a/crates/breez-sdk/core/src/cross_chain/boltz_storage_adapter.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz_storage_adapter.rs
@@ -13,16 +13,16 @@
 //! decrypted and `key_source` spliced back, reconstructing the full
 //! [`BoltzSwap`].
 //!
-//! The encryption key is derived from the wallet identity at a fixed path, so it
-//! is deterministic across every instance restored from the same mnemonic. That
-//! is what lets a second instance decrypt a swap synced to it and drive it to
-//! terminal (see the realtime-sync `CrossChainSwap` record). Correctness and
-//! cross-instance convergence are boltz-client's job: the SDK just persists and
-//! syncs rows with plain last-writer-wins.
+//! The encryption key is derived from the wallet identity at a fixed path (see
+//! [`BOLTZ_SECRETS_ENCRYPTION_PATH`]), so it is deterministic across every
+//! instance restored from the same mnemonic. That is what lets a second instance
+//! decrypt a swap synced to it and drive it to terminal (see the realtime-sync
+//! `CrossChainSwap` record). Correctness and cross-instance convergence are
+//! boltz-client's job: the SDK just persists and syncs rows with plain
+//! last-writer-wins.
 //!
 //! Terminal swap rows are retained (only excluded from `list_active_swaps`),
-//! keeping a completed swap queryable by id for the wallet's lifetime. Growth is
-//! bounded by swap volume; no TTL in v1.
+//! keeping a completed swap queryable by id for the wallet's lifetime.
 
 use std::sync::Arc;
 

--- a/crates/breez-sdk/core/src/cross_chain/boltz_storage_adapter.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz_storage_adapter.rs
@@ -1,173 +1,152 @@
 //! Adapter exposing the SDK [`Storage`] as a [`boltz_client::BoltzStorage`].
 //!
-//! Canonical Boltz swap state lives in a dedicated cache KV namespace
-//! rather than on payment metadata rows. The adapter is payment-row
-//! agnostic: it can run at prepare time, before any [`crate::Payment`]
-//! has been written.
+//! boltz-client runs in seedless mode: each swap carries its own random preimage
+//! and gas/claim key under `key_source` ([`boltz_client::models::SwapKeySource::Stored`]).
+//! Those secrets are money-critical, so before a swap row reaches local storage
+//! this adapter lifts `key_source` out of the swap JSON, ECIES-encrypts it via
+//! the SDK signer, and persists only the ciphertext in
+//! [`StoredBoltzSwap::secrets`]. The rest of the swap is stored as plaintext
+//! JSON in [`StoredBoltzSwap::data`]. On read the ciphertext is decrypted and
+//! `key_source` spliced back, reconstructing the full [`BoltzSwap`].
 //!
-//! # Retention
+//! The encryption key is derived from the wallet identity at a fixed path, so it
+//! is deterministic across every instance restored from the same mnemonic. That
+//! is what lets a second instance decrypt a swap synced to it and drive it to
+//! terminal (see the realtime-sync `BoltzSwap` record). Correctness and
+//! cross-instance convergence are boltz-client's job: the SDK just persists and
+//! syncs rows with plain last-writer-wins.
 //!
-//! Terminal swap rows are intentionally **not** removed from the cache:
-//! only the `boltz_active_swap_ids` list is pruned on terminal transitions
-//! (see [`BoltzStorage::upsert_swap`]). This keeps terminal swaps queryable
-//! by id for the lifetime of the wallet — aligned with payment-history
-//! retention, and lets `boltz-client` re-inspect a completed swap (e.g.
-//! during debug/recovery) without a separate archive. Growth is bounded by
-//! swap volume; no TTL in v1.
+//! Terminal swap rows are retained (only excluded from `list_active_swaps`),
+//! keeping a completed swap queryable by id for the wallet's lifetime. Growth is
+//! bounded by swap volume; no TTL in v1.
 
 use std::sync::Arc;
 
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use bitcoin::bip32::DerivationPath;
 use boltz_client::{BoltzError, BoltzStorage, models::BoltzSwap};
-use platform_utils::tokio::sync::Mutex;
 
-use crate::Storage;
+use crate::{Storage, persist::StoredBoltzSwap, signer::BreezSigner};
 
-/// Cache KV key for a serialized [`BoltzSwap`] row.
-fn swap_row_key(swap_id: &str) -> String {
-    format!("boltz_swap_row_{swap_id}")
-}
+/// JSON key under which a swap's secrets live before they are lifted out.
+const KEY_SOURCE_FIELD: &str = "key_source";
 
-/// Cache KV key for the JSON array of currently-non-terminal swap ids.
-const ACTIVE_SWAP_IDS_KEY: &str = "boltz_active_swap_ids";
-
-/// Cache KV key for the per-instance claim-key counter.
-fn key_index_cache_key(instance_id: &str) -> String {
-    format!("boltz_key_index_{instance_id}")
-}
+/// Hardened derivation path for the at-rest encryption of Boltz swap secrets.
+/// `1112493140` == ASCII "BOLT", distinct from the other SDK subsystems deriving
+/// from the same identity master key. The derived key is deterministic per
+/// mnemonic+network (the signer's master is derived under a network-specific
+/// account), so every instance of the same wallet encrypts and decrypts swap
+/// secrets under the same key: a swap synced to a second instance is decryptable
+/// there. Never change it: altering the path makes every existing encrypted
+/// `secrets` blob undecryptable.
+const BOLTZ_SECRETS_ENCRYPTION_PATH: &str = "m/1112493140'/0'/0'/0/0";
 
 /// Bridge between breez-sdk [`Storage`] and [`boltz_client::BoltzStorage`].
-///
-/// `instance_id` namespaces the local claim-key counter so two concurrent
-/// SDK instances on the same wallet cannot collide on the same HD index. It
-/// is also the forward-compat anchor for v2 (submarine swaps), which will
-/// introduce a `BoltzInstance` rtsync record type and publish the existing
-/// local seed retroactively for cross-device recovery. Nothing outside this
-/// crate references the field in v1.
 pub(crate) struct BoltzStorageAdapter {
     storage: Arc<dyn Storage>,
-    instance_id: String,
-    key_index_mutex: Arc<Mutex<()>>,
-    /// Serializes read-modify-write of `boltz_active_swap_ids` across
-    /// concurrent `upsert_swap` calls. Without it, two concurrent swap
-    /// transitions can race on the load → mutate → save cycle and lose one
-    /// another's update.
-    active_ids_mutex: Arc<Mutex<()>>,
+    signer: Arc<dyn BreezSigner>,
+    encryption_path: DerivationPath,
 }
 
 impl BoltzStorageAdapter {
-    pub(crate) fn new(storage: Arc<dyn Storage>, instance_id: String) -> Self {
-        Self {
+    pub(crate) fn new(
+        storage: Arc<dyn Storage>,
+        signer: Arc<dyn BreezSigner>,
+    ) -> Result<Self, BoltzError> {
+        let encryption_path: DerivationPath = BOLTZ_SECRETS_ENCRYPTION_PATH
+            .parse()
+            .map_err(|e| BoltzError::Store(format!("Invalid Boltz secrets path: {e}")))?;
+        Ok(Self {
             storage,
-            instance_id,
-            key_index_mutex: Arc::new(Mutex::new(())),
-            active_ids_mutex: Arc::new(Mutex::new(())),
-        }
+            signer,
+            encryption_path,
+        })
     }
 
-    async fn load_active_ids(&self) -> Result<Vec<String>, BoltzError> {
-        let raw = self
-            .storage
-            .get_cached_item(ACTIVE_SWAP_IDS_KEY.to_string())
+    /// Lifts `key_source` out of the swap JSON, encrypts it, and assembles the
+    /// persisted row.
+    async fn to_stored(&self, swap: &BoltzSwap) -> Result<StoredBoltzSwap, BoltzError> {
+        let mut value = serde_json::to_value(swap)
+            .map_err(|e| BoltzError::Store(format!("Failed to serialize swap: {e}")))?;
+        let key_source = value
+            .as_object_mut()
+            .and_then(|map| map.remove(KEY_SOURCE_FIELD))
+            .ok_or_else(|| BoltzError::Store("Swap JSON missing key_source".to_string()))?;
+        let plaintext = serde_json::to_vec(&key_source)
+            .map_err(|e| BoltzError::Store(format!("Failed to serialize swap secrets: {e}")))?;
+        let ciphertext = self
+            .signer
+            .encrypt_ecies(&plaintext, &self.encryption_path)
             .await
-            .map_err(|e| BoltzError::Store(format!("Failed to read active swap ids: {e}")))?;
-        match raw {
-            Some(json) => serde_json::from_str::<Vec<String>>(&json).map_err(|e| {
-                BoltzError::Store(format!("Failed to deserialize active swap ids: {e}"))
-            }),
-            None => Ok(Vec::new()),
-        }
+            .map_err(|e| BoltzError::Store(format!("Failed to encrypt swap secrets: {e}")))?;
+        let data = serde_json::to_string(&value)
+            .map_err(|e| BoltzError::Store(format!("Failed to serialize swap data: {e}")))?;
+        Ok(StoredBoltzSwap {
+            id: swap.id.clone(),
+            is_terminal: swap.status.is_terminal(),
+            updated_at: swap.updated_at,
+            data,
+            secrets: BASE64.encode(ciphertext),
+        })
     }
 
-    async fn save_active_ids(&self, ids: &[String]) -> Result<(), BoltzError> {
-        let json = serde_json::to_string(ids)
-            .map_err(|e| BoltzError::Store(format!("Failed to serialize active swap ids: {e}")))?;
-        self.storage
-            .set_cached_item(ACTIVE_SWAP_IDS_KEY.to_string(), json)
+    /// Decrypts the secrets, splices `key_source` back into the data JSON, and
+    /// deserializes the full swap.
+    async fn swap_from_stored(&self, stored: StoredBoltzSwap) -> Result<BoltzSwap, BoltzError> {
+        let ciphertext = BASE64
+            .decode(stored.secrets.as_bytes())
+            .map_err(|e| BoltzError::Store(format!("Invalid base64 swap secrets: {e}")))?;
+        let plaintext = self
+            .signer
+            .decrypt_ecies(&ciphertext, &self.encryption_path)
             .await
-            .map_err(|e| BoltzError::Store(format!("Failed to write active swap ids: {e}")))
+            .map_err(|e| BoltzError::Store(format!("Failed to decrypt swap secrets: {e}")))?;
+        let key_source: serde_json::Value = serde_json::from_slice(&plaintext)
+            .map_err(|e| BoltzError::Store(format!("Failed to deserialize swap secrets: {e}")))?;
+        let mut value: serde_json::Value = serde_json::from_str(&stored.data)
+            .map_err(|e| BoltzError::Store(format!("Failed to deserialize swap data: {e}")))?;
+        value
+            .as_object_mut()
+            .ok_or_else(|| BoltzError::Store("Stored swap data is not a JSON object".to_string()))?
+            .insert(KEY_SOURCE_FIELD.to_string(), key_source);
+        serde_json::from_value(value)
+            .map_err(|e| BoltzError::Store(format!("Failed to deserialize swap: {e}")))
     }
 }
 
 #[macros::async_trait]
 impl BoltzStorage for BoltzStorageAdapter {
     async fn upsert_swap(&self, swap: &BoltzSwap) -> Result<(), BoltzError> {
-        let serialized = serde_json::to_string(swap)
-            .map_err(|e| BoltzError::Store(format!("Failed to serialize swap: {e}")))?;
+        let stored = self.to_stored(swap).await?;
         self.storage
-            .set_cached_item(swap_row_key(&swap.id), serialized)
+            .set_boltz_swap(stored)
             .await
-            .map_err(|e| BoltzError::Store(format!("Failed to persist swap row: {e}")))?;
-
-        // Reconcile the active-id index against the swap's status. A terminal
-        // swap is removed (its row stays queryable by id); a non-terminal swap
-        // is added. Both branches are idempotent, so replaying the same write
-        // (crash/retry) is a no-op.
-        let _guard = self.active_ids_mutex.lock().await;
-        let mut ids = self.load_active_ids().await?;
-        let contained = ids.contains(&swap.id);
-        if swap.status.is_terminal() {
-            if contained {
-                ids.retain(|id| id != &swap.id);
-                self.save_active_ids(&ids).await?;
-            }
-        } else if !contained {
-            ids.push(swap.id.clone());
-            self.save_active_ids(&ids).await?;
-        }
-        Ok(())
+            .map_err(|e| BoltzError::Store(format!("Failed to persist swap row: {e}")))
     }
 
     async fn get_swap(&self, id: &str) -> Result<Option<BoltzSwap>, BoltzError> {
-        let raw = self
+        let stored = self
             .storage
-            .get_cached_item(swap_row_key(id))
+            .get_boltz_swap(id.to_string())
             .await
             .map_err(|e| BoltzError::Store(format!("Failed to read swap row: {e}")))?;
-        match raw {
-            Some(json) => serde_json::from_str::<BoltzSwap>(&json)
-                .map(Some)
-                .map_err(|e| BoltzError::Store(format!("Failed to deserialize swap row: {e}"))),
+        match stored {
+            Some(stored) => Ok(Some(self.swap_from_stored(stored).await?)),
             None => Ok(None),
         }
     }
 
     async fn list_active_swaps(&self) -> Result<Vec<BoltzSwap>, BoltzError> {
-        let ids = self.load_active_ids().await?;
-        let mut swaps = Vec::with_capacity(ids.len());
-        for id in ids {
-            if let Some(swap) = self.get_swap(&id).await? {
-                swaps.push(swap);
-            }
+        let rows = self
+            .storage
+            .list_active_boltz_swaps()
+            .await
+            .map_err(|e| BoltzError::Store(format!("Failed to list active swaps: {e}")))?;
+        let mut swaps = Vec::with_capacity(rows.len());
+        for stored in rows {
+            swaps.push(self.swap_from_stored(stored).await?);
         }
         Ok(swaps)
-    }
-
-    async fn increment_key_index(&self) -> Result<u32, BoltzError> {
-        let _guard = self.key_index_mutex.lock().await;
-        let key = key_index_cache_key(&self.instance_id);
-        // A regressed counter re-derives an already-used preimage, which is a
-        // fund-theft vector (see BoltzStorage::increment_key_index docs). Treat
-        // an absent key as a legitimate first-use 0, but hard-fail on a present-
-        // but-unparseable value rather than silently resetting to 0.
-        let current = match self
-            .storage
-            .get_cached_item(key.clone())
-            .await
-            .map_err(|e| BoltzError::Store(format!("Failed to read key index: {e}")))?
-        {
-            None => 0,
-            Some(v) => v
-                .parse::<u32>()
-                .map_err(|e| BoltzError::Store(format!("Corrupt key index {v:?}: {e}")))?,
-        };
-        let next = current
-            .checked_add(1)
-            .ok_or_else(|| BoltzError::Store("Key index overflow".to_string()))?;
-        self.storage
-            .set_cached_item(key, next.to_string())
-            .await
-            .map_err(|e| BoltzError::Store(format!("Failed to persist key index: {e}")))?;
-        Ok(current)
     }
 }
 
@@ -176,10 +155,13 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    use boltz_client::models::{Asset, BoltzSwap, BoltzSwapStatus, BridgeKind};
+    use bitcoin::Network;
+    use bitcoin::bip32::Xpriv;
+    use boltz_client::models::{Asset, BoltzSwap, BoltzSwapStatus, BridgeKind, SwapKeySource};
 
     use super::*;
     use crate::persist::sqlite::SqliteStorage;
+    use crate::signer::breez::BreezSignerImpl;
 
     fn create_temp_dir(name: &str) -> PathBuf {
         let mut path = std::env::temp_dir();
@@ -188,12 +170,16 @@ mod tests {
         path
     }
 
+    // The seedless `SwapKeySource::Stored` variant wraps `SwapSecrets`, whose
+    // fields are crate-private to boltz-client and so not constructible here.
+    // `Derived` exercises the same lift/encrypt/splice path (it is key-source
+    // agnostic), so the round-trip is covered regardless.
     fn make_swap(id: &str, status: BoltzSwapStatus) -> BoltzSwap {
         BoltzSwap {
             id: id.to_string(),
             status,
             bridge_kind: BridgeKind::Oft,
-            claim_key_index: 0,
+            key_source: SwapKeySource::Derived { claim_key_index: 7 },
             chain_id: 42161,
             claim_address: "0xclaim".to_string(),
             destination_address: "0xdest".to_string(),
@@ -218,21 +204,28 @@ mod tests {
         }
     }
 
-    fn make_adapter() -> BoltzStorageAdapter {
+    fn make_adapter() -> (BoltzStorageAdapter, Arc<dyn Storage>) {
         let dir = create_temp_dir("boltz_storage_adapter");
         let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&dir).unwrap());
-        BoltzStorageAdapter::new(storage, "instance-test".to_string())
+        let master = Xpriv::new_master(Network::Regtest, &[7u8; 32]).unwrap();
+        let signer: Arc<dyn BreezSigner> = Arc::new(BreezSignerImpl::new(master));
+        let adapter = BoltzStorageAdapter::new(Arc::clone(&storage), signer).unwrap();
+        (adapter, storage)
     }
 
     #[tokio::test]
     async fn upsert_get_list_active_roundtrip() {
-        let adapter = make_adapter();
+        let (adapter, _storage) = make_adapter();
         let swap = make_swap("s1", BoltzSwapStatus::Created);
         adapter.upsert_swap(&swap).await.unwrap();
 
         let fetched = adapter.get_swap("s1").await.unwrap().unwrap();
         assert_eq!(fetched.id, "s1");
         assert_eq!(fetched.status, BoltzSwapStatus::Created);
+        match fetched.key_source {
+            SwapKeySource::Derived { claim_key_index } => assert_eq!(claim_key_index, 7),
+            SwapKeySource::Stored(_) => panic!("key_source variant must round-trip"),
+        }
 
         let active = adapter.list_active_swaps().await.unwrap();
         assert_eq!(active.len(), 1);
@@ -240,41 +233,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn concurrent_upserts_do_not_drop_active_ids() {
-        // Spawn many concurrent `upsert_swap` calls. Without the active_ids
-        // mutex the load → mutate → save cycle would race and drop entries.
-        const N: usize = 32;
+    async fn secrets_are_encrypted_and_absent_from_plaintext_data() {
+        let (adapter, storage) = make_adapter();
+        adapter
+            .upsert_swap(&make_swap("s1", BoltzSwapStatus::Created))
+            .await
+            .unwrap();
 
-        let dir = create_temp_dir("boltz_storage_adapter_concurrent");
-        let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&dir).unwrap());
-        let adapter = Arc::new(BoltzStorageAdapter::new(
-            storage,
-            "concurrent-test".to_string(),
-        ));
-
-        let mut handles = Vec::with_capacity(N);
-        for i in 0..N {
-            let adapter = Arc::clone(&adapter);
-            handles.push(tokio::spawn(async move {
-                let swap = make_swap(&format!("race_{i}"), BoltzSwapStatus::Created);
-                adapter.upsert_swap(&swap).await.unwrap();
-            }));
-        }
-        for h in handles {
-            h.await.unwrap();
-        }
-
-        let active = adapter.list_active_swaps().await.unwrap();
-        assert_eq!(
-            active.len(),
-            N,
-            "all concurrent upsert_swap calls must land in active_ids"
+        let stored = storage
+            .get_boltz_swap("s1".to_string())
+            .await
+            .unwrap()
+            .unwrap();
+        // key_source was lifted out of the plaintext data.
+        assert!(
+            !stored.data.contains("key_source"),
+            "key_source must not remain in plaintext data"
         );
+        // The encrypted blob does not reveal the claim_key_index in cleartext.
+        assert!(!stored.secrets.is_empty());
+        let ciphertext = BASE64.decode(stored.secrets.as_bytes()).unwrap();
+        assert!(!ciphertext.is_empty());
     }
 
     #[tokio::test]
-    async fn update_to_terminal_removes_from_active() {
-        let adapter = make_adapter();
+    async fn terminal_swaps_excluded_from_active() {
+        let (adapter, _storage) = make_adapter();
         adapter
             .upsert_swap(&make_swap("s1", BoltzSwapStatus::Created))
             .await
@@ -284,28 +268,17 @@ mod tests {
             .await
             .unwrap();
 
-        let terminal = make_swap("s1", BoltzSwapStatus::Completed);
-        adapter.upsert_swap(&terminal).await.unwrap();
+        // Drive s1 terminal; it leaves the active set but stays queryable by id.
+        adapter
+            .upsert_swap(&make_swap("s1", BoltzSwapStatus::Completed))
+            .await
+            .unwrap();
 
         let active = adapter.list_active_swaps().await.unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].id, "s2");
 
-        // terminal swap is still retrievable by id
         let fetched = adapter.get_swap("s1").await.unwrap().unwrap();
         assert_eq!(fetched.status, BoltzSwapStatus::Completed);
-    }
-
-    #[tokio::test]
-    async fn increment_key_index_persists_and_is_monotonic() {
-        let adapter = make_adapter();
-
-        let first = adapter.increment_key_index().await.unwrap();
-        let second = adapter.increment_key_index().await.unwrap();
-        let third = adapter.increment_key_index().await.unwrap();
-
-        assert_eq!(first, 0);
-        assert_eq!(second, 1);
-        assert_eq!(third, 2);
     }
 }

--- a/crates/breez-sdk/core/src/cross_chain/boltz_storage_adapter.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz_storage_adapter.rs
@@ -1,18 +1,22 @@
 //! Adapter exposing the SDK [`Storage`] as a [`boltz_client::BoltzStorage`].
 //!
+//! Boltz rows live in the provider-agnostic `cross_chain_swaps` table under
+//! `provider = "boltz"`.
+//!
 //! boltz-client runs in seedless mode: each swap carries its own random preimage
 //! and gas/claim key under `key_source` ([`boltz_client::models::SwapKeySource::Stored`]).
 //! Those secrets are money-critical, so before a swap row reaches local storage
 //! this adapter lifts `key_source` out of the swap JSON, ECIES-encrypts it via
 //! the SDK signer, and persists only the ciphertext in
-//! [`StoredBoltzSwap::secrets`]. The rest of the swap is stored as plaintext
-//! JSON in [`StoredBoltzSwap::data`]. On read the ciphertext is decrypted and
-//! `key_source` spliced back, reconstructing the full [`BoltzSwap`].
+//! [`StoredCrossChainSwap::secrets`]. The rest of the swap is stored as
+//! plaintext JSON in [`StoredCrossChainSwap::data`]. On read the ciphertext is
+//! decrypted and `key_source` spliced back, reconstructing the full
+//! [`BoltzSwap`].
 //!
 //! The encryption key is derived from the wallet identity at a fixed path, so it
 //! is deterministic across every instance restored from the same mnemonic. That
 //! is what lets a second instance decrypt a swap synced to it and drive it to
-//! terminal (see the realtime-sync `BoltzSwap` record). Correctness and
+//! terminal (see the realtime-sync `CrossChainSwap` record). Correctness and
 //! cross-instance convergence are boltz-client's job: the SDK just persists and
 //! syncs rows with plain last-writer-wins.
 //!
@@ -27,7 +31,10 @@ use bitcoin::bip32::DerivationPath;
 use boltz_client::{BoltzError, BoltzStorage, models::BoltzSwap};
 use tracing::warn;
 
-use crate::{Storage, persist::StoredBoltzSwap, signer::BreezSigner};
+use crate::{Storage, persist::StoredCrossChainSwap, signer::BreezSigner};
+
+/// Provider tag this adapter writes into `StoredCrossChainSwap::provider`.
+const PROVIDER_TAG_BOLTZ: &str = "boltz";
 
 /// JSON key under which a swap's secrets live before they are lifted out.
 const KEY_SOURCE_FIELD: &str = "key_source";
@@ -66,7 +73,7 @@ impl BoltzStorageAdapter {
 
     /// Lifts `key_source` out of the swap JSON, encrypts it, and assembles the
     /// persisted row.
-    async fn to_stored(&self, swap: &BoltzSwap) -> Result<StoredBoltzSwap, BoltzError> {
+    async fn to_stored(&self, swap: &BoltzSwap) -> Result<StoredCrossChainSwap, BoltzError> {
         let mut value = serde_json::to_value(swap)
             .map_err(|e| BoltzError::Store(format!("Failed to serialize swap: {e}")))?;
         let key_source = value
@@ -82,7 +89,8 @@ impl BoltzStorageAdapter {
             .map_err(|e| BoltzError::Store(format!("Failed to encrypt swap secrets: {e}")))?;
         let data = serde_json::to_string(&value)
             .map_err(|e| BoltzError::Store(format!("Failed to serialize swap data: {e}")))?;
-        Ok(StoredBoltzSwap {
+        Ok(StoredCrossChainSwap {
+            provider: PROVIDER_TAG_BOLTZ.to_string(),
             id: swap.id.clone(),
             is_terminal: swap.status.is_terminal(),
             updated_at: swap.updated_at,
@@ -93,7 +101,10 @@ impl BoltzStorageAdapter {
 
     /// Decrypts the secrets, splices `key_source` back into the data JSON, and
     /// deserializes the full swap.
-    async fn swap_from_stored(&self, stored: StoredBoltzSwap) -> Result<BoltzSwap, BoltzError> {
+    async fn swap_from_stored(
+        &self,
+        stored: StoredCrossChainSwap,
+    ) -> Result<BoltzSwap, BoltzError> {
         let ciphertext = BASE64
             .decode(stored.secrets.as_bytes())
             .map_err(|e| BoltzError::Store(format!("Invalid base64 swap secrets: {e}")))?;
@@ -120,7 +131,7 @@ impl BoltzStorage for BoltzStorageAdapter {
     async fn upsert_swap(&self, swap: &BoltzSwap) -> Result<(), BoltzError> {
         let stored = self.to_stored(swap).await?;
         self.storage
-            .set_boltz_swap(stored)
+            .set_cross_chain_swap(stored)
             .await
             .map_err(|e| BoltzError::Store(format!("Failed to persist swap row: {e}")))
     }
@@ -128,7 +139,7 @@ impl BoltzStorage for BoltzStorageAdapter {
     async fn get_swap(&self, id: &str) -> Result<Option<BoltzSwap>, BoltzError> {
         let stored = self
             .storage
-            .get_boltz_swap(id.to_string())
+            .get_cross_chain_swap(PROVIDER_TAG_BOLTZ.to_string(), id.to_string())
             .await
             .map_err(|e| BoltzError::Store(format!("Failed to read swap row: {e}")))?;
         match stored {
@@ -140,7 +151,7 @@ impl BoltzStorage for BoltzStorageAdapter {
     async fn list_active_swaps(&self) -> Result<Vec<BoltzSwap>, BoltzError> {
         let rows = self
             .storage
-            .list_active_boltz_swaps()
+            .list_active_cross_chain_swaps(PROVIDER_TAG_BOLTZ.to_string())
             .await
             .map_err(|e| BoltzError::Store(format!("Failed to list active swaps: {e}")))?;
         let mut swaps = Vec::with_capacity(rows.len());
@@ -247,10 +258,11 @@ mod tests {
             .unwrap();
 
         let stored = storage
-            .get_boltz_swap("s1".to_string())
+            .get_cross_chain_swap(PROVIDER_TAG_BOLTZ.to_string(), "s1".to_string())
             .await
             .unwrap()
             .unwrap();
+        assert_eq!(stored.provider, PROVIDER_TAG_BOLTZ);
         // key_source was lifted out of the plaintext data.
         assert!(
             !stored.data.contains("key_source"),

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -44,7 +44,8 @@ pub use logger::DEFAULT_FILTER;
 pub use models::*;
 pub use persist::{
     ConversionFilter, PaymentMetadata, SetLnurlMetadataItem, Storage, StorageError,
-    StorageListPaymentsRequest, StoragePaymentDetailsFilter, StoredBoltzSwap, UpdateDepositPayload,
+    StorageListPaymentsRequest, StoragePaymentDetailsFilter, StoredCrossChainSwap,
+    UpdateDepositPayload,
     backend::{PrebuiltBackend, ResolvedStores, StorageBackend, custom_storage},
     path::default_storage_path,
 };

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -44,7 +44,7 @@ pub use logger::DEFAULT_FILTER;
 pub use models::*;
 pub use persist::{
     ConversionFilter, PaymentMetadata, SetLnurlMetadataItem, Storage, StorageError,
-    StorageListPaymentsRequest, StoragePaymentDetailsFilter, UpdateDepositPayload,
+    StorageListPaymentsRequest, StoragePaymentDetailsFilter, StoredBoltzSwap, UpdateDepositPayload,
     backend::{PrebuiltBackend, ResolvedStores, StorageBackend, custom_storage},
     path::default_storage_path,
 };

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -340,6 +340,39 @@ where
     }
 }
 
+/// A Boltz cross-chain swap row as persisted and synced.
+///
+/// The money-critical secrets (preimage + per-swap gas key) never reach this
+/// struct in cleartext: the adapter lifts `key_source` out of the swap JSON,
+/// ECIES-encrypts it, and carries only the ciphertext in [`secrets`]. The
+/// storage layer treats this as opaque, so it needs no signer. The same
+/// representation is what the realtime-sync layer ships (re-wrapped in transit),
+/// so a second instance restores the swap by decrypting [`secrets`] with the
+/// shared identity key.
+///
+/// [`secrets`]: Self::secrets
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[serde(rename_all = "camelCase")]
+pub struct StoredBoltzSwap {
+    /// Boltz swap id (primary key).
+    pub id: String,
+    /// `swap.status.is_terminal()`, lifted into an indexed column so
+    /// `list_active_boltz_swaps` filters without parsing `data`.
+    pub is_terminal: bool,
+    /// `swap.updated_at`, used for ordering and last-writer-wins.
+    pub updated_at: u64,
+    /// The full `BoltzSwap` serialized to a JSON string with `key_source`
+    /// removed. Stored verbatim so unknown fields survive across versions. A
+    /// plain string (not a structured value) so the row crosses every backend,
+    /// the WASM boundary, and the foreign-language FFI uniformly as TEXT.
+    pub data: String,
+    /// Base64 of the ECIES ciphertext of the lifted `key_source` value.
+    /// Base64 (not raw bytes) so it marshals uniformly as TEXT across every
+    /// backend and across the WASM boundary.
+    pub secrets: String,
+}
+
 /// Trait for persistent storage
 #[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
 #[async_trait]
@@ -497,6 +530,15 @@ pub trait Storage: Send + Sync {
 
     /// Deletes a contact by its ID
     async fn delete_contact(&self, id: String) -> Result<(), StorageError>;
+
+    /// Inserts or overwrites a Boltz swap row (upsert by id).
+    async fn set_boltz_swap(&self, swap: StoredBoltzSwap) -> Result<(), StorageError>;
+
+    /// Gets a single Boltz swap row by its id, or `None` if absent.
+    async fn get_boltz_swap(&self, id: String) -> Result<Option<StoredBoltzSwap>, StorageError>;
+
+    /// Lists all non-terminal Boltz swap rows (`is_terminal = false`).
+    async fn list_active_boltz_swaps(&self) -> Result<Vec<StoredBoltzSwap>, StorageError>;
 
     // Sync storage methods
     async fn add_outgoing_change(

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -340,37 +340,45 @@ where
     }
 }
 
-/// A Boltz cross-chain swap row as persisted and synced.
+/// A cross-chain swap row as persisted and synced. Shared across providers
+/// (Boltz, Orchestra, future) so each provider's adapter writes opaque
+/// JSON into [`data`] and (optionally) opaque ciphertext into [`secrets`].
 ///
-/// The money-critical secrets (preimage + per-swap gas key) never reach this
-/// struct in cleartext: the adapter lifts `key_source` out of the swap JSON,
-/// ECIES-encrypts it, and carries only the ciphertext in [`secrets`]. The
-/// storage layer treats this as opaque, so it needs no signer. The same
-/// representation is what the realtime-sync layer ships (re-wrapped in transit),
-/// so a second instance restores the swap by decrypting [`secrets`] with the
-/// shared identity key.
+/// For providers with money-critical secrets, the adapter lifts them out of
+/// the swap JSON, ECIES-encrypts them, and carries only the ciphertext in
+/// [`secrets`]. The storage layer treats both fields as opaque, so it needs
+/// no signer. The same representation is what the realtime-sync layer ships
+/// (re-wrapped in transit), so a second instance restores the swap by
+/// decrypting [`secrets`] with the shared identity key.
 ///
+/// [`data`]: Self::data
 /// [`secrets`]: Self::secrets
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[serde(rename_all = "camelCase")]
-pub struct StoredBoltzSwap {
-    /// Boltz swap id (primary key).
+pub struct StoredCrossChainSwap {
+    /// Provider tag (e.g. `"boltz"`, `"orchestra"`). Together with [`id`] forms
+    /// the composite primary key and the realtime-sync `data_id`.
+    ///
+    /// [`id`]: Self::id
+    pub provider: String,
+    /// Provider-scoped swap id (boltz swap id, orchestra quote-or-order id).
     pub id: String,
-    /// `swap.status.is_terminal()`, lifted into an indexed column so
-    /// `list_active_boltz_swaps` filters without parsing `data`.
+    /// Lifted from the underlying swap's terminal flag into an indexed column
+    /// so `list_active_cross_chain_swaps` filters without parsing `data`.
     pub is_terminal: bool,
-    /// `swap.updated_at`, lifted into a column so the row's freshness is
-    /// inspectable without parsing `data`.
+    /// Lifted from the underlying swap's `updated_at` into a column so the
+    /// row's freshness is inspectable without parsing `data`.
     pub updated_at: u64,
-    /// The full `BoltzSwap` serialized to a JSON string with `key_source`
-    /// removed. Stored verbatim so unknown fields survive across versions. A
-    /// plain string (not a structured value) so the row crosses every backend,
-    /// the WASM boundary, and the foreign-language FFI uniformly as TEXT.
+    /// Provider-opaque JSON. Stored verbatim so unknown fields survive across
+    /// versions. A plain string (not a structured value) so the row crosses
+    /// every backend, the WASM boundary, and the foreign-language FFI
+    /// uniformly as TEXT.
     pub data: String,
-    /// Base64 of the ECIES ciphertext of the lifted `key_source` value.
-    /// Base64 (not raw bytes) so it marshals uniformly as TEXT across every
-    /// backend and across the WASM boundary.
+    /// Base64 of the ECIES ciphertext of the provider's lifted secrets. Empty
+    /// for providers with no money-critical secrets to protect at rest. Base64
+    /// (not raw bytes) so it marshals uniformly as TEXT across every backend
+    /// and across the WASM boundary.
     pub secrets: String,
 }
 
@@ -532,14 +540,22 @@ pub trait Storage: Send + Sync {
     /// Deletes a contact by its ID
     async fn delete_contact(&self, id: String) -> Result<(), StorageError>;
 
-    /// Inserts or overwrites a Boltz swap row (upsert by id).
-    async fn set_boltz_swap(&self, swap: StoredBoltzSwap) -> Result<(), StorageError>;
+    /// Inserts or overwrites a cross-chain swap row (upsert by `(provider, id)`).
+    async fn set_cross_chain_swap(&self, swap: StoredCrossChainSwap) -> Result<(), StorageError>;
 
-    /// Gets a single Boltz swap row by its id, or `None` if absent.
-    async fn get_boltz_swap(&self, id: String) -> Result<Option<StoredBoltzSwap>, StorageError>;
+    /// Gets a single cross-chain swap row by its `(provider, id)`, or `None` if absent.
+    async fn get_cross_chain_swap(
+        &self,
+        provider: String,
+        id: String,
+    ) -> Result<Option<StoredCrossChainSwap>, StorageError>;
 
-    /// Lists all non-terminal Boltz swap rows (`is_terminal = false`).
-    async fn list_active_boltz_swaps(&self) -> Result<Vec<StoredBoltzSwap>, StorageError>;
+    /// Lists all non-terminal cross-chain swap rows for a single provider
+    /// (`provider = ? AND is_terminal = false`).
+    async fn list_active_cross_chain_swaps(
+        &self,
+        provider: String,
+    ) -> Result<Vec<StoredCrossChainSwap>, StorageError>;
 
     // Sync storage methods
     async fn add_outgoing_change(

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -360,7 +360,8 @@ pub struct StoredBoltzSwap {
     /// `swap.status.is_terminal()`, lifted into an indexed column so
     /// `list_active_boltz_swaps` filters without parsing `data`.
     pub is_terminal: bool,
-    /// `swap.updated_at`, used for ordering and last-writer-wins.
+    /// `swap.updated_at`, lifted into a column so the row's freshness is
+    /// inspectable without parsing `data`.
     pub updated_at: u64,
     /// The full `BoltzSwap` serialized to a JSON string with `key_source`
     /// removed. Stored verbatim so unknown fields survive across versions. A

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -342,25 +342,17 @@ where
 
 /// A cross-chain swap row as persisted and synced. Shared across providers
 /// (Boltz, Orchestra, future) so each provider's adapter writes opaque
-/// JSON into [`data`] and (optionally) opaque ciphertext into [`secrets`].
+/// JSON into `data` and (optionally) opaque ciphertext into `secrets`.
 ///
 /// For providers with money-critical secrets, the adapter lifts them out of
 /// the swap JSON, ECIES-encrypts them, and carries only the ciphertext in
-/// [`secrets`]. The storage layer treats both fields as opaque, so it needs
-/// no signer. The same representation is what the realtime-sync layer ships
-/// (re-wrapped in transit), so a second instance restores the swap by
-/// decrypting [`secrets`] with the shared identity key.
-///
-/// [`data`]: Self::data
-/// [`secrets`]: Self::secrets
+/// `secrets`. The storage layer treats both fields as opaque, so it needs
+/// no signer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[serde(rename_all = "camelCase")]
 pub struct StoredCrossChainSwap {
-    /// Provider tag (e.g. `"boltz"`, `"orchestra"`). Together with [`id`] forms
-    /// the composite primary key and the realtime-sync `data_id`.
-    ///
-    /// [`id`]: Self::id
+    /// Provider tag (e.g. `"boltz"`, `"orchestra"`).
     pub provider: String,
     /// Provider-scoped swap id (boltz swap id, orchestra quote-or-order id).
     pub id: String,
@@ -370,15 +362,10 @@ pub struct StoredCrossChainSwap {
     /// Lifted from the underlying swap's `updated_at` into a column so the
     /// row's freshness is inspectable without parsing `data`.
     pub updated_at: u64,
-    /// Provider-opaque JSON. Stored verbatim so unknown fields survive across
-    /// versions. A plain string (not a structured value) so the row crosses
-    /// every backend, the WASM boundary, and the foreign-language FFI
-    /// uniformly as TEXT.
+    /// Serialized JSON owned by the cross-chain provider's storage adapter.
     pub data: String,
-    /// Base64 of the ECIES ciphertext of the provider's lifted secrets. Empty
-    /// for providers with no money-critical secrets to protect at rest. Base64
-    /// (not raw bytes) so it marshals uniformly as TEXT across every backend
-    /// and across the WASM boundary.
+    /// Base64 of the ECIES ciphertext of the provider's lifted secrets.
+    /// Empty for providers with no money-critical secrets to protect at rest.
     pub secrets: String,
 }
 

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -20,8 +20,8 @@ use crate::{
     error::DepositClaimError,
     persist::{
         Payment, PaymentMetadata, SetLnurlMetadataItem, Storage, StorageError,
-        StorageListPaymentsRequest, StoragePaymentDetailsFilter, UpdateDepositPayload,
-        parse_payment_status,
+        StorageListPaymentsRequest, StoragePaymentDetailsFilter, StoredBoltzSwap,
+        UpdateDepositPayload, parse_payment_status,
     },
     sync_storage::{
         IncomingChange, OutgoingChange, Record, RecordChange, RecordId, UnversionedRecordChange,
@@ -512,8 +512,38 @@ impl MysqlStorage {
                  WHERE conversion_info IS NOT NULL \
                    AND JSON_EXTRACT(conversion_info, '$.type') IS NULL",
             )],
+            // Migration 20: Boltz cross-chain swap rows, synced for cross-instance
+            // recovery. `data` is the BoltzSwap JSON with `key_source` lifted out;
+            // the lifted secrets are ECIES-encrypted into `secrets` by the adapter.
+            vec![Migration::sql(
+                "CREATE TABLE IF NOT EXISTS brz_boltz_swaps (
+                    user_id VARBINARY(33) NOT NULL,
+                    id VARCHAR(255) NOT NULL,
+                    is_terminal BOOLEAN NOT NULL,
+                    updated_at BIGINT NOT NULL,
+                    data LONGTEXT NOT NULL,
+                    secrets LONGTEXT NOT NULL,
+                    PRIMARY KEY (user_id, id),
+                    INDEX brz_idx_boltz_swaps_user_is_terminal (user_id, is_terminal)
+                )",
+            )],
         ]
     }
+}
+
+/// Maps a `brz_boltz_swaps` row tuple `(id, is_terminal, updated_at, data,
+/// secrets)` to a [`StoredBoltzSwap`].
+fn boltz_swap_from_parts(
+    parts: (String, bool, i64, String, String),
+) -> Result<StoredBoltzSwap, StorageError> {
+    let (id, is_terminal, updated_at, data, secrets) = parts;
+    Ok(StoredBoltzSwap {
+        id,
+        is_terminal,
+        updated_at: u64::try_from(updated_at)?,
+        data,
+        secrets,
+    })
 }
 
 /// Builds the multi-tenant scoping migration. The `identity` is a 33-byte
@@ -1511,6 +1541,59 @@ impl Storage for MysqlStorage {
         Ok(())
     }
 
+    async fn set_boltz_swap(&self, swap: StoredBoltzSwap) -> Result<(), StorageError> {
+        let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
+        conn.exec_drop(
+            "INSERT INTO brz_boltz_swaps (user_id, id, is_terminal, updated_at, data, secrets)
+             VALUES (?, ?, ?, ?, ?, ?)
+             ON DUPLICATE KEY UPDATE
+               is_terminal = VALUES(is_terminal),
+               updated_at = VALUES(updated_at),
+               data = VALUES(data),
+               secrets = VALUES(secrets)",
+            (
+                self.identity.clone(),
+                swap.id,
+                swap.is_terminal,
+                i64::try_from(swap.updated_at)?,
+                swap.data,
+                swap.secrets,
+            ),
+        )
+        .await
+        .map_err(map_db_error)?;
+        Ok(())
+    }
+
+    async fn get_boltz_swap(&self, id: String) -> Result<Option<StoredBoltzSwap>, StorageError> {
+        let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
+        let row: Option<(String, bool, i64, String, String)> = conn
+            .exec_first(
+                "SELECT id, is_terminal, updated_at, data, secrets
+                 FROM brz_boltz_swaps WHERE user_id = ? AND id = ?",
+                (self.identity.clone(), id),
+            )
+            .await
+            .map_err(map_db_error)?;
+        match row {
+            Some(parts) => Ok(Some(boltz_swap_from_parts(parts)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn list_active_boltz_swaps(&self) -> Result<Vec<StoredBoltzSwap>, StorageError> {
+        let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
+        let rows: Vec<(String, bool, i64, String, String)> = conn
+            .exec(
+                "SELECT id, is_terminal, updated_at, data, secrets
+                 FROM brz_boltz_swaps WHERE user_id = ? AND is_terminal = FALSE",
+                (self.identity.clone(),),
+            )
+            .await
+            .map_err(map_db_error)?;
+        rows.into_iter().map(boltz_swap_from_parts).collect()
+    }
+
     async fn add_outgoing_change(
         &self,
         record: UnversionedRecordChange,
@@ -2235,6 +2318,12 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_boltz_swaps_crud() {
+        let fixture = MysqlTestFixture::new().await;
+        crate::persist::tests::test_boltz_swaps_crud(Box::new(fixture.storage)).await;
+    }
+
+    #[tokio::test]
     async fn test_payment_asset_filtering() {
         let fixture = MysqlTestFixture::new().await;
         crate::persist::tests::test_asset_filtering(Box::new(fixture.storage)).await;
@@ -2345,9 +2434,17 @@ mod tests {
             .expect("Failed to get host port");
         let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
 
-        // Apply all migrations except the discriminator backfill (the last one).
+        // Apply all migrations up to (but not including) the discriminator
+        // backfill. Locate it by content so later appended migrations (e.g. the
+        // brz_boltz_swaps table) don't shift this off the end.
         let migrations = MysqlStorage::migrations(&TEST_IDENTITY_A);
-        let backfill_index = migrations.len() - 1;
+        let backfill_index = migrations
+            .iter()
+            .position(|m| {
+                m.iter()
+                    .any(|step| matches!(step, Migration::Sql(s) if s.contains("'$.type', 'amm'")))
+            })
+            .expect("conversion_info backfill migration present");
         let pool = create_pool(&MysqlStorageConfig::with_defaults(
             connection_string.clone(),
         ))
@@ -2879,11 +2976,11 @@ mod tests {
             .unwrap();
         assert_eq!(
             version,
-            Some(19),
-            "migration version must advance to 19 (the legacy fixture starts at 16; \
+            Some(20),
+            "migration version must advance to 20 (the legacy fixture starts at 16; \
              migration 17 pins applied_at default to UTC; migration 18 moves deposit \
              details into the brz_payment_details_deposit table; migration 19 backfills \
-             the conversion_info type discriminator)"
+             the conversion_info type discriminator; migration 20 adds brz_boltz_swaps)"
         );
 
         let payment_count: Option<i64> = conn
@@ -3156,7 +3253,7 @@ mod tests {
             .exec_first("SELECT MAX(version) FROM brz_schema_migrations", ())
             .await
             .unwrap();
-        assert_eq!(version, Some(19), "migration must advance to 19");
+        assert_eq!(version, Some(20), "migration must advance to 20");
 
         let payment_count: Option<i64> = conn
             .exec_first("SELECT COUNT(*) FROM brz_payments WHERE id = 'p1'", ())

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -20,7 +20,7 @@ use crate::{
     error::DepositClaimError,
     persist::{
         Payment, PaymentMetadata, SetLnurlMetadataItem, Storage, StorageError,
-        StorageListPaymentsRequest, StoragePaymentDetailsFilter, StoredBoltzSwap,
+        StorageListPaymentsRequest, StoragePaymentDetailsFilter, StoredCrossChainSwap,
         UpdateDepositPayload, parse_payment_status,
     },
     sync_storage::{
@@ -512,32 +512,37 @@ impl MysqlStorage {
                  WHERE conversion_info IS NOT NULL \
                    AND JSON_EXTRACT(conversion_info, '$.type') IS NULL",
             )],
-            // Migration 20: Boltz cross-chain swap rows, synced for cross-instance
-            // recovery. `data` is the BoltzSwap JSON with `key_source` lifted out;
-            // the lifted secrets are ECIES-encrypted into `secrets` by the adapter.
+            // Migration 20: Cross-chain swap rows, synced for cross-instance
+            // recovery. Shared across providers, discriminated by `provider`.
+            // `data` is provider-opaque JSON; `secrets` is provider-opaque
+            // ciphertext (empty when the provider has no money-critical
+            // secrets).
             vec![Migration::sql(
-                "CREATE TABLE IF NOT EXISTS brz_boltz_swaps (
+                "CREATE TABLE IF NOT EXISTS brz_cross_chain_swaps (
                     user_id VARBINARY(33) NOT NULL,
+                    provider VARCHAR(64) NOT NULL,
                     id VARCHAR(255) NOT NULL,
                     is_terminal BOOLEAN NOT NULL,
                     updated_at BIGINT NOT NULL,
                     data LONGTEXT NOT NULL,
                     secrets LONGTEXT NOT NULL,
-                    PRIMARY KEY (user_id, id),
-                    INDEX brz_idx_boltz_swaps_user_is_terminal (user_id, is_terminal)
+                    PRIMARY KEY (user_id, provider, id),
+                    INDEX brz_idx_cross_chain_swaps_user_provider_is_terminal
+                        (user_id, provider, is_terminal)
                 )",
             )],
         ]
     }
 }
 
-/// Maps a `brz_boltz_swaps` row tuple `(id, is_terminal, updated_at, data,
-/// secrets)` to a [`StoredBoltzSwap`].
-fn boltz_swap_from_parts(
-    parts: (String, bool, i64, String, String),
-) -> Result<StoredBoltzSwap, StorageError> {
-    let (id, is_terminal, updated_at, data, secrets) = parts;
-    Ok(StoredBoltzSwap {
+/// Maps a `brz_cross_chain_swaps` row tuple `(provider, id, is_terminal,
+/// updated_at, data, secrets)` to a [`StoredCrossChainSwap`].
+fn cross_chain_swap_from_parts(
+    parts: (String, String, bool, i64, String, String),
+) -> Result<StoredCrossChainSwap, StorageError> {
+    let (provider, id, is_terminal, updated_at, data, secrets) = parts;
+    Ok(StoredCrossChainSwap {
+        provider,
         id,
         is_terminal,
         updated_at: u64::try_from(updated_at)?,
@@ -1541,11 +1546,12 @@ impl Storage for MysqlStorage {
         Ok(())
     }
 
-    async fn set_boltz_swap(&self, swap: StoredBoltzSwap) -> Result<(), StorageError> {
+    async fn set_cross_chain_swap(&self, swap: StoredCrossChainSwap) -> Result<(), StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
         conn.exec_drop(
-            "INSERT INTO brz_boltz_swaps (user_id, id, is_terminal, updated_at, data, secrets)
-             VALUES (?, ?, ?, ?, ?, ?)
+            "INSERT INTO brz_cross_chain_swaps
+               (user_id, provider, id, is_terminal, updated_at, data, secrets)
+             VALUES (?, ?, ?, ?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE
                is_terminal = VALUES(is_terminal),
                updated_at = VALUES(updated_at),
@@ -1553,6 +1559,7 @@ impl Storage for MysqlStorage {
                secrets = VALUES(secrets)",
             (
                 self.identity.clone(),
+                swap.provider,
                 swap.id,
                 swap.is_terminal,
                 i64::try_from(swap.updated_at)?,
@@ -1565,33 +1572,42 @@ impl Storage for MysqlStorage {
         Ok(())
     }
 
-    async fn get_boltz_swap(&self, id: String) -> Result<Option<StoredBoltzSwap>, StorageError> {
+    async fn get_cross_chain_swap(
+        &self,
+        provider: String,
+        id: String,
+    ) -> Result<Option<StoredCrossChainSwap>, StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
-        let row: Option<(String, bool, i64, String, String)> = conn
+        let row: Option<(String, String, bool, i64, String, String)> = conn
             .exec_first(
-                "SELECT id, is_terminal, updated_at, data, secrets
-                 FROM brz_boltz_swaps WHERE user_id = ? AND id = ?",
-                (self.identity.clone(), id),
+                "SELECT provider, id, is_terminal, updated_at, data, secrets
+                 FROM brz_cross_chain_swaps
+                 WHERE user_id = ? AND provider = ? AND id = ?",
+                (self.identity.clone(), provider, id),
             )
             .await
             .map_err(map_db_error)?;
         match row {
-            Some(parts) => Ok(Some(boltz_swap_from_parts(parts)?)),
+            Some(parts) => Ok(Some(cross_chain_swap_from_parts(parts)?)),
             None => Ok(None),
         }
     }
 
-    async fn list_active_boltz_swaps(&self) -> Result<Vec<StoredBoltzSwap>, StorageError> {
+    async fn list_active_cross_chain_swaps(
+        &self,
+        provider: String,
+    ) -> Result<Vec<StoredCrossChainSwap>, StorageError> {
         let mut conn = self.pool.get_conn().await.map_err(map_db_error)?;
-        let rows: Vec<(String, bool, i64, String, String)> = conn
+        let rows: Vec<(String, String, bool, i64, String, String)> = conn
             .exec(
-                "SELECT id, is_terminal, updated_at, data, secrets
-                 FROM brz_boltz_swaps WHERE user_id = ? AND is_terminal = FALSE",
-                (self.identity.clone(),),
+                "SELECT provider, id, is_terminal, updated_at, data, secrets
+                 FROM brz_cross_chain_swaps
+                 WHERE user_id = ? AND provider = ? AND is_terminal = FALSE",
+                (self.identity.clone(), provider),
             )
             .await
             .map_err(map_db_error)?;
-        rows.into_iter().map(boltz_swap_from_parts).collect()
+        rows.into_iter().map(cross_chain_swap_from_parts).collect()
     }
 
     async fn add_outgoing_change(
@@ -2318,9 +2334,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_boltz_swaps_crud() {
+    async fn test_cross_chain_swaps_crud() {
         let fixture = MysqlTestFixture::new().await;
-        crate::persist::tests::test_boltz_swaps_crud(Box::new(fixture.storage)).await;
+        crate::persist::tests::test_cross_chain_swaps_crud(Box::new(fixture.storage)).await;
     }
 
     #[tokio::test]
@@ -2435,8 +2451,8 @@ mod tests {
         let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
 
         // Apply all migrations up to (but not including) the discriminator
-        // backfill. Locate it by content so later appended migrations (e.g. the
-        // brz_boltz_swaps table) don't shift this off the end.
+        // backfill. Locate it by content so later appended migrations don't
+        // shift it off the end.
         let migrations = MysqlStorage::migrations(&TEST_IDENTITY_A);
         let backfill_index = migrations
             .iter()
@@ -2974,14 +2990,7 @@ mod tests {
             .exec_first("SELECT MAX(version) FROM brz_schema_migrations", ())
             .await
             .unwrap();
-        assert_eq!(
-            version,
-            Some(20),
-            "migration version must advance to 20 (the legacy fixture starts at 16; \
-             migration 17 pins applied_at default to UTC; migration 18 moves deposit \
-             details into the brz_payment_details_deposit table; migration 19 backfills \
-             the conversion_info type discriminator; migration 20 adds brz_boltz_swaps)"
-        );
+        assert_eq!(version, Some(20), "migration version must advance to 20");
 
         let payment_count: Option<i64> = conn
             .exec_first("SELECT COUNT(*) FROM brz_payments WHERE id = 'p1'", ())

--- a/crates/breez-sdk/core/src/persist/mysql/storage.rs
+++ b/crates/breez-sdk/core/src/persist/mysql/storage.rs
@@ -515,8 +515,7 @@ impl MysqlStorage {
             // Migration 20: Cross-chain swap rows, synced for cross-instance
             // recovery. Shared across providers, discriminated by `provider`.
             // `data` is provider-opaque JSON; `secrets` is provider-opaque
-            // ciphertext (empty when the provider has no money-critical
-            // secrets).
+            // ciphertext (empty when the provider has none).
             vec![Migration::sql(
                 "CREATE TABLE IF NOT EXISTS brz_cross_chain_swaps (
                     user_id VARBINARY(33) NOT NULL,

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -21,8 +21,8 @@ use crate::{
     error::DepositClaimError,
     persist::{
         Payment, PaymentMetadata, SetLnurlMetadataItem, Storage, StorageError,
-        StorageListPaymentsRequest, StoragePaymentDetailsFilter, UpdateDepositPayload,
-        parse_payment_status,
+        StorageListPaymentsRequest, StoragePaymentDetailsFilter, StoredBoltzSwap,
+        UpdateDepositPayload, parse_payment_status,
     },
     sync_storage::{
         IncomingChange, OutgoingChange, Record, RecordChange, RecordId, UnversionedRecordChange,
@@ -449,8 +449,36 @@ impl PostgresStorage {
                SET conversion_info = conversion_info::jsonb || '{\"type\": \"amm\"}'::jsonb
                WHERE conversion_info IS NOT NULL
                  AND (conversion_info::jsonb->>'type') IS NULL".to_string()],
+            // Migration 19: Boltz cross-chain swap rows, synced for cross-instance
+            // recovery. `data` is the BoltzSwap JSON with `key_source` lifted out;
+            // the lifted secrets are ECIES-encrypted into `secrets` by the adapter.
+            vec![
+                "CREATE TABLE IF NOT EXISTS brz_boltz_swaps (
+                    user_id BYTEA NOT NULL,
+                    id TEXT NOT NULL,
+                    is_terminal BOOLEAN NOT NULL,
+                    updated_at BIGINT NOT NULL,
+                    data TEXT NOT NULL,
+                    secrets TEXT NOT NULL,
+                    PRIMARY KEY (user_id, id)
+                 )".to_string(),
+                "CREATE INDEX IF NOT EXISTS brz_idx_boltz_swaps_user_is_terminal
+                    ON brz_boltz_swaps (user_id, is_terminal)".to_string(),
+            ],
         ]
     }
+}
+
+/// Maps a `brz_boltz_swaps` row (columns `id, is_terminal, updated_at, data,
+/// secrets`) to a [`StoredBoltzSwap`].
+fn boltz_swap_from_row(row: &Row) -> Result<StoredBoltzSwap, StorageError> {
+    Ok(StoredBoltzSwap {
+        id: row.get(0),
+        is_terminal: row.get(1),
+        updated_at: u64::try_from(row.get::<_, i64>(2))?,
+        data: row.get(3),
+        secrets: row.get(4),
+    })
 }
 
 /// Builds the multi-tenant scoping migration. The `identity` is a 33-byte
@@ -1394,6 +1422,65 @@ impl Storage for PostgresStorage {
         Ok(())
     }
 
+    async fn set_boltz_swap(&self, swap: StoredBoltzSwap) -> Result<(), StorageError> {
+        let client = self.pool.get().await.map_err(map_pool_error)?;
+        let result = client
+            .execute(
+                "INSERT INTO brz_boltz_swaps (user_id, id, is_terminal, updated_at, data, secrets)
+                 VALUES ($1, $2, $3, $4, $5, $6)
+                 ON CONFLICT (user_id, id) DO UPDATE SET
+                   is_terminal = EXCLUDED.is_terminal,
+                   updated_at = EXCLUDED.updated_at,
+                   data = EXCLUDED.data,
+                   secrets = EXCLUDED.secrets",
+                &[
+                    &self.identity,
+                    &swap.id,
+                    &swap.is_terminal,
+                    &i64::try_from(swap.updated_at)?,
+                    &swap.data,
+                    &swap.secrets,
+                ],
+            )
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) => Err(map_db_error(e)),
+        }
+    }
+
+    async fn get_boltz_swap(&self, id: String) -> Result<Option<StoredBoltzSwap>, StorageError> {
+        let client = self.pool.get().await.map_err(map_pool_error)?;
+        let row = client
+            .query_opt(
+                "SELECT id, is_terminal, updated_at, data, secrets
+                 FROM brz_boltz_swaps WHERE user_id = $1 AND id = $2",
+                &[&self.identity, &id],
+            )
+            .await?;
+        match row {
+            Some(row) => Ok(Some(boltz_swap_from_row(&row)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn list_active_boltz_swaps(&self) -> Result<Vec<StoredBoltzSwap>, StorageError> {
+        let client = self.pool.get().await.map_err(map_pool_error)?;
+        let rows = client
+            .query(
+                "SELECT id, is_terminal, updated_at, data, secrets
+                 FROM brz_boltz_swaps WHERE user_id = $1 AND is_terminal = FALSE",
+                &[&self.identity],
+            )
+            .await?;
+        let mut swaps = Vec::with_capacity(rows.len());
+        for row in rows {
+            swaps.push(boltz_swap_from_row(&row)?);
+        }
+        Ok(swaps)
+    }
+
     async fn add_outgoing_change(
         &self,
         record: UnversionedRecordChange,
@@ -2159,6 +2246,12 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_boltz_swaps_crud() {
+        let fixture = PostgresTestFixture::new().await;
+        crate::persist::tests::test_boltz_swaps_crud(Box::new(fixture.storage)).await;
+    }
+
+    #[tokio::test]
     async fn test_conversion_status_persistence() {
         let fixture = PostgresTestFixture::new().await;
         crate::persist::tests::test_conversion_status_persistence(Box::new(fixture.storage)).await;
@@ -2856,8 +2949,13 @@ mod tests {
         );
 
         // Bring the DB up to the state right before the discriminator backfill.
+        // Locate the backfill by content so later appended migrations (e.g. the
+        // brz_boltz_swaps table) don't shift this off the end.
         let migrations = PostgresStorage::migrations(&TEST_IDENTITY_A);
-        let backfill_index = migrations.len() - 1;
+        let backfill_index = migrations
+            .iter()
+            .position(|m| m.iter().any(|s| s.contains("\"type\": \"amm\"")))
+            .expect("conversion_info backfill migration present");
         {
             let (client, conn) = tokio_postgres::connect(&connection_string, tokio_postgres::NoTls)
                 .await
@@ -3075,7 +3173,7 @@ mod tests {
             .await
             .unwrap()
             .get(0);
-        assert_eq!(version, 18, "migration version must advance to 18");
+        assert_eq!(version, 19, "migration version must advance to 19");
 
         // Seed payment row is preserved on the renamed table — proves the
         // table + PK constraint rename worked and the columns line up.
@@ -3365,13 +3463,13 @@ mod tests {
 
         // Migration version advanced from 15 through 18 (16: multi-tenant scope,
         // 17: brz_payment_details_deposit table, 18: conversion_info
-        // type-discriminator backfill).
+        // type-discriminator backfill, 19: brz_boltz_swaps table).
         let version: i32 = client
             .query_one("SELECT MAX(version) FROM brz_schema_migrations", &[])
             .await
             .unwrap()
             .get(0);
-        assert_eq!(version, 18, "migration must advance to 18");
+        assert_eq!(version, 19, "migration must advance to 19");
 
         // Seed data preserved (multi-tenant backfilled user_id to current tenant).
         let payment_count: i64 = client

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -452,8 +452,7 @@ impl PostgresStorage {
             // Migration 19: Cross-chain swap rows, synced for cross-instance
             // recovery. Shared across providers, discriminated by `provider`.
             // `data` is provider-opaque JSON; `secrets` is provider-opaque
-            // ciphertext (empty when the provider has no money-critical
-            // secrets).
+            // ciphertext (empty when the provider has none).
             vec![
                 "CREATE TABLE IF NOT EXISTS brz_cross_chain_swaps (
                     user_id BYTEA NOT NULL,

--- a/crates/breez-sdk/core/src/persist/postgres/storage.rs
+++ b/crates/breez-sdk/core/src/persist/postgres/storage.rs
@@ -21,7 +21,7 @@ use crate::{
     error::DepositClaimError,
     persist::{
         Payment, PaymentMetadata, SetLnurlMetadataItem, Storage, StorageError,
-        StorageListPaymentsRequest, StoragePaymentDetailsFilter, StoredBoltzSwap,
+        StorageListPaymentsRequest, StoragePaymentDetailsFilter, StoredCrossChainSwap,
         UpdateDepositPayload, parse_payment_status,
     },
     sync_storage::{
@@ -449,35 +449,39 @@ impl PostgresStorage {
                SET conversion_info = conversion_info::jsonb || '{\"type\": \"amm\"}'::jsonb
                WHERE conversion_info IS NOT NULL
                  AND (conversion_info::jsonb->>'type') IS NULL".to_string()],
-            // Migration 19: Boltz cross-chain swap rows, synced for cross-instance
-            // recovery. `data` is the BoltzSwap JSON with `key_source` lifted out;
-            // the lifted secrets are ECIES-encrypted into `secrets` by the adapter.
+            // Migration 19: Cross-chain swap rows, synced for cross-instance
+            // recovery. Shared across providers, discriminated by `provider`.
+            // `data` is provider-opaque JSON; `secrets` is provider-opaque
+            // ciphertext (empty when the provider has no money-critical
+            // secrets).
             vec![
-                "CREATE TABLE IF NOT EXISTS brz_boltz_swaps (
+                "CREATE TABLE IF NOT EXISTS brz_cross_chain_swaps (
                     user_id BYTEA NOT NULL,
+                    provider TEXT NOT NULL,
                     id TEXT NOT NULL,
                     is_terminal BOOLEAN NOT NULL,
                     updated_at BIGINT NOT NULL,
                     data TEXT NOT NULL,
                     secrets TEXT NOT NULL,
-                    PRIMARY KEY (user_id, id)
+                    PRIMARY KEY (user_id, provider, id)
                  )".to_string(),
-                "CREATE INDEX IF NOT EXISTS brz_idx_boltz_swaps_user_is_terminal
-                    ON brz_boltz_swaps (user_id, is_terminal)".to_string(),
+                "CREATE INDEX IF NOT EXISTS brz_idx_cross_chain_swaps_user_provider_is_terminal
+                    ON brz_cross_chain_swaps (user_id, provider, is_terminal)".to_string(),
             ],
         ]
     }
 }
 
-/// Maps a `brz_boltz_swaps` row (columns `id, is_terminal, updated_at, data,
-/// secrets`) to a [`StoredBoltzSwap`].
-fn boltz_swap_from_row(row: &Row) -> Result<StoredBoltzSwap, StorageError> {
-    Ok(StoredBoltzSwap {
-        id: row.get(0),
-        is_terminal: row.get(1),
-        updated_at: u64::try_from(row.get::<_, i64>(2))?,
-        data: row.get(3),
-        secrets: row.get(4),
+/// Maps a `brz_cross_chain_swaps` row (columns `provider, id, is_terminal,
+/// updated_at, data, secrets`) to a [`StoredCrossChainSwap`].
+fn cross_chain_swap_from_row(row: &Row) -> Result<StoredCrossChainSwap, StorageError> {
+    Ok(StoredCrossChainSwap {
+        provider: row.get(0),
+        id: row.get(1),
+        is_terminal: row.get(2),
+        updated_at: u64::try_from(row.get::<_, i64>(3))?,
+        data: row.get(4),
+        secrets: row.get(5),
     })
 }
 
@@ -1422,19 +1426,21 @@ impl Storage for PostgresStorage {
         Ok(())
     }
 
-    async fn set_boltz_swap(&self, swap: StoredBoltzSwap) -> Result<(), StorageError> {
+    async fn set_cross_chain_swap(&self, swap: StoredCrossChainSwap) -> Result<(), StorageError> {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         let result = client
             .execute(
-                "INSERT INTO brz_boltz_swaps (user_id, id, is_terminal, updated_at, data, secrets)
-                 VALUES ($1, $2, $3, $4, $5, $6)
-                 ON CONFLICT (user_id, id) DO UPDATE SET
+                "INSERT INTO brz_cross_chain_swaps
+                   (user_id, provider, id, is_terminal, updated_at, data, secrets)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)
+                 ON CONFLICT (user_id, provider, id) DO UPDATE SET
                    is_terminal = EXCLUDED.is_terminal,
                    updated_at = EXCLUDED.updated_at,
                    data = EXCLUDED.data,
                    secrets = EXCLUDED.secrets",
                 &[
                     &self.identity,
+                    &swap.provider,
                     &swap.id,
                     &swap.is_terminal,
                     &i64::try_from(swap.updated_at)?,
@@ -1450,33 +1456,42 @@ impl Storage for PostgresStorage {
         }
     }
 
-    async fn get_boltz_swap(&self, id: String) -> Result<Option<StoredBoltzSwap>, StorageError> {
+    async fn get_cross_chain_swap(
+        &self,
+        provider: String,
+        id: String,
+    ) -> Result<Option<StoredCrossChainSwap>, StorageError> {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         let row = client
             .query_opt(
-                "SELECT id, is_terminal, updated_at, data, secrets
-                 FROM brz_boltz_swaps WHERE user_id = $1 AND id = $2",
-                &[&self.identity, &id],
+                "SELECT provider, id, is_terminal, updated_at, data, secrets
+                 FROM brz_cross_chain_swaps
+                 WHERE user_id = $1 AND provider = $2 AND id = $3",
+                &[&self.identity, &provider, &id],
             )
             .await?;
         match row {
-            Some(row) => Ok(Some(boltz_swap_from_row(&row)?)),
+            Some(row) => Ok(Some(cross_chain_swap_from_row(&row)?)),
             None => Ok(None),
         }
     }
 
-    async fn list_active_boltz_swaps(&self) -> Result<Vec<StoredBoltzSwap>, StorageError> {
+    async fn list_active_cross_chain_swaps(
+        &self,
+        provider: String,
+    ) -> Result<Vec<StoredCrossChainSwap>, StorageError> {
         let client = self.pool.get().await.map_err(map_pool_error)?;
         let rows = client
             .query(
-                "SELECT id, is_terminal, updated_at, data, secrets
-                 FROM brz_boltz_swaps WHERE user_id = $1 AND is_terminal = FALSE",
-                &[&self.identity],
+                "SELECT provider, id, is_terminal, updated_at, data, secrets
+                 FROM brz_cross_chain_swaps
+                 WHERE user_id = $1 AND provider = $2 AND is_terminal = FALSE",
+                &[&self.identity, &provider],
             )
             .await?;
         let mut swaps = Vec::with_capacity(rows.len());
         for row in rows {
-            swaps.push(boltz_swap_from_row(&row)?);
+            swaps.push(cross_chain_swap_from_row(&row)?);
         }
         Ok(swaps)
     }
@@ -2246,9 +2261,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_boltz_swaps_crud() {
+    async fn test_cross_chain_swaps_crud() {
         let fixture = PostgresTestFixture::new().await;
-        crate::persist::tests::test_boltz_swaps_crud(Box::new(fixture.storage)).await;
+        crate::persist::tests::test_cross_chain_swaps_crud(Box::new(fixture.storage)).await;
     }
 
     #[tokio::test]
@@ -2949,8 +2964,8 @@ mod tests {
         );
 
         // Bring the DB up to the state right before the discriminator backfill.
-        // Locate the backfill by content so later appended migrations (e.g. the
-        // brz_boltz_swaps table) don't shift this off the end.
+        // Locate it by content so later appended migrations don't shift it off
+        // the end.
         let migrations = PostgresStorage::migrations(&TEST_IDENTITY_A);
         let backfill_index = migrations
             .iter()
@@ -3463,7 +3478,7 @@ mod tests {
 
         // Migration version advanced from 15 through 18 (16: multi-tenant scope,
         // 17: brz_payment_details_deposit table, 18: conversion_info
-        // type-discriminator backfill, 19: brz_boltz_swaps table).
+        // type-discriminator backfill, 19: brz_cross_chain_swaps table).
         let version: i32 = client
             .query_one("SELECT MAX(version) FROM brz_schema_migrations", &[])
             .await

--- a/crates/breez-sdk/core/src/persist/sqlite.rs
+++ b/crates/breez-sdk/core/src/persist/sqlite.rs
@@ -358,8 +358,7 @@ impl SqliteStorage {
             // Cross-chain swap rows, synced for cross-instance recovery. Shared
             // across providers, discriminated by the `provider` column. `data`
             // is provider-opaque JSON; `secrets` is provider-opaque ciphertext
-            // (empty when the provider has no money-critical secrets to protect
-            // at rest).
+            // (empty when the provider has none).
             "CREATE TABLE cross_chain_swaps (
                 provider TEXT NOT NULL,
                 id TEXT NOT NULL,

--- a/crates/breez-sdk/core/src/persist/sqlite.rs
+++ b/crates/breez-sdk/core/src/persist/sqlite.rs
@@ -14,7 +14,8 @@ use crate::{
     error::DepositClaimError,
     persist::{
         PaymentMetadata, SetLnurlMetadataItem, StorageListPaymentsRequest,
-        StoragePaymentDetailsFilter, StoredBoltzSwap, UpdateDepositPayload, parse_payment_status,
+        StoragePaymentDetailsFilter, StoredCrossChainSwap, UpdateDepositPayload,
+        parse_payment_status,
     },
     sync_storage::{
         IncomingChange, OutgoingChange, Record, RecordChange, RecordId, UnversionedRecordChange,
@@ -354,29 +355,35 @@ impl SqliteStorage {
              SET conversion_info = json_set(conversion_info, '$.type', 'amm')
              WHERE conversion_info IS NOT NULL
                AND json_extract(conversion_info, '$.type') IS NULL;",
-            // Boltz cross-chain swap rows, synced for cross-instance recovery.
-            // `data` is the BoltzSwap JSON with `key_source` lifted out; the
-            // lifted secrets are ECIES-encrypted into `secrets` by the adapter.
-            "CREATE TABLE boltz_swaps (
-                id TEXT PRIMARY KEY,
+            // Cross-chain swap rows, synced for cross-instance recovery. Shared
+            // across providers, discriminated by the `provider` column. `data`
+            // is provider-opaque JSON; `secrets` is provider-opaque ciphertext
+            // (empty when the provider has no money-critical secrets to protect
+            // at rest).
+            "CREATE TABLE cross_chain_swaps (
+                provider TEXT NOT NULL,
+                id TEXT NOT NULL,
                 is_terminal INTEGER NOT NULL,
                 updated_at INTEGER NOT NULL,
                 data TEXT NOT NULL,
-                secrets TEXT NOT NULL
+                secrets TEXT NOT NULL,
+                PRIMARY KEY (provider, id)
             );
-            CREATE INDEX idx_boltz_swaps_is_terminal ON boltz_swaps(is_terminal);",
+            CREATE INDEX idx_cross_chain_swaps_provider_is_terminal
+                ON cross_chain_swaps(provider, is_terminal);",
         ]
     }
 }
 
-/// Maps a `boltz_swaps` row to a [`StoredBoltzSwap`].
-fn parse_boltz_swap_row(row: &Row) -> rusqlite::Result<StoredBoltzSwap> {
-    Ok(StoredBoltzSwap {
-        id: row.get(0)?,
-        is_terminal: row.get(1)?,
-        updated_at: row.get(2)?,
-        data: row.get(3)?,
-        secrets: row.get(4)?,
+/// Maps a `cross_chain_swaps` row to a [`StoredCrossChainSwap`].
+fn parse_cross_chain_swap_row(row: &Row) -> rusqlite::Result<StoredCrossChainSwap> {
+    Ok(StoredCrossChainSwap {
+        provider: row.get(0)?,
+        id: row.get(1)?,
+        is_terminal: row.get(2)?,
+        updated_at: row.get(3)?,
+        data: row.get(4)?,
+        secrets: row.get(5)?,
     })
 }
 
@@ -1105,17 +1112,18 @@ impl Storage for SqliteStorage {
         Ok(())
     }
 
-    async fn set_boltz_swap(&self, swap: StoredBoltzSwap) -> Result<(), StorageError> {
+    async fn set_cross_chain_swap(&self, swap: StoredCrossChainSwap) -> Result<(), StorageError> {
         let connection = self.get_connection()?;
         connection.execute(
-            "INSERT INTO boltz_swaps (id, is_terminal, updated_at, data, secrets)
-             VALUES (?, ?, ?, ?, ?)
-             ON CONFLICT(id) DO UPDATE SET
+            "INSERT INTO cross_chain_swaps (provider, id, is_terminal, updated_at, data, secrets)
+             VALUES (?, ?, ?, ?, ?, ?)
+             ON CONFLICT(provider, id) DO UPDATE SET
                is_terminal = excluded.is_terminal,
                updated_at = excluded.updated_at,
                data = excluded.data,
                secrets = excluded.secrets",
             params![
+                swap.provider,
                 swap.id,
                 swap.is_terminal,
                 swap.updated_at,
@@ -1126,25 +1134,34 @@ impl Storage for SqliteStorage {
         Ok(())
     }
 
-    async fn get_boltz_swap(&self, id: String) -> Result<Option<StoredBoltzSwap>, StorageError> {
+    async fn get_cross_chain_swap(
+        &self,
+        provider: String,
+        id: String,
+    ) -> Result<Option<StoredCrossChainSwap>, StorageError> {
         let connection = self.get_connection()?;
         let mut stmt = connection.prepare(
-            "SELECT id, is_terminal, updated_at, data, secrets FROM boltz_swaps WHERE id = ?",
+            "SELECT provider, id, is_terminal, updated_at, data, secrets
+               FROM cross_chain_swaps WHERE provider = ? AND id = ?",
         )?;
-        match stmt.query_row(params![id], parse_boltz_swap_row) {
+        match stmt.query_row(params![provider, id], parse_cross_chain_swap_row) {
             Ok(swap) => Ok(Some(swap)),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(e) => Err(e.into()),
         }
     }
 
-    async fn list_active_boltz_swaps(&self) -> Result<Vec<StoredBoltzSwap>, StorageError> {
+    async fn list_active_cross_chain_swaps(
+        &self,
+        provider: String,
+    ) -> Result<Vec<StoredCrossChainSwap>, StorageError> {
         let connection = self.get_connection()?;
         let mut stmt = connection.prepare(
-            "SELECT id, is_terminal, updated_at, data, secrets FROM boltz_swaps WHERE is_terminal = 0",
+            "SELECT provider, id, is_terminal, updated_at, data, secrets
+               FROM cross_chain_swaps WHERE provider = ? AND is_terminal = 0",
         )?;
         let swaps = stmt
-            .query_map([], parse_boltz_swap_row)?
+            .query_map(params![provider], parse_cross_chain_swap_row)?
             .collect::<Result<Vec<_>, _>>()?;
         Ok(swaps)
     }
@@ -2458,11 +2475,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_boltz_swaps_crud() {
-        let temp_dir = create_temp_dir("boltz_swaps_crud");
+    async fn test_cross_chain_swaps_crud() {
+        let temp_dir = create_temp_dir("cross_chain_swaps_crud");
         let storage = SqliteStorage::new(&temp_dir).unwrap();
 
-        crate::persist::tests::test_boltz_swaps_crud(Box::new(storage)).await;
+        crate::persist::tests::test_cross_chain_swaps_crud(Box::new(storage)).await;
     }
 
     #[tokio::test]
@@ -2489,8 +2506,8 @@ mod tests {
         // Step 1: bring the database up to the state before the discriminator
         // backfill — the conversion_info column exists, but no `"type"` tag has
         // been backfilled yet.
-        // Locate the backfill by content so later appended migrations (e.g. the
-        // boltz_swaps table) don't shift this off the end.
+        // Locate it by content so later appended migrations don't shift it off
+        // the end.
         let backfill_index = SqliteStorage::current_migrations()
             .iter()
             .position(|s| s.contains("'$.type', 'amm'"))

--- a/crates/breez-sdk/core/src/persist/sqlite.rs
+++ b/crates/breez-sdk/core/src/persist/sqlite.rs
@@ -14,7 +14,7 @@ use crate::{
     error::DepositClaimError,
     persist::{
         PaymentMetadata, SetLnurlMetadataItem, StorageListPaymentsRequest,
-        StoragePaymentDetailsFilter, UpdateDepositPayload, parse_payment_status,
+        StoragePaymentDetailsFilter, StoredBoltzSwap, UpdateDepositPayload, parse_payment_status,
     },
     sync_storage::{
         IncomingChange, OutgoingChange, Record, RecordChange, RecordId, UnversionedRecordChange,
@@ -354,8 +354,30 @@ impl SqliteStorage {
              SET conversion_info = json_set(conversion_info, '$.type', 'amm')
              WHERE conversion_info IS NOT NULL
                AND json_extract(conversion_info, '$.type') IS NULL;",
+            // Boltz cross-chain swap rows, synced for cross-instance recovery.
+            // `data` is the BoltzSwap JSON with `key_source` lifted out; the
+            // lifted secrets are ECIES-encrypted into `secrets` by the adapter.
+            "CREATE TABLE boltz_swaps (
+                id TEXT PRIMARY KEY,
+                is_terminal INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                data TEXT NOT NULL,
+                secrets TEXT NOT NULL
+            );
+            CREATE INDEX idx_boltz_swaps_is_terminal ON boltz_swaps(is_terminal);",
         ]
     }
+}
+
+/// Maps a `boltz_swaps` row to a [`StoredBoltzSwap`].
+fn parse_boltz_swap_row(row: &Row) -> rusqlite::Result<StoredBoltzSwap> {
+    Ok(StoredBoltzSwap {
+        id: row.get(0)?,
+        is_terminal: row.get(1)?,
+        updated_at: row.get(2)?,
+        data: row.get(3)?,
+        secrets: row.get(4)?,
+    })
 }
 
 /// Maps a rusqlite error to the appropriate `StorageError`.
@@ -1081,6 +1103,50 @@ impl Storage for SqliteStorage {
         let connection = self.get_connection()?;
         connection.execute("DELETE FROM contacts WHERE id = ?", params![id])?;
         Ok(())
+    }
+
+    async fn set_boltz_swap(&self, swap: StoredBoltzSwap) -> Result<(), StorageError> {
+        let connection = self.get_connection()?;
+        connection.execute(
+            "INSERT INTO boltz_swaps (id, is_terminal, updated_at, data, secrets)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+               is_terminal = excluded.is_terminal,
+               updated_at = excluded.updated_at,
+               data = excluded.data,
+               secrets = excluded.secrets",
+            params![
+                swap.id,
+                swap.is_terminal,
+                swap.updated_at,
+                swap.data,
+                swap.secrets
+            ],
+        )?;
+        Ok(())
+    }
+
+    async fn get_boltz_swap(&self, id: String) -> Result<Option<StoredBoltzSwap>, StorageError> {
+        let connection = self.get_connection()?;
+        let mut stmt = connection.prepare(
+            "SELECT id, is_terminal, updated_at, data, secrets FROM boltz_swaps WHERE id = ?",
+        )?;
+        match stmt.query_row(params![id], parse_boltz_swap_row) {
+            Ok(swap) => Ok(Some(swap)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn list_active_boltz_swaps(&self) -> Result<Vec<StoredBoltzSwap>, StorageError> {
+        let connection = self.get_connection()?;
+        let mut stmt = connection.prepare(
+            "SELECT id, is_terminal, updated_at, data, secrets FROM boltz_swaps WHERE is_terminal = 0",
+        )?;
+        let swaps = stmt
+            .query_map([], parse_boltz_swap_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(swaps)
     }
 
     async fn add_outgoing_change(
@@ -2392,6 +2458,14 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_boltz_swaps_crud() {
+        let temp_dir = create_temp_dir("boltz_swaps_crud");
+        let storage = SqliteStorage::new(&temp_dir).unwrap();
+
+        crate::persist::tests::test_boltz_swaps_crud(Box::new(storage)).await;
+    }
+
+    #[tokio::test]
     async fn test_contacts_crud() {
         let temp_dir = create_temp_dir("contacts_crud");
         let storage = SqliteStorage::new(&temp_dir).unwrap();
@@ -2415,7 +2489,12 @@ mod tests {
         // Step 1: bring the database up to the state before the discriminator
         // backfill — the conversion_info column exists, but no `"type"` tag has
         // been backfilled yet.
-        let backfill_index = SqliteStorage::current_migrations().len() - 1;
+        // Locate the backfill by content so later appended migrations (e.g. the
+        // boltz_swaps table) don't shift this off the end.
+        let backfill_index = SqliteStorage::current_migrations()
+            .iter()
+            .position(|s| s.contains("'$.type', 'amm'"))
+            .expect("conversion_info backfill migration present");
         {
             let mut conn = Connection::open(&db_path).unwrap();
             let migrations_before_backfill: Vec<_> = SqliteStorage::current_migrations()

--- a/crates/breez-sdk/core/src/persist/tests.rs
+++ b/crates/breez-sdk/core/src/persist/tests.rs
@@ -3409,7 +3409,6 @@ pub async fn test_cross_chain_swaps_crud(storage: Box<dyn Storage>) {
             secrets: format!("c2VjcmV0-{provider}-{id}"),
         };
 
-    // Insert + get round-trip.
     storage
         .set_cross_chain_swap(make("boltz", "s1", false, 1000))
         .await
@@ -3465,7 +3464,6 @@ pub async fn test_cross_chain_swaps_crud(storage: Box<dyn Storage>) {
     let active_ids: Vec<_> = active.iter().map(|s| s.id.as_str()).collect();
     assert_eq!(active_ids, vec!["s2"], "only non-terminal rows are active");
 
-    // Terminal rows stay queryable by id.
     let s3 = storage
         .get_cross_chain_swap("boltz".to_string(), "s3".to_string())
         .await
@@ -3474,7 +3472,7 @@ pub async fn test_cross_chain_swaps_crud(storage: Box<dyn Storage>) {
     assert!(s3.is_terminal);
 
     // Composite primary key: same id under a different provider is a distinct
-    // row, not a collision. Locks in the (provider, id) PK contract.
+    // row, not a collision.
     storage
         .set_cross_chain_swap(make("orchestra", "s1", false, 3000))
         .await

--- a/crates/breez-sdk/core/src/persist/tests.rs
+++ b/crates/breez-sdk/core/src/persist/tests.rs
@@ -3393,40 +3393,43 @@ pub async fn test_contacts_crud(storage: Box<dyn Storage>) {
     assert_ne!(page1[0].id, page2[0].id);
 }
 
-/// Storage-layer CRUD for Boltz swap rows. Exercises the opaque
-/// [`StoredBoltzSwap`] shape; the encrypt/lift logic is the adapter's job and is
-/// tested there.
-pub async fn test_boltz_swaps_crud(storage: Box<dyn Storage>) {
-    use crate::persist::StoredBoltzSwap;
+/// Storage-layer CRUD for cross-chain swap rows. Exercises the opaque
+/// [`StoredCrossChainSwap`] shape; the encrypt/lift logic is each adapter's
+/// job and is tested there.
+pub async fn test_cross_chain_swaps_crud(storage: Box<dyn Storage>) {
+    use crate::persist::StoredCrossChainSwap;
 
-    let make = |id: &str, is_terminal: bool, updated_at: u64| StoredBoltzSwap {
-        id: id.to_string(),
-        is_terminal,
-        updated_at,
-        data: format!(r#"{{"id":"{id}","status":"Created","extra":1}}"#),
-        secrets: format!("c2VjcmV0-{id}"),
-    };
+    let make =
+        |provider: &str, id: &str, is_terminal: bool, updated_at: u64| StoredCrossChainSwap {
+            provider: provider.to_string(),
+            id: id.to_string(),
+            is_terminal,
+            updated_at,
+            data: format!(r#"{{"id":"{id}","status":"Created","extra":1}}"#),
+            secrets: format!("c2VjcmV0-{provider}-{id}"),
+        };
 
     // Insert + get round-trip.
     storage
-        .set_boltz_swap(make("s1", false, 1000))
+        .set_cross_chain_swap(make("boltz", "s1", false, 1000))
         .await
         .unwrap();
     let fetched = storage
-        .get_boltz_swap("s1".to_string())
+        .get_cross_chain_swap("boltz".to_string(), "s1".to_string())
         .await
         .unwrap()
         .expect("s1 present");
+    assert_eq!(fetched.provider, "boltz");
     assert_eq!(fetched.id, "s1");
     assert!(!fetched.is_terminal);
     assert_eq!(fetched.updated_at, 1000);
     assert_eq!(fetched.data, r#"{"id":"s1","status":"Created","extra":1}"#);
-    assert_eq!(fetched.secrets, "c2VjcmV0-s1");
+    assert_eq!(fetched.secrets, "c2VjcmV0-boltz-s1");
 
-    // Missing id returns None (not an error).
+    // Missing (provider, id) returns None (not an error).
     assert!(
         storage
-            .get_boltz_swap("nope".to_string())
+            .get_cross_chain_swap("boltz".to_string(), "nope".to_string())
             .await
             .unwrap()
             .is_none()
@@ -3434,38 +3437,77 @@ pub async fn test_boltz_swaps_crud(storage: Box<dyn Storage>) {
 
     // Upsert overwrites every mutable column.
     storage
-        .set_boltz_swap(make("s1", true, 2000))
+        .set_cross_chain_swap(make("boltz", "s1", true, 2000))
         .await
         .unwrap();
     let updated = storage
-        .get_boltz_swap("s1".to_string())
+        .get_cross_chain_swap("boltz".to_string(), "s1".to_string())
         .await
         .unwrap()
         .expect("s1 still present");
     assert!(updated.is_terminal);
     assert_eq!(updated.updated_at, 2000);
 
-    // list_active filters out terminal rows.
+    // list_active filters out terminal rows for the given provider.
     storage
-        .set_boltz_swap(make("s2", false, 1500))
+        .set_cross_chain_swap(make("boltz", "s2", false, 1500))
         .await
         .unwrap();
     storage
-        .set_boltz_swap(make("s3", true, 1500))
+        .set_cross_chain_swap(make("boltz", "s3", true, 1500))
         .await
         .unwrap();
-    let mut active = storage.list_active_boltz_swaps().await.unwrap();
+    let mut active = storage
+        .list_active_cross_chain_swaps("boltz".to_string())
+        .await
+        .unwrap();
     active.sort_by(|a, b| a.id.cmp(&b.id));
     let active_ids: Vec<_> = active.iter().map(|s| s.id.as_str()).collect();
     assert_eq!(active_ids, vec!["s2"], "only non-terminal rows are active");
 
     // Terminal rows stay queryable by id.
     let s3 = storage
-        .get_boltz_swap("s3".to_string())
+        .get_cross_chain_swap("boltz".to_string(), "s3".to_string())
         .await
         .unwrap()
         .expect("terminal row retained");
     assert!(s3.is_terminal);
+
+    // Composite primary key: same id under a different provider is a distinct
+    // row, not a collision. Locks in the (provider, id) PK contract.
+    storage
+        .set_cross_chain_swap(make("orchestra", "s1", false, 3000))
+        .await
+        .unwrap();
+    let boltz_s1 = storage
+        .get_cross_chain_swap("boltz".to_string(), "s1".to_string())
+        .await
+        .unwrap()
+        .expect("boltz/s1 still present");
+    assert!(boltz_s1.is_terminal, "boltz/s1 unchanged by orchestra/s1");
+    assert_eq!(boltz_s1.updated_at, 2000);
+    let orchestra_s1 = storage
+        .get_cross_chain_swap("orchestra".to_string(), "s1".to_string())
+        .await
+        .unwrap()
+        .expect("orchestra/s1 present");
+    assert!(!orchestra_s1.is_terminal);
+    assert_eq!(orchestra_s1.updated_at, 3000);
+
+    // list_active is provider-scoped: a non-terminal orchestra row does not
+    // appear in the boltz list, and vice versa.
+    let boltz_active = storage
+        .list_active_cross_chain_swaps("boltz".to_string())
+        .await
+        .unwrap();
+    let boltz_ids: Vec<_> = boltz_active.iter().map(|s| s.id.as_str()).collect();
+    assert_eq!(boltz_ids, vec!["s2"]);
+    let orchestra_active = storage
+        .list_active_cross_chain_swaps("orchestra".to_string())
+        .await
+        .unwrap();
+    let orchestra_ids: Vec<_> = orchestra_active.iter().map(|s| s.id.as_str()).collect();
+    assert_eq!(orchestra_ids, vec!["s1"]);
 }
 
 /// Tests that `conversion_status` in `PaymentMetadata` is correctly persisted and

--- a/crates/breez-sdk/core/src/persist/tests.rs
+++ b/crates/breez-sdk/core/src/persist/tests.rs
@@ -3393,6 +3393,81 @@ pub async fn test_contacts_crud(storage: Box<dyn Storage>) {
     assert_ne!(page1[0].id, page2[0].id);
 }
 
+/// Storage-layer CRUD for Boltz swap rows. Exercises the opaque
+/// [`StoredBoltzSwap`] shape; the encrypt/lift logic is the adapter's job and is
+/// tested there.
+pub async fn test_boltz_swaps_crud(storage: Box<dyn Storage>) {
+    use crate::persist::StoredBoltzSwap;
+
+    let make = |id: &str, is_terminal: bool, updated_at: u64| StoredBoltzSwap {
+        id: id.to_string(),
+        is_terminal,
+        updated_at,
+        data: format!(r#"{{"id":"{id}","status":"Created","extra":1}}"#),
+        secrets: format!("c2VjcmV0-{id}"),
+    };
+
+    // Insert + get round-trip.
+    storage
+        .set_boltz_swap(make("s1", false, 1000))
+        .await
+        .unwrap();
+    let fetched = storage
+        .get_boltz_swap("s1".to_string())
+        .await
+        .unwrap()
+        .expect("s1 present");
+    assert_eq!(fetched.id, "s1");
+    assert!(!fetched.is_terminal);
+    assert_eq!(fetched.updated_at, 1000);
+    assert_eq!(fetched.data, r#"{"id":"s1","status":"Created","extra":1}"#);
+    assert_eq!(fetched.secrets, "c2VjcmV0-s1");
+
+    // Missing id returns None (not an error).
+    assert!(
+        storage
+            .get_boltz_swap("nope".to_string())
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    // Upsert overwrites every mutable column.
+    storage
+        .set_boltz_swap(make("s1", true, 2000))
+        .await
+        .unwrap();
+    let updated = storage
+        .get_boltz_swap("s1".to_string())
+        .await
+        .unwrap()
+        .expect("s1 still present");
+    assert!(updated.is_terminal);
+    assert_eq!(updated.updated_at, 2000);
+
+    // list_active filters out terminal rows.
+    storage
+        .set_boltz_swap(make("s2", false, 1500))
+        .await
+        .unwrap();
+    storage
+        .set_boltz_swap(make("s3", true, 1500))
+        .await
+        .unwrap();
+    let mut active = storage.list_active_boltz_swaps().await.unwrap();
+    active.sort_by(|a, b| a.id.cmp(&b.id));
+    let active_ids: Vec<_> = active.iter().map(|s| s.id.as_str()).collect();
+    assert_eq!(active_ids, vec!["s2"], "only non-terminal rows are active");
+
+    // Terminal rows stay queryable by id.
+    let s3 = storage
+        .get_boltz_swap("s3".to_string())
+        .await
+        .unwrap()
+        .expect("terminal row retained");
+    assert!(s3.is_terminal);
+}
+
 /// Tests that `conversion_status` in `PaymentMetadata` is correctly persisted and
 /// read back as `conversion_details` on the `Payment`. Also verifies COALESCE
 /// behavior preserves it across partial metadata updates, and that all

--- a/crates/breez-sdk/core/src/realtime_sync/storage.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/storage.rs
@@ -416,11 +416,6 @@ impl SyncedRecordHandler {
         Ok(())
     }
 
-    /// Applies a synced-in cross-chain swap row via the inner store (bypassing
-    /// the outgoing-emit wrapper). Plain last-writer-wins: each provider's
-    /// convergence logic, not the SDK, owns correctness. `data_id` is
-    /// `"{provider}:{id}"`, which is already carried inside the serialized
-    /// fields.
     async fn handle_cross_chain_swap_change(
         &self,
         fields: HashMap<String, Value>,
@@ -1203,12 +1198,6 @@ mod tests {
         assert!(storage.get_contact("c3".to_string()).await.is_err());
     }
 
-    /// Plumbing round-trip for the `CrossChainSwap` record: a swap set on one
-    /// instance is serialized into an outgoing record, then applied as an
-    /// incoming change on a second instance's store, reconstructing an
-    /// identical row. Exercised for both provider tags so any hard-coded
-    /// "boltz" / "orchestra" in the emit or apply path is caught. No real swap
-    /// or cross-chain infra involved.
     #[tokio::test]
     async fn test_cross_chain_swap_sync_round_trip_boltz() {
         run_cross_chain_swap_round_trip("boltz", "swap-1").await;

--- a/crates/breez-sdk/core/src/realtime_sync/storage.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/storage.rs
@@ -19,8 +19,8 @@ use crate::{
     events::{InternalSyncedEvent, SdkEvent},
     lnurl::LnurlServerClient,
     persist::{
-        LIGHTNING_ADDRESS_KEY, ObjectCacheRepository, StorageListPaymentsRequest, StoredBoltzSwap,
-        parse_cached_lightning_address,
+        LIGHTNING_ADDRESS_KEY, ObjectCacheRepository, StorageListPaymentsRequest,
+        StoredCrossChainSwap, parse_cached_lightning_address,
     },
     sync_storage::{IncomingChange, OutgoingChange, Record, UnversionedRecordChange},
 };
@@ -33,7 +33,7 @@ enum RecordType {
     PaymentMetadata,
     Contact,
     LightningAddress,
-    BoltzSwap,
+    CrossChainSwap,
 }
 
 impl RecordType {
@@ -43,7 +43,7 @@ impl RecordType {
             Self::PaymentMetadata => SchemaVersion::new(1, 0, 0),
             Self::Contact => SchemaVersion::new(1, 0, 0),
             Self::LightningAddress => SchemaVersion::new(1, 0, 0),
-            Self::BoltzSwap => SchemaVersion::new(1, 0, 0),
+            Self::CrossChainSwap => SchemaVersion::new(1, 0, 0),
         }
     }
 }
@@ -54,7 +54,7 @@ impl Display for RecordType {
             RecordType::PaymentMetadata => "PaymentMetadata",
             RecordType::Contact => "Contact",
             RecordType::LightningAddress => "LightningAddress",
-            RecordType::BoltzSwap => "BoltzSwap",
+            RecordType::CrossChainSwap => "CrossChainSwap",
         };
         write!(f, "{s}")
     }
@@ -68,7 +68,7 @@ impl FromStr for RecordType {
             "PaymentMetadata" => Ok(RecordType::PaymentMetadata),
             "Contact" => Ok(RecordType::Contact),
             "LightningAddress" => Ok(RecordType::LightningAddress),
-            "BoltzSwap" => Ok(RecordType::BoltzSwap),
+            "CrossChainSwap" => Ok(RecordType::CrossChainSwap),
             _ => Err(format!("Unknown record type: {s}")),
         }
     }
@@ -324,7 +324,10 @@ impl SyncedRecordHandler {
             RecordType::LightningAddress => {
                 return Ok(self.handle_lightning_address_change());
             }
-            RecordType::BoltzSwap => self.handle_boltz_swap_change(change.new_state.data).await,
+            RecordType::CrossChainSwap => {
+                self.handle_cross_chain_swap_change(change.new_state.data)
+                    .await
+            }
         }?;
         Ok(RecordOutcome::Completed)
     }
@@ -360,8 +363,8 @@ impl SyncedRecordHandler {
                     .await
             }
             RecordType::LightningAddress => Ok(()),
-            RecordType::BoltzSwap => {
-                self.handle_boltz_swap_change(change.change.updated_fields)
+            RecordType::CrossChainSwap => {
+                self.handle_cross_chain_swap_change(change.change.updated_fields)
                     .await
             }
         }
@@ -413,17 +416,21 @@ impl SyncedRecordHandler {
         Ok(())
     }
 
-    /// Applies a synced-in Boltz swap row via the inner store (bypassing the
-    /// outgoing-emit wrapper). Plain last-writer-wins: the boltz-client
-    /// convergence logic, not the SDK, owns correctness. `data_id` equals the
-    /// swap id, which is already carried inside the serialized fields.
-    async fn handle_boltz_swap_change(&self, fields: HashMap<String, Value>) -> anyhow::Result<()> {
-        let swap: StoredBoltzSwap = serde_json::from_value(
+    /// Applies a synced-in cross-chain swap row via the inner store (bypassing
+    /// the outgoing-emit wrapper). Plain last-writer-wins: each provider's
+    /// convergence logic, not the SDK, owns correctness. `data_id` is
+    /// `"{provider}:{id}"`, which is already carried inside the serialized
+    /// fields.
+    async fn handle_cross_chain_swap_change(
+        &self,
+        fields: HashMap<String, Value>,
+    ) -> anyhow::Result<()> {
+        let swap: StoredCrossChainSwap = serde_json::from_value(
             serde_json::to_value(&fields)
                 .map_err(|e| StorageError::Serialization(e.to_string()))?,
         )
         .map_err(|e| StorageError::Serialization(e.to_string()))?;
-        self.storage.set_boltz_swap(swap).await?;
+        self.storage.set_cross_chain_swap(swap).await?;
         Ok(())
     }
 
@@ -662,11 +669,12 @@ impl Storage for SyncedStorage {
         self.inner.delete_contact(id).await
     }
 
-    async fn set_boltz_swap(&self, swap: StoredBoltzSwap) -> Result<(), StorageError> {
+    async fn set_cross_chain_swap(&self, swap: StoredCrossChainSwap) -> Result<(), StorageError> {
+        let data_id = format!("{}:{}", swap.provider, swap.id);
         self.sync_service
             .set_outgoing_record(&RecordChangeRequest {
-                id: RecordId::new(RecordType::BoltzSwap.to_string(), &swap.id),
-                schema_version: RecordType::BoltzSwap.schema_version(),
+                id: RecordId::new(RecordType::CrossChainSwap.to_string(), &data_id),
+                schema_version: RecordType::CrossChainSwap.schema_version(),
                 updated_fields: serde_json::from_value(
                     serde_json::to_value(&swap)
                         .map_err(|e| StorageError::Serialization(e.to_string()))?,
@@ -675,15 +683,22 @@ impl Storage for SyncedStorage {
             })
             .await
             .map_err(|e| StorageError::Implementation(e.to_string()))?;
-        self.inner.set_boltz_swap(swap).await
+        self.inner.set_cross_chain_swap(swap).await
     }
 
-    async fn get_boltz_swap(&self, id: String) -> Result<Option<StoredBoltzSwap>, StorageError> {
-        self.inner.get_boltz_swap(id).await
+    async fn get_cross_chain_swap(
+        &self,
+        provider: String,
+        id: String,
+    ) -> Result<Option<StoredCrossChainSwap>, StorageError> {
+        self.inner.get_cross_chain_swap(provider, id).await
     }
 
-    async fn list_active_boltz_swaps(&self) -> Result<Vec<StoredBoltzSwap>, StorageError> {
-        self.inner.list_active_boltz_swaps().await
+    async fn list_active_cross_chain_swaps(
+        &self,
+        provider: String,
+    ) -> Result<Vec<StoredCrossChainSwap>, StorageError> {
+        self.inner.list_active_cross_chain_swaps(provider).await
     }
 
     async fn add_outgoing_change(
@@ -1188,25 +1203,40 @@ mod tests {
         assert!(storage.get_contact("c3".to_string()).await.is_err());
     }
 
-    /// Plumbing round-trip for the `BoltzSwap` record: a swap set on one instance
-    /// is serialized into an outgoing record, then applied as an incoming change
-    /// on a second instance's store, reconstructing an identical row. No real
-    /// swap or cross-chain infra involved.
+    /// Plumbing round-trip for the `CrossChainSwap` record: a swap set on one
+    /// instance is serialized into an outgoing record, then applied as an
+    /// incoming change on a second instance's store, reconstructing an
+    /// identical row. Exercised for both provider tags so any hard-coded
+    /// "boltz" / "orchestra" in the emit or apply path is caught. No real swap
+    /// or cross-chain infra involved.
     #[tokio::test]
-    async fn test_boltz_swap_sync_round_trip() {
-        // Instance A: set_boltz_swap emits an outgoing record and writes locally.
-        let writer_dir = create_temp_dir("boltz_sync_writer");
+    async fn test_cross_chain_swap_sync_round_trip_boltz() {
+        run_cross_chain_swap_round_trip("boltz", "swap-1").await;
+    }
+
+    #[tokio::test]
+    async fn test_cross_chain_swap_sync_round_trip_orchestra() {
+        run_cross_chain_swap_round_trip("orchestra", "quote-1").await;
+    }
+
+    async fn run_cross_chain_swap_round_trip(provider: &str, id: &str) {
+        // Instance A: set_cross_chain_swap emits an outgoing record and writes
+        // locally.
+        let writer_dir = create_temp_dir(&format!("cross_chain_sync_writer_{provider}"));
         let writer_inner: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&writer_dir).unwrap());
         let synced = create_test_synced_storage(Arc::clone(&writer_inner));
 
-        let stored = StoredBoltzSwap {
-            id: "swap-1".to_string(),
+        let stored = StoredCrossChainSwap {
+            provider: provider.to_string(),
+            id: id.to_string(),
             is_terminal: false,
             updated_at: 1700,
-            data: r#"{"id":"swap-1","status":"Created"}"#.to_string(),
+            data: format!(r#"{{"id":"{id}","status":"Created"}}"#),
             secrets: "c2VjcmV0".to_string(),
         };
-        synced.set_boltz_swap(stored.clone()).await.unwrap();
+        synced.set_cross_chain_swap(stored.clone()).await.unwrap();
+
+        let expected_data_id = format!("{provider}:{id}");
 
         // Exactly the fields the writer emitted are replayed (not re-serialized
         // here), so the test catches any emit/apply field mismatch.
@@ -1216,10 +1246,10 @@ mod tests {
             .unwrap()
             .into_iter()
             .find(|c| {
-                c.change.id.r#type == RecordType::BoltzSwap.to_string()
-                    && c.change.id.data_id == "swap-1"
+                c.change.id.r#type == RecordType::CrossChainSwap.to_string()
+                    && c.change.id.data_id == expected_data_id
             })
-            .expect("set_boltz_swap must queue a BoltzSwap outgoing record");
+            .expect("set_cross_chain_swap must queue a CrossChainSwap outgoing record");
         let fields: HashMap<String, Value> = emitted
             .change
             .updated_fields
@@ -1228,14 +1258,14 @@ mod tests {
             .collect();
 
         // Instance B: apply the emitted record as an incoming change.
-        let reader_dir = create_temp_dir("boltz_sync_reader");
+        let reader_dir = create_temp_dir(&format!("cross_chain_sync_reader_{provider}"));
         let reader_inner: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&reader_dir).unwrap());
         let handler = create_test_record_handler(Arc::clone(&reader_inner));
 
         let change = make_incoming_change(
-            &RecordType::BoltzSwap.to_string(),
-            "swap-1",
-            RecordType::BoltzSwap.schema_version(),
+            &RecordType::CrossChainSwap.to_string(),
+            &expected_data_id,
+            RecordType::CrossChainSwap.schema_version(),
             fields,
         );
         let outcome = handler.handle_incoming_change(change).await.unwrap();
@@ -1243,10 +1273,11 @@ mod tests {
 
         // Instance B's local store now holds an identical row.
         let fetched = reader_inner
-            .get_boltz_swap("swap-1".to_string())
+            .get_cross_chain_swap(provider.to_string(), id.to_string())
             .await
             .unwrap()
             .expect("swap applied to reader store");
+        assert_eq!(fetched.provider, stored.provider);
         assert_eq!(fetched.id, stored.id);
         assert_eq!(fetched.is_terminal, stored.is_terminal);
         assert_eq!(fetched.updated_at, stored.updated_at);

--- a/crates/breez-sdk/core/src/realtime_sync/storage.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/storage.rs
@@ -19,7 +19,7 @@ use crate::{
     events::{InternalSyncedEvent, SdkEvent},
     lnurl::LnurlServerClient,
     persist::{
-        LIGHTNING_ADDRESS_KEY, ObjectCacheRepository, StorageListPaymentsRequest,
+        LIGHTNING_ADDRESS_KEY, ObjectCacheRepository, StorageListPaymentsRequest, StoredBoltzSwap,
         parse_cached_lightning_address,
     },
     sync_storage::{IncomingChange, OutgoingChange, Record, UnversionedRecordChange},
@@ -33,6 +33,7 @@ enum RecordType {
     PaymentMetadata,
     Contact,
     LightningAddress,
+    BoltzSwap,
 }
 
 impl RecordType {
@@ -42,6 +43,7 @@ impl RecordType {
             Self::PaymentMetadata => SchemaVersion::new(1, 0, 0),
             Self::Contact => SchemaVersion::new(1, 0, 0),
             Self::LightningAddress => SchemaVersion::new(1, 0, 0),
+            Self::BoltzSwap => SchemaVersion::new(1, 0, 0),
         }
     }
 }
@@ -52,6 +54,7 @@ impl Display for RecordType {
             RecordType::PaymentMetadata => "PaymentMetadata",
             RecordType::Contact => "Contact",
             RecordType::LightningAddress => "LightningAddress",
+            RecordType::BoltzSwap => "BoltzSwap",
         };
         write!(f, "{s}")
     }
@@ -65,6 +68,7 @@ impl FromStr for RecordType {
             "PaymentMetadata" => Ok(RecordType::PaymentMetadata),
             "Contact" => Ok(RecordType::Contact),
             "LightningAddress" => Ok(RecordType::LightningAddress),
+            "BoltzSwap" => Ok(RecordType::BoltzSwap),
             _ => Err(format!("Unknown record type: {s}")),
         }
     }
@@ -320,6 +324,7 @@ impl SyncedRecordHandler {
             RecordType::LightningAddress => {
                 return Ok(self.handle_lightning_address_change());
             }
+            RecordType::BoltzSwap => self.handle_boltz_swap_change(change.new_state.data).await,
         }?;
         Ok(RecordOutcome::Completed)
     }
@@ -355,6 +360,10 @@ impl SyncedRecordHandler {
                     .await
             }
             RecordType::LightningAddress => Ok(()),
+            RecordType::BoltzSwap => {
+                self.handle_boltz_swap_change(change.change.updated_fields)
+                    .await
+            }
         }
     }
 
@@ -401,6 +410,20 @@ impl SyncedRecordHandler {
         };
         self.storage.insert_contact(contact).await?;
 
+        Ok(())
+    }
+
+    /// Applies a synced-in Boltz swap row via the inner store (bypassing the
+    /// outgoing-emit wrapper). Plain last-writer-wins: the boltz-client
+    /// convergence logic, not the SDK, owns correctness. `data_id` equals the
+    /// swap id, which is already carried inside the serialized fields.
+    async fn handle_boltz_swap_change(&self, fields: HashMap<String, Value>) -> anyhow::Result<()> {
+        let swap: StoredBoltzSwap = serde_json::from_value(
+            serde_json::to_value(&fields)
+                .map_err(|e| StorageError::Serialization(e.to_string()))?,
+        )
+        .map_err(|e| StorageError::Serialization(e.to_string()))?;
+        self.storage.set_boltz_swap(swap).await?;
         Ok(())
     }
 
@@ -637,6 +660,30 @@ impl Storage for SyncedStorage {
             .await
             .map_err(|e| StorageError::Implementation(e.to_string()))?;
         self.inner.delete_contact(id).await
+    }
+
+    async fn set_boltz_swap(&self, swap: StoredBoltzSwap) -> Result<(), StorageError> {
+        self.sync_service
+            .set_outgoing_record(&RecordChangeRequest {
+                id: RecordId::new(RecordType::BoltzSwap.to_string(), &swap.id),
+                schema_version: RecordType::BoltzSwap.schema_version(),
+                updated_fields: serde_json::from_value(
+                    serde_json::to_value(&swap)
+                        .map_err(|e| StorageError::Serialization(e.to_string()))?,
+                )
+                .map_err(|e| StorageError::Serialization(e.to_string()))?,
+            })
+            .await
+            .map_err(|e| StorageError::Implementation(e.to_string()))?;
+        self.inner.set_boltz_swap(swap).await
+    }
+
+    async fn get_boltz_swap(&self, id: String) -> Result<Option<StoredBoltzSwap>, StorageError> {
+        self.inner.get_boltz_swap(id).await
+    }
+
+    async fn list_active_boltz_swaps(&self) -> Result<Vec<StoredBoltzSwap>, StorageError> {
+        self.inner.list_active_boltz_swaps().await
     }
 
     async fn add_outgoing_change(
@@ -1139,6 +1186,72 @@ mod tests {
         assert!(result.is_ok());
 
         assert!(storage.get_contact("c3".to_string()).await.is_err());
+    }
+
+    /// Plumbing round-trip for the `BoltzSwap` record: a swap set on one instance
+    /// is serialized into an outgoing record, then applied as an incoming change
+    /// on a second instance's store, reconstructing an identical row. No real
+    /// swap or cross-chain infra involved.
+    #[tokio::test]
+    async fn test_boltz_swap_sync_round_trip() {
+        // Instance A: set_boltz_swap emits an outgoing record and writes locally.
+        let writer_dir = create_temp_dir("boltz_sync_writer");
+        let writer_inner: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&writer_dir).unwrap());
+        let synced = create_test_synced_storage(Arc::clone(&writer_inner));
+
+        let stored = StoredBoltzSwap {
+            id: "swap-1".to_string(),
+            is_terminal: false,
+            updated_at: 1700,
+            data: r#"{"id":"swap-1","status":"Created"}"#.to_string(),
+            secrets: "c2VjcmV0".to_string(),
+        };
+        synced.set_boltz_swap(stored.clone()).await.unwrap();
+
+        // Exactly the fields the writer emitted are replayed (not re-serialized
+        // here), so the test catches any emit/apply field mismatch.
+        let emitted = writer_inner
+            .get_pending_outgoing_changes(100)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|c| {
+                c.change.id.r#type == RecordType::BoltzSwap.to_string()
+                    && c.change.id.data_id == "swap-1"
+            })
+            .expect("set_boltz_swap must queue a BoltzSwap outgoing record");
+        let fields: HashMap<String, Value> = emitted
+            .change
+            .updated_fields
+            .into_iter()
+            .map(|(k, v)| (k, serde_json::from_str(&v).unwrap()))
+            .collect();
+
+        // Instance B: apply the emitted record as an incoming change.
+        let reader_dir = create_temp_dir("boltz_sync_reader");
+        let reader_inner: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&reader_dir).unwrap());
+        let handler = create_test_record_handler(Arc::clone(&reader_inner));
+
+        let change = make_incoming_change(
+            &RecordType::BoltzSwap.to_string(),
+            "swap-1",
+            RecordType::BoltzSwap.schema_version(),
+            fields,
+        );
+        let outcome = handler.handle_incoming_change(change).await.unwrap();
+        assert_eq!(outcome, RecordOutcome::Completed);
+
+        // Instance B's local store now holds an identical row.
+        let fetched = reader_inner
+            .get_boltz_swap("swap-1".to_string())
+            .await
+            .unwrap()
+            .expect("swap applied to reader store");
+        assert_eq!(fetched.id, stored.id);
+        assert_eq!(fetched.is_terminal, stored.is_terminal);
+        assert_eq!(fetched.updated_at, stored.updated_at);
+        assert_eq!(fetched.data, stored.data);
+        assert_eq!(fetched.secrets, stored.secrets);
     }
 
     /// Helper: returns the number of pending outgoing sync changes with record type

--- a/crates/breez-sdk/core/src/token_conversion/models.rs
+++ b/crates/breez-sdk/core/src/token_conversion/models.rs
@@ -216,12 +216,10 @@ pub enum ConversionInfo {
         #[serde(default)]
         asset_contract: Option<String>,
     },
-    /// Boltz reverse swap — cross-chain conversion via Lightning hold invoice.
+    /// Boltz reverse swap: cross-chain conversion via Lightning hold invoice.
     ///
-    /// The swap's secrets and full lifecycle state live on the separate, synced
-    /// Boltz swap row keyed by `swap_id`, not here. This payment-row metadata
-    /// carries only what the UI and reconciliation need; recovery on another
-    /// instance is driven from that synced swap row.
+    /// The swap's secrets and lifecycle state live on the synced Boltz swap row
+    /// keyed by `swap_id`, which also drives cross-instance recovery.
     #[serde(rename = "boltz")]
     Boltz {
         /// The Boltz swap id returned by `POST /swap/reverse`.

--- a/crates/breez-sdk/core/src/token_conversion/models.rs
+++ b/crates/breez-sdk/core/src/token_conversion/models.rs
@@ -218,9 +218,10 @@ pub enum ConversionInfo {
     },
     /// Boltz reverse swap — cross-chain conversion via Lightning hold invoice.
     ///
-    /// `instance_id` and `claim_key_index` are intentionally not stored on
-    /// the payment row in v1: they would only be needed for cross-device
-    /// re-derivation of the preimage, which v1 does not support.
+    /// The swap's secrets and full lifecycle state live on the separate, synced
+    /// Boltz swap row keyed by `swap_id`, not here. This payment-row metadata
+    /// carries only what the UI and reconciliation need; recovery on another
+    /// instance is driven from that synced swap row.
     #[serde(rename = "boltz")]
     Boltz {
         /// The Boltz swap id returned by `POST /swap/reverse`.

--- a/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
@@ -105,6 +105,20 @@ function toBool(value) {
   return value === 1 || value === "1" || value === true;
 }
 
+/**
+ * Maps a brz_boltz_swaps row to the camelCase StoredBoltzSwap shape the SDK
+ * expects, coercing TINYINT(1) to a boolean and parsing the `data` JSON.
+ */
+function boltzSwapFromRow(row) {
+  return {
+    id: row.id,
+    isTerminal: toBool(row.is_terminal),
+    updatedAt: Number(row.updated_at),
+    data: row.data,
+    secrets: row.secrets,
+  };
+}
+
 class MysqlStorage {
   /**
    * @param {import('mysql2/promise').Pool} pool - Connection pool (may be shared with other tenants).
@@ -1057,6 +1071,66 @@ class MysqlStorage {
     } catch (error) {
       throw new StorageError(
         `Failed to delete contact: ${error.message}`,
+        error
+      );
+    }
+  }
+
+  // ===== Boltz Swap Operations =====
+
+  async setBoltzSwap(swap) {
+    try {
+      await this.pool.query(
+        `INSERT INTO brz_boltz_swaps (user_id, id, is_terminal, updated_at, data, secrets)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+           is_terminal = VALUES(is_terminal),
+           updated_at = VALUES(updated_at),
+           data = VALUES(data),
+           secrets = VALUES(secrets)`,
+        [
+          this.identity,
+          swap.id,
+          swap.isTerminal ? 1 : 0,
+          swap.updatedAt,
+          swap.data,
+          swap.secrets,
+        ]
+      );
+    } catch (error) {
+      throw new StorageError(`Failed to set boltz swap: ${error.message}`, error);
+    }
+  }
+
+  async getBoltzSwap(id) {
+    try {
+      const [rows] = await this.pool.query(
+        `SELECT id, is_terminal, updated_at, data, secrets
+         FROM brz_boltz_swaps
+         WHERE user_id = ? AND id = ?`,
+        [this.identity, id]
+      );
+      if (rows.length === 0) {
+        return null;
+      }
+      return boltzSwapFromRow(rows[0]);
+    } catch (error) {
+      throw new StorageError(`Failed to get boltz swap: ${error.message}`, error);
+    }
+  }
+
+  async listActiveBoltzSwaps() {
+    try {
+      const [rows] = await this.pool.query(
+        `SELECT id, is_terminal, updated_at, data, secrets
+         FROM brz_boltz_swaps
+         WHERE user_id = ? AND is_terminal = FALSE`,
+        [this.identity]
+      );
+      return rows.map(boltzSwapFromRow);
+    } catch (error) {
+      throw new StorageError(
+        `Failed to list active boltz swaps: ${error.message}`,
         error
       );
     }

--- a/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/index.cjs
@@ -106,11 +106,12 @@ function toBool(value) {
 }
 
 /**
- * Maps a brz_boltz_swaps row to the camelCase StoredBoltzSwap shape the SDK
- * expects, coercing TINYINT(1) to a boolean and parsing the `data` JSON.
+ * Maps a brz_cross_chain_swaps row to the camelCase StoredCrossChainSwap shape
+ * the SDK expects, coercing TINYINT(1) to a boolean.
  */
-function boltzSwapFromRow(row) {
+function crossChainSwapFromRow(row) {
   return {
+    provider: row.provider,
     id: row.id,
     isTerminal: toBool(row.is_terminal),
     updatedAt: Number(row.updated_at),
@@ -1076,13 +1077,14 @@ class MysqlStorage {
     }
   }
 
-  // ===== Boltz Swap Operations =====
+  // ===== Cross-Chain Swap Operations =====
 
-  async setBoltzSwap(swap) {
+  async setCrossChainSwap(swap) {
     try {
       await this.pool.query(
-        `INSERT INTO brz_boltz_swaps (user_id, id, is_terminal, updated_at, data, secrets)
-         VALUES (?, ?, ?, ?, ?, ?)
+        `INSERT INTO brz_cross_chain_swaps
+           (user_id, provider, id, is_terminal, updated_at, data, secrets)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
          ON DUPLICATE KEY UPDATE
            is_terminal = VALUES(is_terminal),
            updated_at = VALUES(updated_at),
@@ -1090,6 +1092,7 @@ class MysqlStorage {
            secrets = VALUES(secrets)`,
         [
           this.identity,
+          swap.provider,
           swap.id,
           swap.isTerminal ? 1 : 0,
           swap.updatedAt,
@@ -1098,39 +1101,45 @@ class MysqlStorage {
         ]
       );
     } catch (error) {
-      throw new StorageError(`Failed to set boltz swap: ${error.message}`, error);
+      throw new StorageError(
+        `Failed to set cross-chain swap: ${error.message}`,
+        error
+      );
     }
   }
 
-  async getBoltzSwap(id) {
+  async getCrossChainSwap(provider, id) {
     try {
       const [rows] = await this.pool.query(
-        `SELECT id, is_terminal, updated_at, data, secrets
-         FROM brz_boltz_swaps
-         WHERE user_id = ? AND id = ?`,
-        [this.identity, id]
+        `SELECT provider, id, is_terminal, updated_at, data, secrets
+         FROM brz_cross_chain_swaps
+         WHERE user_id = ? AND provider = ? AND id = ?`,
+        [this.identity, provider, id]
       );
       if (rows.length === 0) {
         return null;
       }
-      return boltzSwapFromRow(rows[0]);
+      return crossChainSwapFromRow(rows[0]);
     } catch (error) {
-      throw new StorageError(`Failed to get boltz swap: ${error.message}`, error);
+      throw new StorageError(
+        `Failed to get cross-chain swap: ${error.message}`,
+        error
+      );
     }
   }
 
-  async listActiveBoltzSwaps() {
+  async listActiveCrossChainSwaps(provider) {
     try {
       const [rows] = await this.pool.query(
-        `SELECT id, is_terminal, updated_at, data, secrets
-         FROM brz_boltz_swaps
-         WHERE user_id = ? AND is_terminal = FALSE`,
-        [this.identity]
+        `SELECT provider, id, is_terminal, updated_at, data, secrets
+         FROM brz_cross_chain_swaps
+         WHERE user_id = ? AND provider = ? AND is_terminal = FALSE`,
+        [this.identity, provider]
       );
-      return rows.map(boltzSwapFromRow);
+      return rows.map(crossChainSwapFromRow);
     } catch (error) {
       throw new StorageError(
-        `Failed to list active boltz swaps: ${error.message}`,
+        `Failed to list active cross-chain swaps: ${error.message}`,
         error
       );
     }

--- a/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
@@ -545,8 +545,7 @@ class MysqlMigrationManager {
         // Cross-chain swap rows, synced for cross-instance recovery. Shared
         // across providers, discriminated by `provider`. Born multi-tenant
         // (user_id in the PK). `data` is provider-opaque JSON; `secrets` is
-        // provider-opaque ciphertext (empty when the provider has no
-        // money-critical secrets).
+        // provider-opaque ciphertext (empty when the provider has none).
         name: "Create brz_cross_chain_swaps table",
         sql: [
           `CREATE TABLE IF NOT EXISTS brz_cross_chain_swaps (

--- a/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
@@ -541,6 +541,25 @@ class MysqlMigrationManager {
           `UPDATE brz_payment_metadata SET conversion_info = JSON_SET(conversion_info, '$.type', 'amm') WHERE conversion_info IS NOT NULL AND JSON_EXTRACT(conversion_info, '$.type') IS NULL`,
         ],
       },
+      {
+        // Boltz cross-chain swap rows, synced for cross-instance recovery.
+        // Born multi-tenant (user_id in the PK). `data` is the BoltzSwap JSON
+        // with `key_source` lifted out; the lifted secrets are ECIES-encrypted
+        // (base64) into `secrets` by the adapter.
+        name: "Create brz_boltz_swaps table",
+        sql: [
+          `CREATE TABLE IF NOT EXISTS brz_boltz_swaps (
+              user_id VARBINARY(33) NOT NULL,
+              id VARCHAR(255) NOT NULL,
+              is_terminal TINYINT(1) NOT NULL,
+              updated_at BIGINT NOT NULL,
+              data LONGTEXT NOT NULL,
+              secrets LONGTEXT NOT NULL,
+              PRIMARY KEY (user_id, id),
+              INDEX brz_idx_boltz_swaps_user_is_terminal (user_id, is_terminal)
+          )`,
+        ],
+      },
     ];
   }
 }

--- a/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-storage/migrations.cjs
@@ -542,21 +542,24 @@ class MysqlMigrationManager {
         ],
       },
       {
-        // Boltz cross-chain swap rows, synced for cross-instance recovery.
-        // Born multi-tenant (user_id in the PK). `data` is the BoltzSwap JSON
-        // with `key_source` lifted out; the lifted secrets are ECIES-encrypted
-        // (base64) into `secrets` by the adapter.
-        name: "Create brz_boltz_swaps table",
+        // Cross-chain swap rows, synced for cross-instance recovery. Shared
+        // across providers, discriminated by `provider`. Born multi-tenant
+        // (user_id in the PK). `data` is provider-opaque JSON; `secrets` is
+        // provider-opaque ciphertext (empty when the provider has no
+        // money-critical secrets).
+        name: "Create brz_cross_chain_swaps table",
         sql: [
-          `CREATE TABLE IF NOT EXISTS brz_boltz_swaps (
+          `CREATE TABLE IF NOT EXISTS brz_cross_chain_swaps (
               user_id VARBINARY(33) NOT NULL,
+              provider VARCHAR(64) NOT NULL,
               id VARCHAR(255) NOT NULL,
               is_terminal TINYINT(1) NOT NULL,
               updated_at BIGINT NOT NULL,
               data LONGTEXT NOT NULL,
               secrets LONGTEXT NOT NULL,
-              PRIMARY KEY (user_id, id),
-              INDEX brz_idx_boltz_swaps_user_is_terminal (user_id, is_terminal)
+              PRIMARY KEY (user_id, provider, id),
+              INDEX brz_idx_cross_chain_swaps_user_provider_is_terminal
+                  (user_id, provider, is_terminal)
           )`,
         ],
       },

--- a/crates/breez-sdk/wasm/js/node-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/node-storage/index.cjs
@@ -1412,6 +1412,74 @@ class SqliteStorage {
       );
     }
   }
+
+  // ===== Boltz Swap Operations =====
+
+  setBoltzSwap(swap) {
+    try {
+      const stmt = this.db.prepare(`
+        INSERT INTO boltz_swaps (id, is_terminal, updated_at, data, secrets)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          is_terminal = excluded.is_terminal,
+          updated_at = excluded.updated_at,
+          data = excluded.data,
+          secrets = excluded.secrets
+      `);
+      stmt.run(
+        swap.id,
+        swap.isTerminal ? 1 : 0,
+        swap.updatedAt,
+        swap.data,
+        swap.secrets
+      );
+      return Promise.resolve();
+    } catch (error) {
+      return Promise.reject(
+        new StorageError(`Failed to set boltz swap: ${error.message}`, error)
+      );
+    }
+  }
+
+  getBoltzSwap(id) {
+    try {
+      const stmt = this.db.prepare(
+        "SELECT id, is_terminal, updated_at, data, secrets FROM boltz_swaps WHERE id = ?"
+      );
+      const row = stmt.get(id);
+      return Promise.resolve(row ? boltzSwapFromRow(row) : null);
+    } catch (error) {
+      return Promise.reject(
+        new StorageError(`Failed to get boltz swap: ${error.message}`, error)
+      );
+    }
+  }
+
+  listActiveBoltzSwaps() {
+    try {
+      const stmt = this.db.prepare(
+        "SELECT id, is_terminal, updated_at, data, secrets FROM boltz_swaps WHERE is_terminal = 0"
+      );
+      const rows = stmt.all();
+      return Promise.resolve(rows.map(boltzSwapFromRow));
+    } catch (error) {
+      return Promise.reject(
+        new StorageError(`Failed to list active boltz swaps: ${error.message}`, error)
+      );
+    }
+  }
+}
+
+/// Maps a `boltz_swaps` row to a StoredBoltzSwap, parsing `data` and the
+/// is_terminal flag back into the camelCase shape the SDK expects.
+function boltzSwapFromRow(row) {
+  return {
+    id: row.id,
+    isTerminal: row.is_terminal !== 0,
+    updatedAt: Number(row.updated_at),
+    data: row.data,
+    secrets: row.secrets,
+  };
 }
 
 async function createDefaultStorage(dataDir, logger = null) {

--- a/crates/breez-sdk/wasm/js/node-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/node-storage/index.cjs
@@ -1413,20 +1413,21 @@ class SqliteStorage {
     }
   }
 
-  // ===== Boltz Swap Operations =====
+  // ===== Cross-Chain Swap Operations =====
 
-  setBoltzSwap(swap) {
+  setCrossChainSwap(swap) {
     try {
       const stmt = this.db.prepare(`
-        INSERT INTO boltz_swaps (id, is_terminal, updated_at, data, secrets)
-        VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT(id) DO UPDATE SET
+        INSERT INTO cross_chain_swaps (provider, id, is_terminal, updated_at, data, secrets)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(provider, id) DO UPDATE SET
           is_terminal = excluded.is_terminal,
           updated_at = excluded.updated_at,
           data = excluded.data,
           secrets = excluded.secrets
       `);
       stmt.run(
+        swap.provider,
         swap.id,
         swap.isTerminal ? 1 : 0,
         swap.updatedAt,
@@ -1436,44 +1437,47 @@ class SqliteStorage {
       return Promise.resolve();
     } catch (error) {
       return Promise.reject(
-        new StorageError(`Failed to set boltz swap: ${error.message}`, error)
+        new StorageError(`Failed to set cross-chain swap: ${error.message}`, error)
       );
     }
   }
 
-  getBoltzSwap(id) {
+  getCrossChainSwap(provider, id) {
     try {
       const stmt = this.db.prepare(
-        "SELECT id, is_terminal, updated_at, data, secrets FROM boltz_swaps WHERE id = ?"
+        `SELECT provider, id, is_terminal, updated_at, data, secrets
+         FROM cross_chain_swaps WHERE provider = ? AND id = ?`
       );
-      const row = stmt.get(id);
-      return Promise.resolve(row ? boltzSwapFromRow(row) : null);
+      const row = stmt.get(provider, id);
+      return Promise.resolve(row ? crossChainSwapFromRow(row) : null);
     } catch (error) {
       return Promise.reject(
-        new StorageError(`Failed to get boltz swap: ${error.message}`, error)
+        new StorageError(`Failed to get cross-chain swap: ${error.message}`, error)
       );
     }
   }
 
-  listActiveBoltzSwaps() {
+  listActiveCrossChainSwaps(provider) {
     try {
       const stmt = this.db.prepare(
-        "SELECT id, is_terminal, updated_at, data, secrets FROM boltz_swaps WHERE is_terminal = 0"
+        `SELECT provider, id, is_terminal, updated_at, data, secrets
+         FROM cross_chain_swaps WHERE provider = ? AND is_terminal = 0`
       );
-      const rows = stmt.all();
-      return Promise.resolve(rows.map(boltzSwapFromRow));
+      const rows = stmt.all(provider);
+      return Promise.resolve(rows.map(crossChainSwapFromRow));
     } catch (error) {
       return Promise.reject(
-        new StorageError(`Failed to list active boltz swaps: ${error.message}`, error)
+        new StorageError(`Failed to list active cross-chain swaps: ${error.message}`, error)
       );
     }
   }
 }
 
-/// Maps a `boltz_swaps` row to a StoredBoltzSwap, parsing `data` and the
-/// is_terminal flag back into the camelCase shape the SDK expects.
-function boltzSwapFromRow(row) {
+/// Maps a `cross_chain_swaps` row to a StoredCrossChainSwap, parsing `data` and
+/// the is_terminal flag back into the camelCase shape the SDK expects.
+function crossChainSwapFromRow(row) {
   return {
+    provider: row.provider,
     id: row.id,
     isTerminal: row.is_terminal !== 0,
     updatedAt: Number(row.updated_at),

--- a/crates/breez-sdk/wasm/js/node-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/node-storage/migrations.cjs
@@ -461,19 +461,23 @@ class MigrationManager {
         sql: `UPDATE payment_metadata SET conversion_info = json_set(conversion_info, '$.type', 'amm') WHERE conversion_info IS NOT NULL AND json_extract(conversion_info, '$.type') IS NULL`,
       },
       {
-        // Boltz cross-chain swap rows, synced for cross-instance recovery.
-        // `data` is the BoltzSwap JSON with `key_source` lifted out; the lifted
-        // secrets are ECIES-encrypted (base64) into `secrets` by the adapter.
-        name: "Create boltz_swaps table",
+        // Cross-chain swap rows, synced for cross-instance recovery. Shared
+        // across providers, discriminated by `provider`. `data` is
+        // provider-opaque JSON; `secrets` is provider-opaque ciphertext (empty
+        // when the provider has no money-critical secrets).
+        name: "Create cross_chain_swaps table",
         sql: [
-          `CREATE TABLE boltz_swaps (
-              id TEXT PRIMARY KEY,
+          `CREATE TABLE cross_chain_swaps (
+              provider TEXT NOT NULL,
+              id TEXT NOT NULL,
               is_terminal INTEGER NOT NULL,
               updated_at INTEGER NOT NULL,
               data TEXT NOT NULL,
-              secrets TEXT NOT NULL
+              secrets TEXT NOT NULL,
+              PRIMARY KEY (provider, id)
           )`,
-          `CREATE INDEX idx_boltz_swaps_is_terminal ON boltz_swaps(is_terminal)`,
+          `CREATE INDEX idx_cross_chain_swaps_provider_is_terminal
+            ON cross_chain_swaps(provider, is_terminal)`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/js/node-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/node-storage/migrations.cjs
@@ -464,7 +464,7 @@ class MigrationManager {
         // Cross-chain swap rows, synced for cross-instance recovery. Shared
         // across providers, discriminated by `provider`. `data` is
         // provider-opaque JSON; `secrets` is provider-opaque ciphertext (empty
-        // when the provider has no money-critical secrets).
+        // when the provider has none).
         name: "Create cross_chain_swaps table",
         sql: [
           `CREATE TABLE cross_chain_swaps (

--- a/crates/breez-sdk/wasm/js/node-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/node-storage/migrations.cjs
@@ -460,6 +460,22 @@ class MigrationManager {
         name: "Backfill conversion_info type discriminator",
         sql: `UPDATE payment_metadata SET conversion_info = json_set(conversion_info, '$.type', 'amm') WHERE conversion_info IS NOT NULL AND json_extract(conversion_info, '$.type') IS NULL`,
       },
+      {
+        // Boltz cross-chain swap rows, synced for cross-instance recovery.
+        // `data` is the BoltzSwap JSON with `key_source` lifted out; the lifted
+        // secrets are ECIES-encrypted (base64) into `secrets` by the adapter.
+        name: "Create boltz_swaps table",
+        sql: [
+          `CREATE TABLE boltz_swaps (
+              id TEXT PRIMARY KEY,
+              is_terminal INTEGER NOT NULL,
+              updated_at INTEGER NOT NULL,
+              data TEXT NOT NULL,
+              secrets TEXT NOT NULL
+          )`,
+          `CREATE INDEX idx_boltz_swaps_is_terminal ON boltz_swaps(is_terminal)`,
+        ],
+      },
     ];
   }
 }

--- a/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
@@ -1044,20 +1044,22 @@ class PostgresStorage {
     }
   }
 
-  // ===== Boltz Swap Operations =====
+  // ===== Cross-Chain Swap Operations =====
 
-  async setBoltzSwap(swap) {
+  async setCrossChainSwap(swap) {
     try {
       await this.pool.query(
-        `INSERT INTO brz_boltz_swaps (user_id, id, is_terminal, updated_at, data, secrets)
-         VALUES ($1, $2, $3, $4, $5, $6)
-         ON CONFLICT(user_id, id) DO UPDATE SET
+        `INSERT INTO brz_cross_chain_swaps
+           (user_id, provider, id, is_terminal, updated_at, data, secrets)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT(user_id, provider, id) DO UPDATE SET
            is_terminal = EXCLUDED.is_terminal,
            updated_at = EXCLUDED.updated_at,
            data = EXCLUDED.data,
            secrets = EXCLUDED.secrets`,
         [
           this.identity,
+          swap.provider,
           swap.id,
           swap.isTerminal,
           swap.updatedAt,
@@ -1066,39 +1068,45 @@ class PostgresStorage {
         ]
       );
     } catch (error) {
-      throw new StorageError(`Failed to set boltz swap: ${error.message}`, error);
+      throw new StorageError(
+        `Failed to set cross-chain swap: ${error.message}`,
+        error
+      );
     }
   }
 
-  async getBoltzSwap(id) {
+  async getCrossChainSwap(provider, id) {
     try {
       const result = await this.pool.query(
-        `SELECT id, is_terminal, updated_at, data, secrets
-         FROM brz_boltz_swaps
-         WHERE user_id = $1 AND id = $2`,
-        [this.identity, id]
+        `SELECT provider, id, is_terminal, updated_at, data, secrets
+         FROM brz_cross_chain_swaps
+         WHERE user_id = $1 AND provider = $2 AND id = $3`,
+        [this.identity, provider, id]
       );
       if (result.rows.length === 0) {
         return null;
       }
-      return boltzSwapFromRow(result.rows[0]);
+      return crossChainSwapFromRow(result.rows[0]);
     } catch (error) {
-      throw new StorageError(`Failed to get boltz swap: ${error.message}`, error);
+      throw new StorageError(
+        `Failed to get cross-chain swap: ${error.message}`,
+        error
+      );
     }
   }
 
-  async listActiveBoltzSwaps() {
+  async listActiveCrossChainSwaps(provider) {
     try {
       const result = await this.pool.query(
-        `SELECT id, is_terminal, updated_at, data, secrets
-         FROM brz_boltz_swaps
-         WHERE user_id = $1 AND is_terminal = FALSE`,
-        [this.identity]
+        `SELECT provider, id, is_terminal, updated_at, data, secrets
+         FROM brz_cross_chain_swaps
+         WHERE user_id = $1 AND provider = $2 AND is_terminal = FALSE`,
+        [this.identity, provider]
       );
-      return result.rows.map(boltzSwapFromRow);
+      return result.rows.map(crossChainSwapFromRow);
     } catch (error) {
       throw new StorageError(
-        `Failed to list active boltz swaps: ${error.message}`,
+        `Failed to list active cross-chain swaps: ${error.message}`,
         error
       );
     }
@@ -1531,11 +1539,12 @@ class PostgresStorage {
 }
 
 /**
- * Maps a brz_boltz_swaps row to the camelCase StoredBoltzSwap shape the SDK
- * expects, parsing the `data` JSON.
+ * Maps a brz_cross_chain_swaps row to the camelCase StoredCrossChainSwap shape
+ * the SDK expects.
  */
-function boltzSwapFromRow(row) {
+function crossChainSwapFromRow(row) {
   return {
+    provider: row.provider,
     id: row.id,
     isTerminal: row.is_terminal,
     updatedAt: Number(row.updated_at),

--- a/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/index.cjs
@@ -1044,6 +1044,66 @@ class PostgresStorage {
     }
   }
 
+  // ===== Boltz Swap Operations =====
+
+  async setBoltzSwap(swap) {
+    try {
+      await this.pool.query(
+        `INSERT INTO brz_boltz_swaps (user_id, id, is_terminal, updated_at, data, secrets)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ON CONFLICT(user_id, id) DO UPDATE SET
+           is_terminal = EXCLUDED.is_terminal,
+           updated_at = EXCLUDED.updated_at,
+           data = EXCLUDED.data,
+           secrets = EXCLUDED.secrets`,
+        [
+          this.identity,
+          swap.id,
+          swap.isTerminal,
+          swap.updatedAt,
+          swap.data,
+          swap.secrets,
+        ]
+      );
+    } catch (error) {
+      throw new StorageError(`Failed to set boltz swap: ${error.message}`, error);
+    }
+  }
+
+  async getBoltzSwap(id) {
+    try {
+      const result = await this.pool.query(
+        `SELECT id, is_terminal, updated_at, data, secrets
+         FROM brz_boltz_swaps
+         WHERE user_id = $1 AND id = $2`,
+        [this.identity, id]
+      );
+      if (result.rows.length === 0) {
+        return null;
+      }
+      return boltzSwapFromRow(result.rows[0]);
+    } catch (error) {
+      throw new StorageError(`Failed to get boltz swap: ${error.message}`, error);
+    }
+  }
+
+  async listActiveBoltzSwaps() {
+    try {
+      const result = await this.pool.query(
+        `SELECT id, is_terminal, updated_at, data, secrets
+         FROM brz_boltz_swaps
+         WHERE user_id = $1 AND is_terminal = FALSE`,
+        [this.identity]
+      );
+      return result.rows.map(boltzSwapFromRow);
+    } catch (error) {
+      throw new StorageError(
+        `Failed to list active boltz swaps: ${error.message}`,
+        error
+      );
+    }
+  }
+
   // ===== Sync Operations =====
 
   async syncAddOutgoingChange(record) {
@@ -1468,6 +1528,20 @@ class PostgresStorage {
       );
     }
   }
+}
+
+/**
+ * Maps a brz_boltz_swaps row to the camelCase StoredBoltzSwap shape the SDK
+ * expects, parsing the `data` JSON.
+ */
+function boltzSwapFromRow(row) {
+  return {
+    id: row.id,
+    isTerminal: row.is_terminal,
+    updatedAt: Number(row.updated_at),
+    data: row.data,
+    secrets: row.secrets,
+  };
 }
 
 /**

--- a/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
@@ -497,6 +497,26 @@ class PostgresMigrationManager {
           `UPDATE brz_payment_metadata SET conversion_info = conversion_info::jsonb || '{"type": "amm"}'::jsonb WHERE conversion_info IS NOT NULL AND conversion_info::jsonb->>'type' IS NULL`,
         ],
       },
+      {
+        // Boltz cross-chain swap rows, synced for cross-instance recovery.
+        // Born multi-tenant (user_id in the PK). `data` is the BoltzSwap JSON
+        // with `key_source` lifted out; the lifted secrets are ECIES-encrypted
+        // (base64) into `secrets` by the adapter.
+        name: "Create brz_boltz_swaps table",
+        sql: [
+          `CREATE TABLE IF NOT EXISTS brz_boltz_swaps (
+              user_id BYTEA NOT NULL,
+              id TEXT NOT NULL,
+              is_terminal BOOLEAN NOT NULL,
+              updated_at BIGINT NOT NULL,
+              data TEXT NOT NULL,
+              secrets TEXT NOT NULL,
+              PRIMARY KEY (user_id, id)
+          )`,
+          `CREATE INDEX brz_idx_boltz_swaps_user_is_terminal
+             ON brz_boltz_swaps(user_id, is_terminal)`,
+        ],
+      },
     ];
   }
 }

--- a/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
@@ -498,23 +498,25 @@ class PostgresMigrationManager {
         ],
       },
       {
-        // Boltz cross-chain swap rows, synced for cross-instance recovery.
-        // Born multi-tenant (user_id in the PK). `data` is the BoltzSwap JSON
-        // with `key_source` lifted out; the lifted secrets are ECIES-encrypted
-        // (base64) into `secrets` by the adapter.
-        name: "Create brz_boltz_swaps table",
+        // Cross-chain swap rows, synced for cross-instance recovery. Shared
+        // across providers, discriminated by `provider`. Born multi-tenant
+        // (user_id in the PK). `data` is provider-opaque JSON; `secrets` is
+        // provider-opaque ciphertext (empty when the provider has no
+        // money-critical secrets).
+        name: "Create brz_cross_chain_swaps table",
         sql: [
-          `CREATE TABLE IF NOT EXISTS brz_boltz_swaps (
+          `CREATE TABLE IF NOT EXISTS brz_cross_chain_swaps (
               user_id BYTEA NOT NULL,
+              provider TEXT NOT NULL,
               id TEXT NOT NULL,
               is_terminal BOOLEAN NOT NULL,
               updated_at BIGINT NOT NULL,
               data TEXT NOT NULL,
               secrets TEXT NOT NULL,
-              PRIMARY KEY (user_id, id)
+              PRIMARY KEY (user_id, provider, id)
           )`,
-          `CREATE INDEX brz_idx_boltz_swaps_user_is_terminal
-             ON brz_boltz_swaps(user_id, is_terminal)`,
+          `CREATE INDEX brz_idx_cross_chain_swaps_user_provider_is_terminal
+             ON brz_cross_chain_swaps(user_id, provider, is_terminal)`,
         ],
       },
     ];

--- a/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-storage/migrations.cjs
@@ -501,8 +501,7 @@ class PostgresMigrationManager {
         // Cross-chain swap rows, synced for cross-instance recovery. Shared
         // across providers, discriminated by `provider`. Born multi-tenant
         // (user_id in the PK). `data` is provider-opaque JSON; `secrets` is
-        // provider-opaque ciphertext (empty when the provider has no
-        // money-critical secrets).
+        // provider-opaque ciphertext (empty when the provider has none).
         name: "Create brz_cross_chain_swaps table",
         sql: [
           `CREATE TABLE IF NOT EXISTS brz_cross_chain_swaps (

--- a/crates/breez-sdk/wasm/js/web-storage/index.js
+++ b/crates/breez-sdk/wasm/js/web-storage/index.js
@@ -575,6 +575,19 @@ class MigrationManager {
           }
         },
       },
+      {
+        // Boltz cross-chain swap rows, synced for cross-instance recovery.
+        // `data` is the BoltzSwap JSON with `key_source` lifted out; the lifted
+        // secrets are ECIES-encrypted (base64) into `secrets` by the adapter.
+        // No index on isTerminal: IndexedDB can't key on a boolean, so
+        // listActiveBoltzSwaps scans and filters (swap volume is low).
+        name: "Create boltz_swaps store",
+        upgrade: (db) => {
+          if (!db.objectStoreNames.contains("boltz_swaps")) {
+            db.createObjectStore("boltz_swaps", { keyPath: "id" });
+          }
+        },
+      },
     ];
   }
 }
@@ -603,7 +616,7 @@ class IndexedDBStorage {
     // so existing databases depend on indices never shifting. Never insert,
     // reorder, or delete a migration — only append. dbVersion MUST equal the
     // number of migrations (enforced by the guard in initialize()).
-    this.dbVersion = 19; // Current schema version (= migration count)
+    this.dbVersion = 20; // Current schema version (= migration count)
   }
 
   /**
@@ -2213,6 +2226,75 @@ class IndexedDBStorage {
         reject(
           new StorageError(
             `Failed to delete contact '${id}': ${request.error?.message || "Unknown error"}`,
+            request.error
+          )
+        );
+      };
+    });
+  }
+
+  // ===== Boltz Swap Operations =====
+
+  async setBoltzSwap(swap) {
+    if (!this.db) {
+      throw new StorageError("Database not initialized");
+    }
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction("boltz_swaps", "readwrite");
+      const store = transaction.objectStore("boltz_swaps");
+      // IndexedDB stores nested objects natively, so `data` is kept as-is.
+      const request = store.put(swap);
+      request.onsuccess = () => resolve();
+      request.onerror = () => {
+        reject(
+          new StorageError(
+            `Failed to set boltz swap '${swap.id}': ${request.error?.message || "Unknown error"}`,
+            request.error
+          )
+        );
+      };
+    });
+  }
+
+  async getBoltzSwap(id) {
+    if (!this.db) {
+      throw new StorageError("Database not initialized");
+    }
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction("boltz_swaps", "readonly");
+      const store = transaction.objectStore("boltz_swaps");
+      const request = store.get(id);
+      request.onsuccess = () => resolve(request.result || null);
+      request.onerror = () => {
+        reject(
+          new StorageError(
+            `Failed to get boltz swap '${id}': ${request.error?.message || "Unknown error"}`,
+            request.error
+          )
+        );
+      };
+    });
+  }
+
+  async listActiveBoltzSwaps() {
+    if (!this.db) {
+      throw new StorageError("Database not initialized");
+    }
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction("boltz_swaps", "readonly");
+      const store = transaction.objectStore("boltz_swaps");
+      const request = store.getAll();
+      request.onsuccess = () => {
+        const all = request.result || [];
+        resolve(all.filter((swap) => !swap.isTerminal));
+      };
+      request.onerror = () => {
+        reject(
+          new StorageError(
+            `Failed to list active boltz swaps: ${request.error?.message || "Unknown error"}`,
             request.error
           )
         );

--- a/crates/breez-sdk/wasm/js/web-storage/index.js
+++ b/crates/breez-sdk/wasm/js/web-storage/index.js
@@ -580,7 +580,7 @@ class MigrationManager {
         // `data` is the BoltzSwap JSON with `key_source` lifted out; the lifted
         // secrets are ECIES-encrypted (base64) into `secrets` by the adapter.
         // No index on isTerminal: IndexedDB can't key on a boolean, so
-        // listActiveBoltzSwaps scans and filters (swap volume is low).
+        // listActiveBoltzSwaps scans and filters.
         name: "Create boltz_swaps store",
         upgrade: (db) => {
           if (!db.objectStoreNames.contains("boltz_swaps")) {

--- a/crates/breez-sdk/wasm/js/web-storage/index.js
+++ b/crates/breez-sdk/wasm/js/web-storage/index.js
@@ -576,15 +576,13 @@ class MigrationManager {
         },
       },
       {
-        // Boltz cross-chain swap rows, synced for cross-instance recovery.
-        // `data` is the BoltzSwap JSON with `key_source` lifted out; the lifted
-        // secrets are ECIES-encrypted (base64) into `secrets` by the adapter.
-        // No index on isTerminal: IndexedDB can't key on a boolean, so
-        // listActiveBoltzSwaps scans and filters.
-        name: "Create boltz_swaps store",
+        // listActiveCrossChainSwaps scans and filters.
+        name: "Create cross_chain_swaps store",
         upgrade: (db) => {
-          if (!db.objectStoreNames.contains("boltz_swaps")) {
-            db.createObjectStore("boltz_swaps", { keyPath: "id" });
+          if (!db.objectStoreNames.contains("cross_chain_swaps")) {
+            db.createObjectStore("cross_chain_swaps", {
+              keyPath: ["provider", "id"],
+            });
           }
         },
       },
@@ -2233,23 +2231,23 @@ class IndexedDBStorage {
     });
   }
 
-  // ===== Boltz Swap Operations =====
+  // ===== Cross-Chain Swap Operations =====
 
-  async setBoltzSwap(swap) {
+  async setCrossChainSwap(swap) {
     if (!this.db) {
       throw new StorageError("Database not initialized");
     }
 
     return new Promise((resolve, reject) => {
-      const transaction = this.db.transaction("boltz_swaps", "readwrite");
-      const store = transaction.objectStore("boltz_swaps");
+      const transaction = this.db.transaction("cross_chain_swaps", "readwrite");
+      const store = transaction.objectStore("cross_chain_swaps");
       // IndexedDB stores nested objects natively, so `data` is kept as-is.
       const request = store.put(swap);
       request.onsuccess = () => resolve();
       request.onerror = () => {
         reject(
           new StorageError(
-            `Failed to set boltz swap '${swap.id}': ${request.error?.message || "Unknown error"}`,
+            `Failed to set cross-chain swap '${swap.provider}:${swap.id}': ${request.error?.message || "Unknown error"}`,
             request.error
           )
         );
@@ -2257,20 +2255,20 @@ class IndexedDBStorage {
     });
   }
 
-  async getBoltzSwap(id) {
+  async getCrossChainSwap(provider, id) {
     if (!this.db) {
       throw new StorageError("Database not initialized");
     }
 
     return new Promise((resolve, reject) => {
-      const transaction = this.db.transaction("boltz_swaps", "readonly");
-      const store = transaction.objectStore("boltz_swaps");
-      const request = store.get(id);
+      const transaction = this.db.transaction("cross_chain_swaps", "readonly");
+      const store = transaction.objectStore("cross_chain_swaps");
+      const request = store.get([provider, id]);
       request.onsuccess = () => resolve(request.result || null);
       request.onerror = () => {
         reject(
           new StorageError(
-            `Failed to get boltz swap '${id}': ${request.error?.message || "Unknown error"}`,
+            `Failed to get cross-chain swap '${provider}:${id}': ${request.error?.message || "Unknown error"}`,
             request.error
           )
         );
@@ -2278,23 +2276,25 @@ class IndexedDBStorage {
     });
   }
 
-  async listActiveBoltzSwaps() {
+  async listActiveCrossChainSwaps(provider) {
     if (!this.db) {
       throw new StorageError("Database not initialized");
     }
 
     return new Promise((resolve, reject) => {
-      const transaction = this.db.transaction("boltz_swaps", "readonly");
-      const store = transaction.objectStore("boltz_swaps");
+      const transaction = this.db.transaction("cross_chain_swaps", "readonly");
+      const store = transaction.objectStore("cross_chain_swaps");
       const request = store.getAll();
       request.onsuccess = () => {
         const all = request.result || [];
-        resolve(all.filter((swap) => !swap.isTerminal));
+        resolve(
+          all.filter((swap) => swap.provider === provider && !swap.isTerminal)
+        );
       };
       request.onerror = () => {
         reject(
           new StorageError(
-            `Failed to list active boltz swaps: ${request.error?.message || "Unknown error"}`,
+            `Failed to list active cross-chain swaps for '${provider}': ${request.error?.message || "Unknown error"}`,
             request.error
           )
         );

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -1690,6 +1690,15 @@ pub struct ListContactsRequest {
     pub limit: Option<u32>,
 }
 
+#[macros::extern_wasm_bindgen(breez_sdk_spark::StoredBoltzSwap)]
+pub struct StoredBoltzSwap {
+    pub id: String,
+    pub is_terminal: bool,
+    pub updated_at: u64,
+    pub data: String,
+    pub secrets: String,
+}
+
 #[allow(clippy::enum_variant_names)]
 #[macros::extern_wasm_bindgen(breez_sdk_spark::WebhookEventType)]
 pub enum WebhookEventType {

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -1690,8 +1690,9 @@ pub struct ListContactsRequest {
     pub limit: Option<u32>,
 }
 
-#[macros::extern_wasm_bindgen(breez_sdk_spark::StoredBoltzSwap)]
-pub struct StoredBoltzSwap {
+#[macros::extern_wasm_bindgen(breez_sdk_spark::StoredCrossChainSwap)]
+pub struct StoredCrossChainSwap {
+    pub provider: String,
     pub id: String,
     pub is_terminal: bool,
     pub updated_at: u64,

--- a/crates/breez-sdk/wasm/src/persist/mod.rs
+++ b/crates/breez-sdk/wasm/src/persist/mod.rs
@@ -14,8 +14,8 @@ use std::collections::HashMap;
 
 use crate::models::{
     Contact, DepositInfo, IncomingChange, ListContactsRequest, OutgoingChange, Payment,
-    PaymentMetadata, Record, SetLnurlMetadataItem, StorageListPaymentsRequest, StoredBoltzSwap,
-    UnversionedRecordChange, UpdateDepositPayload,
+    PaymentMetadata, Record, SetLnurlMetadataItem, StorageListPaymentsRequest,
+    StoredCrossChainSwap, UnversionedRecordChange, UpdateDepositPayload,
 };
 
 pub struct WasmStorage {
@@ -350,14 +350,14 @@ impl breez_sdk_spark::Storage for WasmStorage {
         Ok(())
     }
 
-    async fn set_boltz_swap(
+    async fn set_cross_chain_swap(
         &self,
-        swap: breez_sdk_spark::StoredBoltzSwap,
+        swap: breez_sdk_spark::StoredCrossChainSwap,
     ) -> Result<(), StorageError> {
-        let swap: StoredBoltzSwap = swap.into();
+        let swap: StoredCrossChainSwap = swap.into();
         let promise = self
             .storage
-            .set_boltz_swap(swap)
+            .set_cross_chain_swap(swap)
             .map_err(js_error_to_storage_error)?;
         JsFuture::from(promise)
             .await
@@ -365,13 +365,14 @@ impl breez_sdk_spark::Storage for WasmStorage {
         Ok(())
     }
 
-    async fn get_boltz_swap(
+    async fn get_cross_chain_swap(
         &self,
+        provider: String,
         id: String,
-    ) -> Result<Option<breez_sdk_spark::StoredBoltzSwap>, StorageError> {
+    ) -> Result<Option<breez_sdk_spark::StoredCrossChainSwap>, StorageError> {
         let promise = self
             .storage
-            .get_boltz_swap(id)
+            .get_cross_chain_swap(provider, id)
             .map_err(js_error_to_storage_error)?;
         let result = JsFuture::from(promise)
             .await
@@ -379,22 +380,23 @@ impl breez_sdk_spark::Storage for WasmStorage {
         if result.is_null() || result.is_undefined() {
             return Ok(None);
         }
-        let swap: StoredBoltzSwap = serde_wasm_bindgen::from_value(result)
+        let swap: StoredCrossChainSwap = serde_wasm_bindgen::from_value(result)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
         Ok(Some(swap.into()))
     }
 
-    async fn list_active_boltz_swaps(
+    async fn list_active_cross_chain_swaps(
         &self,
-    ) -> Result<Vec<breez_sdk_spark::StoredBoltzSwap>, StorageError> {
+        provider: String,
+    ) -> Result<Vec<breez_sdk_spark::StoredCrossChainSwap>, StorageError> {
         let promise = self
             .storage
-            .list_active_boltz_swaps()
+            .list_active_cross_chain_swaps(provider)
             .map_err(js_error_to_storage_error)?;
         let result = JsFuture::from(promise)
             .await
             .map_err(js_error_to_storage_error)?;
-        let swaps: Vec<StoredBoltzSwap> = serde_wasm_bindgen::from_value(result)
+        let swaps: Vec<StoredCrossChainSwap> = serde_wasm_bindgen::from_value(result)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
         Ok(swaps.into_iter().map(|s| s.into()).collect())
     }
@@ -562,9 +564,9 @@ const STORAGE_INTERFACE: &'static str = r#"export interface Storage {
     getContact: (id: string) => Promise<Contact>;
     insertContact: (contact: Contact) => Promise<void>;
     deleteContact: (id: string) => Promise<void>;
-    setBoltzSwap: (swap: StoredBoltzSwap) => Promise<void>;
-    getBoltzSwap: (id: string) => Promise<StoredBoltzSwap | null>;
-    listActiveBoltzSwaps: () => Promise<StoredBoltzSwap[]>;
+    setCrossChainSwap: (swap: StoredCrossChainSwap) => Promise<void>;
+    getCrossChainSwap: (provider: string, id: string) => Promise<StoredCrossChainSwap | null>;
+    listActiveCrossChainSwaps: (provider: string) => Promise<StoredCrossChainSwap[]>;
     syncAddOutgoingChange: (record: UnversionedRecordChange) => Promise<number>;
     syncCompleteOutgoingSync: (record: Record) => Promise<void>;
     syncGetPendingOutgoingChanges: (limit: number) => Promise<OutgoingChange[]>;
@@ -659,14 +661,24 @@ extern "C" {
     #[wasm_bindgen(structural, method, js_name = deleteContact, catch)]
     pub fn delete_contact(this: &Storage, id: String) -> Result<Promise, JsValue>;
 
-    #[wasm_bindgen(structural, method, js_name = setBoltzSwap, catch)]
-    pub fn set_boltz_swap(this: &Storage, swap: StoredBoltzSwap) -> Result<Promise, JsValue>;
+    #[wasm_bindgen(structural, method, js_name = setCrossChainSwap, catch)]
+    pub fn set_cross_chain_swap(
+        this: &Storage,
+        swap: StoredCrossChainSwap,
+    ) -> Result<Promise, JsValue>;
 
-    #[wasm_bindgen(structural, method, js_name = getBoltzSwap, catch)]
-    pub fn get_boltz_swap(this: &Storage, id: String) -> Result<Promise, JsValue>;
+    #[wasm_bindgen(structural, method, js_name = getCrossChainSwap, catch)]
+    pub fn get_cross_chain_swap(
+        this: &Storage,
+        provider: String,
+        id: String,
+    ) -> Result<Promise, JsValue>;
 
-    #[wasm_bindgen(structural, method, js_name = listActiveBoltzSwaps, catch)]
-    pub fn list_active_boltz_swaps(this: &Storage) -> Result<Promise, JsValue>;
+    #[wasm_bindgen(structural, method, js_name = listActiveCrossChainSwaps, catch)]
+    pub fn list_active_cross_chain_swaps(
+        this: &Storage,
+        provider: String,
+    ) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, js_name = syncAddOutgoingChange, catch)]
     pub fn sync_add_outgoing_change(

--- a/crates/breez-sdk/wasm/src/persist/mod.rs
+++ b/crates/breez-sdk/wasm/src/persist/mod.rs
@@ -350,6 +350,56 @@ impl breez_sdk_spark::Storage for WasmStorage {
         Ok(())
     }
 
+    async fn set_boltz_swap(
+        &self,
+        swap: breez_sdk_spark::StoredBoltzSwap,
+    ) -> Result<(), StorageError> {
+        let swap = serde_wasm_bindgen::to_value(&swap)
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
+        let promise = self
+            .storage
+            .set_boltz_swap(swap)
+            .map_err(js_error_to_storage_error)?;
+        JsFuture::from(promise)
+            .await
+            .map_err(js_error_to_storage_error)?;
+        Ok(())
+    }
+
+    async fn get_boltz_swap(
+        &self,
+        id: String,
+    ) -> Result<Option<breez_sdk_spark::StoredBoltzSwap>, StorageError> {
+        let promise = self
+            .storage
+            .get_boltz_swap(id)
+            .map_err(js_error_to_storage_error)?;
+        let result = JsFuture::from(promise)
+            .await
+            .map_err(js_error_to_storage_error)?;
+        if result.is_null() || result.is_undefined() {
+            return Ok(None);
+        }
+        let swap = serde_wasm_bindgen::from_value(result)
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
+        Ok(Some(swap))
+    }
+
+    async fn list_active_boltz_swaps(
+        &self,
+    ) -> Result<Vec<breez_sdk_spark::StoredBoltzSwap>, StorageError> {
+        let promise = self
+            .storage
+            .list_active_boltz_swaps()
+            .map_err(js_error_to_storage_error)?;
+        let result = JsFuture::from(promise)
+            .await
+            .map_err(js_error_to_storage_error)?;
+        let swaps = serde_wasm_bindgen::from_value(result)
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
+        Ok(swaps)
+    }
+
     async fn add_outgoing_change(
         &self,
         record: breez_sdk_spark::sync_storage::UnversionedRecordChange,
@@ -486,6 +536,15 @@ impl breez_sdk_spark::Storage for WasmStorage {
 }
 
 #[wasm_bindgen(typescript_custom_section)]
+const STORED_BOLTZ_SWAP_INTERFACE: &'static str = r#"export interface StoredBoltzSwap {
+    id: string;
+    isTerminal: boolean;
+    updatedAt: number;
+    data: string;
+    secrets: string;
+}"#;
+
+#[wasm_bindgen(typescript_custom_section)]
 const STORAGE_INTERFACE: &'static str = r#"export interface Storage {
     getCachedItem: (key: string) => Promise<string | null>;
     setCachedItem: (key: string, value: string) => Promise<void>;
@@ -513,6 +572,9 @@ const STORAGE_INTERFACE: &'static str = r#"export interface Storage {
     getContact: (id: string) => Promise<Contact>;
     insertContact: (contact: Contact) => Promise<void>;
     deleteContact: (id: string) => Promise<void>;
+    setBoltzSwap: (swap: StoredBoltzSwap) => Promise<void>;
+    getBoltzSwap: (id: string) => Promise<StoredBoltzSwap | null>;
+    listActiveBoltzSwaps: () => Promise<StoredBoltzSwap[]>;
     syncAddOutgoingChange: (record: UnversionedRecordChange) => Promise<number>;
     syncCompleteOutgoingSync: (record: Record) => Promise<void>;
     syncGetPendingOutgoingChanges: (limit: number) => Promise<OutgoingChange[]>;
@@ -606,6 +668,15 @@ extern "C" {
 
     #[wasm_bindgen(structural, method, js_name = deleteContact, catch)]
     pub fn delete_contact(this: &Storage, id: String) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(structural, method, js_name = setBoltzSwap, catch)]
+    pub fn set_boltz_swap(this: &Storage, swap: JsValue) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(structural, method, js_name = getBoltzSwap, catch)]
+    pub fn get_boltz_swap(this: &Storage, id: String) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(structural, method, js_name = listActiveBoltzSwaps, catch)]
+    pub fn list_active_boltz_swaps(this: &Storage) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, js_name = syncAddOutgoingChange, catch)]
     pub fn sync_add_outgoing_change(

--- a/crates/breez-sdk/wasm/src/persist/mod.rs
+++ b/crates/breez-sdk/wasm/src/persist/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 
 use crate::models::{
     Contact, DepositInfo, IncomingChange, ListContactsRequest, OutgoingChange, Payment,
-    PaymentMetadata, Record, SetLnurlMetadataItem, StorageListPaymentsRequest,
+    PaymentMetadata, Record, SetLnurlMetadataItem, StorageListPaymentsRequest, StoredBoltzSwap,
     UnversionedRecordChange, UpdateDepositPayload,
 };
 
@@ -354,8 +354,7 @@ impl breez_sdk_spark::Storage for WasmStorage {
         &self,
         swap: breez_sdk_spark::StoredBoltzSwap,
     ) -> Result<(), StorageError> {
-        let swap = serde_wasm_bindgen::to_value(&swap)
-            .map_err(|e| StorageError::Serialization(e.to_string()))?;
+        let swap: StoredBoltzSwap = swap.into();
         let promise = self
             .storage
             .set_boltz_swap(swap)
@@ -380,9 +379,9 @@ impl breez_sdk_spark::Storage for WasmStorage {
         if result.is_null() || result.is_undefined() {
             return Ok(None);
         }
-        let swap = serde_wasm_bindgen::from_value(result)
+        let swap: StoredBoltzSwap = serde_wasm_bindgen::from_value(result)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
-        Ok(Some(swap))
+        Ok(Some(swap.into()))
     }
 
     async fn list_active_boltz_swaps(
@@ -395,9 +394,9 @@ impl breez_sdk_spark::Storage for WasmStorage {
         let result = JsFuture::from(promise)
             .await
             .map_err(js_error_to_storage_error)?;
-        let swaps = serde_wasm_bindgen::from_value(result)
+        let swaps: Vec<StoredBoltzSwap> = serde_wasm_bindgen::from_value(result)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
-        Ok(swaps)
+        Ok(swaps.into_iter().map(|s| s.into()).collect())
     }
 
     async fn add_outgoing_change(
@@ -536,15 +535,6 @@ impl breez_sdk_spark::Storage for WasmStorage {
 }
 
 #[wasm_bindgen(typescript_custom_section)]
-const STORED_BOLTZ_SWAP_INTERFACE: &'static str = r#"export interface StoredBoltzSwap {
-    id: string;
-    isTerminal: boolean;
-    updatedAt: number;
-    data: string;
-    secrets: string;
-}"#;
-
-#[wasm_bindgen(typescript_custom_section)]
 const STORAGE_INTERFACE: &'static str = r#"export interface Storage {
     getCachedItem: (key: string) => Promise<string | null>;
     setCachedItem: (key: string, value: string) => Promise<void>;
@@ -670,7 +660,7 @@ extern "C" {
     pub fn delete_contact(this: &Storage, id: String) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, js_name = setBoltzSwap, catch)]
-    pub fn set_boltz_swap(this: &Storage, swap: JsValue) -> Result<Promise, JsValue>;
+    pub fn set_boltz_swap(this: &Storage, swap: StoredBoltzSwap) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, js_name = getBoltzSwap, catch)]
     pub fn get_boltz_swap(this: &Storage, id: String) -> Result<Promise, JsValue>;

--- a/crates/breez-sdk/wasm/src/persist/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/mysql.rs
@@ -162,6 +162,12 @@ async fn test_contacts_crud() {
 }
 
 #[wasm_bindgen_test]
+async fn test_boltz_swaps_crud() {
+    let storage = create_test_storage("my_boltz_swaps_crud").await;
+    breez_sdk_spark::storage_tests::test_boltz_swaps_crud(Box::new(storage)).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_conversion_status_persistence() {
     let storage = create_test_storage("my_conversion_status_persistence").await;
     breez_sdk_spark::storage_tests::test_conversion_status_persistence(Box::new(storage)).await;

--- a/crates/breez-sdk/wasm/src/persist/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/mysql.rs
@@ -162,9 +162,9 @@ async fn test_contacts_crud() {
 }
 
 #[wasm_bindgen_test]
-async fn test_boltz_swaps_crud() {
-    let storage = create_test_storage("my_boltz_swaps_crud").await;
-    breez_sdk_spark::storage_tests::test_boltz_swaps_crud(Box::new(storage)).await;
+async fn test_cross_chain_swaps_crud() {
+    let storage = create_test_storage("my_cross_chain_swaps_crud").await;
+    breez_sdk_spark::storage_tests::test_cross_chain_swaps_crud(Box::new(storage)).await;
 }
 
 #[wasm_bindgen_test]

--- a/crates/breez-sdk/wasm/src/persist/tests/node.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/node.rs
@@ -185,6 +185,13 @@ async fn test_contacts_crud() {
 }
 
 #[wasm_bindgen_test]
+async fn test_boltz_swaps_crud() {
+    let storage = create_test_storage("boltz_swaps_crud").await;
+
+    breez_sdk_spark::storage_tests::test_boltz_swaps_crud(Box::new(storage)).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_conversion_status_persistence() {
     let storage = create_test_storage("conversion_status_persistence").await;
 

--- a/crates/breez-sdk/wasm/src/persist/tests/node.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/node.rs
@@ -185,10 +185,10 @@ async fn test_contacts_crud() {
 }
 
 #[wasm_bindgen_test]
-async fn test_boltz_swaps_crud() {
-    let storage = create_test_storage("boltz_swaps_crud").await;
+async fn test_cross_chain_swaps_crud() {
+    let storage = create_test_storage("cross_chain_swaps_crud").await;
 
-    breez_sdk_spark::storage_tests::test_boltz_swaps_crud(Box::new(storage)).await;
+    breez_sdk_spark::storage_tests::test_cross_chain_swaps_crud(Box::new(storage)).await;
 }
 
 #[wasm_bindgen_test]

--- a/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
@@ -162,9 +162,9 @@ async fn test_contacts_crud() {
 }
 
 #[wasm_bindgen_test]
-async fn test_boltz_swaps_crud() {
-    let storage = create_test_storage("pg_boltz_swaps_crud").await;
-    breez_sdk_spark::storage_tests::test_boltz_swaps_crud(Box::new(storage)).await;
+async fn test_cross_chain_swaps_crud() {
+    let storage = create_test_storage("pg_cross_chain_swaps_crud").await;
+    breez_sdk_spark::storage_tests::test_cross_chain_swaps_crud(Box::new(storage)).await;
 }
 
 #[wasm_bindgen_test]

--- a/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/postgres.rs
@@ -162,6 +162,12 @@ async fn test_contacts_crud() {
 }
 
 #[wasm_bindgen_test]
+async fn test_boltz_swaps_crud() {
+    let storage = create_test_storage("pg_boltz_swaps_crud").await;
+    breez_sdk_spark::storage_tests::test_boltz_swaps_crud(Box::new(storage)).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_conversion_status_persistence() {
     let storage = create_test_storage("pg_conversion_status_persistence").await;
     breez_sdk_spark::storage_tests::test_conversion_status_persistence(Box::new(storage)).await;

--- a/crates/breez-sdk/wasm/src/persist/tests/web.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/web.rs
@@ -175,6 +175,13 @@ async fn test_contacts_crud() {
 }
 
 #[wasm_bindgen_test]
+async fn test_boltz_swaps_crud() {
+    let storage = create_test_storage("boltz_swaps_crud").await;
+
+    breez_sdk_spark::storage_tests::test_boltz_swaps_crud(Box::new(storage)).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_conversion_status_persistence() {
     let storage = create_test_storage("conversion_status_persistence").await;
 

--- a/crates/breez-sdk/wasm/src/persist/tests/web.rs
+++ b/crates/breez-sdk/wasm/src/persist/tests/web.rs
@@ -175,10 +175,10 @@ async fn test_contacts_crud() {
 }
 
 #[wasm_bindgen_test]
-async fn test_boltz_swaps_crud() {
-    let storage = create_test_storage("boltz_swaps_crud").await;
+async fn test_cross_chain_swaps_crud() {
+    let storage = create_test_storage("cross_chain_swaps_crud").await;
 
-    breez_sdk_spark::storage_tests::test_boltz_swaps_crud(Box::new(storage)).await;
+    breez_sdk_spark::storage_tests::test_cross_chain_swaps_crud(Box::new(storage)).await;
 }
 
 #[wasm_bindgen_test]

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=6906a0d84fb2252df827665a52b0356aca64ed2d#6906a0d84fb2252df827665a52b0356aca64ed2d"
+source = "git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730#809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -1100,8 +1100,8 @@ dependencies = [
  "hex",
  "k256",
  "lightning-invoice 0.34.0",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=6906a0d84fb2252df827665a52b0356aca64ed2d)",
- "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=6906a0d84fb2252df827665a52b0356aca64ed2d)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730)",
+ "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730)",
  "serde",
  "serde_json",
  "sha2",
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=6906a0d84fb2252df827665a52b0356aca64ed2d#6906a0d84fb2252df827665a52b0356aca64ed2d"
+source = "git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730#809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3595,11 +3595,11 @@ dependencies = [
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=6906a0d84fb2252df827665a52b0356aca64ed2d#6906a0d84fb2252df827665a52b0356aca64ed2d"
+source = "git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730#809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730"
 dependencies = [
  "async-trait",
  "base64",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=6906a0d84fb2252df827665a52b0356aca64ed2d)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730)",
  "reqwest",
  "serde",
  "serde_json",


### PR DESCRIPTION
## What

A Boltz cross-chain swap is known only to its creator instance; if the creator goes offline, other instances show it stuck `Pending` forever. This bumps `boltz-client` to `809ac77` (seedless mode) and persists + syncs full swap rows so any instance of the same wallet can drive a swap to terminal. boltz-client owns correctness and multi-instance convergence; the SDK just persists and syncs rows with plain last-writer-wins.

## How

- **Seedless boltz-client**: construct via `new_seedless`; drop the random per-device seed, the encrypted seed handle, the instance id, and the key-index counter.
- **Encrypted-at-rest, signer-free storage**: new `StoredCrossChainSwap { provider, id, is_terminal, updated_at, data, secrets }`, shared across cross-chain providers and discriminated by `provider`. The Boltz adapter tags rows `provider = "boltz"`, lifts `key_source` out of the swap JSON, ECIES-encrypts it under a fixed identity-derived path (deterministic per mnemonic+network, so a second instance can decrypt), and persists only the ciphertext in `secrets`. The storage layer needs no signer and treats `data` and `secrets` as opaque. The encrypt/decrypt boundary lives in the adapter.
- **Storage + migrations**: `Storage::{set_cross_chain_swap, get_cross_chain_swap(provider, id), list_active_cross_chain_swaps(provider)}` and a `cross_chain_swaps` table (composite PK `(provider, id)`) across all 7 backends (Rust SQLite/Postgres/MySQL, JS Web/Node-SQLite/Node-Postgres/Node-MySQL); `brz_` prefix on Postgres/MySQL.
- **Realtime sync**: `RecordType::CrossChainSwap` with `data_id = "{provider}:{id}"` — `SyncedStorage::set_cross_chain_swap` emits then delegates; `SyncedRecordHandler::handle_cross_chain_swap_change` applies via the inner store (structural loop guard). Plain last-writer-wins.
- **Convergence**: the always-on delivery tick is the pickup path for synced-in swaps (resume is only a startup accelerator); `conversion_info` is derived locally from the synced swap row.

## Decisions

- **Encrypt at rest** (in the adapter, not the storage layer) rather than plaintext — money-critical secrets get at-rest protection while storage stays signer-free.
- **Provider-keyed table over per-provider tables** — Orchestra has the same row shape (quote/order id, opaque JSON, optional secrets) and the same pre-payment lifetime need on the receive path. Landing the rename now (table is unreleased) means future providers add only an adapter, no storage / trait / sync changes.
- **v1 upgrade = clean break**: seedless `RandomSecretProvider` rejects derived swaps, so in-flight v1 swaps can't run under the new service (funds are safe via the LN hold-invoice timeout refund). Legacy KV keys are left orphaned.

## Tests

- Shared `cross_chain_swaps` CRUD wired into all 7 storage harnesses, exercising composite-PK isolation across providers and provider-scoped `list_active`.
- Adapter encrypt/lift round-trip (secrets encrypted, absent from plaintext `data`, terminal swaps excluded from the active list).
- Plumbing sync round-trip for the `CrossChainSwap` record (serialize → outgoing queue → incoming-apply → second-instance store), replaying the actually-emitted fields under both `"boltz"` and `"orchestra"` provider tags so any hard-coded provider in emit/apply is caught.
- Out of scope (no cross-chain test infra): end-to-end recovery scenarios — that convergence logic lives in and is unit-tested by boltz-client.