### PR TITLE
docs: remove theme picker, pin the docs to the Auto theme

### DIFF
--- a/docs/breez-sdk/brand-header.js
+++ b/docs/breez-sdk/brand-header.js
@@ -15,19 +15,52 @@
             return;
         }
         // The sidebar toggle leads the bar, to the left of the logo, next to
-        // the sidebar it controls. The rest join the right-hand controls.
+        // the sidebar it controls. Search joins the right-hand controls. The
+        // theme picker (#theme-toggle / #theme-list) is deliberately NOT
+        // rescued from the hidden #menu-bar: the docs are pinned to the
+        // "Auto" theme, which book.toml resolves to navy either way.
         var sidebarToggle = document.getElementById("sidebar-toggle");
         if (sidebarToggle) {
             header.insertBefore(sidebarToggle, header.firstChild);
         }
-        ["theme-toggle", "theme-list", "search-toggle"].forEach(function (id) {
+        ["search-toggle"].forEach(function (id) {
             var el = document.getElementById(id);
             if (el) {
                 controls.appendChild(el);
             }
         });
+        forceAutoTheme();
         markActiveNav();
         wireSidebarBehavior();
+    }
+
+    // The docs are pinned to the Auto theme: with no picker in the UI, a
+    // visitor who chose a theme in the past would be stuck with it forever.
+    // Wipe the stored choice and correct the current page load in place
+    // (theme class + matching highlight stylesheet, mirroring book.js).
+    function forceAutoTheme() {
+        var stored = null;
+        try {
+            stored = localStorage.getItem("mdbook-theme");
+            if (stored !== null) {
+                localStorage.removeItem("mdbook-theme");
+            }
+        } catch (e) { }
+        if (stored === null || stored === "navy") {
+            return; // fresh visitors already resolve to navy via book.toml
+        }
+        var html = document.documentElement;
+        ["light", "rust", "coal", "ayu"].forEach(function (cls) {
+            html.classList.remove(cls);
+        });
+        html.classList.add("navy");
+        var sheet = function (id) { return document.getElementById(id); };
+        var hl = sheet("highlight-css");
+        var tn = sheet("tomorrow-night-css");
+        var ayu = sheet("ayu-highlight-css");
+        if (hl) { hl.disabled = true; }
+        if (tn) { tn.disabled = false; }
+        if (ayu) { ayu.disabled = true; }
     }
 
     // Highlight the current top-level section link (Home / GitHub) when it matches.

--- a/docs/breez-sdk/styles.css
+++ b/docs/breez-sdk/styles.css
@@ -202,7 +202,6 @@ html.rust #brand-header .icon-button:hover { background: var(--theme-hover); }
    sidebar on narrow windows and never restores it on grow) and leads the
    bar, left of the logo, next to the sidebar it controls. */
 #brand-header #sidebar-toggle { display: inline-flex; margin-right: 6px; }
-.brand-controls #theme-list { top: 40px; }
 
 /* ---- Reconcile the fixed header with mdBook's layout -------------------- */
 /* The brand header replaces mdBook's #menu-bar entirely. */


### PR DESCRIPTION
The theme toggle and its dropdown stay in the hidden stock #menu-bar instead of being relocated into the brand header, so the picker is gone. Any previously stored theme choice is wiped on load and the page is corrected in place (theme class + matching highlight stylesheet), so every visitor resolves to Auto — which book.toml maps to navy in both OS color schemes.

<img width="477" height="282" alt="Screenshot 2026-07-20 at 11 03 57 PM" src="https://github.com/user-attachments/assets/aa9c8464-47f4-48e4-9f99-4d4f3ebb5e3f" />
