### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -27,6 +27,7 @@ public static class CommandNames
         "list-payments",
         "receive",
         "pay",
+        "pay-batch",
         "lnurl-pay",
         "lnurl-withdraw",
         "lnurl-auth",
@@ -100,6 +101,12 @@ public static class Commands
                 Name = "pay",
                 Description = "Pay the given payment request",
                 Run = HandlePay
+            },
+            ["pay-batch"] = new()
+            {
+                Name = "pay-batch",
+                Description = "Pay several recipients with one token transaction",
+                Run = HandlePayBatch
             },
             ["lnurl-pay"] = new()
             {
@@ -283,6 +290,19 @@ public static class Commands
     private static bool HasFlag(string[] args, params string[] names)
     {
         return args.Any(a => names.Contains(a));
+    }
+
+    private static string[] GetAllFlags(string[] args, params string[] names)
+    {
+        var values = new List<string>();
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            if (names.Contains(args[i]))
+            {
+                values.Add(args[i + 1]);
+            }
+        }
+        return values.ToArray();
     }
 
     /// <summary>
@@ -684,6 +704,83 @@ public static class Commands
         ));
 
         Serialization.PrintValue(result);
+    }
+
+    // --- pay-batch ---
+
+    private static async Task HandlePayBatch(BreezSdk sdk, Func<string, string?> readline, string[] args)
+    {
+        var recipientStrs = GetAllFlags(args, "-r", "--recipient");
+        if (recipientStrs.Length == 0)
+        {
+            Console.WriteLine("Usage: pay-batch -r <recipient> [-r <recipient> ...]");
+            Console.WriteLine("  recipient format: payment_request[:amount[:token_identifier]]");
+            return;
+        }
+
+        var recipients = new List<BatchRecipient>();
+        foreach (var s in recipientStrs)
+        {
+            var parts = s.Split(':', 4);
+            var paymentRequest = parts[0];
+            if (string.IsNullOrEmpty(paymentRequest))
+            {
+                Console.Error.WriteLine($"Missing payment request in '{s}'");
+                return;
+            }
+
+            BigInteger? amount = null;
+            if (parts.Length > 1 && !string.IsNullOrEmpty(parts[1]))
+            {
+                if (!BigInteger.TryParse(parts[1], out var parsed))
+                {
+                    Console.Error.WriteLine($"Invalid amount '{parts[1]}': must be a valid number");
+                    return;
+                }
+                amount = parsed;
+            }
+
+            string? tokenIdentifier = null;
+            if (parts.Length > 2 && !string.IsNullOrEmpty(parts[2]))
+            {
+                tokenIdentifier = parts[2];
+            }
+
+            if (parts.Length > 3)
+            {
+                Console.Error.WriteLine($"Invalid recipient '{s}'. Expected 'payment_request[:amount[:token_identifier]]'");
+                return;
+            }
+
+            recipients.Add(new BatchRecipient(
+                paymentRequest: paymentRequest,
+                amount: amount,
+                tokenIdentifier: tokenIdentifier
+            ));
+        }
+
+        var prepareResponse = await sdk.PrepareSendBatch(
+            request: new PrepareSendBatchRequest(recipients: recipients.ToArray())
+        );
+
+        foreach (var total in prepareResponse.totals)
+        {
+            var asset = total.tokenIdentifier ?? "sats";
+            Console.WriteLine($"Sending {total.amount} base units of {asset}");
+        }
+
+        var line = readline("Do you want to continue (y/n) [y]: ");
+        if (line != null && line.Trim().ToLower() != "" && line.Trim().ToLower() != "y")
+        {
+            Console.WriteLine("Payment cancelled");
+            return;
+        }
+
+        var response = await sdk.SendBatch(
+            request: new SendBatchRequest(prepareResponse: prepareResponse)
+        );
+
+        Serialization.PrintValue(response.payments);
     }
 
     // --- lnurl-pay ---
@@ -1240,6 +1337,7 @@ public static class Commands
 
         await sdk.UpdateUserSettings(new UpdateUserSettingsRequest(
             sparkPrivateModeEnabled: sparkPrivateMode,
+            stableBalanceActiveLabel: null,
             sparkMasterIdentityPublicKey: sparkMasterIdentityPublicKey
         ));
         Console.WriteLine("User settings updated");

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -16,6 +16,7 @@ const commandNames = [
   'list-payments',
   'receive',
   'pay',
+  'pay-batch',
   'lnurl-pay',
   'lnurl-withdraw',
   'lnurl-auth',
@@ -58,6 +59,7 @@ Map<String, CommandEntry> buildCommandRegistry() {
     'list-payments': CommandEntry('List payments', _handleListPayments),
     'receive': CommandEntry('Receive a payment', _handleReceive),
     'pay': CommandEntry('Pay the given payment request', _handlePay),
+    'pay-batch': CommandEntry('Pay several recipients with one token transaction', _handlePayBatch),
     'lnurl-pay': CommandEntry('Pay using LNURL', _handleLnurlPay),
     'lnurl-withdraw': CommandEntry('Withdraw using LNURL', _handleLnurlWithdraw),
     'lnurl-auth': CommandEntry('Authenticate using LNURL', _handleLnurlAuth),
@@ -492,6 +494,76 @@ Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args
     ),
   );
   printValue(sendResponse);
+}
+
+// --- pay-batch ---
+
+BatchRecipient? _parseBatchRecipient(String s) {
+  final parts = s.split(':');
+  final paymentRequest = parts[0];
+  if (paymentRequest.isEmpty) {
+    print("Missing payment request in '$s'");
+    return null;
+  }
+
+  BigInt? amount;
+  if (parts.length > 1 && parts[1].isNotEmpty) {
+    final parsed = BigInt.tryParse(parts[1]);
+    if (parsed == null) {
+      print("Invalid amount '${parts[1]}': must be a valid number");
+      return null;
+    }
+    amount = parsed;
+  }
+
+  String? tokenIdentifier;
+  if (parts.length > 2 && parts[2].isNotEmpty) {
+    tokenIdentifier = parts[2];
+  }
+
+  if (parts.length > 3) {
+    print("Invalid recipient '$s'. Expected 'payment_request[:amount[:token_identifier]]'");
+    return null;
+  }
+
+  return BatchRecipient(paymentRequest: paymentRequest, amount: amount, tokenIdentifier: tokenIdentifier);
+}
+
+Future<void> _handlePayBatch(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
+  final parser = _parser('pay-batch')
+    ..addMultiOption('recipient', abbr: 'r', help: 'payment_request[:amount[:token_identifier]]');
+  final results = _parseArgs(parser, args, 'pay-batch -r <recipient> [-r <recipient> ...]');
+  if (results == null) return;
+
+  final recipientStrs = results.multiOption('recipient');
+  if (recipientStrs.isEmpty) {
+    print('At least one --recipient (-r) is required');
+    return;
+  }
+
+  final recipients = <BatchRecipient>[];
+  for (final s in recipientStrs) {
+    final r = _parseBatchRecipient(s);
+    if (r == null) return;
+    recipients.add(r);
+  }
+
+  final prepareResponse = await sdk.prepareSendBatch(
+    request: PrepareSendBatchRequest(recipients: recipients),
+  );
+
+  for (final total in prepareResponse.totals) {
+    final asset = total.tokenIdentifier ?? 'sats';
+    print('Sending ${total.amount} base units of $asset');
+  }
+  final answer = prompt('Do you want to continue (y/n): ', defaultValue: 'y');
+  if (answer.toLowerCase() != 'y') {
+    print('Payment cancelled');
+    return;
+  }
+
+  final response = await sdk.sendBatch(request: SendBatchRequest(prepareResponse: prepareResponse));
+  printValue(response.payments);
 }
 
 // --- lnurl-pay ---

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -54,6 +54,7 @@ var CommandNames = []string{
 	"get-user-settings",
 	"set-user-settings",
 	"get-spark-status",
+	"pay-batch",
 }
 
 // BuildCommandRegistry returns a map of command name → Command.
@@ -88,6 +89,7 @@ func BuildCommandRegistry() map[string]Command {
 		"get-user-settings":                    {Name: "get-user-settings", Description: "Get user settings", Run: handleGetUserSettings},
 		"set-user-settings":                    {Name: "set-user-settings", Description: "Update user settings", Run: handleSetUserSettings},
 		"get-spark-status":                     {Name: "get-spark-status", Description: "Get Spark network service status", Run: handleGetSparkStatus},
+		"pay-batch":                            {Name: "pay-batch", Description: "Pay several recipients with one token transaction", Run: handlePayBatch},
 	}
 }
 
@@ -554,6 +556,95 @@ func handlePay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []stri
 		return err
 	}
 	printValue(result)
+	return nil
+}
+
+// --- pay-batch ---
+
+func parseBatchRecipient(s string) (breez_sdk_spark.BatchRecipient, error) {
+	parts := strings.Split(s, ":")
+	if len(parts) > 3 {
+		return breez_sdk_spark.BatchRecipient{}, fmt.Errorf("invalid recipient '%s'. Expected 'payment_request[:amount[:token_identifier]]'", s)
+	}
+
+	paymentRequest := parts[0]
+	if paymentRequest == "" {
+		return breez_sdk_spark.BatchRecipient{}, fmt.Errorf("missing payment request in '%s'", s)
+	}
+
+	recipient := breez_sdk_spark.BatchRecipient{
+		PaymentRequest: paymentRequest,
+	}
+
+	if len(parts) > 1 && parts[1] != "" {
+		amount, ok := new(big.Int).SetString(parts[1], 10)
+		if !ok {
+			return breez_sdk_spark.BatchRecipient{}, fmt.Errorf("invalid amount '%s': must be a valid number", parts[1])
+		}
+		recipient.Amount = &amount
+	}
+
+	if len(parts) > 2 && parts[2] != "" {
+		tokenId := parts[2]
+		recipient.TokenIdentifier = &tokenId
+	}
+
+	return recipient, nil
+}
+
+func handlePayBatch(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []string) error {
+	fs := flag.NewFlagSet("pay-batch", flag.ContinueOnError)
+	var recipientArgs stringSliceFlag
+	fs.Var(&recipientArgs, "r", "Recipient: payment_request[:amount[:token_identifier]] (repeatable)")
+	fs.Var(&recipientArgs, "recipient", "Recipient: payment_request[:amount[:token_identifier]]")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if len(recipientArgs) == 0 {
+		fmt.Println("Usage: pay-batch -r <recipient> [-r <recipient> ...]")
+		fmt.Println("  Each recipient: payment_request[:amount[:token_identifier]]")
+		return nil
+	}
+
+	var recipients []breez_sdk_spark.BatchRecipient
+	for _, raw := range recipientArgs {
+		r, err := parseBatchRecipient(raw)
+		if err != nil {
+			return err
+		}
+		recipients = append(recipients, r)
+	}
+
+	prepareResponse, err := sdk.PrepareSendBatch(breez_sdk_spark.PrepareSendBatchRequest{
+		Recipients: recipients,
+	})
+	if err = liftError(err); err != nil {
+		return err
+	}
+
+	for _, total := range prepareResponse.Totals {
+		asset := "sats"
+		if total.TokenIdentifier != nil {
+			asset = *total.TokenIdentifier
+		}
+		fmt.Printf("Sending %v base units of %s\n", total.Amount, asset)
+	}
+	line, err := readlineWithDefault(rl, "Do you want to continue (y/n): ", "y")
+	if err != nil {
+		return err
+	}
+	if strings.ToLower(strings.TrimSpace(line)) != "y" {
+		return fmt.Errorf("payment cancelled")
+	}
+
+	response, err := sdk.SendBatch(breez_sdk_spark.SendBatchRequest{
+		PrepareResponse: prepareResponse,
+	})
+	if err = liftError(err); err != nil {
+		return err
+	}
+	printValue(response.Payments)
 	return nil
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -21,6 +21,7 @@ val COMMAND_NAMES = listOf(
     "list-payments",
     "receive",
     "pay",
+    "pay-batch",
     "lnurl-pay",
     "lnurl-withdraw",
     "lnurl-auth",
@@ -57,6 +58,7 @@ fun buildCommandRegistry(): Map<String, CliCommand> {
         "list-payments" to CliCommand("list-payments", "List payments", ::handleListPayments),
         "receive" to CliCommand("receive", "Receive a payment", ::handleReceive),
         "pay" to CliCommand("pay", "Pay the given payment request", ::handlePay),
+        "pay-batch" to CliCommand("pay-batch", "Pay several recipients with one token transaction", ::handlePayBatch),
         "lnurl-pay" to CliCommand("lnurl-pay", "Pay using LNURL", ::handleLnurlPay),
         "lnurl-withdraw" to CliCommand("lnurl-withdraw", "Withdraw using LNURL", ::handleLnurlWithdraw),
         "lnurl-auth" to CliCommand("lnurl-auth", "Authenticate using LNURL", ::handleLnurlAuth),
@@ -521,6 +523,63 @@ suspend fun handlePay(sdk: BreezSdk, reader: LineReader, args: List<String>) {
         )
     )
     printValue(result)
+}
+
+// --- pay-batch ---
+
+suspend fun handlePayBatch(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    val fp = FlagParser(args)
+    val recipientStrs = fp.getAll("r", "recipient")
+
+    if (recipientStrs.isEmpty()) {
+        println("Usage: pay-batch -r <recipient> [-r <recipient> ...]")
+        println("Each recipient: payment_request[:amount[:token_identifier]]")
+        return
+    }
+
+    val recipients = recipientStrs.map { s ->
+        val parts = s.split(":", limit = 4)
+        val paymentRequest = parts[0]
+        if (paymentRequest.isEmpty()) {
+            println("Error: Missing payment request in '$s'")
+            return
+        }
+        val amount = if (parts.size > 1 && parts[1].isNotEmpty()) {
+            try {
+                BigInteger.parseString(parts[1])
+            } catch (e: Exception) {
+                println("Error: Invalid amount '${parts[1]}': must be a valid number")
+                return
+            }
+        } else null
+        val tokenIdentifier = if (parts.size > 2 && parts[2].isNotEmpty()) parts[2] else null
+        if (parts.size > 3) {
+            println("Error: Invalid recipient '$s'. Expected 'payment_request[:amount[:token_identifier]]'")
+            return
+        }
+        BatchRecipient(
+            paymentRequest = paymentRequest,
+            amount = amount,
+            tokenIdentifier = tokenIdentifier,
+        )
+    }
+
+    val prepareResponse = sdk.prepareSendBatch(
+        PrepareSendBatchRequest(recipients = recipients)
+    )
+
+    for (total in prepareResponse.totals) {
+        val asset = total.tokenIdentifier ?: "sats"
+        println("Sending ${total.amount} base units of $asset")
+    }
+    val line = readlineWithDefault(reader, "Do you want to continue (y/n): ", "y").lowercase()
+    if (line != "y") {
+        println("Payment cancelled")
+        return
+    }
+
+    val response = sdk.sendBatch(SendBatchRequest(prepareResponse = prepareResponse))
+    printValue(response.payments)
 }
 
 // --- lnurl-pay ---

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -8,6 +8,7 @@ import breez_sdk_spark
 from breez_sdk_spark import (
     AssetFilter,
     AuthorizeTransferRequest,
+    BatchRecipient,
     BuyBitcoinRequest,
     CheckLightningAddressRequest,
     ClaimDepositRequest,
@@ -34,11 +35,13 @@ from breez_sdk_spark import (
     PaymentStatus,
     PaymentType,
     PrepareLnurlPayRequest,
+    PrepareSendBatchRequest,
     PrepareSendPaymentRequest,
     ReceivePaymentMethod,
     ReceivePaymentRequest,
     RefundDepositRequest,
     RegisterLightningAddressRequest,
+    SendBatchRequest,
     SendPaymentMethod,
     SendPaymentOptions,
     SendPaymentRequest,
@@ -61,6 +64,7 @@ COMMAND_NAMES = [
     "list-payments",
     "receive",
     "pay",
+    "pay-batch",
     "lnurl-pay",
     "lnurl-withdraw",
     "lnurl-auth",
@@ -408,6 +412,74 @@ async def _handle_pay(sdk, _token_issuer, session, args):
         )
     )
     print_value(send_response)
+
+
+# --- pay-batch ---
+
+def _parse_batch_recipient(s):
+    """Parse a recipient string: payment_request[:amount[:token_identifier]]."""
+    parts = s.split(":")
+    payment_request = parts[0]
+    if not payment_request:
+        raise argparse.ArgumentTypeError(f"Missing payment request in '{s}'")
+
+    amount = None
+    if len(parts) >= 2 and parts[1]:
+        try:
+            amount = int(parts[1])
+        except ValueError:
+            raise argparse.ArgumentTypeError(
+                f"Invalid amount '{parts[1]}': must be a valid number"
+            )
+
+    token_identifier = None
+    if len(parts) >= 3 and parts[2]:
+        token_identifier = parts[2]
+
+    if len(parts) > 3:
+        raise argparse.ArgumentTypeError(
+            f"Invalid recipient '{s}'. Expected "
+            "'payment_request[:amount[:token_identifier]]'"
+        )
+
+    return BatchRecipient(
+        payment_request=payment_request,
+        amount=amount,
+        token_identifier=token_identifier,
+    )
+
+
+def _build_pay_batch_parser():
+    p = _parser("pay-batch", "Pay several recipients with one token transaction")
+    p.add_argument(
+        "-r", "--recipient",
+        type=_parse_batch_recipient,
+        action="append",
+        required=True,
+        dest="recipients",
+        help="payment_request[:amount[:token_identifier]] (repeat for each recipient)",
+    )
+    return p
+
+
+async def _handle_pay_batch(sdk, _token_issuer, session, args):
+    prepare_response = await sdk.prepare_send_batch(
+        request=PrepareSendBatchRequest(recipients=args.recipients)
+    )
+
+    for total in prepare_response.totals:
+        asset = total.token_identifier if total.token_identifier else "sats"
+        print(f"Sending {total.amount} base units of {asset}")
+
+    line = await session.prompt_async("Do you want to continue (y/n): ", default="y")
+    if line.strip().lower() != "y":
+        print("Payment cancelled")
+        return
+
+    response = await sdk.send_batch(
+        request=SendBatchRequest(prepare_response=prepare_response)
+    )
+    print_value(response.payments)
 
 
 # --- lnurl-pay ---
@@ -1040,6 +1112,7 @@ def build_command_registry():
         "list-payments": (_build_list_payments_parser(), _handle_list_payments),
         "receive": (_build_receive_parser(), _handle_receive),
         "pay": (_build_pay_parser(), _handle_pay),
+        "pay-batch": (_build_pay_batch_parser(), _handle_pay_batch),
         "lnurl-pay": (_build_lnurl_pay_parser(), _handle_lnurl_pay),
         "lnurl-withdraw": (_build_lnurl_withdraw_parser(), _handle_lnurl_withdraw),
         "lnurl-auth": (_build_lnurl_auth_parser(), _handle_lnurl_auth),

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
@@ -99,6 +99,7 @@ declare module '@breeztech/breez-sdk-spark-react-native' {
   export type DomainAssociation = any;
 
   // --- types only ---
+  export type BatchRecipient = any;
   export type BreezSdkInterface = any;
   export type TokenIssuerInterface = any;
   export type SdkEvent = any;

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -2,7 +2,7 @@
  * Command registry and all command handlers for the Breez SDK React Native CLI.
  *
  * Mirrors ALL commands from the Rust CLI:
- *   get-info, get-payment, sync, list-payments, receive, pay, lnurl-pay,
+ *   get-info, get-payment, sync, list-payments, receive, pay, pay-batch, lnurl-pay,
  *   lnurl-withdraw, lnurl-auth, claim-htlc-payment, claim-deposit, parse,
  *   refund-deposit, list-unclaimed-deposits, buy-bitcoin,
  *   check-lightning-address-available, get-lightning-address,
@@ -38,6 +38,7 @@ import {
   CrossChainProvider,
 } from '@breeztech/breez-sdk-spark-react-native'
 import type {
+  BatchRecipient,
   BreezSdkInterface,
   TokenIssuerInterface,
   CrossChainRoutePair,
@@ -156,6 +157,7 @@ export const COMMAND_NAMES = [
   'list-payments',
   'receive',
   'pay',
+  'pay-batch',
   'lnurl-pay',
   'lnurl-withdraw',
   'lnurl-auth',
@@ -199,6 +201,7 @@ export function buildCommandRegistry(): Map<string, CommandDef> {
     { name: 'list-payments', description: 'List payments', run: handleListPayments },
     { name: 'receive', description: 'Receive a payment', run: handleReceive },
     { name: 'pay', description: 'Pay the given payment request', run: handlePay },
+    { name: 'pay-batch', description: 'Pay several recipients with one token transaction', run: handlePayBatch },
     { name: 'lnurl-pay', description: 'Pay using LNURL', run: handleLnurlPay },
     { name: 'lnurl-withdraw', description: 'Withdraw using LNURL', run: handleLnurlWithdraw },
     { name: 'lnurl-auth', description: 'Authenticate using LNURL', run: handleLnurlAuth },
@@ -686,6 +689,67 @@ async function handlePay(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterf
   })
 
   lines.push(formatValue(sendResponse))
+  return lines.join('\n')
+}
+
+// --- pay-batch ---
+
+function parseBatchRecipient(s: string): BatchRecipient {
+  const parts = s.split(':')
+  const paymentRequest = parts[0]
+  if (!paymentRequest) {
+    throw new Error(`Missing payment request in '${s}'`)
+  }
+  const amountStr = parts.length > 1 ? parts[1] : undefined
+  let amount: bigint | undefined
+  if (amountStr !== undefined && amountStr !== '') {
+    const parsed = Number(amountStr)
+    if (isNaN(parsed)) {
+      throw new Error(`Invalid amount '${amountStr}': must be a valid number`)
+    }
+    amount = BigInt(amountStr)
+  }
+  const tokenId = parts.length > 2 ? parts[2] : undefined
+  const tokenIdentifier = tokenId !== undefined && tokenId !== '' ? tokenId : undefined
+  if (parts.length > 3) {
+    throw new Error(
+      `Invalid recipient '${s}'. Expected 'payment_request[:amount[:token_identifier]]'`
+    )
+  }
+  return { paymentRequest, amount, tokenIdentifier }
+}
+
+function parseRepeatedFlag(args: string[], ...flags: string[]): string[] {
+  const values: string[] = []
+  for (let i = 0; i < args.length; i++) {
+    if (flags.includes(args[i]) && i + 1 < args.length) {
+      values.push(args[i + 1])
+      i++
+    }
+  }
+  return values
+}
+
+async function handlePayBatch(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
+  const recipientArgs = parseRepeatedFlag(args, '-r', '--recipient')
+  if (recipientArgs.length === 0) {
+    return 'Usage: pay-batch -r <recipient> [-r <recipient> ...]\n' +
+      'Each recipient: payment_request[:amount[:token_identifier]]'
+  }
+
+  const recipients: BatchRecipient[] = recipientArgs.map(parseBatchRecipient)
+
+  const prepareResponse = await sdk.prepareSendBatch({ recipients })
+
+  const lines: string[] = []
+  for (const total of prepareResponse.totals) {
+    const asset = total.tokenIdentifier ?? 'sats'
+    lines.push(`Sending ${total.amount} base units of ${asset}`)
+  }
+
+  const response = await sdk.sendBatch({ prepareResponse })
+
+  lines.push(formatValue(response.payments))
   return lines.join('\n')
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -7,7 +7,7 @@ import CryptoKit
 
 struct FlagParser {
     var positional: [String] = []
-    private var flags: [String: String] = [:]
+    private var flags: [String: [String]] = [:]
 
     init(_ args: [String]) {
         var i = 0
@@ -16,19 +16,19 @@ struct FlagParser {
             if arg.hasPrefix("--") {
                 let key = String(arg.dropFirst(2))
                 if i + 1 < args.count && !args[i + 1].hasPrefix("-") {
-                    flags[key] = args[i + 1]
+                    flags[key, default: []].append(args[i + 1])
                     i += 2
                 } else {
-                    flags[key] = ""
+                    flags[key, default: []].append("")
                     i += 1
                 }
             } else if arg.hasPrefix("-") && arg.count == 2 {
                 let key = String(arg.dropFirst(1))
                 if i + 1 < args.count && !args[i + 1].hasPrefix("-") {
-                    flags[key] = args[i + 1]
+                    flags[key, default: []].append(args[i + 1])
                     i += 2
                 } else {
-                    flags[key] = ""
+                    flags[key, default: []].append("")
                     i += 1
                 }
             } else {
@@ -40,9 +40,19 @@ struct FlagParser {
 
     func get(_ keys: String...) -> String? {
         for key in keys {
-            if let val = flags[key], !val.isEmpty { return val }
+            if let vals = flags[key], let last = vals.last, !last.isEmpty { return last }
         }
         return nil
+    }
+
+    func getAll(_ keys: String...) -> [String] {
+        for key in keys {
+            if let vals = flags[key] {
+                let nonEmpty = vals.filter { !$0.isEmpty }
+                if !nonEmpty.isEmpty { return nonEmpty }
+            }
+        }
+        return []
     }
 
     func has(_ keys: String...) -> Bool {
@@ -68,6 +78,7 @@ let commandNames: [String] = [
     "list-payments",
     "receive",
     "pay",
+    "pay-batch",
     "lnurl-pay",
     "lnurl-withdraw",
     "lnurl-auth",
@@ -103,6 +114,7 @@ func buildCommandRegistry() -> [String: CommandEntry] {
         "list-payments":                     CommandEntry(name: "list-payments", description: "List payments", run: handleListPayments),
         "receive":                           CommandEntry(name: "receive", description: "Receive a payment", run: handleReceive),
         "pay":                               CommandEntry(name: "pay", description: "Pay the given payment request", run: handlePay),
+        "pay-batch":                         CommandEntry(name: "pay-batch", description: "Pay several recipients with one token transaction", run: handlePayBatch),
         "lnurl-pay":                         CommandEntry(name: "lnurl-pay", description: "Pay using LNURL", run: handleLnurlPay),
         "lnurl-withdraw":                    CommandEntry(name: "lnurl-withdraw", description: "Withdraw using LNURL", run: handleLnurlWithdraw),
         "lnurl-auth":                        CommandEntry(name: "lnurl-auth", description: "Authenticate using LNURL", run: handleLnurlAuth),
@@ -517,6 +529,71 @@ func handlePay(_ sdk: BreezSdk, _ args: [String]) async throws {
         idempotencyKey: idempotencyKey
     ))
     printValue(result)
+}
+
+// --- pay-batch ---
+
+func handlePayBatch(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let fp = FlagParser(args)
+    let recipientStrs = fp.getAll("r", "recipient")
+    if recipientStrs.isEmpty {
+        print("Usage: pay-batch -r <recipient> [-r <recipient> ...]")
+        print("Recipient format: payment_request[:amount[:token_identifier]]")
+        return
+    }
+
+    var recipients: [BatchRecipient] = []
+    for raw in recipientStrs {
+        let parts = raw.split(separator: ":", omittingEmptySubsequences: false).map { String($0) }
+        let paymentRequest = parts[0]
+        if paymentRequest.isEmpty {
+            print("Error: Missing payment request in '\(raw)'")
+            return
+        }
+        let amount: BInt?
+        if parts.count > 1 && !parts[1].isEmpty {
+            guard let parsed = BInt(parts[1]) else {
+                print("Error: Invalid amount '\(parts[1])': must be a valid number")
+                return
+            }
+            amount = parsed
+        } else {
+            amount = nil
+        }
+        let tokenIdentifier: String?
+        if parts.count > 2 && !parts[2].isEmpty {
+            tokenIdentifier = parts[2]
+        } else {
+            tokenIdentifier = nil
+        }
+        if parts.count > 3 {
+            print("Error: Invalid recipient '\(raw)'. Expected 'payment_request[:amount[:token_identifier]]'")
+            return
+        }
+        recipients.append(BatchRecipient(
+            paymentRequest: paymentRequest,
+            amount: amount,
+            tokenIdentifier: tokenIdentifier
+        ))
+    }
+
+    let prepareResponse = try await sdk.prepareSendBatch(
+        request: PrepareSendBatchRequest(recipients: recipients))
+
+    for total in prepareResponse.totals {
+        let asset = total.tokenIdentifier ?? "sats"
+        print("Sending \(total.amount) base units of \(asset)")
+    }
+
+    let line = readlineWithDefault("Do you want to continue (y/n): ", defaultValue: "y")
+    if line.trimmingCharacters(in: .whitespaces).lowercased() != "y" {
+        print("Payment cancelled")
+        return
+    }
+
+    let response = try await sdk.sendBatch(
+        request: SendBatchRequest(prepareResponse: prepareResponse))
+    printValue(response.payments)
 }
 
 // --- lnurl-pay ---

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
@@ -86,7 +86,7 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **Wallet**: `get-info`, `sync`, `get-payment`, `list-payments`, `recommended-fees`
 
-**Payments**: `receive`, `pay`, `lnurl-pay`, `lnurl-withdraw`, `lnurl-auth`, `claim-htlc-payment`
+**Payments**: `receive`, `pay`, `pay-batch`, `lnurl-pay`, `lnurl-withdraw`, `lnurl-auth`, `claim-htlc-payment`
 
 **On-chain**: `claim-deposit`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -63,6 +63,7 @@ const COMMAND_NAMES = [
   'stable-balance get',
   'stable-balance set',
   'stable-balance unset',
+  'pay-batch',
   'advanced unilateral-exit'
 ]
 
@@ -391,6 +392,52 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
       })
 
       printValue(sendPaymentResponse)
+    })
+
+  // --- pay-batch ---
+  program
+    .command('pay-batch')
+    .description('Pay several recipients with one token transaction')
+    .requiredOption('-r, --recipient <values...>', 'Recipients as payment_request[:amount[:token_identifier]]')
+    .action(async (options) => {
+      const sdk = getSdk()
+
+      const recipients = options.recipient.map((r) => {
+        const parts = r.split(':')
+        const paymentRequest = parts[0]
+        if (!paymentRequest) {
+          throw new Error(`Missing payment request in '${r}'`)
+        }
+        const amountStr = parts[1]
+        let amount
+        if (amountStr != null && amountStr !== '') {
+          amount = BigInt(amountStr)
+        }
+        const tokenId = parts[2]
+        let tokenIdentifier
+        if (tokenId != null && tokenId !== '') {
+          tokenIdentifier = tokenId
+        }
+        if (parts.length > 3) {
+          throw new Error(`Invalid recipient '${r}'. Expected 'payment_request[:amount[:token_identifier]]'`)
+        }
+        return { paymentRequest, amount, tokenIdentifier }
+      })
+
+      const prepareResponse = await sdk.prepareSendBatch({ recipients })
+
+      for (const total of prepareResponse.totals) {
+        const asset = total.tokenIdentifier || 'sats'
+        console.log(`Sending ${total.amount} base units of ${asset}`)
+      }
+      const answer = await questionWithDefault(rl, 'Do you want to continue (y/n): ', 'y')
+      if (answer.toLowerCase() !== 'y') {
+        throw new Error('Payment cancelled')
+      }
+
+      const response = await sdk.sendBatch({ prepareResponse })
+
+      printValue(response.payments)
     })
 
   // --- lnurl-pay ---


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`566a91f`](https://github.com/breez/spark-sdk/commit/566a91f1a2d622630334dcd868ade3299a292229)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/30446631175)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :white_check_mark: React Native
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- Missing `pay-batch` command in C# CLI (added in Rust CLI with `PayBatch` command, `PrepareSendBatchRequest`, `SendBatchRequest`, `BatchRecipient`)
- `HandleSetUserSettings` missing `stableBalanceActiveLabel: null` parameter in `UpdateUserSettingsRequest` constructor

## Applied
- Added `pay-batch` command with `HandlePayBatch` handler, registry entry, and `CommandNames` entry in `Commands.cs`
- Added `GetAllFlags` helper method for repeatable `-r`/`--recipient` flags in `Commands.cs`
- Added `stableBalanceActiveLabel: null` to `UpdateUserSettingsRequest` in `HandleSetUserSettings` in `Commands.cs`

## Skipped
- (none)

### Dart
## Divergences
- Rust CLI has `pay-batch` command; Dart CLI did not

## Applied
- Added `pay-batch` command to Dart CLI with `_parseBatchRecipient` parser and `_handlePayBatch` handler in `commands.dart`, matching Rust CLI behavior: parses `payment_request[:amount[:token_identifier]]` recipients via `-r`/`--recipient`, calls `sdk.prepareSendBatch()` and `sdk.sendBatch()`, shows totals and confirms before sending

## Skipped
- (none)

### Go
## Divergences
- Go CLI was missing the `pay-batch` command (added in Rust CLI via `PayBatch` variant with `-r`/`--recipient` repeatable flag, calling `prepare_send_batch` and `send_batch`)

## Applied
- Added `handlePayBatch` handler with `parseBatchRecipient` helper to `commands.go`, matching the Rust CLI's recipient parsing format (`payment_request[:amount[:token_identifier]]`)
- Added `"pay-batch"` to `CommandNames` and `BuildCommandRegistry()` in `commands.go`

## Skipped
- (none)

### Kotlin
## Divergences
- Kotlin CLI was missing `pay-batch` command (Rust `Command::PayBatch` with `-r`/`--recipient` flag for batch token sends via `prepareSendBatch`/`sendBatch`)

## Applied
- Added `pay-batch` command to `Commands.kt`: registry entry, command name list entry, and `handlePayBatch` handler with recipient parsing, confirmation prompt, and batch send

## Skipped
- (none)

### Python
## Divergences
- Python CLI missing `pay-batch` command (Rust `Command::PayBatch` with `-r`/`--recipient` flag, calls `prepare_send_batch` + `send_batch`)

## Applied
- Added `pay-batch` command to `commands.py`: imports (`BatchRecipient`, `PrepareSendBatchRequest`, `SendBatchRequest`), `_parse_batch_recipient()` parser, `_build_pay_batch_parser()`, `_handle_pay_batch()`, `COMMAND_NAMES` entry, and registry entry

## Skipped
- (none)

### React Native
## Divergences
- Rust CLI added `pay-batch` command (with `-r`/`--recipient` repeated flag, `BatchRecipientArg` parsing, `prepare_send_batch` + `send_batch` SDK calls); React Native CLI was missing it entirely

## Applied
- Added `pay-batch` command to `commands.ts`: `parseBatchRecipient()` parser, `parseRepeatedFlag()` helper, `handlePayBatch()` handler, command registry entry, and `COMMAND_NAMES` entry
- Added `BatchRecipient` type export to `breez-sdk-spark-react-native.d.ts` type stubs

## Skipped
- (none)

### Swift
## Divergences
- Swift CLI missing `pay-batch` command (Rust CLI added `PayBatch` with `-r`/`--recipient` repeated flags for batch token payments)
- Swift `FlagParser` only stored the last value for each flag key, preventing repeated flags like `-r addr1 -r addr2`

## Applied
- Updated `FlagParser` internal storage from `[String: String]` to `[String: [String]]` and added `getAll` method for repeated flags (Commands.swift)
- Added `pay-batch` to `commandNames` array (Commands.swift)
- Added `pay-batch` entry to `buildCommandRegistry()` (Commands.swift)
- Added `handlePayBatch` function with recipient parsing (`payment_request[:amount[:token_identifier]]`), `prepareSendBatch`, totals display, confirmation prompt, and `sendBatch` call (Commands.swift)

## Skipped
- Nothing skipped

### TypeScript
## Divergences
- `pay-batch` command exists in Rust CLI but was missing from the TypeScript CLI

## Applied
- Added `pay-batch` command to `commands.js` with `-r, --recipient` option supporting `payment_request[:amount[:token_identifier]]` format, calling `sdk.prepareSendBatch()` and `sdk.sendBatch()` with confirmation prompt
- Added `pay-batch` to `COMMAND_NAMES` array in `commands.js` for tab completion
- Added `pay-batch` to the Payments section in `README.md`

## Skipped
- (none)

</details>

All languages synced cleanly. This PR merges automatically once the gating CI checks pass (integration test checks excluded).