### PR TITLE
Bump boltz-client: fix ATA creation bug and detect manual recovery on Solana

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414#63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414"
+source = "git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879#b5f4683aba10efd875d674f2bb9a5800b047a879"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -1335,8 +1335,8 @@ dependencies = [
  "hex",
  "k256",
  "lightning-invoice 0.34.0",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)",
- "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879)",
+ "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879)",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2502,7 +2502,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2708,7 +2708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3633,7 +3633,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414#63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414"
+source = "git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879#b5f4683aba10efd875d674f2bb9a5800b047a879"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -4542,7 +4542,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4968,11 +4968,11 @@ dependencies = [
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414#63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414"
+source = "git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879#b5f4683aba10efd875d674f2bb9a5800b047a879"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879)",
  "reqwest",
  "serde",
  "serde_json",
@@ -5314,7 +5314,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5351,9 +5351,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5868,7 +5868,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6968,7 +6968,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730#809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730"
+source = "git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414#63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -1335,8 +1335,8 @@ dependencies = [
  "hex",
  "k256",
  "lightning-invoice 0.34.0",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730)",
- "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)",
+ "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730#809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730"
+source = "git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414#63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -4968,11 +4968,11 @@ dependencies = [
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730#809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730"
+source = "git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414#63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ bech32 = "0.11.0"
 bip39 = "2.2.0"
 bitcoin = { version = "0.32.6", features = ["serde"] }
 bitflags = "2.10.0"
-boltz-client = { git = "https://github.com/breez/boltz-client", rev = "809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730" }
+boltz-client = { git = "https://github.com/breez/boltz-client", rev = "63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414" }
 breez-sdk-common = { path = "crates/breez-sdk/common", default-features = false }
 breez-sdk-spark = { path = "crates/breez-sdk/core" }
 built = { version = "0.8.0", features = ["git2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ bech32 = "0.11.0"
 bip39 = "2.2.0"
 bitcoin = { version = "0.32.6", features = ["serde"] }
 bitflags = "2.10.0"
-boltz-client = { git = "https://github.com/breez/boltz-client", rev = "63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414" }
+boltz-client = { git = "https://github.com/breez/boltz-client", rev = "b5f4683aba10efd875d674f2bb9a5800b047a879" }
 breez-sdk-common = { path = "crates/breez-sdk/common", default-features = false }
 breez-sdk-spark = { path = "crates/breez-sdk/core" }
 built = { version = "0.8.0", features = ["git2"] }

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414#63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414"
+source = "git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879#b5f4683aba10efd875d674f2bb9a5800b047a879"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -1100,8 +1100,8 @@ dependencies = [
  "hex",
  "k256",
  "lightning-invoice 0.34.0",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)",
- "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879)",
+ "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879)",
  "serde",
  "serde_json",
  "sha2",
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414#63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414"
+source = "git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879#b5f4683aba10efd875d674f2bb9a5800b047a879"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3595,11 +3595,11 @@ dependencies = [
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414#63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414"
+source = "git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879#b5f4683aba10efd875d674f2bb9a5800b047a879"
 dependencies = [
  "async-trait",
  "base64",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879)",
  "reqwest",
  "serde",
  "serde_json",

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730#809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730"
+source = "git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414#63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -1100,8 +1100,8 @@ dependencies = [
  "hex",
  "k256",
  "lightning-invoice 0.34.0",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730)",
- "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)",
+ "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)",
  "serde",
  "serde_json",
  "sha2",
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730#809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730"
+source = "git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414#63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3595,11 +3595,11 @@ dependencies = [
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730#809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730"
+source = "git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414#63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414"
 dependencies = [
  "async-trait",
  "base64",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=809ac77cfc9ab2d809e3ef05f31c6d23ee9c4730)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)",
  "reqwest",
  "serde",
  "serde_json",


### PR DESCRIPTION
Commits from boltz client:
- [fix: set correct SOLANA_FORWARD_PREFIX_LeN](https://github.com/breez/boltz-client/commit/b5f4683aba10efd875d674f2bb9a5800b047a879)
- [Complete stalled CCTP forwards via Solana destination-nonce read](https://github.com/breez/boltz-client/commit/63fa0dfdbaad0be716dfcaf2531ccfa36bc8d414)