### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Advanced.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Advanced.cs
@@ -1,0 +1,248 @@
+using Breez.Sdk.Spark;
+
+namespace BreezCli;
+
+/// <summary>
+/// Represents a single advanced subcommand.
+/// </summary>
+public class AdvancedCliCommand
+{
+    public required string Name { get; init; }
+    public required string Description { get; init; }
+    public required Func<BreezSdk, Func<string, string?>, string[], Task> Run { get; init; }
+}
+
+/// <summary>
+/// Advanced subcommand names (used for REPL completion).
+/// </summary>
+public static class AdvancedCommandNames
+{
+    public static readonly string[] All =
+    {
+        "advanced unilateral-exit",
+    };
+}
+
+/// <summary>
+/// Advanced subcommand handlers.
+/// </summary>
+public static class AdvancedCommands
+{
+    /// <summary>
+    /// Builds the advanced subcommand registry.
+    /// </summary>
+    public static Dictionary<string, AdvancedCliCommand> BuildRegistry()
+    {
+        return new Dictionary<string, AdvancedCliCommand>
+        {
+            ["unilateral-exit"] = new()
+            {
+                Name = "unilateral-exit",
+                Description = "Build and sign a unilateral exit",
+                Run = HandleUnilateralExit
+            },
+        };
+    }
+
+    /// <summary>
+    /// Dispatches an advanced subcommand.
+    /// </summary>
+    public static async Task DispatchCommand(
+        string[] args,
+        BreezSdk sdk,
+        Func<string, string?> readline)
+    {
+        var registry = BuildRegistry();
+
+        if (args.Length == 0 || args[0] == "help")
+        {
+            Console.WriteLine();
+            Console.WriteLine("Advanced subcommands:");
+            var names = registry.Keys.OrderBy(k => k).ToList();
+            foreach (var name in names)
+            {
+                Console.WriteLine($"  advanced {name,-30} {registry[name].Description}");
+            }
+            Console.WriteLine();
+            return;
+        }
+
+        var subName = args[0];
+        var subArgs = args.Skip(1).ToArray();
+
+        if (!registry.TryGetValue(subName, out var cmd))
+        {
+            Console.WriteLine($"Unknown advanced subcommand: {subName}. Use 'advanced help' for available commands.");
+            return;
+        }
+
+        await cmd.Run(sdk, readline, subArgs);
+    }
+
+    // -----------------------------------------------------------------------
+    // Argument parsing helpers
+    // -----------------------------------------------------------------------
+
+    private static string? GetFlag(string[] args, params string[] names)
+    {
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            if (names.Contains(args[i]))
+            {
+                return args[i + 1];
+            }
+        }
+        return null;
+    }
+
+    private static string[] GetAllFlags(string[] args, params string[] names)
+    {
+        var results = new List<string>();
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            if (names.Contains(args[i]))
+            {
+                results.Add(args[i + 1]);
+            }
+        }
+        return results.ToArray();
+    }
+
+    // -----------------------------------------------------------------------
+    // Advanced command handlers
+    // -----------------------------------------------------------------------
+
+    // --- unilateral-exit ---
+
+    private static async Task HandleUnilateralExit(BreezSdk sdk, Func<string, string?> readline, string[] args)
+    {
+        var feeRateStr = GetFlag(args, "--fee-rate");
+        var fundingKindStr = GetFlag(args, "--funding-kind") ?? "p2tr";
+        var destination = GetFlag(args, "--destination");
+        var leafIds = GetAllFlags(args, "--leaf");
+
+        if (feeRateStr == null || destination == null)
+        {
+            Console.WriteLine("Usage: advanced unilateral-exit --fee-rate <N> --destination <addr> [--funding-kind p2tr|p2wpkh] [--leaf <id> ...]");
+            return;
+        }
+
+        var feeRate = ulong.Parse(feeRateStr);
+
+        CpfpFundingKind fundingKind = fundingKindStr.ToLower() switch
+        {
+            "p2wpkh" => new CpfpFundingKind.P2wpkh(),
+            "p2tr" => new CpfpFundingKind.P2tr(),
+            _ => throw new ArgumentException($"Invalid funding kind: {fundingKindStr}. Use 'p2wpkh' or 'p2tr'")
+        };
+
+        ExitLeafSelection selection = leafIds.Length == 0
+            ? new ExitLeafSelection.Auto()
+            : new ExitLeafSelection.Specific(leafIds: leafIds);
+
+        var prepared = await sdk.PrepareUnilateralExit(
+            request: new PrepareUnilateralExitRequest(
+                feeRateSatPerVbyte: feeRate,
+                fundingKind: fundingKind,
+                destination: destination,
+                selection: selection
+            )
+        );
+        Serialization.PrintValue(prepared);
+
+        if (prepared.leaves.Length == 0)
+        {
+            Console.WriteLine("No leaves to exit.");
+            return;
+        }
+
+        var utxoLine = readline(
+            "Funding UTXO(s) as txid:vout:value:pubkey (space-separated, blank to stop): ");
+        if (utxoLine == null || string.IsNullOrWhiteSpace(utxoLine))
+        {
+            Console.WriteLine("No funding provided; showing the quote only.");
+            return;
+        }
+
+        var fundingInputs = utxoLine.Trim()
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(u => ParseCpfpInput(u, fundingKindStr.ToLower()))
+            .ToArray();
+
+        var keyLine = readline("Hex secret key for the funding UTXO(s): ");
+        if (keyLine == null || string.IsNullOrWhiteSpace(keyLine))
+        {
+            Console.WriteLine("No key provided.");
+            return;
+        }
+
+        var secretKeyBytes = Convert.FromHexString(keyLine.Trim());
+        var signer = BreezSdkSparkMethods.SingleKeyCpfpSigner(secretKeyBytes);
+
+        var response = await sdk.UnilateralExit(
+            request: new UnilateralExitRequest(
+                prepared: prepared,
+                fundingInputs: fundingInputs
+            ),
+            signer: signer
+        );
+
+        PrintExitTransactions(response);
+    }
+
+    private static CpfpInput ParseCpfpInput(string s, string kind)
+    {
+        var parts = s.Split(':');
+        if (parts.Length != 4)
+        {
+            throw new ArgumentException(
+                $"Invalid funding UTXO '{s}', expected txid:vout:value:pubkey");
+        }
+
+        var txid = parts[0];
+        var vout = uint.Parse(parts[1]);
+        var value = ulong.Parse(parts[2]);
+        var pubkey = parts[3];
+
+        return kind switch
+        {
+            "p2wpkh" => new CpfpInput.P2wpkh(
+                txid: txid, vout: vout, value: value, pubkey: pubkey),
+            "p2tr" => new CpfpInput.P2tr(
+                txid: txid, vout: vout, value: value, pubkey: pubkey),
+            _ => throw new ArgumentException($"Invalid funding kind: {kind}")
+        };
+    }
+
+    private static void PrintExitTransactions(UnilateralExitResponse response)
+    {
+        Console.WriteLine(
+            $"Recoverable {response.recoverableValueSat} sats, " +
+            $"total fee {response.totalFeeSat} sats, " +
+            $"{response.transactions.Length} transaction(s):");
+
+        for (int i = 0; i < response.transactions.Length; i++)
+        {
+            var tx = response.transactions[i];
+            var after = tx.dependsOn.Length == 0
+                ? ""
+                : $", after {string.Join(",", tx.dependsOn)}";
+            var csv = tx.csvTimelockBlocks != null
+                ? $", csv {tx.csvTimelockBlocks} blocks"
+                : "";
+            Console.WriteLine(
+                $"  [{i}] {tx.kind} status={tx.status} txid={tx.txid}{after}{csv}");
+
+            if (tx.status == ConfirmationStatus.Confirmed)
+            {
+                Console.WriteLine("      (already confirmed, nothing to broadcast)");
+                continue;
+            }
+
+            var package = tx.cpfpTxHex != null
+                ? $"{tx.txHex},{tx.cpfpTxHex}"
+                : tx.txHex;
+            Console.WriteLine($"      Package: {package}");
+        }
+    }
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -254,6 +254,7 @@ public static class Commands
         {
             Console.WriteLine($"  {name,-40} {registry[name].Description}");
         }
+        Console.WriteLine($"  {"advanced <subcommand>",-40} Expert-only commands (use 'advanced help' for details)");
         Console.WriteLine($"  {"issuer <subcommand>",-40} Token issuer commands (use 'issuer help' for details)");
         Console.WriteLine($"  {"contacts <subcommand>",-40} Contact commands (use 'contacts help' for details)");
         Console.WriteLine($"  {"webhooks <subcommand>",-40} Webhook commands (use 'webhooks help' for details)");

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
@@ -342,6 +342,7 @@ static async Task RunInteractiveMode(
     // Set up tab-completion
     var allCommands = new List<string>();
     allCommands.AddRange(CommandNames.All);
+    allCommands.AddRange(AdvancedCommandNames.All);
     allCommands.AddRange(IssuerCommandNames.All);
     allCommands.AddRange(ContactCommandNames.All);
     allCommands.AddRange(WebhookCommandNames.All);
@@ -428,7 +429,11 @@ static async Task RunInteractiveMode(
 
         try
         {
-            if (cmdName == "issuer")
+            if (cmdName == "advanced")
+            {
+                await AdvancedCommands.DispatchCommand(cmdArgs, sdk, Readline);
+            }
+            else if (cmdName == "issuer")
             {
                 await IssuerCommands.DispatchCommand(cmdArgs, tokenIssuer, Readline);
             }

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/README.md
@@ -88,6 +88,8 @@ Once inside the REPL, type `help` for all commands:
 
 **Tokens**: `get-tokens-metadata`, `fetch-conversion-limits`, `issuer <subcommand>`
 
+**Advanced**: `advanced <subcommand>` (expert-only commands for building raw transactions)
+
 **Contacts**: `contacts <subcommand>`
 
 **Webhooks**: `webhooks <subcommand>`

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
@@ -93,6 +93,7 @@ Once the CLI is running, type `help` to see all available commands:
 - `get-user-settings` — Get user settings
 - `set-user-settings` — Update user settings
 - `get-spark-status` — Get Spark network status
+- `advanced <subcommand>` — Expert-only commands (unilateral exit)
 - `issuer <subcommand>` — Token issuer commands
 - `contacts <subcommand>` — Contacts commands (add, update, delete, list)
 - `webhooks <subcommand>` — Webhook commands (register, unregister, list)

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/advanced.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/advanced.dart
@@ -1,0 +1,206 @@
+import 'dart:typed_data';
+
+import 'package:args/args.dart';
+import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
+
+import 'cli.dart';
+import 'serialization.dart';
+
+/// Advanced subcommand names (used for help and tab completion).
+const advancedCommandNames = [
+  'advanced unilateral-exit',
+];
+
+typedef AdvancedHandler = Future<void> Function(BreezSdk sdk, List<String> args);
+
+class _AdvancedEntry {
+  final String description;
+  final AdvancedHandler handler;
+  const _AdvancedEntry(this.description, this.handler);
+}
+
+Map<String, _AdvancedEntry>? _registry;
+
+Map<String, _AdvancedEntry> _getRegistry() {
+  return _registry ??= {
+    'unilateral-exit': _AdvancedEntry(
+      'Build and sign a unilateral exit (expert-only)',
+      _handleUnilateralExit,
+    ),
+  };
+}
+
+/// Dispatch an advanced subcommand given the args after 'advanced'.
+Future<void> dispatchAdvancedCommand(List<String> args, BreezSdk sdk) async {
+  final registry = _getRegistry();
+
+  if (args.isEmpty || args[0] == 'help' || args[0] == '--help') {
+    print('\nAdvanced subcommands (expert-only, misuse can strand or lose funds):\n');
+    for (final entry in registry.entries.toList()..sort((a, b) => a.key.compareTo(b.key))) {
+      print('  advanced ${entry.key.padRight(30)} ${entry.value.description}');
+    }
+    print('');
+    return;
+  }
+
+  final subName = args[0];
+  final subArgs = args.sublist(1);
+
+  if (!registry.containsKey(subName)) {
+    print("Unknown advanced subcommand: $subName. Use 'advanced help' for available commands.");
+    return;
+  }
+
+  await registry[subName]!.handler(sdk, subArgs);
+}
+
+// --- unilateral-exit ---
+
+CpfpFundingKind? _parseFundingKind(String s) {
+  switch (s.toLowerCase()) {
+    case 'p2wpkh':
+      return const CpfpFundingKind.p2Wpkh();
+    case 'p2tr':
+      return const CpfpFundingKind.p2Tr();
+    default:
+      return null;
+  }
+}
+
+/// Parse [args] with [parser], returning `null` if the user asked for help
+/// or if parsing fails (prints usage + error in that case).
+ArgResults? _parseArgs(ArgParser parser, List<String> args, String usage) {
+  if (args.contains('help') || args.contains('--help') || args.contains('-h')) {
+    print('Usage: $usage');
+    print(parser.usage);
+    return null;
+  }
+  try {
+    return parser.parse(args);
+  } on ArgParserException catch (e) {
+    print('Usage: $usage');
+    print(parser.usage);
+    print('\nError: ${e.message}');
+    return null;
+  }
+}
+
+Future<void> _handleUnilateralExit(BreezSdk sdk, List<String> args) async {
+  final parser = ArgParser(usageLineLength: 80)
+    ..addOption('fee-rate', mandatory: true, help: 'Target fee rate in sat/vByte')
+    ..addOption('funding-kind', defaultsTo: 'p2tr', help: 'Funding UTXO kind: p2wpkh or p2tr')
+    ..addOption('destination', mandatory: true, help: 'Destination address for swept funds')
+    ..addMultiOption('leaf', help: 'Leaf id to exit (repeatable). Omit to auto-select.');
+  final results = _parseArgs(
+    parser,
+    args,
+    'advanced unilateral-exit --fee-rate <rate> --destination <addr> [--funding-kind p2tr] [--leaf <id>...]',
+  );
+  if (results == null) return;
+
+  final feeRate = BigInt.parse(results.option('fee-rate')!);
+  final fundingKindStr = results.option('funding-kind')!;
+  final fundingKind = _parseFundingKind(fundingKindStr);
+  if (fundingKind == null) {
+    print('Invalid funding kind: $fundingKindStr (expected p2wpkh or p2tr)');
+    return;
+  }
+  final destination = results.option('destination')!;
+  final leafIds = results.multiOption('leaf');
+
+  final ExitLeafSelection selection =
+      leafIds.isEmpty ? const ExitLeafSelection.auto() : ExitLeafSelection.specific(leafIds: leafIds);
+
+  final prepared = await sdk.prepareUnilateralExit(
+    request: PrepareUnilateralExitRequest(
+      feeRateSatPerVbyte: feeRate,
+      fundingKind: fundingKind,
+      destination: destination,
+      selection: selection,
+    ),
+  );
+  printValue(prepared);
+
+  if (prepared.leaves.isEmpty) {
+    print('No leaves to exit.');
+    return;
+  }
+
+  final utxoLine = prompt(
+    'Funding UTXO(s) as txid:vout:value:pubkey (space-separated, blank to stop): ',
+  );
+  if (utxoLine.trim().isEmpty) {
+    print('No funding provided; showing the quote only.');
+    return;
+  }
+
+  final fundingInputs = <CpfpInput>[];
+  for (final u in utxoLine.split(RegExp(r'\s+'))) {
+    if (u.isEmpty) continue;
+    final input = _parseCpfpInput(u, fundingKindStr);
+    if (input == null) return;
+    fundingInputs.add(input);
+  }
+
+  final keyLine = prompt('Hex secret key for the funding UTXO(s): ');
+  final secretKeyBytes = _hexDecode(keyLine.trim());
+
+  final response = await sdk.unilateralExit(
+    request: UnilateralExitRequest(prepared: prepared, fundingInputs: fundingInputs),
+    signerSecretKey: secretKeyBytes,
+  );
+  _printExitTransactions(response);
+}
+
+CpfpInput? _parseCpfpInput(String s, String kindStr) {
+  final parts = s.split(':');
+  if (parts.length != 4) {
+    print("Invalid funding UTXO '$s', expected txid:vout:value:pubkey");
+    return null;
+  }
+  final txid = parts[0];
+  final vout = int.tryParse(parts[1]);
+  final value = BigInt.tryParse(parts[2]);
+  final pubkey = parts[3];
+  if (vout == null || value == null) {
+    print("Invalid funding UTXO '$s': could not parse vout or value");
+    return null;
+  }
+  switch (kindStr.toLowerCase()) {
+    case 'p2wpkh':
+      return CpfpInput.p2Wpkh(txid: txid, vout: vout, value: value, pubkey: pubkey);
+    case 'p2tr':
+      return CpfpInput.p2Tr(txid: txid, vout: vout, value: value, pubkey: pubkey);
+    default:
+      print('Invalid funding kind: $kindStr');
+      return null;
+  }
+}
+
+void _printExitTransactions(UnilateralExitResponse response) {
+  print(
+    'Recoverable ${response.recoverableValueSat} sats, '
+    'total fee ${response.totalFeeSat} sats, '
+    '${response.transactions.length} transaction(s):',
+  );
+  for (var i = 0; i < response.transactions.length; i++) {
+    final tx = response.transactions[i];
+    final after = tx.dependsOn.isEmpty ? '' : ', after ${tx.dependsOn.join(",")}';
+    final csv = tx.csvTimelockBlocks != null ? ', csv ${tx.csvTimelockBlocks} blocks' : '';
+    print('  [$i] ${tx.kind} status=${tx.status} txid=${tx.txid}$after$csv');
+    if (tx.status == ConfirmationStatus.confirmed) {
+      print('      (already confirmed, nothing to broadcast)');
+      continue;
+    }
+    final package = tx.cpfpTxHex != null ? '${tx.txHex},${tx.cpfpTxHex}' : tx.txHex;
+    print('      Package: $package');
+  }
+}
+
+Uint8List _hexDecode(String hexStr) {
+  final bytes = Uint8List(hexStr.length ~/ 2);
+  for (var i = 0; i < bytes.length; i++) {
+    bytes[i] = int.parse(hexStr.substring(i * 2, i * 2 + 2), radix: 16);
+  }
+  return bytes;
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/advanced.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/advanced.dart
@@ -7,9 +7,7 @@ import 'cli.dart';
 import 'serialization.dart';
 
 /// Advanced subcommand names (used for help and tab completion).
-const advancedCommandNames = [
-  'advanced unilateral-exit',
-];
+const advancedCommandNames = ['advanced unilateral-exit'];
 
 typedef AdvancedHandler = Future<void> Function(BreezSdk sdk, List<String> args);
 
@@ -86,11 +84,12 @@ ArgResults? _parseArgs(ArgParser parser, List<String> args, String usage) {
 }
 
 Future<void> _handleUnilateralExit(BreezSdk sdk, List<String> args) async {
-  final parser = ArgParser(usageLineLength: 80)
-    ..addOption('fee-rate', mandatory: true, help: 'Target fee rate in sat/vByte')
-    ..addOption('funding-kind', defaultsTo: 'p2tr', help: 'Funding UTXO kind: p2wpkh or p2tr')
-    ..addOption('destination', mandatory: true, help: 'Destination address for swept funds')
-    ..addMultiOption('leaf', help: 'Leaf id to exit (repeatable). Omit to auto-select.');
+  final parser =
+      ArgParser(usageLineLength: 80)
+        ..addOption('fee-rate', mandatory: true, help: 'Target fee rate in sat/vByte')
+        ..addOption('funding-kind', defaultsTo: 'p2tr', help: 'Funding UTXO kind: p2wpkh or p2tr')
+        ..addOption('destination', mandatory: true, help: 'Destination address for swept funds')
+        ..addMultiOption('leaf', help: 'Leaf id to exit (repeatable). Omit to auto-select.');
   final results = _parseArgs(
     parser,
     args,
@@ -126,9 +125,7 @@ Future<void> _handleUnilateralExit(BreezSdk sdk, List<String> args) async {
     return;
   }
 
-  final utxoLine = prompt(
-    'Funding UTXO(s) as txid:vout:value:pubkey (space-separated, blank to stop): ',
-  );
+  final utxoLine = prompt('Funding UTXO(s) as txid:vout:value:pubkey (space-separated, blank to stop): ');
   if (utxoLine.trim().isEmpty) {
     print('No funding provided; showing the quote only.');
     return;

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/cli.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:breez_sdk_spark_flutter/breez_sdk_spark.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
+import 'advanced.dart';
 import 'commands.dart';
 import 'contacts.dart';
 import 'issuer.dart';
@@ -129,6 +130,7 @@ Future<void> _runRepl(
   final registry = buildCommandRegistry();
   final allCommands = [
     ...commandNames,
+    ...advancedCommandNames,
     ...issuerCommandNames,
     ...contactsCommandNames,
     ...webhookCommandNames,
@@ -162,7 +164,9 @@ Future<void> _runRepl(
       final cmdName = args[0];
       final cmdArgs = args.sublist(1);
 
-      if (cmdName == 'issuer') {
+      if (cmdName == 'advanced') {
+        await dispatchAdvancedCommand(cmdArgs, sdk);
+      } else if (cmdName == 'issuer') {
         await dispatchIssuerCommand(cmdArgs, tokenIssuer);
       } else if (cmdName == 'contacts') {
         await dispatchContactsCommand(cmdArgs, sdk);
@@ -201,6 +205,9 @@ void _printHelp(Map<String, CommandEntry> registry) {
     final desc = registry[name]!.description;
     stdout.writeln('  ${name.padRight(40)} $desc');
   }
+  stdout.writeln(
+    '  ${'advanced <subcommand>'.padRight(40)} Expert-only commands (use \'advanced help\' for details)',
+  );
   stdout.writeln(
     '  ${'issuer <subcommand>'.padRight(40)} Token issuer commands (use \'issuer help\' for details)',
   );

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/README.md
@@ -92,6 +92,8 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **Stable Balance**: `stable-balance get`, `stable-balance set`, `stable-balance unset`
 
+**Advanced**: `advanced unilateral-exit` (expert-only, builds raw exit transactions)
+
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 
 Each command supports `--help` for detailed usage.

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/advanced.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/advanced.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	breez_sdk_spark "github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
+	"github.com/chzyer/readline"
+)
+
+// AdvancedCommand represents a single advanced subcommand.
+type AdvancedCommand struct {
+	Name        string
+	Description string
+	Run         func(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []string) error
+}
+
+// AdvancedCommandNames lists all advanced subcommand names (used for REPL completion).
+var AdvancedCommandNames = []string{
+	"advanced unilateral-exit",
+}
+
+// BuildAdvancedRegistry returns a map of advanced subcommand name -> AdvancedCommand.
+func BuildAdvancedRegistry() map[string]AdvancedCommand {
+	return map[string]AdvancedCommand{
+		"unilateral-exit": {
+			Name:        "unilateral-exit",
+			Description: "Build and sign a unilateral exit",
+			Run:         handleUnilateralExit,
+		},
+	}
+}
+
+// DispatchAdvancedCommand dispatches an advanced subcommand.
+func DispatchAdvancedCommand(args []string, sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance) {
+	registry := BuildAdvancedRegistry()
+
+	if len(args) == 0 || args[0] == "help" {
+		fmt.Println("\nAdvanced subcommands (expert-only, misuse can strand or lose funds):")
+		names := make([]string, 0, len(registry))
+		for name := range registry {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			cmd := registry[name]
+			fmt.Printf("  advanced %-30s %s\n", name, cmd.Description)
+		}
+		fmt.Println()
+		return
+	}
+
+	subName := args[0]
+	subArgs := args[1:]
+
+	cmd, ok := registry[subName]
+	if !ok {
+		fmt.Printf("Unknown advanced subcommand: %s. Use 'advanced help' for available commands.\n", subName)
+		return
+	}
+
+	if err := cmd.Run(sdk, rl, subArgs); err != nil {
+		fmt.Printf("Error: %v\n", err)
+	}
+}
+
+// --- unilateral-exit ---
+
+func handleUnilateralExit(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []string) error {
+	fs := flag.NewFlagSet("unilateral-exit", flag.ContinueOnError)
+	feeRate := fs.Uint64("fee-rate", 0, "Target fee rate in sat/vByte")
+	fundingKind := fs.String("funding-kind", "p2tr", "Funding UTXO kind: p2wpkh or p2tr")
+	destination := fs.String("destination", "", "Destination address for the swept funds")
+	var leafIDs stringSliceFlag
+	fs.Var(&leafIDs, "leaf", "Leaf id to exit (repeatable). Omit to auto-select every profitable leaf.")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *feeRate == 0 || *destination == "" {
+		fmt.Println("Usage: advanced unilateral-exit --fee-rate <sat/vByte> --destination <address> [--funding-kind p2wpkh|p2tr] [--leaf <id> ...]")
+		return nil
+	}
+
+	var cpfpFundingKind breez_sdk_spark.CpfpFundingKind
+	switch strings.ToLower(*fundingKind) {
+	case "p2wpkh":
+		cpfpFundingKind = breez_sdk_spark.CpfpFundingKindP2wpkh{}
+	case "p2tr":
+		cpfpFundingKind = breez_sdk_spark.CpfpFundingKindP2tr{}
+	default:
+		return fmt.Errorf("invalid funding kind '%s', expected p2wpkh or p2tr", *fundingKind)
+	}
+
+	var selection breez_sdk_spark.ExitLeafSelection
+	if len(leafIDs) == 0 {
+		selection = breez_sdk_spark.ExitLeafSelectionAuto{}
+	} else {
+		selection = breez_sdk_spark.ExitLeafSelectionSpecific{LeafIds: leafIDs}
+	}
+
+	prepared, err := sdk.PrepareUnilateralExit(breez_sdk_spark.PrepareUnilateralExitRequest{
+		FeeRateSatPerVbyte: *feeRate,
+		FundingKind:        cpfpFundingKind,
+		Destination:        *destination,
+		Selection:          selection,
+	})
+	if err = liftError(err); err != nil {
+		return err
+	}
+	printValue(prepared)
+
+	if len(prepared.Leaves) == 0 {
+		fmt.Println("No leaves to exit.")
+		return nil
+	}
+
+	utxoLine, err := readlinePrompt(rl, "Funding UTXO(s) as txid:vout:value:pubkey (space-separated, blank to stop): ")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(utxoLine) == "" {
+		fmt.Println("No funding provided; showing the quote only.")
+		return nil
+	}
+
+	var fundingInputs []breez_sdk_spark.CpfpInput
+	for _, u := range strings.Fields(utxoLine) {
+		input, err := parseCpfpInput(u, *fundingKind)
+		if err != nil {
+			return err
+		}
+		fundingInputs = append(fundingInputs, input)
+	}
+
+	keyLine, err := readlinePrompt(rl, "Hex secret key for the funding UTXO(s): ")
+	if err != nil {
+		return err
+	}
+	secretKeyBytes, err := hex.DecodeString(strings.TrimSpace(keyLine))
+	if err != nil {
+		return fmt.Errorf("invalid hex key: %w", err)
+	}
+	signer, err := breez_sdk_spark.SingleKeyCpfpSigner(secretKeyBytes)
+	if err = liftError(err); err != nil {
+		return err
+	}
+
+	response, err := sdk.UnilateralExit(breez_sdk_spark.UnilateralExitRequest{
+		Prepared:      prepared,
+		FundingInputs: fundingInputs,
+	}, signer)
+	if err = liftError(err); err != nil {
+		return err
+	}
+	printExitTransactions(response)
+	return nil
+}
+
+func parseCpfpInput(s string, kindStr string) (breez_sdk_spark.CpfpInput, error) {
+	parts := strings.Split(s, ":")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid funding UTXO '%s', expected txid:vout:value:pubkey", s)
+	}
+	txid := parts[0]
+	vout, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid vout in '%s': %w", s, err)
+	}
+	value, err := strconv.ParseUint(parts[2], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid value in '%s': %w", s, err)
+	}
+	pubkey := parts[3]
+
+	switch strings.ToLower(kindStr) {
+	case "p2wpkh":
+		return breez_sdk_spark.CpfpInputP2wpkh{
+			Txid:   txid,
+			Vout:   uint32(vout),
+			Value:  value,
+			Pubkey: pubkey,
+		}, nil
+	default:
+		return breez_sdk_spark.CpfpInputP2tr{
+			Txid:   txid,
+			Vout:   uint32(vout),
+			Value:  value,
+			Pubkey: pubkey,
+		}, nil
+	}
+}
+
+func printExitTransactions(response breez_sdk_spark.UnilateralExitResponse) {
+	fmt.Printf("Recoverable %d sats, total fee %d sats, %d transaction(s):\n",
+		response.RecoverableValueSat, response.TotalFeeSat, len(response.Transactions))
+	for i, tx := range response.Transactions {
+		after := ""
+		if len(tx.DependsOn) > 0 {
+			after = ", after " + strings.Join(tx.DependsOn, ",")
+		}
+		csv := ""
+		if tx.CsvTimelockBlocks != nil {
+			csv = fmt.Sprintf(", csv %d blocks", *tx.CsvTimelockBlocks)
+		}
+		fmt.Printf("  [%d] %v status=%v txid=%s%s%s\n",
+			i, tx.Kind, tx.Status, tx.Txid, after, csv)
+		if tx.Status == breez_sdk_spark.ConfirmationStatusConfirmed {
+			fmt.Println("      (already confirmed, nothing to broadcast)")
+			continue
+		}
+		pkg := tx.TxHex
+		if tx.CpfpTxHex != nil {
+			pkg = tx.TxHex + "," + *tx.CpfpTxHex
+		}
+		fmt.Printf("      Package: %s\n", pkg)
+	}
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -103,7 +103,8 @@ func PrintHelp(registry map[string]Command) {
 		cmd := registry[name]
 		fmt.Printf("  %-40s %s\n", name, cmd.Description)
 	}
-	fmt.Printf("\n  %-40s %s\n", "issuer <subcommand>", "Token issuer commands (use 'issuer help' for details)")
+	fmt.Printf("\n  %-40s %s\n", "advanced <subcommand>", "Expert-only commands (use 'advanced help' for details)")
+	fmt.Printf("  %-40s %s\n", "issuer <subcommand>", "Token issuer commands (use 'issuer help' for details)")
 	fmt.Printf("  %-40s %s\n", "contacts <subcommand>", "Contacts commands (use 'contacts help' for details)")
 	fmt.Printf("  %-40s %s\n", "webhooks <subcommand>", "Webhook commands (use 'webhooks help' for details)")
 	fmt.Printf("  %-40s %s\n", "stable-balance <subcommand>", "Stable balance commands (use 'stable-balance help' for details)")

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/main.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/main.go
@@ -248,6 +248,7 @@ func runRepl(sdk *breez_sdk_spark.BreezSdk, tokenIssuer *breez_sdk_spark.TokenIs
 	// Build completion list
 	allCommands := make([]string, 0)
 	allCommands = append(allCommands, CommandNames...)
+	allCommands = append(allCommands, AdvancedCommandNames...)
 	allCommands = append(allCommands, IssuerCommandNames...)
 	allCommands = append(allCommands, ContactCommandNames...)
 	allCommands = append(allCommands, WebhookCommandNames...)
@@ -317,7 +318,9 @@ func runRepl(sdk *breez_sdk_spark.BreezSdk, tokenIssuer *breez_sdk_spark.TokenIs
 		cmdName := args[0]
 		cmdArgs := args[1:]
 
-		if cmdName == "issuer" {
+		if cmdName == "advanced" {
+			DispatchAdvancedCommand(cmdArgs, sdk, rl)
+		} else if cmdName == "issuer" {
 			DispatchIssuerCommand(cmdArgs, tokenIssuer, rl)
 		} else if cmdName == "contacts" {
 			DispatchContactCommand(cmdArgs, sdk, rl)

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/README.md
@@ -123,6 +123,8 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 
+**Advanced** (expert-only): `advanced unilateral-exit`
+
 **Token issuer**: `issuer create-token`, `issuer mint-token`, `issuer burn-token`, `issuer token-balance`, `issuer token-metadata`, `issuer freeze-token`, `issuer unfreeze-token`
 
 **Contacts**: `contacts add`, `contacts update`, `contacts delete`, `contacts list`

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Advanced.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Advanced.kt
@@ -177,6 +177,8 @@ fun parseCpfpInput(s: String, kind: CpfpFundingKind): CpfpInput {
             value = value,
             pubkey = pubkey,
         )
+        is CpfpFundingKind.Custom ->
+            throw IllegalArgumentException("custom funding kind is not supported by this CLI")
     }
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Advanced.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Advanced.kt
@@ -1,0 +1,208 @@
+import breez_sdk_spark.*
+import org.jline.reader.LineReader
+
+/**
+ * Represents a single advanced subcommand.
+ */
+data class AdvancedCliCommand(
+    val name: String,
+    val description: String,
+    val run: suspend (sdk: BreezSdk, reader: LineReader, args: List<String>) -> Unit
+)
+
+/**
+ * All advanced subcommand names.
+ */
+val ADVANCED_COMMAND_NAMES = listOf(
+    "unilateral-exit",
+)
+
+/**
+ * Builds the advanced command registry.
+ */
+fun buildAdvancedRegistry(): Map<String, AdvancedCliCommand> {
+    return mapOf(
+        "unilateral-exit" to AdvancedCliCommand(
+            "unilateral-exit",
+            "Build and sign a unilateral exit",
+            ::handleUnilateralExit,
+        ),
+    )
+}
+
+/**
+ * Dispatches an advanced subcommand.
+ */
+suspend fun dispatchAdvancedCommand(
+    args: List<String>,
+    sdk: BreezSdk,
+    registry: Map<String, AdvancedCliCommand>,
+    reader: LineReader,
+) {
+    if (args.isEmpty() || args[0] == "help") {
+        println()
+        println("Advanced subcommands (expert-only, misuse can strand or lose funds):")
+        registry.keys.sorted().forEach { name ->
+            val cmd = registry[name]!!
+            println("  advanced %-26s %s".format(name, cmd.description))
+        }
+        println()
+        return
+    }
+
+    val subName = args[0]
+    val subArgs = args.drop(1)
+
+    val cmd = registry[subName]
+    if (cmd == null) {
+        println("Unknown advanced subcommand: $subName. Use 'advanced help' for available commands.")
+        return
+    }
+
+    try {
+        cmd.run(sdk, reader, subArgs)
+    } catch (e: Exception) {
+        println("Error: ${e.message}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Advanced command handlers
+// ---------------------------------------------------------------------------
+
+// --- unilateral-exit ---
+
+@OptIn(kotlin.ExperimentalStdlibApi::class)
+suspend fun handleUnilateralExit(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    val fp = FlagParser(args)
+    val feeRate = fp.getULong("fee-rate")
+    val fundingKindStr = fp.getString("funding-kind") ?: "p2tr"
+    val destination = fp.getString("destination")
+    val leafIds = fp.getAll("leaf")
+
+    if (feeRate == null || destination == null) {
+        println("Usage: advanced unilateral-exit --fee-rate <sat/vByte> --destination <address> [options]")
+        println("Options:")
+        println("  --funding-kind <p2wpkh|p2tr>   Funding UTXO kind (default: p2tr)")
+        println("  --leaf <id>                     Leaf id to exit (repeatable, omit for auto)")
+        return
+    }
+
+    val fundingKind = when (fundingKindStr.lowercase()) {
+        "p2wpkh" -> CpfpFundingKind.P2wpkh
+        "p2tr" -> CpfpFundingKind.P2tr
+        else -> {
+            println("Invalid funding kind: $fundingKindStr (expected p2wpkh or p2tr)")
+            return
+        }
+    }
+
+    val selection = if (leafIds.isEmpty()) {
+        ExitLeafSelection.Auto
+    } else {
+        ExitLeafSelection.Specific(leafIds = leafIds)
+    }
+
+    val prepared = sdk.prepareUnilateralExit(
+        PrepareUnilateralExitRequest(
+            feeRateSatPerVbyte = feeRate,
+            fundingKind = fundingKind,
+            destination = destination,
+            selection = selection,
+        )
+    )
+    printValue(prepared)
+
+    if (prepared.leaves.isEmpty()) {
+        println("No leaves to exit.")
+        return
+    }
+
+    val utxoLine = readlinePrompt(
+        reader,
+        "Funding UTXO(s) as txid:vout:value:pubkey (space-separated, blank to stop): ",
+    )
+    if (utxoLine.isBlank()) {
+        println("No funding provided; showing the quote only.")
+        return
+    }
+
+    val fundingInputs = try {
+        utxoLine.split("\\s+".toRegex()).map { parseCpfpInput(it, fundingKind) }
+    } catch (e: Exception) {
+        println("Error parsing funding UTXOs: ${e.message}")
+        return
+    }
+
+    val keyLine = readlinePrompt(reader, "Hex secret key for the funding UTXO(s): ")
+    val signer = try {
+        singleKeyCpfpSigner(keyLine.trim().hexToByteArray())
+    } catch (e: Exception) {
+        println("Error creating signer: ${e.message}")
+        return
+    }
+
+    val response = sdk.unilateralExit(
+        UnilateralExitRequest(
+            prepared = prepared,
+            fundingInputs = fundingInputs,
+        ),
+        signer,
+    )
+    printExitTransactions(response)
+}
+
+fun parseCpfpInput(s: String, kind: CpfpFundingKind): CpfpInput {
+    val parts = s.split(":")
+    if (parts.size != 4) {
+        throw IllegalArgumentException("invalid funding UTXO '$s', expected txid:vout:value:pubkey")
+    }
+    val txid = parts[0]
+    val vout = parts[1].toUIntOrNull()
+        ?: throw IllegalArgumentException("invalid vout in '$s'")
+    val value = parts[2].toULongOrNull()
+        ?: throw IllegalArgumentException("invalid value in '$s'")
+    val pubkey = parts[3]
+
+    return when (kind) {
+        CpfpFundingKind.P2wpkh -> CpfpInput.P2wpkh(
+            txid = txid,
+            vout = vout,
+            value = value,
+            pubkey = pubkey,
+        )
+        CpfpFundingKind.P2tr -> CpfpInput.P2tr(
+            txid = txid,
+            vout = vout,
+            value = value,
+            pubkey = pubkey,
+        )
+    }
+}
+
+fun printExitTransactions(response: UnilateralExitResponse) {
+    println(
+        "Recoverable ${response.recoverableValueSat} sats, " +
+        "total fee ${response.totalFeeSat} sats, " +
+        "${response.transactions.size} transaction(s):"
+    )
+    for ((i, tx) in response.transactions.withIndex()) {
+        val after = if (tx.dependsOn.isEmpty()) {
+            ""
+        } else {
+            ", after ${tx.dependsOn.joinToString(",")}"
+        }
+        val csv = tx.csvTimelockBlocks?.let { ", csv $it blocks" } ?: ""
+        println("  [$i] ${tx.kind} status=${tx.status} txid=${tx.txid}$after$csv")
+        if (tx.status == ConfirmationStatus.CONFIRMED) {
+            println("      (already confirmed, nothing to broadcast)")
+            continue
+        }
+        val pkg = if (tx.cpfpTxHex != null) {
+            "${tx.txHex},${tx.cpfpTxHex}"
+        } else {
+            tx.txHex
+        }
+        println("      Package: $pkg")
+    }
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -107,6 +107,7 @@ fun readlineWithDefault(reader: LineReader, prompt: String, defaultVal: String):
  */
 class FlagParser(args: List<String>) {
     private val flags = mutableMapOf<String, String?>()
+    private val multiFlags = mutableMapOf<String, MutableList<String>>()
     val positional = mutableListOf<String>()
 
     init {
@@ -115,18 +116,19 @@ class FlagParser(args: List<String>) {
             val arg = args[i]
             if (arg.startsWith("--")) {
                 val key = arg.substring(2)
-                // Check if next arg is a value (not another flag)
                 if (i + 1 < args.size && !args[i + 1].startsWith("--")) {
                     flags[key] = args[i + 1]
+                    multiFlags.getOrPut(key) { mutableListOf() }.add(args[i + 1])
                     i += 2
                 } else {
-                    flags[key] = null // Boolean flag
+                    flags[key] = null
                     i++
                 }
             } else if (arg.startsWith("-") && arg.length == 2) {
                 val key = arg.substring(1)
                 if (i + 1 < args.size && !args[i + 1].startsWith("-")) {
                     flags[key] = args[i + 1]
+                    multiFlags.getOrPut(key) { mutableListOf() }.add(args[i + 1])
                     i += 2
                 } else {
                     flags[key] = null
@@ -161,6 +163,13 @@ class FlagParser(args: List<String>) {
 
     fun hasFlag(vararg names: String): Boolean {
         return names.any { it in flags }
+    }
+
+    fun getAll(vararg names: String): List<String> {
+        for (name in names) {
+            multiFlags[name]?.let { return it }
+        }
+        return emptyList()
     }
 
     fun getBool(vararg names: String): Boolean? {

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Main.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Main.kt
@@ -318,6 +318,7 @@ suspend fun runInteractiveMode(
 
     // Build command registries
     val commandRegistry = buildCommandRegistry()
+    val advancedRegistry = buildAdvancedRegistry()
     val issuerRegistry = buildIssuerRegistry()
     val contactsRegistry = buildContactsRegistry()
     val webhooksRegistry = buildWebhooksRegistry()
@@ -326,6 +327,8 @@ suspend fun runInteractiveMode(
     // Build completion list
     val allCommands = mutableListOf<String>()
     allCommands.addAll(COMMAND_NAMES)
+    allCommands.addAll(ADVANCED_COMMAND_NAMES.map { "advanced $it" })
+    allCommands.add("advanced")
     allCommands.addAll(ISSUER_COMMAND_NAMES.map { "issuer $it" })
     allCommands.add("issuer")
     allCommands.addAll(CONTACTS_COMMAND_NAMES.map { "contacts $it" })
@@ -376,7 +379,7 @@ suspend fun runInteractiveMode(
         }
 
         if (trimmed == "help") {
-            printHelp(commandRegistry, issuerRegistry, contactsRegistry, webhooksRegistry, stableBalanceRegistry)
+            printHelp(commandRegistry, advancedRegistry, issuerRegistry, contactsRegistry, webhooksRegistry, stableBalanceRegistry)
             continue
         }
 
@@ -386,6 +389,7 @@ suspend fun runInteractiveMode(
 
         try {
             when (cmdName) {
+                "advanced" -> dispatchAdvancedCommand(cmdArgs, sdk, advancedRegistry, lineReader)
                 "issuer" -> dispatchIssuerCommand(cmdArgs, tokenIssuer, issuerRegistry, lineReader)
                 "contacts" -> dispatchContactsCommand(cmdArgs, sdk, contactsRegistry, lineReader)
                 "webhooks" -> dispatchWebhooksCommand(cmdArgs, sdk, webhooksRegistry, lineReader)
@@ -415,6 +419,7 @@ suspend fun runInteractiveMode(
 
 fun printHelp(
     commandRegistry: Map<String, CliCommand>,
+    advancedRegistry: Map<String, AdvancedCliCommand>,
     issuerRegistry: Map<String, IssuerCliCommand>,
     contactsRegistry: Map<String, ContactsCliCommand>,
     webhooksRegistry: Map<String, WebhooksCliCommand>,
@@ -426,6 +431,7 @@ fun printHelp(
         val cmd = commandRegistry[name]!!
         println("  %-40s %s".format(name, cmd.description))
     }
+    println("  %-40s %s".format("advanced <subcommand>", "Expert-only commands (use 'advanced help' for details)"))
     println("  %-40s %s".format("issuer <subcommand>", "Token issuer commands (use 'issuer help' for details)"))
     println("  %-40s %s".format("contacts <subcommand>", "Contacts commands (use 'contacts help' for details)"))
     println("  %-40s %s".format("webhooks <subcommand>", "Webhook commands (use 'webhooks help' for details)"))

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
@@ -85,6 +85,8 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **Webhooks**: `webhooks register`, `webhooks unregister`, `webhooks list`
 
+**Advanced**: `advanced unilateral-exit` (expert-only, builds raw transactions for self-broadcast)
+
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 
 Each command supports `--help` for detailed usage, e.g. `receive --help`.

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/advanced.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/advanced.py
@@ -1,0 +1,175 @@
+import argparse
+
+from breez_sdk_spark import (
+    ConfirmationStatus,
+    CpfpFundingKind,
+    CpfpInput,
+    ExitLeafSelection,
+    PrepareUnilateralExitRequest,
+    UnilateralExitRequest,
+    single_key_cpfp_signer,
+)
+
+from breez_cli.serialization import print_value
+
+# Advanced subcommand names (used for REPL completion)
+ADVANCED_COMMAND_NAMES = [
+    "advanced unilateral-exit",
+]
+
+
+def _parser(name, description=""):
+    return argparse.ArgumentParser(prog=f"advanced {name}", description=description)
+
+
+# --- unilateral-exit ---
+
+def _build_unilateral_exit_parser():
+    p = _parser(
+        "unilateral-exit",
+        "Build and sign a unilateral exit. Quotes first, then prompts for funding UTXOs and signing key.",
+    )
+    p.add_argument("--fee-rate", type=int, required=True,
+                   help="Target fee rate in sat/vByte")
+    p.add_argument("--funding-kind", default="p2tr", choices=["p2wpkh", "p2tr"],
+                   help="Funding UTXO kind (default: p2tr)")
+    p.add_argument("--destination", required=True,
+                   help="Destination address for the swept funds")
+    p.add_argument("--leaf", dest="leaf_ids", action="append", default=None,
+                   help="Leaf id to exit (repeatable). Omit to auto-select every profitable leaf.")
+    return p
+
+
+def _parse_funding_kind(kind_str):
+    if kind_str == "p2wpkh":
+        return CpfpFundingKind.P2WPKH()
+    return CpfpFundingKind.P2TR()
+
+
+def _parse_cpfp_input(s, funding_kind_str):
+    parts = s.split(":")
+    if len(parts) != 4:
+        raise ValueError(f"Invalid funding UTXO '{s}', expected txid:vout:value:pubkey")
+    txid, vout, value, pubkey = parts
+    vout = int(vout)
+    value = int(value)
+    if funding_kind_str == "p2wpkh":
+        return CpfpInput.P2WPKH(txid=txid, vout=vout, value=value, pubkey=pubkey)
+    return CpfpInput.P2TR(txid=txid, vout=vout, value=value, pubkey=pubkey)
+
+
+def _print_exit_transactions(response):
+    print(
+        f"Recoverable {response.recoverable_value_sat} sats, "
+        f"total fee {response.total_fee_sat} sats, "
+        f"{len(response.transactions)} transaction(s):"
+    )
+    for i, tx in enumerate(response.transactions):
+        after = ""
+        if tx.depends_on:
+            after = f", after {','.join(tx.depends_on)}"
+        csv = ""
+        if tx.csv_timelock_blocks is not None:
+            csv = f", csv {tx.csv_timelock_blocks} blocks"
+        print(f"  [{i}] {tx.kind} status={tx.status} txid={tx.txid}{after}{csv}")
+        if tx.status == ConfirmationStatus.CONFIRMED:
+            print("      (already confirmed, nothing to broadcast)")
+            continue
+        if tx.cpfp_tx_hex is not None:
+            package = f"{tx.tx_hex},{tx.cpfp_tx_hex}"
+        else:
+            package = tx.tx_hex
+        print(f"      Package: {package}")
+
+
+async def _handle_unilateral_exit(sdk, session, args):
+    leaf_ids = args.leaf_ids or []
+    if leaf_ids:
+        selection = ExitLeafSelection.SPECIFIC(leaf_ids=leaf_ids)
+    else:
+        selection = ExitLeafSelection.AUTO()
+
+    prepared = await sdk.prepare_unilateral_exit(
+        request=PrepareUnilateralExitRequest(
+            fee_rate_sat_per_vbyte=args.fee_rate,
+            funding_kind=_parse_funding_kind(args.funding_kind),
+            destination=args.destination,
+            selection=selection,
+        )
+    )
+    print_value(prepared)
+
+    if not prepared.leaves:
+        print("No leaves to exit.")
+        return
+
+    utxo_line = await session.prompt_async(
+        "Funding UTXO(s) as txid:vout:value:pubkey (space-separated, blank to stop): "
+    )
+    if not utxo_line.strip():
+        print("No funding provided; showing the quote only.")
+        return
+
+    funding_inputs = []
+    for u in utxo_line.split():
+        funding_inputs.append(_parse_cpfp_input(u, args.funding_kind))
+
+    key_line = await session.prompt_async("Hex secret key for the funding UTXO(s): ")
+    secret_key_bytes = bytes.fromhex(key_line.strip())
+    signer = single_key_cpfp_signer(secret_key_bytes=secret_key_bytes)
+
+    response = await sdk.unilateral_exit(
+        request=UnilateralExitRequest(
+            prepared=prepared,
+            funding_inputs=funding_inputs,
+        ),
+        signer=signer,
+    )
+    _print_exit_transactions(response)
+
+
+# ---------------------------------------------------------------------------
+# Registry and dispatch
+# ---------------------------------------------------------------------------
+
+def _build_advanced_registry():
+    return {
+        "unilateral-exit": (_build_unilateral_exit_parser(), _handle_unilateral_exit),
+    }
+
+
+_REGISTRY = None
+
+def _get_registry():
+    global _REGISTRY
+    if _REGISTRY is None:
+        _REGISTRY = _build_advanced_registry()
+    return _REGISTRY
+
+
+async def dispatch_advanced_command(args, sdk, session):
+    """Dispatch an advanced subcommand given the args after 'advanced'."""
+    registry = _get_registry()
+
+    if not args or args[0] == "help":
+        print("\nAdvanced subcommands (expert-only, misuse can strand or lose funds):\n")
+        for name, (parser, _) in sorted(registry.items()):
+            desc = parser.description or ""
+            print(f"  advanced {name:30s} {desc}")
+        print()
+        return
+
+    sub_name = args[0]
+    sub_args = args[1:]
+
+    if sub_name not in registry:
+        print(f"Unknown advanced subcommand: {sub_name}. Use 'advanced help' for available commands.")
+        return
+
+    parser, handler = registry[sub_name]
+    try:
+        parsed = parser.parse_args(sub_args)
+    except SystemExit:
+        return
+
+    await handler(sdk, session, parsed)

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
@@ -27,6 +27,7 @@ from breez_sdk_spark import (
     postgres_storage,
 )
 
+from breez_cli.advanced import ADVANCED_COMMAND_NAMES, dispatch_advanced_command
 from breez_cli.commands import COMMAND_NAMES, build_command_registry
 from breez_cli.contacts import CONTACTS_COMMAND_NAMES, dispatch_contacts_command
 from breez_cli.issuer import ISSUER_COMMAND_NAMES, dispatch_issuer_command
@@ -172,7 +173,7 @@ async def main(data_dir, network, account_number, postgres_connection_string,
 
 async def run_repl(sdk, token_issuer, network, persistence):
     history_file = persistence.history_file()
-    all_commands = sorted(set(COMMAND_NAMES + CONTACTS_COMMAND_NAMES + ISSUER_COMMAND_NAMES + STABLE_BALANCE_COMMAND_NAMES + WEBHOOKS_COMMAND_NAMES + ["exit", "quit", "help"]))
+    all_commands = sorted(set(ADVANCED_COMMAND_NAMES + COMMAND_NAMES + CONTACTS_COMMAND_NAMES + ISSUER_COMMAND_NAMES + STABLE_BALANCE_COMMAND_NAMES + WEBHOOKS_COMMAND_NAMES + ["exit", "quit", "help"]))
     session = PromptSession(
         history=FileHistory(history_file),
         auto_suggest=AutoSuggestFromHistory(),
@@ -210,7 +211,9 @@ async def run_repl(sdk, token_issuer, network, persistence):
             cmd_name = args[0]
             cmd_args = args[1:]
 
-            if cmd_name == "contacts":
+            if cmd_name == "advanced":
+                await dispatch_advanced_command(cmd_args, sdk, session)
+            elif cmd_name == "contacts":
                 await dispatch_contacts_command(cmd_args, sdk)
             elif cmd_name == "issuer":
                 await dispatch_issuer_command(cmd_args, token_issuer)
@@ -252,7 +255,8 @@ def print_help(registry):
         parser, _ = registry[name]
         desc = parser.description or ""
         print(f"  {name:40s} {desc}")
-    print(f"\n  {'contacts <subcommand>':40s} Contacts commands (use 'contacts help' for details)")
+    print(f"\n  {'advanced <subcommand>':40s} Advanced commands (use 'advanced help' for details)")
+    print(f"  {'contacts <subcommand>':40s} Contacts commands (use 'contacts help' for details)")
     print(f"  {'issuer <subcommand>':40s} Token issuer commands (use 'issuer help' for details)")
     print(f"  {'stable-balance <subcommand>':40s} Stable balance commands (use 'stable-balance help' for details)")
     print(f"  {'webhooks <subcommand>':40s} Webhook commands (use 'webhooks help' for details)")

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
@@ -93,6 +93,8 @@ The CLI supports:
 
 **Stable balance**: `stable-balance get`, `stable-balance set`, `stable-balance unset`
 
+**Advanced**: `advanced unilateral-exit`
+
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 
 ## Passkey

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Advanced.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Advanced.swift
@@ -1,0 +1,187 @@
+import Foundation
+import BreezSdkSpark
+
+// MARK: - Advanced command names (for REPL completion)
+
+let advancedCommandNames: [String] = [
+    "advanced unilateral-exit",
+]
+
+// MARK: - Dispatch
+
+func dispatchAdvancedCommand(_ args: [String], sdk: BreezSdk) async {
+    if args.isEmpty || args[0] == "help" {
+        printAdvancedHelp()
+        return
+    }
+
+    let subName = args[0]
+    let subArgs = Array(args.dropFirst())
+
+    do {
+        switch subName {
+        case "unilateral-exit":
+            try await handleUnilateralExit(sdk, subArgs)
+        default:
+            print("Unknown advanced subcommand: \(subName). Use 'advanced help' for available commands.")
+        }
+    } catch {
+        print("Error: \(error)")
+    }
+}
+
+// MARK: - Help
+
+private func printAdvancedHelp() {
+    print("\nAdvanced subcommands (expert-only, misuse can strand or lose funds):")
+    print("  advanced \("unilateral-exit".padding(toLength: 30, withPad: " ", startingAt: 0))Build and sign a unilateral exit")
+    print()
+}
+
+// MARK: - Handlers
+
+private func handleUnilateralExit(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let fp = FlagParser(args)
+    guard let feeRateStr = fp.get("fee-rate"),
+          let feeRate = UInt64(feeRateStr) else {
+        print("Usage: advanced unilateral-exit --fee-rate <sat/vbyte> --destination <address> [--funding-kind p2wpkh|p2tr] [--leaf <id> ...]")
+        return
+    }
+    guard let destination = fp.get("destination") else {
+        print("Usage: advanced unilateral-exit --fee-rate <sat/vbyte> --destination <address> [--funding-kind p2wpkh|p2tr] [--leaf <id> ...]")
+        return
+    }
+
+    let fundingKindStr = fp.get("funding-kind") ?? "p2tr"
+    let fundingKind: CpfpFundingKind
+    switch fundingKindStr.lowercased() {
+    case "p2wpkh": fundingKind = .p2wpkh
+    case "p2tr":   fundingKind = .p2tr
+    default:
+        print("Invalid funding kind '\(fundingKindStr)'. Use 'p2wpkh' or 'p2tr'.")
+        return
+    }
+
+    let leafIds = collectRepeatedFlag(args, flag: "--leaf")
+    let selection: ExitLeafSelection = leafIds.isEmpty ? .auto : .specific(leafIds: leafIds)
+
+    let prepared = try await sdk.prepareUnilateralExit(
+        request: PrepareUnilateralExitRequest(
+            feeRateSatPerVbyte: feeRate,
+            fundingKind: fundingKind,
+            destination: destination,
+            selection: selection
+        )
+    )
+    printValue(prepared)
+
+    if prepared.leaves.isEmpty {
+        print("No leaves to exit.")
+        return
+    }
+
+    guard let utxoLine = readlinePrompt(
+        "Funding UTXO(s) as txid:vout:value:pubkey (space-separated, blank to stop): "
+    ) else { return }
+
+    if utxoLine.trimmingCharacters(in: .whitespaces).isEmpty {
+        print("No funding provided; showing the quote only.")
+        return
+    }
+
+    let utxoParts = utxoLine.split(separator: " ").map(String.init)
+    var fundingInputs: [CpfpInput] = []
+    for part in utxoParts {
+        guard let input = parseCpfpInput(part, fundingKind) else {
+            print("Invalid funding UTXO '\(part)', expected txid:vout:value:pubkey")
+            return
+        }
+        fundingInputs.append(input)
+    }
+
+    guard let keyLine = readlinePrompt("Hex secret key for the funding UTXO(s): ") else { return }
+    guard let keyData = dataFromHex(keyLine.trimmingCharacters(in: .whitespaces)) else {
+        print("Invalid hex key")
+        return
+    }
+    let signer = try singleKeyCpfpSigner(secretKeyBytes: keyData)
+
+    let response = try await sdk.unilateralExit(
+        request: UnilateralExitRequest(
+            prepared: prepared,
+            fundingInputs: fundingInputs
+        ),
+        signer: signer
+    )
+    printExitTransactions(response)
+}
+
+// MARK: - Helpers
+
+private func collectRepeatedFlag(_ args: [String], flag: String) -> [String] {
+    var values: [String] = []
+    var i = 0
+    while i < args.count {
+        if args[i] == flag {
+            i += 1
+            if i < args.count { values.append(args[i]) }
+        }
+        i += 1
+    }
+    return values
+}
+
+private func parseCpfpInput(_ s: String, _ kind: CpfpFundingKind) -> CpfpInput? {
+    let parts = s.split(separator: ":").map(String.init)
+    guard parts.count == 4,
+          let vout = UInt32(parts[1]),
+          let value = UInt64(parts[2]) else {
+        return nil
+    }
+    let txid = parts[0]
+    let pubkey = parts[3]
+    switch kind {
+    case .p2wpkh:
+        return .p2wpkh(txid: txid, vout: vout, value: value, pubkey: pubkey)
+    case .p2tr:
+        return .p2tr(txid: txid, vout: vout, value: value, pubkey: pubkey)
+    }
+}
+
+private func printExitTransactions(_ response: UnilateralExitResponse) {
+    print(
+        "Recoverable \(response.recoverableValueSat) sats, " +
+        "total fee \(response.totalFeeSat) sats, " +
+        "\(response.transactions.count) transaction(s):"
+    )
+    for (i, tx) in response.transactions.enumerated() {
+        let after = tx.dependsOn.isEmpty ? "" : ", after \(tx.dependsOn.joined(separator: ","))"
+        let csv = tx.csvTimelockBlocks.map { ", csv \($0) blocks" } ?? ""
+        print("  [\(i)] \(tx.kind) status=\(tx.status) txid=\(tx.txid)\(after)\(csv)")
+        if case .confirmed = tx.status {
+            print("      (already confirmed, nothing to broadcast)")
+            continue
+        }
+        let package: String
+        if let cpfp = tx.cpfpTxHex {
+            package = "\(tx.txHex),\(cpfp)"
+        } else {
+            package = tx.txHex
+        }
+        print("      Package: \(package)")
+    }
+}
+
+private func dataFromHex(_ hex: String) -> Data? {
+    let trimmed = hex.trimmingCharacters(in: .whitespaces)
+    guard trimmed.count % 2 == 0 else { return nil }
+    var data = Data(capacity: trimmed.count / 2)
+    var index = trimmed.startIndex
+    while index < trimmed.endIndex {
+        let nextIndex = trimmed.index(index, offsetBy: 2)
+        guard let byte = UInt8(trimmed[index..<nextIndex], radix: 16) else { return nil }
+        data.append(byte)
+        index = nextIndex
+    }
+    return data
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Advanced.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Advanced.swift
@@ -145,6 +145,8 @@ private func parseCpfpInput(_ s: String, _ kind: CpfpFundingKind) -> CpfpInput? 
         return .p2wpkh(txid: txid, vout: vout, value: value, pubkey: pubkey)
     case .p2tr:
         return .p2tr(txid: txid, vout: vout, value: value, pubkey: pubkey)
+    case .custom:
+        return nil
     }
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -138,7 +138,8 @@ func printHelp(_ registry: [String: CommandEntry]) {
         let cmd = registry[name]!
         print("  \(name.padding(toLength: 40, withPad: " ", startingAt: 0))\(cmd.description)")
     }
-    print("\n  \("issuer <subcommand>".padding(toLength: 40, withPad: " ", startingAt: 0))Token issuer commands (use 'issuer help' for details)")
+    print("\n  \("advanced <subcommand>".padding(toLength: 40, withPad: " ", startingAt: 0))Expert-only commands (use 'advanced help' for details)")
+    print("  \("issuer <subcommand>".padding(toLength: 40, withPad: " ", startingAt: 0))Token issuer commands (use 'issuer help' for details)")
     print("  \("contacts <subcommand>".padding(toLength: 40, withPad: " ", startingAt: 0))Contacts commands (use 'contacts help' for details)")
     print("  \("webhooks <subcommand>".padding(toLength: 40, withPad: " ", startingAt: 0))Webhook commands (use 'webhooks help' for details)")
     print("  \("stable-balance <subcommand>".padding(toLength: 40, withPad: " ", startingAt: 0))Stable balance commands (use 'stable-balance help' for details)")

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
@@ -292,7 +292,7 @@ let tokenIssuer = sdk.getTokenIssuer()
 let registry = buildCommandRegistry()
 
 // Set up tab completion
-allCompletionCommands = commandNames + issuerCommandNames + contactsCommandNames + webhooksCommandNames + stableBalanceCommandNames + ["help", "exit", "quit"]
+allCompletionCommands = commandNames + advancedCommandNames + issuerCommandNames + contactsCommandNames + webhooksCommandNames + stableBalanceCommandNames + ["help", "exit", "quit"]
 rl_attempted_completion_function = attemptedCompletion
 
 // Load history
@@ -334,7 +334,9 @@ replLoop: while true {
     let cmdName = args[0]
     let cmdArgs = Array(args.dropFirst())
 
-    if cmdName == "issuer" {
+    if cmdName == "advanced" {
+        await dispatchAdvancedCommand(cmdArgs, sdk: sdk)
+    } else if cmdName == "issuer" {
         await dispatchIssuerCommand(cmdArgs, tokenIssuer: tokenIssuer)
     } else if cmdName == "contacts" {
         await dispatchContactsCommand(cmdArgs, sdk: sdk)

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
@@ -99,6 +99,8 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **Stable Balance**: `stable-balance get`, `stable-balance set`, `stable-balance unset`
 
+**Advanced**: `advanced unilateral-exit`
+
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 
 Each command supports `--help` for detailed usage, e.g., `receive --help`.

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/advanced.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/advanced.js
@@ -1,0 +1,142 @@
+'use strict'
+
+const { Command, Option } = require('commander')
+const { singleKeyCpfpSigner } = require('@breeztech/breez-sdk-spark/nodejs')
+const { printValue } = require('./serialization')
+
+/**
+ * Prompt the user for input via readline.
+ *
+ * @param {import('readline').Interface} rl - The readline interface
+ * @param {string} prompt - The prompt to display
+ * @returns {Promise<string>} The user's input
+ */
+function question(rl, prompt) {
+  return new Promise((resolve) => {
+    rl.question(prompt, (answer) => {
+      resolve(answer)
+    })
+  })
+}
+
+/**
+ * Parse a `txid:vout:value:pubkey` funding UTXO string into a CpfpInput
+ * of the given kind.
+ *
+ * @param {string} s - The UTXO string
+ * @param {string} kind - The funding kind ('p2wpkh' or 'p2tr')
+ * @returns {object} The CpfpInput object
+ */
+function parseCpfpInput(s, kind) {
+  const parts = s.split(':')
+  if (parts.length !== 4) {
+    throw new Error(`Invalid funding UTXO '${s}', expected txid:vout:value:pubkey`)
+  }
+  const [txid, voutStr, valueStr, pubkey] = parts
+  const vout = parseInt(voutStr, 10)
+  const value = parseInt(valueStr, 10)
+  if (isNaN(vout) || isNaN(value)) {
+    throw new Error(`Invalid funding UTXO '${s}': vout and value must be integers`)
+  }
+  return { type: kind, txid, vout, value, pubkey }
+}
+
+/**
+ * Print each exit transaction with a copy-pasteable Package line.
+ *
+ * @param {object} response - The UnilateralExitResponse
+ */
+function printExitTransactions(response) {
+  console.log(
+    `Recoverable ${response.recoverableValueSat} sats, total fee ${response.totalFeeSat} sats, ${response.transactions.length} transaction(s):`
+  )
+  for (let i = 0; i < response.transactions.length; i++) {
+    const tx = response.transactions[i]
+    const after = tx.dependsOn && tx.dependsOn.length > 0
+      ? `, after ${tx.dependsOn.join(',')}`
+      : ''
+    const csv = tx.csvTimelockBlocks != null
+      ? `, csv ${tx.csvTimelockBlocks} blocks`
+      : ''
+    console.log(`  [${i}] ${tx.kind} status=${tx.status} txid=${tx.txid}${after}${csv}`)
+    if (tx.status === 'confirmed') {
+      console.log('      (already confirmed, nothing to broadcast)')
+      continue
+    }
+    const pkg = tx.cpfpTxHex
+      ? `${tx.txHex},${tx.cpfpTxHex}`
+      : tx.txHex
+    console.log(`      Package: ${pkg}`)
+  }
+}
+
+/**
+ * Register all advanced subcommands on the given commander program.
+ *
+ * @param {Command} program - The parent commander program
+ * @param {() => object} getSdk - Function that returns the SDK instance
+ * @param {import('readline').Interface} rl - The readline interface for interactive prompts
+ */
+function registerAdvancedCommands(program, getSdk, rl) {
+  const advanced = program
+    .command('advanced')
+    .description('Expert-only commands that build raw transactions for you to broadcast yourself. Misuse can strand or lose funds.')
+
+  // --- unilateral-exit ---
+  advanced
+    .command('unilateral-exit')
+    .description('Build and sign a unilateral exit')
+    .requiredOption('--fee-rate <rate>', 'Target fee rate in sat/vByte', parseInt)
+    .option('--funding-kind <kind>', 'Funding UTXO kind (p2wpkh or p2tr)', 'p2tr')
+    .requiredOption('--destination <address>', 'Destination address for the swept funds')
+    .option('--leaf <ids...>', 'Leaf id(s) to exit (omit to auto-select every profitable leaf)')
+    .action(async (options) => {
+      const sdk = getSdk()
+
+      const fundingKind = { type: options.fundingKind }
+      const leafIds = options.leaf || []
+      const selection = leafIds.length > 0
+        ? { type: 'specific', leafIds }
+        : { type: 'auto' }
+
+      const prepared = await sdk.prepareUnilateralExit({
+        feeRateSatPerVbyte: options.feeRate,
+        fundingKind,
+        destination: options.destination,
+        selection
+      })
+      printValue(prepared)
+
+      if (!prepared.leaves || prepared.leaves.length === 0) {
+        console.log('No leaves to exit.')
+        return
+      }
+
+      const utxoLine = await question(
+        rl,
+        'Funding UTXO(s) as txid:vout:value:pubkey (space-separated, blank to stop): '
+      )
+      if (utxoLine.trim() === '') {
+        console.log('No funding provided; showing the quote only.')
+        return
+      }
+      const fundingInputs = utxoLine.trim().split(/\s+/).map(
+        (u) => parseCpfpInput(u, options.fundingKind)
+      )
+
+      const keyLine = await question(rl, 'Hex secret key for the funding UTXO(s): ')
+      const secretKeyBytes = Buffer.from(keyLine.trim(), 'hex')
+      const signer = singleKeyCpfpSigner(secretKeyBytes)
+
+      const response = await sdk.unilateralExit(
+        {
+          prepared,
+          fundingInputs
+        },
+        signer
+      )
+      printExitTransactions(response)
+    })
+}
+
+module.exports = { registerAdvancedCommands }

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -3,6 +3,7 @@
 const { Command, Option } = require('commander')
 const crypto = require('crypto')
 const { printValue } = require('./serialization')
+const { registerAdvancedCommands } = require('./advanced')
 const { registerIssuerCommands } = require('./issuer')
 const { registerContactsCommands } = require('./contacts')
 const { registerWebhooksCommands } = require('./webhooks')
@@ -61,7 +62,8 @@ const COMMAND_NAMES = [
   'webhooks list',
   'stable-balance get',
   'stable-balance set',
-  'stable-balance unset'
+  'stable-balance unset',
+  'advanced unilateral-exit'
 ]
 
 /**
@@ -837,6 +839,9 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
       const res = await getSparkStatus()
       printValue(res)
     })
+
+  // --- advanced subcommands ---
+  registerAdvancedCommands(program, getSdk, rl)
 
   // --- issuer subcommands ---
   registerIssuerCommands(program, getTokenIssuer)


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`73b2260`](https://github.com/breez/spark-sdk/commit/73b2260fc2e8c5ffd105c11f972dac7cff47c6a6)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/29760295193)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :next_track_button: React Native (no changes needed)
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- Rust CLI added `Advanced` subcommand group with `UnilateralExit` command; C# CLI was missing it entirely

## Applied
- Created `Advanced.cs` with `AdvancedCommands` class implementing `unilateral-exit` subcommand (prepare, prompt for funding UTXOs and signing key, build and print exit transactions)
- Updated `Commands.cs` to add "advanced" to the help output
- Updated `Program.cs` to dispatch "advanced" subcommands and include `AdvancedCommandNames` in tab-completion
- Updated `README.md` to document the new "Advanced" command group

## Skipped
- (none)

### Dart
## Divergences
- Rust CLI added `advanced` subcommand group with `unilateral-exit` command (new file `command/advanced.rs`, wired into `command/mod.rs`). Dart CLI was missing this entirely.

## Applied
- Created `lib/advanced.dart` with `dispatchAdvancedCommand`, `advancedCommandNames`, and `_handleUnilateralExit` handler implementing the full unilateral exit flow (prepare, prompt for UTXOs and secret key, execute, print transactions). Uses `sdk.unilateralExit(request:, signerSecretKey:)` which is the Dart/FRB equivalent of Rust's `single_key_cpfp_signer`.
- Updated `lib/cli.dart` to import `advanced.dart`, add `advancedCommandNames` to REPL tab completion, add `advanced` dispatch in the REPL command loop, and add help text entry.
- Updated `README.md` to list `advanced <subcommand>` in the commands section.

## Skipped
- Nothing skipped. All SDK types needed (`PrepareUnilateralExitRequest`, `CpfpInput`, `CpfpFundingKind`, `ExitLeafSelection`, `ConfirmationStatus`, etc.) are available in the Flutter/FRB bindings.
- Build check (`make -C crates/breez-sdk/bindings/examples/cli check-flutter`) could not be run due to sandbox permission restrictions on `dart` commands. CI will validate.

### Go
## Divergences
- Rust CLI added `Advanced` subcommand group with `UnilateralExit` command (new file `advanced.rs`, new dispatch in `mod.rs`). Go CLI had no equivalent.

## Applied
- Created `crates/breez-sdk/bindings/examples/cli/langs/golang/advanced.go` with `AdvancedCommand` type, `BuildAdvancedRegistry()`, `DispatchAdvancedCommand()`, and `handleUnilateralExit` handler implementing the full unilateral exit flow (prepare, interactive UTXO input, signing key input, exit, formatted transaction output).
- Updated `crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go` to include "advanced" in the help output.
- Updated `crates/breez-sdk/bindings/examples/cli/langs/golang/main.go` to add `AdvancedCommandNames` to REPL completion and `DispatchAdvancedCommand` to the command dispatch chain.
- Updated `crates/breez-sdk/bindings/examples/cli/langs/golang/README.md` to list the new `advanced` subcommand group in Available Commands.

## Skipped
- (none)

### Kotlin
## Divergences
- Rust CLI added `advanced` subcommand group with `unilateral-exit` command (new file `advanced.rs`, wired in `mod.rs`); Kotlin CLI had no equivalent
- Kotlin `FlagParser` did not support repeatable flags (`--leaf` can appear multiple times in `unilateral-exit`)

## Applied
- Created `Advanced.kt` with `AdvancedCliCommand` data class, `ADVANCED_COMMAND_NAMES`, `buildAdvancedRegistry()`, `dispatchAdvancedCommand()`, `handleUnilateralExit()`, `parseCpfpInput()`, and `printExitTransactions()` (mirroring the Rust `advanced.rs` structure)
- Added `getAll()` method to `FlagParser` in `Commands.kt` to support repeatable flags
- Added `multiFlags` map to `FlagParser` to track all values for repeatable flags
- Wired `advanced` subgroup in `Main.kt`: registry construction, tab completion, REPL dispatch, and help output
- Added `advanced unilateral-exit` to the Available Commands section in `README.md`

## Skipped
- Build check (`make check-kotlin-multiplatform`) could not run due to sandbox restrictions blocking Gradle/Java execution; code was verified by manual review against the Kotlin SDK snippets and existing CLI patterns

### Python
## Divergences
- Rust CLI added `advanced` subcommand group with `unilateral-exit` command; Python CLI had no equivalent.

## Applied
- Created `advanced.py` with `unilateral-exit` subcommand: parser, handler, UTXO parsing, exit transaction printing (`crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/advanced.py`)
- Updated `main.py` to import and dispatch `advanced` commands, added to REPL completion and help output (`crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py`)
- Updated Python README to list `advanced unilateral-exit` in Available Commands (`crates/breez-sdk/bindings/examples/cli/langs/python/README.md`)

## Skipped
- (none)

### Swift
## Divergences
- Rust CLI added `advanced` subcommand group with `unilateral-exit` command (new `advanced.rs` module + dispatch in `mod.rs`); Swift CLI had no equivalent

## Applied
- Created `Advanced.swift` with `dispatchAdvancedCommand`, `handleUnilateralExit`, and helpers (`collectRepeatedFlag`, `parseCpfpInput`, `printExitTransactions`, `dataFromHex`)
- Updated `Commands.swift` to add "advanced" to the help text in `printHelp`
- Updated `main.swift` to dispatch "advanced" subcommand in the REPL loop and add `advancedCommandNames` to tab completion
- Updated `README.md` to document the "Advanced" command group

## Skipped
- (none)

### TypeScript
## Divergences
- Missing `advanced` subcommand group with `unilateral-exit` command (added in Rust CLI via `advanced.rs` and `mod.rs`)

## Applied
- Created `crates/breez-sdk/bindings/examples/cli/langs/wasm/src/advanced.js` with `registerAdvancedCommands()` implementing `unilateral-exit` (prepareUnilateralExit, interactive UTXO/key prompts, singleKeyCpfpSigner, unilateralExit, printExitTransactions)
- Updated `crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js` to import and register advanced commands, added `advanced unilateral-exit` to COMMAND_NAMES
- Updated `crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md` to list the new Advanced command group

## Skipped
- (none)

</details>