### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -575,16 +575,17 @@ public static class Commands
 
     private static async Task HandlePay(BreezSdk sdk, Func<string, string?> readline, string[] args)
     {
-        var paymentRequest = GetFlag(args, "-r", "--payment-request");
+        var paymentRequestStr = GetFlag(args, "-r", "--payment-request");
         var amountStr = GetFlag(args, "-a", "--amount");
         var tokenIdentifier = GetFlag(args, "-t", "--token-identifier");
         var idempotencyKey = GetFlag(args, "-i", "--idempotency-key");
         var fromBitcoin = HasFlag(args, "--from-bitcoin");
         var fromTokenId = GetFlag(args, "--from-token");
         var maxSlippageStr = GetFlag(args, "-s", "--convert-max-slippage-bps");
+        var crossChainMaxSlippageStr = GetFlag(args, "--cross-chain-max-slippage-bps");
         var feesIncluded = HasFlag(args, "--fees-included");
 
-        if (paymentRequest == null)
+        if (paymentRequestStr == null)
         {
             Console.WriteLine("Usage: pay -r <payment_request> [-a <amount>] [-t <token_identifier>]");
             return;
@@ -611,8 +612,27 @@ public static class Commands
 
         FeePolicy? feePolicy = feesIncluded ? FeePolicy.FeesIncluded : null;
 
+        PaymentRequest paymentRequest;
+        var parsed = await sdk.Parse(paymentRequestStr);
+        if (parsed is InputType.CrossChainAddress crossChainAddr)
+        {
+            var address = crossChainAddr.v1.address;
+            var route = await SelectCrossChainRoute(sdk, readline, crossChainAddr.v1);
+            if (route == null) return;
+            paymentRequest = new PaymentRequest.CrossChain(
+                address: address,
+                route: route,
+                maxSlippageBps: ParseOptionalUint(crossChainMaxSlippageStr),
+                targetOverpayBps: null
+            );
+        }
+        else
+        {
+            paymentRequest = new PaymentRequest.Input(input: paymentRequestStr);
+        }
+
         var prepareResponse = await sdk.PrepareSendPayment(request: new PrepareSendPaymentRequest(
-            paymentRequest: new PaymentRequest.Input(input: paymentRequest),
+            paymentRequest: paymentRequest,
             amount: ParseOptionalUlong(amountStr),
             tokenIdentifier: tokenIdentifier,
             conversionOptions: conversionOptions,
@@ -624,6 +644,27 @@ public static class Commands
         {
             var est = prepareResponse.conversionEstimate;
             Console.WriteLine($"Estimated conversion of {est.amountIn} → {est.amountOut} with a {est.fee} fee");
+            var line = readline("Do you want to continue (y/n) [y]: ");
+            if (line != null && line.Trim().ToLower() != "" && line.Trim().ToLower() != "y")
+            {
+                Console.WriteLine("Payment cancelled");
+                return;
+            }
+        }
+
+        // Show cross-chain quote details before confirming
+        if (prepareResponse.paymentMethod is SendPaymentMethod.CrossChainAddress ccMethod)
+        {
+            var serviceFeeDenom = ccMethod.serviceFeeAsset ?? "sats";
+            var denomination = tokenIdentifier != null ? "token base units" : "sats";
+            Console.WriteLine(
+                $"Cross-chain send: {ccMethod.amountIn} {denomination} " +
+                $"(~{ccMethod.assetAmountIn} {ccMethod.route.asset}) " +
+                $"→ ~{ccMethod.estimatedOut} {ccMethod.route.asset} " +
+                $"on {ccMethod.route.chain} to {ccMethod.recipientAddress}");
+            Console.WriteLine($"Fee (total, in {ccMethod.route.asset}): {ccMethod.feeAmount}");
+            Console.WriteLine($"Service fee: {ccMethod.serviceFeeAmount} {serviceFeeDenom}");
+            Console.WriteLine($"Source transfer fee: {ccMethod.sourceTransferFeeSats} sats");
             var line = readline("Do you want to continue (y/n) [y]: ");
             if (line != null && line.Trim().ToLower() != "" && line.Trim().ToLower() != "y")
             {
@@ -1293,13 +1334,64 @@ public static class Commands
             );
         }
 
-        // SparkInvoice -> no options
+        // SparkInvoice / CrossChainAddress -> no options
         return null;
     }
 
     // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
+
+    private static async Task<CrossChainRoutePair?> SelectCrossChainRoute(
+        BreezSdk sdk,
+        Func<string, string?> readline,
+        CrossChainAddressDetails addressDetails)
+    {
+        var filter = new CrossChainRouteFilter.Send(addressDetails: addressDetails);
+        var routes = await sdk.GetCrossChainRoutes(filter: filter);
+        if (routes.Length == 0)
+        {
+            Console.WriteLine("No cross-chain routes available for this address");
+            return null;
+        }
+
+        if (routes.Length == 1)
+        {
+            var route = routes[0];
+            Console.WriteLine(
+                $"Auto-selected route: {route.asset} on {route.chain}" +
+                $"{MaybeTruncateAddress(route.contractAddress)} [{route.provider}]");
+            return route;
+        }
+
+        Console.WriteLine("Available cross-chain routes:");
+        for (int i = 0; i < routes.Length; i++)
+        {
+            var r = routes[i];
+            Console.WriteLine(
+                $"  {i + 1}. {r.asset} on {r.chain}" +
+                $"{MaybeTruncateAddress(r.contractAddress)} [{r.provider}]");
+        }
+
+        var line = readline("Select route: ");
+        if (line == null || !int.TryParse(line.Trim(), out int choice) || choice < 1 || choice > routes.Length)
+        {
+            Console.WriteLine("Invalid selection");
+            return null;
+        }
+
+        return routes[choice - 1];
+    }
+
+    private static string MaybeTruncateAddress(string? addr)
+    {
+        if (addr == null) return "";
+        if (addr.Length > 12)
+        {
+            return $" ({addr[..6]}...{addr[^6..]})";
+        }
+        return $" ({addr})";
+    }
 
     private static string ComputeSha256Hex(byte[] data)
     {

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
@@ -279,6 +279,10 @@ static async Task RunInteractiveMode(
     {
         config = config with { stableBalanceConfig = stableBalanceConfig };
     }
+    if (network == Network.Mainnet)
+    {
+        config = config with { crossChainConfig = new CrossChainConfig() };
+    }
 
     // Resolve seed: passkey or mnemonic
     Seed seed;

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/cli.dart
@@ -59,6 +59,10 @@ Future<void> runCli({
     );
   }
 
+  if (networkEnum == Network.mainnet) {
+    config = config.copyWith(crossChainConfig: CrossChainConfig());
+  }
+
   Seed seed;
   if (passkeyConfig != null) {
     seed = await resolvePasskeySeed(passkeyConfig, dataDir, apiKey);

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -385,11 +385,12 @@ Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args
         ..addFlag('from-bitcoin', defaultsTo: false)
         ..addOption('from-token')
         ..addOption('convert-max-slippage-bps', abbr: 's')
+        ..addOption('cross-chain-max-slippage-bps')
         ..addFlag('fees-included', defaultsTo: false);
   final results = _parseArgs(parser, args, 'pay -r <request> [options]');
   if (results == null) return;
 
-  final paymentRequest = results.option('payment-request')!;
+  final paymentRequestInput = results.option('payment-request')!;
   final amountStr = results.option('amount');
   final amount = amountStr != null ? BigInt.parse(amountStr) : null;
   final tokenIdentifier = results.option('token-identifier');
@@ -398,6 +399,8 @@ Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args
   final fromToken = results.option('from-token');
   final slippageStr = results.option('convert-max-slippage-bps');
   final slippage = slippageStr != null ? int.parse(slippageStr) : null;
+  final crossChainSlippageStr = results.option('cross-chain-max-slippage-bps');
+  final crossChainSlippage = crossChainSlippageStr != null ? int.parse(crossChainSlippageStr) : null;
   final feesIncluded = results.flag('fees-included');
 
   ConversionOptions? conversionOptions;
@@ -417,9 +420,26 @@ Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args
 
   final feePolicy = feesIncluded ? FeePolicy.feesIncluded : null;
 
+  PaymentRequest paymentRequest;
+  final parsed = await sdk.parse(input: paymentRequestInput);
+  if (parsed is InputType_CrossChainAddress) {
+    final addressDetails = parsed.field0;
+    final address = addressDetails.address;
+    final route = await _selectCrossChainRoute(sdk, addressDetails);
+    if (route == null) return;
+    paymentRequest = PaymentRequest.crossChain(
+      address: address,
+      route: route,
+      maxSlippageBps: crossChainSlippage,
+      targetOverpayBps: null,
+    );
+  } else {
+    paymentRequest = PaymentRequest.input(input: paymentRequestInput);
+  }
+
   final prepareResponse = await sdk.prepareSendPayment(
     request: PrepareSendPaymentRequest(
-      paymentRequest: PaymentRequest.input(input: paymentRequest),
+      paymentRequest: paymentRequest,
       amount: amount,
       tokenIdentifier: tokenIdentifier,
       conversionOptions: conversionOptions,
@@ -435,6 +455,26 @@ Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args
       'Estimated conversion from ${est.amountIn} $inUnits to ${est.amountOut} $outUnits '
       'with a ${est.fee} token base units fee',
     );
+    final answer = prompt('Do you want to continue (y/n): ', defaultValue: 'y');
+    if (answer.toLowerCase() != 'y') {
+      print('Payment cancelled');
+      return;
+    }
+  }
+
+  if (prepareResponse.paymentMethod is SendPaymentMethod_CrossChainAddress) {
+    final cc = prepareResponse.paymentMethod as SendPaymentMethod_CrossChainAddress;
+    final serviceFeeDenom = cc.serviceFeeAsset ?? 'sats';
+    final denomination = tokenIdentifier != null ? 'token base units' : 'sats';
+    print(
+      'Cross-chain send: ${cc.amountIn} $denomination '
+      '(~${cc.assetAmountIn} ${cc.route.asset}) '
+      '-> ~${cc.estimatedOut} ${cc.route.asset} on ${cc.route.chain} '
+      'to ${cc.recipientAddress}',
+    );
+    print('Fee (total, in ${cc.route.asset}): ${cc.feeAmount}');
+    print('Service fee: ${cc.serviceFeeAmount} $serviceFeeDenom');
+    print('Source transfer fee: ${cc.sourceTransferFeeSats} sats');
     final answer = prompt('Do you want to continue (y/n): ', defaultValue: 'y');
     if (answer.toLowerCase() != 'y') {
       print('Payment cancelled');
@@ -1027,8 +1067,58 @@ SendPaymentOptions? _readPaymentOptions(SendPaymentMethod paymentMethod) {
     );
   }
 
-  // SendPaymentMethod_SparkInvoice
+  // SendPaymentMethod_SparkInvoice, SendPaymentMethod_CrossChainAddress
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Cross-chain route selection
+// ---------------------------------------------------------------------------
+
+Future<CrossChainRoutePair?> _selectCrossChainRoute(
+  BreezSdk sdk,
+  CrossChainAddressDetails addressDetails,
+) async {
+  final filter = CrossChainRouteFilter.send(addressDetails: addressDetails);
+  final routes = await sdk.getCrossChainRoutes(filter: filter);
+  if (routes.isEmpty) {
+    print('No cross-chain routes available for this address');
+    return null;
+  }
+
+  if (routes.length == 1) {
+    final route = routes.first;
+    print(
+      'Auto-selected route: ${route.asset} on ${route.chain}'
+      '${_maybeTruncateAddress(route.contractAddress)} [${route.provider}]',
+    );
+    return route;
+  }
+
+  print('Available cross-chain routes:');
+  for (var i = 0; i < routes.length; i++) {
+    final route = routes[i];
+    print(
+      '  ${i + 1}. ${route.asset} on ${route.chain}'
+      '${_maybeTruncateAddress(route.contractAddress)} [${route.provider}]',
+    );
+  }
+
+  final line = prompt('Select route: ');
+  final choice = int.tryParse(line.trim());
+  if (choice == null || choice < 1 || choice > routes.length) {
+    print('Invalid selection');
+    return null;
+  }
+  return routes[choice - 1];
+}
+
+String _maybeTruncateAddress(String? addr) {
+  if (addr == null) return '';
+  if (addr.length > 12) {
+    return ' (${addr.substring(0, 6)}...${addr.substring(addr.length - 6)})';
+  }
+  return ' ($addr)';
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -395,18 +395,51 @@ func handlePay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []stri
 	fromToken := fs.String("from-token", "", "Convert from token to Bitcoin to fulfill payment")
 	maxSlippage := fs.String("s", "", "Max slippage in basis points for conversion")
 	fs.StringVar(maxSlippage, "convert-max-slippage-bps", "", "Max slippage in basis points")
+	crossChainMaxSlippageStr := fs.String("cross-chain-max-slippage-bps", "", "Max slippage in basis points for cross-chain sends (10..500)")
 	feesIncluded := fs.Bool("fees-included", false, "Deduct fees from amount instead of adding on top")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
 	if *paymentRequest == "" {
-		fmt.Println("Usage: pay -r <payment_request> [-a <amount>] [-t <token_identifier>] [--from-bitcoin | --from-token <id>] [-s <slippage_bps>] [--fees-included] [-i <idempotency_key>]")
+		fmt.Println("Usage: pay -r <payment_request> [-a <amount>] [-t <token_identifier>] [--from-bitcoin | --from-token <id>] [-s <slippage_bps>] [--cross-chain-max-slippage-bps <bps>] [--fees-included] [-i <idempotency_key>]")
 		return nil
 	}
 
+	// Check if the input is a cross-chain address; if so, we need
+	// route selection before we can prepare.
+	var payReq breez_sdk_spark.PaymentRequest
+	parsed, parseErr := sdk.Parse(*paymentRequest)
+	parseErr = liftError(parseErr)
+	if parseErr == nil {
+		if ccAddr, ok := parsed.(breez_sdk_spark.InputTypeCrossChainAddress); ok {
+			address := ccAddr.Field0.Address
+			route, err := selectCrossChainRoute(sdk, rl, ccAddr.Field0)
+			if err != nil {
+				return err
+			}
+			ccReq := breez_sdk_spark.PaymentRequestCrossChain{
+				Address: address,
+				Route:   route,
+			}
+			if *crossChainMaxSlippageStr != "" {
+				val, err := strconv.ParseUint(*crossChainMaxSlippageStr, 10, 32)
+				if err != nil {
+					return fmt.Errorf("invalid cross-chain max slippage: %s", *crossChainMaxSlippageStr)
+				}
+				val32 := uint32(val)
+				ccReq.MaxSlippageBps = &val32
+			}
+			payReq = ccReq
+		} else {
+			payReq = breez_sdk_spark.PaymentRequestInput{Input: *paymentRequest}
+		}
+	} else {
+		payReq = breez_sdk_spark.PaymentRequestInput{Input: *paymentRequest}
+	}
+
 	req := breez_sdk_spark.PrepareSendPaymentRequest{
-		PaymentRequest: breez_sdk_spark.PaymentRequestInput{Input: *paymentRequest},
+		PaymentRequest: payReq,
 	}
 
 	if *amountStr != "" {
@@ -467,6 +500,31 @@ func handlePay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []stri
 			outUnits = "token base units"
 		}
 		fmt.Printf("Estimated conversion from %v %s to %v %s with a %v token base units fee\n", est.AmountIn, inUnits, est.AmountOut, outUnits, est.Fee)
+		line, err := readlineWithDefault(rl, "Do you want to continue (y/n): ", "y")
+		if err != nil {
+			return err
+		}
+		if strings.ToLower(strings.TrimSpace(line)) != "y" {
+			return fmt.Errorf("payment cancelled")
+		}
+	}
+
+	// Show cross-chain quote details before confirming
+	if ccMethod, ok := prepareResponse.PaymentMethod.(breez_sdk_spark.SendPaymentMethodCrossChainAddress); ok {
+		serviceFeeDenom := "sats"
+		if ccMethod.ServiceFeeAsset != nil {
+			serviceFeeDenom = *ccMethod.ServiceFeeAsset
+		}
+		denomination := "sats"
+		if *tokenId != "" {
+			denomination = "token base units"
+		}
+		fmt.Printf("Cross-chain send: %v %s (~%v %s) -> ~%v %s on %s to %s\n",
+			ccMethod.AmountIn, denomination, ccMethod.AssetAmountIn, ccMethod.Route.Asset,
+			ccMethod.EstimatedOut, ccMethod.Route.Asset, ccMethod.Route.Chain, ccMethod.RecipientAddress)
+		fmt.Printf("Fee (total, in %s): %v\n", ccMethod.Route.Asset, ccMethod.FeeAmount)
+		fmt.Printf("Service fee: %v %s\n", ccMethod.ServiceFeeAmount, serviceFeeDenom)
+		fmt.Printf("Source transfer fee: %d sats\n", ccMethod.SourceTransferFeeSats)
 		line, err := readlineWithDefault(rl, "Do you want to continue (y/n): ", "y")
 		if err != nil {
 			return err
@@ -1189,6 +1247,59 @@ func handleGetSparkStatus(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, _
 	}
 	printValue(result)
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// selectCrossChainRoute — fetch routes and prompt the user to pick one
+// ---------------------------------------------------------------------------
+
+func selectCrossChainRoute(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, addressDetails breez_sdk_spark.CrossChainAddressDetails) (breez_sdk_spark.CrossChainRoutePair, error) {
+	var filter breez_sdk_spark.CrossChainRouteFilter = breez_sdk_spark.CrossChainRouteFilterSend{AddressDetails: addressDetails}
+	routes, err := sdk.GetCrossChainRoutes(filter)
+	if err = liftError(err); err != nil {
+		return breez_sdk_spark.CrossChainRoutePair{}, err
+	}
+	if len(routes) == 0 {
+		return breez_sdk_spark.CrossChainRoutePair{}, fmt.Errorf("no cross-chain routes available for this address")
+	}
+
+	if len(routes) == 1 {
+		route := routes[0]
+		fmt.Printf("Auto-selected route: %s on %s%s [%v]\n",
+			route.Asset, route.Chain, maybeTruncateAddress(route.ContractAddress), route.Provider)
+		return route, nil
+	}
+
+	fmt.Println("Available cross-chain routes:")
+	for i, route := range routes {
+		fmt.Printf("  %d. %s on %s%s [%v]\n",
+			i+1, route.Asset, route.Chain, maybeTruncateAddress(route.ContractAddress), route.Provider)
+	}
+
+	line, err := readlinePrompt(rl, "Select route: ")
+	if err != nil {
+		return breez_sdk_spark.CrossChainRoutePair{}, err
+	}
+	choice, err := strconv.Atoi(strings.TrimSpace(line))
+	if err != nil {
+		return breez_sdk_spark.CrossChainRoutePair{}, fmt.Errorf("invalid selection")
+	}
+	idx := choice - 1
+	if idx < 0 || idx >= len(routes) {
+		return breez_sdk_spark.CrossChainRoutePair{}, fmt.Errorf("selection out of range")
+	}
+	return routes[idx], nil
+}
+
+func maybeTruncateAddress(addr *string) string {
+	if addr == nil {
+		return ""
+	}
+	c := *addr
+	if len(c) > 12 {
+		return fmt.Sprintf(" (%s...%s)", c[:6], c[len(c)-6:])
+	}
+	return fmt.Sprintf(" (%s)", c)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/main.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/main.go
@@ -125,6 +125,14 @@ func main() {
 		config.ApiKey = &apiKey
 	}
 
+	// Cross-chain sends are opt-in by the caller and mainnet-only (enabling on
+	// other networks fails config validation). Enable with default slippage so
+	// `pay` can route cross-chain destinations.
+	if networkEnum == breez_sdk_spark.NetworkMainnet {
+		crossChainConfig := breez_sdk_spark.CrossChainConfig{}
+		config.CrossChainConfig = &crossChainConfig
+	}
+
 	// Stable balance config
 	if len(stableBalanceTokens) > 0 {
 		var tokens []breez_sdk_spark.StableBalanceToken

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -391,25 +391,27 @@ suspend fun handleReceive(sdk: BreezSdk, reader: LineReader, args: List<String>)
 
 suspend fun handlePay(sdk: BreezSdk, reader: LineReader, args: List<String>) {
     val fp = FlagParser(args)
-    val paymentRequest = fp.getString("r", "payment-request")
+    val paymentRequestStr = fp.getString("r", "payment-request")
     val amountStr = fp.getString("a", "amount")
     val tokenId = fp.getString("t", "token-identifier")
     val idempotencyKey = fp.getString("i", "idempotency-key")
     val convertFromBitcoin = fp.hasFlag("from-bitcoin")
     val convertFromToken = fp.getString("from-token")
     val maxSlippageBps = fp.getUInt("s", "convert-max-slippage-bps")
+    val crossChainMaxSlippageBps = fp.getUInt("cross-chain-max-slippage-bps")
     val feesIncluded = fp.hasFlag("fees-included")
 
-    if (paymentRequest == null) {
+    if (paymentRequestStr == null) {
         println("Usage: pay -r <payment_request> [options]")
         println("Options:")
-        println("  -a, --amount <amount>            Optional amount")
-        println("  -t, --token-identifier <id>      Optional token identifier")
-        println("  -i, --idempotency-key <key>      Optional idempotency key")
-        println("  --from-bitcoin                   Convert from Bitcoin")
-        println("  --from-token <token_id>          Convert from token to Bitcoin")
-        println("  -s, --convert-max-slippage-bps   Max slippage in basis points")
-        println("  --fees-included                  Deduct fees from amount")
+        println("  -a, --amount <amount>                  Optional amount")
+        println("  -t, --token-identifier <id>            Optional token identifier")
+        println("  -i, --idempotency-key <key>            Optional idempotency key")
+        println("  --from-bitcoin                         Convert from Bitcoin")
+        println("  --from-token <token_id>                Convert from token to Bitcoin")
+        println("  -s, --convert-max-slippage-bps <bps>   Max slippage in basis points")
+        println("  --cross-chain-max-slippage-bps <bps>   Max slippage for cross-chain sends (10..500)")
+        println("  --fees-included                        Deduct fees from amount")
         return
     }
 
@@ -438,9 +440,24 @@ suspend fun handlePay(sdk: BreezSdk, reader: LineReader, args: List<String>) {
 
     val feePolicy = if (feesIncluded) FeePolicy.FEES_INCLUDED else null
 
+    val paymentRequest = when (val parsed = sdk.parse(paymentRequestStr)) {
+        is InputType.CrossChainAddress -> {
+            val addressDetails = parsed.v1
+            val address = addressDetails.address
+            val route = selectCrossChainRoute(sdk, reader, addressDetails)
+            PaymentRequest.CrossChain(
+                address = address,
+                route = route,
+                maxSlippageBps = crossChainMaxSlippageBps,
+                targetOverpayBps = null,
+            )
+        }
+        else -> PaymentRequest.Input(input = paymentRequestStr)
+    }
+
     val prepareResponse = sdk.prepareSendPayment(
         PrepareSendPaymentRequest(
-            paymentRequest = PaymentRequest.Input(input = paymentRequest),
+            paymentRequest = paymentRequest,
             amount = amount,
             tokenIdentifier = tokenId,
             conversionOptions = conversionOptions,
@@ -456,6 +473,27 @@ suspend fun handlePay(sdk: BreezSdk, reader: LineReader, args: List<String>) {
             "token base units" to "sats"
         }
         println("Estimated conversion from ${conversionEstimate.amountIn} $inUnits to ${conversionEstimate.amountOut} $outUnits with a ${conversionEstimate.fee} token base units fee")
+        val line = readlineWithDefault(reader, "Do you want to continue (y/n): ", "y").lowercase()
+        if (line != "y") {
+            println("Payment cancelled")
+            return
+        }
+    }
+
+    // Show cross-chain quote details before confirming
+    val method = prepareResponse.paymentMethod
+    if (method is SendPaymentMethod.CrossChainAddress) {
+        val serviceFeeDenom = method.serviceFeeAsset ?: "sats"
+        val denomination = if (tokenId != null) "token base units" else "sats"
+        println(
+            "Cross-chain send: ${method.amountIn} $denomination " +
+            "(~${method.assetAmountIn} ${method.route.asset}) " +
+            "-> ~${method.estimatedOut} ${method.route.asset} " +
+            "on ${method.route.chain} to ${method.recipientAddress}"
+        )
+        println("Fee (total, in ${method.route.asset}): ${method.feeAmount}")
+        println("Service fee: ${method.serviceFeeAmount} $serviceFeeDenom")
+        println("Source transfer fee: ${method.sourceTransferFeeSats} sats")
         val line = readlineWithDefault(reader, "Do you want to continue (y/n): ", "y").lowercase()
         if (line != "y") {
             println("Payment cancelled")
@@ -984,6 +1022,57 @@ suspend fun handleGetSparkStatus(sdk: BreezSdk, reader: LineReader, args: List<S
 }
 
 // ---------------------------------------------------------------------------
+// Cross-chain route selection
+// ---------------------------------------------------------------------------
+
+suspend fun selectCrossChainRoute(
+    sdk: BreezSdk,
+    reader: LineReader,
+    addressDetails: CrossChainAddressDetails,
+): CrossChainRoutePair {
+    val filter = CrossChainRouteFilter.Send(addressDetails = addressDetails)
+    val routes = sdk.getCrossChainRoutes(filter)
+    if (routes.isEmpty()) {
+        throw Exception("No cross-chain routes available for this address")
+    }
+
+    if (routes.size == 1) {
+        val route = routes[0]
+        println(
+            "Auto-selected route: ${route.asset} on ${route.chain}" +
+            "${maybeTruncateAddress(route.contractAddress)} [${route.provider}]"
+        )
+        return route
+    }
+
+    println("Available cross-chain routes:")
+    for ((i, route) in routes.withIndex()) {
+        val idx = i + 1
+        println(
+            "  $idx. ${route.asset} on ${route.chain}" +
+            "${maybeTruncateAddress(route.contractAddress)} [${route.provider}]"
+        )
+    }
+
+    val line = readlinePrompt(reader, "Select route: ")
+    val choice = line.toIntOrNull() ?: throw Exception("Invalid selection")
+    val index = choice - 1
+    if (index < 0 || index >= routes.size) {
+        throw Exception("Selection out of range")
+    }
+    return routes[index]
+}
+
+fun maybeTruncateAddress(addr: String?): String {
+    if (addr == null) return ""
+    return if (addr.length > 12) {
+        " (${addr.take(6)}...${addr.takeLast(6)})"
+    } else {
+        " ($addr)"
+    }
+}
+
+// ---------------------------------------------------------------------------
 // readPaymentOptions -- interactive fee/option selection
 // ---------------------------------------------------------------------------
 
@@ -1078,7 +1167,8 @@ suspend fun readPaymentOptions(
             )
         }
 
-        is SendPaymentMethod.SparkInvoice -> null
+        is SendPaymentMethod.SparkInvoice,
+        is SendPaymentMethod.CrossChainAddress -> null
 
         else -> null
     }

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Main.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Main.kt
@@ -274,6 +274,9 @@ suspend fun runInteractiveMode(
         config.apiKey = apiKey
     }
     config.stableBalanceConfig = stableBalanceConfig
+    if (network == Network.MAINNET) {
+        config.crossChainConfig = CrossChainConfig()
+    }
 
     // Resolve seed: passkey or mnemonic
     val seed: Seed = if (passkeyConfig != null) {

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -15,6 +15,7 @@ from breez_sdk_spark import (
     ClaimTransferRequest,
     ConversionOptions,
     ConversionType,
+    CrossChainRouteFilter,
     Fee,
     FeePolicy,
     FetchConversionLimitsRequest,
@@ -316,6 +317,8 @@ def _build_pay_parser():
     p.add_argument("--from-bitcoin", action="store_true", default=False)
     p.add_argument("--from-token", default=None)
     p.add_argument("-s", "--convert-max-slippage-bps", type=int, default=None)
+    p.add_argument("--cross-chain-max-slippage-bps", type=int, default=None,
+                   help="Max slippage in basis points for cross-chain sends (10..500)")
     p.add_argument("--fees-included", action="store_true", default=False)
     return p
 
@@ -336,9 +339,23 @@ async def _handle_pay(sdk, _token_issuer, session, args):
 
     fee_policy = FeePolicy.FEES_INCLUDED if args.fees_included else None
 
+    parsed = await sdk.parse(input=args.payment_request)
+    if isinstance(parsed, InputType.CROSS_CHAIN_ADDRESS):
+        address_details = parsed[0]
+        address = address_details.address
+        route = await _select_cross_chain_route(sdk, session, address_details)
+        payment_request = PaymentRequest.CROSS_CHAIN(
+            address=address,
+            route=route,
+            max_slippage_bps=args.cross_chain_max_slippage_bps,
+            target_overpay_bps=None,
+        )
+    else:
+        payment_request = PaymentRequest.INPUT(input=args.payment_request)
+
     prepare_response = await sdk.prepare_send_payment(
         request=PrepareSendPaymentRequest(
-            payment_request=PaymentRequest.INPUT(input=args.payment_request),
+            payment_request=payment_request,
             amount=args.amount,
             token_identifier=args.token_identifier,
             conversion_options=conversion_options,
@@ -357,6 +374,24 @@ async def _handle_pay(sdk, _token_issuer, session, args):
             f"to {est.amount_out} {out_units} "
             f"with a {est.fee} token base units fee"
         )
+        line = await session.prompt_async("Do you want to continue (y/n): ", default="y")
+        if line.strip().lower() != "y":
+            print("Payment cancelled")
+            return
+
+    if isinstance(prepare_response.payment_method, SendPaymentMethod.CROSS_CHAIN_ADDRESS):
+        m = prepare_response.payment_method
+        service_fee_denom = m.service_fee_asset if m.service_fee_asset else "sats"
+        denomination = "token base units" if args.token_identifier else "sats"
+        print(
+            f"Cross-chain send: {m.amount_in} {denomination} "
+            f"(~{m.asset_amount_in} {m.route.asset}) "
+            f"-> ~{m.estimated_out} {m.route.asset} "
+            f"on {m.route.chain} to {m.recipient_address}"
+        )
+        print(f"Fee (total, in {m.route.asset}): {m.fee_amount}")
+        print(f"Service fee: {m.service_fee_amount} {service_fee_denom}")
+        print(f"Source transfer fee: {m.source_transfer_fee_sats} sats")
         line = await session.prompt_async("Do you want to continue (y/n): ", default="y")
         if line.strip().lower() != "y":
             print("Payment cancelled")
@@ -853,6 +888,52 @@ async def _handle_get_spark_status(_sdk, _token_issuer, _session, _args):
 
 
 # ---------------------------------------------------------------------------
+# Cross-chain route selection
+# ---------------------------------------------------------------------------
+
+def _maybe_truncate_address(addr):
+    if addr is None:
+        return ""
+    if len(addr) > 12:
+        return f" ({addr[:6]}...{addr[-6:]})"
+    return f" ({addr})"
+
+
+async def _select_cross_chain_route(sdk, session, address_details):
+    """Fetch cross-chain routes and prompt the user to select one."""
+    route_filter = CrossChainRouteFilter.SEND(address_details=address_details)
+    routes = await sdk.get_cross_chain_routes(filter=route_filter)
+    if not routes:
+        raise ValueError("No cross-chain routes available for this address")
+
+    if len(routes) == 1:
+        route = routes[0]
+        print(
+            f"Auto-selected route: {route.asset} on {route.chain}"
+            f"{_maybe_truncate_address(route.contract_address)}"
+            f" [{route.provider}]"
+        )
+        return route
+
+    print("Available cross-chain routes:")
+    for i, route in enumerate(routes, 1):
+        print(
+            f"  {i}. {route.asset} on {route.chain}"
+            f"{_maybe_truncate_address(route.contract_address)}"
+            f" [{route.provider}]"
+        )
+
+    line = await session.prompt_async("Select route: ")
+    try:
+        choice = int(line.strip())
+    except ValueError:
+        raise ValueError("Invalid selection")
+    if choice < 1 or choice > len(routes):
+        raise ValueError("Selection out of range")
+    return routes[choice - 1]
+
+
+# ---------------------------------------------------------------------------
 # read_payment_options — interactive fee/option selection
 # ---------------------------------------------------------------------------
 
@@ -926,7 +1007,7 @@ async def read_payment_options(payment_method, session):
             )
         )
 
-    # SendPaymentMethod.SPARK_INVOICE
+    # SendPaymentMethod.SPARK_INVOICE or SendPaymentMethod.CROSS_CHAIN_ADDRESS
     return None
 
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
@@ -10,6 +10,7 @@ from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.history import FileHistory
 
 from breez_sdk_spark import (
+    CrossChainConfig,
     EventListener,
     Network,
     SdkBuilder,
@@ -114,6 +115,8 @@ async def main(data_dir, network, account_number, postgres_connection_string,
     else:
         config = default_config(network=network_enum)
     config.api_key = breez_api_key
+    if network_enum == Network.MAINNET:
+        config.cross_chain_config = CrossChainConfig()
 
     if stable_balance_tokens:
         tokens = []

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/App.tsx
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/App.tsx
@@ -413,6 +413,13 @@ const CliScreen: React.FC<CliScreenProps> = ({ config, onDisconnect }) => {
           appendLog('Warning: No API key found. Create secrets.json with { "apiKey": "..." }')
         }
 
+        if (config.network === Network.Mainnet) {
+          sdkConfig.crossChainConfig = {
+            defaultSlippageBps: undefined,
+            defaultTargetOverpayBps: undefined,
+          }
+        }
+
         let seed: Seed
 
         if (config.passkeyConfig) {

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
@@ -72,6 +72,11 @@ declare module '@breeztech/breez-sdk-spark-react-native' {
   export const SendPaymentOptions: any;
   export const OnchainConfirmationSpeed: any;
   export const getSparkStatus: any;
+  export const PaymentRequest: any;
+  export const CrossChainRouteFilter: any;
+  export const CrossChainProvider: any;
+  export type CrossChainRoutePair = any;
+  export type CrossChainAddressDetails = any;
 
   // --- passkey ---
   // Note: PasskeyProvider (concrete class) ships at the

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -32,10 +32,15 @@ import {
   TokenTransactionType,
   BuyBitcoinRequest,
   getSparkStatus,
+  PaymentRequest,
+  CrossChainRouteFilter,
+  CrossChainProvider,
 } from '@breeztech/breez-sdk-spark-react-native'
 import type {
   BreezSdkInterface,
   TokenIssuerInterface,
+  CrossChainRoutePair,
+  CrossChainAddressDetails,
 } from '@breeztech/breez-sdk-spark-react-native'
 import { generateRandomBytes, sha256Hash, bytesToHex } from './crypto_utils'
 import { formatValue } from './serialization'
@@ -534,9 +539,9 @@ async function handleReceive(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerIn
 // --- pay ---
 
 async function handlePay(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
-  const paymentRequest = parseFlag(args, '--payment-request', '-r')
-  if (!paymentRequest) {
-    return 'Usage: pay -r <payment_request> [-a <amount>] [-t <token_identifier>] [-i <idempotency_key>] [--from-bitcoin] [--from-token <token_id>] [-s <max_slippage_bps>] [--fees-included]'
+  const paymentRequestInput = parseFlag(args, '--payment-request', '-r')
+  if (!paymentRequestInput) {
+    return 'Usage: pay -r <payment_request> [-a <amount>] [-t <token_identifier>] [-i <idempotency_key>] [--from-bitcoin] [--from-token <token_id>] [-s <max_slippage_bps>] [--cross-chain-max-slippage-bps <bps>] [--fees-included]'
   }
 
   const amount = parseBigIntFlag(args, '--amount', '-a')
@@ -545,6 +550,8 @@ async function handlePay(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterf
   const convertFromBitcoin = hasFlag(args, '--from-bitcoin')
   const convertFromTokenIdentifier = parseFlag(args, '--from-token')
   const maxSlippageBps = parseNumericFlag(args, '--convert-max-slippage-bps', '-s')
+  const crossChainMaxSlippageBps = parseNumericFlag(args, '--cross-chain-max-slippage-bps')
+  const routeIndex = parseNumericFlag(args, '--route')
   const feesIncluded = hasFlag(args, '--fees-included')
 
   // Build conversion options
@@ -568,15 +575,34 @@ async function handlePay(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterf
 
   const feePolicy = feesIncluded ? FeePolicy.FeesIncluded : undefined
 
+  const lines: string[] = []
+
+  // Check if the input is a cross-chain address. If so, we need
+  // route selection before we can prepare.
+  let paymentRequest: InstanceType<typeof PaymentRequest.Input>
+    | InstanceType<typeof PaymentRequest.CrossChain>
+  const parsed = await sdk.parse(paymentRequestInput)
+  if (parsed.tag === InputType_Tags.CrossChainAddress) {
+    const addressDetails: CrossChainAddressDetails = parsed.inner[0]
+    const routeResult = await selectCrossChainRoute(sdk, addressDetails, routeIndex)
+    lines.push(routeResult.message)
+    paymentRequest = new PaymentRequest.CrossChain({
+      address: addressDetails.address,
+      route: routeResult.route,
+      maxSlippageBps: crossChainMaxSlippageBps,
+      targetOverpayBps: undefined,
+    })
+  } else {
+    paymentRequest = new PaymentRequest.Input({ input: paymentRequestInput })
+  }
+
   const prepareResponse = await sdk.prepareSendPayment({
-    paymentRequest: { input: paymentRequest },
+    paymentRequest,
     amount,
     tokenIdentifier,
     conversionOptions,
     feePolicy,
   })
-
-  const lines: string[] = []
 
   // Show conversion estimate if present
   if (prepareResponse.conversionEstimate) {
@@ -584,6 +610,20 @@ async function handlePay(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterf
     const isFromBitcoin = est.options?.conversionType?.tag === 'FromBitcoin'
     const units = isFromBitcoin ? 'sats' : 'token base units'
     lines.push(`Estimated conversion of ${est.amount} ${units} with a ${est.fee} ${units} fee`)
+  }
+
+  // Show cross-chain quote details
+  if (prepareResponse.paymentMethod?.tag === SendPaymentMethod_Tags.CrossChainAddress) {
+    const pm = prepareResponse.paymentMethod.inner
+    const serviceFeeAsset = pm.serviceFeeAsset ?? 'sats'
+    const denomination = tokenIdentifier ? 'token base units' : 'sats'
+    lines.push(
+      `Cross-chain send: ${pm.amountIn} ${denomination} (~${pm.assetAmountIn} ${pm.route.asset})` +
+      ` -> ~${pm.estimatedOut} ${pm.route.asset} on ${pm.route.chain} to ${pm.recipientAddress}`
+    )
+    lines.push(`Fee (total, in ${pm.route.asset}): ${pm.feeAmount}`)
+    lines.push(`Service fee: ${pm.serviceFeeAmount} ${serviceFeeAsset}`)
+    lines.push(`Source transfer fee: ${pm.sourceTransferFeeSats} sats`)
   }
 
   // Determine payment options based on the payment method type
@@ -1151,4 +1191,54 @@ async function handleWebhooks(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerI
 
 async function handleStableBalance(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
   return dispatchStableBalanceCommand(args, sdk)
+}
+
+// ---------------------------------------------------------------------------
+// Cross-chain helpers
+// ---------------------------------------------------------------------------
+
+function maybeTruncateAddress(addr: string | undefined | null): string {
+  if (!addr) return ''
+  if (addr.length > 12) {
+    return ` (${addr.slice(0, 6)}...${addr.slice(-6)})`
+  }
+  return ` (${addr})`
+}
+
+async function selectCrossChainRoute(
+  sdk: BreezSdkInterface,
+  addressDetails: CrossChainAddressDetails,
+  preferredIndex: number | undefined,
+): Promise<{ route: CrossChainRoutePair; message: string }> {
+  const filter = new CrossChainRouteFilter.Send({ addressDetails })
+  const routes: CrossChainRoutePair[] = await sdk.getCrossChainRoutes(filter)
+
+  if (routes.length === 0) {
+    throw new Error('No cross-chain routes available for this address')
+  }
+
+  if (routes.length === 1) {
+    const route = routes[0]
+    const message = `Auto-selected route: ${route.asset} on ${route.chain}` +
+      `${maybeTruncateAddress(route.contractAddress)} [${CrossChainProvider[route.provider] ?? route.provider}]`
+    return { route, message }
+  }
+
+  const routeLines = ['Available cross-chain routes:']
+  for (let i = 0; i < routes.length; i++) {
+    const r = routes[i]
+    routeLines.push(
+      `  ${i + 1}. ${r.asset} on ${r.chain}` +
+      `${maybeTruncateAddress(r.contractAddress)} [${CrossChainProvider[r.provider] ?? r.provider}]`
+    )
+  }
+
+  const idx = (preferredIndex ?? 1) - 1
+  if (idx < 0 || idx >= routes.length) {
+    throw new Error(`Route selection out of range (1 to ${routes.length}). Use --route <n> to choose.`)
+  }
+
+  const route = routes[idx]
+  routeLines.push(`Selected route ${idx + 1}. Use --route <n> to choose a different route.`)
+  return { route, message: routeLines.join('\n') }
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -423,8 +423,8 @@ func handleReceive(_ sdk: BreezSdk, _ args: [String]) async throws {
 
 func handlePay(_ sdk: BreezSdk, _ args: [String]) async throws {
     let fp = FlagParser(args)
-    guard let paymentRequest = fp.get("r", "payment-request") else {
-        print("Usage: pay -r <payment_request> [-a <amount>] [-t <token_identifier>] [--from-bitcoin] [--from-token <id>] [-s <slippage_bps>] [--fees-included]")
+    guard let paymentRequestStr = fp.get("r", "payment-request") else {
+        print("Usage: pay -r <payment_request> [-a <amount>] [-t <token_identifier>] [--from-bitcoin] [--from-token <id>] [-s <slippage_bps>] [--cross-chain-max-slippage-bps <bps>] [--fees-included]")
         return
     }
 
@@ -434,6 +434,7 @@ func handlePay(_ sdk: BreezSdk, _ args: [String]) async throws {
     let fromBitcoin = fp.has("from-bitcoin")
     let fromTokenId = fp.get("from-token")
     let maxSlippageBps = fp.get("s", "convert-max-slippage-bps").flatMap { UInt32($0) }
+    let crossChainMaxSlippageBps = fp.get("cross-chain-max-slippage-bps").flatMap { UInt32($0) }
     let feesIncluded = fp.has("fees-included")
 
     let conversionOptions: ConversionOptions?
@@ -455,8 +456,23 @@ func handlePay(_ sdk: BreezSdk, _ args: [String]) async throws {
 
     let feePolicy: FeePolicy? = feesIncluded ? .feesIncluded : nil
 
+    let paymentRequest: PaymentRequest
+    let parsed = try? await sdk.parse(input: paymentRequestStr)
+    if case let .crossChainAddress(v1) = parsed {
+        let address = v1.address
+        let route = try await selectCrossChainRoute(sdk: sdk, addressDetails: v1)
+        paymentRequest = .crossChain(
+            address: address,
+            route: route,
+            maxSlippageBps: crossChainMaxSlippageBps,
+            targetOverpayBps: nil
+        )
+    } else {
+        paymentRequest = .input(input: paymentRequestStr)
+    }
+
     let prepareResponse = try await sdk.prepareSendPayment(request: PrepareSendPaymentRequest(
-        paymentRequest: .input(input: paymentRequest),
+        paymentRequest: paymentRequest,
         amount: amount,
         tokenIdentifier: tokenIdentifier,
         conversionOptions: conversionOptions,
@@ -470,7 +486,21 @@ func handlePay(_ sdk: BreezSdk, _ args: [String]) async throws {
         } else {
             units = "token base units"
         }
-        print("Estimated conversion of \(estimate.amountIn) \(units) → \(estimate.amountOut) \(units) with a \(estimate.fee) \(units) fee")
+        print("Estimated conversion of \(estimate.amountIn) \(units) -> \(estimate.amountOut) \(units) with a \(estimate.fee) \(units) fee")
+        let line = readlineWithDefault("Do you want to continue (y/n): ", defaultValue: "y")
+        if line.trimmingCharacters(in: .whitespaces).lowercased() != "y" {
+            print("Payment cancelled")
+            return
+        }
+    }
+
+    if case let .crossChainAddress(route, recipientAddress, amountIn, assetAmountIn, estimatedOut, feeAmount, serviceFeeAmount, serviceFeeAsset, sourceTransferFeeSats, _, _, _) = prepareResponse.paymentMethod {
+        let serviceFeeDenom = serviceFeeAsset ?? "sats"
+        let denomination = tokenIdentifier != nil ? "token base units" : "sats"
+        print("Cross-chain send: \(amountIn) \(denomination) (~\(assetAmountIn) \(route.asset)) -> ~\(estimatedOut) \(route.asset) on \(route.chain) to \(recipientAddress)")
+        print("Fee (total, in \(route.asset)): \(feeAmount)")
+        print("Service fee: \(serviceFeeAmount) \(serviceFeeDenom)")
+        print("Source transfer fee: \(sourceTransferFeeSats) sats")
         let line = readlineWithDefault("Do you want to continue (y/n): ", defaultValue: "y")
         if line.trimmingCharacters(in: .whitespaces).lowercased() != "y" {
             print("Payment cancelled")
@@ -961,4 +991,51 @@ func handleSetUserSettings(_ sdk: BreezSdk, _ args: [String]) async throws {
 func handleGetSparkStatus(_ sdk: BreezSdk, _ args: [String]) async throws {
     let result = try await getSparkStatus()
     printValue(result)
+}
+
+// MARK: - Cross-chain route selection
+
+func selectCrossChainRoute(
+    sdk: BreezSdk,
+    addressDetails: CrossChainAddressDetails
+) async throws -> CrossChainRoutePair {
+    let filter = CrossChainRouteFilter.send(addressDetails: addressDetails)
+    let routes = try await sdk.getCrossChainRoutes(filter: filter)
+    if routes.isEmpty {
+        throw NSError(domain: "BreezCLI", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "No cross-chain routes available for this address",
+        ])
+    }
+
+    if routes.count == 1 {
+        let route = routes[0]
+        print("Auto-selected route: \(route.asset) on \(route.chain)\(maybeTruncateAddress(route.contractAddress)) [\(route.provider)]")
+        return route
+    }
+
+    print("Available cross-chain routes:")
+    for (i, route) in routes.enumerated() {
+        let idx = i + 1
+        print("  \(idx). \(route.asset) on \(route.chain)\(maybeTruncateAddress(route.contractAddress)) [\(route.provider)]")
+    }
+
+    guard let line = readlinePrompt("Select route: "),
+          let choice = Int(line.trimmingCharacters(in: .whitespaces)),
+          choice >= 1, choice <= routes.count else {
+        throw NSError(domain: "BreezCLI", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Invalid selection",
+        ])
+    }
+
+    return routes[choice - 1]
+}
+
+private func maybeTruncateAddress(_ addr: String?) -> String {
+    guard let c = addr else { return "" }
+    if c.count > 12 {
+        let prefix = c.prefix(6)
+        let suffix = c.suffix(6)
+        return " (\(prefix)...\(suffix))"
+    }
+    return " (\(c))"
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
@@ -221,6 +221,9 @@ let breezApiKey: String? = {
     return nil
 }()
 config.apiKey = breezApiKey
+if network == .mainnet {
+    config.crossChainConfig = CrossChainConfig()
+}
 if !opts.stableBalanceTokens.isEmpty {
     let tokens: [StableBalanceToken] = opts.stableBalanceTokens.map { s in
         let parts = s.split(separator: ":", maxSplits: 1)

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -299,6 +299,7 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
     .option('--from-bitcoin', 'Convert from Bitcoin to fulfill the payment')
     .option('--from-token <identifier>', 'Convert from the specified token to Bitcoin')
     .option('-s, --convert-max-slippage-bps <bps>', 'Max slippage in basis points for conversion', parseInt)
+    .option('--cross-chain-max-slippage-bps <bps>', 'Max slippage in basis points for cross-chain sends (10..500)', parseInt)
     .option('--fees-included', 'Deduct fees from the specified amount', false)
     .action(async (options) => {
       const sdk = getSdk()
@@ -321,8 +322,25 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
 
       const feePolicy = options.feesIncluded ? 'feesIncluded' : undefined
 
+      // Check if the input is a cross-chain address
+      let paymentRequest
+      const parsed = await sdk.parse(options.paymentRequest).catch(() => null)
+      if (parsed && parsed.type === 'crossChainAddress') {
+        const address = parsed.address
+        const route = await selectCrossChainRoute(sdk, rl, parsed)
+        paymentRequest = {
+          type: 'crossChain',
+          address,
+          route,
+          maxSlippageBps: options.crossChainMaxSlippageBps,
+          targetOverpayBps: undefined
+        }
+      } else {
+        paymentRequest = { type: 'input', input: options.paymentRequest }
+      }
+
       const prepareResponse = await sdk.prepareSendPayment({
-        paymentRequest: { input: options.paymentRequest },
+        paymentRequest,
         amount: options.amount != null ? BigInt(options.amount) : undefined,
         tokenIdentifier: options.tokenIdentifier,
         conversionOptions,
@@ -337,6 +355,24 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
           ? ['sats', 'token base units']
           : ['token base units', 'sats']
         console.log(`Estimated conversion from ${estimate.amountIn} ${inUnits} to ${estimate.amountOut} ${outUnits} with a ${estimate.fee} token base units fee`)
+        const answer = await questionWithDefault(rl, 'Do you want to continue (y/n): ', 'y')
+        if (answer.toLowerCase() !== 'y') {
+          throw new Error('Payment cancelled')
+        }
+      }
+
+      // Show cross-chain quote details before confirming
+      if (prepareResponse.paymentMethod && prepareResponse.paymentMethod.type === 'crossChainAddress') {
+        const pm = prepareResponse.paymentMethod
+        const serviceFeeDenom = pm.serviceFeeAsset || 'sats'
+        const denomination = options.tokenIdentifier ? 'token base units' : 'sats'
+        console.log(
+          `Cross-chain send: ${pm.amountIn} ${denomination} (~${pm.assetAmountIn} ${pm.route.asset})` +
+          ` -> ~${pm.estimatedOut} ${pm.route.asset} on ${pm.route.chain} to ${pm.recipientAddress}`
+        )
+        console.log(`Fee (total, in ${pm.route.asset}): ${pm.feeAmount}`)
+        console.log(`Service fee: ${pm.serviceFeeAmount} ${serviceFeeDenom}`)
+        console.log(`Source transfer fee: ${pm.sourceTransferFeeSats} sats`)
         const answer = await questionWithDefault(rl, 'Do you want to continue (y/n): ', 'y')
         if (answer.toLowerCase() !== 'y') {
           throw new Error('Payment cancelled')
@@ -917,13 +953,61 @@ async function readPaymentOptions(paymentMethod, rl) {
       }
     }
 
-    case 'sparkInvoice': {
+    case 'sparkInvoice':
+    case 'crossChainAddress': {
       return undefined
     }
 
     default:
       return undefined
   }
+}
+
+/**
+ * Fetch cross-chain routes for an address and prompt the user to select one.
+ * Auto-selects if only a single route is available.
+ */
+async function selectCrossChainRoute(sdk, rl, addressDetails) {
+  const filter = { type: 'send', addressDetails }
+  const routes = await sdk.getCrossChainRoutes(filter)
+
+  if (!routes || routes.length === 0) {
+    throw new Error('No cross-chain routes available for this address')
+  }
+
+  if (routes.length === 1) {
+    const route = routes[0]
+    console.log(
+      `Auto-selected route: ${route.asset} on ${route.chain}` +
+      `${maybeTruncateAddress(route.contractAddress)} [${route.provider}]`
+    )
+    return route
+  }
+
+  console.log('Available cross-chain routes:')
+  for (let i = 0; i < routes.length; i++) {
+    const route = routes[i]
+    console.log(
+      `  ${i + 1}. ${route.asset} on ${route.chain}` +
+      `${maybeTruncateAddress(route.contractAddress)} [${route.provider}]`
+    )
+  }
+
+  const line = await question(rl, 'Select route: ')
+  const choice = parseInt(line.trim(), 10)
+  if (isNaN(choice) || choice < 1 || choice > routes.length) {
+    throw new Error('Selection out of range')
+  }
+
+  return routes[choice - 1]
+}
+
+function maybeTruncateAddress(addr) {
+  if (!addr) return ''
+  if (addr.length > 12) {
+    return ` (${addr.slice(0, 6)}...${addr.slice(-6)})`
+  }
+  return ` (${addr})`
 }
 
 module.exports = { buildProgram, COMMAND_NAMES }

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
@@ -241,6 +241,10 @@ async function main() {
     config.apiKey = breezApiKey
   }
 
+  if (network === 'mainnet') {
+    config.crossChainConfig = {}
+  }
+
   // Stable balance config
   if (opts.stableBalanceTokens.length > 0) {
     const tokens = opts.stableBalanceTokens.map((s) => {


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`53e5b01`](https://github.com/breez/spark-sdk/commit/53e5b01ebd458c7519e9579ee4e4c4a03363c4ca)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/27899171173)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :white_check_mark: React Native
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- Program.cs missing `CrossChainConfig` setup for mainnet (Rust sets `config.cross_chain_config = Some(CrossChainConfig::default())` when network is mainnet)
- Commands.cs `pay` command missing `--cross-chain-max-slippage-bps` flag
- Commands.cs `pay` command missing cross-chain address detection via `sdk.Parse()` and route selection before prepare
- Commands.cs `pay` command missing cross-chain quote display (SendPaymentMethod.CrossChainAddress details) after prepare
- Commands.cs `ReadPaymentOptions` did not explicitly handle `SendPaymentMethod.CrossChainAddress` (fell through to null implicitly)
- Commands.cs missing `SelectCrossChainRoute` helper method (route discovery and interactive selection)
- Commands.cs missing `MaybeTruncateAddress` helper method (contract address display truncation)

## Applied
- Program.cs: Added `CrossChainConfig` initialization when network is mainnet, matching Rust CLI behavior
- Commands.cs: Added `--cross-chain-max-slippage-bps` flag parsing in `HandlePay`
- Commands.cs: Added cross-chain address detection via `sdk.Parse()` and `PaymentRequest.CrossChain` construction with route selection in `HandlePay`
- Commands.cs: Added cross-chain quote display block (amount, fees, route info) with user confirmation in `HandlePay`
- Commands.cs: Updated `ReadPaymentOptions` comment to explicitly mention `CrossChainAddress` alongside `SparkInvoice`
- Commands.cs: Added `SelectCrossChainRoute` async helper (calls `sdk.GetCrossChainRoutes`, auto-selects single route, prompts user for multi-route selection)
- Commands.cs: Added `MaybeTruncateAddress` helper for contract address display truncation

## Skipped
- (none)

### Dart
## Divergences
- `cli.dart`: Missing cross-chain config setup for mainnet (Rust sets `CrossChainConfig::default()` on mainnet)
- `commands.dart`: Missing `--cross-chain-max-slippage-bps` CLI flag on the `pay` command
- `commands.dart`: Missing cross-chain address detection in `_handlePay` (Rust parses input and checks for `InputType::CrossChainAddress`)
- `commands.dart`: Missing cross-chain route selection (`select_cross_chain_route` function with interactive prompt)
- `commands.dart`: Missing cross-chain quote details display and confirmation before sending
- `commands.dart`: Missing `maybe_truncate_address` helper for formatting contract addresses
- `commands.dart`: `_readPaymentOptions` did not explicitly handle `SendPaymentMethod_CrossChainAddress` (returned null implicitly but lacked the comment)

## Applied
- `cli.dart`: Added cross-chain config setup for mainnet using `config.copyWith(crossChainConfig: CrossChainConfig())`
- `commands.dart`: Added `--cross-chain-max-slippage-bps` option to the pay command parser
- `commands.dart`: Added cross-chain address detection in `_handlePay` that parses input, detects `InputType_CrossChainAddress`, and calls `_selectCrossChainRoute`
- `commands.dart`: Added `PaymentRequest.crossChain()` construction with route, address, and slippage params
- `commands.dart`: Added cross-chain quote details display (amount, fees, route info) with confirmation prompt before sending
- `commands.dart`: Added `_selectCrossChainRoute` function that fetches routes via `sdk.getCrossChainRoutes`, auto-selects single routes, and prompts for selection when multiple routes are available
- `commands.dart`: Added `_maybeTruncateAddress` helper for formatting long contract addresses
- `commands.dart`: Updated `_readPaymentOptions` comment to explicitly mention `SendPaymentMethod_CrossChainAddress`

## Skipped
- No items skipped; all Rust CLI changes were portable to Dart

### Go
## Divergences
- `main.go` missing `CrossChainConfig` setup for mainnet (Rust enables cross-chain sends on mainnet with default config)
- `commands.go` `pay` command missing `--cross-chain-max-slippage-bps` CLI flag
- `commands.go` `pay` command missing cross-chain address detection via `sdk.Parse()` and route selection before prepare
- `commands.go` `pay` command missing cross-chain quote display (route, fees, amounts) before confirming send
- `commands.go` missing `selectCrossChainRoute()` helper to fetch and interactively select a cross-chain route
- `commands.go` missing `maybeTruncateAddress()` helper for display formatting

## Applied
- Added `CrossChainConfig` initialization for mainnet in `main.go`
- Added `--cross-chain-max-slippage-bps` flag to `handlePay` in `commands.go`
- Added cross-chain address detection: parse input, check for `InputTypeCrossChainAddress`, construct `PaymentRequestCrossChain` with route selection in `commands.go`
- Added cross-chain quote display block showing route details, fees, and confirmation prompt in `commands.go`
- Added `selectCrossChainRoute()` function with auto-select for single route and interactive selection for multiple routes in `commands.go`
- Added `maybeTruncateAddress()` helper for display formatting in `commands.go`

## Skipped
- (none)

### Kotlin
## Divergences
- Main.kt: missing `CrossChainConfig` setup on mainnet (Rust sets `config.cross_chain_config = Some(CrossChainConfig::default())` when network is mainnet)
- Commands.kt: `pay` command missing `--cross-chain-max-slippage-bps` flag
- Commands.kt: `pay` command always uses `PaymentRequest.Input`, never detects `InputType.CrossChainAddress` for cross-chain route selection
- Commands.kt: `pay` command missing cross-chain quote display (`SendPaymentMethod.CrossChainAddress`) before payment confirmation
- Commands.kt: `readPaymentOptions` does not explicitly handle `SendPaymentMethod.CrossChainAddress` (falls through to `else -> null`)
- Commands.kt: missing `selectCrossChainRoute()` helper (interactive route selection with auto-select for single-route)
- Commands.kt: missing `maybeTruncateAddress()` helper (contract address formatting)

## Applied
- Main.kt: added `config.crossChainConfig = CrossChainConfig()` when network is MAINNET
- Commands.kt: added `--cross-chain-max-slippage-bps` flag parsing in `handlePay`
- Commands.kt: added cross-chain address detection via `sdk.parse()` and route selection before `prepareSendPayment` in `handlePay`
- Commands.kt: added cross-chain quote display (amount, fees, route details) with confirmation prompt before `sendPayment` in `handlePay`
- Commands.kt: added `selectCrossChainRoute()` function for interactive route selection with auto-select
- Commands.kt: added `maybeTruncateAddress()` helper for formatting contract addresses
- Commands.kt: added explicit `SendPaymentMethod.CrossChainAddress` case in `readPaymentOptions`

## Skipped
- (none)

### Python
## Divergences
- `main.py`: Missing `CrossChainConfig` import and cross-chain config setup for mainnet networks
- `commands.py` (`pay`): Missing `--cross-chain-max-slippage-bps` CLI flag
- `commands.py` (`pay`): Missing cross-chain address detection via `sdk.parse()` and `PaymentRequest.CROSS_CHAIN` variant
- `commands.py` (`pay`): Missing `_select_cross_chain_route` interactive route selection (with auto-select for single route)
- `commands.py` (`pay`): Missing cross-chain quote display (amount, fees, service fee, source transfer fee) before confirmation
- `commands.py` (`read_payment_options`): Missing `SendPaymentMethod.CROSS_CHAIN_ADDRESS` in the fallthrough return path

## Applied
- `main.py`: Added `CrossChainConfig` import and `config.cross_chain_config = CrossChainConfig()` for mainnet
- `commands.py`: Added `CrossChainRouteFilter` import
- `commands.py`: Added `--cross-chain-max-slippage-bps` argument to `_build_pay_parser()`
- `commands.py`: Added cross-chain address detection in `_handle_pay()` using `sdk.parse()` and `InputType.CROSS_CHAIN_ADDRESS`
- `commands.py`: Added `_select_cross_chain_route()` function with interactive route selection and auto-select for single route
- `commands.py`: Added `_maybe_truncate_address()` helper for route display
- `commands.py`: Added cross-chain quote display block in `_handle_pay()` showing amounts, fees, and confirmation prompt
- `commands.py`: Updated `read_payment_options()` comment to include `CROSS_CHAIN_ADDRESS` in the fallthrough path

## Skipped
- (none)

### React Native
## Divergences
- `App.tsx`: Missing `crossChainConfig` on mainnet config (Rust sets `CrossChainConfig::default()` for mainnet)
- `commands.ts`: `pay` command missing `--cross-chain-max-slippage-bps` flag
- `commands.ts`: `pay` command not detecting cross-chain addresses via `parse()` and selecting routes before preparing
- `commands.ts`: `pay` command not displaying cross-chain quote details (`SendPaymentMethod::CrossChainAddress`) after prepare
- `commands.ts`: `pay` command using plain object `{ input: paymentRequest }` instead of `new PaymentRequest.Input(...)` tagged union constructor

## Applied
- `App.tsx`: Set `sdkConfig.crossChainConfig` with defaults when network is mainnet
- `commands.ts`: Added `PaymentRequest`, `CrossChainRouteFilter`, `CrossChainProvider` imports and `CrossChainRoutePair`/`CrossChainAddressDetails` type imports
- `commands.ts`: Added `--cross-chain-max-slippage-bps` and `--route` flag parsing to `handlePay`
- `commands.ts`: Added cross-chain address detection: parse input, detect `CrossChainAddress`, call `selectCrossChainRoute()`, build `PaymentRequest.CrossChain`
- `commands.ts`: Added cross-chain quote display for `SendPaymentMethod_Tags.CrossChainAddress` after prepare
- `commands.ts`: Changed non-cross-chain path to use `new PaymentRequest.Input(...)` tagged union constructor
- `commands.ts`: Updated `handlePay` usage string to include `--cross-chain-max-slippage-bps`
- `commands.ts`: Added `selectCrossChainRoute()` helper (auto-selects single route, supports `--route` flag for multiple)
- `commands.ts`: Added `maybeTruncateAddress()` helper
- `breez-sdk-spark-react-native.d.ts`: Added `PaymentRequest`, `CrossChainRouteFilter`, `CrossChainProvider`, `CrossChainRoutePair`, `CrossChainAddressDetails` declarations

## Skipped
- No features were skipped; all cross-chain changes are portable SDK API calls with no platform-specific dependencies

### Swift
## Divergences
- `main.swift`: Missing `CrossChainConfig` setup for mainnet (Rust sets `config.cross_chain_config = Some(CrossChainConfig::default())` when `network == Mainnet`)
- `Commands.swift` `handlePay`: Missing `--cross-chain-max-slippage-bps` CLI flag
- `Commands.swift` `handlePay`: Always used `PaymentRequest.input` instead of detecting cross-chain addresses via `sdk.parse()` and constructing `PaymentRequest.crossChain` with route selection
- `Commands.swift` `handlePay`: Missing cross-chain quote confirmation prompt (displaying route, fees, amounts before sending)
- `Commands.swift`: Missing `selectCrossChainRoute` helper function for interactive route selection
- `Commands.swift`: Missing `maybeTruncateAddress` helper for displaying contract addresses

## Applied
- `main.swift`: Added `config.crossChainConfig = CrossChainConfig()` for mainnet network
- `Commands.swift` `handlePay`: Added `--cross-chain-max-slippage-bps` flag parsing
- `Commands.swift` `handlePay`: Added cross-chain address detection via `sdk.parse()`, route selection via `selectCrossChainRoute`, and `PaymentRequest.crossChain` construction
- `Commands.swift` `handlePay`: Added cross-chain quote confirmation prompt matching Rust output (amounts, fees, service fees, source transfer fees)
- `Commands.swift`: Added `selectCrossChainRoute` function with auto-selection for single routes and interactive numbered selection for multiple routes
- `Commands.swift`: Added `maybeTruncateAddress` helper for truncating long contract addresses

## Skipped
- No features were skipped. All Rust CLI changes were portable SDK API calls with no platform-specific dependencies.

### TypeScript
## Divergences
- `main.js`: Missing cross-chain config enablement for mainnet (`config.crossChainConfig = {}`)
- `commands.js` (pay): Missing `--cross-chain-max-slippage-bps` CLI option
- `commands.js` (pay): Missing cross-chain address detection via `sdk.parse()` before `prepareSendPayment`
- `commands.js` (pay): `PaymentRequest` passed as plain `{ input }` instead of tagged `{ type: 'input', input }` enum
- `commands.js` (pay): Missing cross-chain quote display and user confirmation after `prepareSendPayment`
- `commands.js`: Missing `selectCrossChainRoute()` helper function for interactive route selection
- `commands.js`: Missing `maybeTruncateAddress()` helper function for display formatting
- `commands.js` (readPaymentOptions): Missing `crossChainAddress` case (should return undefined)

## Applied
- `main.js`: Added `config.crossChainConfig = {}` when network is mainnet
- `commands.js` (pay): Added `--cross-chain-max-slippage-bps` option with parseInt parser
- `commands.js` (pay): Added cross-chain address detection: parses input, builds `PaymentRequest.CrossChain` with route selection when `crossChainAddress` is detected, falls back to `PaymentRequest.Input` otherwise
- `commands.js` (pay): Added cross-chain quote display showing amount, route, fees, and user confirmation prompt
- `commands.js`: Added `selectCrossChainRoute()` function that fetches routes via `sdk.getCrossChainRoutes()`, auto-selects single routes, and prompts for multi-route selection
- `commands.js`: Added `maybeTruncateAddress()` helper for contract address display
- `commands.js` (readPaymentOptions): Added `crossChainAddress` alongside `sparkInvoice` to return undefined

## Skipped
- (none)

</details>