### PR TITLE
lnurl: remove deprecated publish_zap_receipt endpoint

### DIFF
--- a/crates/breez-sdk/lnurl-models/src/lib.rs
+++ b/crates/breez-sdk/lnurl-models/src/lib.rs
@@ -89,13 +89,6 @@ pub struct ListMetadataMetadata {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct PublishZapReceiptRequest {
-    pub signature: String,
-    pub timestamp: u64,
-    pub zap_receipt: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 pub struct InvoicePaidRequest {
     pub signature: String,
     pub timestamp: u64,
@@ -113,12 +106,6 @@ pub struct InvoicesPaidRequest {
 pub struct PaidInvoice {
     pub preimage: String,
     pub invoice: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct PublishZapReceiptResponse {
-    pub published: bool,
-    pub zap_receipt: String,
 }
 
 pub fn sanitize_username(username: &str) -> String {

--- a/crates/breez-sdk/lnurl/src/main.rs
+++ b/crates/breez-sdk/lnurl/src/main.rs
@@ -490,10 +490,6 @@ where
             get(LnurlServer::<DB>::list_metadata),
         )
         .route(
-            "/lnurlpay/{pubkey}/metadata/{payment_hash}/zap",
-            post(LnurlServer::<DB>::publish_zap_receipt),
-        )
-        .route(
             "/lnurlpay/{pubkey}/invoice-paid",
             post(LnurlServer::<DB>::invoice_paid),
         )

--- a/crates/breez-sdk/lnurl/src/postgresql/repository.rs
+++ b/crates/breez-sdk/lnurl/src/postgresql/repository.rs
@@ -181,34 +181,6 @@ impl crate::repository::LnurlRepository for LnurlRepository {
         Ok(())
     }
 
-    async fn get_zap_by_payment_hash(
-        &self,
-        payment_hash: &str,
-    ) -> Result<Option<Zap>, LnurlRepositoryError> {
-        let maybe_zap = sqlx::query(
-            "SELECT payment_hash, zap_request, zap_event, user_pubkey
-            , invoice_expiry, updated_at, is_user_nostr_key
-             FROM zaps
-             WHERE payment_hash = $1",
-        )
-        .bind(payment_hash)
-        .fetch_optional(&self.pool)
-        .await?
-        .map(|row| {
-            Ok::<_, sqlx::Error>(Zap {
-                payment_hash: row.try_get(0)?,
-                zap_request: row.try_get(1)?,
-                zap_event: row.try_get(2)?,
-                user_pubkey: row.try_get(3)?,
-                invoice_expiry: row.try_get(4)?,
-                updated_at: row.try_get(5)?,
-                is_user_nostr_key: row.try_get(6)?,
-            })
-        })
-        .transpose()?;
-        Ok(maybe_zap)
-    }
-
     async fn insert_lnurl_sender_comment(
         &self,
         comment: &LnurlSenderComment,

--- a/crates/breez-sdk/lnurl/src/repository.rs
+++ b/crates/breez-sdk/lnurl/src/repository.rs
@@ -81,10 +81,6 @@ pub trait LnurlRepository {
     ) -> Result<(), LnurlRepositoryError>;
 
     async fn upsert_zap(&self, zap: &Zap) -> Result<(), LnurlRepositoryError>;
-    async fn get_zap_by_payment_hash(
-        &self,
-        payment_hash: &str,
-    ) -> Result<Option<Zap>, LnurlRepositoryError>;
     async fn insert_lnurl_sender_comment(
         &self,
         comment: &LnurlSenderComment,

--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -13,12 +13,11 @@ use bitcoin::{
 use lightning_invoice::Bolt11Invoice;
 use lnurl_models::{
     CheckUsernameAvailableResponse, InvoicePaidRequest, InvoicesPaidRequest, ListMetadataRequest,
-    ListMetadataResponse, PublishZapReceiptRequest, PublishZapReceiptResponse,
-    RecoverLnurlPayRequest, RecoverLnurlPayResponse, RegisterLnurlPayRequest,
+    ListMetadataResponse, RecoverLnurlPayRequest, RecoverLnurlPayResponse, RegisterLnurlPayRequest,
     RegisterLnurlPayResponse, TransferLnurlPayRequest, TransferLnurlPayResponse,
     UnregisterLnurlPayRequest, sanitize_username,
 };
-use nostr::{Alphabet, Event, EventBuilder, JsonUtil, Kind, TagStandard, key::Keys};
+use nostr::{Alphabet, Event, JsonUtil, Kind, TagStandard};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -43,8 +42,6 @@ use crate::{
 const ACCEPTABLE_TIME_DIFF_SECS: u64 = 600;
 const DEFAULT_METADATA_OFFSET: u32 = 0;
 const DEFAULT_METADATA_LIMIT: u32 = 100;
-/// Maximum number of nostr relays to connect to when publishing zap receipts.
-const MAX_NOSTR_RELAYS: usize = 10;
 /// Maximum size (bytes) of a nostr event JSON (zap request or zap receipt).
 const MAX_NOSTR_EVENT_SIZE: usize = 32_768;
 /// Maximum length of a sender comment (LUD-12).
@@ -364,272 +361,6 @@ where
                 )
             })?;
         Ok(Json(ListMetadataResponse { metadata }))
-    }
-
-    #[allow(clippy::too_many_lines)]
-    pub async fn publish_zap_receipt(
-        Path((pubkey, payment_hash)): Path<(String, String)>,
-        Extension(state): Extension<State<DB>>,
-        Json(payload): Json<PublishZapReceiptRequest>,
-    ) -> Result<Json<PublishZapReceiptResponse>, (StatusCode, Json<Value>)> {
-        let pubkey = validate(
-            &pubkey,
-            &payload.signature,
-            &payload.zap_receipt,
-            payload.timestamp,
-            &state,
-        )
-        .await?;
-
-        if payload.zap_receipt.len() > MAX_NOSTR_EVENT_SIZE {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "zap receipt too large"})),
-            ));
-        }
-
-        // Parse and validate the zap receipt
-        let zap_receipt = Event::from_json(&payload.zap_receipt).map_err(|e| {
-            trace!("invalid zap receipt, could not parse: {}", e);
-            (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "invalid zap receipt"})),
-            )
-        })?;
-
-        // Validate it's a zap receipt (kind 9735)
-        if zap_receipt.kind != Kind::ZapReceipt {
-            trace!(
-                "event is not a zap receipt, got kind: {:?}",
-                zap_receipt.kind
-            );
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "event is not a zap receipt"})),
-            ));
-        }
-
-        // Verify the zap receipt signature
-        if zap_receipt.verify().is_err() {
-            trace!("invalid zap receipt signature");
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "invalid zap receipt signature"})),
-            ));
-        }
-
-        // Extract preimage from zap receipt for LUD-21 backward compatibility
-        // This allows old clients using publish_zap_receipt to still populate
-        // the invoice's preimage for the verify endpoint
-        let preimage_from_receipt = zap_receipt.tags.iter().find_map(|t| {
-            if let Some(TagStandard::Preimage(p)) = t.as_standardized() {
-                Some(p.clone())
-            } else {
-                None
-            }
-        });
-
-        // Get the existing zap record
-        let mut zap = state
-            .db
-            .get_zap_by_payment_hash(&payment_hash)
-            .await
-            .map_err(|e| {
-                error!("failed to query zap: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": "internal server error"})),
-                )
-            })?
-            .ok_or_else(|| {
-                trace!("zap not found for payment hash: {}", payment_hash);
-                (
-                    StatusCode::NOT_FOUND,
-                    Json(json!({"error": "zap not found"})),
-                )
-            })?;
-
-        // Verify the zap belongs to this user
-        if zap.user_pubkey != pubkey.to_string() {
-            trace!("zap does not belong to this user");
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(json!({"error": "unauthorized"})),
-            ));
-        }
-
-        // If we have a preimage, call the invoice paid handler for LUD-21 compatibility
-        // This ensures the preimage is stored in the invoices table
-        if let Some(preimage) = &preimage_from_receipt {
-            match handle_invoice_paid(
-                &state.db,
-                &state.webhook_service,
-                &payment_hash,
-                preimage,
-                None,
-                &state.invoice_paid_trigger,
-            )
-            .await
-            {
-                Err(HandleInvoicePaidError::InvalidPreimage(_)) => {
-                    trace!("invalid preimage in zap receipt for {}", payment_hash);
-                    return Err((
-                        StatusCode::BAD_REQUEST,
-                        Json(json!({"error": "invalid preimage"})),
-                    ));
-                }
-                Err(e) => {
-                    // Log but don't fail - this is for backward compatibility
-                    debug!(
-                        "Failed to handle invoice paid from zap receipt for {}: {}",
-                        payment_hash, e
-                    );
-                }
-                Ok(()) => {}
-            }
-        }
-
-        // Check if zap receipt already exists
-        let mut published = false;
-        if let Some(zap_receipt) = &zap.zap_event {
-            debug!(
-                "Zap receipt already exists for payment hash {}",
-                payment_hash
-            );
-            return Ok(Json(PublishZapReceiptResponse {
-                published,
-                zap_receipt: zap_receipt.clone(),
-            }));
-        }
-
-        // Parse the zap request to get relay info
-        let zap_request = Event::from_json(&zap.zap_request).map_err(|e| {
-            error!("failed to parse stored zap request: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "internal server error"})),
-            )
-        })?;
-
-        // Determine if we need to recreate the zap receipt with server nostr key
-        let zap_receipt = match (zap.is_user_nostr_key, &state.nostr_keys) {
-            (true, _) => zap_receipt,
-            (false, None) => {
-                warn!("server nostr keys not configured, but should publish zap receipt.");
-                return Err((
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(
-                        json!({"error": "zap receipt should be server-published, but server does not support nostr (anymore)"}),
-                    ),
-                ));
-            }
-            (false, Some(signing_keys)) => {
-                // Recreate zap receipt signed by server nostr key
-                let preimage = zap_receipt.tags.iter().find_map(|t| {
-                    if let Some(TagStandard::Preimage(p)) = t.as_standardized() {
-                        Some(p.clone())
-                    } else {
-                        None
-                    }
-                });
-
-                let invoice = zap_receipt
-                    .tags
-                    .iter()
-                    .find_map(|t| {
-                        if let Some(TagStandard::Bolt11(b)) = t.as_standardized() {
-                            Some(b)
-                        } else {
-                            None
-                        }
-                    })
-                    .ok_or_else(|| {
-                        warn!("zap receipt missing bolt11 tag");
-                        (
-                            StatusCode::BAD_REQUEST,
-                            Json(json!({"error": "zap receipt missing bolt11 tag"})),
-                        )
-                    })?;
-
-                let zap_request_event = Event::from_json(&zap.zap_request).map_err(|e| {
-                    error!("failed to parse zap request: {}", e);
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({"error": "internal server error"})),
-                    )
-                })?;
-                let builder = EventBuilder::zap_receipt(invoice, preimage, &zap_request_event);
-
-                builder.sign_with_keys(signing_keys).map_err(|e| {
-                    error!("failed to sign zap receipt: {}", e);
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({"error": "internal server error"})),
-                    )
-                })?
-            }
-        };
-
-        let relays: Vec<_> = zap_request
-            .tags
-            .iter()
-            .filter_map(|t| {
-                if let Some(TagStandard::Relays(r)) = t.as_standardized() {
-                    Some(r.clone())
-                } else {
-                    None
-                }
-            })
-            .flatten()
-            .take(MAX_NOSTR_RELAYS)
-            .collect();
-
-        if !relays.is_empty() {
-            // The nostr keys are not really needed here, but we use them to create the client
-            let publish_nostr_keys = match &state.nostr_keys {
-                Some(keys) => keys.clone(),
-                None => Keys::generate(),
-            };
-            let nostr_client = nostr_sdk::Client::new(publish_nostr_keys);
-            for r in &relays {
-                if let Err(e) = nostr_client.add_relay(r).await {
-                    warn!("Failed to add relay {r}: {e}");
-                }
-            }
-
-            nostr_client.connect().await;
-
-            if let Err(e) = nostr_client.send_event(&zap_receipt).await {
-                error!("Failed to publish zap receipt to relays: {e}");
-            } else {
-                debug!("Published zap receipt to {} relays", relays.len());
-                published = true;
-            }
-
-            nostr_client.disconnect().await;
-        }
-
-        let zap_receipt_json = zap_receipt.try_as_json().map_err(|e| {
-            error!("failed to serialize zap receipt: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "internal server error"})),
-            )
-        })?;
-        zap.zap_event = Some(zap_receipt_json.clone());
-        zap.updated_at = now_millis();
-        state.db.upsert_zap(&zap).await.map_err(|e| {
-            error!("failed to save zap receipt: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "internal server error"})),
-            )
-        })?;
-
-        Ok(Json(PublishZapReceiptResponse {
-            published,
-            zap_receipt: zap_receipt_json,
-        }))
     }
 
     pub async fn handle_lnurl_pay(
@@ -1581,12 +1312,6 @@ mod tests {
         }
         async fn upsert_zap(&self, _: &Zap) -> Result<(), LnurlRepositoryError> {
             Ok(())
-        }
-        async fn get_zap_by_payment_hash(
-            &self,
-            _: &str,
-        ) -> Result<Option<Zap>, LnurlRepositoryError> {
-            Ok(None)
         }
         async fn insert_lnurl_sender_comment(
             &self,

--- a/crates/breez-sdk/lnurl/src/sqlite/repository.rs
+++ b/crates/breez-sdk/lnurl/src/sqlite/repository.rs
@@ -174,34 +174,6 @@ impl crate::repository::LnurlRepository for LnurlRepository {
         Ok(())
     }
 
-    async fn get_zap_by_payment_hash(
-        &self,
-        payment_hash: &str,
-    ) -> Result<Option<Zap>, LnurlRepositoryError> {
-        let maybe_zap = sqlx::query(
-            "SELECT payment_hash, zap_request, zap_event
-            , user_pubkey, invoice_expiry, updated_at, is_user_nostr_key
-                FROM zaps
-                WHERE payment_hash = $1",
-        )
-        .bind(payment_hash)
-        .fetch_optional(&self.pool)
-        .await?
-        .map(|row| {
-            Ok::<_, sqlx::Error>(Zap {
-                payment_hash: row.try_get(0)?,
-                zap_request: row.try_get(1)?,
-                zap_event: row.try_get(2)?,
-                user_pubkey: row.try_get(3)?,
-                invoice_expiry: row.try_get(4)?,
-                updated_at: row.try_get(5)?,
-                is_user_nostr_key: row.try_get(6)?,
-            })
-        })
-        .transpose()?;
-        Ok(maybe_zap)
-    }
-
     async fn insert_lnurl_sender_comment(
         &self,
         comment: &LnurlSenderComment,


### PR DESCRIPTION
The legacy zap-receipt endpoint has been superseded by the background zap publishing path, which automatically publishes receipts after payment. SDK clients stopped calling this endpoint in v0.12.3.