### PR TITLE
Turnkey signer provisioning for network-free re-init

### DIFF
--- a/crates/breez-sdk/breez-itest/src/turnkey.rs
+++ b/crates/breez-sdk/breez-itest/src/turnkey.rs
@@ -172,7 +172,7 @@ pub async fn build_sdk_with_turnkey(
     let (turnkey_config, guard) = provision_turnkey_wallet().await?;
     let turnkey_guard = Some(guard);
 
-    let signers = breez_sdk_spark::turnkey::create_turnkey_signer(turnkey_config)
+    let signers = breez_sdk_spark::turnkey::create_turnkey_signer(turnkey_config, None)
         .await
         .map_err(|e| anyhow::anyhow!("create_turnkey_signer failed: {e}"))?;
 

--- a/crates/breez-sdk/breez-itest/tests/turnkey_breez_signer.rs
+++ b/crates/breez-sdk/breez-itest/tests/turnkey_breez_signer.rs
@@ -19,7 +19,7 @@ const TEST_PATH: &str = "m/138'/1'/2'/3'";
 #[test_log::test(tokio::test)]
 async fn breez_signer_signing_flows() -> Result<()> {
     let (config, _guard) = provision_turnkey_wallet().await?;
-    let signers = breez_sdk_spark::turnkey::create_turnkey_signer(config)
+    let signers = breez_sdk_spark::turnkey::create_turnkey_signer(config, None)
         .await
         .map_err(|e| anyhow::anyhow!("create_turnkey_signer failed: {e}"))?;
     let breez = signers.breez_signer;

--- a/crates/breez-sdk/core/src/error.rs
+++ b/crates/breez-sdk/core/src/error.rs
@@ -338,6 +338,9 @@ pub enum SignerError {
     #[error("Encryption unavailable: {0}")]
     EncryptionUnavailable(String),
 
+    #[error("Provisioned signer state is outdated or invalid: {0}")]
+    ProvisioningOutdated(String),
+
     #[error("FROST error: {0}")]
     Frost(String),
 

--- a/crates/breez-sdk/core/src/turnkey/accounts.rs
+++ b/crates/breez-sdk/core/src/turnkey/accounts.rs
@@ -31,6 +31,14 @@ pub(crate) fn spark_address_format(network: Network) -> &'static str {
     }
 }
 
+/// Dedicated SDK-layer encryption key path. The Spark signer only derives the
+/// account's low-index children (identity/signing/deposit/static/preimage), so
+/// this reserved max-index child is never a Spark key and can be exported to
+/// seed local ECIES/HMAC without exposing any Spark key.
+pub(crate) fn encryption_key_path(account: u32) -> String {
+    format!("m/8797555'/{account}'/2147483647'")
+}
+
 impl TurnkeyClient {
     /// Materializes the wallet account at `path` with `address_format`,
     /// returning its address. Idempotent: a path can only be created once, so if

--- a/crates/breez-sdk/core/src/turnkey/accounts.rs
+++ b/crates/breez-sdk/core/src/turnkey/accounts.rs
@@ -3,9 +3,11 @@
 
 use bitcoin::NetworkKind;
 use bitcoin::bip32::{ChainCode, ChildNumber, Fingerprint, Xpriv};
-use bitcoin::secp256k1::{SecretKey, ecdsa, schnorr};
+use bitcoin::secp256k1::{PublicKey, SecretKey, ecdsa, schnorr};
+use spark_wallet::SparkAddress;
 
 use crate::Network;
+use crate::error::SignerError;
 
 use turnkey_enclave_encrypt::{ExportClient, QuorumPublicKey};
 
@@ -37,6 +39,18 @@ pub(crate) fn spark_address_format(network: Network) -> &'static str {
 /// seed local ECIES/HMAC without exposing any Spark key.
 pub(crate) fn encryption_key_path(account: u32) -> String {
     format!("m/8797555'/{account}'/2147483647'")
+}
+
+/// The canonical Spark address for the wallet identity key: the address Turnkey
+/// assigns the Spark-format account at the identity path. Derived locally to
+/// avoid the ambiguous get-by-path once both account formats coexist there.
+pub(crate) fn spark_identity_address(
+    identity: PublicKey,
+    network: Network,
+) -> Result<String, SignerError> {
+    SparkAddress::new(identity, network.into(), None)
+        .to_address_string()
+        .map_err(|e| SignerError::Generic(e.to_string()))
 }
 
 impl TurnkeyClient {

--- a/crates/breez-sdk/core/src/turnkey/breez_signer.rs
+++ b/crates/breez-sdk/core/src/turnkey/breez_signer.rs
@@ -70,7 +70,7 @@ impl TurnkeyBreezSigner {
     /// Builds the signer with its encryption backend initialized per `backend`:
     /// seeded from a persisted key, pre-marked denied, or left to export lazily
     /// on first use.
-    pub(crate) fn new_seeded(
+    pub(crate) fn new(
         client: Arc<TurnkeyClient>,
         network: Network,
         account: u32,

--- a/crates/breez-sdk/core/src/turnkey/breez_signer.rs
+++ b/crates/breez-sdk/core/src/turnkey/breez_signer.rs
@@ -24,8 +24,8 @@ use crate::signer::external_types::{
 use crate::signer::{BreezSigner, ExternalBreezSigner};
 
 use super::accounts::{
-    ecdsa_from_rs, ecdsa_recoverable_low_s, schnorr_from_rs, spark_address_format,
-    xpriv_from_secret,
+    ecdsa_from_rs, ecdsa_recoverable_low_s, encryption_key_path, schnorr_from_rs,
+    spark_address_format, xpriv_from_secret,
 };
 use super::error::TurnkeyError;
 use super::transport::TurnkeyClient;
@@ -35,12 +35,15 @@ fn to_signer_err<E: std::fmt::Display>(e: E) -> SignerError {
     SignerError::Generic(e.to_string())
 }
 
-/// Dedicated SDK-layer encryption key path. The Spark signer only derives the
-/// account's low-index children (identity/signing/deposit/static/preimage), so
-/// this reserved max-index child is never a Spark key and can be exported to
-/// seed local ECIES/HMAC without exposing any Spark key.
-fn encryption_key_path(account: u32) -> String {
-    format!("m/8797555'/{account}'/2147483647'")
+/// How a [`TurnkeyBreezSigner`]'s local ECIES/HMAC backend is initialized.
+pub(crate) enum EncryptionBackend {
+    /// Pre-exported key: the backend is ready and no export ever runs.
+    Seeded(BreezSignerImpl),
+    /// Export is known to be denied by policy: encryption fails fast with this
+    /// message, without a network round-trip.
+    Denied(String),
+    /// Unprovisioned: export the key lazily on first ECIES/HMAC use.
+    Lazy,
 }
 
 /// SDK-layer signer backed by Turnkey. Sign/derive go to Turnkey; ECIES/HMAC
@@ -64,13 +67,32 @@ pub(crate) struct TurnkeyBreezSigner {
 }
 
 impl TurnkeyBreezSigner {
-    pub(crate) fn new(client: Arc<TurnkeyClient>, network: Network, account: u32) -> Self {
+    /// Builds the signer with its encryption backend initialized per `backend`:
+    /// seeded from a persisted key, pre-marked denied, or left to export lazily
+    /// on first use.
+    pub(crate) fn new_seeded(
+        client: Arc<TurnkeyClient>,
+        network: Network,
+        account: u32,
+        backend: EncryptionBackend,
+    ) -> Self {
+        let (encryption, export_denied) = match backend {
+            EncryptionBackend::Seeded(signer) => {
+                (OnceCell::new_with(Some(signer)), OnceLock::new())
+            }
+            EncryptionBackend::Denied(msg) => {
+                let denied = OnceLock::new();
+                let _ = denied.set(msg);
+                (OnceCell::new(), denied)
+            }
+            EncryptionBackend::Lazy => (OnceCell::new(), OnceLock::new()),
+        };
         Self {
             client,
             network,
             account,
-            encryption: OnceCell::new(),
-            export_denied: OnceLock::new(),
+            encryption,
+            export_denied,
         }
     }
 

--- a/crates/breez-sdk/core/src/turnkey/factory.rs
+++ b/crates/breez-sdk/core/src/turnkey/factory.rs
@@ -6,14 +6,15 @@ use std::sync::Arc;
 use bitcoin::secp256k1::{PublicKey, SecretKey};
 use platform_utils::create_http_client;
 use serde::{Deserialize, Serialize};
-use spark_wallet::SparkAddress;
 
 use crate::ExternalSigners;
 use crate::error::SignerError;
 use crate::signer::breez::BreezSignerImpl;
 use crate::signer::{ExternalBreezSigner, ExternalSparkSigner};
 
-use super::accounts::{encryption_key_path, spark_address_format, xpriv_from_secret};
+use super::accounts::{
+    encryption_key_path, spark_address_format, spark_identity_address, xpriv_from_secret,
+};
 use super::breez_signer::{EncryptionBackend, TurnkeyBreezSigner};
 use super::config::TurnkeyConfig;
 use super::error::TurnkeyError;
@@ -41,7 +42,7 @@ fn identity_path(account: u32) -> String {
 /// Layout version of [`TurnkeyProvisionedSigner`]'s bytes. Bumped when the blob
 /// contents change so an older blob is rejected as outdated rather than
 /// misread; the caller re-provisions to upgrade.
-const PROVISION_VERSION: u16 = 2;
+const PROVISION_VERSION: u16 = 3;
 
 /// The encryption-key verdict captured at provisioning time.
 #[derive(Serialize, Deserialize)]
@@ -55,37 +56,49 @@ enum ProvisionedEncryption {
     Unavailable,
 }
 
-/// Versioned, persisted provisioning state. Bound to the wallet/network/account
-/// so a blob paired with the wrong config (or an older layout) is rejected.
+/// Versioned, persisted provisioning state. Bound to the
+/// organization/wallet/network/account so a blob paired with the wrong config
+/// (or an older layout) is rejected.
 ///
-/// Alongside the encryption verdict it carries the wallet's stable Spark values,
-/// the identity public key (hex) and Spark address, so a provisioned per-request
-/// signer serves them from memory instead of re-fetching them from Turnkey on
-/// every request. Both are fixed per wallet. Dynamic per-leaf keys are not here:
-/// they change with the wallet's leaves and stay lazy.
+/// Alongside the encryption verdict it carries the wallet's stable identity
+/// public key (hex), so a provisioned per-request signer serves it from memory
+/// instead of re-fetching from Turnkey on every request. The Spark address is
+/// not stored: it is derived locally from the identity key at build time.
+/// Dynamic per-leaf keys are not here either: they change with the wallet's
+/// leaves and stay lazy.
 #[derive(Serialize, Deserialize)]
 struct ProvisionBlob {
     version: u16,
     network: u8,
     account: u32,
+    organization_id: String,
     wallet_id: String,
     encryption: ProvisionedEncryption,
     identity_public_key: String,
-    spark_address: String,
 }
 
 impl ProvisionBlob {
     /// Rejects a blob whose layout version or wallet binding does not match this
     /// config, so a stale or mispaired blob triggers a re-provision instead of
     /// building a signer against the wrong keys.
-    fn ensure_usable(&self, network: u8, account: u32, wallet_id: &str) -> Result<(), SignerError> {
+    fn ensure_usable(
+        &self,
+        network: u8,
+        account: u32,
+        organization_id: &str,
+        wallet_id: &str,
+    ) -> Result<(), SignerError> {
         if self.version != PROVISION_VERSION {
             return Err(SignerError::ProvisioningOutdated(format!(
                 "provisioned state version {} is not {PROVISION_VERSION}; re-provision",
                 self.version
             )));
         }
-        if self.network != network || self.account != account || self.wallet_id != wallet_id {
+        if self.network != network
+            || self.account != account
+            || self.organization_id != organization_id
+            || self.wallet_id != wallet_id
+        {
             return Err(SignerError::ProvisioningOutdated(
                 "provisioned state does not match this config; re-provision".to_string(),
             ));
@@ -127,25 +140,25 @@ pub async fn provision_turnkey_signer(
     let http = create_http_client(Some("breez-sdk-spark-turnkey"));
     let client = TurnkeyClient::new(&config, http).map_err(to_signer_err)?;
 
-    // Materialize the compressed identity account (idempotent). Its address is
-    // the compressed identity pubkey hex, which `create` seeds into the Spark
-    // signer so a network-free build can sign ECDSA identity messages.
+    // Materialize the compressed identity account and read its pubkey, which
+    // `create` seeds into the Spark signer so a network-free build can sign ECDSA
+    // identity messages. Read via `compressed_pubkey_at` (the account's
+    // format-independent `publicKey`), not `create_account`'s returned address:
+    // on a re-provision both account formats coexist at this path and get-by-path
+    // is ambiguous, so the address read-back could return the Spark bech32 form.
     let identity_public_key = client
-        .create_account(identity_path(account), ADDRESS_FORMAT_COMPRESSED)
+        .compressed_pubkey_at(identity_path(account))
         .await
         .map_err(to_signer_err)?;
-    let identity_pubkey = PublicKey::from_str(&identity_public_key).map_err(to_signer_err)?;
+    // Validate now so a malformed pubkey fails at provisioning, not at build.
+    PublicKey::from_str(&identity_public_key).map_err(to_signer_err)?;
 
     // Materialize the Spark-format account at the same path so enclave Schnorr
-    // and Spark-protocol signing work; the address itself is derived locally (the
-    // canonical Spark address for the identity key), matching the Spark signer
-    // and avoiding the ambiguous get-by-path once both formats exist.
+    // and Spark-protocol signing work. Its address is not needed here: `create`
+    // derives the canonical Spark address locally from the identity key.
     client
         .create_account(identity_path(account), spark_address_format(config.network))
         .await
-        .map_err(to_signer_err)?;
-    let spark_address = SparkAddress::new(identity_pubkey, config.network.into(), None)
-        .to_address_string()
         .map_err(to_signer_err)?;
 
     // Export the dedicated ECIES/HMAC key. A deny-export policy (403) is a
@@ -163,10 +176,10 @@ pub async fn provision_turnkey_signer(
         version: PROVISION_VERSION,
         network: config.network as u8,
         account,
+        organization_id: config.organization_id.clone(),
         wallet_id: config.wallet_id.clone(),
         encryption,
         identity_public_key,
-        spark_address,
     };
     Ok(TurnkeyProvisionedSigner {
         bytes: serde_json::to_vec(&blob).map_err(to_signer_err)?,
@@ -179,8 +192,8 @@ pub async fn provision_turnkey_signer(
 /// With `provisioned` from a prior [`provision_turnkey_signer`], this makes no
 /// network calls: the blob attests the identity account exists and carries the
 /// encryption-key verdict (a seeded key, or that export is denied). A blob that
-/// does not match `config` (wallet, network, account, or an older layout) is
-/// rejected with [`SignerError::ProvisioningOutdated`] so the caller
+/// does not match `config` (organization, wallet, network, account, or an older
+/// layout) is rejected with [`SignerError::ProvisioningOutdated`] so the caller
 /// re-provisions.
 ///
 /// Without `provisioned` (mobile/CLI), the identity account is materialized
@@ -219,7 +232,12 @@ pub async fn create_turnkey_signer(
             let blob: ProvisionBlob = serde_json::from_slice(&provisioned.bytes).map_err(|e| {
                 SignerError::ProvisioningOutdated(format!("unreadable provisioned state: {e}"))
             })?;
-            blob.ensure_usable(network as u8, account, &config.wallet_id)?;
+            blob.ensure_usable(
+                network as u8,
+                account,
+                &config.organization_id,
+                &config.wallet_id,
+            )?;
             let encryption = match blob.encryption {
                 ProvisionedEncryption::Key(bytes) => {
                     let secret = SecretKey::from_slice(&bytes).map_err(to_signer_err)?;
@@ -233,11 +251,14 @@ pub async fn create_turnkey_signer(
             };
             let identity_pubkey =
                 PublicKey::from_str(&blob.identity_public_key).map_err(to_signer_err)?;
-            (encryption, Some((identity_pubkey, blob.spark_address)))
+            // The Spark address is the canonical address for the identity key, so
+            // derive it locally rather than persisting a second, redundant copy.
+            let spark_address = spark_identity_address(identity_pubkey, network)?;
+            (encryption, Some((identity_pubkey, spark_address)))
         }
     };
 
-    let breez_signer: Arc<dyn ExternalBreezSigner> = Arc::new(TurnkeyBreezSigner::new_seeded(
+    let breez_signer: Arc<dyn ExternalBreezSigner> = Arc::new(TurnkeyBreezSigner::new(
         client.clone(),
         network,
         account,
@@ -299,10 +320,10 @@ mod tests {
             version: PROVISION_VERSION,
             network: config.network as u8,
             account: account_number(config),
+            organization_id: config.organization_id.clone(),
             wallet_id: config.wallet_id.clone(),
             encryption,
             identity_public_key: hex::encode(test_identity_pubkey().serialize()),
-            spark_address: "sprt1qqtestsparkaddress".to_string(),
         };
         TurnkeyProvisionedSigner {
             bytes: serde_json::to_vec(&blob).unwrap(),
@@ -384,6 +405,24 @@ mod tests {
         }
     }
 
+    // A blob provisioned under a different organization (even with the same
+    // wallet id) is rejected rather than used against the wrong keys.
+    #[tokio::test]
+    async fn mismatched_org_is_rejected() {
+        let config = test_config();
+        let mut other = test_config();
+        other.organization_id = "other-org".to_string();
+        let state = provisioned(&other, ProvisionedEncryption::Key([7u8; 32]));
+
+        match create_turnkey_signer(config, Some(state)).await {
+            Err(SignerError::ProvisioningOutdated(_)) => {}
+            result => panic!(
+                "expected ProvisioningOutdated, got {:?}",
+                result.map(|_| ())
+            ),
+        }
+    }
+
     // An older layout version is rejected as outdated so the caller re-provisions.
     #[tokio::test]
     async fn outdated_version_is_rejected() {
@@ -392,10 +431,10 @@ mod tests {
             version: PROVISION_VERSION - 1,
             network: config.network as u8,
             account: account_number(&config),
+            organization_id: config.organization_id.clone(),
             wallet_id: config.wallet_id.clone(),
             encryption: ProvisionedEncryption::Unavailable,
             identity_public_key: hex::encode(test_identity_pubkey().serialize()),
-            spark_address: "sprt1qqtestsparkaddress".to_string(),
         };
         let state = TurnkeyProvisionedSigner {
             bytes: serde_json::to_vec(&old_blob).unwrap(),

--- a/crates/breez-sdk/core/src/turnkey/factory.rs
+++ b/crates/breez-sdk/core/src/turnkey/factory.rs
@@ -2,14 +2,19 @@
 
 use std::sync::Arc;
 
+use bitcoin::secp256k1::SecretKey;
 use platform_utils::create_http_client;
+use serde::{Deserialize, Serialize};
 
 use crate::ExternalSigners;
 use crate::error::SignerError;
+use crate::signer::breez::BreezSignerImpl;
 use crate::signer::{ExternalBreezSigner, ExternalSparkSigner};
 
-use super::breez_signer::TurnkeyBreezSigner;
+use super::accounts::{encryption_key_path, xpriv_from_secret};
+use super::breez_signer::{EncryptionBackend, TurnkeyBreezSigner};
 use super::config::TurnkeyConfig;
+use super::error::TurnkeyError;
 use super::spark_signer::TurnkeySparkSigner;
 use super::transport::TurnkeyClient;
 use super::types::ADDRESS_FORMAT_COMPRESSED;
@@ -31,34 +36,307 @@ fn identity_path(account: u32) -> String {
     format!("m/8797555'/{account}'/0'")
 }
 
-/// Builds the Turnkey-backed Breez and Spark signers from `config`, sharing one
-/// Turnkey client.
+/// Layout version of [`TurnkeyProvisionedSigner`]'s bytes. Bumped when the blob
+/// contents change so an older blob is rejected as outdated rather than
+/// misread; the caller re-provisions to upgrade.
+const PROVISION_VERSION: u16 = 1;
+
+/// The encryption-key verdict captured at provisioning time.
+#[derive(Serialize, Deserialize)]
+enum ProvisionedEncryption {
+    /// Exportable key, already exported: seed the local ECIES/HMAC backend and
+    /// never touch the network.
+    Key([u8; 32]),
+    /// Export is denied by wallet policy (a 403 at provisioning time): encryption
+    /// is unavailable. Recorded so `create` never re-probes; re-provision after
+    /// changing the policy to pick up a now-exportable key.
+    Unavailable,
+}
+
+/// Versioned, persisted provisioning state. Bound to the wallet/network/account
+/// so a blob paired with the wrong config (or an older layout) is rejected.
+#[derive(Serialize, Deserialize)]
+struct ProvisionBlob {
+    version: u16,
+    network: u8,
+    account: u32,
+    wallet_id: String,
+    encryption: ProvisionedEncryption,
+}
+
+impl ProvisionBlob {
+    /// Rejects a blob whose layout version or wallet binding does not match this
+    /// config, so a stale or mispaired blob triggers a re-provision instead of
+    /// building a signer against the wrong keys.
+    fn ensure_usable(&self, network: u8, account: u32, wallet_id: &str) -> Result<(), SignerError> {
+        if self.version != PROVISION_VERSION {
+            return Err(SignerError::ProvisioningOutdated(format!(
+                "provisioned state version {} is not {PROVISION_VERSION}; re-provision",
+                self.version
+            )));
+        }
+        if self.network != network || self.account != account || self.wallet_id != wallet_id {
+            return Err(SignerError::ProvisioningOutdated(
+                "provisioned state does not match this config; re-provision".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Persistable result of provisioning a Turnkey wallet for SDK use.
 ///
-/// The Spark signer keeps every signing operation in the Turnkey enclave; the
-/// Breez signer does too, except ECIES and HMAC, which run locally against a
-/// dedicated, non-Spark key exported lazily on first use (see
-/// `TurnkeyBreezSigner`). Exporting a non-Spark key keeps every Spark key (the
-/// identity key included) in the enclave; ECIES/HMAC only need a stable key, not
-/// a Spark one.
+/// Opaque bytes holding either a scoped secret (a non-Spark key used only for
+/// local ECIES/HMAC, never funds or the Spark identity) or a record that the
+/// wallet denies export, plus the wallet binding. Store it encrypted, once, at
+/// user creation, then pass it to [`create_turnkey_signer`] on every later init
+/// to build the signer with no network calls. Re-provision when a later
+/// `create_turnkey_signer` rejects it as outdated (an SDK upgrade), or after
+/// changing the wallet's export policy.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct TurnkeyProvisionedSigner {
+    pub bytes: Vec<u8>,
+}
+
+/// One-time setup for a Turnkey-backed wallet, to run once at user creation.
+///
+/// Materializes the enclave identity account and exports the SDK-layer
+/// encryption key, returning a [`TurnkeyProvisionedSigner`] to persist. Later
+/// inits pass it to [`create_turnkey_signer`] to build the signer with no
+/// network. Idempotent, so it is safe to re-run if the persisted result is lost
+/// or after a policy or SDK-version change.
+///
+/// A wallet whose policy denies key export still provisions: the export's 403 is
+/// recorded as unavailable, and the built signer reports encryption unavailable
+/// without ever attempting the export.
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
-pub async fn create_turnkey_signer(config: TurnkeyConfig) -> Result<ExternalSigners, SignerError> {
-    let network = config.network;
+pub async fn provision_turnkey_signer(
+    config: TurnkeyConfig,
+) -> Result<TurnkeyProvisionedSigner, SignerError> {
     let account = account_number(&config);
     let http = create_http_client(Some("breez-sdk-spark-turnkey"));
-    let client = Arc::new(TurnkeyClient::new(&config, http).map_err(to_signer_err)?);
-    // Materialize the compressed identity account so ECDSA identity signing
-    // (operator auth, messages) can use it as signWith; the key stays in the
-    // enclave (the Spark signer adds the Spark-format account at the same path).
+    let client = TurnkeyClient::new(&config, http).map_err(to_signer_err)?;
+
+    // Materialize the compressed identity account (idempotent) so a network-free
+    // `create` can use it as signWith for ECDSA identity signing.
     client
         .create_account(identity_path(account), ADDRESS_FORMAT_COMPRESSED)
         .await
         .map_err(to_signer_err)?;
-    let breez_signer: Arc<dyn ExternalBreezSigner> =
-        Arc::new(TurnkeyBreezSigner::new(client.clone(), network, account));
+
+    // Export the dedicated ECIES/HMAC key. A deny-export policy (403) is a
+    // definitive verdict recorded in the blob, so `create` never re-probes.
+    let encryption = match client
+        .export_secret_key(encryption_key_path(account), ADDRESS_FORMAT_COMPRESSED)
+        .await
+    {
+        Ok(secret) => ProvisionedEncryption::Key(secret.secret_bytes()),
+        Err(TurnkeyError::Http { status: 403, .. }) => ProvisionedEncryption::Unavailable,
+        Err(e) => return Err(to_signer_err(e)),
+    };
+
+    let blob = ProvisionBlob {
+        version: PROVISION_VERSION,
+        network: config.network as u8,
+        account,
+        wallet_id: config.wallet_id.clone(),
+        encryption,
+    };
+    Ok(TurnkeyProvisionedSigner {
+        bytes: serde_json::to_vec(&blob).map_err(to_signer_err)?,
+    })
+}
+
+/// Builds the Turnkey-backed Breez and Spark signers from `config`, sharing one
+/// Turnkey client.
+///
+/// With `provisioned` from a prior [`provision_turnkey_signer`], this makes no
+/// network calls: the blob attests the identity account exists and carries the
+/// encryption-key verdict (a seeded key, or that export is denied). A blob that
+/// does not match `config` (wallet, network, account, or an older layout) is
+/// rejected with [`SignerError::ProvisioningOutdated`] so the caller
+/// re-provisions.
+///
+/// Without `provisioned` (mobile/CLI), the identity account is materialized
+/// eagerly and the encryption key is exported lazily on first ECIES/HMAC use.
+///
+/// The Spark signer keeps every signing operation in the Turnkey enclave; the
+/// Breez signer does too, except ECIES and HMAC, which run locally against a
+/// dedicated, non-Spark key. Using a non-Spark key keeps every Spark key (the
+/// identity key included) in the enclave; ECIES/HMAC only need a stable key.
+#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+pub async fn create_turnkey_signer(
+    config: TurnkeyConfig,
+    provisioned: Option<TurnkeyProvisionedSigner>,
+) -> Result<ExternalSigners, SignerError> {
+    let network = config.network;
+    let account = account_number(&config);
+    let http = create_http_client(Some("breez-sdk-spark-turnkey"));
+    let client = Arc::new(TurnkeyClient::new(&config, http).map_err(to_signer_err)?);
+
+    let encryption = match provisioned {
+        // Unprovisioned: materialize the identity account now, export lazily.
+        None => {
+            client
+                .create_account(identity_path(account), ADDRESS_FORMAT_COMPRESSED)
+                .await
+                .map_err(to_signer_err)?;
+            EncryptionBackend::Lazy
+        }
+        // Provisioned once: no network. The blob attests the identity account
+        // exists and tells us whether the encryption key is seedable or denied.
+        Some(provisioned) => {
+            let blob: ProvisionBlob = serde_json::from_slice(&provisioned.bytes).map_err(|e| {
+                SignerError::ProvisioningOutdated(format!("unreadable provisioned state: {e}"))
+            })?;
+            blob.ensure_usable(network as u8, account, &config.wallet_id)?;
+            match blob.encryption {
+                ProvisionedEncryption::Key(bytes) => {
+                    let secret = SecretKey::from_slice(&bytes).map_err(to_signer_err)?;
+                    EncryptionBackend::Seeded(BreezSignerImpl::new(xpriv_from_secret(
+                        secret, network,
+                    )))
+                }
+                ProvisionedEncryption::Unavailable => {
+                    EncryptionBackend::Denied("Turnkey wallet policy denies key export".to_string())
+                }
+            }
+        }
+    };
+
+    let breez_signer: Arc<dyn ExternalBreezSigner> = Arc::new(TurnkeyBreezSigner::new_seeded(
+        client.clone(),
+        network,
+        account,
+        encryption,
+    ));
     let spark_signer: Arc<dyn ExternalSparkSigner> =
         Arc::new(TurnkeySparkSigner::new(client, network, account));
     Ok(ExternalSigners {
         breez_signer,
         spark_signer,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Network;
+    use bitcoin::secp256k1::Secp256k1;
+
+    // Unroutable base URL: every test here exercises the provisioned path, which
+    // must not touch the network, so a real request would be a bug (and hang).
+    fn test_config() -> TurnkeyConfig {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[0x11; 32]).unwrap();
+        let pk = sk.public_key(&secp);
+        TurnkeyConfig {
+            base_url: Some("https://turnkey.invalid".to_string()),
+            organization_id: "test-org".to_string(),
+            api_public_key: hex::encode(pk.serialize()),
+            api_private_key: hex::encode(sk.secret_bytes()),
+            wallet_id: "test-wallet".to_string(),
+            network: Network::Regtest,
+            account_number: Some(0),
+            retry: None,
+        }
+    }
+
+    fn provisioned(
+        config: &TurnkeyConfig,
+        encryption: ProvisionedEncryption,
+    ) -> TurnkeyProvisionedSigner {
+        let blob = ProvisionBlob {
+            version: PROVISION_VERSION,
+            network: config.network as u8,
+            account: account_number(config),
+            wallet_id: config.wallet_id.clone(),
+            encryption,
+        };
+        TurnkeyProvisionedSigner {
+            bytes: serde_json::to_vec(&blob).unwrap(),
+        }
+    }
+
+    // A seeded blob builds a signer whose ECIES runs locally: encrypt/decrypt
+    // round-trips with no network (the base URL is unroutable).
+    #[tokio::test]
+    async fn seeded_blob_builds_offline_encryptor() {
+        let config = test_config();
+        let state = provisioned(&config, ProvisionedEncryption::Key([7u8; 32]));
+        let signers = create_turnkey_signer(config, Some(state)).await.unwrap();
+
+        let message = vec![1, 2, 3, 4];
+        let ciphertext = signers
+            .breez_signer
+            .encrypt_ecies(message.clone(), "m/0'".to_string())
+            .await
+            .unwrap();
+        let plaintext = signers
+            .breez_signer
+            .decrypt_ecies(ciphertext, "m/0'".to_string())
+            .await
+            .unwrap();
+        assert_eq!(plaintext, message);
+    }
+
+    // A blob recording denied export builds a signer that reports encryption
+    // unavailable without attempting the export (no network).
+    #[tokio::test]
+    async fn unavailable_blob_reports_encryption_unavailable() {
+        let config = test_config();
+        let state = provisioned(&config, ProvisionedEncryption::Unavailable);
+        let signers = create_turnkey_signer(config, Some(state)).await.unwrap();
+
+        match signers
+            .breez_signer
+            .encrypt_ecies(vec![1], "m/0'".to_string())
+            .await
+        {
+            Err(SignerError::EncryptionUnavailable(_)) => {}
+            other => panic!("expected EncryptionUnavailable, got {other:?}"),
+        }
+    }
+
+    // A blob for a different wallet is rejected rather than used against the
+    // wrong keys.
+    #[tokio::test]
+    async fn mismatched_blob_is_rejected() {
+        let config = test_config();
+        let mut other = test_config();
+        other.wallet_id = "other-wallet".to_string();
+        let state = provisioned(&other, ProvisionedEncryption::Key([7u8; 32]));
+
+        match create_turnkey_signer(config, Some(state)).await {
+            Err(SignerError::ProvisioningOutdated(_)) => {}
+            result => panic!(
+                "expected ProvisioningOutdated, got {:?}",
+                result.map(|_| ())
+            ),
+        }
+    }
+
+    // An older layout version is rejected as outdated so the caller re-provisions.
+    #[tokio::test]
+    async fn outdated_version_is_rejected() {
+        let config = test_config();
+        let old_blob = ProvisionBlob {
+            version: PROVISION_VERSION - 1,
+            network: config.network as u8,
+            account: account_number(&config),
+            wallet_id: config.wallet_id.clone(),
+            encryption: ProvisionedEncryption::Unavailable,
+        };
+        let state = TurnkeyProvisionedSigner {
+            bytes: serde_json::to_vec(&old_blob).unwrap(),
+        };
+
+        match create_turnkey_signer(config, Some(state)).await {
+            Err(SignerError::ProvisioningOutdated(_)) => {}
+            result => panic!(
+                "expected ProvisioningOutdated, got {:?}",
+                result.map(|_| ())
+            ),
+        }
+    }
 }

--- a/crates/breez-sdk/core/src/turnkey/factory.rs
+++ b/crates/breez-sdk/core/src/turnkey/factory.rs
@@ -1,17 +1,19 @@
 //! Factory for the Turnkey-backed signers, exposed over uniffi.
 
+use std::str::FromStr;
 use std::sync::Arc;
 
-use bitcoin::secp256k1::SecretKey;
+use bitcoin::secp256k1::{PublicKey, SecretKey};
 use platform_utils::create_http_client;
 use serde::{Deserialize, Serialize};
+use spark_wallet::SparkAddress;
 
 use crate::ExternalSigners;
 use crate::error::SignerError;
 use crate::signer::breez::BreezSignerImpl;
 use crate::signer::{ExternalBreezSigner, ExternalSparkSigner};
 
-use super::accounts::{encryption_key_path, xpriv_from_secret};
+use super::accounts::{encryption_key_path, spark_address_format, xpriv_from_secret};
 use super::breez_signer::{EncryptionBackend, TurnkeyBreezSigner};
 use super::config::TurnkeyConfig;
 use super::error::TurnkeyError;
@@ -39,7 +41,7 @@ fn identity_path(account: u32) -> String {
 /// Layout version of [`TurnkeyProvisionedSigner`]'s bytes. Bumped when the blob
 /// contents change so an older blob is rejected as outdated rather than
 /// misread; the caller re-provisions to upgrade.
-const PROVISION_VERSION: u16 = 1;
+const PROVISION_VERSION: u16 = 2;
 
 /// The encryption-key verdict captured at provisioning time.
 #[derive(Serialize, Deserialize)]
@@ -55,6 +57,12 @@ enum ProvisionedEncryption {
 
 /// Versioned, persisted provisioning state. Bound to the wallet/network/account
 /// so a blob paired with the wrong config (or an older layout) is rejected.
+///
+/// Alongside the encryption verdict it carries the wallet's stable Spark values,
+/// the identity public key (hex) and Spark address, so a provisioned per-request
+/// signer serves them from memory instead of re-fetching them from Turnkey on
+/// every request. Both are fixed per wallet. Dynamic per-leaf keys are not here:
+/// they change with the wallet's leaves and stay lazy.
 #[derive(Serialize, Deserialize)]
 struct ProvisionBlob {
     version: u16,
@@ -62,6 +70,8 @@ struct ProvisionBlob {
     account: u32,
     wallet_id: String,
     encryption: ProvisionedEncryption,
+    identity_public_key: String,
+    spark_address: String,
 }
 
 impl ProvisionBlob {
@@ -117,11 +127,25 @@ pub async fn provision_turnkey_signer(
     let http = create_http_client(Some("breez-sdk-spark-turnkey"));
     let client = TurnkeyClient::new(&config, http).map_err(to_signer_err)?;
 
-    // Materialize the compressed identity account (idempotent) so a network-free
-    // `create` can use it as signWith for ECDSA identity signing.
-    client
+    // Materialize the compressed identity account (idempotent). Its address is
+    // the compressed identity pubkey hex, which `create` seeds into the Spark
+    // signer so a network-free build can sign ECDSA identity messages.
+    let identity_public_key = client
         .create_account(identity_path(account), ADDRESS_FORMAT_COMPRESSED)
         .await
+        .map_err(to_signer_err)?;
+    let identity_pubkey = PublicKey::from_str(&identity_public_key).map_err(to_signer_err)?;
+
+    // Materialize the Spark-format account at the same path so enclave Schnorr
+    // and Spark-protocol signing work; the address itself is derived locally (the
+    // canonical Spark address for the identity key), matching the Spark signer
+    // and avoiding the ambiguous get-by-path once both formats exist.
+    client
+        .create_account(identity_path(account), spark_address_format(config.network))
+        .await
+        .map_err(to_signer_err)?;
+    let spark_address = SparkAddress::new(identity_pubkey, config.network.into(), None)
+        .to_address_string()
         .map_err(to_signer_err)?;
 
     // Export the dedicated ECIES/HMAC key. A deny-export policy (403) is a
@@ -141,6 +165,8 @@ pub async fn provision_turnkey_signer(
         account,
         wallet_id: config.wallet_id.clone(),
         encryption,
+        identity_public_key,
+        spark_address,
     };
     Ok(TurnkeyProvisionedSigner {
         bytes: serde_json::to_vec(&blob).map_err(to_signer_err)?,
@@ -174,23 +200,27 @@ pub async fn create_turnkey_signer(
     let http = create_http_client(Some("breez-sdk-spark-turnkey"));
     let client = Arc::new(TurnkeyClient::new(&config, http).map_err(to_signer_err)?);
 
-    let encryption = match provisioned {
-        // Unprovisioned: materialize the identity account now, export lazily.
+    // `encryption` seeds the Breez signer's ECIES/HMAC backend; `spark_identity`
+    // seeds the Spark signer's identity pubkey and Spark address so a provisioned
+    // build makes no Turnkey calls for either.
+    let (encryption, spark_identity) = match provisioned {
+        // Unprovisioned: materialize the identity account now, export lazily, and
+        // let the Spark signer fetch its identity/address on first use.
         None => {
             client
                 .create_account(identity_path(account), ADDRESS_FORMAT_COMPRESSED)
                 .await
                 .map_err(to_signer_err)?;
-            EncryptionBackend::Lazy
+            (EncryptionBackend::Lazy, None)
         }
-        // Provisioned once: no network. The blob attests the identity account
-        // exists and tells us whether the encryption key is seedable or denied.
+        // Provisioned once: no network. The blob attests the accounts exist and
+        // carries the encryption verdict plus the stable Spark identity values.
         Some(provisioned) => {
             let blob: ProvisionBlob = serde_json::from_slice(&provisioned.bytes).map_err(|e| {
                 SignerError::ProvisioningOutdated(format!("unreadable provisioned state: {e}"))
             })?;
             blob.ensure_usable(network as u8, account, &config.wallet_id)?;
-            match blob.encryption {
+            let encryption = match blob.encryption {
                 ProvisionedEncryption::Key(bytes) => {
                     let secret = SecretKey::from_slice(&bytes).map_err(to_signer_err)?;
                     EncryptionBackend::Seeded(BreezSignerImpl::new(xpriv_from_secret(
@@ -200,7 +230,10 @@ pub async fn create_turnkey_signer(
                 ProvisionedEncryption::Unavailable => {
                     EncryptionBackend::Denied("Turnkey wallet policy denies key export".to_string())
                 }
-            }
+            };
+            let identity_pubkey =
+                PublicKey::from_str(&blob.identity_public_key).map_err(to_signer_err)?;
+            (encryption, Some((identity_pubkey, blob.spark_address)))
         }
     };
 
@@ -210,8 +243,16 @@ pub async fn create_turnkey_signer(
         account,
         encryption,
     ));
-    let spark_signer: Arc<dyn ExternalSparkSigner> =
-        Arc::new(TurnkeySparkSigner::new(client, network, account));
+    let spark_signer: Arc<dyn ExternalSparkSigner> = Arc::new(match spark_identity {
+        Some((identity_pubkey, spark_address)) => TurnkeySparkSigner::new_seeded(
+            client,
+            network,
+            account,
+            Some(identity_pubkey),
+            Some(spark_address),
+        ),
+        None => TurnkeySparkSigner::new(client, network, account),
+    });
     Ok(ExternalSigners {
         breez_signer,
         spark_signer,
@@ -242,6 +283,14 @@ mod tests {
         }
     }
 
+    // A fixed, valid identity pubkey to seed provisioned blobs with.
+    fn test_identity_pubkey() -> PublicKey {
+        let secp = Secp256k1::new();
+        SecretKey::from_slice(&[0x22; 32])
+            .unwrap()
+            .public_key(&secp)
+    }
+
     fn provisioned(
         config: &TurnkeyConfig,
         encryption: ProvisionedEncryption,
@@ -252,6 +301,8 @@ mod tests {
             account: account_number(config),
             wallet_id: config.wallet_id.clone(),
             encryption,
+            identity_public_key: hex::encode(test_identity_pubkey().serialize()),
+            spark_address: "sprt1qqtestsparkaddress".to_string(),
         };
         TurnkeyProvisionedSigner {
             bytes: serde_json::to_vec(&blob).unwrap(),
@@ -278,6 +329,23 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(plaintext, message);
+    }
+
+    // A seeded blob serves the Spark identity pubkey from memory: it returns the
+    // provisioned key with no network (the base URL is unroutable, so a fetch
+    // would fail), matching what the whole-signer in-memory cache did.
+    #[tokio::test]
+    async fn seeded_blob_serves_spark_identity_offline() {
+        let config = test_config();
+        let state = provisioned(&config, ProvisionedEncryption::Key([7u8; 32]));
+        let signers = create_turnkey_signer(config, Some(state)).await.unwrap();
+
+        let identity = signers
+            .spark_signer
+            .get_identity_public_key()
+            .await
+            .unwrap();
+        assert_eq!(identity.to_public_key().unwrap(), test_identity_pubkey());
     }
 
     // A blob recording denied export builds a signer that reports encryption
@@ -326,6 +394,8 @@ mod tests {
             account: account_number(&config),
             wallet_id: config.wallet_id.clone(),
             encryption: ProvisionedEncryption::Unavailable,
+            identity_public_key: hex::encode(test_identity_pubkey().serialize()),
+            spark_address: "sprt1qqtestsparkaddress".to_string(),
         };
         let state = TurnkeyProvisionedSigner {
             bytes: serde_json::to_vec(&old_blob).unwrap(),

--- a/crates/breez-sdk/core/src/turnkey/mod.rs
+++ b/crates/breez-sdk/core/src/turnkey/mod.rs
@@ -20,6 +20,6 @@ mod types;
 
 pub use config::{TurnkeyConfig, TurnkeyRetryConfig};
 pub use error::TurnkeyError;
-pub use factory::create_turnkey_signer;
+pub use factory::{TurnkeyProvisionedSigner, create_turnkey_signer, provision_turnkey_signer};
 #[cfg(feature = "test-utils")]
 pub use management::{TurnkeyWalletInfo, TurnkeyWalletManager};

--- a/crates/breez-sdk/core/src/turnkey/spark_signer.rs
+++ b/crates/breez-sdk/core/src/turnkey/spark_signer.rs
@@ -36,7 +36,7 @@ use frost_secp256k1_tr::round2::SignatureShare;
 use spark_wallet::{
     AggregateFrostRequest, DefaultSigner, FrostDerivation, FrostJob, FrostShareResult,
     FrostSigningCommitmentsWithNonces, NewLeafKey, OperatorPackage, OperatorRecipient,
-    SecretSource, SignFrostRequest, Signer, SparkAddress, TreeNodeId, aggregate_frost,
+    SecretSource, SignFrostRequest, Signer, TreeNodeId, aggregate_frost,
 };
 
 use crate::Network;
@@ -57,7 +57,8 @@ use crate::signer::{
 };
 
 use super::accounts::{
-    decode_scalar_32, ecdsa_from_rs, schnorr_from_rs, spark_address_format, xpriv_from_secret,
+    decode_scalar_32, ecdsa_from_rs, schnorr_from_rs, spark_address_format, spark_identity_address,
+    xpriv_from_secret,
 };
 use super::error::TurnkeyError;
 use super::transport::{OnConflict, TurnkeyClient};
@@ -394,9 +395,7 @@ impl TurnkeySparkSigner {
             .await
             .map_err(to_spark_err)?;
         let identity = self.identity_public_key().await?;
-        let addr = SparkAddress::new(identity, self.network.into(), None)
-            .to_address_string()
-            .map_err(to_spark_err)?;
+        let addr = spark_identity_address(identity, self.network)?;
         *self.spark_address.lock().await = Some(addr.clone());
         Ok(addr)
     }
@@ -936,7 +935,7 @@ mod tests {
 
     #[tokio::test]
     async fn breez_signer_lazy_export_denied_reports_unavailable() {
-        let signer = TurnkeyBreezSigner::new_seeded(
+        let signer = TurnkeyBreezSigner::new(
             deny_client(Arc::new(Always403::default())),
             Network::Regtest,
             0,
@@ -958,7 +957,7 @@ mod tests {
     async fn breez_signer_export_denial_is_memoized() {
         let http = Arc::new(Always403::default());
         let post_calls = http.post_calls.clone();
-        let signer = TurnkeyBreezSigner::new_seeded(
+        let signer = TurnkeyBreezSigner::new(
             deny_client(http),
             Network::Regtest,
             0,

--- a/crates/breez-sdk/core/src/turnkey/spark_signer.rs
+++ b/crates/breez-sdk/core/src/turnkey/spark_signer.rs
@@ -848,7 +848,7 @@ mod tests {
     use crate::Network;
     use crate::error::SignerError;
     use crate::signer::ExternalBreezSigner;
-    use crate::turnkey::breez_signer::TurnkeyBreezSigner;
+    use crate::turnkey::breez_signer::{EncryptionBackend, TurnkeyBreezSigner};
     use crate::turnkey::config::TurnkeyConfig;
     use crate::turnkey::transport::TurnkeyClient;
 
@@ -919,10 +919,11 @@ mod tests {
 
     #[tokio::test]
     async fn breez_signer_lazy_export_denied_reports_unavailable() {
-        let signer = TurnkeyBreezSigner::new(
+        let signer = TurnkeyBreezSigner::new_seeded(
             deny_client(Arc::new(Always403::default())),
             Network::Regtest,
             0,
+            EncryptionBackend::Lazy,
         );
         // The encryption key is exported lazily on first ECIES use. Under a
         // deny-export policy that export is rejected (403), surfaced as
@@ -940,7 +941,12 @@ mod tests {
     async fn breez_signer_export_denial_is_memoized() {
         let http = Arc::new(Always403::default());
         let post_calls = http.post_calls.clone();
-        let signer = TurnkeyBreezSigner::new(deny_client(http), Network::Regtest, 0);
+        let signer = TurnkeyBreezSigner::new_seeded(
+            deny_client(http),
+            Network::Regtest,
+            0,
+            EncryptionBackend::Lazy,
+        );
 
         // First ECIES use attempts the export and is denied (403).
         assert!(matches!(

--- a/crates/breez-sdk/core/src/turnkey/spark_signer.rs
+++ b/crates/breez-sdk/core/src/turnkey/spark_signer.rs
@@ -285,12 +285,29 @@ pub(crate) struct TurnkeySparkSigner {
 
 impl TurnkeySparkSigner {
     pub(crate) fn new(client: Arc<TurnkeyClient>, network: Network, account: u32) -> Self {
+        Self::new_seeded(client, network, account, None, None)
+    }
+
+    /// Builds the signer with the wallet's stable identity pubkey and Spark
+    /// address pre-filled into their memos, so a provisioned per-request signer
+    /// serves them without the `get_wallet_account` / `create_wallet_accounts`
+    /// round-trips `new` would otherwise make on first use. Both are fixed per
+    /// wallet (identity is `HD(m/8797555'/{account}'/0')`, the Spark address is
+    /// derived from it), so seeding is always correct. `None`/`None` reproduces
+    /// `new`. Leaf and static-deposit keys are dynamic and stay lazy.
+    pub(crate) fn new_seeded(
+        client: Arc<TurnkeyClient>,
+        network: Network,
+        account: u32,
+        identity_pubkey: Option<PublicKey>,
+        spark_address: Option<String>,
+    ) -> Self {
         Self {
             client,
             account,
             network,
-            identity_pubkey: Mutex::new(None),
-            spark_address: Mutex::new(None),
+            identity_pubkey: Mutex::new(identity_pubkey),
+            spark_address: Mutex::new(spark_address),
             leaf_pubkeys: Mutex::new(HashMap::new()),
             static_deposit_pubkeys: Mutex::new(HashMap::new()),
             static_deposit_secret_keys: Mutex::new(HashMap::new()),

--- a/crates/breez-sdk/wasm/src/turnkey.rs
+++ b/crates/breez-sdk/wasm/src/turnkey.rs
@@ -31,14 +31,35 @@ pub struct TurnkeyConfig {
     pub retry: Option<TurnkeyRetryConfig>,
 }
 
+/// Provisions a Turnkey wallet once (at user creation) and returns opaque bytes
+/// to persist. Pass them back to `createTurnkeySigner` on later inits to build
+/// the signer with no network calls. Store them encrypted: they hold a scoped
+/// ECIES/HMAC key (never funds or the Spark identity).
+#[wasm_bindgen(js_name = "provisionTurnkeySigner")]
+pub async fn provision_turnkey_signer(config: TurnkeyConfig) -> WasmResult<Vec<u8>> {
+    Ok(
+        breez_sdk_spark::turnkey::provision_turnkey_signer(config.into())
+            .await?
+            .bytes,
+    )
+}
+
 /// Builds the Turnkey-backed signers from `config`, then pass
 /// `signers.breezSigner` and `signers.sparkSigner` to `connectWithSigner`,
 /// exactly as with any other external signer.
+///
+/// Pass `provisioned` (from `provisionTurnkeySigner`) to build with no network
+/// calls; omit it to provision lazily on first use. A `provisioned` blob that no
+/// longer matches `config` throws, signalling a re-provision.
 #[wasm_bindgen(js_name = "createTurnkeySigner")]
 pub async fn create_turnkey_signer(
     config: TurnkeyConfig,
+    provisioned: Option<Vec<u8>>,
 ) -> WasmResult<crate::sdk::ExternalSigners> {
-    let signers = breez_sdk_spark::turnkey::create_turnkey_signer(config.into()).await?;
+    let provisioned =
+        provisioned.map(|bytes| breez_sdk_spark::turnkey::TurnkeyProvisionedSigner { bytes });
+    let signers =
+        breez_sdk_spark::turnkey::create_turnkey_signer(config.into(), provisioned).await?;
     Ok(crate::sdk::ExternalSigners::new(
         ExternalBreezSignerHandle::new(signers.breez_signer),
         ExternalSparkSignerHandle::new(signers.spark_signer),


### PR DESCRIPTION
## Problem

Server deployments build an SDK, and its signer, per request. Creating a Turnkey signer costs sequential network round-trips: materialize the enclave identity account, then export the SDK-layer ECIES/HMAC key. #970 made the export lazy, but the memo is in-memory per instance, so every per-request instance that encrypts (sync, session storage, LNURL-auth) re-pays the export. Laziness defers the cost; it can't amortize it across instances.

## Change

Split the factory into two entry points:

- **`provision_turnkey_signer(config)`** — run once, at user creation. Materializes the identity account, exports the encryption key, and captures the wallet's stable Spark values, returning an opaque, versioned, wallet-bound `TurnkeyProvisionedSigner` blob to persist (encrypted).
- **`create_turnkey_signer(config, provisioned)`** — with a blob, rebuilds the signer with **no network**: seeds the encryption backend and the Spark signer's identity pubkey / Spark address, and skips the identity create. Without a blob (mobile/CLI), behavior is unchanged (eager identity create, lazy export/fetch).

### What the blob carries

- **Encryption key** (or a record that export is policy-denied) → seeds the Breez signer's ECIES/HMAC backend.
- **Identity public key + Spark address** → seeds the Spark signer's memos. These are stable and deterministic per wallet, so a provisioned per-request signer serves them from memory instead of re-fetching (`get_wallet_account` / `create_wallet_accounts`) on every request.

Dynamic per-leaf and static-deposit keys are intentionally **not** in the blob (they change with the wallet's leaves) and stay lazy.

### Absent-key disambiguation

The blob's encryption state is a two-state enum, resolved authoritatively at provisioning time:

- `Key(..)` → seed the local ECIES/HMAC backend, no network.
- `Unavailable` (export 403'd under a deny policy) → the built signer reports `EncryptionUnavailable` **without ever probing**, so a provisioned no-export wallet doesn't re-attempt the export per request.

### Staleness

A blob that does not match the config (wallet / network / account, or an older layout version) is rejected with the new `SignerError::ProvisioningOutdated`, so the caller re-provisions (e.g. after an SDK upgrade or a wallet policy change).

### Relationship to lazy export (#970)

Lazy export/fetch is kept for the **unprovisioned** path. Persistence seeds the existing memos (`EncryptionBackend::{Seeded,Denied,Lazy}` for the Breez signer; `TurnkeySparkSigner::new_seeded` for the Spark signer) rather than replacing the lazy machinery, so the integration is a pre-fill and the delta stays small.

## Caller shape

```ts
// once, at user creation
const { bytes } = await provisionTurnkeySigner(config)
await store.set(userId, bytes)

// per request — no network in createTurnkeySigner
const signers = await createTurnkeySigner(config, await store.get(userId))
await connectWithSigner({ config, signers })
```

## Commits

1. **provisioning for network-free re-init** — the `provision`/`create` split, encryption seeding, deny handling, staleness.
2. **seed Spark identity pubkey and address** — closes a gap found in server-mode measurement: the first commit removed the export from the hot path, but the Spark signer still lazy-fetched its identity pubkey / Spark address per request. Carrying them in the blob (bumping `PROVISION_VERSION` to 2) makes provisioned per-request init truly network-free for signer setup.