### PR TITLE
Cross-chain: Add mainnet itests

### DIFF
--- a/.github/workflows/breez-itest-mainnet.yaml
+++ b/.github/workflows/breez-itest-mainnet.yaml
@@ -1,8 +1,9 @@
 name: Breez mainnet conversion tests
 
-# Runs the token-conversion / stable-balance integration tests against MAINNET,
-# using real Flashnet pool liquidity. Gated on the MAINNET_TEST_MNEMONIC /
-# BREEZ_API_KEY secrets; the tests skip if those are unset. Triggered manually
+# Runs the token-conversion / stable-balance / cross-chain integration tests
+# against MAINNET, using real Flashnet pool liquidity (and, for cross-chain, real
+# Orchestra/Boltz routes to external EVM chains). Gated on the MAINNET_TEST_MNEMONIC
+# / BREEZ_API_KEY secrets; the tests skip if those are unset. Triggered manually
 # (workflow_dispatch) or by another workflow (workflow_call), e.g. on release.
 
 on:
@@ -23,6 +24,7 @@ on:
           - mainnet_token_conversion
           - mainnet_stable_balance
           - mainnet_server_mode_conversion
+          - mainnet_cross_chain
   workflow_call:
     inputs:
       token_id:
@@ -31,7 +33,7 @@ on:
         type: string
         default: ''
       tests:
-        description: 'Which tests to run (all | mainnet_token_conversion | mainnet_stable_balance | mainnet_server_mode_conversion)'
+        description: 'Which tests to run (all | mainnet_token_conversion | mainnet_stable_balance | mainnet_server_mode_conversion | mainnet_cross_chain)'
         required: false
         type: string
         default: all
@@ -66,7 +68,7 @@ jobs:
           TESTS: ${{ inputs.tests }}
         run: |
           case "$TESTS" in
-            mainnet_token_conversion|mainnet_stable_balance|mainnet_server_mode_conversion)
+            mainnet_token_conversion|mainnet_stable_balance|mainnet_server_mode_conversion|mainnet_cross_chain)
               cargo xtask test --package breez-sdk-itest --test "$TESTS" -- --test-threads=1
               ;;
             *)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
  "rustc-hash",
  "secp256k1 0.31.1",
  "serde",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -410,9 +410,12 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "async-trait",
+ "coins-bip32",
+ "coins-bip39",
  "k256",
  "rand 0.8.6",
  "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]
@@ -442,7 +445,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote 1.0.45",
- "sha3",
+ "sha3 0.11.0",
  "syn 2.0.117",
  "syn-solidity",
 ]
@@ -1090,6 +1093,12 @@ dependencies = [
 
 [[package]]
 name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
@@ -1148,7 +1157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
  "base58ck",
- "bech32",
+ "bech32 0.11.1",
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
@@ -1401,7 +1410,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
- "bech32",
+ "bech32 0.11.1",
  "bitcoin",
  "cbc",
  "dnssec-prover",
@@ -1436,11 +1445,13 @@ dependencies = [
 name = "breez-sdk-itest"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-signer-local",
  "anyhow",
  "async-trait",
  "axum",
  "base64 0.22.1",
- "bech32",
+ "bech32 0.11.1",
  "bip39",
  "bitcoin",
  "breez-sdk-common",
@@ -1452,6 +1463,7 @@ dependencies = [
  "mysql_async",
  "platform-utils 0.1.0",
  "rand 0.8.6",
+ "reqwest",
  "rstest",
  "rstest_reuse",
  "serde",
@@ -1904,6 +1916,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "coins-bip32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2073678591747aed4000dd468b97b14d7007f7936851d3f2f01846899f5ebf08"
+dependencies = [
+ "bs58",
+ "coins-core",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+ "k256",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b169b26623ff17e9db37a539fe4f15342080df39f129ef7631df7683d6d9d4"
+dependencies = [
+ "bitvec",
+ "coins-bip32",
+ "hmac 0.12.1",
+ "once_cell",
+ "pbkdf2",
+ "rand 0.8.6",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b962ad8545e43a28e14e87377812ba9ae748dd4fd963f4c10e9fcc6d13475b"
+dependencies = [
+ "base64 0.21.7",
+ "bech32 0.9.1",
+ "bs58",
+ "const-hex",
+ "digest 0.10.7",
+ "generic-array",
+ "ripemd",
+ "serde",
+ "sha2 0.10.9",
+ "sha3 0.10.9",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3900,6 +3963,15 @@ dependencies = [
 
 [[package]]
 name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
@@ -4030,7 +4102,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ffe63f56b10d214be1ade8698ee80af82d981237cae3e581e7a631f5f4959f3"
 dependencies = [
- "bech32",
+ "bech32 0.11.1",
  "bitcoin",
  "dnssec-prover",
  "hashbrown 0.13.2",
@@ -4046,7 +4118,7 @@ version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
 dependencies = [
- "bech32",
+ "bech32 0.11.1",
  "bitcoin",
  "lightning-types 0.2.0",
 ]
@@ -4057,7 +4129,7 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b85e5e14bcdb30d746e9785b04f27938292e8944f78f26517e01e91691f6b3f2"
 dependencies = [
- "bech32",
+ "bech32 0.11.1",
  "bitcoin",
  "lightning-types 0.3.1",
 ]
@@ -4398,7 +4470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62a97d745f1bd8d5e05a978632bbb87b0614567d5142906fe7c86fb2440faac6"
 dependencies = [
  "base64 0.22.1",
- "bech32",
+ "bech32 0.11.1",
  "bip39",
  "bitcoin_hashes",
  "cbc",
@@ -6361,12 +6433,22 @@ dependencies = [
 
 [[package]]
 name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.2",
- "keccak",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -6637,7 +6719,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581bac52c5aa0a0aede9c7e639fe8d3b09d75cae57a036018ee5f5c3e0647669"
 dependencies = [
- "bech32",
+ "bech32 0.11.1",
  "prost",
  "prost-build",
  "prost-types",

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ breez-itest-mainnet:
 	cargo xtask test --package breez-sdk-itest --test mainnet_token_conversion -- --test-threads=1
 	cargo xtask test --package breez-sdk-itest --test mainnet_stable_balance -- --test-threads=1
 	cargo xtask test --package breez-sdk-itest --test mainnet_server_mode_conversion -- --test-threads=1
+	cargo xtask test --package breez-sdk-itest --test mainnet_cross_chain -- --test-threads=1
 
 # Mainnet teardown: drains the deterministic Bob wallet back to the test account,
 # converting tokens to sats. Run last (e.g. as an always() CI step) so funds are

--- a/crates/breez-sdk/breez-itest/Cargo.toml
+++ b/crates/breez-sdk/breez-itest/Cargo.toml
@@ -51,3 +51,11 @@ uuid.workspace = true
 futures.workspace = true
 axum = "0.7"
 bech32.workspace = true
+
+# EVM tooling for the mainnet cross-chain send itests: derive the deterministic
+# recipient from the test mnemonic (alloy-signer-local `mnemonic` feature) and
+# read ERC-20 balances over JSON-RPC (reqwest). The alloy crates are already in
+# the workspace lock via boltz-client; the `mnemonic` feature adds coins-bip39.
+alloy-signer-local = { version = "1.8.3", features = ["mnemonic"] }
+alloy-primitives = "1.6.0"
+reqwest.workspace = true

--- a/crates/breez-sdk/breez-itest/src/helpers/cross_chain_evm.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers/cross_chain_evm.rs
@@ -1,0 +1,183 @@
+//! EVM-side helpers for the mainnet cross-chain send itests: derive the
+//! deterministic recipient from the test mnemonic, and read ERC-20 balances over
+//! JSON-RPC so a cross-chain send can be verified independently of the SDK's own
+//! status reporting.
+//!
+//! The recipient is derived at the standard Ethereum path `m/44'/60'/0'/0/0` with
+//! an empty BIP-39 passphrase, from the same mnemonic the test account ("Alice")
+//! uses. Importing that mnemonic into any EVM wallet at the default path
+//! reproduces this address and its private key, so funds delivered here are
+//! recoverable (no automated sweep: the SDK has no Spark-inbound path from EVM).
+
+use std::time::{Duration, Instant};
+
+use alloy_primitives::{Address, U256};
+use alloy_signer_local::{MnemonicBuilder, PrivateKeySigner, coins_bip39::English};
+use anyhow::{Result, anyhow, bail};
+use serde_json::json;
+use tracing::{debug, info};
+
+/// Standard Ethereum BIP-44 derivation path (first account, first address). The
+/// same address every mainstream EVM wallet shows for a freshly imported seed.
+const EVM_DERIVATION_PATH: &str = "m/44'/60'/0'/0/0";
+
+/// ERC-20 `balanceOf(address)` selector: first 4 bytes of `keccak256` of the
+/// signature.
+const ERC20_BALANCE_OF_SELECTOR: [u8; 4] = [0x70, 0xa0, 0x82, 0x31];
+
+/// Poll interval while waiting on an external-chain balance to change. Kept
+/// gentle so public RPC endpoints don't rate-limit during the long settlement
+/// window.
+const EVM_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Shared HTTP client, built once. `wait_for_evm_balance_increase` reads the
+/// balance every few seconds over a multi-minute window, so a fresh client (and
+/// its connection pool / TLS setup) per call would be wasteful.
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+/// Derive the deterministic EVM recipient (checksummed address string + signer)
+/// from the mainnet test mnemonic. See the module docs for the path / recovery.
+///
+/// The signer is returned alongside the address so a future recovery step (or the
+/// deferred cross-chain receive tests) can sign outbound transfers without
+/// re-deriving.
+pub fn mainnet_evm_recipient(mnemonic: &str) -> Result<(String, PrivateKeySigner)> {
+    let signer = MnemonicBuilder::<English>::default()
+        .phrase(mnemonic)
+        .derivation_path(EVM_DERIVATION_PATH)?
+        .build()?;
+    Ok((signer.address().to_string(), signer))
+}
+
+/// Map a route `chain` string to a public JSON-RPC URL. The primary target is
+/// Arbitrum One. Returns `None` for chains we have no endpoint for, so callers
+/// skip rather than fail. A single `balanceOf` read per test is well within
+/// public-endpoint limits, so there's no override knob.
+pub fn evm_rpc_url(chain: &str) -> Option<String> {
+    let url = match chain.to_lowercase().as_str() {
+        "arbitrum" | "arbitrum one" | "arbitrum-one" => "https://arb1.arbitrum.io/rpc",
+        "base" => "https://mainnet.base.org",
+        "polygon" | "polygon pos" => "https://polygon-rpc.com",
+        _ => return None,
+    };
+    Some(url.to_string())
+}
+
+/// Read an ERC-20 `balanceOf(holder)` via a single `eth_call`, returning the
+/// balance in the token's base units. Stateless: no provider/contract crates,
+/// just a JSON-RPC POST.
+pub async fn evm_erc20_balance(rpc_url: &str, token_contract: &str, holder: &str) -> Result<u128> {
+    let token: Address = token_contract
+        .parse()
+        .map_err(|e| anyhow!("invalid token contract {token_contract}: {e}"))?;
+    let holder: Address = holder
+        .parse()
+        .map_err(|e| anyhow!("invalid holder address {holder}: {e}"))?;
+
+    // calldata = selector ++ 32-byte left-padded holder address
+    let mut data = Vec::with_capacity(4 + 32);
+    data.extend_from_slice(&ERC20_BALANCE_OF_SELECTOR);
+    data.extend_from_slice(&[0u8; 12]);
+    data.extend_from_slice(holder.as_slice());
+
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_call",
+        "params": [
+            { "to": token.to_string(), "data": format!("0x{}", hex::encode(&data)) },
+            "latest",
+        ],
+    });
+
+    let resp: serde_json::Value = http_client()
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    if let Some(err) = resp.get("error") {
+        bail!("eth_call error from {rpc_url}: {err}");
+    }
+    let result = resp
+        .get("result")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("eth_call returned no result: {resp}"))?;
+    let value = U256::from_str_radix(result.trim_start_matches("0x"), 16)
+        .map_err(|e| anyhow!("eth_call: bad hex result {result}: {e}"))?;
+    u128::try_from(value).map_err(|_| anyhow!("ERC-20 balance exceeds u128: {value}"))
+}
+
+/// Poll `evm_erc20_balance` until the holder's balance is at least `baseline +
+/// min_delta`, or `timeout_secs` elapses. Returns the observed balance on
+/// success. Transient RPC errors are retried (not fatal) until the deadline.
+pub async fn wait_for_evm_balance_increase(
+    rpc_url: &str,
+    token_contract: &str,
+    holder: &str,
+    baseline: u128,
+    min_delta: u128,
+    timeout_secs: u64,
+) -> Result<u128> {
+    let start = Instant::now();
+    let timeout = Duration::from_secs(timeout_secs);
+    let target = baseline.saturating_add(min_delta);
+    loop {
+        match evm_erc20_balance(rpc_url, token_contract, holder).await {
+            Ok(balance) if balance >= target => return Ok(balance),
+            Ok(balance) => {
+                debug!("EVM balance {balance} (baseline {baseline}, need >= {target}); waiting...");
+            }
+            Err(e) => debug!("EVM balance read failed (retrying): {e:#}"),
+        }
+        if start.elapsed() >= timeout {
+            bail!(
+                "timeout after {timeout_secs}s waiting for {holder} balance to reach {target} \
+                 (baseline {baseline}, +{min_delta}) for token {token_contract}"
+            );
+        }
+        tokio::time::sleep(EVM_POLL_INTERVAL).await;
+    }
+}
+
+/// Log where standing test funds live so a human can recover them later (the
+/// derivation path in the module docs plus this address + balance is everything
+/// needed to import the wallet and sweep).
+pub async fn log_evm_recovery_balance(
+    rpc_url: &str,
+    token_contract: &str,
+    holder: &str,
+    asset: &str,
+) {
+    match evm_erc20_balance(rpc_url, token_contract, holder).await {
+        Ok(balance) => info!(
+            "[cross-chain-recovery] {asset} balance {balance} (base units) at {holder} \
+             (token {token_contract}); recover via m/44'/60'/0'/0/0 of the test mnemonic"
+        ),
+        Err(e) => info!("[cross-chain-recovery] could not read {asset} balance at {holder}: {e:#}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evm_recipient_matches_known_vector() {
+        // Hardhat/Anvil default mnemonic; account 0 at m/44'/60'/0'/0/0 is a
+        // widely-published vector, so this pins our derivation to the standard
+        // path without any network access.
+        let mnemonic = "test test test test test test test test test test test junk";
+        let (address, _signer) =
+            mainnet_evm_recipient(mnemonic).expect("derivation should succeed");
+        assert_eq!(
+            address.to_lowercase(),
+            "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+        );
+    }
+}

--- a/crates/breez-sdk/breez-itest/src/helpers/mainnet.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers/mainnet.rs
@@ -65,12 +65,16 @@ pub async fn build_mainnet_sdk_from_mnemonic(
     api_key: String,
     temp_dir: Option<TempDir>,
     stable_balance_config: Option<StableBalanceConfig>,
+    cross_chain_config: Option<CrossChainConfig>,
 ) -> Result<SdkInstance> {
     let mut config = default_config(Network::Mainnet);
     config.api_key = Some(api_key);
     config.prefer_spark_over_lightning = true;
     config.sync_interval_secs = 5;
     config.stable_balance_config = stable_balance_config;
+    // Required for the cross-chain providers (Orchestra/Boltz) to register;
+    // without it the registry is empty and `get_cross_chain_routes` returns none.
+    config.cross_chain_config = cross_chain_config;
 
     let seed = Seed::Mnemonic {
         mnemonic,
@@ -142,6 +146,7 @@ pub async fn mainnet_alice_bob(
         api_key.to_string(),
         Some(alice_dir),
         None,
+        None,
     )
     .await?;
 
@@ -157,6 +162,7 @@ pub async fn mainnet_alice_bob(
         api_key.to_string(),
         Some(bob_dir),
         bob_stable,
+        None,
     )
     .await?;
 
@@ -434,6 +440,55 @@ pub async fn mainnet_test_setup(
     Ok(Some((alice, bob, token_id, snapshot)))
 }
 
+/// Cross-chain test preamble: gate on credentials, then build a **funded** Alice
+/// with `cross_chain_config` enabled (required for the Orchestra/Boltz providers
+/// to register; without it `get_cross_chain_routes` is empty and the tests would
+/// skip). Returns `None` to skip (logged) when creds are absent or Alice has 0
+/// sats; otherwise `(alice, token_id, mnemonic)`.
+///
+/// Only Alice is built — the cross-chain flow is entirely Alice → external
+/// chain, so there's no second Spark wallet. The mnemonic is returned so the
+/// caller can derive the deterministic EVM recipient
+/// ([`crate::mainnet_evm_recipient`]) from the same seed.
+pub async fn mainnet_cross_chain_setup() -> Result<Option<(SdkInstance, String, String)>> {
+    let Some((mnemonic, api_key)) = mainnet_test_creds() else {
+        warn!(
+            "Skipping mainnet cross-chain test: set MAINNET_TEST_MNEMONIC and BREEZ_API_KEY to run it"
+        );
+        return Ok(None);
+    };
+
+    let alice_dir = tempfile::Builder::new()
+        .prefix("breez-sdk-mainnet-cc-alice")
+        .tempdir()?;
+    let alice_path = alice_dir.path().to_string_lossy().to_string();
+    info!("Initializing mainnet cross-chain Alice (cross_chain_config enabled) at: {alice_path}");
+    let alice = build_mainnet_sdk_from_mnemonic(
+        alice_path,
+        mnemonic.clone(),
+        None,
+        api_key.clone(),
+        Some(alice_dir),
+        None,
+        Some(CrossChainConfig::default()),
+    )
+    .await?;
+
+    let alice_sats = alice
+        .sdk
+        .get_info(GetInfoRequest {
+            ensure_synced: Some(false),
+        })
+        .await?
+        .balance_sats;
+    if alice_sats == 0 {
+        warn!("Skipping mainnet cross-chain test: test account (Alice) has 0 sats");
+        return Ok(None);
+    }
+
+    Ok(Some((alice, mainnet_test_token_id(), mnemonic)))
+}
+
 /// Format a signed token base-unit amount with the token's `decimals` and
 /// `ticker`, e.g. `+0.999342 USDB` or `-2.890307 USDB`. Falls back to raw base
 /// units when `decimals == 0`.
@@ -506,22 +561,25 @@ pub async fn log_test_diff(
     Ok(())
 }
 
-/// Ensures Bob holds at least `min_required` units of `token_id`. If he
-/// doesn't, runs a Bitcoin→Token conversion from Alice for `seed_amount` to
-/// top him up.
+/// Ensures `recipient` holds at least `min_required` units of `token_id`,
+/// topping up `topup_amount` via a `FromBitcoin` conversion funded by `funder`
+/// (the wallet that pays the sats) if it falls short. `funder` and `recipient`
+/// may be the same wallet for a self top-up (e.g. Alice funding her own token
+/// balance for the cross-chain tests). `recipient_label` is used only in logs.
 ///
-/// Returns `Ok(true)` when Bob has enough tokens (already, or freshly seeded).
-/// Returns `Ok(false)` when seeding was required but Alice's sat balance can't
-/// cover the conversion — callers should skip the test.
-pub async fn ensure_bob_has_tokens(
-    alice: &SdkInstance,
-    bob: &SdkInstance,
+/// Returns `Ok(true)` when the recipient has enough tokens (already, or freshly
+/// topped up). Returns `Ok(false)` when a top-up was required but the funder's
+/// sat balance can't cover the conversion — callers should skip the test.
+pub async fn ensure_wallet_has_tokens(
+    funder: &SdkInstance,
+    recipient: &SdkInstance,
+    recipient_label: &str,
     token_id: &str,
     min_required: u128,
-    seed_amount: u128,
+    topup_amount: u128,
 ) -> Result<bool> {
-    bob.sdk.sync_wallet(SyncWalletRequest {}).await?;
-    let bob_tokens_before = bob
+    recipient.sdk.sync_wallet(SyncWalletRequest {}).await?;
+    let before = recipient
         .sdk
         .get_info(GetInfoRequest {
             ensure_synced: Some(false),
@@ -531,25 +589,27 @@ pub async fn ensure_bob_has_tokens(
         .get(token_id)
         .map(|b| b.balance)
         .unwrap_or(0);
-    info!("Bob token balance: {bob_tokens_before}");
+    info!("{recipient_label} token balance: {before}");
 
-    if bob_tokens_before >= min_required {
+    if before >= min_required {
         return Ok(true);
     }
 
-    info!("Seeding Bob with {seed_amount} units of {token_id} via Bitcoin→Token");
-    let bob_spark = bob
+    info!("Topping up {recipient_label} with {topup_amount} units of {token_id} via Bitcoin→Token");
+    let recipient_spark = recipient
         .sdk
         .receive_payment(ReceivePaymentRequest {
             payment_method: ReceivePaymentMethod::SparkAddress,
         })
         .await?
         .payment_request;
-    let seed_prepare = alice
+    let topup_prepare = funder
         .sdk
         .prepare_send_payment(PrepareSendPaymentRequest {
-            payment_request: PaymentRequest::Input { input: bob_spark },
-            amount: Some(seed_amount),
+            payment_request: PaymentRequest::Input {
+                input: recipient_spark,
+            },
+            amount: Some(topup_amount),
             token_identifier: Some(token_id.to_string()),
             conversion_options: Some(ConversionOptions {
                 conversion_type: ConversionType::FromBitcoin,
@@ -559,32 +619,35 @@ pub async fn ensure_bob_has_tokens(
             fee_policy: None,
         })
         .await?;
-    let estimate = seed_prepare
+    let estimate = topup_prepare
         .conversion_estimate
         .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("seed conversion estimate missing"))?;
-    let seed_cost = estimate.amount_in.saturating_add(estimate.fee);
+        .ok_or_else(|| anyhow::anyhow!("top-up conversion estimate missing"))?;
+    let topup_cost = estimate.amount_in.saturating_add(estimate.fee);
 
-    let alice_balance = alice
+    let funder_balance = funder
         .sdk
         .get_info(GetInfoRequest {
             ensure_synced: Some(false),
         })
         .await?
         .balance_sats;
-    if u128::from(alice_balance) < seed_cost {
-        warn!("Cannot seed Bob: Alice balance {alice_balance} sats < seed cost ~{seed_cost} sats");
+    if u128::from(funder_balance) < topup_cost {
+        warn!(
+            "Cannot top up {recipient_label}: funder balance {funder_balance} sats \
+             < top-up cost ~{topup_cost} sats"
+        );
         return Ok(false);
     }
 
-    alice
+    funder
         .sdk
         .send_payment(SendPaymentRequest {
-            prepare_response: seed_prepare,
+            prepare_response: topup_prepare,
             options: None,
             idempotency_key: None,
         })
         .await?;
-    wait_for_token_balance_increase(&bob.sdk, token_id, bob_tokens_before, 120).await?;
+    wait_for_token_balance_increase(&recipient.sdk, token_id, before, 120).await?;
     Ok(true)
 }

--- a/crates/breez-sdk/breez-itest/src/helpers/mod.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers/mod.rs
@@ -14,8 +14,10 @@ use rand::RngCore;
 use tokio::sync::mpsc;
 use tracing::{debug, info};
 
+pub mod cross_chain_evm;
 pub mod mainnet;
 pub mod regtest;
+pub use cross_chain_evm::*;
 pub use mainnet::*;
 pub use regtest::*;
 

--- a/crates/breez-sdk/breez-itest/tests/mainnet_cross_chain.rs
+++ b/crates/breez-sdk/breez-itest/tests/mainnet_cross_chain.rs
@@ -1,0 +1,629 @@
+//! Mainnet cross-chain send itests (env-gated).
+//!
+//! Performs a real cross-chain send from the funded test account ("Alice") to a
+//! **deterministic EVM address derived from the test mnemonic**, then verifies
+//! receipt *independently* by reading the recipient's ERC-20 balance over
+//! JSON-RPC. This exercises the fees-excluded / target-overpay guarantee: the
+//! recipient should land at or above the requested target.
+//!
+//! Target chain is **Arbitrum One**, the only chain offering a USD-stable asset
+//! on both providers: Orchestra `USDB→USDC` (exercises the USD-stable
+//! target-overpay path) and Boltz `BTC→USDT`.
+//!
+//! Funds are **not** swept back (the SDK has no Spark-inbound path from EVM).
+//! They accumulate at the deterministic recipient, recoverable by importing the
+//! mnemonic at `m/44'/60'/0'/0/0`; each run logs the address + balance. Keep the
+//! source-amount overrides below small to bound accumulation.
+//!
+//! NOTE: the cross-chain `amount` is denominated in the **source** asset, not the
+//! destination: USDB base units for the Orchestra case, **sats** for the Boltz
+//! (BTC source) case. The two are sized via separate env vars accordingly.
+//!
+//! # Required environment variables
+//! - `MAINNET_TEST_MNEMONIC` — mnemonic of the funded test account. Primary gate.
+//! - `BREEZ_API_KEY` — API key the mainnet SDK requires.
+//!
+//! # Optional
+//! - `MAINNET_TEST_TOKEN_ID` — USD-stable source token; defaults to USDB.
+//! - `MAINNET_TEST_CROSS_CHAIN_USDB` — Orchestra source in USDB base units
+//!   (6-decimals); defaults to 1_000_000 (= 1.00 USDB, ~1.00 USDC delivered).
+//! - `MAINNET_TEST_CROSS_CHAIN_SATS` — Boltz source in **sats** (BTC source);
+//!   defaults to 1_600. The recipient lands the fiat-equivalent in USDT.
+//!
+//! # Run locally
+//! ```bash
+//! MAINNET_TEST_MNEMONIC="..." BREEZ_API_KEY="..." \
+//!   cargo test -p breez-sdk-itest --test mainnet_cross_chain -- --test-threads=1 --nocapture
+//! ```
+
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use breez_sdk_itest::*;
+use breez_sdk_spark::*;
+use tracing::{debug, info, warn};
+
+/// Destination chain for both tests: Arbitrum One. Matched on `chain_id` (the
+/// decimal EVM chainId), since providers spell the chain *name* differently
+/// (Orchestra reports `"arbitrum"`, Boltz reports `"Arbitrum One"`); `chain_id`
+/// is the stable cross-provider key.
+const TARGET_CHAIN_ID: &str = "42161";
+
+/// Whether a route's destination is Arbitrum One. Prefers `chain_id`; falls back
+/// to the normalized chain name for the (documented) case where a provider
+/// doesn't surface a chainId. The name set is exact (not a prefix) so sibling
+/// chains like "Arbitrum Nova" (chainId 42170) don't match.
+fn is_target_chain(route: &CrossChainRoutePair) -> bool {
+    if route.chain_id.as_deref() == Some(TARGET_CHAIN_ID) {
+        return true;
+    }
+    matches!(
+        route.chain.to_lowercase().replace(['-', '_'], " ").trim(),
+        "arbitrum" | "arbitrum one"
+    )
+}
+
+// IMPORTANT: the cross-chain `amount` is in the **source** asset's units, not the
+// destination's. For the Orchestra (USDB token) case that's USDB base units; for
+// the Boltz (BTC) case that's **sats**. They are sized and asserted separately.
+
+/// Orchestra source budget in USDB base units (6-decimals), so 1_000_000 = 1.00
+/// USDB. USDB↔USDC are ~1:1, so this also approximates the USDC the recipient
+/// lands. Override via `MAINNET_TEST_CROSS_CHAIN_USDB`. A too-small value (below
+/// the route minimum) makes `prepare` error (loudly).
+const DEFAULT_ORCHESTRA_SOURCE_USDB: u128 = 1_000_000;
+
+/// Boltz source budget in **sats** (BTC source). Override via
+/// `MAINNET_TEST_CROSS_CHAIN_SATS`. Note this is sats, NOT a USD amount: the
+/// recipient lands the fiat-equivalent in USDT. A value below the route minimum
+/// makes `prepare` error (loudly).
+const DEFAULT_BOLTZ_SOURCE_SATS: u128 = 1_600;
+
+/// Tolerance (bps) allowed between the SDK-reported `delivered_amount` and the
+/// balance actually observed on-chain, to absorb rounding / settlement timing.
+const ONCHAIN_TOLERANCE_BPS: u128 = 100;
+
+/// How far below the *requested* amount a successful delivery may legitimately
+/// land, in bps. The SDK tolerates up to its default slippage (~100 bps) between
+/// quote and execution, while the fees-excluded overpay pad is only ~15 bps, so
+/// a fully successful send can land somewhat under target. Sized above the SDK
+/// slippage default with headroom for bridge/rounding dust, so a real success
+/// isn't flagged as a shortfall.
+const SLIPPAGE_TOLERANCE_BPS: u128 = 150;
+
+/// Settlement timeout for both the SDK status poll and the on-chain balance
+/// poll. Cross-chain bridging (CCTP / LayerZero) adds minutes of latency.
+const SETTLE_TIMEOUT_SECS: u64 = 600;
+
+/// Poll interval while waiting on the SDK's conversion status to go terminal.
+const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+fn env_amount_or(var: &str, default: u128) -> u128 {
+    std::env::var(var)
+        .ok()
+        .and_then(|s| s.trim().parse::<u128>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(default)
+}
+
+/// `amount` reduced by `bps` basis points (floored), e.g. a lower bound that
+/// allows for slippage. Saturating, so it never underflows.
+fn reduce_by_bps(amount: u128, bps: u128) -> u128 {
+    amount.saturating_sub(amount.saturating_mul(bps) / 10_000)
+}
+
+/// Alice's `(sats, token)` balances, for the per-test cost breadcrumb. Syncs
+/// first so the read reflects the latest state.
+async fn alice_balances(alice: &SdkInstance, token_id: &str) -> Result<(u64, u128)> {
+    alice.sdk.sync_wallet(SyncWalletRequest {}).await?;
+    let info = alice
+        .sdk
+        .get_info(GetInfoRequest {
+            ensure_synced: Some(false),
+        })
+        .await?;
+    let tokens = info
+        .token_balances
+        .get(token_id)
+        .map(|b| b.balance)
+        .unwrap_or(0);
+    Ok((info.balance_sats, tokens))
+}
+
+/// Log Alice's net sats/token movement over a test — the cross-chain flow is
+/// Alice → external chain, so her drain (plus any setup conversion) is the cost.
+fn log_cost(label: &str, token_id: &str, pre: (u64, u128), post: (u64, u128)) {
+    let sats_delta = i128::from(post.0) - i128::from(pre.0);
+    let token_delta =
+        i128::try_from(post.1).unwrap_or(i128::MAX) - i128::try_from(pre.1).unwrap_or(i128::MAX);
+    info!("[cross-chain-cost] {label}: alice sats Δ {sats_delta}, {token_id} Δ {token_delta}");
+}
+
+/// Orchestra: USD-stable token (USDB) → USDC on Arbitrum, fees-excluded. This is
+/// the case that exercises target-overpay (USD-stable source→destination).
+#[test_log::test(tokio::test)]
+async fn test_cross_chain_orchestra_fees_excluded_evm() -> Result<()> {
+    let Some((mut alice, token_id, mnemonic)) = mainnet_cross_chain_setup().await? else {
+        return Ok(());
+    };
+    info!("=== Starting test_cross_chain_orchestra_fees_excluded_evm ===");
+    let pre = alice_balances(&alice, &token_id).await?;
+
+    // Source budget in USDB base units (USD-stable, ~1:1 with the USDC delivered).
+    let usdb_amount = env_amount_or(
+        "MAINNET_TEST_CROSS_CHAIN_USDB",
+        DEFAULT_ORCHESTRA_SOURCE_USDB,
+    );
+
+    // Alice needs USDB to spend; ensure she holds ~1.3x the source amount (to
+    // cover the send plus fees with a little headroom), topping up from her own
+    // sats if short.
+    let required_usdb = usdb_amount.saturating_mul(13) / 10;
+    if !ensure_wallet_has_tokens(
+        &alice,
+        &alice,
+        "Alice",
+        &token_id,
+        required_usdb,
+        required_usdb,
+    )
+    .await?
+    {
+        warn!("Could not top up Alice with {token_id}; skipping");
+        return Ok(());
+    }
+
+    let (recipient, _signer) = mainnet_evm_recipient(&mnemonic)?;
+    // No conversion_options: Orchestra accepts USDB directly as a source, so the
+    // dispatcher uses the direct USDB-source path (no AMM hop) and applies the
+    // fees-excluded target-overpay on the stable-token source.
+    run_cross_chain_evm_send(
+        &mut alice,
+        &recipient,
+        CrossChainProvider::Orchestra,
+        "USDC",
+        Some(token_id.clone()),
+        None,
+        usdb_amount,
+        // USDB↔USDC parity: the recipient should land at least the requested USDB
+        // amount in USDC base units (the fees-excluded / overpay guarantee).
+        Some(usdb_amount),
+    )
+    .await?;
+
+    log_cost(
+        "orchestra",
+        &token_id,
+        pre,
+        alice_balances(&alice, &token_id).await?,
+    );
+    Ok(())
+}
+
+/// Boltz: BTC (Alice's sats) → USDT on Arbitrum, fees-excluded. Exercises a
+/// different asset + provider than the Orchestra case, on the same chain.
+#[test_log::test(tokio::test)]
+async fn test_cross_chain_boltz_fees_excluded_evm() -> Result<()> {
+    let Some((mut alice, token_id, mnemonic)) = mainnet_cross_chain_setup().await? else {
+        return Ok(());
+    };
+    info!("=== Starting test_cross_chain_boltz_fees_excluded_evm ===");
+    let pre = alice_balances(&alice, &token_id).await?;
+
+    // Source budget in SATS (BTC source). The recipient lands the fiat-equivalent
+    // in USDT, so there's no parity unit to assert against the sats amount.
+    let sats_amount = env_amount_or("MAINNET_TEST_CROSS_CHAIN_SATS", DEFAULT_BOLTZ_SOURCE_SATS);
+    let (recipient, _signer) = mainnet_evm_recipient(&mnemonic)?;
+    run_cross_chain_evm_send(
+        &mut alice,
+        &recipient,
+        CrossChainProvider::Boltz,
+        "USDT",
+        None, // BTC source
+        None, // no conversion: amount is sats
+        sats_amount,
+        None, // sats source has no parity with the USDT delivered
+    )
+    .await?;
+
+    log_cost(
+        "boltz",
+        &token_id,
+        pre,
+        alice_balances(&alice, &token_id).await?,
+    );
+    Ok(())
+}
+
+/// Shared flow: discover the route, baseline the recipient's on-chain balance,
+/// prepare+send fees-excluded, wait for the SDK to report `Completed`, then
+/// verify the on-chain receipt. Skips (warn + `Ok`) when no matching route
+/// exists or Alice is underfunded.
+///
+/// - `amount` is in the route's **source** units (USDB base units for a token
+///   source, sats for a BTC source).
+/// - `parity_min_out` is the minimum delivery to assert in **destination** base
+///   units, set only when the source is parity-equivalent to the destination
+///   (USDB→USDC). `None` for non-parity sources (BTC→USDT), where we instead
+///   verify the on-chain balance against the SDK's reported `delivered_amount`.
+#[allow(clippy::too_many_arguments)]
+async fn run_cross_chain_evm_send(
+    alice: &mut SdkInstance,
+    recipient: &str,
+    provider: CrossChainProvider,
+    asset: &str,
+    token_identifier: Option<String>,
+    conversion_options: Option<ConversionOptions>,
+    amount: u128,
+    parity_min_out: Option<u128>,
+) -> Result<()> {
+    // Log the destination up front (derived at m/44'/60'/0'/0/0 of the test
+    // mnemonic) so it's captured before any send — this is the address holding
+    // any funds that need manual recovery.
+    info!("Cross-chain {provider:?} {asset} send → EVM recipient {recipient} (m/44'/60'/0'/0/0)");
+
+    // 1. Discover the route for this EVM recipient, then pick provider+chain+asset.
+    let address_details = CrossChainAddressDetails {
+        address: recipient.to_string(),
+        address_family: CrossChainAddressFamily::Evm,
+        contract_address: None,
+        chain_id: None,
+        amount: None,
+    };
+    let routes = alice
+        .sdk
+        .get_cross_chain_routes(&CrossChainRouteFilter::Send { address_details })
+        .await?;
+    let Some(route) = routes.into_iter().find(|r| {
+        r.provider == provider && is_target_chain(r) && r.asset.eq_ignore_ascii_case(asset)
+    }) else {
+        warn!("No {provider:?} {asset} route on Arbitrum One; skipping");
+        return Ok(());
+    };
+    let contract = route
+        .contract_address
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("{provider:?} {asset} route has no contract address"))?;
+    let Some(rpc_url) = evm_rpc_url(&route.chain) else {
+        warn!("No JSON-RPC endpoint for chain {}; skipping", route.chain);
+        return Ok(());
+    };
+    info!(
+        "Selected route: {asset} on {} ({contract}) [{provider:?}], recipient {recipient}",
+        route.chain
+    );
+
+    // 2. Baseline the recipient's on-chain balance before sending.
+    let baseline = evm_erc20_balance(&rpc_url, &contract, recipient).await?;
+    info!("Recipient baseline {asset} balance: {baseline}");
+
+    // 3. Prepare fees-excluded with default target-overpay.
+    let prepared = alice
+        .sdk
+        .prepare_send_payment(PrepareSendPaymentRequest {
+            payment_request: PaymentRequest::CrossChain {
+                address: recipient.to_string(),
+                route,
+                max_slippage_bps: None,
+                target_overpay_bps: None,
+            },
+            amount: Some(amount),
+            token_identifier: token_identifier.clone(),
+            conversion_options,
+            fee_policy: Some(FeePolicy::FeesExcluded),
+        })
+        .await?;
+
+    // 4. Assert the fees-excluded contract.
+    let (fee_mode, estimated_out, amount_in, source_transfer_fee_sats) = match &prepared
+        .payment_method
+    {
+        SendPaymentMethod::CrossChainAddress {
+            fee_mode,
+            estimated_out,
+            amount_in,
+            asset_amount_in,
+            fee_amount,
+            service_fee_amount,
+            service_fee_asset,
+            source_transfer_fee_sats,
+            expires_at,
+            ..
+        } => {
+            info!(
+                "Cross-chain quote [{provider:?} {asset}]: amount_in={amount_in} \
+                     asset_amount_in={asset_amount_in} estimated_out={estimated_out} \
+                     fee_amount={fee_amount} service_fee={service_fee_amount} {service_fee_asset:?} \
+                     source_transfer_fee_sats={source_transfer_fee_sats} fee_mode={fee_mode:?} \
+                     expires_at={expires_at}"
+            );
+            (
+                *fee_mode,
+                *estimated_out,
+                *amount_in,
+                *source_transfer_fee_sats,
+            )
+        }
+        other => anyhow::bail!("expected CrossChainAddress payment method, got {other:?}"),
+    };
+    assert_eq!(
+        fee_mode,
+        CrossChainFeeMode::FeesExcluded,
+        "cross-chain prepare should run under FeesExcluded"
+    );
+    assert!(
+        estimated_out > 0,
+        "prepare should estimate a positive delivery"
+    );
+    // For parity sources, the prepare-time estimate (in destination units)
+    // should be ~the requested amount: the fees-excluded / overpay guarantee.
+    // Allow a slippage band below it — the SDK tolerates quote-vs-execution
+    // slippage larger than the overpay pad, so the estimate can sit slightly
+    // under target without the send being wrong.
+    if let Some(min_out) = parity_min_out {
+        let floor = reduce_by_bps(min_out, SLIPPAGE_TOLERANCE_BPS);
+        assert!(
+            estimated_out >= floor,
+            "fees-excluded estimated_out {estimated_out} should be >= {floor} \
+             (requested {min_out} less {SLIPPAGE_TOLERANCE_BPS} bps)"
+        );
+    }
+
+    // 5. Funding check (skip if Alice can't cover the source leg + transfer fee).
+    if !alice_can_cover(
+        alice,
+        token_identifier.as_deref(),
+        amount_in,
+        source_transfer_fee_sats,
+    )
+    .await?
+    {
+        warn!("Alice underfunded for the cross-chain send; skipping");
+        return Ok(());
+    }
+
+    // 6. Send.
+    let resp = alice
+        .sdk
+        .send_payment(SendPaymentRequest {
+            prepare_response: prepared,
+            options: None,
+            idempotency_key: None,
+        })
+        .await?;
+    let payment_id = resp.payment.id.clone();
+    info!("Cross-chain send dispatched: payment {payment_id}");
+
+    // 7. Wait for the SDK's background monitor to report a terminal status.
+    let delivered =
+        wait_for_cross_chain_completion(&alice.sdk, &payment_id, SETTLE_TIMEOUT_SECS).await?;
+    info!("SDK reports conversion Completed, delivered_amount = {delivered:?}");
+
+    // 8. Verify delivery (all in destination base units).
+    //
+    // `delivered_amount` (SDK-reported, per-payment) is the source of truth for
+    // "how much this send delivered"; the on-chain read is independent
+    // corroboration that those funds actually landed. Anchoring the pass
+    // criterion on `delivered_amount` (not the raw balance delta) is what keeps
+    // standing funds from prior runs at this reused address from masking a
+    // genuine shortfall — a short delivery shows up in `delivered_amount`, and
+    // stale funds can only ever help the on-chain floor be met sooner.
+    // (A fresh recipient per run would fully isolate runs, but conflicts with
+    // the deterministic-recovery design; the residual is a narrow window where
+    // the SDK over-reports AND stale funds happen to cover it.)
+    //
+    // For a parity (USD-stable) source, also assert the fees-excluded guarantee:
+    // the recipient lands ~the requested amount, within the slippage band.
+    if let (Some(target), Some(d)) = (parity_min_out, delivered) {
+        let floor = reduce_by_bps(target, SLIPPAGE_TOLERANCE_BPS);
+        assert!(
+            d >= floor,
+            "fees-excluded: delivered {d} should be >= {floor} \
+             (requested {target} less {SLIPPAGE_TOLERANCE_BPS} bps) — recipient landed short"
+        );
+    }
+
+    // Minimum increase we require to observe on-chain.
+    let onchain_floor = match (delivered, parity_min_out) {
+        // Trust the SDK's per-payment delivered amount; confirm it landed.
+        (Some(d), _) => reduce_by_bps(d, ONCHAIN_TOLERANCE_BPS),
+        // delivered unknown (terminal reached before the amount was recorded)
+        // but we have a parity target: require ~that amount, slippage-adjusted.
+        (None, Some(target)) => reduce_by_bps(target, SLIPPAGE_TOLERANCE_BPS),
+        // No SDK amount and no parity target: only confirm some funds arrived.
+        (None, None) => {
+            warn!(
+                "Conversion Completed without a delivered_amount and no parity target; \
+                 verifying only that some funds arrived on-chain"
+            );
+            1
+        }
+    };
+    let final_balance = wait_for_evm_balance_increase(
+        &rpc_url,
+        &contract,
+        recipient,
+        baseline,
+        onchain_floor,
+        SETTLE_TIMEOUT_SECS,
+    )
+    .await?;
+    let on_chain_delta = final_balance.saturating_sub(baseline);
+    info!(
+        "On-chain {asset} delta = {on_chain_delta} (required floor {onchain_floor}, \
+         SDK delivered {delivered:?})"
+    );
+
+    log_evm_recovery_balance(&rpc_url, &contract, recipient, asset).await;
+    Ok(())
+}
+
+/// Whether Alice can cover the source leg of a cross-chain send. For a token
+/// source she needs `amount_in` token base units plus the sats transfer fee; for
+/// a BTC source she needs `amount_in + source_transfer_fee_sats` sats.
+async fn alice_can_cover(
+    alice: &SdkInstance,
+    token_identifier: Option<&str>,
+    amount_in: u128,
+    source_transfer_fee_sats: u64,
+) -> Result<bool> {
+    let info = alice
+        .sdk
+        .get_info(GetInfoRequest {
+            ensure_synced: Some(false),
+        })
+        .await?;
+    match token_identifier {
+        Some(tid) => {
+            let token_balance = info.token_balances.get(tid).map(|b| b.balance).unwrap_or(0);
+            let ok = token_balance >= amount_in
+                && u128::from(info.balance_sats) >= u128::from(source_transfer_fee_sats);
+            if !ok {
+                warn!(
+                    "Funding check: have {token_balance} {tid} + {} sats; \
+                     need {amount_in} {tid} + {source_transfer_fee_sats} sats",
+                    info.balance_sats
+                );
+            }
+            Ok(ok)
+        }
+        None => {
+            let need = amount_in.saturating_add(u128::from(source_transfer_fee_sats));
+            let ok = u128::from(info.balance_sats) >= need;
+            if !ok {
+                warn!(
+                    "Funding check: have {} sats; need {need} sats \
+                     (amount_in {amount_in} + transfer fee {source_transfer_fee_sats})",
+                    info.balance_sats
+                );
+            }
+            Ok(ok)
+        }
+    }
+}
+
+/// Short description of a conversion's provider handles, for correlating a run
+/// with the provider dashboard / chain explorer when debugging.
+fn describe_conversion(info: &ConversionInfo) -> String {
+    match info {
+        ConversionInfo::Orchestra {
+            order_id,
+            quote_id,
+            chain,
+            asset,
+            recipient_address,
+            ..
+        } => format!(
+            "Orchestra order_id={order_id} quote_id={quote_id} chain={chain} \
+             asset={asset} recipient={recipient_address}"
+        ),
+        ConversionInfo::Boltz {
+            swap_id,
+            chain,
+            asset,
+            bridge_ref,
+            recipient_address,
+            ..
+        } => format!(
+            "Boltz swap_id={swap_id} chain={chain} asset={asset} \
+             bridge_ref={bridge_ref:?} recipient={recipient_address}"
+        ),
+        ConversionInfo::Amm { conversion_id, .. } => {
+            format!("AMM conversion_id={conversion_id} (unexpected for a cross-chain send)")
+        }
+    }
+}
+
+/// Poll the payment until its cross-chain `ConversionInfo` reaches a terminal
+/// state. Returns `delivered_amount` on `Completed`; errors on a failed/refunded
+/// outcome or timeout. Logs the provider handles once and every status change,
+/// so a debugging run has a trail to correlate against the provider/explorer.
+async fn wait_for_cross_chain_completion(
+    sdk: &BreezSdk,
+    payment_id: &str,
+    timeout_secs: u64,
+) -> Result<Option<u128>> {
+    let start = Instant::now();
+    let mut handles_logged = false;
+    let mut last_status: Option<String> = None;
+    loop {
+        let payment = sdk
+            .get_payment(GetPaymentRequest {
+                payment_id: payment_id.to_string(),
+            })
+            .await?
+            .payment;
+
+        let conversion_info = payment.details.as_ref().and_then(|d| match d {
+            PaymentDetails::Spark {
+                conversion_info, ..
+            }
+            | PaymentDetails::Token {
+                conversion_info, ..
+            }
+            | PaymentDetails::Lightning {
+                conversion_info, ..
+            } => conversion_info.as_ref(),
+            _ => None,
+        });
+
+        if let Some(info) = conversion_info {
+            if !handles_logged {
+                info!("Cross-chain conversion: {}", describe_conversion(info));
+                handles_logged = true;
+            }
+            let (status, delivered) = match info {
+                ConversionInfo::Orchestra {
+                    status,
+                    delivered_amount,
+                    ..
+                }
+                | ConversionInfo::Boltz {
+                    status,
+                    delivered_amount,
+                    ..
+                } => (status, *delivered_amount),
+                // A cross-chain send should carry an Orchestra/Boltz conversion,
+                // never a plain AMM one. Fail fast rather than spin to timeout.
+                ConversionInfo::Amm { status, .. } => anyhow::bail!(
+                    "cross-chain payment {payment_id} has an unexpected AMM conversion_info \
+                     (status {status:?})"
+                ),
+            };
+            let status_str = format!("{status:?}");
+            if last_status.as_deref() != Some(status_str.as_str()) {
+                info!(
+                    "Cross-chain status: {status_str} (delivered_amount={delivered:?}, \
+                     elapsed {}s)",
+                    start.elapsed().as_secs()
+                );
+                last_status = Some(status_str);
+            }
+            match status {
+                ConversionStatus::Completed => return Ok(delivered),
+                ConversionStatus::Failed
+                | ConversionStatus::Refunded
+                | ConversionStatus::RefundNeeded => {
+                    anyhow::bail!("cross-chain conversion for {payment_id} ended in {status:?}")
+                }
+                ConversionStatus::Pending => {}
+            }
+        } else {
+            debug!(
+                "payment {payment_id} has no conversion_info yet (status {:?})",
+                payment.status
+            );
+        }
+
+        if start.elapsed() >= Duration::from_secs(timeout_secs) {
+            anyhow::bail!(
+                "timeout after {timeout_secs}s waiting for cross-chain completion on \
+                 {payment_id} (last status {last_status:?})"
+            );
+        }
+        // The status update arrives via the background monitor; nudge a sync so
+        // the locally-read payment reflects it promptly.
+        let _ = sdk.sync_wallet(SyncWalletRequest {}).await;
+        tokio::time::sleep(STATUS_POLL_INTERVAL).await;
+    }
+}

--- a/crates/breez-sdk/breez-itest/tests/mainnet_stable_balance.rs
+++ b/crates/breez-sdk/breez-itest/tests/mainnet_stable_balance.rs
@@ -566,8 +566,17 @@ async fn test_stable_balance_send_lightning_address() -> Result<()> {
     // Step 2: ensure Bob has enough tokens for the auto-fill to source from.
     let to_btc_min_token = tobtc_min_token_input(&alice.sdk, &token_id).await?;
     let min_required_tokens = to_btc_min_token.saturating_mul(2);
-    let seed_amount = to_btc_min_token.saturating_mul(3);
-    if !ensure_bob_has_tokens(&alice, &bob, &token_id, min_required_tokens, seed_amount).await? {
+    let topup_amount = to_btc_min_token.saturating_mul(3);
+    if !ensure_wallet_has_tokens(
+        &alice,
+        &bob,
+        "Bob",
+        &token_id,
+        min_required_tokens,
+        topup_amount,
+    )
+    .await?
+    {
         return Ok(());
     }
 


### PR DESCRIPTION
Adds env-gated mainnet integration tests for cross-chain sends, covering both providers to an external EVM chain (Arbitrum One) with independent on-chain verification.

### What's tested
- **Orchestra** — USDB → USDC, fees-excluded (exercises the target-overpay path).
- **Boltz** — BTC → USDT, fees-excluded.

Each test discovers a route, sends to a deterministic EVM address derived from the test mnemonic, waits for the SDK to report `Completed`, then independently confirms the recipient's on-chain ERC-20 balance rose to match the SDK's reported `delivered_amount` (slippage-tolerant).

### Running
Gated on `MAINNET_TEST_MNEMONIC` + `BREEZ_API_KEY` — skips cleanly (no-op) without them, so normal CI is unaffected. Run via `make breez-itest-mainnet` or the `mainnet_cross_chain` workflow job. Source amounts default to ~$1 and are env-overridable.

### Notes
- New `cross_chain_evm` test helper: mnemonic → EVM address derivation (`m/44'/60'/0'/0/0`) + ERC-20 `balanceOf` reads over JSON-RPC. No new heavy deps (uses `alloy` already in-tree + `reqwest`).
- Test wallet (Alice) is built with `cross_chain_config` enabled so the providers register.
- Funds delivered to the recipient are **not** auto-swept (the SDK has no Spark-inbound path from EVM); they're recoverable by importing the test mnemonic at `m/44'/60'/0'/0/0`. Each run logs the address + balance.
