### PR TITLE
fix(wasm/passkey): honor preferImmediatelyAvailableCredentials on web

### DIFF
--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -272,11 +272,11 @@ impl PasskeyClient {
     /// register path; every other error (`Cancel`, `Timeout`, ...) propagates
     /// unchanged.
     ///
-    /// Mobile-only: meant for iOS 18+ / Android 9+ where
-    /// `preferImmediatelyAvailableCredentials` is honored. The web
-    /// equivalent (`mediation: 'immediate'`) is not yet stable
-    /// cross-browser, so this is not surfaced on WASM; web hosts call
-    /// [`Self::sign_in`] and catch `CredentialNotFound` themselves.
+    /// Not surfaced on WASM: web hosts drive the same flow via
+    /// [`Self::sign_in`] with `prefer_immediately_available_credentials =
+    /// true` and catch `CredentialNotFound`. The web provider maps the flag
+    /// to `mediation: 'immediate'` where `getClientCapabilities().immediateGet`
+    /// advertises it, falling back to the standard picker elsewhere.
     pub async fn connect_with_passkey(
         &self,
         request: ConnectWithPasskeyRequest,

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -275,7 +275,7 @@ impl PasskeyClient {
     /// Not surfaced on WASM: web hosts drive the same flow via
     /// [`Self::sign_in`] with `prefer_immediately_available_credentials =
     /// true` and catch `CredentialNotFound`. The web provider maps the flag
-    /// to `mediation: 'immediate'` where `getClientCapabilities().immediateGet`
+    /// to `uiMode: 'immediate'` where `getClientCapabilities().immediateGet`
     /// advertises it, falling back to the standard picker elsewhere.
     pub async fn connect_with_passkey(
         &self,

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
@@ -22,10 +22,11 @@ const BREEZ_RP_ID = 'keys.breez.technology';
 /** Default `rpName` for the zero-config {@link PasskeyClient} path. */
 const DEFAULT_RP_NAME = 'Breez';
 
-// WebAuthn collapses "no matching credential" and "user dismissed" into
-// one NotAllowedError, but a no-credential fast-fail resolves before any
-// UI shows while a dismiss takes seconds. Elapsed time below this is
-// classified as no-credential, at or above as user-cancel.
+// A no-credential reject resolves before any UI shows; a dismiss takes
+// seconds. This fast-fail window only applies under `mediation:
+// 'immediate'`: that is the only path where a no-credential reject shows
+// no UI. On the modal path the OS always shows a picker first, so a
+// NotAllowedError there is a dismiss/timeout, never a fast no-credential.
 const NO_CRED_FAST_FAIL_MS = 250;
 
 // iOS and Android tear the biometric sheet down around 55s of inactivity
@@ -42,6 +43,27 @@ function randomBytes(length) {
     const bytes = new Uint8Array(length);
     crypto.getRandomValues(bytes);
     return bytes;
+}
+
+/**
+ * Whether this browser honors `mediation: 'immediate'`, probed via
+ * `getClientCapabilities().immediateGet`. The gate is mandatory: the
+ * unknown `mediation` enum throws a `TypeError` on browsers without
+ * WebAuthn L3 support. Uncached: the probe is cheap and runs at most once
+ * per assertion.
+ * @returns {Promise<boolean>}
+ */
+async function supportsImmediateMediation() {
+    try {
+        if (typeof PublicKeyCredential === 'undefined'
+            || typeof PublicKeyCredential.getClientCapabilities !== 'function') {
+            return false;
+        }
+        const caps = await PublicKeyCredential.getClientCapabilities();
+        return caps?.immediateGet === true;
+    } catch {
+        return false;
+    }
 }
 
 /**
@@ -434,6 +456,20 @@ export class PasskeyProvider {
         }
 
         const requestOptions = { publicKey };
+        // Immediate mediation: fast-fail with no UI when no credential is
+        // present so a single-CTA host can fall through to register. Only
+        // where the browser advertises it (else `get()` throws on the
+        // unknown `mediation` enum). The fast NotAllowedError this raises
+        // on no-credential is classified as CredentialNotFound below.
+        if (options.preferImmediatelyAvailableCredentials) {
+            if (await supportsImmediateMediation()) {
+                requestOptions.mediation = 'immediate';
+            } else {
+                // Surface the fallback: silently using standard mediation
+                // hides why a single-CTA probe still shows a sheet.
+                console.debug('breez-sdk: preferImmediatelyAvailableCredentials set but immediate mediation is unsupported by this browser; using standard mediation');
+            }
+        }
 
         let credential;
         const startedAt = (typeof performance !== 'undefined' && performance.now)
@@ -445,7 +481,7 @@ export class PasskeyProvider {
             const elapsed = ((typeof performance !== 'undefined' && performance.now)
                 ? performance.now()
                 : Date.now()) - startedAt;
-            throw this._mapAssertionError(error, elapsed);
+            throw this._mapAssertionError(error, elapsed, requestOptions.mediation === 'immediate');
         }
         if (!credential) {
             throw new PasskeyCredentialNotFoundError();
@@ -583,18 +619,24 @@ export class PasskeyProvider {
 
     /**
      * Map a `navigator.credentials.get` failure into a typed error.
-     * `elapsedMs` resolves the `NotAllowedError` ambiguity (cancel vs
-     * no-credential vs timeout, which all share the error) by elapsed
-     * time, since only the cancel path shows dismissable UI.
+     * `elapsedMs` disambiguates the shared `NotAllowedError` (cancel vs
+     * no-credential vs timeout) by time, since only cancel shows UI. The
+     * fast no-credential branch is immediate-only: the modal path shows a
+     * picker first, so its NotAllowedError is a dismiss/timeout.
      * @param {Error} error
      * @param {number} elapsedMs
+     * @param {boolean} [immediate=false]
      * @returns {Error}
      * @private
      */
-    _mapAssertionError(error, elapsedMs) {
+    _mapAssertionError(error, elapsedMs, immediate = false) {
         if (!error) return new Error('Unknown WebAuthn error');
         if (error.name === 'NotAllowedError') {
-            if (elapsedMs < NO_CRED_FAST_FAIL_MS) {
+            // Fast no-credential only under immediate mediation: that's the
+            // only path where a no-credential reject shows no UI. On the
+            // modal path the OS always shows a picker first, so a
+            // NotAllowedError is a dismiss/timeout, not a no-credential.
+            if (immediate && elapsedMs < NO_CRED_FAST_FAIL_MS) {
                 return new PasskeyCredentialNotFoundError();
             }
             if (elapsedMs >= this._cancelVsTimeoutThresholdMs()) {

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
@@ -23,10 +23,11 @@ const BREEZ_RP_ID = 'keys.breez.technology';
 const DEFAULT_RP_NAME = 'Breez';
 
 // A no-credential reject resolves before any UI shows; a dismiss takes
-// seconds. This fast-fail window only applies under `mediation:
-// 'immediate'`: that is the only path where a no-credential reject shows
-// no UI. On the modal path the OS always shows a picker first, so a
-// NotAllowedError there is a dismiss/timeout, never a fast no-credential.
+// seconds. This fast-fail window only applies under immediate UI mode
+// (`uiMode: 'immediate'`): that is the only path where a no-credential
+// reject shows no UI. On the modal path the OS always shows a picker
+// first, so a NotAllowedError there is a dismiss/timeout, never a fast
+// no-credential.
 const NO_CRED_FAST_FAIL_MS = 250;
 
 // iOS and Android tear the biometric sheet down around 55s of inactivity
@@ -46,11 +47,11 @@ function randomBytes(length) {
 }
 
 /**
- * Whether this browser honors `mediation: 'immediate'`, probed via
- * `getClientCapabilities().immediateGet`. The gate is mandatory: the
- * unknown `mediation` enum throws a `TypeError` on browsers without
- * WebAuthn L3 support. Uncached: the probe is cheap and runs at most once
- * per assertion.
+ * Whether this browser honors WebAuthn immediate UI mode
+ * (`uiMode: 'immediate'`), probed via `getClientCapabilities().immediateGet`.
+ * The gate is mandatory: immediate mode is discoverable-only and fast-fails
+ * with no UI, so it must not run where unsupported. Uncached: the probe is
+ * cheap and runs at most once per assertion.
  * @returns {Promise<boolean>}
  */
 async function supportsImmediateMediation() {
@@ -456,18 +457,20 @@ export class PasskeyProvider {
         }
 
         const requestOptions = { publicKey };
-        // Immediate mediation: fast-fail with no UI when no credential is
+        // Immediate UI mode: fast-fail with no UI when no credential is
         // present so a single-CTA host can fall through to register. Only
-        // where the browser advertises it (else `get()` throws on the
-        // unknown `mediation` enum). The fast NotAllowedError this raises
-        // on no-credential is classified as CredentialNotFound below.
+        // where the browser advertises it (`getClientCapabilities().immediateGet`).
+        // The fast NotAllowedError it raises on no-credential is classified
+        // as CredentialNotFound below. Immediate mode is discoverable-only:
+        // a non-empty allowCredentials throws, so clear the pin here.
         if (options.preferImmediatelyAvailableCredentials) {
             if (await supportsImmediateMediation()) {
-                requestOptions.mediation = 'immediate';
+                requestOptions.uiMode = 'immediate';
+                publicKey.allowCredentials = [];
             } else {
                 // Surface the fallback: silently using standard mediation
                 // hides why a single-CTA probe still shows a sheet.
-                console.debug('breez-sdk: preferImmediatelyAvailableCredentials set but immediate mediation is unsupported by this browser; using standard mediation');
+                console.debug('breez-sdk: preferImmediatelyAvailableCredentials set but immediate UI mode is unsupported by this browser; using standard mediation');
             }
         }
 
@@ -481,7 +484,7 @@ export class PasskeyProvider {
             const elapsed = ((typeof performance !== 'undefined' && performance.now)
                 ? performance.now()
                 : Date.now()) - startedAt;
-            throw this._mapAssertionError(error, elapsed, requestOptions.mediation === 'immediate');
+            throw this._mapAssertionError(error, elapsed, requestOptions.uiMode === 'immediate');
         }
         if (!credential) {
             throw new PasskeyCredentialNotFoundError();

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
@@ -458,15 +458,19 @@ export class PasskeyProvider {
 
         const requestOptions = { publicKey };
         // Immediate UI mode: fast-fail with no UI when no credential is
-        // present so a single-CTA host can fall through to register. Only
-        // where the browser advertises it (`getClientCapabilities().immediateGet`).
-        // The fast NotAllowedError it raises on no-credential is classified
-        // as CredentialNotFound below. Immediate mode is discoverable-only:
-        // a non-empty allowCredentials throws, so clear the pin here.
-        if (options.preferImmediatelyAvailableCredentials) {
+        // present so a single-CTA host can fall through to register. Only on
+        // the first, unpinned probe (`allowList` empty): immediate mode is
+        // discoverable-only (rejects a non-empty allowCredentials) and spends
+        // the transient activation, which the pinned later ceremonies of a
+        // multi-salt derive no longer have. Once a credential is pinned we
+        // already know one exists, so the modal path (which keeps the pin) is
+        // correct and avoids a second, credential-substituting chooser. Only
+        // where the browser advertises it (`getClientCapabilities().immediateGet`);
+        // the fast NotAllowedError it raises on no-credential is classified as
+        // CredentialNotFound below.
+        if (options.preferImmediatelyAvailableCredentials && allowList.length === 0) {
             if (await supportsImmediateMediation()) {
                 requestOptions.uiMode = 'immediate';
-                publicKey.allowCredentials = [];
             } else {
                 // Surface the fallback: silently using standard mediation
                 // hides why a single-CTA probe still shows a sheet.


### PR DESCRIPTION
## Problem

The web PRF provider accepted `preferImmediatelyAvailableCredentials` but ignored it: `_performAssertion` called `navigator.credentials.get()` with no `mediation`, so web assertions always ran modal. As Chrome rolls out immediate mediation (enabled by default on some platforms in recent versions), single-CTA hosts switched to the immediate path but still got the account/QR sheet, because the SDK never requested it.

## Fix (two parts)

1. Set `mediation: 'immediate'` when the flag is set and the browser advertises `immediateGet` (via `getClientCapabilities()`). The capability gate is required: passing the unknown enum to `get()` throws `TypeError` on browsers without L3 immediate support.
2. Classify the fast no-credential reject only on the immediate path. `immediate` is the only mediation where a no-credential reject shows no UI; the modal path always shows a picker first, so a NotAllowedError there is a dismiss/timeout, never a fast no-credential. `_mapAssertionError` now applies the fast-fail window only when immediate.

Also logs at debug when the flag is requested but `immediateGet` isn't advertised, so the silent fallback to standard mediation is visible. JS-only beyond the `connect_with_passkey` doc; native unaffected.