### PR TITLE
perf(spark): batch FROST signing and derive owned-leaf pubkeys locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,6 +1496,7 @@ dependencies = [
  "chrono",
  "flashnet",
  "frost-secp256k1-tr",
+ "futures",
  "hex",
  "k256",
  "lnurl-models",

--- a/crates/breez-sdk/breez-itest/src/turnkey.rs
+++ b/crates/breez-sdk/breez-itest/src/turnkey.rs
@@ -28,6 +28,7 @@ pub fn turnkey_config_from_env() -> Option<TurnkeyConfig> {
         // non-default accounts against the live API.
         account_number: var("TURNKEY_ACCOUNT_NUMBER").and_then(|v| v.parse().ok()),
         retry: None,
+        max_rps: None,
     })
 }
 

--- a/crates/breez-sdk/breez-itest/tests/turnkey_sign_frost_chunking.rs
+++ b/crates/breez-sdk/breez-itest/tests/turnkey_sign_frost_chunking.rs
@@ -1,0 +1,97 @@
+//! Live coverage that a batched `sign_frost` survives past Turnkey's single-
+//! activity ceiling.
+//!
+//! The batched send/coop-exit/claim/timelock paths pack one to three FROST jobs
+//! per leaf into a single `sign_frost` call, and nothing upstream caps the leaf
+//! count (a full-balance coop-exit signs every wallet leaf). A single Turnkey
+//! `SPARK_SIGN_FROST` activity fails with HTTP 500 (an internal ~15s timeout)
+//! past roughly 250 to 300 jobs, well below its ~11 MB request-body cap, so
+//! `TurnkeySparkSigner` chunks its submissions (`MAX_FROST_JOBS_PER_ACTIVITY`).
+//! This signs a batch above that ceiling and checks one share returns per job,
+//! which only holds if the chunking splits the batch across activities.
+#![cfg(feature = "turnkey")]
+
+use anyhow::Result;
+use bitcoin::secp256k1::{Secp256k1, SecretKey};
+use breez_sdk_itest::turnkey::provision_turnkey_wallet;
+use breez_sdk_spark::signer::{
+    ExternalFrostDerivation, ExternalFrostJob, ExternalIdentifier, ExternalSigningCommitments,
+    ExternalTreeNodeId, IdentifierCommitmentPair,
+};
+use tracing::info;
+
+/// FROST jobs carry one commitment per signing operator; the production pool has
+/// three, so each synthetic job is representative in size.
+const OPERATORS: u8 = 3;
+
+/// Comfortably above Turnkey's ~250 to 300 job single-activity ceiling, so a
+/// success proves the signer split the batch across activities rather than
+/// submitting it as one (which would fail).
+const BATCH_JOBS: usize = 300;
+
+/// Builds `n` synthetic FROST jobs. Every field is a real, deserializable value
+/// (curve points from throwaway keys, 32-byte scalars for identifiers), so
+/// Turnkey signs each against a locally derived key and returns a real share;
+/// only the leaf id varies per job, matching a real batch's shape.
+fn build_jobs(n: usize) -> Vec<ExternalFrostJob> {
+    let secp = Secp256k1::new();
+    let point = |b: u8| {
+        SecretKey::from_slice(&[b.max(1); 32])
+            .unwrap()
+            .public_key(&secp)
+            .serialize()
+            .to_vec()
+    };
+    let verifying_key = point(7);
+    let operator_commitments: Vec<IdentifierCommitmentPair> = (0..OPERATORS)
+        .map(|k| {
+            // 32-byte big-endian scalar (k+1): a valid, canonical FROST identifier.
+            let mut id = [0u8; 32];
+            id[31] = k + 1;
+            IdentifierCommitmentPair {
+                identifier: ExternalIdentifier { bytes: id.to_vec() },
+                commitment: ExternalSigningCommitments {
+                    hiding: point(10 + k),
+                    binding: point(20 + k),
+                },
+            }
+        })
+        .collect();
+
+    (0..n)
+        .map(|i| ExternalFrostJob {
+            derivation: ExternalFrostDerivation::SigningLeaf {
+                leaf_id: ExternalTreeNodeId {
+                    id: format!("00000000-0000-7000-8000-{i:012x}"),
+                },
+            },
+            sighash: vec![0u8; 32],
+            verifying_key: verifying_key.clone(),
+            operator_commitments: operator_commitments.clone(),
+            adaptor_public_key: None,
+        })
+        .collect()
+}
+
+#[test_log::test(tokio::test)]
+async fn sign_frost_chunks_batch_above_single_activity_limit() -> Result<()> {
+    let (config, _guard) = provision_turnkey_wallet().await?;
+    let signers = breez_sdk_spark::turnkey::create_turnkey_signer(config)
+        .await
+        .map_err(|e| anyhow::anyhow!("create_turnkey_signer failed: {e}"))?;
+
+    let jobs = build_jobs(BATCH_JOBS);
+    let shares = signers
+        .spark_signer
+        .sign_frost(jobs)
+        .await
+        .map_err(|e| anyhow::anyhow!("sign_frost({BATCH_JOBS} jobs) failed: {e}"))?;
+
+    assert_eq!(
+        shares.len(),
+        BATCH_JOBS,
+        "chunked sign_frost must return one share per job"
+    );
+    info!("[Turnkey] sign_frost chunked {BATCH_JOBS} jobs into shares");
+    Ok(())
+}

--- a/crates/breez-sdk/core/Cargo.toml
+++ b/crates/breez-sdk/core/Cargo.toml
@@ -49,6 +49,7 @@ platform-utils.workspace = true
 chrono.workspace = true
 utils.workspace = true
 flashnet.workspace = true
+futures.workspace = true
 hex.workspace = true
 lnurl-models.workspace = true
 macros.workspace = true

--- a/crates/breez-sdk/core/src/signer/external_spark.rs
+++ b/crates/breez-sdk/core/src/signer/external_spark.rs
@@ -38,6 +38,14 @@ pub trait ExternalSparkSigner: Send + Sync {
         leaf_id: ExternalTreeNodeId,
     ) -> Result<PublicKeyBytes, SignerError>;
 
+    /// Whether this signer is backed by a remote service, so its operations are
+    /// network round-trips rather than local computation. Local signers return
+    /// false; a hosted signer like Turnkey returns true so the SDK can avoid
+    /// redundant calls, e.g. re-deriving keys for leaves it has already verified.
+    fn is_remote(&self) -> bool {
+        false
+    }
+
     /// The static-deposit signing public key at `index`.
     async fn get_static_deposit_public_key(
         &self,

--- a/crates/breez-sdk/core/src/signer/external_spark_adapter.rs
+++ b/crates/breez-sdk/core/src/signer/external_spark_adapter.rs
@@ -66,6 +66,10 @@ impl spark_wallet::SparkSigner for ExternalSparkSignerAdapter {
             .map_err(to_spark_err)
     }
 
+    fn is_remote(&self) -> bool {
+        self.inner.is_remote()
+    }
+
     async fn get_static_deposit_public_key(&self, index: u32) -> Result<PublicKey, SignerError> {
         self.inner
             .get_static_deposit_public_key(index)

--- a/crates/breez-sdk/core/src/turnkey/config.rs
+++ b/crates/breez-sdk/core/src/turnkey/config.rs
@@ -89,4 +89,11 @@ pub struct TurnkeyConfig {
     pub account_number: Option<u32>,
     /// Retry policy for Turnkey requests. Unset uses the default policy.
     pub retry: Option<TurnkeyRetryConfig>,
+    /// Maximum requests per second the client issues to this suborganization,
+    /// across all concurrent operations. The client paces itself to this rate.
+    /// Unset uses Turnkey's documented per-suborganization cap of 10 RPS; set it
+    /// to the account's actual limit if a different one is provisioned. Must be
+    /// greater than 0 when set: 0 is rejected at connect.
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub max_rps: Option<u32>,
 }

--- a/crates/breez-sdk/core/src/turnkey/error.rs
+++ b/crates/breez-sdk/core/src/turnkey/error.rs
@@ -6,6 +6,9 @@ pub enum TurnkeyError {
     #[error("invalid Turnkey API key: {0}")]
     InvalidApiKey(String),
 
+    #[error("invalid Turnkey config: {0}")]
+    InvalidConfig(String),
+
     #[error("failed to serialize request: {0}")]
     Serialize(String),
 

--- a/crates/breez-sdk/core/src/turnkey/spark_signer.rs
+++ b/crates/breez-sdk/core/src/turnkey/spark_signer.rs
@@ -25,7 +25,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 use std::sync::Arc;
 
-use futures::{StreamExt, TryStreamExt};
 use tokio::sync::Mutex;
 
 use bitcoin::bip32::DerivationPath;
@@ -274,13 +273,8 @@ fn ffi_public_key_map(
 /// to 300 jobs, far below its ~11 MB request-body cap. The batched send/coop-exit/
 /// claim/timelock paths can exceed that (a full-balance coop-exit signs every
 /// wallet leaf, one to three jobs each), so submissions are chunked with wide
-/// margin. Measured by the probe in `breez-itest/tests/turnkey_frost_batch_limit`.
+/// margin. Exercised by `breez-itest/tests/turnkey_sign_frost_chunking`.
 const MAX_FROST_JOBS_PER_ACTIVITY: usize = 100;
-
-/// How many chunk activities to submit concurrently. Kept low so a many-chunk
-/// batch stays within Turnkey's 10 RPS per-suborganization rate limit (each
-/// activity is a submit plus a few status polls).
-const SIGN_FROST_CHUNK_CONCURRENCY: usize = 4;
 
 pub(crate) struct TurnkeySparkSigner {
     client: Arc<TurnkeyClient>,
@@ -450,21 +444,17 @@ impl TurnkeySparkSigner {
         jobs: &[FrostJob],
     ) -> Result<Vec<FrostShareResult>, SignerError> {
         let sign_with = self.spark_identity_address().await?;
-        // One activity per chunk (see MAX_FROST_JOBS_PER_ACTIVITY), submitted with
-        // bounded concurrency and reassembled in job order. FROST jobs are
-        // independent, so splitting the batch is signing-equivalent to one call.
-        let chunks: Vec<Vec<FrostJob>> = jobs
-            .chunks(MAX_FROST_JOBS_PER_ACTIVITY)
-            .map(<[FrostJob]>::to_vec)
-            .collect();
-        let chunk_shares: Vec<Vec<FrostShareResult>> = futures::stream::iter(chunks)
-            .map(|chunk| {
-                let sign_with = sign_with.clone();
-                async move { self.sign_frost_chunk(sign_with, &chunk).await }
-            })
-            .buffered(SIGN_FROST_CHUNK_CONCURRENCY)
-            .try_collect()
-            .await?;
+        // One activity per chunk (see MAX_FROST_JOBS_PER_ACTIVITY), all fired
+        // concurrently and reassembled in job order. FROST jobs are independent,
+        // so splitting the batch is signing-equivalent to one call. The Turnkey
+        // client paces submissions to the per-suborg rate limit, so no concurrency
+        // cap is needed here.
+        let chunk_futures = jobs.chunks(MAX_FROST_JOBS_PER_ACTIVITY).map(|chunk| {
+            let sign_with = sign_with.clone();
+            async move { self.sign_frost_chunk(sign_with, chunk).await }
+        });
+        let chunk_shares: Vec<Vec<FrostShareResult>> =
+            futures::future::try_join_all(chunk_futures).await?;
         Ok(chunk_shares.into_iter().flatten().collect())
     }
 

--- a/crates/breez-sdk/core/src/turnkey/spark_signer.rs
+++ b/crates/breez-sdk/core/src/turnkey/spark_signer.rs
@@ -564,6 +564,10 @@ impl ExternalSparkSigner for TurnkeySparkSigner {
         ))
     }
 
+    fn is_remote(&self) -> bool {
+        true
+    }
+
     async fn get_static_deposit_public_key(
         &self,
         index: u32,

--- a/crates/breez-sdk/core/src/turnkey/spark_signer.rs
+++ b/crates/breez-sdk/core/src/turnkey/spark_signer.rs
@@ -959,6 +959,7 @@ mod tests {
             network: Network::Regtest,
             account_number: Some(0),
             retry: None,
+            max_rps: None,
         };
         Arc::new(TurnkeyClient::new(&config, http).unwrap())
     }

--- a/crates/breez-sdk/core/src/turnkey/spark_signer.rs
+++ b/crates/breez-sdk/core/src/turnkey/spark_signer.rs
@@ -25,6 +25,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 use std::sync::Arc;
 
+use futures::{StreamExt, TryStreamExt};
 use tokio::sync::Mutex;
 
 use bitcoin::bip32::DerivationPath;
@@ -268,6 +269,19 @@ fn ffi_public_key_map(
         .collect()
 }
 
+/// Maximum FROST jobs per `SPARK_SIGN_FROST` activity. Turnkey's enclave fails a
+/// single `sign_frost` with HTTP 500 (an internal ~15s timeout) past roughly 250
+/// to 300 jobs, far below its ~11 MB request-body cap. The batched send/coop-exit/
+/// claim/timelock paths can exceed that (a full-balance coop-exit signs every
+/// wallet leaf, one to three jobs each), so submissions are chunked with wide
+/// margin. Measured by the probe in `breez-itest/tests/turnkey_frost_batch_limit`.
+const MAX_FROST_JOBS_PER_ACTIVITY: usize = 100;
+
+/// How many chunk activities to submit concurrently. Kept low so a many-chunk
+/// batch stays within Turnkey's 10 RPS per-suborganization rate limit (each
+/// activity is a submit plus a few status polls).
+const SIGN_FROST_CHUNK_CONCURRENCY: usize = 4;
+
 pub(crate) struct TurnkeySparkSigner {
     client: Arc<TurnkeyClient>,
     account: u32,
@@ -436,8 +450,33 @@ impl TurnkeySparkSigner {
         jobs: &[FrostJob],
     ) -> Result<Vec<FrostShareResult>, SignerError> {
         let sign_with = self.spark_identity_address().await?;
-        let mut signatures = Vec::with_capacity(jobs.len());
-        for job in jobs {
+        // One activity per chunk (see MAX_FROST_JOBS_PER_ACTIVITY), submitted with
+        // bounded concurrency and reassembled in job order. FROST jobs are
+        // independent, so splitting the batch is signing-equivalent to one call.
+        let chunks: Vec<Vec<FrostJob>> = jobs
+            .chunks(MAX_FROST_JOBS_PER_ACTIVITY)
+            .map(<[FrostJob]>::to_vec)
+            .collect();
+        let chunk_shares: Vec<Vec<FrostShareResult>> = futures::stream::iter(chunks)
+            .map(|chunk| {
+                let sign_with = sign_with.clone();
+                async move { self.sign_frost_chunk(sign_with, &chunk).await }
+            })
+            .buffered(SIGN_FROST_CHUNK_CONCURRENCY)
+            .try_collect()
+            .await?;
+        Ok(chunk_shares.into_iter().flatten().collect())
+    }
+
+    /// Signs one chunk of FROST jobs as a single `SPARK_SIGN_FROST` activity,
+    /// returning the shares in job order.
+    async fn sign_frost_chunk(
+        &self,
+        sign_with: String,
+        chunk: &[FrostJob],
+    ) -> Result<Vec<FrostShareResult>, SignerError> {
+        let mut signatures = Vec::with_capacity(chunk.len());
+        for job in chunk {
             signatures.push(frost_job_to_request(job).map_err(to_spark_err)?);
         }
         let result: SparkSignFrostResult = self
@@ -454,10 +493,10 @@ impl TurnkeySparkSigner {
             )
             .await
             .map_err(to_spark_err)?;
-        if result.signatures.len() != jobs.len() {
+        if result.signatures.len() != chunk.len() {
             return Err(SignerError::Generic(format!(
                 "turnkey sign_frost: expected {} shares, got {}",
-                jobs.len(),
+                chunk.len(),
                 result.signatures.len()
             )));
         }

--- a/crates/breez-sdk/core/src/turnkey/transport.rs
+++ b/crates/breez-sdk/core/src/turnkey/transport.rs
@@ -6,9 +6,10 @@
 //! the activity reaches a terminal status.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use platform_utils::time::Instant;
 use platform_utils::tokio::time::sleep;
 use platform_utils::{HttpClient, HttpResponse};
 use serde::Serialize;
@@ -117,6 +118,100 @@ pub(crate) enum OnConflict {
     Surface,
 }
 
+/// Default cap on requests per second when `TurnkeyConfig::max_rps` is unset:
+/// Turnkey's documented per-suborganization limit of 10 RPS.
+const DEFAULT_MAX_RPS: u32 = 10;
+/// Absolute floor on the inter-request gap. A mechanism guard, not the operating
+/// rate: the gap must stay non-zero so multiplicative back-off can double it, and
+/// a misconfigured rate cannot busy-fire.
+const PACE_FLOOR: Duration = Duration::from_millis(1);
+/// Ceiling on the inter-request gap, so a sustained 429 streak cannot stall the
+/// client indefinitely.
+const PACE_MAX_GAP: Duration = Duration::from_secs(5);
+/// Additive gap reduction applied once per `PACE_RECOVER_STREAK` successes.
+const PACE_RECOVER_STEP: Duration = Duration::from_millis(25);
+/// Successes between gap reductions. Additive-increase of the rate: recover
+/// gently so one lucky window does not immediately re-provoke the limit.
+const PACE_RECOVER_STREAK: u32 = 4;
+
+/// Adaptive request pacer shared across all concurrent callers of one Turnkey
+/// suborganization. The steady-state rate is the configured `max_rps`, which the
+/// pacer never exceeds; a 429 backs it off further (double the gap) and success
+/// recovers it (additive) back to that rate. Turnkey returns no `Retry-After`,
+/// so a 429 is the only throttle signal. All callers reserve emission slots from
+/// one shared cursor, so firing N requests concurrently drains them at the paced
+/// rate instead of bursting.
+struct AdaptivePacer {
+    inner: Mutex<PacerInner>,
+}
+
+struct PacerInner {
+    /// Earliest time the next request may be sent.
+    next_slot: Instant,
+    /// Current spacing between successive requests.
+    gap: Duration,
+    /// Steady-state floor on the gap, derived from the configured max rate.
+    min_gap: Duration,
+    /// Successes since the last gap reduction or throttle.
+    successes: u32,
+}
+
+impl AdaptivePacer {
+    fn new(max_rps: u32) -> Self {
+        // `max_rps` of 0 is rejected at config; `max(1)` plus `checked_div` is a
+        // defensive guard so the division can never divide by zero.
+        let min_gap = Duration::from_secs(1)
+            .checked_div(max_rps.max(1))
+            .unwrap_or(PACE_FLOOR)
+            .max(PACE_FLOOR);
+        Self {
+            inner: Mutex::new(PacerInner {
+                next_slot: Instant::now(),
+                gap: min_gap,
+                min_gap,
+                successes: 0,
+            }),
+        }
+    }
+
+    /// Reserves the next emission slot and returns how long the caller must wait
+    /// before sending. The lock is never held across the wait.
+    fn reserve(&self) -> Duration {
+        let now = Instant::now();
+        let mut inner = self.inner.lock().expect("pacer mutex poisoned");
+        let slot = inner.next_slot.max(now);
+        inner.next_slot = slot.checked_add(inner.gap).unwrap_or(slot);
+        slot.saturating_duration_since(now)
+    }
+
+    /// Records a successful request, narrowing the gap by one step every
+    /// `PACE_RECOVER_STREAK` successes (down to the configured rate).
+    fn on_success(&self) {
+        let mut inner = self.inner.lock().expect("pacer mutex poisoned");
+        inner.successes = inner.successes.saturating_add(1);
+        if inner.successes >= PACE_RECOVER_STREAK {
+            inner.successes = 0;
+            let min_gap = inner.min_gap;
+            inner.gap = inner.gap.saturating_sub(PACE_RECOVER_STEP).max(min_gap);
+        }
+    }
+
+    /// Records a 429, doubling the gap (up to `PACE_MAX_GAP`) and pushing the
+    /// cursor out so this retry and every future reservation back off. Callers
+    /// already waiting on earlier slots keep their schedule; they widen the gap
+    /// further if they also 429. Returns the new gap for the retry-budget check.
+    fn on_throttle(&self) -> Duration {
+        let now = Instant::now();
+        let mut inner = self.inner.lock().expect("pacer mutex poisoned");
+        inner.successes = 0;
+        inner.gap = inner.gap.saturating_mul(2).min(PACE_MAX_GAP);
+        inner.next_slot = inner
+            .next_slot
+            .max(now.checked_add(inner.gap).unwrap_or(now));
+        inner.gap
+    }
+}
+
 pub(crate) struct TurnkeyClient {
     http: Arc<dyn HttpClient>,
     base_url: String,
@@ -124,6 +219,7 @@ pub(crate) struct TurnkeyClient {
     pub(crate) wallet_id: String,
     stamper: ApiKeyStamper,
     retry: TurnkeyRetryConfig,
+    pacer: AdaptivePacer,
 }
 
 impl TurnkeyClient {
@@ -131,6 +227,11 @@ impl TurnkeyClient {
         config: &TurnkeyConfig,
         http: Arc<dyn HttpClient>,
     ) -> Result<Self, TurnkeyError> {
+        if config.max_rps == Some(0) {
+            return Err(TurnkeyError::InvalidConfig(
+                "max_rps must be greater than 0".to_string(),
+            ));
+        }
         Ok(Self {
             http,
             base_url: config
@@ -143,6 +244,7 @@ impl TurnkeyClient {
             wallet_id: config.wallet_id.clone(),
             stamper: ApiKeyStamper::from_hex(&config.api_private_key, &config.api_public_key)?,
             retry: config.retry.clone().unwrap_or_default(),
+            pacer: AdaptivePacer::new(config.max_rps.unwrap_or(DEFAULT_MAX_RPS)),
         })
     }
 
@@ -161,7 +263,10 @@ impl TurnkeyClient {
     /// `Retry-After` overrides the backoff delay. Every retry is bounded by the
     /// configured request timeout: a wait that would end past it (a long
     /// `Retry-After`, or a late attempt with little budget left) fails the
-    /// request with the error at hand instead of stalling.
+    /// request with the error at hand instead of stalling. The timeout is
+    /// measured from the first attempt (after the initial paced slot), so time
+    /// spent waiting behind other concurrent callers does not eat the retry
+    /// budget.
     pub(crate) async fn process_request<Req, Resp>(
         &self,
         path: &str,
@@ -181,22 +286,52 @@ impl TurnkeyClient {
         headers.insert("Content-Type".to_string(), "application/json".to_string());
         headers.insert(stamp_name, stamp_value);
 
-        let started = platform_utils::time::Instant::now();
         let timeout = self.retry.request_timeout();
         let mut attempt: u32 = 0;
+        // Set on the first attempt, after the initial paced slot. Queue wait
+        // (waiting our turn behind other concurrent callers) is deliberately
+        // excluded from the timeout: it must not consume the request's retry
+        // budget, or a deeply-queued request would arrive with none left.
+        let mut started: Option<Instant> = None;
         loop {
+            // Pace emission to the adaptive rate before every attempt, so
+            // concurrent callers self-throttle to Turnkey's per-suborg RPS limit
+            // rather than bursting into 429s.
+            let wait = self.pacer.reserve();
+            if !wait.is_zero() {
+                sleep(wait).await;
+            }
+            let started = *started.get_or_insert_with(Instant::now);
             let outcome = self
                 .http
                 .post(url.clone(), Some(headers.clone()), Some(body.clone()))
                 .await;
             match outcome {
                 Ok(resp) if resp.is_success() => {
+                    self.pacer.on_success();
                     return resp
                         .json::<Resp>()
                         .map_err(|e| TurnkeyError::Deserialize(e.to_string()));
                 }
+                // A 429 is a rate signal: widen the pacer (Turnkey sends no
+                // Retry-After) and let the next reserve() impose the back-off.
+                Ok(resp) if resp.status == 429 && attempt < self.retry.max_retries => {
+                    attempt = attempt.saturating_add(1);
+                    let backoff = self.pacer.on_throttle();
+                    if !retry_within_budget(started.elapsed(), backoff, timeout) {
+                        return Err(TurnkeyError::Http {
+                            status: resp.status,
+                            body: resp.body,
+                        });
+                    }
+                }
+                // Other transient failures (408, 5xx, conflict-retry) are not
+                // rate signals, so back off on the exponential schedule and leave
+                // the pacer untouched. 429 is excluded explicitly so this arm's
+                // behavior does not depend on the 429 arm above coming first.
                 Ok(resp)
                     if attempt < self.retry.max_retries
+                        && resp.status != 429
                         && (is_retryable_status(resp.status)
                             || (resp.status == 409 && on_conflict == OnConflict::Retry)) =>
                 {
@@ -396,5 +531,61 @@ mod tests {
             Duration::ZERO,
             timeout
         ));
+    }
+
+    #[test]
+    fn pacer_backs_off_on_throttle_and_recovers_on_success() {
+        let pacer = AdaptivePacer::new(10);
+        // 1s / 10 RPS.
+        let min_gap = Duration::from_millis(100);
+
+        // Fresh pacer: the first slot is immediate, the next is spaced by the
+        // configured-rate gap.
+        assert_eq!(pacer.reserve(), Duration::ZERO);
+        let second = pacer.reserve();
+        assert!(second > Duration::from_millis(50) && second <= min_gap);
+
+        // Each 429 doubles the gap (multiplicative decrease of the rate).
+        let g1 = pacer.on_throttle();
+        let g2 = pacer.on_throttle();
+        assert_eq!(g1, min_gap.saturating_mul(2));
+        assert_eq!(g2, g1.saturating_mul(2));
+
+        // Sustained throttling saturates at the ceiling, never beyond.
+        for _ in 0..10 {
+            assert!(pacer.on_throttle() <= PACE_MAX_GAP);
+        }
+        assert_eq!(pacer.on_throttle(), PACE_MAX_GAP);
+
+        // Sustained success walks the gap back down to the configured rate
+        // (additive increase), and stops there.
+        for _ in 0..10_000 {
+            pacer.on_success();
+        }
+        assert_eq!(pacer.on_throttle(), min_gap.saturating_mul(2));
+    }
+
+    #[test]
+    fn pacer_steady_state_gap_tracks_configured_rate() {
+        // A faster configured rate settles at a smaller gap.
+        let fast = AdaptivePacer::new(100);
+        for _ in 0..10_000 {
+            fast.on_success();
+        }
+        assert_eq!(
+            fast.on_throttle(),
+            Duration::from_millis(10).saturating_mul(2)
+        );
+
+        // Defensive: config rejects 0, but the pacer still never divides by
+        // zero, clamping to 1 RPS (a 1s gap).
+        let guarded = AdaptivePacer::new(0);
+        for _ in 0..10_000 {
+            guarded.on_success();
+        }
+        assert_eq!(
+            guarded.on_throttle(),
+            Duration::from_secs(1).saturating_mul(2)
+        );
     }
 }

--- a/crates/breez-sdk/core/src/turnkey/transport.rs
+++ b/crates/breez-sdk/core/src/turnkey/transport.rs
@@ -174,14 +174,30 @@ impl AdaptivePacer {
         }
     }
 
-    /// Reserves the next emission slot and returns how long the caller must wait
-    /// before sending. The lock is never held across the wait.
-    fn reserve(&self) -> Duration {
+    /// Reserves the next emission slot, returning a guard that carries the wait
+    /// and reclaims the slot if the caller is dropped before sending. The lock is
+    /// never held across the wait.
+    ///
+    /// A dropped-before-commit reservation (the request future cancelled during
+    /// the pacing wait) would otherwise leave the cursor advanced with nothing
+    /// sent, so a burst of cancellations would push the cursor far ahead and make
+    /// the next real request wait needlessly. The guard rolls the cursor back on
+    /// such a drop; [`SlotReservation::commit`] disarms it once the request is
+    /// actually sent.
+    fn reserve(&self) -> SlotReservation<'_> {
         let now = Instant::now();
         let mut inner = self.inner.lock().expect("pacer mutex poisoned");
-        let slot = inner.next_slot.max(now);
-        inner.next_slot = slot.checked_add(inner.gap).unwrap_or(slot);
-        slot.saturating_duration_since(now)
+        let prev_slot = inner.next_slot;
+        let slot = prev_slot.max(now);
+        let reserved = slot.checked_add(inner.gap).unwrap_or(slot);
+        inner.next_slot = reserved;
+        SlotReservation {
+            pacer: self,
+            wait: slot.saturating_duration_since(now),
+            prev_slot,
+            reserved,
+            committed: false,
+        }
     }
 
     /// Records a successful request, narrowing the gap by one step every
@@ -209,6 +225,46 @@ impl AdaptivePacer {
             .next_slot
             .max(now.checked_add(inner.gap).unwrap_or(now));
         inner.gap
+    }
+}
+
+/// A reserved emission slot. Holds the wait until the slot opens and, until
+/// [`commit`](Self::commit) is called, rolls the pacer cursor back on drop so a
+/// cancelled request does not consume its slot.
+struct SlotReservation<'a> {
+    pacer: &'a AdaptivePacer,
+    wait: Duration,
+    /// Cursor value before this reservation, restored on rollback.
+    prev_slot: Instant,
+    /// Cursor value this reservation set. Rollback applies only while the cursor
+    /// still holds it: once a later caller has advanced past our slot, their
+    /// schedule depends on it, so we leave it in place and reclaim nothing.
+    reserved: Instant,
+    committed: bool,
+}
+
+impl SlotReservation<'_> {
+    /// How long the caller must wait before sending.
+    fn wait(&self) -> Duration {
+        self.wait
+    }
+
+    /// Marks the slot as used, so dropping the guard no longer rolls it back.
+    /// Called once the request is actually being sent.
+    fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for SlotReservation<'_> {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        let mut inner = self.pacer.inner.lock().expect("pacer mutex poisoned");
+        if inner.next_slot == self.reserved {
+            inner.next_slot = self.prev_slot;
+        }
     }
 }
 
@@ -297,10 +353,14 @@ impl TurnkeyClient {
             // Pace emission to the adaptive rate before every attempt, so
             // concurrent callers self-throttle to Turnkey's per-suborg RPS limit
             // rather than bursting into 429s.
-            let wait = self.pacer.reserve();
+            let reservation = self.pacer.reserve();
+            let wait = reservation.wait();
             if !wait.is_zero() {
                 sleep(wait).await;
             }
+            // Past the pacing wait: the request is about to go out, so keep the
+            // slot even if the POST below is later cancelled.
+            reservation.commit();
             let started = *started.get_or_insert_with(Instant::now);
             let outcome = self
                 .http
@@ -540,10 +600,13 @@ mod tests {
         let min_gap = Duration::from_millis(100);
 
         // Fresh pacer: the first slot is immediate, the next is spaced by the
-        // configured-rate gap.
-        assert_eq!(pacer.reserve(), Duration::ZERO);
+        // configured-rate gap. Commit each so the cursor advances.
+        let first = pacer.reserve();
+        assert_eq!(first.wait(), Duration::ZERO);
+        first.commit();
         let second = pacer.reserve();
-        assert!(second > Duration::from_millis(50) && second <= min_gap);
+        assert!(second.wait() > Duration::from_millis(50) && second.wait() <= min_gap);
+        second.commit();
 
         // Each 429 doubles the gap (multiplicative decrease of the rate).
         let g1 = pacer.on_throttle();
@@ -563,6 +626,21 @@ mod tests {
             pacer.on_success();
         }
         assert_eq!(pacer.on_throttle(), min_gap.saturating_mul(2));
+    }
+
+    #[test]
+    fn pacer_reclaims_slot_when_reservation_dropped_uncommitted() {
+        let pacer = AdaptivePacer::new(10);
+        let min_gap = Duration::from_millis(100);
+
+        // Commit one slot so the cursor sits one gap in the future.
+        pacer.reserve().commit();
+        // Reserve then drop without committing: models a caller cancelled during
+        // the pacing wait. The tail slot must be reclaimed.
+        drop(pacer.reserve());
+        // The next caller reuses the reclaimed slot: one gap out, not two.
+        let next = pacer.reserve();
+        assert!(next.wait() <= min_gap);
     }
 
     #[test]

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -275,6 +275,32 @@ class MysqlTreeStore {
     }
   }
 
+  async getVerifiedLeafKeys() {
+    try {
+      // Project just the two pubkeys out of the JSON, skipping each leaf's
+      // `data` blob (up to five transactions). The filter matches the verified
+      // categories the SDK expects: every reserved leaf plus every Available
+      // one, and nothing non-Available and unreserved.
+      const [rows] = await this.pool.query(
+        `SELECT l.id AS id,
+                l.data->>'$.verifying_public_key' AS verifying,
+                l.data->>'$.signing_keyshare.public_key' AS keyshare
+         FROM brz_tree_leaves l
+         LEFT JOIN brz_tree_reservations r
+           ON l.reservation_id = r.id AND l.user_id = r.user_id
+         WHERE l.user_id = ?
+           AND (r.purpose IS NOT NULL OR l.status = 'Available')`,
+        [this.identity]
+      );
+      return rows.map((row) => [row.id, row.verifying, row.keyshare]);
+    } catch (error) {
+      throw new TreeStoreError(
+        `Failed to get verified leaf keys: ${error.message}`,
+        error
+      );
+    }
+  }
+
   async getLeaves() {
     try {
       const [rows] = await this.pool.query(

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -246,6 +246,34 @@ class PostgresTreeStore {
     }
   }
 
+  async getVerifiedLeafKeys() {
+    try {
+      // Project just the two pubkeys out of the JSON, skipping each leaf's
+      // `data` blob (up to five transactions). The filter matches the verified
+      // categories the SDK expects: every reserved leaf plus every Available
+      // one, and nothing non-Available and unreserved.
+      const result = await this.pool.query(
+        `
+        SELECT l.id AS id,
+               l.data->>'verifying_public_key' AS verifying,
+               l.data->'signing_keyshare'->>'public_key' AS keyshare
+        FROM brz_tree_leaves l
+        LEFT JOIN brz_tree_reservations r
+          ON l.reservation_id = r.id AND l.user_id = r.user_id
+        WHERE l.user_id = $1
+          AND (r.purpose IS NOT NULL OR l.status = 'Available')
+      `,
+        [this.identity]
+      );
+      return result.rows.map((row) => [row.id, row.verifying, row.keyshare]);
+    } catch (error) {
+      throw new TreeStoreError(
+        `Failed to get verified leaf keys: ${error.message}`,
+        error
+      );
+    }
+  }
+
   async getLeaves() {
     try {
       const result = await this.pool.query(

--- a/crates/breez-sdk/wasm/src/tree_store/mod.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(all(test, not(feature = "browser-tests")))]
 mod tests;
 
+use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use macros::async_trait;
@@ -8,8 +10,9 @@ use platform_utils::time::Instant;
 use platform_utils::tokio::sync::watch;
 use serde::{Deserialize, Serialize};
 use spark_wallet::{
-    LeafSelection, Leaves, LeavesReservation, LeavesReservationId, ReservationPurpose,
+    LeafSelection, Leaves, LeavesReservation, LeavesReservationId, PublicKey, ReservationPurpose,
     ReserveResult, TargetAmounts, TreeNode, TreeNodeId, TreeServiceError, TreeStore,
+    VerifiedLeafKeys,
 };
 use tracing::info;
 use wasm_bindgen::prelude::*;
@@ -232,6 +235,37 @@ impl TreeStore for WasmTreeStore {
 
         info!("WasmTreeStore::get_available_balance: {balance}, js_promise: {js_dt:?}");
         Ok(balance)
+    }
+
+    async fn get_verified_leaf_keys(
+        &self,
+    ) -> Result<HashMap<TreeNodeId, VerifiedLeafKeys>, TreeServiceError> {
+        let promise = self
+            .tree_store
+            .get_verified_leaf_keys()
+            .map_err(js_error_to_tree_error)?;
+        let result = JsFuture::from(promise)
+            .await
+            .map_err(js_error_to_tree_error)?;
+
+        // Each row is `[id, verifyingPublicKeyHex, signingKeysharePublicKeyHex]`.
+        // Pubkeys cross the boundary as hex strings and are parsed here, sidestepping
+        // serde_wasm_bindgen's non-human-readable encoding of `PublicKey`.
+        let rows: Vec<(String, String, String)> = serde_wasm_bindgen::from_value(result)
+            .map_err(|e| TreeServiceError::Generic(e.to_string()))?;
+        let mut keys = HashMap::with_capacity(rows.len());
+        for (id, verifying, keyshare) in rows {
+            keys.insert(
+                TreeNodeId::from_str(&id).map_err(TreeServiceError::Generic)?,
+                VerifiedLeafKeys {
+                    verifying_public_key: PublicKey::from_str(&verifying)
+                        .map_err(|e| TreeServiceError::Generic(e.to_string()))?,
+                    signing_keyshare_public_key: PublicKey::from_str(&keyshare)
+                        .map_err(|e| TreeServiceError::Generic(e.to_string()))?,
+                },
+            );
+        }
+        Ok(keys)
     }
 
     async fn get_leaves(&self) -> Result<Leaves, TreeServiceError> {
@@ -503,6 +537,7 @@ export interface TreeStore {
     addLeaves: (leaves: TreeNode[]) => Promise<void>;
     getLeaves: () => Promise<Leaves>;
     getAvailableBalance: () => Promise<bigint>;
+    getVerifiedLeafKeys: () => Promise<[string, string, string][]>;
     setLeaves: (leaves: TreeNode[], missingLeaves: TreeNode[], refreshStartedAtMs: number) => Promise<void>;
     cancelReservation: (id: string, leavesToKeep: TreeNode[]) => Promise<void>;
     finalizeReservation: (id: string, newLeaves: TreeNode[] | null) => Promise<void>;
@@ -526,6 +561,9 @@ extern "C" {
 
     #[wasm_bindgen(structural, method, js_name = getAvailableBalance, catch)]
     pub fn get_available_balance(this: &TreeStoreJs) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(structural, method, js_name = getVerifiedLeafKeys, catch)]
+    pub fn get_verified_leaf_keys(this: &TreeStoreJs) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, js_name = setLeaves, catch)]
     pub fn set_leaves(

--- a/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
@@ -54,6 +54,12 @@ async fn test_new() {
 }
 
 #[wasm_bindgen_test]
+async fn test_get_verified_leaf_keys() {
+    let store = create_test_tree_store("mysql_tree_verified_leaf_keys").await;
+    breez_sdk_spark::tree_store_tests::test_get_verified_leaf_keys(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_add_leaves() {
     let store = create_test_tree_store("mysql_tree_add_leaves").await;
     breez_sdk_spark::tree_store_tests::test_add_leaves(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
@@ -54,6 +54,12 @@ async fn test_new() {
 }
 
 #[wasm_bindgen_test]
+async fn test_get_verified_leaf_keys() {
+    let store = create_test_tree_store("pg_tree_verified_leaf_keys").await;
+    breez_sdk_spark::tree_store_tests::test_get_verified_leaf_keys(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_add_leaves() {
     let store = create_test_tree_store("pg_tree_add_leaves").await;
     breez_sdk_spark::tree_store_tests::test_add_leaves(&store).await;

--- a/crates/breez-sdk/wasm/src/turnkey.rs
+++ b/crates/breez-sdk/wasm/src/turnkey.rs
@@ -31,6 +31,7 @@ pub struct TurnkeyConfig {
     pub network: Network,
     pub account_number: Option<u32>,
     pub retry: Option<TurnkeyRetryConfig>,
+    pub max_rps: Option<u32>,
 }
 
 /// Builds the Turnkey-backed signers from `config`, then pass

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -18,8 +18,10 @@
 //!   selectivity is acceptable on full indexes for our workload.
 
 use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
 use std::sync::Arc;
 
+use bitcoin::secp256k1::PublicKey;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use macros::async_trait;
 use mysql_async::prelude::*;
@@ -28,7 +30,7 @@ use platform_utils::time::{Instant, SystemTime};
 use spark_wallet::{
     LeafLike, LeafSelection, Leaves, LeavesReservation, LeavesReservationId, ReservationPurpose,
     ReserveResult, TargetAmounts, TreeNode, TreeNodeId, TreeNodeStatus, TreeServiceError,
-    TreeStore, select_leaves_by_minimum_amount, select_leaves_by_target_amounts,
+    TreeStore, VerifiedLeafKeys, select_leaves_by_minimum_amount, select_leaves_by_target_amounts,
 };
 use tokio::sync::watch;
 use tracing::{debug, info, trace};
@@ -397,6 +399,49 @@ impl TreeStore for MysqlTreeStore {
             .await
             .map_err(map_err)?;
         Ok(u64::try_from(row.unwrap_or(0)).unwrap_or(0))
+    }
+
+    async fn get_verified_leaf_keys(
+        &self,
+    ) -> Result<HashMap<TreeNodeId, VerifiedLeafKeys>, TreeServiceError> {
+        let mut conn = self.pool.get_conn().await.map_err(map_err)?;
+
+        // Project just the two pubkeys straight out of the JSON, skipping the
+        // per-leaf `data` blob (up to five transactions). The filter mirrors the
+        // verified categories in `verified_leaf_keys_from_leaves`: every
+        // reserved leaf plus every Available one, and nothing non-Available and
+        // unreserved (never verified).
+        let rows: Vec<(String, Option<String>, Option<String>)> = conn
+            .exec(
+                r"SELECT l.id,
+                         l.data->>'$.verifying_public_key' AS verifying,
+                         l.data->>'$.signing_keyshare.public_key' AS keyshare
+                  FROM brz_tree_leaves l
+                  LEFT JOIN brz_tree_reservations r
+                    ON l.reservation_id = r.id AND l.user_id = r.user_id
+                  WHERE l.user_id = ?
+                    AND (r.purpose IS NOT NULL OR l.status = 'Available')",
+                (self.identity.clone(),),
+            )
+            .await
+            .map_err(map_err)?;
+
+        let mut keys = HashMap::with_capacity(rows.len());
+        for (id, verifying, keyshare) in rows {
+            // A valid node always carries both pubkeys; treat a missing one as a
+            // non-verified leaf (skip) rather than failing the whole refresh.
+            let (Some(verifying), Some(keyshare)) = (verifying, keyshare) else {
+                continue;
+            };
+            keys.insert(
+                TreeNodeId::from_str(&id).map_err(TreeServiceError::Generic)?,
+                VerifiedLeafKeys {
+                    verifying_public_key: PublicKey::from_str(&verifying).map_err(map_err)?,
+                    signing_keyshare_public_key: PublicKey::from_str(&keyshare).map_err(map_err)?,
+                },
+            );
+        }
+        Ok(keys)
     }
 
     async fn get_leaves(&self) -> Result<Leaves, TreeServiceError> {
@@ -1873,6 +1918,12 @@ mod tests {
     async fn test_new() {
         let fixture = MysqlTreeStoreTestFixture::new().await;
         shared_tests::test_new(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_get_verified_leaf_keys() {
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        shared_tests::test_get_verified_leaf_keys(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -5,16 +5,18 @@
 //! in-memory storage is insufficient.
 
 use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use platform_utils::time::{Instant, SystemTime};
 
+use bitcoin::secp256k1::PublicKey;
 use deadpool_postgres::Pool;
 use macros::async_trait;
 use spark_wallet::{
     LeafLike, LeafSelection, Leaves, LeavesReservation, LeavesReservationId, ReservationPurpose,
     ReserveResult, TargetAmounts, TreeNode, TreeNodeId, TreeNodeStatus, TreeServiceError,
-    TreeStore, select_leaves_by_minimum_amount, select_leaves_by_target_amounts,
+    TreeStore, VerifiedLeafKeys, select_leaves_by_minimum_amount, select_leaves_by_target_amounts,
 };
 use tokio::sync::watch;
 use tracing::{debug, info, trace};
@@ -302,6 +304,54 @@ impl TreeStore for PostgresTreeStore {
             .map_err(map_err)?;
         let balance: i64 = row.get("balance");
         Ok(u64::try_from(balance).unwrap_or(0))
+    }
+
+    async fn get_verified_leaf_keys(
+        &self,
+    ) -> Result<HashMap<TreeNodeId, VerifiedLeafKeys>, TreeServiceError> {
+        let client = self.pool.get().await.map_err(map_err)?;
+
+        // Project just the two pubkeys straight out of the JSON, skipping the
+        // per-leaf `data` blob (up to five transactions). The filter mirrors the
+        // verified categories in `verified_leaf_keys_from_leaves`: every
+        // reserved leaf plus every Available one, and nothing non-Available and
+        // unreserved (never verified).
+        let rows = client
+            .query(
+                r"
+                SELECT l.id AS id,
+                       l.data->>'verifying_public_key' AS verifying,
+                       l.data->'signing_keyshare'->>'public_key' AS keyshare
+                FROM brz_tree_leaves l
+                LEFT JOIN brz_tree_reservations r
+                  ON l.reservation_id = r.id AND l.user_id = r.user_id
+                WHERE l.user_id = $1
+                  AND (r.purpose IS NOT NULL OR l.status = 'Available')
+                ",
+                &[&self.identity],
+            )
+            .await
+            .map_err(map_err)?;
+
+        let mut keys = HashMap::with_capacity(rows.len());
+        for row in rows {
+            let id: String = row.get("id");
+            // A valid node always carries both pubkeys; treat a missing one as a
+            // non-verified leaf (skip) rather than failing the whole refresh.
+            let (Some(verifying), Some(keyshare)): (Option<String>, Option<String>) =
+                (row.get("verifying"), row.get("keyshare"))
+            else {
+                continue;
+            };
+            keys.insert(
+                TreeNodeId::from_str(&id).map_err(TreeServiceError::Generic)?,
+                VerifiedLeafKeys {
+                    verifying_public_key: PublicKey::from_str(&verifying).map_err(map_err)?,
+                    signing_keyshare_public_key: PublicKey::from_str(&keyshare).map_err(map_err)?,
+                },
+            );
+        }
+        Ok(keys)
     }
 
     async fn get_leaves(&self) -> Result<Leaves, TreeServiceError> {
@@ -1550,6 +1600,12 @@ mod tests {
     async fn test_new() {
         let fixture = PostgresTreeStoreTestFixture::new().await;
         shared_tests::test_new(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_get_verified_leaf_keys() {
+        let fixture = PostgresTreeStoreTestFixture::new().await;
+        shared_tests::test_get_verified_leaf_keys(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-wallet/src/lib.rs
+++ b/crates/spark-wallet/src/lib.rs
@@ -53,8 +53,9 @@ pub use spark::{
         InMemoryTreeStore, LeafLike, LeafOptimizationOptions, LeafSelection, Leaves,
         LeavesReservation, LeavesReservationId, OptimizationError, OptimizationOutcome,
         ReservationPurpose, ReserveResult, SelectLeavesOptions, SigningKeyshare, TargetAmounts,
-        TreeNode, TreeNodeId, TreeNodeStatus, TreeServiceError, TreeStore,
+        TreeNode, TreeNodeId, TreeNodeStatus, TreeServiceError, TreeStore, VerifiedLeafKeys,
         select_leaves_by_minimum_amount, select_leaves_by_target_amounts,
+        verified_leaf_keys_from_leaves,
     },
     utils::frost::aggregate_frost,
     utils::{

--- a/crates/spark/src/services/coop_exit.rs
+++ b/crates/spark/src/services/coop_exit.rs
@@ -14,18 +14,19 @@ use crate::core::{Network, next_sequence};
 use crate::operator::OperatorPool;
 use crate::operator::rpc as operator_rpc;
 use crate::services::models::{
-    SignedTx, map_signing_nonce_commitments, split_signing_commitments_by_variant,
+    RefundVariant, build_refund_signing_job, map_signing_nonce_commitments,
+    split_signing_commitments_by_variant,
 };
 use crate::services::{ExitSpeed, LeafKeyTweak, Transfer, TransferId, TransferService};
 use crate::services::{ServiceError, TransferObserver};
 use crate::signer::{
-    FrostDerivation, FrostJob, OperatorRecipient, PrepareTransferRequest, PreparedTransfer,
-    SparkSigner, TransferLeafInput,
+    OperatorRecipient, PrepareTransferRequest, PreparedTransfer, SparkSigner, TransferLeafInput,
 };
 use crate::ssp::RequestCoopExitInput;
 use crate::ssp::ServiceProvider;
 use crate::tree::TreeNode;
 use crate::tree::TreeNodeId;
+use crate::utils::frost::sign_frost_batch;
 use crate::utils::leaf_key_tweak::prepare_leaf_key_tweaks_to_send;
 use crate::utils::time::web_time_to_prost_timestamp;
 use crate::utils::transactions::{
@@ -474,9 +475,11 @@ impl CoopExitService {
         ),
         ServiceError,
     > {
-        let mut cpfp_jobs = Vec::new();
-        let mut direct_jobs = Vec::new();
-        let mut direct_from_cpfp_jobs = Vec::new();
+        // Build every leaf-variant connector-refund FROST job up front, then sign
+        // the whole batch in one call. A per-job loop would cost one sign_frost
+        // network round-trip per leaf-variant on a remote signer.
+        let mut jobs = Vec::new();
+        let mut pending = Vec::new();
         for (i, leaf) in leaves.iter().enumerate() {
             // The connector refund is signed with the leaf's current derived key.
             let signing_public_key = self
@@ -528,17 +531,18 @@ impl CoopExitService {
             } else {
                 sighash_from_tx(&cpfp_refund_tx, 0, &node_tx.output[0])
             }?;
-            cpfp_jobs.push(
-                self.sign_coop_exit_refund_job(
-                    &leaf.node.id,
-                    cpfp_refund_tx,
-                    cpfp_sighash.as_byte_array(),
-                    &signing_public_key,
-                    cpfp_commitments[i].clone(),
-                    &verifying_key,
-                )
-                .await?,
+            let (job, entry) = build_refund_signing_job(
+                &leaf.node.id,
+                &verifying_key,
+                &signing_public_key,
+                cpfp_refund_tx,
+                *cpfp_sighash.as_byte_array(),
+                cpfp_commitments[i].clone(),
+                RefundVariant::Cpfp,
+                self.network,
             );
+            jobs.push(job);
+            pending.push(entry);
 
             if let (Some(direct_tx), Some(direct_refund_tx)) =
                 (leaf.node.direct_tx.as_ref(), direct_refund_tx)
@@ -554,17 +558,18 @@ impl CoopExitService {
                 } else {
                     sighash_from_tx(&direct_refund_tx, 0, &direct_tx.output[0])
                 }?;
-                direct_jobs.push(
-                    self.sign_coop_exit_refund_job(
-                        &leaf.node.id,
-                        direct_refund_tx,
-                        sighash.as_byte_array(),
-                        &signing_public_key,
-                        direct_commitments[i].clone(),
-                        &verifying_key,
-                    )
-                    .await?,
+                let (job, entry) = build_refund_signing_job(
+                    &leaf.node.id,
+                    &verifying_key,
+                    &signing_public_key,
+                    direct_refund_tx,
+                    *sighash.as_byte_array(),
+                    direct_commitments[i].clone(),
+                    RefundVariant::Direct,
+                    self.network,
                 );
+                jobs.push(job);
+                pending.push(entry);
             }
 
             if let Some(dfc_refund_tx) = direct_from_cpfp_refund_tx {
@@ -576,62 +581,35 @@ impl CoopExitService {
                 } else {
                     sighash_from_tx(&dfc_refund_tx, 0, &node_tx.output[0])
                 }?;
-                direct_from_cpfp_jobs.push(
-                    self.sign_coop_exit_refund_job(
-                        &leaf.node.id,
-                        dfc_refund_tx,
-                        sighash.as_byte_array(),
-                        &signing_public_key,
-                        direct_from_cpfp_commitments[i].clone(),
-                        &verifying_key,
-                    )
-                    .await?,
+                let (job, entry) = build_refund_signing_job(
+                    &leaf.node.id,
+                    &verifying_key,
+                    &signing_public_key,
+                    dfc_refund_tx,
+                    *sighash.as_byte_array(),
+                    direct_from_cpfp_commitments[i].clone(),
+                    RefundVariant::DirectFromCpfp,
+                    self.network,
                 );
+                jobs.push(job);
+                pending.push(entry);
+            }
+        }
+
+        let signed = sign_frost_batch(&self.spark_signer, jobs, pending).await?;
+        let mut cpfp_jobs = Vec::new();
+        let mut direct_jobs = Vec::new();
+        let mut direct_from_cpfp_jobs = Vec::new();
+        for (entry, share) in signed {
+            let (variant, job) = entry.into_user_signed_job(share)?;
+            match variant {
+                RefundVariant::Cpfp => cpfp_jobs.push(job),
+                RefundVariant::Direct => direct_jobs.push(job),
+                RefundVariant::DirectFromCpfp => direct_from_cpfp_jobs.push(job),
             }
         }
 
         Ok((cpfp_jobs, direct_jobs, direct_from_cpfp_jobs))
-    }
-
-    async fn sign_coop_exit_refund_job(
-        &self,
-        node_id: &TreeNodeId,
-        refund_tx: Transaction,
-        sighash_bytes: &[u8; 32],
-        signing_public_key: &PublicKey,
-        operator_commitments: std::collections::BTreeMap<
-            Identifier,
-            frost_secp256k1_tr::round1::SigningCommitments,
-        >,
-        verifying_key: &PublicKey,
-    ) -> Result<operator_rpc::spark::UserSignedTxSigningJob, ServiceError> {
-        // The connector refund is signed with the leaf's current derived key.
-        let share = self
-            .spark_signer
-            .sign_frost(vec![FrostJob {
-                derivation: FrostDerivation::SigningLeaf {
-                    leaf_id: node_id.clone(),
-                },
-                sighash: *sighash_bytes,
-                verifying_key: *verifying_key,
-                operator_commitments: operator_commitments.clone(),
-                adaptor_public_key: None,
-            }])
-            .await?
-            .into_iter()
-            .next()
-            .ok_or_else(|| ServiceError::Generic("sign_frost returned no share".to_string()))?;
-
-        let signed_tx = SignedTx {
-            node_id: node_id.clone(),
-            signing_public_key: *signing_public_key,
-            tx: refund_tx,
-            user_signature: share.signature_share,
-            signing_commitments: operator_commitments,
-            self_nonce_commitment: share.commitment,
-            network: self.network,
-        };
-        (&signed_tx).try_into()
     }
 }
 

--- a/crates/spark/src/services/coop_exit.rs
+++ b/crates/spark/src/services/coop_exit.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bitcoin::hashes::Hash;
-use bitcoin::secp256k1::{PublicKey, Secp256k1};
+use bitcoin::secp256k1::{All, PublicKey, Secp256k1};
 use bitcoin::{Address, OutPoint, Transaction, Txid};
 use frost_secp256k1_tr::Identifier;
 use platform_utils::time::SystemTime;
@@ -108,6 +108,7 @@ pub struct CoopExitService {
     network: Network,
     spark_signer: Arc<dyn SparkSigner>,
     transfer_observer: Option<Arc<dyn TransferObserver>>,
+    secp: Secp256k1<All>,
 }
 
 impl CoopExitService {
@@ -126,6 +127,7 @@ impl CoopExitService {
             network,
             spark_signer,
             transfer_observer,
+            secp: Secp256k1::new(),
         }
     }
 
@@ -480,12 +482,12 @@ impl CoopExitService {
         // network round-trip per leaf-variant on a remote signer.
         let mut jobs = Vec::new();
         let mut pending = Vec::new();
-        let secp = Secp256k1::new();
         for (i, leaf) in leaves.iter().enumerate() {
             // The connector refund is signed with the leaf's current (owned)
             // derived key, recovered locally from the tree node instead of the
-            // signer (see derive_leaf_signing_public_key).
-            let signing_public_key = derive_leaf_signing_public_key(&leaf.node, &secp)?;
+            // signer (see derive_leaf_signing_public_key). Safe here: the derived
+            // value is the signing key, not the refund destination.
+            let signing_public_key = derive_leaf_signing_public_key(&leaf.node, &self.secp)?;
             let verifying_key = leaf.node.verifying_public_key;
             let node_tx = &leaf.node.node_tx;
             let connector_prev_out = connector_tx_parsed.output.get(i).cloned();

--- a/crates/spark/src/services/coop_exit.rs
+++ b/crates/spark/src/services/coop_exit.rs
@@ -478,8 +478,7 @@ impl CoopExitService {
         ServiceError,
     > {
         // Build every leaf-variant connector-refund FROST job up front, then sign
-        // the whole batch in one call. A per-job loop would cost one sign_frost
-        // network round-trip per leaf-variant on a remote signer.
+        // the whole batch in one call.
         let mut leaf_jobs: Vec<LeafRefundJobs> = Vec::new();
         for (i, leaf) in leaves.iter().enumerate() {
             // The connector refund is signed with the leaf's current (owned)

--- a/crates/spark/src/services/coop_exit.rs
+++ b/crates/spark/src/services/coop_exit.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bitcoin::hashes::Hash;
-use bitcoin::secp256k1::PublicKey;
+use bitcoin::secp256k1::{PublicKey, Secp256k1};
 use bitcoin::{Address, OutPoint, Transaction, Txid};
 use frost_secp256k1_tr::Identifier;
 use platform_utils::time::SystemTime;
@@ -26,7 +26,7 @@ use crate::ssp::RequestCoopExitInput;
 use crate::ssp::ServiceProvider;
 use crate::tree::TreeNode;
 use crate::tree::TreeNodeId;
-use crate::utils::frost::sign_frost_batch;
+use crate::utils::frost::{derive_leaf_signing_public_key, sign_frost_batch};
 use crate::utils::leaf_key_tweak::prepare_leaf_key_tweaks_to_send;
 use crate::utils::time::web_time_to_prost_timestamp;
 use crate::utils::transactions::{
@@ -480,12 +480,12 @@ impl CoopExitService {
         // network round-trip per leaf-variant on a remote signer.
         let mut jobs = Vec::new();
         let mut pending = Vec::new();
+        let secp = Secp256k1::new();
         for (i, leaf) in leaves.iter().enumerate() {
-            // The connector refund is signed with the leaf's current derived key.
-            let signing_public_key = self
-                .spark_signer
-                .get_public_key_for_leaf(&leaf.node.id)
-                .await?;
+            // The connector refund is signed with the leaf's current (owned)
+            // derived key, recovered locally from the tree node instead of the
+            // signer (see derive_leaf_signing_public_key).
+            let signing_public_key = derive_leaf_signing_public_key(&leaf.node, &secp)?;
             let verifying_key = leaf.node.verifying_public_key;
             let node_tx = &leaf.node.node_tx;
             let connector_prev_out = connector_tx_parsed.output.get(i).cloned();

--- a/crates/spark/src/services/coop_exit.rs
+++ b/crates/spark/src/services/coop_exit.rs
@@ -538,6 +538,7 @@ impl CoopExitService {
                 cpfp_refund_tx,
                 *cpfp_sighash.as_byte_array(),
                 cpfp_commitments[i].clone(),
+                None, // connector refunds never use adaptor signatures
                 RefundVariant::Cpfp,
                 self.network,
             );
@@ -565,6 +566,7 @@ impl CoopExitService {
                     direct_refund_tx,
                     *sighash.as_byte_array(),
                     direct_commitments[i].clone(),
+                    None, // connector refunds never use adaptor signatures
                     RefundVariant::Direct,
                     self.network,
                 );
@@ -588,6 +590,7 @@ impl CoopExitService {
                     dfc_refund_tx,
                     *sighash.as_byte_array(),
                     direct_from_cpfp_commitments[i].clone(),
+                    None, // connector refunds never use adaptor signatures
                     RefundVariant::DirectFromCpfp,
                     self.network,
                 );

--- a/crates/spark/src/services/coop_exit.rs
+++ b/crates/spark/src/services/coop_exit.rs
@@ -14,8 +14,8 @@ use crate::core::{Network, next_sequence};
 use crate::operator::OperatorPool;
 use crate::operator::rpc as operator_rpc;
 use crate::services::models::{
-    RefundVariant, build_refund_signing_job, map_signing_nonce_commitments,
-    split_signing_commitments_by_variant,
+    LeafRefundJobs, build_refund_signing_job, into_user_signed_job_groups,
+    map_signing_nonce_commitments, sign_leaf_refunds, split_signing_commitments_by_variant,
 };
 use crate::services::{ExitSpeed, LeafKeyTweak, Transfer, TransferId, TransferService};
 use crate::services::{ServiceError, TransferObserver};
@@ -26,7 +26,7 @@ use crate::ssp::RequestCoopExitInput;
 use crate::ssp::ServiceProvider;
 use crate::tree::TreeNode;
 use crate::tree::TreeNodeId;
-use crate::utils::frost::{derive_leaf_signing_public_key, sign_frost_batch};
+use crate::utils::frost::derive_leaf_signing_public_key;
 use crate::utils::leaf_key_tweak::prepare_leaf_key_tweaks_to_send;
 use crate::utils::time::web_time_to_prost_timestamp;
 use crate::utils::transactions::{
@@ -480,8 +480,7 @@ impl CoopExitService {
         // Build every leaf-variant connector-refund FROST job up front, then sign
         // the whole batch in one call. A per-job loop would cost one sign_frost
         // network round-trip per leaf-variant on a remote signer.
-        let mut jobs = Vec::new();
-        let mut pending = Vec::new();
+        let mut leaf_jobs: Vec<LeafRefundJobs> = Vec::new();
         for (i, leaf) in leaves.iter().enumerate() {
             // The connector refund is signed with the leaf's current (owned)
             // derived key, recovered locally from the tree node instead of the
@@ -533,7 +532,7 @@ impl CoopExitService {
             } else {
                 sighash_from_tx(&cpfp_refund_tx, 0, &node_tx.output[0])
             }?;
-            let (job, entry) = build_refund_signing_job(
+            let cpfp = build_refund_signing_job(
                 &leaf.node.id,
                 &verifying_key,
                 &signing_public_key,
@@ -541,13 +540,10 @@ impl CoopExitService {
                 *cpfp_sighash.as_byte_array(),
                 cpfp_commitments[i].clone(),
                 None, // connector refunds never use adaptor signatures
-                RefundVariant::Cpfp,
                 self.network,
             );
-            jobs.push(job);
-            pending.push(entry);
 
-            if let (Some(direct_tx), Some(direct_refund_tx)) =
+            let direct = if let (Some(direct_tx), Some(direct_refund_tx)) =
                 (leaf.node.direct_tx.as_ref(), direct_refund_tx)
             {
                 let direct_all_prev_outs = connector_prev_out
@@ -561,7 +557,7 @@ impl CoopExitService {
                 } else {
                     sighash_from_tx(&direct_refund_tx, 0, &direct_tx.output[0])
                 }?;
-                let (job, entry) = build_refund_signing_job(
+                Some(build_refund_signing_job(
                     &leaf.node.id,
                     &verifying_key,
                     &signing_public_key,
@@ -569,14 +565,13 @@ impl CoopExitService {
                     *sighash.as_byte_array(),
                     direct_commitments[i].clone(),
                     None, // connector refunds never use adaptor signatures
-                    RefundVariant::Direct,
                     self.network,
-                );
-                jobs.push(job);
-                pending.push(entry);
-            }
+                ))
+            } else {
+                None
+            };
 
-            if let Some(dfc_refund_tx) = direct_from_cpfp_refund_tx {
+            let direct_from_cpfp = if let Some(dfc_refund_tx) = direct_from_cpfp_refund_tx {
                 let sighash = if let Some(prev_outs) = node_all_prev_outs
                     .as_ref()
                     .filter(|_| dfc_refund_tx.input.len() > 1)
@@ -585,7 +580,7 @@ impl CoopExitService {
                 } else {
                     sighash_from_tx(&dfc_refund_tx, 0, &node_tx.output[0])
                 }?;
-                let (job, entry) = build_refund_signing_job(
+                Some(build_refund_signing_job(
                     &leaf.node.id,
                     &verifying_key,
                     &signing_public_key,
@@ -593,28 +588,21 @@ impl CoopExitService {
                     *sighash.as_byte_array(),
                     direct_from_cpfp_commitments[i].clone(),
                     None, // connector refunds never use adaptor signatures
-                    RefundVariant::DirectFromCpfp,
                     self.network,
-                );
-                jobs.push(job);
-                pending.push(entry);
-            }
+                ))
+            } else {
+                None
+            };
+
+            leaf_jobs.push(LeafRefundJobs {
+                cpfp,
+                direct,
+                direct_from_cpfp,
+            });
         }
 
-        let signed = sign_frost_batch(&self.spark_signer, jobs, pending).await?;
-        let mut cpfp_jobs = Vec::new();
-        let mut direct_jobs = Vec::new();
-        let mut direct_from_cpfp_jobs = Vec::new();
-        for (entry, share) in signed {
-            let (variant, job) = entry.into_user_signed_job(share)?;
-            match variant {
-                RefundVariant::Cpfp => cpfp_jobs.push(job),
-                RefundVariant::Direct => direct_jobs.push(job),
-                RefundVariant::DirectFromCpfp => direct_from_cpfp_jobs.push(job),
-            }
-        }
-
-        Ok((cpfp_jobs, direct_jobs, direct_from_cpfp_jobs))
+        let signed = sign_leaf_refunds(&self.spark_signer, leaf_jobs).await?;
+        into_user_signed_job_groups(signed)
     }
 }
 

--- a/crates/spark/src/services/models.rs
+++ b/crates/spark/src/services/models.rs
@@ -20,7 +20,9 @@ use crate::address::SparkAddress;
 use crate::core::Network;
 use crate::operator::rpc as operator_rpc;
 use crate::operator::rpc::spark::PreimageRequestRole;
-use crate::signer::{EncryptedSecret, FrostSigningCommitmentsWithNonces};
+use crate::signer::{
+    EncryptedSecret, FrostDerivation, FrostJob, FrostShareResult, FrostSigningCommitmentsWithNonces,
+};
 use crate::ssp::BitcoinNetwork;
 use crate::token::{HashableTokenTransaction, bech32m_encode_token_id};
 use crate::token::{TokenMetadata, TokenOutput, TokenOutputWithPrevOut};
@@ -143,6 +145,81 @@ impl TryFrom<&SignedTx> for operator_rpc::spark::UserSignedTxSigningJob {
             additional_inputs: vec![],
         })
     }
+}
+
+/// Which refund-transaction variant a claim/coop-exit signing job belongs to, so
+/// a flat batch of signed shares can be routed back to its output bucket.
+#[derive(Clone, Copy)]
+pub(crate) enum RefundVariant {
+    Cpfp,
+    Direct,
+    DirectFromCpfp,
+}
+
+/// A refund transaction whose FROST job has been queued for batched signing,
+/// carrying what's needed to build its `UserSignedTxSigningJob` once the share
+/// returns.
+pub(crate) struct PendingUserSignedJob {
+    pub variant: RefundVariant,
+    pub node_id: TreeNodeId,
+    pub signing_public_key: PublicKey,
+    pub refund_tx: Transaction,
+    pub operator_commitments: BTreeMap<Identifier, SigningCommitments>,
+    pub network: Network,
+}
+
+impl PendingUserSignedJob {
+    /// Combines the batched share into the operator-facing signing job, tagged
+    /// with its variant so the caller can route it to the right bucket.
+    pub(crate) fn into_user_signed_job(
+        self,
+        share: FrostShareResult,
+    ) -> Result<(RefundVariant, operator_rpc::spark::UserSignedTxSigningJob), ServiceError> {
+        let signed_tx = SignedTx {
+            node_id: self.node_id,
+            signing_public_key: self.signing_public_key,
+            tx: self.refund_tx,
+            user_signature: share.signature_share,
+            signing_commitments: self.operator_commitments,
+            self_nonce_commitment: share.commitment,
+            network: self.network,
+        };
+        Ok((self.variant, (&signed_tx).try_into()?))
+    }
+}
+
+/// Builds the FROST job for one refund transaction plus the `PendingUserSignedJob`
+/// that pairs with it. Pure client-side work: no signing. Shared by the claim and
+/// coop-exit paths, which sign every leaf-variant refund in one batched call.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_refund_signing_job(
+    node_id: &TreeNodeId,
+    verifying_key: &PublicKey,
+    signing_public_key: &PublicKey,
+    refund_tx: Transaction,
+    sighash: [u8; 32],
+    operator_commitments: BTreeMap<Identifier, SigningCommitments>,
+    variant: RefundVariant,
+    network: Network,
+) -> (FrostJob, PendingUserSignedJob) {
+    let job = FrostJob {
+        derivation: FrostDerivation::SigningLeaf {
+            leaf_id: node_id.clone(),
+        },
+        sighash,
+        verifying_key: *verifying_key,
+        operator_commitments: operator_commitments.clone(),
+        adaptor_public_key: None,
+    };
+    let pending = PendingUserSignedJob {
+        variant,
+        node_id: node_id.clone(),
+        signing_public_key: *signing_public_key,
+        refund_tx,
+        operator_commitments,
+        network,
+    };
+    (job, pending)
 }
 
 pub(crate) struct SigningResult {

--- a/crates/spark/src/services/models.rs
+++ b/crates/spark/src/services/models.rs
@@ -210,8 +210,7 @@ struct LeafRefundShape {
 impl LeafRefundJobs {
     /// Moves this leaf's jobs and pending metadata into the shared batch buffers
     /// in field order (cpfp, then direct, then direct-from-cpfp), returning the
-    /// variant shape needed to regroup the shares. Moves rather than clones: each
-    /// job is consumed by the single `sign_frost` batch.
+    /// variant shape needed to regroup the shares.
     fn flatten_into(
         self,
         jobs: &mut Vec<FrostJob>,
@@ -262,9 +261,7 @@ fn next_signed(signed: &mut impl Iterator<Item = SignedTx>) -> Result<SignedTx, 
 /// Signs every leaf's refund jobs in one batched `sign_frost` call, then
 /// reattaches the shares. Flatten and rebuild walk the same fields in the same
 /// order, and the count is length-checked inside `sign_frost_batch`, so the
-/// single reliance on share ordering is confined here. Remote signer backends
-/// (e.g. Turnkey) collapse the whole batch into one round-trip instead of one
-/// per job.
+/// single reliance on share ordering is confined here.
 pub(crate) async fn sign_leaf_refunds(
     spark_signer: &Arc<dyn SparkSigner>,
     leaves: Vec<LeafRefundJobs>,

--- a/crates/spark/src/services/models.rs
+++ b/crates/spark/src/services/models.rs
@@ -22,14 +22,15 @@ use crate::core::Network;
 use crate::operator::rpc as operator_rpc;
 use crate::operator::rpc::spark::PreimageRequestRole;
 use crate::signer::{
-    EncryptedSecret, FrostDerivation, FrostJob, FrostShareResult, FrostSigningCommitmentsWithNonces,
-    SignerError, SparkSigner,
+    EncryptedSecret, FrostDerivation, FrostJob, FrostShareResult,
+    FrostSigningCommitmentsWithNonces, SignerError, SparkSigner,
 };
 use crate::ssp::BitcoinNetwork;
 use crate::token::{HashableTokenTransaction, bech32m_encode_token_id};
 use crate::token::{TokenMetadata, TokenOutput, TokenOutputWithPrevOut};
 use crate::tree::{SigningKeyshare, TreeNode, TreeNodeId, TreeNodeStatus};
 use crate::utils::byte_padding::BytePadding;
+use crate::utils::frost::sign_frost_batch;
 
 use super::ServiceError;
 
@@ -198,35 +199,52 @@ impl PendingRefundSignature {
     }
 }
 
+/// Which optional refund variants a leaf carries. Regroups a flat, field-ordered
+/// stream of signed refunds back into per-leaf buckets, matching the order
+/// [`LeafRefundJobs::flatten_into`] emitted them.
+struct LeafRefundShape {
+    has_direct: bool,
+    has_direct_from_cpfp: bool,
+}
+
 impl LeafRefundJobs {
-    /// The leaf's FROST jobs in field order: cpfp, then direct, then
-    /// direct-from-cpfp.
-    fn jobs(&self) -> impl Iterator<Item = FrostJob> + '_ {
-        std::iter::once(self.cpfp.job.clone())
-            .chain(self.direct.as_ref().map(|r| r.job.clone()))
-            .chain(self.direct_from_cpfp.as_ref().map(|r| r.job.clone()))
+    /// Moves this leaf's jobs and pending metadata into the shared batch buffers
+    /// in field order (cpfp, then direct, then direct-from-cpfp), returning the
+    /// variant shape needed to regroup the shares. Moves rather than clones: each
+    /// job is consumed by the single `sign_frost` batch.
+    fn flatten_into(
+        self,
+        jobs: &mut Vec<FrostJob>,
+        pending: &mut Vec<PendingRefundSignature>,
+    ) -> LeafRefundShape {
+        let shape = LeafRefundShape {
+            has_direct: self.direct.is_some(),
+            has_direct_from_cpfp: self.direct_from_cpfp.is_some(),
+        };
+        for refund in std::iter::once(self.cpfp)
+            .chain(self.direct)
+            .chain(self.direct_from_cpfp)
+        {
+            jobs.push(refund.job);
+            pending.push(refund.pending);
+        }
+        shape
     }
+}
 
-    /// Number of jobs this leaf contributes (cpfp plus each present variant).
-    fn job_count(&self) -> usize {
-        1 + usize::from(self.direct.is_some()) + usize::from(self.direct_from_cpfp.is_some())
-    }
-
-    /// Pulls one share per present variant from `shares`, in the same field order
-    /// as [`Self::jobs`], and reattaches them into the signed refunds.
+impl LeafRefundShape {
+    /// Pulls one signed refund per present variant from `signed`, in the same
+    /// field order as [`LeafRefundJobs::flatten_into`].
     fn rebuild(
         self,
-        shares: &mut impl Iterator<Item = FrostShareResult>,
+        signed: &mut impl Iterator<Item = SignedTx>,
     ) -> Result<SignedLeafRefunds, SignerError> {
-        let cpfp = self.cpfp.pending.into_signed_tx(next_share(shares)?);
-        let direct = match self.direct {
-            Some(r) => Some(r.pending.into_signed_tx(next_share(shares)?)),
-            None => None,
-        };
-        let direct_from_cpfp = match self.direct_from_cpfp {
-            Some(r) => Some(r.pending.into_signed_tx(next_share(shares)?)),
-            None => None,
-        };
+        let cpfp = next_signed(signed)?;
+        let direct = self.has_direct.then(|| next_signed(signed)).transpose()?;
+        let direct_from_cpfp = self
+            .has_direct_from_cpfp
+            .then(|| next_signed(signed))
+            .transpose()?;
         Ok(SignedLeafRefunds {
             cpfp,
             direct,
@@ -235,36 +253,36 @@ impl LeafRefundJobs {
     }
 }
 
-fn next_share(
-    shares: &mut impl Iterator<Item = FrostShareResult>,
-) -> Result<FrostShareResult, SignerError> {
-    shares
+fn next_signed(signed: &mut impl Iterator<Item = SignedTx>) -> Result<SignedTx, SignerError> {
+    signed
         .next()
         .ok_or_else(|| SignerError::Generic("sign_frost returned too few shares".to_string()))
 }
 
 /// Signs every leaf's refund jobs in one batched `sign_frost` call, then
 /// reattaches the shares. Flatten and rebuild walk the same fields in the same
-/// order, so the single reliance on share ordering is confined here and
-/// length-checked. Remote signer backends (e.g. Turnkey) collapse the whole
-/// batch into one round-trip instead of one per job.
+/// order, and the count is length-checked inside `sign_frost_batch`, so the
+/// single reliance on share ordering is confined here. Remote signer backends
+/// (e.g. Turnkey) collapse the whole batch into one round-trip instead of one
+/// per job.
 pub(crate) async fn sign_leaf_refunds(
     spark_signer: &Arc<dyn SparkSigner>,
     leaves: Vec<LeafRefundJobs>,
 ) -> Result<Vec<SignedLeafRefunds>, SignerError> {
-    let jobs: Vec<FrostJob> = leaves.iter().flat_map(LeafRefundJobs::jobs).collect();
-    let shares = spark_signer.sign_frost(jobs).await?;
-    let expected: usize = leaves.iter().map(LeafRefundJobs::job_count).sum();
-    if shares.len() != expected {
-        return Err(SignerError::Generic(format!(
-            "sign_frost returned {} shares, expected {expected}",
-            shares.len(),
-        )));
-    }
-    let mut shares = shares.into_iter();
-    leaves
+    // Flatten to parallel job/pending buffers, remembering each leaf's variant
+    // shape so the flat share stream can be regrouped per leaf.
+    let mut jobs = Vec::new();
+    let mut pending = Vec::new();
+    let shapes: Vec<LeafRefundShape> = leaves
         .into_iter()
-        .map(|leaf| leaf.rebuild(&mut shares))
+        .map(|leaf| leaf.flatten_into(&mut jobs, &mut pending))
+        .collect();
+
+    let signed = sign_frost_batch(spark_signer, jobs, pending).await?;
+    let mut signed = signed.into_iter().map(|(p, share)| p.into_signed_tx(share));
+    shapes
+        .into_iter()
+        .map(|shape| shape.rebuild(&mut signed))
         .collect()
 }
 
@@ -274,8 +292,8 @@ pub(crate) fn into_signed_tx_groups(
     signed: Vec<SignedLeafRefunds>,
 ) -> (Vec<SignedTx>, Vec<SignedTx>, Vec<SignedTx>) {
     let mut cpfp = Vec::with_capacity(signed.len());
-    let mut direct = Vec::new();
-    let mut direct_from_cpfp = Vec::new();
+    let mut direct = Vec::with_capacity(signed.len());
+    let mut direct_from_cpfp = Vec::with_capacity(signed.len());
     for s in signed {
         cpfp.push(s.cpfp);
         if let Some(d) = s.direct {

--- a/crates/spark/src/services/models.rs
+++ b/crates/spark/src/services/models.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Display};
 use std::str::FromStr;
+use std::sync::Arc;
 
 use bitcoin::hashes::{Hash, sha256};
 use bitcoin::secp256k1::ecdsa::Signature;
@@ -22,6 +23,7 @@ use crate::operator::rpc as operator_rpc;
 use crate::operator::rpc::spark::PreimageRequestRole;
 use crate::signer::{
     EncryptedSecret, FrostDerivation, FrostJob, FrostShareResult, FrostSigningCommitmentsWithNonces,
+    SignerError, SparkSigner,
 };
 use crate::ssp::BitcoinNetwork;
 use crate::token::{HashableTokenTransaction, bech32m_encode_token_id};
@@ -147,19 +149,33 @@ impl TryFrom<&SignedTx> for operator_rpc::spark::UserSignedTxSigningJob {
     }
 }
 
-/// Which refund-transaction variant a signed share belongs to, so a flat batch
-/// of shares can be routed back to its output bucket.
-#[derive(Clone, Copy)]
-pub(crate) enum RefundVariant {
-    Cpfp,
-    Direct,
-    DirectFromCpfp,
+/// One refund transaction's FROST job paired with the metadata that rebuilds its
+/// signed form once the batched share returns.
+pub(crate) struct RefundJob {
+    pub job: FrostJob,
+    pub pending: PendingRefundSignature,
 }
 
-/// A refund transaction whose FROST job has been queued for batched signing,
-/// carrying what's needed to rebuild its signed form once the share returns.
+/// A leaf's refund jobs: the cpfp variant always, the direct variants when the
+/// leaf carries them. Field position encodes the variant, so no runtime tag is
+/// needed and a share can never be routed to the wrong bucket.
+pub(crate) struct LeafRefundJobs {
+    pub cpfp: RefundJob,
+    pub direct: Option<RefundJob>,
+    pub direct_from_cpfp: Option<RefundJob>,
+}
+
+/// A leaf's signed refund transactions, mirroring `LeafRefundJobs` field for
+/// field.
+pub(crate) struct SignedLeafRefunds {
+    pub cpfp: SignedTx,
+    pub direct: Option<SignedTx>,
+    pub direct_from_cpfp: Option<SignedTx>,
+}
+
+/// The metadata that rebuilds a refund transaction's signed form once its
+/// batched FROST share returns.
 pub(crate) struct PendingRefundSignature {
-    pub variant: RefundVariant,
     pub node_id: TreeNodeId,
     pub signing_public_key: PublicKey,
     pub refund_tx: Transaction,
@@ -180,24 +196,124 @@ impl PendingRefundSignature {
             network: self.network,
         }
     }
+}
 
-    /// Combines the batched share into the operator-facing signing job, tagged
-    /// with its variant so the caller can route it to the right bucket.
-    pub(crate) fn into_user_signed_job(
+impl LeafRefundJobs {
+    /// The leaf's FROST jobs in field order: cpfp, then direct, then
+    /// direct-from-cpfp.
+    fn jobs(&self) -> impl Iterator<Item = FrostJob> + '_ {
+        std::iter::once(self.cpfp.job.clone())
+            .chain(self.direct.as_ref().map(|r| r.job.clone()))
+            .chain(self.direct_from_cpfp.as_ref().map(|r| r.job.clone()))
+    }
+
+    /// Number of jobs this leaf contributes (cpfp plus each present variant).
+    fn job_count(&self) -> usize {
+        1 + usize::from(self.direct.is_some()) + usize::from(self.direct_from_cpfp.is_some())
+    }
+
+    /// Pulls one share per present variant from `shares`, in the same field order
+    /// as [`Self::jobs`], and reattaches them into the signed refunds.
+    fn rebuild(
         self,
-        share: FrostShareResult,
-    ) -> Result<(RefundVariant, operator_rpc::spark::UserSignedTxSigningJob), ServiceError> {
-        let variant = self.variant;
-        let signed_tx = self.into_signed_tx(share);
-        Ok((variant, (&signed_tx).try_into()?))
+        shares: &mut impl Iterator<Item = FrostShareResult>,
+    ) -> Result<SignedLeafRefunds, SignerError> {
+        let cpfp = self.cpfp.pending.into_signed_tx(next_share(shares)?);
+        let direct = match self.direct {
+            Some(r) => Some(r.pending.into_signed_tx(next_share(shares)?)),
+            None => None,
+        };
+        let direct_from_cpfp = match self.direct_from_cpfp {
+            Some(r) => Some(r.pending.into_signed_tx(next_share(shares)?)),
+            None => None,
+        };
+        Ok(SignedLeafRefunds {
+            cpfp,
+            direct,
+            direct_from_cpfp,
+        })
     }
 }
 
-/// Builds the FROST job for one refund transaction plus the
-/// `PendingRefundSignature` that pairs with it. Pure client-side work: no
-/// signing. Refund signing always uses the leaf's own (derived) signing key,
-/// keyed by the leaf's node id. Signature aggregation happens later, when the
-/// returned share is combined with operator signatures.
+fn next_share(
+    shares: &mut impl Iterator<Item = FrostShareResult>,
+) -> Result<FrostShareResult, SignerError> {
+    shares
+        .next()
+        .ok_or_else(|| SignerError::Generic("sign_frost returned too few shares".to_string()))
+}
+
+/// Signs every leaf's refund jobs in one batched `sign_frost` call, then
+/// reattaches the shares. Flatten and rebuild walk the same fields in the same
+/// order, so the single reliance on share ordering is confined here and
+/// length-checked. Remote signer backends (e.g. Turnkey) collapse the whole
+/// batch into one round-trip instead of one per job.
+pub(crate) async fn sign_leaf_refunds(
+    spark_signer: &Arc<dyn SparkSigner>,
+    leaves: Vec<LeafRefundJobs>,
+) -> Result<Vec<SignedLeafRefunds>, SignerError> {
+    let jobs: Vec<FrostJob> = leaves.iter().flat_map(LeafRefundJobs::jobs).collect();
+    let shares = spark_signer.sign_frost(jobs).await?;
+    let expected: usize = leaves.iter().map(LeafRefundJobs::job_count).sum();
+    if shares.len() != expected {
+        return Err(SignerError::Generic(format!(
+            "sign_frost returned {} shares, expected {expected}",
+            shares.len(),
+        )));
+    }
+    let mut shares = shares.into_iter();
+    leaves
+        .into_iter()
+        .map(|leaf| leaf.rebuild(&mut shares))
+        .collect()
+}
+
+/// Splits signed leaf refunds into per-variant `SignedTx` buckets. Each bucket
+/// keeps leaf order.
+pub(crate) fn into_signed_tx_groups(
+    signed: Vec<SignedLeafRefunds>,
+) -> (Vec<SignedTx>, Vec<SignedTx>, Vec<SignedTx>) {
+    let mut cpfp = Vec::with_capacity(signed.len());
+    let mut direct = Vec::new();
+    let mut direct_from_cpfp = Vec::new();
+    for s in signed {
+        cpfp.push(s.cpfp);
+        if let Some(d) = s.direct {
+            direct.push(d);
+        }
+        if let Some(d) = s.direct_from_cpfp {
+            direct_from_cpfp.push(d);
+        }
+    }
+    (cpfp, direct, direct_from_cpfp)
+}
+
+/// Per-variant operator-facing signing jobs (cpfp, direct, direct-from-cpfp).
+pub(crate) type UserSignedJobGroups = (
+    Vec<operator_rpc::spark::UserSignedTxSigningJob>,
+    Vec<operator_rpc::spark::UserSignedTxSigningJob>,
+    Vec<operator_rpc::spark::UserSignedTxSigningJob>,
+);
+
+/// Splits signed leaf refunds into per-variant operator-facing signing jobs.
+pub(crate) fn into_user_signed_job_groups(
+    signed: Vec<SignedLeafRefunds>,
+) -> Result<UserSignedJobGroups, ServiceError> {
+    let (cpfp, direct, direct_from_cpfp) = into_signed_tx_groups(signed);
+    Ok((to_jobs(cpfp)?, to_jobs(direct)?, to_jobs(direct_from_cpfp)?))
+}
+
+fn to_jobs(
+    txs: Vec<SignedTx>,
+) -> Result<Vec<operator_rpc::spark::UserSignedTxSigningJob>, ServiceError> {
+    txs.iter().map(|tx| tx.try_into()).collect()
+}
+
+/// Builds the [`RefundJob`] for one refund transaction: the FROST job plus the
+/// metadata that rebuilds its signed form. Pure client-side work: no signing.
+/// Refund signing always uses the leaf's own (derived) signing key, keyed by the
+/// leaf's node id. Signature aggregation happens later, when the returned share
+/// is combined with operator signatures.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_refund_signing_job(
     node_id: &TreeNodeId,
@@ -207,9 +323,8 @@ pub(crate) fn build_refund_signing_job(
     sighash: [u8; 32],
     operator_commitments: BTreeMap<Identifier, SigningCommitments>,
     adaptor_public_key: Option<&PublicKey>,
-    variant: RefundVariant,
     network: Network,
-) -> (FrostJob, PendingRefundSignature) {
+) -> RefundJob {
     let job = FrostJob {
         derivation: FrostDerivation::SigningLeaf {
             leaf_id: node_id.clone(),
@@ -220,14 +335,13 @@ pub(crate) fn build_refund_signing_job(
         adaptor_public_key: adaptor_public_key.copied(),
     };
     let pending = PendingRefundSignature {
-        variant,
         node_id: node_id.clone(),
         signing_public_key: *signing_public_key,
         refund_tx,
         operator_commitments,
         network,
     };
-    (job, pending)
+    RefundJob { job, pending }
 }
 
 pub(crate) struct SigningResult {

--- a/crates/spark/src/services/models.rs
+++ b/crates/spark/src/services/models.rs
@@ -158,8 +158,6 @@ pub(crate) enum RefundVariant {
 
 /// A refund transaction whose FROST job has been queued for batched signing,
 /// carrying what's needed to rebuild its signed form once the share returns.
-/// Shared by the send, claim, and coop-exit paths, which each sign every
-/// leaf-variant refund in one batched call.
 pub(crate) struct PendingRefundSignature {
     pub variant: RefundVariant,
     pub node_id: TreeNodeId,

--- a/crates/spark/src/services/models.rs
+++ b/crates/spark/src/services/models.rs
@@ -147,8 +147,8 @@ impl TryFrom<&SignedTx> for operator_rpc::spark::UserSignedTxSigningJob {
     }
 }
 
-/// Which refund-transaction variant a claim/coop-exit signing job belongs to, so
-/// a flat batch of signed shares can be routed back to its output bucket.
+/// Which refund-transaction variant a signed share belongs to, so a flat batch
+/// of shares can be routed back to its output bucket.
 #[derive(Clone, Copy)]
 pub(crate) enum RefundVariant {
     Cpfp,
@@ -157,9 +157,10 @@ pub(crate) enum RefundVariant {
 }
 
 /// A refund transaction whose FROST job has been queued for batched signing,
-/// carrying what's needed to build its `UserSignedTxSigningJob` once the share
-/// returns.
-pub(crate) struct PendingUserSignedJob {
+/// carrying what's needed to rebuild its signed form once the share returns.
+/// Shared by the send, claim, and coop-exit paths, which each sign every
+/// leaf-variant refund in one batched call.
+pub(crate) struct PendingRefundSignature {
     pub variant: RefundVariant,
     pub node_id: TreeNodeId,
     pub signing_public_key: PublicKey,
@@ -168,14 +169,10 @@ pub(crate) struct PendingUserSignedJob {
     pub network: Network,
 }
 
-impl PendingUserSignedJob {
-    /// Combines the batched share into the operator-facing signing job, tagged
-    /// with its variant so the caller can route it to the right bucket.
-    pub(crate) fn into_user_signed_job(
-        self,
-        share: FrostShareResult,
-    ) -> Result<(RefundVariant, operator_rpc::spark::UserSignedTxSigningJob), ServiceError> {
-        let signed_tx = SignedTx {
+impl PendingRefundSignature {
+    /// Combines the batched share into the signed refund transaction.
+    pub(crate) fn into_signed_tx(self, share: FrostShareResult) -> SignedTx {
+        SignedTx {
             node_id: self.node_id,
             signing_public_key: self.signing_public_key,
             tx: self.refund_tx,
@@ -183,14 +180,26 @@ impl PendingUserSignedJob {
             signing_commitments: self.operator_commitments,
             self_nonce_commitment: share.commitment,
             network: self.network,
-        };
-        Ok((self.variant, (&signed_tx).try_into()?))
+        }
+    }
+
+    /// Combines the batched share into the operator-facing signing job, tagged
+    /// with its variant so the caller can route it to the right bucket.
+    pub(crate) fn into_user_signed_job(
+        self,
+        share: FrostShareResult,
+    ) -> Result<(RefundVariant, operator_rpc::spark::UserSignedTxSigningJob), ServiceError> {
+        let variant = self.variant;
+        let signed_tx = self.into_signed_tx(share);
+        Ok((variant, (&signed_tx).try_into()?))
     }
 }
 
-/// Builds the FROST job for one refund transaction plus the `PendingUserSignedJob`
-/// that pairs with it. Pure client-side work: no signing. Shared by the claim and
-/// coop-exit paths, which sign every leaf-variant refund in one batched call.
+/// Builds the FROST job for one refund transaction plus the
+/// `PendingRefundSignature` that pairs with it. Pure client-side work: no
+/// signing. Refund signing always uses the leaf's own (derived) signing key,
+/// keyed by the leaf's node id. Signature aggregation happens later, when the
+/// returned share is combined with operator signatures.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_refund_signing_job(
     node_id: &TreeNodeId,
@@ -199,9 +208,10 @@ pub(crate) fn build_refund_signing_job(
     refund_tx: Transaction,
     sighash: [u8; 32],
     operator_commitments: BTreeMap<Identifier, SigningCommitments>,
+    adaptor_public_key: Option<&PublicKey>,
     variant: RefundVariant,
     network: Network,
-) -> (FrostJob, PendingUserSignedJob) {
+) -> (FrostJob, PendingRefundSignature) {
     let job = FrostJob {
         derivation: FrostDerivation::SigningLeaf {
             leaf_id: node_id.clone(),
@@ -209,9 +219,9 @@ pub(crate) fn build_refund_signing_job(
         sighash,
         verifying_key: *verifying_key,
         operator_commitments: operator_commitments.clone(),
-        adaptor_public_key: None,
+        adaptor_public_key: adaptor_public_key.copied(),
     };
-    let pending = PendingUserSignedJob {
+    let pending = PendingRefundSignature {
         variant,
         node_id: node_id.clone(),
         signing_public_key: *signing_public_key,

--- a/crates/spark/src/services/timelock_manager.rs
+++ b/crates/spark/src/services/timelock_manager.rs
@@ -17,6 +17,7 @@ use crate::{
     signer::SparkSigner,
     tree::{TreeNode, TreeNodeId},
     utils::{
+        frost::derive_leaf_signing_public_key,
         signing_job::{SigningJob, SigningJobType, sign_signing_jobs},
         transactions::{
             NodeTransactions, RefundTransactions, create_decremented_timelock_node_txs,
@@ -25,6 +26,7 @@ use crate::{
         },
     },
 };
+use bitcoin::secp256k1::Secp256k1;
 use frost_secp256k1_tr::{Identifier, round1::SigningCommitments};
 use std::collections::BTreeMap;
 enum RenewType<'a> {
@@ -188,7 +190,9 @@ impl TimelockManager {
         info!("Renewing node: {:?}", node.id);
         let mut signing_jobs = Vec::new();
 
-        let signing_public_key = self.spark_signer.get_public_key_for_leaf(&node.id).await?;
+        // Owned node: recover the signing key locally from the tree node instead
+        // of a signer round-trip (see derive_leaf_signing_public_key).
+        let signing_public_key = derive_leaf_signing_public_key(node, &Secp256k1::new())?;
 
         let parent_node_tx = &parent_node.node_tx;
 
@@ -370,7 +374,9 @@ impl TimelockManager {
         info!("Renewing refund: {:?}", node.id);
         let mut signing_jobs = Vec::new();
 
-        let signing_public_key = self.spark_signer.get_public_key_for_leaf(&node.id).await?;
+        // Owned node: recover the signing key locally from the tree node instead
+        // of a signer round-trip (see derive_leaf_signing_public_key).
+        let signing_public_key = derive_leaf_signing_public_key(node, &Secp256k1::new())?;
 
         let parent_node_tx = &parent_node.node_tx;
         let node_tx = &node.node_tx;
@@ -517,7 +523,9 @@ impl TimelockManager {
         info!("Renewing zero timelock: {:?}", node.id);
         let mut signing_jobs = Vec::new();
 
-        let signing_public_key = self.spark_signer.get_public_key_for_leaf(&node.id).await?;
+        // Owned node: recover the signing key locally from the tree node instead
+        // of a signer round-trip (see derive_leaf_signing_public_key).
+        let signing_public_key = derive_leaf_signing_public_key(node, &Secp256k1::new())?;
 
         let node_tx = &node.node_tx;
 

--- a/crates/spark/src/services/timelock_manager.rs
+++ b/crates/spark/src/services/timelock_manager.rs
@@ -17,7 +17,6 @@ use crate::{
     signer::SparkSigner,
     tree::{TreeNode, TreeNodeId},
     utils::{
-        frost::derive_leaf_signing_public_key,
         signing_job::{SigningJob, SigningJobType, sign_signing_jobs},
         transactions::{
             NodeTransactions, RefundTransactions, create_decremented_timelock_node_txs,
@@ -26,7 +25,6 @@ use crate::{
         },
     },
 };
-use bitcoin::secp256k1::Secp256k1;
 use frost_secp256k1_tr::{Identifier, round1::SigningCommitments};
 use std::collections::BTreeMap;
 enum RenewType<'a> {
@@ -190,9 +188,11 @@ impl TimelockManager {
         info!("Renewing node: {:?}", node.id);
         let mut signing_jobs = Vec::new();
 
-        // Owned node: recover the signing key locally from the tree node instead
-        // of a signer round-trip (see derive_leaf_signing_public_key).
-        let signing_public_key = derive_leaf_signing_public_key(node, &Secp256k1::new())?;
+        // Fetch the signing key from the signer, never derived from persisted
+        // tree data: the renewed refund pays to this key, so a coordinator that
+        // lied about the stored keyshare pubkey could otherwise steer the exit
+        // refund to a key it controls.
+        let signing_public_key = self.spark_signer.get_public_key_for_leaf(&node.id).await?;
 
         let parent_node_tx = &parent_node.node_tx;
 
@@ -374,9 +374,11 @@ impl TimelockManager {
         info!("Renewing refund: {:?}", node.id);
         let mut signing_jobs = Vec::new();
 
-        // Owned node: recover the signing key locally from the tree node instead
-        // of a signer round-trip (see derive_leaf_signing_public_key).
-        let signing_public_key = derive_leaf_signing_public_key(node, &Secp256k1::new())?;
+        // Fetch the signing key from the signer, never derived from persisted
+        // tree data: the renewed refund pays to this key, so a coordinator that
+        // lied about the stored keyshare pubkey could otherwise steer the exit
+        // refund to a key it controls.
+        let signing_public_key = self.spark_signer.get_public_key_for_leaf(&node.id).await?;
 
         let parent_node_tx = &parent_node.node_tx;
         let node_tx = &node.node_tx;
@@ -523,9 +525,11 @@ impl TimelockManager {
         info!("Renewing zero timelock: {:?}", node.id);
         let mut signing_jobs = Vec::new();
 
-        // Owned node: recover the signing key locally from the tree node instead
-        // of a signer round-trip (see derive_leaf_signing_public_key).
-        let signing_public_key = derive_leaf_signing_public_key(node, &Secp256k1::new())?;
+        // Fetch the signing key from the signer, never derived from persisted
+        // tree data: the renewed refund pays to this key, so a coordinator that
+        // lied about the stored keyshare pubkey could otherwise steer the exit
+        // refund to a key it controls.
+        let signing_public_key = self.spark_signer.get_public_key_for_leaf(&node.id).await?;
 
         let node_tx = &node.node_tx;
 

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -831,6 +831,7 @@ impl TransferService {
                 cpfp_refund_tx,
                 *cpfp_sighash.as_byte_array(),
                 cpfp_commitments[i].clone(),
+                None, // claim refunds never use adaptor signatures
                 RefundVariant::Cpfp,
                 self.network,
             );
@@ -848,6 +849,7 @@ impl TransferService {
                     direct_refund_tx,
                     *sighash.as_byte_array(),
                     direct_commitments[i].clone(),
+                    None, // claim refunds never use adaptor signatures
                     RefundVariant::Direct,
                     self.network,
                 );
@@ -864,6 +866,7 @@ impl TransferService {
                     dfc_refund_tx,
                     *sighash.as_byte_array(),
                     direct_from_cpfp_commitments[i].clone(),
+                    None, // claim refunds never use adaptor signatures
                     RefundVariant::DirectFromCpfp,
                     self.network,
                 );

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -18,7 +18,6 @@ use crate::utils::refund::{SignRefundsParams, SignedRefundTransactions, sign_ref
 use crate::utils::tagged_hasher::TaggedHasher;
 use crate::utils::time::web_time_to_prost_timestamp;
 
-use bitcoin::Transaction;
 use bitcoin::hashes::{Hash, sha256};
 use bitcoin::secp256k1::PublicKey;
 use frost_secp256k1_tr::Identifier;
@@ -30,15 +29,16 @@ use crate::{
     bitcoin::sighash_from_tx,
     core::{current_sequence, enforce_timelock},
     signer::{
-        ClaimLeafInput, FrostDerivation, FrostJob, OperatorRecipient, PrepareClaimRequest,
-        PrepareTransferRequest, PreparedTransfer, SparkSigner, TransferLeafInput,
+        ClaimLeafInput, OperatorRecipient, PrepareClaimRequest, PrepareTransferRequest,
+        PreparedTransfer, SparkSigner, TransferLeafInput,
     },
     tree::{TreeNode, TreeNodeId},
+    utils::frost::sign_frost_batch,
     utils::transactions::{RefundTransactions, create_refund_txs},
 };
 
 use super::ServiceError;
-use super::models::{PreparedTransferRequest, SignedTx};
+use super::models::{PreparedTransferRequest, RefundVariant, SignedTx, build_refund_signing_job};
 
 /// Result of preparing a transfer package, containing both the package and the signed transaction data
 pub(crate) struct PreparedTransferPackage {
@@ -781,9 +781,11 @@ impl TransferService {
         ),
         ServiceError,
     > {
-        let mut cpfp_jobs = Vec::new();
-        let mut direct_jobs = Vec::new();
-        let mut direct_from_cpfp_jobs = Vec::new();
+        // Build every leaf-variant claim-refund FROST job up front, then sign the
+        // whole batch in one call. A per-job loop would cost one sign_frost
+        // network round-trip per leaf-variant on a remote signer.
+        let mut jobs = Vec::new();
+        let mut pending = Vec::new();
         for (i, leaf) in leaves.iter().enumerate() {
             // The claim refund is signed with the receiver's new leaf key, which
             // is the derived key for this node id.
@@ -818,94 +820,68 @@ impl TransferService {
             );
 
             let cpfp_sighash = sighash_from_tx(&cpfp_refund_tx, 0, &node_tx.output[0])?;
-            cpfp_jobs.push(
-                self.sign_claim_refund_job(
-                    &leaf.node.id,
-                    cpfp_refund_tx,
-                    cpfp_sighash.as_byte_array(),
-                    &signing_public_key,
-                    cpfp_commitments[i].clone(),
-                    &verifying_key,
-                )
-                .await?,
+            let (job, entry) = build_refund_signing_job(
+                &leaf.node.id,
+                &verifying_key,
+                &signing_public_key,
+                cpfp_refund_tx,
+                *cpfp_sighash.as_byte_array(),
+                cpfp_commitments[i].clone(),
+                RefundVariant::Cpfp,
+                self.network,
             );
+            jobs.push(job);
+            pending.push(entry);
 
             if let (Some(direct_tx), Some(direct_refund_tx)) =
                 (leaf.node.direct_tx.as_ref(), direct_refund_tx)
             {
                 let sighash = sighash_from_tx(&direct_refund_tx, 0, &direct_tx.output[0])?;
-                direct_jobs.push(
-                    self.sign_claim_refund_job(
-                        &leaf.node.id,
-                        direct_refund_tx,
-                        sighash.as_byte_array(),
-                        &signing_public_key,
-                        direct_commitments[i].clone(),
-                        &verifying_key,
-                    )
-                    .await?,
+                let (job, entry) = build_refund_signing_job(
+                    &leaf.node.id,
+                    &verifying_key,
+                    &signing_public_key,
+                    direct_refund_tx,
+                    *sighash.as_byte_array(),
+                    direct_commitments[i].clone(),
+                    RefundVariant::Direct,
+                    self.network,
                 );
+                jobs.push(job);
+                pending.push(entry);
             }
 
             if let Some(dfc_refund_tx) = direct_from_cpfp_refund_tx {
                 let sighash = sighash_from_tx(&dfc_refund_tx, 0, &node_tx.output[0])?;
-                direct_from_cpfp_jobs.push(
-                    self.sign_claim_refund_job(
-                        &leaf.node.id,
-                        dfc_refund_tx,
-                        sighash.as_byte_array(),
-                        &signing_public_key,
-                        direct_from_cpfp_commitments[i].clone(),
-                        &verifying_key,
-                    )
-                    .await?,
+                let (job, entry) = build_refund_signing_job(
+                    &leaf.node.id,
+                    &verifying_key,
+                    &signing_public_key,
+                    dfc_refund_tx,
+                    *sighash.as_byte_array(),
+                    direct_from_cpfp_commitments[i].clone(),
+                    RefundVariant::DirectFromCpfp,
+                    self.network,
                 );
+                jobs.push(job);
+                pending.push(entry);
+            }
+        }
+
+        let signed = sign_frost_batch(&self.spark_signer, jobs, pending).await?;
+        let mut cpfp_jobs = Vec::new();
+        let mut direct_jobs = Vec::new();
+        let mut direct_from_cpfp_jobs = Vec::new();
+        for (entry, share) in signed {
+            let (variant, job) = entry.into_user_signed_job(share)?;
+            match variant {
+                RefundVariant::Cpfp => cpfp_jobs.push(job),
+                RefundVariant::Direct => direct_jobs.push(job),
+                RefundVariant::DirectFromCpfp => direct_from_cpfp_jobs.push(job),
             }
         }
 
         Ok((cpfp_jobs, direct_jobs, direct_from_cpfp_jobs))
-    }
-
-    async fn sign_claim_refund_job(
-        &self,
-        node_id: &TreeNodeId,
-        refund_tx: Transaction,
-        sighash_bytes: &[u8; 32],
-        signing_public_key: &PublicKey,
-        operator_commitments: std::collections::BTreeMap<
-            Identifier,
-            frost_secp256k1_tr::round1::SigningCommitments,
-        >,
-        verifying_key: &PublicKey,
-    ) -> Result<operator_rpc::spark::UserSignedTxSigningJob, ServiceError> {
-        // The claim refund is signed with the receiver's new leaf key, which is
-        // the derived key for this node id.
-        let share = self
-            .spark_signer
-            .sign_frost(vec![FrostJob {
-                derivation: FrostDerivation::SigningLeaf {
-                    leaf_id: node_id.clone(),
-                },
-                sighash: *sighash_bytes,
-                verifying_key: *verifying_key,
-                operator_commitments: operator_commitments.clone(),
-                adaptor_public_key: None,
-            }])
-            .await?
-            .into_iter()
-            .next()
-            .ok_or_else(|| ServiceError::Generic("sign_frost returned no share".to_string()))?;
-
-        let signed_tx = SignedTx {
-            node_id: node_id.clone(),
-            signing_public_key: *signing_public_key,
-            tx: refund_tx,
-            user_signature: share.signature_share,
-            signing_commitments: operator_commitments,
-            self_nonce_commitment: share.commitment,
-            network: self.network,
-        };
-        (&signed_tx).try_into()
     }
 
     pub async fn verify_pending_transfer(

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -33,12 +33,14 @@ use crate::{
         PreparedTransfer, SparkSigner, TransferLeafInput,
     },
     tree::{TreeNode, TreeNodeId},
-    utils::frost::sign_frost_batch,
     utils::transactions::{RefundTransactions, create_refund_txs},
 };
 
 use super::ServiceError;
-use super::models::{PreparedTransferRequest, RefundVariant, SignedTx, build_refund_signing_job};
+use super::models::{
+    LeafRefundJobs, PreparedTransferRequest, SignedTx, build_refund_signing_job,
+    into_user_signed_job_groups, sign_leaf_refunds,
+};
 
 /// Result of preparing a transfer package, containing both the package and the signed transaction data
 pub(crate) struct PreparedTransferPackage {
@@ -788,8 +790,7 @@ impl TransferService {
         // Build every leaf-variant claim-refund FROST job up front, then sign the
         // whole batch in one call. A per-job loop would cost one sign_frost
         // network round-trip per leaf-variant on a remote signer.
-        let mut jobs = Vec::new();
-        let mut pending = Vec::new();
+        let mut leaf_jobs: Vec<LeafRefundJobs> = Vec::new();
         for (i, leaf) in leaves.iter().enumerate() {
             // The claim refund is signed with the receiver's new leaf key, which
             // is the derived key for this node id.
@@ -824,7 +825,7 @@ impl TransferService {
             );
 
             let cpfp_sighash = sighash_from_tx(&cpfp_refund_tx, 0, &node_tx.output[0])?;
-            let (job, entry) = build_refund_signing_job(
+            let cpfp = build_refund_signing_job(
                 &leaf.node.id,
                 &verifying_key,
                 &signing_public_key,
@@ -832,17 +833,14 @@ impl TransferService {
                 *cpfp_sighash.as_byte_array(),
                 cpfp_commitments[i].clone(),
                 None, // claim refunds never use adaptor signatures
-                RefundVariant::Cpfp,
                 self.network,
             );
-            jobs.push(job);
-            pending.push(entry);
 
-            if let (Some(direct_tx), Some(direct_refund_tx)) =
+            let direct = if let (Some(direct_tx), Some(direct_refund_tx)) =
                 (leaf.node.direct_tx.as_ref(), direct_refund_tx)
             {
                 let sighash = sighash_from_tx(&direct_refund_tx, 0, &direct_tx.output[0])?;
-                let (job, entry) = build_refund_signing_job(
+                Some(build_refund_signing_job(
                     &leaf.node.id,
                     &verifying_key,
                     &signing_public_key,
@@ -850,16 +848,15 @@ impl TransferService {
                     *sighash.as_byte_array(),
                     direct_commitments[i].clone(),
                     None, // claim refunds never use adaptor signatures
-                    RefundVariant::Direct,
                     self.network,
-                );
-                jobs.push(job);
-                pending.push(entry);
-            }
+                ))
+            } else {
+                None
+            };
 
-            if let Some(dfc_refund_tx) = direct_from_cpfp_refund_tx {
+            let direct_from_cpfp = if let Some(dfc_refund_tx) = direct_from_cpfp_refund_tx {
                 let sighash = sighash_from_tx(&dfc_refund_tx, 0, &node_tx.output[0])?;
-                let (job, entry) = build_refund_signing_job(
+                Some(build_refund_signing_job(
                     &leaf.node.id,
                     &verifying_key,
                     &signing_public_key,
@@ -867,28 +864,21 @@ impl TransferService {
                     *sighash.as_byte_array(),
                     direct_from_cpfp_commitments[i].clone(),
                     None, // claim refunds never use adaptor signatures
-                    RefundVariant::DirectFromCpfp,
                     self.network,
-                );
-                jobs.push(job);
-                pending.push(entry);
-            }
+                ))
+            } else {
+                None
+            };
+
+            leaf_jobs.push(LeafRefundJobs {
+                cpfp,
+                direct,
+                direct_from_cpfp,
+            });
         }
 
-        let signed = sign_frost_batch(&self.spark_signer, jobs, pending).await?;
-        let mut cpfp_jobs = Vec::new();
-        let mut direct_jobs = Vec::new();
-        let mut direct_from_cpfp_jobs = Vec::new();
-        for (entry, share) in signed {
-            let (variant, job) = entry.into_user_signed_job(share)?;
-            match variant {
-                RefundVariant::Cpfp => cpfp_jobs.push(job),
-                RefundVariant::Direct => direct_jobs.push(job),
-                RefundVariant::DirectFromCpfp => direct_from_cpfp_jobs.push(job),
-            }
-        }
-
-        Ok((cpfp_jobs, direct_jobs, direct_from_cpfp_jobs))
+        let signed = sign_leaf_refunds(&self.spark_signer, leaf_jobs).await?;
+        into_user_signed_job_groups(signed)
     }
 
     pub async fn verify_pending_transfer(

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -682,14 +682,12 @@ impl TransferService {
         let [cpfp_chunk, direct_chunk, direct_from_cpfp_chunk] =
             split_signing_commitments_by_variant(&signing_commitments, leaves.len())?;
 
-        // Sign the claim refunds (current timelock) operator-commits-first via
-        // sign_frost; the operators aggregate server-side during `claim_transfer`.
-        let (cpfp_jobs, direct_jobs, direct_from_cpfp_jobs) = self
-            .sign_claim_refunds(leaves, cpfp_chunk, direct_chunk, direct_from_cpfp_chunk)
-            .await?;
-
         // Key-tweak step (decrypt incoming key, derive new key, compute tweak,
-        // Feldman-split, ECIES per operator, sign the claim-package payload).
+        // Feldman-split, ECIES per operator). Run before signing the refunds: for
+        // a remote signer (e.g. Turnkey) prepare_claim returns and caches every
+        // new leaf pubkey in one activity, so the per-leaf get_public_key_for_leaf
+        // inside sign_claim_refunds is then a cache hit instead of a round-trip
+        // per incoming leaf.
         let claim_leaves = leaves
             .iter()
             .map(|leaf| {
@@ -734,6 +732,12 @@ impl TransferService {
                 )
             })
             .collect();
+
+        // Sign the claim refunds (current timelock) operator-commits-first via
+        // sign_frost; the operators aggregate server-side during `claim_transfer`.
+        let (cpfp_jobs, direct_jobs, direct_from_cpfp_jobs) = self
+            .sign_claim_refunds(leaves, cpfp_chunk, direct_chunk, direct_from_cpfp_chunk)
+            .await?;
 
         // Claim-package user signature: identity-key ECDSA over the tagged
         // payload (tag || transfer_id || tweak map). Done here, not in the

--- a/crates/spark/src/services/transfer.rs
+++ b/crates/spark/src/services/transfer.rs
@@ -685,11 +685,10 @@ impl TransferService {
             split_signing_commitments_by_variant(&signing_commitments, leaves.len())?;
 
         // Key-tweak step (decrypt incoming key, derive new key, compute tweak,
-        // Feldman-split, ECIES per operator). Run before signing the refunds: for
-        // a remote signer (e.g. Turnkey) prepare_claim returns and caches every
-        // new leaf pubkey in one activity, so the per-leaf get_public_key_for_leaf
-        // inside sign_claim_refunds is then a cache hit instead of a round-trip
-        // per incoming leaf.
+        // Feldman-split, ECIES per operator). Run before signing the refunds:
+        // prepare_claim resolves every new leaf pubkey up front, so the per-leaf
+        // get_public_key_for_leaf inside sign_claim_refunds can reuse those rather
+        // than resolving each one again.
         let claim_leaves = leaves
             .iter()
             .map(|leaf| {
@@ -788,8 +787,7 @@ impl TransferService {
         ServiceError,
     > {
         // Build every leaf-variant claim-refund FROST job up front, then sign the
-        // whole batch in one call. A per-job loop would cost one sign_frost
-        // network round-trip per leaf-variant on a remote signer.
+        // whole batch in one call.
         let mut leaf_jobs: Vec<LeafRefundJobs> = Vec::new();
         for (i, leaf) in leaves.iter().enumerate() {
             // The claim refund is signed with the receiver's new leaf key, which

--- a/crates/spark/src/signer/spark_signer.rs
+++ b/crates/spark/src/signer/spark_signer.rs
@@ -332,6 +332,15 @@ pub trait SparkSigner: Send + Sync + 'static {
     async fn get_public_key_for_leaf(&self, leaf_id: &TreeNodeId)
     -> Result<PublicKey, SignerError>;
 
+    /// Whether this signer is backed by a remote service, so its operations
+    /// (deriving a leaf's public key, signing) are network round-trips rather
+    /// than local computation. When true, callers should avoid redundant signer
+    /// calls, e.g. re-deriving keys for leaves whose ownership is already
+    /// verified in storage. Defaults to false: most signers are local.
+    fn is_remote(&self) -> bool {
+        false
+    }
+
     /// Returns the static-deposit public key at `index`. The wallet hands this
     /// to the operators to derive a static-deposit address. Analogous to
     /// [`get_public_key_for_leaf`](Self::get_public_key_for_leaf).

--- a/crates/spark/src/tree/mod.rs
+++ b/crates/spark/src/tree/mod.rs
@@ -20,6 +20,7 @@ pub use store::{
 };
 use tracing::trace;
 
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -62,6 +63,41 @@ impl Leaves {
     pub fn balance(&self) -> u64 {
         self.available_balance() + self.missing_operators_balance() + self.swap_reserved_balance()
     }
+}
+
+/// The two public keys needed to confirm a stored leaf's ownership was already
+/// verified, without loading the full node (and its transaction blobs). Its
+/// signing pubkey is a deterministic function of the leaf id, so a stored leaf
+/// whose verifying and signing-keyshare keys still match the coordinator's is
+/// known-good: re-running the ownership check would only confirm it again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VerifiedLeafKeys {
+    pub verifying_public_key: PublicKey,
+    pub signing_keyshare_public_key: PublicKey,
+}
+
+/// Projects the verified-leaf categories of `leaves` into the keys keyed by id.
+/// The set mirrors `Leaves::balance` inputs plus payment-reserved leaves: every
+/// category whose leaves passed the ownership check before being stored, and
+/// deliberately excludes `not_available` (never verified). Backends that
+/// override `TreeStore::get_verified_leaf_keys` must project the same set.
+pub fn verified_leaf_keys_from_leaves(leaves: &Leaves) -> HashMap<TreeNodeId, VerifiedLeafKeys> {
+    leaves
+        .available
+        .iter()
+        .chain(&leaves.available_missing_from_operators)
+        .chain(&leaves.reserved_for_payment)
+        .chain(&leaves.reserved_for_swap)
+        .map(|leaf| {
+            (
+                leaf.id.clone(),
+                VerifiedLeafKeys {
+                    verifying_public_key: leaf.verifying_public_key,
+                    signing_keyshare_public_key: leaf.signing_keyshare.public_key,
+                },
+            )
+        })
+        .collect()
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -534,6 +570,18 @@ pub trait TreeStore: Send + Sync {
     async fn get_available_balance(&self) -> Result<u64, TreeServiceError> {
         let leaves = self.get_leaves().await?;
         Ok(leaves.balance())
+    }
+
+    /// Returns, keyed by leaf id, the keys needed to tell whether a stored
+    /// leaf's ownership was already verified (see [`VerifiedLeafKeys`]). Lets a
+    /// refresh skip re-deriving a signer pubkey for leaves that are unchanged
+    /// since they were stored. Default impl falls through to `get_leaves`;
+    /// storage backends should override to project only these columns and skip
+    /// loading full nodes (and their transaction blobs).
+    async fn get_verified_leaf_keys(
+        &self,
+    ) -> Result<HashMap<TreeNodeId, VerifiedLeafKeys>, TreeServiceError> {
+        Ok(verified_leaf_keys_from_leaves(&self.get_leaves().await?))
     }
 
     /// Replaces all leaves in the store with the provided set.

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -275,20 +275,43 @@ impl TreeService for SynchronousTreeService {
             })
             .collect();
 
-        // Fetch our signing pubkey for each Available leaf concurrently rather
-        // than one at a time, leaving the signer to bound its own concurrency.
-        // Order is preserved for the zip below.
-        // TODO: validate each leaf once and persist the result, to skip
-        // re-checking unchanged leaves on every refresh.
+        // A leaf enters the store only after this ownership check has passed, so
+        // one already stored with the same verifying and signing-keyshare keys is
+        // known-good and skipped. Only leaves new or changed since the last
+        // refresh need their pubkey fetched, which is a network round-trip on some
+        // signers: re-deriving every leaf each refresh would flood the signer and
+        // stall payments behind the rate limiter on large wallets. Remaining
+        // fetches run concurrently, leaving the signer to bound its own
+        // concurrency; order is preserved for the zip below.
+        let stored_leaves = self.state.get_leaves().await?;
+        let stored_by_id: HashMap<&TreeNodeId, &TreeNode> = stored_leaves
+            .available
+            .iter()
+            .chain(&stored_leaves.available_missing_from_operators)
+            .chain(&stored_leaves.reserved_for_payment)
+            .chain(&stored_leaves.reserved_for_swap)
+            .map(|leaf| (&leaf.id, leaf))
+            .collect();
+        let unverified_leaves: Vec<&TreeNode> = available_leaves
+            .iter()
+            .copied()
+            .filter(|leaf| {
+                !stored_by_id.get(&leaf.id).is_some_and(|stored| {
+                    stored.verifying_public_key == leaf.verifying_public_key
+                        && stored.signing_keyshare.public_key == leaf.signing_keyshare.public_key
+                })
+            })
+            .collect();
+
         let signer = &self.spark_signer;
         let our_pubkeys: Vec<PublicKey> = futures::future::try_join_all(
-            available_leaves
+            unverified_leaves
                 .iter()
                 .map(|leaf| async move { signer.get_public_key_for_leaf(&leaf.id).await }),
         )
         .await?;
 
-        for (leaf, our_node_pubkey) in available_leaves.iter().zip(our_pubkeys) {
+        for (leaf, our_node_pubkey) in unverified_leaves.iter().zip(our_pubkeys) {
             let combined_pubkey = our_node_pubkey
                 .combine(&leaf.signing_keyshare.public_key)
                 .map_err(|_| {

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -275,30 +275,26 @@ impl TreeService for SynchronousTreeService {
             })
             .collect();
 
-        // A leaf enters the store only after this ownership check has passed, so
-        // one already stored with the same verifying and signing-keyshare keys is
-        // known-good and skipped. Only leaves new or changed since the last
-        // refresh need their pubkey fetched, which is a network round-trip on some
-        // signers: re-deriving every leaf each refresh would flood the signer and
-        // stall payments behind the rate limiter on large wallets. Remaining
+        // Deriving our leaf pubkey is a network round-trip on a remote signer, so
+        // re-deriving every leaf each refresh would flood the signer and stall
+        // payments behind its rate limiter on large wallets. For remote signers we
+        // skip leaves already stored with matching keys (see `VerifiedLeafKeys`),
+        // re-checking only new or changed leaves. Local signers derive cheaply, so
+        // they skip the store read and verify every available leaf. Remaining
         // fetches run concurrently, leaving the signer to bound its own
         // concurrency; order is preserved for the zip below.
-        let stored_leaves = self.state.get_leaves().await?;
-        let stored_by_id: HashMap<&TreeNodeId, &TreeNode> = stored_leaves
-            .available
-            .iter()
-            .chain(&stored_leaves.available_missing_from_operators)
-            .chain(&stored_leaves.reserved_for_payment)
-            .chain(&stored_leaves.reserved_for_swap)
-            .map(|leaf| (&leaf.id, leaf))
-            .collect();
+        let already_verified = if self.spark_signer.is_remote() {
+            self.state.get_verified_leaf_keys().await?
+        } else {
+            HashMap::new()
+        };
         let unverified_leaves: Vec<&TreeNode> = available_leaves
             .iter()
             .copied()
             .filter(|leaf| {
-                !stored_by_id.get(&leaf.id).is_some_and(|stored| {
-                    stored.verifying_public_key == leaf.verifying_public_key
-                        && stored.signing_keyshare.public_key == leaf.signing_keyshare.public_key
+                !already_verified.get(&leaf.id).is_some_and(|keys| {
+                    keys.verifying_public_key == leaf.verifying_public_key
+                        && keys.signing_keyshare_public_key == leaf.signing_keyshare.public_key
                 })
             })
             .collect();

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -1,4 +1,5 @@
 use futures::future::join_all;
+use futures::{StreamExt, TryStreamExt};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -32,6 +33,11 @@ use crate::{
 };
 
 use super::{TreeNode, error::TreeServiceError};
+
+/// Max in-flight signer pubkey lookups while validating leaves in `refresh_leaves`.
+/// Bounds concurrency so a large wallet does not fire one request per leaf at
+/// the signer all at once.
+const REFRESH_LEAVES_PUBKEY_CONCURRENCY: usize = 16;
 
 pub struct SynchronousTreeService {
     identity_pubkey: PublicKey,
@@ -259,27 +265,51 @@ impl TreeService for SynchronousTreeService {
             }
         }
 
-        for leaf in &coordinator_leaves {
-            if leaf.status != TreeNodeStatus::Available {
-                info!("Ignoring leaf {} due to status: {:?}", leaf.id, leaf.status);
-                ignored_leaves_map.insert(leaf.id.clone(), leaf.clone());
-                continue;
-            }
+        // Leaves not Available are ignored outright; the rest need an ownership
+        // check (our signing share + the operators' share must equal the
+        // verifying key).
+        let available_leaves: Vec<&TreeNode> = coordinator_leaves
+            .iter()
+            .filter(|leaf| {
+                if leaf.status == TreeNodeStatus::Available {
+                    true
+                } else {
+                    info!("Ignoring leaf {} due to status: {:?}", leaf.id, leaf.status);
+                    ignored_leaves_map.insert(leaf.id.clone(), (*leaf).clone());
+                    false
+                }
+            })
+            .collect();
 
-            let our_node_pubkey = self.spark_signer.get_public_key_for_leaf(&leaf.id).await?;
-            let other_node_pubkey = leaf.signing_keyshare.public_key;
-            let verifying_pubkey = leaf.verifying_public_key;
+        // Fetch our signing pubkey for each Available leaf with bounded
+        // concurrency, so a remote signer resolves them in parallel instead of one
+        // blocking round-trip per leaf. Order is preserved for the zip below.
+        // TODO: validate each leaf once and persist the result, to skip
+        // re-checking unchanged leaves on every refresh.
+        let signer = &self.spark_signer;
+        let available_ids: Vec<TreeNodeId> = available_leaves
+            .iter()
+            .map(|leaf| leaf.id.clone())
+            .collect();
+        let our_pubkeys: Vec<PublicKey> = futures::stream::iter(available_ids)
+            .map(|leaf_id| async move { signer.get_public_key_for_leaf(&leaf_id).await })
+            .buffered(REFRESH_LEAVES_PUBKEY_CONCURRENCY)
+            .try_collect()
+            .await?;
 
-            let combined_pubkey = our_node_pubkey.combine(&other_node_pubkey).map_err(|_| {
-                TreeServiceError::Generic("Failed to combine public keys".to_string())
-            })?;
+        for (leaf, our_node_pubkey) in available_leaves.iter().zip(our_pubkeys) {
+            let combined_pubkey = our_node_pubkey
+                .combine(&leaf.signing_keyshare.public_key)
+                .map_err(|_| {
+                    TreeServiceError::Generic("Failed to combine public keys".to_string())
+                })?;
 
-            if combined_pubkey != verifying_pubkey {
+            if combined_pubkey != leaf.verifying_public_key {
                 warn!(
                     "Leaf {}'s verifying public key does not match the expected value",
                     leaf.id
                 );
-                ignored_leaves_map.insert(leaf.id.clone(), leaf.clone());
+                ignored_leaves_map.insert(leaf.id.clone(), (*leaf).clone());
             }
         }
 

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -1,5 +1,4 @@
 use futures::future::join_all;
-use futures::{StreamExt, TryStreamExt};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -33,11 +32,6 @@ use crate::{
 };
 
 use super::{TreeNode, error::TreeServiceError};
-
-/// Max in-flight signer pubkey lookups while validating leaves in `refresh_leaves`.
-/// Bounds concurrency so a large wallet does not fire one request per leaf at
-/// the signer all at once.
-const REFRESH_LEAVES_PUBKEY_CONCURRENCY: usize = 16;
 
 pub struct SynchronousTreeService {
     identity_pubkey: PublicKey,
@@ -281,21 +275,20 @@ impl TreeService for SynchronousTreeService {
             })
             .collect();
 
-        // Fetch our signing pubkey for each Available leaf with bounded
-        // concurrency, so a remote signer resolves them in parallel instead of one
-        // blocking round-trip per leaf. Order is preserved for the zip below.
+        // Fetch our signing pubkey for each Available leaf concurrently, so a
+        // remote signer resolves them in parallel instead of one blocking
+        // round-trip per leaf. A rate-limited signer (e.g. Turnkey) paces the
+        // calls internally, so no concurrency cap is imposed here. Order is
+        // preserved for the zip below.
         // TODO: validate each leaf once and persist the result, to skip
         // re-checking unchanged leaves on every refresh.
         let signer = &self.spark_signer;
-        let available_ids: Vec<TreeNodeId> = available_leaves
-            .iter()
-            .map(|leaf| leaf.id.clone())
-            .collect();
-        let our_pubkeys: Vec<PublicKey> = futures::stream::iter(available_ids)
-            .map(|leaf_id| async move { signer.get_public_key_for_leaf(&leaf_id).await })
-            .buffered(REFRESH_LEAVES_PUBKEY_CONCURRENCY)
-            .try_collect()
-            .await?;
+        let our_pubkeys: Vec<PublicKey> = futures::future::try_join_all(
+            available_leaves
+                .iter()
+                .map(|leaf| async move { signer.get_public_key_for_leaf(&leaf.id).await }),
+        )
+        .await?;
 
         for (leaf, our_node_pubkey) in available_leaves.iter().zip(our_pubkeys) {
             let combined_pubkey = our_node_pubkey

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -275,11 +275,9 @@ impl TreeService for SynchronousTreeService {
             })
             .collect();
 
-        // Fetch our signing pubkey for each Available leaf concurrently, so a
-        // remote signer resolves them in parallel instead of one blocking
-        // round-trip per leaf. A rate-limited signer (e.g. Turnkey) paces the
-        // calls internally, so no concurrency cap is imposed here. Order is
-        // preserved for the zip below.
+        // Fetch our signing pubkey for each Available leaf concurrently rather
+        // than one at a time, leaving the signer to bound its own concurrency.
+        // Order is preserved for the zip below.
         // TODO: validate each leaf once and persist the result, to skip
         // re-checking unchanged leaves on every refresh.
         let signer = &self.spark_signer;

--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -1067,6 +1067,11 @@ mod tests {
     }
 
     #[async_test_all]
+    async fn test_get_verified_leaf_keys() {
+        shared_tests::test_get_verified_leaf_keys(&InMemoryTreeStore::new()).await;
+    }
+
+    #[async_test_all]
     async fn test_add_leaves() {
         shared_tests::test_add_leaves(&InMemoryTreeStore::new()).await;
     }

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -115,6 +115,56 @@ pub async fn test_new(store: &dyn TreeStore) {
     assert!(store.get_leaves().await.unwrap().available.is_empty());
 }
 
+pub async fn test_get_verified_leaf_keys(store: &dyn TreeStore) {
+    // `create_test_tree_node` uses one key for both fields; override these so a
+    // projection that swaps or drops a field is caught. Both are valid points.
+    let verifying = "02e6642fd69bd211f93f7f1f36ca51a26a5290eb2dd1b0d8279a87bb0d480c8443";
+    let keyshare = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+    let mut available = create_test_tree_node("verified-available", 1000);
+    available.verifying_public_key = PublicKey::from_str(verifying).unwrap();
+    available.signing_keyshare.public_key = PublicKey::from_str(keyshare).unwrap();
+
+    // Reserved leaves were verified before storage, so they must be included.
+    let reserved = create_test_tree_node("verified-reserved", 2000);
+
+    // Non-Available and unreserved: never verified, so it must be excluded.
+    let mut not_available = create_test_tree_node("verified-not-available", 3000);
+    not_available.status = TreeNodeStatus::TransferLocked;
+
+    store
+        .add_leaves(&[available.clone(), reserved.clone(), not_available.clone()])
+        .await
+        .unwrap();
+    store
+        .try_reserve_leaves_by_ids(
+            std::slice::from_ref(&reserved.id),
+            ReservationPurpose::Payment,
+        )
+        .await
+        .unwrap();
+
+    let keys = store.get_verified_leaf_keys().await.unwrap();
+
+    // The override must agree with the canonical projection of `get_leaves`.
+    let expected = crate::tree::verified_leaf_keys_from_leaves(&store.get_leaves().await.unwrap());
+    assert_eq!(keys, expected);
+
+    // Available leaf verified with the right (non-swapped) keys.
+    let got = keys.get(&available.id).expect("available leaf verified");
+    assert_eq!(
+        got.verifying_public_key,
+        PublicKey::from_str(verifying).unwrap()
+    );
+    assert_eq!(
+        got.signing_keyshare_public_key,
+        PublicKey::from_str(keyshare).unwrap()
+    );
+    // Reserved leaf included; non-Available unreserved leaf excluded.
+    assert!(keys.contains_key(&reserved.id));
+    assert!(!keys.contains_key(&not_available.id));
+}
+
 pub async fn test_add_leaves(store: &dyn TreeStore) {
     let leaves = vec![
         create_test_tree_node("node1", 100),

--- a/crates/spark/src/utils/frost.rs
+++ b/crates/spark/src/utils/frost.rs
@@ -181,3 +181,33 @@ pub fn aggregate_frost(
         ))
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::secp256k1::SecretKey;
+
+    use super::*;
+    use crate::tree::tests::create_test_tree_node;
+
+    /// `derive_leaf_signing_public_key` must recover the user's signing key from
+    /// the FROST relation `verifying_public_key = user_share + se_share`, i.e.
+    /// return `verifying_public_key - signing_keyshare.public_key`.
+    #[test]
+    fn derives_user_share_from_verifying_and_se_share() {
+        let secp = Secp256k1::new();
+
+        // se_share = a*G (operators' aggregate), user_share = b*G (what we derive).
+        let a = SecretKey::from_slice(&[0x11; 32]).unwrap();
+        let b = SecretKey::from_slice(&[0x22; 32]).unwrap();
+        let se_share = a.public_key(&secp);
+        let user_share = b.public_key(&secp);
+        let verifying = se_share.combine(&user_share).unwrap();
+
+        let mut node = create_test_tree_node("test_leaf", 1000);
+        node.signing_keyshare.public_key = se_share;
+        node.verifying_public_key = verifying;
+
+        let derived = derive_leaf_signing_public_key(&node, &secp).unwrap();
+        assert_eq!(derived, user_share);
+    }
+}

--- a/crates/spark/src/utils/frost.rs
+++ b/crates/spark/src/utils/frost.rs
@@ -1,12 +1,33 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
-use bitcoin::secp256k1::PublicKey;
+use bitcoin::secp256k1::{All, PublicKey, Secp256k1};
 use frost_secp256k1_tr::keys::{PublicKeyPackage, VerifyingShare};
 use frost_secp256k1_tr::round1::SigningCommitments;
 use frost_secp256k1_tr::{Identifier, SigningPackage, VerifyingKey};
 
 use crate::signer::{AggregateFrostRequest, FrostJob, FrostShareResult, SignerError, SparkSigner};
+use crate::tree::TreeNode;
+
+/// The user's own signing public key for an OWNED leaf, derived from persisted
+/// tree data instead of asking the signer: `verifying_public_key -
+/// signing_keyshare.public_key`. FROST composes the group verifying key as the
+/// user's verifying share plus the operators' aggregate share, and
+/// `refresh_leaves` validates this relation for every Available leaf, so the
+/// user's share is recoverable locally. This avoids a per-leaf signer round-trip
+/// on the send/coop-exit/timelock hot paths (for a remote signer with a cold
+/// in-memory cache, e.g. a per-request server instance, that would otherwise be
+/// one network call per leaf). Only valid for owned leaves: an incoming (claim)
+/// leaf is mid-transfer, so its stored SE share need not pair with the new key.
+pub(crate) fn derive_leaf_signing_public_key(
+    node: &TreeNode,
+    secp: &Secp256k1<All>,
+) -> Result<PublicKey, SignerError> {
+    let se_share = node.signing_keyshare.public_key.negate(secp);
+    node.verifying_public_key
+        .combine(&se_share)
+        .map_err(|e| SignerError::Generic(format!("failed to derive leaf signing key: {e}")))
+}
 
 /// Signs a batch of FROST jobs in a single `sign_frost` call, pairing each
 /// returned share with its caller-side metadata (order preserved). Remote signer

--- a/crates/spark/src/utils/frost.rs
+++ b/crates/spark/src/utils/frost.rs
@@ -49,9 +49,7 @@ pub(crate) fn zip_checked<S, T>(
 }
 
 /// Signs a batch of FROST jobs in a single `sign_frost` call, pairing each
-/// returned share with its caller-side metadata (order preserved). Remote signer
-/// backends (e.g. Turnkey) collapse the whole batch into one round-trip instead
-/// of one per job.
+/// returned share with its caller-side metadata (order preserved).
 pub(crate) async fn sign_frost_batch<T>(
     spark_signer: &Arc<dyn SparkSigner>,
     jobs: Vec<FrostJob>,

--- a/crates/spark/src/utils/frost.rs
+++ b/crates/spark/src/utils/frost.rs
@@ -9,16 +9,13 @@ use frost_secp256k1_tr::{Identifier, SigningPackage, VerifyingKey};
 use crate::signer::{AggregateFrostRequest, FrostJob, FrostShareResult, SignerError, SparkSigner};
 use crate::tree::TreeNode;
 
-/// The user's own signing public key for an OWNED leaf, derived from persisted
-/// tree data instead of asking the signer: `verifying_public_key -
-/// signing_keyshare.public_key`. FROST composes the group verifying key as the
-/// user's verifying share plus the operators' aggregate share, and
-/// `refresh_leaves` validates this relation for every Available leaf, so the
-/// user's share is recoverable locally. This avoids a per-leaf signer round-trip
-/// on the send/coop-exit/timelock hot paths (for a remote signer with a cold
-/// in-memory cache, e.g. a per-request server instance, that would otherwise be
-/// one network call per leaf). Only valid for owned leaves: an incoming (claim)
-/// leaf is mid-transfer, so its stored SE share need not pair with the new key.
+/// The user's own signing public key for an OWNED leaf, recovered from persisted
+/// tree data as `verifying_public_key - signing_keyshare.public_key` instead of
+/// via a signer round-trip. FROST composes the group verifying key as the user's
+/// share plus the operators' aggregate share, an invariant `refresh_leaves`
+/// validates for every Available leaf, so the user's share is derivable locally.
+/// Only valid for owned leaves: an incoming (claim) leaf is mid-transfer, so its
+/// stored SE share need not pair with the new key.
 pub(crate) fn derive_leaf_signing_public_key(
     node: &TreeNode,
     secp: &Secp256k1<All>,
@@ -31,8 +28,8 @@ pub(crate) fn derive_leaf_signing_public_key(
 
 /// Signs a batch of FROST jobs in a single `sign_frost` call, pairing each
 /// returned share with its caller-side metadata (order preserved). Remote signer
-/// backends (e.g. Turnkey) collapse this into one round-trip instead of one per
-/// job, so callers should build all jobs up front rather than signing per item.
+/// backends (e.g. Turnkey) collapse the whole batch into one round-trip instead
+/// of one per job.
 pub(crate) async fn sign_frost_batch<T>(
     spark_signer: &Arc<dyn SparkSigner>,
     jobs: Vec<FrostJob>,

--- a/crates/spark/src/utils/frost.rs
+++ b/crates/spark/src/utils/frost.rs
@@ -10,11 +10,14 @@ use crate::signer::{AggregateFrostRequest, FrostJob, FrostShareResult, SignerErr
 use crate::tree::TreeNode;
 
 /// The user's own signing public key for an OWNED leaf, recovered from persisted
-/// tree data as `verifying_public_key - signing_keyshare.public_key` instead of
-/// via a signer round-trip. FROST composes the group verifying key as the user's
-/// share plus the operators' aggregate share, an invariant `refresh_leaves`
-/// validates for every Available leaf, so the user's share is derivable locally.
-/// Only valid for owned leaves: an incoming (claim) leaf is mid-transfer, so its
+/// tree data as `verifying_public_key - signing_keyshare.public_key` rather than
+/// via a signer round-trip: FROST composes the group verifying key as the user's
+/// share plus the operators' aggregate share.
+///
+/// The result is only as trustworthy as the persisted operands: a poisoned
+/// `signing_keyshare.public_key` steers it, so use it only where a wrong value
+/// fails closed (an invalid signature), never to choose a payout destination.
+/// Valid only for owned leaves: an incoming (claim) leaf is mid-transfer, so its
 /// stored SE share need not pair with the new key.
 pub(crate) fn derive_leaf_signing_public_key(
     node: &TreeNode,

--- a/crates/spark/src/utils/frost.rs
+++ b/crates/spark/src/utils/frost.rs
@@ -1,11 +1,32 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
 use bitcoin::secp256k1::PublicKey;
 use frost_secp256k1_tr::keys::{PublicKeyPackage, VerifyingShare};
 use frost_secp256k1_tr::round1::SigningCommitments;
 use frost_secp256k1_tr::{Identifier, SigningPackage, VerifyingKey};
 
-use crate::signer::{AggregateFrostRequest, SignerError};
+use crate::signer::{AggregateFrostRequest, FrostJob, FrostShareResult, SignerError, SparkSigner};
+
+/// Signs a batch of FROST jobs in a single `sign_frost` call, pairing each
+/// returned share with its caller-side metadata (order preserved). Remote signer
+/// backends (e.g. Turnkey) collapse this into one round-trip instead of one per
+/// job, so callers should build all jobs up front rather than signing per item.
+pub(crate) async fn sign_frost_batch<T>(
+    spark_signer: &Arc<dyn SparkSigner>,
+    jobs: Vec<FrostJob>,
+    pending: Vec<T>,
+) -> Result<Vec<(T, FrostShareResult)>, SignerError> {
+    let shares = spark_signer.sign_frost(jobs).await?;
+    if shares.len() != pending.len() {
+        return Err(SignerError::Generic(format!(
+            "sign_frost returned {} shares, expected {}",
+            shares.len(),
+            pending.len()
+        )));
+    }
+    Ok(pending.into_iter().zip(shares).collect())
+}
 
 /// Builds the FROST [`SigningPackage`] for a user + statechain signing round.
 ///

--- a/crates/spark/src/utils/frost.rs
+++ b/crates/spark/src/utils/frost.rs
@@ -29,6 +29,25 @@ pub(crate) fn derive_leaf_signing_public_key(
         .map_err(|e| SignerError::Generic(format!("failed to derive leaf signing key: {e}")))
 }
 
+/// Zips signer shares back onto their caller-side metadata one-to-one, erroring
+/// on a count mismatch instead of silently dropping the tail (a plain `zip`
+/// truncates to the shorter side, misrouting every share past the gap). This is
+/// the single length guard behind the batched signing paths, so the reliance on
+/// `sign_frost` returning one share per job in order is enforced in one place.
+pub(crate) fn zip_checked<S, T>(
+    shares: Vec<S>,
+    pending: Vec<T>,
+) -> Result<Vec<(T, S)>, SignerError> {
+    if shares.len() != pending.len() {
+        return Err(SignerError::Generic(format!(
+            "sign_frost returned {} shares, expected {}",
+            shares.len(),
+            pending.len()
+        )));
+    }
+    Ok(pending.into_iter().zip(shares).collect())
+}
+
 /// Signs a batch of FROST jobs in a single `sign_frost` call, pairing each
 /// returned share with its caller-side metadata (order preserved). Remote signer
 /// backends (e.g. Turnkey) collapse the whole batch into one round-trip instead
@@ -39,14 +58,7 @@ pub(crate) async fn sign_frost_batch<T>(
     pending: Vec<T>,
 ) -> Result<Vec<(T, FrostShareResult)>, SignerError> {
     let shares = spark_signer.sign_frost(jobs).await?;
-    if shares.len() != pending.len() {
-        return Err(SignerError::Generic(format!(
-            "sign_frost returned {} shares, expected {}",
-            shares.len(),
-            pending.len()
-        )));
-    }
-    Ok(pending.into_iter().zip(shares).collect())
+    zip_checked(shares, pending)
 }
 
 /// Builds the FROST [`SigningPackage`] for a user + statechain signing round.
@@ -209,5 +221,20 @@ mod tests {
 
         let derived = derive_leaf_signing_public_key(&node, &secp).unwrap();
         assert_eq!(derived, user_share);
+    }
+
+    /// `zip_checked` pairs shares with pending metadata one-to-one and rejects a
+    /// count mismatch rather than silently truncating: a plain `zip` would drop
+    /// the tail and misroute every share past the gap.
+    #[test]
+    fn zip_checked_pairs_equal_lengths_and_rejects_mismatch() {
+        // Equal lengths: (pending, share) pairs, order preserved.
+        let paired = zip_checked(vec!['a', 'b'], vec![1, 2]).unwrap();
+        assert_eq!(paired, vec![(1, 'a'), (2, 'b')]);
+
+        // Too few shares (a truncated signer response) errors.
+        assert!(zip_checked(vec!['a'], vec![1, 2]).is_err());
+        // Too many shares errors as well.
+        assert!(zip_checked(vec!['a', 'b', 'c'], vec![1, 2]).is_err());
     }
 }

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -9,17 +9,16 @@ use frost_secp256k1_tr::round1::SigningCommitments;
 use tracing::info;
 
 use crate::core::next_lightning_htlc_sequence;
-use crate::services::SignedTx;
-use crate::signer::{FrostDerivation, FrostJob, FrostShareResult, SignerError, SparkSigner};
+use crate::services::{
+    PendingRefundSignature, RefundVariant, SignedTx, build_refund_signing_job,
+};
+use crate::signer::{FrostJob, SignerError, SparkSigner};
 use crate::utils::frost::derive_leaf_signing_public_key;
 use crate::utils::htlc_transactions::{
     CreateLightningHtlcRefundTxsParams, create_lightning_htlc_refund_txs,
 };
 use crate::utils::transactions::{RefundTransactions, create_refund_txs};
-use crate::{
-    Network, bitcoin::sighash_from_tx, core::next_sequence, services::LeafKeyTweak,
-    tree::TreeNodeId,
-};
+use crate::{Network, bitcoin::sighash_from_tx, core::next_sequence, services::LeafKeyTweak};
 
 pub struct SignRefundsParams<'a> {
     pub spark_signer: &'a Arc<dyn SparkSigner>,
@@ -60,7 +59,7 @@ pub async fn sign_refunds(
     // needed to rebuild its SignedTx once the batched shares return. A leaf
     // contributes up to three jobs: cpfp, direct, direct-from-cpfp.
     let mut jobs: Vec<FrostJob> = Vec::new();
-    let mut pending: Vec<PendingSignedTx> = Vec::new();
+    let mut pending: Vec<PendingRefundSignature> = Vec::new();
     let secp = Secp256k1::new();
 
     for (i, leaf) in leaves.iter().enumerate() {
@@ -203,45 +202,10 @@ pub async fn sign_refunds(
     })
 }
 
-/// Which refund-transaction variant a signed share belongs to, so a flat batch
-/// of shares can be routed back to the right output bucket.
-#[derive(Clone, Copy)]
-enum RefundVariant {
-    Cpfp,
-    Direct,
-    DirectFromCpfp,
-}
-
-/// A refund transaction whose FROST job has been queued for signing, holding
-/// everything needed to build its `SignedTx` once the share returns.
-struct PendingSignedTx {
-    variant: RefundVariant,
-    node_id: TreeNodeId,
-    signing_public_key: PublicKey,
-    refund_tx: Transaction,
-    spark_commitments: BTreeMap<Identifier, SigningCommitments>,
-    network: Network,
-}
-
-impl PendingSignedTx {
-    fn into_signed_tx(self, share: FrostShareResult) -> SignedTx {
-        SignedTx {
-            node_id: self.node_id,
-            signing_public_key: self.signing_public_key,
-            tx: self.refund_tx,
-            user_signature: share.signature_share,
-            self_nonce_commitment: share.commitment,
-            signing_commitments: self.spark_commitments,
-            network: self.network,
-        }
-    }
-}
-
-/// Builds the FROST job for one refund transaction plus the `PendingSignedTx`
-/// that pairs with it. Pure client-side work: computes the sighash and the
-/// signing job but does not sign. Refund signing always uses the leaf's own
-/// (derived) signing key, keyed by the leaf's node id. Signature aggregation
-/// happens later, when the returned share is combined with operator signatures.
+/// Builds the shared refund FROST job, computing the sighash from the parent
+/// output first. A thin wrapper over `build_refund_signing_job` that keeps the
+/// send-path call sites terse (they pass the leaf and its parent tx rather than
+/// a precomputed sighash).
 #[allow(clippy::too_many_arguments)]
 fn build_refund_job(
     leaf: &LeafKeyTweak,
@@ -252,26 +216,18 @@ fn build_refund_job(
     network: Network,
     adaptor_public_key: Option<&PublicKey>,
     variant: RefundVariant,
-) -> Result<(FrostJob, PendingSignedTx), SignerError> {
+) -> Result<(FrostJob, PendingRefundSignature), SignerError> {
     let sighash = sighash_from_tx(&refund_tx, 0, &tx.output[0])
         .map_err(|e| SignerError::Generic(e.to_string()))?;
-
-    let job = FrostJob {
-        derivation: FrostDerivation::SigningLeaf {
-            leaf_id: leaf.node.id.clone(),
-        },
-        sighash: sighash.to_raw_hash().to_byte_array(),
-        verifying_key: leaf.node.verifying_public_key,
-        operator_commitments: spark_commitments.clone(),
-        adaptor_public_key: adaptor_public_key.copied(),
-    };
-    let pending = PendingSignedTx {
-        variant,
-        node_id: leaf.node.id.clone(),
-        signing_public_key,
+    Ok(build_refund_signing_job(
+        &leaf.node.id,
+        &leaf.node.verifying_public_key,
+        &signing_public_key,
         refund_tx,
+        sighash.to_raw_hash().to_byte_array(),
         spark_commitments,
+        adaptor_public_key,
+        variant,
         network,
-    };
-    Ok((job, pending))
+    ))
 }

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use bitcoin::Transaction;
 use bitcoin::hashes::{Hash, sha256};
-use bitcoin::secp256k1::{All, PublicKey, Secp256k1};
+use bitcoin::secp256k1::{PublicKey, Secp256k1};
 use frost_secp256k1_tr::Identifier;
 use frost_secp256k1_tr::round1::SigningCommitments;
 use tracing::info;
@@ -11,16 +11,14 @@ use tracing::info;
 use crate::core::next_lightning_htlc_sequence;
 use crate::services::SignedTx;
 use crate::signer::{FrostDerivation, FrostJob, FrostShareResult, SignerError, SparkSigner};
+use crate::utils::frost::derive_leaf_signing_public_key;
 use crate::utils::htlc_transactions::{
     CreateLightningHtlcRefundTxsParams, create_lightning_htlc_refund_txs,
 };
 use crate::utils::transactions::{RefundTransactions, create_refund_txs};
 use crate::{
-    Network,
-    bitcoin::sighash_from_tx,
-    core::next_sequence,
-    services::LeafKeyTweak,
-    tree::{TreeNode, TreeNodeId},
+    Network, bitcoin::sighash_from_tx, core::next_sequence, services::LeafKeyTweak,
+    tree::TreeNodeId,
 };
 
 pub struct SignRefundsParams<'a> {
@@ -237,24 +235,6 @@ impl PendingSignedTx {
             network: self.network,
         }
     }
-}
-
-/// The user's own signing public key for a leaf, derived from persisted tree
-/// data instead of asking the signer. FROST composes the group verifying key as
-/// the user's verifying share plus the operators' aggregate share, so the user's
-/// share is recoverable as `verifying_public_key - signing_keyshare.public_key`.
-/// `refresh_leaves` validates this exact relation for every Available leaf, so
-/// deriving it here avoids a per-leaf signer round-trip on the send hot path
-/// (which, for a remote signer with no warm in-memory cache, e.g. a per-request
-/// server instance, would otherwise be one network call per leaf).
-fn derive_leaf_signing_public_key(
-    node: &TreeNode,
-    secp: &Secp256k1<All>,
-) -> Result<PublicKey, SignerError> {
-    let se_share = node.signing_keyshare.public_key.negate(secp);
-    node.verifying_public_key
-        .combine(&se_share)
-        .map_err(|e| SignerError::Generic(format!("failed to derive leaf signing key: {e}")))
 }
 
 /// Builds the FROST job for one refund transaction plus the `PendingSignedTx`

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -10,12 +10,15 @@ use tracing::info;
 
 use crate::core::next_lightning_htlc_sequence;
 use crate::services::SignedTx;
-use crate::signer::{FrostDerivation, FrostJob, SignerError, SparkSigner};
+use crate::signer::{FrostDerivation, FrostJob, FrostShareResult, SignerError, SparkSigner};
 use crate::utils::htlc_transactions::{
     CreateLightningHtlcRefundTxsParams, create_lightning_htlc_refund_txs,
 };
 use crate::utils::transactions::{RefundTransactions, create_refund_txs};
-use crate::{Network, bitcoin::sighash_from_tx, core::next_sequence, services::LeafKeyTweak};
+use crate::{
+    Network, bitcoin::sighash_from_tx, core::next_sequence, services::LeafKeyTweak,
+    tree::TreeNodeId,
+};
 
 pub struct SignRefundsParams<'a> {
     pub spark_signer: &'a Arc<dyn SparkSigner>,
@@ -52,9 +55,11 @@ pub async fn sign_refunds(
     } = params;
     let identity_pubkey = spark_signer.get_identity_public_key().await?;
 
-    let mut cpfp_signed_refunds = Vec::with_capacity(leaves.len());
-    let mut direct_signed_refunds = Vec::with_capacity(leaves.len());
-    let mut direct_from_cpfp_signed_refunds = Vec::with_capacity(leaves.len());
+    // Build every FROST job up front (all local work), tagging each with what's
+    // needed to rebuild its SignedTx once the batched shares return. A leaf
+    // contributes up to three jobs: cpfp, direct, direct-from-cpfp.
+    let mut jobs: Vec<FrostJob> = Vec::new();
+    let mut pending: Vec<PendingSignedTx> = Vec::new();
 
     for (i, leaf) in leaves.iter().enumerate() {
         let node_tx = &leaf.node.node_tx;
@@ -111,8 +116,7 @@ pub async fn sign_refunds(
 
         let signing_public_key = spark_signer.get_public_key_for_leaf(&leaf.node.id).await?;
 
-        let cpfp_signed_tx = sign_refund(
-            spark_signer,
+        let (job, entry) = build_refund_job(
             leaf,
             node_tx,
             cpfp_refund_tx,
@@ -120,9 +124,10 @@ pub async fn sign_refunds(
             cpfp_signing_commitments[i].clone(),
             network,
             cpfp_adaptor_public_key,
-        )
-        .await?;
-        cpfp_signed_refunds.push(cpfp_signed_tx);
+            RefundVariant::Cpfp,
+        )?;
+        jobs.push(job);
+        pending.push(entry);
 
         if let Some(direct_tx) = direct_tx {
             let Some(direct_refund_tx) = direct_refund_tx else {
@@ -131,8 +136,7 @@ pub async fn sign_refunds(
                 ));
             };
 
-            let direct_refund_tx = sign_refund(
-                spark_signer,
+            let (job, entry) = build_refund_job(
                 leaf,
                 direct_tx,
                 direct_refund_tx,
@@ -140,16 +144,16 @@ pub async fn sign_refunds(
                 direct_signing_commitments[i].clone(),
                 network,
                 None, // Direct transactions don't use adaptor signatures
-            )
-            .await?;
-            direct_signed_refunds.push(direct_refund_tx);
+                RefundVariant::Direct,
+            )?;
+            jobs.push(job);
+            pending.push(entry);
         }
 
         // direct_from_cpfp_refund_tx spends from the CPFP (node_tx) output, not from
         // direct_tx, so it must be signed regardless of whether direct_tx exists.
         if let Some(direct_from_cpfp_refund_tx) = direct_from_cpfp_refund_tx {
-            let direct_from_cpfp_signed_tx = sign_refund(
-                spark_signer,
+            let (job, entry) = build_refund_job(
                 leaf,
                 node_tx,
                 direct_from_cpfp_refund_tx,
@@ -157,9 +161,36 @@ pub async fn sign_refunds(
                 direct_from_cpfp_signing_commitments[i].clone(),
                 network,
                 None, // Direct transactions don't use adaptor signatures
-            )
-            .await?;
-            direct_from_cpfp_signed_refunds.push(direct_from_cpfp_signed_tx);
+                RefundVariant::DirectFromCpfp,
+            )?;
+            jobs.push(job);
+            pending.push(entry);
+        }
+    }
+
+    // Sign every job in a single batched call. Remote-signer backends (e.g.
+    // Turnkey) collapse this into one round-trip instead of one per leaf-variant.
+    let shares = spark_signer.sign_frost(jobs).await?;
+    if shares.len() != pending.len() {
+        return Err(SignerError::Generic(format!(
+            "sign_frost returned {} shares, expected {}",
+            shares.len(),
+            pending.len()
+        )));
+    }
+
+    // Reassemble each SignedTx and route it to its variant bucket. Jobs were
+    // pushed in leaf order, so per-variant order is preserved.
+    let mut cpfp_signed_refunds = Vec::new();
+    let mut direct_signed_refunds = Vec::new();
+    let mut direct_from_cpfp_signed_refunds = Vec::new();
+    for (entry, share) in pending.into_iter().zip(shares) {
+        let variant = entry.variant;
+        let signed_tx = entry.into_signed_tx(share);
+        match variant {
+            RefundVariant::Cpfp => cpfp_signed_refunds.push(signed_tx),
+            RefundVariant::Direct => direct_signed_refunds.push(signed_tx),
+            RefundVariant::DirectFromCpfp => direct_from_cpfp_signed_refunds.push(signed_tx),
         }
     }
 
@@ -170,34 +201,47 @@ pub async fn sign_refunds(
     })
 }
 
-/// Signs a refund transaction using FROST threshold signatures.
-///
-/// This function performs the client-side portion of the FROST signing protocol for a refund transaction:
-/// 1. Calculates the transaction sighash
-/// 2. Generates new nonce commitments for signing
-/// 3. Signs the transaction using the FROST protocol
-/// 4. Returns a structured `SignedTx` object with all data needed for later aggregation
-///
-/// The function does not perform signature aggregation - it only creates the user's signature share.
-/// Aggregation happens later when combined with operator signatures.
-///
-/// # Arguments
-///
-/// * `signer` - Reference to the signer implementation
-/// * `leaf` - The leaf key data containing node info and signing key
-/// * `tx` - The original transaction being spent by the refund transaction
-/// * `refund_tx` - The refund transaction to sign
-/// * `signing_public_key` - The public key corresponding to the user's signing key
-/// * `spark_commitments` - The FROST signing commitments from the Spark operators
-/// * `network` - The Bitcoin network being used
-///
-/// # Returns
-///
-/// * `Ok(SignedTx)` - A structure containing the signed transaction and signing metadata
-/// * `Err(SignerError)` - If the signing process fails
+/// Which refund-transaction variant a signed share belongs to, so a flat batch
+/// of shares can be routed back to the right output bucket.
+#[derive(Clone, Copy)]
+enum RefundVariant {
+    Cpfp,
+    Direct,
+    DirectFromCpfp,
+}
+
+/// A refund transaction whose FROST job has been queued for signing, holding
+/// everything needed to build its `SignedTx` once the share returns.
+struct PendingSignedTx {
+    variant: RefundVariant,
+    node_id: TreeNodeId,
+    signing_public_key: PublicKey,
+    refund_tx: Transaction,
+    spark_commitments: BTreeMap<Identifier, SigningCommitments>,
+    network: Network,
+}
+
+impl PendingSignedTx {
+    fn into_signed_tx(self, share: FrostShareResult) -> SignedTx {
+        SignedTx {
+            node_id: self.node_id,
+            signing_public_key: self.signing_public_key,
+            tx: self.refund_tx,
+            user_signature: share.signature_share,
+            self_nonce_commitment: share.commitment,
+            signing_commitments: self.spark_commitments,
+            network: self.network,
+        }
+    }
+}
+
+/// Builds the FROST job for one refund transaction plus the `PendingSignedTx`
+/// that pairs with it. Pure client-side work: computes the sighash and the
+/// signing job but does not sign. Refund signing always uses the leaf's own
+/// (derived) signing key, keyed by the leaf's node id. Signature aggregation
+/// happens later, when the returned share is combined with operator signatures.
 #[allow(clippy::too_many_arguments)]
-async fn sign_refund(
-    spark_signer: &Arc<dyn SparkSigner>,
+fn build_refund_job(
     leaf: &LeafKeyTweak,
     tx: &Transaction,
     refund_tx: Transaction,
@@ -205,12 +249,11 @@ async fn sign_refund(
     spark_commitments: BTreeMap<Identifier, SigningCommitments>,
     network: Network,
     adaptor_public_key: Option<&PublicKey>,
-) -> Result<SignedTx, SignerError> {
+    variant: RefundVariant,
+) -> Result<(FrostJob, PendingSignedTx), SignerError> {
     let sighash = sighash_from_tx(&refund_tx, 0, &tx.output[0])
         .map_err(|e| SignerError::Generic(e.to_string()))?;
 
-    // Refund signing always uses the leaf's own (derived) signing key, keyed by
-    // the leaf's node id.
     let job = FrostJob {
         derivation: FrostDerivation::SigningLeaf {
             leaf_id: leaf.node.id.clone(),
@@ -220,20 +263,13 @@ async fn sign_refund(
         operator_commitments: spark_commitments.clone(),
         adaptor_public_key: adaptor_public_key.copied(),
     };
-    let share = spark_signer
-        .sign_frost(vec![job])
-        .await?
-        .into_iter()
-        .next()
-        .ok_or_else(|| SignerError::Generic("sign_frost returned no share".to_string()))?;
-
-    Ok(SignedTx {
+    let pending = PendingSignedTx {
+        variant,
         node_id: leaf.node.id.clone(),
         signing_public_key,
-        tx: refund_tx,
-        user_signature: share.signature_share,
-        self_nonce_commitment: share.commitment,
-        signing_commitments: spark_commitments,
+        refund_tx,
+        spark_commitments,
         network,
-    })
+    };
+    Ok((job, pending))
 }

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -9,9 +9,12 @@ use frost_secp256k1_tr::round1::SigningCommitments;
 use tracing::info;
 
 use crate::core::next_lightning_htlc_sequence;
-use crate::services::{PendingRefundSignature, RefundVariant, SignedTx, build_refund_signing_job};
-use crate::signer::{FrostJob, SignerError, SparkSigner};
-use crate::utils::frost::{derive_leaf_signing_public_key, sign_frost_batch};
+use crate::services::{
+    LeafRefundJobs, RefundJob, SignedTx, build_refund_signing_job, into_signed_tx_groups,
+    sign_leaf_refunds,
+};
+use crate::signer::{SignerError, SparkSigner};
+use crate::utils::frost::derive_leaf_signing_public_key;
 use crate::utils::htlc_transactions::{
     CreateLightningHtlcRefundTxsParams, create_lightning_htlc_refund_txs,
 };
@@ -56,8 +59,7 @@ pub async fn sign_refunds(
     // Build every FROST job up front (all local work), tagging each with what's
     // needed to rebuild its SignedTx once the batched shares return. A leaf
     // contributes up to three jobs: cpfp, direct, direct-from-cpfp.
-    let mut jobs: Vec<FrostJob> = Vec::new();
-    let mut pending: Vec<PendingRefundSignature> = Vec::new();
+    let mut leaf_jobs: Vec<LeafRefundJobs> = Vec::new();
     let secp = Secp256k1::new();
 
     for (i, leaf) in leaves.iter().enumerate() {
@@ -115,7 +117,7 @@ pub async fn sign_refunds(
 
         let signing_public_key = derive_leaf_signing_public_key(&leaf.node, &secp)?;
 
-        let (job, entry) = build_refund_job(
+        let cpfp = build_refund_job(
             leaf,
             node_tx,
             cpfp_refund_tx,
@@ -123,19 +125,16 @@ pub async fn sign_refunds(
             cpfp_signing_commitments[i].clone(),
             network,
             cpfp_adaptor_public_key,
-            RefundVariant::Cpfp,
         )?;
-        jobs.push(job);
-        pending.push(entry);
 
-        if let Some(direct_tx) = direct_tx {
+        let direct = if let Some(direct_tx) = direct_tx {
             let Some(direct_refund_tx) = direct_refund_tx else {
                 return Err(SignerError::Generic(
                     "Direct refund transaction is missing".to_string(),
                 ));
             };
 
-            let (job, entry) = build_refund_job(
+            Some(build_refund_job(
                 leaf,
                 direct_tx,
                 direct_refund_tx,
@@ -143,16 +142,15 @@ pub async fn sign_refunds(
                 direct_signing_commitments[i].clone(),
                 network,
                 None, // Direct transactions don't use adaptor signatures
-                RefundVariant::Direct,
-            )?;
-            jobs.push(job);
-            pending.push(entry);
-        }
+            )?)
+        } else {
+            None
+        };
 
         // direct_from_cpfp_refund_tx spends from the CPFP (node_tx) output, not from
         // direct_tx, so it must be signed regardless of whether direct_tx exists.
-        if let Some(direct_from_cpfp_refund_tx) = direct_from_cpfp_refund_tx {
-            let (job, entry) = build_refund_job(
+        let direct_from_cpfp = if let Some(direct_from_cpfp_refund_tx) = direct_from_cpfp_refund_tx {
+            Some(build_refund_job(
                 leaf,
                 node_tx,
                 direct_from_cpfp_refund_tx,
@@ -160,36 +158,29 @@ pub async fn sign_refunds(
                 direct_from_cpfp_signing_commitments[i].clone(),
                 network,
                 None, // Direct transactions don't use adaptor signatures
-                RefundVariant::DirectFromCpfp,
-            )?;
-            jobs.push(job);
-            pending.push(entry);
-        }
+            )?)
+        } else {
+            None
+        };
+
+        leaf_jobs.push(LeafRefundJobs {
+            cpfp,
+            direct,
+            direct_from_cpfp,
+        });
     }
 
-    // Sign every job in a single batched call. Remote-signer backends (e.g.
-    // Turnkey) collapse this into one round-trip instead of one per leaf-variant.
-    let signed = sign_frost_batch(spark_signer, jobs, pending).await?;
-
-    // Reassemble each SignedTx and route it to its variant bucket. Jobs were
-    // pushed in leaf order, so per-variant order is preserved.
-    let mut cpfp_signed_refunds = Vec::new();
-    let mut direct_signed_refunds = Vec::new();
-    let mut direct_from_cpfp_signed_refunds = Vec::new();
-    for (entry, share) in signed {
-        let variant = entry.variant;
-        let signed_tx = entry.into_signed_tx(share);
-        match variant {
-            RefundVariant::Cpfp => cpfp_signed_refunds.push(signed_tx),
-            RefundVariant::Direct => direct_signed_refunds.push(signed_tx),
-            RefundVariant::DirectFromCpfp => direct_from_cpfp_signed_refunds.push(signed_tx),
-        }
-    }
+    // Sign every leaf's jobs in one batched call, then split by variant. Remote
+    // signer backends (e.g. Turnkey) collapse this into one round-trip instead of
+    // one per leaf-variant.
+    let signed = sign_leaf_refunds(spark_signer, leaf_jobs).await?;
+    let (cpfp_signed_tx, direct_signed_tx, direct_from_cpfp_signed_tx) =
+        into_signed_tx_groups(signed);
 
     Ok(SignedRefundTransactions {
-        cpfp_signed_tx: cpfp_signed_refunds,
-        direct_signed_tx: direct_signed_refunds,
-        direct_from_cpfp_signed_tx: direct_from_cpfp_signed_refunds,
+        cpfp_signed_tx,
+        direct_signed_tx,
+        direct_from_cpfp_signed_tx,
     })
 }
 
@@ -197,7 +188,6 @@ pub async fn sign_refunds(
 /// output first. A thin wrapper over `build_refund_signing_job` that keeps the
 /// send-path call sites terse (they pass the leaf and its parent tx rather than
 /// a precomputed sighash).
-#[allow(clippy::too_many_arguments)]
 fn build_refund_job(
     leaf: &LeafKeyTweak,
     tx: &Transaction,
@@ -206,8 +196,7 @@ fn build_refund_job(
     spark_commitments: BTreeMap<Identifier, SigningCommitments>,
     network: Network,
     adaptor_public_key: Option<&PublicKey>,
-    variant: RefundVariant,
-) -> Result<(FrostJob, PendingRefundSignature), SignerError> {
+) -> Result<RefundJob, SignerError> {
     let sighash = sighash_from_tx(&refund_tx, 0, &tx.output[0])
         .map_err(|e| SignerError::Generic(e.to_string()))?;
     Ok(build_refund_signing_job(
@@ -218,7 +207,6 @@ fn build_refund_job(
         sighash.to_raw_hash().to_byte_array(),
         spark_commitments,
         adaptor_public_key,
-        variant,
         network,
     ))
 }

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use bitcoin::Transaction;
 use bitcoin::hashes::{Hash, sha256};
-use bitcoin::secp256k1::PublicKey;
+use bitcoin::secp256k1::{All, PublicKey, Secp256k1};
 use frost_secp256k1_tr::Identifier;
 use frost_secp256k1_tr::round1::SigningCommitments;
 use tracing::info;
@@ -17,7 +17,7 @@ use crate::utils::htlc_transactions::{
 use crate::utils::transactions::{RefundTransactions, create_refund_txs};
 use crate::{
     Network, bitcoin::sighash_from_tx, core::next_sequence, services::LeafKeyTweak,
-    tree::TreeNodeId,
+    tree::{TreeNode, TreeNodeId},
 };
 
 pub struct SignRefundsParams<'a> {
@@ -60,6 +60,7 @@ pub async fn sign_refunds(
     // contributes up to three jobs: cpfp, direct, direct-from-cpfp.
     let mut jobs: Vec<FrostJob> = Vec::new();
     let mut pending: Vec<PendingSignedTx> = Vec::new();
+    let secp = Secp256k1::new();
 
     for (i, leaf) in leaves.iter().enumerate() {
         let node_tx = &leaf.node.node_tx;
@@ -114,7 +115,7 @@ pub async fn sign_refunds(
             leaf.node.id, cpfp_refund_tx.input[0].sequence
         );
 
-        let signing_public_key = spark_signer.get_public_key_for_leaf(&leaf.node.id).await?;
+        let signing_public_key = derive_leaf_signing_public_key(&leaf.node, &secp)?;
 
         let (job, entry) = build_refund_job(
             leaf,
@@ -233,6 +234,24 @@ impl PendingSignedTx {
             network: self.network,
         }
     }
+}
+
+/// The user's own signing public key for a leaf, derived from persisted tree
+/// data instead of asking the signer. FROST composes the group verifying key as
+/// the user's verifying share plus the operators' aggregate share, so the user's
+/// share is recoverable as `verifying_public_key - signing_keyshare.public_key`.
+/// `refresh_leaves` validates this exact relation for every Available leaf, so
+/// deriving it here avoids a per-leaf signer round-trip on the send hot path
+/// (which, for a remote signer with no warm in-memory cache, e.g. a per-request
+/// server instance, would otherwise be one network call per leaf).
+fn derive_leaf_signing_public_key(
+    node: &TreeNode,
+    secp: &Secp256k1<All>,
+) -> Result<PublicKey, SignerError> {
+    let se_share = node.signing_keyshare.public_key.negate(secp);
+    node.verifying_public_key
+        .combine(&se_share)
+        .map_err(|e| SignerError::Generic(format!("failed to derive leaf signing key: {e}")))
 }
 
 /// Builds the FROST job for one refund transaction plus the `PendingSignedTx`

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -149,7 +149,8 @@ pub async fn sign_refunds(
 
         // direct_from_cpfp_refund_tx spends from the CPFP (node_tx) output, not from
         // direct_tx, so it must be signed regardless of whether direct_tx exists.
-        let direct_from_cpfp = if let Some(direct_from_cpfp_refund_tx) = direct_from_cpfp_refund_tx {
+        let direct_from_cpfp = if let Some(direct_from_cpfp_refund_tx) = direct_from_cpfp_refund_tx
+        {
             Some(build_refund_job(
                 leaf,
                 node_tx,

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -171,9 +171,7 @@ pub async fn sign_refunds(
         });
     }
 
-    // Sign every leaf's jobs in one batched call, then split by variant. Remote
-    // signer backends (e.g. Turnkey) collapse this into one round-trip instead of
-    // one per leaf-variant.
+    // Sign every leaf's jobs in one batched call, then split by variant.
     let signed = sign_leaf_refunds(spark_signer, leaf_jobs).await?;
     let (cpfp_signed_tx, direct_signed_tx, direct_from_cpfp_signed_tx) =
         into_signed_tx_groups(signed);

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -11,7 +11,7 @@ use tracing::info;
 use crate::core::next_lightning_htlc_sequence;
 use crate::services::{PendingRefundSignature, RefundVariant, SignedTx, build_refund_signing_job};
 use crate::signer::{FrostJob, SignerError, SparkSigner};
-use crate::utils::frost::derive_leaf_signing_public_key;
+use crate::utils::frost::{derive_leaf_signing_public_key, sign_frost_batch};
 use crate::utils::htlc_transactions::{
     CreateLightningHtlcRefundTxsParams, create_lightning_htlc_refund_txs,
 };
@@ -169,21 +169,14 @@ pub async fn sign_refunds(
 
     // Sign every job in a single batched call. Remote-signer backends (e.g.
     // Turnkey) collapse this into one round-trip instead of one per leaf-variant.
-    let shares = spark_signer.sign_frost(jobs).await?;
-    if shares.len() != pending.len() {
-        return Err(SignerError::Generic(format!(
-            "sign_frost returned {} shares, expected {}",
-            shares.len(),
-            pending.len()
-        )));
-    }
+    let signed = sign_frost_batch(spark_signer, jobs, pending).await?;
 
     // Reassemble each SignedTx and route it to its variant bucket. Jobs were
     // pushed in leaf order, so per-variant order is preserved.
     let mut cpfp_signed_refunds = Vec::new();
     let mut direct_signed_refunds = Vec::new();
     let mut direct_from_cpfp_signed_refunds = Vec::new();
-    for (entry, share) in pending.into_iter().zip(shares) {
+    for (entry, share) in signed {
         let variant = entry.variant;
         let signed_tx = entry.into_signed_tx(share);
         match variant {

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -16,7 +16,10 @@ use crate::utils::htlc_transactions::{
 };
 use crate::utils::transactions::{RefundTransactions, create_refund_txs};
 use crate::{
-    Network, bitcoin::sighash_from_tx, core::next_sequence, services::LeafKeyTweak,
+    Network,
+    bitcoin::sighash_from_tx,
+    core::next_sequence,
+    services::LeafKeyTweak,
     tree::{TreeNode, TreeNodeId},
 };
 

--- a/crates/spark/src/utils/refund.rs
+++ b/crates/spark/src/utils/refund.rs
@@ -9,9 +9,7 @@ use frost_secp256k1_tr::round1::SigningCommitments;
 use tracing::info;
 
 use crate::core::next_lightning_htlc_sequence;
-use crate::services::{
-    PendingRefundSignature, RefundVariant, SignedTx, build_refund_signing_job,
-};
+use crate::services::{PendingRefundSignature, RefundVariant, SignedTx, build_refund_signing_job};
 use crate::signer::{FrostJob, SignerError, SparkSigner};
 use crate::utils::frost::derive_leaf_signing_public_key;
 use crate::utils::htlc_transactions::{

--- a/crates/spark/src/utils/signing_job.rs
+++ b/crates/spark/src/utils/signing_job.rs
@@ -47,8 +47,7 @@ pub async fn sign_signing_jobs(
     network: Network,
 ) -> Result<Vec<SignedJob>, SignerError> {
     // Build every renewal-tx FROST job up front, then sign the whole batch in one
-    // call: remote signers turn each sign_frost into a network round-trip, so a
-    // per-job loop would cost one round-trip per renewal.
+    // call.
     let mut jobs = Vec::with_capacity(signing_jobs.len());
     for (i, signing_job) in signing_jobs.iter().enumerate() {
         let sighash = sighash_from_tx(&signing_job.tx, 0, &signing_job.parent_tx_out)

--- a/crates/spark/src/utils/signing_job.rs
+++ b/crates/spark/src/utils/signing_job.rs
@@ -11,6 +11,7 @@ use crate::Network;
 use crate::bitcoin::sighash_from_tx;
 use crate::services::SignedTx;
 use crate::signer::{FrostDerivation, FrostJob, SparkSigner};
+use crate::utils::frost::sign_frost_batch;
 use crate::{signer::SignerError, tree::TreeNodeId};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -45,39 +46,42 @@ pub async fn sign_signing_jobs(
     signing_commitments: Vec<BTreeMap<Identifier, SigningCommitments>>,
     network: Network,
 ) -> Result<Vec<SignedJob>, SignerError> {
-    let mut signed_txs = Vec::new();
-
+    // Build every renewal-tx FROST job up front, then sign the whole batch in one
+    // call: remote signers turn each sign_frost into a network round-trip, so a
+    // per-job loop would cost one round-trip per renewal.
+    let mut jobs = Vec::with_capacity(signing_jobs.len());
     for (i, signing_job) in signing_jobs.iter().enumerate() {
         let sighash = sighash_from_tx(&signing_job.tx, 0, &signing_job.parent_tx_out)
             .map_err(|e| SignerError::Generic(e.to_string()))?;
         // Each renewal tx is signed with the node's derived leaf key.
-        let share = spark_signer
-            .sign_frost(vec![FrostJob {
-                derivation: FrostDerivation::SigningLeaf {
-                    leaf_id: signing_job.node_id.clone(),
-                },
-                sighash: sighash.to_raw_hash().to_byte_array(),
-                verifying_key: signing_job.verifying_public_key,
-                operator_commitments: signing_commitments[i].clone(),
-                adaptor_public_key: None,
-            }])
-            .await?
-            .into_iter()
-            .next()
-            .ok_or_else(|| SignerError::Generic("sign_frost returned no share".to_string()))?;
-        signed_txs.push(SignedJob {
+        jobs.push(FrostJob {
+            derivation: FrostDerivation::SigningLeaf {
+                leaf_id: signing_job.node_id.clone(),
+            },
+            sighash: sighash.to_raw_hash().to_byte_array(),
+            verifying_key: signing_job.verifying_public_key,
+            operator_commitments: signing_commitments[i].clone(),
+            adaptor_public_key: None,
+        });
+    }
+
+    let signed = sign_frost_batch(spark_signer, jobs, signing_jobs).await?;
+    let signed_txs = signed
+        .into_iter()
+        .zip(signing_commitments)
+        .map(|((signing_job, share), commitments)| SignedJob {
             job_type: signing_job.job_type,
             signed_tx: SignedTx {
-                node_id: signing_job.node_id.clone(),
+                node_id: signing_job.node_id,
                 signing_public_key: signing_job.signing_public_key,
-                tx: signing_job.tx.clone(),
+                tx: signing_job.tx,
                 user_signature: share.signature_share,
                 self_nonce_commitment: share.commitment,
-                signing_commitments: signing_commitments[i].clone(),
+                signing_commitments: commitments,
                 network,
             },
         })
-    }
+        .collect();
 
     Ok(signed_txs)
 }

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -1189,6 +1189,7 @@ dependencies = [
  "chrono",
  "flashnet",
  "frost-secp256k1-tr",
+ "futures",
  "hex",
  "k256",
  "lnurl-models",


### PR DESCRIPTION
## Summary

Reduces signer round-trips on the FROST signing hot paths (send, claim, coop-exit, timelock renewal, and leaf refresh). On a remote signer each `sign_frost` / `get_public_key_for_leaf` is a network round-trip, so the previous per-leaf-variant loops cost one round-trip per job. This batches the signing calls and, where the value is not a payout destination, derives owned-leaf signing pubkeys locally from persisted tree data. It also adds the Turnkey-side handling (request chunking + rate pacing) that the larger batched activities require.

## Changes

### Signing hot paths (spark)

- **Batch FROST signing** into a single `sign_frost(Vec<FrostJob>)` call on the send (`sign_refunds`), claim, coop-exit, and timelock-renewal (`sign_signing_jobs`) paths. Jobs are built up front, then reattached to their per-variant outputs in order.
- **Derive owned-leaf signing pubkeys locally** as `verifying_public_key - signing_keyshare.public_key` instead of asking the signer, on the **send and coop-exit** paths. There the derived value is used only as the signing key (a wrong value fails closed as an invalid signature), never as a payout destination. Not applied to claim (incoming leaf uses the new key) or timelock (see Security).
- **Warm the claim leaf-pubkey cache** by running the key-tweak (`prepare_claim`) step before signing refunds, so per-leaf `get_public_key_for_leaf` in the claim path is a cache hit rather than a round-trip.
- **Fetch refresh-leaf pubkeys concurrently** in `refresh_leaves` (unbounded, order-preserving). A rate-limited signer (Turnkey) paces the calls internally, so no per-call-site concurrency cap is imposed.
- **Encode refund variants as struct fields**: `LeafRefundJobs` / `SignedLeafRefunds` replace the `RefundVariant` enum and the parallel jobs/pending lists. One `sign_leaf_refunds` helper flattens every leaf's jobs, signs the batch, and rebuilds in field order, confining the sole reliance on share ordering to one length-checked place. Shared by the send / claim / coop-exit paths.

### Turnkey remote signer

- **Chunk batched `sign_frost`** under Turnkey's per-activity limit: a single enclave `sign_frost` fails past ~250-300 jobs, so submissions are chunked at 100 jobs per activity (`MAX_FROST_JOBS_PER_ACTIVITY`).
- **Adaptive per-suborg rate pacer**: a client-level pacer holds requests to a configurable `max_rps` (default: Turnkey's documented 10 RPS), backing off on 429 and recovering on success, shared across all concurrent callers of one suborganization. Replaces the per-call-site concurrency caps.

### Security

- **Timelock renewal fetches its signing key from the signer**, not derived. The renewed exit refund pays to this key, so deriving it from persisted (coordinator-supplied) tree data would let a malicious coordinator steer the refund destination. Renewal is infrequent and off the send hot path, so the round-trip cost is negligible.

## Testing

- `cargo clippy -p spark` and `cargo clippy -p breez-sdk-spark --features turnkey` clean
- `cargo test -p spark` (247 tests) passing
- `cargo test -p breez-sdk-spark --features turnkey` (turnkey transport / pacer tests) passing
