### PR TITLE
fix(swift): bump snippet Swift-BigInt pin to 2.4.0 (follow-up to #969)

### DIFF
--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Package.resolved
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mkrd/Swift-BigInt.git",
       "state" : {
-        "revision" : "b07e961f4c999671cf8c2dc80e740899e8946013",
-        "version" : "2.3.0"
+        "revision" : "7e2117797cd1b608303cc2da1a3a2263cc4e7727",
+        "version" : "2.4.0"
       }
     }
   ],


### PR DESCRIPTION
#969 bumped Swift-BigInt to 2.4.0 in `crates/breez-sdk/bindings/langs/swift` but overlooked the doc-snippets package, which references that package by path and so inherits its `from: "2.4.0"` constraint. Its `Package.resolved` was left pinned at 2.3.0.

Not a hard failure (SwiftPM auto-resolves up at build time), but it leaves the committed pin inconsistent and dirties `Package.resolved` on the first local snippet build. This realigns it with the revision pinned in #969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)