### PR TITLE
Fix doubled balance from leaf counted in two maps

### DIFF
--- a/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
@@ -380,6 +380,21 @@ async fn test_missing_operators_replaced_on_set_leaves() {
 }
 
 #[wasm_bindgen_test]
+async fn test_add_leaves_clears_missing_from_operators() {
+    let store = create_test_tree_store("mysql_tree_add_clears_missing_ops").await;
+    breez_sdk_spark::tree_store_tests::test_add_leaves_clears_missing_from_operators(&store).await;
+}
+
+#[wasm_bindgen_test]
+async fn test_missing_from_operators_leaves_are_not_selectable() {
+    let store = create_test_tree_store("mysql_tree_missing_not_selectable").await;
+    breez_sdk_spark::tree_store_tests::test_missing_from_operators_leaves_are_not_selectable(
+        &store,
+    )
+    .await;
+}
+
+#[wasm_bindgen_test]
 async fn test_reserve_with_none_target_reserves_all() {
     let store = create_test_tree_store("mysql_tree_none_target").await;
     breez_sdk_spark::tree_store_tests::test_reserve_with_none_target_reserves_all(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
@@ -380,6 +380,21 @@ async fn test_missing_operators_replaced_on_set_leaves() {
 }
 
 #[wasm_bindgen_test]
+async fn test_add_leaves_clears_missing_from_operators() {
+    let store = create_test_tree_store("pg_tree_add_clears_missing_ops").await;
+    breez_sdk_spark::tree_store_tests::test_add_leaves_clears_missing_from_operators(&store).await;
+}
+
+#[wasm_bindgen_test]
+async fn test_missing_from_operators_leaves_are_not_selectable() {
+    let store = create_test_tree_store("pg_tree_missing_not_selectable").await;
+    breez_sdk_spark::tree_store_tests::test_missing_from_operators_leaves_are_not_selectable(
+        &store,
+    )
+    .await;
+}
+
+#[wasm_bindgen_test]
 async fn test_reserve_with_none_target_reserves_all() {
     let store = create_test_tree_store("pg_tree_none_target").await;
     breez_sdk_spark::tree_store_tests::test_reserve_with_none_target_reserves_all(&store).await;

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -380,8 +380,8 @@ impl TreeStore for MysqlTreeStore {
     async fn get_available_balance(&self) -> Result<u64, TreeServiceError> {
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
         // Server-side aggregation: counts the same set as `Leaves::balance()`
-        // (available + missing-from-operators is excluded; swap-reserved is
-        // included). Avoids fetching every leaf's `data` JSON when callers
+        // (available + missing-from-operators + swap-reserved; payment-reserved
+        // is excluded). Avoids fetching every leaf's `data` JSON when callers
         // only need the spendable total.
         let row: Option<i64> = conn
             .exec_first(
@@ -2160,6 +2160,18 @@ mod tests {
     async fn test_missing_operators_replaced_on_set_leaves() {
         let fixture = MysqlTreeStoreTestFixture::new().await;
         shared_tests::test_missing_operators_replaced_on_set_leaves(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_add_leaves_clears_missing_from_operators() {
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        shared_tests::test_add_leaves_clears_missing_from_operators(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_missing_from_operators_leaves_are_not_selectable() {
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        shared_tests::test_missing_from_operators_leaves_are_not_selectable(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -1924,6 +1924,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_add_leaves_clears_missing_from_operators() {
+        let fixture = PostgresTreeStoreTestFixture::new().await;
+        shared_tests::test_add_leaves_clears_missing_from_operators(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_missing_from_operators_leaves_are_not_selectable() {
+        let fixture = PostgresTreeStoreTestFixture::new().await;
+        shared_tests::test_missing_from_operators_leaves_are_not_selectable(&fixture.store).await;
+    }
+
+    #[tokio::test]
     async fn test_reserve_with_none_target_reserves_all() {
         let fixture = PostgresTreeStoreTestFixture::new().await;
         shared_tests::test_reserve_with_none_target_reserves_all(&fixture.store).await;

--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -67,7 +67,6 @@ struct ReservationEntry {
 #[derive(Default)]
 struct LeavesState {
     /// Every unreserved leaf, whether or not the operators all reported it.
-    /// Keyed by leaf id, so a leaf can never be counted twice.
     leaves: HashMap<TreeNodeId, StoredLeaf>,
     leaves_reservations: HashMap<LeavesReservationId, ReservationEntry>,
     /// Leaf IDs that have been finalized (spent) with their spent timestamp.

--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -26,6 +26,29 @@ pub const DEFAULT_RESERVATION_TIMEOUT: Duration = Duration::from_secs(60);
 struct StoredLeaf {
     node: TreeNode,
     added_at: SystemTime,
+    /// The coordinator returned this leaf but at least one operator did not.
+    /// It still counts towards the wallet balance, but cannot be selected to
+    /// back a payment or a swap until every operator reports it again.
+    /// Mirrors the `is_missing_from_operators` column of the SQL stores.
+    missing_from_operators: bool,
+}
+
+impl StoredLeaf {
+    fn available(node: &TreeNode, added_at: SystemTime) -> Self {
+        StoredLeaf {
+            node: node.clone(),
+            added_at,
+            missing_from_operators: false,
+        }
+    }
+
+    fn missing_from_operators(node: &TreeNode, added_at: SystemTime) -> Self {
+        StoredLeaf {
+            node: node.clone(),
+            added_at,
+            missing_from_operators: true,
+        }
+    }
 }
 
 /// Entry in the reservation map, containing leaves, purpose, and the semaphore permit.
@@ -43,8 +66,9 @@ struct ReservationEntry {
 
 #[derive(Default)]
 struct LeavesState {
+    /// Every unreserved leaf, whether or not the operators all reported it.
+    /// Keyed by leaf id, so a leaf can never be counted twice.
     leaves: HashMap<TreeNodeId, StoredLeaf>,
-    missing_operators_leaves: HashMap<TreeNodeId, StoredLeaf>,
     leaves_reservations: HashMap<LeavesReservationId, ReservationEntry>,
     /// Leaf IDs that have been finalized (spent) with their spent timestamp.
     /// Prevents re-adding during refresh. Cleaned up when leaf is no longer
@@ -57,11 +81,19 @@ struct LeavesState {
 }
 
 impl LeavesState {
-    /// Calculate the available balance (unreserved available leaves).
+    /// The pool leaf selection draws from: unreserved, available, and reported
+    /// by every operator.
+    fn selectable_leaves(&self) -> impl Iterator<Item = &StoredLeaf> {
+        self.leaves.values().filter(|stored| {
+            stored.node.status == TreeNodeStatus::Available && !stored.missing_from_operators
+        })
+    }
+
+    /// Total value of the selectable pool. Not the wallet balance:
+    /// `TreeStore::get_available_balance` also counts missing-from-operators and
+    /// swap-reserved leaves.
     fn available_balance(&self) -> u64 {
-        self.leaves
-            .values()
-            .filter(|stored| stored.node.status == TreeNodeStatus::Available)
+        self.selectable_leaves()
             .map(|stored| stored.node.value)
             .sum()
     }
@@ -345,13 +377,13 @@ impl InMemoryTreeStore {
                 "leaf_lifecycle add_leaves: leaf={} value={} cleared_spent_marker={}",
                 leaf.id, leaf.value, was_spent
             );
-            state.leaves.insert(
-                leaf.id.clone(),
-                StoredLeaf {
-                    node: leaf.clone(),
-                    added_at: now,
-                },
-            );
+            // Overwrites any missing-from-operators entry for the same id: a
+            // refresh racing an in-flight claim classifies the claimed leaves as
+            // missing (the coordinator has them, a lagging operator does not),
+            // and the claim then adds the very same leaves.
+            state
+                .leaves
+                .insert(leaf.id.clone(), StoredLeaf::available(leaf, now));
         }
         Ok(())
     }
@@ -372,25 +404,25 @@ impl InMemoryTreeStore {
             }
         }
 
+        let mut available = Vec::new();
+        let mut not_available = Vec::new();
+        let mut available_missing_from_operators = Vec::new();
+        for stored in state.leaves.values() {
+            let is_available = stored.node.status == TreeNodeStatus::Available;
+            match (stored.missing_from_operators, is_available) {
+                (true, true) => available_missing_from_operators.push(stored.node.clone()),
+                // A leaf the operators no longer report and that is not available
+                // is not spendable under any classification: leave it out.
+                (true, false) => (),
+                (false, true) => available.push(stored.node.clone()),
+                (false, false) => not_available.push(stored.node.clone()),
+            }
+        }
+
         Ok(Leaves {
-            available: state
-                .leaves
-                .values()
-                .filter(|stored| stored.node.status == TreeNodeStatus::Available)
-                .map(|stored| stored.node.clone())
-                .collect(),
-            not_available: state
-                .leaves
-                .values()
-                .filter(|stored| stored.node.status != TreeNodeStatus::Available)
-                .map(|stored| stored.node.clone())
-                .collect(),
-            available_missing_from_operators: state
-                .missing_operators_leaves
-                .values()
-                .filter(|stored| stored.node.status == TreeNodeStatus::Available)
-                .map(|stored| stored.node.clone())
-                .collect(),
+            available,
+            not_available,
+            available_missing_from_operators,
             reserved_for_payment,
             reserved_for_swap,
         })
@@ -443,7 +475,6 @@ impl InMemoryTreeStore {
             .retain(|_, spent_at| *spent_at >= refresh_started_at);
 
         let old_leaves = std::mem::take(&mut state.leaves);
-        let old_missing = std::mem::take(&mut state.missing_operators_leaves);
 
         let now = SystemTime::now();
         for leaf in leaves {
@@ -455,13 +486,9 @@ impl InMemoryTreeStore {
                         leaf.id, leaf.value
                     );
                 }
-                state.leaves.insert(
-                    leaf.id.clone(),
-                    StoredLeaf {
-                        node: leaf.clone(),
-                        added_at: now,
-                    },
-                );
+                state
+                    .leaves
+                    .insert(leaf.id.clone(), StoredLeaf::available(leaf, now));
             } else {
                 trace!(
                     "leaf_lifecycle set_leaves: skipped leaf={} (in spent_leaf_ids)",
@@ -469,42 +496,26 @@ impl InMemoryTreeStore {
                 );
             }
         }
+        // Applied after the available leaves so that a leaf the coordinator
+        // reports in both lists ends up flagged missing, matching the upsert
+        // order of the SQL stores.
         for leaf in missing_operators_leaves {
             if !state.spent_leaf_ids.contains_key(&leaf.id) {
-                state.missing_operators_leaves.insert(
+                state.leaves.insert(
                     leaf.id.clone(),
-                    StoredLeaf {
-                        node: leaf.clone(),
-                        added_at: now,
-                    },
+                    StoredLeaf::missing_from_operators(leaf, now),
                 );
             }
         }
 
         let mut preserved_count = 0u32;
         for (id, stored) in old_leaves {
-            if stored.added_at >= refresh_started_at
-                && !state.leaves.contains_key(&id)
-                && !state.missing_operators_leaves.contains_key(&id)
-            {
+            if stored.added_at >= refresh_started_at && !state.leaves.contains_key(&id) {
                 trace!(
-                    "leaf_lifecycle set_leaves: preserved old leaf={} value={} (added after refresh started)",
-                    id, stored.node.value
+                    "leaf_lifecycle set_leaves: preserved old leaf={} value={} missing_from_operators={} (added after refresh started)",
+                    id, stored.node.value, stored.missing_from_operators
                 );
                 state.leaves.insert(id, stored);
-                preserved_count += 1;
-            }
-        }
-        for (id, stored) in old_missing {
-            if stored.added_at >= refresh_started_at
-                && !state.leaves.contains_key(&id)
-                && !state.missing_operators_leaves.contains_key(&id)
-            {
-                trace!(
-                    "leaf_lifecycle set_leaves: preserved old missing leaf={} value={}",
-                    id, stored.node.value
-                );
-                state.missing_operators_leaves.insert(id, stored);
                 preserved_count += 1;
             }
         }
@@ -514,16 +525,18 @@ impl InMemoryTreeStore {
             for stored in &mut entry.leaves {
                 if let Some(fresh) = state.leaves.remove(&stored.node.id) {
                     *stored = fresh;
-                } else if let Some(fresh) = state.missing_operators_leaves.remove(&stored.node.id) {
-                    *stored = fresh;
                 }
             }
         }
 
         trace!(
-            "set_leaves: {} leaves, {} missing, {} preserved from previous state",
+            "set_leaves: {} leaves ({} missing from operators), {} preserved from previous state",
             state.leaves.len(),
-            state.missing_operators_leaves.len(),
+            state
+                .leaves
+                .values()
+                .filter(|stored| stored.missing_from_operators)
+                .count(),
             preserved_count
         );
 
@@ -545,11 +558,8 @@ impl InMemoryTreeStore {
         let available = state.available_balance();
         let pending = state.pending_balance();
 
-        // Filter available leaves
         let leaves: Vec<TreeNode> = state
-            .leaves
-            .values()
-            .filter(|stored| stored.node.status == TreeNodeStatus::Available)
+            .selectable_leaves()
             .map(|stored| stored.node.clone())
             .collect();
 
@@ -625,9 +635,7 @@ impl InMemoryTreeStore {
         target_amounts: Option<&TargetAmounts>,
     ) -> Result<LeafSelection, TreeServiceError> {
         let leaves: Vec<TreeNode> = state
-            .leaves
-            .values()
-            .filter(|stored| stored.node.status == TreeNodeStatus::Available)
+            .selectable_leaves()
             .map(|stored| stored.node.clone())
             .collect();
 
@@ -677,13 +685,9 @@ impl InMemoryTreeStore {
 
         let now = SystemTime::now();
         for leaf in leaves_to_keep {
-            state.leaves.insert(
-                leaf.id.clone(),
-                StoredLeaf {
-                    node: leaf.clone(),
-                    added_at: now,
-                },
-            );
+            state
+                .leaves
+                .insert(leaf.id.clone(), StoredLeaf::available(leaf, now));
         }
     }
 
@@ -718,13 +722,9 @@ impl InMemoryTreeStore {
                     "leaf_lifecycle finalize: adding new leaf={} value={} reservation={}",
                     leaf.id, leaf.value, id
                 );
-                state.leaves.insert(
-                    leaf.id.clone(),
-                    StoredLeaf {
-                        node: leaf.clone(),
-                        added_at: now,
-                    },
-                );
+                state
+                    .leaves
+                    .insert(leaf.id.clone(), StoredLeaf::available(leaf, now));
             }
         }
         trace!("Finalized leaves reservation: {}", id);
@@ -756,23 +756,16 @@ impl InMemoryTreeStore {
                 "leaf_lifecycle update_reservation: adding change leaf={} value={} reservation={}",
                 leaf.id, leaf.value, reservation_id
             );
-            state.leaves.insert(
-                leaf.id.clone(),
-                StoredLeaf {
-                    node: leaf.clone(),
-                    added_at: now,
-                },
-            );
+            state
+                .leaves
+                .insert(leaf.id.clone(), StoredLeaf::available(leaf, now));
         }
 
         // Re-insert the reservation with updated leaves but same permit
         // Pending change is cleared since the swap completed
         let reserved: Vec<StoredLeaf> = reserved_leaves
             .iter()
-            .map(|leaf| StoredLeaf {
-                node: leaf.clone(),
-                added_at: now,
-            })
+            .map(|leaf| StoredLeaf::available(leaf, now))
             .collect();
         state.leaves_reservations.insert(
             reservation_id.clone(),
@@ -811,7 +804,13 @@ impl InMemoryTreeStore {
             return Err(TreeServiceError::NonReservableLeaves);
         }
         for leaf in leaves {
-            if !state.leaves.contains_key(&leaf.id) {
+            // A leaf the operators no longer report cannot back a payment or a
+            // swap, even though it still counts towards the balance.
+            let reservable = state
+                .leaves
+                .get(&leaf.id)
+                .is_some_and(|stored| !stored.missing_from_operators);
+            if !reservable {
                 return Err(TreeServiceError::NonReservableLeaves);
             }
         }
@@ -1353,6 +1352,20 @@ mod tests {
     async fn test_missing_operators_replaced_on_set_leaves() {
         shared_tests::test_missing_operators_replaced_on_set_leaves(&InMemoryTreeStore::new())
             .await;
+    }
+
+    #[async_test_all]
+    async fn test_add_leaves_clears_missing_from_operators() {
+        shared_tests::test_add_leaves_clears_missing_from_operators(&InMemoryTreeStore::new())
+            .await;
+    }
+
+    #[async_test_all]
+    async fn test_missing_from_operators_leaves_are_not_selectable() {
+        shared_tests::test_missing_from_operators_leaves_are_not_selectable(
+            &InMemoryTreeStore::new(),
+        )
+        .await;
     }
 
     #[async_test_all]

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -1833,6 +1833,89 @@ pub async fn test_missing_operators_replaced_on_set_leaves(store: &dyn TreeStore
     );
 }
 
+/// A leaf must never be both available and missing-from-operators: `balance()`
+/// sums the two sets.
+pub async fn test_add_leaves_clears_missing_from_operators(store: &dyn TreeStore) {
+    let leaf = create_test_tree_node("leaf1", 49_901);
+
+    let refresh_start = future_refresh_start(store).await;
+    store
+        .set_leaves(&[], std::slice::from_ref(&leaf), refresh_start)
+        .await
+        .unwrap();
+    assert_eq!(get_all(store).await.balance(), 49_901);
+
+    store.add_leaves(std::slice::from_ref(&leaf)).await.unwrap();
+
+    let all = get_all(store).await;
+    assert_eq!(
+        all.balance(),
+        49_901,
+        "leaf counted twice: available={}, missing_from_operators={}",
+        all.available_balance(),
+        all.missing_operators_balance()
+    );
+    assert_eq!(store.get_available_balance().await.unwrap(), 49_901);
+    assert_eq!(all.available.len(), 1);
+    assert!(
+        all.available_missing_from_operators.is_empty(),
+        "add_leaves must clear the missing-from-operators entry"
+    );
+}
+
+/// A leaf an operator no longer reports still counts towards the balance, but
+/// cannot back a payment or a swap: signing needs every operator.
+pub async fn test_missing_from_operators_leaves_are_not_selectable(store: &dyn TreeStore) {
+    let available = create_test_tree_node("available1", 1_000);
+    let missing = create_test_tree_node("missing1", 500);
+
+    let refresh_start = future_refresh_start(store).await;
+    store
+        .set_leaves(
+            std::slice::from_ref(&available),
+            std::slice::from_ref(&missing),
+            refresh_start,
+        )
+        .await
+        .unwrap();
+    assert_eq!(get_all(store).await.balance(), 1_500);
+
+    let by_ids = store
+        .try_reserve_leaves_by_ids(
+            std::slice::from_ref(&missing.id),
+            ReservationPurpose::Payment,
+        )
+        .await;
+    assert!(
+        matches!(by_ids, Err(TreeServiceError::NonReservableLeaves)),
+        "reserving a missing-from-operators leaf by id must fail"
+    );
+
+    // The 1_500 balance includes the missing leaf, but only 1_000 is selectable.
+    let too_large = reserve_leaves(
+        store,
+        Some(&TargetAmounts::new_amount_and_fee(1_500, None)),
+        false,
+        ReservationPurpose::Payment,
+    )
+    .await;
+    assert!(
+        matches!(too_large, Err(TreeServiceError::InsufficientFunds)),
+        "a missing-from-operators leaf must not be selected to reach the target"
+    );
+
+    let reservation = reserve_leaves(
+        store,
+        Some(&TargetAmounts::new_amount_and_fee(1_000, None)),
+        true,
+        ReservationPurpose::Payment,
+    )
+    .await
+    .unwrap();
+    assert_eq!(reservation.leaves.len(), 1);
+    assert_eq!(reservation.leaves[0].id, available.id);
+}
+
 pub async fn test_reserve_with_none_target_reserves_all(store: &dyn TreeStore) {
     let leaves = vec![
         create_test_tree_node("node1", 100),


### PR DESCRIPTION
## What

`InMemoryTreeStore` could report double the real wallet balance for several seconds after a transfer was claimed. This collapses the store's two leaf maps into one, making the double-count structurally impossible.

## Root cause

`LeavesState` kept unreserved leaves in two separate maps, `leaves` and `missing_operators_leaves`, and `Leaves::balance()` summed both. Nothing enforced that the maps were disjoint. `add_leaves` inserted into `leaves` without removing the id from `missing_operators_leaves`, so a leaf that a refresh had flagged as missing-from-an-operator, and that an in-flight claim then re-added, was counted once as available and once as missing.

This is exactly what a deposit claim triggers: a refresh flags the just-claimed leaves as missing (the coordinator reports them, a lagging operator has not indexed them yet), then the claim adds the same leaves. The wrong value is sticky because `missing_operators_leaves` is only rebuilt by `set_leaves`, which returns early during the auto-optimization swap that starts right after the claim.

Only the in-memory store was affected. The Postgres and MySQL stores keep one row per leaf with an `is_missing_from_operators` flag that `add_leaves` upserts back to `FALSE`, so a single row can never be double-counted.

## Fix

Collapse `leaves` and `missing_operators_leaves` into a single id-keyed map, with a `missing_from_operators` flag on each entry, mirroring the SQL stores' model. One entry per id makes double-counting unrepresentable. Missing-from-operators leaves still count towards the balance but are excluded from the selectable pool, so they cannot back a payment or swap that would fail at FROST signing.

## Impact beyond CI

Any integrator polling `getInfo` shortly after a claim could observe double their real balance until the next refresh. This is the top offender behind the `Breez integration tests` job flakiness (`test_08_lnurl_send_all_with_fee_overpayment` and friends), where the doubled balance makes the test compute an impossible send amount and fail with `InsufficientFunds`.

## Observed in CI

The doubled-balance signature (`2 x (deposit - 99)`) appeared in these `Breez integration tests` runs:

- [run 29330756375](https://github.com/breez/spark-sdk/actions/runs/29330756375) (PR #991): `test_08` reported `99802` for a `50000` sat deposit.
- [run 29326871323](https://github.com/breez/spark-sdk/actions/runs/29326871323) (PR #992): same signature on `test_08` (`50000` -> `99802`) and `test_07` (`10000` -> `19802`). This branch never contained #991, confirming the bug predates it.

## Tests

Two new cases in the shared tree-store suite, run against every backend (in-memory, Postgres, MySQL):
- `test_add_leaves_clears_missing_from_operators`: a leaf set as missing-from-operators then re-added must not change the balance.
- `test_missing_from_operators_leaves_are_not_selectable`: such a leaf counts towards balance but cannot be reserved for payment.

The first fails on the pre-fix in-memory store (`available=49901 missing=49901 => balance=99802`) and passed on Postgres/MySQL, confirming the divergence this closes.
