### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -1059,14 +1059,15 @@ public static class Commands
 
     private static async Task HandleRegisterLightningAddress(BreezSdk sdk, Func<string, string?> readline, string[] args)
     {
-        var description = GetFlag(args, "-d", "--description");
         var positional = GetPositionalArgs(args);
 
         if (positional.Length < 1)
         {
-            Console.WriteLine("Usage: register-lightning-address <username> [-d <description>]");
+            Console.WriteLine("Usage: register-lightning-address <username> [<description>]");
             return;
         }
+
+        var description = positional.Length > 1 ? positional[1] : null;
 
         var result = await sdk.RegisterLightningAddress(new RegisterLightningAddressRequest(
             username: positional[0],

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
@@ -14,6 +14,7 @@ var stableBalanceTokens = new List<string>();
 string? stableBalanceDefaultActiveLabel = null;
 ulong? stableBalanceThreshold = null;
 bool serverMode = false;
+string? lnurlDomain = null;
 string? passkeyProviderStr = null;
 string? label = null;
 bool listLabels = false;
@@ -66,6 +67,9 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--server-mode":
             serverMode = true;
+            break;
+        case "--lnurl-domain":
+            if (i + 1 < args.Length) lnurlDomain = args[++i];
             break;
         case "--help":
         case "-h":
@@ -192,7 +196,8 @@ await RunInteractiveMode(
     postgresConnectionString,
     mysqlConnectionString,
     stableBalanceConfig,
-    passkeyConfig
+    passkeyConfig,
+    lnurlDomain
 );
 
 return;
@@ -232,6 +237,7 @@ static void PrintUsage()
     Console.WriteLine("  --store-label                               Publish label to Nostr (requires --passkey and --label)");
     Console.WriteLine("  --rpid <RPID>                               Relying party ID for FIDO2 provider (requires --passkey)");
     Console.WriteLine("  --server-mode                               Run in server mode (background tasks disabled)");
+    Console.WriteLine("  --lnurl-domain <DOMAIN>                     LNURL server domain for lightning address registration");
     Console.WriteLine("  -h, --help                                  Show this help");
 }
 
@@ -243,7 +249,8 @@ static async Task RunInteractiveMode(
     string? postgresConnectionString,
     string? mysqlConnectionString,
     StableBalanceConfig? stableBalanceConfig,
-    CliPasskeyConfig? passkeyConfig)
+    CliPasskeyConfig? passkeyConfig,
+    string? lnurlDomain)
 {
     // Init logging
     try
@@ -278,6 +285,10 @@ static async Task RunInteractiveMode(
     if (stableBalanceConfig != null)
     {
         config = config with { stableBalanceConfig = stableBalanceConfig };
+    }
+    if (lnurlDomain != null)
+    {
+        config = config with { lnurlDomain = lnurlDomain };
     }
     if (network == Network.Mainnet)
     {

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/README.md
@@ -45,6 +45,7 @@ dotnet run --project BreezCli.csproj -- [OPTIONS]
 | `--store-label` | - | Publish the label to Nostr (requires `--passkey` and `--label`) |
 | `--rpid` | - | Relying party ID for FIDO2 provider (requires `--passkey`) |
 | `--server-mode` | - | Run in server mode (background tasks disabled; drive `sync` manually) |
+| `--lnurl-domain` | network default | LNURL server domain for lightning address registration; accepts a plain domain or an `http://host:port` test server URL |
 
 ### Passkey Support
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
@@ -57,6 +57,7 @@ make run-mainnet
     --store-label                       Publish label to Nostr (requires --passkey and --label)
     --rpid                              Relying party ID for FIDO2 provider (requires --passkey)
     --server-mode                       Run in server mode (background_tasks_enabled=false)
+    --lnurl-domain                      LNURL server domain for lightning address registration
 -h, --help                              Show usage
 ```
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
@@ -44,6 +44,10 @@ Future<void> main(List<String> arguments) async {
           negatable: false,
           help: 'Run in server mode (background_tasks_enabled=false)',
         )
+        ..addOption(
+          'lnurl-domain',
+          help: 'LNURL server domain for lightning address registration',
+        )
         ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage');
 
   final ArgResults results;
@@ -141,6 +145,7 @@ Future<void> main(List<String> arguments) async {
     stableBalanceThreshold: stableBalanceThreshold,
     passkeyConfig: passkeyConfig,
     serverMode: results.flag('server-mode'),
+    lnurlDomain: results.option('lnurl-domain'),
   );
 
   // Force exit — the native FFI library may keep background threads alive

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
@@ -44,10 +44,7 @@ Future<void> main(List<String> arguments) async {
           negatable: false,
           help: 'Run in server mode (background_tasks_enabled=false)',
         )
-        ..addOption(
-          'lnurl-domain',
-          help: 'LNURL server domain for lightning address registration',
-        )
+        ..addOption('lnurl-domain', help: 'LNURL server domain for lightning address registration')
         ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage');
 
   final ArgResults results;

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/cli.dart
@@ -26,6 +26,7 @@ Future<void> runCli({
   BigInt? stableBalanceThreshold,
   CliPasskeyConfig? passkeyConfig,
   bool serverMode = false,
+  String? lnurlDomain,
 }) async {
   await BreezSdkSparkLib.init(externalLibrary: ExternalLibrary.open(_nativeLibPath()));
 
@@ -58,6 +59,10 @@ Future<void> runCli({
         maxSlippageBps: null,
       ),
     );
+  }
+
+  if (lnurlDomain != null) {
+    config = config.copyWith(lnurlDomain: lnurlDomain);
   }
 
   if (networkEnum == Network.mainnet) {

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/README.md
@@ -60,6 +60,7 @@ make clean            Remove binary
 | `--stable-balance-default-active-label` | - | Default active label for stable balance |
 | `--stable-balance-threshold` | - | Stable balance threshold in sats |
 | `--server-mode` | false | Run in server mode (`background_tasks_enabled=false`) |
+| `--lnurl-domain` | network default | LNURL server domain for lightning address registration; accepts a plain domain or an `http://host:port` test server URL |
 | `--passkey` | - | Use Passkey with PRF provider (`file`, `yubikey` or `fido2`) |
 | `--label` | `Default` | Requires `--passkey`. The label to use |
 | `--list-labels` | false | Requires `--passkey`. Select label from Nostr |

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -121,7 +121,7 @@ func PrintHelp(registry map[string]Command) {
 
 func handleGetInfo(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []string) error {
 	fs := flag.NewFlagSet("get-info", flag.ContinueOnError)
-	ensureSynced := fs.String("s", "", "Force sync (true/false)")
+	ensureSynced := fs.String("e", "", "Force sync (true/false)")
 	fs.StringVar(ensureSynced, "ensure-synced", "", "Force sync (true/false)")
 	if err := fs.Parse(args); err != nil {
 		return err

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/main.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/main.go
@@ -85,6 +85,7 @@ func main() {
 	stableBalanceDefaultActiveLabel := flag.String("stable-balance-default-active-label", "", "Default active label for stable balance")
 	stableBalanceThreshold := flag.Uint64("stable-balance-threshold", 0, "Stable balance threshold in sats")
 	serverMode := flag.Bool("server-mode", false, "Run in server mode (background_tasks_enabled=false)")
+	lnurlDomain := flag.String("lnurl-domain", "", "LNURL server domain for lightning address registration; accepts a plain domain or an http://host:port test server URL")
 	passkeyProviderStr := flag.String("passkey", "", "Use passkey with PRF provider (file, yubikey, or fido2)")
 	label := flag.String("label", "", "Label for seed derivation (requires --passkey)")
 	listLabels := flag.Bool("list-labels", false, "List and select from labels published to Nostr (requires --passkey)")
@@ -123,6 +124,10 @@ func main() {
 	apiKey := os.Getenv("BREEZ_API_KEY")
 	if apiKey != "" {
 		config.ApiKey = &apiKey
+	}
+
+	if *lnurlDomain != "" {
+		config.LnurlDomain = lnurlDomain
 	}
 
 	// Cross-chain sends are opt-in by the caller and mainnet-only (enabling on

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/README.md
@@ -66,6 +66,7 @@ make clean            Remove build artifacts
 | `--store-label` | | Publish the label to Nostr (requires `--passkey` + `--label`) |
 | `--rpid` | | Relying party ID for FIDO2 provider (requires `--passkey`) |
 | `--server-mode` | | Run in server mode (no background tasks) |
+| `--lnurl-domain` | network default | LNURL server domain for lightning address registration; accepts a plain domain or an `http://host:port` test server URL |
 
 ## Environment Variables
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
@@ -58,6 +58,7 @@ make clean            Remove venv and build artifacts
 | `--list-labels` | false | Requires `--passkey`. Select label from NOSTR |
 | `--store-label` | false | Requires `--passkey`. Publish label to NOSTR |
 | `--rpid` | `keys.breez.technology` | Requires `--passkey`. Relying party ID for FIDO2 provider |
+| `--lnurl-domain` | network default | LNURL server domain for lightning address registration; accepts a plain domain or an `http://host:port` test server URL |
 
 ## Environment Variables
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
@@ -77,12 +77,15 @@ def expand_path(path: str) -> Path:
 @click.option("--list-labels", is_flag=True, default=False, help="List and select from labels published to Nostr (requires --passkey)")
 @click.option("--store-label", is_flag=True, default=False, help="Publish the label to Nostr (requires --passkey and --label)")
 @click.option("--rpid", default=None, help="Relying party ID for FIDO2 provider (requires --passkey)")
+@click.option("--lnurl-domain", default=None,
+              help="LNURL server domain for lightning address registration; accepts a plain domain or an http://host:port test server URL")
 async def main(data_dir, network, account_number, postgres_connection_string,
                mysql_connection_string,
                stable_balance_tokens, stable_balance_default_active_label,
                stable_balance_threshold,
                server_mode,
-               passkey_provider, label, list_labels, store_label, rpid):
+               passkey_provider, label, list_labels, store_label, rpid,
+               lnurl_domain):
     """CLI client for Breez SDK with Spark."""
     data_dir = expand_path(data_dir)
     data_dir.mkdir(parents=True, exist_ok=True)
@@ -116,6 +119,8 @@ async def main(data_dir, network, account_number, postgres_connection_string,
     else:
         config = default_config(network=network_enum)
     config.api_key = breez_api_key
+    if lnurl_domain is not None:
+        config.lnurl_domain = lnurl_domain
     if network_enum == Network.MAINNET:
         config.cross_chain_config = CrossChainConfig()
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
@@ -64,6 +64,7 @@ make clean            Remove build artifacts
 | `--list-labels` | false | Requires `--passkey`. Select label from Nostr |
 | `--store-label` | false | Requires `--passkey`. Publish label to Nostr |
 | `--rpid` | `keys.breez.technology` | Requires `--passkey`. Relying party ID for FIDO2 provider |
+| `--lnurl-domain` | network default | LNURL server domain for lightning address registration; accepts a plain domain or an `http://host:port` test server URL |
 
 ## Environment Variables
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
@@ -62,6 +62,7 @@ node src/main.js [OPTIONS]
 | `--store-label` | false | Requires `--passkey`. Publish label to Nostr |
 | `--rpid` | `keys.breez.technology` | Requires `--passkey`. Relying party ID for FIDO2 provider |
 | `--server-mode` | false | Run in server mode (`background_tasks_enabled=false`) |
+| `--lnurl-domain` | network default | LNURL server domain for lightning address registration; accepts a plain domain or an `http://host:port` test server URL |
 
 ### Examples
 


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`f434bd7`](https://github.com/breez/spark-sdk/commit/f434bd72c5a913790fb3a42a6bf0f93b6a25e083)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/30019717158)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :next_track_button: React Native (no changes needed)
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- `--lnurl-domain` CLI flag present in Rust CLI (`main.rs`) but missing from C# CLI (`Program.cs`)
- `register-lightning-address` description argument: Rust uses positional arg, C# used `-d`/`--description` flag only (positional form from scenario tests would silently drop the description)
- Rust CLI README documents `--lnurl-domain` option; C# README did not

## Applied
- Added `--lnurl-domain` CLI flag to `Program.cs` (arg parsing, `RunInteractiveMode` parameter, config application, `PrintUsage` help text)
- Added `--lnurl-domain` row to CLI Options table in `README.md`
- Fixed `register-lightning-address` in `Commands.cs` to accept description as positional arg (matching Rust grammar), removing the `-d`/`--description` flag-only approach

## Skipped
- `grammar_tests.rs` and `parse_command_tests` in `main.rs`: test-only code, not ported per policy

### Dart
## Divergences
- Missing `--lnurl-domain` CLI option in Dart CLI (added to Rust CLI in recent commit)

## Applied
- Added `--lnurl-domain` option to `bin/breez_cli.dart` argument parser
- Added `lnurlDomain` parameter to `runCli()` in `lib/cli.dart` and applied it to config via `copyWith`
- Added `--lnurl-domain` to the CLI Options table in `README.md`

## Skipped
- `grammar_tests.rs` and `parse_command_tests` in `main.rs`: test files are not ported per policy

### Go
## Divergences
- Missing `--lnurl-domain` CLI flag in Go CLI (added in Rust main.rs to override the network default LNURL server domain for lightning address registration)
- `get-info` short flag mismatch: Go used `-s`, Rust uses `-e` (derived from `ensure_synced`)
- Go README missing `--lnurl-domain` entry in CLI Options table
- `issuer create-token` uses named flags in Go (`--name`, `--ticker`, `--decimals`, `--freezable`, `--max-supply`) vs positional args in Rust (`<name> <ticker> <decimals> [-f] <max_supply>`) (pre-existing)
- `register-lightning-address` description is a named flag (`-d`/`--description`) in Go vs positional in Rust (pre-existing)

## Applied
- Added `--lnurl-domain` flag to Go CLI and applied it to `config.LnurlDomain` (`main.go`)
- Fixed `get-info` short flag from `-s` to `-e` to match Rust (`commands.go`)
- Added `--lnurl-domain` entry to Go CLI README CLI Options table (`README.md`)

## Skipped
- `issuer create-token` positional vs named-flag argument format: pre-existing divergence, both produce identical SDK calls. Changing would break existing Go CLI usage patterns.
- `register-lightning-address` description positional vs flag format: pre-existing divergence. Go's `-d` flag is a UX addition that works correctly.
- Rust `grammar_tests.rs` and `parse_command_tests`: test-only code, not ported per policy.

### Kotlin
## Divergences
- Kotlin README missing `--lnurl-domain` CLI option documentation (Rust README has it)

## Applied
- Added `--lnurl-domain` row to Kotlin README CLI Options table (`README.md`)

## Skipped
- `grammar_tests.rs`: Rust-only test file pinning clap grammar; test files are never ported
- `command/mod.rs`: Only change was adding `#[cfg(test)] mod grammar_tests;`; test module, not ported
- `main.rs` test module (`parse_command_tests`): Rust-only unit tests; not ported
- `main.rs` `--lnurl-domain` flag: Already present in Kotlin `Main.kt` (lines 74, 133-136, 155, 248, 261, 288-290)

### Python
## Divergences
- `--lnurl-domain` CLI flag present in Rust CLI but missing from Python CLI
- `--lnurl-domain` row present in Rust README but missing from Python README

## Applied
- Added `--lnurl-domain` click option and `config.lnurl_domain` assignment in `main.py`
- Added `--lnurl-domain` row to CLI Options table in Python `README.md`

## Skipped
- `grammar_tests.rs` and `mod grammar_tests` in `mod.rs`: test-only code (`#[cfg(test)]`), not ported per policy

### Swift
## Divergences
- Swift README CLI Options table was missing the `--lnurl-domain` flag that was added to the Rust README

## Applied
- Added `--lnurl-domain` row to the CLI Options table in `crates/breez-sdk/bindings/examples/cli/langs/swift/README.md`

## Skipped
- `crates/breez-sdk/cli/src/command/grammar_tests.rs`: test file, never ported per policy
- `crates/breez-sdk/cli/src/main.rs` `parse_command_tests` module: test code, never ported per policy
- `crates/breez-sdk/cli/src/command/mod.rs` `#[cfg(test)] mod grammar_tests`: test-only module declaration, never ported per policy
- The `--lnurl-domain` flag implementation in Swift CLI code (`main.swift` lines 22, 70-72, 236-238) was already present and correct

### TypeScript
## Divergences
- TypeScript CLI README missing `--lnurl-domain` in CLI Options table (Rust README already documents it)

## Applied
- Added `--lnurl-domain` row to CLI Options table in `crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md`

## Skipped
- `grammar_tests.rs` and `parse_command_tests` in `main.rs`: Rust-only test code (`#[cfg(test)]`), not ported per task rules

</details>