### PR TITLE
fix(turnkey): create leaf accounts as Bitcoin P2TR

### DIFF
--- a/crates/breez-sdk/core/src/turnkey/accounts.rs
+++ b/crates/breez-sdk/core/src/turnkey/accounts.rs
@@ -12,6 +12,7 @@ use turnkey_enclave_encrypt::{ExportClient, QuorumPublicKey};
 use super::error::TurnkeyError;
 use super::transport::{OnConflict, TurnkeyClient};
 use super::types::{
+    ADDRESS_FORMAT_BITCOIN_MAINNET_P2TR, ADDRESS_FORMAT_BITCOIN_REGTEST_P2TR,
     ADDRESS_FORMAT_COMPRESSED, ADDRESS_FORMAT_SPARK_MAINNET, ADDRESS_FORMAT_SPARK_REGTEST,
     CREATE_WALLET_ACCOUNTS_PATH, CREATE_WALLET_ACCOUNTS_RESULT, CREATE_WALLET_ACCOUNTS_TYPE,
     CURVE_SECP256K1, CreateWalletAccountsIntent, CreateWalletAccountsResult, ENCODING_HEXADECIMAL,
@@ -28,6 +29,16 @@ pub(crate) fn spark_address_format(network: Network) -> &'static str {
     match network {
         Network::Mainnet => ADDRESS_FORMAT_SPARK_MAINNET,
         Network::Regtest => ADDRESS_FORMAT_SPARK_REGTEST,
+    }
+}
+
+/// The Bitcoin P2TR address format (and thus the BIP341 tweaked-Schnorr signing
+/// scheme) for the wallet's network. Used to sign leaf refund outputs in a
+/// unilateral exit.
+pub(crate) fn bitcoin_p2tr_format(network: Network) -> &'static str {
+    match network {
+        Network::Mainnet => ADDRESS_FORMAT_BITCOIN_MAINNET_P2TR,
+        Network::Regtest => ADDRESS_FORMAT_BITCOIN_REGTEST_P2TR,
     }
 }
 
@@ -107,6 +118,44 @@ impl TurnkeyClient {
             return Ok(public_key);
         }
         self.create_account(path, ADDRESS_FORMAT_COMPRESSED).await
+    }
+
+    /// Internal (untweaked) public key (hex) for a P2TR account at `path`,
+    /// provisioning it P2TR-format if absent. Creating it P2TR (not compressed)
+    /// lets the same path later sign its refund output as a tweaked BIP341
+    /// key-path spend for a unilateral exit, with one account per leaf path.
+    /// `create_account` returns the taproot address, so the key is read back.
+    pub(crate) async fn p2tr_pubkey_at(
+        &self,
+        path: String,
+        network: Network,
+    ) -> Result<String, TurnkeyError> {
+        let request = GetWalletAccountRequest {
+            organization_id: self.organization_id.clone(),
+            wallet_id: self.wallet_id.clone(),
+            path: path.clone(),
+        };
+        if let Ok(resp) = self
+            .process_request::<_, GetWalletAccountResponse>(
+                GET_WALLET_ACCOUNT_PATH,
+                &request,
+                OnConflict::Surface,
+            )
+            .await
+            && let Some(public_key) = resp.account.public_key
+        {
+            return Ok(public_key);
+        }
+        self.create_account(path, bitcoin_p2tr_format(network))
+            .await?;
+        let resp: GetWalletAccountResponse = self
+            .process_request(GET_WALLET_ACCOUNT_PATH, &request, OnConflict::Surface)
+            .await?;
+        resp.account.public_key.ok_or_else(|| {
+            TurnkeyError::UnexpectedResponse(
+                "P2TR wallet account did not expose a public key".into(),
+            )
+        })
     }
 
     /// Submits a `SIGN_RAW_PAYLOAD` activity: signs `payload_hex` with the

--- a/crates/breez-sdk/core/src/turnkey/spark_signer.rs
+++ b/crates/breez-sdk/core/src/turnkey/spark_signer.rs
@@ -331,13 +331,22 @@ impl TurnkeySparkSigner {
         Ok(pk)
     }
 
-    /// The signing public key for a tree leaf, memoized.
+    /// The signing public key for a tree leaf, memoized. The leaf account is
+    /// provisioned P2TR-format (rather than compressed) so the same path can
+    /// later sign the leaf's refund output as tweaked Schnorr in a unilateral
+    /// exit; the returned key is the internal (untweaked) key either way, so
+    /// FROST and transaction construction are unaffected.
     async fn leaf_public_key(&self, leaf_id: &TreeNodeId) -> Result<PublicKey, SignerError> {
         if let Some(pk) = self.leaf_pubkeys.lock().await.get(leaf_id).copied() {
             return Ok(pk);
         }
         let path = format!("{}/1'/{}'", self.base_path(), Self::leaf_index(leaf_id));
-        let pk = self.pubkey_at_path(path).await?;
+        let hex = self
+            .client
+            .p2tr_pubkey_at(path, self.network)
+            .await
+            .map_err(to_spark_err)?;
+        let pk = PublicKey::from_str(&hex).map_err(to_spark_err)?;
         self.leaf_pubkeys.lock().await.insert(leaf_id.clone(), pk);
         Ok(pk)
     }

--- a/crates/breez-sdk/core/src/turnkey/types.rs
+++ b/crates/breez-sdk/core/src/turnkey/types.rs
@@ -86,6 +86,14 @@ pub(crate) struct SignRawPayloadResult {
 pub(crate) const ADDRESS_FORMAT_SPARK_MAINNET: &str = "ADDRESS_FORMAT_SPARK_MAINNET";
 pub(crate) const ADDRESS_FORMAT_SPARK_REGTEST: &str = "ADDRESS_FORMAT_SPARK_REGTEST";
 
+// Bitcoin P2TR address formats. Signing against a P2TR-format account makes
+// Turnkey switch to Schnorr and apply the BIP341 taproot key-path tweak (empty
+// script tree), unlike the Spark formats above which sign plain BIP340. Used to
+// spend leaf refund outputs in a unilateral exit. See
+// https://docs.turnkey.com/features/networks/bitcoin.
+pub(crate) const ADDRESS_FORMAT_BITCOIN_MAINNET_P2TR: &str = "ADDRESS_FORMAT_BITCOIN_MAINNET_P2TR";
+pub(crate) const ADDRESS_FORMAT_BITCOIN_REGTEST_P2TR: &str = "ADDRESS_FORMAT_BITCOIN_REGTEST_P2TR";
+
 pub(crate) const SPARK_SIGN_FROST_PATH: &str = "/public/v1/submit/spark_sign_frost";
 pub(crate) const SPARK_SIGN_FROST_TYPE: &str = "ACTIVITY_TYPE_SPARK_SIGN_FROST";
 pub(crate) const SPARK_SIGN_FROST_RESULT: &str = "sparkSignFrostResult";


### PR DESCRIPTION
Correctness fix for the Turnkey signer.

Each wallet leaf gets its own account on the Turnkey side. We were creating a generic (compressed-key) account, but a leaf's funds are actually held at a Bitcoin P2TR (taproot) address. This change creates the leaf account as the matching Bitcoin P2TR account, so the account type matches how the funds are held.

It does not change any existing behaviour: the underlying key is the same, so signing and balances are unaffected. It only ensures the right type of account is created on Turnkey.
