### PR TITLE
Cross-chain: make SDK storage the source of truth for sends

### DIFF
--- a/crates/breez-sdk/core/src/cross_chain/boltz.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz.rs
@@ -568,6 +568,9 @@ impl CrossChainService for BoltzService {
         let invoice_amount_sats = swap.invoice_amount_sats;
         let max_slippage_bps = swap.slippage_bps;
 
+        // `expires_at` and the LN fee budget come from `prepared`, not the
+        // stored swap: neither is on `BoltzSwap` (only `timeout_block_height`,
+        // enforced by Boltz server-side), and neither can misdirect the send.
         validate_quote_expiry(&prepared.expires_at)?;
 
         let transfer_id = Some(derive_btc_leg_transfer_id(

--- a/crates/breez-sdk/core/src/cross_chain/boltz.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz.rs
@@ -21,9 +21,8 @@ use spark_wallet::SparkWallet;
 use tracing::{debug, error, info};
 
 use super::{
-    CrossChainFeeMode, CrossChainPrepared, CrossChainProvider, CrossChainProviderContext,
-    CrossChainRouteFilter, CrossChainRoutePair, CrossChainService, SourceAsset,
-    derive_btc_leg_transfer_id,
+    CrossChainFeeMode, CrossChainPrepared, CrossChainProvider, CrossChainRouteFilter,
+    CrossChainRoutePair, CrossChainService, SourceAsset, derive_btc_leg_transfer_id,
 };
 use crate::{
     ConversionInfo, ConversionStatus, CrossChainAddressDetails, Network, PaymentMetadata,
@@ -230,7 +229,6 @@ impl BoltzService {
             created,
             ln_fee_sats,
             asset_amount_in,
-            max_slippage_bps,
             CrossChainFeeMode::FeesExcluded,
         ))
     }
@@ -329,7 +327,6 @@ impl BoltzService {
             created,
             ln_fee_probe_sats,
             asset_amount_in,
-            max_slippage_bps,
             CrossChainFeeMode::FeesIncluded,
         ))
     }
@@ -420,7 +417,6 @@ impl BoltzService {
         created: boltz_client::models::CreatedSwap,
         ln_fee_sats: u64,
         asset_amount_in: u128,
-        max_slippage_bps: Option<u32>,
         fee_mode: CrossChainFeeMode,
     ) -> CrossChainPrepared {
         // `service_fee_amount` is just the Boltz spread (invoice sats minus
@@ -432,15 +428,7 @@ impl BoltzService {
         let service_fee_amount = u128::from(boltz_spread_sats);
         let estimated_out = u128::from(prepared.output_amount);
         let invoice_amount_sats = created.invoice_amount_sats;
-        let resolved_slippage = max_slippage_bps.unwrap_or(prepared.slippage_bps);
         let fee_amount = asset_amount_in.saturating_sub(estimated_out);
-
-        let provider_context = CrossChainProviderContext::Boltz {
-            swap_id: created.swap_id.clone(),
-            invoice: created.invoice,
-            invoice_amount_sats,
-            max_slippage_bps: resolved_slippage,
-        };
 
         CrossChainPrepared {
             amount_in: u128::from(invoice_amount_sats),
@@ -454,8 +442,7 @@ impl BoltzService {
             expires_at: prepared.expires_at.to_string(),
             pair: route.clone(),
             recipient_address: recipient_address.to_string(),
-            token_identifier: None,
-            provider_context,
+            reference_id: created.swap_id,
         }
     }
 }
@@ -564,20 +551,22 @@ impl CrossChainService for BoltzService {
         prepared: &CrossChainPrepared,
         idempotency_key: Option<String>,
     ) -> Result<crate::Payment, SdkError> {
-        let CrossChainProviderContext::Boltz {
-            swap_id,
-            invoice,
-            invoice_amount_sats,
-            max_slippage_bps,
-        } = &prepared.provider_context
-        else {
-            return Err(SdkError::Generic(
-                "Boltz send called with non-Boltz provider context".to_string(),
-            ));
-        };
-        // Read from the context — `prepared.amount_in` may carry a user-facing
-        // display value (token base units on the conversion path) instead of sats.
-        let invoice_amount_sats = *invoice_amount_sats;
+        // Load the swap boltz-client persisted at prepare; the invoice, its
+        // amount, and slippage come from this row.
+        let swap = self
+            .client
+            .get_swap(&prepared.reference_id)
+            .await?
+            .ok_or_else(|| {
+                SdkError::InvalidInput(
+                    "This cross-chain quote is no longer available. Please prepare and send it again."
+                        .to_string(),
+                )
+            })?;
+        let swap_id = &swap.id;
+        let invoice = swap.invoice.as_str();
+        let invoice_amount_sats = swap.invoice_amount_sats;
+        let max_slippage_bps = swap.slippage_bps;
 
         validate_quote_expiry(&prepared.expires_at)?;
 
@@ -647,7 +636,7 @@ impl CrossChainService for BoltzService {
             chain_id: prepared.pair.chain_id.clone(),
             asset: prepared.pair.asset.clone(),
             recipient_address: prepared.recipient_address.clone(),
-            invoice: invoice.clone(),
+            invoice: invoice.to_string(),
             invoice_amount_sats,
             asset_amount_in: Some(prepared.asset_amount_in),
             estimated_out: prepared.estimated_out,
@@ -657,7 +646,7 @@ impl CrossChainService for BoltzService {
             fee_amount: Some(prepared.fee_amount),
             service_fee_amount: Some(prepared.service_fee_amount),
             service_fee_asset: prepared.service_fee_asset.clone(),
-            max_slippage_bps: *max_slippage_bps,
+            max_slippage_bps,
             quote_degraded: false,
             asset_decimals: u32::from(prepared.pair.decimals),
             asset_contract: prepared.pair.contract_address.clone(),
@@ -785,7 +774,7 @@ fn validate_quote_expiry(expires_at: &str) -> Result<(), SdkError> {
         .as_secs();
     if now_secs >= exp_secs {
         return Err(SdkError::InvalidInput(
-            "Cross-chain quote has expired. Please re-prepare.".to_string(),
+            "This cross-chain quote has expired. Please prepare and send it again.".to_string(),
         ));
     }
     Ok(())

--- a/crates/breez-sdk/core/src/cross_chain/boltz_storage_adapter.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz_storage_adapter.rs
@@ -5,7 +5,7 @@
 //!
 //! boltz-client runs in seedless mode: each swap carries its own random preimage
 //! and gas/claim key under `key_source` ([`boltz_client::models::SwapKeySource::Stored`]).
-//! Those secrets are money-critical, so before a swap row reaches local storage
+//! Those secrets must be protected at rest, so before a swap row reaches local storage
 //! this adapter lifts `key_source` out of the swap JSON, ECIES-encrypts it via
 //! the SDK signer, and persists only the ciphertext in
 //! [`StoredCrossChainSwap::secrets`]. The rest of the swap is stored as
@@ -34,7 +34,7 @@ use tracing::warn;
 use crate::{Storage, persist::StoredCrossChainSwap, signer::BreezSigner};
 
 /// Provider tag this adapter writes into `StoredCrossChainSwap::provider`.
-const PROVIDER_TAG_BOLTZ: &str = "boltz";
+pub(crate) const PROVIDER_TAG_BOLTZ: &str = "boltz";
 
 /// JSON key under which a swap's secrets live before they are lifted out.
 const KEY_SOURCE_FIELD: &str = "key_source";

--- a/crates/breez-sdk/core/src/cross_chain/mod.rs
+++ b/crates/breez-sdk/core/src/cross_chain/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod boltz_event_listener;
 pub(crate) mod boltz_storage_adapter;
 mod cached_fiat;
 mod orchestra;
+mod orchestra_storage_adapter;
 
 pub(crate) use boltz::BoltzService;
 pub(crate) use cached_fiat::{CachedFiatService, DEFAULT_FIAT_CACHE_TTL};
@@ -211,34 +212,6 @@ impl CrossChainContext {
     }
 }
 
-/// Provider-internal state produced by `prepare` and consumed by `send`.
-/// Typed per provider so the send stage can resume without re-quoting and
-/// without a serde round-trip. Callers should round-trip this value as-is.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
-pub enum CrossChainProviderContext {
-    Orchestra {
-        /// Orchestra quote id, passed back on `/submit`.
-        quote_id: String,
-        /// Spark address Orchestra expects the deposit transfer to land on.
-        deposit_address: String,
-        /// Spark-side deposit amount in the route's source-asset base units.
-        #[serde(default)]
-        deposit_amount: u128,
-    },
-    Boltz {
-        /// Boltz swap id.
-        swap_id: String,
-        /// Hold invoice to pay.
-        invoice: String,
-        /// Hold invoice amount in sats.
-        #[serde(default)]
-        invoice_amount_sats: u64,
-        /// Slippage tolerance in basis points.
-        max_slippage_bps: u32,
-    },
-}
-
 /// Data stashed on the prepared send payment so the provider can resume
 /// the send stage without re-quoting.
 #[derive(Debug, Clone)]
@@ -276,10 +249,9 @@ pub(crate) struct CrossChainPrepared {
     pub expires_at: String,
     pub pair: CrossChainRoutePair,
     pub recipient_address: String,
-    /// The `token_identifier` on the Spark source (e.g. USDB). `None` for BTC sats.
-    pub token_identifier: Option<String>,
-    /// Provider-internal state carried between `prepare` and `send`.
-    pub provider_context: CrossChainProviderContext,
+    /// Provider-scoped handle (Boltz swap id / Orchestra quote id). The send
+    /// stage loads the quote from storage by it.
+    pub reference_id: String,
 }
 
 /// Abstraction over cross-chain bridge/swap providers.
@@ -647,80 +619,5 @@ mod tests {
             Some(0),
             "saturating_sub must clamp at 0, not underflow"
         );
-    }
-
-    /// Regression: `CrossChainProviderContext::Boltz.invoice_amount_sats` must
-    /// be the source of truth for the LN-leg amount, distinct from
-    /// `CrossChainPrepared::amount_in` (which can carry a user-facing display
-    /// value such as token base units after the dispatcher's conversion-path
-    /// override). Conflating the two persisted USDB base units into the
-    /// `invoice_amount_sats` field of `ConversionInfo::Boltz`, showing a
-    /// ~$1,200,000-sat "from" amount for a ~$1 send. This test asserts the
-    /// two fields are independently representable + survive a serde
-    /// round-trip with their distinct values.
-    #[test_all]
-    fn boltz_provider_context_invoice_amount_sats_is_independent_of_amount_in() {
-        let ctx = CrossChainProviderContext::Boltz {
-            swap_id: "swap_1".to_string(),
-            invoice: "lnbc19090n1pexample".to_string(),
-            invoice_amount_sats: 1_909,
-            max_slippage_bps: 100,
-        };
-        let json = serde_json::to_string(&ctx).unwrap();
-        let decoded: CrossChainProviderContext = serde_json::from_str(&json).unwrap();
-        let CrossChainProviderContext::Boltz {
-            invoice_amount_sats,
-            ..
-        } = &decoded
-        else {
-            panic!("expected Boltz variant");
-        };
-        assert_eq!(*invoice_amount_sats, 1_909);
-        assert!(
-            *invoice_amount_sats != 1_222_703,
-            "the LN invoice sats must never be conflated with a user-facing display value (e.g. USDB base units)"
-        );
-    }
-
-    /// Pre-bug-fix persisted contexts lack `invoice_amount_sats`. Serde must
-    /// default the missing field to 0 rather than failing to deserialize — the
-    /// downstream send-time error becomes obvious instead of corrupting the
-    /// stored Payment.
-    #[test_all]
-    fn boltz_provider_context_legacy_row_without_invoice_amount_sats_defaults_to_zero() {
-        let legacy = r#"{
-            "Boltz": {
-                "swap_id": "swap_legacy",
-                "invoice": "lnbc19090n1p",
-                "max_slippage_bps": 100
-            }
-        }"#;
-        let decoded: CrossChainProviderContext = serde_json::from_str(legacy).unwrap();
-        let CrossChainProviderContext::Boltz {
-            invoice_amount_sats,
-            ..
-        } = &decoded
-        else {
-            panic!("expected Boltz variant");
-        };
-        assert_eq!(*invoice_amount_sats, 0);
-    }
-
-    /// Same invariant for Orchestra: `deposit_amount` is the source of truth
-    /// for the deposit transfer size and is distinct from
-    /// `CrossChainPrepared::amount_in`.
-    #[test_all]
-    fn orchestra_provider_context_deposit_amount_is_independent_of_amount_in() {
-        let ctx = CrossChainProviderContext::Orchestra {
-            quote_id: "q_1".to_string(),
-            deposit_address: "spark1...".to_string(),
-            deposit_amount: 1_020_434,
-        };
-        let json = serde_json::to_string(&ctx).unwrap();
-        let decoded: CrossChainProviderContext = serde_json::from_str(&json).unwrap();
-        let CrossChainProviderContext::Orchestra { deposit_amount, .. } = &decoded else {
-            panic!("expected Orchestra variant");
-        };
-        assert_eq!(*deposit_amount, 1_020_434);
     }
 }

--- a/crates/breez-sdk/core/src/cross_chain/mod.rs
+++ b/crates/breez-sdk/core/src/cross_chain/mod.rs
@@ -22,7 +22,7 @@ use breez_sdk_common::fiat::FiatService;
 use serde::{Deserialize, Serialize};
 use spark_wallet::TransferId;
 
-use crate::{CrossChainAddressDetails, error::SdkError};
+use crate::{CrossChainAddressDetails, SendPaymentMethod, Storage, error::SdkError};
 
 /// SDK-level bounds for cross-chain slippage.
 pub(crate) const MIN_CROSS_CHAIN_SLIPPAGE_BPS: u32 = 10;
@@ -62,6 +62,47 @@ pub(crate) fn derive_btc_leg_transfer_id(
         Some(key) => TransferId::from_str(key).map_err(SdkError::Generic),
         None => Ok(TransferId::from_name(fallback_seed)),
     }
+}
+
+/// Provider tag used to key rows in the `cross_chain_swaps` table.
+pub(crate) fn provider_tag(provider: CrossChainProvider) -> &'static str {
+    match provider {
+        CrossChainProvider::Orchestra => orchestra_storage_adapter::PROVIDER_TAG_ORCHESTRA,
+        CrossChainProvider::Boltz => boltz_storage_adapter::PROVIDER_TAG_BOLTZ,
+    }
+}
+
+/// Rejects a send whose cross-chain swap row is already terminal: a prior send
+/// consumed it, or it was pruned as abandoned. Called before any conversion or
+/// transfer so a replayed or reused prepared response can't re-run the send
+/// (the send-stage token conversion is not idempotent). No-op for
+/// non-cross-chain payment methods.
+pub(crate) async fn validate_swap_not_terminal(
+    storage: &Arc<dyn Storage>,
+    method: &SendPaymentMethod,
+) -> Result<(), SdkError> {
+    let SendPaymentMethod::CrossChainAddress {
+        route,
+        reference_id,
+        ..
+    } = method
+    else {
+        return Ok(());
+    };
+    let terminal = storage
+        .get_cross_chain_swap(
+            provider_tag(route.provider).to_string(),
+            reference_id.clone(),
+        )
+        .await?
+        .is_some_and(|row| row.is_terminal);
+    if terminal {
+        return Err(SdkError::InvalidInput(
+            "This cross-chain quote is no longer available. Please prepare and send it again."
+                .to_string(),
+        ));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -619,5 +660,93 @@ mod tests {
             Some(0),
             "saturating_sub must clamp at 0, not underflow"
         );
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod swap_guard_tests {
+    use super::*;
+    use crate::persist::StoredCrossChainSwap;
+    use crate::persist::sqlite::SqliteStorage;
+
+    fn make_storage() -> Arc<dyn Storage> {
+        let mut path = std::env::temp_dir();
+        path.push(format!("breez-swap-guard-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&path).unwrap();
+        Arc::new(SqliteStorage::new(&path).unwrap())
+    }
+
+    fn cross_chain_method(provider: CrossChainProvider, reference_id: &str) -> SendPaymentMethod {
+        SendPaymentMethod::CrossChainAddress {
+            route: CrossChainRoutePair {
+                provider,
+                chain: "base".to_string(),
+                chain_id: Some("8453".to_string()),
+                asset: "USDC".to_string(),
+                contract_address: None,
+                decimals: 6,
+                exact_out_eligible: false,
+                supported_sources: vec![],
+            },
+            reference_id: reference_id.to_string(),
+            recipient_address: "0xabc".to_string(),
+            amount_in: 0,
+            asset_amount_in: 0,
+            estimated_out: 0,
+            fee_amount: 0,
+            service_fee_amount: 0,
+            service_fee_asset: None,
+            source_transfer_fee_sats: 0,
+            fee_mode: CrossChainFeeMode::FeesExcluded,
+            expires_at: "2099-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    async fn store_row(storage: &Arc<dyn Storage>, provider: &str, id: &str, is_terminal: bool) {
+        storage
+            .set_cross_chain_swap(StoredCrossChainSwap {
+                provider: provider.to_string(),
+                id: id.to_string(),
+                is_terminal,
+                updated_at: 0,
+                data: "{}".to_string(),
+                secrets: String::new(),
+            })
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn passes_when_no_row() {
+        let storage = make_storage();
+        let method = cross_chain_method(CrossChainProvider::Orchestra, "q1");
+        assert!(validate_swap_not_terminal(&storage, &method).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn passes_when_row_active() {
+        let storage = make_storage();
+        store_row(&storage, "orchestra", "q1", false).await;
+        let method = cross_chain_method(CrossChainProvider::Orchestra, "q1");
+        assert!(validate_swap_not_terminal(&storage, &method).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_when_row_terminal() {
+        let storage = make_storage();
+        store_row(&storage, "orchestra", "q1", true).await;
+        let method = cross_chain_method(CrossChainProvider::Orchestra, "q1");
+        let err = validate_swap_not_terminal(&storage, &method)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SdkError::InvalidInput(_)));
+    }
+
+    #[tokio::test]
+    async fn rejects_terminal_boltz_row_too() {
+        let storage = make_storage();
+        store_row(&storage, "boltz", "s1", true).await;
+        let method = cross_chain_method(CrossChainProvider::Boltz, "s1");
+        assert!(validate_swap_not_terminal(&storage, &method).await.is_err());
     }
 }

--- a/crates/breez-sdk/core/src/cross_chain/orchestra.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra.rs
@@ -653,6 +653,14 @@ impl CrossChainService for OrchestraService {
         let spark_tx_hash = asset_transfer.id();
         debug!("Orchestra: deposit transfer {spark_tx_hash} sent for quote {quote_id}");
 
+        // The deposit transfer has moved funds: this is the point of no return.
+        // Mark the quote consumed now, before /submit, so a retry of the same
+        // prepared response can't re-run the (non-idempotent) re-deposit.
+        // A failed submit is recovered by re-preparing, not re-sending.
+        if let Err(e) = self.swap_storage.mark_terminal(quote_id).await {
+            debug!("Orchestra: failed to mark quote {quote_id} terminal: {e:?}");
+        }
+
         // Step 2: Submit the deposit to Orchestra.
         // Include the source spark address for BTC transfers so Orchestra
         // can verify the deposit sender.
@@ -730,11 +738,6 @@ impl CrossChainService for OrchestraService {
             );
             spark_tx_hash
         });
-
-        // Mark the prepared-quote row terminal now the Payment row exists.
-        if let Err(e) = self.swap_storage.mark_terminal(quote_id).await {
-            debug!("Orchestra: failed to mark quote {quote_id} terminal: {e:?}");
-        }
 
         self.trigger_monitor();
 

--- a/crates/breez-sdk/core/src/cross_chain/orchestra.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra.rs
@@ -29,10 +29,10 @@ use crate::error::SdkError;
 use crate::persist::{ConversionFilter, StorageListPaymentsRequest, StoragePaymentDetailsFilter};
 use crate::{ConversionInfo, ConversionStatus, PaymentDetails, Storage};
 
+use super::orchestra_storage_adapter::{OrchestraSendData, OrchestraStorageAdapter};
 use super::{
-    CrossChainFeeMode, CrossChainPrepared, CrossChainProvider, CrossChainProviderContext,
-    CrossChainRouteFilter, CrossChainRoutePair, CrossChainService, SourceAsset,
-    derive_btc_leg_transfer_id,
+    CrossChainFeeMode, CrossChainPrepared, CrossChainProvider, CrossChainRouteFilter,
+    CrossChainRoutePair, CrossChainService, SourceAsset, derive_btc_leg_transfer_id,
 };
 
 use crate::utils::{
@@ -98,6 +98,7 @@ pub(crate) struct OrchestraService {
     client: Arc<OrchestraClient>,
     spark_wallet: Arc<SparkWallet>,
     storage: Arc<dyn Storage>,
+    swap_storage: OrchestraStorageAdapter,
     fiat_service: Arc<dyn FiatService>,
     monitor_trigger: broadcast::Sender<()>,
 }
@@ -116,10 +117,12 @@ impl OrchestraService {
         ));
         let (monitor_trigger, _) = broadcast::channel(10);
 
+        let swap_storage = OrchestraStorageAdapter::new(Arc::clone(&storage));
         let service = Self {
             client,
             spark_wallet,
             storage,
+            swap_storage,
             fiat_service,
             monitor_trigger: monitor_trigger.clone(),
         };
@@ -561,11 +564,34 @@ impl CrossChainService for OrchestraService {
             .await?;
         let fee_amount = asset_amount_in.saturating_sub(estimated_out);
 
-        let provider_context = CrossChainProviderContext::Orchestra {
-            quote_id: quote.quote_id,
+        let service_fee_asset = if quote.fee_asset.eq_ignore_ascii_case("BTC") {
+            None
+        } else {
+            Some(quote.fee_asset)
+        };
+        let quote_id = quote.quote_id;
+        let expires_at = quote.expires_at;
+
+        // Persist the quote so `send` can reload it.
+        let send_data = OrchestraSendData {
+            quote_id: quote_id.clone(),
             deposit_address: quote.deposit_address,
             deposit_amount: amount_in,
+            source_token_identifier: token_identifier.clone(),
+            expires_at: expires_at.clone(),
+            recipient_address: recipient_address.to_string(),
+            chain: route.chain.clone(),
+            chain_id: route.chain_id.clone(),
+            asset: route.asset.clone(),
+            asset_decimals: u32::from(route.decimals),
+            asset_contract: route.contract_address.clone(),
+            estimated_out,
+            asset_amount_in,
+            fee_amount,
+            service_fee_amount,
+            service_fee_asset: service_fee_asset.clone(),
         };
+        self.swap_storage.upsert(&send_data).await?;
 
         Ok(CrossChainPrepared {
             amount_in,
@@ -573,19 +599,14 @@ impl CrossChainService for OrchestraService {
             estimated_out,
             fee_amount,
             service_fee_amount,
-            service_fee_asset: if quote.fee_asset.eq_ignore_ascii_case("BTC") {
-                None
-            } else {
-                Some(quote.fee_asset)
-            },
+            service_fee_asset,
             // Source-side Spark transfer fee is 0 today.
             source_transfer_fee_sats: 0,
             fee_mode,
-            expires_at: quote.expires_at,
+            expires_at,
             pair: route.clone(),
             recipient_address: recipient_address.to_string(),
-            token_identifier,
-            provider_context,
+            reference_id: quote_id,
         })
     }
 
@@ -594,21 +615,25 @@ impl CrossChainService for OrchestraService {
         prepared: &CrossChainPrepared,
         idempotency_key: Option<String>,
     ) -> Result<crate::Payment, SdkError> {
-        let CrossChainProviderContext::Orchestra {
-            quote_id,
-            deposit_address,
-            deposit_amount,
-        } = &prepared.provider_context
-        else {
-            return Err(SdkError::Generic(
-                "Orchestra send called with non-Orchestra provider context".to_string(),
-            ));
-        };
-        // Read from the context — `prepared.amount_in` may carry a user-facing
-        // display value (token base units on the conversion path) instead.
-        let deposit_amount = *deposit_amount;
+        // Load the prepared quote; the deposit address, amount, and source
+        // asset come from this row.
+        let stored = self
+            .swap_storage
+            .get(&prepared.reference_id)
+            .await?
+            .ok_or_else(|| {
+                SdkError::InvalidInput(
+                    "This cross-chain quote is no longer available. Please prepare and send \
+                     it again."
+                        .to_string(),
+                )
+            })?;
 
-        validate_quote_expiry(&prepared.expires_at)?;
+        validate_quote_expiry(&stored.expires_at)?;
+
+        let quote_id = &stored.quote_id;
+        let deposit_amount = stored.deposit_amount;
+        let source_token_identifier = stored.source_token_identifier.as_deref();
 
         let transfer_id = Some(derive_btc_leg_transfer_id(
             idempotency_key.as_deref(),
@@ -619,9 +644,9 @@ impl CrossChainService for OrchestraService {
         let asset_transfer = self
             .client
             .transfer_to_deposit(
-                deposit_address,
+                &stored.deposit_address,
                 deposit_amount,
-                prepared.token_identifier.as_deref(),
+                source_token_identifier,
                 transfer_id,
             )
             .await?;
@@ -631,7 +656,7 @@ impl CrossChainService for OrchestraService {
         // Step 2: Submit the deposit to Orchestra.
         // Include the source spark address for BTC transfers so Orchestra
         // can verify the deposit sender.
-        let source_spark_address = if prepared.token_identifier.is_none() {
+        let source_spark_address = if source_token_identifier.is_none() {
             let addr = self
                 .spark_wallet
                 .get_spark_address()?
@@ -669,20 +694,20 @@ impl CrossChainService for OrchestraService {
         let conversion_info = ConversionInfo::Orchestra {
             order_id: order_id.clone(),
             quote_id: quote_id.clone(),
-            chain: prepared.pair.chain.clone(),
-            chain_id: prepared.pair.chain_id.clone(),
-            asset: prepared.pair.asset.clone(),
-            recipient_address: prepared.recipient_address.clone(),
-            asset_amount_in: Some(prepared.asset_amount_in),
-            estimated_out: prepared.estimated_out,
+            chain: stored.chain.clone(),
+            chain_id: stored.chain_id.clone(),
+            asset: stored.asset.clone(),
+            recipient_address: stored.recipient_address.clone(),
+            asset_amount_in: Some(stored.asset_amount_in),
+            estimated_out: stored.estimated_out,
             delivered_amount: None,
             status,
-            fee_amount: Some(prepared.fee_amount),
-            service_fee_amount: Some(prepared.service_fee_amount),
-            service_fee_asset: prepared.service_fee_asset.clone(),
+            fee_amount: Some(stored.fee_amount),
+            service_fee_amount: Some(stored.service_fee_amount),
+            service_fee_asset: stored.service_fee_asset.clone(),
             read_token,
-            asset_decimals: u32::from(prepared.pair.decimals),
-            asset_contract: prepared.pair.contract_address.clone(),
+            asset_decimals: stored.asset_decimals,
+            asset_contract: stored.asset_contract.clone(),
         };
         let metadata = crate::PaymentMetadata {
             conversion_info: Some(conversion_info.clone()),
@@ -705,6 +730,11 @@ impl CrossChainService for OrchestraService {
             );
             spark_tx_hash
         });
+
+        // Mark the prepared-quote row terminal now the Payment row exists.
+        if let Err(e) = self.swap_storage.mark_terminal(quote_id).await {
+            debug!("Orchestra: failed to mark quote {quote_id} terminal: {e:?}");
+        }
 
         self.trigger_monitor();
 
@@ -916,7 +946,7 @@ fn validate_quote_expiry(expires_at: &str) -> Result<(), SdkError> {
         .as_secs();
     if now_secs >= exp_secs {
         return Err(SdkError::InvalidInput(
-            "Cross-chain quote has expired. Please re-prepare.".to_string(),
+            "This cross-chain quote has expired. Please prepare and send it again.".to_string(),
         ));
     }
     Ok(())

--- a/crates/breez-sdk/core/src/cross_chain/orchestra_storage_adapter.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra_storage_adapter.rs
@@ -1,6 +1,6 @@
 //! Orchestra rows in the provider-agnostic `cross_chain_swaps` table.
 //!
-//! Orchestra has no money-critical secrets to keep at rest, so the row's
+//! Orchestra has no at-rest secrets to protect, so the row's
 //! `secrets` field stays empty. The row's `data` JSON is the SDK's
 //! authoritative record of a prepared send quote: the send stage reads the
 //! deposit address, amount, and source asset back from here rather than from
@@ -22,9 +22,9 @@ pub(crate) const PROVIDER_TAG_ORCHESTRA: &str = "orchestra";
 /// SDK-authoritative record of a prepared Orchestra send quote, serialized
 /// into [`StoredCrossChainSwap::data`].
 ///
-/// `deposit_address`, `deposit_amount`, and `source_token_identifier` are the
-/// money-path fields the send stage transfers against; the remaining fields
-/// reconstruct `ConversionInfo::Orchestra` without re-fetching the quote.
+/// `deposit_address`, `deposit_amount`, and `source_token_identifier` are what
+/// the send stage transfers against; the remaining fields reconstruct
+/// `ConversionInfo::Orchestra` without re-fetching the quote.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct OrchestraSendData {

--- a/crates/breez-sdk/core/src/cross_chain/orchestra_storage_adapter.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra_storage_adapter.rs
@@ -1,0 +1,283 @@
+//! Orchestra rows in the provider-agnostic `cross_chain_swaps` table.
+//!
+//! Orchestra has no money-critical secrets to keep at rest, so the row's
+//! `secrets` field stays empty. The row's `data` JSON is the SDK's
+//! authoritative record of a prepared send quote: the send stage reads the
+//! deposit address, amount, and source asset back from here rather than from
+//! the caller-held prepared response, so a mutated or reused response can't
+//! redirect funds or switch the asset.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    Storage,
+    error::SdkError,
+    persist::{StorageError, StoredCrossChainSwap},
+};
+
+pub(crate) const PROVIDER_TAG_ORCHESTRA: &str = "orchestra";
+
+/// SDK-authoritative record of a prepared Orchestra send quote, serialized
+/// into [`StoredCrossChainSwap::data`].
+///
+/// `deposit_address`, `deposit_amount`, and `source_token_identifier` are the
+/// money-path fields the send stage transfers against; the remaining fields
+/// reconstruct `ConversionInfo::Orchestra` without re-fetching the quote.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OrchestraSendData {
+    /// Orchestra quote id. Equals [`StoredCrossChainSwap::id`].
+    pub quote_id: String,
+    /// Spark address Orchestra expects the deposit transfer to land on.
+    pub deposit_address: String,
+    /// Spark-side deposit amount in the source asset's base units.
+    pub deposit_amount: u128,
+    /// Source asset on the Spark side: `None` = BTC (sats), `Some(id)` = token.
+    #[serde(default)]
+    pub source_token_identifier: Option<String>,
+    /// Quote expiry (RFC3339), checked before the deposit transfer.
+    pub expires_at: String,
+    /// Destination recipient + route, kept for `ConversionInfo` rendering.
+    pub recipient_address: String,
+    pub chain: String,
+    #[serde(default)]
+    pub chain_id: Option<String>,
+    pub asset: String,
+    pub asset_decimals: u32,
+    #[serde(default)]
+    pub asset_contract: Option<String>,
+    pub estimated_out: u128,
+    pub asset_amount_in: u128,
+    pub fee_amount: u128,
+    pub service_fee_amount: u128,
+    #[serde(default)]
+    pub service_fee_asset: Option<String>,
+}
+
+/// Thin bridge over the SDK [`Storage`] for Orchestra rows in
+/// `cross_chain_swaps`. Orchestra keeps no at-rest secrets, so `secrets` is
+/// always empty and no signer is involved (cf. `BoltzStorageAdapter`).
+pub(crate) struct OrchestraStorageAdapter {
+    storage: Arc<dyn Storage>,
+}
+
+impl OrchestraStorageAdapter {
+    pub(crate) fn new(storage: Arc<dyn Storage>) -> Self {
+        Self { storage }
+    }
+
+    /// Assembles a row for the given send-quote data. Pure: no I/O.
+    fn to_stored(
+        data: &OrchestraSendData,
+        is_terminal: bool,
+    ) -> Result<StoredCrossChainSwap, SdkError> {
+        let serialized = serde_json::to_string(data)
+            .map_err(|e| SdkError::Generic(format!("Failed to serialize Orchestra row: {e}")))?;
+        Ok(StoredCrossChainSwap {
+            provider: PROVIDER_TAG_ORCHESTRA.to_string(),
+            id: data.quote_id.clone(),
+            is_terminal,
+            updated_at: current_unix_seconds(),
+            data: serialized,
+            secrets: String::new(),
+        })
+    }
+
+    /// Persist (or overwrite) a prepared send quote as an active row.
+    pub(crate) async fn upsert(&self, data: &OrchestraSendData) -> Result<(), SdkError> {
+        let stored = Self::to_stored(data, false)?;
+        self.storage
+            .set_cross_chain_swap(stored)
+            .await
+            .map_err(|e| map_storage_err(&e))
+    }
+
+    /// Load a prepared send quote by its Orchestra quote id.
+    pub(crate) async fn get(&self, quote_id: &str) -> Result<Option<OrchestraSendData>, SdkError> {
+        let stored = self
+            .storage
+            .get_cross_chain_swap(PROVIDER_TAG_ORCHESTRA.to_string(), quote_id.to_string())
+            .await
+            .map_err(|e| map_storage_err(&e))?;
+        match stored {
+            Some(row) => {
+                let data = serde_json::from_str(&row.data).map_err(|e| {
+                    SdkError::Generic(format!("Failed to parse Orchestra row '{}': {e}", row.id))
+                })?;
+                Ok(Some(data))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Flip a row terminal: retained and queryable by id, but out of the
+    /// active set. Idempotent; a missing row is a no-op.
+    pub(crate) async fn mark_terminal(&self, quote_id: &str) -> Result<(), SdkError> {
+        let stored = self
+            .storage
+            .get_cross_chain_swap(PROVIDER_TAG_ORCHESTRA.to_string(), quote_id.to_string())
+            .await
+            .map_err(|e| map_storage_err(&e))?;
+        let Some(mut row) = stored else {
+            return Ok(());
+        };
+        row.is_terminal = true;
+        row.updated_at = current_unix_seconds();
+        self.storage
+            .set_cross_chain_swap(row)
+            .await
+            .map_err(|e| map_storage_err(&e))
+    }
+}
+
+fn map_storage_err(e: &StorageError) -> SdkError {
+    SdkError::StorageError(e.to_string())
+}
+
+fn current_unix_seconds() -> u64 {
+    use platform_utils::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    pub(super) fn sample_data() -> OrchestraSendData {
+        OrchestraSendData {
+            quote_id: "q_abc".to_string(),
+            deposit_address: "spark1deposit".to_string(),
+            deposit_amount: 1_020_434,
+            source_token_identifier: None,
+            expires_at: "2099-01-01T00:00:00Z".to_string(),
+            recipient_address: "0xdead".to_string(),
+            chain: "base".to_string(),
+            chain_id: Some("8453".to_string()),
+            asset: "USDC".to_string(),
+            asset_decimals: 6,
+            asset_contract: Some("0xUSDC".to_string()),
+            estimated_out: 1_000_000,
+            asset_amount_in: 1_020_434,
+            fee_amount: 20_434,
+            service_fee_amount: 500,
+            service_fee_asset: Some("USDC".to_string()),
+        }
+    }
+
+    /// `data` is serialized at prepare and deserialized untouched at send, so
+    /// every field (incl. the `u128` amounts) must survive the round-trip.
+    #[test]
+    fn data_roundtrip_preserves_all_fields() {
+        let data = sample_data();
+        let json = serde_json::to_string(&data).unwrap();
+        let decoded: OrchestraSendData = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    /// A token source must round-trip as `Some(id)` (BTC is `None`).
+    #[test]
+    fn data_roundtrip_token_source() {
+        let mut data = sample_data();
+        data.source_token_identifier = Some("btkn1usdb".to_string());
+        let json = serde_json::to_string(&data).unwrap();
+        let decoded: OrchestraSendData = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            decoded.source_token_identifier,
+            Some("btkn1usdb".to_string())
+        );
+    }
+
+    /// Unknown fields from a future schema must not break deserialization.
+    #[test]
+    fn data_accepts_extra_unknown_fields() {
+        let mut json: serde_json::Value = serde_json::to_value(sample_data()).unwrap();
+        json["someFutureField"] = serde_json::json!("ignored");
+        let decoded: OrchestraSendData = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.quote_id, "q_abc");
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod storage_tests {
+    use std::path::PathBuf;
+
+    use super::tests::sample_data;
+    use super::*;
+    use crate::persist::sqlite::SqliteStorage;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "breez-orchestra-storage-test-{}-{}",
+            name,
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn make_adapter() -> (OrchestraStorageAdapter, Arc<dyn Storage>) {
+        let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::new(&temp_dir("adapter")).unwrap());
+        (OrchestraStorageAdapter::new(Arc::clone(&storage)), storage)
+    }
+
+    #[tokio::test]
+    async fn upsert_get_roundtrip_with_empty_secrets() {
+        let (adapter, storage) = make_adapter();
+        let data = sample_data();
+        adapter.upsert(&data).await.unwrap();
+
+        let fetched = adapter.get("q_abc").await.unwrap().unwrap();
+        assert_eq!(fetched, data);
+
+        // Orchestra keeps no at-rest secrets.
+        let row = storage
+            .get_cross_chain_swap(PROVIDER_TAG_ORCHESTRA.to_string(), "q_abc".to_string())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.provider, PROVIDER_TAG_ORCHESTRA);
+        assert!(row.secrets.is_empty());
+        assert!(!row.is_terminal);
+    }
+
+    #[tokio::test]
+    async fn get_missing_row_is_none() {
+        let (adapter, _storage) = make_adapter();
+        assert!(adapter.get("nope").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn mark_terminal_drops_from_active_but_stays_queryable() {
+        let (adapter, storage) = make_adapter();
+        adapter.upsert(&sample_data()).await.unwrap();
+
+        let active = storage
+            .list_active_cross_chain_swaps(PROVIDER_TAG_ORCHESTRA.to_string())
+            .await
+            .unwrap();
+        assert_eq!(active.len(), 1);
+
+        adapter.mark_terminal("q_abc").await.unwrap();
+
+        let active = storage
+            .list_active_cross_chain_swaps(PROVIDER_TAG_ORCHESTRA.to_string())
+            .await
+            .unwrap();
+        assert!(active.is_empty(), "terminal row must leave the active set");
+        assert!(
+            adapter.get("q_abc").await.unwrap().is_some(),
+            "terminal row must stay queryable by id"
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_terminal_missing_row_is_noop() {
+        let (adapter, _storage) = make_adapter();
+        adapter.mark_terminal("nope").await.unwrap();
+    }
+}

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -34,8 +34,7 @@ pub use chain::{
 pub use common::rest::{RestClient, RestResponse};
 pub use common::{fiat::*, models::*, sync_storage};
 pub use cross_chain::{
-    CrossChainFeeMode, CrossChainProvider, CrossChainProviderContext, CrossChainRouteFilter,
-    CrossChainRoutePair, SourceAsset,
+    CrossChainFeeMode, CrossChainProvider, CrossChainRouteFilter, CrossChainRoutePair, SourceAsset,
 };
 pub use error::{DepositClaimError, SdkError, SignerError};
 pub use events::{AutoOptimizationEvent, EventEmitter, EventListener, SdkEvent};

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     BitcoinAddressDetails, BitcoinChainService, BitcoinNetwork, Bolt11InvoiceDetails,
     ExternalInputParser, FiatCurrency, LnurlPayRequestDetails, LnurlWithdrawRequestDetails, Rate,
     SdkError, SparkInvoiceDetails, SuccessAction, SuccessActionProcessed,
-    cross_chain::{CrossChainFeeMode, CrossChainProviderContext, CrossChainRoutePair},
+    cross_chain::{CrossChainFeeMode, CrossChainRoutePair},
     error::DepositClaimError,
 };
 
@@ -1306,6 +1306,8 @@ pub enum SendPaymentMethod {
     CrossChainAddress {
         /// The route selected for this cross-chain send (includes provider, chain, asset).
         route: CrossChainRoutePair,
+        /// Provider handle for this prepared send.
+        reference_id: String,
         /// Raw destination address (e.g. `0xabc...`).
         recipient_address: String,
         /// Amount routed to the provider, in the route's source-asset units
@@ -1335,9 +1337,6 @@ pub enum SendPaymentMethod {
         fee_mode: CrossChainFeeMode,
         /// ISO8601 timestamp after which the quote is no longer valid.
         expires_at: String,
-        /// Provider-internal state, produced when preparing and consumed
-        /// when sending.
-        provider_context: CrossChainProviderContext,
     },
 }
 

--- a/crates/breez-sdk/core/src/sdk/payments/prepare/cross_chain.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/prepare/cross_chain.rs
@@ -669,6 +669,7 @@ fn build_response(
     PrepareSendPaymentResponse {
         payment_method: SendPaymentMethod::CrossChainAddress {
             route: prepared.pair,
+            reference_id: prepared.reference_id,
             recipient_address: prepared.recipient_address,
             amount_in,
             asset_amount_in,
@@ -679,7 +680,6 @@ fn build_response(
             source_transfer_fee_sats: prepared.source_transfer_fee_sats,
             fee_mode: prepared.fee_mode,
             expires_at: prepared.expires_at,
-            provider_context: prepared.provider_context,
         },
         amount: response_amount,
         token_identifier: response_token_identifier,
@@ -1359,12 +1359,7 @@ mod tests {
                 supported_sources: vec![],
             },
             recipient_address: "0xabc".to_string(),
-            token_identifier: None,
-            provider_context: crate::cross_chain::CrossChainProviderContext::Orchestra {
-                quote_id: "q1".to_string(),
-                deposit_address: "sp1...".to_string(),
-                deposit_amount: amount_in,
-            },
+            reference_id: "q1".to_string(),
         }
     }
 

--- a/crates/breez-sdk/core/src/sdk/payments/send/cross_chain.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/send/cross_chain.rs
@@ -19,6 +19,7 @@ pub(in crate::sdk) async fn send(
 ) -> Result<SendPaymentResponse, SdkError> {
     let SendPaymentMethod::CrossChainAddress {
         route,
+        reference_id,
         recipient_address,
         amount_in,
         asset_amount_in,
@@ -29,7 +30,6 @@ pub(in crate::sdk) async fn send(
         source_transfer_fee_sats,
         fee_mode,
         expires_at,
-        provider_context,
     } = method
     else {
         return Err(SdkError::Generic(
@@ -49,8 +49,7 @@ pub(in crate::sdk) async fn send(
         expires_at: expires_at.clone(),
         pair: route.clone(),
         recipient_address: recipient_address.clone(),
-        token_identifier: token_identifier.clone(),
-        provider_context: provider_context.clone(),
+        reference_id: reference_id.clone(),
     };
 
     // Token transfers may not trigger the same wallet event path as BTC

--- a/crates/breez-sdk/core/src/sdk/payments/send/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/send/mod.rs
@@ -54,6 +54,16 @@ pub(in crate::sdk) async fn orchestrate_send(
             return Ok(SendPaymentResponse { payment });
         }
     }
+
+    // Reject a replayed/reused prepared response whose cross-chain swap is
+    // already terminal, before running any (non-idempotent) conversion or
+    // transfer.
+    crate::cross_chain::validate_swap_not_terminal(
+        &sdk.storage,
+        &request.prepare_response.payment_method,
+    )
+    .await?;
+
     let conversion_estimate = request.prepare_response.conversion_estimate.clone();
     // Perform the send payment, with conversion if requested
     let res = if let Some(ConversionEstimate {

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -889,24 +889,6 @@ pub struct CrossChainRoutePair {
     pub supported_sources: Vec<SourceAsset>,
 }
 
-#[macros::extern_wasm_bindgen(breez_sdk_spark::CrossChainProviderContext)]
-pub enum CrossChainProviderContext {
-    Orchestra {
-        quote_id: String,
-        deposit_address: String,
-        #[tsify(type = "string")]
-        #[serde(default, with = "serde_u128_as_string")]
-        deposit_amount: u128,
-    },
-    Boltz {
-        swap_id: String,
-        invoice: String,
-        #[serde(default)]
-        invoice_amount_sats: u64,
-        max_slippage_bps: u32,
-    },
-}
-
 #[macros::extern_wasm_bindgen(breez_sdk_spark::PaymentRequest)]
 pub enum PaymentRequest {
     Input {
@@ -947,6 +929,7 @@ pub enum SendPaymentMethod {
     },
     CrossChainAddress {
         route: CrossChainRoutePair,
+        reference_id: String,
         recipient_address: String,
         #[tsify(type = "string")]
         #[serde(with = "serde_u128_as_string")]
@@ -967,7 +950,6 @@ pub enum SendPaymentMethod {
         source_transfer_fee_sats: u64,
         fee_mode: CrossChainFeeMode,
         expires_at: String,
-        provider_context: CrossChainProviderContext,
     },
 }
 

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -281,21 +281,6 @@ pub struct _CrossChainRoutePair {
     pub supported_sources: Vec<SourceAsset>,
 }
 
-#[frb(mirror(CrossChainProviderContext))]
-pub enum _CrossChainProviderContext {
-    Orchestra {
-        quote_id: String,
-        deposit_address: String,
-        deposit_amount: u128,
-    },
-    Boltz {
-        swap_id: String,
-        invoice: String,
-        invoice_amount_sats: u64,
-        max_slippage_bps: u32,
-    },
-}
-
 #[frb(mirror(CrossChainRouteFilter))]
 pub enum _CrossChainRouteFilter {
     Send {
@@ -569,6 +554,7 @@ pub enum _SendPaymentMethod {
     },
     CrossChainAddress {
         route: CrossChainRoutePair,
+        reference_id: String,
         recipient_address: String,
         amount_in: u128,
         asset_amount_in: u128,
@@ -579,7 +565,6 @@ pub enum _SendPaymentMethod {
         source_transfer_fee_sats: u64,
         fee_mode: CrossChainFeeMode,
         expires_at: String,
-        provider_context: CrossChainProviderContext,
     },
 }
 


### PR DESCRIPTION
The cross-chain send stage read its state (Orchestra deposit address / amount / source asset; Boltz invoice / amount / slippage) from the caller-round-tripped `provider_context` on the prepared response. A mutated prepare response could redirect funds or switch the source asset — resulting in a failed order execution (wrong source tx id).

### Fix
Make SDK-owned storage authoritative:
- Remove `CrossChainProviderContext`; `SendPaymentMethod::CrossChainAddress` now carries only an `reference_id` handle.
- Orchestra persists its prepared quote to the existing `cross_chain_swaps` table at prepare (new `orchestra_storage_adapter`) and reloads deposit address / amount / source asset at send, then marks it terminal.
- Boltz `send` reloads the swap boltz-client already persisted (invoice / amount / slippage).
