### PR TITLE
fix(swift): bump Swift-BigInt to 2.4.0 for current Swift toolchains

### DIFF
--- a/crates/breez-sdk/bindings/langs/swift/Package.resolved
+++ b/crates/breez-sdk/bindings/langs/swift/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mkrd/Swift-BigInt.git",
         "state": {
           "branch": null,
-          "revision": "b07e961f4c999671cf8c2dc80e740899e8946013",
-          "version": "2.3.0"
+          "revision": "7e2117797cd1b608303cc2da1a3a2263cc4e7727",
+          "version": "2.4.0"
         }
       }
     ]

--- a/crates/breez-sdk/bindings/langs/swift/Package.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "BreezSdkSpark", targets: ["breez_sdk_sparkFFI", "BreezSdkSpark", "PasskeyPRFHelperObjC"])
     ],
     dependencies: [
-        .package(url: "https://github.com/mkrd/Swift-BigInt.git", from: "2.0.0")
+        .package(url: "https://github.com/mkrd/Swift-BigInt.git", from: "2.4.0")
     ],
     targets: [
         .binaryTarget(name: "breez_sdk_sparkFFI", path: "./breez_sdk_sparkFFI.xcframework"),


### PR DESCRIPTION
This PR bumps `Swift-BigInt` to `2.4.0`.

Swift bindings pinned `Swift-BigInt` at `2.0.0`, which doesn't build with current Swift toolchains, and the package failed to resolve on recent Xcode and broke CI (`CI / Docs / swift`).

