### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -291,7 +291,7 @@ public static class Commands
     private static readonly HashSet<string> BooleanFlags = new()
     {
         "--fees-included", "--from-bitcoin", "--hodl", "-f", "--freezable",
-        "--new-address"
+        "--new-address", "--clear-master-key"
     };
 
     private static string[] GetPositionalArgs(string[] args)
@@ -1219,9 +1219,28 @@ public static class Commands
     {
         var privateModeStr = GetFlag(args, "-p", "--private");
         bool? sparkPrivateMode = privateModeStr != null ? privateModeStr.ToLower() == "true" : null;
+        var masterKey = GetFlag(args, "-m", "--master-key");
+        var clearMasterKey = HasFlag(args, "--clear-master-key");
+
+        if (masterKey != null && clearMasterKey)
+        {
+            Console.Error.WriteLine("Cannot specify both --master-key and --clear-master-key");
+            return;
+        }
+
+        SparkMasterIdentityPublicKey? sparkMasterIdentityPublicKey = null;
+        if (masterKey != null)
+        {
+            sparkMasterIdentityPublicKey = new SparkMasterIdentityPublicKey.Set(publicKey: masterKey);
+        }
+        else if (clearMasterKey)
+        {
+            sparkMasterIdentityPublicKey = new SparkMasterIdentityPublicKey.Unset();
+        }
 
         await sdk.UpdateUserSettings(new UpdateUserSettingsRequest(
-            sparkPrivateModeEnabled: sparkPrivateMode
+            sparkPrivateModeEnabled: sparkPrivateMode,
+            sparkMasterIdentityPublicKey: sparkMasterIdentityPublicKey
         ));
         Console.WriteLine("User settings updated");
     }

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/StableBalance.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/StableBalance.cs
@@ -113,7 +113,8 @@ public static class StableBalanceCommands
 
         await sdk.UpdateUserSettings(new UpdateUserSettingsRequest(
             sparkPrivateModeEnabled: null,
-            stableBalanceActiveLabel: new StableBalanceActiveLabel.Set(label: args[0])
+            stableBalanceActiveLabel: new StableBalanceActiveLabel.Set(label: args[0]),
+            sparkMasterIdentityPublicKey: null
         ));
         var settings = await sdk.GetUserSettings();
         Serialization.PrintValue(settings);
@@ -125,7 +126,8 @@ public static class StableBalanceCommands
     {
         await sdk.UpdateUserSettings(new UpdateUserSettingsRequest(
             sparkPrivateModeEnabled: null,
-            stableBalanceActiveLabel: new StableBalanceActiveLabel.Unset()
+            stableBalanceActiveLabel: new StableBalanceActiveLabel.Unset(),
+            sparkMasterIdentityPublicKey: null
         ));
         var settings = await sdk.GetUserSettings();
         Serialization.PrintValue(settings);

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -983,12 +983,36 @@ Future<void> _handleGetUserSettings(BreezSdk sdk, TokenIssuer tokenIssuer, List<
 // --- set-user-settings ---
 
 Future<void> _handleSetUserSettings(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final parser = _parser('set-user-settings')..addOption('private', abbr: 'p');
+  final parser =
+      _parser('set-user-settings')
+        ..addOption('private', abbr: 'p')
+        ..addOption('master-key', abbr: 'm', help: 'Hex encoded public key for master identity')
+        ..addFlag('clear-master-key', defaultsTo: false, help: 'Remove the master identity');
   final results = _parseArgs(parser, args, 'set-user-settings [options]');
   if (results == null) return;
+
+  final masterKey = results.option('master-key');
+  final clearMasterKey = results.flag('clear-master-key');
+  if (masterKey != null && clearMasterKey) {
+    print('Cannot specify both --master-key and --clear-master-key');
+    return;
+  }
+
   final privateMode = _parseBool(results.option('private'));
 
-  await sdk.updateUserSettings(request: UpdateUserSettingsRequest(sparkPrivateModeEnabled: privateMode));
+  SparkMasterIdentityPublicKey? sparkMasterIdentityPublicKey;
+  if (masterKey != null) {
+    sparkMasterIdentityPublicKey = SparkMasterIdentityPublicKey_Set(publicKey: masterKey);
+  } else if (clearMasterKey) {
+    sparkMasterIdentityPublicKey = SparkMasterIdentityPublicKey_Unset();
+  }
+
+  await sdk.updateUserSettings(
+    request: UpdateUserSettingsRequest(
+      sparkPrivateModeEnabled: privateMode,
+      sparkMasterIdentityPublicKey: sparkMasterIdentityPublicKey,
+    ),
+  );
   print('User settings updated');
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/stable_balance.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/stable_balance.dart
@@ -63,7 +63,11 @@ Future<void> _handleSet(BreezSdk sdk, List<String> args) async {
   }
   final label = args[0];
   await sdk.updateUserSettings(
-    request: UpdateUserSettingsRequest(stableBalanceActiveLabel: StableBalanceActiveLabel_Set(label: label)),
+    request: UpdateUserSettingsRequest(
+      sparkPrivateModeEnabled: null,
+      stableBalanceActiveLabel: StableBalanceActiveLabel_Set(label: label),
+      sparkMasterIdentityPublicKey: null,
+    ),
   );
   final settings = await sdk.getUserSettings();
   printValue(settings);
@@ -73,7 +77,11 @@ Future<void> _handleSet(BreezSdk sdk, List<String> args) async {
 
 Future<void> _handleUnset(BreezSdk sdk, List<String> args) async {
   await sdk.updateUserSettings(
-    request: UpdateUserSettingsRequest(stableBalanceActiveLabel: StableBalanceActiveLabel_Unset()),
+    request: UpdateUserSettingsRequest(
+      sparkPrivateModeEnabled: null,
+      stableBalanceActiveLabel: StableBalanceActiveLabel_Unset(),
+      sparkMasterIdentityPublicKey: null,
+    ),
   );
   final settings = await sdk.getUserSettings();
   printValue(settings);

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -1222,14 +1222,31 @@ func handleSetUserSettings(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, 
 	fs := flag.NewFlagSet("set-user-settings", flag.ContinueOnError)
 	privateMode := fs.String("p", "", "Enable spark private mode (true/false)")
 	fs.StringVar(privateMode, "private", "", "Enable spark private mode (true/false)")
+	masterKey := fs.String("m", "", "Hex encoded public key for master identity")
+	fs.StringVar(masterKey, "master-key", "", "Hex encoded public key for master identity")
+	clearMasterKey := fs.Bool("clear-master-key", false, "Remove the wallet's designated master identity")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	if *masterKey != "" && *clearMasterKey {
+		return fmt.Errorf("cannot specify both --master-key and --clear-master-key")
 	}
 
 	req := breez_sdk_spark.UpdateUserSettingsRequest{}
 	if *privateMode != "" {
 		val := *privateMode == "true"
 		req.SparkPrivateModeEnabled = &val
+	}
+
+	if *masterKey != "" {
+		var mk breez_sdk_spark.SparkMasterIdentityPublicKey = breez_sdk_spark.SparkMasterIdentityPublicKeySet{
+			PublicKey: *masterKey,
+		}
+		req.SparkMasterIdentityPublicKey = &mk
+	} else if *clearMasterKey {
+		var mk breez_sdk_spark.SparkMasterIdentityPublicKey = breez_sdk_spark.SparkMasterIdentityPublicKeyUnset{}
+		req.SparkMasterIdentityPublicKey = &mk
 	}
 
 	if err := liftError(sdk.UpdateUserSettings(req)); err != nil {

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -1014,9 +1014,24 @@ suspend fun handleGetUserSettings(sdk: BreezSdk, reader: LineReader, args: List<
 suspend fun handleSetUserSettings(sdk: BreezSdk, reader: LineReader, args: List<String>) {
     val fp = FlagParser(args)
     val privateMode = fp.getString("p", "private", "spark-private-mode")
+    val masterKey = fp.getString("m", "master-key")
+    val clearMasterKey = fp.hasFlag("clear-master-key")
+
+    if (masterKey != null && clearMasterKey) {
+        println("Error: --master-key and --clear-master-key are mutually exclusive")
+        return
+    }
+
+    val sparkMasterIdentityPublicKey = when {
+        masterKey != null -> SparkMasterIdentityPublicKey.Set(publicKey = masterKey)
+        clearMasterKey -> SparkMasterIdentityPublicKey.Unset
+        else -> null
+    }
 
     val req = UpdateUserSettingsRequest(
         sparkPrivateModeEnabled = if (privateMode != null) privateMode.lowercase() == "true" else null,
+        stableBalanceActiveLabel = null,
+        sparkMasterIdentityPublicKey = sparkMasterIdentityPublicKey,
     )
 
     sdk.updateUserSettings(req)

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/StableBalance.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/StableBalance.kt
@@ -73,6 +73,7 @@ suspend fun handleStableBalanceSet(sdk: BreezSdk, reader: LineReader, args: List
         UpdateUserSettingsRequest(
             sparkPrivateModeEnabled = null,
             stableBalanceActiveLabel = StableBalanceActiveLabel.Set(label = args[0]),
+            sparkMasterIdentityPublicKey = null,
         )
     )
     val settings = sdk.getUserSettings()
@@ -84,6 +85,7 @@ suspend fun handleStableBalanceUnset(sdk: BreezSdk, reader: LineReader, args: Li
         UpdateUserSettingsRequest(
             sparkPrivateModeEnabled = null,
             stableBalanceActiveLabel = StableBalanceActiveLabel.Unset,
+            sparkMasterIdentityPublicKey = null,
         )
     )
     val settings = sdk.getUserSettings()

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -44,6 +44,7 @@ from breez_sdk_spark import (
     SendPaymentRequest,
     SparkHtlcOptions,
     SparkHtlcStatus,
+    SparkMasterIdentityPublicKey,
     SyncWalletRequest,
     TokenTransactionType,
     TransferAuthorization,
@@ -865,13 +866,28 @@ def _build_set_user_settings_parser():
     p = _parser("set-user-settings", "Update user settings")
     _add_bool_option(p, "-p", "--private", dest="spark_private_mode_enabled",
                      help="Whether spark private mode is enabled")
+    group = p.add_mutually_exclusive_group()
+    group.add_argument("-m", "--master-key", default=None,
+                       help="Hex encoded public key to designate as the wallet's master identity")
+    group.add_argument("--clear-master-key", action="store_true", default=False,
+                       help="Remove the wallet's designated master identity")
     return p
 
 async def _handle_set_user_settings(sdk, _token_issuer, _session, args):
+    if args.master_key is not None:
+        spark_master_identity_public_key = SparkMasterIdentityPublicKey.SET(
+            public_key=args.master_key,
+        )
+    elif args.clear_master_key:
+        spark_master_identity_public_key = SparkMasterIdentityPublicKey.UNSET()
+    else:
+        spark_master_identity_public_key = None
+
     await sdk.update_user_settings(
         request=UpdateUserSettingsRequest(
             spark_private_mode_enabled=args.spark_private_mode_enabled,
             stable_balance_active_label=None,
+            spark_master_identity_public_key=spark_master_identity_public_key,
         )
     )
     print("User settings updated")

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/stable_balance.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/stable_balance.py
@@ -41,6 +41,7 @@ async def _handle_set(sdk, args):
         request=UpdateUserSettingsRequest(
             spark_private_mode_enabled=None,
             stable_balance_active_label=StableBalanceActiveLabel.SET(label=args.label),
+            spark_master_identity_public_key=None,
         )
     )
     settings = await sdk.get_user_settings()
@@ -57,6 +58,7 @@ async def _handle_unset(sdk, _args):
         request=UpdateUserSettingsRequest(
             spark_private_mode_enabled=None,
             stable_balance_active_label=StableBalanceActiveLabel.UNSET(),
+            spark_master_identity_public_key=None,
         )
     )
     settings = await sdk.get_user_settings()

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
@@ -59,6 +59,9 @@ declare module '@breeztech/breez-sdk-spark-react-native' {
   export const WebhookEventType: any;
   export type WebhookEventType = any;
 
+  export const SparkMasterIdentityPublicKey: any;
+  export type SparkMasterIdentityPublicKey = any;
+
   export const StableBalanceActiveLabel: any;
   export type StableBalanceActiveLabel = any;
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -29,6 +29,7 @@ import {
   MaxFee,
   Fee,
   SparkHtlcStatus,
+  SparkMasterIdentityPublicKey,
   TokenTransactionType,
   BuyBitcoinRequest,
   getSparkStatus,
@@ -1155,9 +1156,24 @@ async function handleSetUserSettings(sdk: BreezSdkInterface, _tokenIssuer: Token
     sparkPrivateModeEnabled = privateModeStr === 'true'
   }
 
+  const masterKey = parseFlag(args, '--master-key', '-m')
+  const clearMasterKey = hasFlag(args, '--clear-master-key')
+
+  if (masterKey !== undefined && clearMasterKey) {
+    return 'Error: --master-key and --clear-master-key are mutually exclusive'
+  }
+
+  let sparkMasterIdentityPublicKey: SparkMasterIdentityPublicKey | undefined
+  if (masterKey !== undefined) {
+    sparkMasterIdentityPublicKey = new SparkMasterIdentityPublicKey.Set({ publicKey: masterKey })
+  } else if (clearMasterKey) {
+    sparkMasterIdentityPublicKey = new SparkMasterIdentityPublicKey.Unset()
+  }
+
   await sdk.updateUserSettings({
     sparkPrivateModeEnabled,
     stableBalanceActiveLabel: undefined,
+    sparkMasterIdentityPublicKey,
   })
   return 'User settings updated'
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/stable_balance.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/stable_balance.ts
@@ -76,6 +76,7 @@ async function handleSet(sdk: BreezSdkInterface, args: string[]): Promise<string
   await sdk.updateUserSettings({
     sparkPrivateModeEnabled: undefined,
     stableBalanceActiveLabel: new StableBalanceActiveLabel.Set({ label }),
+    sparkMasterIdentityPublicKey: undefined,
   })
   const settings = await sdk.getUserSettings()
   return formatValue(settings)
@@ -87,6 +88,7 @@ async function handleUnset(sdk: BreezSdkInterface): Promise<string> {
   await sdk.updateUserSettings({
     sparkPrivateModeEnabled: undefined,
     stableBalanceActiveLabel: new StableBalanceActiveLabel.Unset(),
+    sparkMasterIdentityPublicKey: undefined,
   })
   const settings = await sdk.getUserSettings()
   return formatValue(settings)

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -981,8 +981,26 @@ func handleSetUserSettings(_ sdk: BreezSdk, _ args: [String]) async throws {
     let privateModeStr = fp.get("p", "private", "spark-private-mode")
     let privateMode: Bool? = privateModeStr.map { $0 == "true" }
 
+    let masterKey = fp.get("m", "master-key")
+    let clearMasterKey = fp.has("clear-master-key")
+
+    if masterKey != nil && clearMasterKey {
+        print("Error: --master-key and --clear-master-key are mutually exclusive")
+        return
+    }
+
+    let sparkMasterIdentityPublicKey: SparkMasterIdentityPublicKey?
+    if let publicKey = masterKey {
+        sparkMasterIdentityPublicKey = .set(publicKey: publicKey)
+    } else if clearMasterKey {
+        sparkMasterIdentityPublicKey = .unset
+    } else {
+        sparkMasterIdentityPublicKey = nil
+    }
+
     try await sdk.updateUserSettings(request: UpdateUserSettingsRequest(
-        sparkPrivateModeEnabled: privateMode
+        sparkPrivateModeEnabled: privateMode,
+        sparkMasterIdentityPublicKey: sparkMasterIdentityPublicKey
     ))
     print("User settings updated")
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -820,13 +820,28 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
     .command('set-user-settings')
     .description('Update user settings')
     .option('-p, --private [value]', 'Whether spark private mode is enabled')
+    .option('-m, --master-key <key>', 'Hex encoded public key to designate as the wallet\'s master identity')
+    .option('--clear-master-key', 'Remove the wallet\'s designated master identity')
     .action(async (options) => {
       const sdk = getSdk()
+      if (options.masterKey && options.clearMasterKey) {
+        throw new Error('Cannot specify both --master-key and --clear-master-key')
+      }
       let sparkPrivateModeEnabled
       if (options.private != null) {
         sparkPrivateModeEnabled = options.private === 'true' || options.private === true
       }
-      await sdk.updateUserSettings({ sparkPrivateModeEnabled, stableBalanceActiveLabel: undefined })
+      let sparkMasterIdentityPublicKey
+      if (options.masterKey) {
+        sparkMasterIdentityPublicKey = { type: 'set', publicKey: options.masterKey }
+      } else if (options.clearMasterKey) {
+        sparkMasterIdentityPublicKey = { type: 'unset' }
+      }
+      await sdk.updateUserSettings({
+        sparkPrivateModeEnabled,
+        stableBalanceActiveLabel: undefined,
+        sparkMasterIdentityPublicKey
+      })
       console.log('User settings updated')
     })
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/stable-balance.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/stable-balance.js
@@ -33,7 +33,8 @@ function registerStableBalanceCommands(program, getSdk) {
       const sdk = getSdk()
       await sdk.updateUserSettings({
         sparkPrivateModeEnabled: undefined,
-        stableBalanceActiveLabel: { type: 'set', label }
+        stableBalanceActiveLabel: { type: 'set', label },
+        sparkMasterIdentityPublicKey: undefined
       })
       const settings = await sdk.getUserSettings()
       printValue(settings)
@@ -47,7 +48,8 @@ function registerStableBalanceCommands(program, getSdk) {
       const sdk = getSdk()
       await sdk.updateUserSettings({
         sparkPrivateModeEnabled: undefined,
-        stableBalanceActiveLabel: { type: 'unset' }
+        stableBalanceActiveLabel: { type: 'unset' },
+        sparkMasterIdentityPublicKey: undefined
       })
       const settings = await sdk.getUserSettings()
       printValue(settings)


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`eea0cf9`](https://github.com/breez/spark-sdk/commit/eea0cf967924d94dcf5163d790519991836f46c8)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/30437613981)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :white_check_mark: React Native
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- `set-user-settings` command missing `-m`/`--master-key` and `--clear-master-key` flags (added in Rust CLI to set/clear the wallet's master identity public key)
- `HandleSetUserSettings` in `Commands.cs` not passing `sparkMasterIdentityPublicKey` to `UpdateUserSettingsRequest`
- `HandleSet` and `HandleUnset` in `StableBalance.cs` not passing `sparkMasterIdentityPublicKey: null` to `UpdateUserSettingsRequest`

## Applied
- Added `-m`/`--master-key` flag and `--clear-master-key` boolean flag to `HandleSetUserSettings` in `Commands.cs`, with mutual exclusion validation
- Added `SparkMasterIdentityPublicKey` construction logic (Set/Unset/null) matching Rust CLI pattern in `Commands.cs`
- Added `--clear-master-key` to `BooleanFlags` set in `Commands.cs`
- Added `sparkMasterIdentityPublicKey: null` to both `UpdateUserSettingsRequest` calls in `StableBalance.cs`

## Skipped
- Nothing skipped

### Dart
## Divergences
- `set-user-settings` command missing `--master-key` (`-m`) and `--clear-master-key` flags for the new `SparkMasterIdentityPublicKey` field on `UpdateUserSettingsRequest`
- `stable-balance set` and `stable-balance unset` handlers not passing explicit `sparkPrivateModeEnabled: null` and `sparkMasterIdentityPublicKey: null` to `UpdateUserSettingsRequest` (matching the Rust CLI which passes all fields explicitly)

## Applied
- Added `--master-key` (`-m`) and `--clear-master-key` options to `set-user-settings` in `commands.dart`, with mutual exclusion validation and `SparkMasterIdentityPublicKey` construction matching the Rust CLI
- Updated `stable_balance.dart` `_handleSet` and `_handleUnset` to pass all three `UpdateUserSettingsRequest` fields explicitly (`sparkPrivateModeEnabled: null`, `stableBalanceActiveLabel`, `sparkMasterIdentityPublicKey: null`)

## Skipped
- (none)

### Go
## Divergences
- `set-user-settings` command missing `--master-key` (`-m`) and `--clear-master-key` flags for the `SparkMasterIdentityPublicKey` field

## Applied
- Added `--master-key` (`-m`) and `--clear-master-key` flags to `handleSetUserSettings` in `commands.go`, with mutual exclusion check and `SparkMasterIdentityPublicKey` construction matching the Rust CLI logic

## Skipped
- (none)

### Kotlin
## Divergences
- `handleSetUserSettings` in Commands.kt was missing `-m`/`--master-key` and `--clear-master-key` flags, plus `sparkMasterIdentityPublicKey` field in `UpdateUserSettingsRequest`
- `handleSetUserSettings` in Commands.kt was missing explicit `stableBalanceActiveLabel = null` in `UpdateUserSettingsRequest`
- `handleStableBalanceSet` and `handleStableBalanceUnset` in StableBalance.kt were missing explicit `sparkMasterIdentityPublicKey = null` in `UpdateUserSettingsRequest`

## Applied
- Added `master_key` (`-m`/`--master-key`) and `clear_master_key` (`--clear-master-key`) flag parsing with mutual exclusion check to `handleSetUserSettings` in Commands.kt
- Added `SparkMasterIdentityPublicKey` enum construction (Set/Unset/null) matching Rust logic to `handleSetUserSettings` in Commands.kt
- Added `stableBalanceActiveLabel = null` and `sparkMasterIdentityPublicKey` to `UpdateUserSettingsRequest` in Commands.kt
- Added `sparkMasterIdentityPublicKey = null` to both `UpdateUserSettingsRequest` calls in StableBalance.kt

## Skipped
- (none)

### Python
## Divergences
- `set-user-settings` command missing `--master-key` (`-m`) and `--clear-master-key` flags for managing the wallet's master identity public key
- `set-user-settings` handler missing `spark_master_identity_public_key` field in `UpdateUserSettingsRequest`
- `stable_balance.py` handlers (`set`, `unset`) missing `spark_master_identity_public_key=None` in `UpdateUserSettingsRequest`

## Applied
- Added `SparkMasterIdentityPublicKey` import to `commands.py`
- Added mutually exclusive `--master-key` (`-m`) and `--clear-master-key` flags to `_build_set_user_settings_parser()` in `commands.py`
- Updated `_handle_set_user_settings()` in `commands.py` to construct `SparkMasterIdentityPublicKey` from the new flags and pass it to `UpdateUserSettingsRequest`
- Added `spark_master_identity_public_key=None` to both `UpdateUserSettingsRequest` calls in `stable_balance.py` (`_handle_set` and `_handle_unset`)

## Skipped
- (none)

### React Native
## Divergences
- `set-user-settings` command missing `--master-key`/`-m` and `--clear-master-key` flags for the new `SparkMasterIdentityPublicKey` field
- `set-user-settings` handler not passing `sparkMasterIdentityPublicKey` to `updateUserSettings`
- `stable-balance set` handler not passing `sparkMasterIdentityPublicKey: undefined` to `updateUserSettings`
- `stable-balance unset` handler not passing `sparkMasterIdentityPublicKey: undefined` to `updateUserSettings`
- Ambient type declarations missing `SparkMasterIdentityPublicKey` export

## Applied
- Added `SparkMasterIdentityPublicKey` to ambient type declarations in `breez-sdk-spark-react-native.d.ts`
- Added `SparkMasterIdentityPublicKey` import to `commands.ts`
- Added `--master-key`/`-m` and `--clear-master-key` flag parsing with mutual exclusion validation to `handleSetUserSettings` in `commands.ts`
- Added `sparkMasterIdentityPublicKey` field to `updateUserSettings` call in `handleSetUserSettings` in `commands.ts`
- Added `sparkMasterIdentityPublicKey: undefined` to `updateUserSettings` calls in `stable_balance.ts` (both `set` and `unset` handlers)

## Skipped
- Nothing skipped

### Swift
## Divergences
- `set-user-settings` command missing `--master-key` / `-m` and `--clear-master-key` flags for the `SparkMasterIdentityPublicKey` setting
- `UpdateUserSettingsRequest` in `handleSetUserSettings` not passing `sparkMasterIdentityPublicKey`

## Applied
- Added `-m`/`--master-key` and `--clear-master-key` flag parsing to `handleSetUserSettings` in `Commands.swift`
- Added mutual exclusion check between `--master-key` and `--clear-master-key`
- Construct `SparkMasterIdentityPublicKey` enum (`.set(publicKey:)` / `.unset` / `nil`) and pass it to `UpdateUserSettingsRequest`
- StableBalance.swift calls omit the new field (UniFFI defaults it to nil), matching Rust's explicit `None`

## Skipped
- Nothing skipped

### TypeScript
## Divergences
- `set-user-settings` command missing `--master-key` / `-m` and `--clear-master-key` options for managing the wallet's master identity public key
- `set-user-settings` command not passing `sparkMasterIdentityPublicKey` field to `updateUserSettings`
- `stable-balance set` and `stable-balance unset` commands not passing `sparkMasterIdentityPublicKey: undefined` to `updateUserSettings` (matches Rust passing `None`)

## Applied
- Added `-m, --master-key <key>` and `--clear-master-key` options to `set-user-settings` in `commands.js`, with mutual exclusion validation
- Added `sparkMasterIdentityPublicKey` construction logic (set/unset/undefined) in `set-user-settings` handler in `commands.js`
- Added `sparkMasterIdentityPublicKey: undefined` to `updateUserSettings` calls in `stable-balance.js` (set and unset commands)

## Skipped
- Nothing skipped

</details>

All languages synced cleanly. This PR merges automatically once the gating CI checks pass (integration test checks excluded).