### PR TITLE
lnurl: remove unused invoice-paid endpoints

### DIFF
--- a/crates/breez-sdk/lnurl-models/src/lib.rs
+++ b/crates/breez-sdk/lnurl-models/src/lib.rs
@@ -88,26 +88,6 @@ pub struct ListMetadataMetadata {
     pub preimage: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct InvoicePaidRequest {
-    pub signature: String,
-    pub timestamp: u64,
-    pub preimage: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct InvoicesPaidRequest {
-    pub signature: String,
-    pub timestamp: u64,
-    pub invoices: Vec<PaidInvoice>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PaidInvoice {
-    pub preimage: String,
-    pub invoice: String,
-}
-
 pub fn sanitize_username(username: &str) -> String {
     username.trim().to_lowercase()
 }

--- a/crates/breez-sdk/lnurl/src/invoice_paid.rs
+++ b/crates/breez-sdk/lnurl/src/invoice_paid.rs
@@ -1,8 +1,4 @@
-use std::str::FromStr;
-
 use bitcoin::hashes::{Hash, sha256};
-use lightning_invoice::Bolt11Invoice;
-use lnurl_models::PaidInvoice;
 use tokio::sync::watch;
 use tracing::{debug, error};
 
@@ -12,8 +8,6 @@ use crate::webhooks::{WebhookRepository, WebhookService};
 
 #[derive(Debug, thiserror::Error)]
 pub enum HandleInvoicePaidError {
-    #[error("invalid invoice: {0}")]
-    InvalidInvoice(String),
     #[error("invalid preimage: {0}")]
     InvalidPreimage(String),
     #[error(transparent)]
@@ -91,105 +85,6 @@ where
     Ok(())
 }
 
-/// Handle multiple invoices being paid by storing preimages and queueing for background
-/// processing in batch. Only processes invoices for payment hashes the server already
-/// knows about (has an existing invoice, zap, or sender comment record).
-/// Existing invoices are only updated if they belong to the same user and don't already
-/// have a preimage.
-pub async fn handle_invoices_paid<DB>(
-    db: &DB,
-    webhook_service: &WebhookService<DB>,
-    items: &[PaidInvoice],
-    user_pubkey: &str,
-    trigger: &watch::Sender<()>,
-) -> Result<(), HandleInvoicePaidError>
-where
-    DB: LnurlRepository + WebhookRepository + Clone + Send + Sync + 'static,
-{
-    let now = now_millis();
-    let mut invoices = Vec::with_capacity(items.len());
-
-    for item in items {
-        let preimage_bytes = hex::decode(&item.preimage).map_err(|e| {
-            HandleInvoicePaidError::InvalidPreimage(format!("could not hex-decode preimage: {e}"))
-        })?;
-        let payment_hash = sha256::Hash::hash(&preimage_bytes).to_string();
-
-        let bolt11 = Bolt11Invoice::from_str(&item.invoice).map_err(|e| {
-            HandleInvoicePaidError::InvalidInvoice(format!("invalid bolt11 invoice: {e}"))
-        })?;
-
-        if bolt11.payment_hash().to_string() != payment_hash {
-            return Err(HandleInvoicePaidError::InvalidPreimage(format!(
-                "invoice payment hash does not match preimage for hash {payment_hash}"
-            )));
-        }
-
-        let invoice_expiry = bolt11
-            .expires_at()
-            .map_or(0, |t| i64::try_from(t.as_millis()).unwrap_or(i64::MAX));
-
-        invoices.push(Invoice {
-            payment_hash,
-            user_pubkey: user_pubkey.to_string(),
-            invoice: item.invoice.clone(),
-            preimage: Some(item.preimage.clone()),
-            invoice_expiry,
-            created_at: now,
-            updated_at: now,
-            domain: None,
-            amount_received_sat: None,
-        });
-    }
-
-    // Only process invoices for payment hashes the server already knows about
-    // (has an existing invoice, zap, or sender comment).
-    let all_hashes: Vec<String> = invoices.iter().map(|i| i.payment_hash.clone()).collect();
-    let known_hashes: std::collections::HashSet<String> = db
-        .filter_known_payment_hashes(&all_hashes)
-        .await?
-        .into_iter()
-        .collect();
-
-    let invoices: Vec<Invoice> = invoices
-        .into_iter()
-        .filter(|i| known_hashes.contains(&i.payment_hash))
-        .collect();
-
-    if invoices.is_empty() {
-        debug!("No known payment hashes in invoices-paid request, skipping");
-        return Ok(());
-    }
-
-    let payment_hashes: Vec<String> = invoices.iter().map(|i| i.payment_hash.clone()).collect();
-    let affected = db.upsert_invoices_paid(&invoices).await?;
-
-    if !affected.is_empty() {
-        debug!("Stored preimages for {} invoices", affected.len());
-    }
-
-    // Enqueue for all known hashes, not just newly-affected ones, so a zap receipt
-    // is still queued if a prior attempt stored the preimage but failed before
-    // enqueueing. Idempotent via ON CONFLICT DO NOTHING, and the background
-    // publisher drops receipts that were already published.
-    crate::zap::enqueue_zap_receipts(db, &payment_hashes).await?;
-
-    // Notify for all payment hashes, not just newly-affected ones, so that
-    // webhooks are delivered even if the server crashed after storing preimages
-    // but before enqueueing webhooks. Idempotent via ON CONFLICT DO NOTHING.
-    if let Err(e) =
-        crate::webhook_notify::notify_webhooks(db, webhook_service, &payment_hashes).await
-    {
-        error!("Failed to enqueue webhooks: {}", e);
-    }
-
-    if trigger.send(()).is_err() {
-        error!("Failed to trigger background processor - receiver dropped");
-    }
-
-    Ok(())
-}
-
 /// Create a new invoice record for LUD-21 and NIP-57 support.
 pub async fn create_invoice<DB>(
     db: &DB,
@@ -252,112 +147,8 @@ mod test_helpers {
 #[cfg(test)]
 mod shared_tests {
     use super::*;
-    use crate::repository::LnurlSenderComment;
 
     use super::test_helpers::generate_test_invoice;
-
-    pub async fn invoices_paid_creates_invoice_when_only_comment_exists<DB>(db: &DB)
-    where
-        DB: LnurlRepository + WebhookRepository + Clone + Send + Sync + 'static,
-    {
-        let (trigger, _rx) = watch::channel(());
-        let webhook_service = WebhookService::new(db.clone());
-
-        let preimage_bytes = [1u8; 32];
-        let (preimage_hex, payment_hash, invoice_str) = generate_test_invoice(&preimage_bytes);
-        let user_pubkey = "test_user_pubkey";
-
-        db.insert_lnurl_sender_comment(&LnurlSenderComment {
-            comment: "hello from sender".to_string(),
-            payment_hash: payment_hash.clone(),
-            user_pubkey: user_pubkey.to_string(),
-            updated_at: 1000,
-        })
-        .await
-        .unwrap();
-
-        assert!(
-            db.get_invoice_by_payment_hash(&payment_hash)
-                .await
-                .unwrap()
-                .is_none()
-        );
-
-        handle_invoices_paid(
-            db,
-            &webhook_service,
-            &[PaidInvoice {
-                preimage: preimage_hex.clone(),
-                invoice: invoice_str.clone(),
-            }],
-            user_pubkey,
-            &trigger,
-        )
-        .await
-        .unwrap();
-
-        let stored = db
-            .get_invoice_by_payment_hash(&payment_hash)
-            .await
-            .unwrap()
-            .expect("invoice should have been created");
-        assert_eq!(stored.preimage.as_deref(), Some(preimage_hex.as_str()));
-        assert_eq!(stored.user_pubkey, user_pubkey);
-        assert_eq!(stored.invoice, invoice_str);
-    }
-
-    pub async fn invoices_paid_creates_invoice_when_only_zap_exists<DB>(db: &DB)
-    where
-        DB: LnurlRepository + WebhookRepository + Clone + Send + Sync + 'static,
-    {
-        let (trigger, _rx) = watch::channel(());
-        let webhook_service = WebhookService::new(db.clone());
-
-        let preimage_bytes = [2u8; 32];
-        let (preimage_hex, payment_hash, invoice_str) = generate_test_invoice(&preimage_bytes);
-        let user_pubkey = "test_user_pubkey";
-
-        db.upsert_zap(&crate::zap::Zap {
-            payment_hash: payment_hash.clone(),
-            zap_request: r#"{"kind":9734}"#.to_string(),
-            zap_event: None,
-            user_pubkey: user_pubkey.to_string(),
-            invoice_expiry: i64::MAX,
-            updated_at: 1000,
-            is_user_nostr_key: false,
-        })
-        .await
-        .unwrap();
-
-        assert!(
-            db.get_invoice_by_payment_hash(&payment_hash)
-                .await
-                .unwrap()
-                .is_none()
-        );
-
-        handle_invoices_paid(
-            db,
-            &webhook_service,
-            &[PaidInvoice {
-                preimage: preimage_hex.clone(),
-                invoice: invoice_str.clone(),
-            }],
-            user_pubkey,
-            &trigger,
-        )
-        .await
-        .unwrap();
-
-        let stored = db
-            .get_invoice_by_payment_hash(&payment_hash)
-            .await
-            .unwrap()
-            .expect("invoice should have been created");
-        assert_eq!(stored.preimage.as_deref(), Some(preimage_hex.as_str()));
-        assert_eq!(stored.user_pubkey, user_pubkey);
-        assert_eq!(stored.invoice, invoice_str);
-    }
 
     /// Regression: a prior attempt stored the preimage but failed before
     /// enqueueing the zap receipt. A subsequent call must still enqueue it,
@@ -418,155 +209,6 @@ mod shared_tests {
         );
     }
 
-    /// Batch variant of the regression above: an already-paid invoice is not in
-    /// `affected`, so the zap must be enqueued from the full known-hash set.
-    pub async fn invoices_paid_enqueues_zap_when_preimage_already_stored<DB>(db: &DB)
-    where
-        DB: LnurlRepository + WebhookRepository + Clone + Send + Sync + 'static,
-    {
-        let (trigger, _rx) = watch::channel(());
-        let webhook_service = WebhookService::new(db.clone());
-
-        let preimage_bytes = [8u8; 32];
-        let (preimage_hex, payment_hash, invoice_str) = generate_test_invoice(&preimage_bytes);
-        let user_pubkey = "test_user_pubkey";
-
-        db.upsert_zap(&crate::zap::Zap {
-            payment_hash: payment_hash.clone(),
-            zap_request: r#"{"kind":9734}"#.to_string(),
-            zap_event: None,
-            user_pubkey: user_pubkey.to_string(),
-            invoice_expiry: i64::MAX,
-            updated_at: 1000,
-            is_user_nostr_key: false,
-        })
-        .await
-        .unwrap();
-
-        db.upsert_invoice(&Invoice {
-            payment_hash: payment_hash.clone(),
-            user_pubkey: user_pubkey.to_string(),
-            invoice: invoice_str.clone(),
-            preimage: Some(preimage_hex.clone()),
-            invoice_expiry: i64::MAX,
-            created_at: 1000,
-            updated_at: 1000,
-            domain: None,
-            amount_received_sat: None,
-        })
-        .await
-        .unwrap();
-
-        handle_invoices_paid(
-            db,
-            &webhook_service,
-            &[PaidInvoice {
-                preimage: preimage_hex,
-                invoice: invoice_str,
-            }],
-            user_pubkey,
-            &trigger,
-        )
-        .await
-        .unwrap();
-
-        let pending = db.take_pending_zap_receipts(100).await.unwrap();
-        assert!(
-            pending.iter().any(|p| p.payment_hash == payment_hash),
-            "zap receipt must be enqueued even when the preimage was already stored"
-        );
-    }
-
-    pub async fn invoices_paid_ignores_unknown_payment_hash<DB>(db: &DB)
-    where
-        DB: LnurlRepository + WebhookRepository + Clone + Send + Sync + 'static,
-    {
-        let (trigger, _rx) = watch::channel(());
-        let webhook_service = WebhookService::new(db.clone());
-
-        let preimage_bytes = [3u8; 32];
-        let (preimage_hex, payment_hash, invoice_str) = generate_test_invoice(&preimage_bytes);
-        let user_pubkey = "test_user_pubkey";
-
-        handle_invoices_paid(
-            db,
-            &webhook_service,
-            &[PaidInvoice {
-                preimage: preimage_hex,
-                invoice: invoice_str,
-            }],
-            user_pubkey,
-            &trigger,
-        )
-        .await
-        .unwrap();
-
-        assert!(
-            db.get_invoice_by_payment_hash(&payment_hash)
-                .await
-                .unwrap()
-                .is_none(),
-            "invoice should not be created for unknown payment hash"
-        );
-    }
-
-    pub async fn invoices_paid_filters_mixed_batch<DB>(db: &DB)
-    where
-        DB: LnurlRepository + WebhookRepository + Clone + Send + Sync + 'static,
-    {
-        let (trigger, _rx) = watch::channel(());
-        let webhook_service = WebhookService::new(db.clone());
-        let user_pubkey = "test_user_pubkey";
-
-        let known_preimage = [4u8; 32];
-        let (known_hex, known_hash, known_invoice) = generate_test_invoice(&known_preimage);
-        db.insert_lnurl_sender_comment(&LnurlSenderComment {
-            comment: "known".to_string(),
-            payment_hash: known_hash.clone(),
-            user_pubkey: user_pubkey.to_string(),
-            updated_at: 1000,
-        })
-        .await
-        .unwrap();
-
-        let unknown_preimage = [5u8; 32];
-        let (unknown_hex, unknown_hash, unknown_invoice) = generate_test_invoice(&unknown_preimage);
-
-        handle_invoices_paid(
-            db,
-            &webhook_service,
-            &[
-                PaidInvoice {
-                    preimage: known_hex.clone(),
-                    invoice: known_invoice.clone(),
-                },
-                PaidInvoice {
-                    preimage: unknown_hex,
-                    invoice: unknown_invoice,
-                },
-            ],
-            user_pubkey,
-            &trigger,
-        )
-        .await
-        .unwrap();
-
-        let stored = db
-            .get_invoice_by_payment_hash(&known_hash)
-            .await
-            .unwrap()
-            .expect("known invoice should have been created");
-        assert_eq!(stored.preimage.as_deref(), Some(known_hex.as_str()));
-
-        assert!(
-            db.get_invoice_by_payment_hash(&unknown_hash)
-                .await
-                .unwrap()
-                .is_none(),
-            "unknown invoice should not be created"
-        );
-    }
-
     pub async fn get_or_create_setting_returns_default_on_first_call<DB>(db: &DB)
     where
         DB: LnurlRepository + Clone + Send + Sync + 'static,
@@ -612,39 +254,9 @@ mod sqlite_tests {
     }
 
     #[tokio::test]
-    async fn invoices_paid_creates_invoice_when_only_comment_exists() {
-        let db = setup_test_db().await;
-        shared_tests::invoices_paid_creates_invoice_when_only_comment_exists(&db).await;
-    }
-
-    #[tokio::test]
-    async fn invoices_paid_creates_invoice_when_only_zap_exists() {
-        let db = setup_test_db().await;
-        shared_tests::invoices_paid_creates_invoice_when_only_zap_exists(&db).await;
-    }
-
-    #[tokio::test]
     async fn invoice_paid_enqueues_zap_when_preimage_already_stored() {
         let db = setup_test_db().await;
         shared_tests::invoice_paid_enqueues_zap_when_preimage_already_stored(&db).await;
-    }
-
-    #[tokio::test]
-    async fn invoices_paid_enqueues_zap_when_preimage_already_stored() {
-        let db = setup_test_db().await;
-        shared_tests::invoices_paid_enqueues_zap_when_preimage_already_stored(&db).await;
-    }
-
-    #[tokio::test]
-    async fn invoices_paid_ignores_unknown_payment_hash() {
-        let db = setup_test_db().await;
-        shared_tests::invoices_paid_ignores_unknown_payment_hash(&db).await;
-    }
-
-    #[tokio::test]
-    async fn invoices_paid_filters_mixed_batch() {
-        let db = setup_test_db().await;
-        shared_tests::invoices_paid_filters_mixed_batch(&db).await;
     }
 
     #[tokio::test]
@@ -689,51 +301,11 @@ mod postgres_tests {
     }
 
     #[tokio::test]
-    async fn invoices_paid_creates_invoice_when_only_comment_exists() {
-        let Some(db) = setup_test_db().await else {
-            return;
-        };
-        shared_tests::invoices_paid_creates_invoice_when_only_comment_exists(&db).await;
-    }
-
-    #[tokio::test]
-    async fn invoices_paid_creates_invoice_when_only_zap_exists() {
-        let Some(db) = setup_test_db().await else {
-            return;
-        };
-        shared_tests::invoices_paid_creates_invoice_when_only_zap_exists(&db).await;
-    }
-
-    #[tokio::test]
     async fn invoice_paid_enqueues_zap_when_preimage_already_stored() {
         let Some(db) = setup_test_db().await else {
             return;
         };
         shared_tests::invoice_paid_enqueues_zap_when_preimage_already_stored(&db).await;
-    }
-
-    #[tokio::test]
-    async fn invoices_paid_enqueues_zap_when_preimage_already_stored() {
-        let Some(db) = setup_test_db().await else {
-            return;
-        };
-        shared_tests::invoices_paid_enqueues_zap_when_preimage_already_stored(&db).await;
-    }
-
-    #[tokio::test]
-    async fn invoices_paid_ignores_unknown_payment_hash() {
-        let Some(db) = setup_test_db().await else {
-            return;
-        };
-        shared_tests::invoices_paid_ignores_unknown_payment_hash(&db).await;
-    }
-
-    #[tokio::test]
-    async fn invoices_paid_filters_mixed_batch() {
-        let Some(db) = setup_test_db().await else {
-            return;
-        };
-        shared_tests::invoices_paid_filters_mixed_batch(&db).await;
     }
 
     #[tokio::test]

--- a/crates/breez-sdk/lnurl/src/main.rs
+++ b/crates/breez-sdk/lnurl/src/main.rs
@@ -505,14 +505,6 @@ where
             "/lnurlpay/{pubkey}/metadata",
             get(LnurlServer::<DB>::list_metadata),
         )
-        .route(
-            "/lnurlpay/{pubkey}/invoice-paid",
-            post(LnurlServer::<DB>::invoice_paid),
-        )
-        .route(
-            "/lnurlpay/{pubkey}/invoices-paid",
-            post(LnurlServer::<DB>::invoices_paid),
-        )
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             auth::auth::<DB>,

--- a/crates/breez-sdk/lnurl/src/postgresql/repository.rs
+++ b/crates/breez-sdk/lnurl/src/postgresql/repository.rs
@@ -296,27 +296,6 @@ impl crate::repository::LnurlRepository for LnurlRepository {
         Ok(())
     }
 
-    async fn filter_known_payment_hashes(
-        &self,
-        payment_hashes: &[String],
-    ) -> Result<Vec<String>, LnurlRepositoryError> {
-        if payment_hashes.is_empty() {
-            return Ok(vec![]);
-        }
-
-        let known: Vec<String> = sqlx::query_scalar(
-            "SELECT payment_hash FROM invoices WHERE payment_hash = ANY($1)
-             UNION
-             SELECT payment_hash FROM zaps WHERE payment_hash = ANY($1)
-             UNION
-             SELECT payment_hash FROM sender_comments WHERE payment_hash = ANY($1)",
-        )
-        .bind(payment_hashes)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(known)
-    }
-
     async fn upsert_invoice(&self, invoice: &Invoice) -> Result<(), LnurlRepositoryError> {
         sqlx::query(
             "INSERT INTO invoices (payment_hash, user_pubkey, invoice, preimage, invoice_expiry, created_at, updated_at, domain, amount_received_sat)
@@ -342,47 +321,6 @@ impl crate::repository::LnurlRepository for LnurlRepository {
         .execute(&self.pool)
         .await?;
         Ok(())
-    }
-
-    async fn upsert_invoices_paid(
-        &self,
-        invoices: &[Invoice],
-    ) -> Result<Vec<String>, LnurlRepositoryError> {
-        if invoices.is_empty() {
-            return Ok(vec![]);
-        }
-        let payment_hashes: Vec<&str> = invoices.iter().map(|i| i.payment_hash.as_str()).collect();
-        let user_pubkeys: Vec<&str> = invoices.iter().map(|i| i.user_pubkey.as_str()).collect();
-        let invoice_strs: Vec<&str> = invoices.iter().map(|i| i.invoice.as_str()).collect();
-        let preimages: Vec<Option<&str>> = invoices.iter().map(|i| i.preimage.as_deref()).collect();
-        let invoice_expiries: Vec<i64> = invoices.iter().map(|i| i.invoice_expiry).collect();
-        let created_ats: Vec<i64> = invoices.iter().map(|i| i.created_at).collect();
-        let updated_ats: Vec<i64> = invoices.iter().map(|i| i.updated_at).collect();
-
-        let rows = sqlx::query(
-            "INSERT INTO invoices (payment_hash, user_pubkey, invoice, preimage, invoice_expiry, created_at, updated_at)
-             SELECT * FROM UNNEST($1::text[], $2::text[], $3::text[], $4::text[], $5::bigint[], $6::bigint[], $7::bigint[])
-             ON CONFLICT(payment_hash) DO UPDATE
-             SET preimage = excluded.preimage
-             ,   updated_at = excluded.updated_at
-             WHERE invoices.user_pubkey = excluded.user_pubkey AND invoices.preimage IS NULL
-             RETURNING payment_hash",
-        )
-        .bind(&payment_hashes)
-        .bind(&user_pubkeys)
-        .bind(&invoice_strs)
-        .bind(&preimages)
-        .bind(&invoice_expiries)
-        .bind(&created_ats)
-        .bind(&updated_ats)
-        .fetch_all(&self.pool)
-        .await?;
-
-        let affected = rows
-            .into_iter()
-            .map(|row| row.try_get(0))
-            .collect::<Result<Vec<String>, sqlx::Error>>()?;
-        Ok(affected)
     }
 
     async fn get_invoice_by_payment_hash(
@@ -490,32 +428,6 @@ impl crate::repository::LnurlRepository for LnurlRepository {
         .bind(pending.created_at)
         .bind(pending.retry_count)
         .bind(pending.next_retry_at)
-        .execute(&self.pool)
-        .await?;
-        Ok(())
-    }
-
-    async fn insert_pending_zap_receipt_batch(
-        &self,
-        pending: &[PendingZapReceipt],
-    ) -> Result<(), LnurlRepositoryError> {
-        if pending.is_empty() {
-            return Ok(());
-        }
-        let payment_hashes: Vec<&str> = pending.iter().map(|n| n.payment_hash.as_str()).collect();
-        let created_ats: Vec<i64> = pending.iter().map(|n| n.created_at).collect();
-        let retry_counts: Vec<i32> = pending.iter().map(|n| n.retry_count).collect();
-        let next_retry_ats: Vec<i64> = pending.iter().map(|n| n.next_retry_at).collect();
-
-        sqlx::query(
-            "INSERT INTO pending_zap_receipts (payment_hash, created_at, retry_count, next_retry_at)
-             SELECT * FROM UNNEST($1::text[], $2::bigint[], $3::int[], $4::bigint[])
-             ON CONFLICT(payment_hash) DO NOTHING",
-        )
-        .bind(&payment_hashes)
-        .bind(&created_ats)
-        .bind(&retry_counts)
-        .bind(&next_retry_ats)
         .execute(&self.pool)
         .await?;
         Ok(())

--- a/crates/breez-sdk/lnurl/src/repository.rs
+++ b/crates/breez-sdk/lnurl/src/repository.rs
@@ -102,23 +102,8 @@ pub trait LnurlRepository {
     /// Store the cached partner JWT for a domain.
     async fn set_domain_jwt(&self, domain: &str, jwt: &str) -> Result<(), LnurlRepositoryError>;
 
-    /// Filter a list of payment hashes to only those the server already knows about
-    /// (i.e. have an existing invoice, zap, or sender comment record).
-    async fn filter_known_payment_hashes(
-        &self,
-        payment_hashes: &[String],
-    ) -> Result<Vec<String>, LnurlRepositoryError>;
-
     /// Insert or update an invoice
     async fn upsert_invoice(&self, invoice: &Invoice) -> Result<(), LnurlRepositoryError>;
-
-    /// Batch upsert invoices with preimages. Inserts new records, or updates existing
-    /// ones only if they belong to the same user and don't already have a preimage.
-    /// Returns payment hashes that were actually inserted or updated.
-    async fn upsert_invoices_paid(
-        &self,
-        invoices: &[Invoice],
-    ) -> Result<Vec<String>, LnurlRepositoryError>;
 
     /// Get an invoice by payment hash
     async fn get_invoice_by_payment_hash(
@@ -135,12 +120,6 @@ pub trait LnurlRepository {
     async fn insert_pending_zap_receipt(
         &self,
         pending: &PendingZapReceipt,
-    ) -> Result<(), LnurlRepositoryError>;
-
-    /// Batch insert pending zap receipts into the queue
-    async fn insert_pending_zap_receipt_batch(
-        &self,
-        pending: &[PendingZapReceipt],
     ) -> Result<(), LnurlRepositoryError>;
 
     /// Get pending zap receipts ready for processing (`next_retry_at` <= now),

--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -12,8 +12,8 @@ use bitcoin::{
 };
 use lightning_invoice::Bolt11Invoice;
 use lnurl_models::{
-    CheckUsernameAvailableResponse, InvoicePaidRequest, InvoicesPaidRequest, ListMetadataRequest,
-    ListMetadataResponse, RecoverLnurlPayRequest, RecoverLnurlPayResponse, RegisterLnurlPayRequest,
+    CheckUsernameAvailableResponse, ListMetadataRequest, ListMetadataResponse,
+    RecoverLnurlPayRequest, RecoverLnurlPayResponse, RegisterLnurlPayRequest,
     RegisterLnurlPayResponse, TransferLnurlPayRequest, TransferLnurlPayResponse,
     UnregisterLnurlPayRequest, sanitize_username,
 };
@@ -26,9 +26,7 @@ use std::str::FromStr;
 use tracing::{debug, error, trace, warn};
 
 use crate::{
-    invoice_paid::{
-        HandleInvoicePaidError, create_invoice, handle_invoice_paid, handle_invoices_paid,
-    },
+    invoice_paid::{create_invoice, handle_invoice_paid},
     repository::LnurlSenderComment,
     time::{now_millis, now_u64},
     zap::Zap,
@@ -624,150 +622,6 @@ where
             "preimage": invoice.preimage,
             "pr": invoice.invoice
         }))
-    }
-
-    /// Invoice-paid notification endpoint (single invoice).
-    /// Deprecated: use `invoices_paid` instead, which supports batch notifications.
-    /// TODO: Remove this endpoint after all clients have migrated to `invoices_paid`.
-    pub async fn invoice_paid(
-        Path(pubkey): Path<String>,
-        Extension(state): Extension<State<DB>>,
-        Json(payload): Json<InvoicePaidRequest>,
-    ) -> Result<(), (StatusCode, Json<Value>)> {
-        let pubkey = validate(
-            &pubkey,
-            &payload.signature,
-            &payload.preimage,
-            payload.timestamp,
-            &state,
-        )
-        .await?;
-
-        let preimage_bytes = hex::decode(&payload.preimage).map_err(|e| {
-            trace!("invalid preimage, could not decode: {}", e);
-            (
-                StatusCode::BAD_REQUEST,
-                Json(Value::String("invalid preimage".into())),
-            )
-        })?;
-        let payment_hash = bitcoin::hashes::sha256::Hash::hash(&preimage_bytes);
-        let payment_hash_hex = payment_hash.to_string();
-
-        // Verify the invoice belongs to this user
-        let invoice = state
-            .db
-            .get_invoice_by_payment_hash(&payment_hash_hex)
-            .await
-            .map_err(|e| {
-                error!("Failed to get invoice: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(Value::String("internal server error".into())),
-                )
-            })?
-            .ok_or_else(|| {
-                trace!("invoice not found for payment hash: {}", payment_hash_hex);
-                (
-                    StatusCode::NOT_FOUND,
-                    Json(Value::String("invoice not found".into())),
-                )
-            })?;
-
-        if invoice.user_pubkey != pubkey.to_string() {
-            trace!("invoice does not belong to this user");
-            return Err((
-                StatusCode::NOT_FOUND,
-                Json(Value::String("invoice not found".into())),
-            ));
-        }
-
-        // Use the central invoice paid handler
-        handle_invoice_paid(
-            &state.db,
-            &state.webhook_service,
-            &payment_hash_hex,
-            &payload.preimage,
-            None,
-            &state.invoice_paid_trigger,
-        )
-        .await
-        .map_err(|e| {
-            error!("Failed to handle invoice paid: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(Value::String("internal server error".into())),
-            )
-        })?;
-
-        debug!(
-            "Invoice paid notification received for payment hash {}",
-            payment_hash_hex
-        );
-        Ok(())
-    }
-
-    /// Batch invoices-paid notification endpoint.
-    /// Client notifies server that multiple invoices were paid with their preimages.
-    pub async fn invoices_paid(
-        Path(pubkey): Path<String>,
-        Extension(state): Extension<State<DB>>,
-        Json(payload): Json<InvoicesPaidRequest>,
-    ) -> Result<(), (StatusCode, Json<Value>)> {
-        const MAX_PREIMAGES: usize = 100;
-
-        if payload.invoices.is_empty() {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(Value::String("invoices must not be empty".into())),
-            ));
-        }
-
-        if payload.invoices.len() > MAX_PREIMAGES {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(Value::String(format!(
-                    "too many invoices, max is {MAX_PREIMAGES}"
-                ))),
-            ));
-        }
-
-        let pubkey = validate(
-            &pubkey,
-            &payload.signature,
-            &pubkey,
-            payload.timestamp,
-            &state,
-        )
-        .await?;
-
-        handle_invoices_paid(
-            &state.db,
-            &state.webhook_service,
-            &payload.invoices,
-            &pubkey.to_string(),
-            &state.invoice_paid_trigger,
-        )
-        .await
-        .map_err(|e| match &e {
-            HandleInvoicePaidError::InvalidInvoice(msg)
-            | HandleInvoicePaidError::InvalidPreimage(msg) => {
-                trace!("Invalid input in invoices-paid: {}", msg);
-                (StatusCode::BAD_REQUEST, Json(Value::String(msg.clone())))
-            }
-            HandleInvoicePaidError::Repository(_) => {
-                error!("Failed to handle invoices paid: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(Value::String("internal server error".into())),
-                )
-            }
-        })?;
-
-        debug!(
-            "Invoices paid notification received for {} invoices",
-            payload.invoices.len()
-        );
-        Ok(())
     }
 
     /// Webhook endpoint for SSP payment notifications.
@@ -1394,34 +1248,6 @@ mod tests {
                 .lock()
                 .unwrap()
                 .remove(payment_hash);
-            Ok(())
-        }
-        async fn filter_known_payment_hashes(
-            &self,
-            _payment_hashes: &[String],
-        ) -> Result<Vec<String>, LnurlRepositoryError> {
-            Ok(vec![])
-        }
-        async fn upsert_invoices_paid(
-            &self,
-            invoices: &[Invoice],
-        ) -> Result<Vec<String>, LnurlRepositoryError> {
-            let mut store = self.invoices.lock().unwrap();
-            let mut updated = Vec::new();
-            for invoice in invoices {
-                store.insert(invoice.payment_hash.clone(), invoice.clone());
-                updated.push(invoice.payment_hash.clone());
-            }
-            Ok(updated)
-        }
-        async fn insert_pending_zap_receipt_batch(
-            &self,
-            pending: &[PendingZapReceipt],
-        ) -> Result<(), LnurlRepositoryError> {
-            let mut store = self.pending_zap_receipts.lock().unwrap();
-            for p in pending {
-                store.insert(p.payment_hash.clone(), p.clone());
-            }
             Ok(())
         }
         async fn get_or_create_setting(

--- a/crates/breez-sdk/lnurl/src/sqlite/repository.rs
+++ b/crates/breez-sdk/lnurl/src/sqlite/repository.rs
@@ -289,38 +289,6 @@ impl crate::repository::LnurlRepository for LnurlRepository {
         Ok(())
     }
 
-    async fn filter_known_payment_hashes(
-        &self,
-        payment_hashes: &[String],
-    ) -> Result<Vec<String>, LnurlRepositoryError> {
-        if payment_hashes.is_empty() {
-            return Ok(vec![]);
-        }
-
-        let placeholders: Vec<String> = (1..=payment_hashes.len())
-            .map(|i| format!("${i}"))
-            .collect();
-        let placeholders = placeholders.join(",");
-
-        let query = format!(
-            "SELECT payment_hash FROM invoices WHERE payment_hash IN ({placeholders})
-             UNION
-             SELECT payment_hash FROM zaps WHERE payment_hash IN ({placeholders})
-             UNION
-             SELECT payment_hash FROM sender_comments WHERE payment_hash IN ({placeholders})"
-        );
-
-        let mut q = sqlx::query_scalar::<_, String>(&query);
-        // Bind three times (once per subquery in the UNION)
-        for _ in 0..3 {
-            for hash in payment_hashes {
-                q = q.bind(hash);
-            }
-        }
-        let known = q.fetch_all(&self.pool).await?;
-        Ok(known)
-    }
-
     async fn upsert_invoice(&self, invoice: &Invoice) -> Result<(), LnurlRepositoryError> {
         sqlx::query(
             "INSERT INTO invoices (payment_hash, user_pubkey, invoice, preimage, invoice_expiry, created_at, updated_at, domain, amount_received_sat)
@@ -346,48 +314,6 @@ impl crate::repository::LnurlRepository for LnurlRepository {
         .execute(&self.pool)
         .await?;
         Ok(())
-    }
-
-    async fn upsert_invoices_paid(
-        &self,
-        invoices: &[Invoice],
-    ) -> Result<Vec<String>, LnurlRepositoryError> {
-        if invoices.is_empty() {
-            return Ok(vec![]);
-        }
-        let mut tx = self
-            .pool
-            .begin()
-            .await
-            .map_err(|e| LnurlRepositoryError::General(e.into()))?;
-        let mut affected = Vec::new();
-        for invoice in invoices {
-            let row: Option<(String,)> = sqlx::query_as(
-                "INSERT INTO invoices (payment_hash, user_pubkey, invoice, preimage, invoice_expiry, created_at, updated_at)
-                VALUES ($1, $2, $3, $4, $5, $6, $7)
-                ON CONFLICT(payment_hash) DO UPDATE SET
-                    preimage = excluded.preimage,
-                    updated_at = excluded.updated_at
-                WHERE invoices.user_pubkey = excluded.user_pubkey AND invoices.preimage IS NULL
-                RETURNING payment_hash",
-            )
-            .bind(&invoice.payment_hash)
-            .bind(&invoice.user_pubkey)
-            .bind(&invoice.invoice)
-            .bind(&invoice.preimage)
-            .bind(invoice.invoice_expiry)
-            .bind(invoice.created_at)
-            .bind(invoice.updated_at)
-            .fetch_optional(&mut *tx)
-            .await?;
-            if let Some((payment_hash,)) = row {
-                affected.push(payment_hash);
-            }
-        }
-        tx.commit()
-            .await
-            .map_err(|e| LnurlRepositoryError::General(e.into()))?;
-        Ok(affected)
     }
 
     async fn get_invoice_by_payment_hash(
@@ -497,37 +423,6 @@ impl crate::repository::LnurlRepository for LnurlRepository {
         .bind(pending.next_retry_at)
         .execute(&self.pool)
         .await?;
-        Ok(())
-    }
-
-    async fn insert_pending_zap_receipt_batch(
-        &self,
-        pending: &[PendingZapReceipt],
-    ) -> Result<(), LnurlRepositoryError> {
-        if pending.is_empty() {
-            return Ok(());
-        }
-        let mut tx = self
-            .pool
-            .begin()
-            .await
-            .map_err(|e| LnurlRepositoryError::General(e.into()))?;
-        for item in pending {
-            sqlx::query(
-                "INSERT INTO pending_zap_receipts (payment_hash, created_at, retry_count, next_retry_at)
-                 VALUES ($1, $2, $3, $4)
-                 ON CONFLICT(payment_hash) DO NOTHING",
-            )
-            .bind(&item.payment_hash)
-            .bind(item.created_at)
-            .bind(item.retry_count)
-            .bind(item.next_retry_at)
-            .execute(&mut *tx)
-            .await?;
-        }
-        tx.commit()
-            .await
-            .map_err(|e| LnurlRepositoryError::General(e.into()))?;
         Ok(())
     }
 

--- a/crates/breez-sdk/lnurl/src/zap.rs
+++ b/crates/breez-sdk/lnurl/src/zap.rs
@@ -32,30 +32,6 @@ where
     db.insert_pending_zap_receipt(&pending).await
 }
 
-/// Enqueue multiple zap receipts for background publishing.
-pub async fn enqueue_zap_receipts<DB>(
-    db: &DB,
-    payment_hashes: &[String],
-) -> Result<(), LnurlRepositoryError>
-where
-    DB: LnurlRepository,
-{
-    if payment_hashes.is_empty() {
-        return Ok(());
-    }
-    let now = now_millis();
-    let pending: Vec<PendingZapReceipt> = payment_hashes
-        .iter()
-        .map(|payment_hash| PendingZapReceipt {
-            payment_hash: payment_hash.clone(),
-            created_at: now,
-            retry_count: 0,
-            next_retry_at: now,
-        })
-        .collect();
-    db.insert_pending_zap_receipt_batch(&pending).await
-}
-
 // -- Background processor for publishing zap receipts to nostr relays ----------
 
 use nostr::{JsonUtil, TagStandard};


### PR DESCRIPTION
Similar to #1001, this removes the invoice-paid endpoints, which haven't been used since v0.12.3 (for the batch version) and since v0.11 (for the non-batch version). 