### PR TITLE
Cross-chain: Orchestra receive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,7 +1447,11 @@ dependencies = [
 name = "breez-sdk-itest"
 version = "0.1.0"
 dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
+ "alloy-rlp",
+ "alloy-signer",
  "alloy-signer-local",
  "anyhow",
  "async-trait",

--- a/crates/breez-sdk/breez-itest/Cargo.toml
+++ b/crates/breez-sdk/breez-itest/Cargo.toml
@@ -62,10 +62,16 @@ futures.workspace = true
 axum = "0.7"
 bech32.workspace = true
 
-# EVM tooling for the mainnet cross-chain send itests: derive the deterministic
-# recipient from the test mnemonic (alloy-signer-local `mnemonic` feature) and
-# read ERC-20 balances over JSON-RPC (reqwest). The alloy crates are already in
-# the workspace lock via boltz-client; the `mnemonic` feature adds coins-bip39.
+# EVM tooling for the mainnet cross-chain itests: derive the deterministic
+# recipient from the test mnemonic (alloy-signer-local `mnemonic` feature),
+# read ERC-20 balances over JSON-RPC (reqwest), and sign+broadcast raw EIP-1559
+# transactions for the receive-side sweep (alloy-consensus + alloy-eips +
+# alloy-signer + alloy-rlp). The alloy crates are already in the workspace lock
+# via boltz-client.
 alloy-signer-local = { version = "1.8.3", features = ["mnemonic"] }
+alloy-signer = "1.8.3"
+alloy-consensus = "1.8.3"
+alloy-eips = "1.8.3"
 alloy-primitives = "1.6.0"
+alloy-rlp = "0.3.15"
 reqwest.workspace = true

--- a/crates/breez-sdk/breez-itest/src/helpers/cross_chain_evm.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers/cross_chain_evm.rs
@@ -1,17 +1,24 @@
-//! EVM-side helpers for the mainnet cross-chain send itests: derive the
-//! deterministic recipient from the test mnemonic, and read ERC-20 balances over
-//! JSON-RPC so a cross-chain send can be verified independently of the SDK's own
-//! status reporting.
+//! EVM-side helpers for the mainnet cross-chain itests. Two roles:
 //!
-//! The recipient is derived at the standard Ethereum path `m/44'/60'/0'/0/0` with
-//! an empty BIP-39 passphrase, from the same mnemonic the test account ("Alice")
-//! uses. Importing that mnemonic into any EVM wallet at the default path
-//! reproduces this address and its private key, so funds delivered here are
-//! recoverable (no automated sweep: the SDK has no Spark-inbound path from EVM).
+//! - **Send verification**: derive the deterministic recipient from the test
+//!   mnemonic and read ERC-20 balances via JSON-RPC to confirm a cross-chain
+//!   send actually landed, independent of the SDK's own status reporting.
+//! - **Receive broadcast**: sign and submit an EIP-1559 ERC-20 transfer from
+//!   the same deterministic key into the deposit address returned by the SDK's
+//!   cross-chain receive flow, then wait for the transaction receipt.
+//!
+//! The recipient is derived at the standard Ethereum path `m/44'/60'/0'/0/0`
+//! with an empty BIP-39 passphrase, from the same mnemonic the test account
+//! ("Alice") uses. Importing that mnemonic into any EVM wallet at the default
+//! path reproduces this address and its private key, so any funds accumulated
+//! there are recoverable off-band.
 
 use std::time::{Duration, Instant};
 
-use alloy_primitives::{Address, U256};
+use alloy_consensus::{SignableTransaction, TxEip1559, TxEnvelope};
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_signer::SignerSync;
 use alloy_signer_local::{MnemonicBuilder, PrivateKeySigner, coins_bip39::English};
 use anyhow::{Result, anyhow, bail};
 use serde_json::json;
@@ -25,9 +32,11 @@ const EVM_DERIVATION_PATH: &str = "m/44'/60'/0'/0/0";
 /// signature.
 const ERC20_BALANCE_OF_SELECTOR: [u8; 4] = [0x70, 0xa0, 0x82, 0x31];
 
-/// Poll interval while waiting on an external-chain balance to change. Kept
-/// gentle so public RPC endpoints don't rate-limit during the long settlement
-/// window.
+/// ERC-20 `transfer(address,uint256)` selector.
+const ERC20_TRANSFER_SELECTOR: [u8; 4] = [0xa9, 0x05, 0x9c, 0xbb];
+
+/// Poll interval for external-chain reads (balance change, tx receipt). Kept
+/// gentle so public RPC endpoints don't rate-limit during long waits.
 const EVM_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Shared HTTP client, built once. `wait_for_evm_balance_increase` reads the
@@ -43,9 +52,8 @@ fn http_client() -> &'static reqwest::Client {
 /// Derive the deterministic EVM recipient (checksummed address string + signer)
 /// from the mainnet test mnemonic. See the module docs for the path / recovery.
 ///
-/// The signer is returned alongside the address so a future recovery step (or the
-/// deferred cross-chain receive tests) can sign outbound transfers without
-/// re-deriving.
+/// The signer is returned alongside the address so the receive tests can sign
+/// outbound ERC-20 transfers with the same key that owns the deposit.
 pub fn mainnet_evm_recipient(mnemonic: &str) -> Result<(String, PrivateKeySigner)> {
     let signer = MnemonicBuilder::<English>::default()
         .phrase(mnemonic)
@@ -145,6 +153,209 @@ pub async fn wait_for_evm_balance_increase(
         }
         tokio::time::sleep(EVM_POLL_INTERVAL).await;
     }
+}
+
+/// Read the holder's native-token (ETH) balance in wei.
+pub async fn evm_native_balance(rpc_url: &str, holder: &str) -> Result<u128> {
+    let holder: Address = holder
+        .parse()
+        .map_err(|e| anyhow!("invalid holder address {holder}: {e}"))?;
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_getBalance",
+        "params": [holder.to_string(), "latest"],
+    });
+    let resp: serde_json::Value = http_client()
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+    if let Some(err) = resp.get("error") {
+        bail!("eth_getBalance error from {rpc_url}: {err}");
+    }
+    let result = resp
+        .get("result")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("eth_getBalance returned no result: {resp}"))?;
+    let value = U256::from_str_radix(result.trim_start_matches("0x"), 16)
+        .map_err(|e| anyhow!("eth_getBalance: bad hex result {result}: {e}"))?;
+    u128::try_from(value).map_err(|_| anyhow!("native balance exceeds u128: {value}"))
+}
+
+/// Sign and broadcast an ERC-20 `transfer(to, amount)` as an EIP-1559 tx.
+/// Fetches chain id / nonce / gas price / gas estimate via JSON-RPC, signs
+/// with the caller-supplied key, and submits via `eth_sendRawTransaction`.
+/// Returns the transaction hash.
+pub async fn evm_send_erc20(
+    rpc_url: &str,
+    signer: &PrivateKeySigner,
+    token_contract: &str,
+    to: &str,
+    amount: u128,
+) -> Result<String> {
+    let token: Address = token_contract
+        .parse()
+        .map_err(|e| anyhow!("invalid token contract {token_contract}: {e}"))?;
+    let to_addr: Address = to
+        .parse()
+        .map_err(|e| anyhow!("invalid recipient address {to}: {e}"))?;
+
+    let mut calldata = Vec::with_capacity(4 + 32 + 32);
+    calldata.extend_from_slice(&ERC20_TRANSFER_SELECTOR);
+    calldata.extend_from_slice(&[0u8; 12]);
+    calldata.extend_from_slice(to_addr.as_slice());
+    let amount_bytes: [u8; 32] = U256::from(amount).to_be_bytes();
+    calldata.extend_from_slice(&amount_bytes);
+    let calldata = Bytes::from(calldata);
+
+    let from = signer.address();
+    let chain_id = rpc_hex_u64(rpc_url, "eth_chainId", json!([])).await?;
+    let nonce = rpc_hex_u64(
+        rpc_url,
+        "eth_getTransactionCount",
+        json!([from.to_string(), "pending"]),
+    )
+    .await?;
+    let gas_price = rpc_hex_u128(rpc_url, "eth_gasPrice", json!([])).await?;
+    // No priority tip: tests should minimize gas cost, and the Arbitrum
+    // sequencer accepts a zero tip. Buffer the base-fee ceiling by 2x so a
+    // small mid-flight bump doesn't reject the tx.
+    let max_fee_per_gas = gas_price.saturating_mul(2);
+
+    // Gas estimate for the calldata; the RPC accepts an object with `from`,
+    // `to`, and `data`. Overshoot slightly (25%) to cover the L1 calldata
+    // portion on Arbitrum.
+    let est_body = json!([{
+        "from": from.to_string(),
+        "to": token.to_string(),
+        "data": format!("0x{}", hex::encode(&calldata)),
+    }]);
+    let est_gas = rpc_hex_u128(rpc_url, "eth_estimateGas", est_body).await?;
+    let gas_limit = est_gas.saturating_mul(125) / 100;
+    let gas_limit_u64 =
+        u64::try_from(gas_limit).map_err(|_| anyhow!("estimated gas {est_gas} exceeds u64"))?;
+
+    let tx = TxEip1559 {
+        chain_id,
+        nonce,
+        gas_limit: gas_limit_u64,
+        max_fee_per_gas,
+        max_priority_fee_per_gas: 0,
+        to: TxKind::Call(token),
+        value: U256::ZERO,
+        access_list: Default::default(),
+        input: calldata,
+    };
+    let signature = signer
+        .sign_hash_sync(&tx.signature_hash())
+        .map_err(|e| anyhow!("sign tx: {e}"))?;
+    let envelope: TxEnvelope = tx.into_signed(signature).into();
+    let raw = envelope.encoded_2718();
+    let raw_hex = format!("0x{}", hex::encode(&raw));
+
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_sendRawTransaction",
+        "params": [raw_hex],
+    });
+    let resp: serde_json::Value = http_client()
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+    if let Some(err) = resp.get("error") {
+        bail!("eth_sendRawTransaction error from {rpc_url}: {err}");
+    }
+    let tx_hash = resp
+        .get("result")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("eth_sendRawTransaction returned no result: {resp}"))?
+        .to_string();
+    info!(
+        "Broadcast ERC-20 transfer: from={from} to={to_addr} token={token} \
+         amount={amount} tx={tx_hash}"
+    );
+    Ok(tx_hash)
+}
+
+/// Poll `eth_getTransactionReceipt` until the tx lands and returns `status: 0x1`
+/// (success). Bails if the tx reverts or the timeout elapses.
+pub async fn wait_for_evm_tx_confirmation(
+    rpc_url: &str,
+    tx_hash: &str,
+    timeout_secs: u64,
+) -> Result<()> {
+    let start = Instant::now();
+    loop {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_getTransactionReceipt",
+            "params": [tx_hash],
+        });
+        match http_client().post(rpc_url).json(&body).send().await {
+            Ok(r) => match r.json::<serde_json::Value>().await {
+                Ok(resp) => {
+                    if let Some(receipt) = resp.get("result").filter(|v| !v.is_null()) {
+                        let status = receipt
+                            .get("status")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("");
+                        if status == "0x1" {
+                            return Ok(());
+                        }
+                        bail!("tx {tx_hash} reverted (status {status}): {receipt}");
+                    }
+                    debug!("tx {tx_hash} not yet mined; waiting...");
+                }
+                Err(e) => debug!("receipt decode failed (retrying): {e:#}"),
+            },
+            Err(e) => debug!("receipt request failed (retrying): {e:#}"),
+        }
+        if start.elapsed() >= Duration::from_secs(timeout_secs) {
+            bail!("timeout after {timeout_secs}s waiting for tx {tx_hash} to confirm");
+        }
+        tokio::time::sleep(EVM_POLL_INTERVAL).await;
+    }
+}
+
+/// Shared JSON-RPC helper: POST `{method, params}`, decode the `0x…` hex
+/// `result` as a `u64`. For scalar-return methods (`eth_chainId`, nonce, gas).
+async fn rpc_hex_u64(rpc_url: &str, method: &str, params: serde_json::Value) -> Result<u64> {
+    let value = rpc_hex_u128(rpc_url, method, params).await?;
+    u64::try_from(value).map_err(|_| anyhow!("{method} result exceeds u64: {value}"))
+}
+
+async fn rpc_hex_u128(rpc_url: &str, method: &str, params: serde_json::Value) -> Result<u128> {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params,
+    });
+    let resp: serde_json::Value = http_client()
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+    if let Some(err) = resp.get("error") {
+        bail!("{method} error from {rpc_url}: {err}");
+    }
+    let result = resp
+        .get("result")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("{method} returned no result: {resp}"))?;
+    let value = U256::from_str_radix(result.trim_start_matches("0x"), 16)
+        .map_err(|e| anyhow!("{method}: bad hex result {result}: {e}"))?;
+    u128::try_from(value).map_err(|_| anyhow!("{method} result exceeds u128: {value}"))
 }
 
 /// Log where standing test funds live so a human can recover them later (the

--- a/crates/breez-sdk/breez-itest/tests/mainnet_cross_chain.rs
+++ b/crates/breez-sdk/breez-itest/tests/mainnet_cross_chain.rs
@@ -1,34 +1,92 @@
-//! Mainnet cross-chain send itests (env-gated).
+//! Mainnet cross-chain itests (env-gated).
 //!
-//! Performs a real cross-chain send from the funded test account ("Alice") to a
-//! **deterministic EVM address derived from the test mnemonic**, then verifies
-//! receipt *independently* by reading the recipient's ERC-20 balance over
-//! JSON-RPC. This exercises the fees-excluded / target-overpay guarantee: the
-//! recipient should land at or above the requested target.
+//! Exercises both directions against the funded test account ("Alice") on Spark
+//! and a **deterministic EVM wallet derived from the same test mnemonic** at
+//! `m/44'/60'/0'/0/0`. All tests target **Arbitrum One**, the only chain
+//! offering USD-stable assets on both providers.
 //!
-//! Target chain is **Arbitrum One**, the only chain offering a USD-stable asset
-//! on both providers: Orchestra `USDB→USDC` (exercises the USD-stable
-//! target-overpay path) and Boltz `BTC→USDT`.
+//! ## Send tests (Alice → EVM)
 //!
-//! Funds are **not** swept back (the SDK has no Spark-inbound path from EVM).
-//! They accumulate at the deterministic recipient, recoverable by importing the
-//! mnemonic at `m/44'/60'/0'/0/0`; each run logs the address + balance. Keep the
-//! source-amount overrides below small to bound accumulation.
+//! - `test_cross_chain_01_usdt_send_fees_excluded_evm`: BTC (sats) → USDT.
+//!   Provider is selectable via `MAINNET_TEST_CROSS_CHAIN_SEND_USDT_PROVIDER`
+//!   (`orchestra` default, `boltz` alternative) so the USDT stash keeps
+//!   getting produced when one provider is temporarily down.
+//! - `test_cross_chain_02_orchestra_send_fees_excluded_evm`: USDB → USDC via Orchestra.
 //!
-//! NOTE: the cross-chain `amount` is denominated in the **source** asset, not the
-//! destination: USDB base units for the Orchestra case, **sats** for the Boltz
-//! (BTC source) case. The two are sized via separate env vars accordingly.
+//! Verifies receipt independently by reading the EVM recipient's ERC-20 balance
+//! over JSON-RPC. Both exercise the fees-excluded / target-overpay guarantee.
+//!
+//! ## Receive tests (EVM → Alice)
+//!
+//! Each receive test is paired with a send test so the pool an itest pass
+//! drains gets refilled by its counterpart, keeping Alice's Spark-side
+//! balances roughly conservative across runs:
+//!
+//! - `test_cross_chain_03_orchestra_receive_fees_excluded_evm`: **USDT → BTC
+//!   (sats)**. Alice targets a small USD amount (in USDB base units). The SDK
+//!   converts it to sats via the live BTC/USD rate before sizing the USDT
+//!   deposit. Counters test 01 so the sats Alice spent to build the USDT
+//!   stash come back here. Also exercises the receive branch where the USDB
+//!   rounding margin is NOT applied (BTC destination).
+//! - `test_cross_chain_04_orchestra_receive_fees_excluded_usdb_evm`: **USDC →
+//!   USDB**, fees-excluded. Alice targets a small USD amount. The SDK sizes
+//!   the USDC deposit with the USDB rounding margin so delivered lands at or
+//!   above target. This is the receive branch where the rounding margin IS
+//!   applied.
+//! - `test_cross_chain_05_orchestra_receive_fees_included_evm`: **USDC →
+//!   USDB**. Sweep the EVM wallet's remaining USDC balance back into Alice's
+//!   Spark wallet as USDB. Counters test 02 so the USDB Alice spent to build
+//!   the USDC stash comes back here.
+//!
+//! Receive tests need Arbitrum ETH at the deterministic EVM address to pay gas
+//! for the ERC-20 transfer. The tests read the balance and skip loudly (never
+//! hard-fail) if it's below the threshold. Roadmap: when a second cross-chain
+//! receive provider ships, one of these should switch to that provider so both
+//! providers get exercised in a single run.
+//!
+//! ## Test ordering
+//!
+//! Tests are name-prefixed `01_`…`05_` and run in that order under
+//! `--test-threads=1` (libtest sorts tests alphabetically). Ordering matters:
+//! each send test deposits its destination asset at the EVM recipient, and
+//! the three receive tests then consume those balances. Test 03 uses the USDT
+//! from test 01. Tests 04 and 05 share the USDC pool from test 02: test 04
+//! takes a $1 slice first, then test 05 sweeps whatever's left.
+//!
+//! NOTE: the cross-chain `amount` semantics depend on both the fee mode and
+//! the test direction. See [`ReceivePaymentMethod::CrossChain::amount`] and
+//! [`PaymentRequest::CrossChain::amount`] for the full contract.
 //!
 //! # Required environment variables
-//! - `MAINNET_TEST_MNEMONIC` — mnemonic of the funded test account. Primary gate.
-//! - `BREEZ_API_KEY` — API key the mainnet SDK requires.
+//! - `MAINNET_TEST_MNEMONIC`: mnemonic of the funded test account. Primary gate.
+//! - `BREEZ_API_KEY`: API key the mainnet SDK requires.
 //!
 //! # Optional
-//! - `MAINNET_TEST_TOKEN_ID` — USD-stable source token; defaults to USDB.
-//! - `MAINNET_TEST_CROSS_CHAIN_USDB` — Orchestra source in USDB base units
-//!   (6-decimals); defaults to 1_000_000 (= 1.00 USDB, ~1.00 USDC delivered).
-//! - `MAINNET_TEST_CROSS_CHAIN_SATS` — Boltz source in **sats** (BTC source);
-//!   defaults to 1_600. The recipient lands the fiat-equivalent in USDT.
+//! - `MAINNET_TEST_TOKEN_ID`: USD-stable source token. Defaults to USDB.
+//! - `MAINNET_TEST_CROSS_CHAIN_SEND_USDB`: Orchestra send source in USDB base
+//!   units (6-decimals). Defaults to 2_500_000 (2.50 USDB, ~$2.50 USDC
+//!   delivered). Sized to feed both test 04 (fees-excluded slice) and test
+//!   05 (sweep) off a single pool.
+//! - `MAINNET_TEST_CROSS_CHAIN_SEND_SATS`: BTC → USDT send source in **sats**.
+//!   Defaults to 1_500 (~$1.50 USDT delivered). Sized to leave a bit above
+//!   what the fees-excluded receive test consumes each pass.
+//! - `MAINNET_TEST_CROSS_CHAIN_RECEIVE_USDB_TARGET`: fees-excluded receive
+//!   target in USDB base units (6dp). Applies to tests 03 and 04.
+//!   Defaults to `1_000_000` ($1). For test 03 (BTC destination) the SDK
+//!   converts USD to sats at prepare time via the live BTC/USD rate.
+//! - `MAINNET_TEST_CROSS_CHAIN_RECEIVE_USDC_MAX`: cap for the fees-included
+//!   USDC sweep, in USDC base units. Unset by default (sweep the full
+//!   balance).
+//! - `MAINNET_TEST_CROSS_CHAIN_SEND_USDT_PROVIDER`: selects the provider for
+//!   the BTC → USDT send in test 01. `orchestra` (default) exercises the
+//!   Spark-funded direct transfer. `boltz` exercises the Lightning-funded
+//!   reverse swap. Values are case-insensitive. Unknown values fall back to
+//!   Orchestra with a warning.
+//!
+//! # Precondition for the receive tests
+//! The EVM address at `m/44'/60'/0'/0/0` needs a small Arbitrum ETH balance for
+//! gas (~0.00005 ETH is plenty for a single ERC-20 transfer). Top up manually
+//! when needed. Tests skip when it's short.
 //!
 //! # Run locally
 //! ```bash
@@ -43,13 +101,13 @@ use breez_sdk_itest::*;
 use breez_sdk_spark::*;
 use tracing::{debug, info, warn};
 
-/// Destination chain for both tests: Arbitrum One. Matched on `chain_id` (the
+/// Target chain for all tests: Arbitrum One. Matched on `chain_id` (the
 /// decimal EVM chainId), since providers spell the chain *name* differently
-/// (Orchestra reports `"arbitrum"`, Boltz reports `"Arbitrum One"`); `chain_id`
+/// (Orchestra reports `"arbitrum"`, Boltz reports `"Arbitrum One"`). `chain_id`
 /// is the stable cross-provider key.
 const TARGET_CHAIN_ID: &str = "42161";
 
-/// Whether a route's destination is Arbitrum One. Prefers `chain_id`; falls back
+/// Whether a route's destination is Arbitrum One. Prefers `chain_id`. Falls back
 /// to the normalized chain name for the (documented) case where a provider
 /// doesn't surface a chainId. The name set is exact (not a prefix) so sibling
 /// chains like "Arbitrum Nova" (chainId 42170) don't match.
@@ -63,21 +121,30 @@ fn is_target_chain(route: &CrossChainRoutePair) -> bool {
     )
 }
 
-// IMPORTANT: the cross-chain `amount` is in the **source** asset's units, not the
-// destination's. For the Orchestra (USDB token) case that's USDB base units; for
-// the Boltz (BTC) case that's **sats**. They are sized and asserted separately.
+// SEND-side note: `amount` on `PaymentRequest::CrossChain` is denominated in
+// the **source** asset's units. Token-source sends use token base units (USDB
+// for test 02). BTC-source sends use **sats** (test 01). Sized and asserted
+// separately.
 
-/// Orchestra source budget in USDB base units (6-decimals), so 1_000_000 = 1.00
+/// Orchestra source budget in USDB base units (6-decimals), so 2_500_000 = 2.50
 /// USDB. USDB↔USDC are ~1:1, so this also approximates the USDC the recipient
-/// lands. Override via `MAINNET_TEST_CROSS_CHAIN_USDB`. A too-small value (below
+/// lands. Override via `MAINNET_TEST_CROSS_CHAIN_SEND_USDB`. A too-small value (below
 /// the route minimum) makes `prepare` error (loudly).
-const DEFAULT_ORCHESTRA_SOURCE_USDB: u128 = 1_000_000;
+///
+/// Sized to feed BOTH downstream receive tests off a single USDC pool: test
+/// 04 (fees-excluded, ~$1.05 deposit for a $1 target) then test 05 (sweep,
+/// $1 minimum). ~$2.50 delivered leaves headroom for both plus dust.
+const DEFAULT_ORCHESTRA_SEND_USDB: u128 = 2_500_000;
 
-/// Boltz source budget in **sats** (BTC source). Override via
-/// `MAINNET_TEST_CROSS_CHAIN_SATS`. Note this is sats, NOT a USD amount: the
-/// recipient lands the fiat-equivalent in USDT. A value below the route minimum
-/// makes `prepare` error (loudly).
-const DEFAULT_BOLTZ_SOURCE_SATS: u128 = 1_600;
+/// BTC → USDT send source budget in **sats**. Override via
+/// `MAINNET_TEST_CROSS_CHAIN_SEND_SATS`. Note this is sats, NOT a USD amount:
+/// the recipient lands the fiat-equivalent in USDT. A value below the route
+/// minimum makes `prepare` error (loudly).
+///
+/// Sized to leave a small amount of USDT headroom at the deterministic
+/// recipient beyond what the fees-excluded receive test (test 03) consumes
+/// per pass (~$1.10 deposit for a $1 target).
+const DEFAULT_USDT_SEND_SATS: u128 = 1_500;
 
 /// Tolerance (bps) allowed between the SDK-reported `delivered_amount` and the
 /// balance actually observed on-chain, to absorb rounding / settlement timing.
@@ -97,6 +164,32 @@ const SETTLE_TIMEOUT_SECS: u64 = 600;
 
 /// Poll interval while waiting on the SDK's conversion status to go terminal.
 const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Minimum Arbitrum ETH balance (in wei) the deterministic recipient needs to
+/// broadcast an ERC-20 transfer. Set at 0.00005 ETH: an ERC-20 transfer on
+/// Arbitrum costs a fraction of that at typical fees, so this is a generous
+/// skip gate (not a tuning knob).
+const MIN_ARBITRUM_ETH_WEI: u128 = 50_000_000_000_000;
+
+/// Default receive target in the route's source-asset base units (6-decimal
+/// for the USDC/USDT routes exercised here, so `1_000_000 = $1`). USD-stable
+/// parity holds. The SDK translates to sats or USDB on the Spark side at
+/// prepare time.
+const DEFAULT_RECEIVE_USDB_TARGET: u128 = 1_000_000;
+
+/// Minimum stable-source balance (base units, 6-decimal) needed at the
+/// deterministic recipient to run the fees-excluded receive test. Sized to
+/// cover the $1 USDB target plus Orchestra fees + external overhead.
+const MIN_STABLE_FEES_EXCLUDED: u128 = 1_100_000;
+
+/// Minimum stable-source balance (base units, 6-decimal) needed to run the
+/// fees-included sweep test. Set at Orchestra's route minimum of $1.
+const MIN_STABLE_SWEEP: u128 = 1_000_000;
+
+/// Timeout for `eth_getTransactionReceipt` polling. An Arbitrum transaction
+/// lands in a few seconds under normal conditions. Give it 5 minutes so a
+/// public-endpoint latency spike doesn't fail the test.
+const TX_CONFIRM_TIMEOUT_SECS: u64 = 300;
 
 fn env_amount_or(var: &str, default: u128) -> u128 {
     std::env::var(var)
@@ -130,8 +223,9 @@ async fn alice_balances(alice: &SdkInstance, token_id: &str) -> Result<(u64, u12
     Ok((info.balance_sats, tokens))
 }
 
-/// Log Alice's net sats/token movement over a test — the cross-chain flow is
-/// Alice → external chain, so her drain (plus any setup conversion) is the cost.
+/// Log Alice's net sats/token movement over a test as a per-test cost
+/// breadcrumb. Direction depends on the test: on send her balances drain,
+/// on receive they gain. The raw deltas surface both.
 fn log_cost(label: &str, token_id: &str, pre: (u64, u128), post: (u64, u128)) {
     let sats_delta = i128::from(post.0) - i128::from(pre.0);
     let token_delta =
@@ -142,20 +236,20 @@ fn log_cost(label: &str, token_id: &str, pre: (u64, u128), post: (u64, u128)) {
 /// Orchestra: USD-stable token (USDB) → USDC on Arbitrum, fees-excluded. This is
 /// the case that exercises target-overpay (USD-stable source→destination).
 #[test_log::test(tokio::test)]
-async fn test_cross_chain_orchestra_fees_excluded_evm() -> Result<()> {
+async fn test_cross_chain_02_orchestra_send_fees_excluded_evm() -> Result<()> {
     let Some((mut alice, token_id, mnemonic)) = mainnet_cross_chain_setup().await? else {
         return Ok(());
     };
-    info!("=== Starting test_cross_chain_orchestra_fees_excluded_evm ===");
+    info!("=== Starting test_cross_chain_02_orchestra_send_fees_excluded_evm ===");
     let pre = alice_balances(&alice, &token_id).await?;
 
     // Source budget in USDB base units (USD-stable, ~1:1 with the USDC delivered).
     let usdb_amount = env_amount_or(
-        "MAINNET_TEST_CROSS_CHAIN_USDB",
-        DEFAULT_ORCHESTRA_SOURCE_USDB,
+        "MAINNET_TEST_CROSS_CHAIN_SEND_USDB",
+        DEFAULT_ORCHESTRA_SEND_USDB,
     );
 
-    // Alice needs USDB to spend; ensure she holds ~1.3x the source amount (to
+    // Alice needs USDB to spend. Ensure she holds ~1.3x the source amount (to
     // cover the send plus fees with a little headroom), topping up from her own
     // sats if short.
     let required_usdb = usdb_amount.saturating_mul(13) / 10;
@@ -200,24 +294,30 @@ async fn test_cross_chain_orchestra_fees_excluded_evm() -> Result<()> {
     Ok(())
 }
 
-/// Boltz: BTC (Alice's sats) → USDT on Arbitrum, fees-excluded. Exercises a
-/// different asset + provider than the Orchestra case, on the same chain.
+/// BTC (Alice's sats) → USDT on Arbitrum, fees-excluded. The provider is
+/// selectable via `MAINNET_TEST_CROSS_CHAIN_SEND_USDT_PROVIDER` (`orchestra`
+/// default, `boltz` alternative) so downstream receive tests keep their USDT
+/// stash when one provider is temporarily broken. Orchestra funds over Spark
+/// (direct transfer). Boltz funds over Lightning (reverse swap).
 #[test_log::test(tokio::test)]
-async fn test_cross_chain_boltz_fees_excluded_evm() -> Result<()> {
+async fn test_cross_chain_01_usdt_send_fees_excluded_evm() -> Result<()> {
     let Some((mut alice, token_id, mnemonic)) = mainnet_cross_chain_setup().await? else {
         return Ok(());
     };
-    info!("=== Starting test_cross_chain_boltz_fees_excluded_evm ===");
+    let provider = usdt_send_provider();
+    info!(
+        "=== Starting test_cross_chain_01_usdt_send_fees_excluded_evm (provider={provider:?}) ==="
+    );
     let pre = alice_balances(&alice, &token_id).await?;
 
     // Source budget in SATS (BTC source). The recipient lands the fiat-equivalent
     // in USDT, so there's no parity unit to assert against the sats amount.
-    let sats_amount = env_amount_or("MAINNET_TEST_CROSS_CHAIN_SATS", DEFAULT_BOLTZ_SOURCE_SATS);
+    let sats_amount = env_amount_or("MAINNET_TEST_CROSS_CHAIN_SEND_SATS", DEFAULT_USDT_SEND_SATS);
     let (recipient, _signer) = mainnet_evm_recipient(&mnemonic)?;
     run_cross_chain_evm_send(
         &mut alice,
         &recipient,
-        CrossChainProvider::Boltz,
+        provider,
         "USDT",
         None, // BTC source
         None, // no conversion: amount is sats
@@ -227,10 +327,162 @@ async fn test_cross_chain_boltz_fees_excluded_evm() -> Result<()> {
     .await?;
 
     log_cost(
-        "boltz",
+        match provider {
+            CrossChainProvider::Orchestra => "orchestra-usdt",
+            CrossChainProvider::Boltz => "boltz-usdt",
+        },
         &token_id,
         pre,
         alice_balances(&alice, &token_id).await?,
+    );
+    Ok(())
+}
+
+/// Reads `MAINNET_TEST_CROSS_CHAIN_SEND_USDT_PROVIDER` (`orchestra` default,
+/// `boltz` alternative) for the BTC → USDT send in test 01.
+/// Case-insensitive. Unknown values fall back to Orchestra with a warning.
+fn usdt_send_provider() -> CrossChainProvider {
+    match std::env::var("MAINNET_TEST_CROSS_CHAIN_SEND_USDT_PROVIDER")
+        .ok()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        None | Some("") | Some("orchestra") => CrossChainProvider::Orchestra,
+        Some("boltz") => CrossChainProvider::Boltz,
+        Some(other) => {
+            warn!("Unknown MAINNET_TEST_CROSS_CHAIN_SEND_USDT_PROVIDER={other:?}, using orchestra");
+            CrossChainProvider::Orchestra
+        }
+    }
+}
+
+/// Orchestra: USDT on Arbitrum → BTC (sats) on Spark, fees-excluded. Alice
+/// specifies a target in USDB base units (6dp). The SDK converts to sats
+/// internally via the live BTC/USD rate at prepare time, then sizes the USDT
+/// deposit. The deterministic EVM wallet signs & broadcasts it.
+///
+/// Landing as BTC (not USDB) is the counterpart to test 01 (BTC → USDT):
+/// the send drains Alice's sats to fund the EVM wallet's USDT. This receive
+/// returns those sats. Also exercises the receive branch where the USDB
+/// rounding margin is not applied (BTC destination).
+#[test_log::test(tokio::test)]
+async fn test_cross_chain_03_orchestra_receive_fees_excluded_evm() -> Result<()> {
+    let Some((mut alice, usdb_token_id, mnemonic)) = mainnet_cross_chain_setup().await? else {
+        return Ok(());
+    };
+    info!("=== Starting test_cross_chain_03_orchestra_receive_fees_excluded_evm ===");
+    let pre = alice_balances(&alice, &usdb_token_id).await?;
+
+    let target_usdb = env_amount_or(
+        "MAINNET_TEST_CROSS_CHAIN_RECEIVE_USDB_TARGET",
+        DEFAULT_RECEIVE_USDB_TARGET,
+    );
+
+    run_cross_chain_evm_receive(
+        &mut alice,
+        &mnemonic,
+        &usdb_token_id,
+        "USDT",
+        SparkAsset::Bitcoin,
+        ReceiveTestPlan::FeesExcluded {
+            target: target_usdb,
+            min_source: MIN_STABLE_FEES_EXCLUDED,
+        },
+    )
+    .await?;
+
+    log_cost(
+        "orchestra-receive-excluded",
+        &usdb_token_id,
+        pre,
+        alice_balances(&alice, &usdb_token_id).await?,
+    );
+    Ok(())
+}
+
+/// Orchestra: USDC on Arbitrum → USDB on Spark, fees-excluded. Alice targets
+/// a $1 delivery (in USDB base units). The SDK sizes the USDC deposit with
+/// the USDB rounding margin so delivery lands at or above target. Consumes
+/// ~$1.05 from the USDC pool. The sweep test (05) picks up the remainder.
+///
+/// This is the receive branch where the USDB rounding margin IS applied, so
+/// regressions in the probe-time inflation or the reported-value shave
+/// surface as a delivery below the parity floor.
+#[test_log::test(tokio::test)]
+async fn test_cross_chain_04_orchestra_receive_fees_excluded_usdb_evm() -> Result<()> {
+    let Some((mut alice, usdb_token_id, mnemonic)) = mainnet_cross_chain_setup().await? else {
+        return Ok(());
+    };
+    info!("=== Starting test_cross_chain_04_orchestra_receive_fees_excluded_usdb_evm ===");
+    let pre = alice_balances(&alice, &usdb_token_id).await?;
+
+    let target_usdb = env_amount_or(
+        "MAINNET_TEST_CROSS_CHAIN_RECEIVE_USDB_TARGET",
+        DEFAULT_RECEIVE_USDB_TARGET,
+    );
+
+    run_cross_chain_evm_receive(
+        &mut alice,
+        &mnemonic,
+        &usdb_token_id,
+        "USDC",
+        SparkAsset::Token {
+            token_identifier: usdb_token_id.clone(),
+        },
+        ReceiveTestPlan::FeesExcluded {
+            target: target_usdb,
+            min_source: MIN_STABLE_FEES_EXCLUDED,
+        },
+    )
+    .await?;
+
+    log_cost(
+        "orchestra-receive-excluded-usdb",
+        &usdb_token_id,
+        pre,
+        alice_balances(&alice, &usdb_token_id).await?,
+    );
+    Ok(())
+}
+
+/// Orchestra: sweep the deterministic EVM wallet's remaining USDC (Arbitrum)
+/// balance back into Alice's Spark wallet as USDB, fees-included. USDC is
+/// the counterpart to the Orchestra USDB → USDC send test, so sweeping it
+/// back closes the loop and drains the dust each pass. Alice lands whatever's
+/// left after Orchestra's fees + external overhead.
+#[test_log::test(tokio::test)]
+async fn test_cross_chain_05_orchestra_receive_fees_included_evm() -> Result<()> {
+    let Some((mut alice, usdb_token_id, mnemonic)) = mainnet_cross_chain_setup().await? else {
+        return Ok(());
+    };
+    info!("=== Starting test_cross_chain_05_orchestra_receive_fees_included_evm ===");
+    let pre = alice_balances(&alice, &usdb_token_id).await?;
+
+    let cap = std::env::var("MAINNET_TEST_CROSS_CHAIN_RECEIVE_USDC_MAX")
+        .ok()
+        .and_then(|s| s.trim().parse::<u128>().ok())
+        .filter(|v| *v > 0);
+
+    run_cross_chain_evm_receive(
+        &mut alice,
+        &mnemonic,
+        &usdb_token_id,
+        "USDC",
+        SparkAsset::Token {
+            token_identifier: usdb_token_id.clone(),
+        },
+        ReceiveTestPlan::FeesIncludedSweep {
+            min_source: MIN_STABLE_SWEEP,
+            cap,
+        },
+    )
+    .await?;
+
+    log_cost(
+        "orchestra-receive-included",
+        &usdb_token_id,
+        pre,
+        alice_balances(&alice, &usdb_token_id).await?,
     );
     Ok(())
 }
@@ -402,14 +654,14 @@ async fn run_cross_chain_evm_send(
     // 8. Verify delivery (all in destination base units).
     //
     // `delivered_amount` (SDK-reported, per-payment) is the source of truth for
-    // "how much this send delivered"; the on-chain read is independent
+    // "how much this send delivered". The on-chain read is independent
     // corroboration that those funds actually landed. Anchoring the pass
     // criterion on `delivered_amount` (not the raw balance delta) is what keeps
     // standing funds from prior runs at this reused address from masking a
     // genuine shortfall — a short delivery shows up in `delivered_amount`, and
     // stale funds can only ever help the on-chain floor be met sooner.
     // (A fresh recipient per run would fully isolate runs, but conflicts with
-    // the deterministic-recovery design; the residual is a narrow window where
+    // the deterministic-recovery design. The residual is a narrow window where
     // the SDK over-reports AND stale funds happen to cover it.)
     //
     // For a parity (USD-stable) source, also assert the fees-excluded guarantee:
@@ -425,7 +677,7 @@ async fn run_cross_chain_evm_send(
 
     // Minimum increase we require to observe on-chain.
     let onchain_floor = match (delivered, parity_min_out) {
-        // Trust the SDK's per-payment delivered amount; confirm it landed.
+        // Trust the SDK's per-payment delivered amount. Confirm it landed.
         (Some(d), _) => reduce_by_bps(d, ONCHAIN_TOLERANCE_BPS),
         // delivered unknown (terminal reached before the amount was recorded)
         // but we have a parity target: require ~that amount, slippage-adjusted.
@@ -458,8 +710,343 @@ async fn run_cross_chain_evm_send(
     Ok(())
 }
 
+/// How a receive test decides on the source amount and the min-out assertion.
+enum ReceiveTestPlan {
+    /// Alice targets a specific delivery amount, always in USDB base units
+    /// (6dp, `1_000_000 = $1`) regardless of the destination asset. The SDK
+    /// translates internally to destination-native units (sats for BTC
+    /// destinations via the live BTC/USD rate). EVM wallet needs at least
+    /// `min_source` in the source token + gas ETH.
+    FeesExcluded { target: u128, min_source: u128 },
+    /// Sweep the EVM wallet's source-token balance (optionally capped by
+    /// `cap`). Amount passed to the SDK is the source balance numerically:
+    /// safe because Arbitrum USDC is 6dp, same as USDB.
+    FeesIncludedSweep { min_source: u128, cap: Option<u128> },
+}
+
+/// Shared flow for the three receive tests: discover the Arbitrum
+/// source-asset receive route (`source_asset` is the external-chain ticker,
+/// e.g. `"USDT"` or `"USDC"`), gate on ETH-for-gas and source-token balance,
+/// call `receive_payment`, sign + broadcast the source-token deposit from
+/// the EVM wallet, wait for both the tx to confirm and Alice's Spark-side
+/// balance (BTC sats or USDB, per `destination`) to increase.
+///
+/// Skips (warn + `Ok`) when no matching route, the EVM wallet lacks ETH for
+/// gas, or its source-token balance is below the plan's minimum.
+async fn run_cross_chain_evm_receive(
+    alice: &mut SdkInstance,
+    mnemonic: &str,
+    usdb_token_id: &str,
+    source_asset: &str,
+    destination: SparkAsset,
+    plan: ReceiveTestPlan,
+) -> Result<()> {
+    let (recipient, signer) = mainnet_evm_recipient(mnemonic)?;
+    let dest_label = spark_asset_label(&destination, usdb_token_id);
+    info!(
+        "Cross-chain receive: Arbitrum {source_asset} → {dest_label}. Sender EVM wallet \
+         {recipient} (m/44'/60'/0'/0/0)"
+    );
+
+    // 1. Discover the Orchestra {source_asset}-on-Arbitrum receive route.
+    let routes = alice
+        .sdk
+        .get_cross_chain_routes(&CrossChainRouteFilter::Receive {
+            contract_address: None,
+        })
+        .await?;
+    let Some(route) = routes.into_iter().find(|r| {
+        r.provider == CrossChainProvider::Orchestra
+            && is_target_chain(r)
+            && r.asset.eq_ignore_ascii_case(source_asset)
+    }) else {
+        warn!("No Orchestra {source_asset} receive route on Arbitrum One; skipping");
+        return Ok(());
+    };
+    let source_contract = route
+        .contract_address
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("{source_asset} receive route has no contract address"))?;
+    let Some(rpc_url) = evm_rpc_url(&route.chain) else {
+        warn!("No JSON-RPC endpoint for chain {}; skipping", route.chain);
+        return Ok(());
+    };
+    info!(
+        "Selected receive route: {source_asset} on {} ({source_contract})",
+        route.chain
+    );
+
+    // Confirm the route lands the requested destination.
+    if !route.accepted_assets.contains(&destination) {
+        warn!(
+            "Route {source_asset}→Arbitrum does not offer {dest_label} destination \
+             (accepted_assets={:?}); skipping",
+            route.accepted_assets
+        );
+        return Ok(());
+    }
+
+    // 2. Gas-for-broadcast check.
+    let eth_balance = evm_native_balance(&rpc_url, &recipient).await?;
+    if eth_balance < MIN_ARBITRUM_ETH_WEI {
+        warn!(
+            "Recipient {recipient} has {eth_balance} wei on Arbitrum \
+             (< {MIN_ARBITRUM_ETH_WEI} needed to pay gas); skipping"
+        );
+        return Ok(());
+    }
+    info!("Recipient ETH balance: {eth_balance} wei");
+
+    // 3. Source-balance check + plan resolution.
+    let source_balance = evm_erc20_balance(&rpc_url, &source_contract, &recipient).await?;
+    info!("Recipient {source_asset} balance: {source_balance}");
+    let (fee_mode, amount, parity_min_out): (CrossChainFeeMode, u128, Option<u128>) = match &plan {
+        ReceiveTestPlan::FeesExcluded { target, min_source } => {
+            if source_balance < *min_source {
+                warn!(
+                    "Recipient {source_asset} balance {source_balance} below fees-excluded \
+                     minimum {min_source}; skipping"
+                );
+                return Ok(());
+            }
+            // Parity assertion needs target and delivered in matching units.
+            // USDB destinations do. BTC destinations land sats and would need
+            // a BTC/USD conversion (skipped for the signal it adds).
+            let parity = match &destination {
+                SparkAsset::Token { .. } => Some(*target),
+                SparkAsset::Bitcoin => None,
+            };
+            (CrossChainFeeMode::FeesExcluded, *target, parity)
+        }
+        ReceiveTestPlan::FeesIncludedSweep { min_source, cap } => {
+            if source_balance < *min_source {
+                warn!(
+                    "Recipient {source_asset} balance {source_balance} below sweep minimum \
+                     {min_source}; skipping"
+                );
+                return Ok(());
+            }
+            let sweep = cap.map(|c| c.min(source_balance)).unwrap_or(source_balance);
+            info!("Sweep amount: {sweep} (from balance {source_balance}, cap {cap:?})");
+            (CrossChainFeeMode::FeesIncluded, sweep, None)
+        }
+    };
+
+    // 4. Baseline Alice's destination-side balance (sats for BTC, token base
+    //    units for USDB).
+    let (baseline_sats, baseline_usdb) = alice_balances(alice, usdb_token_id).await?;
+    let baseline: u128 = match &destination {
+        SparkAsset::Bitcoin => u128::from(baseline_sats),
+        SparkAsset::Token { .. } => baseline_usdb,
+    };
+    info!("Alice baseline {dest_label}: {baseline}");
+
+    // On BTC destinations, one cent of Orchestra rounding is ~100 bps of a $1
+    // sat target (cent quantum ÷ $1 = 1%), which sits right on the SDK's
+    // default drift threshold and flakes over integer rounding. Widen the
+    // budget for this test class only. USDB destinations already survive the
+    // default because the SDK compensates via the USDB rounding margin.
+    let max_slippage_bps = match &destination {
+        SparkAsset::Bitcoin => Some(200),
+        SparkAsset::Token { .. } => None,
+    };
+
+    // 5. Ask the SDK to prepare the cross-chain receive.
+    let response = alice
+        .sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::CrossChain {
+                route: route.clone(),
+                amount,
+                destination: Some(destination.clone()),
+                fee_mode: Some(fee_mode),
+                max_slippage_bps,
+                target_overpay_bps: None,
+            },
+        })
+        .await?;
+    let info = response
+        .cross_chain_info
+        .ok_or_else(|| anyhow::anyhow!("receive_payment returned no cross_chain_info"))?;
+    info!(
+        "Receive prepared: deposit_address={} deposit_amount={} expected_received={} \
+         service_fee_amount={} service_fee_asset={:?} expires_at={}",
+        info.deposit_address,
+        info.deposit_amount,
+        info.expected_received_amount,
+        info.service_fee_amount,
+        info.service_fee_asset,
+        info.expires_at
+    );
+    // Locks the fee-wiring plumbing in place: `service_fee_amount` is
+    // Orchestra's `total_fee_amount` and is always populated on a receive
+    // quote. `service_fee_asset` is `Some(fee_asset)` unless the quote reports
+    // BTC as the fee unit, which none of these USD-stable-source routes does.
+    assert!(
+        info.service_fee_amount > 0,
+        "cross-chain receive {source_asset}→{dest_label}: expected nonzero \
+         service_fee_amount, got 0",
+    );
+    assert!(
+        info.service_fee_asset.is_some(),
+        "cross-chain receive {source_asset}→{dest_label}: expected some \
+         service_fee_asset for a USD-stable source, got None",
+    );
+
+    // Prepare-time reconciliation for eyeballing in the log. Meaningful only
+    // when deposit and expected share units (USDB destination). For BTC
+    // destinations `deposit_amount` is in source-asset units and
+    // `expected_received_amount` is in sats, so the delta is nonsense and
+    // labeled as such.
+    let implied_fee_from_prepare = i128::try_from(info.deposit_amount).unwrap_or(i128::MAX)
+        - i128::try_from(info.expected_received_amount).unwrap_or(i128::MAX);
+    let reconciliation_scope = match &destination {
+        SparkAsset::Token { .. } => {
+            "matched-units: implied_fee = service_fee + external bridge/gas cost"
+        }
+        SparkAsset::Bitcoin => "unmatched-units: source USDC vs sats, implied_fee not comparable",
+    };
+    info!(
+        "[cross-chain-fee-check] {source_asset}→{dest_label} fee_mode={fee_mode:?} \
+         deposit={} expected={} service_fee={} {:?} implied_fee={implied_fee_from_prepare} \
+         ({reconciliation_scope})",
+        info.deposit_amount,
+        info.expected_received_amount,
+        info.service_fee_amount,
+        info.service_fee_asset,
+    );
+
+    // 6. Confirm the EVM wallet holds enough source-token for the SDK-sized
+    //    deposit. Only meaningful for fees-excluded (sweep case has
+    //    `deposit_amount == source_balance` by construction).
+    if source_balance < info.deposit_amount {
+        warn!(
+            "Recipient {source_asset} balance {source_balance} < SDK-computed deposit {} \
+             (fees + overpay pushed it over the balance); skipping",
+            info.deposit_amount
+        );
+        return Ok(());
+    }
+
+    // 7. Broadcast the ERC-20 transfer.
+    let tx_hash = evm_send_erc20(
+        &rpc_url,
+        &signer,
+        &source_contract,
+        &info.deposit_address,
+        info.deposit_amount,
+    )
+    .await?;
+    wait_for_evm_tx_confirmation(&rpc_url, &tx_hash, TX_CONFIRM_TIMEOUT_SECS).await?;
+    info!("{source_asset} deposit confirmed on Arbitrum: {tx_hash}");
+
+    // 8. Wait for the delivered amount to land on Alice's Spark side.
+    //    Orchestra's background monitor reconciles once bridging completes.
+    let final_balance: u128 = match &destination {
+        SparkAsset::Bitcoin => u128::from(
+            wait_for_balance(
+                &alice.sdk,
+                Some(
+                    u64::try_from(baseline)
+                        .unwrap_or(u64::MAX)
+                        .saturating_add(1),
+                ),
+                None,
+                SETTLE_TIMEOUT_SECS,
+            )
+            .await?,
+        ),
+        SparkAsset::Token { .. } => {
+            wait_for_token_balance_increase(
+                &alice.sdk,
+                usdb_token_id,
+                baseline,
+                SETTLE_TIMEOUT_SECS,
+            )
+            .await?
+        }
+    };
+    let delivered = final_balance.saturating_sub(baseline);
+    info!(
+        "Alice {dest_label} delivered: {delivered} (baseline {baseline} → final {final_balance})"
+    );
+
+    // Cost decomposition:
+    //   `expected_received - delivered`: how much reality fell BELOW the SDK's
+    //     prepare-time estimate. On USDB destinations the estimate is already
+    //     shaved by the rounding margin, so any negative delta signals under-
+    //     delivery beyond the expected margin. Meaningful across both kinds.
+    //   `total_spread = deposit - delivered`: single-number cost, only
+    //     meaningful for stable-to-stable routes where deposit and delivery
+    //     share units. Omitted for BTC destinations (source is 6dp USD-stable,
+    //     delivery is sats).
+    let expected_vs_delivered = i128::try_from(delivered).unwrap_or(i128::MAX)
+        - i128::try_from(info.expected_received_amount).unwrap_or(i128::MAX);
+    match &destination {
+        SparkAsset::Token { .. } => {
+            let total_spread = info.deposit_amount.saturating_sub(delivered);
+            info!(
+                "[cross-chain-breakdown] {source_asset} → USDB: deposit={} expected={} \
+                 delivered={} total_spread={total_spread} \
+                 expected_vs_delivered={expected_vs_delivered}",
+                info.deposit_amount, info.expected_received_amount, delivered
+            );
+        }
+        SparkAsset::Bitcoin => {
+            info!(
+                "[cross-chain-breakdown] {source_asset} → BTC: deposit={} (source units) \
+                 expected={} sats delivered={} sats expected_vs_delivered={expected_vs_delivered}",
+                info.deposit_amount, info.expected_received_amount, delivered
+            );
+        }
+    }
+
+    // 10. Assert the fees-excluded contract when a parity target is set.
+    if let Some(target) = parity_min_out {
+        let floor = reduce_by_bps(target, SLIPPAGE_TOLERANCE_BPS);
+        assert!(
+            delivered >= floor,
+            "fees-excluded receive: delivered {delivered} should be >= {floor} \
+             (target {target} less {SLIPPAGE_TOLERANCE_BPS} bps)"
+        );
+    } else {
+        assert!(
+            delivered > 0,
+            "sweep receive: expected some {dest_label} delivered, got {delivered}"
+        );
+        let deposit_pct = delivered.saturating_mul(10_000) / amount.max(1);
+        info!(
+            "Sweep receive: {delivered} {dest_label} delivered for {amount} {source_asset} \
+             deposit ({deposit_pct} bps of source, i.e. {}%)",
+            deposit_pct / 100
+        );
+    }
+
+    log_evm_recovery_balance(&rpc_url, &source_contract, &recipient, source_asset).await;
+    Ok(())
+}
+
+/// Short label for a receive destination, used in log lines. Distinguishes
+/// BTC (sats) from USDB by matching the token identifier against Alice's
+/// active USDB token id. Any other token identifier renders as
+/// `Token(...prefix)` for debuggability.
+fn spark_asset_label(destination: &SparkAsset, usdb_token_id: &str) -> String {
+    match destination {
+        SparkAsset::Bitcoin => "BTC".to_string(),
+        SparkAsset::Token { token_identifier } if token_identifier == usdb_token_id => {
+            "USDB".to_string()
+        }
+        SparkAsset::Token { token_identifier } => {
+            format!(
+                "Token({}...)",
+                &token_identifier[..token_identifier.len().min(12)]
+            )
+        }
+    }
+}
+
 /// Whether Alice can cover the source leg of a cross-chain send. For a token
-/// source she needs `amount_in` token base units plus the sats transfer fee; for
+/// source she needs `amount_in` token base units plus the sats transfer fee. For
 /// a BTC source she needs `amount_in + source_transfer_fee_sats` sats.
 async fn alice_can_cover(
     alice: &SdkInstance,
@@ -535,7 +1122,7 @@ fn describe_conversion(info: &ConversionInfo) -> String {
 }
 
 /// Poll the payment until its cross-chain `ConversionInfo` reaches a terminal
-/// state. Returns `delivered_amount` on `Completed`; errors on a failed/refunded
+/// state. Returns `delivered_amount` on `Completed`. Errors on a failed/refunded
 /// outcome or timeout. Logs the provider handles once and every status change,
 /// so a debugging run has a trail to correlate against the provider/explorer.
 async fn wait_for_cross_chain_completion(
@@ -621,7 +1208,7 @@ async fn wait_for_cross_chain_completion(
                  {payment_id} (last status {last_status:?})"
             );
         }
-        // The status update arrives via the background monitor; nudge a sync so
+        // The status update arrives via the background monitor. Nudge a sync so
         // the locally-read payment reflects it promptly.
         let _ = sdk.sync_wallet(SyncWalletRequest {}).await;
         tokio::time::sleep(STATUS_POLL_INTERVAL).await;

--- a/crates/breez-sdk/breez-itest/tests/mainnet_cross_chain.rs
+++ b/crates/breez-sdk/breez-itest/tests/mainnet_cross_chain.rs
@@ -191,6 +191,36 @@ const MIN_STABLE_SWEEP: u128 = 1_000_000;
 /// public-endpoint latency spike doesn't fail the test.
 const TX_CONFIRM_TIMEOUT_SECS: u64 = 300;
 
+/// How long to wait for the delivery's payment event after its balance has
+/// already landed. The event trails the balance by a sync pass at most.
+const RECEIVE_EVENT_TIMEOUT_SECS: u64 = 120;
+
+/// The conversion info a payment carries, whichever details variant holds it.
+fn conversion_info_of(payment: &Payment) -> Option<&ConversionInfo> {
+    match payment.details.as_ref()? {
+        PaymentDetails::Spark {
+            conversion_info, ..
+        }
+        | PaymentDetails::Token {
+            conversion_info, ..
+        }
+        | PaymentDetails::Lightning {
+            conversion_info, ..
+        } => conversion_info.as_ref(),
+        _ => None,
+    }
+}
+
+/// Empties the event channel so a later assertion only sees what the deposit
+/// caused.
+fn drain_events(alice: &mut SdkInstance) {
+    let mut drained = 0;
+    while alice.events.try_recv().is_ok() {
+        drained += 1;
+    }
+    debug!("Drained {drained} queued SDK events");
+}
+
 fn env_amount_or(var: &str, default: u128) -> u128 {
     std::env::var(var)
         .ok()
@@ -929,6 +959,7 @@ async fn run_cross_chain_evm_receive(
     }
 
     // 7. Broadcast the ERC-20 transfer.
+    drain_events(alice);
     let tx_hash = evm_send_erc20(
         &rpc_url,
         &signer,
@@ -1000,6 +1031,30 @@ async fn run_cross_chain_evm_receive(
             );
         }
     }
+
+    // 9. The delivery has to reach event listeners, not just the balance.
+    //    The inbound payment carries Orchestra conversion info, and treating a
+    //    conversion-tagged payment as an internal leg has the event middleware
+    //    swallow it, leaving an app with no signal that the money arrived.
+    let event_payment = wait_for_payment_succeeded_event(
+        &mut alice.events,
+        PaymentType::Receive,
+        RECEIVE_EVENT_TIMEOUT_SECS,
+    )
+    .await
+    .map_err(|e| {
+        anyhow::anyhow!(
+            "cross-chain receive {source_asset}→{dest_label} delivered {delivered} but emitted \
+             no PaymentSucceeded event: {e}"
+        )
+    })?;
+    info!(
+        "Receive event: payment {} for {} ({:?}), conversion_info present: {}",
+        event_payment.id,
+        event_payment.amount,
+        event_payment.method,
+        conversion_info_of(&event_payment).is_some()
+    );
 
     // 10. Assert the fees-excluded contract when a parity target is set.
     if let Some(target) = parity_min_out {

--- a/crates/breez-sdk/cli/src/command/grammar_tests.rs
+++ b/crates/breez-sdk/cli/src/command/grammar_tests.rs
@@ -152,6 +152,7 @@ fn receive_methods() {
         ("receive -m bitcoin", "bitcoin"),
         ("receive -m bolt11", "bolt11"),
         ("receive --method bolt11", "bolt11"),
+        ("receive -m crosschain -a 1000000", "crosschain"),
     ] {
         let Command::Receive { payment_method, .. } = parse_ok(line) else {
             panic!("expected Receive for '{line}'");
@@ -161,11 +162,53 @@ fn receive_methods() {
             ReceivePaymentMethodArg::SparkInvoice => expected == "sparkinvoice",
             ReceivePaymentMethodArg::Bitcoin => expected == "bitcoin",
             ReceivePaymentMethodArg::Bolt11 => expected == "bolt11",
+            ReceivePaymentMethodArg::CrossChain => expected == "crosschain",
         };
         assert!(matches_expected, "'{line}' parsed the wrong method");
     }
     parse_err("receive");
     parse_err("receive -m lightning");
+}
+
+#[test]
+fn receive_crosschain_flags() {
+    let Command::Receive {
+        payment_method,
+        amount,
+        cross_chain_max_slippage_bps,
+        cross_chain_fees_included,
+        cross_chain_target_overpay_bps,
+        ..
+    } = parse_ok(
+        "receive -m crosschain -a 1000000 --cross-chain-max-slippage-bps 250 \
+         --cross-chain-fees-included --cross-chain-target-overpay-bps 30",
+    )
+    else {
+        panic!("expected Receive");
+    };
+    assert!(matches!(
+        payment_method,
+        ReceivePaymentMethodArg::CrossChain
+    ));
+    assert_eq!(amount, Some(1_000_000));
+    assert_eq!(cross_chain_max_slippage_bps, Some(250));
+    assert!(cross_chain_fees_included);
+    assert_eq!(cross_chain_target_overpay_bps, Some(30));
+
+    let Command::Receive {
+        cross_chain_max_slippage_bps,
+        cross_chain_fees_included,
+        cross_chain_target_overpay_bps,
+        ..
+    } = parse_ok("receive -m crosschain -a 1000000")
+    else {
+        panic!("expected Receive");
+    };
+    assert_eq!(cross_chain_max_slippage_bps, None);
+    assert!(!cross_chain_fees_included);
+    assert_eq!(cross_chain_target_overpay_bps, None);
+
+    parse_err("receive -m crosschain -a 1000000 --cross-chain-max-slippage-bps ten");
 }
 
 #[test]

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -99,6 +99,7 @@ pub enum ReceivePaymentMethodArg {
     SparkInvoice,
     Bitcoin,
     Bolt11,
+    CrossChain,
 }
 
 #[derive(Clone, Parser)]
@@ -176,11 +177,16 @@ pub enum Command {
         #[clap(short = 'd', long = "description")]
         description: Option<String>,
 
-        /// The amount the payer should send, in sats or token base units.
+        /// The amount the payer should send, in sats, token base units, or
+        /// (for cross-chain receive) the source asset's base units at
+        /// `route.decimals` (USD-stable parity, e.g. `1_000_000` for $1 on
+        /// 6-decimal USDC).
         #[arg(short = 'a', long)]
         amount: Option<u128>,
 
-        /// Optional token identifier. Only used if the payment method is a spark invoice. Absence indicates sats payment.
+        /// Optional token identifier. On spark invoice, names the invoice's asset
+        /// (absent = sats). On cross-chain receive, picks the Spark-side
+        /// destination token (absent = auto: active stable-balance or BTC).
         #[arg(short = 't', long)]
         token_identifier: Option<String>,
 
@@ -199,6 +205,23 @@ pub enum Command {
         /// Request a new bitcoin deposit address instead of reusing the current one.
         #[arg(long)]
         new_address: bool,
+
+        /// Maximum slippage in basis points for cross-chain receives. Must be in 10..=500.
+        /// Falls back to the SDK config default (100 bps) when unset.
+        #[arg(long = "cross-chain-max-slippage-bps")]
+        cross_chain_max_slippage_bps: Option<u32>,
+
+        /// If set, fees will be deducted from the specified amount instead of being
+        /// padded onto the deposit shown to the sender. Defaults to fees-excluded
+        /// (the receiver's net target is preserved).
+        #[arg(long = "cross-chain-fees-included", action = clap::ArgAction::SetTrue)]
+        cross_chain_fees_included: bool,
+
+        /// Per-request override for the overpay buffer applied to the sender's
+        /// deposit when using the default fees-excluded mode. Must be in 0..=500.
+        /// Falls back to the SDK config default (15 bps) when unset.
+        #[arg(long = "cross-chain-target-overpay-bps")]
+        cross_chain_target_overpay_bps: Option<u32>,
     },
 
     /// Pay the given payment request
@@ -765,6 +788,9 @@ pub(crate) async fn execute_command(
             sender_public_key,
             hodl,
             new_address,
+            cross_chain_max_slippage_bps,
+            cross_chain_fees_included,
+            cross_chain_target_overpay_bps,
         } => {
             let payment_method = match payment_method {
                 ReceivePaymentMethodArg::SparkAddress => ReceivePaymentMethod::SparkAddress,
@@ -808,6 +834,31 @@ pub(crate) async fn execute_command(
                         expiry_secs,
                         payment_hash,
                         receiver_identity_public_key: None,
+                    }
+                }
+                ReceivePaymentMethodArg::CrossChain => {
+                    let amount = amount.ok_or_else(|| {
+                        anyhow::anyhow!("--amount is required for cross-chain receive")
+                    })?;
+                    let filter = breez_sdk_spark::CrossChainRouteFilter::Receive {
+                        contract_address: None,
+                    };
+                    let route = select_cross_chain_route(sdk, rl, filter).await?;
+                    let fee_mode = if cross_chain_fees_included {
+                        Some(breez_sdk_spark::CrossChainFeeMode::FeesIncluded)
+                    } else {
+                        None
+                    };
+                    let destination = token_identifier.map(|token_identifier| {
+                        breez_sdk_spark::SparkAsset::Token { token_identifier }
+                    });
+                    ReceivePaymentMethod::CrossChain {
+                        route,
+                        amount,
+                        destination,
+                        fee_mode,
+                        max_slippage_bps: cross_chain_max_slippage_bps,
+                        target_overpay_bps: cross_chain_target_overpay_bps,
                     }
                 }
             };
@@ -1292,7 +1343,7 @@ pub(crate) async fn execute_command(
     }
 }
 
-/// Fetches cross-chain routes for the given address and prompts the user to
+/// Fetches cross-chain routes for the given filter and prompts the user to
 /// select one. If only a single route is available it is auto-selected.
 async fn select_cross_chain_route(
     sdk: &BreezSdk,
@@ -1301,9 +1352,7 @@ async fn select_cross_chain_route(
 ) -> Result<CrossChainRoutePair, anyhow::Error> {
     let routes = sdk.get_cross_chain_routes(&filter).await?;
     if routes.is_empty() {
-        return Err(anyhow::anyhow!(
-            "No cross-chain routes available for this address"
-        ));
+        return Err(anyhow::anyhow!("No cross-chain routes available"));
     }
 
     if routes.len() == 1 {

--- a/crates/breez-sdk/common/src/input/cross_chain.rs
+++ b/crates/breez-sdk/common/src/input/cross_chain.rs
@@ -244,6 +244,40 @@ fn parse_tron_uri(scheme: &str, path: &str, params: &QueryParams) -> ParsedCross
     }
 }
 
+/// Builds the string surfaced to the sender on a cross-chain receive.
+///
+/// `chain_id` is the EIP-681 chain id as a decimal string and is ignored on
+/// Solana/Tron. `amount` is in base units and is ignored on Solana/Tron.
+///
+/// - **EVM with contract** → `ethereum:<contract>[@<chain_id>]/transfer?address=<addr>&uint256=<amount>`
+/// - **EVM without contract** → `ethereum:<addr>[@<chain_id>]?value=<amount>`
+/// - **Solana** → `<address>`
+/// - **Tron** → `<address>`
+pub fn format_cross_chain_uri(
+    family: CrossChainAddressFamily,
+    address: &str,
+    contract_address: Option<&str>,
+    chain_id: Option<&str>,
+    amount: u128,
+) -> String {
+    let scheme = family.canonical_scheme();
+    let chain_id_suffix = chain_id
+        .filter(|_| matches!(family, CrossChainAddressFamily::Evm))
+        .map(|id| format!("@{id}"))
+        .unwrap_or_default();
+    match (family, contract_address) {
+        (CrossChainAddressFamily::Evm, Some(contract)) => {
+            format!(
+                "{scheme}:{contract}{chain_id_suffix}/transfer?address={address}&uint256={amount}"
+            )
+        }
+        (CrossChainAddressFamily::Evm, None) => {
+            format!("{scheme}:{address}{chain_id_suffix}?value={amount}")
+        }
+        (CrossChainAddressFamily::Solana | CrossChainAddressFamily::Tron, _) => address.to_string(),
+    }
+}
+
 /// Top-level entry point: attempt to classify `input` as a cross-chain
 /// address (or canonical URI). Returns `None` if the input is not recognized.
 ///
@@ -720,5 +754,99 @@ mod tests {
             try_parse_cross_chain_address("solana:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")
                 .is_none()
         );
+    }
+
+    // -- format_cross_chain_uri -----------------------------------------------
+
+    /// EVM ERC-20 transfer URI round-trips through `parse_cross_chain_uri`
+    /// to the same address / contract / `chain_id` / amount.
+    #[test]
+    fn format_evm_erc20_roundtrips_through_parser() {
+        let uri = format_cross_chain_uri(
+            CrossChainAddressFamily::Evm,
+            "0xC0Ffee0000000000000000000000000000000000",
+            Some("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"),
+            Some("8453"),
+            1_000_000,
+        );
+        assert_eq!(
+            uri,
+            "ethereum:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913@8453/transfer\
+             ?address=0xC0Ffee0000000000000000000000000000000000&uint256=1000000"
+        );
+        let parsed = parse_cross_chain_uri(&uri).unwrap();
+        assert_eq!(parsed.scheme, "ethereum");
+        assert_eq!(parsed.address, "0xC0Ffee0000000000000000000000000000000000");
+        assert_eq!(
+            parsed.contract_address.as_deref(),
+            Some("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")
+        );
+        assert_eq!(parsed.chain_id, Some(8453));
+        assert_eq!(parsed.amount, Some(1_000_000));
+    }
+
+    /// EVM native send (no contract) uses `value=` per EIP-681.
+    #[test]
+    fn format_evm_native_uses_value_param() {
+        let uri = format_cross_chain_uri(
+            CrossChainAddressFamily::Evm,
+            "0xC0Ffee0000000000000000000000000000000000",
+            None,
+            Some("1"),
+            42,
+        );
+        assert_eq!(
+            uri,
+            "ethereum:0xC0Ffee0000000000000000000000000000000000@1?value=42"
+        );
+        let parsed = parse_cross_chain_uri(&uri).unwrap();
+        assert_eq!(parsed.address, "0xC0Ffee0000000000000000000000000000000000");
+        assert!(parsed.contract_address.is_none());
+        assert_eq!(parsed.chain_id, Some(1));
+        assert_eq!(parsed.amount, Some(42));
+    }
+
+    #[test]
+    fn format_evm_without_chain_id_drops_the_suffix() {
+        let uri = format_cross_chain_uri(
+            CrossChainAddressFamily::Evm,
+            "0xC0Ffee0000000000000000000000000000000000",
+            None,
+            None,
+            1,
+        );
+        assert_eq!(
+            uri,
+            "ethereum:0xC0Ffee0000000000000000000000000000000000?value=1"
+        );
+    }
+
+    /// Solana wallets don't reliably honor Solana Pay URI parameters in
+    /// practice (Phantom partial, Solflare none), so we return the bare
+    /// address and let the integrator drive amount/token rendering.
+    #[test]
+    fn format_solana_returns_bare_address() {
+        let addr = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+        for contract in [None, Some("Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB")] {
+            let out = format_cross_chain_uri(
+                CrossChainAddressFamily::Solana,
+                addr,
+                contract,
+                None,
+                1_500_000,
+            );
+            assert_eq!(out, addr);
+        }
+    }
+
+    /// Tron has no published URI standard, so return the bare address.
+    #[test]
+    fn format_tron_returns_bare_address() {
+        let addr = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+        for contract in [None, Some("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t")] {
+            let out =
+                format_cross_chain_uri(CrossChainAddressFamily::Tron, addr, contract, None, 500);
+            assert_eq!(out, addr);
+        }
     }
 }

--- a/crates/breez-sdk/common/src/input/mod.rs
+++ b/crates/breez-sdk/common/src/input/mod.rs
@@ -5,7 +5,7 @@ mod parser;
 pub(crate) mod percent_encode;
 
 pub use cross_chain::{
-    CrossChainAddressFamily, detect_address_family, parse_cross_chain_uri,
+    CrossChainAddressFamily, detect_address_family, format_cross_chain_uri, parse_cross_chain_uri,
     try_parse_cross_chain_address,
 };
 pub use error::*;

--- a/crates/breez-sdk/core/src/cross_chain/boltz.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz.rs
@@ -26,8 +26,8 @@ use tokio::{select, sync::watch, time::sleep};
 use tracing::{debug, error, info, warn};
 
 use super::{
-    CrossChainFeeMode, CrossChainPrepared, CrossChainProvider, CrossChainProviderContext,
-    CrossChainRouteFilter, CrossChainRoutePair, CrossChainService, SourceAsset, SourceChain,
+    CrossChainFeeMode, CrossChainProvider, CrossChainProviderContext, CrossChainRouteFilter,
+    CrossChainRoutePair, CrossChainSendPrepared, CrossChainService, DeliveryMethod, SparkAsset,
     boltz_storage_adapter::PROVIDER_TAG_BOLTZ, derive_btc_leg_transfer_id,
     payment_with_conversion_info,
 };
@@ -211,7 +211,7 @@ impl BoltzService {
     /// `FeesExcluded`: `amount_sats` is the recipient's USD-equivalent intent.
     /// Convert to a destination-units target via the BTC/USD rate, then ask
     /// Boltz for the inflated `invoice_amount_sats` via its exact-out API.
-    async fn prepare_fees_excluded(
+    async fn prepare_send_fees_excluded(
         &self,
         recipient_address: &str,
         route: &CrossChainRoutePair,
@@ -219,14 +219,14 @@ impl BoltzService {
         asset: Asset,
         amount_sats: u64,
         max_slippage_bps: Option<u32>,
-    ) -> Result<CrossChainPrepared, SdkError> {
+    ) -> Result<CrossChainSendPrepared, SdkError> {
         debug!(
             chain = %route.chain,
             asset = %route.asset,
             recipient = %recipient_address,
             amount_sats,
             slippage_bps = ?max_slippage_bps,
-            "Boltz prepare(FeesExcluded): start"
+            "Boltz prepare_send(FeesExcluded): start"
         );
 
         let btc_usd = super::fetch_btc_usd_rate(self.fiat_service.as_ref()).await?;
@@ -242,11 +242,11 @@ impl BoltzService {
         })?;
         debug!(
             btc_usd,
-            target_dest, "Boltz prepare(FeesExcluded): fiat-derived target_dest"
+            target_dest, "Boltz prepare_send(FeesExcluded): fiat-derived target_dest"
         );
 
         let (prepared, created) = self
-            .create_swap_target_output(
+            .create_reverse_swap_target_output(
                 recipient_address,
                 chain,
                 asset,
@@ -260,7 +260,7 @@ impl BoltzService {
             estimated_onchain_amount = prepared.estimated_onchain_amount,
             output_amount = prepared.output_amount,
             boltz_slippage_bps = prepared.slippage_bps,
-            "Boltz prepare(FeesExcluded): swap created"
+            "Boltz prepare_send(FeesExcluded): swap created"
         );
 
         let ln_fee_sats = self.fetch_ln_fee(&created.invoice).await?;
@@ -276,10 +276,10 @@ impl BoltzService {
             swap_id = %created.swap_id,
             ln_fee_sats,
             asset_amount_in,
-            "Boltz prepare(FeesExcluded): complete"
+            "Boltz prepare_send(FeesExcluded): complete"
         );
 
-        Ok(Self::build_prepared(
+        Ok(Self::build_send_prepared(
             route,
             recipient_address,
             &prepared,
@@ -295,7 +295,7 @@ impl BoltzService {
     /// `total_sats - ln_fee_probe_sats` so the wallet doesn't blow its budget.
     /// Phase 1 uses boltz-client's probe-invoice API (no HD index burn / DB
     /// row / WS subscription); the probed fee is the budget enforced at send.
-    async fn prepare_fees_included(
+    async fn prepare_send_fees_included(
         &self,
         recipient_address: &str,
         route: &CrossChainRoutePair,
@@ -303,14 +303,14 @@ impl BoltzService {
         asset: Asset,
         total_sats: u64,
         max_slippage_bps: Option<u32>,
-    ) -> Result<CrossChainPrepared, SdkError> {
+    ) -> Result<CrossChainSendPrepared, SdkError> {
         debug!(
             chain = %route.chain,
             asset = %route.asset,
             recipient = %recipient_address,
             total_sats,
             slippage_bps = ?max_slippage_bps,
-            "Boltz prepare(FeesIncluded): start"
+            "Boltz prepare_send(FeesIncluded): start"
         );
 
         // Phase 1: throwaway probe invoice at `total_sats` to probe LN fee.
@@ -328,7 +328,7 @@ impl BoltzService {
         let real_invoice_sats = fees_included_real_invoice_sats(total_sats, ln_fee_probe_sats)?;
         debug!(
             ln_fee_probe_sats,
-            real_invoice_sats, "Boltz prepare(FeesIncluded): probe done"
+            real_invoice_sats, "Boltz prepare_send(FeesIncluded): probe done"
         );
 
         // Phase 2: real invoice sized to leave room for the probed fee.
@@ -373,12 +373,12 @@ impl BoltzService {
             ln_fee_final_sats,
             asset_amount_in,
             btc_usd,
-            "Boltz prepare(FeesIncluded): complete"
+            "Boltz prepare_send(FeesIncluded): complete"
         );
 
         // Carry the probed fee as the send-time budget (not the final), to
         // keep `invoice_sats + max_fee <= amount`.
-        Ok(Self::build_prepared(
+        Ok(Self::build_send_prepared(
             route,
             recipient_address,
             &prepared,
@@ -397,7 +397,7 @@ impl BoltzService {
     /// `slippage_bps` tolerance, so the recipient may land slightly under
     /// `output_amount`. `create_reverse_swap` then commits an HD key index
     /// and persists swap state; the only clean exit after that is a timeout.
-    async fn create_swap_target_output(
+    async fn create_reverse_swap_target_output(
         &self,
         recipient_address: &str,
         chain: &str,
@@ -469,7 +469,7 @@ impl BoltzService {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn build_prepared(
+    fn build_send_prepared(
         route: &CrossChainRoutePair,
         recipient_address: &str,
         prepared: &PreparedSwap,
@@ -478,7 +478,7 @@ impl BoltzService {
         asset_amount_in: u128,
         max_slippage_bps: Option<u32>,
         fee_mode: CrossChainFeeMode,
-    ) -> CrossChainPrepared {
+    ) -> CrossChainSendPrepared {
         // `service_fee_amount` is just the Boltz spread (invoice sats minus
         // on-chain payout). LN routing lives on `source_transfer_fee_sats`;
         // bridge/gas/DEX costs land in `fee_amount = asset_amount_in - estimated_out`.
@@ -498,7 +498,7 @@ impl BoltzService {
             max_slippage_bps: resolved_slippage,
         };
 
-        CrossChainPrepared {
+        CrossChainSendPrepared {
             amount_in: u128::from(invoice_amount_sats),
             asset_amount_in,
             estimated_out,
@@ -553,18 +553,18 @@ impl CrossChainService for BoltzService {
         Ok(routes)
     }
 
-    async fn prepare(
+    async fn prepare_send(
         &self,
         recipient_address: &str,
         route: &CrossChainRoutePair,
         amount: u128,
-        source_chain: Option<SourceChain>,
+        delivery_method: Option<DeliveryMethod>,
         source_token_identifier: Option<String>,
         max_slippage_bps: u32,
         fee_mode: CrossChainFeeMode,
-    ) -> Result<CrossChainPrepared, SdkError> {
+    ) -> Result<CrossChainSendPrepared, SdkError> {
         // Boltz reverse swaps are always paid over Lightning.
-        if !matches!(source_chain, None | Some(SourceChain::Lightning)) {
+        if !matches!(delivery_method, None | Some(DeliveryMethod::Lightning)) {
             return Err(SdkError::InvalidInput(
                 "Boltz routes can only be funded over Lightning".to_string(),
             ));
@@ -601,7 +601,7 @@ impl CrossChainService for BoltzService {
         let slippage = Some(max_slippage_bps);
         match fee_mode {
             CrossChainFeeMode::FeesExcluded => {
-                self.prepare_fees_excluded(
+                self.prepare_send_fees_excluded(
                     recipient_address,
                     route,
                     &route.chain,
@@ -612,7 +612,7 @@ impl CrossChainService for BoltzService {
                 .await
             }
             CrossChainFeeMode::FeesIncluded => {
-                self.prepare_fees_included(
+                self.prepare_send_fees_included(
                     recipient_address,
                     route,
                     &route.chain,
@@ -625,10 +625,25 @@ impl CrossChainService for BoltzService {
         }
     }
 
+    async fn prepare_receive(
+        &self,
+        _route: &CrossChainRoutePair,
+        _recipient_address: &str,
+        _amount: u128,
+        _max_slippage_bps: u32,
+        _destination: &crate::cross_chain::SparkAsset,
+        _fee_mode: crate::cross_chain::CrossChainFeeMode,
+        _target_overpay_bps: u32,
+    ) -> Result<crate::cross_chain::CrossChainReceivePrepared, SdkError> {
+        Err(SdkError::InvalidInput(
+            "Boltz does not support cross-chain receive.".to_string(),
+        ))
+    }
+
     #[allow(clippy::large_futures)]
     async fn send(
         &self,
-        prepared: &CrossChainPrepared,
+        prepared: &CrossChainSendPrepared,
         idempotency_key: Option<String>,
     ) -> Result<crate::Payment, SdkError> {
         let CrossChainProviderContext::Boltz {
@@ -910,8 +925,8 @@ fn destination_to_route_pair(
         contract_address: dest.dest_token_address.clone(),
         decimals: 6,
         exact_out_eligible: false,
-        supported_sources: vec![SourceAsset::Bitcoin],
-        supported_source_chains: vec![SourceChain::Lightning],
+        accepted_assets: vec![SparkAsset::Bitcoin],
+        delivery_methods: vec![DeliveryMethod::Lightning],
     }
 }
 
@@ -1000,7 +1015,7 @@ mod tests {
         assert_eq!(pair.contract_address.as_deref(), Some("0xtoken"));
         assert_eq!(pair.decimals, 6);
         assert!(!pair.exact_out_eligible);
-        assert_eq!(pair.supported_source_chains, vec![SourceChain::Lightning]);
+        assert_eq!(pair.delivery_methods, vec![DeliveryMethod::Lightning]);
     }
 
     #[test_all]
@@ -1053,8 +1068,8 @@ mod tests {
             contract_address: contract.map(str::to_string),
             decimals: 6,
             exact_out_eligible: false,
-            supported_sources: vec![SourceAsset::Bitcoin],
-            supported_source_chains: vec![SourceChain::Lightning],
+            accepted_assets: vec![SparkAsset::Bitcoin],
+            delivery_methods: vec![DeliveryMethod::Lightning],
         }
     }
 

--- a/crates/breez-sdk/core/src/cross_chain/boltz.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz.rs
@@ -16,11 +16,8 @@ use boltz_client::{
 };
 use breez_sdk_common::fiat::FiatService;
 use breez_sdk_common::input::CrossChainAddressFamily;
+use platform_utils::tokio;
 use platform_utils::tokio::sync::OnceCell;
-use platform_utils::{
-    time::{SystemTime, UNIX_EPOCH},
-    tokio,
-};
 use spark_wallet::SparkWallet;
 use tokio::{select, sync::watch, time::sleep};
 use tracing::{debug, error, info, warn};
@@ -39,6 +36,7 @@ use crate::{
     utils::{
         payments::resolve_and_insert_payment_metadata,
         polling::{PollSchedule, poll_until},
+        time::try_now_secs,
     },
 };
 
@@ -862,11 +860,7 @@ fn validate_quote_expiry(expires_at: &str) -> Result<(), SdkError> {
     let exp_secs: u64 = expires_at
         .parse()
         .map_err(|e| SdkError::Generic(format!("Boltz: invalid expires_at {expires_at:?}: {e}")))?;
-    let now_secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|_| SdkError::Generic("Failed to read current time".to_string()))?
-        .as_secs();
-    if now_secs >= exp_secs {
+    if try_now_secs()? >= exp_secs {
         return Err(SdkError::InvalidInput(
             "Cross-chain quote has expired. Please re-prepare.".to_string(),
         ));

--- a/crates/breez-sdk/core/src/cross_chain/cached_fiat.rs
+++ b/crates/breez-sdk/core/src/cross_chain/cached_fiat.rs
@@ -15,10 +15,11 @@ use breez_sdk_common::{
     error::ServiceConnectivityError,
     fiat::{FiatCurrency, FiatService, Rate},
 };
-use platform_utils::time::{SystemTime, UNIX_EPOCH};
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::Mutex;
 use tracing::trace;
+
+use crate::utils::time::now_ms;
 
 /// Default cache TTL. Long enough to amortize repeated fetches in a session,
 /// short enough to bound fiat-rate drift between estimate and quote.
@@ -91,12 +92,6 @@ impl CachedFiatService {
         );
         Ok(response)
     }
-}
-
-fn now_ms() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.as_millis())
 }
 
 #[macros::async_trait]

--- a/crates/breez-sdk/core/src/cross_chain/mod.rs
+++ b/crates/breez-sdk/core/src/cross_chain/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod boltz_event_listener;
 pub(crate) mod boltz_storage_adapter;
 mod cached_fiat;
 mod orchestra;
+mod orchestra_storage_adapter;
 
 pub(crate) use boltz::BoltzService;
 pub(crate) use cached_fiat::{CachedFiatService, DEFAULT_FIAT_CACHE_TTL};
@@ -32,14 +33,14 @@ pub(crate) const MAX_CROSS_CHAIN_SLIPPAGE_BPS: u32 = 500;
 pub(crate) const DEFAULT_CROSS_CHAIN_SLIPPAGE_BPS: u32 = 100;
 
 /// Bounds for the target-overpay pad applied to the user's destination amount
-/// on `FeesExcluded` conversion sends. `0` opts out; `500` caps at 5% (matches
+/// on `FeesExcluded` conversion sends. `0` opts out. `500` caps at 5% (matches
 /// the slippage upper bound).
 pub(crate) const MIN_TARGET_OVERPAY_BPS: u32 = 0;
 pub(crate) const MAX_TARGET_OVERPAY_BPS: u32 = 500;
 /// Default pad applied when neither the request nor
 /// [`crate::CrossChainConfig::default_target_overpay_bps`] specifies one.
-/// Calibrated to the observed Orchestra delivery drift; tune per provider as
-/// real-world data accrues.
+/// Calibrated to the observed Orchestra delivery drift. Tune per provider
+/// as real-world data accrues.
 pub(crate) const DEFAULT_TARGET_OVERPAY_BPS: u32 = 15;
 /// Tickers treated as $1-pegged for par-value rescaling. Adding a non-USD
 /// ticker would silently misreport `fee_amount` for routes using it.
@@ -138,30 +139,29 @@ impl std::fmt::Display for CrossChainProvider {
     }
 }
 
-/// The source asset a cross-chain route accepts as input on the Spark side.
+/// The asset a cross-chain route accepts on the Spark side.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
-pub enum SourceAsset {
+pub enum SparkAsset {
     /// Native BTC (sats).
     Bitcoin,
     /// A Spark token, identified by its bech32m `token_identifier` (e.g. `btkn1...`).
     Token { token_identifier: String },
 }
 
-/// The chain a cross-chain route is funded from, orthogonal to the
-/// [`SourceAsset`] that moves.
+/// The rail a cross-chain payment is delivered over.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
-pub enum SourceChain {
-    /// Paid over Spark, using a Bitcoin or token source asset.
+pub enum DeliveryMethod {
+    /// Delivered over the Spark network.
     Spark,
-    /// Paid over Lightning, using a Bitcoin source asset.
+    /// Delivered over Lightning.
     Lightning,
-    /// Paid on-chain to Bitcoin (L1), using a Bitcoin source asset.
+    /// Delivered on-chain over Bitcoin.
     Bitcoin,
 }
 
-impl std::fmt::Display for SourceChain {
+impl std::fmt::Display for DeliveryMethod {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Spark => f.write_str("Spark"),
@@ -221,13 +221,13 @@ pub enum CrossChainRouteFilter {
 pub struct CrossChainRoutePair {
     /// Which provider offers this route.
     pub provider: CrossChainProvider,
-    /// Destination blockchain (e.g. `"base"`, `"solana"`, `"tron"`).
+    /// External blockchain (e.g. `"base"`, `"solana"`, `"tron"`).
     pub chain: String,
-    /// Stable chain identifier (e.g. EVM `chainId` as a decimal string).
+    /// External chain identifier (e.g. EVM `chainId` as a decimal string).
     /// `None` for non-EVM chains that don't expose one, or when the
     /// provider doesn't surface it.
     pub chain_id: Option<String>,
-    /// Destination asset symbol (e.g. `"USDC"`, `"USDT"`).
+    /// External asset symbol (e.g. `"USDC"`, `"USDT"`).
     pub asset: String,
     /// Token contract / mint address on the destination chain.
     pub contract_address: Option<String>,
@@ -235,19 +235,11 @@ pub struct CrossChainRoutePair {
     pub decimals: u8,
     /// Whether the route supports exact-out mode.
     pub exact_out_eligible: bool,
-    /// The source assets this route accepts on the Spark side.
-    ///
-    /// Boltz routes accept `[SourceAsset::Bitcoin]`. Orchestra routes accept
-    /// one or more of `Bitcoin` / `Token(...)` (a given destination endpoint
-    /// may be fronted by multiple source variants on Orchestra).
-    pub supported_sources: Vec<SourceAsset>,
-    /// The chains this route can be paid over, orthogonal to
-    /// `supported_sources` (the asset moved).
-    ///
-    /// This is the actual funding rail, which differs by provider: Boltz routes
-    /// are always paid over Lightning. Orchestra send routes report Spark, and
-    /// Orchestra payment-link routes report Lightning.
-    pub supported_source_chains: Vec<SourceChain>,
+    /// Spark-side assets this route accepts.
+    pub accepted_assets: Vec<SparkAsset>,
+    /// Rails this route can be delivered over, orthogonal to
+    /// `accepted_assets` (the asset moved vs the rail moved on).
+    pub delivery_methods: Vec<DeliveryMethod>,
 }
 
 impl CrossChainRoutePair {
@@ -334,10 +326,49 @@ pub enum CrossChainProviderContext {
     },
 }
 
+/// Prepared cross-chain receive: the payment request to hand to the sender
+/// and the receive-quote details. The provider row is already persisted by
+/// the time this returns.
+#[derive(Debug, Clone)]
+pub(crate) struct CrossChainReceivePrepared {
+    /// Canonical cross-chain URI the sender can paste or scan to pay.
+    pub payment_request: String,
+    pub info: CrossChainReceiveInfo,
+}
+
+/// Information about the cross-chain receive quote.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct CrossChainReceiveInfo {
+    /// Bare external deposit address the sender pays to.
+    pub deposit_address: String,
+    /// Amount the sender must deposit, in source-asset base units
+    /// (`route.decimals`). On `FeesExcluded` this may differ from the
+    /// request's `amount` because the SDK inflates the deposit to absorb
+    /// provider fees. Render this value to the sender.
+    pub deposit_amount: u128,
+    /// Amount the receiver will see, net of provider fees, in
+    /// destination-asset base units. Sats when receiving BTC into Spark,
+    /// or token base units when receiving a Spark token (e.g. USDB). The
+    /// final delivered amount may move within the slippage tolerance.
+    pub expected_received_amount: u128,
+    /// Spark token identifier when the destination is a token. Absent when
+    /// the destination is BTC and the receiver will see sats.
+    pub token_identifier: Option<String>,
+    /// Provider-quoted total fee for this receive, in `service_fee_asset`
+    /// units.
+    pub service_fee_amount: u128,
+    /// Ticker for `service_fee_amount`. Absent when the fee is denominated
+    /// in sats.
+    pub service_fee_asset: Option<String>,
+    /// Quote expiry as a unix timestamp in seconds.
+    pub expires_at: u64,
+}
+
 /// Data stashed on the prepared send payment so the provider can resume
 /// the send stage without re-quoting.
 #[derive(Debug, Clone)]
-pub(crate) struct CrossChainPrepared {
+pub(crate) struct CrossChainSendPrepared {
     pub amount_in: u128,
     /// `amount_in` expressed in the cross-chain (destination) asset's base
     /// units, via the fiat rate or decimal rescale the SDK used at prepare
@@ -381,6 +412,7 @@ pub(crate) struct CrossChainPrepared {
 ///
 /// Each implementation owns its own client, caching, and background monitoring.
 /// The SDK dispatches to the provider via this trait.
+#[allow(clippy::too_many_arguments)]
 #[macros::async_trait]
 pub(crate) trait CrossChainService: Send + Sync {
     /// Returns the available cross-chain route pairs.
@@ -394,22 +426,49 @@ pub(crate) trait CrossChainService: Send + Sync {
     ) -> Result<Vec<CrossChainRoutePair>, SdkError>;
 
     /// Fetch a quote for a cross-chain send or Lightning onramp. `amount` is
-    /// always in the source-leg sats/token base units; the caller converts any
-    /// USD intent to sats first. `source_chain` selects the funding chain;
-    /// `None` uses the provider's default ([`SourceChain::Spark`] for Orchestra).
-    /// `source_token_identifier` is only meaningful for a Spark source
-    /// (`None` = BTC sats, `Some` = a token).
+    /// always in the source-leg sats/token base units. The caller converts any
+    /// USD intent to sats first. `delivery_method` selects the rail the wallet
+    /// dispatches over. `None` uses the provider's default
+    /// ([`DeliveryMethod::Spark`] for Orchestra). `source_token_identifier`
+    /// is only meaningful for a Spark source (`None` = BTC sats, `Some` = a
+    /// token).
     #[allow(clippy::too_many_arguments)]
-    async fn prepare(
+    async fn prepare_send(
         &self,
         recipient_address: &str,
         route: &CrossChainRoutePair,
         amount: u128,
-        source_chain: Option<SourceChain>,
+        delivery_method: Option<DeliveryMethod>,
         source_token_identifier: Option<String>,
         max_slippage_bps: u32,
         fee_mode: CrossChainFeeMode,
-    ) -> Result<CrossChainPrepared, SdkError>;
+    ) -> Result<CrossChainSendPrepared, SdkError>;
+
+    /// Fetch a quote for a cross-chain receive.
+    ///
+    /// `amount` is the caller's raw ask, always:
+    /// - `FeesExcluded`: net amount the receiver wants to land on the Spark
+    ///   side, in `destination`'s base units (sats for BTC, token base units
+    ///   for tokens). The provider inflates by `target_overpay_bps` when
+    ///   sizing the deposit but drift-checks against `amount` itself, so the
+    ///   overpay gives Orchestra headroom without tightening the accept
+    ///   threshold beyond what the user asked for.
+    /// - `FeesIncluded`: the deposit the sender will pay, in the route's
+    ///   source-asset base units. The receiver lands `amount - fees`.
+    ///   `target_overpay_bps` is ignored.
+    async fn prepare_receive(
+        &self,
+        route: &CrossChainRoutePair,
+        recipient_address: &str,
+        amount: u128,
+        max_slippage_bps: u32,
+        // Pre-validated Spark-side destination: the SDK dispatch has
+        // checked this against `route.accepted_assets` and resolved any
+        // wallet-level defaults (e.g. active stable balance).
+        destination: &SparkAsset,
+        fee_mode: CrossChainFeeMode,
+        target_overpay_bps: u32,
+    ) -> Result<CrossChainReceivePrepared, SdkError>;
 
     /// Execute the send: transfer funds to the deposit address, submit to
     /// the provider, persist metadata, monitor to terminal, and return the
@@ -428,7 +487,7 @@ pub(crate) trait CrossChainService: Send + Sync {
     /// SDK dispatcher does not wrap this with an additional wait.
     async fn send(
         &self,
-        prepared: &CrossChainPrepared,
+        prepared: &CrossChainSendPrepared,
         idempotency_key: Option<String>,
     ) -> Result<crate::Payment, SdkError>;
 }
@@ -477,10 +536,68 @@ pub(crate) fn convert_sats_to_destination_amount(
     Ok(target as u128)
 }
 
+/// Converts a source-asset amount (base units at `src_decimals`) to sats
+/// via `fiat_per_btc`. Assumes the source is denominated 1:1 in the same
+/// fiat as the rate. Inverse of [`convert_sats_to_destination_amount`].
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+pub(crate) fn convert_source_amount_to_sats(
+    src_base_units: u128,
+    src_decimals: u32,
+    fiat_per_btc: f64,
+) -> Result<u128, SdkError> {
+    let src_scale = 10f64.powi(i32::try_from(src_decimals).unwrap_or(i32::MAX));
+    let sats = (src_base_units as f64) * 100_000_000f64 / (src_scale * fiat_per_btc);
+    if !sats.is_finite() || sats < 0.0 {
+        return Err(SdkError::Generic(format!(
+            "Cross-chain: invalid stable→sats conversion result: {sats}"
+        )));
+    }
+    Ok(sats as u128)
+}
+
 pub(crate) fn is_usd_stable_asset(asset: &str) -> bool {
     USD_STABLE_ASSETS
         .iter()
         .any(|a| asset.eq_ignore_ascii_case(a))
+}
+
+/// Builds the payment-request URI a sender pays to for a cross-chain
+/// receive. EVM destinations get an EIP-681 URI so wallets like `MetaMask`
+/// auto-fill recipient/token/chain/amount. Solana and Tron destinations
+/// fall back to the bare `deposit_address` because current wallets don't
+/// honor those schemes' parameters reliably (see
+/// [`breez_sdk_common::input::format_cross_chain_uri`]).
+pub(crate) fn build_receive_payment_request(
+    deposit_address: &str,
+    chain: &str,
+    chain_id: Option<&str>,
+    contract_address: Option<&str>,
+    amount: u128,
+) -> Result<String, SdkError> {
+    let family =
+        breez_sdk_common::input::detect_address_family(deposit_address).ok_or_else(|| {
+            SdkError::Generic(format!(
+                "Cross-chain provider returned unrecognised deposit address: {deposit_address}",
+            ))
+        })?;
+    // Guard against a provider returning an address that belongs to a
+    // different chain family than the route we requested.
+    if !family.matches_chain(chain, contract_address) {
+        return Err(SdkError::Generic(format!(
+            "Cross-chain provider returned {family:?} deposit address for {chain} route"
+        )));
+    }
+    Ok(breez_sdk_common::input::format_cross_chain_uri(
+        family,
+        deposit_address,
+        contract_address,
+        chain_id,
+        amount,
+    ))
 }
 
 /// Best-available fee: realized `asset_amount_in − delivered_amount` on
@@ -553,6 +670,39 @@ pub(crate) fn convert_destination_amount_to_sats(
     Ok(sats as u128)
 }
 
+/// Resolves the target-overpay bps to apply on `FeesExcluded` cross-chain
+/// preparations (send and receive). Same precedence as slippage:
+/// caller-supplied value (bounds-checked here), then the config default, then
+/// the built-in default. Config defaults are validated at SDK startup in
+/// `Config::validate`.
+pub(crate) fn resolve_target_overpay_bps(
+    requested: Option<u32>,
+    config_default: Option<u32>,
+) -> Result<u32, SdkError> {
+    if let Some(bps) = requested
+        && !(MIN_TARGET_OVERPAY_BPS..=MAX_TARGET_OVERPAY_BPS).contains(&bps)
+    {
+        return Err(SdkError::InvalidInput(format!(
+            "target_overpay_bps {bps} must be in \
+             {MIN_TARGET_OVERPAY_BPS} to {MAX_TARGET_OVERPAY_BPS}",
+        )));
+    }
+    Ok(requested
+        .or(config_default)
+        .unwrap_or(DEFAULT_TARGET_OVERPAY_BPS))
+}
+
+/// Inflates a target amount by `overpay_bps` so the realized delivery lands at
+/// or above target despite provider slippage. `overpay_bps == 0` is identity.
+/// Used on both directions: send pads the destination target, receive pads
+/// the source-asset deposit.
+pub(crate) fn inflate_target_amount(amount: u128, overpay_bps: u32) -> u128 {
+    if overpay_bps == 0 {
+        return amount;
+    }
+    amount.saturating_add(amount.saturating_mul(u128::from(overpay_bps)) / 10_000)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -562,10 +712,10 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[test_all]
-    fn source_chain_display_is_human_readable() {
-        assert_eq!(SourceChain::Spark.to_string(), "Spark");
-        assert_eq!(SourceChain::Lightning.to_string(), "Lightning");
-        assert_eq!(SourceChain::Bitcoin.to_string(), "Bitcoin");
+    fn delivery_method_display_is_human_readable() {
+        assert_eq!(DeliveryMethod::Spark.to_string(), "Spark");
+        assert_eq!(DeliveryMethod::Lightning.to_string(), "Lightning");
+        assert_eq!(DeliveryMethod::Bitcoin.to_string(), "Bitcoin");
     }
 
     #[test_all]
@@ -760,7 +910,7 @@ mod tests {
 
     /// Regression: `CrossChainProviderContext::Boltz.invoice_amount_sats` must
     /// be the source of truth for the LN-leg amount, distinct from
-    /// `CrossChainPrepared::amount_in` (which can carry a user-facing display
+    /// `CrossChainSendPrepared::amount_in` (which can carry a user-facing display
     /// value such as token base units after the dispatcher's conversion-path
     /// override). Conflating the two persisted USDB base units into the
     /// `invoice_amount_sats` field of `ConversionInfo::Boltz`, showing a
@@ -817,7 +967,7 @@ mod tests {
 
     /// Same invariant for Orchestra: `deposit_amount` is the source of truth
     /// for the deposit transfer size and is distinct from
-    /// `CrossChainPrepared::amount_in`.
+    /// `CrossChainSendPrepared::amount_in`.
     #[test_all]
     fn orchestra_provider_context_deposit_amount_is_independent_of_amount_in() {
         let ctx = CrossChainProviderContext::Orchestra {
@@ -928,5 +1078,186 @@ mod tests {
             out.details,
             Some(PaymentDetails::Withdraw { tx_id }) if tx_id == "tx1"
         ));
+    }
+
+    // ---- resolve_target_overpay_bps ----
+
+    #[test_all]
+    fn resolve_target_overpay_uses_request_when_in_range() {
+        assert_eq!(resolve_target_overpay_bps(Some(50), Some(75)).unwrap(), 50);
+    }
+
+    #[test_all]
+    fn resolve_target_overpay_falls_back_to_config_default() {
+        assert_eq!(resolve_target_overpay_bps(None, Some(75)).unwrap(), 75);
+    }
+
+    #[test_all]
+    fn resolve_target_overpay_falls_back_to_built_in_default() {
+        assert_eq!(
+            resolve_target_overpay_bps(None, None).unwrap(),
+            DEFAULT_TARGET_OVERPAY_BPS
+        );
+    }
+
+    #[test_all]
+    fn resolve_target_overpay_request_zero_opts_out() {
+        assert_eq!(resolve_target_overpay_bps(Some(0), Some(50)).unwrap(), 0);
+    }
+
+    #[test_all]
+    fn resolve_target_overpay_rejects_out_of_range_request() {
+        let too_high = MAX_TARGET_OVERPAY_BPS + 1;
+        assert!(matches!(
+            resolve_target_overpay_bps(Some(too_high), None),
+            Err(SdkError::InvalidInput(_))
+        ));
+    }
+
+    // ---- inflate_target_amount ----
+
+    #[test_all]
+    fn inflate_target_amount_zero_bps_is_identity() {
+        assert_eq!(inflate_target_amount(1_000_000, 0), 1_000_000);
+    }
+
+    #[test_all]
+    fn inflate_target_amount_applies_bps_pad() {
+        // 25 bps on 1_000_000 → 2_500 pad.
+        assert_eq!(inflate_target_amount(1_000_000, 25), 1_002_500);
+    }
+
+    #[test_all]
+    fn inflate_target_amount_truncates_sub_unit_pad() {
+        // 25 bps on 100 → 0.25 pad, truncates to 0.
+        assert_eq!(inflate_target_amount(100, 25), 100);
+    }
+
+    // ---- convert_source_amount_to_sats ----
+
+    #[test_all]
+    fn convert_stable_to_sats_at_par_6dp() {
+        // BTC/USD = 100_000, 1 USD = 1000 sats. 1_000_000 (6dp) = $1 = 1000 sats.
+        assert_eq!(
+            convert_source_amount_to_sats(1_000_000, 6, 100_000.0).unwrap(),
+            1000
+        );
+    }
+
+    #[test_all]
+    fn convert_stable_to_sats_at_a_different_rate() {
+        // BTC/USD = 50_000, $1 = 2000 sats.
+        assert_eq!(
+            convert_source_amount_to_sats(1_000_000, 6, 50_000.0).unwrap(),
+            2000
+        );
+    }
+
+    #[test_all]
+    fn convert_stable_to_sats_matches_across_decimals_at_same_usd_value() {
+        // $1 at 6dp and at 18dp must produce the same sats.
+        let sats_6 = convert_source_amount_to_sats(1_000_000, 6, 100_000.0).unwrap();
+        let sats_18 =
+            convert_source_amount_to_sats(1_000_000_000_000_000_000, 18, 100_000.0).unwrap();
+        assert_eq!(sats_6, sats_18);
+        assert_eq!(sats_6, 1000);
+    }
+
+    #[test_all]
+    fn convert_stable_to_sats_zero_input_is_zero() {
+        assert_eq!(convert_source_amount_to_sats(0, 6, 100_000.0).unwrap(), 0);
+    }
+
+    #[test_all]
+    fn convert_stable_to_sats_rejects_nan_rate() {
+        // Infinity is intentionally allowed (produces 0 sats, a finite result);
+        // NaN is the pathological input we guard against.
+        assert!(matches!(
+            convert_source_amount_to_sats(1_000_000, 6, f64::NAN),
+            Err(SdkError::Generic(_))
+        ));
+    }
+
+    #[test_all]
+    fn convert_stable_to_sats_rejects_negative_rate() {
+        assert!(matches!(
+            convert_source_amount_to_sats(1_000_000, 6, -100_000.0),
+            Err(SdkError::Generic(_))
+        ));
+    }
+
+    // ---- build_receive_payment_request ----
+
+    /// EVM destinations produce an EIP-681 URI (with `chain_id` and token
+    /// contract when present) so wallets like `MetaMask` auto-fill.
+    #[test_all]
+    fn build_receive_payment_request_evm_emits_eip_681_uri() {
+        let uri = build_receive_payment_request(
+            "0x00Df20df75800ca8f40080505a7a802331C1321c",
+            "arbitrum",
+            Some("42161"),
+            Some("0xaf88d065e77c8cC2239327C5EDb3A432268e5831"),
+            1_000_000,
+        )
+        .unwrap();
+        assert!(uri.starts_with("ethereum:"), "got {uri}");
+        assert!(uri.contains("42161"), "chain_id must appear: {uri}");
+        assert!(
+            uri.contains("0xaf88d065e77c8cC2239327C5EDb3A432268e5831"),
+            "token contract must appear: {uri}"
+        );
+        assert!(uri.contains("1000000"), "amount must appear: {uri}");
+    }
+
+    /// Solana falls back to the bare deposit address: current wallets don't
+    /// honor solana: URI parameters reliably.
+    #[test_all]
+    fn build_receive_payment_request_solana_returns_bare_address() {
+        let addr = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+        let out = build_receive_payment_request(addr, "solana", None, None, 1_000_000).unwrap();
+        assert_eq!(out, addr);
+    }
+
+    /// Tron falls back to the bare deposit address for the same reason.
+    #[test_all]
+    fn build_receive_payment_request_tron_returns_bare_address() {
+        let addr = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+        let out = build_receive_payment_request(addr, "tron", None, None, 1_000_000).unwrap();
+        assert_eq!(out, addr);
+    }
+
+    /// An unrecognized address surfaces a Generic error rather than silently
+    /// returning something usable.
+    #[test_all]
+    fn build_receive_payment_request_rejects_unrecognized_address() {
+        let err =
+            build_receive_payment_request("not-an-address", "arbitrum", None, None, 1_000_000)
+                .unwrap_err();
+        assert!(matches!(err, SdkError::Generic(_)));
+    }
+
+    /// An EVM-looking deposit address for a Solana route must be rejected:
+    /// a provider that miswires chains cannot silently redirect funds by
+    /// returning an EVM address where a Solana address was expected.
+    #[test_all]
+    fn build_receive_payment_request_rejects_family_chain_mismatch() {
+        let evm_addr = "0x00Df20df75800ca8f40080505a7a802331C1321c";
+        let err =
+            build_receive_payment_request(evm_addr, "solana", None, None, 1_000_000).unwrap_err();
+        match err {
+            SdkError::Generic(msg) => {
+                assert!(
+                    msg.contains("Evm") && msg.contains("solana"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected Generic mismatch error, got {other:?}"),
+        }
+
+        let solana_addr = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+        assert!(
+            build_receive_payment_request(solana_addr, "tron", None, None, 1_000_000).is_err(),
+            "solana address must not be accepted for tron route",
+        );
     }
 }

--- a/crates/breez-sdk/core/src/cross_chain/mod.rs
+++ b/crates/breez-sdk/core/src/cross_chain/mod.rs
@@ -171,16 +171,24 @@ impl std::fmt::Display for DeliveryMethod {
     }
 }
 
-/// How the caller wants fees handled against the request `amount`.
-///
-/// - `FeesExcluded`: `amount` is the provider invoice/deposit target; the
-///   wallet pays `amount + source_transfer_fee_sats` in total.
-/// - `FeesIncluded`: `amount` is the wallet's total sats budget; the provider
-///   leg is sized so `amount_in + source_transfer_fee_sats <= amount`.
+/// Which side of the transfer the request `amount` sizes: what leaves the
+/// payer, or what reaches the receiver.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum CrossChainFeeMode {
+    /// `amount` sizes the receiving end, and fees are paid on top.
+    ///
+    /// Sending: `amount` is the provider invoice/deposit target, and the
+    /// wallet pays `amount + source_transfer_fee_sats` in total.
+    /// Receiving: `amount` is what the wallet ends up with, and the deposit
+    /// the sender is asked for is sized above it to cover fees.
     FeesExcluded,
+    /// `amount` sizes the paying end, and fees come out of it.
+    ///
+    /// Sending: `amount` is the wallet's total sats budget, and the provider
+    /// leg is sized so `amount_in + source_transfer_fee_sats <= amount`.
+    /// Receiving: `amount` is the deposit the sender makes, and the wallet
+    /// ends up with that minus fees.
     FeesIncluded,
 }
 
@@ -352,6 +360,10 @@ pub struct CrossChainReceiveInfo {
     /// or token base units when receiving a Spark token (e.g. USDB). The
     /// final delivered amount may move within the slippage tolerance.
     pub expected_received_amount: u128,
+    /// Symbol of the Spark-side asset `expected_received_amount` is
+    /// denominated in, as the provider reports it: `"BTC"` for sats, or the
+    /// token symbol (e.g. `"USDB"`).
+    pub destination_asset: String,
     /// Spark token identifier when the destination is a token. Absent when
     /// the destination is BTC and the receiver will see sats.
     pub token_identifier: Option<String>,

--- a/crates/breez-sdk/core/src/cross_chain/orchestra.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra.rs
@@ -12,8 +12,8 @@ use breez_sdk_common::fiat::FiatService;
 use breez_sdk_common::input::CrossChainAddressFamily;
 use chrono::DateTime;
 use flashnet::orchestra::{
-    AmountMode, EstimateRequest, EstimateResponse, OrderStatus, QuoteRequest, QuoteResponse, Route,
-    RouteAsset, StatusResponse, SubmitResponse,
+    AmountMode, EstimateRequest, EstimateResponse, Order, OrderStatus, QuoteRequest, QuoteResponse,
+    Route, RouteAsset, StatusResponse, SubmitResponse,
 };
 use flashnet::{FlashnetError, OrchestraClient, OrchestraConfig, OrchestraConfigResolver};
 use platform_utils::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -30,13 +30,15 @@ use crate::persist::{ConversionFilter, StorageListPaymentsRequest, StoragePaymen
 use crate::{ConversionInfo, ConversionStatus, Payment, PaymentDetails, PaymentStatus, Storage};
 
 use super::{
-    CrossChainFeeMode, CrossChainPrepared, CrossChainProvider, CrossChainProviderContext,
-    CrossChainRouteFilter, CrossChainRoutePair, CrossChainService, SourceAsset, SourceChain,
-    derive_btc_leg_transfer_id, payment_with_conversion_info,
+    CrossChainFeeMode, CrossChainProvider, CrossChainProviderContext, CrossChainReceiveInfo,
+    CrossChainReceivePrepared, CrossChainRouteFilter, CrossChainRoutePair, CrossChainSendPrepared,
+    CrossChainService, DeliveryMethod, SparkAsset, derive_btc_leg_transfer_id,
+    orchestra_storage_adapter::{OrchestraStorageAdapter, OrchestraSwapData},
+    payment_with_conversion_info,
 };
 
 use crate::utils::{
-    payments::fetch_and_process_payment,
+    payments::{fetch_and_process_payment, resolve_and_insert_payment_metadata},
     polling::{PollSchedule, poll_until},
 };
 
@@ -45,24 +47,24 @@ const SOURCE_CHAIN_SPARK: &str = "spark";
 const SOURCE_CHAIN_LIGHTNING: &str = "lightning";
 const SOURCE_CHAIN_BITCOIN: &str = "bitcoin";
 
-/// The Orchestra wire value for a [`SourceChain`].
-fn source_chain_to_wire(source_chain: SourceChain) -> &'static str {
-    match source_chain {
-        SourceChain::Spark => SOURCE_CHAIN_SPARK,
-        SourceChain::Lightning => SOURCE_CHAIN_LIGHTNING,
-        SourceChain::Bitcoin => SOURCE_CHAIN_BITCOIN,
+/// The Orchestra `source_chain` wire value for a [`DeliveryMethod`].
+fn delivery_method_to_wire(delivery_method: DeliveryMethod) -> &'static str {
+    match delivery_method {
+        DeliveryMethod::Spark => SOURCE_CHAIN_SPARK,
+        DeliveryMethod::Lightning => SOURCE_CHAIN_LIGHTNING,
+        DeliveryMethod::Bitcoin => SOURCE_CHAIN_BITCOIN,
     }
 }
 
-/// Parses an Orchestra `source_chain` wire value, or `None` for one that isn't
-/// a local funding chain.
-fn source_chain_from_wire(chain: &str) -> Option<SourceChain> {
+/// Parses an Orchestra `source_chain` wire value into a [`DeliveryMethod`],
+/// or `None` for one that isn't a local delivery rail.
+fn delivery_method_from_wire(chain: &str) -> Option<DeliveryMethod> {
     if chain.eq_ignore_ascii_case(SOURCE_CHAIN_SPARK) {
-        Some(SourceChain::Spark)
+        Some(DeliveryMethod::Spark)
     } else if chain.eq_ignore_ascii_case(SOURCE_CHAIN_LIGHTNING) {
-        Some(SourceChain::Lightning)
+        Some(DeliveryMethod::Lightning)
     } else if chain.eq_ignore_ascii_case(SOURCE_CHAIN_BITCOIN) {
-        Some(SourceChain::Bitcoin)
+        Some(DeliveryMethod::Bitcoin)
     } else {
         None
     }
@@ -73,6 +75,24 @@ const DEFAULT_AFFILIATE_ID: &str = "breez_sdk";
 const SEND_POLL_INITIAL_DELAY_MS: u64 = 500;
 const SEND_POLL_MAX_DELAY_MS: u64 = 2000;
 const SEND_POLL_TIMEOUT_SECS: u64 = 30;
+/// Grace period to keep probing a receive quote before giving up.
+const RECEIVE_GRACE_SECS: u64 = 24 * 60 * 60;
+
+/// One-cent margin (in 6-decimal USDB base units) covering Orchestra's
+/// post-quote rounding drift on USDB deliveries: `estimated_out` rounds up
+/// to the next cent, actual delivery rounds down, so `1_000_000` can arrive
+/// as `990_000`. Applied at both ends of the pipeline: on sizing, so the
+/// deposit is inflated enough for delivery to land at or above `FeesExcluded`
+/// target; on reporting, so `expected_received_amount` doesn't over-promise
+/// the receiver. The pad is meaningful at the $1 boundary (1% of value) and
+/// negligible above roughly $10.
+const USDB_RECEIVE_ROUNDING_MARGIN: u128 = 10_000;
+
+/// Basis points of slack allowed between the source amount we requested
+/// (`ExactIn`) and the `amount_in` Orchestra echoes back on the quote.
+/// Legitimate rounding at provider-side precision boundaries is bounded.
+/// Anything larger is provider misbehavior we refuse to persist.
+const QUOTE_AMOUNT_IN_TOLERANCE_BPS: u32 = 10;
 
 /// Resolves the Orchestra config from Breez server.
 ///
@@ -110,7 +130,7 @@ impl OrchestraConfigResolver for BreezServerOrchestraConfigResolver {
 
 /// Source-side identity of an Orchestra route after `(dest, source)` matching.
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct ResolvedSourceAsset {
+struct ResolvedSparkAsset {
     /// Wire symbol (e.g. `"BTC"`, `"USDB"`).
     asset: String,
     /// Source-asset decimals.
@@ -164,8 +184,10 @@ impl OrchestraService {
         monitor_trigger: &broadcast::Sender<()>,
     ) {
         let storage = Arc::clone(&self.storage);
+        let swap_storage = OrchestraStorageAdapter::new(Arc::clone(&storage));
         let client = Arc::clone(&self.client);
         let spark_wallet = Arc::clone(&self.spark_wallet);
+        let fiat_service = Arc::clone(&self.fiat_service);
         let mut trigger_receiver = monitor_trigger.subscribe();
         let span = tracing::Span::current();
 
@@ -173,9 +195,20 @@ impl OrchestraService {
             async move {
                 loop {
                     if let Err(e) =
-                        Self::poll_in_flight_orders(&storage, &client, &spark_wallet).await
+                        Self::poll_in_flight_sends(&storage, &client, &spark_wallet).await
                     {
-                        error!("Orchestra monitor poll failed: {e:?}");
+                        error!("Orchestra send-monitor poll failed: {e:?}");
+                    }
+                    if let Err(e) = Self::poll_in_flight_receives(
+                        &storage,
+                        &swap_storage,
+                        &client,
+                        &spark_wallet,
+                        fiat_service.as_ref(),
+                    )
+                    .await
+                    {
+                        error!("Orchestra receive-monitor poll failed: {e:?}");
                     }
 
                     select! {
@@ -223,12 +256,16 @@ impl OrchestraService {
             None
         };
 
+        let idempotency_key = flashnet::orchestra::derive_idempotency_key("submit", quote_id);
         match client
-            .submit_spark(flashnet::orchestra::SubmitRequestSpark {
-                quote_id: quote_id.to_string(),
-                spark_tx_hash,
-                source_spark_address,
-            })
+            .submit(
+                flashnet::orchestra::SubmitRequest {
+                    quote_id: quote_id.to_string(),
+                    spark_tx_hash: Some(spark_tx_hash),
+                    source_spark_address,
+                },
+                idempotency_key,
+            )
             .await
         {
             Ok(response) => {
@@ -248,19 +285,18 @@ impl OrchestraService {
         }
     }
 
-    /// Polls Orchestra for status updates on in-flight cross-chain orders.
+    /// Polls Orchestra for status updates on in-flight cross-chain send orders.
     ///
     /// Queries storage for payments with `ConversionFilter::OrchestraPending`,
     /// calls the Orchestra `/status` endpoint for each, and updates the
     /// `ConversionInfo::Orchestra` metadata when the order reaches a terminal
     /// state (replacing the estimated output with the real `amount_out`).
     #[allow(clippy::too_many_lines)]
-    async fn poll_in_flight_orders(
+    async fn poll_in_flight_sends(
         storage: &Arc<dyn Storage>,
         client: &Arc<OrchestraClient>,
         spark_wallet: &Arc<SparkWallet>,
     ) -> Result<(), SdkError> {
-        debug!("Orchestra monitor: polling for in-flight orders");
         let pending = storage
             .list_payments(StorageListPaymentsRequest {
                 payment_details_filter: Some(vec![
@@ -278,7 +314,10 @@ impl OrchestraService {
             })
             .await?;
 
-        debug!("Orchestra monitor: found {} pending orders", pending.len());
+        debug!(
+            "Orchestra monitor: found {} pending send orders",
+            pending.len()
+        );
         for payment in &pending {
             let Some(
                 PaymentDetails::Spark {
@@ -449,6 +488,180 @@ impl OrchestraService {
         Ok(())
     }
 
+    /// Polls Orchestra for status updates on active cross-chain receive orders.
+    /// Dispatches per row based on whether Orchestra has issued an order
+    /// handle: pre-order rows go to [`Self::check_for_receive_deposit`],
+    /// in-flight rows go to [`Self::poll_receive_order_status`].
+    async fn poll_in_flight_receives(
+        storage: &Arc<dyn Storage>,
+        swap_storage: &OrchestraStorageAdapter,
+        client: &Arc<OrchestraClient>,
+        spark_wallet: &Arc<SparkWallet>,
+        fiat_service: &dyn FiatService,
+    ) -> Result<(), SdkError> {
+        let active = swap_storage.list_active().await?;
+        debug!(
+            "Orchestra monitor: found {} active receive rows",
+            active.len()
+        );
+
+        for (row, data) in active {
+            let quote_id = data.quote_id.clone();
+            // Long-stop for unfunded quotes
+            if data.order_id.is_none() && is_past_receive_grace(&data) {
+                info!(
+                    "Orchestra receive {quote_id}: unfunded {RECEIVE_GRACE_SECS}s past expiry, closing row"
+                );
+                if let Err(e) = swap_storage.mark_terminal(row).await {
+                    error!(
+                        "Orchestra receive {quote_id}: failed to mark unfunded row terminal: {e:?}"
+                    );
+                }
+                continue;
+            }
+
+            let (row, data, order_id) = match data.order_id.clone() {
+                Some(order_id) => (row, data, order_id),
+                None => {
+                    match Self::check_for_receive_deposit(swap_storage, client, row, data).await {
+                        Ok(Some((row, data, order_id))) => (row, data, order_id),
+                        Ok(None) => continue,
+                        Err(e) => {
+                            error!("Orchestra receive {quote_id}: deposit check failed: {e:?}");
+                            continue;
+                        }
+                    }
+                }
+            };
+            if let Err(e) = Self::poll_receive_order_status(
+                storage,
+                swap_storage,
+                client,
+                spark_wallet,
+                fiat_service,
+                row,
+                data,
+                &order_id,
+            )
+            .await
+            {
+                error!("Orchestra receive {quote_id}: status poll failed: {e:?}");
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Probes `/submit` with a fresh idempotency key. A 200 means Orchestra
+    /// detected the deposit and issued an order handle: the adapter persists
+    /// it and this returns the updated `(row, data, order_id)` for immediate
+    /// status polling. Any error (including the `invalid_tx_hash` 400
+    /// Orchestra returns before the deposit arrives) leaves the row
+    /// non-terminal for the next tick.
+    async fn check_for_receive_deposit(
+        swap_storage: &OrchestraStorageAdapter,
+        client: &Arc<OrchestraClient>,
+        row: crate::StoredCrossChainSwap,
+        data: OrchestraSwapData,
+    ) -> Result<Option<(crate::StoredCrossChainSwap, OrchestraSwapData, String)>, SdkError> {
+        let quote_id = data.quote_id.clone();
+        let request = flashnet::orchestra::SubmitRequest {
+            quote_id: quote_id.clone(),
+            spark_tx_hash: None,
+            source_spark_address: None,
+        };
+        let idempotency_key = uuid::Uuid::new_v4().to_string();
+        match client.submit(request, idempotency_key).await {
+            Ok(resp) => {
+                info!(
+                    "Orchestra receive {quote_id}: detected deposit, orderId={}",
+                    resp.order_id
+                );
+                let order_id = resp.order_id.clone();
+                let (row, data) = swap_storage
+                    .attach_order_handle(row, data, resp.order_id, resp.read_token)
+                    .await?;
+                Ok(Some((row, data, order_id)))
+            }
+            Err(e) => {
+                // 4xx is the expected "no deposit yet" shape from Orchestra.
+                // 5xx / 429 / transport errors are transient provider issues
+                // worth surfacing so a persistent outage doesn't go silent.
+                if is_expected_no_deposit_error(&e) {
+                    debug!("Orchestra receive {quote_id}: no deposit yet: {e}");
+                } else {
+                    warn!("Orchestra receive {quote_id}: transient submit error: {e}");
+                }
+                Ok(None)
+            }
+        }
+    }
+
+    /// Polls `/status` for an in-flight order. On `Completed` attaches
+    /// metadata to the inbound Spark Payment (caching it if the row is not
+    /// visible yet). On `Failed` / `Refunded` closes the row with no
+    /// metadata.
+    #[allow(clippy::too_many_arguments)]
+    async fn poll_receive_order_status(
+        storage: &Arc<dyn Storage>,
+        swap_storage: &OrchestraStorageAdapter,
+        client: &Arc<OrchestraClient>,
+        spark_wallet: &Arc<SparkWallet>,
+        fiat_service: &dyn FiatService,
+        row: crate::StoredCrossChainSwap,
+        data: OrchestraSwapData,
+        order_id: &str,
+    ) -> Result<(), SdkError> {
+        let quote_id = data.quote_id.clone();
+        let resp = match client
+            .status_by_id(order_id, data.read_token.as_deref())
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                debug!(
+                    "Orchestra receive {quote_id}: status request failed for orderId={order_id}: {e}"
+                );
+                return Ok(());
+            }
+        };
+        let order = resp.order;
+        debug!("Orchestra receive {quote_id}: order response: {order:?}");
+        match order.status {
+            OrderStatus::Completed => {
+                match attach_receive_metadata(storage, spark_wallet, fiat_service, &data, &order)
+                    .await
+                {
+                    Ok(true) => {
+                        info!("Orchestra receive {quote_id} → Completed, metadata attached");
+                        swap_storage.mark_terminal(row).await?;
+                    }
+                    Ok(false) => {
+                        // Order Completed but no sparkTxHash yet: no key to
+                        // link or cache against. Retry next tick once
+                        // Orchestra populates it.
+                        debug!(
+                            "Orchestra receive {quote_id} Completed without sparkTxHash; will retry"
+                        );
+                    }
+                    Err(e) => {
+                        error!("Orchestra receive {quote_id} metadata attach failed: {e:?}");
+                    }
+                }
+            }
+            OrderStatus::Failed | OrderStatus::Refunded => {
+                info!(
+                    "Orchestra receive {quote_id} → {:?}, closing row without metadata",
+                    order.status
+                );
+                swap_storage.mark_terminal(row).await?;
+            }
+            // Non-terminal status.
+            _ => {}
+        }
+        Ok(())
+    }
+
     /// Resolves the Orchestra-side `source_asset` wire symbol (e.g. `"BTC"`,
     /// `"USDB"`) for the given destination route + source chain.
     ///
@@ -463,7 +676,7 @@ impl OrchestraService {
         dest: &CrossChainRoutePair,
         source_chain: &str,
         token_identifier: Option<&str>,
-    ) -> Result<ResolvedSourceAsset, SdkError> {
+    ) -> Result<ResolvedSparkAsset, SdkError> {
         let raw_routes = self.client.filter_routes(source_chain, true).await?;
         find_source_asset(&raw_routes, dest, token_identifier).ok_or_else(|| {
             SdkError::InvalidInput(format!(
@@ -479,7 +692,7 @@ impl OrchestraService {
     /// fiat rate; USD-stable token source rescales between decimals.
     async fn compute_target_destination_amount(
         &self,
-        source_asset: &ResolvedSourceAsset,
+        source_asset: &ResolvedSparkAsset,
         route: &CrossChainRoutePair,
         amount: u128,
     ) -> Result<u128, SdkError> {
@@ -496,23 +709,54 @@ impl OrchestraService {
         }
     }
 
-    /// Probes the live delivery ratio via an `ExactIn` estimate, then scales
-    /// `source_amount` up to deliver `destination_amount`. Floored at
-    /// `source_amount`. Sends the affiliate id so the probe sees the same
-    /// fee schedule the real quote will.
+    /// Destination-units `target` → source-units rough deposit, used as the
+    /// probe seed for Orchestra's `/estimate` on `FeesExcluded` receives.
+    /// Symmetric inverse of [`Self::compute_target_destination_amount`]:
+    /// BTC destination fetches the fiat rate. USD-stable destination rescales
+    /// decimals at par.
+    async fn compute_target_source_amount(
+        &self,
+        destination: &SparkAsset,
+        destination_decimals: u32,
+        route: &CrossChainRoutePair,
+        target: u128,
+    ) -> Result<u128, SdkError> {
+        match destination {
+            SparkAsset::Bitcoin => {
+                let btc_usd = super::fetch_btc_usd_rate(self.fiat_service.as_ref()).await?;
+                super::convert_sats_to_destination_amount(target, btc_usd, route.decimals.into())
+            }
+            SparkAsset::Token { .. } => {
+                super::rescale_decimals(target, destination_decimals, route.decimals.into())
+            }
+        }
+    }
+
+    /// Sizes the source-asset deposit with defensive headroom on top to
+    /// absorb price and fee variance between the probe and the eventual
+    /// quote. `apply_rounding_margin` widens that headroom for destinations
+    /// that floor delivery at a coarser unit (USDB cents). `apply_base_fee_pad`
+    /// adds `estimate.fee_amount` on top when Orchestra reports it in the
+    /// source asset. The check gates the pad so a fee reported in some other
+    /// denomination (e.g. destination units on a BTC-source send) is never
+    /// added to a source-unit quantity.
+    #[allow(clippy::too_many_arguments)]
     async fn estimate_required_source_amount(
         &self,
         source_chain: &str,
         source_asset: &str,
-        route: &CrossChainRoutePair,
+        destination_chain: &str,
+        destination_asset: &str,
         source_amount: u128,
         destination_amount: u128,
+        apply_rounding_margin: bool,
+        apply_base_fee_pad: bool,
     ) -> Result<u128, SdkError> {
         let request = EstimateRequest {
             source_chain: source_chain.to_string(),
             source_asset: source_asset.to_string(),
-            destination_chain: route.chain.clone(),
-            destination_asset: route.asset.clone(),
+            destination_chain: destination_chain.to_string(),
+            destination_asset: destination_asset.to_string(),
             amount: source_amount.to_string(),
             amount_mode: Some(AmountMode::ExactIn),
             affiliate_id: Some(DEFAULT_AFFILIATE_ID.to_string()),
@@ -528,7 +772,33 @@ impl OrchestraService {
         let estimate: EstimateResponse = self.client.estimate(request).await?;
         debug!("Orchestra: estimate response: {:?}", estimate);
         let delivered = parse_amount(&estimate.estimated_out, "estimatedOut")?;
-        proportional_inflation(source_amount, destination_amount, delivered)
+        let effective_delivered = if apply_rounding_margin {
+            delivered.saturating_sub(USDB_RECEIVE_ROUNDING_MARGIN)
+        } else {
+            delivered
+        };
+        let scaled =
+            proportional_inflation(source_amount, destination_amount, effective_delivered)?;
+        let reported_pad =
+            if apply_base_fee_pad && estimate.fee_asset.eq_ignore_ascii_case(source_asset) {
+                parse_amount(&estimate.fee_amount, "feeAmount")?
+            } else {
+                0
+            };
+        let (required_in, base_fee_pad) = pad_required_in(scaled, reported_pad);
+        if base_fee_pad < reported_pad {
+            warn!(
+                "Orchestra: capping base_fee_pad {reported_pad} to scaled {scaled} \
+                 (source_probe={source_amount} target={destination_amount})"
+            );
+        }
+        debug!(
+            "Orchestra: estimate scaling: source_probe={source_amount} \
+             estimated_delivered={delivered} effective_delivered={effective_delivered} \
+             target={destination_amount} scaled={scaled} base_fee_pad={base_fee_pad} \
+             → required_in={required_in}",
+        );
+        Ok(required_in)
     }
 }
 
@@ -557,6 +827,43 @@ fn proportional_inflation(
     Ok(inflated.max(source_amount))
 }
 
+/// Adds `reported_pad` to `scaled`, capping the pad at `scaled` so a bogus
+/// estimate response can grow the deposit by at most 2x. Returns the padded
+/// result and the actually applied pad (less than `reported_pad` when the
+/// cap fired).
+fn pad_required_in(scaled: u128, reported_pad: u128) -> (u128, u128) {
+    let applied = reported_pad.min(scaled);
+    (scaled.saturating_add(applied), applied)
+}
+
+/// Whether an Orchestra error on the receive-side `/submit` probe is the
+/// expected "no deposit yet" shape (any 4xx). Anything else (5xx, 429,
+/// transport failure) is a transient provider issue worth logging louder.
+fn is_expected_no_deposit_error(err: &FlashnetError) -> bool {
+    matches!(err, FlashnetError::Network { code: Some(c), .. } if *c < 500)
+}
+
+/// Errors if `quoted_amount_in` differs from `requested_source_amount` by
+/// more than [`QUOTE_AMOUNT_IN_TOLERANCE_BPS`].
+fn verify_quote_amount_in(
+    requested_source_amount: u128,
+    quoted_amount_in: u128,
+) -> Result<(), SdkError> {
+    let tolerance = requested_source_amount
+        .saturating_mul(u128::from(QUOTE_AMOUNT_IN_TOLERANCE_BPS))
+        / 10_000u128;
+    let low = requested_source_amount.saturating_sub(tolerance);
+    let high = requested_source_amount.saturating_add(tolerance);
+    if quoted_amount_in < low || quoted_amount_in > high {
+        return Err(SdkError::InvalidInput(format!(
+            "Cross-chain quote amountIn out of range: requested {requested_source_amount}, \
+             got {quoted_amount_in} (tolerance {QUOTE_AMOUNT_IN_TOLERANCE_BPS} bps). \
+             Please re-prepare."
+        )));
+    }
+    Ok(())
+}
+
 /// Errors if `quoted_estimated_out` falls below `destination_amount * (1 −
 /// max_slippage_bps / 10000)`.
 fn verify_quote_not_drifted(
@@ -568,45 +875,90 @@ fn verify_quote_not_drifted(
         .saturating_mul(u128::from(10_000u32.saturating_sub(max_slippage_bps)))
         / 10_000u128;
     if quoted_estimated_out < min_acceptable {
+        let drift_bps = destination_amount
+            .saturating_sub(quoted_estimated_out)
+            .saturating_mul(10_000)
+            .checked_div(destination_amount)
+            .unwrap_or(0);
+        warn!(
+            "Cross-chain quote drift: target={destination_amount} \
+             delivered={quoted_estimated_out} min_acceptable={min_acceptable} \
+             drift_bps={drift_bps} slippage_budget_bps={max_slippage_bps}"
+        );
         return Err(SdkError::InvalidInput(format!(
-            "Cross-chain quote rate drift: expected destination amount {destination_amount}, got {quoted_estimated_out}. Please re-prepare."
+            "Cross-chain quote rate drift: expected destination amount {destination_amount}, \
+             got {quoted_estimated_out} (drift {drift_bps} bps > slippage budget \
+             {max_slippage_bps} bps). Retry with a larger `target_overpay_bps` or send a \
+             bigger amount."
         )));
     }
     Ok(())
 }
 
-/// Finds the Orchestra-side source asset for the given `(dest, source)` pair.
-///
-/// Match semantics:
-/// - destination matches by `(chain, asset, contract_address)` exactly.
-/// - source matches by **case-insensitive** asset symbol when
-///   `token_identifier` is `None` (BTC source); otherwise by the source's
-///   `contract_address` (which on the Spark side is the bech32m token
-///   identifier) equalling `token_identifier`.
-///
-/// Returns the matched route's source asset symbol and decimals. `None` if no
-/// route matches.
+/// Finds the Spark-side wire symbol and decimals for a route matching
+/// `(external_pair, spark_asset)`. `is_send` picks direction: Spark is the
+/// source on send, the destination on receive. Returns `None` if no route
+/// matches.
+fn find_spark_side(
+    routes: &[Route],
+    external_pair: &CrossChainRoutePair,
+    spark_asset: &SparkAsset,
+    is_send: bool,
+) -> Option<ResolvedSparkAsset> {
+    routes
+        .iter()
+        .find(|r| {
+            let (external, spark) = if is_send {
+                (&r.destination, &r.source)
+            } else {
+                (&r.source, &r.destination)
+            };
+            external.chain == external_pair.chain
+                && external.asset == external_pair.asset
+                && external.contract_address == external_pair.contract_address
+                && match spark_asset {
+                    SparkAsset::Bitcoin => spark.asset.eq_ignore_ascii_case("BTC"),
+                    SparkAsset::Token { token_identifier } => {
+                        spark.contract_address.as_deref() == Some(token_identifier.as_str())
+                    }
+                }
+        })
+        .map(|r| {
+            let spark = if is_send { &r.source } else { &r.destination };
+            ResolvedSparkAsset {
+                asset: spark.asset.clone(),
+                decimals: spark.decimals,
+            }
+        })
+}
+
+/// Finds the Orchestra source asset for an outbound (Spark → external)
+/// route. Thin wrapper over [`find_spark_side`] in the send direction.
+/// `token_identifier == None` means BTC source. Otherwise the Spark token
+/// id (bech32m).
 fn find_source_asset(
     routes: &[Route],
     dest: &CrossChainRoutePair,
     token_identifier: Option<&str>,
-) -> Option<ResolvedSourceAsset> {
-    routes
-        .iter()
-        .find(|r| {
-            let dest_matches = r.destination.chain == dest.chain
-                && r.destination.asset == dest.asset
-                && r.destination.contract_address == dest.contract_address;
-            let source_matches = match token_identifier {
-                None => r.source.asset.eq_ignore_ascii_case("BTC"),
-                Some(tid) => r.source.contract_address.as_deref() == Some(tid),
-            };
-            dest_matches && source_matches
-        })
-        .map(|r| ResolvedSourceAsset {
-            asset: r.source.asset.clone(),
-            decimals: r.source.decimals,
-        })
+) -> Option<ResolvedSparkAsset> {
+    let spark = match token_identifier {
+        None => SparkAsset::Bitcoin,
+        Some(tid) => SparkAsset::Token {
+            token_identifier: tid.to_string(),
+        },
+    };
+    find_spark_side(routes, dest, &spark, true)
+}
+
+/// Test-only projection of [`find_spark_side`] to just the destination
+/// asset symbol.
+#[cfg(test)]
+fn find_destination_asset_symbol(
+    routes: &[Route],
+    pair: &CrossChainRoutePair,
+    destination: &SparkAsset,
+) -> Option<String> {
+    find_spark_side(routes, pair, destination, false).map(|r| r.asset)
 }
 
 #[macros::async_trait]
@@ -663,21 +1015,22 @@ impl CrossChainService for OrchestraService {
         ))
     }
 
-    async fn prepare(
+    async fn prepare_send(
         &self,
         recipient_address: &str,
         route: &CrossChainRoutePair,
         amount: u128,
-        source_chain: Option<SourceChain>,
+        delivery_method: Option<DeliveryMethod>,
         source_token_identifier: Option<String>,
         max_slippage_bps: u32,
         fee_mode: CrossChainFeeMode,
-    ) -> Result<CrossChainPrepared, SdkError> {
+    ) -> Result<CrossChainSendPrepared, SdkError> {
         // Default to the Spark wallet source. Resolve the real Orchestra source
         // asset for the chain: `spark` matches BTC or the token; `lightning`/
         // `bitcoin` match the externally funded BTC route. The lookup also
         // validates the route exists.
-        let source_chain = source_chain_to_wire(source_chain.unwrap_or(SourceChain::Spark));
+        let source_chain =
+            delivery_method_to_wire(delivery_method.unwrap_or(DeliveryMethod::Spark));
         let source_asset = self
             .resolve_source_asset(route, source_chain, source_token_identifier.as_deref())
             .await?;
@@ -695,9 +1048,12 @@ impl CrossChainService for OrchestraService {
                     .estimate_required_source_amount(
                         source_chain,
                         &source_asset.asset,
-                        route,
+                        &route.chain,
+                        &route.asset,
                         amount,
                         destination_amount,
+                        false,
+                        false,
                     )
                     .await?;
                 (required_in, Some(destination_amount))
@@ -734,6 +1090,7 @@ impl CrossChainService for OrchestraService {
         let estimated_out = parse_amount(&quote.estimated_out, "estimatedOut")?;
         let service_fee_amount = parse_amount(&quote.total_fee_amount, "totalFeeAmount")?;
 
+        verify_quote_amount_in(source_amount, amount_in)?;
         if let Some(target) = destination_amount {
             verify_quote_not_drifted(target, estimated_out, max_slippage_bps)?;
         }
@@ -751,7 +1108,7 @@ impl CrossChainService for OrchestraService {
             deposit_amount: amount_in,
         };
 
-        Ok(CrossChainPrepared {
+        Ok(CrossChainSendPrepared {
             amount_in,
             asset_amount_in,
             estimated_out,
@@ -773,9 +1130,212 @@ impl CrossChainService for OrchestraService {
         })
     }
 
+    async fn prepare_receive(
+        &self,
+        route: &CrossChainRoutePair,
+        recipient_address: &str,
+        amount: u128,
+        max_slippage_bps: u32,
+        destination: &SparkAsset,
+        fee_mode: CrossChainFeeMode,
+        target_overpay_bps: u32,
+    ) -> Result<CrossChainReceivePrepared, SdkError> {
+        // Resolve the destination's Spark-side wire symbol (e.g. "BTC",
+        // "USDB") and decimals from the matching raw route. Route-level
+        // validation of `destination` against `route.accepted_assets` is
+        // the caller's responsibility.
+        let raw_routes = self.client.filter_routes(SOURCE_CHAIN_SPARK, false).await?;
+        let resolved_destination = find_spark_side(&raw_routes, route, destination, false)
+            .ok_or_else(|| {
+                SdkError::Generic(format!(
+                    "Orchestra route {}/{} has no entry matching destination {:?}",
+                    route.chain, route.asset, destination
+                ))
+            })?;
+        let destination_asset_symbol = resolved_destination.asset;
+        let destination_decimals = u32::from(resolved_destination.decimals);
+        let destination_token_identifier = match destination {
+            SparkAsset::Bitcoin => None,
+            SparkAsset::Token { token_identifier } => Some(token_identifier.clone()),
+        };
+        // The dispatcher (`convert_receive_amount_to_provider_units`) hardcodes
+        // the destination-token rescale target at 6dp. Assert here so a new
+        // Spark-side token with different decimals fails loudly rather than
+        // producing miscaled deposits.
+        if destination_token_identifier.is_some() && destination_decimals != 6 {
+            return Err(SdkError::Generic(format!(
+                "Cross-chain receive: Spark-side token {destination_asset_symbol} has \
+                 unexpected decimals {destination_decimals} (expected 6)"
+            )));
+        }
+        // USDB is the only Spark-side token the SDK knows how to target-size
+        // on FeesExcluded (USD-parity with a USD-stable source at 6dp). Reject
+        // other tokens loudly rather than sizing them against an assumption
+        // that doesn't hold.
+        if matches!(fee_mode, CrossChainFeeMode::FeesExcluded)
+            && destination_token_identifier.is_some()
+            && !destination_asset_symbol.eq_ignore_ascii_case("USDB")
+        {
+            return Err(SdkError::InvalidInput(format!(
+                "Cross-chain receive with FeesExcluded currently only supports USDB \
+                 or Bitcoin destinations. Requested destination asset: {destination_asset_symbol}."
+            )));
+        }
+        // USDB delivery rounds below Orchestra's quoted `estimated_out` at
+        // the cent boundary; apply the rounding margin so the receiver gets
+        // at least the quoted amount.
+        let apply_rounding_margin = destination_asset_symbol.eq_ignore_ascii_case("USDB");
+
+        // FeesExcluded inflates the deposit so Orchestra delivers `amount`
+        // on the Spark side. FeesIncluded passes `amount` through as the
+        // deposit.
+        let (source_amount, target_destination_amount) = match fee_mode {
+            CrossChainFeeMode::FeesIncluded => (amount, None),
+            CrossChainFeeMode::FeesExcluded => {
+                // `target_overpay_bps` applies to SIZING only: it pads the
+                // deposit but the drift check (below) still uses `amount`.
+                // Padding both would raise the accept threshold in lockstep
+                // with the deposit and negate the overpay.
+                //
+                // `route.asset` is the cross-chain source on receive, and
+                // `get_cross_chain_routes` restricts it to USD-stable tickers
+                // (USDC / USDT / ...), so the par rescale / fiat anchor
+                // inside the probe is well-defined.
+                let inflated_target = super::inflate_target_amount(amount, target_overpay_bps);
+                let probe_source = self
+                    .compute_target_source_amount(
+                        destination,
+                        destination_decimals,
+                        route,
+                        inflated_target,
+                    )
+                    .await?;
+                debug!(
+                    "Orchestra receive probe: destination_target={amount} \
+                     inflated_target={inflated_target} → probe_source={probe_source} \
+                     (destination_decimals={destination_decimals}, source_decimals={})",
+                    route.decimals,
+                );
+                let required_in = self
+                    .estimate_required_source_amount(
+                        &route.chain,
+                        &route.asset,
+                        SOURCE_CHAIN_SPARK,
+                        &destination_asset_symbol,
+                        probe_source,
+                        inflated_target,
+                        apply_rounding_margin,
+                        true,
+                    )
+                    .await?;
+                (required_in, Some(amount))
+            }
+        };
+
+        let request = QuoteRequest {
+            // On receive the `route` describes the external side, so it maps
+            // to SOURCE on the wire and Spark is the DESTINATION.
+            source_chain: route.chain.clone(),
+            source_asset: route.asset.clone(),
+            destination_chain: SOURCE_CHAIN_SPARK.to_string(),
+            destination_asset: destination_asset_symbol.clone(),
+            amount: source_amount.to_string(),
+            recipient_address: recipient_address.to_string(),
+            // ExactIn: the deposit is fixed (caller-picked on FeesIncluded,
+            // SDK-computed on FeesExcluded); Orchestra forward-computes what
+            // the receiver gets net of fees.
+            amount_mode: Some(AmountMode::ExactIn),
+            refund_address: None,
+            slippage_bps: Some(max_slippage_bps),
+            zeroconf_enabled: None,
+            app_fees: Vec::new(),
+            affiliate_id: Some(DEFAULT_AFFILIATE_ID.to_string()),
+        };
+
+        debug!(
+            "Orchestra: requesting receive quote: {}/{} -> {}/{} amount={}",
+            request.source_chain,
+            request.source_asset,
+            request.destination_chain,
+            request.destination_asset,
+            request.amount
+        );
+        let quote: QuoteResponse = self.client.quote(request).await?;
+        debug!("Orchestra: receive quote response: {:?}", quote);
+
+        let deposit_amount = parse_amount(&quote.amount_in, "amountIn")?;
+        let quote_estimated_out = parse_amount(&quote.estimated_out, "estimatedOut")?;
+        let service_fee_amount = parse_amount(&quote.total_fee_amount, "totalFeeAmount")?;
+        let expires_at_secs = parse_rfc3339_to_unix_seconds(&quote.expires_at)?;
+
+        // Verify the quote's amountIn matches what we requested.
+        verify_quote_amount_in(source_amount, deposit_amount)?;
+        // FeesExcluded only: reject the quote if Orchestra's delivery
+        // estimate drifts outside the slippage tolerance.
+        if let Some(target) = target_destination_amount {
+            verify_quote_not_drifted(target, quote_estimated_out, max_slippage_bps)?;
+        }
+        // Reporting counterpart to the sizing pad: shave the reported
+        // estimate by the same margin so we don't over-promise the receiver.
+        // See [`USDB_RECEIVE_ROUNDING_MARGIN`].
+        let expected_received_amount = if apply_rounding_margin {
+            quote_estimated_out.saturating_sub(USDB_RECEIVE_ROUNDING_MARGIN)
+        } else {
+            quote_estimated_out
+        };
+
+        let data = OrchestraSwapData {
+            quote_id: quote.quote_id.clone(),
+            order_id: None,
+            read_token: None,
+            recipient_address: recipient_address.to_string(),
+            source_chain: route.chain.clone(),
+            source_asset: route.asset.clone(),
+            source_chain_id: route.chain_id.clone(),
+            source_contract_address: route.contract_address.clone(),
+            source_decimals: u32::from(route.decimals),
+            destination_chain: SOURCE_CHAIN_SPARK.to_string(),
+            destination_asset: destination_asset_symbol,
+            destination_decimals,
+            token_identifier: destination_token_identifier.clone(),
+            amount_in: quote.amount_in.clone(),
+            expected_amount_out: expected_received_amount.to_string(),
+            fee_amount: Some(quote.total_fee_amount.clone()),
+            expires_at: expires_at_secs,
+        };
+
+        let adapter = OrchestraStorageAdapter::new(Arc::clone(&self.storage));
+        adapter.upsert(&data).await?;
+
+        let payment_request = super::build_receive_payment_request(
+            &quote.deposit_address,
+            &route.chain,
+            route.chain_id.as_deref(),
+            route.contract_address.as_deref(),
+            deposit_amount,
+        )?;
+
+        Ok(CrossChainReceivePrepared {
+            payment_request,
+            info: CrossChainReceiveInfo {
+                deposit_address: quote.deposit_address,
+                deposit_amount,
+                expected_received_amount,
+                token_identifier: destination_token_identifier,
+                service_fee_amount,
+                service_fee_asset: if quote.fee_asset.eq_ignore_ascii_case("BTC") {
+                    None
+                } else {
+                    Some(quote.fee_asset)
+                },
+                expires_at: expires_at_secs,
+            },
+        })
+    }
+
     async fn send(
         &self,
-        prepared: &CrossChainPrepared,
+        prepared: &CrossChainSendPrepared,
         idempotency_key: Option<String>,
     ) -> Result<crate::Payment, SdkError> {
         let CrossChainProviderContext::Orchestra {
@@ -828,13 +1388,17 @@ impl CrossChainService for OrchestraService {
         } else {
             None
         };
+        let idempotency_key = flashnet::orchestra::derive_idempotency_key("submit", quote_id);
         let submit_res: Result<SubmitResponse, _> = self
             .client
-            .submit_spark(flashnet::orchestra::SubmitRequestSpark {
-                quote_id: quote_id.clone(),
-                spark_tx_hash: spark_tx_hash.clone(),
-                source_spark_address,
-            })
+            .submit(
+                flashnet::orchestra::SubmitRequest {
+                    quote_id: quote_id.clone(),
+                    spark_tx_hash: Some(spark_tx_hash.clone()),
+                    source_spark_address,
+                },
+                idempotency_key,
+            )
             .await;
 
         // Step 3: Persist ConversionInfo::Orchestra metadata.
@@ -970,7 +1534,12 @@ fn non_spark_side(r: &Route, is_send: bool) -> &RouteAsset {
 /// Whether a raw Orchestra route should appear in the deduplicated list,
 /// given the caller's address-family and contract-address filters.
 ///
-/// Both filters operate on the non-Spark side of the route:
+/// Same-chain routes (`source_chain == destination_chain`) are always
+/// dropped: Orchestra advertises on-Spark AMM swaps in the same routes
+/// response, and those belong to the token conversion API, not the
+/// cross-chain surface.
+///
+/// Both address-family and contract filters operate on the non-Spark side:
 /// - `family_filter` restricts to routes whose chain/contract matches the
 ///   address family (e.g. EVM, Solana).
 /// - `contract_filter` restricts to routes whose contract address equals
@@ -983,6 +1552,9 @@ fn route_passes_filters(
     family_filter: Option<CrossChainAddressFamily>,
     contract_filter: Option<&str>,
 ) -> bool {
+    if r.source_chain.eq_ignore_ascii_case(&r.destination_chain) {
+        return false;
+    }
     let side = non_spark_side(r, is_send);
     let contract = side.contract_address.as_deref();
     let family_ok = family_filter.is_none_or(|f| f.matches_chain(&side.chain, contract));
@@ -1151,13 +1723,145 @@ fn apply_terminal_status(
     })
 }
 
-/// Rejects an expired quote at send time so the caller can re-prepare
-/// instead of getting a less helpful error from `/submit`.
-fn validate_quote_expiry(expires_at: &str) -> Result<(), SdkError> {
+/// Reads `order.sparkTxHash` (the receive-side linking key), resolves it to
+/// the inbound Spark `Payment` id, and upserts `ConversionInfo::Orchestra`
+/// onto it. `spark_tx_hash` may be a Spark transfer id (BTC receive) or a
+/// token tx hash (USDB receive: token payment ids carry a `:vout` suffix
+/// that the raw hash lacks), so resolution goes through
+/// `resolve_and_insert_payment_metadata`, which also caches the metadata
+/// when the Payment row is not yet synced.
+///
+/// Returns `false` when the order is `Completed` but `spark_tx_hash` is
+/// absent (nothing to link or cache against), and `true` when metadata
+/// was attached or cached.
+async fn attach_receive_metadata(
+    storage: &Arc<dyn Storage>,
+    spark_wallet: &SparkWallet,
+    fiat_service: &dyn FiatService,
+    data: &OrchestraSwapData,
+    order: &Order,
+) -> Result<bool, SdkError> {
+    let Some(spark_tx_hash) = order.spark_tx_hash.as_deref() else {
+        debug!(
+            "Orchestra receive {}: order Completed but no sparkTxHash yet",
+            data.quote_id
+        );
+        return Ok(false);
+    };
+    let conversion_info = build_orchestra_receive_conversion_info(data, order, fiat_service).await;
+    let metadata = crate::PaymentMetadata {
+        conversion_info: Some(conversion_info),
+        ..Default::default()
+    };
+    // tx_inputs_are_ours = false: on receive, the inbound token tx is funded
+    // by Orchestra's counterparty, not us.
+    resolve_and_insert_payment_metadata(spark_tx_hash, metadata, spark_wallet, storage, false)
+        .await?;
+    Ok(true)
+}
+
+/// Receive-side counterpart to [`apply_terminal_status`]: pulls live bits
+/// from the `Order` and quote-time bits from the stashed `OrchestraSwapData`.
+/// `chain`/`asset` describe the non-Spark side (source on receive) so the UI
+/// renders symmetric to send. `order.amount_in` (actual deposit) takes
+/// precedence over quote-time `data.amount_in` when both are present. The
+/// realized fee comes from [`compute_receive_fee`], falling back to
+/// `data.fee_amount` on missing inputs.
+async fn build_orchestra_receive_conversion_info(
+    data: &OrchestraSwapData,
+    order: &Order,
+    fiat_service: &dyn FiatService,
+) -> ConversionInfo {
+    let asset_amount_in = order
+        .amount_in
+        .as_deref()
+        .and_then(|s| s.parse::<u128>().ok())
+        .or_else(|| data.amount_in.parse::<u128>().ok());
+    let estimated_out = data.expected_amount_out.parse::<u128>().unwrap_or(0);
+    let delivered_amount = order
+        .amount_out
+        .as_deref()
+        .and_then(|s| s.parse::<u128>().ok());
+    let quote_fee_amount = data
+        .fee_amount
+        .as_deref()
+        .and_then(|s| s.parse::<u128>().ok());
+
+    let fee_amount = compute_receive_fee(data, asset_amount_in, delivered_amount, fiat_service)
+        .await
+        .or(quote_fee_amount);
+
+    ConversionInfo::Orchestra {
+        order_id: order.id.clone(),
+        quote_id: data.quote_id.clone(),
+        read_token: None,
+        chain: data.source_chain.clone(),
+        chain_id: data.source_chain_id.clone(),
+        asset: data.source_asset.clone(),
+        recipient_address: data.recipient_address.clone(),
+        asset_amount_in,
+        estimated_out,
+        delivered_amount,
+        status: ConversionStatus::Completed,
+        // Realized total fee in source-asset units.
+        fee_amount,
+        service_fee_amount: quote_fee_amount,
+        service_fee_asset: Some(data.source_asset.clone()),
+        asset_decimals: data.source_decimals,
+        asset_contract: data.source_contract_address.clone(),
+    }
+}
+
+/// Whether a pre-order receive row is past the grace window past
+/// `expires_at`, at which point the poller stops probing `/submit` for it.
+fn is_past_receive_grace(data: &OrchestraSwapData) -> bool {
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    now_secs >= data.expires_at.saturating_add(RECEIVE_GRACE_SECS)
+}
+
+/// Realized cross-chain receive fee in source-asset base units. Returns
+/// `None` on any missing input, a failed fiat lookup, or a converted
+/// delivered amount exceeding the deposit (numerical drift, stale rate,
+/// repricing).
+async fn compute_receive_fee(
+    data: &OrchestraSwapData,
+    asset_amount_in: Option<u128>,
+    delivered_amount: Option<u128>,
+    fiat_service: &dyn FiatService,
+) -> Option<u128> {
+    let amount_in = asset_amount_in?;
+    let amount_out = delivered_amount?;
+    let delivered_in_source = if data.token_identifier.is_some() {
+        // Token destination (USDB): source and destination are both USD-stable.
+        // Rescale destination units to source-asset decimals and subtract.
+        super::rescale_decimals(amount_out, data.destination_decimals, data.source_decimals).ok()?
+    } else {
+        // BTC destination (sats): convert sats to source-asset units via the
+        // BTC/USD rate, then subtract.
+        let btc_usd = super::fetch_btc_usd_rate(fiat_service).await.ok()?;
+        super::convert_sats_to_destination_amount(amount_out, btc_usd, data.source_decimals).ok()?
+    };
+    amount_in.checked_sub(delivered_in_source)
+}
+
+/// Parses Orchestra's RFC3339 `expires_at` into unix seconds.
+fn parse_rfc3339_to_unix_seconds(expires_at: &str) -> Result<u64, SdkError> {
     let exp = DateTime::parse_from_rfc3339(expires_at).map_err(|e| {
         SdkError::Generic(format!("Orchestra: invalid expires_at {expires_at:?}: {e}"))
     })?;
-    let exp_secs = u64::try_from(exp.timestamp()).unwrap_or(0);
+    u64::try_from(exp.timestamp()).map_err(|e| {
+        SdkError::Generic(format!(
+            "Orchestra: invalid expires_at {expires_at:?}: negative or overflowing timestamp: {e}"
+        ))
+    })
+}
+
+/// Rejects an expired quote at send time so the caller can re-prepare
+/// instead of getting a less helpful error from `/submit`.
+fn validate_quote_expiry(expires_at: &str) -> Result<(), SdkError> {
+    let exp_secs = parse_rfc3339_to_unix_seconds(expires_at)?;
     let now_secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|_| SdkError::Generic("Failed to read current time".to_string()))?
@@ -1171,12 +1875,12 @@ fn validate_quote_expiry(expires_at: &str) -> Result<(), SdkError> {
 }
 
 /// Dedupes Orchestra's raw `Route` list into the SDK's [`CrossChainRoutePair`]
-/// shape — one pair per `(chain, asset, contract_address)` endpoint with the
-/// supported Spark-side source variants accumulated into `supported_sources`.
+/// shape: one pair per `(chain, asset, contract_address)` endpoint, with the
+/// supported Spark-side variants accumulated into `accepted_assets`.
 ///
 /// Multiple raw routes can exist for the same external chain (e.g.
-/// `BTC→USDT-on-tron` and `USDB→USDT-on-tron`); the caller wants to see one
-/// `USDT-on-tron` route advertising both source variants.
+/// `BTC->USDT-on-tron` and `USDB->USDT-on-tron`), and the caller wants to see
+/// one `USDT-on-tron` route advertising both.
 fn dedupe_routes(
     routes: &[Route],
     is_send: bool,
@@ -1202,27 +1906,27 @@ fn dedupe_routes(
         // Orchestra's `contract_address` on the Spark side is the bech32m
         // token identifier (`btkn1...`).
         let spark_side = if is_send { &r.source } else { &r.destination };
-        let source_variant = if spark_side.asset.eq_ignore_ascii_case("BTC") {
-            Some(SourceAsset::Bitcoin)
+        let spark_asset = if spark_side.asset.eq_ignore_ascii_case("BTC") {
+            Some(SparkAsset::Bitcoin)
         } else {
             // Non-BTC Spark source without a token identifier: defensive skip.
             // Shouldn't happen per current Orchestra behavior.
             spark_side
                 .contract_address
                 .as_ref()
-                .map(|tid| SourceAsset::Token {
+                .map(|tid| SparkAsset::Token {
                     token_identifier: tid.clone(),
                 })
         };
 
-        // Send/Buy are funded from `source_chain` (spark / lightning / bitcoin);
-        // a receive lands on the Spark side, so its funding chain is Spark. An
-        // unrecognized source chain (a receive route's external chain) parses to
-        // `None` and is skipped.
-        let source_chain = if is_send {
-            source_chain_from_wire(&r.source_chain)
+        // Send/Buy delivery method comes from Orchestra's `source_chain` (spark /
+        // lightning / bitcoin). A receive lands on Spark, so its delivery method
+        // is always Spark. An unrecognized source chain (a receive route's
+        // external chain) parses to `None` and is skipped.
+        let delivery_method = if is_send {
+            delivery_method_from_wire(&r.source_chain)
         } else {
-            Some(SourceChain::Spark)
+            Some(DeliveryMethod::Spark)
         };
 
         let entry = grouped.entry(key.clone()).or_insert_with(|| {
@@ -1230,15 +1934,15 @@ fn dedupe_routes(
             side_to_route_pair(side, r.exact_out_eligible)
         });
 
-        if let Some(variant) = source_variant
-            && !entry.supported_sources.contains(&variant)
+        if let Some(asset) = spark_asset
+            && !entry.accepted_assets.contains(&asset)
         {
-            entry.supported_sources.push(variant);
+            entry.accepted_assets.push(asset);
         }
-        if let Some(chain) = source_chain
-            && !entry.supported_source_chains.contains(&chain)
+        if let Some(method) = delivery_method
+            && !entry.delivery_methods.contains(&method)
         {
-            entry.supported_source_chains.push(chain);
+            entry.delivery_methods.push(method);
         }
     }
 
@@ -1262,37 +1966,260 @@ fn side_to_route_pair(side: &RouteAsset, exact_out_eligible: bool) -> CrossChain
         contract_address: side.contract_address.clone(),
         decimals: side.decimals,
         exact_out_eligible,
-        supported_sources: Vec::new(),
-        supported_source_chains: Vec::new(),
+        accepted_assets: Vec::new(),
+        delivery_methods: Vec::new(),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use breez_sdk_common::error::ServiceConnectivityError;
+    use breez_sdk_common::fiat::{FiatCurrency, Rate};
+
     use super::*;
-    use macros::test_all;
+    use macros::{async_test_all, test_all};
 
     #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[test_all]
-    fn source_chain_wire_round_trips_case_insensitively() {
+    fn delivery_method_wire_round_trips_case_insensitively() {
         for chain in [
-            SourceChain::Spark,
-            SourceChain::Lightning,
-            SourceChain::Bitcoin,
+            DeliveryMethod::Spark,
+            DeliveryMethod::Lightning,
+            DeliveryMethod::Bitcoin,
         ] {
             assert_eq!(
-                source_chain_from_wire(source_chain_to_wire(chain)),
+                delivery_method_from_wire(delivery_method_to_wire(chain)),
                 Some(chain)
             );
         }
         assert_eq!(
-            source_chain_from_wire("Lightning"),
-            Some(SourceChain::Lightning)
+            delivery_method_from_wire("Lightning"),
+            Some(DeliveryMethod::Lightning)
         );
-        // A receive route's external source chain is not a funding chain.
-        assert_eq!(source_chain_from_wire("base"), None);
+        // A receive route's external source chain is not a delivery method.
+        assert_eq!(delivery_method_from_wire("base"), None);
+    }
+
+    /// A `FiatService` that fails every call. The receive-fee builder uses
+    /// it to exercise the quote-time fallback path.
+    struct FailingFiat;
+
+    #[macros::async_trait]
+    impl FiatService for FailingFiat {
+        async fn fetch_fiat_currencies(
+            &self,
+        ) -> Result<Vec<FiatCurrency>, ServiceConnectivityError> {
+            Err(ServiceConnectivityError::Other("not used".to_string()))
+        }
+        async fn fetch_fiat_rates(&self) -> Result<Vec<Rate>, ServiceConnectivityError> {
+            Err(ServiceConnectivityError::Other("upstream down".to_string()))
+        }
+    }
+
+    #[async_test_all]
+    async fn build_receive_conversion_info_pulls_quote_time_and_live_fields() {
+        let data = OrchestraSwapData {
+            quote_id: "q_xyz".to_string(),
+            order_id: Some("ord_xyz".to_string()),
+            read_token: Some("rt_xyz".to_string()),
+            recipient_address: "sp1rcv".to_string(),
+            source_chain: "ethereum".to_string(),
+            source_asset: "USDC".to_string(),
+            source_chain_id: Some("1".to_string()),
+            source_contract_address: Some("0xUSDC".to_string()),
+            source_decimals: 6,
+            destination_chain: "spark".to_string(),
+            destination_asset: "BTC".to_string(),
+            destination_decimals: 8,
+            token_identifier: None,
+            amount_in: "100".to_string(),             // quote-time
+            expected_amount_out: "50000".to_string(), // quote-time
+            fee_amount: Some("250".to_string()),      // quote-time
+            expires_at: 1_700_000_120,
+        };
+        let order = Order {
+            id: "ord_xyz".to_string(),
+            status: OrderStatus::Completed,
+            kind: Some("order".to_string()),
+            quote_id: Some("q_xyz".to_string()),
+            source_chain: None,
+            source_asset: None,
+            source_address: None,
+            source_tx_hash: Some("0xeth-tx".to_string()),
+            source_tx_vout: None,
+            sweep_tx_hash: None,
+            destination_chain: None,
+            destination_asset: None,
+            destination_address: None,
+            destination_tx_hash: None,
+            deposit_address: None,
+            recipient_address: None,
+            amount_in: None,
+            amount_out: Some("49500".to_string()), // live
+            amount_fiat_usd: None,
+            amount_fiat_currency: None,
+            spot_usd_per_btc: None,
+            fee_bps: None,
+            fee_amount: None,
+            fee_asset: None,
+            rounding_fee_amount: None,
+            slippage_bps: None,
+            flashnet_request_id: None,
+            spark_tx_hash: Some("spark-tx-hash".to_string()),
+            refund_asset: None,
+            refund_amount: None,
+            refund_tx_hash: None,
+            error_code: None,
+            error_message: None,
+            total_fee_bps: None,
+            total_fee_amount: None,
+            created_at: "now".to_string(),
+            updated_at: "now".to_string(),
+            completed_at: None,
+        };
+        let info = build_orchestra_receive_conversion_info(&data, &order, &FailingFiat).await;
+        match info {
+            ConversionInfo::Orchestra {
+                order_id,
+                quote_id,
+                chain,
+                asset,
+                recipient_address,
+                asset_amount_in,
+                estimated_out,
+                delivered_amount,
+                status,
+                ..
+            } => {
+                assert_eq!(order_id, "ord_xyz");
+                assert_eq!(quote_id, "q_xyz");
+                // chain/asset describe the NON-Spark side (source on receive).
+                assert_eq!(chain, "ethereum");
+                assert_eq!(asset, "USDC");
+                assert_eq!(recipient_address, "sp1rcv");
+                assert_eq!(asset_amount_in, Some(100));
+                assert_eq!(estimated_out, 50_000);
+                assert_eq!(delivered_amount, Some(49_500));
+                assert_eq!(status, ConversionStatus::Completed);
+            }
+            _ => panic!("expected Orchestra variant"),
+        }
+    }
+
+    /// USDB destination: `compute_receive_fee` takes the rescale-and-subtract
+    /// branch (no fiat lookup needed since source and destination are both
+    /// USD-stable). Realized fee = `amount_in − rescale(amount_out, dst, src)`.
+    #[async_test_all]
+    async fn build_receive_conversion_info_token_destination_realizes_fee_via_rescale() {
+        let data = OrchestraSwapData {
+            quote_id: "q_usdb".to_string(),
+            order_id: Some("ord_usdb".to_string()),
+            read_token: Some("rt_usdb".to_string()),
+            recipient_address: "sp1rcv".to_string(),
+            source_chain: "arbitrum".to_string(),
+            source_asset: "USDC".to_string(),
+            source_chain_id: Some("42161".to_string()),
+            source_contract_address: Some("0xUSDC".to_string()),
+            source_decimals: 6,
+            destination_chain: "spark".to_string(),
+            destination_asset: "USDB".to_string(),
+            destination_decimals: 6,
+            token_identifier: Some(
+                "btkn1xgrvjwey5ngcagvap2dzzvsy4uk8ua9x69k82dwvt5e7ef9drm9qztux87".to_string(),
+            ),
+            amount_in: "1050000".to_string(),
+            expected_amount_out: "1000000".to_string(),
+            fee_amount: Some("20000".to_string()), // quote-time estimate, superseded on Completed
+            expires_at: 1_700_000_120,
+        };
+        let mut order = Order {
+            id: "ord_usdb".to_string(),
+            status: OrderStatus::Completed,
+            kind: Some("order".to_string()),
+            quote_id: Some("q_usdb".to_string()),
+            source_chain: None,
+            source_asset: None,
+            source_address: None,
+            source_tx_hash: None,
+            source_tx_vout: None,
+            sweep_tx_hash: None,
+            destination_chain: None,
+            destination_asset: None,
+            destination_address: None,
+            destination_tx_hash: None,
+            deposit_address: None,
+            recipient_address: None,
+            amount_in: Some("1050000".to_string()),
+            amount_out: Some("1000000".to_string()),
+            amount_fiat_usd: None,
+            amount_fiat_currency: None,
+            spot_usd_per_btc: None,
+            fee_bps: None,
+            fee_amount: None,
+            fee_asset: None,
+            rounding_fee_amount: None,
+            slippage_bps: None,
+            flashnet_request_id: None,
+            spark_tx_hash: Some("spark-tx-hash".to_string()),
+            refund_asset: None,
+            refund_amount: None,
+            refund_tx_hash: None,
+            error_code: None,
+            error_message: None,
+            total_fee_bps: None,
+            total_fee_amount: None,
+            created_at: "now".to_string(),
+            updated_at: "now".to_string(),
+            completed_at: None,
+        };
+        let info = build_orchestra_receive_conversion_info(&data, &order, &FailingFiat).await;
+        match info {
+            ConversionInfo::Orchestra {
+                fee_amount,
+                service_fee_amount,
+                ..
+            } => {
+                // Realized fee = 1_050_000 - rescale(1_000_000, dst=6, src=6) = 50_000.
+                assert_eq!(fee_amount, Some(50_000));
+                // Quote-time service_fee is preserved separately.
+                assert_eq!(service_fee_amount, Some(20_000));
+            }
+            _ => panic!("expected Orchestra variant"),
+        }
+
+        // If delivered > deposit (shouldn't happen, but guards against
+        // silent negative fees), compute_receive_fee falls back to the
+        // quote-time estimate rather than producing an underflow.
+        order.amount_out = Some("2000000".to_string());
+        let info = build_orchestra_receive_conversion_info(&data, &order, &FailingFiat).await;
+        match info {
+            ConversionInfo::Orchestra { fee_amount, .. } => {
+                assert_eq!(fee_amount, Some(20_000));
+            }
+            _ => panic!("expected Orchestra variant"),
+        }
+    }
+
+    /// Fixed future timestamp pins the conversion so a TZ regression
+    /// surfaces here, not as a UI bug downstream.
+    #[test_all]
+    fn parse_rfc3339_to_unix_seconds_accepts_future_timestamps() {
+        let ts = parse_rfc3339_to_unix_seconds("2099-01-01T00:00:00Z").unwrap();
+        assert_eq!(ts, 4_070_908_800);
+    }
+
+    /// Malformed input surfaces as a descriptive error, not a panic or a
+    /// silent zero.
+    #[test_all]
+    fn parse_rfc3339_to_unix_seconds_rejects_malformed_input() {
+        let err =
+            parse_rfc3339_to_unix_seconds("not-a-date").expect_err("malformed input must fail");
+        match err {
+            SdkError::Generic(msg) => assert!(msg.contains("invalid expires_at"), "{msg}"),
+            other => panic!("expected Generic, got {other:?}"),
+        }
     }
 
     fn test_route_asset(chain: &str, chain_id: Option<&str>) -> RouteAsset {
@@ -1366,7 +2293,7 @@ mod tests {
     fn dedupe_routes_accumulates_source_variants() {
         // Same external endpoint (tron/USDT) fronted by two Spark sources
         // (BTC and a USDB token). Caller should see one pair with both
-        // variants in `supported_sources`.
+        // variants in `accepted_assets`.
         let usdb_contract = "btkn1usdb_contract";
         let routes = vec![
             route(
@@ -1389,18 +2316,18 @@ mod tests {
         let p = &pairs[0];
         assert_eq!(p.chain, "tron");
         assert_eq!(p.asset, "USDT");
-        assert!(p.supported_sources.contains(&SourceAsset::Bitcoin));
-        assert!(p.supported_sources.contains(&SourceAsset::Token {
+        assert!(p.accepted_assets.contains(&SparkAsset::Bitcoin));
+        assert!(p.accepted_assets.contains(&SparkAsset::Token {
             token_identifier: usdb_contract.to_string(),
         }));
-        // A Spark-sourced send reports the Spark funding chain.
-        assert_eq!(p.supported_source_chains, vec![SourceChain::Spark]);
+        // A Spark-sourced send reports Spark as the delivery method.
+        assert_eq!(p.delivery_methods, vec![DeliveryMethod::Spark]);
     }
 
     #[test_all]
     fn dedupe_routes_accumulates_buy_source_chains() {
         // One buy destination (base/USDC) reachable from both a Lightning and a
-        // Bitcoin source dedups to a single pair listing both funding chains.
+        // Bitcoin source dedups to a single pair listing both delivery methods.
         let routes = vec![
             route(
                 ra("lightning", "BTC", None),
@@ -1416,15 +2343,15 @@ mod tests {
 
         assert_eq!(pairs.len(), 1);
         let p = &pairs[0];
-        assert!(p.supported_source_chains.contains(&SourceChain::Lightning));
-        assert!(p.supported_source_chains.contains(&SourceChain::Bitcoin));
-        assert_eq!(p.supported_source_chains.len(), 2);
+        assert!(p.delivery_methods.contains(&DeliveryMethod::Lightning));
+        assert!(p.delivery_methods.contains(&DeliveryMethod::Bitcoin));
+        assert_eq!(p.delivery_methods.len(), 2);
     }
 
     #[test_all]
-    fn dedupe_routes_receive_funding_chain_is_spark() {
-        // Receiving into Spark reports the Spark funding chain, not the external
-        // source chain.
+    fn dedupe_routes_receive_delivery_method_is_spark() {
+        // Receiving into Spark reports Spark as the delivery method, not the
+        // external source chain.
         let routes = vec![route(
             ra("base", "USDC", Some("0xUSDC")),
             ra("spark", "BTC", None),
@@ -1433,7 +2360,7 @@ mod tests {
         let pairs = dedupe_routes(&routes, false, None, None);
 
         assert_eq!(pairs.len(), 1);
-        assert_eq!(pairs[0].supported_source_chains, vec![SourceChain::Spark]);
+        assert_eq!(pairs[0].delivery_methods, vec![DeliveryMethod::Spark]);
     }
 
     #[test_all]
@@ -1483,8 +2410,8 @@ mod tests {
 
         assert_eq!(pairs.len(), 1, "receive dedup groups by source side");
         assert_eq!(pairs[0].chain, "base");
-        assert!(pairs[0].supported_sources.contains(&SourceAsset::Bitcoin));
-        assert!(pairs[0].supported_sources.contains(&SourceAsset::Token {
+        assert!(pairs[0].accepted_assets.contains(&SparkAsset::Bitcoin));
+        assert!(pairs[0].accepted_assets.contains(&SparkAsset::Token {
             token_identifier: "btkn1usdb".to_string(),
         }));
     }
@@ -1536,6 +2463,22 @@ mod tests {
             Some(CrossChainAddressFamily::Solana),
             None
         ));
+    }
+
+    #[test_all]
+    fn route_passes_filters_rejects_same_chain_route() {
+        // Orchestra advertises on-Spark AMM swaps (spark→spark) alongside
+        // cross-chain bridges; those must not appear in the receive list.
+        let r = route(
+            ra(
+                "spark",
+                "USDB",
+                Some("btkn1xgrvjwey5ngcagvap2dzzvsy4uk8ua9x69k82dwvt5e7ef9drm9qztux87"),
+            ),
+            ra("spark", "BTC", None),
+        );
+        assert!(!route_passes_filters(&r, false, None, None));
+        assert!(!route_passes_filters(&r, true, None, None));
     }
 
     #[test_all]
@@ -1913,23 +2856,39 @@ mod tests {
             order: flashnet::orchestra::Order {
                 id: "ord1".to_string(),
                 status,
-                quote_id: "q1".to_string(),
-                source_chain: "spark".to_string(),
-                source_asset: "BTC".to_string(),
+                kind: Some("order".to_string()),
+                quote_id: Some("q1".to_string()),
+                source_chain: Some("spark".to_string()),
+                source_asset: Some("BTC".to_string()),
                 source_address: None,
-                source_tx_hash: "txh".to_string(),
+                source_tx_hash: Some("txh".to_string()),
                 source_tx_vout: None,
-                deposit_address: "dep".to_string(),
-                destination_chain: "base".to_string(),
-                destination_asset: "USDC".to_string(),
-                recipient_address: "0xabc".to_string(),
-                amount_in: "1000".to_string(),
+                sweep_tx_hash: None,
+                deposit_address: Some("dep".to_string()),
+                destination_chain: Some("base".to_string()),
+                destination_asset: Some("USDC".to_string()),
+                destination_address: None,
+                destination_tx_hash: None,
+                recipient_address: Some("0xabc".to_string()),
+                amount_in: Some("1000".to_string()),
                 amount_out: amount_out.map(str::to_string),
-                fee_bps: 50,
-                fee_amount: "50".to_string(),
-                slippage_bps: 100,
+                amount_fiat_usd: None,
+                amount_fiat_currency: None,
+                spot_usd_per_btc: None,
+                fee_bps: Some(50),
+                fee_amount: Some("50".to_string()),
+                fee_asset: None,
+                rounding_fee_amount: None,
+                slippage_bps: Some(100),
+                flashnet_request_id: None,
+                spark_tx_hash: None,
+                refund_asset: None,
+                refund_amount: None,
+                refund_tx_hash: None,
                 error_code: None,
                 error_message: None,
+                total_fee_bps: None,
+                total_fee_amount: None,
                 created_at: "0".to_string(),
                 updated_at: "0".to_string(),
                 completed_at: None,
@@ -2099,8 +3058,8 @@ mod tests {
             contract_address: contract.map(str::to_string),
             decimals: 6,
             exact_out_eligible: false,
-            supported_sources: Vec::new(),
-            supported_source_chains: Vec::new(),
+            accepted_assets: Vec::new(),
+            delivery_methods: Vec::new(),
         }
     }
 
@@ -2166,6 +3125,95 @@ mod tests {
         assert_eq!(found.asset, "BTC");
     }
 
+    // ---- find_destination_asset_symbol ----
+
+    /// Build a [`CrossChainRoutePair`] describing the external (source)
+    /// side of a receive-direction route. Mirrors `dest_pair` in shape but
+    /// reads naturally from receive call sites.
+    fn external_pair(chain: &str, asset: &str, contract: Option<&str>) -> CrossChainRoutePair {
+        CrossChainRoutePair {
+            provider: CrossChainProvider::Orchestra,
+            chain: chain.to_string(),
+            chain_id: None,
+            asset: asset.to_string(),
+            contract_address: contract.map(str::to_string),
+            decimals: 6,
+            exact_out_eligible: false,
+            accepted_assets: Vec::new(),
+            delivery_methods: Vec::new(),
+        }
+    }
+
+    /// Bitcoin destination resolves to the wire symbol "BTC" from the
+    /// matching raw route's Spark side.
+    #[test_all]
+    fn find_destination_asset_symbol_resolves_bitcoin() {
+        let routes = vec![
+            // On receive routes, source = external, destination = Spark.
+            route(ra("base", "USDC", Some("0xUSDC")), ra("spark", "BTC", None)),
+            route(
+                ra("base", "USDC", Some("0xUSDC")),
+                ra("spark", "USDB", Some("btkn1usdb")),
+            ),
+        ];
+        let pair = external_pair("base", "USDC", Some("0xUSDC"));
+        let sym = find_destination_asset_symbol(&routes, &pair, &SparkAsset::Bitcoin);
+        assert_eq!(sym.as_deref(), Some("BTC"));
+    }
+
+    /// Token destination picks the raw route whose Spark-side
+    /// `contract_address` matches the requested token id, and surfaces
+    /// that route's asset symbol.
+    #[test_all]
+    fn find_destination_asset_symbol_resolves_token_by_identifier() {
+        let routes = vec![
+            route(ra("base", "USDC", Some("0xUSDC")), ra("spark", "BTC", None)),
+            route(
+                ra("base", "USDC", Some("0xUSDC")),
+                ra("spark", "USDB", Some("btkn1usdb")),
+            ),
+        ];
+        let pair = external_pair("base", "USDC", Some("0xUSDC"));
+        let sym = find_destination_asset_symbol(
+            &routes,
+            &pair,
+            &SparkAsset::Token {
+                token_identifier: "btkn1usdb".to_string(),
+            },
+        );
+        assert_eq!(sym.as_deref(), Some("USDB"));
+    }
+
+    /// A token id that no raw route exposes returns `None`.
+    #[test_all]
+    fn find_destination_asset_symbol_returns_none_for_unknown_token() {
+        let routes = vec![route(
+            ra("base", "USDC", Some("0xUSDC")),
+            ra("spark", "BTC", None),
+        )];
+        let pair = external_pair("base", "USDC", Some("0xUSDC"));
+        let sym = find_destination_asset_symbol(
+            &routes,
+            &pair,
+            &SparkAsset::Token {
+                token_identifier: "btkn1nothing".to_string(),
+            },
+        );
+        assert!(sym.is_none());
+    }
+
+    /// An external pair the route catalogue doesn't carry returns `None`.
+    #[test_all]
+    fn find_destination_asset_symbol_returns_none_when_external_pair_unknown() {
+        let routes = vec![route(
+            ra("base", "USDC", Some("0xUSDC")),
+            ra("spark", "BTC", None),
+        )];
+        let pair = external_pair("solana", "USDC", Some("USDCsol"));
+        let sym = find_destination_asset_symbol(&routes, &pair, &SparkAsset::Bitcoin);
+        assert!(sym.is_none());
+    }
+
     // `rescale_decimals` and `is_usd_stable_asset` live in cross_chain/mod.rs;
     // tests for them are colocated there.
 
@@ -2200,6 +3248,41 @@ mod tests {
     }
 
     #[test_all]
+    fn pad_required_in_passes_pad_through_when_within_scaled() {
+        // Real-world case: on a $1 receive, scaled=1_000_244 USDC, pad=10_000
+        // (Orchestra's per-order settlement fee). Pad is a small fraction of
+        // scaled, so it passes through untouched.
+        let (required_in, applied) = pad_required_in(1_000_244, 10_000);
+        assert_eq!(required_in, 1_010_244);
+        assert_eq!(applied, 10_000);
+    }
+
+    #[test_all]
+    fn pad_required_in_caps_pad_at_scaled() {
+        // Malformed or adversarial estimate returning fee_amount > scaled.
+        // Cap fires so required_in is at most 2x scaled.
+        let (required_in, applied) = pad_required_in(1000, 10_000_000);
+        assert_eq!(required_in, 2000);
+        assert_eq!(applied, 1000);
+    }
+
+    #[test_all]
+    fn pad_required_in_zero_pad_returns_scaled_unchanged() {
+        // apply_base_fee_pad = false (send path) resolves to pad = 0 upstream.
+        let (required_in, applied) = pad_required_in(1_000_244, 0);
+        assert_eq!(required_in, 1_000_244);
+        assert_eq!(applied, 0);
+    }
+
+    #[test_all]
+    fn pad_required_in_exact_scaled_pad_still_within_cap() {
+        // pad == scaled sits exactly at the cap boundary; both flow through.
+        let (required_in, applied) = pad_required_in(500, 500);
+        assert_eq!(required_in, 1000);
+        assert_eq!(applied, 500);
+    }
+
+    #[test_all]
     fn verify_quote_not_drifted_accepts_exact_target() {
         assert!(verify_quote_not_drifted(1_000_000, 1_000_000, 100).is_ok());
     }
@@ -2221,6 +3304,12 @@ mod tests {
                     msg.contains("rate drift") && msg.contains("1000000") && msg.contains("989999"),
                     "unexpected message: {msg}"
                 );
+                // Error must name the slippage budget and the observed drift,
+                // and point the caller at `target_overpay_bps`.
+                assert!(
+                    msg.contains("100 bps") && msg.contains("target_overpay_bps"),
+                    "expected drift/slippage bps and overpay hint in message: {msg}"
+                );
             }
             other => panic!("expected InvalidInput rate-drift error, got {other:?}"),
         }
@@ -2230,6 +3319,44 @@ mod tests {
     fn verify_quote_not_drifted_extreme_slippage_accepts_anything() {
         // 100% slippage = no floor.
         assert!(verify_quote_not_drifted(1_000_000, 0, 10_000).is_ok());
+    }
+
+    // ---- verify_quote_amount_in ----
+
+    #[test_all]
+    fn verify_quote_amount_in_accepts_exact_match() {
+        assert!(verify_quote_amount_in(1_000_000, 1_000_000).is_ok());
+    }
+
+    #[test_all]
+    fn verify_quote_amount_in_accepts_within_tolerance() {
+        // 10 bps of 1_000_000 = 1000, so 999_000..=1_001_000 is fine.
+        assert!(verify_quote_amount_in(1_000_000, 999_000).is_ok());
+        assert!(verify_quote_amount_in(1_000_000, 1_001_000).is_ok());
+    }
+
+    #[test_all]
+    fn verify_quote_amount_in_rejects_inflated_echo() {
+        // Provider returns 10x the requested deposit: refuse rather than
+        // ask the sender to deposit an inflated amount.
+        let err = verify_quote_amount_in(1_000_000, 10_000_000).unwrap_err();
+        match err {
+            SdkError::InvalidInput(msg) => {
+                assert!(
+                    msg.contains("amountIn out of range")
+                        && msg.contains("1000000")
+                        && msg.contains("10000000"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test_all]
+    fn verify_quote_amount_in_rejects_deflated_echo() {
+        // Below tolerance floor: quote does not honor our ExactIn contract.
+        assert!(verify_quote_amount_in(1_000_000, 500_000).is_err());
     }
 
     // ---- validate_quote_expiry ----
@@ -2274,8 +3401,8 @@ mod tests {
         let pairs = dedupe_routes(&routes, true, None, None);
 
         // The route still produces a pair (the destination still matters),
-        // but `supported_sources` is empty.
+        // but `accepted_assets` is empty.
         assert_eq!(pairs.len(), 1);
-        assert!(pairs[0].supported_sources.is_empty());
+        assert!(pairs[0].accepted_assets.is_empty());
     }
 }

--- a/crates/breez-sdk/core/src/cross_chain/orchestra.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra.rs
@@ -1379,9 +1379,9 @@ impl CrossChainService for OrchestraService {
             expires_at: expires_at_secs,
         };
 
-        let adapter = OrchestraStorageAdapter::new(Arc::clone(&self.storage));
-        adapter.upsert(&data).await?;
-
+        // Persist only once the request the caller gets back is in hand: a
+        // row written for a request that failed to build is polled for the
+        // whole grace window against a quote nobody is paying.
         let payment_request = super::build_receive_payment_request(
             &quote.deposit_address,
             &route.chain,
@@ -1389,6 +1389,9 @@ impl CrossChainService for OrchestraService {
             route.contract_address.as_deref(),
             deposit_amount,
         )?;
+
+        let adapter = OrchestraStorageAdapter::new(Arc::clone(&self.storage));
+        adapter.upsert(&data).await?;
 
         Ok(CrossChainReceivePrepared {
             payment_request,

--- a/crates/breez-sdk/core/src/cross_chain/orchestra.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra.rs
@@ -16,7 +16,7 @@ use flashnet::orchestra::{
     Route, RouteAsset, StatusResponse, SubmitResponse,
 };
 use flashnet::{FlashnetError, OrchestraClient, OrchestraConfig, OrchestraConfigResolver};
-use platform_utils::time::{Duration, SystemTime, UNIX_EPOCH};
+use platform_utils::time::Duration;
 use platform_utils::tokio;
 use spark_wallet::SparkWallet;
 use tokio::{
@@ -26,7 +26,10 @@ use tokio::{
 use tracing::{Instrument, debug, error, info, warn};
 
 use crate::error::SdkError;
-use crate::persist::{ConversionFilter, StorageListPaymentsRequest, StoragePaymentDetailsFilter};
+use crate::persist::{
+    ConversionFilter, ObjectCacheRepository, StorageListPaymentsRequest,
+    StoragePaymentDetailsFilter,
+};
 use crate::{ConversionInfo, ConversionStatus, Payment, PaymentDetails, PaymentStatus, Storage};
 
 use super::{
@@ -38,8 +41,9 @@ use super::{
 };
 
 use crate::utils::{
-    payments::{fetch_and_process_payment, resolve_and_insert_payment_metadata},
+    payments::{fetch_and_process_payment, resolve_payment_id},
     polling::{PollSchedule, poll_until},
+    time::{now_secs, try_now_secs},
 };
 
 // Orchestra `/quote` `source_chain` wire values.
@@ -77,6 +81,10 @@ const SEND_POLL_MAX_DELAY_MS: u64 = 2000;
 const SEND_POLL_TIMEOUT_SECS: u64 = 30;
 /// Grace period to keep probing a receive quote before giving up.
 const RECEIVE_GRACE_SECS: u64 = 24 * 60 * 60;
+/// How often a receive row may hit `/submit`, once it is off the every-tick
+/// cadence: an expired quote probing for a late deposit (Orchestra reprices
+/// those), and a funded row re-acquiring a rejected read token.
+const RECEIVE_EXPIRED_PROBE_SECS: u64 = 10 * 60;
 
 /// One-cent margin (in 6-decimal USDB base units) covering Orchestra's
 /// post-quote rounding drift on USDB deliveries: `estimated_out` rounds up
@@ -193,6 +201,11 @@ impl OrchestraService {
 
         tokio::spawn(
             async move {
+                // Probe clock for expired receive quotes, keyed by quote id.
+                // In-memory on purpose: a persisted one writes through
+                // `SyncedStorage` and replicates a bump to every device. A
+                // restart costs one extra probe per expired row.
+                let mut probe_clock: HashMap<String, u64> = HashMap::new();
                 loop {
                     if let Err(e) =
                         Self::poll_in_flight_sends(&storage, &client, &spark_wallet).await
@@ -205,6 +218,7 @@ impl OrchestraService {
                         &client,
                         &spark_wallet,
                         fiat_service.as_ref(),
+                        &mut probe_clock,
                     )
                     .await
                     {
@@ -489,21 +503,23 @@ impl OrchestraService {
     }
 
     /// Polls Orchestra for status updates on active cross-chain receive orders.
-    /// Dispatches per row based on whether Orchestra has issued an order
-    /// handle: pre-order rows go to [`Self::check_for_receive_deposit`],
-    /// in-flight rows go to [`Self::poll_receive_order_status`].
+    /// Each row is resolved to an order handle by
+    /// [`Self::ensure_receive_order_handle`], then polled by
+    /// [`Self::poll_receive_order_status`].
     async fn poll_in_flight_receives(
         storage: &Arc<dyn Storage>,
         swap_storage: &OrchestraStorageAdapter,
         client: &Arc<OrchestraClient>,
         spark_wallet: &Arc<SparkWallet>,
         fiat_service: &dyn FiatService,
+        probe_clock: &mut HashMap<String, u64>,
     ) -> Result<(), SdkError> {
         let active = swap_storage.list_active().await?;
         debug!(
             "Orchestra monitor: found {} active receive rows",
             active.len()
         );
+        prune_probe_clock(probe_clock, &active);
 
         for (row, data) in active {
             let quote_id = data.quote_id.clone();
@@ -520,18 +536,11 @@ impl OrchestraService {
                 continue;
             }
 
-            let (row, data, order_id) = match data.order_id.clone() {
-                Some(order_id) => (row, data, order_id),
-                None => {
-                    match Self::check_for_receive_deposit(swap_storage, client, row, data).await {
-                        Ok(Some((row, data, order_id))) => (row, data, order_id),
-                        Ok(None) => continue,
-                        Err(e) => {
-                            error!("Orchestra receive {quote_id}: deposit check failed: {e:?}");
-                            continue;
-                        }
-                    }
-                }
+            let Some((row, data, order_id)) =
+                Self::ensure_receive_order_handle(swap_storage, client, row, data, probe_clock)
+                    .await
+            else {
+                continue;
             };
             if let Err(e) = Self::poll_receive_order_status(
                 storage,
@@ -542,6 +551,7 @@ impl OrchestraService {
                 row,
                 data,
                 &order_id,
+                probe_clock,
             )
             .await
             {
@@ -552,13 +562,46 @@ impl OrchestraService {
         Ok(())
     }
 
+    /// Resolves a row to the `(row, data, order_id)` triple `/status` needs,
+    /// probing `/submit` first for a row without an order handle. `None` means
+    /// there is nothing to poll this tick.
+    async fn ensure_receive_order_handle(
+        swap_storage: &OrchestraStorageAdapter,
+        client: &Arc<OrchestraClient>,
+        row: crate::StoredCrossChainSwap,
+        data: OrchestraSwapData,
+        probe_clock: &mut HashMap<String, u64>,
+    ) -> Option<(crate::StoredCrossChainSwap, OrchestraSwapData, String)> {
+        if let Some(order_id) = data.order_id.clone() {
+            return Some((row, data, order_id));
+        }
+        let quote_id = data.quote_id.clone();
+        // A live quote is probed every tick. Past expiry it drops to the
+        // slower clock.
+        if is_past_quote_expiry(&data) && !is_probe_due(probe_clock, &quote_id) {
+            return None;
+        }
+        record_probe(probe_clock, &quote_id);
+        match Self::submit_receive_probe(swap_storage, client, row, data).await {
+            Ok(handle) => handle,
+            Err(e) => {
+                error!("Orchestra receive {quote_id}: deposit check failed: {e:?}");
+                None
+            }
+        }
+    }
+
     /// Probes `/submit` with a fresh idempotency key. A 200 means Orchestra
-    /// detected the deposit and issued an order handle: the adapter persists
-    /// it and this returns the updated `(row, data, order_id)` for immediate
+    /// has the deposit and issues an order handle: the adapter persists it
+    /// and this returns the updated `(row, data, order_id)` for immediate
     /// status polling. Any error (including the `invalid_tx_hash` 400
     /// Orchestra returns before the deposit arrives) leaves the row
     /// non-terminal for the next tick.
-    async fn check_for_receive_deposit(
+    ///
+    /// `/submit` is idempotent, so this also serves as the recovery path for
+    /// a read token `/status` has rejected: the same order id comes back with
+    /// a fresh token.
+    async fn submit_receive_probe(
         swap_storage: &OrchestraStorageAdapter,
         client: &Arc<OrchestraClient>,
         row: crate::StoredCrossChainSwap,
@@ -584,13 +627,13 @@ impl OrchestraService {
                 Ok(Some((row, data, order_id)))
             }
             Err(e) => {
-                // 4xx is the expected "no deposit yet" shape from Orchestra.
-                // 5xx / 429 / transport errors are transient provider issues
-                // worth surfacing so a persistent outage doesn't go silent.
+                // Everything else (rejected credentials, throttling, 5xx,
+                // transport failure) is surfaced so a persistent outage or a
+                // bad key doesn't read as a quote waiting on its deposit.
                 if is_expected_no_deposit_error(&e) {
                     debug!("Orchestra receive {quote_id}: no deposit yet: {e}");
                 } else {
-                    warn!("Orchestra receive {quote_id}: transient submit error: {e}");
+                    warn!("Orchestra receive {quote_id}: submit error: {e}");
                 }
                 Ok(None)
             }
@@ -611,17 +654,29 @@ impl OrchestraService {
         row: crate::StoredCrossChainSwap,
         data: OrchestraSwapData,
         order_id: &str,
+        probe_clock: &mut HashMap<String, u64>,
     ) -> Result<(), SdkError> {
         let quote_id = data.quote_id.clone();
-        let resp = match client
+        let status = client
             .status_by_id(order_id, data.read_token.as_deref())
-            .await
-        {
+            .await;
+        let resp = match status {
             Ok(resp) => resp,
             Err(e) => {
                 debug!(
                     "Orchestra receive {quote_id}: status request failed for orderId={order_id}: {e}"
                 );
+                // Read tokens expire. `/submit` is idempotent and reissues
+                // one against the same order, so the next tick can poll again.
+                // On the probe clock, so a token the provider keeps rejecting
+                // costs one submit per window rather than one per tick.
+                if is_invalid_read_token(&e) && is_probe_due(probe_clock, &quote_id) {
+                    info!(
+                        "Orchestra receive {quote_id}: read token rejected, re-acquiring via submit"
+                    );
+                    record_probe(probe_clock, &quote_id);
+                    Self::submit_receive_probe(swap_storage, client, row, data).await?;
+                }
                 return Ok(());
             }
         };
@@ -629,24 +684,38 @@ impl OrchestraService {
         debug!("Orchestra receive {quote_id}: order response: {order:?}");
         match order.status {
             OrderStatus::Completed => {
-                match attach_receive_metadata(storage, spark_wallet, fiat_service, &data, &order)
-                    .await
+                let attached = match attach_receive_metadata(
+                    storage,
+                    spark_wallet,
+                    fiat_service,
+                    &data,
+                    &order,
+                )
+                .await
                 {
-                    Ok(true) => {
-                        info!("Orchestra receive {quote_id} → Completed, metadata attached");
-                        swap_storage.mark_terminal(row).await?;
-                    }
-                    Ok(false) => {
-                        // Order Completed but no sparkTxHash yet: no key to
-                        // link or cache against. Retry next tick once
-                        // Orchestra populates it.
+                    Ok(ReceiveMetadataOutcome::Attached) => true,
+                    Ok(ReceiveMetadataOutcome::Pending) => {
                         debug!(
-                            "Orchestra receive {quote_id} Completed without sparkTxHash; will retry"
+                            "Orchestra receive {quote_id} Completed, metadata not on the \
+                             payment row yet; will retry"
                         );
+                        false
                     }
                     Err(e) => {
                         error!("Orchestra receive {quote_id} metadata attach failed: {e:?}");
+                        false
                     }
+                };
+                if attached {
+                    info!("Orchestra receive {quote_id} → Completed, metadata attached");
+                    swap_storage.mark_terminal(row).await?;
+                } else if is_past_receive_grace(&data) {
+                    // Out of retries. The metadata stays in the cache.
+                    warn!(
+                        "Orchestra receive {quote_id} Completed but metadata never reached the \
+                         payment row within the grace window, closing row"
+                    );
+                    swap_storage.mark_terminal(row).await?;
                 }
             }
             OrderStatus::Failed | OrderStatus::Refunded => {
@@ -837,10 +906,16 @@ fn pad_required_in(scaled: u128, reported_pad: u128) -> (u128, u128) {
 }
 
 /// Whether an Orchestra error on the receive-side `/submit` probe is the
-/// expected "no deposit yet" shape (any 4xx). Anything else (5xx, 429,
-/// transport failure) is a transient provider issue worth logging louder.
+/// expected "no deposit yet" shape: a 4xx that isn't about credentials or
+/// rate limiting. Anything else (401, 403, 429, 5xx, transport failure) is a
+/// provider or configuration issue worth logging louder, not a quote still
+/// waiting on its deposit.
 fn is_expected_no_deposit_error(err: &FlashnetError) -> bool {
-    matches!(err, FlashnetError::Network { code: Some(c), .. } if *c < 500)
+    matches!(
+        err,
+        FlashnetError::Network { code: Some(c), .. }
+            if *c < 500 && !matches!(*c, 401 | 403 | 429)
+    )
 }
 
 /// Errors if `quoted_amount_in` differs from `requested_source_amount` by
@@ -1295,7 +1370,7 @@ impl CrossChainService for OrchestraService {
             source_contract_address: route.contract_address.clone(),
             source_decimals: u32::from(route.decimals),
             destination_chain: SOURCE_CHAIN_SPARK.to_string(),
-            destination_asset: destination_asset_symbol,
+            destination_asset: destination_asset_symbol.clone(),
             destination_decimals,
             token_identifier: destination_token_identifier.clone(),
             amount_in: quote.amount_in.clone(),
@@ -1321,6 +1396,7 @@ impl CrossChainService for OrchestraService {
                 deposit_address: quote.deposit_address,
                 deposit_amount,
                 expected_received_amount,
+                destination_asset: destination_asset_symbol,
                 token_identifier: destination_token_identifier,
                 service_fee_amount,
                 service_fee_asset: if quote.fee_asset.eq_ignore_ascii_case("BTC") {
@@ -1723,30 +1799,41 @@ fn apply_terminal_status(
     })
 }
 
+/// Where a receive order's `ConversionInfo` ended up.
+enum ReceiveMetadataOutcome {
+    /// Written against the inbound `Payment` row.
+    Attached,
+    /// Not on the row yet, and cached under the order's `sparkTxHash`: the
+    /// order carries no hash, the hash did not resolve to a payment id, or
+    /// the row write failed.
+    Pending,
+}
+
 /// Reads `order.sparkTxHash` (the receive-side linking key), resolves it to
 /// the inbound Spark `Payment` id, and upserts `ConversionInfo::Orchestra`
 /// onto it. `spark_tx_hash` may be a Spark transfer id (BTC receive) or a
 /// token tx hash (USDB receive: token payment ids carry a `:vout` suffix
-/// that the raw hash lacks), so resolution goes through
-/// `resolve_and_insert_payment_metadata`, which also caches the metadata
-/// when the Payment row is not yet synced.
+/// that the raw hash lacks), so token hashes resolve through a
+/// `get_token_transactions_by_hashes` lookup.
 ///
-/// Returns `false` when the order is `Completed` but `spark_tx_hash` is
-/// absent (nothing to link or cache against), and `true` when metadata
-/// was attached or cached.
+/// Anything short of a row write caches the metadata under the hash and
+/// reports [`ReceiveMetadataOutcome::Pending`], leaving the row to try again:
+/// the cache is only reapplied for a payment the sync cursor still covers, so
+/// a lookup or write that failed on a payment already synced would otherwise
+/// strand the conversion there.
 async fn attach_receive_metadata(
     storage: &Arc<dyn Storage>,
     spark_wallet: &SparkWallet,
     fiat_service: &dyn FiatService,
     data: &OrchestraSwapData,
     order: &Order,
-) -> Result<bool, SdkError> {
+) -> Result<ReceiveMetadataOutcome, SdkError> {
     let Some(spark_tx_hash) = order.spark_tx_hash.as_deref() else {
         debug!(
             "Orchestra receive {}: order Completed but no sparkTxHash yet",
             data.quote_id
         );
-        return Ok(false);
+        return Ok(ReceiveMetadataOutcome::Pending);
     };
     let conversion_info = build_orchestra_receive_conversion_info(data, order, fiat_service).await;
     let metadata = crate::PaymentMetadata {
@@ -1755,9 +1842,29 @@ async fn attach_receive_metadata(
     };
     // tx_inputs_are_ours = false: on receive, the inbound token tx is funded
     // by Orchestra's counterparty, not us.
-    resolve_and_insert_payment_metadata(spark_tx_hash, metadata, spark_wallet, storage, false)
-        .await?;
-    Ok(true)
+    match resolve_payment_id(spark_tx_hash, spark_wallet, storage, false).await {
+        Ok(payment_id) => match storage
+            .insert_payment_metadata(payment_id.clone(), metadata.clone())
+            .await
+        {
+            Ok(()) => return Ok(ReceiveMetadataOutcome::Attached),
+            Err(e) => warn!(
+                "Orchestra receive {}: failed to write metadata onto payment {payment_id} ({e}), \
+                 caching it",
+                data.quote_id
+            ),
+        },
+        Err(e) => debug!(
+            "Orchestra receive {}: {spark_tx_hash} did not resolve to a payment id ({e}), \
+             caching metadata",
+            data.quote_id
+        ),
+    }
+    ObjectCacheRepository::new(Arc::clone(storage))
+        .save_payment_metadata(spark_tx_hash, &metadata)
+        .await
+        .map_err(|e| SdkError::Generic(format!("Failed to cache payment metadata: {e}")))?;
+    Ok(ReceiveMetadataOutcome::Pending)
 }
 
 /// Receive-side counterpart to [`apply_terminal_status`]: pulls live bits
@@ -1815,10 +1922,37 @@ async fn build_orchestra_receive_conversion_info(
 /// Whether a pre-order receive row is past the grace window past
 /// `expires_at`, at which point the poller stops probing `/submit` for it.
 fn is_past_receive_grace(data: &OrchestraSwapData) -> bool {
-    let now_secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs());
-    now_secs >= data.expires_at.saturating_add(RECEIVE_GRACE_SECS)
+    now_secs() >= data.expires_at.saturating_add(RECEIVE_GRACE_SECS)
+}
+
+/// Whether the quote behind a receive row has expired. Probing stays on the
+/// every-tick cadence while it is live, and drops to the slower clock after.
+fn is_past_quote_expiry(data: &OrchestraSwapData) -> bool {
+    now_secs() >= data.expires_at
+}
+
+/// Whether `quote_id` is due another `/submit`, at most one per
+/// [`RECEIVE_EXPIRED_PROBE_SECS`] window. A quote the clock has never seen
+/// (a fresh row, or the first pass after a restart) is due immediately.
+fn is_probe_due(probe_clock: &HashMap<String, u64>, quote_id: &str) -> bool {
+    is_probe_due_at(probe_clock.get(quote_id).copied(), now_secs())
+}
+
+fn is_probe_due_at(last_probe_secs: Option<u64>, now_secs: u64) -> bool {
+    last_probe_secs.is_none_or(|last| now_secs.saturating_sub(last) >= RECEIVE_EXPIRED_PROBE_SECS)
+}
+
+fn record_probe(probe_clock: &mut HashMap<String, u64>, quote_id: &str) {
+    probe_clock.insert(quote_id.to_string(), now_secs());
+}
+
+/// Drops the entries of rows that are no longer active, so a quote that went
+/// terminal cannot pin one for the life of the process.
+fn prune_probe_clock(
+    probe_clock: &mut HashMap<String, u64>,
+    active: &[(crate::StoredCrossChainSwap, OrchestraSwapData)],
+) {
+    probe_clock.retain(|quote_id, _| active.iter().any(|(_, data)| &data.quote_id == quote_id));
 }
 
 /// Realized cross-chain receive fee in source-asset base units. Returns
@@ -1862,11 +1996,7 @@ fn parse_rfc3339_to_unix_seconds(expires_at: &str) -> Result<u64, SdkError> {
 /// instead of getting a less helpful error from `/submit`.
 fn validate_quote_expiry(expires_at: &str) -> Result<(), SdkError> {
     let exp_secs = parse_rfc3339_to_unix_seconds(expires_at)?;
-    let now_secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|_| SdkError::Generic("Failed to read current time".to_string()))?
-        .as_secs();
-    if now_secs >= exp_secs {
+    if try_now_secs()? >= exp_secs {
         return Err(SdkError::InvalidInput(
             "Cross-chain quote has expired. Please re-prepare.".to_string(),
         ));
@@ -2760,6 +2890,106 @@ mod tests {
         assert!(!is_invalid_read_token(&FlashnetError::Generic(
             "boom".to_string()
         )));
+    }
+
+    fn receive_swap_data() -> OrchestraSwapData {
+        OrchestraSwapData {
+            quote_id: "q_xyz".to_string(),
+            order_id: None,
+            read_token: None,
+            recipient_address: "sp1rcv".to_string(),
+            source_chain: "ethereum".to_string(),
+            source_asset: "USDC".to_string(),
+            source_chain_id: Some("1".to_string()),
+            source_contract_address: Some("0xUSDC".to_string()),
+            source_decimals: 6,
+            destination_chain: "spark".to_string(),
+            destination_asset: "BTC".to_string(),
+            destination_decimals: 8,
+            token_identifier: None,
+            amount_in: "100".to_string(),
+            expected_amount_out: "50000".to_string(),
+            fee_amount: Some("250".to_string()),
+            expires_at: 1_700_000_120,
+        }
+    }
+
+    fn stored_receive_row(data: &OrchestraSwapData) -> crate::StoredCrossChainSwap {
+        crate::StoredCrossChainSwap {
+            provider: super::super::orchestra_storage_adapter::PROVIDER_TAG_ORCHESTRA.to_string(),
+            id: data.quote_id.clone(),
+            is_terminal: false,
+            updated_at: 0,
+            data: serde_json::to_string(data).unwrap(),
+            secrets: String::new(),
+        }
+    }
+
+    #[test_all]
+    fn a_rate_limit_is_not_read_as_a_missing_deposit() {
+        // The probe treats 4xx as "the deposit isn't there yet", but a 429 is
+        // the provider throttling us and deserves a louder log.
+        for code in [400, 404] {
+            assert!(
+                is_expected_no_deposit_error(&FlashnetError::Network {
+                    reason: "invalid_tx_hash".to_string(),
+                    code: Some(code),
+                }),
+                "{code} should read as no deposit yet"
+            );
+        }
+        // A rejected key or read token is not a quote waiting on its deposit,
+        // and must not log at debug as one.
+        for code in [401, 403, 429, 500, 503] {
+            assert!(
+                !is_expected_no_deposit_error(&FlashnetError::Network {
+                    reason: "throttled".to_string(),
+                    code: Some(code),
+                }),
+                "{code} should surface as a provider issue"
+            );
+        }
+    }
+
+    #[test_all]
+    fn an_expired_quote_is_probed_on_the_slower_clock() {
+        // A live quote never reaches the backoff: it is probed every tick.
+        let mut data = receive_swap_data();
+        data.expires_at = u64::MAX;
+        assert!(!is_past_quote_expiry(&data));
+
+        data.expires_at = 1_000;
+        assert!(is_past_quote_expiry(&data));
+
+        // A quote the clock has never seen is due at once: a restart drops the
+        // clock, and one probe per row is the price of not persisting it.
+        assert!(is_probe_due_at(None, 1_000));
+
+        // Otherwise, only once the window since the last probe has elapsed.
+        assert!(!is_probe_due_at(
+            Some(1_000),
+            1_000 + RECEIVE_EXPIRED_PROBE_SECS - 1
+        ));
+        assert!(is_probe_due_at(
+            Some(1_000),
+            1_000 + RECEIVE_EXPIRED_PROBE_SECS
+        ));
+    }
+
+    #[test_all]
+    fn a_probe_clock_entry_dies_with_its_row() {
+        let mut probe_clock = HashMap::new();
+        record_probe(&mut probe_clock, "q_live");
+        record_probe(&mut probe_clock, "q_gone");
+
+        let mut live = receive_swap_data();
+        live.quote_id = "q_live".to_string();
+        let active = vec![(stored_receive_row(&live), live)];
+        prune_probe_clock(&mut probe_clock, &active);
+
+        assert!(!is_probe_due(&probe_clock, "q_live"));
+        // The row is gone, so its entry no longer holds off a probe.
+        assert!(is_probe_due(&probe_clock, "q_gone"));
     }
 
     #[test_all]

--- a/crates/breez-sdk/core/src/cross_chain/orchestra_storage_adapter.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra_storage_adapter.rs
@@ -1,0 +1,414 @@
+//! Orchestra rows in the provider-agnostic `cross_chain_swaps` table.
+//!
+//! Orchestra has no money-critical secrets to keep at rest, so `secrets` is
+//! always empty. The row's `data` JSON carries the lookup key and the
+//! quote-time values that don't appear on the live `Order` polled per tick.
+//! Live status / `sparkTxHash` / `amountOut` / refund tx are read off the
+//! `/status` response, never cached.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    Storage,
+    error::SdkError,
+    persist::{StorageError, StoredCrossChainSwap},
+};
+
+pub(crate) const PROVIDER_TAG_ORCHESTRA: &str = "orchestra";
+
+/// Persisted shape of an Orchestra row's `data`. The receive poller drives
+/// the row through two states:
+///
+/// * **Pre-order** (`order_id` / `read_token` absent): probe `POST /submit`
+///   with a fresh idempotency key each tick. Any error means "no deposit
+///   yet". A 200 returns `{ orderId, readToken }` and the adapter writes
+///   both. This is the only mid-flight mutation before the terminal flip.
+/// * **Order in flight** (`order_id` / `read_token` set): poll
+///   `GET /status?id={orderId}&readToken={token}` until terminal.
+///
+/// Live status / `sparkTxHash` / `amountOut` / refund tx are always read
+/// off the poll response, never cached here.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OrchestraSwapData {
+    pub quote_id: String,
+    /// Orchestra order id. Populated on the first `/submit` 200, then stable.
+    #[serde(default)]
+    pub order_id: Option<String>,
+    /// `X-Read-Token` for `/status` calls. Born together with `order_id` on
+    /// the same `/submit` 200.
+    #[serde(default)]
+    pub read_token: Option<String>,
+    /// Wallet's Spark address (the receive destination).
+    pub recipient_address: String,
+    pub source_chain: String,
+    pub source_asset: String,
+    /// Source chain identifier (e.g. EVM `chainId` as a decimal string).
+    /// `None` for non-EVM chains.
+    #[serde(default)]
+    pub source_chain_id: Option<String>,
+    /// Source token contract address. `None` for native-asset routes.
+    #[serde(default)]
+    pub source_contract_address: Option<String>,
+    /// Source asset decimals. Cached here because `ConversionInfo` rendering
+    /// needs them and the live `Order` doesn't carry them.
+    pub source_decimals: u32,
+    pub destination_chain: String,
+    pub destination_asset: String,
+    /// Destination asset decimals: 8 for BTC sats, the token metadata
+    /// decimals (e.g. 6 for USDB) for token destinations.
+    #[serde(default = "default_destination_decimals")]
+    pub destination_decimals: u32,
+    /// Destination Spark token id (`Some("...")` for USDB) or `None` for BTC.
+    #[serde(default)]
+    pub token_identifier: Option<String>,
+    /// Orchestra `amountIn` at quote time. The live `Order.amount_in` may
+    /// differ if Orchestra repriced a late deposit, but the quote-time
+    /// value is what gets surfaced in `ConversionInfo`.
+    pub amount_in: String,
+    /// Orchestra `estimatedOut` at quote time. The live `Order.amount_out` is
+    /// what the receiver actually gets and is read off the poll response.
+    pub expected_amount_out: String,
+    #[serde(default)]
+    pub fee_amount: Option<String>,
+    /// Quote expiry, unix seconds. Not authoritative for the receive
+    /// lifecycle: Orchestra may reprice late deposits.
+    pub expires_at: u64,
+}
+
+fn default_destination_decimals() -> u32 {
+    8
+}
+
+/// Thin wrapper over [`Storage`]'s `cross_chain_swaps` methods, keyed to
+/// the Orchestra provider tag.
+pub(crate) struct OrchestraStorageAdapter {
+    storage: Arc<dyn Storage>,
+}
+
+impl OrchestraStorageAdapter {
+    pub(crate) fn new(storage: Arc<dyn Storage>) -> Self {
+        Self { storage }
+    }
+
+    /// Assembles a `StoredCrossChainSwap` row for the given Orchestra data.
+    /// Pure (no I/O): Orchestra keeps no money-critical secrets, so
+    /// `secrets` stays empty and no signer is involved.
+    fn to_stored(data: &OrchestraSwapData) -> Result<StoredCrossChainSwap, SdkError> {
+        let serialized = serde_json::to_string(data)
+            .map_err(|e| SdkError::Generic(format!("Failed to serialize Orchestra row: {e}")))?;
+        Ok(StoredCrossChainSwap {
+            provider: PROVIDER_TAG_ORCHESTRA.to_string(),
+            id: data.quote_id.clone(),
+            is_terminal: false,
+            updated_at: current_unix_seconds(),
+            data: serialized,
+            secrets: String::new(),
+        })
+    }
+
+    /// Upsert an Orchestra row.
+    pub(crate) async fn upsert(&self, data: &OrchestraSwapData) -> Result<(), SdkError> {
+        let stored = Self::to_stored(data)?;
+        self.storage
+            .set_cross_chain_swap(stored)
+            .await
+            .map_err(|e| map_storage_err(&e))
+    }
+
+    /// Returns the active rows the receive poller should sweep. Corrupt
+    /// rows are logged and skipped so one bad row doesn't stall the rest.
+    pub(crate) async fn list_active(
+        &self,
+    ) -> Result<Vec<(StoredCrossChainSwap, OrchestraSwapData)>, SdkError> {
+        let rows = self
+            .storage
+            .list_active_cross_chain_swaps(PROVIDER_TAG_ORCHESTRA.to_string())
+            .await
+            .map_err(|e| map_storage_err(&e))?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            match serde_json::from_str::<OrchestraSwapData>(&row.data) {
+                Ok(data) => out.push((row, data)),
+                Err(e) => {
+                    tracing::warn!(
+                        "Skipping Orchestra row '{}': failed to parse data: {e}",
+                        row.id
+                    );
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Pre-order to in-flight transition: persist `order_id` and
+    /// `read_token` from the first successful `/submit`, returning the
+    /// updated `(row, data)` so the caller can poll `/status` in the same
+    /// tick. `data` is stable after this until `mark_terminal`.
+    pub(crate) async fn attach_order_handle(
+        &self,
+        mut row: StoredCrossChainSwap,
+        mut data: OrchestraSwapData,
+        order_id: String,
+        read_token: Option<String>,
+    ) -> Result<(StoredCrossChainSwap, OrchestraSwapData), SdkError> {
+        data.order_id = Some(order_id);
+        data.read_token = read_token;
+        row.data = serde_json::to_string(&data).map_err(|e| {
+            SdkError::Generic(format!(
+                "Failed to serialize Orchestra row after submit response: {e}"
+            ))
+        })?;
+        row.updated_at = current_unix_seconds();
+        self.storage
+            .set_cross_chain_swap(row.clone())
+            .await
+            .map_err(|e| map_storage_err(&e))?;
+        Ok((row, data))
+    }
+
+    /// Flip a row terminal.
+    pub(crate) async fn mark_terminal(
+        &self,
+        mut row: StoredCrossChainSwap,
+    ) -> Result<(), SdkError> {
+        row.is_terminal = true;
+        row.updated_at = current_unix_seconds();
+        self.storage
+            .set_cross_chain_swap(row)
+            .await
+            .map_err(|e| map_storage_err(&e))
+    }
+}
+
+fn map_storage_err(e: &StorageError) -> SdkError {
+    SdkError::StorageError(e.to_string())
+}
+
+fn current_unix_seconds() -> u64 {
+    use platform_utils::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    pub(super) fn sample_data() -> OrchestraSwapData {
+        OrchestraSwapData {
+            quote_id: "q_abc".to_string(),
+            order_id: None,
+            read_token: None,
+            recipient_address: "sp1...".to_string(),
+            source_chain: "base".to_string(),
+            source_asset: "USDC".to_string(),
+            source_chain_id: Some("8453".to_string()),
+            source_contract_address: Some("0xUSDC".to_string()),
+            source_decimals: 6,
+            destination_chain: "spark".to_string(),
+            destination_asset: "BTC".to_string(),
+            destination_decimals: 8,
+            token_identifier: None,
+            amount_in: "100000000".to_string(),
+            expected_amount_out: "100000".to_string(),
+            fee_amount: Some("500".to_string()),
+            expires_at: 1_700_000_120,
+        }
+    }
+
+    pub(super) fn sample_data_usdb_destination() -> OrchestraSwapData {
+        OrchestraSwapData {
+            quote_id: "q_usdb".to_string(),
+            order_id: Some("o_usdb".to_string()),
+            read_token: Some("rt_usdb".to_string()),
+            recipient_address: "sp1...".to_string(),
+            source_chain: "arbitrum".to_string(),
+            source_asset: "USDC".to_string(),
+            source_chain_id: Some("42161".to_string()),
+            source_contract_address: Some("0xUSDC".to_string()),
+            source_decimals: 6,
+            destination_chain: "spark".to_string(),
+            destination_asset: "USDB".to_string(),
+            destination_decimals: 6,
+            token_identifier: Some(
+                "btkn1xgrvjwey5ngcagvap2dzzvsy4uk8ua9x69k82dwvt5e7ef9drm9qztux87".to_string(),
+            ),
+            amount_in: "1050000".to_string(),
+            expected_amount_out: "1000000".to_string(),
+            fee_amount: Some("20000".to_string()),
+            expires_at: 1_700_000_120,
+        }
+    }
+
+    /// JSON round-trip preserves every field. Important because the row's
+    /// `data` is serialised at `prepare_receive` time and the poller
+    /// deserialises it untouched on every tick.
+    #[test]
+    fn data_roundtrip_preserves_all_fields() {
+        let data = sample_data();
+        let json = serde_json::to_string(&data).unwrap();
+        let decoded: OrchestraSwapData = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    /// Same round-trip guarantee for token-destination rows: `token_identifier`
+    /// is `Some`, decimals match at 6, `order_id`/`read_token` populated.
+    #[test]
+    fn data_roundtrip_preserves_token_destination_fields() {
+        let data = sample_data_usdb_destination();
+        let json = serde_json::to_string(&data).unwrap();
+        let decoded: OrchestraSwapData = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    /// Forward compatibility: future fields added by the server must not
+    /// break deserialization of older row schemas.
+    #[test]
+    fn data_accepts_extra_unknown_fields() {
+        let mut json: serde_json::Value = serde_json::to_value(sample_data()).unwrap();
+        json["someFutureField"] = serde_json::json!("ignored");
+        let decoded: OrchestraSwapData = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.quote_id, "q_abc");
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod storage_tests {
+    use std::path::PathBuf;
+
+    use super::tests::*; // sample_data
+    use super::*;
+    use crate::persist::sqlite::SqliteStorage;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "breez-orchestra-storage-test-{}-{}",
+            name,
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn make_adapter() -> OrchestraStorageAdapter {
+        let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&temp_dir("adapter")).unwrap());
+        OrchestraStorageAdapter::new(storage)
+    }
+
+    fn stored_row_for(data: &OrchestraSwapData) -> StoredCrossChainSwap {
+        StoredCrossChainSwap {
+            provider: PROVIDER_TAG_ORCHESTRA.to_string(),
+            id: data.quote_id.clone(),
+            is_terminal: false,
+            updated_at: 0,
+            data: serde_json::to_string(data).unwrap(),
+            secrets: String::new(),
+        }
+    }
+
+    /// Mid-flight write: populates `order_id` + `read_token`, preserves
+    /// the rest of `data`, keeps the row non-terminal.
+    #[tokio::test]
+    async fn attach_order_handle_persists_handle_and_keeps_row_active() {
+        let adapter = make_adapter();
+        let initial_data = sample_data();
+        adapter
+            .storage
+            .set_cross_chain_swap(stored_row_for(&initial_data))
+            .await
+            .unwrap();
+
+        let row = adapter
+            .storage
+            .get_cross_chain_swap(
+                PROVIDER_TAG_ORCHESTRA.to_string(),
+                initial_data.quote_id.clone(),
+            )
+            .await
+            .unwrap()
+            .expect("seeded row");
+
+        adapter
+            .attach_order_handle(
+                row,
+                initial_data.clone(),
+                "ord_xyz".to_string(),
+                Some("rt_xyz".to_string()),
+            )
+            .await
+            .unwrap();
+
+        let after_row = adapter
+            .storage
+            .get_cross_chain_swap(
+                PROVIDER_TAG_ORCHESTRA.to_string(),
+                initial_data.quote_id.clone(),
+            )
+            .await
+            .unwrap()
+            .expect("row still present");
+        assert!(!after_row.is_terminal, "still active until terminal poll");
+
+        let after: OrchestraSwapData = serde_json::from_str(&after_row.data).unwrap();
+        assert_eq!(after.order_id.as_deref(), Some("ord_xyz"));
+        assert_eq!(after.read_token.as_deref(), Some("rt_xyz"));
+        // Every other field stays exactly as written at quote time.
+        assert_eq!(after.quote_id, initial_data.quote_id);
+        assert_eq!(after.recipient_address, initial_data.recipient_address);
+        assert_eq!(after.amount_in, initial_data.amount_in);
+        assert_eq!(after.expected_amount_out, initial_data.expected_amount_out);
+        assert_eq!(after.fee_amount, initial_data.fee_amount);
+    }
+
+    /// `list_active` returns non-terminal rows only.
+    #[tokio::test]
+    async fn list_active_returns_only_non_terminal_rows() {
+        let adapter = make_adapter();
+        let row_data = sample_data();
+        adapter
+            .storage
+            .set_cross_chain_swap(stored_row_for(&row_data))
+            .await
+            .unwrap();
+
+        let active = adapter.list_active().await.unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].1.quote_id, "q_abc");
+    }
+
+    /// `mark_terminal` flips `is_terminal` and drops the row from the next
+    /// `list_active`.
+    #[tokio::test]
+    async fn mark_terminal_flips_flag_and_drops_from_active_list() {
+        let adapter = make_adapter();
+        let data = sample_data();
+        adapter
+            .storage
+            .set_cross_chain_swap(stored_row_for(&data))
+            .await
+            .unwrap();
+        let row = adapter
+            .storage
+            .get_cross_chain_swap(PROVIDER_TAG_ORCHESTRA.to_string(), data.quote_id.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        adapter.mark_terminal(row).await.unwrap();
+
+        let after = adapter
+            .storage
+            .get_cross_chain_swap(PROVIDER_TAG_ORCHESTRA.to_string(), data.quote_id.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(after.is_terminal);
+
+        let active = adapter.list_active().await.unwrap();
+        assert!(active.is_empty());
+    }
+}

--- a/crates/breez-sdk/core/src/cross_chain/orchestra_storage_adapter.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra_storage_adapter.rs
@@ -14,6 +14,7 @@ use crate::{
     Storage,
     error::SdkError,
     persist::{StorageError, StoredCrossChainSwap},
+    utils::time::now_secs,
 };
 
 pub(crate) const PROVIDER_TAG_ORCHESTRA: &str = "orchestra";
@@ -22,11 +23,13 @@ pub(crate) const PROVIDER_TAG_ORCHESTRA: &str = "orchestra";
 /// the row through two states:
 ///
 /// * **Pre-order** (`order_id` / `read_token` absent): probe `POST /submit`
-///   with a fresh idempotency key each tick. Any error means "no deposit
-///   yet". A 200 returns `{ orderId, readToken }` and the adapter writes
-///   both. This is the only mid-flight mutation before the terminal flip.
+///   with a fresh idempotency key, every tick while the quote is live and on
+///   the poller's slower in-memory clock once it expires. Any error means "no
+///   deposit yet". A 200 returns `{ orderId, readToken }` and the adapter
+///   writes both.
 /// * **Order in flight** (`order_id` / `read_token` set): poll
-///   `GET /status?id={orderId}&readToken={token}` until terminal.
+///   `GET /status?id={orderId}&readToken={token}` until terminal. `/submit`
+///   is idempotent, so a rejected read token is refreshed by probing again.
 ///
 /// Live status / `sparkTxHash` / `amountOut` / refund tx are always read
 /// off the poll response, never cached here.
@@ -103,7 +106,7 @@ impl OrchestraStorageAdapter {
             provider: PROVIDER_TAG_ORCHESTRA.to_string(),
             id: data.quote_id.clone(),
             is_terminal: false,
-            updated_at: current_unix_seconds(),
+            updated_at: now_secs(),
             data: serialized,
             secrets: String::new(),
         })
@@ -161,7 +164,7 @@ impl OrchestraStorageAdapter {
                 "Failed to serialize Orchestra row after submit response: {e}"
             ))
         })?;
-        row.updated_at = current_unix_seconds();
+        row.updated_at = now_secs();
         self.storage
             .set_cross_chain_swap(row.clone())
             .await
@@ -175,7 +178,7 @@ impl OrchestraStorageAdapter {
         mut row: StoredCrossChainSwap,
     ) -> Result<(), SdkError> {
         row.is_terminal = true;
-        row.updated_at = current_unix_seconds();
+        row.updated_at = now_secs();
         self.storage
             .set_cross_chain_swap(row)
             .await
@@ -185,13 +188,6 @@ impl OrchestraStorageAdapter {
 
 fn map_storage_err(e: &StorageError) -> SdkError {
     SdkError::StorageError(e.to_string())
-}
-
-fn current_unix_seconds() -> u64 {
-    use platform_utils::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs())
 }
 
 #[cfg(test)]

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -34,8 +34,8 @@ pub use chain::{
 pub use common::rest::{RestClient, RestResponse};
 pub use common::{fiat::*, models::*, sync_storage};
 pub use cross_chain::{
-    CrossChainFeeMode, CrossChainProvider, CrossChainProviderContext, CrossChainRouteFilter,
-    CrossChainRoutePair, SourceAsset, SourceChain,
+    CrossChainFeeMode, CrossChainProvider, CrossChainProviderContext, CrossChainReceiveInfo,
+    CrossChainRouteFilter, CrossChainRoutePair, DeliveryMethod, SparkAsset,
 };
 pub use error::{DepositClaimError, SdkError, SignerError};
 pub use events::{AutoOptimizationEvent, EventEmitter, EventListener, SdkEvent};

--- a/crates/breez-sdk/core/src/lnurl.rs
+++ b/crates/breez-sdk/core/src/lnurl.rs
@@ -4,11 +4,12 @@ use lnurl_models::{
     RecoverLnurlPayRequest, RecoverLnurlPayResponse, RegisterLnurlPayRequest,
     RegisterLnurlPayResponse, TransferLnurlPayRequest, UnregisterLnurlPayRequest, signed_message,
 };
-use platform_utils::time::{SystemTime, UNIX_EPOCH};
 use platform_utils::{ContentType, HttpClient, add_content_type_header};
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::sync::Arc;
+
+use crate::utils::time::try_now_secs;
 
 /// Headers `list_metadata` sends its credential in, keeping it out of the query
 /// string and so out of proxy and access logs. The response carries preimages.
@@ -218,10 +219,7 @@ impl DefaultLnurlServerClient {
     /// Seconds since the Unix epoch, the unit every signed message and every
     /// `timestamp` field on the wire uses.
     fn now() -> Result<u64, LnurlServerError> {
-        Ok(SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|_| LnurlServerError::SigningError("invalid systemtime".to_string()))?
-            .as_secs())
+        try_now_secs().map_err(|_| LnurlServerError::SigningError("invalid systemtime".to_string()))
     }
 
     /// Sign one canonical message, hex-encoding the DER signature the way the

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -847,15 +847,15 @@ pub struct Config {
 pub struct CrossChainConfig {
     /// Default maximum slippage in basis points used when
     /// [`PaymentRequest::CrossChain::max_slippage_bps`] is not set on the
-    /// prepare request. Must be in `10..=500`. Falls back to 100 bps (1%)
-    /// when this field is `None`.
+    /// prepare request. Must be in 10 to 500. Falls back to 100 bps (1%)
+    /// when this field is unset.
     #[cfg_attr(feature = "uniffi", uniffi(default = None))]
     pub default_slippage_bps: Option<u32>,
     /// Default target-overpay pad in basis points applied to the user's
     /// destination amount on `FeesExcluded` conversion sends. Bumps the
     /// target upward before quoting so the recipient lands at or above the
-    /// requested amount despite provider slippage. Must be in `0..=500`.
-    /// Falls back to 15 bps when `None`.
+    /// requested amount despite provider slippage. Must be in 0 to 500.
+    /// Falls back to 15 bps when unset.
     #[cfg_attr(feature = "uniffi", uniffi(default = None))]
     pub default_target_overpay_bps: Option<u32>,
 }
@@ -1612,6 +1612,38 @@ pub enum ReceivePaymentMethod {
         /// If absent, the connected wallet's identity public key is used.
         receiver_identity_public_key: Option<String>,
     },
+    CrossChain {
+        /// The selected cross-chain route in the receive direction.
+        route: crate::cross_chain::CrossChainRoutePair,
+        /// The amount, in the source asset's base units (`route.decimals`).
+        /// USD-stable sources are at parity, so `1 USD = 10^route.decimals`
+        /// (e.g. `1_000_000` for 6-decimal USDC/USDT, `10^18` for 18-decimal
+        /// BSC USDC).
+        ///
+        /// - `FeesExcluded` (default): what the receiver ends up with, sized
+        ///   as if `amount` source units were converted to the Spark-side
+        ///   destination at parity (USDB) or the live BTC/USD rate (Bitcoin).
+        /// - `FeesIncluded`: what the sender deposits. The receiver ends up
+        ///   with that amount minus provider fees.
+        amount: u128,
+        /// Spark-side asset the receiver wants delivered. When absent, the
+        /// SDK auto-selects: the wallet's active stable-balance token if
+        /// the route supports it, otherwise Bitcoin (sats). When set, the
+        /// value must appear in the route's `accepted_assets`.
+        destination: Option<crate::cross_chain::SparkAsset>,
+        /// How `amount` should be interpreted. When absent, defaults to
+        /// `FeesExcluded`.
+        fee_mode: Option<crate::cross_chain::CrossChainFeeMode>,
+        /// Maximum slippage in basis points. When absent, the SDK default
+        /// (100 bps) is used.
+        max_slippage_bps: Option<u32>,
+        /// Per-request override for the overpay buffer applied to the
+        /// sender's deposit when `fee_mode == FeesExcluded`. Range 0 to 500.
+        /// When absent, falls back to `CrossChainConfig::default_target_overpay_bps`
+        /// then the built-in default (15 bps). Ignored when `fee_mode`
+        /// is `FeesIncluded`.
+        target_overpay_bps: Option<u32>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1718,6 +1750,8 @@ pub struct ReceivePaymentResponse {
     /// Fee to pay to receive the payment
     /// Denominated in sats or token base units
     pub fee: u128,
+    /// Optional information populated only for cross-chain receives.
+    pub cross_chain_info: Option<crate::cross_chain::CrossChainReceiveInfo>,
 }
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -1907,15 +1941,15 @@ pub enum PaymentRequest {
         address: String,
         route: CrossChainRoutePair,
         /// Maximum slippage tolerance in basis points (1/100 of a percent)
-        /// for the cross-chain quote. Must be in `10..=500`. Falls back to
-        /// [`Config::default_slippage_bps`] when `None`, which itself
-        /// defaults to 100 bps (1%) when unset.
+        /// for the cross-chain quote. Must be in 10 to 500. Falls back to
+        /// [`Config::default_slippage_bps`] when unset, which itself
+        /// defaults to 100 bps (1%).
         max_slippage_bps: Option<u32>,
         /// Target-overpay pad in basis points applied on `FeesExcluded`
         /// conversion sends. Inflates the destination target before quoting
         /// so the recipient lands at or above the user's requested amount
-        /// despite provider slippage. Must be in `0..=500`. Falls back to
-        /// [`CrossChainConfig::default_target_overpay_bps`] when `None`,
+        /// despite provider slippage. Must be in 0 to 500. Falls back to
+        /// [`CrossChainConfig::default_target_overpay_bps`] when unset,
         /// which itself defaults to 15 bps.
         target_overpay_bps: Option<u32>,
     },

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -258,18 +258,20 @@ pub struct Payment {
 impl Payment {
     /// Returns `true` if this payment is a child of a conversion operation.
     ///
-    /// Conversion operations (stable balance, ongoing sends) create internal child
-    /// payments (send sats→Flashnet, receive tokens). These are identified by having
-    /// `conversion_info` set in their payment details.
+    /// An AMM conversion (stable balance, convert-on-send) settles as its own
+    /// payments: sats out to the pool, tokens back in. Those legs are internal
+    /// plumbing, so they carry [`ConversionInfo::Amm`]. A cross-chain
+    /// conversion has no such legs: it annotates the payment the user made or
+    /// received, which is never a child.
     pub fn is_conversion_child(&self) -> bool {
         matches!(
             &self.details,
             Some(
                 PaymentDetails::Spark {
-                    conversion_info: Some(_),
+                    conversion_info: Some(ConversionInfo::Amm { .. }),
                     ..
                 } | PaymentDetails::Token {
-                    conversion_info: Some(_),
+                    conversion_info: Some(ConversionInfo::Amm { .. }),
                     ..
                 }
             )
@@ -3045,4 +3047,79 @@ pub struct ImportUnilateralExitStateResponse {
     /// incomplete, the wallet's own copy can already back an exit, or the leaf
     /// was named more than once. The leaf itself is in the wallet either way.
     pub skipped_chains: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ConversionStatus, PaymentMethod};
+    use macros::test_all;
+
+    #[cfg(feature = "browser-tests")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    fn spark_payment(conversion_info: Option<ConversionInfo>) -> Payment {
+        Payment {
+            id: "pmt".to_string(),
+            payment_type: PaymentType::Receive,
+            status: PaymentStatus::Completed,
+            amount: 1_000,
+            fees: 0,
+            timestamp: 0,
+            method: PaymentMethod::Spark,
+            details: Some(PaymentDetails::Spark {
+                invoice_details: None,
+                htlc_details: None,
+                conversion_info,
+            }),
+            conversion_details: None,
+        }
+    }
+
+    fn amm_info() -> ConversionInfo {
+        ConversionInfo::Amm {
+            pool_id: "pool".to_string(),
+            conversion_id: "conv".to_string(),
+            status: ConversionStatus::Completed,
+            fee: None,
+            purpose: None,
+            amount_adjustment: None,
+            degradation: None,
+        }
+    }
+
+    fn orchestra_info() -> ConversionInfo {
+        ConversionInfo::Orchestra {
+            order_id: "ord".to_string(),
+            quote_id: "q".to_string(),
+            read_token: None,
+            chain: "base".to_string(),
+            chain_id: Some("8453".to_string()),
+            asset: "USDC".to_string(),
+            recipient_address: "sp1rcv".to_string(),
+            asset_amount_in: Some(1_000_000),
+            estimated_out: 990_000,
+            delivered_amount: Some(990_000),
+            status: ConversionStatus::Completed,
+            fee_amount: Some(10_000),
+            service_fee_amount: None,
+            service_fee_asset: None,
+            asset_decimals: 6,
+            asset_contract: None,
+        }
+    }
+
+    #[test_all]
+    fn only_amm_legs_are_conversion_children() {
+        // The AMM settles a conversion as its own payments, and those are the
+        // ones the event middleware keeps to itself.
+        assert!(spark_payment(Some(amm_info())).is_conversion_child());
+
+        // A cross-chain conversion annotates the payment the user made or
+        // received. Treating it as a child would swallow its events, which on
+        // receive is the only signal the funds arrived.
+        assert!(!spark_payment(Some(orchestra_info())).is_conversion_child());
+
+        assert!(!spark_payment(None).is_conversion_child());
+    }
 }

--- a/crates/breez-sdk/core/src/realtime_sync/storage.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/storage.rs
@@ -23,6 +23,7 @@ use crate::{
         StoredCrossChainSwap, parse_cached_lightning_address,
     },
     sync_storage::{IncomingChange, OutgoingChange, Record, UnversionedRecordChange},
+    utils::time::now_secs,
 };
 use platform_utils::tokio;
 use serde::{Deserialize, Serialize};
@@ -648,9 +649,7 @@ impl Storage for SyncedStorage {
     }
 
     async fn delete_contact(&self, id: String) -> Result<(), StorageError> {
-        let now = platform_utils::time::SystemTime::now()
-            .duration_since(platform_utils::time::UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs());
+        let now = now_secs();
         let mut updated_fields = HashMap::new();
         updated_fields.insert(DELETED_AT_FIELD.to_string(), serde_json::json!(now));
         self.sync_service

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -6,11 +6,11 @@ use tracing::{debug, info};
 
 use crate::{
     BuyBitcoinRequest, BuyBitcoinResponse, CheckMessageRequest, CheckMessageResponse,
-    CrossChainProvider, CrossChainRouteFilter, CrossChainRoutePair, GetTokensMetadataRequest,
-    GetTokensMetadataResponse, InputType, ListFiatCurrenciesResponse, ListFiatRatesResponse,
-    Network, OptimizationMode, OptimizeLeavesRequest, OptimizeLeavesResponse,
-    PreparePaymentLinkRequest, PreparePaymentLinkResponse, RegisterWebhookRequest,
-    RegisterWebhookResponse, SignMessageRequest, SignMessageResponse, SourceChain,
+    CrossChainProvider, CrossChainRouteFilter, CrossChainRoutePair, DeliveryMethod,
+    GetTokensMetadataRequest, GetTokensMetadataResponse, InputType, ListFiatCurrenciesResponse,
+    ListFiatRatesResponse, Network, OptimizationMode, OptimizeLeavesRequest,
+    OptimizeLeavesResponse, PreparePaymentLinkRequest, PreparePaymentLinkResponse,
+    RegisterWebhookRequest, RegisterWebhookResponse, SignMessageRequest, SignMessageResponse,
     UnregisterWebhookRequest, UpdateUserSettingsRequest, UserSettings, Webhook,
     chain::RecommendedFees,
     cross_chain::{
@@ -28,7 +28,7 @@ use crate::{
 
 use super::payments::validation::{
     known_token_contracts, resolve_direct_overpay_amount, resolve_slippage_bps,
-    resolve_target_overpay_bps, validate_address_family_against_route, validate_amount,
+    validate_address_family_against_route, validate_amount,
     validate_recipient_not_contract_address,
 };
 use super::{BreezSdk, helpers::get_deposit_address};
@@ -490,9 +490,9 @@ impl BreezSdk {
 
         // Cash App funds the deposit over Lightning. Fail fast before quoting if
         // the route can't be funded that way. Rejecting an empty
-        // `supported_source_chains` stops a hand-built route from reaching
+        // `delivery_methods` stops a hand-built route from reaching
         // `prepare` and committing provider state it can't fund.
-        if !route_supports_source_chain(&route, SourceChain::Lightning) {
+        if !route_supports_source_chain(&route, DeliveryMethod::Lightning) {
             return Err(SdkError::InvalidInput(
                 "The selected route can't be funded over Lightning".to_string(),
             ));
@@ -541,7 +541,7 @@ impl BreezSdk {
         // lands at or above target despite provider slippage. The pad comes from
         // config (no per-request override on a payment link).
         let fee_policy = fee_policy.unwrap_or_default();
-        let overpay_bps = resolve_target_overpay_bps(
+        let overpay_bps = crate::cross_chain::resolve_target_overpay_bps(
             None,
             self.config
                 .cross_chain_config
@@ -551,11 +551,11 @@ impl BreezSdk {
         let source_sats = resolve_direct_overpay_amount(source_sats, fee_policy, overpay_bps);
 
         let prepared = service
-            .prepare(
+            .prepare_send(
                 &recipient.address,
                 &route,
                 source_sats,
-                Some(SourceChain::Lightning),
+                Some(DeliveryMethod::Lightning),
                 None,
                 slippage_bps,
                 fee_policy.into(),
@@ -588,10 +588,10 @@ impl BreezSdk {
 }
 
 /// Whether `route` advertises `required` as a fundable source chain. An empty
-/// `supported_source_chains` (e.g. a hand-built route) matches nothing and is
+/// `delivery_methods` (e.g. a hand-built route) matches nothing and is
 /// rejected.
-fn route_supports_source_chain(route: &CrossChainRoutePair, required: SourceChain) -> bool {
-    route.supported_source_chains.contains(&required)
+fn route_supports_source_chain(route: &CrossChainRoutePair, required: DeliveryMethod) -> bool {
+    route.delivery_methods.contains(&required)
 }
 
 /// Verifies the provider's deposit `target` is a BOLT11 invoice requesting
@@ -630,7 +630,7 @@ fn deposit_target(context: &CrossChainProviderContext) -> String {
     }
 }
 
-/// Maps a [`crate::cross_chain::CrossChainPrepared`] + funding `url` to a
+/// Maps a [`crate::cross_chain::CrossChainSendPrepared`] + funding `url` to a
 /// [`PreparePaymentLinkResponse`].
 ///
 /// `estimated_out` is in the destination `asset`'s base units. The fee mirrors
@@ -638,7 +638,7 @@ fn deposit_target(context: &CrossChainProviderContext) -> String {
 /// base units, where `None` means sats (Boltz denominates its fee in sats;
 /// Orchestra in the stablecoin).
 fn prepare_payment_link_response(
-    prepared: crate::cross_chain::CrossChainPrepared,
+    prepared: crate::cross_chain::CrossChainSendPrepared,
     url: String,
     amount_sats: u64,
 ) -> PreparePaymentLinkResponse {
@@ -705,8 +705,8 @@ mod tests {
         CashAppProvider, SdkError, deposit_target, parse_compressed_public_key,
         prepare_payment_link_response, reject_reserved_namespace, route_supports_source_chain,
     };
-    use crate::cross_chain::{CrossChainPrepared, CrossChainProviderContext};
-    use crate::{CrossChainFeeMode, CrossChainProvider, CrossChainRoutePair, SourceChain};
+    use crate::cross_chain::{CrossChainProviderContext, CrossChainSendPrepared};
+    use crate::{CrossChainFeeMode, CrossChainProvider, CrossChainRoutePair, DeliveryMethod};
     use macros::test_all;
 
     #[cfg(feature = "browser-tests")]
@@ -720,7 +720,7 @@ mod tests {
         }
     }
 
-    fn route_with_source_chains(chains: Vec<SourceChain>) -> CrossChainRoutePair {
+    fn route_with_source_chains(chains: Vec<DeliveryMethod>) -> CrossChainRoutePair {
         CrossChainRoutePair {
             provider: CrossChainProvider::Orchestra,
             chain: "base".to_string(),
@@ -729,35 +729,39 @@ mod tests {
             contract_address: None,
             decimals: 6,
             exact_out_eligible: false,
-            supported_sources: vec![],
-            supported_source_chains: chains,
+            accepted_assets: vec![],
+            delivery_methods: chains,
         }
     }
 
     #[test_all]
     fn route_supports_source_chain_checks_membership() {
-        let lightning_only = route_with_source_chains(vec![SourceChain::Lightning]);
+        let lightning_only = route_with_source_chains(vec![DeliveryMethod::Lightning]);
         // Cash App (Lightning) is supported; MoonPay (Bitcoin) is not.
         assert!(route_supports_source_chain(
             &lightning_only,
-            SourceChain::Lightning
+            DeliveryMethod::Lightning
         ));
         assert!(!route_supports_source_chain(
             &lightning_only,
-            SourceChain::Bitcoin
+            DeliveryMethod::Bitcoin
         ));
 
-        let both = route_with_source_chains(vec![SourceChain::Lightning, SourceChain::Bitcoin]);
-        assert!(route_supports_source_chain(&both, SourceChain::Bitcoin));
+        let both =
+            route_with_source_chains(vec![DeliveryMethod::Lightning, DeliveryMethod::Bitcoin]);
+        assert!(route_supports_source_chain(&both, DeliveryMethod::Bitcoin));
 
         // An empty list matches nothing: a route must advertise its rails, so a
         // hand-built route can't slip a bad rail through to `prepare`.
         let empty = route_with_source_chains(vec![]);
-        assert!(!route_supports_source_chain(&empty, SourceChain::Bitcoin));
+        assert!(!route_supports_source_chain(
+            &empty,
+            DeliveryMethod::Bitcoin
+        ));
     }
 
-    fn prepared(provider_context: CrossChainProviderContext) -> CrossChainPrepared {
-        CrossChainPrepared {
+    fn prepared(provider_context: CrossChainProviderContext) -> CrossChainSendPrepared {
+        CrossChainSendPrepared {
             amount_in: 5000,
             asset_amount_in: 6_500_000,
             estimated_out: 6_450_000,
@@ -775,8 +779,8 @@ mod tests {
                 contract_address: None,
                 decimals: 6,
                 exact_out_eligible: false,
-                supported_sources: vec![],
-                supported_source_chains: vec![],
+                accepted_assets: vec![],
+                delivery_methods: vec![],
             },
             recipient_address: "0xabc".to_string(),
             token_identifier: None,

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -492,7 +492,7 @@ impl BreezSdk {
         // the route can't be funded that way. Rejecting an empty
         // `delivery_methods` stops a hand-built route from reaching
         // `prepare` and committing provider state it can't fund.
-        if !route_supports_source_chain(&route, DeliveryMethod::Lightning) {
+        if !route_supports_delivery_method(&route, DeliveryMethod::Lightning) {
             return Err(SdkError::InvalidInput(
                 "The selected route can't be funded over Lightning".to_string(),
             ));
@@ -587,10 +587,10 @@ impl BreezSdk {
     }
 }
 
-/// Whether `route` advertises `required` as a fundable source chain. An empty
-/// `delivery_methods` (e.g. a hand-built route) matches nothing and is
+/// Whether `route` advertises `required` as a fundable delivery method. An
+/// empty `delivery_methods` (e.g. a hand-built route) matches nothing and is
 /// rejected.
-fn route_supports_source_chain(route: &CrossChainRoutePair, required: DeliveryMethod) -> bool {
+fn route_supports_delivery_method(route: &CrossChainRoutePair, required: DeliveryMethod) -> bool {
     route.delivery_methods.contains(&required)
 }
 
@@ -703,7 +703,7 @@ fn parse_compressed_public_key(hex_encoded: &str) -> Result<PublicKey, SdkError>
 mod tests {
     use super::{
         CashAppProvider, SdkError, deposit_target, parse_compressed_public_key,
-        prepare_payment_link_response, reject_reserved_namespace, route_supports_source_chain,
+        prepare_payment_link_response, reject_reserved_namespace, route_supports_delivery_method,
     };
     use crate::cross_chain::{CrossChainProviderContext, CrossChainSendPrepared};
     use crate::{CrossChainFeeMode, CrossChainProvider, CrossChainRoutePair, DeliveryMethod};
@@ -720,7 +720,7 @@ mod tests {
         }
     }
 
-    fn route_with_source_chains(chains: Vec<DeliveryMethod>) -> CrossChainRoutePair {
+    fn route_with_delivery_methods(methods: Vec<DeliveryMethod>) -> CrossChainRoutePair {
         CrossChainRoutePair {
             provider: CrossChainProvider::Orchestra,
             chain: "base".to_string(),
@@ -730,31 +730,34 @@ mod tests {
             decimals: 6,
             exact_out_eligible: false,
             accepted_assets: vec![],
-            delivery_methods: chains,
+            delivery_methods: methods,
         }
     }
 
     #[test_all]
-    fn route_supports_source_chain_checks_membership() {
-        let lightning_only = route_with_source_chains(vec![DeliveryMethod::Lightning]);
+    fn route_supports_delivery_method_checks_membership() {
+        let lightning_only = route_with_delivery_methods(vec![DeliveryMethod::Lightning]);
         // Cash App (Lightning) is supported; MoonPay (Bitcoin) is not.
-        assert!(route_supports_source_chain(
+        assert!(route_supports_delivery_method(
             &lightning_only,
             DeliveryMethod::Lightning
         ));
-        assert!(!route_supports_source_chain(
+        assert!(!route_supports_delivery_method(
             &lightning_only,
             DeliveryMethod::Bitcoin
         ));
 
         let both =
-            route_with_source_chains(vec![DeliveryMethod::Lightning, DeliveryMethod::Bitcoin]);
-        assert!(route_supports_source_chain(&both, DeliveryMethod::Bitcoin));
+            route_with_delivery_methods(vec![DeliveryMethod::Lightning, DeliveryMethod::Bitcoin]);
+        assert!(route_supports_delivery_method(
+            &both,
+            DeliveryMethod::Bitcoin
+        ));
 
         // An empty list matches nothing: a route must advertise its rails, so a
         // hand-built route can't slip a bad rail through to `prepare`.
-        let empty = route_with_source_chains(vec![]);
-        assert!(!route_supports_source_chain(
+        let empty = route_with_delivery_methods(vec![]);
+        assert!(!route_supports_delivery_method(
             &empty,
             DeliveryMethod::Bitcoin
         ));

--- a/crates/breez-sdk/core/src/sdk/lightning_address.rs
+++ b/crates/breez-sdk/core/src/sdk/lightning_address.rs
@@ -2,8 +2,8 @@ use std::str::FromStr;
 
 use bitcoin::hex::DisplayHex;
 use lnurl_models::{sanitize_username, signed_message};
-use platform_utils::time::{SystemTime, UNIX_EPOCH};
 
+use crate::utils::time::try_now_secs;
 use crate::{
     AuthorizeTransferRequest, CheckLightningAddressRequest, ClaimTransferRequest,
     LightningAddressInfo, LnurlInfo, RegisterLightningAddressRequest, TransferAuthorization,
@@ -11,13 +11,6 @@ use crate::{
 };
 
 use super::BreezSdk;
-
-fn now_secs() -> Result<u64, SdkError> {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|elapsed| elapsed.as_secs())
-        .map_err(|_| SdkError::Generic("system clock is before the Unix epoch".to_string()))
-}
 
 /// Lowercase compressed hex, the form the server rebuilds the signed message
 /// with. A caller-supplied pubkey that differs only in case or encoding would
@@ -166,7 +159,7 @@ impl BreezSdk {
 
         let self_pubkey = self.spark_wallet.get_identity_public_key().to_string();
         let transferee_pubkey = normalized_pubkey(&request.transferee_pubkey)?;
-        let timestamp = now_secs()?;
+        let timestamp = try_now_secs()?;
         let signature = self
             .spark_wallet
             .sign_message(&signed_message::transfer_from(
@@ -213,7 +206,8 @@ impl BreezSdk {
         // transferee sat on fails saying so rather than as a generic rejection.
         // Deliberately short: nothing revokes an authorization, so expiry is the
         // only thing that takes one back.
-        if now_secs()?.abs_diff(request.authorization.timestamp) > signed_message::VALIDITY_SECS {
+        if try_now_secs()?.abs_diff(request.authorization.timestamp) > signed_message::VALIDITY_SECS
+        {
             return Err(SdkError::InvalidInput(
                 "authorization is expired or not yet valid; ask the current owner to \
                  authorize the transfer again"

--- a/crates/breez-sdk/core/src/sdk/payments/prepare/cross_chain.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/prepare/cross_chain.rs
@@ -4,7 +4,8 @@ use crate::{
     ConversionEstimate, ConversionOptions, ConversionType, CrossChainFeeMode, CrossChainRoutePair,
     FeePolicy, SendPaymentMethod,
     cross_chain::{
-        SourceAsset, convert_destination_amount_to_sats, fetch_btc_usd_rate, rescale_decimals,
+        SparkAsset, convert_destination_amount_to_sats, fetch_btc_usd_rate, inflate_target_amount,
+        rescale_decimals, resolve_target_overpay_bps,
     },
     error::SdkError,
     models::PrepareSendPaymentResponse,
@@ -13,9 +14,8 @@ use crate::{
 };
 
 use super::super::validation::{
-    inflate_target_amount, known_token_contracts, resolve_direct_overpay_amount,
-    resolve_slippage_bps, resolve_target_overpay_bps, validate_address_family_against_route,
-    validate_recipient_not_contract_address,
+    known_token_contracts, resolve_direct_overpay_amount, resolve_slippage_bps,
+    validate_address_family_against_route, validate_recipient_not_contract_address,
 };
 use super::super::{conversion, validation};
 
@@ -60,7 +60,7 @@ fn validate_request(
 
 /// Post-resolution check: the effective source asset (the one the wallet
 /// actually pays on, after the source-selection decision tree) must be in
-/// the route's `supported_sources`.
+/// the route's `accepted_assets`.
 fn validate_route_supports_effective_source(
     route: &CrossChainRoutePair,
     token_identifier: Option<&String>,
@@ -68,23 +68,23 @@ fn validate_route_supports_effective_source(
 ) -> Result<(), SdkError> {
     let effective_source = if effective_conversion_options.is_some() {
         // Conversion runs before the provider leg → source is always sats.
-        SourceAsset::Bitcoin
+        SparkAsset::Bitcoin
     } else {
         match token_identifier {
-            Some(tid) => SourceAsset::Token {
+            Some(tid) => SparkAsset::Token {
                 token_identifier: tid.clone(),
             },
-            None => SourceAsset::Bitcoin,
+            None => SparkAsset::Bitcoin,
         }
     };
 
-    if !route.supported_sources.contains(&effective_source) {
+    if !route.accepted_assets.contains(&effective_source) {
         let supported_list = route
-            .supported_sources
+            .accepted_assets
             .iter()
             .map(|s| match s {
-                SourceAsset::Bitcoin => "sats".to_string(),
-                SourceAsset::Token {
+                SparkAsset::Bitcoin => "sats".to_string(),
+                SparkAsset::Token {
                     token_identifier: t,
                 } => t.clone(),
             })
@@ -314,7 +314,7 @@ async fn prepare_sats_denominated(
 
     let service = sdk.cross_chain_context.get(route.provider)?;
     let prepared = service
-        .prepare(
+        .prepare_send(
             address,
             route,
             provider_amount,
@@ -366,7 +366,7 @@ async fn prepare_sats_denominated_with_conversion(
 
     let service = sdk.cross_chain_context.get(route.provider)?;
     let prepared = service
-        .prepare(
+        .prepare_send(
             address,
             route,
             provider_amount,
@@ -448,7 +448,7 @@ async fn prepare_token_denominated_fees_included(
 
     let service = sdk.cross_chain_context.get(route.provider)?;
     let prepared = service
-        .prepare(
+        .prepare_send(
             address,
             route,
             sats,
@@ -546,7 +546,7 @@ async fn prepare_token_denominated_fees_excluded(
 
     let service = sdk.cross_chain_context.get(route.provider)?;
     let prepared = service
-        .prepare(
+        .prepare_send(
             address,
             route,
             sats_for_provider,
@@ -659,7 +659,7 @@ fn compute_conversion_overrides(
 }
 
 fn build_response(
-    prepared: crate::cross_chain::CrossChainPrepared,
+    prepared: crate::cross_chain::CrossChainSendPrepared,
     response_amount: u128,
     response_token_identifier: Option<String>,
     conversion_estimate: Option<ConversionEstimate>,
@@ -774,15 +774,15 @@ fn decide_cross_chain_source(
         // 2) Caller specified a token.
         Some(token_id) => {
             let route_accepts_token = route
-                .supported_sources
+                .accepted_assets
                 .iter()
-                .any(|s| matches!(s, SourceAsset::Token { token_identifier: t } if t == token_id));
+                .any(|s| matches!(s, SparkAsset::Token { token_identifier: t } if t == token_id));
             if route_accepts_token {
                 // Direct token send — no conversion needed.
                 return CrossChainSourceDecision::UseAsIs(None);
             }
 
-            let route_accepts_bitcoin = route.supported_sources.contains(&SourceAsset::Bitcoin);
+            let route_accepts_bitcoin = route.accepted_assets.contains(&SparkAsset::Bitcoin);
             if !route_accepts_bitcoin {
                 // Neither direct nor auto-inject; caller must handle.
                 return CrossChainSourceDecision::UseAsIs(None);
@@ -803,7 +803,7 @@ fn decide_cross_chain_source(
         }
         // 3) No token specified.
         None => {
-            if route.supported_sources.contains(&SourceAsset::Bitcoin) {
+            if route.accepted_assets.contains(&SparkAsset::Bitcoin) {
                 // Defer to stable_balance auto-inject: fires when the sats
                 // balance is insufficient to cover `amount`.
                 CrossChainSourceDecision::DeferToStableBalance
@@ -820,7 +820,7 @@ fn decide_cross_chain_source(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CrossChainProvider, cross_chain::SourceChain, error::SdkError};
+    use crate::{CrossChainProvider, cross_chain::DeliveryMethod, error::SdkError};
     use macros::test_all;
 
     #[cfg(feature = "browser-tests")]
@@ -867,7 +867,7 @@ mod tests {
 
     // ---- decide_cross_chain_source ----
 
-    fn route_with_sources(sources: Vec<SourceAsset>) -> CrossChainRoutePair {
+    fn route_with_sources(sources: Vec<SparkAsset>) -> CrossChainRoutePair {
         CrossChainRoutePair {
             provider: CrossChainProvider::Orchestra,
             chain: "base".to_string(),
@@ -876,8 +876,8 @@ mod tests {
             contract_address: None,
             decimals: 6,
             exact_out_eligible: false,
-            supported_sources: sources,
-            supported_source_chains: vec![SourceChain::Spark],
+            accepted_assets: sources,
+            delivery_methods: vec![DeliveryMethod::Spark],
         }
     }
 
@@ -888,7 +888,7 @@ mod tests {
             max_slippage_bps: None,
             completion_timeout_secs: None,
         };
-        let route = route_with_sources(vec![SourceAsset::Bitcoin]);
+        let route = route_with_sources(vec![SparkAsset::Bitcoin]);
         let result = decide_cross_chain_source(&route, None, Some(&opts), None, None);
         assert!(matches!(result, CrossChainSourceDecision::UseAsIs(Some(_))));
     }
@@ -896,7 +896,7 @@ mod tests {
     #[test_all]
     fn source_resolution_token_directly_supported() {
         let token = "USDB".to_string();
-        let route = route_with_sources(vec![SourceAsset::Token {
+        let route = route_with_sources(vec![SparkAsset::Token {
             token_identifier: "USDB".to_string(),
         }]);
         let result = decide_cross_chain_source(&route, Some(&token), None, None, None);
@@ -906,7 +906,7 @@ mod tests {
     #[test_all]
     fn source_resolution_auto_inject_to_bitcoin_for_active_stable_token() {
         let token = "USDB".to_string();
-        let route = route_with_sources(vec![SourceAsset::Bitcoin]);
+        let route = route_with_sources(vec![SparkAsset::Bitcoin]);
         let result = decide_cross_chain_source(&route, Some(&token), None, Some(&token), Some(150));
         match result {
             CrossChainSourceDecision::UseAsIs(Some(opts)) => {
@@ -923,7 +923,7 @@ mod tests {
     #[test_all]
     fn source_resolution_token_not_supported_no_stable() {
         let token = "USDC".to_string();
-        let route = route_with_sources(vec![SourceAsset::Bitcoin]);
+        let route = route_with_sources(vec![SparkAsset::Bitcoin]);
         // Active stable is a different token → don't auto-inject.
         let other = "USDB".to_string();
         let result = decide_cross_chain_source(&route, Some(&token), None, Some(&other), None);
@@ -932,14 +932,14 @@ mod tests {
 
     #[test_all]
     fn source_resolution_no_token_route_accepts_bitcoin_defers_to_stable() {
-        let route = route_with_sources(vec![SourceAsset::Bitcoin]);
+        let route = route_with_sources(vec![SparkAsset::Bitcoin]);
         let result = decide_cross_chain_source(&route, None, None, None, None);
         assert_eq!(result, CrossChainSourceDecision::DeferToStableBalance);
     }
 
     #[test_all]
     fn source_resolution_no_token_route_token_only() {
-        let route = route_with_sources(vec![SourceAsset::Token {
+        let route = route_with_sources(vec![SparkAsset::Token {
             token_identifier: "USDB".to_string(),
         }]);
         let result = decide_cross_chain_source(&route, None, None, None, None);
@@ -959,10 +959,10 @@ mod tests {
             completion_timeout_secs: None,
         };
         let route = route_with_sources(vec![
-            SourceAsset::Token {
+            SparkAsset::Token {
                 token_identifier: "USDB".to_string(),
             },
-            SourceAsset::Bitcoin,
+            SparkAsset::Bitcoin,
         ]);
         let result =
             decide_cross_chain_source(&route, Some(&token), Some(&explicit), Some(&token), None);
@@ -982,15 +982,15 @@ mod tests {
 
     #[test_all]
     fn source_resolution_token_directly_supported_wins_over_stable_auto_inject() {
-        // When the token is in the route's supported_sources AND it's the
+        // When the token is in the route's accepted_assets AND it's the
         // active stable token, prefer the direct token path over auto-injecting
         // ToBitcoin.
         let token = "USDB".to_string();
         let route = route_with_sources(vec![
-            SourceAsset::Token {
+            SparkAsset::Token {
                 token_identifier: "USDB".to_string(),
             },
-            SourceAsset::Bitcoin,
+            SparkAsset::Bitcoin,
         ]);
         let result = decide_cross_chain_source(&route, Some(&token), None, Some(&token), Some(150));
         assert_eq!(
@@ -1007,7 +1007,7 @@ mod tests {
         // doesn't accept sats. Falls through to UseAsIs(None) and the
         // post-validation will surface the route-mismatch error.
         let token = "USDB".to_string();
-        let route = route_with_sources(vec![SourceAsset::Token {
+        let route = route_with_sources(vec![SparkAsset::Token {
             token_identifier: "USDC".to_string(),
         }]);
         let result = decide_cross_chain_source(&route, Some(&token), None, Some(&token), Some(150));
@@ -1018,13 +1018,13 @@ mod tests {
 
     #[test_all]
     fn validate_effective_source_no_token_no_conversion_route_accepts_bitcoin() {
-        let route = route_with_sources(vec![SourceAsset::Bitcoin]);
+        let route = route_with_sources(vec![SparkAsset::Bitcoin]);
         assert!(validate_route_supports_effective_source(&route, None, None).is_ok());
     }
 
     #[test_all]
     fn validate_effective_source_no_token_no_conversion_route_token_only_errors() {
-        let route = route_with_sources(vec![SourceAsset::Token {
+        let route = route_with_sources(vec![SparkAsset::Token {
             token_identifier: "USDB".to_string(),
         }]);
         let err = validate_route_supports_effective_source(&route, None, None).unwrap_err();
@@ -1040,7 +1040,7 @@ mod tests {
     #[test_all]
     fn validate_effective_source_token_supported_directly() {
         let token = "USDB".to_string();
-        let route = route_with_sources(vec![SourceAsset::Token {
+        let route = route_with_sources(vec![SparkAsset::Token {
             token_identifier: "USDB".to_string(),
         }]);
         assert!(validate_route_supports_effective_source(&route, Some(&token), None).is_ok());
@@ -1050,10 +1050,10 @@ mod tests {
     fn validate_effective_source_token_unsupported_errors() {
         let token = "USDC".to_string();
         let route = route_with_sources(vec![
-            SourceAsset::Token {
+            SparkAsset::Token {
                 token_identifier: "USDB".to_string(),
             },
-            SourceAsset::Bitcoin,
+            SparkAsset::Bitcoin,
         ]);
         let err = validate_route_supports_effective_source(&route, Some(&token), None).unwrap_err();
         let SdkError::InvalidInput(msg) = err else {
@@ -1077,7 +1077,7 @@ mod tests {
             max_slippage_bps: None,
             completion_timeout_secs: None,
         };
-        let route = route_with_sources(vec![SourceAsset::Bitcoin]);
+        let route = route_with_sources(vec![SparkAsset::Bitcoin]);
         assert!(
             validate_route_supports_effective_source(&route, Some(&token), Some(&opts)).is_ok(),
             "conversion → sats should pass when route accepts sats"
@@ -1096,7 +1096,7 @@ mod tests {
             max_slippage_bps: None,
             completion_timeout_secs: None,
         };
-        let route = route_with_sources(vec![SourceAsset::Token {
+        let route = route_with_sources(vec![SparkAsset::Token {
             token_identifier: "USDC".to_string(),
         }]);
         let err = validate_route_supports_effective_source(&route, Some(&token), Some(&opts))
@@ -1185,8 +1185,8 @@ mod tests {
     fn mk_prepared(
         amount_in: u128,
         source_transfer_fee_sats: u64,
-    ) -> crate::cross_chain::CrossChainPrepared {
-        crate::cross_chain::CrossChainPrepared {
+    ) -> crate::cross_chain::CrossChainSendPrepared {
+        crate::cross_chain::CrossChainSendPrepared {
             amount_in,
             asset_amount_in: amount_in,
             estimated_out: amount_in.saturating_sub(30),
@@ -1204,8 +1204,8 @@ mod tests {
                 contract_address: None,
                 decimals: 6,
                 exact_out_eligible: false,
-                supported_sources: vec![],
-                supported_source_chains: vec![],
+                accepted_assets: vec![],
+                delivery_methods: vec![],
             },
             recipient_address: "0xabc".to_string(),
             token_identifier: None,

--- a/crates/breez-sdk/core/src/sdk/payments/receive.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/receive.rs
@@ -4,9 +4,14 @@ use bitcoin::hashes::sha256;
 use bitcoin::secp256k1::PublicKey;
 use platform_utils::time::{Duration, SystemTime};
 use spark_wallet::{InvoiceDescription, LightningReceivePayment, Preimage};
+use tracing::debug;
 
 use crate::{
     ClaimHtlcPaymentRequest, ClaimHtlcPaymentResponse,
+    cross_chain::{
+        CrossChainReceivePrepared, CrossChainRoutePair, DEFAULT_CROSS_CHAIN_SLIPPAGE_BPS,
+        MAX_CROSS_CHAIN_SLIPPAGE_BPS, MIN_CROSS_CHAIN_SLIPPAGE_BPS, SparkAsset,
+    },
     error::SdkError,
     models::{Payment, ReceivePaymentMethod, ReceivePaymentRequest, ReceivePaymentResponse},
 };
@@ -21,6 +26,7 @@ pub(super) async fn receive_payment(
     match request.payment_method {
         ReceivePaymentMethod::SparkAddress => Ok(ReceivePaymentResponse {
             fee: 0,
+            cross_chain_info: None,
             payment_request: sdk
                 .spark_wallet
                 .get_spark_address()?
@@ -58,6 +64,7 @@ pub(super) async fn receive_payment(
                 .await?;
             Ok(ReceivePaymentResponse {
                 fee: 0,
+                cross_chain_info: None,
                 payment_request: invoice,
             })
         }
@@ -67,6 +74,7 @@ pub(super) async fn receive_payment(
             Ok(ReceivePaymentResponse {
                 payment_request: address,
                 fee: 0,
+                cross_chain_info: None,
             })
         }
         ReceivePaymentMethod::Bolt11Invoice {
@@ -86,7 +94,188 @@ pub(super) async fn receive_payment(
             )
             .await
         }
+        ReceivePaymentMethod::CrossChain {
+            route,
+            amount,
+            destination,
+            fee_mode,
+            max_slippage_bps,
+            target_overpay_bps,
+        } => {
+            receive_cross_chain(
+                sdk,
+                route,
+                amount,
+                destination,
+                fee_mode,
+                max_slippage_bps,
+                target_overpay_bps,
+            )
+            .await
+        }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn receive_cross_chain(
+    sdk: &BreezSdk,
+    route: CrossChainRoutePair,
+    amount: u128,
+    destination: Option<SparkAsset>,
+    fee_mode: Option<crate::cross_chain::CrossChainFeeMode>,
+    max_slippage_bps: Option<u32>,
+    target_overpay_bps: Option<u32>,
+) -> Result<ReceivePaymentResponse, SdkError> {
+    if amount == 0 {
+        return Err(SdkError::InvalidInput(
+            "Cross-chain receive amount must be greater than zero.".to_string(),
+        ));
+    }
+    // `get_cross_chain_routes` filters the discovery list to USD-stable
+    // sources. Re-check here so a hand-built route can't bypass the USD-par
+    // assumption that `convert_receive_amount_to_provider_units` relies on.
+    if !crate::cross_chain::is_usd_stable_asset(&route.asset) {
+        return Err(SdkError::InvalidInput(format!(
+            "Cross-chain receive source asset must be USD-stable. Got {}",
+            route.asset
+        )));
+    }
+    let slippage = max_slippage_bps.unwrap_or(DEFAULT_CROSS_CHAIN_SLIPPAGE_BPS);
+    if !(MIN_CROSS_CHAIN_SLIPPAGE_BPS..=MAX_CROSS_CHAIN_SLIPPAGE_BPS).contains(&slippage) {
+        return Err(SdkError::InvalidInput(format!(
+            "Cross-chain max_slippage_bps must be in \
+             {MIN_CROSS_CHAIN_SLIPPAGE_BPS} to {MAX_CROSS_CHAIN_SLIPPAGE_BPS}. \
+             Got {slippage}."
+        )));
+    }
+    let fee_mode = fee_mode.unwrap_or(crate::cross_chain::CrossChainFeeMode::FeesExcluded);
+    let overpay_bps = crate::cross_chain::resolve_target_overpay_bps(
+        target_overpay_bps,
+        sdk.config
+            .cross_chain_config
+            .as_ref()
+            .and_then(|c| c.default_target_overpay_bps),
+    )?;
+
+    let resolved_destination = resolve_receive_destination(sdk, &route, destination).await?;
+
+    let provider_amount = convert_receive_amount_to_provider_units(
+        sdk,
+        &route,
+        &resolved_destination,
+        fee_mode,
+        amount,
+    )
+    .await?;
+
+    let service = sdk.cross_chain_context.get(route.provider)?.clone();
+
+    let recipient = sdk
+        .spark_wallet
+        .get_spark_address()?
+        .to_address_string()
+        .map_err(|e| {
+            SdkError::Generic(format!("Failed to convert Spark address to string: {e}"))
+        })?;
+
+    debug!(
+        "Cross-chain receive: fee_mode={fee_mode:?} source_amount={amount} \
+         source_decimals={} provider_amount={provider_amount} overpay_bps={overpay_bps} \
+         slippage_bps={slippage}",
+        route.decimals,
+    );
+
+    let CrossChainReceivePrepared {
+        payment_request,
+        info,
+    } = service
+        .prepare_receive(
+            &route,
+            &recipient,
+            provider_amount,
+            slippage,
+            &resolved_destination,
+            fee_mode,
+            overpay_bps,
+        )
+        .await?;
+
+    Ok(ReceivePaymentResponse {
+        payment_request,
+        fee: 0,
+        cross_chain_info: Some(info),
+    })
+}
+
+/// Converts the caller-facing receive amount (in `route.decimals` base
+/// units of the source asset, at USD parity for USD-stable sources) into
+/// the units the provider layer expects.
+///
+/// - `FeesIncluded` (any destination): identity. The source-asset amount
+///   IS the sender's deposit, and the receiver gets it minus fees.
+/// - `FeesExcluded` + USDB destination: rescale source-asset units to USDB
+///   (6dp), at par.
+/// - `FeesExcluded` + BTC destination: convert source-asset units to sats
+///   via the live BTC/USD rate, at USD parity.
+async fn convert_receive_amount_to_provider_units(
+    sdk: &BreezSdk,
+    route: &CrossChainRoutePair,
+    destination: &SparkAsset,
+    fee_mode: crate::cross_chain::CrossChainFeeMode,
+    amount: u128,
+) -> Result<u128, SdkError> {
+    use crate::cross_chain::{
+        CrossChainFeeMode, convert_source_amount_to_sats, fetch_btc_usd_rate, rescale_decimals,
+    };
+    let src_decimals = u32::from(route.decimals);
+    match (fee_mode, destination) {
+        (CrossChainFeeMode::FeesIncluded, _) => Ok(amount),
+        (CrossChainFeeMode::FeesExcluded, SparkAsset::Token { .. }) => {
+            rescale_decimals(amount, src_decimals, 6)
+        }
+        (CrossChainFeeMode::FeesExcluded, SparkAsset::Bitcoin) => {
+            let btc_usd = fetch_btc_usd_rate(sdk.fiat_service.as_ref()).await?;
+            convert_source_amount_to_sats(amount, src_decimals, btc_usd)
+        }
+    }
+}
+
+/// Picks a Spark-side destination asset for a cross-chain receive.
+///
+/// * A caller-supplied asset is honoured only if it appears in
+///   `route.accepted_assets`. Otherwise `InvalidInput`.
+/// * When unset, prefers the wallet's active stable-balance token if the
+///   route supports it, otherwise Bitcoin. Returns `InvalidInput` if the
+///   route exposes neither.
+async fn resolve_receive_destination(
+    sdk: &BreezSdk,
+    route: &CrossChainRoutePair,
+    requested: Option<SparkAsset>,
+) -> Result<SparkAsset, SdkError> {
+    if let Some(asset) = requested {
+        if route.accepted_assets.contains(&asset) {
+            return Ok(asset);
+        }
+        return Err(SdkError::InvalidInput(format!(
+            "Requested destination {asset:?} is not supported by this route. \
+             Pick one of route.accepted_assets."
+        )));
+    }
+    if let Some(sb) = &sdk.stable_balance
+        && let Some(token_identifier) = sb.get_active_token_identifier().await
+    {
+        let token_asset = SparkAsset::Token { token_identifier };
+        if route.accepted_assets.contains(&token_asset) {
+            return Ok(token_asset);
+        }
+    }
+    if route.accepted_assets.contains(&SparkAsset::Bitcoin) {
+        return Ok(SparkAsset::Bitcoin);
+    }
+    Err(SdkError::InvalidInput(
+        "Route exposes no usable Spark destination (neither Bitcoin nor a supported token)."
+            .to_string(),
+    ))
 }
 
 pub(super) async fn claim_htlc_payment(
@@ -138,6 +327,7 @@ pub(super) async fn receive_bolt11_invoice(
     Ok(ReceivePaymentResponse {
         payment_request: receive.invoice,
         fee: 0,
+        cross_chain_info: None,
     })
 }
 

--- a/crates/breez-sdk/core/src/sdk/payments/receive.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/receive.rs
@@ -234,7 +234,8 @@ async fn convert_receive_amount_to_provider_units(
             rescale_decimals(amount, src_decimals, 6)
         }
         (CrossChainFeeMode::FeesExcluded, SparkAsset::Bitcoin) => {
-            let btc_usd = fetch_btc_usd_rate(sdk.fiat_service.as_ref()).await?;
+            let btc_usd =
+                fetch_btc_usd_rate(sdk.cross_chain_context.fiat_service().as_ref()).await?;
             convert_source_amount_to_sats(amount, src_decimals, btc_usd)
         }
     }

--- a/crates/breez-sdk/core/src/sdk/payments/receive.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/receive.rs
@@ -8,15 +8,13 @@ use tracing::debug;
 
 use crate::{
     ClaimHtlcPaymentRequest, ClaimHtlcPaymentResponse,
-    cross_chain::{
-        CrossChainReceivePrepared, CrossChainRoutePair, DEFAULT_CROSS_CHAIN_SLIPPAGE_BPS,
-        MAX_CROSS_CHAIN_SLIPPAGE_BPS, MIN_CROSS_CHAIN_SLIPPAGE_BPS, SparkAsset,
-    },
+    cross_chain::{CrossChainReceivePrepared, CrossChainRoutePair, SparkAsset},
     error::SdkError,
     models::{Payment, ReceivePaymentMethod, ReceivePaymentRequest, ReceivePaymentResponse},
 };
 
 use super::super::{BreezSdk, helpers::get_deposit_address};
+use super::validation::resolve_slippage_bps;
 
 pub(super) async fn receive_payment(
     sdk: &BreezSdk,
@@ -140,14 +138,13 @@ async fn receive_cross_chain(
             route.asset
         )));
     }
-    let slippage = max_slippage_bps.unwrap_or(DEFAULT_CROSS_CHAIN_SLIPPAGE_BPS);
-    if !(MIN_CROSS_CHAIN_SLIPPAGE_BPS..=MAX_CROSS_CHAIN_SLIPPAGE_BPS).contains(&slippage) {
-        return Err(SdkError::InvalidInput(format!(
-            "Cross-chain max_slippage_bps must be in \
-             {MIN_CROSS_CHAIN_SLIPPAGE_BPS} to {MAX_CROSS_CHAIN_SLIPPAGE_BPS}. \
-             Got {slippage}."
-        )));
-    }
+    let slippage = resolve_slippage_bps(
+        max_slippage_bps,
+        sdk.config
+            .cross_chain_config
+            .as_ref()
+            .and_then(|c| c.default_slippage_bps),
+    )?;
     let fee_mode = fee_mode.unwrap_or(crate::cross_chain::CrossChainFeeMode::FeesExcluded);
     let overpay_bps = crate::cross_chain::resolve_target_overpay_bps(
         target_overpay_bps,
@@ -167,6 +164,12 @@ async fn receive_cross_chain(
         amount,
     )
     .await?;
+    if provider_amount == 0 {
+        return Err(SdkError::InvalidInput(format!(
+            "Cross-chain receive amount {amount} is too small for this route: it converts to \
+             zero units of the requested destination."
+        )));
+    }
 
     let service = sdk.cross_chain_context.get(route.provider)?.clone();
 

--- a/crates/breez-sdk/core/src/sdk/payments/send/cross_chain.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/send/cross_chain.rs
@@ -1,6 +1,6 @@
 use crate::{
     ConversionOptions, SendPaymentMethod, SendPaymentResponse,
-    cross_chain::CrossChainPrepared,
+    cross_chain::CrossChainSendPrepared,
     error::SdkError,
     sdk::{BreezSdk, SyncType},
     token_conversion::{ConversionAmount, ConversionPurpose, TokenConversionResponse},
@@ -11,7 +11,7 @@ use tracing::warn;
 /// Dispatches a `SendPaymentMethod::CrossChainAddress` to its provider.
 ///
 /// The caller passes the variant by reference rather than destructured fields;
-/// this fn rebuilds the [`CrossChainPrepared`] internally and hands it to the
+/// this fn rebuilds the [`CrossChainSendPrepared`] internally and hands it to the
 /// provider's `send`, which polls to terminal and returns the [`Payment`].
 pub(in crate::sdk) async fn send(
     sdk: &BreezSdk,
@@ -39,7 +39,7 @@ pub(in crate::sdk) async fn send(
         ));
     };
 
-    let prepared = CrossChainPrepared {
+    let prepared = CrossChainSendPrepared {
         amount_in: *amount_in,
         asset_amount_in: *asset_amount_in,
         estimated_out: *estimated_out,

--- a/crates/breez-sdk/core/src/sdk/payments/validation.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/validation.rs
@@ -11,8 +11,8 @@ use crate::{
     ConversionOptions, ConversionType, CrossChainRouteFilter, CrossChainRoutePair, FeePolicy,
     SparkInvoiceDetails,
     cross_chain::{
-        DEFAULT_CROSS_CHAIN_SLIPPAGE_BPS, DEFAULT_TARGET_OVERPAY_BPS, MAX_CROSS_CHAIN_SLIPPAGE_BPS,
-        MAX_TARGET_OVERPAY_BPS, MIN_CROSS_CHAIN_SLIPPAGE_BPS, MIN_TARGET_OVERPAY_BPS,
+        DEFAULT_CROSS_CHAIN_SLIPPAGE_BPS, MAX_CROSS_CHAIN_SLIPPAGE_BPS,
+        MIN_CROSS_CHAIN_SLIPPAGE_BPS,
     },
     error::SdkError,
     sdk::BreezSdk,
@@ -198,43 +198,12 @@ pub(in crate::sdk) fn resolve_slippage_bps(
     {
         return Err(SdkError::InvalidInput(format!(
             "max_slippage_bps {bps} must be in \
-             {MIN_CROSS_CHAIN_SLIPPAGE_BPS}..={MAX_CROSS_CHAIN_SLIPPAGE_BPS}",
+             {MIN_CROSS_CHAIN_SLIPPAGE_BPS} to {MAX_CROSS_CHAIN_SLIPPAGE_BPS}",
         )));
     }
     Ok(requested
         .or(config_default)
         .unwrap_or(DEFAULT_CROSS_CHAIN_SLIPPAGE_BPS))
-}
-
-/// Resolves the target-overpay bps to apply on `FeesExcluded` orders.
-///
-/// Same precedence as slippage: caller-supplied value (bounds-checked here),
-/// then the config default, then the built-in default. Config defaults are
-/// validated at SDK startup in `Config::validate`.
-pub(in crate::sdk) fn resolve_target_overpay_bps(
-    requested: Option<u32>,
-    config_default: Option<u32>,
-) -> Result<u32, SdkError> {
-    if let Some(bps) = requested
-        && !(MIN_TARGET_OVERPAY_BPS..=MAX_TARGET_OVERPAY_BPS).contains(&bps)
-    {
-        return Err(SdkError::InvalidInput(format!(
-            "target_overpay_bps {bps} must be in \
-             {MIN_TARGET_OVERPAY_BPS}..={MAX_TARGET_OVERPAY_BPS}",
-        )));
-    }
-    Ok(requested
-        .or(config_default)
-        .unwrap_or(DEFAULT_TARGET_OVERPAY_BPS))
-}
-
-/// Inflates a destination amount by `overpay_bps` so the recipient lands at
-/// or above target despite provider slippage. `overpay_bps == 0` is identity.
-pub(in crate::sdk) fn inflate_target_amount(amount: u128, overpay_bps: u32) -> u128 {
-    if overpay_bps == 0 {
-        return amount;
-    }
-    amount.saturating_add(amount.saturating_mul(u128::from(overpay_bps)) / 10_000)
 }
 
 /// Pads a sats-denominated order for `FeesExcluded` so the recipient lands at
@@ -251,13 +220,13 @@ pub(in crate::sdk) fn resolve_direct_overpay_amount(
     if overpay_bps == 0 || !matches!(fee_policy, FeePolicy::FeesExcluded) {
         return amount;
     }
-    inflate_target_amount(amount, overpay_bps)
+    crate::cross_chain::inflate_target_amount(amount, overpay_bps)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CrossChainProvider, SourceAsset, SourceChain};
+    use crate::{CrossChainProvider, DeliveryMethod, SparkAsset};
     use macros::test_all;
 
     #[cfg(feature = "browser-tests")]
@@ -381,60 +350,6 @@ mod tests {
         ));
     }
 
-    // ---- resolve_target_overpay_bps ----
-
-    #[test_all]
-    fn resolve_overpay_uses_request_when_in_range() {
-        assert_eq!(resolve_target_overpay_bps(Some(50), Some(75)).unwrap(), 50);
-    }
-
-    #[test_all]
-    fn resolve_overpay_falls_back_to_config_when_request_none() {
-        assert_eq!(resolve_target_overpay_bps(None, Some(75)).unwrap(), 75);
-    }
-
-    #[test_all]
-    fn resolve_overpay_falls_back_to_built_in_when_both_none() {
-        assert_eq!(
-            resolve_target_overpay_bps(None, None).unwrap(),
-            DEFAULT_TARGET_OVERPAY_BPS
-        );
-    }
-
-    #[test_all]
-    fn resolve_overpay_accepts_zero_to_opt_out() {
-        assert_eq!(resolve_target_overpay_bps(Some(0), Some(50)).unwrap(), 0);
-    }
-
-    #[test_all]
-    fn resolve_overpay_rejects_above_max() {
-        let too_high = MAX_TARGET_OVERPAY_BPS + 1;
-        assert!(matches!(
-            resolve_target_overpay_bps(Some(too_high), None),
-            Err(SdkError::InvalidInput(_))
-        ));
-    }
-
-    // ---- inflate_target_amount ----
-
-    #[test_all]
-    fn inflate_target_amount_zero_bps_is_identity() {
-        assert_eq!(inflate_target_amount(1_000_000, 0), 1_000_000);
-    }
-
-    #[test_all]
-    fn inflate_target_amount_applies_bps_pad() {
-        // 25 bps on 1_000_000 -> 1_000_000 + 2_500 = 1_002_500.
-        assert_eq!(inflate_target_amount(1_000_000, 25), 1_002_500);
-    }
-
-    #[test_all]
-    fn inflate_target_amount_truncates_sub_unit_pad() {
-        // 25 bps on 100 -> 100 + (100 * 25 / 10_000) = 100 + 0 (integer floor).
-        // Acceptable: pad is sub-unit for tiny amounts.
-        assert_eq!(inflate_target_amount(100, 25), 100);
-    }
-
     #[test_all]
     fn resolve_direct_overpay_pads_only_fees_excluded() {
         // FeesExcluded pads; FeesIncluded and zero-bps are identity.
@@ -463,8 +378,8 @@ mod tests {
             contract_address: contract.map(str::to_string),
             decimals: 6,
             exact_out_eligible: false,
-            supported_sources: vec![SourceAsset::Bitcoin],
-            supported_source_chains: vec![SourceChain::Spark],
+            accepted_assets: vec![SparkAsset::Bitcoin],
+            delivery_methods: vec![DeliveryMethod::Spark],
         }
     }
 

--- a/crates/breez-sdk/core/src/sdk/payments/validation.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/validation.rs
@@ -5,8 +5,8 @@
 //! complete set of rules for an input type is visible in that type's own file.
 
 use breez_sdk_common::input;
-use platform_utils::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use crate::utils::time::try_now_secs;
 use crate::{
     ConversionOptions, ConversionType, CrossChainRouteFilter, CrossChainRoutePair, FeePolicy,
     SparkInvoiceDetails,
@@ -24,13 +24,10 @@ pub(in crate::sdk) fn validate_spark_invoice_payable(
     details: &SparkInvoiceDetails,
     identity_public_key: &str,
 ) -> Result<(), SdkError> {
-    if let Some(expiry_time) = details.expiry_time {
-        let current_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|_| SdkError::Generic("Failed to get current time".to_string()))?;
-        if current_time > Duration::from_secs(expiry_time) {
-            return Err(SdkError::InvalidInput("Invoice has expired".to_string()));
-        }
+    if let Some(expiry_time) = details.expiry_time
+        && try_now_secs()? > expiry_time
+    {
+        return Err(SdkError::InvalidInput("Invoice has expired".to_string()));
     }
 
     if let Some(sender_public_key) = &details.sender_public_key

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -1,4 +1,4 @@
-use platform_utils::time::{Instant, SystemTime};
+use platform_utils::time::Instant;
 use platform_utils::tokio;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -7,6 +7,7 @@ use tracing::{debug, error, info, trace, warn};
 use super::{
     BreezSdk, CLAIM_TX_SIZE_VBYTES, SYNC_PAGING_LIMIT, SyncType, deposits::InstantClaimOutcome,
 };
+use crate::utils::time::now_secs;
 use crate::{
     DepositInfo, Fee, InputType, InstantClaimStatus, MaxFee, PaymentDetails, PaymentType,
     error::SdkError,
@@ -155,10 +156,7 @@ impl BreezSdk {
     ) -> Result<(), SdkError> {
         let cache = ObjectCacheRepository::new(self.storage.clone());
         let sync_interval_secs = u64::from(self.config.sync_interval_secs);
-
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs());
+        let now = now_secs();
 
         // Skip if we synced recently (unless forced).
         if !force

--- a/crates/breez-sdk/core/src/stable_balance/queue.rs
+++ b/crates/breez-sdk/core/src/stable_balance/queue.rs
@@ -5,24 +5,16 @@
 
 use std::sync::Arc;
 
-use platform_utils::{
-    time::{SystemTime, UNIX_EPOCH},
-    tokio,
-};
+use platform_utils::tokio;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, Notify, watch};
 use tracing::{Instrument, debug, info, warn};
 
 use crate::models::ConversionStatus;
 use crate::persist::{ObjectCacheRepository, PaymentMetadata, Storage};
+use crate::utils::time::now_secs;
 
 use super::{StableBalance, per_receive_transfer_id};
-
-fn now_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs())
-}
 
 /// A conversion task to be processed by the worker.
 #[derive(Clone, Debug)]

--- a/crates/breez-sdk/core/src/token_conversion/flashnet.rs
+++ b/crates/breez-sdk/core/src/token_conversion/flashnet.rs
@@ -7,7 +7,6 @@ use flashnet::{
     GetMinAmountsRequest, ListClawbackTransfersRequest, ListPoolsRequest, ListUserSwapsRequest,
     PoolSortOrder, SimulateSwapRequest, Swap, SwapOutcome, SwapSortOrder,
 };
-use platform_utils::time::{SystemTime, UNIX_EPOCH};
 use spark_wallet::{SparkWallet, TransferId};
 use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
@@ -23,6 +22,7 @@ use crate::{
             insert_payment_with_metadata, resolve_and_insert_payment_metadata, resolve_payment_id,
         },
         polling::{PollSchedule, poll_until},
+        time::now_secs,
     },
 };
 
@@ -529,10 +529,7 @@ impl FlashnetTokenConverter {
             clawback_transfers.transfers.len()
         );
 
-        let cutoff_secs = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs())
-            .saturating_sub(RECONCILE_MIN_AGE_SECS);
+        let cutoff_secs = now_secs().saturating_sub(RECONCILE_MIN_AGE_SECS);
         let mut res = RefundPendingConversionsResponse::default();
         for transfer in clawback_transfers.transfers {
             if !transfer_is_older_than(&transfer, cutoff_secs) {

--- a/crates/breez-sdk/core/src/token_conversion/models.rs
+++ b/crates/breez-sdk/core/src/token_conversion/models.rs
@@ -161,8 +161,9 @@ impl FromStr for ConversionStatus {
 ///
 /// The variant identifies which provider handled the conversion:
 /// - [`ConversionInfo::Amm`] for Spark token swaps via Flashnet AMM pools.
-/// - [`ConversionInfo::Orchestra`] for cross-chain sends via Flashnet
-///   Orchestra (Spark → external chain).
+/// - [`ConversionInfo::Orchestra`] for cross-chain transfers via Flashnet
+///   Orchestra, in either direction (Spark → external chain, or external
+///   chain → Spark).
 /// - [`ConversionInfo::Boltz`] for sats → stable-coin reverse swaps via Boltz.
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 #[derive(Clone, Serialize, Deserialize, PartialEq)]
@@ -191,7 +192,13 @@ pub enum ConversionInfo {
         #[serde(default)]
         degradation: Option<SwapDegradation>,
     },
-    /// Orchestra cross-chain conversion via the Flashnet orchestration API.
+    /// Orchestra cross-chain conversion via the Flashnet orchestration API,
+    /// in either direction.
+    ///
+    /// `chain`, `asset`, `asset_decimals` and `asset_contract` always describe
+    /// the external (non-Spark) side: the destination on a send, the source on
+    /// a receive. Amounts follow the direction of the transfer, so read each
+    /// amount field's own denomination.
     #[serde(rename = "orchestra")]
     Orchestra {
         /// The Orchestra order id returned by `/v1/orchestration/submit`.
@@ -212,20 +219,25 @@ pub enum ConversionInfo {
         /// Asset ticker (e.g. `"USDC"`, `"USDT"`).
         #[serde(default)]
         asset: String,
-        /// Recipient address on the target chain.
+        /// The target-chain address on a send, the receiving Spark address
+        /// on a receive.
         recipient_address: String,
-        /// Amount in expressed in the cross-chain asset's base units, via
-        /// the rate the SDK used at prepare time.
+        /// Amount paid in, in `asset` base units. On a send it is the Spark
+        /// amount expressed in `asset` via the rate the SDK used at prepare
+        /// time. On a receive it is the deposit the sender made on `chain`.
         #[serde(default, with = "serde_option_u128_as_string")]
         asset_amount_in: Option<u128>,
-        /// Estimated recipient amount, frozen at prepare time.
+        /// Estimated amount delivered to the receiving end, frozen at prepare
+        /// time. In `asset` base units on a send, and in Spark-side units on
+        /// a receive (sats for Bitcoin, token base units for a token).
         #[serde(with = "serde_u128_as_string")]
         estimated_out: u128,
-        /// Actual delivered amount, Unset until the order reaches a terminal state.
+        /// Actual delivered amount, in the same units as `estimated_out`.
+        /// Unset until the order reaches a terminal state.
         #[serde(default, with = "serde_option_u128_as_string")]
         delivered_amount: Option<u128>,
         status: ConversionStatus,
-        /// Best-available total fee in destination asset base units.
+        /// Best-available total fee, in `asset` base units.
         /// Prepare-time estimate while pending, realized fee when Completed.
         #[serde(default, with = "serde_option_u128_as_string")]
         fee_amount: Option<u128>,
@@ -242,7 +254,8 @@ pub enum ConversionInfo {
         service_fee_asset: Option<String>,
         /// Asset decimals (e.g. 6 for USDC).
         asset_decimals: u32,
-        /// Token contract / mint address. Unset for native-asset destinations.
+        /// Token contract / mint address on `chain`. Unset when that side is
+        /// the chain's native asset.
         #[serde(default)]
         asset_contract: Option<String>,
     },
@@ -310,7 +323,8 @@ pub enum ConversionInfo {
         service_fee_asset: Option<String>,
         /// Asset decimals (e.g. 6 for USDT).
         asset_decimals: u32,
-        /// Token contract / mint address. Unset for native-asset destinations.
+        /// Token contract / mint address on `chain`. Unset when that side is
+        /// the chain's native asset.
         #[serde(default)]
         asset_contract: Option<String>,
     },

--- a/crates/breez-sdk/core/src/utils/conversions.rs
+++ b/crates/breez-sdk/core/src/utils/conversions.rs
@@ -10,7 +10,8 @@ use flashnet::AssetTransfer;
 use spark_wallet::SparkWallet;
 
 use crate::{
-    ConversionInfo, ConversionStatus, Payment, PaymentDetails, PaymentMetadata, Storage,
+    ConversionInfo, ConversionStatus, Payment, PaymentDetails, PaymentMetadata, PaymentType,
+    Storage,
     error::SdkError,
     models::{Conversion, ConversionAsset, ConversionChain, ConversionProvider, ConversionSide},
     persist::ObjectCacheRepository,
@@ -234,6 +235,7 @@ pub fn build_crosschain_conversion(
             chain,
             chain_id,
             asset,
+            asset_amount_in,
             estimated_out,
             delivered_amount,
             status,
@@ -241,16 +243,8 @@ pub fn build_crosschain_conversion(
             asset_decimals,
             asset_contract,
             ..
-        } => Some(Conversion {
-            provider: ConversionProvider::Orchestra,
-            status: status.clone(),
-            from: ConversionSide {
-                chain: from_side.chain,
-                asset: from_side.asset,
-                amount: source_payment.amount,
-                fee: 0,
-            },
-            to: ConversionSide {
+        } => {
+            let external_side = |amount| ConversionSide {
                 chain: ConversionChain::External {
                     name: chain.clone(),
                     chain_id: chain_id.clone(),
@@ -260,11 +254,33 @@ pub fn build_crosschain_conversion(
                     identifier: asset_contract.clone(),
                     decimals: *asset_decimals,
                 },
-                amount: delivered_amount.unwrap_or(*estimated_out),
+                amount,
                 fee: fee_amount.unwrap_or(0),
-            },
-            amount_adjustment: None,
-        }),
+            };
+            let spark_side = ConversionSide {
+                chain: from_side.chain,
+                asset: from_side.asset,
+                amount: source_payment.amount,
+                fee: 0,
+            };
+            // The payment row sits on the Spark side (outgoing on send,
+            // inbound on receive). `asset_amount_in` is the source-asset
+            // amount the sender deposited on receive.
+            let (from, to) = match source_payment.payment_type {
+                PaymentType::Send => (
+                    spark_side,
+                    external_side(delivered_amount.unwrap_or(*estimated_out)),
+                ),
+                PaymentType::Receive => (external_side(asset_amount_in.unwrap_or(0)), spark_side),
+            };
+            Some(Conversion {
+                provider: ConversionProvider::Orchestra,
+                status: status.clone(),
+                from,
+                to,
+                amount_adjustment: None,
+            })
+        }
         ConversionInfo::Boltz {
             chain,
             chain_id,
@@ -632,6 +648,61 @@ mod tests {
         // spread is exposed separately as `service_fee_amount`.
         assert_eq!(conv.to.fee, 500_000);
         assert_eq!(conv.to.asset.decimals, 6);
+    }
+
+    #[test]
+    fn orchestra_to_spark_on_receive() {
+        // Receive: external (USDC on base) → Spark (BTC sats).
+        // The payment row sits on the Spark side; its amount is what
+        // landed (= delivered_amount). The external side carries the
+        // source-asset deposit (asset_amount_in) and the fee.
+        let info = orchestra_info(ConversionStatus::Completed);
+        let mut payment = spark_payment("p1", PaymentType::Receive, 1_542, 0, info.clone());
+        // Patch payment.amount to delivered_amount for realism.
+        payment.amount = 1_542;
+        let info = if let ConversionInfo::Orchestra { .. } = &info {
+            ConversionInfo::Orchestra {
+                order_id: "ord_1".to_string(),
+                quote_id: "q_1".to_string(),
+                chain: "base".to_string(),
+                chain_id: Some("8453".to_string()),
+                asset: "USDC".to_string(),
+                recipient_address: "0x1234".to_string(),
+                asset_amount_in: Some(1_000_000),
+                estimated_out: 1_572,
+                delivered_amount: Some(1_542),
+                status: ConversionStatus::Completed,
+                fee_amount: Some(20_980),
+                service_fee_amount: Some(20_980),
+                service_fee_asset: Some("USDC".to_string()),
+                read_token: None,
+                asset_decimals: 6,
+                asset_contract: Some("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string()),
+            }
+        } else {
+            unreachable!()
+        };
+
+        let conv = build_crosschain_conversion(&info, &payment).unwrap();
+        assert_eq!(conv.provider, ConversionProvider::Orchestra);
+        assert_eq!(
+            conv.from.chain,
+            ConversionChain::External {
+                name: "base".to_string(),
+                chain_id: Some("8453".to_string()),
+            }
+        );
+        assert_eq!(conv.from.asset.ticker, "USDC");
+        assert_eq!(
+            conv.from.asset.identifier,
+            Some("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string())
+        );
+        assert_eq!(conv.from.amount, 1_000_000);
+        assert_eq!(conv.from.fee, 20_980);
+        assert_eq!(conv.to.chain, ConversionChain::Spark);
+        assert_eq!(conv.to.asset.ticker, "BTC");
+        assert_eq!(conv.to.amount, 1_542);
+        assert_eq!(conv.to.fee, 0);
     }
 
     #[test]

--- a/crates/breez-sdk/core/src/utils/expiring_cell.rs
+++ b/crates/breez-sdk/core/src/utils/expiring_cell.rs
@@ -1,6 +1,7 @@
-use platform_utils::time::{SystemTime, UNIX_EPOCH};
 use platform_utils::tokio;
 use tokio::sync::RwLock;
+
+use super::time::{checked_now_ms, now_ms};
 
 /// A cell that holds a value with a time-to-live (TTL) expiration.
 ///
@@ -28,11 +29,7 @@ impl<T: Clone> ExpiringCell<T> {
     pub async fn get(&self) -> Option<T> {
         let guard = self.inner.read().await;
         let (value, expiration) = guard.as_ref()?;
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .ok()?
-            .as_millis();
-        if now < *expiration {
+        if checked_now_ms()? < *expiration {
             Some(value.clone())
         } else {
             None
@@ -41,9 +38,7 @@ impl<T: Clone> ExpiringCell<T> {
 
     /// Sets a new value with the specified TTL in milliseconds.
     pub async fn set(&self, value: T, ttl_ms: u128) {
-        let expiration = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0, |d| d.as_millis().saturating_add(ttl_ms));
+        let expiration = now_ms().saturating_add(ttl_ms);
         *self.inner.write().await = Some((value, expiration));
     }
 }

--- a/crates/breez-sdk/core/src/utils/mod.rs
+++ b/crates/breez-sdk/core/src/utils/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod fees;
 pub(crate) mod payments;
 pub(crate) mod polling;
 pub mod serde_helpers;
+pub(crate) mod time;
 pub(crate) mod token;
 pub(crate) mod utxo_fetcher;
 

--- a/crates/breez-sdk/core/src/utils/time.rs
+++ b/crates/breez-sdk/core/src/utils/time.rs
@@ -1,0 +1,33 @@
+use platform_utils::time::{SystemTime, UNIX_EPOCH};
+
+use crate::error::SdkError;
+
+/// Seconds since the Unix epoch, reading 0 on a clock set before it.
+pub(crate) fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+/// Milliseconds since the Unix epoch, reading 0 on a clock set before it.
+pub(crate) fn now_ms() -> u128 {
+    checked_now_ms().unwrap_or(0)
+}
+
+/// Milliseconds since the Unix epoch, `None` on a clock set before it, for
+/// callers whose 0 reading would keep something alive that should expire.
+pub(crate) fn checked_now_ms() -> Option<u128> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_millis())
+}
+
+/// Seconds since the Unix epoch, for callers that must refuse to act on a
+/// clock set before it rather than read it as 0.
+pub(crate) fn try_now_secs() -> Result<u64, SdkError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .map_err(|_| SdkError::Generic("System clock is before the Unix epoch".to_string()))
+}

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -1019,6 +1019,16 @@ pub enum ReceivePaymentMethod {
         payment_hash: Option<String>,
         receiver_identity_public_key: Option<String>,
     },
+    CrossChain {
+        route: CrossChainRoutePair,
+        #[tsify(type = "string")]
+        #[serde(with = "serde_u128_as_string")]
+        amount: u128,
+        destination: Option<SparkAsset>,
+        fee_mode: Option<CrossChainFeeMode>,
+        max_slippage_bps: Option<u32>,
+        target_overpay_bps: Option<u32>,
+    },
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::SendOnchainFeeQuote)]
@@ -1063,14 +1073,14 @@ pub enum CrossChainRouteFilter {
     },
 }
 
-#[macros::extern_wasm_bindgen(breez_sdk_spark::SourceAsset)]
-pub enum SourceAsset {
+#[macros::extern_wasm_bindgen(breez_sdk_spark::SparkAsset)]
+pub enum SparkAsset {
     Bitcoin,
     Token { token_identifier: String },
 }
 
-#[macros::extern_wasm_bindgen(breez_sdk_spark::SourceChain)]
-pub enum SourceChain {
+#[macros::extern_wasm_bindgen(breez_sdk_spark::DeliveryMethod)]
+pub enum DeliveryMethod {
     Spark,
     Lightning,
     Bitcoin,
@@ -1092,8 +1102,8 @@ pub struct CrossChainRoutePair {
     pub contract_address: Option<String>,
     pub decimals: u8,
     pub exact_out_eligible: bool,
-    pub supported_sources: Vec<SourceAsset>,
-    pub supported_source_chains: Vec<SourceChain>,
+    pub accepted_assets: Vec<SparkAsset>,
+    pub delivery_methods: Vec<DeliveryMethod>,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::CrossChainProviderContext)]
@@ -1187,6 +1197,24 @@ pub struct ReceivePaymentRequest {
 pub struct ReceivePaymentResponse {
     pub payment_request: String,
     pub fee: u128,
+    pub cross_chain_info: Option<CrossChainReceiveInfo>,
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::CrossChainReceiveInfo)]
+pub struct CrossChainReceiveInfo {
+    pub deposit_address: String,
+    #[tsify(type = "string")]
+    #[serde(with = "serde_u128_as_string")]
+    pub deposit_amount: u128,
+    #[tsify(type = "string")]
+    #[serde(with = "serde_u128_as_string")]
+    pub expected_received_amount: u128,
+    pub token_identifier: Option<String>,
+    #[tsify(type = "string")]
+    #[serde(with = "serde_u128_as_string")]
+    pub service_fee_amount: u128,
+    pub service_fee_asset: Option<String>,
+    pub expires_at: u64,
 }
 
 #[derive(Clone, Copy, Default)]

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -1209,6 +1209,7 @@ pub struct CrossChainReceiveInfo {
     #[tsify(type = "string")]
     #[serde(with = "serde_u128_as_string")]
     pub expected_received_amount: u128,
+    pub destination_asset: String,
     pub token_identifier: Option<String>,
     #[tsify(type = "string")]
     #[serde(with = "serde_u128_as_string")]

--- a/crates/flashnet/src/orchestra/client.rs
+++ b/crates/flashnet/src/orchestra/client.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 
 use super::models::{
     EstimateRequest, EstimateResponse, QuoteRequest, QuoteResponse, Route, RoutesResponse,
-    StatusResponse, SubmitRequestSpark, SubmitResponse,
+    StatusResponse, SubmitRequest, SubmitResponse,
 };
 use crate::cache::CacheStore;
 use crate::config::OrchestraConfig;
@@ -133,30 +133,28 @@ impl OrchestraClient {
             .await
     }
 
-    /// Submit an already-sent deposit tx hash for an existing quote, returning
-    /// the processing order id. Send the deposit with
-    /// [`Self::transfer_to_deposit`] first. The idempotency key is derived from
-    /// the quote id, so retries are safe.
+    /// Submit a quote.
     ///
-    /// Accepted after the quote expires, which is what lets a failed submit be
-    /// retried later, though the rate is requoted at that point.
-    ///
-    /// The response carries the `read_token` that authorises reading the order,
-    /// and this is the only call that returns one. Orchestra detects the deposit
-    /// on the address whether or not this is called, so a failure costs the
-    /// ability to observe the order rather than the deposit itself, and
-    /// resubmitting is how that ability is regained.
-    pub async fn submit_spark(
+    /// `idempotency_key` is sent as `X-Idempotency-Key`. Reusing a key
+    /// replays the cached response, so a caller that expects Orchestra state
+    /// to advance between calls must vary the key. The caller picks the
+    /// policy (deterministic to collide retries, or fresh per call).
+    pub async fn submit(
         &self,
-        request: SubmitRequestSpark,
+        request: SubmitRequest,
+        idempotency_key: String,
     ) -> Result<SubmitResponse, FlashnetError> {
-        let idem = derive_idempotency_key("submit", &request.quote_id);
         debug!(
             "Orchestra: POST /v1/orchestration/submit quoteId={} idem={}",
-            request.quote_id, idem
+            request.quote_id, idempotency_key
         );
-        self.post("v1/orchestration/submit", &request, true, Some(idem))
-            .await
+        self.post(
+            "v1/orchestration/submit",
+            &request,
+            true,
+            Some(idempotency_key),
+        )
+        .await
     }
 
     /// Send `amount_in` sats (or tokens) to the Orchestra-provided `deposit_address`
@@ -353,7 +351,7 @@ impl OrchestraClient {
 
 /// Build a deterministic idempotency key so that retrying the same logical
 /// request (same endpoint + scope) is safe.
-fn derive_idempotency_key(scope: &str, key_input: &str) -> String {
+pub fn derive_idempotency_key(scope: &str, key_input: &str) -> String {
     let hash = sha256::Hash::hash(format!("orchestra:{scope}:{key_input}").as_bytes());
     hash.to_string()
 }
@@ -371,4 +369,29 @@ fn extract_error_message(body: &str) -> String {
                 .map(String::from)
         })
         .unwrap_or_else(|| body.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Same scope + same input must always produce the same key.
+    #[test]
+    fn derive_idempotency_key_is_deterministic() {
+        let a = derive_idempotency_key("submit", "q_abc");
+        let b = derive_idempotency_key("submit", "q_abc");
+        assert_eq!(a, b);
+    }
+
+    /// Different inputs (or scopes) must produce different keys: a single
+    /// collision would conflate two logically distinct requests.
+    #[test]
+    fn derive_idempotency_key_disambiguates_inputs_and_scopes() {
+        let by_input = derive_idempotency_key("submit", "q_abc");
+        let other_input = derive_idempotency_key("submit", "q_xyz");
+        assert_ne!(by_input, other_input);
+
+        let other_scope = derive_idempotency_key("refund", "q_abc");
+        assert_ne!(by_input, other_scope);
+    }
 }

--- a/crates/flashnet/src/orchestra/mod.rs
+++ b/crates/flashnet/src/orchestra/mod.rs
@@ -7,5 +7,5 @@
 pub mod client;
 pub mod models;
 
-pub use client::{OrchestraClient, OrchestraConfigResolver};
+pub use client::{OrchestraClient, OrchestraConfigResolver, derive_idempotency_key};
 pub use models::*;

--- a/crates/flashnet/src/orchestra/models.rs
+++ b/crates/flashnet/src/orchestra/models.rs
@@ -177,9 +177,10 @@ pub struct QuoteResponse {
 /// originate on Spark.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SubmitRequestSpark {
+pub struct SubmitRequest {
     pub quote_id: String,
-    pub spark_tx_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spark_tx_hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_spark_address: Option<String>,
 }
@@ -248,28 +249,73 @@ pub struct StatusResponse {
 pub struct Order {
     pub id: String,
     pub status: OrderStatus,
-    pub quote_id: String,
-    pub source_chain: String,
-    pub source_asset: String,
+    #[serde(default, rename = "type")]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub quote_id: Option<String>,
+    #[serde(default)]
+    pub source_chain: Option<String>,
+    #[serde(default)]
+    pub source_asset: Option<String>,
     #[serde(default)]
     pub source_address: Option<String>,
-    pub source_tx_hash: String,
+    #[serde(default)]
+    pub source_tx_hash: Option<String>,
     #[serde(default)]
     pub source_tx_vout: Option<u32>,
-    pub deposit_address: String,
-    pub destination_chain: String,
-    pub destination_asset: String,
-    pub recipient_address: String,
-    pub amount_in: String,
+    #[serde(default)]
+    pub sweep_tx_hash: Option<String>,
+    #[serde(default)]
+    pub destination_chain: Option<String>,
+    #[serde(default)]
+    pub destination_asset: Option<String>,
+    #[serde(default)]
+    pub destination_address: Option<String>,
+    #[serde(default)]
+    pub destination_tx_hash: Option<String>,
+    #[serde(default)]
+    pub deposit_address: Option<String>,
+    #[serde(default)]
+    pub recipient_address: Option<String>,
+    #[serde(default)]
+    pub amount_in: Option<String>,
     #[serde(default)]
     pub amount_out: Option<String>,
-    pub fee_bps: u32,
-    pub fee_amount: String,
-    pub slippage_bps: u32,
+    #[serde(default)]
+    pub amount_fiat_usd: Option<String>,
+    #[serde(default)]
+    pub amount_fiat_currency: Option<String>,
+    #[serde(default)]
+    pub spot_usd_per_btc: Option<String>,
+    #[serde(default)]
+    pub fee_bps: Option<u32>,
+    #[serde(default)]
+    pub fee_amount: Option<String>,
+    #[serde(default)]
+    pub fee_asset: Option<String>,
+    #[serde(default)]
+    pub rounding_fee_amount: Option<String>,
+    #[serde(default)]
+    pub slippage_bps: Option<u32>,
+    #[serde(default)]
+    pub flashnet_request_id: Option<String>,
+    /// Spark transfer id the receiver sees, on Spark-destination orders.
+    #[serde(default)]
+    pub spark_tx_hash: Option<String>,
+    #[serde(default)]
+    pub refund_asset: Option<String>,
+    #[serde(default)]
+    pub refund_amount: Option<String>,
+    #[serde(default)]
+    pub refund_tx_hash: Option<String>,
     #[serde(default)]
     pub error_code: Option<String>,
     #[serde(default)]
     pub error_message: Option<String>,
+    #[serde(default)]
+    pub total_fee_bps: Option<u32>,
+    #[serde(default)]
+    pub total_fee_amount: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     #[serde(default)]

--- a/docs/breez-sdk/snippets/csharp/CrossChain.cs
+++ b/docs/breez-sdk/snippets/csharp/CrossChain.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Breez.Sdk.Spark;
 
 namespace BreezSdkSnippets
@@ -71,6 +72,59 @@ namespace BreezSdkSnippets
             var sendResponse = await sdk.SendPayment(request: request);
             Console.WriteLine($"Payment: {sendResponse.payment}");
             // ANCHOR_END: cross-chain-send
+        }
+
+        async Task GetCrossChainReceiveRoutes(BreezSdk sdk)
+        {
+            // ANCHOR: cross-chain-get-receive-routes
+            var filter = new CrossChainRouteFilter.Receive(contractAddress: null);
+            var routes = await sdk.GetCrossChainRoutes(filter: filter);
+
+            foreach (var route in routes)
+            {
+                Console.WriteLine(
+                    $"Route via {route.provider}: {route.chain}/{route.asset} -> Spark"
+                );
+            }
+            // ANCHOR_END: cross-chain-get-receive-routes
+        }
+
+        async Task ReceivePaymentCrossChain(BreezSdk sdk, CrossChainRoutePair route)
+        {
+            // ANCHOR: cross-chain-receive
+            // amount is in the route's source-asset base units (USD-stable
+            // parity: 1_000_000 = $1 on 6-decimal routes). See the guide for
+            // feeMode, destination, and the slippage/overpay overrides.
+            var amount = new BigInteger(1_000_000);
+            SparkAsset? optionalDestination = null;
+            uint? optionalMaxSlippageBps = 100;
+            uint? optionalTargetOverpayBps = null;
+            CrossChainFeeMode? optionalFeeMode = null;
+
+            var request = new ReceivePaymentRequest(
+                paymentMethod: new ReceivePaymentMethod.CrossChain(
+                    route: route,
+                    amount: amount,
+                    destination: optionalDestination,
+                    feeMode: optionalFeeMode,
+                    maxSlippageBps: optionalMaxSlippageBps,
+                    targetOverpayBps: optionalTargetOverpayBps
+                )
+            );
+            var response = await sdk.ReceivePayment(request: request);
+
+            Console.WriteLine($"Payment request: {response.paymentRequest}");
+            if (response.crossChainInfo is { } info)
+            {
+                Console.WriteLine($"Deposit address: {info.depositAddress}");
+                Console.WriteLine($"Deposit amount: {info.depositAmount}");
+                var denom = info.tokenIdentifier is null ? "BTC" : "USDB";
+                Console.WriteLine(
+                    $"Expected received: {info.expectedReceivedAmount} {denom}"
+                );
+                Console.WriteLine($"Expires at: {info.expiresAt}");
+            }
+            // ANCHOR_END: cross-chain-receive
         }
     }
 }

--- a/docs/breez-sdk/snippets/csharp/CrossChain.cs
+++ b/docs/breez-sdk/snippets/csharp/CrossChain.cs
@@ -118,9 +118,9 @@ namespace BreezSdkSnippets
             {
                 Console.WriteLine($"Deposit address: {info.depositAddress}");
                 Console.WriteLine($"Deposit amount: {info.depositAmount}");
-                var denom = info.tokenIdentifier is null ? "BTC" : "USDB";
                 Console.WriteLine(
-                    $"Expected received: {info.expectedReceivedAmount} {denom}"
+                    "Expected received: "
+                        + $"{info.expectedReceivedAmount} {info.destinationAsset}"
                 );
                 Console.WriteLine($"Expires at: {info.expiresAt}");
             }

--- a/docs/breez-sdk/snippets/flutter/lib/cross_chain.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/cross_chain.dart
@@ -71,3 +71,57 @@ Future<SendPaymentResponse> sendPaymentCrossChain(
   // ANCHOR_END: cross-chain-send
   return response;
 }
+
+Future<List<CrossChainRoutePair>> getCrossChainReceiveRoutes(BreezSdk sdk) async {
+  // ANCHOR: cross-chain-get-receive-routes
+  List<CrossChainRoutePair> routes = await sdk.getCrossChainRoutes(
+    filter: CrossChainRouteFilter.receive(contractAddress: null),
+  );
+
+  for (var route in routes) {
+    print(
+      "Route via ${route.provider}: ${route.chain}/${route.asset} -> Spark",
+    );
+  }
+  // ANCHOR_END: cross-chain-get-receive-routes
+  return routes;
+}
+
+Future<ReceivePaymentResponse> receivePaymentCrossChain(
+  BreezSdk sdk,
+  CrossChainRoutePair route,
+) async {
+  // ANCHOR: cross-chain-receive
+  // amount is in the route's source-asset base units (USD-stable parity:
+  // 1_000_000 = $1 on 6-decimal routes). See the guide for feeMode,
+  // destination, and the slippage/overpay overrides.
+  final amount = BigInt.from(1000000);
+  SparkAsset? optionalDestination;
+  int? optionalMaxSlippageBps = 100;
+  int? optionalTargetOverpayBps;
+  CrossChainFeeMode? optionalFeeMode;
+
+  final request = ReceivePaymentRequest(
+    paymentMethod: ReceivePaymentMethod.crossChain(
+      route: route,
+      amount: amount,
+      destination: optionalDestination,
+      feeMode: optionalFeeMode,
+      maxSlippageBps: optionalMaxSlippageBps,
+      targetOverpayBps: optionalTargetOverpayBps,
+    ),
+  );
+  final response = await sdk.receivePayment(request: request);
+
+  print("Payment request: ${response.paymentRequest}");
+  final info = response.crossChainInfo;
+  if (info != null) {
+    final denom = info.tokenIdentifier != null ? "USDB" : "BTC";
+    print("Deposit address: ${info.depositAddress}");
+    print("Deposit amount: ${info.depositAmount}");
+    print("Expected received: ${info.expectedReceivedAmount} $denom");
+    print("Expires at: ${info.expiresAt}");
+  }
+  // ANCHOR_END: cross-chain-receive
+  return response;
+}

--- a/docs/breez-sdk/snippets/flutter/lib/cross_chain.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/cross_chain.dart
@@ -116,10 +116,11 @@ Future<ReceivePaymentResponse> receivePaymentCrossChain(
   print("Payment request: ${response.paymentRequest}");
   final info = response.crossChainInfo;
   if (info != null) {
-    final denom = info.tokenIdentifier != null ? "USDB" : "BTC";
     print("Deposit address: ${info.depositAddress}");
     print("Deposit amount: ${info.depositAmount}");
-    print("Expected received: ${info.expectedReceivedAmount} $denom");
+    print(
+      "Expected received: ${info.expectedReceivedAmount} ${info.destinationAsset}",
+    );
     print("Expires at: ${info.expiresAt}");
   }
   // ANCHOR_END: cross-chain-receive

--- a/docs/breez-sdk/snippets/go/cross_chain.go
+++ b/docs/breez-sdk/snippets/go/cross_chain.go
@@ -97,3 +97,68 @@ func SendPaymentCrossChain(
 	// ANCHOR_END: cross-chain-send
 	return &response, nil
 }
+
+func GetCrossChainReceiveRoutes(sdk *breez_sdk_spark.BreezSdk) ([]breez_sdk_spark.CrossChainRoutePair, error) {
+	// ANCHOR: cross-chain-get-receive-routes
+	filter := breez_sdk_spark.CrossChainRouteFilterReceive{ContractAddress: nil}
+	routes, err := sdk.GetCrossChainRoutes(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, route := range routes {
+		log.Printf(
+			"Route via %v: %s/%s -> Spark",
+			route.Provider, route.Chain, route.Asset,
+		)
+	}
+	// ANCHOR_END: cross-chain-get-receive-routes
+	return routes, nil
+}
+
+func ReceivePaymentCrossChain(
+	sdk *breez_sdk_spark.BreezSdk,
+	route breez_sdk_spark.CrossChainRoutePair,
+) (*breez_sdk_spark.ReceivePaymentResponse, error) {
+	// ANCHOR: cross-chain-receive
+	// amount is in the route's source-asset base units (USD-stable parity:
+	// 1_000_000 = $1 on 6-decimal routes). See the guide for FeeMode,
+	// destination, and the slippage/overpay overrides.
+	amount := new(big.Int).SetInt64(1_000_000)
+	var optionalDestination *breez_sdk_spark.SparkAsset = nil
+	optionalMaxSlippageBps := uint32(100)
+	var optionalTargetOverpayBps *uint32 = nil
+	var optionalFeeMode *breez_sdk_spark.CrossChainFeeMode = nil
+
+	request := breez_sdk_spark.ReceivePaymentRequest{
+		PaymentMethod: breez_sdk_spark.ReceivePaymentMethodCrossChain{
+			Route:             route,
+			Amount:            amount,
+			Destination:       optionalDestination,
+			FeeMode:           optionalFeeMode,
+			MaxSlippageBps:    &optionalMaxSlippageBps,
+			TargetOverpayBps:  optionalTargetOverpayBps,
+		},
+	}
+	response, err := sdk.ReceivePayment(request)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("Payment request: %s", response.PaymentRequest)
+	if info := response.CrossChainInfo; info != nil {
+		log.Printf("Deposit address: %s", info.DepositAddress)
+		log.Printf("Deposit amount: %v", info.DepositAmount)
+		denom := "BTC"
+		if info.TokenIdentifier != nil {
+			denom = "USDB"
+		}
+		log.Printf(
+			"Expected received: %v %s",
+			info.ExpectedReceivedAmount, denom,
+		)
+		log.Printf("Expires at: %d", info.ExpiresAt)
+	}
+	// ANCHOR_END: cross-chain-receive
+	return &response, nil
+}

--- a/docs/breez-sdk/snippets/go/cross_chain.go
+++ b/docs/breez-sdk/snippets/go/cross_chain.go
@@ -149,13 +149,9 @@ func ReceivePaymentCrossChain(
 	if info := response.CrossChainInfo; info != nil {
 		log.Printf("Deposit address: %s", info.DepositAddress)
 		log.Printf("Deposit amount: %v", info.DepositAmount)
-		denom := "BTC"
-		if info.TokenIdentifier != nil {
-			denom = "USDB"
-		}
 		log.Printf(
 			"Expected received: %v %s",
-			info.ExpectedReceivedAmount, denom,
+			info.ExpectedReceivedAmount, info.DestinationAsset,
 		)
 		log.Printf("Expires at: %d", info.ExpiresAt)
 	}

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/CrossChain.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/CrossChain.kt
@@ -90,4 +90,57 @@ class CrossChain {
         }
         // ANCHOR_END: cross-chain-send
     }
+
+    suspend fun getCrossChainReceiveRoutes(sdk: BreezSdk) {
+        // ANCHOR: cross-chain-get-receive-routes
+        try {
+            val routes = sdk.getCrossChainRoutes(
+                CrossChainRouteFilter.Receive(contractAddress = null)
+            )
+
+            for (route in routes) {
+                println("Route via ${route.provider}: ${route.chain}/${route.asset} -> Spark")
+            }
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: cross-chain-get-receive-routes
+    }
+
+    suspend fun receivePaymentCrossChain(sdk: BreezSdk, route: CrossChainRoutePair) {
+        // ANCHOR: cross-chain-receive
+        // amount is in the route's source-asset base units (USD-stable parity:
+        // 1_000_000 = $1 on 6-decimal routes). See the guide for feeMode,
+        // destination, and the slippage/overpay overrides.
+        val amount = BigInteger.fromLong(1_000_000L)
+        val optionalDestination: SparkAsset? = null
+        val optionalMaxSlippageBps: UInt? = 100u
+        val optionalTargetOverpayBps: UInt? = null
+        val optionalFeeMode: CrossChainFeeMode? = null
+        try {
+            val req = ReceivePaymentRequest(
+                paymentMethod = ReceivePaymentMethod.CrossChain(
+                    route = route,
+                    amount = amount,
+                    destination = optionalDestination,
+                    feeMode = optionalFeeMode,
+                    maxSlippageBps = optionalMaxSlippageBps,
+                    targetOverpayBps = optionalTargetOverpayBps,
+                ),
+            )
+            val response = sdk.receivePayment(req)
+            println("Payment request: ${response.paymentRequest}")
+            val info = response.crossChainInfo
+            if (info != null) {
+                val denom = if (info.tokenIdentifier != null) "USDB" else "BTC"
+                println("Deposit address: ${info.depositAddress}")
+                println("Deposit amount: ${info.depositAmount}")
+                println("Expected received: ${info.expectedReceivedAmount} $denom")
+                println("Expires at: ${info.expiresAt}")
+            }
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: cross-chain-receive
+    }
 }

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/CrossChain.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/CrossChain.kt
@@ -132,10 +132,12 @@ class CrossChain {
             println("Payment request: ${response.paymentRequest}")
             val info = response.crossChainInfo
             if (info != null) {
-                val denom = if (info.tokenIdentifier != null) "USDB" else "BTC"
                 println("Deposit address: ${info.depositAddress}")
                 println("Deposit amount: ${info.depositAmount}")
-                println("Expected received: ${info.expectedReceivedAmount} $denom")
+                println(
+                    "Expected received: ${info.expectedReceivedAmount} " +
+                        "${info.destinationAsset}",
+                )
                 println("Expires at: ${info.expiresAt}")
             }
         } catch (e: Exception) {

--- a/docs/breez-sdk/snippets/python/src/cross_chain.py
+++ b/docs/breez-sdk/snippets/python/src/cross_chain.py
@@ -8,6 +8,8 @@ from breez_sdk_spark import (
     PaymentRequest,
     PrepareSendPaymentRequest,
     PrepareSendPaymentResponse,
+    ReceivePaymentMethod,
+    ReceivePaymentRequest,
     SendPaymentMethod,
     SendPaymentRequest,
 )
@@ -93,3 +95,58 @@ async def send_payment_cross_chain(
         logging.error(error)
         raise
     # ANCHOR_END: cross-chain-send
+
+
+async def get_cross_chain_receive_routes(sdk: BreezSdk):
+    # ANCHOR: cross-chain-get-receive-routes
+    try:
+        routes = await sdk.get_cross_chain_routes(
+            filter=CrossChainRouteFilter.RECEIVE(contract_address=None)
+        )
+
+        for route in routes:
+            logging.debug(
+                f"Route via {route.provider}: {route.chain}/{route.asset} -> Spark"
+            )
+    except Exception as error:
+        logging.error(error)
+        raise
+    # ANCHOR_END: cross-chain-get-receive-routes
+
+
+async def receive_payment_cross_chain(sdk: BreezSdk, route: CrossChainRoutePair):
+    # ANCHOR: cross-chain-receive
+    # amount is in the route's source-asset base units (USD-stable parity:
+    # 1_000_000 = $1 on 6-decimal routes). See the guide for fee_mode,
+    # destination, and the slippage/overpay overrides.
+    amount = 1_000_000
+    optional_destination = None
+    optional_max_slippage_bps = 100
+    optional_target_overpay_bps = None
+    optional_fee_mode = None
+    try:
+        request = ReceivePaymentRequest(
+            payment_method=ReceivePaymentMethod.CROSS_CHAIN(
+                route=route,
+                amount=amount,
+                destination=optional_destination,
+                fee_mode=optional_fee_mode,
+                max_slippage_bps=optional_max_slippage_bps,
+                target_overpay_bps=optional_target_overpay_bps,
+            )
+        )
+        response = await sdk.receive_payment(request=request)
+        logging.debug(f"Payment request: {response.payment_request}")
+        info = response.cross_chain_info
+        if info is not None:
+            logging.debug(f"Deposit address: {info.deposit_address}")
+            logging.debug(f"Deposit amount: {info.deposit_amount}")
+            denom = "USDB" if info.token_identifier else "BTC"
+            logging.debug(
+                f"Expected received: {info.expected_received_amount} {denom}"
+            )
+            logging.debug(f"Expires at: {info.expires_at}")
+    except Exception as error:
+        logging.error(error)
+        raise
+    # ANCHOR_END: cross-chain-receive

--- a/docs/breez-sdk/snippets/python/src/cross_chain.py
+++ b/docs/breez-sdk/snippets/python/src/cross_chain.py
@@ -141,9 +141,9 @@ async def receive_payment_cross_chain(sdk: BreezSdk, route: CrossChainRoutePair)
         if info is not None:
             logging.debug(f"Deposit address: {info.deposit_address}")
             logging.debug(f"Deposit amount: {info.deposit_amount}")
-            denom = "USDB" if info.token_identifier else "BTC"
             logging.debug(
-                f"Expected received: {info.expected_received_amount} {denom}"
+                f"Expected received: {info.expected_received_amount} "
+                f"{info.destination_asset}"
             )
             logging.debug(f"Expires at: {info.expires_at}")
     except Exception as error:

--- a/docs/breez-sdk/snippets/react-native/cross_chain.ts
+++ b/docs/breez-sdk/snippets/react-native/cross_chain.ts
@@ -2,11 +2,13 @@ import {
   CrossChainRouteFilter,
   InputType_Tags,
   PaymentRequest,
+  ReceivePaymentMethod,
   SendPaymentMethod_Tags,
   type BreezSdk,
   type CrossChainAddressDetails,
   type CrossChainRoutePair,
-  type PrepareSendPaymentResponse
+  type PrepareSendPaymentResponse,
+  type SparkAsset
 } from '@breeztech/breez-sdk-spark-react-native'
 
 const exampleGetCrossChainRoutes = async (sdk: BreezSdk) => {
@@ -74,4 +76,61 @@ const exampleSendPaymentCrossChain = async (
   })
   console.debug('Payment:', sendResponse.payment)
   // ANCHOR_END: cross-chain-send
+}
+
+const exampleGetCrossChainReceiveRoutes = async (sdk: BreezSdk) => {
+  // ANCHOR: cross-chain-get-receive-routes
+  const routes = await sdk.getCrossChainRoutes(
+    new CrossChainRouteFilter.Receive({ contractAddress: undefined })
+  )
+
+  for (const route of routes) {
+    console.debug(
+      `Route via ${route.provider}: ${route.chain}/${route.asset} -> Spark`
+    )
+  }
+  // ANCHOR_END: cross-chain-get-receive-routes
+}
+
+const exampleReceivePaymentCrossChain = async (
+  sdk: BreezSdk,
+  route: CrossChainRoutePair
+) => {
+  // ANCHOR: cross-chain-receive
+  // amount is in the route's source-asset base units (USD-stable parity:
+  // 1_000_000 = $1 on 6-decimal routes). See the guide for feeMode,
+  // destination, and the slippage/overpay overrides.
+  const amount = BigInt(1_000_000)
+  const optionalDestination: SparkAsset | undefined = undefined
+  const optionalMaxSlippageBps = 100
+  const optionalTargetOverpayBps = undefined
+  const optionalFeeMode = undefined
+
+  const response = await sdk.receivePayment({
+    paymentMethod: new ReceivePaymentMethod.CrossChain({
+      route,
+      amount,
+      destination: optionalDestination,
+      feeMode: optionalFeeMode,
+      maxSlippageBps: optionalMaxSlippageBps,
+      targetOverpayBps: optionalTargetOverpayBps
+    })
+  })
+
+  console.debug(`Payment request: ${response.paymentRequest}`)
+  if (response.crossChainInfo !== undefined) {
+    const {
+      depositAddress,
+      depositAmount,
+      expectedReceivedAmount,
+      tokenIdentifier,
+      expiresAt
+    } = response.crossChainInfo
+    const denom = tokenIdentifier !== undefined ? 'USDB' : 'BTC'
+    console.debug(`Deposit address: ${depositAddress}`)
+    console.debug(`Deposit amount: ${depositAmount}`)
+    console.debug(`Expected received: ${expectedReceivedAmount} ${denom}`)
+    console.debug(`Expires at: ${expiresAt}`)
+  }
+  // ANCHOR_END: cross-chain-receive
 }

--- a/docs/breez-sdk/snippets/react-native/cross_chain.ts
+++ b/docs/breez-sdk/snippets/react-native/cross_chain.ts
@@ -123,13 +123,14 @@ const exampleReceivePaymentCrossChain = async (
       depositAddress,
       depositAmount,
       expectedReceivedAmount,
-      tokenIdentifier,
+      destinationAsset,
       expiresAt
     } = response.crossChainInfo
-    const denom = tokenIdentifier !== undefined ? 'USDB' : 'BTC'
     console.debug(`Deposit address: ${depositAddress}`)
     console.debug(`Deposit amount: ${depositAmount}`)
-    console.debug(`Expected received: ${expectedReceivedAmount} ${denom}`)
+    console.debug(
+      `Expected received: ${expectedReceivedAmount} ${destinationAsset}`
+    )
     console.debug(`Expires at: ${expiresAt}`)
   }
   // ANCHOR_END: cross-chain-receive

--- a/docs/breez-sdk/snippets/rust/src/cross_chain.rs
+++ b/docs/breez-sdk/snippets/rust/src/cross_chain.rs
@@ -85,3 +85,60 @@ async fn send_payment_cross_chain(
     // ANCHOR_END: cross-chain-send
     Ok(())
 }
+
+async fn get_cross_chain_receive_routes(sdk: &BreezSdk) -> Result<()> {
+    // ANCHOR: cross-chain-get-receive-routes
+    let routes = sdk
+        .get_cross_chain_routes(&CrossChainRouteFilter::Receive {
+            contract_address: None,
+        })
+        .await?;
+
+    for route in &routes {
+        info!(
+            "Route via {:?}: {}/{} -> Spark",
+            route.provider, route.chain, route.asset
+        );
+    }
+    // ANCHOR_END: cross-chain-get-receive-routes
+    Ok(())
+}
+
+async fn receive_payment_cross_chain(sdk: &BreezSdk, route: CrossChainRoutePair) -> Result<()> {
+    // ANCHOR: cross-chain-receive
+    // amount is in the route's source-asset base units (USD-stable parity:
+    // 1_000_000 = $1 on 6-decimal routes). See the guide for fee_mode,
+    // destination, and the slippage/overpay overrides.
+    let amount = 1_000_000u128;
+    let optional_destination: Option<SparkAsset> = None;
+    let optional_max_slippage_bps = Some(100);
+    let optional_target_overpay_bps: Option<u32> = None;
+    let optional_fee_mode: Option<CrossChainFeeMode> = None;
+
+    let response = sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::CrossChain {
+                route,
+                amount,
+                destination: optional_destination,
+                fee_mode: optional_fee_mode,
+                max_slippage_bps: optional_max_slippage_bps,
+                target_overpay_bps: optional_target_overpay_bps,
+            },
+        })
+        .await?;
+
+    info!("Payment request: {}", response.payment_request);
+    if let Some(info) = response.cross_chain_info {
+        info!("Deposit address: {}", info.deposit_address);
+        info!("Deposit amount: {}", info.deposit_amount);
+        let denom = if info.token_identifier.is_some() { "USDB" } else { "BTC" };
+        info!(
+            "Expected received: {} {denom}",
+            info.expected_received_amount
+        );
+        info!("Expires at: {}", info.expires_at);
+    }
+    // ANCHOR_END: cross-chain-receive
+    Ok(())
+}

--- a/docs/breez-sdk/snippets/rust/src/cross_chain.rs
+++ b/docs/breez-sdk/snippets/rust/src/cross_chain.rs
@@ -132,10 +132,9 @@ async fn receive_payment_cross_chain(sdk: &BreezSdk, route: CrossChainRoutePair)
     if let Some(info) = response.cross_chain_info {
         info!("Deposit address: {}", info.deposit_address);
         info!("Deposit amount: {}", info.deposit_amount);
-        let denom = if info.token_identifier.is_some() { "USDB" } else { "BTC" };
         info!(
-            "Expected received: {} {denom}",
-            info.expected_received_amount
+            "Expected received: {} {}",
+            info.expected_received_amount, info.destination_asset
         );
         info!("Expires at: {}", info.expires_at);
     }

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/CrossChain.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/CrossChain.swift
@@ -68,3 +68,48 @@ func sendPaymentCrossChain(sdk: BreezSdk, prepareResponse: PrepareSendPaymentRes
     print(payment)
     // ANCHOR_END: cross-chain-send
 }
+
+func getCrossChainReceiveRoutes(sdk: BreezSdk) async throws {
+    // ANCHOR: cross-chain-get-receive-routes
+    let routes = try await sdk.getCrossChainRoutes(
+        filter: .receive(contractAddress: nil))
+
+    for route in routes {
+        print("Route via \(route.provider): \(route.chain)/\(route.asset) -> Spark")
+    }
+    // ANCHOR_END: cross-chain-get-receive-routes
+}
+
+func receivePaymentCrossChain(sdk: BreezSdk, route: CrossChainRoutePair) async throws {
+    // ANCHOR: cross-chain-receive
+    // amount is in the route's source-asset base units (USD-stable parity:
+    // 1_000_000 = $1 on 6-decimal routes). See the guide for feeMode,
+    // destination, and the slippage/overpay overrides.
+    let amount = BInt(1_000_000)
+    let optionalDestination: SparkAsset? = nil
+    let optionalMaxSlippageBps: UInt32? = 100
+    let optionalTargetOverpayBps: UInt32? = nil
+    let optionalFeeMode: CrossChainFeeMode? = nil
+
+    let response = try await sdk.receivePayment(
+        request: ReceivePaymentRequest(
+            paymentMethod: .crossChain(
+                route: route,
+                amount: amount,
+                destination: optionalDestination,
+                feeMode: optionalFeeMode,
+                maxSlippageBps: optionalMaxSlippageBps,
+                targetOverpayBps: optionalTargetOverpayBps
+            )
+        ))
+
+    print("Payment request: \(response.paymentRequest)")
+    if let info = response.crossChainInfo {
+        let denom = info.tokenIdentifier != nil ? "USDB" : "BTC"
+        print("Deposit address: \(info.depositAddress)")
+        print("Deposit amount: \(info.depositAmount)")
+        print("Expected received: \(info.expectedReceivedAmount) \(denom)")
+        print("Expires at: \(info.expiresAt)")
+    }
+    // ANCHOR_END: cross-chain-receive
+}

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/CrossChain.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/CrossChain.swift
@@ -105,10 +105,12 @@ func receivePaymentCrossChain(sdk: BreezSdk, route: CrossChainRoutePair) async t
 
     print("Payment request: \(response.paymentRequest)")
     if let info = response.crossChainInfo {
-        let denom = info.tokenIdentifier != nil ? "USDB" : "BTC"
         print("Deposit address: \(info.depositAddress)")
         print("Deposit amount: \(info.depositAmount)")
-        print("Expected received: \(info.expectedReceivedAmount) \(denom)")
+        print(
+            "Expected received: \(info.expectedReceivedAmount) "
+                + "\(info.destinationAsset)"
+        )
         print("Expires at: \(info.expiresAt)")
     }
     // ANCHOR_END: cross-chain-receive

--- a/docs/breez-sdk/snippets/wasm/cross_chain.ts
+++ b/docs/breez-sdk/snippets/wasm/cross_chain.ts
@@ -72,3 +72,62 @@ const exampleSendPaymentCrossChain = async (
   console.debug('Payment:', payment)
   // ANCHOR_END: cross-chain-send
 }
+
+const exampleGetCrossChainReceiveRoutes = async (sdk: BreezSdk) => {
+  // ANCHOR: cross-chain-get-receive-routes
+  const routes = await sdk.getCrossChainRoutes({
+    type: 'receive',
+    contractAddress: undefined
+  })
+
+  for (const route of routes) {
+    console.debug(
+      `Route via ${route.provider}: ${route.chain}/${route.asset} -> Spark`
+    )
+  }
+  // ANCHOR_END: cross-chain-get-receive-routes
+}
+
+const exampleReceivePaymentCrossChain = async (
+  sdk: BreezSdk,
+  route: CrossChainRoutePair
+) => {
+  // ANCHOR: cross-chain-receive
+  // amount is in the route's source-asset base units (USD-stable parity:
+  // 1_000_000 = $1 on 6-decimal routes). See the guide for feeMode,
+  // destination, and the slippage/overpay overrides.
+  const amount = '1000000'
+  const optionalDestination = undefined
+  const optionalMaxSlippageBps = 100
+  const optionalTargetOverpayBps = undefined
+  const optionalFeeMode = undefined
+
+  const response = await sdk.receivePayment({
+    paymentMethod: {
+      type: 'crossChain',
+      route,
+      amount,
+      destination: optionalDestination,
+      feeMode: optionalFeeMode,
+      maxSlippageBps: optionalMaxSlippageBps,
+      targetOverpayBps: optionalTargetOverpayBps
+    }
+  })
+
+  console.debug(`Payment request: ${response.paymentRequest}`)
+  if (response.crossChainInfo !== undefined) {
+    const {
+      depositAddress,
+      depositAmount,
+      expectedReceivedAmount,
+      tokenIdentifier,
+      expiresAt
+    } = response.crossChainInfo
+    const denom = tokenIdentifier !== undefined ? 'USDB' : 'BTC'
+    console.debug(`Deposit address: ${depositAddress}`)
+    console.debug(`Deposit amount: ${depositAmount}`)
+    console.debug(`Expected received: ${expectedReceivedAmount} ${denom}`)
+    console.debug(`Expires at: ${expiresAt}`)
+  }
+  // ANCHOR_END: cross-chain-receive
+}

--- a/docs/breez-sdk/snippets/wasm/cross_chain.ts
+++ b/docs/breez-sdk/snippets/wasm/cross_chain.ts
@@ -120,13 +120,14 @@ const exampleReceivePaymentCrossChain = async (
       depositAddress,
       depositAmount,
       expectedReceivedAmount,
-      tokenIdentifier,
+      destinationAsset,
       expiresAt
     } = response.crossChainInfo
-    const denom = tokenIdentifier !== undefined ? 'USDB' : 'BTC'
     console.debug(`Deposit address: ${depositAddress}`)
     console.debug(`Deposit amount: ${depositAmount}`)
-    console.debug(`Expected received: ${expectedReceivedAmount} ${denom}`)
+    console.debug(
+      `Expected received: ${expectedReceivedAmount} ${destinationAsset}`
+    )
     console.debug(`Expires at: ${expiresAt}`)
   }
   // ANCHOR_END: cross-chain-receive

--- a/docs/breez-sdk/src/SUMMARY.md
+++ b/docs/breez-sdk/src/SUMMARY.md
@@ -64,7 +64,7 @@
   - [Server mode](guide/server_mode.md)
   - [Client signing](guide/client_signing.md)
   - [Using Turnkey](guide/turnkey.md)
-  - [Send USDC/USDT](guide/cross_chain.md)
+  - [USDC/USDT payments](guide/cross_chain.md)
   - [Unilateral exit](guide/unilateral_exit.md)
 - [Moving to production](guide/moving_to_production.md)
 

--- a/docs/breez-sdk/src/guide/about_breez_sdk_spark.md
+++ b/docs/breez-sdk/src/guide/about_breez_sdk_spark.md
@@ -14,7 +14,7 @@ It’s a nodeless integration that offers a non-custodial, end-to-end solution f
 
 - [x] Send and receive Lightning payments
 - [x] Send and receive via LNURL-pay & Lightning addresses
-- [x] Send USDC/USDT
+- [x] Send and receive USDC/USDT
 - [x] Send and receive Spark payments (BTC)
 - [x] Passkey login for seedless experience
 - [x] Stable Balance - hold your balance in USD

--- a/docs/breez-sdk/src/guide/advanced.md
+++ b/docs/breez-sdk/src/guide/advanced.md
@@ -9,4 +9,4 @@ The SDK supports advanced features that may be useful in specific use cases:
 - **[Server mode](server_mode.md)** is the SDK profile for multi-tenant server deployments where each request builds an ephemeral SDK and the host orchestrates sync, claiming, and event delivery explicitly
 - **[Client signing](client_signing.md)** lets a server drive payments while the key that approves them stays with the user, who reviews and signs each payment on their side
 - **[Using Turnkey](turnkey.md)** runs the wallet's signing inside a Turnkey secure enclave, so a server can operate wallets without holding key material
-- **[Send USDC/USDT](cross_chain.md)** to a recipient on an external chain
+- **[USDC/USDT payments](cross_chain.md)** between Spark and a supported external chain (Ethereum-family, Solana, Tron)

--- a/docs/breez-sdk/src/guide/config.md
+++ b/docs/breez-sdk/src/guide/config.md
@@ -170,12 +170,12 @@ Routes the connections the SDK opens through a SOCKS5 proxy, such as a local Tor
 
 {{#tabs config:config-proxy}}
 
-<h2 id="send-usdc-usdt">
-    <a class="header" href="#send-usdc-usdt">Send USDC/USDT</a>
+<h2 id="usdc-usdt">
+    <a class="header" href="#usdc-usdt">USDC/USDT</a>
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.CrossChainConfig.html">API docs</a>
 </h2>
 
-USDC/USDT sends require explicit opt-in: {{#name default_config}} leaves {{#name cross_chain_config}} unset. Set it to a default {{#name CrossChainConfig}} to enable the feature, or to your own to override the slippage default. The SDK only returns routes whose destination is USDC or USDT on a supported chain.
+USDC/USDT (send and receive) requires explicit opt-in: {{#name default_config}} leaves {{#name cross_chain_config}} unset. Set it to a default {{#name CrossChainConfig}} to enable the feature, or to your own to override the slippage default. The SDK only returns routes whose destination is USDC or USDT on a supported chain.
 
 Constraints:
 
@@ -186,4 +186,4 @@ Constraints:
 
 The {{#name default_slippage_bps}} field sets the per-instance slippage default applied when the per-request {{#name max_slippage_bps}} is unset. It must be in the 10 to 500 basis-point range; when {{#name default_slippage_bps}} itself is unset, the SDK falls back to a built-in default of 100 bps (1%).
 
-See [Send USDC/USDT](./cross_chain.md) for the provider lineup, status lifecycle, retry-safety semantics, and limitations.
+See [USDC/USDT](./cross_chain.md) for the provider lineup, status lifecycle, retry-safety semantics, and limitations.

--- a/docs/breez-sdk/src/guide/cross_chain.md
+++ b/docs/breez-sdk/src/guide/cross_chain.md
@@ -1,12 +1,14 @@
-# Send USDC/USDT
+# USDC/USDT payments
 
-The SDK can send USDC or USDT from a Spark wallet to a recipient on any of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The source on the Spark side is either BTC sats or USDB. The SDK orchestrates two legs — a Spark-side transfer to a provider-controlled deposit and the provider-driven delivery of the destination asset — and reconciles both onto a single {{#name Payment}} row.
+The SDK can send and receive USDC and USDT between a Spark wallet and several supported external chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The Spark side is either BTC sats or [USDB](./stable_balance.md), the 6-decimal USD-pegged token on Spark. Each payment runs as two legs (a Spark-side transfer and the provider-driven external delivery) reconciled onto a single {{#name Payment}} row.
 
-The send flow itself lives in the [Sending payments](./send_payment.md#usdc-usdt) page. This page covers how it works under the hood: the providers, the lifecycle, retry semantics, and limitations.
+The send flow is documented on the [Sending payments](./send_payment.md#usdc-usdt) page; the receive flow on the [Receiving payments](./receive_payment.md#usdc-usdt) page. This page covers shared concepts: providers, lifecycle, retry safety, and limitations.
 
 ## Supported address formats
 
 {{#name parse}} recognizes cross-chain destinations in the following forms, returning {{#enum InputType::CrossChainAddress}} with the parsed {{#name CrossChainAddressDetails}} — address family, bare address, and optional token contract address, chain id, and amount.
+
+Parsing is for send only. Receives don't take a counterparty address: the receiver chooses a route and the SDK returns a provider-controlled deposit address for the sender to pay.
 
 ### Bare addresses
 
@@ -49,54 +51,68 @@ URIs whose recipient address doesn't match the scheme's address family (e.g. a `
 
 The SDK ships with two cross-chain providers. {{#name get_cross_chain_routes}} returns the union of routes offered by each, tagged with {{#name CrossChainRoutePair.provider}}.
 
-| Provider     | Source assets    | Destinations                                                | Mechanism                            |
-| ------------ | ---------------- | ----------------------------------------------------------- | ------------------------------------ |
-| **Orchestra** (Flashnet) | BTC sats + USDB | USDC / USDT on Ethereum chains (Arbitrum, Base), Solana, Tron | Spark transfer to a deposit address, then provider bridges to the destination chain |
-| **Boltz**    | BTC sats only    | USDC / USDT on Ethereum chains (Arbitrum, Base), Solana, Tron                 | Lightning reverse swap: SDK pays a hold invoice, provider claims the on-chain leg |
+| Provider     | Direction        | Spark side       | External side                                                | Mechanism                            |
+| ------------ | ---------------- | ---------------- | ------------------------------------------------------------ | ------------------------------------ |
+| **Orchestra** (Flashnet) | Send + Receive  | BTC sats + USDB | USDC / USDT on Ethereum chains (Arbitrum, Base), Solana, Tron | Spark transfer to a deposit address, then provider bridges to the destination chain |
+| **Boltz**    | Send             | BTC sats only    | USDC / USDT on Ethereum chains (Arbitrum, Base), Solana, Tron                 | Lightning reverse swap: SDK pays a hold invoice, provider claims the on-chain leg |
 
-The provider tag on each {{#name CrossChainRoutePair}} is the source of truth. When the same destination is offered by multiple providers, both routes are returned; the caller picks one based on supported source assets, fees, or other preferences.
+The provider tag on each {{#name CrossChainRoutePair}} is the source of truth. When the same destination is offered by multiple providers, both routes are returned; the caller picks one based on supported source/destination assets, fees, or other preferences.
 
 ## Slippage
 
-Cross-chain slippage protects the recipient from price movement between quote and delivery. Values are expressed in basis points (1 bps = 0.01%).
+Cross-chain slippage protects against price movement between quote and delivery. Values are expressed in basis points (1 bps = 0.01%).
 
-Resolution at prepare time:
+Resolution at prepare/receive time:
 
-1. The per-request {{#name max_slippage_bps}} on {{#enum PaymentRequest::CrossChain}} wins if set.
-2. Otherwise, the SDK falls back to {{#name default_slippage_bps}} on {{#name CrossChainConfig}} from [the SDK configuration](./config.md#send-usdc-usdt).
+1. The per-request {{#name max_slippage_bps}} on the request if set.
+2. Otherwise, the SDK falls back to {{#name default_slippage_bps}} on {{#name CrossChainConfig}} from [the SDK configuration](./config.md#usdc-usdt).
 3. Otherwise, the built-in default of 100 bps (1%) is used.
 
 Values outside 10 to 500 are rejected at both config validation and per-request validation.
 
-## Quote expiry
+## Target overpay
 
-Each cross-chain prepare response carries an {{#name expires_at}} quote-expiry timestamp on {{#enum SendPaymentMethod::CrossChainAddress}}. If the quote has expired by the time you call {{#name send_payment}}, you must re-prepare to obtain a fresh quote (with a new {{#name expires_at}}) and try again.
+On {{#enum CrossChainFeeMode::FeesExcluded}} sends and receives the SDK pads the user's target amount by {{#name target_overpay_bps}} so the realized delivery lands at or above target despite provider slippage.
+
+Resolution at prepare/receive time:
+
+1. The per-request {{#name target_overpay_bps}} on the request if set.
+2. Otherwise, the SDK falls back to {{#name default_target_overpay_bps}} on {{#name CrossChainConfig}}.
+3. Otherwise, the built-in default of 15 bps is used.
+
+Values outside 0 to 500 are rejected at both config validation and per-request validation. {{#enum CrossChainFeeMode::FeesIncluded}} requests ignore this field.
 
 ## Status lifecycle
 
-The Spark/USDB token transfer and the cross-chain delivery have distinct status fields. They are tracked separately on the persisted {{#name Payment}} row so each can settle independently.
+The Spark-side transfer and the external cross-chain leg have distinct status fields. They are tracked separately on the persisted {{#name Payment}} row so each can settle independently.
 
-| Field                                                 | Reflects                                                       |
-| ----------------------------------------------------- | -------------------------------------------------------------- |
-| {{#name status}}                                      | The Spark or USDB token transfer (sender-side settlement)      |
-| {{#name conversion_info.status}}                      | The provider-driven cross-chain leg                            |
-| {{#name conversion_info.delivered_amount}}            | Final amount delivered to the recipient, set when terminal     |
+| Field                                                 | Reflects                                                                    |
+| ----------------------------------------------------- | --------------------------------------------------------------------------- |
+| {{#name status}}                                      | The Spark-side transfer (outbound on send; inbound claim on receive)        |
+| {{#name conversion_info.status}}                      | The provider-driven cross-chain leg                                         |
+| {{#name conversion_info.delivered_amount}}            | Final amount delivered to the recipient, set when terminal                  |
 
 The cross-chain status walks one of:
 
-- **{{#enum ConversionStatus::Pending}}** — deposit transfer submitted, provider working on the cross-chain leg.
-- **{{#enum ConversionStatus::Completed}}** — provider reports the order terminal-successful; {{#name delivered_amount}} is set.
-- **{{#enum ConversionStatus::RefundNeeded}}** — provider rejected the submit or order failed before delivery; the local Spark transfer is settled and the deposit is sitting at the provider awaiting refund.
-- **{{#enum ConversionStatus::Refunded}}** — the funds have been refunded back to the wallet.
-- **{{#enum ConversionStatus::Failed}}** — terminal failure with no refund pending.
+- **{{#enum ConversionStatus::Pending}}**: deposit/transfer submitted, provider working on the cross-chain leg.
+- **{{#enum ConversionStatus::Completed}}**: provider reports the order terminal-successful; {{#name delivered_amount}} is set.
+- **{{#enum ConversionStatus::RefundNeeded}}**: the cross-chain leg was rejected after deposit (typically because the realized rate exceeded {{#name max_slippage_bps}}); the deposit is awaiting refund. *(send only)*
+- **{{#enum ConversionStatus::Refunded}}**: the funds have been refunded back to the wallet.
+- **{{#enum ConversionStatus::Failed}}**: terminal failure with no refund pending.
 
-A background monitor runs while the SDK is active and reconciles {{#enum ConversionStatus::RefundNeeded}} and {{#enum ConversionStatus::Pending}} rows onto their terminal state by polling the provider.
+A background monitor runs while the SDK is active and reconciles non-terminal payments by polling the provider.
 
-<h2 id="retry-safety">Retry safety</h2>
+## Send
+
+### Quote expiry
+
+Each cross-chain send prepare response carries an {{#name expires_at}} quote-expiry timestamp on {{#enum SendPaymentMethod::CrossChainAddress}}. If the quote has expired by the time you call {{#name send_payment}}, you must re-prepare to obtain a fresh quote (with a new {{#name expires_at}}) and try again.
+
+<h3 id="retry-safety">Retry safety</h3>
 
 Calling {{#name send_payment}} is safe to retry on transient errors **only when the send has no token-transfer leg.** Whether the source asset displayed on the route is BTC or USDB is not the determinant — what matters is the actual first leg the SDK executes.
 
-### Sends with no token leg
+#### Sends with no token leg
 
 When the first leg is a Spark sats transfer (Orchestra with BTC source, or Boltz funded directly from the sats balance), the SDK threads a deterministic transfer id through to the underlying Spark transfer. Retrying with the same {{#name PrepareSendPaymentResponse}} produces the same transfer id, and the Spark protocol returns the original transfer instead of firing a new one — no double-deposit.
 
@@ -105,7 +121,7 @@ Two ways to drive idempotency:
 1. **Pass a caller-supplied {{#name idempotency_key}}** on {{#name SendPaymentRequest}}. The top-level dispatcher first looks for an existing payment with that id and short-circuits the retry if found; otherwise the key is used as the Spark transfer id.
 2. **Omit {{#name idempotency_key}}** — the SDK derives a deterministic UUIDv5 from the provider's quote/swap id. Re-sending the same prepared shape produces the same id and dedupes at the Spark protocol layer even if the first attempt's persistence step never completed.
 
-### Sends with a token leg
+#### Sends with a token leg
 
 When the first leg is a token transfer at the Spark protocol layer, there is no upstream idempotency hook. The dispatcher rejects a caller-supplied {{#name idempotency_key}} with {{#enum SdkError::InvalidInput}}, and a retry can fire a second token transfer and overpay.
 
@@ -117,6 +133,20 @@ This arises in two ways for a cross-chain send:
 This matches the existing contract for direct token sends.
 
 If you need at-most-once semantics in either of these cases, debounce retries at the application layer until the SDK either returns a payment or a terminal error.
+
+## Receive
+
+The receiver picks a route, sets an `amount` in the source asset's base units (`route.decimals`; USD-stable parity, so `1_000_000` is one USD on any 6-decimal route), and gets back a provider-controlled deposit address to share with the sender. See [Receive payment](./receive_payment.md#usdc-usdt) for the full request shape and fee-mode semantics.
+
+### Destination selection
+
+The {{#name destination}} on {{#enum ReceivePaymentMethod::CrossChain}} is a {{#name SparkAsset}} indicating which Spark-side asset the receiver wants to land. When unset, the SDK auto-picks: the wallet's active stable-balance token if the route supports landing it, otherwise BTC. An explicit choice must appear in the selected {{#name CrossChainRoutePair.accepted_assets}}.
+
+To force a specific destination, build a {{#name SparkAsset}} variant: {{#enum SparkAsset::Bitcoin}} for BTC, or {{#enum SparkAsset::Token}} carrying the Spark {{#name token_identifier}} (the `btkn1...` bech32m id from {{#name CrossChainRoutePair.accepted_assets}}) for USDB or any other supported token.
+
+### Quote expiry
+
+The receive prepare response carries an {{#name expires_at}} timestamp. The SDK does not gate on it: Orchestra reprices late deposits at the live rate. The receive monitor keeps probing for the deposit for 24 hours past {{#name expires_at}} before locally closing the row as unfunded; late deposits inside that window still link correctly.
 
 ## Limitations
 

--- a/docs/breez-sdk/src/guide/external_signer.md
+++ b/docs/breez-sdk/src/guide/external_signer.md
@@ -59,4 +59,4 @@ Some external signers can't perform the SDK's local ECIES/HMAC operations (for e
 
 - **LNURL-auth** returns an error when called.
 - **Real-time sync** must be disabled: leave [{{#name real_time_sync_server_url}}](./config.md#real-time-sync-server-url) unset, or the build fails.
-- **Cross-chain** must be disabled: leave [{{#name cross_chain_config}}](./config.md#send-usdc-usdt) unset, or the build fails.
+- **Cross-chain** must be disabled: leave [{{#name cross_chain_config}}](./config.md#usdc-usdt) unset, or the build fails.

--- a/docs/breez-sdk/src/guide/prepare_payment_link.md
+++ b/docs/breez-sdk/src/guide/prepare_payment_link.md
@@ -2,7 +2,7 @@
 
 {{#name prepare_payment_link}} lets a user send USDC or USDT to a recipient on an external chain (Ethereum-family, Solana, or Tron). The user pays through Cash App (over Lightning) and a cross-chain provider delivers the stablecoin to the recipient.
 
-The SDK acts as orchestrator only. No wallet funds move, and nothing is written to the payment history: Cash App funds the purchase externally and the provider delivers autonomously. This is distinct from the wallet-funded, tracked flow on the [Send USDC/USDT](./cross_chain.md) page.
+The SDK acts as orchestrator only. No wallet funds move, and nothing is written to the payment history: Cash App funds the purchase externally and the provider delivers autonomously. This is distinct from the wallet-funded, tracked flow on the [USDC/USDT](./cross_chain.md) page.
 
 ## How it works
 

--- a/docs/breez-sdk/src/guide/receive_payment.md
+++ b/docs/breez-sdk/src/guide/receive_payment.md
@@ -3,7 +3,7 @@
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.receive_payment">API docs</a>
 </h1>
 
-Once the SDK is initialized, you can directly begin receiving payments. The SDK currently supports three methods of receiving: Lightning, Bitcoin and Spark.
+Once the SDK is initialized, you can directly begin receiving payments. The SDK supports receiving via Lightning, Bitcoin, Spark, and USDC/USDT into Spark from a supported external chain.
 
 ## Lightning
 
@@ -55,6 +55,33 @@ Spark invoices are single-use and may impose restrictions on the payment, such a
 
 {{#tabs receive_payment:receive-payment-spark-invoice}}
 
+<h2 id="usdc-usdt">
+    <a class="header" href="#usdc-usdt">USDC/USDT</a>
+</h2>
+
+Cross-chain receive is supported only via the Orchestra provider. Receive USDC or USDT from a sender on one of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The receiver lands either BTC sats or [USDB](./stable_balance.md) (a 6-decimal USD-pegged token on Spark) on the Spark side. This feature must be enabled in [the SDK configuration](./config.md#usdc-usdt) before using. See [USDC/USDT](./cross_chain.md) for provider details and the status lifecycle.
+
+Call {{#name get_cross_chain_routes}} with {{#enum CrossChainRouteFilter::Receive}} to discover supported source assets. Each {{#name CrossChainRoutePair}} names the provider, source chain and asset, decimals, optional token contract address, and the Spark-side destinations the route lands ({{#name CrossChainRoutePair.accepted_assets}}).
+
+{{#tabs cross_chain:cross-chain-get-receive-routes}}
+
+Build {{#enum ReceivePaymentMethod::CrossChain}} with the chosen route and an `amount`.
+
+The {{#name amount}} on {{#name ReceivePaymentMethod::CrossChain}} is in the source asset's base units, per the route's {{#name CrossChainRoutePair.decimals}}. USD-stable sources sit at USD parity, so `1_000_000` is 1 USDC (6 decimals), about $1.
+
+{{#name fee_mode}} controls what the amount means:
+
+- {{#enum CrossChainFeeMode::FeesExcluded}} (default): `amount` is the receiver's target on Spark. The SDK pads the sender's deposit to cover provider fees plus an overpay buffer.
+- {{#enum CrossChainFeeMode::FeesIncluded}}: `amount` is the deposit the sender pays. The receiver lands `amount - fees`.
+
+{{#name destination}} picks which Spark-side asset the receiver wants delivered. Left unset, the SDK auto-picks the wallet's active stable-balance token if the route supports it, otherwise BTC (converted from the USD amount via the live BTC/USD rate).
+
+{{#name max_slippage_bps}} (10 to 500) bounds the price movement tolerated between quote and delivery. {{#name target_overpay_bps}} (0 to 500) sets the FeesExcluded overpay buffer. Left unset, the SDK defaults apply.
+
+The {{#name payment_request}} field carries an EIP-681 URI for EVM routes and the bare deposit address for Solana and Tron. The {{#name cross_chain_info}} block surfaces the bare deposit address, deposit amount, expected receive amount, destination denomination, and quote {{#name expires_at}}. The receiver pays no fee; the sender's deposit covers it.
+
+{{#tabs cross_chain:cross-chain-receive}}
+
 ## Event Flows
 
 Once a receive payment is initiated, you can follow and react to the different payment events using the guide below for each payment method. See [listening to events](/guide/events.md) for how to subscribe to events. 
@@ -86,3 +113,12 @@ The following events are emitted in order during the deposit lifecycle. See [Lis
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
 | **PaymentPending**   | The Spark transfer was detected and the claim process will start. For Spark HTLC payments, the claim will only start once the HTLC is claimed. For more details see [Spark HTLC payments](htlcs.md). | Show payment as pending.                         |
 | **PaymentSucceeded** | The Spark transfer is claimed and the payment is complete.                                                                                                                                           | Show the payment as complete and call {{#name get_info}} to read the updated balance. The SDK refreshes the cached balance before emitting this event. See [fetching the balance](/guide/get_info.md). |
+
+<h4 id="usdc-usdt-1">
+    <a class="header" href="#usdc-usdt-1">USDC/USDT</a>
+</h4>
+
+| Event                | Description                                                                                          | UX Suggestion                                    |
+| -------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **PaymentPending**   | The sender's deposit was detected and the inbound Spark transfer claim is in progress.               | Show payment as pending.                         |
+| **PaymentSucceeded** | The inbound Spark transfer is claimed and the payment is complete.                                   | Show the payment as complete and call {{#name get_info}} to read the updated balance. The SDK refreshes the cached balance before emitting this event. See [fetching the balance](/guide/get_info.md). |

--- a/docs/breez-sdk/src/guide/send_payment.md
+++ b/docs/breez-sdk/src/guide/send_payment.md
@@ -61,7 +61,7 @@ Spark invoices may require a token (non-Bitcoin) as the payment asset. To determ
     <a class="header" href="#usdc-usdt">USDC/USDT</a>
 </h3>
 
-Send USDC or USDT from a Spark wallet to a recipient on one of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The source on the Spark side is BTC sats or USDB. This feature must be enabled in [the SDK configuration](./config.md#send-usdc-usdt) before using. See [Send USDC/USDT](./cross_chain.md) for provider details and the status lifecycle.
+Send USDC or USDT from a Spark wallet to a recipient on one of several supported chains: Ethereum-family chains (Arbitrum, Base, and similar EVM networks), Solana, and Tron. The source on the Spark side is BTC sats or [USDB](./stable_balance.md) (a 6-decimal USD-pegged token on Spark). This feature must be enabled in [the SDK configuration](./config.md#usdc-usdt) before using. See [USDC/USDT](./cross_chain.md) for provider details and the status lifecycle.
 
 After [parsing](./parse.md) the recipient address into {{#enum InputType::CrossChainAddress}}, call {{#name get_cross_chain_routes}} with {{#enum CrossChainRouteFilter::Send}} carrying the parsed {{#name CrossChainAddressDetails}}. The returned {{#name CrossChainRoutePair}}s name the provider, destination chain and asset, decimals, optional token contract address, and which source assets (BTC sats or USDB) each route accepts.
 

--- a/docs/breez-sdk/src/guide/testing.md
+++ b/docs/breez-sdk/src/guide/testing.md
@@ -31,7 +31,7 @@ The Regtest Network doesn't have a developed Lightning Network, so test Lightnin
 The stablecoin assets are only available on Mainnet:
 
 - **USDB** is the Spark-native stablecoin behind [Stable Balance](./stable_balance.md).
-- **USDC** and **USDT** are cross-chain assets. Use [Send USDC/USDT](./cross_chain.md) to pay recipients on their native chains. The cross-chain providers operate against live external networks and have no testnet equivalent.
+- **USDC** and **USDT** are cross-chain assets. Use [USDC/USDT](./cross_chain.md) to pay recipients on their native chains or receive from them. The cross-chain providers operate against live external networks and have no testnet equivalent.
 
 Test these integrations on Mainnet with small amounts.
 

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -458,14 +458,14 @@ pub struct _CrossChainAddressDetails {
     pub amount: Option<u128>,
 }
 
-#[frb(mirror(SourceAsset))]
-pub enum _SourceAsset {
+#[frb(mirror(SparkAsset))]
+pub enum _SparkAsset {
     Bitcoin,
     Token { token_identifier: String },
 }
 
-#[frb(mirror(SourceChain))]
-pub enum _SourceChain {
+#[frb(mirror(DeliveryMethod))]
+pub enum _DeliveryMethod {
     Spark,
     Lightning,
     Bitcoin,
@@ -486,8 +486,19 @@ pub struct _CrossChainRoutePair {
     pub contract_address: Option<String>,
     pub decimals: u8,
     pub exact_out_eligible: bool,
-    pub supported_sources: Vec<SourceAsset>,
-    pub supported_source_chains: Vec<SourceChain>,
+    pub accepted_assets: Vec<SparkAsset>,
+    pub delivery_methods: Vec<DeliveryMethod>,
+}
+
+#[frb(mirror(CrossChainReceiveInfo))]
+pub struct _CrossChainReceiveInfo {
+    pub deposit_address: String,
+    pub deposit_amount: u128,
+    pub expected_received_amount: u128,
+    pub token_identifier: Option<String>,
+    pub service_fee_amount: u128,
+    pub service_fee_asset: Option<String>,
+    pub expires_at: u64,
 }
 
 #[frb(mirror(CrossChainProviderContext))]
@@ -887,6 +898,14 @@ pub enum _ReceivePaymentMethod {
         payment_hash: Option<String>,
         receiver_identity_public_key: Option<String>,
     },
+    CrossChain {
+        route: CrossChainRoutePair,
+        amount: u128,
+        destination: Option<SparkAsset>,
+        fee_mode: Option<CrossChainFeeMode>,
+        max_slippage_bps: Option<u32>,
+        target_overpay_bps: Option<u32>,
+    },
 }
 
 #[frb(mirror(ReceivePaymentRequest))]
@@ -898,6 +917,7 @@ pub struct _ReceivePaymentRequest {
 pub struct _ReceivePaymentResponse {
     pub payment_request: String,
     pub fee: u128,
+    pub cross_chain_info: Option<CrossChainReceiveInfo>,
 }
 
 #[frb(mirror(RefundDepositRequest))]

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -495,6 +495,7 @@ pub struct _CrossChainReceiveInfo {
     pub deposit_address: String,
     pub deposit_amount: u128,
     pub expected_received_amount: u128,
+    pub destination_asset: String,
     pub token_identifier: Option<String>,
     pub service_fee_amount: u128,
     pub service_fee_asset: Option<String>,


### PR DESCRIPTION
Adds Orchestra-backed cross-chain receive: external chain → Spark (BTC sats or USDB). Companion to the existing cross-chain send.

### What's new

- New `ReceivePaymentMethod::CrossChain { route, amount, destination, fee_mode, max_slippage_bps, target_overpay_bps }` variant.
- `amount` is denominated in the source asset's base units (`route.decimals`), matching `prepare_payment_link`. USD-stable sources sit at USD parity, so `1_000_000` is 1 USDC (6dp) ≈ \$1. `FeesExcluded` (default) treats it as the receiver's target on Spark (translated at parity for USDB or via the live BTC/USD rate for Bitcoin) and the SDK sizes the sender's deposit. `FeesIncluded` treats it as the deposit and the receiver lands `amount − fees`.
- `destination` auto-picks the wallet's active stable-balance token if the route supports it, otherwise Bitcoin. Explicit values must appear in `route.accepted_assets`.
- `ReceivePaymentResponse.cross_chain_info` carries the deposit amount, expected received amount, destination denomination, provider fee (`service_fee_amount` + `service_fee_asset`, symmetric with the send-side field), and quote expiry.
- New `CrossChainService::prepare_receive` trait method. Orchestra implements it; Boltz returns `InvalidInput`.
- Sizing pads the deposit by `estimate.fee_amount` to absorb Orchestra's per-order settlement charge that only appears at quote time, so small-amount (~\$1) receives no longer trip the drift check on the first try.
- Provider-response guards refuse a same-chain route (Orchestra's on-Spark AMM shouldn't appear as a cross-chain option), a deposit address whose family doesn't match `route.chain`, and a quote whose `amount_in` echoes back materially different from what we requested.
- Drift error names the actionable lever: `Retry with a larger target_overpay_bps or send a bigger amount`.
- Unrelated to the feature: this also folds the several private copies of the current-time helper scattered across core into `utils::time` (`now_secs` / `now_ms` / `try_now_secs`), behavior-preserving.

### Breaking changes

Two enums and two `CrossChainRoutePair` fields are renamed so the names read naturally from both send and receive:

- `SourceAsset` → `SparkAsset` (enum)
- `SourceChain` → `DeliveryMethod` (enum)
- `CrossChainRoutePair.supported_sources` → `accepted_assets`
- `CrossChainRoutePair.supported_source_chains` → `delivery_methods`

Renames propagate through UniFFI / wasm-bindgen / FRB, so downstream integrators referencing the old names will need to update.
