### PR TITLE
feat: enable unified passkey login on web

### DIFF
--- a/crates/breez-sdk/core/src/passkey/mod.rs
+++ b/crates/breez-sdk/core/src/passkey/mod.rs
@@ -322,7 +322,13 @@ impl Passkey {
         }
         let association = self.prf_provider.check_domain_association().await?;
         Ok(match association {
-            DomainAssociation::Associated => PasskeyAvailability::Available,
+            DomainAssociation::Associated => PasskeyAvailability::Available {
+                // Native authenticators always support the silent single-CTA
+                // probe (a no-credential sign-in fast-fails with no UI). Only
+                // the browser varies, so the WASM client overrides this from
+                // its immediate-mediation capability.
+                immediate_mediation_supported: true,
+            },
             DomainAssociation::NotAssociated { source, reason } => {
                 PasskeyAvailability::NotAssociated { source, reason }
             }
@@ -428,7 +434,7 @@ mod tests {
         let availability = passkey.check_availability().await.unwrap();
         assert!(matches!(
             availability,
-            PasskeyAvailability::Available | PasskeyAvailability::Skipped { .. }
+            PasskeyAvailability::Available { .. } | PasskeyAvailability::Skipped { .. }
         ));
     }
 

--- a/crates/breez-sdk/core/src/passkey/mod.rs
+++ b/crates/breez-sdk/core/src/passkey/mod.rs
@@ -322,13 +322,7 @@ impl Passkey {
         }
         let association = self.prf_provider.check_domain_association().await?;
         Ok(match association {
-            DomainAssociation::Associated => PasskeyAvailability::Available {
-                // Native authenticators always support the silent single-CTA
-                // probe (a no-credential sign-in fast-fails with no UI). Only
-                // the browser varies, so the WASM client overrides this from
-                // its immediate-mediation capability.
-                immediate_mediation_supported: true,
-            },
+            DomainAssociation::Associated => PasskeyAvailability::Available,
             DomainAssociation::NotAssociated { source, reason } => {
                 PasskeyAvailability::NotAssociated { source, reason }
             }
@@ -434,7 +428,7 @@ mod tests {
         let availability = passkey.check_availability().await.unwrap();
         assert!(matches!(
             availability,
-            PasskeyAvailability::Available { .. } | PasskeyAvailability::Skipped { .. }
+            PasskeyAvailability::Available | PasskeyAvailability::Skipped { .. }
         ));
     }
 

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -124,10 +124,11 @@ pub struct ConnectWithPasskeyRequest {
     #[cfg_attr(feature = "uniffi", uniffi(default = None))]
     pub label: Option<String>,
 
-    /// Optional credential IDs to restrict the silent sign-in
-    /// attempt to (reauthentication path). See
-    /// [`SignInRequest::allow_credentials`]. Ignored on the fallback
-    /// registration path.
+    /// Optional credential IDs to restrict the sign-in attempt to
+    /// (reauthentication path). A non-empty list runs the modal sign-in
+    /// rather than the immediate probe (a pin means a credential is already
+    /// known). See [`SignInRequest::allow_credentials`]. Ignored on the
+    /// fallback registration path.
     #[cfg_attr(feature = "uniffi", uniffi(default = None))]
     pub allow_credentials: Option<Vec<Vec<u8>>>,
 

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -21,12 +21,7 @@ use super::{LabelStore, LabelStoreBuilder};
 pub enum PasskeyAvailability {
     /// PRF is supported and the platform's domain-association check
     /// (when present) passed. Safe to proceed with register / sign-in.
-    ///
-    /// `immediate_mediation_supported` is whether the silent single-CTA
-    /// flow ([`PasskeyClient::connect_with_passkey`]) works here: `true`
-    /// on native, and on web only where the browser advertises immediate
-    /// mediation. Web hosts pick single- vs two-button onboarding on it.
-    Available { immediate_mediation_supported: bool },
+    Available,
     /// The authenticator does not implement the `WebAuthn` PRF
     /// extension. Hosts gate the passkey UX path off this value.
     PrfUnsupported,
@@ -286,8 +281,8 @@ impl PasskeyClient {
     /// unchanged.
     ///
     /// On WASM the silent sign-in maps to `WebAuthn` `uiMode: 'immediate'`
-    /// where the browser advertises it. Web hosts gate on
-    /// `immediate_mediation_supported` from [`Self::check_availability`]:
+    /// where the browser advertises it. Web hosts gate on the browser's
+    /// immediate-mediation capability (the WASM client surfaces it):
     /// without it the probe shows the standard picker and a dismiss is a
     /// cancel, not `CredentialNotFound`, so it never reaches register.
     /// Present an explicit create / sign-in choice there instead.

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -273,11 +273,11 @@ impl PasskeyClient {
     /// register path; every other error (`Cancel`, `Timeout`, ...) propagates
     /// unchanged.
     ///
-    /// Mobile-only: meant for iOS 18+ / Android 9+ where
-    /// `preferImmediatelyAvailableCredentials` is honored. The web
-    /// equivalent (`mediation: 'immediate'`) is not yet stable
-    /// cross-browser, so this is not surfaced on WASM; web hosts call
-    /// [`Self::sign_in`] and catch `CredentialNotFound` themselves.
+    /// Not surfaced on WASM: web hosts drive the same flow via
+    /// [`Self::sign_in`] with `prefer_immediately_available_credentials =
+    /// true` and catch `CredentialNotFound`. The web provider maps the flag
+    /// to `mediation: 'immediate'` where `getClientCapabilities().immediateGet`
+    /// advertises it, falling back to the standard picker elsewhere.
     pub async fn connect_with_passkey(
         &self,
         request: ConnectWithPasskeyRequest,

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -276,7 +276,7 @@ impl PasskeyClient {
     /// Not surfaced on WASM: web hosts drive the same flow via
     /// [`Self::sign_in`] with `prefer_immediately_available_credentials =
     /// true` and catch `CredentialNotFound`. The web provider maps the flag
-    /// to `mediation: 'immediate'` where `getClientCapabilities().immediateGet`
+    /// to `uiMode: 'immediate'` where `getClientCapabilities().immediateGet`
     /// advertises it, falling back to the standard picker elsewhere.
     pub async fn connect_with_passkey(
         &self,

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -21,7 +21,12 @@ use super::{LabelStore, LabelStoreBuilder};
 pub enum PasskeyAvailability {
     /// PRF is supported and the platform's domain-association check
     /// (when present) passed. Safe to proceed with register / sign-in.
-    Available,
+    ///
+    /// `immediate_mediation_supported` is whether the silent single-CTA
+    /// flow ([`PasskeyClient::connect_with_passkey`]) works here: `true`
+    /// on native, and on web only where the browser advertises immediate
+    /// mediation. Web hosts pick single- vs two-button onboarding on it.
+    Available { immediate_mediation_supported: bool },
     /// The authenticator does not implement the `WebAuthn` PRF
     /// extension. Hosts gate the passkey UX path off this value.
     PrfUnsupported,
@@ -140,11 +145,18 @@ pub struct ConnectWithPasskeyRequest {
 /// registered, when the provider surfaces it. The register path also
 /// populates the attestation fields (`aaguid`, `backup_eligible`); the
 /// sign-in path sets only `credential_id`.
+///
+/// `labels` is the user's discovered label set when `request.label` was
+/// `None` (the returning-user multi-wallet case): `wallet` is the default
+/// label, and a host showing more than one entry lets the user pick
+/// another via [`PasskeyClient::sign_in`]. Empty on the register path (a
+/// new user has no other labels) and when a specific label was requested.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct ConnectWithPasskeyResponse {
     pub wallet: Wallet,
     pub credential: Option<PasskeyCredential>,
+    pub labels: Vec<String>,
 }
 
 /// High-level orchestration over a [`PrfProvider`] and the internal
@@ -263,8 +275,7 @@ impl PasskeyClient {
     }
 
     /// Single-CTA onboarding: silent sign-in, falling through to
-    /// registration when no credential exists on the device. The returned
-    /// [`ConnectFlow`] tells the caller which path ran.
+    /// registration when no credential exists on the device.
     ///
     /// The silent sign-in pins `prefer_immediately_available_credentials =
     /// true` regardless of [`SignInRequest`]: the fallback depends on the OS
@@ -273,11 +284,12 @@ impl PasskeyClient {
     /// register path; every other error (`Cancel`, `Timeout`, ...) propagates
     /// unchanged.
     ///
-    /// Not surfaced on WASM: web hosts drive the same flow via
-    /// [`Self::sign_in`] with `prefer_immediately_available_credentials =
-    /// true` and catch `CredentialNotFound`. The web provider maps the flag
-    /// to `uiMode: 'immediate'` where `getClientCapabilities().immediateGet`
-    /// advertises it, falling back to the standard picker elsewhere.
+    /// On WASM the silent sign-in maps to `WebAuthn` `uiMode: 'immediate'`
+    /// where the browser advertises it. Web hosts gate on
+    /// `immediate_mediation_supported` from [`Self::check_availability`]:
+    /// without it the probe shows the standard picker and a dismiss is a
+    /// cancel, not `CredentialNotFound`, so it never reaches register.
+    /// Present an explicit create / sign-in choice there instead.
     pub async fn connect_with_passkey(
         &self,
         request: ConnectWithPasskeyRequest,
@@ -294,6 +306,9 @@ impl PasskeyClient {
             Ok(response) => Ok(ConnectWithPasskeyResponse {
                 wallet: response.wallet,
                 credential: response.credential,
+                // Discovery labels (populated when `label` was None) so a
+                // returning multi-wallet user can be offered a picker.
+                labels: response.labels,
             }),
             Err(PasskeyError::Prf(PrfProviderError::CredentialNotFound(_))) => {
                 let register_response = self
@@ -305,6 +320,8 @@ impl PasskeyClient {
                 Ok(ConnectWithPasskeyResponse {
                     wallet: register_response.wallet,
                     credential: register_response.credential,
+                    // New user: nothing to pick from.
+                    labels: Vec::new(),
                 })
             }
             Err(e) => Err(e),

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.d.ts
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.d.ts
@@ -145,6 +145,14 @@ export declare class PasskeyProvider {
     isSupported(): Promise<boolean>;
 
     /**
+     * Whether the silent single-CTA flow works in this browser: WebAuthn
+     * immediate mediation (`getClientCapabilities().immediateGet`). The SDK
+     * surfaces this on `checkAvailability().immediateMediationSupported`;
+     * hosts gate single- vs two-button onboarding on it.
+     */
+    supportsImmediateMediation(): Promise<boolean>;
+
+    /**
      * Check whether the configured `rpId` is a valid WebAuthn scope for
      * the current origin (must be a registrable suffix of
      * `window.location.hostname`, or equal to it). Mirrors the browser's

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.d.ts
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.d.ts
@@ -147,7 +147,7 @@ export declare class PasskeyProvider {
     /**
      * Whether the silent single-CTA flow works in this browser: WebAuthn
      * immediate mediation (`getClientCapabilities().immediateGet`). The SDK
-     * surfaces this on `checkAvailability().immediateMediationSupported`;
+     * surfaces this on the WASM client's `supportsImmediateMediation()`;
      * hosts gate single- vs two-button onboarding on it.
      */
     supportsImmediateMediation(): Promise<boolean>;

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
@@ -22,10 +22,11 @@ const BREEZ_RP_ID = 'keys.breez.technology';
 /** Default `rpName` for the zero-config {@link PasskeyClient} path. */
 const DEFAULT_RP_NAME = 'Breez';
 
-// WebAuthn collapses "no matching credential" and "user dismissed" into
-// one NotAllowedError, but a no-credential fast-fail resolves before any
-// UI shows while a dismiss takes seconds. Elapsed time below this is
-// classified as no-credential, at or above as user-cancel.
+// A no-credential reject resolves before any UI shows; a dismiss takes
+// seconds. This fast-fail window only applies under `mediation:
+// 'immediate'`: that is the only path where a no-credential reject shows
+// no UI. On the modal path the OS always shows a picker first, so a
+// NotAllowedError there is a dismiss/timeout, never a fast no-credential.
 const NO_CRED_FAST_FAIL_MS = 250;
 
 // iOS and Android tear the biometric sheet down around 55s of inactivity
@@ -42,6 +43,27 @@ function randomBytes(length) {
     const bytes = new Uint8Array(length);
     crypto.getRandomValues(bytes);
     return bytes;
+}
+
+/**
+ * Whether this browser honors `mediation: 'immediate'`, probed via
+ * `getClientCapabilities().immediateGet`. The gate is mandatory: the
+ * unknown `mediation` enum throws a `TypeError` on browsers without
+ * WebAuthn L3 support. Uncached: the probe is cheap and runs at most once
+ * per assertion.
+ * @returns {Promise<boolean>}
+ */
+async function supportsImmediateMediation() {
+    try {
+        if (typeof PublicKeyCredential === 'undefined'
+            || typeof PublicKeyCredential.getClientCapabilities !== 'function') {
+            return false;
+        }
+        const caps = await PublicKeyCredential.getClientCapabilities();
+        return caps?.immediateGet === true;
+    } catch {
+        return false;
+    }
 }
 
 /**
@@ -434,6 +456,20 @@ export class PasskeyProvider {
         }
 
         const requestOptions = { publicKey };
+        // Immediate mediation: fast-fail with no UI when no credential is
+        // present so a single-CTA host can fall through to register. Only
+        // where the browser advertises it (else `get()` throws on the
+        // unknown `mediation` enum). The fast NotAllowedError this raises
+        // on no-credential is classified as CredentialNotFound below.
+        if (options.preferImmediatelyAvailableCredentials) {
+            if (await supportsImmediateMediation()) {
+                requestOptions.mediation = 'immediate';
+            } else {
+                // Surface the fallback: silently using standard mediation
+                // hides why a single-CTA probe still shows a sheet.
+                console.debug('breez-sdk: preferImmediatelyAvailableCredentials set but immediate mediation is unsupported by this browser; using standard mediation');
+            }
+        }
 
         let credential;
         const startedAt = (typeof performance !== 'undefined' && performance.now)
@@ -445,7 +481,7 @@ export class PasskeyProvider {
             const elapsed = ((typeof performance !== 'undefined' && performance.now)
                 ? performance.now()
                 : Date.now()) - startedAt;
-            throw this._mapAssertionError(error, elapsed);
+            throw this._mapAssertionError(error, elapsed, requestOptions.mediation === 'immediate');
         }
         if (!credential) {
             throw new PasskeyCredentialNotFoundError();
@@ -583,18 +619,24 @@ export class PasskeyProvider {
 
     /**
      * Map a `navigator.credentials.get` failure into a typed error.
-     * `elapsedMs` resolves the `NotAllowedError` ambiguity (cancel vs
-     * no-credential vs timeout, which all share the error) by elapsed
-     * time, since only the cancel path shows dismissable UI.
+     * `elapsedMs` disambiguates the shared `NotAllowedError` (cancel vs
+     * no-credential vs timeout) by time, since only cancel shows UI. The
+     * fast no-credential branch is immediate-only: the modal path shows a
+     * picker first, so its NotAllowedError is a dismiss/timeout.
      * @param {Error} error
      * @param {number} elapsedMs
+     * @param {boolean} [immediate=false]
      * @returns {Error}
      * @private
      */
-    _mapAssertionError(error, elapsedMs) {
+    _mapAssertionError(error, elapsedMs, immediate = false) {
         if (!error) return new Error('Unknown WebAuthn error');
         if (error.name === 'NotAllowedError') {
-            if (elapsedMs < NO_CRED_FAST_FAIL_MS) {
+            // Fast no-credential only under immediate mediation: that's the
+            // only path where a no-credential reject shows no UI. On the
+            // modal path the OS always shows a picker first, so a
+            // NotAllowedError is a dismiss/timeout, not a no-credential.
+            if (immediate && elapsedMs < NO_CRED_FAST_FAIL_MS) {
                 return new PasskeyCredentialNotFoundError();
             }
             if (elapsedMs >= this._cancelVsTimeoutThresholdMs()) {

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
@@ -23,10 +23,11 @@ const BREEZ_RP_ID = 'keys.breez.technology';
 const DEFAULT_RP_NAME = 'Breez';
 
 // A no-credential reject resolves before any UI shows; a dismiss takes
-// seconds. This fast-fail window only applies under `mediation:
-// 'immediate'`: that is the only path where a no-credential reject shows
-// no UI. On the modal path the OS always shows a picker first, so a
-// NotAllowedError there is a dismiss/timeout, never a fast no-credential.
+// seconds. This fast-fail window only applies under immediate UI mode
+// (`uiMode: 'immediate'`): that is the only path where a no-credential
+// reject shows no UI. On the modal path the OS always shows a picker
+// first, so a NotAllowedError there is a dismiss/timeout, never a fast
+// no-credential.
 const NO_CRED_FAST_FAIL_MS = 250;
 
 // iOS and Android tear the biometric sheet down around 55s of inactivity
@@ -46,11 +47,11 @@ function randomBytes(length) {
 }
 
 /**
- * Whether this browser honors `mediation: 'immediate'`, probed via
- * `getClientCapabilities().immediateGet`. The gate is mandatory: the
- * unknown `mediation` enum throws a `TypeError` on browsers without
- * WebAuthn L3 support. Uncached: the probe is cheap and runs at most once
- * per assertion.
+ * Whether this browser honors WebAuthn immediate UI mode
+ * (`uiMode: 'immediate'`), probed via `getClientCapabilities().immediateGet`.
+ * The gate is mandatory: immediate mode is discoverable-only and fast-fails
+ * with no UI, so it must not run where unsupported. Uncached: the probe is
+ * cheap and runs at most once per assertion.
  * @returns {Promise<boolean>}
  */
 async function supportsImmediateMediation() {
@@ -456,18 +457,20 @@ export class PasskeyProvider {
         }
 
         const requestOptions = { publicKey };
-        // Immediate mediation: fast-fail with no UI when no credential is
+        // Immediate UI mode: fast-fail with no UI when no credential is
         // present so a single-CTA host can fall through to register. Only
-        // where the browser advertises it (else `get()` throws on the
-        // unknown `mediation` enum). The fast NotAllowedError this raises
-        // on no-credential is classified as CredentialNotFound below.
+        // where the browser advertises it (`getClientCapabilities().immediateGet`).
+        // The fast NotAllowedError it raises on no-credential is classified
+        // as CredentialNotFound below. Immediate mode is discoverable-only:
+        // a non-empty allowCredentials throws, so clear the pin here.
         if (options.preferImmediatelyAvailableCredentials) {
             if (await supportsImmediateMediation()) {
-                requestOptions.mediation = 'immediate';
+                requestOptions.uiMode = 'immediate';
+                publicKey.allowCredentials = [];
             } else {
                 // Surface the fallback: silently using standard mediation
                 // hides why a single-CTA probe still shows a sheet.
-                console.debug('breez-sdk: preferImmediatelyAvailableCredentials set but immediate mediation is unsupported by this browser; using standard mediation');
+                console.debug('breez-sdk: preferImmediatelyAvailableCredentials set but immediate UI mode is unsupported by this browser; using standard mediation');
             }
         }
 
@@ -481,7 +484,7 @@ export class PasskeyProvider {
             const elapsed = ((typeof performance !== 'undefined' && performance.now)
                 ? performance.now()
                 : Date.now()) - startedAt;
-            throw this._mapAssertionError(error, elapsed, requestOptions.mediation === 'immediate');
+            throw this._mapAssertionError(error, elapsed, requestOptions.uiMode === 'immediate');
         }
         if (!credential) {
             throw new PasskeyCredentialNotFoundError();

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
@@ -47,27 +47,6 @@ function randomBytes(length) {
 }
 
 /**
- * Whether this browser honors WebAuthn immediate UI mode
- * (`uiMode: 'immediate'`), probed via `getClientCapabilities().immediateGet`.
- * The gate is mandatory: immediate mode is discoverable-only and fast-fails
- * with no UI, so it must not run where unsupported. Uncached: the probe is
- * cheap and runs at most once per assertion.
- * @returns {Promise<boolean>}
- */
-async function supportsImmediateMediation() {
-    try {
-        if (typeof PublicKeyCredential === 'undefined'
-            || typeof PublicKeyCredential.getClientCapabilities !== 'function') {
-            return false;
-        }
-        const caps = await PublicKeyCredential.getClientCapabilities();
-        return caps?.immediateGet === true;
-    } catch {
-        return false;
-    }
-}
-
-/**
  * Extract AAGUID + BE flag from a create response via WebAuthn L2
  * `getAuthenticatorData()`. authData layout once the AT flag is set:
  * byte 32 = flags (BE=bit3, AT=bit6), bytes 37 to 53 = AAGUID.
@@ -308,6 +287,28 @@ export class PasskeyProvider {
     }
 
     /**
+     * Whether the silent single-CTA flow works in this browser: WebAuthn
+     * immediate UI mode (`uiMode: 'immediate'`), probed via
+     * `getClientCapabilities().immediateGet`. The SDK surfaces this on
+     * `checkAvailability().immediateMediationSupported`; hosts gate single-
+     * vs two-button onboarding on it.
+     *
+     * @returns {Promise<boolean>}
+     */
+    async supportsImmediateMediation() {
+        try {
+            if (typeof PublicKeyCredential === 'undefined'
+                || typeof PublicKeyCredential.getClientCapabilities !== 'function') {
+                return false;
+            }
+            const caps = await PublicKeyCredential.getClientCapabilities();
+            return caps?.immediateGet === true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
      * Check whether the configured rpId is a valid WebAuthn scope for
      * the current origin (must be a registrable suffix of
      * `window.location.hostname`, or equal to it). Mirrors the browser's
@@ -469,7 +470,7 @@ export class PasskeyProvider {
         // the fast NotAllowedError it raises on no-credential is classified as
         // CredentialNotFound below.
         if (options.preferImmediatelyAvailableCredentials && allowList.length === 0) {
-            if (await supportsImmediateMediation()) {
+            if (await this.supportsImmediateMediation()) {
                 requestOptions.uiMode = 'immediate';
             } else {
                 // Surface the fallback: silently using standard mediation

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
@@ -458,15 +458,19 @@ export class PasskeyProvider {
 
         const requestOptions = { publicKey };
         // Immediate UI mode: fast-fail with no UI when no credential is
-        // present so a single-CTA host can fall through to register. Only
-        // where the browser advertises it (`getClientCapabilities().immediateGet`).
-        // The fast NotAllowedError it raises on no-credential is classified
-        // as CredentialNotFound below. Immediate mode is discoverable-only:
-        // a non-empty allowCredentials throws, so clear the pin here.
-        if (options.preferImmediatelyAvailableCredentials) {
+        // present so a single-CTA host can fall through to register. Only on
+        // the first, unpinned probe (`allowList` empty): immediate mode is
+        // discoverable-only (rejects a non-empty allowCredentials) and spends
+        // the transient activation, which the pinned later ceremonies of a
+        // multi-salt derive no longer have. Once a credential is pinned we
+        // already know one exists, so the modal path (which keeps the pin) is
+        // correct and avoids a second, credential-substituting chooser. Only
+        // where the browser advertises it (`getClientCapabilities().immediateGet`);
+        // the fast NotAllowedError it raises on no-credential is classified as
+        // CredentialNotFound below.
+        if (options.preferImmediatelyAvailableCredentials && allowList.length === 0) {
             if (await supportsImmediateMediation()) {
                 requestOptions.uiMode = 'immediate';
-                publicKey.allowCredentials = [];
             } else {
                 // Surface the fallback: silently using standard mediation
                 // hides why a single-CTA probe still shows a sheet.

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
@@ -289,9 +289,9 @@ export class PasskeyProvider {
     /**
      * Whether the silent single-CTA flow works in this browser: WebAuthn
      * immediate UI mode (`uiMode: 'immediate'`), probed via
-     * `getClientCapabilities().immediateGet`. The SDK surfaces this on
-     * `checkAvailability().immediateMediationSupported`; hosts gate single-
-     * vs two-button onboarding on it.
+     * `getClientCapabilities().immediateGet`. The SDK surfaces this on the
+     * WASM client's `supportsImmediateMediation()`; hosts gate single- vs
+     * two-button onboarding on it.
      *
      * @returns {Promise<boolean>}
      */

--- a/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
+++ b/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
@@ -67,11 +67,10 @@ impl WasmPrfProvider {
     }
 
     /// Whether the browser advertises WebAuthn immediate mediation, the
-    /// signal the WASM `PasskeyClient` folds into
-    /// `checkAvailability().immediateMediationSupported`. A provider that
-    /// omits the method is treated as unsupported (`false`); a custom
-    /// provider opts in by implementing it. (Native reports `true` from the
-    /// core; only the WASM path consults this override.)
+    /// signal the WASM `PasskeyClient` surfaces as
+    /// `supportsImmediateMediation()`. A provider that omits the method is
+    /// treated as unsupported (`false`); a custom provider opts in by
+    /// implementing it.
     pub async fn supports_immediate_mediation(&self) -> bool {
         if !self.js_has_method("supportsImmediateMediation", &self.supports_immediate) {
             return false;

--- a/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
+++ b/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
@@ -39,6 +39,9 @@ pub struct WasmPrfProvider {
     /// Cached `createPasskey` presence probe: JS providers may omit
     /// it (only platform passkey backends implement registration).
     supports_create: OnceLock<bool>,
+    /// Cached `supportsImmediateMediation` presence probe: custom
+    /// providers may omit it and inherit the `true` trait default.
+    supports_immediate: OnceLock<bool>,
 }
 
 impl WasmPrfProvider {
@@ -46,6 +49,7 @@ impl WasmPrfProvider {
         Self {
             inner,
             supports_create: OnceLock::new(),
+            supports_immediate: OnceLock::new(),
         }
     }
 
@@ -60,6 +64,25 @@ impl WasmPrfProvider {
                     .map(|v| v.is_function())
                     .unwrap_or(false)
         })
+    }
+
+    /// Whether the browser advertises WebAuthn immediate mediation, the
+    /// signal the WASM `PasskeyClient` folds into
+    /// `checkAvailability().immediateMediationSupported`. A provider that
+    /// omits the method is assumed native-like (`true`); a present but
+    /// failing probe is treated as unsupported.
+    pub async fn supports_immediate_mediation(&self) -> bool {
+        if !self.js_has_method("supportsImmediateMediation", &self.supports_immediate) {
+            return true;
+        }
+        let Ok(promise) = self.inner.supports_immediate_mediation() else {
+            return false;
+        };
+        JsFuture::from(promise)
+            .await
+            .ok()
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
     }
 }
 
@@ -282,6 +305,14 @@ export interface PrfProvider {
      * device. Hosts gate UX on the result.
      */
     isSupported(): Promise<boolean>;
+
+    /**
+     * Optional. Whether the silent single-CTA flow works here (a
+     * no-credential sign-in fast-fails with no UI). Omit to inherit the
+     * `true` default; the built-in browser provider returns the WebAuthn
+     * immediate-mediation capability.
+     */
+    supportsImmediateMediation?(): Promise<boolean>;
 }
 
 /**
@@ -337,4 +368,9 @@ extern "C" {
         this: &PrfProvider,
         exclude_credentials: JsValue,
     ) -> Result<Promise, JsValue>;
+
+    // Optional method. Custom providers may omit it and inherit the
+    // `true` default; probed with `js_has_method` before invoking.
+    #[wasm_bindgen(structural, method, js_name = "supportsImmediateMediation", catch)]
+    pub fn supports_immediate_mediation(this: &PrfProvider) -> Result<Promise, JsValue>;
 }

--- a/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
+++ b/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
@@ -40,7 +40,7 @@ pub struct WasmPrfProvider {
     /// it (only platform passkey backends implement registration).
     supports_create: OnceLock<bool>,
     /// Cached `supportsImmediateMediation` presence probe: custom
-    /// providers may omit it and inherit the `true` trait default.
+    /// providers may omit it, in which case it is treated as unsupported.
     supports_immediate: OnceLock<bool>,
 }
 
@@ -309,9 +309,9 @@ export interface PrfProvider {
 
     /**
      * Optional. Whether the silent single-CTA flow works here (a
-     * no-credential sign-in fast-fails with no UI). Omit to inherit the
-     * `true` default; the built-in browser provider returns the WebAuthn
-     * immediate-mediation capability.
+     * no-credential sign-in fast-fails with no UI). Omit to be treated as
+     * unsupported (`false`); the built-in browser provider returns the
+     * WebAuthn immediate-mediation capability.
      */
     supportsImmediateMediation?(): Promise<boolean>;
 }
@@ -372,8 +372,8 @@ extern "C" {
         exclude_credentials: JsValue,
     ) -> Result<Promise, JsValue>;
 
-    // Optional method. Custom providers may omit it and inherit the
-    // `true` default; probed with `js_has_method` before invoking.
+    // Optional method. Custom providers may omit it (then treated as
+    // unsupported); probed with `js_has_method` before invoking.
     #[wasm_bindgen(structural, method, js_name = "supportsImmediateMediation", catch)]
     pub fn supports_immediate_mediation(this: &PrfProvider) -> Result<Promise, JsValue>;
 }

--- a/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
+++ b/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
@@ -69,11 +69,12 @@ impl WasmPrfProvider {
     /// Whether the browser advertises WebAuthn immediate mediation, the
     /// signal the WASM `PasskeyClient` folds into
     /// `checkAvailability().immediateMediationSupported`. A provider that
-    /// omits the method is assumed native-like (`true`); a present but
-    /// failing probe is treated as unsupported.
+    /// omits the method is treated as unsupported (`false`); a custom
+    /// provider opts in by implementing it. (Native reports `true` from the
+    /// core; only the WASM path consults this override.)
     pub async fn supports_immediate_mediation(&self) -> bool {
         if !self.js_has_method("supportsImmediateMediation", &self.supports_immediate) {
-            return true;
+            return false;
         }
         let Ok(promise) = self.inner.supports_immediate_mediation() else {
             return false;

--- a/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
+++ b/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
@@ -328,7 +328,9 @@ export interface DeriveSeedOptions {
     allowCredentials?: Uint8Array[];
     /**
      * Fast-fail when no local credential is available. On the web this maps
-     * to WebAuthn `mediation: 'immediate'`: `true` opts in where the browser
+     * to WebAuthn `uiMode: 'immediate'`, used only on the unpinned probe (a
+     * non-empty allowCredentials keeps the standard picker, since a pin means
+     * a credential is already known): `true` opts in where the browser
      * advertises support, `false` uses the standard picker. Unset uses the
      * provider default.
      */

--- a/crates/breez-sdk/wasm/src/passkey.rs
+++ b/crates/breez-sdk/wasm/src/passkey.rs
@@ -42,7 +42,7 @@ pub struct PasskeyConfig {
 /// `checkDomainAssociation` into one tagged value hosts branch on.
 #[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::PasskeyAvailability)]
 pub enum PasskeyAvailability {
-    Available,
+    Available { immediate_mediation_supported: bool },
     PrfUnsupported,
     NotAssociated { source: String, reason: String },
     Skipped { reason: String },
@@ -108,12 +108,33 @@ pub struct SignInResponse {
     pub credential: Option<PasskeyCredential>,
 }
 
+/// Request shape for `PasskeyClient.connectWithPasskey`.
+#[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::ConnectWithPasskeyRequest)]
+pub struct ConnectWithPasskeyRequest {
+    pub label: Option<String>,
+    #[tsify(type = "Uint8Array[]")]
+    pub allow_credentials: Option<Vec<Vec<u8>>>,
+    #[tsify(type = "Uint8Array[]")]
+    pub exclude_credentials: Option<Vec<Vec<u8>>>,
+}
+
+/// Response shape for `PasskeyClient.connectWithPasskey`.
+#[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::ConnectWithPasskeyResponse)]
+pub struct ConnectWithPasskeyResponse {
+    pub wallet: Wallet,
+    pub credential: Option<PasskeyCredential>,
+    pub labels: Vec<String>,
+}
+
 /// High-level orchestrator that collapses register / sign-in flows
 /// into single calls. See the matching Rust types for full semantics;
 /// the JS surface is a thin wasm-bindgen wrapper.
 #[wasm_bindgen]
 pub struct PasskeyClient {
     inner: breez_sdk_spark::passkey::PasskeyClient,
+    /// Kept to fold the browser immediate-mediation capability into
+    /// `checkAvailability` (the core defaults it to native-`true`).
+    provider: Arc<WasmPrfProvider>,
 }
 
 #[wasm_bindgen]
@@ -128,13 +149,14 @@ impl PasskeyClient {
         breez_api_key: Option<String>,
         config: Option<PasskeyConfig>,
     ) -> Self {
-        let wasm_provider = WasmPrfProvider::new(prf_provider);
+        let provider = Arc::new(WasmPrfProvider::new(prf_provider));
         Self {
             inner: breez_sdk_spark::passkey::PasskeyClient::new(
-                Arc::new(wasm_provider),
+                provider.clone(),
                 breez_api_key,
                 config.map(Into::into),
             ),
+            provider,
         }
     }
 
@@ -142,7 +164,16 @@ impl PasskeyClient {
     /// hosts can gate UX on.
     #[wasm_bindgen(js_name = "checkAvailability")]
     pub async fn check_availability(&self) -> WasmResult<PasskeyAvailability> {
-        Ok(self.inner.check_availability().await?.into())
+        let mut availability = self.inner.check_availability().await?;
+        // The core reports native-`true`; on web fold in the browser's actual
+        // immediate-mediation capability so hosts gate single- vs two-CTA on it.
+        if let breez_sdk_spark::passkey::PasskeyAvailability::Available {
+            immediate_mediation_supported,
+        } = &mut availability
+        {
+            *immediate_mediation_supported = self.provider.supports_immediate_mediation().await;
+        }
+        Ok(availability.into())
     }
 
     /// First-time setup. Drives the platform's create-passkey ceremony
@@ -160,6 +191,27 @@ impl PasskeyClient {
     #[wasm_bindgen(js_name = "signIn")]
     pub async fn sign_in(&self, request: SignInRequest) -> WasmResult<SignInResponse> {
         Ok(self.inner.sign_in(request.into()).await?.into())
+    }
+
+    /// Single-CTA onboarding: silent sign-in that falls through to
+    /// registration when no credential exists on the device. Pins
+    /// immediate mediation, so on web only use it where the browser
+    /// advertises it (`immediateMediationSupported` from
+    /// `checkAvailability`); otherwise the silent probe degrades to the
+    /// standard picker and a dismiss does not fall through to register, so
+    /// present an explicit create / sign-in choice instead. Called without
+    /// a `label`, the response `labels` lists a returning user's wallets
+    /// for a picker.
+    #[wasm_bindgen(js_name = "connectWithPasskey")]
+    pub async fn connect_with_passkey(
+        &self,
+        request: ConnectWithPasskeyRequest,
+    ) -> WasmResult<ConnectWithPasskeyResponse> {
+        Ok(self
+            .inner
+            .connect_with_passkey(request.into())
+            .await?
+            .into())
     }
 
     /// Label sub-object. List / publish labels for this passkey's identity.

--- a/crates/breez-sdk/wasm/src/passkey.rs
+++ b/crates/breez-sdk/wasm/src/passkey.rs
@@ -42,7 +42,7 @@ pub struct PasskeyConfig {
 /// `checkDomainAssociation` into one tagged value hosts branch on.
 #[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::PasskeyAvailability)]
 pub enum PasskeyAvailability {
-    Available { immediate_mediation_supported: bool },
+    Available,
     PrfUnsupported,
     NotAssociated { source: String, reason: String },
     Skipped { reason: String },
@@ -164,16 +164,17 @@ impl PasskeyClient {
     /// hosts can gate UX on.
     #[wasm_bindgen(js_name = "checkAvailability")]
     pub async fn check_availability(&self) -> WasmResult<PasskeyAvailability> {
-        let mut availability = self.inner.check_availability().await?;
-        // The core reports native-`true`; on web fold in the browser's actual
-        // immediate-mediation capability so hosts gate single- vs two-CTA on it.
-        if let breez_sdk_spark::passkey::PasskeyAvailability::Available {
-            immediate_mediation_supported,
-        } = &mut availability
-        {
-            *immediate_mediation_supported = self.provider.supports_immediate_mediation().await;
-        }
-        Ok(availability.into())
+        Ok(self.inner.check_availability().await?.into())
+    }
+
+    /// Whether this browser advertises WebAuthn immediate mediation: the
+    /// silent single-CTA probe (a no-credential sign-in fast-fails with no
+    /// UI) works here, so a web host can pick single- vs two-button
+    /// onboarding. Web-only and WASM-only: native does the silent probe
+    /// inherently, so there is nothing to query off-web.
+    #[wasm_bindgen(js_name = "supportsImmediateMediation")]
+    pub async fn supports_immediate_mediation(&self) -> bool {
+        self.provider.supports_immediate_mediation().await
     }
 
     /// First-time setup. Drives the platform's create-passkey ceremony
@@ -196,9 +197,9 @@ impl PasskeyClient {
     /// Single-CTA onboarding: silent sign-in that falls through to
     /// registration when no credential exists on the device. Pins
     /// immediate mediation, so on web only use it where the browser
-    /// advertises it (`immediateMediationSupported` from
-    /// `checkAvailability`); otherwise the silent probe degrades to the
-    /// standard picker and a dismiss does not fall through to register, so
+    /// advertises it (`supportsImmediateMediation`); otherwise the silent
+    /// probe degrades to the standard picker and a dismiss does not fall
+    /// through to register, so
     /// present an explicit create / sign-in choice instead. Called without
     /// a `label`, the response `labels` lists a returning user's wallets
     /// for a picker.

--- a/crates/breez-sdk/wasm/src/passkey.rs
+++ b/crates/breez-sdk/wasm/src/passkey.rs
@@ -132,8 +132,8 @@ pub struct ConnectWithPasskeyResponse {
 #[wasm_bindgen]
 pub struct PasskeyClient {
     inner: breez_sdk_spark::passkey::PasskeyClient,
-    /// Kept to fold the browser immediate-mediation capability into
-    /// `checkAvailability` (the core defaults it to native-`true`).
+    /// Kept so `supportsImmediateMediation` can query the provider
+    /// directly: the core client does not expose this capability.
     provider: Arc<WasmPrfProvider>,
 }
 

--- a/docs/breez-sdk/snippets/csharp/Passkey.cs
+++ b/docs/breez-sdk/snippets/csharp/Passkey.cs
@@ -77,8 +77,14 @@ namespace BreezSdkSnippets
             // Single-CTA onboarding: silent sign-in for a returning user,
             // fall-through to register on a fresh device.
             var response = await passkey.ConnectWithPasskey(
-                new ConnectWithPasskeyRequest(label: "personal")
+                new ConnectWithPasskeyRequest()
             );
+
+            if (response.labels.Length > 1)
+            {
+                // Returning multi-wallet user: let them pick a label, then
+                // SignIn to the chosen wallet.
+            }
 
             var config = BreezSdkSparkMethods.DefaultConfig(network: Network.Mainnet);
             var sdk = await BreezSdkSparkMethods.Connect(new ConnectRequest(

--- a/docs/breez-sdk/snippets/flutter/lib/passkey.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/passkey.dart
@@ -69,8 +69,14 @@ Future<BreezSdk> connectWithPasskey() async {
   final config = defaultConfig(network: Network.mainnet)
       .copyWith(apiKey: '<breez api key>');
   final response = await passkey.connectWithPasskey(
-    request: ConnectWithPasskeyRequest(label: 'personal'),
+    request: ConnectWithPasskeyRequest(),
   );
+
+  if (response.labels.length > 1) {
+    // Returning multi-wallet user: let them pick a label, then sign in to it.
+    // final chosen = await showWalletPicker(response.labels);
+    // return (await passkey.signIn(request: SignInRequest(label: chosen))).wallet;
+  }
 
   final sdk = await connect(
       request: ConnectRequest(

--- a/docs/breez-sdk/snippets/go/passkey.go
+++ b/docs/breez-sdk/snippets/go/passkey.go
@@ -77,12 +77,15 @@ func ConnectWithPasskey() (*breez_sdk_spark.BreezSdk, error) {
 
 	// ANCHOR: connect-with-passkey
 	// Silent sign-in for a returning user, fall-through to register on a fresh device.
-	label := "personal"
-	response, err := passkey.ConnectWithPasskey(breez_sdk_spark.ConnectWithPasskeyRequest{
-		Label: &label,
-	})
+	// No label: derives the default wallet and discovers this passkey's full label set.
+	response, err := passkey.ConnectWithPasskey(breez_sdk_spark.ConnectWithPasskeyRequest{})
 	if err != nil {
 		return nil, err
+	}
+
+	if len(response.Labels) > 1 {
+		// Returning multi-wallet user: let them pick a label and SignIn to it.
+		// passkey.SignIn(breez_sdk_spark.SignInRequest{Label: &chosenLabel})
 	}
 
 	config := breez_sdk_spark.DefaultConfig(breez_sdk_spark.NetworkMainnet)

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
@@ -79,9 +79,13 @@ class PasskeySnippets(private val activity: Activity) {
         // ANCHOR: connect-with-passkey
         // Single-CTA onboarding: silent sign-in, fall through to register.
         val config = defaultConfig(Network.MAINNET).apply { apiKey = "<breez api key>" }
-        val response = passkey.connectWithPasskey(
-            ConnectWithPasskeyRequest(label = "personal")
-        )
+        val response = passkey.connectWithPasskey(ConnectWithPasskeyRequest())
+
+        if (response.labels.size > 1) {
+            // Returning multi-wallet user: let them pick a label and sign in to it.
+            // val chosen = promptForLabel(response.labels)
+            // return connect(ConnectRequest(config, passkey.signIn(SignInRequest(label = chosen)).wallet.seed, "./.data"))
+        }
 
         val sdk = connect(ConnectRequest(config, response.wallet.seed, "./.data"))
         // ANCHOR_END: connect-with-passkey

--- a/docs/breez-sdk/snippets/python/src/passkey.py
+++ b/docs/breez-sdk/snippets/python/src/passkey.py
@@ -87,9 +87,14 @@ async def connect_with_passkey():
 
     # ANCHOR: connect-with-passkey
     # Silent sign-in for a returning user, fall-through to register on a fresh device.
-    response = await passkey.connect_with_passkey(
-        ConnectWithPasskeyRequest(label="personal")
-    )
+    # No label: derive the default wallet and discover this passkey's label set.
+    response = await passkey.connect_with_passkey(ConnectWithPasskeyRequest())
+
+    if len(response.labels) > 1:
+        # Returning multi-wallet user: let them pick a label and sign in to it.
+        # chosen = ...  # prompt the user with response.labels
+        # response = await passkey.sign_in(SignInRequest(label=chosen))
+        pass
 
     config = default_config(network=Network.MAINNET)
     sdk = await connect(

--- a/docs/breez-sdk/snippets/react-native/passkey.ts
+++ b/docs/breez-sdk/snippets/react-native/passkey.ts
@@ -90,13 +90,20 @@ const connectWithPasskey = async () => {
   )
 
   // ANCHOR: connect-with-passkey
-  // Silent sign-in, fall through to register.
+  // Silent sign-in, fall through to register. No label: a returning user's
+  // wallets come back in `response.labels` (the default is signed in).
   const config = { ...defaultConfig(Network.Mainnet), apiKey: '<breez api key>' }
   const response = await passkey.connectWithPasskey({
-    label: 'personal',
+    label: undefined,
     allowCredentials: undefined,
     excludeCredentials: undefined
   })
+
+  if (response.labels.length > 1) {
+    // Returning multi-wallet user: let them pick a label and sign in to it.
+    // const chosen = await pickLabel(response.labels)
+    // return await passkey.signIn({ label: chosen, allowCredentials: undefined, preferImmediatelyAvailableCredentials: undefined })
+  }
 
   const sdk = await connect({ config, seed: response.wallet.seed, storageDir: './.data' })
   // ANCHOR_END: connect-with-passkey

--- a/docs/breez-sdk/snippets/rust/src/passkey.rs
+++ b/docs/breez-sdk/snippets/rust/src/passkey.rs
@@ -49,16 +49,10 @@ async fn check_availability() -> Result<()> {
 
     // ANCHOR: check-availability
     match passkey.check_availability().await? {
-        PasskeyAvailability::Available {
-            immediate_mediation_supported,
-        } => {
-            // On web, immediate_mediation_supported chooses single- vs
-            // two-button onboarding (always true on native).
-            if immediate_mediation_supported {
-                // Single button: connect_with_passkey.
-            } else {
-                // Two buttons: register / sign_in.
-            }
+        PasskeyAvailability::Available => {
+            // Passkey supported: proceed with connect_with_passkey. On web,
+            // call PasskeyClient::supports_immediate_mediation to pick
+            // single- vs two-button onboarding (native is always single).
         }
         PasskeyAvailability::PrfUnsupported => {
             // Fall back to mnemonic flow.

--- a/docs/breez-sdk/snippets/rust/src/passkey.rs
+++ b/docs/breez-sdk/snippets/rust/src/passkey.rs
@@ -49,8 +49,16 @@ async fn check_availability() -> Result<()> {
 
     // ANCHOR: check-availability
     match passkey.check_availability().await? {
-        PasskeyAvailability::Available => {
-            // Show passkey as primary option.
+        PasskeyAvailability::Available {
+            immediate_mediation_supported,
+        } => {
+            // On web, immediate_mediation_supported chooses single- vs
+            // two-button onboarding (always true on native).
+            if immediate_mediation_supported {
+                // Single button: connect_with_passkey.
+            } else {
+                // Two buttons: register / sign_in.
+            }
         }
         PasskeyAvailability::PrfUnsupported => {
             // Fall back to mnemonic flow.
@@ -79,12 +87,15 @@ async fn connect_with_passkey_unified() -> Result<breez_sdk_spark::BreezSdk> {
 
     // ANCHOR: connect-with-passkey
     // Single-CTA onboarding: silent sign-in, fall through to register.
+    // Without a label, a returning user's wallets are discovered in
+    // `response.labels` (the response wallet is the default); a new user
+    // gets a freshly registered default wallet.
     let response = passkey
-        .connect_with_passkey(ConnectWithPasskeyRequest {
-            label: Some("personal".to_string()),
-            ..Default::default()
-        })
+        .connect_with_passkey(ConnectWithPasskeyRequest::default())
         .await?;
+    if response.labels.len() > 1 {
+        // Multiple wallets: let the user pick, then sign_in to the chosen label.
+    }
 
     let config = default_config(Network::Mainnet);
     let sdk = connect(ConnectRequest {

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
@@ -72,8 +72,14 @@ func connectWithPasskey() async throws -> BreezSdk {
     config.apiKey = "<breez api key>"
 
     let response = try await passkey.connectWithPasskey(
-        request: ConnectWithPasskeyRequest(label: "personal")
+        request: ConnectWithPasskeyRequest()
     )
+
+    if response.labels.count > 1 {
+        // Returning multi-wallet user: let them pick a label, then sign in to it.
+        // let chosen = promptForLabel(response.labels)
+        // return try await passkey.signIn(request: SignInRequest(label: chosen))
+    }
 
     let sdk = try await connect(
         request: ConnectRequest(

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -74,8 +74,20 @@ const connectWithPasskey = async () => {
   })
 
   // ANCHOR: connect-with-passkey
-  // Not available on web; use two buttons (signIn / register) instead.
-  const response = await passkey.signIn({ label: 'personal' })
+  // Single-button flow. On web it works only where the browser supports
+  // immediate mediation; checkAvailability reports it. Otherwise use the
+  // two-button flow (register / signIn).
+  const availability = await passkey.checkAvailability()
+  if (availability.type !== 'available' || !availability.immediateMediationSupported) {
+    throw new Error('Use the two-button flow (register / signIn) on this browser')
+  }
+  // No label: a returning user's wallets are discovered (response.labels,
+  // with wallet being the default); a new user gets a freshly registered
+  // default wallet.
+  const response = await passkey.connectWithPasskey({})
+  if (response.labels.length > 1) {
+    // Multiple wallets: let the user pick, then signIn to the chosen label.
+  }
 
   const config = defaultConfig('mainnet')
   const sdk = await connect({ config, seed: response.wallet.seed, storageDir: './.data' })

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -75,10 +75,10 @@ const connectWithPasskey = async () => {
 
   // ANCHOR: connect-with-passkey
   // Single-button flow. On web it works only where the browser supports
-  // immediate mediation; checkAvailability reports it. Otherwise use the
-  // two-button flow (register / signIn).
+  // immediate mediation; supportsImmediateMediation() reports it. Otherwise
+  // use the two-button flow (register / signIn).
   const availability = await passkey.checkAvailability()
-  if (availability.type !== 'available' || !availability.immediateMediationSupported) {
+  if (availability.type !== 'available' || !(await passkey.supportsImmediateMediation())) {
     throw new Error('Use the two-button flow (register / signIn) on this browser')
   }
   // No label: a returning user's wallets are discovered (response.labels,

--- a/docs/breez-sdk/src/guide/passkey_onboarding.md
+++ b/docs/breez-sdk/src/guide/passkey_onboarding.md
@@ -55,7 +55,7 @@ Call it without a label to support multiple wallets per passkey: {{#name labels}
 
 ### Web flow
 
-{{#name PasskeyClient.connect_with_passkey}} works on web too, **where the browser supports immediate mediation** (recent Chromium). Check {{#name immediate_mediation_supported}} on {{#name PasskeyClient.check_availability}} and use the same single-button unified flow.
+{{#name PasskeyClient.connect_with_passkey}} works on web too, **where the browser supports immediate mediation** (recent Chromium). Check {{#name PasskeyClient.supports_immediate_mediation}} and use the same single-button unified flow.
 
 Where it isn't supported (Safari, Firefox, older browsers), present two buttons: **Create a new passkey** (calls {{#name PasskeyClient.register}}) and **Sign in with a passkey** (calls {{#name PasskeyClient.sign_in}}). Without immediate mediation, WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect the flow.
 

--- a/docs/breez-sdk/src/guide/passkey_onboarding.md
+++ b/docs/breez-sdk/src/guide/passkey_onboarding.md
@@ -39,7 +39,7 @@ Call {{#name PasskeyClient.check_availability}} before showing the passkey butto
 The right flow depends on the platform:
 
 - **iOS / Android** use a single-call unified flow backed by {{#name PasskeyClient.connect_with_passkey}}.
-- **Web** uses two buttons ("Create a new passkey" and "Sign in with a passkey") and lets the user pick.
+- **Web** uses the same unified flow where the browser supports immediate mediation, and two buttons ("Create a new passkey" / "Sign in with a passkey") otherwise.
 
 For explicit control over each path, call {{#name PasskeyClient.sign_in}} and {{#name PasskeyClient.register}} directly.
 
@@ -49,13 +49,15 @@ One "Use Passkey" button: a silent sign-in for returning users, with automatic f
 
 The response's {{#name credential}} field carries whichever credential signed in or was registered. See [Credential metadata](./passkey_credential_metadata.md) for using it.
 
+Call it without a label to support multiple wallets per passkey: `labels` then holds the returning user's full set (the response wallet is the default label). Show a picker when it has more than one entry and {{#name PasskeyClient.sign_in}} to the chosen label.
+
 {{#tabs passkey:connect-with-passkey}}
 
-### Two-button flow (Web)
+### Web flow
 
-On web, present two buttons: **Create a new passkey** (calls {{#name PasskeyClient.register}}) and **Sign in with a passkey** (calls {{#name PasskeyClient.sign_in}}).
+{{#name PasskeyClient.connect_with_passkey}} works on web too, **where the browser supports immediate mediation** (recent Chromium). Check `immediate_mediation_supported` on {{#name PasskeyClient.check_availability}} and use the same single-button unified flow.
 
-{{#name PasskeyClient.connect_with_passkey}} is not available on the WASM target. WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect the flow. Let the user choose.
+Where it isn't supported (Safari, Firefox, older browsers), present two buttons: **Create a new passkey** (calls {{#name PasskeyClient.register}}) and **Sign in with a passkey** (calls {{#name PasskeyClient.sign_in}}). Without immediate mediation, WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect the flow.
 
 ### Sign in and register
 

--- a/docs/breez-sdk/src/guide/passkey_onboarding.md
+++ b/docs/breez-sdk/src/guide/passkey_onboarding.md
@@ -49,13 +49,13 @@ One "Use Passkey" button: a silent sign-in for returning users, with automatic f
 
 The response's {{#name credential}} field carries whichever credential signed in or was registered. See [Credential metadata](./passkey_credential_metadata.md) for using it.
 
-Call it without a label to support multiple wallets per passkey: `labels` then holds the returning user's full set (the response wallet is the default label). Show a picker when it has more than one entry and {{#name PasskeyClient.sign_in}} to the chosen label.
+Call it without a label to support multiple wallets per passkey: {{#name labels}} then holds the returning user's full set (the response wallet is the default label). Show a picker when it has more than one entry and {{#name PasskeyClient.sign_in}} to the chosen label.
 
 {{#tabs passkey:connect-with-passkey}}
 
 ### Web flow
 
-{{#name PasskeyClient.connect_with_passkey}} works on web too, **where the browser supports immediate mediation** (recent Chromium). Check `immediate_mediation_supported` on {{#name PasskeyClient.check_availability}} and use the same single-button unified flow.
+{{#name PasskeyClient.connect_with_passkey}} works on web too, **where the browser supports immediate mediation** (recent Chromium). Check {{#name immediate_mediation_supported}} on {{#name PasskeyClient.check_availability}} and use the same single-button unified flow.
 
 Where it isn't supported (Safari, Firefox, older browsers), present two buttons: **Create a new passkey** (calls {{#name PasskeyClient.register}}) and **Sign in with a passkey** (calls {{#name PasskeyClient.sign_in}}). Without immediate mediation, WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect the flow.
 

--- a/docs/breez-sdk/src/guide/uxguide_passkey.md
+++ b/docs/breez-sdk/src/guide/uxguide_passkey.md
@@ -8,7 +8,9 @@
 ### Guidelines
 
 1. **Gate passkey UI on availability.** Call {{#name PasskeyClient.check_availability}} at startup and fall back to mnemonic onboarding on unsupported devices. The same call surfaces domain-association failures, so one check covers both "device can't" and "config is broken".
-2. **Match the CTA layout to the platform.** iOS and Android: a single primary CTA backed by {{#name PasskeyClient.connect_with_passkey}} (silent sign-in for returning users, fall-through to register for new ones). Web: the same single CTA where {{#name PasskeyClient.supports_immediate_mediation}} is true, otherwise two CTAs ("Create a new passkey" / "Sign in with a passkey"), since without immediate mediation WebAuthn can't tell "no credential" from "cancel".
+2. **Match the CTA layout to the platform.**
+   - **iOS and Android:** a single primary CTA backed by {{#name PasskeyClient.connect_with_passkey}} (silent sign-in for returning users, fall-through to register for new ones).
+   - **Web:** the same single CTA where {{#name PasskeyClient.supports_immediate_mediation}} is true, otherwise two CTAs ("Create a new passkey" / "Sign in with a passkey"), since without immediate mediation WebAuthn can't tell "no credential" from "cancel".
 3. **Don't add your own consent screen.** The OS shows its own consent UI, so don't gate registration behind a separate "I understand" review step.
 4. **Cache the derived seed within a session.** A sign-in or register call avoids re-prompting for later {{#name PasskeyLabels.list}} / {{#name PasskeyLabels.store}} calls in the same session. For reuse across an app relaunch, keep the seed in your own in-memory cache and pass it to {{#name connect}}; never persist it to disk.
 5. **Never persist the derived mnemonic.** Re-derive it from the passkey and label on each session. Persisting it would bypass the OS authentication prompt.

--- a/docs/breez-sdk/src/guide/uxguide_passkey.md
+++ b/docs/breez-sdk/src/guide/uxguide_passkey.md
@@ -8,7 +8,7 @@
 ### Guidelines
 
 1. **Gate passkey UI on availability.** Call {{#name PasskeyClient.check_availability}} at startup and fall back to mnemonic onboarding on unsupported devices. The same call surfaces domain-association failures, so one check covers both "device can't" and "config is broken".
-2. **Match the CTA layout to the platform.** iOS and Android: a single primary CTA backed by {{#name PasskeyClient.connect_with_passkey}} (silent sign-in for returning users, fall-through to register for new ones). Web: the same single CTA where {{#name immediate_mediation_supported}} is set on {{#name PasskeyClient.check_availability}}, otherwise two CTAs ("Create a new passkey" / "Sign in with a passkey"), since without immediate mediation WebAuthn can't tell "no credential" from "cancel".
+2. **Match the CTA layout to the platform.** iOS and Android: a single primary CTA backed by {{#name PasskeyClient.connect_with_passkey}} (silent sign-in for returning users, fall-through to register for new ones). Web: the same single CTA where {{#name PasskeyClient.supports_immediate_mediation}} is true, otherwise two CTAs ("Create a new passkey" / "Sign in with a passkey"), since without immediate mediation WebAuthn can't tell "no credential" from "cancel".
 3. **Don't add your own consent screen.** The OS shows its own consent UI, so don't gate registration behind a separate "I understand" review step.
 4. **Cache the derived seed within a session.** A sign-in or register call avoids re-prompting for later {{#name PasskeyLabels.list}} / {{#name PasskeyLabels.store}} calls in the same session. For reuse across an app relaunch, keep the seed in your own in-memory cache and pass it to {{#name connect}}; never persist it to disk.
 5. **Never persist the derived mnemonic.** Re-derive it from the passkey and label on each session. Persisting it would bypass the OS authentication prompt.
@@ -27,7 +27,7 @@ Browsers and native authenticators expose different error semantics, so the reco
 | Returning user | **1** (one assertion derives master + label) |
 | New user | **2** (1 create, 1 assertion) |
 
-**Web:** where the browser supports immediate mediation ({{#name immediate_mediation_supported}} on {{#name PasskeyClient.check_availability}}), the same single "Use Passkey" button backed by {{#name PasskeyClient.connect_with_passkey}}. Otherwise two buttons, "Create a new passkey" and "Sign in with a passkey": without immediate mediation WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect which the user wants.
+**Web:** where the browser supports immediate mediation ({{#name PasskeyClient.supports_immediate_mediation}}), the same single "Use Passkey" button backed by {{#name PasskeyClient.connect_with_passkey}}. Otherwise two buttons, "Create a new passkey" and "Sign in with a passkey": without immediate mediation WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect which the user wants.
 
 See [Onboarding](./passkey_onboarding.md) for the call shapes.
 

--- a/docs/breez-sdk/src/guide/uxguide_passkey.md
+++ b/docs/breez-sdk/src/guide/uxguide_passkey.md
@@ -8,7 +8,7 @@
 ### Guidelines
 
 1. **Gate passkey UI on availability.** Call {{#name PasskeyClient.check_availability}} at startup and fall back to mnemonic onboarding on unsupported devices. The same call surfaces domain-association failures, so one check covers both "device can't" and "config is broken".
-2. **Match the CTA layout to the platform.** iOS and Android: a single primary CTA backed by {{#name PasskeyClient.connect_with_passkey}} (silent sign-in for returning users, fall-through to register for new ones). Web: two CTAs, "Create a new passkey" and "Sign in with a passkey", since WebAuthn can't tell "no credential" from "cancel" for auto-detection.
+2. **Match the CTA layout to the platform.** iOS and Android: a single primary CTA backed by {{#name PasskeyClient.connect_with_passkey}} (silent sign-in for returning users, fall-through to register for new ones). Web: the same single CTA where `immediate_mediation_supported` is set on {{#name PasskeyClient.check_availability}}, otherwise two CTAs ("Create a new passkey" / "Sign in with a passkey"), since without immediate mediation WebAuthn can't tell "no credential" from "cancel".
 3. **Don't add your own consent screen.** The OS shows its own consent UI, so don't gate registration behind a separate "I understand" review step.
 4. **Cache the derived seed within a session.** A sign-in or register call avoids re-prompting for later {{#name PasskeyLabels.list}} / {{#name PasskeyLabels.store}} calls in the same session. For reuse across an app relaunch, keep the seed in your own in-memory cache and pass it to {{#name connect}}; never persist it to disk.
 5. **Never persist the derived mnemonic.** Re-derive it from the passkey and label on each session. Persisting it would bypass the OS authentication prompt.
@@ -27,7 +27,7 @@ Browsers and native authenticators expose different error semantics, so the reco
 | Returning user | **1** (one assertion derives master + label) |
 | New user | **2** (1 create, 1 assertion) |
 
-**Web:** two buttons, "Create a new passkey" and "Sign in with a passkey". WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect which the user wants. {{#name PasskeyClient.connect_with_passkey}} is not surfaced on the WASM target.
+**Web:** where the browser supports immediate mediation (`immediate_mediation_supported` on {{#name PasskeyClient.check_availability}}), the same single "Use Passkey" button backed by {{#name PasskeyClient.connect_with_passkey}}. Otherwise two buttons, "Create a new passkey" and "Sign in with a passkey": without immediate mediation WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect which the user wants.
 
 See [Onboarding](./passkey_onboarding.md) for the call shapes.
 

--- a/docs/breez-sdk/src/guide/uxguide_passkey.md
+++ b/docs/breez-sdk/src/guide/uxguide_passkey.md
@@ -8,7 +8,7 @@
 ### Guidelines
 
 1. **Gate passkey UI on availability.** Call {{#name PasskeyClient.check_availability}} at startup and fall back to mnemonic onboarding on unsupported devices. The same call surfaces domain-association failures, so one check covers both "device can't" and "config is broken".
-2. **Match the CTA layout to the platform.** iOS and Android: a single primary CTA backed by {{#name PasskeyClient.connect_with_passkey}} (silent sign-in for returning users, fall-through to register for new ones). Web: the same single CTA where `immediate_mediation_supported` is set on {{#name PasskeyClient.check_availability}}, otherwise two CTAs ("Create a new passkey" / "Sign in with a passkey"), since without immediate mediation WebAuthn can't tell "no credential" from "cancel".
+2. **Match the CTA layout to the platform.** iOS and Android: a single primary CTA backed by {{#name PasskeyClient.connect_with_passkey}} (silent sign-in for returning users, fall-through to register for new ones). Web: the same single CTA where {{#name immediate_mediation_supported}} is set on {{#name PasskeyClient.check_availability}}, otherwise two CTAs ("Create a new passkey" / "Sign in with a passkey"), since without immediate mediation WebAuthn can't tell "no credential" from "cancel".
 3. **Don't add your own consent screen.** The OS shows its own consent UI, so don't gate registration behind a separate "I understand" review step.
 4. **Cache the derived seed within a session.** A sign-in or register call avoids re-prompting for later {{#name PasskeyLabels.list}} / {{#name PasskeyLabels.store}} calls in the same session. For reuse across an app relaunch, keep the seed in your own in-memory cache and pass it to {{#name connect}}; never persist it to disk.
 5. **Never persist the derived mnemonic.** Re-derive it from the passkey and label on each session. Persisting it would bypass the OS authentication prompt.
@@ -27,7 +27,7 @@ Browsers and native authenticators expose different error semantics, so the reco
 | Returning user | **1** (one assertion derives master + label) |
 | New user | **2** (1 create, 1 assertion) |
 
-**Web:** where the browser supports immediate mediation (`immediate_mediation_supported` on {{#name PasskeyClient.check_availability}}), the same single "Use Passkey" button backed by {{#name PasskeyClient.connect_with_passkey}}. Otherwise two buttons, "Create a new passkey" and "Sign in with a passkey": without immediate mediation WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect which the user wants.
+**Web:** where the browser supports immediate mediation ({{#name immediate_mediation_supported}} on {{#name PasskeyClient.check_availability}}), the same single "Use Passkey" button backed by {{#name PasskeyClient.connect_with_passkey}}. Otherwise two buttons, "Create a new passkey" and "Sign in with a passkey": without immediate mediation WebAuthn reports "no credential" and "user cancelled" identically, so the SDK can't auto-detect which the user wants.
 
 See [Onboarding](./passkey_onboarding.md) for the call shapes.
 

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1817,7 +1817,7 @@ pub struct _PasskeyConfig {
 
 #[frb(mirror(PasskeyAvailability))]
 pub enum _PasskeyAvailability {
-    Available { immediate_mediation_supported: bool },
+    Available,
     PrfUnsupported,
     NotAssociated { source: String, reason: String },
     Skipped { reason: String },

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1817,7 +1817,7 @@ pub struct _PasskeyConfig {
 
 #[frb(mirror(PasskeyAvailability))]
 pub enum _PasskeyAvailability {
-    Available,
+    Available { immediate_mediation_supported: bool },
     PrfUnsupported,
     NotAssociated { source: String, reason: String },
     Skipped { reason: String },
@@ -1887,4 +1887,5 @@ pub struct _ConnectWithPasskeyRequest {
 pub struct _ConnectWithPasskeyResponse {
     pub wallet: Wallet,
     pub credential: Option<PasskeyCredential>,
+    pub labels: Vec<String>,
 }


### PR DESCRIPTION
This PR brings the SDK's unified passkey login flow, `connect_with_passkey`, to the web.

`connect_with_passkey` is a unified entry point that handles silent sign-in, label discovery, and fallback to registration for users without an existing passkey.

Previously, this flow was only available on native platforms because the web lacked support for silent passkey detection. Web support requires WebAuthn Immediate UI (formerly “immediate mediation”) capability, which enables browsers to check for available credentials without showing a authentication prompt.

With this capability now generally available in Chrome 149, the unified flow can now be used on the web as well.

## What this adds

* Adds a `supportsImmediateMediation()` method to the WASM `PasskeyClient`, allowing hosts to choose between a unified `connectWithPasskey` flow or separate `register` / `signIn` flows.
* Enables `connectWithPasskey` on the WASM `PasskeyClient`.
  * When called without a label, `connectWithPasskey` returns the user's discovered wallet `labels`, allowing hosts to present a wallet picker for multi-wallet users.
* The web provider now honors `preferImmediatelyAvailableCredentials`, using WebAuthn Immediate UI when supported. Returning users with a pinned credential still go directly to biometric authentication.


## How it works

On supported browsers, the provider uses `uiMode: "immediate"` to perform a silent passkey check. Browsers without WebAuthn Immediate UI continue to use the existing flow. The fast "no credential" path is only used for Immediate UI, where the browser can reject without displaying any UI.

Discovered wallet labels were already available internally during sign-in; this change simply exposes them in the `connectWithPasskey` response. Native behavior is unchanged.

