### PR TITLE
lnurl: harden the unregister endpoint

### DIFF
--- a/crates/breez-sdk/core/src/lnurl.rs
+++ b/crates/breez-sdk/core/src/lnurl.rs
@@ -297,7 +297,9 @@ impl LnurlServerClient for DefaultLnurlServerClient {
     ) -> Result<(), LnurlServerError> {
         let pubkey = self.wallet.get_identity_public_key();
 
-        let (signature, timestamp) = self.sign_message(&request.username).await?;
+        let (signature, timestamp) = self
+            .sign_message(&format!("unregister:{}", request.username))
+            .await?;
 
         let api_request = UnregisterLnurlPayRequest {
             username: request.username.clone(),

--- a/crates/breez-sdk/core/src/sdk/lightning_address.rs
+++ b/crates/breez-sdk/core/src/sdk/lightning_address.rs
@@ -4,7 +4,7 @@ use lnurl_models::sanitize_username;
 use crate::{
     AuthorizeTransferRequest, CheckLightningAddressRequest, ClaimTransferRequest,
     LightningAddressInfo, LnurlInfo, RegisterLightningAddressRequest, TransferAuthorization,
-    error::SdkError, persist::ObjectCacheRepository,
+    error::SdkError, lnurl::LnurlServerError, persist::ObjectCacheRepository,
 };
 
 use super::BreezSdk;
@@ -153,7 +153,24 @@ impl BreezSdk {
             username: address_info.username,
         };
 
-        client.unregister_lightning_address(&params).await?;
+        match client.unregister_lightning_address(&params).await {
+            Ok(()) => {}
+            // A 409 means the cached username is not the address the server
+            // holds, so the signature authorized deleting a name this wallet no
+            // longer has (another device re-registered under the same identity
+            // key). Resync from the server, which leaves a retry signing the
+            // real address.
+            Err(
+                e @ LnurlServerError::Network {
+                    statuscode: 409, ..
+                },
+            ) => {
+                self.recover_lightning_address().await?;
+                return Err(e.into());
+            }
+            Err(e) => return Err(e.into()),
+        }
+
         cache.delete_lightning_address(false).await?;
         Ok(())
     }

--- a/crates/breez-sdk/lnurl/src/postgresql/repository.rs
+++ b/crates/breez-sdk/lnurl/src/postgresql/repository.rs
@@ -32,14 +32,15 @@ impl crate::repository::LnurlRepository for LnurlRepository {
         domain: &str,
         pubkey: &str,
         name: &str,
-    ) -> Result<(), LnurlRepositoryError> {
-        sqlx::query("DELETE FROM users WHERE domain = $1 AND pubkey = $2 AND name = $3")
-            .bind(domain)
-            .bind(pubkey)
-            .bind(name)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
+    ) -> Result<bool, LnurlRepositoryError> {
+        let result =
+            sqlx::query("DELETE FROM users WHERE domain = $1 AND pubkey = $2 AND name = $3")
+                .bind(domain)
+                .bind(pubkey)
+                .bind(name)
+                .execute(&self.pool)
+                .await?;
+        Ok(result.rows_affected() > 0)
     }
 
     async fn get_user_by_name(

--- a/crates/breez-sdk/lnurl/src/postgresql/repository.rs
+++ b/crates/breez-sdk/lnurl/src/postgresql/repository.rs
@@ -27,10 +27,16 @@ impl LnurlRepository {
 
 #[async_trait::async_trait]
 impl crate::repository::LnurlRepository for LnurlRepository {
-    async fn delete_user(&self, domain: &str, pubkey: &str) -> Result<(), LnurlRepositoryError> {
-        sqlx::query("DELETE FROM users WHERE domain = $1 AND pubkey = $2")
+    async fn delete_user(
+        &self,
+        domain: &str,
+        pubkey: &str,
+        name: &str,
+    ) -> Result<(), LnurlRepositoryError> {
+        sqlx::query("DELETE FROM users WHERE domain = $1 AND pubkey = $2 AND name = $3")
             .bind(domain)
             .bind(pubkey)
+            .bind(name)
             .execute(&self.pool)
             .await?;
         Ok(())
@@ -900,5 +906,14 @@ mod postgres_tests {
         };
         let db = super::LnurlRepository::new(pool);
         shared_tests::registering_taken_name_with_other_pubkey_is_rejected(&db).await;
+    }
+
+    #[tokio::test]
+    async fn deleting_a_name_the_pubkey_no_longer_holds_is_a_no_op() {
+        let Some(pool) = setup_pool().await else {
+            return;
+        };
+        let db = super::LnurlRepository::new(pool);
+        shared_tests::deleting_a_name_the_pubkey_no_longer_holds_is_a_no_op(&db).await;
     }
 }

--- a/crates/breez-sdk/lnurl/src/repository.rs
+++ b/crates/breez-sdk/lnurl/src/repository.rs
@@ -55,16 +55,18 @@ pub struct DomainConfig {
 #[async_trait::async_trait]
 pub trait LnurlRepository {
     /// Delete `pubkey`'s row in `domain`, but only while it still holds `name`.
+    /// Returns whether a row was removed.
     ///
     /// `name` is part of the condition so the caller's authorization check and
     /// the delete cannot disagree: a row that changed name in between is left
-    /// alone rather than deleted on the strength of a stale read.
+    /// alone rather than deleted on the strength of a stale read. The caller
+    /// reads before deleting, so `false` means the row changed in between.
     async fn delete_user(
         &self,
         domain: &str,
         pubkey: &str,
         name: &str,
-    ) -> Result<(), LnurlRepositoryError>;
+    ) -> Result<bool, LnurlRepositoryError>;
     async fn get_user_by_name(
         &self,
         domain: &str,
@@ -272,7 +274,11 @@ pub mod shared_tests {
         .await
         .unwrap();
 
-        db.delete_user("a.com", "dddd", "erin").await.unwrap();
+        let removed = db.delete_user("a.com", "dddd", "erin").await.unwrap();
+        assert!(
+            !removed,
+            "deleting 'erin' must report that it removed nothing"
+        );
         let held = db.get_user_by_pubkey("a.com", "dddd").await.unwrap();
         assert_eq!(
             held.map(|u| u.name),
@@ -280,7 +286,8 @@ pub mod shared_tests {
             "deleting 'erin' must not touch the 'dave' the pubkey holds"
         );
 
-        db.delete_user("a.com", "dddd", "dave").await.unwrap();
+        let removed = db.delete_user("a.com", "dddd", "dave").await.unwrap();
+        assert!(removed, "deleting the held name must report the removal");
         assert!(
             db.get_user_by_pubkey("a.com", "dddd")
                 .await

--- a/crates/breez-sdk/lnurl/src/repository.rs
+++ b/crates/breez-sdk/lnurl/src/repository.rs
@@ -54,7 +54,17 @@ pub struct DomainConfig {
 
 #[async_trait::async_trait]
 pub trait LnurlRepository {
-    async fn delete_user(&self, domain: &str, pubkey: &str) -> Result<(), LnurlRepositoryError>;
+    /// Delete `pubkey`'s row in `domain`, but only while it still holds `name`.
+    ///
+    /// `name` is part of the condition so the caller's authorization check and
+    /// the delete cannot disagree: a row that changed name in between is left
+    /// alone rather than deleted on the strength of a stale read.
+    async fn delete_user(
+        &self,
+        domain: &str,
+        pubkey: &str,
+        name: &str,
+    ) -> Result<(), LnurlRepositoryError>;
     async fn get_user_by_name(
         &self,
         domain: &str,
@@ -240,6 +250,43 @@ pub mod shared_tests {
             owner.pubkey, "aaaa",
             "existing owner was replaced, now resolves to pubkey {}",
             owner.pubkey
+        );
+    }
+
+    /// `delete_user` removes the row only while it still holds the named
+    /// address, so an unregister authorized for one name cannot delete another.
+    ///
+    /// Uses its own pubkey and name: the postgres harness shares one database
+    /// across tests that run in parallel, and `users` is keyed by
+    /// `(domain, pubkey)` with `name` unique per domain.
+    pub async fn deleting_a_name_the_pubkey_no_longer_holds_is_a_no_op<DB>(db: &DB)
+    where
+        DB: LnurlRepository + Clone + Send + Sync + 'static,
+    {
+        db.upsert_user(&User {
+            domain: "a.com".into(),
+            pubkey: "dddd".into(),
+            name: "dave".into(),
+            description: "dave".into(),
+        })
+        .await
+        .unwrap();
+
+        db.delete_user("a.com", "dddd", "erin").await.unwrap();
+        let held = db.get_user_by_pubkey("a.com", "dddd").await.unwrap();
+        assert_eq!(
+            held.map(|u| u.name),
+            Some("dave".to_string()),
+            "deleting 'erin' must not touch the 'dave' the pubkey holds"
+        );
+
+        db.delete_user("a.com", "dddd", "dave").await.unwrap();
+        assert!(
+            db.get_user_by_pubkey("a.com", "dddd")
+                .await
+                .unwrap()
+                .is_none(),
+            "deleting the held name must remove the row"
         );
     }
 

--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -266,18 +266,51 @@ where
         Json(payload): Json<UnregisterLnurlPayRequest>,
     ) -> Result<(), (StatusCode, Json<Value>)> {
         let username = sanitize_username(&payload.username);
-        let pubkey = validate(
+        let messages = unregister_candidate_messages(&username);
+        let pubkey = validate_any(
             &pubkey,
             &payload.signature,
-            &username,
+            &messages,
             payload.timestamp,
             &state,
         )
         .await?;
+        let domain = sanitize_domain(&state, &host).await?;
+
+        let registered = state
+            .db
+            .get_user_by_pubkey(&domain, &pubkey.to_string())
+            .await
+            .map_err(|e| {
+                error!("failed to execute query: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(Value::String("internal server error".into())),
+                )
+            })?;
+
+        match unregister_action(&username, registered.as_ref()) {
+            UnregisterAction::Delete => {}
+            UnregisterAction::AlreadyGone => {
+                debug!("pubkey {pubkey} holds no address, nothing to unregister");
+                return Ok(());
+            }
+            UnregisterAction::NameMismatch => {
+                debug!(
+                    "unregister signature names '{username}', not the address pubkey {pubkey} holds"
+                );
+                return Err((
+                    StatusCode::CONFLICT,
+                    Json(Value::String(
+                        "signature does not cover the registered address".into(),
+                    )),
+                ));
+            }
+        }
 
         state
             .db
-            .delete_user(&sanitize_domain(&state, &host).await?, &pubkey.to_string())
+            .delete_user(&domain, &pubkey.to_string(), &username)
             .await
             .map_err(|e| {
                 error!("failed to execute query: {}", e);
@@ -1083,13 +1116,15 @@ fn validate_description(description: &str) -> Result<(), (StatusCode, Json<Value
     Ok(())
 }
 
-async fn validate<DB>(
+/// Parse a signed request and bound it in time.
+///
+/// Everything here is independent of the message the signature covers, so
+/// `validate_any` runs it once rather than per candidate message.
+fn parse_signed_request(
     pubkey: &str,
     signature: &str,
-    message: &str,
     timestamp: u64,
-    state: &State<DB>,
-) -> Result<PublicKey, (StatusCode, Json<Value>)> {
+) -> Result<(PublicKey, Signature), (StatusCode, Json<Value>)> {
     let pubkey = parse_pubkey(pubkey)?;
     let signature = hex::decode(signature).map_err(|e| {
         trace!("invalid signature, could not decode: {}", e);
@@ -1119,19 +1154,82 @@ async fn validate<DB>(
         ));
     }
 
-    state
-        .wallet
-        .verify_message(&format!("{message}-{timestamp}"), &signature, &pubkey)
-        .await
-        .map_err(|e| {
-            trace!("invalid signature with timestamp, could not verify: {}", e);
-            (
-                StatusCode::BAD_REQUEST,
-                Json(Value::String("invalid signature".into())),
-            )
-        })?;
+    Ok((pubkey, signature))
+}
 
-    Ok(pubkey)
+async fn validate<DB>(
+    pubkey: &str,
+    signature: &str,
+    message: &str,
+    timestamp: u64,
+    state: &State<DB>,
+) -> Result<PublicKey, (StatusCode, Json<Value>)> {
+    validate_any(pubkey, signature, &[message.to_string()], timestamp, state).await
+}
+
+/// The messages an unregister signature may cover, most-preferred first.
+///
+/// The `unregister:` prefix domain-separates deletion from the other signed
+/// messages, so a signature captured from another route cannot authorize one.
+/// The bare form is `register`'s and stays interchangeable with it, which keeps
+/// a captured register request replayable as a deletion.
+///
+/// TODO: Remove the bare candidate after all clients have migrated to the
+/// prefix, and flip `register_signature_authorizes_unregister_until_the_legacy_form_is_dropped`.
+fn unregister_candidate_messages(username: &str) -> Vec<String> {
+    vec![format!("unregister:{username}"), username.to_string()]
+}
+
+/// What an unregister request does to the address a pubkey holds.
+#[derive(Debug, PartialEq, Eq)]
+enum UnregisterAction {
+    /// The signature names the registered address: remove it.
+    Delete,
+    /// The pubkey holds no address, so the request's goal already holds.
+    AlreadyGone,
+    /// The pubkey holds an address the signature does not name.
+    NameMismatch,
+}
+
+/// Decide an unregister from the name the signature covers and the address the
+/// pubkey holds.
+///
+/// The signature approves removing one specific name, so a name it does not
+/// cover is never removed, whichever address the pubkey currently holds.
+fn unregister_action(signed_name: &str, registered: Option<&User>) -> UnregisterAction {
+    match registered {
+        None => UnregisterAction::AlreadyGone,
+        Some(user) if user.name == signed_name => UnregisterAction::Delete,
+        Some(_) => UnregisterAction::NameMismatch,
+    }
+}
+
+/// Verify `signature` against each candidate message, accepting the first match.
+async fn validate_any<DB>(
+    pubkey: &str,
+    signature: &str,
+    messages: &[String],
+    timestamp: u64,
+    state: &State<DB>,
+) -> Result<PublicKey, (StatusCode, Json<Value>)> {
+    let (pubkey, signature) = parse_signed_request(pubkey, signature, timestamp)?;
+
+    for message in messages {
+        if state
+            .wallet
+            .verify_message(&format!("{message}-{timestamp}"), &signature, &pubkey)
+            .await
+            .is_ok()
+        {
+            return Ok(pubkey);
+        }
+    }
+
+    trace!("invalid signature, no candidate message verified");
+    Err((
+        StatusCode::BAD_REQUEST,
+        Json(Value::String("invalid signature".into())),
+    ))
 }
 
 /// Verify a transfer-route signature over the canonical message
@@ -1280,7 +1378,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl LnurlRepository for MockRepository {
-        async fn delete_user(&self, _: &str, _: &str) -> Result<(), LnurlRepositoryError> {
+        async fn delete_user(&self, _: &str, _: &str, _: &str) -> Result<(), LnurlRepositoryError> {
             Ok(())
         }
         async fn get_user_by_name(
@@ -2227,5 +2325,123 @@ mod tests {
             assert_eq!(err.0, StatusCode::OK, "LNURL errors use HTTP 200");
             assert_eq!(err.1.0["reason"], "amount out of bounds");
         }
+    }
+
+    // -- unregister signature domain separation --------------------------------
+
+    const TEST_TIMESTAMP: u64 = 1_752_000_000;
+
+    /// Whether `signature` authorizes unregistering `username`, mirroring what
+    /// the route accepts.
+    fn authorizes_unregister(
+        public_key: &PublicKey,
+        signature: &Signature,
+        username: &str,
+        timestamp: u64,
+    ) -> bool {
+        let secp = Secp256k1::new();
+        unregister_candidate_messages(username)
+            .iter()
+            .any(|message| {
+                spark::utils::verify_signature::verify_signature_ecdsa(
+                    &secp,
+                    format!("{message}-{timestamp}"),
+                    signature,
+                    public_key,
+                )
+                .is_ok()
+            })
+    }
+
+    fn registered_as(name: &str) -> User {
+        User {
+            domain: "example.com".to_string(),
+            pubkey: "02abc123".to_string(),
+            name: name.to_string(),
+            description: String::new(),
+        }
+    }
+
+    #[test]
+    fn unregister_accepts_the_prefixed_and_legacy_messages() {
+        assert_eq!(
+            unregister_candidate_messages("alice"),
+            vec!["unregister:alice".to_string(), "alice".to_string()]
+        );
+    }
+
+    #[test]
+    fn unregister_signature_authorizes_unregister() {
+        let (secret_key, public_key) = transfer_key(0x11);
+        let signature = sign(&secret_key, &format!("unregister:alice-{TEST_TIMESTAMP}"));
+
+        assert!(authorizes_unregister(
+            &public_key,
+            &signature,
+            "alice",
+            TEST_TIMESTAMP
+        ));
+    }
+
+    #[test]
+    fn register_signature_authorizes_unregister_until_the_legacy_form_is_dropped() {
+        let (secret_key, public_key) = transfer_key(0x11);
+        let signature = sign(&secret_key, &format!("alice-{TEST_TIMESTAMP}"));
+
+        // Register's format is still accepted while clients migrate. Flip this to
+        // assert!(!...) when the legacy candidate is removed.
+        assert!(authorizes_unregister(
+            &public_key,
+            &signature,
+            "alice",
+            TEST_TIMESTAMP
+        ));
+    }
+
+    #[test]
+    fn a_pubkey_signature_does_not_delete_the_registered_address() {
+        // recover and list_metadata sign "{pubkey}-{timestamp}", and a metadata
+        // signature travels in the request URL. That signature does verify against
+        // the legacy candidate, so the name it covers is what stops the deletion.
+        let (secret_key, public_key) = transfer_key(0x11);
+        let pubkey_hex = public_key.to_string();
+        let signature = sign(&secret_key, &format!("{pubkey_hex}-{TEST_TIMESTAMP}"));
+
+        assert!(
+            authorizes_unregister(&public_key, &signature, &pubkey_hex, TEST_TIMESTAMP),
+            "the signature itself still verifies while the legacy form is accepted"
+        );
+        assert_eq!(
+            unregister_action(&pubkey_hex, Some(&registered_as("alice"))),
+            UnregisterAction::NameMismatch
+        );
+    }
+
+    #[test]
+    fn deleting_requires_the_signed_name_to_be_the_registered_one() {
+        assert_eq!(
+            unregister_action("alice", Some(&registered_as("alice"))),
+            UnregisterAction::Delete
+        );
+        assert_eq!(
+            unregister_action("bob", Some(&registered_as("alice"))),
+            UnregisterAction::NameMismatch
+        );
+    }
+
+    #[test]
+    fn unregistering_an_address_that_is_already_gone_succeeds() {
+        // Nothing to remove, so the request's goal already holds. Reporting
+        // success is what lets a client holding a stale name clear it.
+        assert_eq!(
+            unregister_action("alice", None),
+            UnregisterAction::AlreadyGone
+        );
+    }
+
+    #[test]
+    fn username_cannot_forge_the_unregister_prefix() {
+        // The prefix only separates because ':' is outside the username charset.
+        assert!(validate_username("unregister:alice").is_err());
     }
 }

--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -299,16 +299,11 @@ where
                 debug!(
                     "unregister signature names '{username}', not the address pubkey {pubkey} holds"
                 );
-                return Err((
-                    StatusCode::CONFLICT,
-                    Json(Value::String(
-                        "signature does not cover the registered address".into(),
-                    )),
-                ));
+                return Err(unregister_name_mismatch());
             }
         }
 
-        state
+        let removed = state
             .db
             .delete_user(&domain, &pubkey.to_string(), &username)
             .await
@@ -319,6 +314,12 @@ where
                     Json(Value::String("internal server error".into())),
                 )
             })?;
+
+        if !removed {
+            debug!("address for pubkey {pubkey} changed while unregistering '{username}'");
+            return Err(unregister_name_mismatch());
+        }
+
         debug!("unregistered user for pubkey {}", pubkey);
         Ok(())
     }
@@ -1116,10 +1117,8 @@ fn validate_description(description: &str) -> Result<(), (StatusCode, Json<Value
     Ok(())
 }
 
-/// Parse a signed request and bound it in time.
-///
-/// Everything here is independent of the message the signature covers, so
-/// `validate_any` runs it once rather than per candidate message.
+/// Parse a signed request and bound it in time. Independent of the message the
+/// signature covers.
 fn parse_signed_request(
     pubkey: &str,
     signature: &str,
@@ -1180,6 +1179,17 @@ fn unregister_candidate_messages(username: &str) -> Vec<String> {
     vec![format!("unregister:{username}"), username.to_string()]
 }
 
+/// The response when the signed name is not the one the pubkey holds, whether
+/// the read saw that or the delete raced with a change.
+fn unregister_name_mismatch() -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::CONFLICT,
+        Json(Value::String(
+            "signature does not cover the registered address".into(),
+        )),
+    )
+}
+
 /// What an unregister request does to the address a pubkey holds.
 #[derive(Debug, PartialEq, Eq)]
 enum UnregisterAction {
@@ -1212,6 +1222,7 @@ async fn validate_any<DB>(
     timestamp: u64,
     state: &State<DB>,
 ) -> Result<PublicKey, (StatusCode, Json<Value>)> {
+    // Hoisted out of the loop below: parsing does not depend on the message.
     let (pubkey, signature) = parse_signed_request(pubkey, signature, timestamp)?;
 
     for message in messages {
@@ -1378,8 +1389,13 @@ mod tests {
 
     #[async_trait::async_trait]
     impl LnurlRepository for MockRepository {
-        async fn delete_user(&self, _: &str, _: &str, _: &str) -> Result<(), LnurlRepositoryError> {
-            Ok(())
+        async fn delete_user(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> Result<bool, LnurlRepositoryError> {
+            Ok(true)
         }
         async fn get_user_by_name(
             &self,

--- a/crates/breez-sdk/lnurl/src/sqlite/repository.rs
+++ b/crates/breez-sdk/lnurl/src/sqlite/repository.rs
@@ -27,10 +27,16 @@ impl LnurlRepository {
 
 #[async_trait::async_trait]
 impl crate::repository::LnurlRepository for LnurlRepository {
-    async fn delete_user(&self, domain: &str, pubkey: &str) -> Result<(), LnurlRepositoryError> {
-        sqlx::query("DELETE FROM users WHERE domain = $1 AND pubkey = $2")
+    async fn delete_user(
+        &self,
+        domain: &str,
+        pubkey: &str,
+        name: &str,
+    ) -> Result<(), LnurlRepositoryError> {
+        sqlx::query("DELETE FROM users WHERE domain = $1 AND pubkey = $2 AND name = $3")
             .bind(domain)
             .bind(pubkey)
+            .bind(name)
             .execute(&self.pool)
             .await?;
         Ok(())
@@ -898,5 +904,12 @@ mod sqlite_tests {
         let pool = setup_pool().await;
         let db = super::LnurlRepository::new(pool);
         shared_tests::registering_taken_name_with_other_pubkey_is_rejected(&db).await;
+    }
+
+    #[tokio::test]
+    async fn deleting_a_name_the_pubkey_no_longer_holds_is_a_no_op() {
+        let pool = setup_pool().await;
+        let db = super::LnurlRepository::new(pool);
+        shared_tests::deleting_a_name_the_pubkey_no_longer_holds_is_a_no_op(&db).await;
     }
 }

--- a/crates/breez-sdk/lnurl/src/sqlite/repository.rs
+++ b/crates/breez-sdk/lnurl/src/sqlite/repository.rs
@@ -32,14 +32,15 @@ impl crate::repository::LnurlRepository for LnurlRepository {
         domain: &str,
         pubkey: &str,
         name: &str,
-    ) -> Result<(), LnurlRepositoryError> {
-        sqlx::query("DELETE FROM users WHERE domain = $1 AND pubkey = $2 AND name = $3")
-            .bind(domain)
-            .bind(pubkey)
-            .bind(name)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
+    ) -> Result<bool, LnurlRepositoryError> {
+        let result =
+            sqlx::query("DELETE FROM users WHERE domain = $1 AND pubkey = $2 AND name = $3")
+                .bind(domain)
+                .bind(pubkey)
+                .bind(name)
+                .execute(&self.pool)
+                .await?;
+        Ok(result.rows_affected() > 0)
     }
 
     async fn get_user_by_name(


### PR DESCRIPTION
Harden the LNURL unregister endpoint:
- Only delete if the unregister message specifies the current username
- Add prefix to unregister message to avoid replay from a captured register for same username (old format without prefix still accepted to allow migration)