### PR TITLE
fix(android): handle passkey indexing delay

### DIFF
--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -82,12 +82,14 @@ private const val CORE_TAG = "PasskeyPrfCore"
 // =====================================================================
 
 /**
- * A newly-registered passkey is briefly not ready for the immediate
- * post-create assertion: Credential Manager can drop `prf.second` from a
- * dual-salt assertion (forcing a second single-salt prompt) or surface
- * the credential as not yet discoverable in the picker. [arm] opens a
- * window in which the next derive re-asks instead of trusting the first
- * miss.
+ * A newly-registered passkey is briefly not discoverable, so the
+ * immediate post-create assertion can miss a credential that exists.
+ * [arm] opens a window in which the next derive re-asks instead of
+ * trusting that first miss.
+ *
+ * Scoped to that case only: the retry catches `NoCredentialException`,
+ * so a dropped `prf.second` is not covered and still falls through to
+ * the single-salt recover in [CredentialManagerPrfCore.deriveSeeds].
  *
  * The window is a ceiling, not a wait: indexing takes as long as the
  * device takes, so a fixed sleep either returns before the credential is

--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -85,8 +85,14 @@ private const val CORE_TAG = "PasskeyPrfCore"
  * A newly-registered passkey is briefly not ready for the immediate
  * post-create assertion: Credential Manager can drop `prf.second` from a
  * dual-salt assertion (forcing a second single-salt prompt) or surface
- * the credential as not yet discoverable in the picker. Holding the next
- * derive up to [DEFAULT_DURATION_MS] lets the OS finish indexing.
+ * the credential as not yet discoverable in the picker. [arm] opens a
+ * window in which the next derive re-asks instead of trusting the first
+ * miss.
+ *
+ * The window is a ceiling, not a wait: indexing takes as long as the
+ * device takes, so a fixed sleep either returns before the credential is
+ * queryable or taxes every registration. Retrying costs nothing once the
+ * credential resolves.
  *
  * Mirrors iOS `PostCreateGraceTracker`; an instance lives inside
  * [CredentialManagerPrfCore] so every consumer that holds onto a single
@@ -103,19 +109,22 @@ public class PostCreateGraceTracker {
         }
     }
 
-    public suspend fun consume() {
-        val waitMs = mutex.withLock {
-            val remaining = deadlineMs - System.currentTimeMillis()
-            deadlineMs = 0L
-            if (remaining > 0L) remaining else 0L
-        }
-        if (waitMs > 0L) {
-            delay(waitMs)
-        }
+    /**
+     * Absolute time until which a post-create assertion may re-ask, or 0
+     * when no registration preceded this derive. Clears the window, so a
+     * later derive is not covered by it.
+     */
+    public suspend fun consumeDeadline(): Long = mutex.withLock {
+        val deadline = deadlineMs
+        deadlineMs = 0L
+        deadline
     }
 
     public companion object {
-        public const val DEFAULT_DURATION_MS: Long = 800L
+        public const val DEFAULT_DURATION_MS: Long = 5_000L
+
+        /** Gap between re-asks; each miss is a fast local no-UI failure. */
+        public const val RETRY_INTERVAL_MS: Long = 100L
     }
 }
 
@@ -221,9 +230,10 @@ public class CredentialManagerPrfCore(
         allowCredentials: List<ByteArray> = emptyList(),
         preferImmediatelyAvailableCredentials: Boolean = true,
     ): PrfDerivation = withContext(Dispatchers.Main) {
-        // Wait out the post-create grace so an immediate derive doesn't
-        // race the credential's PRF-readiness window (see grace tracker).
-        graceTracker.consume()
+        // Re-ask, rather than sleep, while a just-created credential is
+        // still being indexed (see grace tracker). 0 when no register
+        // preceded this call, which disables the retry entirely.
+        val indexRetryUntilMs = graceTracker.consumeDeadline()
         // Pinned to the first asserted credential after the first chunk so
         // every salt in this call derives from one passkey.
         var allow = allowCredentials
@@ -236,7 +246,12 @@ public class CredentialManagerPrfCore(
         // it, so every chunk resolves to the same credential.
         suspend fun assertChunk(chunk: List<String>): Pair<List<ByteArray>, ByteArray?> =
             try {
-                assertPrf(chunk, allow, preferImmediatelyAvailableCredentials)
+                assertPrfAwaitingIndex(
+                    chunk,
+                    allow,
+                    preferImmediatelyAvailableCredentials,
+                    indexRetryUntilMs,
+                )
             } catch (e: NoCredentialException) {
                 if (!autoRegister) {
                     throw CredentialManagerPrfCoreException(
@@ -451,6 +466,38 @@ public class CredentialManagerPrfCore(
      * the asserted credential ID. A dropped `results.second` yields a
      * single-element list.
      */
+    /**
+     * [assertPrf], re-asking until [retryUntilMs] while Credential Manager
+     * still reports no credential. A passkey that exists but is not yet
+     * queryable is indistinguishable from an absent one (both raise
+     * `NoCredentialException`), so asking again is the only way to tell
+     * them apart, and the caller has just created one.
+     *
+     * Only retries under [preferImmediatelyAvailableCredentials], where a
+     * miss is a fast local failure with no UI. Without it a miss means the
+     * user saw and dismissed a picker, which must not be re-shown.
+     */
+    private suspend fun assertPrfAwaitingIndex(
+        salts: List<String>,
+        allowCredentials: List<ByteArray>,
+        preferImmediatelyAvailableCredentials: Boolean,
+        retryUntilMs: Long,
+    ): Pair<List<ByteArray>, ByteArray?> {
+        while (true) {
+            try {
+                return assertPrf(salts, allowCredentials, preferImmediatelyAvailableCredentials)
+            } catch (e: NoCredentialException) {
+                if (!preferImmediatelyAvailableCredentials
+                    || System.currentTimeMillis() >= retryUntilMs
+                ) {
+                    throw e
+                }
+                Log.d(CORE_TAG, "Credential not indexed yet, re-asking")
+                delay(PostCreateGraceTracker.RETRY_INTERVAL_MS)
+            }
+        }
+    }
+
     private suspend fun assertPrf(
         salts: List<String>,
         allowCredentials: List<ByteArray>,

--- a/crates/breez-sdk/core/src/passkey/error.rs
+++ b/crates/breez-sdk/core/src/passkey/error.rs
@@ -118,18 +118,19 @@ pub enum PasskeyError {
     #[error("Invalid salt: {0}")]
     InvalidSalt(String),
 
-    /// Registration created the credential, then failed to derive from
-    /// it. The passkey exists on the device: recover by signing in
-    /// pinned to `credential_id`. Registering again would leave this one
-    /// behind, owning a wallet nothing points to.
+    /// Registration created the credential, then the derive that
+    /// followed it failed. The passkey exists on the device: recover by
+    /// signing in pinned to `credential_id`. Registering again would
+    /// leave this one behind, owning a wallet nothing points to.
     ///
-    /// `kind` classifies the derive failure that followed the create, so
-    /// hosts keep the branching they would have had on the inner error.
-    #[error("Passkey created but derivation failed: {reason}")]
+    /// Only wraps a [`PrfProviderError`], so hosts unwrap once and keep
+    /// the arms they already have. Failures that are not the
+    /// authenticator's (mnemonic, key derivation, invalid PRF output)
+    /// propagate as their own variant, unwrapped.
+    #[error("Passkey created but derivation failed: {source}")]
     CreatedButNotDerived {
         credential_id: Vec<u8>,
-        kind: ErrorKind,
-        reason: String,
+        source: PrfProviderError,
     },
 
     #[error("Passkey error: {0}")]
@@ -144,7 +145,7 @@ impl PasskeyError {
     pub fn kind(&self) -> ErrorKind {
         match self {
             Self::Prf(inner) => inner.kind(),
-            Self::CreatedButNotDerived { kind, .. } => *kind,
+            Self::CreatedButNotDerived { source, .. } => source.kind(),
             _ => ErrorKind::Internal,
         }
     }

--- a/crates/breez-sdk/core/src/passkey/error.rs
+++ b/crates/breez-sdk/core/src/passkey/error.rs
@@ -118,6 +118,20 @@ pub enum PasskeyError {
     #[error("Invalid salt: {0}")]
     InvalidSalt(String),
 
+    /// Registration created the credential, then failed to derive from
+    /// it. The passkey exists on the device: recover by signing in
+    /// pinned to `credential_id`. Registering again would leave this one
+    /// behind, owning a wallet nothing points to.
+    ///
+    /// `kind` classifies the derive failure that followed the create, so
+    /// hosts keep the branching they would have had on the inner error.
+    #[error("Passkey created but derivation failed: {reason}")]
+    CreatedButNotDerived {
+        credential_id: Vec<u8>,
+        kind: ErrorKind,
+        reason: String,
+    },
+
     #[error("Passkey error: {0}")]
     Generic(String),
 }
@@ -130,6 +144,7 @@ impl PasskeyError {
     pub fn kind(&self) -> ErrorKind {
         match self {
             Self::Prf(inner) => inner.kind(),
+            Self::CreatedButNotDerived { kind, .. } => *kind,
             _ => ErrorKind::Internal,
         }
     }

--- a/crates/breez-sdk/core/src/passkey/mod.rs
+++ b/crates/breez-sdk/core/src/passkey/mod.rs
@@ -214,12 +214,6 @@ impl Passkey {
         Ok(client)
     }
 
-    /// Derive the Nostr identity and the wallet seed for `request.label`
-    /// in one PRF ceremony (dual-salt where the platform supports it).
-    /// Primes the identity cache so subsequent [`Self::list_labels`] /
-    /// [`Self::store_label`] need no extra PRF prompts.
-    /// `publish_label = false` skips the Nostr write: used by
-    /// speculative cold-restore.
     /// Resolve a caller-supplied label against the configured default and
     /// validate it. Exposed so a caller can reject a bad label before
     /// driving any ceremony.
@@ -229,6 +223,12 @@ impl Passkey {
         Ok(label)
     }
 
+    /// Derive the Nostr identity and the wallet seed for `request.label`
+    /// in one PRF ceremony (dual-salt where the platform supports it).
+    /// Primes the identity cache so subsequent [`Self::list_labels`] /
+    /// [`Self::store_label`] need no extra PRF prompts.
+    /// `publish_label = false` skips the Nostr write: used by
+    /// speculative cold-restore.
     pub async fn setup_wallet(
         &self,
         request: SetupWalletRequest,

--- a/crates/breez-sdk/core/src/passkey/mod.rs
+++ b/crates/breez-sdk/core/src/passkey/mod.rs
@@ -220,12 +220,20 @@ impl Passkey {
     /// [`Self::store_label`] need no extra PRF prompts.
     /// `publish_label = false` skips the Nostr write: used by
     /// speculative cold-restore.
+    /// Resolve a caller-supplied label against the configured default and
+    /// validate it. Exposed so a caller can reject a bad label before
+    /// driving any ceremony.
+    pub(crate) fn resolve_label(&self, label: Option<String>) -> Result<String, PasskeyError> {
+        let label = label.unwrap_or_else(|| self.default_label.clone());
+        validate_label(&label)?;
+        Ok(label)
+    }
+
     pub async fn setup_wallet(
         &self,
         request: SetupWalletRequest,
     ) -> Result<WalletSetup, PasskeyError> {
-        let label = request.label.unwrap_or_else(|| self.default_label.clone());
-        validate_label(&label)?;
+        let label = self.resolve_label(request.label)?;
 
         // [account_master, label]: dual-salt single ceremony where the
         // platform supports it, fallback to two prompts otherwise.

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -206,6 +206,12 @@ impl PasskeyClient {
         &self,
         request: RegisterRequest,
     ) -> Result<RegisterResponse, PasskeyError> {
+        // Validate before anything is created: an invalid label would
+        // otherwise mint a real passkey and only then fail, and the
+        // recovery that failure points at runs the same validation on the
+        // same label.
+        let label = self.passkey.resolve_label(request.label)?;
+
         let credential = self
             .passkey
             .prf_provider()
@@ -215,7 +221,7 @@ impl PasskeyClient {
         let setup = match self
             .passkey
             .setup_wallet(SetupWalletRequest {
-                label: request.label,
+                label: Some(label),
                 publish_label: true,
                 // Pin the derive to the just-created credential so the
                 // seed comes from it, not another resident passkey for
@@ -230,13 +236,17 @@ impl PasskeyClient {
             // has to carry it. Dropping it leaves the host unable to tell
             // "nothing was created" from "created, not derived", and the
             // natural recovery (register again) strands this passkey.
-            Err(e) => {
+            //
+            // Only the authenticator's own failures are wrapped: the rest
+            // are SDK-internal and keep their own variant, so hosts have
+            // one shape to unwrap rather than two.
+            Err(PasskeyError::Prf(source)) => {
                 return Err(PasskeyError::CreatedButNotDerived {
                     credential_id: credential.credential_id,
-                    kind: e.kind(),
-                    reason: e.to_string(),
+                    source,
                 });
             }
+            Err(e) => return Err(e),
         };
 
         Ok(RegisterResponse {

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -212,7 +212,7 @@ impl PasskeyClient {
             .create_passkey(request.exclude_credentials.unwrap_or_default())
             .await?;
 
-        let setup = self
+        let setup = match self
             .passkey
             .setup_wallet(SetupWalletRequest {
                 label: request.label,
@@ -223,7 +223,21 @@ impl PasskeyClient {
                 allow_credentials: vec![credential.credential_id.clone()],
                 prefer_immediately_available_credentials: None,
             })
-            .await?;
+            .await
+        {
+            Ok(setup) => setup,
+            // The credential is on the device from here on, so the error
+            // has to carry it. Dropping it leaves the host unable to tell
+            // "nothing was created" from "created, not derived", and the
+            // natural recovery (register again) strands this passkey.
+            Err(e) => {
+                return Err(PasskeyError::CreatedButNotDerived {
+                    credential_id: credential.credential_id,
+                    kind: e.kind(),
+                    reason: e.to_string(),
+                });
+            }
+        };
 
         Ok(RegisterResponse {
             wallet: setup.wallet,

--- a/docs/breez-sdk/src/guide/passkey_onboarding.md
+++ b/docs/breez-sdk/src/guide/passkey_onboarding.md
@@ -91,8 +91,8 @@ Most passkey failures normalize to a {{#name PrfProviderError}} variant. Match o
 
 Those rows cover {{#name PasskeyClient.sign_in}}, and
 {{#name PasskeyClient.register}} up to the point the credential is created.
-Once it exists, every failure arrives as the variant below instead, whatever
-caused it: a cancel, a timeout or an unsupported authenticator during the
+Once it exists, a failure from the authenticator arrives as the variant below
+instead: a cancel, a timeout or an unsupported authenticator during the
 derive no longer surfaces as its own `PrfProviderError`.
 
 {{#name PasskeyClient.register}} has one failure of its own that is **not** a

--- a/docs/breez-sdk/src/guide/passkey_onboarding.md
+++ b/docs/breez-sdk/src/guide/passkey_onboarding.md
@@ -77,7 +77,7 @@ Register a fresh credential:
 
 ## Error recovery
 
-Every passkey failure normalizes to a {{#name PrfProviderError}} variant. Match on the variant to drive recovery:
+Most passkey failures normalize to a {{#name PrfProviderError}} variant. Match on the variant to drive recovery:
 
 | Variant | What it means | Recommended action |
 |---|---|---|
@@ -88,6 +88,21 @@ Every passkey failure normalizes to a {{#name PrfProviderError}} variant. Match 
 | {{#enum PrfProviderError::PrfNotSupported}} | Authenticator lacks the PRF extension | Fall back to mnemonic onboarding. |
 | {{#enum PrfProviderError::Configuration}} | Entitlement missing, AASA stale, or assetlinks malformed | Developer-facing error; surface the {{#enum PasskeyAvailability::NotAssociated}} reason. |
 | {{#enum PrfProviderError::Generic}} | Network or generic failure | Generic "try again later" UI. |
+
+{{#name PasskeyClient.register}} has one failure of its own that is **not** a
+{{#name PrfProviderError}}:
+
+| Variant | What it means | Recommended action |
+|---|---|---|
+| {{#enum PasskeyError::CreatedButNotDerived}} | The passkey was created, then deriving from it failed | Sign in pinned to the `credential_id` on the error. **Do not** register again. |
+
+Handle it explicitly. The passkey exists on the device from that point on, so
+registering again leaves the first one behind owning a wallet nothing points
+to. A catch-all `else` branch will not fail to compile: it routes this into
+your generic "try again" path, which is usually a retry that registers a
+second passkey. `kind()` reports the classification of the derive failure that
+followed the create, so a caller branching on `kind()` alone cannot tell this
+apart from a plain derive failure.
 
 Web exposes typed exception classes (`PasskeyAlreadyExistsError`, `PasskeyTimedOutError`, `PasskeyCredentialNotFoundError`) for `instanceof` matching. Rust callers can branch on the collapsed `error.kind()` instead of every variant.
 

--- a/docs/breez-sdk/src/guide/passkey_onboarding.md
+++ b/docs/breez-sdk/src/guide/passkey_onboarding.md
@@ -89,6 +89,12 @@ Most passkey failures normalize to a {{#name PrfProviderError}} variant. Match o
 | {{#enum PrfProviderError::Configuration}} | Entitlement missing, AASA stale, or assetlinks malformed | Developer-facing error; surface the {{#enum PasskeyAvailability::NotAssociated}} reason. |
 | {{#enum PrfProviderError::Generic}} | Network or generic failure | Generic "try again later" UI. |
 
+Those rows cover {{#name PasskeyClient.sign_in}}, and
+{{#name PasskeyClient.register}} up to the point the credential is created.
+Once it exists, every failure arrives as the variant below instead, whatever
+caused it: a cancel, a timeout or an unsupported authenticator during the
+derive no longer surfaces as its own `PrfProviderError`.
+
 {{#name PasskeyClient.register}} has one failure of its own that is **not** a
 {{#name PrfProviderError}}:
 

--- a/docs/breez-sdk/src/guide/passkey_onboarding.md
+++ b/docs/breez-sdk/src/guide/passkey_onboarding.md
@@ -100,15 +100,16 @@ derive no longer surfaces as its own `PrfProviderError`.
 
 | Variant | What it means | Recommended action |
 |---|---|---|
-| {{#enum PasskeyError::CreatedButNotDerived}} | The passkey was created, then deriving from it failed | Sign in pinned to the `credential_id` on the error. **Do not** register again. |
+| {{#enum PasskeyError::CreatedButNotDerived}} | The passkey was created, then the authenticator failed the derive that followed | Sign in pinned to the `credential_id` on the error. **Do not** register again. |
 
 Handle it explicitly. The passkey exists on the device from that point on, so
 registering again leaves the first one behind owning a wallet nothing points
 to. A catch-all `else` branch will not fail to compile: it routes this into
 your generic "try again" path, which is usually a retry that registers a
-second passkey. `kind()` reports the classification of the derive failure that
-followed the create, so a caller branching on `kind()` alone cannot tell this
-apart from a plain derive failure.
+second passkey. It carries the underlying
+{{#name PrfProviderError}} as `source`, so unwrap once and reuse the arms
+above. Failures that are not the authenticator's (mnemonic, key derivation,
+invalid PRF output) keep their own variant and are not wrapped.
 
 Web exposes typed exception classes (`PasskeyAlreadyExistsError`, `PasskeyTimedOutError`, `PasskeyCredentialNotFoundError`) for `instanceof` matching. Rust callers can branch on the collapsed `error.kind()` instead of every variant.
 

--- a/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -82,12 +82,14 @@ private const val CORE_TAG = "PasskeyPrfCore"
 // =====================================================================
 
 /**
- * A newly-registered passkey is briefly not ready for the immediate
- * post-create assertion: Credential Manager can drop `prf.second` from a
- * dual-salt assertion (forcing a second single-salt prompt) or surface
- * the credential as not yet discoverable in the picker. [arm] opens a
- * window in which the next derive re-asks instead of trusting the first
- * miss.
+ * A newly-registered passkey is briefly not discoverable, so the
+ * immediate post-create assertion can miss a credential that exists.
+ * [arm] opens a window in which the next derive re-asks instead of
+ * trusting that first miss.
+ *
+ * Scoped to that case only: the retry catches `NoCredentialException`,
+ * so a dropped `prf.second` is not covered and still falls through to
+ * the single-salt recover in [CredentialManagerPrfCore.deriveSeeds].
  *
  * The window is a ceiling, not a wait: indexing takes as long as the
  * device takes, so a fixed sleep either returns before the credential is

--- a/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -85,8 +85,14 @@ private const val CORE_TAG = "PasskeyPrfCore"
  * A newly-registered passkey is briefly not ready for the immediate
  * post-create assertion: Credential Manager can drop `prf.second` from a
  * dual-salt assertion (forcing a second single-salt prompt) or surface
- * the credential as not yet discoverable in the picker. Holding the next
- * derive up to [DEFAULT_DURATION_MS] lets the OS finish indexing.
+ * the credential as not yet discoverable in the picker. [arm] opens a
+ * window in which the next derive re-asks instead of trusting the first
+ * miss.
+ *
+ * The window is a ceiling, not a wait: indexing takes as long as the
+ * device takes, so a fixed sleep either returns before the credential is
+ * queryable or taxes every registration. Retrying costs nothing once the
+ * credential resolves.
  *
  * Mirrors iOS `PostCreateGraceTracker`; an instance lives inside
  * [CredentialManagerPrfCore] so every consumer that holds onto a single
@@ -103,19 +109,22 @@ public class PostCreateGraceTracker {
         }
     }
 
-    public suspend fun consume() {
-        val waitMs = mutex.withLock {
-            val remaining = deadlineMs - System.currentTimeMillis()
-            deadlineMs = 0L
-            if (remaining > 0L) remaining else 0L
-        }
-        if (waitMs > 0L) {
-            delay(waitMs)
-        }
+    /**
+     * Absolute time until which a post-create assertion may re-ask, or 0
+     * when no registration preceded this derive. Clears the window, so a
+     * later derive is not covered by it.
+     */
+    public suspend fun consumeDeadline(): Long = mutex.withLock {
+        val deadline = deadlineMs
+        deadlineMs = 0L
+        deadline
     }
 
     public companion object {
-        public const val DEFAULT_DURATION_MS: Long = 800L
+        public const val DEFAULT_DURATION_MS: Long = 5_000L
+
+        /** Gap between re-asks; each miss is a fast local no-UI failure. */
+        public const val RETRY_INTERVAL_MS: Long = 100L
     }
 }
 
@@ -221,9 +230,10 @@ public class CredentialManagerPrfCore(
         allowCredentials: List<ByteArray> = emptyList(),
         preferImmediatelyAvailableCredentials: Boolean = true,
     ): PrfDerivation = withContext(Dispatchers.Main) {
-        // Wait out the post-create grace so an immediate derive doesn't
-        // race the credential's PRF-readiness window (see grace tracker).
-        graceTracker.consume()
+        // Re-ask, rather than sleep, while a just-created credential is
+        // still being indexed (see grace tracker). 0 when no register
+        // preceded this call, which disables the retry entirely.
+        val indexRetryUntilMs = graceTracker.consumeDeadline()
         // Pinned to the first asserted credential after the first chunk so
         // every salt in this call derives from one passkey.
         var allow = allowCredentials
@@ -236,7 +246,12 @@ public class CredentialManagerPrfCore(
         // it, so every chunk resolves to the same credential.
         suspend fun assertChunk(chunk: List<String>): Pair<List<ByteArray>, ByteArray?> =
             try {
-                assertPrf(chunk, allow, preferImmediatelyAvailableCredentials)
+                assertPrfAwaitingIndex(
+                    chunk,
+                    allow,
+                    preferImmediatelyAvailableCredentials,
+                    indexRetryUntilMs,
+                )
             } catch (e: NoCredentialException) {
                 if (!autoRegister) {
                     throw CredentialManagerPrfCoreException(
@@ -451,6 +466,38 @@ public class CredentialManagerPrfCore(
      * the asserted credential ID. A dropped `results.second` yields a
      * single-element list.
      */
+    /**
+     * [assertPrf], re-asking until [retryUntilMs] while Credential Manager
+     * still reports no credential. A passkey that exists but is not yet
+     * queryable is indistinguishable from an absent one (both raise
+     * `NoCredentialException`), so asking again is the only way to tell
+     * them apart, and the caller has just created one.
+     *
+     * Only retries under [preferImmediatelyAvailableCredentials], where a
+     * miss is a fast local failure with no UI. Without it a miss means the
+     * user saw and dismissed a picker, which must not be re-shown.
+     */
+    private suspend fun assertPrfAwaitingIndex(
+        salts: List<String>,
+        allowCredentials: List<ByteArray>,
+        preferImmediatelyAvailableCredentials: Boolean,
+        retryUntilMs: Long,
+    ): Pair<List<ByteArray>, ByteArray?> {
+        while (true) {
+            try {
+                return assertPrf(salts, allowCredentials, preferImmediatelyAvailableCredentials)
+            } catch (e: NoCredentialException) {
+                if (!preferImmediatelyAvailableCredentials
+                    || System.currentTimeMillis() >= retryUntilMs
+                ) {
+                    throw e
+                }
+                Log.d(CORE_TAG, "Credential not indexed yet, re-asking")
+                delay(PostCreateGraceTracker.RETRY_INTERVAL_MS)
+            }
+        }
+    }
+
     private suspend fun assertPrf(
         salts: List<String>,
         allowCredentials: List<ByteArray>,

--- a/packages/flutter/rust/src/errors.rs
+++ b/packages/flutter/rust/src/errors.rs
@@ -1,4 +1,4 @@
-pub use breez_sdk_spark::passkey::{PasskeyError, PrfProviderError};
+pub use breez_sdk_spark::passkey::{ErrorKind, PasskeyError, PrfProviderError};
 pub use breez_sdk_spark::{DepositClaimError, Fee, SdkError, StorageError};
 use flutter_rust_bridge::frb;
 
@@ -72,6 +72,21 @@ pub enum _PrfProviderError {
     Generic(String),
 }
 
+/// Mirrored so `_PasskeyError::CreatedButNotDerived` can carry the
+/// classification of the derive failure that followed the create.
+#[frb(mirror(ErrorKind))]
+pub enum _ErrorKind {
+    Cancel,
+    NoCredential,
+    PrfUnsupported,
+    PrfFailed,
+    Configuration,
+    AlreadyExists,
+    Timeout,
+    AuthFailure,
+    Internal,
+}
+
 #[frb(mirror(PasskeyError))]
 pub enum _PasskeyError {
     Prf(PrfProviderError),
@@ -82,5 +97,10 @@ pub enum _PasskeyError {
     InvalidPrfOutput(String),
     MnemonicError(String),
     InvalidSalt(String),
+    CreatedButNotDerived {
+        credential_id: Vec<u8>,
+        kind: ErrorKind,
+        reason: String,
+    },
     Generic(String),
 }

--- a/packages/flutter/rust/src/errors.rs
+++ b/packages/flutter/rust/src/errors.rs
@@ -1,4 +1,4 @@
-pub use breez_sdk_spark::passkey::{ErrorKind, PasskeyError, PrfProviderError};
+pub use breez_sdk_spark::passkey::{PasskeyError, PrfProviderError};
 pub use breez_sdk_spark::{DepositClaimError, Fee, SdkError, StorageError};
 use flutter_rust_bridge::frb;
 
@@ -72,21 +72,6 @@ pub enum _PrfProviderError {
     Generic(String),
 }
 
-/// Mirrored so `_PasskeyError::CreatedButNotDerived` can carry the
-/// classification of the derive failure that followed the create.
-#[frb(mirror(ErrorKind))]
-pub enum _ErrorKind {
-    Cancel,
-    NoCredential,
-    PrfUnsupported,
-    PrfFailed,
-    Configuration,
-    AlreadyExists,
-    Timeout,
-    AuthFailure,
-    Internal,
-}
-
 #[frb(mirror(PasskeyError))]
 pub enum _PasskeyError {
     Prf(PrfProviderError),
@@ -99,8 +84,7 @@ pub enum _PasskeyError {
     InvalidSalt(String),
     CreatedButNotDerived {
         credential_id: Vec<u8>,
-        kind: ErrorKind,
-        reason: String,
+        source: PrfProviderError,
     },
     Generic(String),
 }

--- a/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -82,12 +82,14 @@ private const val CORE_TAG = "PasskeyPrfCore"
 // =====================================================================
 
 /**
- * A newly-registered passkey is briefly not ready for the immediate
- * post-create assertion: Credential Manager can drop `prf.second` from a
- * dual-salt assertion (forcing a second single-salt prompt) or surface
- * the credential as not yet discoverable in the picker. [arm] opens a
- * window in which the next derive re-asks instead of trusting the first
- * miss.
+ * A newly-registered passkey is briefly not discoverable, so the
+ * immediate post-create assertion can miss a credential that exists.
+ * [arm] opens a window in which the next derive re-asks instead of
+ * trusting that first miss.
+ *
+ * Scoped to that case only: the retry catches `NoCredentialException`,
+ * so a dropped `prf.second` is not covered and still falls through to
+ * the single-salt recover in [CredentialManagerPrfCore.deriveSeeds].
  *
  * The window is a ceiling, not a wait: indexing takes as long as the
  * device takes, so a fixed sleep either returns before the credential is

--- a/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -85,8 +85,14 @@ private const val CORE_TAG = "PasskeyPrfCore"
  * A newly-registered passkey is briefly not ready for the immediate
  * post-create assertion: Credential Manager can drop `prf.second` from a
  * dual-salt assertion (forcing a second single-salt prompt) or surface
- * the credential as not yet discoverable in the picker. Holding the next
- * derive up to [DEFAULT_DURATION_MS] lets the OS finish indexing.
+ * the credential as not yet discoverable in the picker. [arm] opens a
+ * window in which the next derive re-asks instead of trusting the first
+ * miss.
+ *
+ * The window is a ceiling, not a wait: indexing takes as long as the
+ * device takes, so a fixed sleep either returns before the credential is
+ * queryable or taxes every registration. Retrying costs nothing once the
+ * credential resolves.
  *
  * Mirrors iOS `PostCreateGraceTracker`; an instance lives inside
  * [CredentialManagerPrfCore] so every consumer that holds onto a single
@@ -103,19 +109,22 @@ public class PostCreateGraceTracker {
         }
     }
 
-    public suspend fun consume() {
-        val waitMs = mutex.withLock {
-            val remaining = deadlineMs - System.currentTimeMillis()
-            deadlineMs = 0L
-            if (remaining > 0L) remaining else 0L
-        }
-        if (waitMs > 0L) {
-            delay(waitMs)
-        }
+    /**
+     * Absolute time until which a post-create assertion may re-ask, or 0
+     * when no registration preceded this derive. Clears the window, so a
+     * later derive is not covered by it.
+     */
+    public suspend fun consumeDeadline(): Long = mutex.withLock {
+        val deadline = deadlineMs
+        deadlineMs = 0L
+        deadline
     }
 
     public companion object {
-        public const val DEFAULT_DURATION_MS: Long = 800L
+        public const val DEFAULT_DURATION_MS: Long = 5_000L
+
+        /** Gap between re-asks; each miss is a fast local no-UI failure. */
+        public const val RETRY_INTERVAL_MS: Long = 100L
     }
 }
 
@@ -221,9 +230,10 @@ public class CredentialManagerPrfCore(
         allowCredentials: List<ByteArray> = emptyList(),
         preferImmediatelyAvailableCredentials: Boolean = true,
     ): PrfDerivation = withContext(Dispatchers.Main) {
-        // Wait out the post-create grace so an immediate derive doesn't
-        // race the credential's PRF-readiness window (see grace tracker).
-        graceTracker.consume()
+        // Re-ask, rather than sleep, while a just-created credential is
+        // still being indexed (see grace tracker). 0 when no register
+        // preceded this call, which disables the retry entirely.
+        val indexRetryUntilMs = graceTracker.consumeDeadline()
         // Pinned to the first asserted credential after the first chunk so
         // every salt in this call derives from one passkey.
         var allow = allowCredentials
@@ -236,7 +246,12 @@ public class CredentialManagerPrfCore(
         // it, so every chunk resolves to the same credential.
         suspend fun assertChunk(chunk: List<String>): Pair<List<ByteArray>, ByteArray?> =
             try {
-                assertPrf(chunk, allow, preferImmediatelyAvailableCredentials)
+                assertPrfAwaitingIndex(
+                    chunk,
+                    allow,
+                    preferImmediatelyAvailableCredentials,
+                    indexRetryUntilMs,
+                )
             } catch (e: NoCredentialException) {
                 if (!autoRegister) {
                     throw CredentialManagerPrfCoreException(
@@ -451,6 +466,38 @@ public class CredentialManagerPrfCore(
      * the asserted credential ID. A dropped `results.second` yields a
      * single-element list.
      */
+    /**
+     * [assertPrf], re-asking until [retryUntilMs] while Credential Manager
+     * still reports no credential. A passkey that exists but is not yet
+     * queryable is indistinguishable from an absent one (both raise
+     * `NoCredentialException`), so asking again is the only way to tell
+     * them apart, and the caller has just created one.
+     *
+     * Only retries under [preferImmediatelyAvailableCredentials], where a
+     * miss is a fast local failure with no UI. Without it a miss means the
+     * user saw and dismissed a picker, which must not be re-shown.
+     */
+    private suspend fun assertPrfAwaitingIndex(
+        salts: List<String>,
+        allowCredentials: List<ByteArray>,
+        preferImmediatelyAvailableCredentials: Boolean,
+        retryUntilMs: Long,
+    ): Pair<List<ByteArray>, ByteArray?> {
+        while (true) {
+            try {
+                return assertPrf(salts, allowCredentials, preferImmediatelyAvailableCredentials)
+            } catch (e: NoCredentialException) {
+                if (!preferImmediatelyAvailableCredentials
+                    || System.currentTimeMillis() >= retryUntilMs
+                ) {
+                    throw e
+                }
+                Log.d(CORE_TAG, "Credential not indexed yet, re-asking")
+                delay(PostCreateGraceTracker.RETRY_INTERVAL_MS)
+            }
+        }
+    }
+
     private suspend fun assertPrf(
         salts: List<String>,
         allowCredentials: List<ByteArray>,


### PR DESCRIPTION
Android can briefly fail to find a passkey immediately after creating it because Google Password Manager indexing is asynchronous.

Instead of waiting a fixed delay, the SDK now retries the lookup for up to 5 seconds. If the passkey still cannot be derived, the created passkey is returned so hosts can continue without creating a duplicate.

This makes the race condition harmless while avoiding unnecessary extra passkeys.

**Integrators**: `PasskeyError` gains a new variant, so exhaustive `when` / `switch` statements need an additional arm.

**Follow-up:** requesting the PRF value during passkey creation would remove this second step entirely on supported providers, but requires a provider interface change across all platforms. See #1024.