### PR TITLE
LNURL: Require a default API key on mainnet

### DIFF
--- a/crates/breez-sdk/lnurl/README.md
+++ b/crates/breez-sdk/lnurl/README.md
@@ -67,6 +67,7 @@ Running the container:
 docker run -p 8080:8080 \
   -e BREEZ_LNURL_DB_URL="postgres://user:password@postgres_host:5432/lnurl_db" \
   -e BREEZ_LNURL_DOMAINS="yourdomain.com" \
+  -e BREEZ_LNURL_DEFAULT_API_KEY="<breez-api-key>" \
   -e BREEZ_LNURL_AUTO_MIGRATE=true \
   lnurl-server
 ```
@@ -76,7 +77,7 @@ docker run -p 8080:8080 \
 If you've built the binary, you can run it directly:
 
 ```shell
-./target/release/lnurl --db-url="lnurl.sqlite" --domains="yourdomain.com" --auto-migrate
+./target/release/lnurl --db-url="lnurl.sqlite" --domains="yourdomain.com" --default-api-key="<breez-api-key>" --auto-migrate
 ```
 
 ## Configuration
@@ -112,7 +113,7 @@ db_url = "postgres://user:password@localhost:5432/lnurl_db"
 min_sendable = 1000                 # Minimum amount in millisatoshi (1 sat)
 max_sendable = 4000000000           # Maximum amount in millisatoshi (4,000,000 sats)
 domains = "yourdomain.com"          # Comma-separated list of allowed domains
-default_api_key = "<breez-api-key>" # Fallback Breez API key for partner attribution
+default_api_key = "<breez-api-key>" # Fallback Breez API key for partner attribution (required on mainnet)
 ```
 
 ### Important Configuration Options
@@ -123,7 +124,7 @@ default_api_key = "<breez-api-key>" # Fallback Breez API key for partner attribu
 | `--auto-migrate` | Automatically apply database migrations | `false` |
 | `--db-url` | Database connection string | `""` |
 | `--domains` | Comma-separated list of allowed domains | `localhost:8080` |
-| `--default-api-key` | Fallback Breez API key for partner attribution | (none) |
+| `--default-api-key` | Fallback Breez API key for partner attribution (**required on mainnet**) | (none) |
 | `--log-level` | RUST_LOG style format (e.g., `info`, `lnurl=trace,info`, `lnurl=trace,spark_wallet=debug,info`) | `info` |
 | `--network` | Spark network (mainnet, testnet, regtest) | `mainnet` |
 | `--min-sendable` | Minimum payment amount (millisatoshi) | `1000` |
@@ -141,6 +142,14 @@ For a complete list of options, run:
 ```shell
 lnurl --help
 ```
+
+### Partner Attribution
+
+This server creates invoices on behalf of its users, so each lightning-address receive is attributed to a partner when the invoice is created.
+
+A receive is attributed to the domain's own Breez API key when one is configured for that domain, otherwise to the **default API key** (`--default-api-key` / `BREEZ_LNURL_DEFAULT_API_KEY`).
+
+On **mainnet the default API key is required**, and the server will not start without it. This ensures a self-hosted server attributes all of its receives (to its own partner) instead of leaving any unattributed.
 
 ### Database Support
 

--- a/crates/breez-sdk/lnurl/src/main.rs
+++ b/crates/breez-sdk/lnurl/src/main.rs
@@ -109,8 +109,7 @@ struct Args {
     pub domains: String,
 
     /// Fallback Breez API key used to attribute lightning-address receives for
-    /// any allowed domain that has no `api_key` of its own, so no domain is left
-    /// unattributed. Mainnet only.
+    /// any allowed domain that has no `api_key` of its own. Required on mainnet.
     #[arg(long)]
     pub default_api_key: Option<String>,
 
@@ -256,6 +255,22 @@ fn parse_auth_seed(hex_str: Option<&str>) -> Result<[u8; 32], anyhow::Error> {
         .map_err(|_| anyhow!("ssp_auth_seed must be 32 bytes"))
 }
 
+fn resolve_default_api_key(
+    arg: Option<&str>,
+    is_mainnet: bool,
+) -> Result<Option<String>, anyhow::Error> {
+    let key = arg
+        .map(str::trim)
+        .filter(|k| !k.is_empty())
+        .map(str::to_string);
+    if is_mainnet && key.is_none() {
+        return Err(anyhow!(
+            "a default API key is required on mainnet: set --default-api-key (or BREEZ_LNURL_DEFAULT_API_KEY)"
+        ));
+    }
+    Ok(key.filter(|_| is_mainnet))
+}
+
 #[allow(clippy::too_many_lines)]
 async fn run_server<DB>(args: Args, repository: DB) -> Result<(), anyhow::Error>
 where
@@ -304,7 +319,8 @@ where
     // mainnet-only, so regtest/testnet have no API keys or partner JWTs.
     let is_mainnet = matches!(args.network, Network::Mainnet);
     // Fallback key for domains without their own, so none are unattributed.
-    let default_api_key = is_mainnet.then(|| args.default_api_key.clone()).flatten();
+    // Mandatory on mainnet (fails startup if missing), ignored otherwise.
+    let default_api_key = resolve_default_api_key(args.default_api_key.as_deref(), is_mainnet)?;
 
     let domains = domains::start(repository.clone(), is_mainnet, default_api_key.clone()).await?;
 
@@ -580,7 +596,7 @@ fn register_webhook(service_provider: Arc<ServiceProvider>, webhook_url: String,
 
 #[cfg(test)]
 mod tests {
-    use super::{Args, explicit_cli_overrides, parse_auth_seed};
+    use super::{Args, explicit_cli_overrides, parse_auth_seed, resolve_default_api_key};
     use clap::{CommandFactory, FromArgMatches};
     use figment::{Figment, providers::Serialized};
 
@@ -654,5 +670,25 @@ mod tests {
     fn auth_seed_wrong_length_is_fatal() {
         // 31 bytes, valid hex but wrong length.
         assert!(parse_auth_seed(Some(&"22".repeat(31))).is_err());
+    }
+
+    #[test]
+    fn default_api_key_required_on_mainnet() {
+        // Present and trimmed on mainnet.
+        assert_eq!(
+            resolve_default_api_key(Some("  key  "), true).unwrap(),
+            Some("key".to_string())
+        );
+        // Missing or blank is a startup error on mainnet.
+        assert!(resolve_default_api_key(None, true).is_err());
+        assert!(resolve_default_api_key(Some(""), true).is_err());
+        assert!(resolve_default_api_key(Some("   "), true).is_err());
+    }
+
+    #[test]
+    fn default_api_key_ignored_off_mainnet() {
+        // No JWT endpoint off mainnet, so no key is required and any key is dropped.
+        assert_eq!(resolve_default_api_key(None, false).unwrap(), None);
+        assert_eq!(resolve_default_api_key(Some("key"), false).unwrap(), None);
     }
 }


### PR DESCRIPTION
Makes `--default-api-key` (`BREEZ_LNURL_DEFAULT_API_KEY`) mandatory on mainnet: the server now fails to start without it. This ensures a self-hosted LNURL server attributes all of its lightning-address receives to its own partner, rather than leaving any unattributed.

- On mainnet a missing or blank key is a startup error.
- README updated (new Partner Attribution section, flags table, example commands) and unit tests added for the key resolution.
