### PR TITLE
test(itest): fix flaky test_03_reconcile_stale_pending_payment

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
+++ b/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
@@ -330,9 +330,10 @@ async fn test_03_reconcile_stale_pending_payment(
 
     ensure_funded(&mut alice, 200).await?;
 
-    // Step 1: Alice sends a Spark HTLC with a 60-second expiry.
-    // 60 seconds is long enough such that the offset advances past it,
-    // yet short enough to fail well before the 120s test timeout.
+    // Step 1: Alice sends a Spark HTLC with a 30-second expiry. The expiry only
+    // needs to outlast steps 2-3 below, so the HTLC is still Pending when the
+    // offset advances past it. The operators then mark it Returned ~60s after
+    // expiry, so the reconcile event lands late (see the generous wait below).
     let (_, payment_hash) = generate_preimage_hash_pair();
 
     let bob_spark_address = bob
@@ -363,14 +364,14 @@ async fn test_03_reconcile_stale_pending_payment(
             options: Some(SendPaymentOptions::SparkAddress {
                 htlc_options: Some(SparkHtlcOptions {
                     payment_hash: payment_hash.clone(),
-                    expiry_duration_secs: 60,
+                    expiry_duration_secs: 30,
                 }),
             }),
             idempotency_key: None,
         })
         .await?;
 
-    info!("Alice sent HTLC (75s expiry) — payment is Pending at position N");
+    info!("Alice sent HTLC (30s expiry): payment is Pending at position N");
 
     // Step 2: Alice sends a regular (non-HTLC) Spark to advance the sync offset past the
     // HTLC's position. Once the auto-sync processes both transfers, the stored
@@ -427,9 +428,9 @@ async fn test_03_reconcile_stale_pending_payment(
     );
 
     // Step 4: Wait for the paymentFailed event emitted by reconciliation.
-    info!("Waiting for paymentFailed event from reconciliation (up to 120s)...");
+    info!("Waiting for paymentFailed event from reconciliation (up to 180s)...");
     let failed_payment =
-        wait_for_payment_failed_event(&mut alice.events, PaymentType::Send, 120).await?;
+        wait_for_payment_failed_event(&mut alice.events, PaymentType::Send, 180).await?;
 
     assert_eq!(failed_payment.status, PaymentStatus::Failed);
     assert_eq!(failed_payment.amount, 5);


### PR DESCRIPTION
## Problem

`test_03_reconcile_stale_pending_payment` is a structurally flaky itest. It fails
by only a few seconds when the operators are slow to return the expired HTLC.

Evidence from a failing run
([run 29330756375](https://github.com/breez/spark-sdk/actions/runs/29330756375/job/87077847750?pr=991)):

| event | wall clock | Δ from HTLC send |
|---|---|---|
| Alice sends HTLC (60s expiry) | 12:30:34.5 | 0 |
| 120s reconcile wait starts | 12:30:40.3 | +6s (deadline 12:32:40.3) |
| operators mark HTLC `Returned`; reconcile emits `PaymentFailed` | 12:32:38.5 | **+124s** |
| wait deadline hits, sender-side `Send` event not yet polled | 12:32:40.5 | timeout |

The HTLC was genuinely returned and reconciled (not a hang): `send → Returned`
took ~124s, of which ~60s is the fixed expiry and ~60s is server-side operator
lag *after* expiry. The sender-side reconcile runs on a separate ≤10s poll, so
it lands just past the 120s deadline.

## Fix

- **Expiry 60s → 30s.** `send → Returned ≈ expiry + ~60s operator lag`, so the
  expiry is a direct additive term. It only needs to outlast the offset-advance
  steps (the HTLC must still be `Pending` at that assertion, ~6-10s in), and
  `test_02_htlc_refund` already uses a 5s expiry successfully, so there is no
  server-side minimum in the way.
- **Reconcile wait 120s → 180s.** With a 30s expiry the reconcile needs ~94s of
  wait in the observed case; 180s leaves ~86s of headroom, covering even a ~2x
  spike in the (unbounded, server-side) operator lag.
- Fix the stale `"75s expiry"` log line and the over-optimistic comment.

Net effect: ~30s faster runtime *and* a wider correctness margin than a plain
120 → 240 bump.