### PR TITLE
feat: expose the Spark master identity public key user setting

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/mainnet_stable_balance.rs
+++ b/crates/breez-sdk/breez-itest/tests/mainnet_stable_balance.rs
@@ -773,6 +773,7 @@ async fn test_stable_balance_zz_deactivation() -> Result<()> {
         .update_user_settings(UpdateUserSettingsRequest {
             spark_private_mode_enabled: None,
             stable_balance_active_label: Some(StableBalanceActiveLabel::Unset),
+            spark_master_identity_public_key: None,
         })
         .await?;
 

--- a/crates/breez-sdk/breez-itest/tests/signer_backends.rs
+++ b/crates/breez-sdk/breez-itest/tests/signer_backends.rs
@@ -366,6 +366,7 @@ async fn assert_update_settings_fails_under_deny_export(config: Config) -> Resul
         .update_user_settings(UpdateUserSettingsRequest {
             spark_private_mode_enabled: Some(true),
             stable_balance_active_label: None,
+            spark_master_identity_public_key: None,
         })
         .await
         .expect_err(

--- a/crates/breez-sdk/breez-itest/tests/user_settings.rs
+++ b/crates/breez-sdk/breez-itest/tests/user_settings.rs
@@ -60,6 +60,7 @@ async fn test_01_spark_private_mode_user_setting(
         .sdk
         .update_user_settings(UpdateUserSettingsRequest {
             stable_balance_active_label: None,
+            spark_master_identity_public_key: None,
             spark_private_mode_enabled: Some(false),
         })
         .await?;
@@ -67,6 +68,7 @@ async fn test_01_spark_private_mode_user_setting(
         .sdk
         .update_user_settings(UpdateUserSettingsRequest {
             stable_balance_active_label: None,
+            spark_master_identity_public_key: None,
             spark_private_mode_enabled: Some(true),
         })
         .await?;
@@ -96,6 +98,88 @@ async fn test_01_spark_private_mode_user_setting(
     assert!(reinitialized_non_private_settings.spark_private_mode_enabled);
 
     info!("=== Test test_01_spark_private_mode_user_setting PASSED ===");
+    Ok(())
+}
+
+/// Test 1b: Master identity public key user setting
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn test_01b_spark_master_identity_public_key_user_setting(
+    persistent_sdk_private: ReinitializableSdkInstance,
+) -> Result<()> {
+    info!("=== Starting test_01b_spark_master_identity_public_key_user_setting ===");
+
+    const MASTER_KEY: &str = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    const OTHER_MASTER_KEY: &str =
+        "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+
+    let instance = persistent_sdk_private.build_sdk().await?;
+
+    let initial_settings = instance.sdk.get_user_settings().await?;
+    assert_eq!(initial_settings.spark_master_identity_public_key, None);
+    assert!(initial_settings.spark_private_mode_enabled);
+
+    // Designating a master identity must leave private mode untouched.
+    instance
+        .sdk
+        .update_user_settings(UpdateUserSettingsRequest {
+            spark_private_mode_enabled: None,
+            stable_balance_active_label: None,
+            spark_master_identity_public_key: Some(SparkMasterIdentityPublicKey::Set {
+                public_key: MASTER_KEY.to_string(),
+            }),
+        })
+        .await?;
+    let settings = instance.sdk.get_user_settings().await?;
+    assert_eq!(
+        settings.spark_master_identity_public_key.as_deref(),
+        Some(MASTER_KEY)
+    );
+    assert!(settings.spark_private_mode_enabled);
+
+    // Setting again replaces the previously designated key.
+    instance
+        .sdk
+        .update_user_settings(UpdateUserSettingsRequest {
+            spark_private_mode_enabled: None,
+            stable_balance_active_label: None,
+            spark_master_identity_public_key: Some(SparkMasterIdentityPublicKey::Set {
+                public_key: OTHER_MASTER_KEY.to_string(),
+            }),
+        })
+        .await?;
+    let settings = instance.sdk.get_user_settings().await?;
+    assert_eq!(
+        settings.spark_master_identity_public_key.as_deref(),
+        Some(OTHER_MASTER_KEY)
+    );
+
+    instance
+        .sdk
+        .update_user_settings(UpdateUserSettingsRequest {
+            spark_private_mode_enabled: None,
+            stable_balance_active_label: None,
+            spark_master_identity_public_key: Some(SparkMasterIdentityPublicKey::Unset),
+        })
+        .await?;
+    let settings = instance.sdk.get_user_settings().await?;
+    assert_eq!(settings.spark_master_identity_public_key, None);
+    assert!(settings.spark_private_mode_enabled);
+
+    let err = instance
+        .sdk
+        .update_user_settings(UpdateUserSettingsRequest {
+            spark_private_mode_enabled: None,
+            stable_balance_active_label: None,
+            spark_master_identity_public_key: Some(SparkMasterIdentityPublicKey::Set {
+                public_key: "not-a-public-key".to_string(),
+            }),
+        })
+        .await
+        .expect_err("a malformed master identity public key must be rejected");
+    assert!(matches!(err, SdkError::InvalidInput(_)));
+
+    info!("=== Test test_01b_spark_master_identity_public_key_user_setting PASSED ===");
     Ok(())
 }
 
@@ -154,6 +238,7 @@ async fn test_02_stable_balance_user_setting(
         .update_user_settings(UpdateUserSettingsRequest {
             spark_private_mode_enabled: None,
             stable_balance_active_label: Some(StableBalanceActiveLabel::Unset),
+            spark_master_identity_public_key: None,
         })
         .await?;
     let settings = sdk_instance.sdk.get_user_settings().await?;
@@ -167,6 +252,7 @@ async fn test_02_stable_balance_user_setting(
             stable_balance_active_label: Some(StableBalanceActiveLabel::Set {
                 label: "BEAN".to_string(),
             }),
+            spark_master_identity_public_key: None,
         })
         .await?;
     let settings = sdk_instance.sdk.get_user_settings().await?;

--- a/crates/breez-sdk/cli/src/command/grammar_tests.rs
+++ b/crates/breez-sdk/cli/src/command/grammar_tests.rs
@@ -538,11 +538,39 @@ fn user_settings() {
     ));
     let Command::SetUserSettings {
         spark_private_mode_enabled,
+        master_key,
+        clear_master_key,
     } = parse_ok("set-user-settings -p true")
     else {
         panic!("expected SetUserSettings");
     };
     assert_eq!(spark_private_mode_enabled, Some(true));
+    assert_eq!(master_key, None);
+    assert!(!clear_master_key);
+
+    let Command::SetUserSettings {
+        master_key,
+        clear_master_key,
+        ..
+    } = parse_ok("set-user-settings -m 02a1b2")
+    else {
+        panic!("expected SetUserSettings");
+    };
+    assert_eq!(master_key.as_deref(), Some("02a1b2"));
+    assert!(!clear_master_key);
+
+    let Command::SetUserSettings {
+        master_key,
+        clear_master_key,
+        ..
+    } = parse_ok("set-user-settings --clear-master-key")
+    else {
+        panic!("expected SetUserSettings");
+    };
+    assert_eq!(master_key, None);
+    assert!(clear_master_key);
+
+    parse_err("set-user-settings -m 02a1b2 --clear-master-key");
 }
 
 #[test]

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -17,8 +17,8 @@ use breez_sdk_spark::{
     PaymentRequest, PaymentStatus, PaymentType, PrepareLnurlPayRequest, PrepareSendPaymentRequest,
     ReceivePaymentMethod, ReceivePaymentRequest, RefundDepositRequest,
     RegisterLightningAddressRequest, SendPaymentMethod, SendPaymentOptions, SendPaymentRequest,
-    SparkHtlcOptions, SparkHtlcStatus, SyncWalletRequest, TokenIssuer, TokenTransactionType,
-    TransferAuthorization, UpdateUserSettingsRequest,
+    SparkHtlcOptions, SparkHtlcStatus, SparkMasterIdentityPublicKey, SyncWalletRequest,
+    TokenIssuer, TokenTransactionType, TransferAuthorization, UpdateUserSettingsRequest,
 };
 use clap::{Parser, ValueEnum};
 use rand::RngCore;
@@ -367,6 +367,15 @@ pub enum Command {
         /// Whether spark private mode is enabled.
         #[clap(short = 'p', long = "private")]
         spark_private_mode_enabled: Option<bool>,
+
+        /// Hex encoded public key to designate as the wallet's master identity,
+        /// allowing its holder to read the wallet under private mode.
+        #[clap(short = 'm', long = "master-key", conflicts_with = "clear_master_key")]
+        master_key: Option<String>,
+
+        /// Remove the wallet's designated master identity.
+        #[clap(long = "clear-master-key", action = clap::ArgAction::SetTrue)]
+        clear_master_key: bool,
     },
 
     /// Get the status of the Spark network services
@@ -1061,10 +1070,18 @@ pub(crate) async fn execute_command(
         }
         Command::SetUserSettings {
             spark_private_mode_enabled,
+            master_key,
+            clear_master_key,
         } => {
+            let spark_master_identity_public_key = match (master_key, clear_master_key) {
+                (Some(public_key), _) => Some(SparkMasterIdentityPublicKey::Set { public_key }),
+                (None, true) => Some(SparkMasterIdentityPublicKey::Unset),
+                (None, false) => None,
+            };
             sdk.update_user_settings(UpdateUserSettingsRequest {
                 spark_private_mode_enabled,
                 stable_balance_active_label: None,
+                spark_master_identity_public_key,
             })
             .await?;
             Ok(true)

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -370,11 +370,11 @@ pub enum Command {
 
         /// Hex encoded public key to designate as the wallet's master identity,
         /// allowing its holder to read the wallet under private mode.
-        #[clap(short = 'm', long = "master-key", conflicts_with = "clear_master_key")]
+        #[clap(short, long, conflicts_with = "clear_master_key")]
         master_key: Option<String>,
 
         /// Remove the wallet's designated master identity.
-        #[clap(long = "clear-master-key", action = clap::ArgAction::SetTrue)]
+        #[clap(long, action = clap::ArgAction::SetTrue)]
         clear_master_key: bool,
     },
 

--- a/crates/breez-sdk/cli/src/command/stable_balance.rs
+++ b/crates/breez-sdk/cli/src/command/stable_balance.rs
@@ -30,6 +30,7 @@ pub async fn handle_command(
             sdk.update_user_settings(UpdateUserSettingsRequest {
                 spark_private_mode_enabled: None,
                 stable_balance_active_label: Some(StableBalanceActiveLabel::Set { label }),
+                spark_master_identity_public_key: None,
             })
             .await?;
             let settings = sdk.get_user_settings().await?;
@@ -40,6 +41,7 @@ pub async fn handle_command(
             sdk.update_user_settings(UpdateUserSettingsRequest {
                 spark_private_mode_enabled: None,
                 stable_balance_active_label: Some(StableBalanceActiveLabel::Unset),
+                spark_master_identity_public_key: None,
             })
             .await?;
             let settings = sdk.get_user_settings().await?;

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -2116,8 +2116,9 @@ pub struct UserSettings {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum SparkMasterIdentityPublicKey {
-    /// Designate the holder of this hex encoded public key as the wallet's
-    /// master identity, replacing any previously designated key.
+    /// Designate the holder of this public key as the wallet's master
+    /// identity, replacing any previously designated key. Must be hex encoded
+    /// in the 33-byte compressed form.
     Set { public_key: String },
     /// Remove the designated master identity, leaving the owner as the only
     /// party able to read the wallet under private mode.

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -2106,6 +2106,22 @@ pub struct UserSettings {
 
     /// The label of the currently active stable balance token, or `None` if deactivated.
     pub stable_balance_active_label: Option<String>,
+
+    /// The hex encoded public key designated as this wallet's master identity
+    /// key, or `None` if none is designated.
+    pub spark_master_identity_public_key: Option<String>,
+}
+
+/// Specifies how to update the wallet's Spark master identity public key.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum SparkMasterIdentityPublicKey {
+    /// Designate the holder of this hex encoded public key as the wallet's
+    /// master identity, replacing any previously designated key.
+    Set { public_key: String },
+    /// Remove the designated master identity, leaving the owner as the only
+    /// party able to read the wallet under private mode.
+    Unset,
 }
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -2115,6 +2131,14 @@ pub struct UpdateUserSettingsRequest {
     /// Update the active stable balance token. `None` means no change.
     #[cfg_attr(feature = "uniffi", uniffi(default = None))]
     pub stable_balance_active_label: Option<StableBalanceActiveLabel>,
+
+    /// Designate or remove the wallet's master identity, a second public key
+    /// the Spark operators accept as a reader of this wallet's balance and
+    /// history while `spark_private_mode_enabled` is set. The master identity
+    /// can only read: payments still require the owner's keys. `None` means no
+    /// change.
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub spark_master_identity_public_key: Option<SparkMasterIdentityPublicKey>,
 }
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -1,5 +1,6 @@
 use bitcoin::secp256k1::{PublicKey, ecdsa::Signature};
 use breez_sdk_common::buy::cashapp::CashAppProvider;
+use spark_wallet::MasterIdentityPublicKeyUpdate;
 use std::str::FromStr;
 use tracing::{debug, info};
 
@@ -14,7 +15,9 @@ use crate::{
     error::SdkError,
     events::EventListener,
     issuer::TokenIssuer,
-    models::{GetInfoRequest, GetInfoResponse, StableBalanceActiveLabel},
+    models::{
+        GetInfoRequest, GetInfoResponse, SparkMasterIdentityPublicKey, StableBalanceActiveLabel,
+    },
     persist::ObjectCacheRepository,
     utils::token::get_tokens_metadata_cached_or_query,
 };
@@ -244,6 +247,9 @@ impl BreezSdk {
         Ok(UserSettings {
             spark_private_mode_enabled: spark_user_settings.private_enabled,
             stable_balance_active_label,
+            spark_master_identity_public_key: spark_user_settings
+                .master_identity_public_key
+                .map(|key| key.to_string()),
         })
     }
 
@@ -254,11 +260,26 @@ impl BreezSdk {
         &self,
         request: UpdateUserSettingsRequest,
     ) -> Result<(), SdkError> {
-        if let Some(spark_private_mode_enabled) = request.spark_private_mode_enabled {
-            self.spark_wallet
-                .update_wallet_settings(spark_private_mode_enabled)
-                .await?;
-        }
+        let master_identity_public_key = request
+            .spark_master_identity_public_key
+            .map(|update| match update {
+                SparkMasterIdentityPublicKey::Set { public_key } => {
+                    PublicKey::from_str(&public_key)
+                        .map(MasterIdentityPublicKeyUpdate::Set)
+                        .map_err(|_| {
+                            SdkError::InvalidInput("Invalid master identity public key".to_string())
+                        })
+                }
+                SparkMasterIdentityPublicKey::Unset => Ok(MasterIdentityPublicKeyUpdate::Clear),
+            })
+            .transpose()?;
+
+        self.spark_wallet
+            .update_wallet_settings(
+                request.spark_private_mode_enabled,
+                master_identity_public_key,
+            )
+            .await?;
 
         if let Some(active_label) = request.stable_balance_active_label {
             let sb = self

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -264,11 +264,7 @@ impl BreezSdk {
             .spark_master_identity_public_key
             .map(|update| match update {
                 SparkMasterIdentityPublicKey::Set { public_key } => {
-                    PublicKey::from_str(&public_key)
-                        .map(MasterIdentityPublicKeyUpdate::Set)
-                        .map_err(|_| {
-                            SdkError::InvalidInput("Invalid master identity public key".to_string())
-                        })
+                    parse_compressed_public_key(&public_key).map(MasterIdentityPublicKeyUpdate::Set)
                 }
                 SparkMasterIdentityPublicKey::Unset => Ok(MasterIdentityPublicKeyUpdate::Clear),
             })
@@ -438,5 +434,47 @@ impl BreezSdk {
         };
 
         Ok(BuyBitcoinResponse { url })
+    }
+}
+
+/// Parses a 33-byte compressed public key from hex.
+///
+/// Rejects the uncompressed encoding, which `PublicKey::from_str` also accepts:
+/// Spark serializes identity keys compressed, so accepting it would make the
+/// key read back differ from the one that was set.
+fn parse_compressed_public_key(hex_encoded: &str) -> Result<PublicKey, SdkError> {
+    let invalid = || SdkError::InvalidInput("Invalid master identity public key".to_string());
+    let bytes: [u8; 33] = hex::decode(hex_encoded)
+        .map_err(|_| invalid())?
+        .try_into()
+        .map_err(|_| invalid())?;
+    PublicKey::from_slice(&bytes).map_err(|_| invalid())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const COMPRESSED: &str = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    const UNCOMPRESSED: &str = "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179\
+        8483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8";
+
+    #[test]
+    fn parse_compressed_public_key_round_trips() {
+        let key = parse_compressed_public_key(COMPRESSED).unwrap();
+        assert_eq!(key.to_string(), COMPRESSED);
+    }
+
+    #[test]
+    fn parse_compressed_public_key_rejects_invalid() {
+        for input in ["", "not-a-public-key", UNCOMPRESSED, &COMPRESSED[..64]] {
+            assert!(
+                matches!(
+                    parse_compressed_public_key(input),
+                    Err(SdkError::InvalidInput(_))
+                ),
+                "expected {input} to be rejected"
+            );
+        }
     }
 }

--- a/crates/breez-sdk/core/src/sdk/init.rs
+++ b/crates/breez-sdk/core/src/sdk/init.rs
@@ -126,6 +126,7 @@ impl BreezSdk {
         self.update_user_settings(crate::UpdateUserSettingsRequest {
             spark_private_mode_enabled: Some(true),
             stable_balance_active_label: None,
+            spark_master_identity_public_key: None,
         })
         .await?;
         ObjectCacheRepository::new(self.storage.clone())

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -1667,6 +1667,7 @@ pub struct OutgoingChange {
 pub struct UserSettings {
     pub spark_private_mode_enabled: bool,
     pub stable_balance_active_label: Option<String>,
+    pub spark_master_identity_public_key: Option<String>,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::StableBalanceActiveLabel)]
@@ -1675,10 +1676,17 @@ pub enum StableBalanceActiveLabel {
     Unset,
 }
 
+#[macros::extern_wasm_bindgen(breez_sdk_spark::SparkMasterIdentityPublicKey)]
+pub enum SparkMasterIdentityPublicKey {
+    Set { public_key: String },
+    Unset,
+}
+
 #[macros::extern_wasm_bindgen(breez_sdk_spark::UpdateUserSettingsRequest)]
 pub struct UpdateUserSettingsRequest {
     pub spark_private_mode_enabled: Option<bool>,
     pub stable_balance_active_label: Option<StableBalanceActiveLabel>,
+    pub spark_master_identity_public_key: Option<SparkMasterIdentityPublicKey>,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::ClaimHtlcPaymentRequest)]

--- a/crates/internal/src/command/wallet_settings.rs
+++ b/crates/internal/src/command/wallet_settings.rs
@@ -1,5 +1,5 @@
 use clap::Subcommand;
-use spark_wallet::SparkWallet;
+use spark_wallet::{MasterIdentityPublicKeyUpdate, PublicKey, SparkWallet};
 
 #[derive(Debug, Subcommand)]
 pub enum WalletSettingsCommand {
@@ -9,7 +9,15 @@ pub enum WalletSettingsCommand {
     Update {
         #[clap(short, long)]
         /// Whether private mode is enabled.
-        private_enabled: bool,
+        private_enabled: Option<bool>,
+
+        /// Hex encoded public key to designate as the wallet's master identity.
+        #[clap(short, long, conflicts_with = "clear_master_key")]
+        master_key: Option<PublicKey>,
+
+        /// Remove the wallet's designated master identity.
+        #[clap(long, action = clap::ArgAction::SetTrue)]
+        clear_master_key: bool,
     },
 }
 
@@ -22,8 +30,19 @@ pub async fn handle_command(
             let settings = wallet.query_wallet_settings().await?;
             println!("{}", serde_json::to_string_pretty(&settings)?);
         }
-        WalletSettingsCommand::Update { private_enabled } => {
-            wallet.update_wallet_settings(private_enabled).await?;
+        WalletSettingsCommand::Update {
+            private_enabled,
+            master_key,
+            clear_master_key,
+        } => {
+            let master_identity_public_key = match (master_key, clear_master_key) {
+                (Some(key), _) => Some(MasterIdentityPublicKeyUpdate::Set(key)),
+                (None, true) => Some(MasterIdentityPublicKeyUpdate::Clear),
+                (None, false) => None,
+            };
+            wallet
+                .update_wallet_settings(private_enabled, master_identity_public_key)
+                .await?;
             println!("Wallet settings updated successfully.");
         }
     }

--- a/crates/spark-itest/Cargo.toml
+++ b/crates/spark-itest/Cargo.toml
@@ -18,7 +18,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 spark-mysql.workspace = true
 spark-postgres.workspace = true
-spark-wallet.workspace = true
+spark-wallet = { workspace = true, features = ["test-utils"] }
 test-log = { workspace = true, features = ["trace"] }
 testcontainers.workspace = true
 testcontainers-modules = { workspace = true, features = ["postgres", "mysql"] }

--- a/crates/spark-itest/tests/deployed_wallet_settings_tests.rs
+++ b/crates/spark-itest/tests/deployed_wallet_settings_tests.rs
@@ -1,0 +1,112 @@
+use anyhow::Result;
+use bitcoin::Address;
+use rstest::*;
+use spark_itest::{
+    faucet::RegtestFaucet,
+    helpers::{create_regtest_wallet, wait_for_event},
+    mempool::MempoolClient,
+};
+use spark_wallet::{MasterIdentityPublicKeyUpdate, WalletEvent};
+use tracing::info;
+
+const DEPOSIT_AMOUNT_SATS: u64 = 50_000;
+
+/// Exercises the operator-side read access granted by a wallet's master
+/// identity.
+///
+/// `owner` funds itself and enables private mode, which hides its balance from
+/// every session but its own, then designates `reader` as its master identity.
+#[rstest]
+#[tokio::test]
+#[test_log::test]
+async fn test_master_identity_grants_read_access() -> Result<()> {
+    info!("=== Starting test_master_identity_grants_read_access ===");
+
+    let faucet = RegtestFaucet::new()?;
+    let mempool = MempoolClient::new()?;
+
+    let (owner, mut owner_listener) = create_regtest_wallet().await?;
+    let (reader, _reader_listener) = create_regtest_wallet().await?;
+
+    let owner_identity = owner.get_identity_public_key();
+    let reader_identity = reader.get_identity_public_key();
+
+    // Fund the owner, so there is a balance worth hiding.
+    let deposit = owner.generate_deposit_address().await?;
+    let deposit_address = &deposit.address;
+    let txid = faucet
+        .fund_address(&deposit_address.to_string(), DEPOSIT_AMOUNT_SATS)
+        .await?;
+    let tx = mempool.get_transaction(&txid).await?;
+    let vout = tx
+        .output
+        .iter()
+        .enumerate()
+        .find(|(_, output)| {
+            Address::from_script(&output.script_pubkey, bitcoin::Network::Regtest)
+                .is_ok_and(|addr| &addr == deposit_address)
+        })
+        .map(|(i, _)| i as u32)
+        .expect("Could not find deposit address in transaction outputs");
+    owner.claim_deposit(tx, vout).await?;
+    wait_for_event(&mut owner_listener, 180, "DepositConfirmed", |e| match e {
+        WalletEvent::DepositConfirmed(_) => Ok(Some(e)),
+        _ => Ok(None),
+    })
+    .await?;
+    assert_eq!(owner.get_balance().await?, DEPOSIT_AMOUNT_SATS);
+
+    owner.update_wallet_settings(Some(true), None).await?;
+    let settings = owner.query_wallet_settings().await?;
+    assert!(settings.private_enabled);
+    assert_eq!(settings.master_identity_public_key, None);
+
+    // The owner always reads its own wallet, private mode or not.
+    assert_eq!(
+        owner.query_available_balance_of(&owner_identity).await?,
+        DEPOSIT_AMOUNT_SATS,
+        "the owner must see its own balance under private mode"
+    );
+
+    // No master identity designated yet, so the reader is blind.
+    assert_eq!(
+        reader.query_available_balance_of(&owner_identity).await?,
+        0,
+        "a private wallet must not be readable before a master identity is designated"
+    );
+
+    owner
+        .update_wallet_settings(
+            None,
+            Some(MasterIdentityPublicKeyUpdate::Set(reader_identity)),
+        )
+        .await?;
+
+    // Designating a master identity must not disturb private mode.
+    let settings = owner.query_wallet_settings().await?;
+    assert!(settings.private_enabled);
+    assert_eq!(settings.master_identity_public_key, Some(reader_identity));
+
+    assert_eq!(
+        reader.query_available_balance_of(&owner_identity).await?,
+        DEPOSIT_AMOUNT_SATS,
+        "the designated master identity must read the private wallet's balance"
+    );
+
+    owner
+        .update_wallet_settings(None, Some(MasterIdentityPublicKeyUpdate::Clear))
+        .await?;
+
+    let settings = owner.query_wallet_settings().await?;
+    assert!(settings.private_enabled);
+    assert_eq!(settings.master_identity_public_key, None);
+
+    assert_eq!(
+        reader.query_available_balance_of(&owner_identity).await?,
+        0,
+        "clearing the master identity must revoke read access"
+    );
+
+    info!("=== Test test_master_identity_grants_read_access PASSED ===");
+    Ok(())
+}

--- a/crates/spark-wallet/src/model.rs
+++ b/crates/spark-wallet/src/model.rs
@@ -388,14 +388,40 @@ impl TryFrom<InvoiceTransferType> for SparkInvoiceTransferType {
 #[derive(Clone, Debug, Serialize)]
 pub struct WalletSettings {
     pub private_enabled: bool,
+
+    /// The identity public key that may read this wallet in addition to its
+    /// owner, or `None` when no such key is designated.
+    pub master_identity_public_key: Option<PublicKey>,
 }
 
-impl From<WalletSetting> for WalletSettings {
-    fn from(value: WalletSetting) -> Self {
-        WalletSettings {
+impl TryFrom<WalletSetting> for WalletSettings {
+    type Error = SparkWalletError;
+    fn try_from(value: WalletSetting) -> Result<Self, Self::Error> {
+        Ok(WalletSettings {
             private_enabled: value.private_enabled,
-        }
+            master_identity_public_key: value
+                .master_identity_public_key
+                .map(|key| {
+                    PublicKey::from_slice(&key).map_err(|_| {
+                        SparkWalletError::ValidationError(
+                            "Invalid master identity public key".to_string(),
+                        )
+                    })
+                })
+                .transpose()?,
+        })
     }
+}
+
+/// Specifies how to update the identity public key that may read the wallet in
+/// addition to its owner.
+#[derive(Clone, Debug)]
+pub enum MasterIdentityPublicKeyUpdate {
+    /// Designate `key` as the wallet's master identity public key, replacing
+    /// any previously designated key.
+    Set(PublicKey),
+    /// Remove the designated master identity public key, if any.
+    Clear,
 }
 
 pub(crate) struct WithdrawInnerParams<'a> {

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -18,7 +18,7 @@ use platform_utils::tokio;
 use spark::bitcoin::sighash_from_multi_input_tx;
 #[cfg(feature = "test-utils")]
 use spark::operator::rpc::spark::{
-    Network as ProtoNetwork, QueryNodesRequest, TreeNodeStatus as ProtoTreeNodeStatus,
+    QueryNodesRequest, TreeNodeStatus as ProtoTreeNodeStatus,
     query_nodes_request::Source as QueryNodesSource,
 };
 use spark::{
@@ -2082,7 +2082,7 @@ impl SparkWallet {
                     identity_public_key.serialize().to_vec(),
                 )),
                 statuses: vec![ProtoTreeNodeStatus::Available as i32],
-                network: self.proto_network() as i32,
+                network: self.config.network.to_proto_network() as i32,
                 include_parents: false,
                 offset: 0,
                 limit: 100,
@@ -2090,17 +2090,6 @@ impl SparkWallet {
             .await?;
 
         Ok(response.nodes.values().map(|node| node.value).sum())
-    }
-
-    /// `Network::to_proto_network` is crate-private to `spark`.
-    #[cfg(feature = "test-utils")]
-    fn proto_network(&self) -> ProtoNetwork {
-        match self.config.network {
-            crate::Network::Mainnet => ProtoNetwork::Mainnet,
-            crate::Network::Regtest => ProtoNetwork::Regtest,
-            crate::Network::Testnet => ProtoNetwork::Testnet,
-            crate::Network::Signet => ProtoNetwork::Signet,
-        }
     }
 
     /// Manually drives leaf optimization, blocking until the requested work

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -16,6 +16,11 @@ use futures::stream::{self, StreamExt};
 use platform_utils::time::{SystemTime, UNIX_EPOCH};
 use platform_utils::tokio;
 use spark::bitcoin::sighash_from_multi_input_tx;
+#[cfg(feature = "test-utils")]
+use spark::operator::rpc::spark::{
+    Network as ProtoNetwork, QueryNodesRequest, TreeNodeStatus as ProtoTreeNodeStatus,
+    query_nodes_request::Source as QueryNodesSource,
+};
 use spark::{
     address::{
         SatsPayment, SparkAddress, SparkAddressPaymentType, SparkInvoiceFields, TokensPayment,
@@ -27,7 +32,10 @@ use spark::{
         OperatorPool,
         rpc::{
             ConnectionManager, DefaultConnectionManager, OperatorRpcError,
-            spark::{PreimageRequestRole, QuerySparkInvoicesRequest, UpdateWalletSettingRequest},
+            spark::{
+                PreimageRequestRole, QuerySparkInvoicesRequest, UpdateWalletSettingRequest,
+                update_wallet_setting_request::MasterIdentityPublicKey as ProtoMasterIdentityPublicKey,
+            },
         },
     },
     services::{
@@ -60,9 +68,9 @@ use tonic_types::StatusExt;
 use tracing::{Instrument, debug, error, info, trace, warn};
 
 use crate::{
-    FulfillSparkInvoiceResult, ListTokenTransactionsRequest, ListTransfersRequest, PreimageRequest,
-    QuerySparkInvoiceResult, TokenBalance, WalletEvent, WalletLeaves, WalletSettings,
-    WithdrawInnerParams,
+    FulfillSparkInvoiceResult, ListTokenTransactionsRequest, ListTransfersRequest,
+    MasterIdentityPublicKeyUpdate, PreimageRequest, QuerySparkInvoiceResult, TokenBalance,
+    WalletEvent, WalletLeaves, WalletSettings, WithdrawInnerParams,
     event::EventManager,
     model::{PayLightningInvoiceResult, WalletInfo, WalletLeaf, WalletTransfer},
     unilateral_exit::{CpfpChangeInput, ExitLeafSelection, PreparedUnilateralExit, RefundOutput},
@@ -2010,8 +2018,7 @@ impl SparkWallet {
     }
 
     pub async fn query_wallet_settings(&self) -> Result<WalletSettings, SparkWalletError> {
-        Ok(self
-            .operator_pool
+        self.operator_pool
             .get_coordinator()
             .client
             .query_wallet_setting()
@@ -2020,22 +2027,80 @@ impl SparkWallet {
             .ok_or(SparkWalletError::Generic(
                 "Response doesn't include wallet settings".to_string(),
             ))?
-            .into())
+            .try_into()
     }
 
+    /// Updates the wallet settings, leaving any setting passed as `None`
+    /// untouched. Passing `None` for every setting performs no request.
     pub async fn update_wallet_settings(
         &self,
-        private_enabled: bool,
+        private_enabled: Option<bool>,
+        master_identity_public_key: Option<MasterIdentityPublicKeyUpdate>,
     ) -> Result<(), SparkWalletError> {
+        // The operator rejects an update that carries no field.
+        if private_enabled.is_none() && master_identity_public_key.is_none() {
+            return Ok(());
+        }
+
         self.operator_pool
             .get_coordinator()
             .client
             .update_wallet_setting(UpdateWalletSettingRequest {
-                private_enabled: Some(private_enabled),
-                master_identity_public_key: None,
+                private_enabled,
+                master_identity_public_key: master_identity_public_key.map(|update| match update {
+                    MasterIdentityPublicKeyUpdate::Set(key) => {
+                        ProtoMasterIdentityPublicKey::SetMasterIdentityPublicKey(
+                            key.serialize().to_vec(),
+                        )
+                    }
+                    MasterIdentityPublicKeyUpdate::Clear => {
+                        ProtoMasterIdentityPublicKey::ClearMasterIdentityPublicKey(true)
+                    }
+                }),
             })
             .await?;
         Ok(())
+    }
+
+    /// Sums the available leaves of an arbitrary wallet, using this wallet's
+    /// own session.
+    ///
+    /// Under Spark private mode the operators serve identity-keyed reads only
+    /// to the target wallet's owner or its designated master identity, and
+    /// return nothing otherwise.
+    #[cfg(feature = "test-utils")]
+    pub async fn query_available_balance_of(
+        &self,
+        identity_public_key: &PublicKey,
+    ) -> Result<u64, SparkWalletError> {
+        let response = self
+            .operator_pool
+            .get_coordinator()
+            .client
+            .query_nodes(QueryNodesRequest {
+                source: Some(QueryNodesSource::OwnerIdentityPubkey(
+                    identity_public_key.serialize().to_vec(),
+                )),
+                statuses: vec![ProtoTreeNodeStatus::Available as i32],
+                network: self.proto_network() as i32,
+                include_parents: false,
+                offset: 0,
+                limit: 100,
+            })
+            .await?;
+
+        Ok(response.nodes.values().map(|node| node.value).sum())
+    }
+
+    /// `Network::to_proto_network` is crate-private to `spark`.
+    #[cfg(feature = "test-utils")]
+    fn proto_network(&self) -> ProtoNetwork {
+        match self.config.network {
+            crate::Network::Mainnet => ProtoNetwork::Mainnet,
+            crate::Network::Regtest => ProtoNetwork::Regtest,
+            crate::Network::Testnet => ProtoNetwork::Testnet,
+            crate::Network::Signet => ProtoNetwork::Signet,
+        }
     }
 
     /// Manually drives leaf optimization, blocking until the requested work

--- a/crates/spark/src/core/network.rs
+++ b/crates/spark/src/core/network.rs
@@ -46,7 +46,7 @@ impl FromStr for Network {
 }
 
 impl Network {
-    pub(crate) fn to_proto_network(self) -> operator_rpc::spark::Network {
+    pub fn to_proto_network(self) -> operator_rpc::spark::Network {
         match self {
             Network::Mainnet => operator_rpc::spark::Network::Mainnet,
             Network::Regtest => operator_rpc::spark::Network::Regtest,

--- a/docs/breez-sdk/snippets/csharp/UserSettings.cs
+++ b/docs/breez-sdk/snippets/csharp/UserSettings.cs
@@ -16,8 +16,6 @@ namespace BreezSdkSnippets
         async Task UpdateUserSettings(BreezSdk sdk)
         {
             // ANCHOR: update-user-settings
-            // Fields left as null are not changed. Settings that take an enum value
-            // accept Set to assign one, or Unset to clear it.
             await sdk.UpdateUserSettings(
                 request: new UpdateUserSettingsRequest(
                     sparkPrivateModeEnabled: true,

--- a/docs/breez-sdk/snippets/csharp/UserSettings.cs
+++ b/docs/breez-sdk/snippets/csharp/UserSettings.cs
@@ -16,10 +16,15 @@ namespace BreezSdkSnippets
         async Task UpdateUserSettings(BreezSdk sdk)
         {
             // ANCHOR: update-user-settings
-            var sparkPrivateModeEnabled = true;
+            // Fields left as null are not changed. Settings that take an enum value
+            // accept Set to assign one, or Unset to clear it.
             await sdk.UpdateUserSettings(
                 request: new UpdateUserSettingsRequest(
-                    sparkPrivateModeEnabled: sparkPrivateModeEnabled
+                    sparkPrivateModeEnabled: true,
+                    stableBalanceActiveLabel: null,
+                    sparkMasterIdentityPublicKey: new SparkMasterIdentityPublicKey.Set(
+                        publicKey: "<hex encoded public key>"
+                    )
                 )
             );
             // ANCHOR_END: update-user-settings

--- a/docs/breez-sdk/snippets/flutter/lib/user_settings.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/user_settings.dart
@@ -9,11 +9,14 @@ Future<void> getUserSettings(BreezSdk sdk) async {
 
 Future<void> updateUserSettings(BreezSdk sdk) async {
   // ANCHOR: update-user-settings
-  final bool sparkPrivateModeEnabled = true;
-
+  // Fields left as null are not changed. Settings that take an enum value
+  // accept Set to assign one, or Unset to clear it.
   await sdk.updateUserSettings(
       request: UpdateUserSettingsRequest(
-          sparkPrivateModeEnabled: sparkPrivateModeEnabled));
+          sparkPrivateModeEnabled: true,
+          stableBalanceActiveLabel: null,
+          sparkMasterIdentityPublicKey: SparkMasterIdentityPublicKey_Set(
+              publicKey: "<hex encoded public key>")));
   // ANCHOR_END: update-user-settings
 }
 

--- a/docs/breez-sdk/snippets/flutter/lib/user_settings.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/user_settings.dart
@@ -9,8 +9,6 @@ Future<void> getUserSettings(BreezSdk sdk) async {
 
 Future<void> updateUserSettings(BreezSdk sdk) async {
   // ANCHOR: update-user-settings
-  // Fields left as null are not changed. Settings that take an enum value
-  // accept Set to assign one, or Unset to clear it.
   await sdk.updateUserSettings(
       request: UpdateUserSettingsRequest(
           sparkPrivateModeEnabled: true,

--- a/docs/breez-sdk/snippets/go/user_settings.go
+++ b/docs/breez-sdk/snippets/go/user_settings.go
@@ -27,9 +27,18 @@ func GetUserSettings(sdk *breez_sdk_spark.BreezSdk) error {
 
 func UpdateUserSettings(sdk *breez_sdk_spark.BreezSdk) error {
 	// ANCHOR: update-user-settings
+	// Fields left nil are not changed. Settings that take an enum value
+	// accept Set to assign one, or Unset to clear it.
 	sparkPrivateModeEnabled := true
+	masterIdentityPublicKey := breez_sdk_spark.SparkMasterIdentityPublicKey(
+		breez_sdk_spark.SparkMasterIdentityPublicKeySet{
+			PublicKey: "<hex encoded public key>",
+		},
+	)
 	err := sdk.UpdateUserSettings(breez_sdk_spark.UpdateUserSettingsRequest{
-		SparkPrivateModeEnabled: &sparkPrivateModeEnabled,
+		SparkPrivateModeEnabled:      &sparkPrivateModeEnabled,
+		StableBalanceActiveLabel:     nil,
+		SparkMasterIdentityPublicKey: &masterIdentityPublicKey,
 	})
 
 	if err != nil {

--- a/docs/breez-sdk/snippets/go/user_settings.go
+++ b/docs/breez-sdk/snippets/go/user_settings.go
@@ -27,8 +27,6 @@ func GetUserSettings(sdk *breez_sdk_spark.BreezSdk) error {
 
 func UpdateUserSettings(sdk *breez_sdk_spark.BreezSdk) error {
 	// ANCHOR: update-user-settings
-	// Fields left nil are not changed. Settings that take an enum value
-	// accept Set to assign one, or Unset to clear it.
 	sparkPrivateModeEnabled := true
 	masterIdentityPublicKey := breez_sdk_spark.SparkMasterIdentityPublicKey(
 		breez_sdk_spark.SparkMasterIdentityPublicKeySet{

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/UserSettings.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/UserSettings.kt
@@ -16,8 +16,6 @@ class UserSettings {
 
     suspend fun updateUserSettings(sdk: BreezSdk) {
         // ANCHOR: update-user-settings
-        // Fields left as null are not changed. Settings that take an enum value
-        // accept Set to assign one, or Unset to clear it.
         try {
             sdk.updateUserSettings(UpdateUserSettingsRequest(
                 sparkPrivateModeEnabled = true,

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/UserSettings.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/UserSettings.kt
@@ -16,9 +16,16 @@ class UserSettings {
 
     suspend fun updateUserSettings(sdk: BreezSdk) {
         // ANCHOR: update-user-settings
+        // Fields left as null are not changed. Settings that take an enum value
+        // accept Set to assign one, or Unset to clear it.
         try {
-            val sparkPrivateModeEnabled = true
-            sdk.updateUserSettings(UpdateUserSettingsRequest(sparkPrivateModeEnabled))
+            sdk.updateUserSettings(UpdateUserSettingsRequest(
+                sparkPrivateModeEnabled = true,
+                stableBalanceActiveLabel = null,
+                sparkMasterIdentityPublicKey = SparkMasterIdentityPublicKey.Set(
+                    publicKey = "<hex encoded public key>"
+                )
+            ))
         } catch (e: Exception) {
             // handle error
         }

--- a/docs/breez-sdk/snippets/python/src/user_settings.py
+++ b/docs/breez-sdk/snippets/python/src/user_settings.py
@@ -20,8 +20,6 @@ async def get_user_settings(sdk: BreezSdk):
 
 async def update_user_settings(sdk: BreezSdk):
     # ANCHOR: update-user-settings
-    # Fields left as None are not changed. Settings that take an enum value
-    # accept SET to assign one, or UNSET to clear it.
     try:
         await sdk.update_user_settings(
             request=UpdateUserSettingsRequest(

--- a/docs/breez-sdk/snippets/python/src/user_settings.py
+++ b/docs/breez-sdk/snippets/python/src/user_settings.py
@@ -1,6 +1,7 @@
 import logging
 from breez_sdk_spark import (
     BreezSdk,
+    SparkMasterIdentityPublicKey,
     StableBalanceActiveLabel,
     UpdateUserSettingsRequest,
 )
@@ -19,11 +20,16 @@ async def get_user_settings(sdk: BreezSdk):
 
 async def update_user_settings(sdk: BreezSdk):
     # ANCHOR: update-user-settings
+    # Fields left as None are not changed. Settings that take an enum value
+    # accept SET to assign one, or UNSET to clear it.
     try:
-        spark_private_mode_enabled = True
         await sdk.update_user_settings(
             request=UpdateUserSettingsRequest(
-                spark_private_mode_enabled=spark_private_mode_enabled
+                spark_private_mode_enabled=True,
+                stable_balance_active_label=None,
+                spark_master_identity_public_key=SparkMasterIdentityPublicKey.SET(
+                    public_key="<hex encoded public key>"
+                )
             )
         )
     except Exception as error:

--- a/docs/breez-sdk/snippets/react-native/sdk_building.ts
+++ b/docs/breez-sdk/snippets/react-native/sdk_building.ts
@@ -170,7 +170,8 @@ const exampleServerModeProvisioning = async (sdk: BreezSdk) => {
   // server-mode SDKs do not, so opt in once here via updateUserSettings.
   await sdk.updateUserSettings({
     sparkPrivateModeEnabled: true,
-    stableBalanceActiveLabel: undefined
+    stableBalanceActiveLabel: undefined,
+    sparkMasterIdentityPublicKey: undefined
   })
 
   await sdk.disconnect()

--- a/docs/breez-sdk/snippets/react-native/user_settings.ts
+++ b/docs/breez-sdk/snippets/react-native/user_settings.ts
@@ -1,4 +1,8 @@
-import { type BreezSdk, StableBalanceActiveLabel } from '@breeztech/breez-sdk-spark-react-native'
+import {
+  type BreezSdk,
+  SparkMasterIdentityPublicKey,
+  StableBalanceActiveLabel
+} from '@breeztech/breez-sdk-spark-react-native'
 
 const exampleGetUserSettings = async (sdk: BreezSdk) => {
   // ANCHOR: get-user-settings
@@ -9,10 +13,14 @@ const exampleGetUserSettings = async (sdk: BreezSdk) => {
 
 const exampleUpdateUserSettings = async (sdk: BreezSdk) => {
   // ANCHOR: update-user-settings
-  const sparkPrivateModeEnabled = true
+  // Fields left undefined are not changed. Settings that take an enum value
+  // accept Set to assign one, or Unset to clear it.
   await sdk.updateUserSettings({
-    sparkPrivateModeEnabled,
-    stableBalanceActiveLabel: undefined
+    sparkPrivateModeEnabled: true,
+    stableBalanceActiveLabel: undefined,
+    sparkMasterIdentityPublicKey: new SparkMasterIdentityPublicKey.Set({
+      publicKey: '<hex encoded public key>'
+    })
   })
   // ANCHOR_END: update-user-settings
 }
@@ -21,7 +29,8 @@ const exampleActivateStableBalance = async (sdk: BreezSdk) => {
   // ANCHOR: activate-stable-balance
   await sdk.updateUserSettings({
     sparkPrivateModeEnabled: undefined,
-    stableBalanceActiveLabel: new StableBalanceActiveLabel.Set({ label: 'USDB' })
+    stableBalanceActiveLabel: new StableBalanceActiveLabel.Set({ label: 'USDB' }),
+    sparkMasterIdentityPublicKey: undefined
   })
   // ANCHOR_END: activate-stable-balance
 }
@@ -30,7 +39,8 @@ const exampleDeactivateStableBalance = async (sdk: BreezSdk) => {
   // ANCHOR: deactivate-stable-balance
   await sdk.updateUserSettings({
     sparkPrivateModeEnabled: undefined,
-    stableBalanceActiveLabel: new StableBalanceActiveLabel.Unset()
+    stableBalanceActiveLabel: new StableBalanceActiveLabel.Unset(),
+    sparkMasterIdentityPublicKey: undefined
   })
   // ANCHOR_END: deactivate-stable-balance
 }

--- a/docs/breez-sdk/snippets/react-native/user_settings.ts
+++ b/docs/breez-sdk/snippets/react-native/user_settings.ts
@@ -13,8 +13,6 @@ const exampleGetUserSettings = async (sdk: BreezSdk) => {
 
 const exampleUpdateUserSettings = async (sdk: BreezSdk) => {
   // ANCHOR: update-user-settings
-  // Fields left undefined are not changed. Settings that take an enum value
-  // accept Set to assign one, or Unset to clear it.
   await sdk.updateUserSettings({
     sparkPrivateModeEnabled: true,
     stableBalanceActiveLabel: undefined,

--- a/docs/breez-sdk/snippets/rust/src/sdk_building.rs
+++ b/docs/breez-sdk/snippets/rust/src/sdk_building.rs
@@ -266,6 +266,7 @@ pub(crate) async fn server_mode_provisioning(sdk: &BreezSdk) -> Result<()> {
     sdk.update_user_settings(UpdateUserSettingsRequest {
         spark_private_mode_enabled: Some(true),
         stable_balance_active_label: None,
+        spark_master_identity_public_key: None,
     })
     .await?;
 

--- a/docs/breez-sdk/snippets/rust/src/user_settings.rs
+++ b/docs/breez-sdk/snippets/rust/src/user_settings.rs
@@ -12,10 +12,14 @@ pub(crate) async fn get_user_settings(sdk: &BreezSdk) -> Result<()> {
 
 pub(crate) async fn update_user_settings(sdk: &BreezSdk) -> Result<()> {
     // ANCHOR: update-user-settings
-    let spark_private_mode_enabled = true;
+    // Fields left as None are not changed. Settings that take an enum value
+    // accept Set to assign one, or Unset to clear it.
     sdk.update_user_settings(UpdateUserSettingsRequest {
-        spark_private_mode_enabled: Some(spark_private_mode_enabled),
+        spark_private_mode_enabled: Some(true),
         stable_balance_active_label: None,
+        spark_master_identity_public_key: Some(SparkMasterIdentityPublicKey::Set {
+            public_key: "<hex encoded public key>".to_string(),
+        }),
     })
     .await?;
     // ANCHOR_END: update-user-settings
@@ -29,6 +33,7 @@ pub(crate) async fn activate_stable_balance(sdk: &BreezSdk) -> Result<()> {
         stable_balance_active_label: Some(StableBalanceActiveLabel::Set {
             label: "USDB".to_string(),
         }),
+        spark_master_identity_public_key: None,
     })
     .await?;
     // ANCHOR_END: activate-stable-balance
@@ -40,6 +45,7 @@ pub(crate) async fn deactivate_stable_balance(sdk: &BreezSdk) -> Result<()> {
     sdk.update_user_settings(UpdateUserSettingsRequest {
         spark_private_mode_enabled: None,
         stable_balance_active_label: Some(StableBalanceActiveLabel::Unset),
+        spark_master_identity_public_key: None,
     })
     .await?;
     // ANCHOR_END: deactivate-stable-balance

--- a/docs/breez-sdk/snippets/rust/src/user_settings.rs
+++ b/docs/breez-sdk/snippets/rust/src/user_settings.rs
@@ -12,8 +12,6 @@ pub(crate) async fn get_user_settings(sdk: &BreezSdk) -> Result<()> {
 
 pub(crate) async fn update_user_settings(sdk: &BreezSdk) -> Result<()> {
     // ANCHOR: update-user-settings
-    // Fields left as None are not changed. Settings that take an enum value
-    // accept Set to assign one, or Unset to clear it.
     sdk.update_user_settings(UpdateUserSettingsRequest {
         spark_private_mode_enabled: Some(true),
         stable_balance_active_label: None,

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/UserSettings.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/UserSettings.swift
@@ -9,10 +9,13 @@ func getUserSettings(sdk: BreezSdk) async throws {
 
 func updateUserSettings(sdk: BreezSdk) async throws {
     // ANCHOR: update-user-settings
-    let sparkPrivateModeEnabled = true
+    // Fields left as nil are not changed. Settings that take an enum value
+    // accept set to assign one, or unset to clear it.
     try await sdk.updateUserSettings(
         request: UpdateUserSettingsRequest(
-            sparkPrivateModeEnabled: sparkPrivateModeEnabled
+            sparkPrivateModeEnabled: true,
+            stableBalanceActiveLabel: nil,
+            sparkMasterIdentityPublicKey: .set(publicKey: "<hex encoded public key>")
         ))
     // ANCHOR_END: update-user-settings
 }

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/UserSettings.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/UserSettings.swift
@@ -9,8 +9,6 @@ func getUserSettings(sdk: BreezSdk) async throws {
 
 func updateUserSettings(sdk: BreezSdk) async throws {
     // ANCHOR: update-user-settings
-    // Fields left as nil are not changed. Settings that take an enum value
-    // accept set to assign one, or unset to clear it.
     try await sdk.updateUserSettings(
         request: UpdateUserSettingsRequest(
             sparkPrivateModeEnabled: true,

--- a/docs/breez-sdk/snippets/wasm/user_settings.ts
+++ b/docs/breez-sdk/snippets/wasm/user_settings.ts
@@ -9,10 +9,15 @@ const exampleGetUserSettings = async (sdk: BreezSdk) => {
 
 const exampleUpdateUserSettings = async (sdk: BreezSdk) => {
   // ANCHOR: update-user-settings
-  const sparkPrivateModeEnabled = true
+  // Fields left undefined are not changed. Settings that take an enum value
+  // accept set to assign one, or unset to clear it.
   await sdk.updateUserSettings({
-    sparkPrivateModeEnabled,
-    stableBalanceActiveLabel: undefined
+    sparkPrivateModeEnabled: true,
+    stableBalanceActiveLabel: undefined,
+    sparkMasterIdentityPublicKey: {
+      type: 'set',
+      publicKey: '<hex encoded public key>'
+    }
   })
   // ANCHOR_END: update-user-settings
 }

--- a/docs/breez-sdk/snippets/wasm/user_settings.ts
+++ b/docs/breez-sdk/snippets/wasm/user_settings.ts
@@ -9,8 +9,6 @@ const exampleGetUserSettings = async (sdk: BreezSdk) => {
 
 const exampleUpdateUserSettings = async (sdk: BreezSdk) => {
   // ANCHOR: update-user-settings
-  // Fields left undefined are not changed. Settings that take an enum value
-  // accept set to assign one, or unset to clear it.
   await sdk.updateUserSettings({
     sparkPrivateModeEnabled: true,
     stableBalanceActiveLabel: undefined,

--- a/docs/breez-sdk/src/guide/user_settings.md
+++ b/docs/breez-sdk/src/guide/user_settings.md
@@ -29,4 +29,6 @@ The following user settings are available:
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.update_user_settings">API docs</a>
 </h2>
 
+Every field of {{#name UpdateUserSettingsRequest}} is optional, and a field left unset is not changed. Settings that hold a value use an enum to distinguish assigning one from clearing it: {{#enum SparkMasterIdentityPublicKey::Set}} and {{#enum StableBalanceActiveLabel::Set}} assign, {{#enum SparkMasterIdentityPublicKey::Unset}} and {{#enum StableBalanceActiveLabel::Unset}} clear.
+
 {{#tabs user_settings:update-user-settings}}

--- a/docs/breez-sdk/src/guide/user_settings.md
+++ b/docs/breez-sdk/src/guide/user_settings.md
@@ -15,6 +15,8 @@ The following user settings are available:
 
 - **Stable balance active label**: Controls which stable token is active for automatic Bitcoin-to-token conversion. Set to a label from your [stable balance configuration](./config.md#stable-balance-configuration) to activate, or unset to deactivate. See the [Stable balance](./stable_balance.md) guide for details.
 
+- **Spark master identity public key**: A second public key that Spark accepts as a reader of the wallet while private mode is enabled. It enables watch-only views of a private wallet: designate a key you control, and a Spark client authenticating with the corresponding private key can query the wallet's Bitcoin balance and payment history. The master identity is read-only, so making payments still requires the wallet's own keys. The same public key can be designated across many wallets.
+
 <h2 id="getting-the-current-user-settings">
     <a class="header" href="#getting-the-current-user-settings">Getting the current user settings</a>
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.get_user_settings">API docs</a>

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1506,6 +1506,7 @@ pub struct _RecordChange {
 pub struct _UserSettings {
     pub spark_private_mode_enabled: bool,
     pub stable_balance_active_label: Option<String>,
+    pub spark_master_identity_public_key: Option<String>,
 }
 
 #[frb(mirror(StableBalanceActiveLabel))]
@@ -1514,10 +1515,17 @@ pub enum _StableBalanceActiveLabel {
     Unset,
 }
 
+#[frb(mirror(SparkMasterIdentityPublicKey))]
+pub enum _SparkMasterIdentityPublicKey {
+    Set { public_key: String },
+    Unset,
+}
+
 #[frb(mirror(UpdateUserSettingsRequest))]
 pub struct _UpdateUserSettingsRequest {
     pub spark_private_mode_enabled: Option<bool>,
     pub stable_balance_active_label: Option<StableBalanceActiveLabel>,
+    pub spark_master_identity_public_key: Option<SparkMasterIdentityPublicKey>,
 }
 
 #[frb(mirror(CreateIssuerTokenRequest))]


### PR DESCRIPTION
This exposes Spark's `master_identity_public_key` wallet setting as a user setting on the Breez SDK API. Setting it allows the defined identity to have read access to the current instance identity even when it is in private mode, enabling watch-only clients that can show balance and payment history. 