### PR TITLE
Tighten JWT handling

### DIFF
--- a/crates/breez-sdk/core/src/jwt_header_provider.rs
+++ b/crates/breez-sdk/core/src/jwt_header_provider.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use breez_sdk_common::utils::now;
@@ -17,6 +17,12 @@ use crate::persist::Storage;
 const PARTNER_ID_HEADER: &str = "x-partner-jwt";
 const KEY_BREEZ_JWT: &str = "breez_jwt";
 const JWT_EXPIRY_GRACE_PERIOD_SECS: u64 = 60 * 5;
+/// Stop serving a token this many seconds before its real `exp`, as a
+/// clock-skew guard so we never hand out a token the server may already treat
+/// as expired. Distinct from the 5-minute refresh lead in
+/// [`JWT_EXPIRY_GRACE_PERIOD_SECS`]: the token stays servable through the
+/// refresh window, and is only withheld in this final margin before expiry.
+const JWT_SERVE_SKEW_SECS: u64 = 30;
 /// Fallback refresh interval used only if a freshly-fetched token has no
 /// parseable `exp` claim. In practice the server always returns a token with
 /// an `exp`, so this path is for malformed-response robustness.
@@ -49,7 +55,9 @@ struct CachedToken {
 struct Inner {
     token: RwLock<Option<CachedToken>>,
     api_key: String,
-    storage: Option<Arc<dyn Storage>>,
+    /// Bound once by [`BreezJwtHeaderProvider::start`] before the refresh task
+    /// spawns; empty when the provider persists nothing (in-memory only).
+    storage: OnceLock<Arc<dyn Storage>>,
     http_client: Arc<dyn HttpClient>,
 }
 
@@ -71,33 +79,48 @@ struct Inner {
 pub struct BreezJwtHeaderProvider {
     inner: Arc<Inner>,
     _shutdown_tx: oneshot::Sender<()>,
+    /// Holds the refresh task's shutdown receiver until [`start`](Self::start)
+    /// spawns the task. Taking it makes `start` idempotent.
+    pending_rx: Mutex<Option<oneshot::Receiver<()>>>,
 }
 
 impl BreezJwtHeaderProvider {
-    /// Constructs the provider and spawns its background refresh task.
-    /// Does not block on the initial JWT load.
+    /// Constructs the provider without starting its background refresh task.
+    /// Non-blocking. Call [`start`](Self::start) once storage is known to bind
+    /// it and begin refreshing.
     ///
     /// `http_client` is the shared client used for the JWT refresh fetch
     /// (typically supplied from the surrounding [`SdkContext`](crate::SdkContext)).
-    pub fn new(
-        api_key: String,
-        storage: Option<Arc<dyn Storage>>,
-        http_client: Arc<dyn HttpClient>,
-    ) -> Arc<Self> {
+    pub fn new(api_key: String, http_client: Arc<dyn HttpClient>) -> Arc<Self> {
         let inner = Arc::new(Inner {
             token: RwLock::new(None),
             api_key,
-            storage,
+            storage: OnceLock::new(),
             http_client,
         });
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        spawn_refresh_task(Arc::clone(&inner), shutdown_rx);
 
         Arc::new(Self {
             inner,
             _shutdown_tx: shutdown_tx,
+            pending_rx: Mutex::new(Some(shutdown_rx)),
         })
+    }
+
+    /// Binds `storage` (for warm-start and cross-restart persistence) and spawns
+    /// the refresh task. Idempotent: only the first call starts the task, so a
+    /// provider shared across SDK instances is started once. Pass `None` to run
+    /// in-memory only. Storage is bound before the task spawns, so its one-shot
+    /// `load_cached_token` observes it.
+    pub fn start(&self, storage: Option<Arc<dyn Storage>>) {
+        let Some(shutdown_rx) = self.pending_rx.lock().unwrap().take() else {
+            return;
+        };
+        if let Some(storage) = storage {
+            let _ = self.inner.storage.set(storage);
+        }
+        spawn_refresh_task(Arc::clone(&self.inner), shutdown_rx);
     }
 }
 
@@ -109,7 +132,7 @@ impl HeaderProvider for BreezJwtHeaderProvider {
             return Ok(HashMap::new());
         };
 
-        if is_expired(cached.exp) {
+        if is_past_serve_expiry(cached.exp) {
             return Ok(HashMap::new());
         }
 
@@ -121,7 +144,7 @@ impl HeaderProvider for BreezJwtHeaderProvider {
 }
 
 async fn load_cached_token(inner: &Inner) -> bool {
-    let Some(storage) = &inner.storage else {
+    let Some(storage) = inner.storage.get() else {
         return false;
     };
     let stored = match storage.get_cached_item(KEY_BREEZ_JWT.to_string()).await {
@@ -135,6 +158,12 @@ async fn load_cached_token(inner: &Inner) -> bool {
     let Some(exp) = jwt_exp(&stored) else {
         return false;
     };
+    // Warm-start gates on is_expired (5-min grace), not the tighter serve skew:
+    // a loaded token must be comfortably fresh so the spawn task's refresh-sleep
+    // shortcut holds. A near-expiry token would hit the 60s fallback (see
+    // spawn_refresh_task), installing an about-to-expire token then sleeping
+    // before the first fetch, so a restart in the last 5 min drops it and
+    // refetches now.
     if is_expired(exp) {
         return false;
     }
@@ -152,7 +181,7 @@ async fn store_token(inner: &Inner, token: String) {
         token: token.clone(),
         exp,
     });
-    if let Some(storage) = &inner.storage
+    if let Some(storage) = inner.storage.get()
         && let Err(err) = storage
             .set_cached_item(KEY_BREEZ_JWT.to_string(), token)
             .await
@@ -198,9 +227,19 @@ fn calculate_expiry(exp: u64) -> u64 {
 }
 
 /// Returns `true` when the cached `exp` is within (or past) the
-/// [`JWT_EXPIRY_GRACE_PERIOD_SECS`] grace window.
+/// [`JWT_EXPIRY_GRACE_PERIOD_SECS`] grace window. Drives refresh scheduling, not
+/// the serve decision: a token in this window is refreshed early but still
+/// served (see [`is_past_serve_expiry`]).
 fn is_expired(exp: u64) -> bool {
     calculate_expiry(exp) == 0
+}
+
+/// Returns `true` once the cached `exp` is within [`JWT_SERVE_SKEW_SECS`] of (or
+/// past) its real expiry, so the token must no longer be served. Unlike
+/// [`is_expired`], this keeps serving a still-valid token through the refresh
+/// window and withholds it only in the final clock-skew margin.
+fn is_past_serve_expiry(exp: u64) -> bool {
+    Into::<u64>::into(now()).saturating_add(JWT_SERVE_SKEW_SECS) >= exp
 }
 
 #[cfg(test)]
@@ -265,15 +304,18 @@ fn spawn_refresh_task(inner: Arc<Inner>, mut shutdown_rx: oneshot::Receiver<()>)
     );
 }
 
+/// Builds a syntactically valid JWT carrying the given `exp` claim (with a
+/// fake signature). Shared by the pure-function and persistence test modules.
+#[cfg(test)]
+fn make_jwt(exp: u64) -> String {
+    let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"HS256","typ":"JWT"}"#);
+    let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
+    format!("{header}.{payload}.fakesignature")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn make_jwt(exp: u64) -> String {
-        let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"HS256","typ":"JWT"}"#);
-        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
-        format!("{header}.{payload}.fakesignature")
-    }
 
     // --- jwt_exp ---
 
@@ -319,6 +361,35 @@ mod tests {
         assert!(is_jwt_expired("onlyone"));
     }
 
+    // --- is_past_serve_expiry ---
+
+    #[test]
+    fn test_is_past_serve_expiry_far_future() {
+        // Well beyond the skew margin: servable.
+        assert!(!is_past_serve_expiry(u64::from(now()) + 3600));
+    }
+
+    #[test]
+    fn test_is_past_serve_expiry_within_refresh_grace_still_served() {
+        // Expires in 2 minutes: inside the 5-minute refresh lead but outside the
+        // 30s serve margin, so it must still be served. This is the case the old
+        // grace check dropped, and is the core regression guard for this fix.
+        assert!(!is_past_serve_expiry(u64::from(now()) + 120));
+    }
+
+    #[test]
+    fn test_is_past_serve_expiry_within_skew_margin() {
+        // Expires in 10s: inside the 30s clock-skew margin, so stop serving.
+        assert!(is_past_serve_expiry(u64::from(now()) + 10));
+    }
+
+    #[test]
+    fn test_is_past_serve_expiry_past_and_sentinel() {
+        // Already past expiry, and the exp == 0 unparseable-token sentinel.
+        assert!(is_past_serve_expiry(u64::from(now()).saturating_sub(60)));
+        assert!(is_past_serve_expiry(0));
+    }
+
     // --- backoff_duration ---
 
     #[test]
@@ -339,5 +410,73 @@ mod tests {
             backoff_duration(u32::MAX),
             Duration::from_secs(JWT_BACKOFF_MAX_SECS)
         );
+    }
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod persistence_tests {
+    use super::*;
+    use crate::persist::sqlite::SqliteStorage;
+    use platform_utils::create_http_client;
+
+    /// Fresh on-disk `SQLite` storage in a unique temp directory.
+    fn temp_storage() -> Arc<dyn Storage> {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("breez-jwt-test-{}", uuid::Uuid::new_v4()));
+        Arc::new(SqliteStorage::new(&dir).expect("create sqlite storage"))
+    }
+
+    /// An `Inner` with the given storage (or none). The HTTP client is unused:
+    /// these tests exercise only the storage paths, which never fetch.
+    fn inner_with_storage(storage: Option<Arc<dyn Storage>>) -> Inner {
+        let cell = OnceLock::new();
+        if let Some(storage) = storage {
+            let _ = cell.set(storage);
+        }
+        Inner {
+            token: RwLock::new(None),
+            api_key: "test-key".to_string(),
+            storage: cell,
+            http_client: create_http_client(Some("jwt-test")),
+        }
+    }
+
+    #[tokio::test]
+    async fn store_then_load_round_trips_a_valid_token() {
+        let inner = inner_with_storage(Some(temp_storage()));
+        let token = make_jwt(u64::from(now()) + 3600);
+
+        store_token(&inner, token.clone()).await;
+        // Clear the in-memory copy so the reload must come from storage: this is
+        // the warm-start path that `start(Some(storage))` re-enables.
+        *inner.token.write().await = None;
+
+        assert!(load_cached_token(&inner).await);
+        assert_eq!(
+            inner.token.read().await.as_ref().map(|c| c.token.clone()),
+            Some(token)
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_persisted_token_is_not_loaded() {
+        let storage = temp_storage();
+        storage
+            .set_cached_item(KEY_BREEZ_JWT.to_string(), make_jwt(1))
+            .await
+            .expect("persist token");
+        let inner = inner_with_storage(Some(storage));
+
+        assert!(!load_cached_token(&inner).await);
+        assert!(inner.token.read().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn store_without_storage_stays_in_memory_only() {
+        // `start(None)` binds no storage: `store_token` updates the live token
+        // but persists nothing, so a later provider has no warm-start to load.
+        let inner = inner_with_storage(None);
+        store_token(&inner, make_jwt(u64::from(now()) + 3600)).await;
+        assert!(inner.token.read().await.is_some());
     }
 }

--- a/crates/breez-sdk/core/src/jwt_header_provider.rs
+++ b/crates/breez-sdk/core/src/jwt_header_provider.rs
@@ -372,8 +372,7 @@ mod tests {
     #[test]
     fn test_is_past_serve_expiry_within_refresh_grace_still_served() {
         // Expires in 2 minutes: inside the 5-minute refresh lead but outside the
-        // 30s serve margin, so it must still be served. This is the case the old
-        // grace check dropped, and is the core regression guard for this fix.
+        // 30s serve margin, so it must still be served.
         assert!(!is_past_serve_expiry(u64::from(now()) + 120));
     }
 

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -472,8 +472,16 @@ impl SdkBuilder {
         let signers = build_signers(&self.config, self.signer_source)?;
         validate_signer_capabilities(&self.config, signers.ecies.is_some())?;
 
+        let creates_context = self.context.is_none();
         let context = resolve_context(self.context, &self.config).await?;
         let stores = resolve_storage(self.storage, &context, &signers.spark, &self.config).await?;
+        // Start the partner-JWT provider now that storage is resolved. When the builder
+        // creates its own context (no shared context supplied), bind the resolved
+        // storage so the token warm-starts and survives restarts; a shared context
+        // starts in-memory only.
+        if let Some(provider) = &context.jwt_header_provider {
+            provider.start(creates_context.then(|| Arc::clone(&stores.storage)));
+        }
         let chain_service = resolve_chain_service(
             self.chain_service,
             self.rest_chain_service_config,

--- a/crates/breez-sdk/core/src/sdk_context.rs
+++ b/crates/breez-sdk/core/src/sdk_context.rs
@@ -104,9 +104,9 @@ impl SdkContextConfig {
 ///
 /// The returned `Arc` is cheap to clone and can back many SDK instances,
 /// sharing their HTTP client and operator gRPC channels.
-// Async-on-tokio so UniFFI runs it on the managed runtime: building the
-// shared resources `tokio::spawn`s internally (gRPC channel; mainnet JWT
-// task) and aborts off-runtime, despite no `.await` here.
+// `async` with no `.await`, and `async_runtime = "tokio"`: building the shared
+// gRPC client starts a background connection task that needs a tokio runtime,
+// so UniFFI must run this on its managed one.
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 pub async fn new_shared_sdk_context(config: SdkContextConfig) -> Result<Arc<SdkContext>, SdkError> {
     let user_agent = default_user_agent();
@@ -125,7 +125,6 @@ pub async fn new_shared_sdk_context(config: SdkContextConfig) -> Result<Arc<SdkC
     {
         Some(BreezJwtHeaderProvider::new(
             key.clone(),
-            None,
             http_client.clone(),
         ))
     } else {

--- a/crates/spark/src/header_provider.rs
+++ b/crates/spark/src/header_provider.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use futures::future::try_join_all;
 use thiserror::Error;
 
 #[derive(Debug, Error, Clone)]
@@ -25,9 +24,13 @@ pub trait HeaderProvider: Send + Sync {
     }
 }
 
-/// Composes multiple [`HeaderProvider`]s by fanning out their `headers()`
-/// calls in parallel and merging the results. On key collisions, later
-/// providers win.
+/// Composes multiple [`HeaderProvider`]s by resolving their `headers()` in
+/// order and merging the results. On key collisions, later providers win.
+///
+/// Resolution is sequential, not parallel, so a later provider benefits from an
+/// earlier one's latency: pairing an auth provider (whose first call performs a
+/// challenge/response handshake) before a best-effort provider gives the latter
+/// the handshake window to hydrate before its header is snapshotted.
 pub struct CombinedHeaderProvider {
     providers: Vec<Arc<dyn HeaderProvider>>,
 }
@@ -41,23 +44,20 @@ impl CombinedHeaderProvider {
 #[macros::async_trait]
 impl HeaderProvider for CombinedHeaderProvider {
     async fn headers(&self) -> Result<HashMap<String, String>, HeaderProviderError> {
-        merge(try_join_all(self.providers.iter().map(|p| p.headers())).await?)
+        let mut merged = HashMap::new();
+        for provider in &self.providers {
+            merged.extend(provider.headers().await?);
+        }
+        Ok(merged)
     }
 
     async fn headers_refresh(&self) -> Result<HashMap<String, String>, HeaderProviderError> {
-        merge(try_join_all(self.providers.iter().map(|p| p.headers_refresh())).await?)
+        let mut merged = HashMap::new();
+        for provider in &self.providers {
+            merged.extend(provider.headers_refresh().await?);
+        }
+        Ok(merged)
     }
-}
-
-/// Merges header maps left to right; later providers win on key collisions.
-fn merge(
-    results: Vec<HashMap<String, String>>,
-) -> Result<HashMap<String, String>, HeaderProviderError> {
-    let mut merged = HashMap::new();
-    for headers in results {
-        merged.extend(headers);
-    }
-    Ok(merged)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Tightens 3 cases where the partner JWT is missing from requests:

### 1. Persist the JWT across restarts

The provider was built with `storage: None`, leaving its persistence code inactive: the JWT was re-fetched from scratch on every launch, so clients had an unattributed cold-start window on each start.

Construction is now two-phase: `new()` to initialize and `start(storage)` to bind storage then spawn the refresh task. `SdkBuilder::build` binds storage only with no provided shared context; a shared server context stays in-memory. Clients now warm-start from cache and persist refreshes.

### 2. Resolve composed headers sequentially

`CombinedHeaderProvider` resolved `[auth, jwt]` with `try_join_all` (parallel), so the best-effort JWT was snapshotted immediately and gained nothing from the auth handshake latency. It is now sequential: the auth provider's first call performs a challenge/response handshake, so running it first gives the background JWT fetch that round-trip to land before its header is read. The JWT header read is a cache only call so adds little latency.

### 3. Serve a valid token through the refresh window

`headers()` gated on `is_expired` (the 5-minute refresh grace), so a still-valid token was withheld for its last 5 minutes, emitting no header during every refresh cycle. Serve is now split from refresh: `is_past_serve_expiry` withholds
only within a 30-second clock-skew margin of real `exp`; the refresh loop still fires 5 minutes early (unchanged).
