### PR TITLE
Make the passkey label publish non-blocking

### DIFF
--- a/crates/breez-sdk/core/src/passkey/mod.rs
+++ b/crates/breez-sdk/core/src/passkey/mod.rs
@@ -272,9 +272,24 @@ impl Passkey {
 
         if request.publish_label
             && let Ok(client) = self.nostr_client().await
-            && let Err(e) = client.store_label(&label).await
         {
-            warn!("setup_wallet: store_label failed, returning wallet anyway: {e}");
+            // The label publish is a non-fatal discovery convenience, so run
+            // it off the critical path rather than blocking on slow relays.
+            // store_label is idempotent, so the bounded retry is safe.
+            let label = label.clone();
+            tokio::spawn(async move {
+                for attempt in 0..3u32 {
+                    match client.store_label(&label).await {
+                        Ok(()) => return,
+                        Err(e) => warn!(
+                            "setup_wallet: background store_label attempt {attempt} failed: {e}"
+                        ),
+                    }
+                    if attempt < 2 {
+                        tokio::time::sleep(std::time::Duration::from_secs(2u64.pow(attempt))).await;
+                    }
+                }
+            });
         }
 
         Ok(WalletSetup {

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -380,6 +380,10 @@ mod tests {
 
     use super::super::error::PrfProviderError;
     use super::super::{DeriveSeedsOutput, DeriveSeedsRequest};
+    // Wasm-safe tokio (tokio_with_wasm under wasm-bindgen-test) so the sleep in
+    // wait_for_stored uses web timers instead of std::time, which is unsupported
+    // on wasm32-unknown-unknown.
+    use platform_utils::tokio;
 
     /// Salt-aware mock that produces deterministic per-salt PRF
     /// outputs so multi-salt ceremonies can round-trip through tests.

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -569,6 +569,18 @@ mod tests {
         client_with_store(prf_provider, config).0
     }
 
+    /// Poll until the spawned label publish lands, since it no longer
+    /// completes before `register` returns.
+    async fn wait_for_stored(store: &Arc<Mutex<StoreCalls>>, expected: &str) {
+        for _ in 0..100 {
+            if store.lock().unwrap().stored.iter().any(|l| l == expected) {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        panic!("label '{expected}' was not stored");
+    }
+
     #[macros::async_test_all]
     async fn register_returns_credential_and_publishes_label() {
         let provider = Arc::new(MockProvider::new([7u8; 32]));
@@ -593,7 +605,9 @@ mod tests {
         assert_eq!(credential.backup_eligible, Some(true));
         assert_eq!(*provider.create_calls.lock().unwrap(), 1);
         assert_eq!(response.wallet.label, "alice");
-        // Registration publishes the label to the store exactly once.
+        // Registration publishes the label exactly once. It now happens off
+        // the setup path, so wait for the spawned task before asserting.
+        wait_for_stored(&store, "alice").await;
         assert_eq!(store.lock().unwrap().stored, vec!["alice".to_string()]);
     }
 


### PR DESCRIPTION
`register` previously waited for the `store_label` publish to complete. On slow or unresponsive Nostr relays, that wait could last tens of seconds.

This change moves the label publish into a background task, so `register` returns immediately without waiting for relay responses.

This is safe because:

* Publishing the label is a non-critical discovery convenience, not a requirement for successful registration.
* The operation is idempotent, so bounded retries safely handle transient failures.
* This matches the existing behavior of NIP-65 relay-list synchronization.
