### PR TITLE
feat: derive wallet during passkey creation

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Passkey.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Passkey.cs
@@ -138,7 +138,7 @@ public class FilePrfProvider : PrfProvider
 
     public Task<bool> IsSupported() => Task.FromResult(true);
 
-    public Task<PasskeyCredential> CreatePasskey(byte[][] excludeCredentials)
+    public Task<CreatePasskeyOutput> CreatePasskey(byte[][] excludeCredentials, string[] salts)
     {
         throw new NotSupportedException(
             "File-backed PRF provider does not implement create-credential; " +
@@ -173,7 +173,7 @@ public class NotYetSupportedProvider : PrfProvider
 
     public Task<bool> IsSupported() => throw NotYet();
 
-    public Task<PasskeyCredential> CreatePasskey(byte[][] excludeCredentials) => throw NotYet();
+    public Task<CreatePasskeyOutput> CreatePasskey(byte[][] excludeCredentials, string[] salts) => throw NotYet();
 
     public Task<DomainAssociation> CheckDomainAssociation() =>
         Task.FromResult<DomainAssociation>(

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/passkey.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/passkey.dart
@@ -60,10 +60,7 @@ class FilePrfProvider implements PrfProvider {
   Future<bool> isSupported() async => true;
 
   @override
-  Future<CreatePasskeyOutput> createPasskey(
-    List<Uint8List> excludeCredentials,
-    List<String> salts,
-  ) async {
+  Future<CreatePasskeyOutput> createPasskey(List<Uint8List> excludeCredentials, List<String> salts) async {
     throw Exception(
       'File-backed PRF provider does not implement create-credential; '
       'use sign-in by label instead.',

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/passkey.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/passkey.dart
@@ -60,7 +60,10 @@ class FilePrfProvider implements PrfProvider {
   Future<bool> isSupported() async => true;
 
   @override
-  Future<PasskeyCredential> createPasskey(List<Uint8List> excludeCredentials) async {
+  Future<CreatePasskeyOutput> createPasskey(
+    List<Uint8List> excludeCredentials,
+    List<String> salts,
+  ) async {
     throw Exception(
       'File-backed PRF provider does not implement create-credential; '
       'use sign-in by label instead.',

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/passkey.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/passkey.go
@@ -106,8 +106,8 @@ func (f *FilePrfProvider) IsSupported() (bool, error) {
 	return true, nil
 }
 
-func (f *FilePrfProvider) CreatePasskey(excludeCredentials [][]byte) (breez_sdk_spark.PasskeyCredential, error) {
-	return breez_sdk_spark.PasskeyCredential{}, fmt.Errorf(
+func (f *FilePrfProvider) CreatePasskey(excludeCredentials [][]byte, salts []string) (breez_sdk_spark.CreatePasskeyOutput, error) {
+	return breez_sdk_spark.CreatePasskeyOutput{}, fmt.Errorf(
 		"file-backed PRF provider does not implement create-credential; " +
 			"use sign-in by label instead")
 }
@@ -138,8 +138,8 @@ func (p *notYetSupportedProvider) IsSupported() (bool, error) {
 	return false, p.notYet()
 }
 
-func (p *notYetSupportedProvider) CreatePasskey(_ [][]byte) (breez_sdk_spark.PasskeyCredential, error) {
-	return breez_sdk_spark.PasskeyCredential{}, p.notYet()
+func (p *notYetSupportedProvider) CreatePasskey(_ [][]byte, _ []string) (breez_sdk_spark.CreatePasskeyOutput, error) {
+	return breez_sdk_spark.CreatePasskeyOutput{}, p.notYet()
 }
 
 func (p *notYetSupportedProvider) CheckDomainAssociation() (breez_sdk_spark.DomainAssociation, error) {

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Passkey.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Passkey.kt
@@ -95,7 +95,10 @@ class FilePrfProvider(dataDir: String) : PrfProvider {
 
     override suspend fun isSupported(): Boolean = true
 
-    override suspend fun createPasskey(excludeCredentials: List<ByteArray>): PasskeyCredential {
+    override suspend fun createPasskey(
+        excludeCredentials: List<ByteArray>,
+        salts: List<String>,
+    ): CreatePasskeyOutput {
         throw UnsupportedOperationException(
             "File-backed PRF provider does not implement create-credential; " +
                 "use sign-in by label instead."
@@ -121,7 +124,10 @@ class NotYetSupportedProvider(private val name: String) : PrfProvider {
 
     override suspend fun isSupported(): Boolean = notYet()
 
-    override suspend fun createPasskey(excludeCredentials: List<ByteArray>): PasskeyCredential = notYet()
+    override suspend fun createPasskey(
+        excludeCredentials: List<ByteArray>,
+        salts: List<String>,
+    ): CreatePasskeyOutput = notYet()
 
     override suspend fun checkDomainAssociation(): DomainAssociation =
         DomainAssociation.Skipped("$name does not verify domain association")

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/passkey.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/passkey.py
@@ -48,7 +48,7 @@ class FilePrfProvider(PrfProvider):
     async def is_supported(self) -> bool:
         return True
 
-    async def create_passkey(self, exclude_credentials):
+    async def create_passkey(self, exclude_credentials, salts):
         raise NotImplementedError
 
     async def check_domain_association(self) -> DomainAssociation:
@@ -77,7 +77,7 @@ class YubiKeyPrfProvider(PrfProvider):
     async def is_supported(self) -> bool:
         return False
 
-    async def create_passkey(self, exclude_credentials):
+    async def create_passkey(self, exclude_credentials, salts):
         raise NotImplementedError
 
     async def check_domain_association(self) -> DomainAssociation:
@@ -104,7 +104,7 @@ class Fido2PrfProvider(PrfProvider):
     async def is_supported(self) -> bool:
         return False
 
-    async def create_passkey(self, exclude_credentials):
+    async def create_passkey(self, exclude_credentials, salts):
         raise NotImplementedError
 
     async def check_domain_association(self) -> DomainAssociation:

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/passkey.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/passkey.ts
@@ -17,7 +17,7 @@ import {
   type PrfProvider,
   type DeriveSeedsRequest,
   type DeriveSeedsOutput,
-  type PasskeyCredential,
+  type CreatePasskeyOutput,
   DomainAssociation,
 } from '@breeztech/breez-sdk-spark-react-native'
 import { PasskeyProvider as PlatformPasskeyProvider } from '@breeztech/breez-sdk-spark-react-native/passkey-prf-provider'
@@ -193,7 +193,10 @@ class FilePrfProvider implements PrfProvider {
   }
 
   /** File-backed seeds derive lazily; there is no credential to register. */
-  createPasskey = async (_excludeCredentials: ArrayBuffer[]): Promise<PasskeyCredential> => {
+  createPasskey = async (
+    _excludeCredentials: ArrayBuffer[],
+    _salts: string[]
+  ): Promise<CreatePasskeyOutput> => {
     throw new Error('file-backed PRF provider does not support credential creation; use sign-in by label instead')
   }
 
@@ -230,7 +233,10 @@ class NotYetSupportedProvider implements PrfProvider {
     return false
   }
 
-  createPasskey = async (_excludeCredentials: ArrayBuffer[]): Promise<PasskeyCredential> => {
+  createPasskey = async (
+    _excludeCredentials: ArrayBuffer[],
+    _salts: string[]
+  ): Promise<CreatePasskeyOutput> => {
     throw this.notYet()
   }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/passkey.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/passkey.ts
@@ -19,10 +19,22 @@ import {
   type DeriveSeedsOutput,
   DomainAssociation,
 } from '@breeztech/breez-sdk-spark-react-native'
-import {
-  PasskeyProvider as PlatformPasskeyProvider,
-  type CreatePasskeyOutput,
-} from '@breeztech/breez-sdk-spark-react-native/passkey-prf-provider'
+import { PasskeyProvider as PlatformPasskeyProvider } from '@breeztech/breez-sdk-spark-react-native/passkey-prf-provider'
+
+/**
+ * Shape of the SDK's create-passkey result. Declared here rather than
+ * imported: this file is type-checked against the package as published,
+ * and the generated binding surface is not regenerated for that check.
+ */
+type CreatePasskeyOutput = {
+  credential: {
+    credentialId: Uint8Array
+    userId: Uint8Array | null
+    aaguid: Uint8Array | null
+    backupEligible: boolean | null
+  }
+  seeds: Uint8Array[] | null
+}
 import RNFS from 'react-native-fs'
 import { generateRandomBytes, hmacSha256 } from './crypto_utils'
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/passkey.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/passkey.ts
@@ -17,10 +17,12 @@ import {
   type PrfProvider,
   type DeriveSeedsRequest,
   type DeriveSeedsOutput,
-  type CreatePasskeyOutput,
   DomainAssociation,
 } from '@breeztech/breez-sdk-spark-react-native'
-import { PasskeyProvider as PlatformPasskeyProvider } from '@breeztech/breez-sdk-spark-react-native/passkey-prf-provider'
+import {
+  PasskeyProvider as PlatformPasskeyProvider,
+  type CreatePasskeyOutput,
+} from '@breeztech/breez-sdk-spark-react-native/passkey-prf-provider'
 import RNFS from 'react-native-fs'
 import { generateRandomBytes, hmacSha256 } from './crypto_utils'
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Passkey.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Passkey.swift
@@ -83,7 +83,10 @@ class FilePrfProvider: PrfProvider {
 
     func isSupported() async throws -> Bool { true }
 
-    func createPasskey(excludeCredentials: [Data]) async throws -> PasskeyCredential {
+    func createPasskey(
+        excludeCredentials: [Data],
+        salts: [String]
+    ) async throws -> CreatePasskeyOutput {
         throw PrfProviderError.Generic(
             "File-backed PRF provider does not implement create-credential; " +
             "use sign-in by label instead."
@@ -115,7 +118,10 @@ class YubiKeyPrfProvider: PrfProvider {
 
     func isSupported() async throws -> Bool { false }
 
-    func createPasskey(excludeCredentials: [Data]) async throws -> PasskeyCredential {
+    func createPasskey(
+        excludeCredentials: [Data],
+        salts: [String]
+    ) async throws -> CreatePasskeyOutput {
         throw notYet()
     }
 
@@ -144,7 +150,10 @@ class Fido2PrfProvider: PrfProvider {
 
     func isSupported() async throws -> Bool { false }
 
-    func createPasskey(excludeCredentials: [Data]) async throws -> PasskeyCredential {
+    func createPasskey(
+        excludeCredentials: [Data],
+        salts: [String]
+    ) async throws -> CreatePasskeyOutput {
         throw notYet()
     }
 

--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyProvider.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyProvider.kt
@@ -1,6 +1,7 @@
 package technology.breez.spark.passkey
 
 import android.app.Activity
+import breez_sdk_spark.CreatePasskeyOutput
 import breez_sdk_spark.DeriveSeedsOutput
 import breez_sdk_spark.DeriveSeedsRequest
 import breez_sdk_spark.DomainAssociation
@@ -142,10 +143,31 @@ public class PasskeyProvider(
      * registered IDs in `excludeCredentials` so the platform refuses a
      * duplicate even after reinstall.
      */
-    override suspend fun createPasskey(excludeCredentials: List<ByteArray>): PasskeyCredential {
+    override suspend fun createPasskey(excludeCredentials: List<ByteArray>): PasskeyCredential =
+        createPasskeyWithPrf(excludeCredentials, emptyList()).credential
+
+    /**
+     * Registers with `prf.eval` requested, so an authenticator that
+     * evaluates PRF at create returns the seeds here and the caller needs
+     * no assertion. Credential Manager reports a credential it has not
+     * finished indexing as absent, so removing that assertion removes the
+     * only step that can trip over it.
+     *
+     * `seeds` stays null on authenticators that report PRF support without
+     * evaluating, which is every pre-eval-at-create implementation. The
+     * caller then derives as it always has.
+     */
+    override suspend fun createPasskeyWithPrf(
+        excludeCredentials: List<ByteArray>,
+        salts: List<String>,
+    ): CreatePasskeyOutput {
         try {
-            val c = core.register(excludeCredentials)
-            return PasskeyCredential(c.credentialId, c.userId, c.aaguid, c.backupEligible)
+            val registration = core.register(excludeCredentials, salts)
+            val c = registration.credential
+            return CreatePasskeyOutput(
+                PasskeyCredential(c.credentialId, c.userId, c.aaguid, c.backupEligible),
+                registration.seeds,
+            )
         } catch (e: CredentialManagerPrfCoreException) {
             throw e.toPrfProviderException()
         }

--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyProvider.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyProvider.kt
@@ -136,17 +136,14 @@ public class PasskeyProvider(
     }
 
     /**
-     * Register a new passkey with PRF support. One ceremony, no derivation.
+     * Registers with `prf.eval` requested, so an authenticator that
+     * evaluates PRF at create returns the seeds here and the caller needs
+     * no assertion.
      *
      * `user.id` is never host-supplied: the core mints a fresh random 16-byte
      * handle and returns it as [PasskeyCredential.userId]. Pass already-
      * registered IDs in `excludeCredentials` so the platform refuses a
-     * duplicate even after reinstall.
-     */
-    /**
-     * Registers with `prf.eval` requested, so an authenticator that
-     * evaluates PRF at create returns the seeds here and the caller needs
-     * no assertion. Credential Manager reports a credential it has not
+     * duplicate even after reinstall. Credential Manager reports a credential it has not
      * finished indexing as absent, so removing that assertion removes the
      * only step that can trip over it.
      *

--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyProvider.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyProvider.kt
@@ -162,7 +162,7 @@ public class PasskeyProvider(
         salts: List<String>,
     ): CreatePasskeyOutput {
         try {
-            val registration = core.register(excludeCredentials, salts)
+            val registration = core.registerWithPrf(excludeCredentials, salts)
             val c = registration.credential
             return CreatePasskeyOutput(
                 PasskeyCredential(c.credentialId, c.userId, c.aaguid, c.backupEligible),

--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyProvider.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/PasskeyProvider.kt
@@ -143,9 +143,6 @@ public class PasskeyProvider(
      * registered IDs in `excludeCredentials` so the platform refuses a
      * duplicate even after reinstall.
      */
-    override suspend fun createPasskey(excludeCredentials: List<ByteArray>): PasskeyCredential =
-        createPasskeyWithPrf(excludeCredentials, emptyList()).credential
-
     /**
      * Registers with `prf.eval` requested, so an authenticator that
      * evaluates PRF at create returns the seeds here and the caller needs
@@ -157,12 +154,12 @@ public class PasskeyProvider(
      * evaluating, which is every pre-eval-at-create implementation. The
      * caller then derives as it always has.
      */
-    override suspend fun createPasskeyWithPrf(
+    override suspend fun createPasskey(
         excludeCredentials: List<ByteArray>,
         salts: List<String>,
     ): CreatePasskeyOutput {
         try {
-            val registration = core.registerWithPrf(excludeCredentials, salts)
+            val registration = core.register(excludeCredentials, salts)
             val c = registration.credential
             return CreatePasskeyOutput(
                 PasskeyCredential(c.credentialId, c.userId, c.aaguid, c.backupEligible),

--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -475,6 +475,10 @@ public class CredentialManagerPrfCore(
             ?.optJSONObject("prf")
             ?.optJSONObject("results")
             ?: return null
+        // Never throw: the passkey exists by now, so a decode failure that
+        // escapes fails the whole registration, and the caller's natural
+        // recovery is to register again and strand this one. Null falls
+        // back to the assertion path, which derives from the same passkey.
         val first = results.optString("first").takeIf { it.isNotEmpty() } ?: return null
         val out = ArrayList<ByteArray>(2)
         out.add(decodeBase64UrlOrNull(first, "registration prf.first") ?: return null)

--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -461,13 +461,29 @@ public class CredentialManagerPrfCore(
     // ------------------------------------------------------------------
 
     /**
-     * Run one assertion ceremony for [salts] (1 or 2): build the WebAuthn
-     * request (cross-device hybrid suppressed unless
-     * [preferImmediatelyAvailableCredentials] is false), evaluate PRF, and
-     * return one 32-byte output per salt the authenticator evaluated plus
-     * the asserted credential ID. A dropped `results.second` yields a
-     * single-element list.
+     * PRF outputs carried on a registration response, or null when the
+     * authenticator reported support without evaluating (`prf.enabled`
+     * with no `results`), which is the pre-eval-at-create behavior.
      */
+    private fun readRegistrationPrfResults(responseJson: JSONObject): List<ByteArray>? {
+        // Never throw: the passkey exists by now, so a decode failure that
+        // escapes fails the whole registration, and the caller's natural
+        // recovery is to register again and strand this one. Null falls
+        // back to the assertion path, which derives from the same passkey.
+        val results = responseJson
+            .optJSONObject("clientExtensionResults")
+            ?.optJSONObject("prf")
+            ?.optJSONObject("results")
+            ?: return null
+        val first = results.optString("first").takeIf { it.isNotEmpty() } ?: return null
+        val out = ArrayList<ByteArray>(2)
+        out.add(decodeBase64UrlOrNull(first, "registration prf.first") ?: return null)
+        results.optString("second").takeIf { it.isNotEmpty() }?.let {
+            out.add(decodeBase64UrlOrNull(it, "registration prf.second") ?: return null)
+        }
+        return out
+    }
+
     /**
      * [assertPrf], re-asking until [retryUntilMs] while Credential Manager
      * still reports no credential. A passkey that exists but is not yet
@@ -499,6 +515,15 @@ public class CredentialManagerPrfCore(
             }
         }
     }
+
+    /**
+     * Run one assertion ceremony for [salts] (1 or 2): build the WebAuthn
+     * request (cross-device hybrid suppressed unless
+     * [preferImmediatelyAvailableCredentials] is false), evaluate PRF, and
+     * return one 32-byte output per salt the authenticator evaluated plus
+     * the asserted credential ID. A dropped `results.second` yields a
+     * single-element list.
+     */
 
     private suspend fun assertPrf(
         salts: List<String>,
@@ -586,7 +611,8 @@ public class CredentialManagerPrfCore(
      */
     public suspend fun register(
         excludeCredentials: List<ByteArray> = emptyList(),
-    ): PasskeyCredential = withContext(Dispatchers.Main) {
+        salts: List<String> = emptyList(),
+    ): PasskeyRegistration = withContext(Dispatchers.Main) {
         val startedAtMs = System.currentTimeMillis()
         try {
             val activity = activityProvider()
@@ -629,7 +655,25 @@ public class CredentialManagerPrfCore(
                     put("userVerification", "required")
                 })
                 put("extensions", JSONObject().apply {
-                    put("prf", JSONObject())
+                    // Ask the create ceremony to evaluate PRF as well as
+                    // report support. An authenticator that answers turns
+                    // registration into a single ceremony, so no assertion
+                    // has to race the credential becoming resolvable. One
+                    // that ignores it returns `enabled` only, and the
+                    // caller falls back to `deriveSeeds`.
+                    put("prf", JSONObject().apply {
+                        if (salts.isNotEmpty()) {
+                            put("eval", JSONObject().apply {
+                                put("first", encodeBase64Url(salts[0].toByteArray(Charsets.UTF_8)))
+                                if (salts.size > 1) {
+                                    put(
+                                        "second",
+                                        encodeBase64Url(salts[1].toByteArray(Charsets.UTF_8)),
+                                    )
+                                }
+                            })
+                        }
+                    })
                 })
             }.toString()
 
@@ -659,10 +703,20 @@ public class CredentialManagerPrfCore(
                     backupEligible = meta.second
                 }
             }
-            // Arm the post-create grace so the immediate derive doesn't
-            // race the credential's PRF-readiness window (see grace tracker).
+            // Only usable as a complete set: a dropped `prf.eval.second`
+            // yields one output where the caller asked for two, and a
+            // partial derive is no derive at all.
+            val seeds = readRegistrationPrfResults(responseJson)
+                ?.takeIf { it.size == salts.size }
+            // Arm the post-create grace so a fallback derive doesn't race
+            // the credential's PRF-readiness window (see grace tracker).
+            // Unnecessary when seeds came back inline, but harmless: the
+            // window is consumed without waiting when nothing asserts.
             graceTracker.arm(postCreateGraceMs)
-            PasskeyCredential(credentialId, userIdBytes, aaguid, backupEligible)
+            PasskeyRegistration(
+                PasskeyCredential(credentialId, userIdBytes, aaguid, backupEligible),
+                seeds,
+            )
         } catch (e: CredentialManagerPrfCoreException) {
             throw e
         } catch (e: Exception) {
@@ -857,6 +911,17 @@ public class CredentialManagerPrfCore(
 public data class PrfDerivation(
     public val seeds: List<ByteArray>,
     public val credentialId: ByteArray?,
+)
+
+/**
+ * A created credential, plus the PRF outputs when the authenticator
+ * evaluated them during the create ceremony. `seeds` null means it did
+ * not (or returned fewer than asked for), so the caller derives through
+ * [CredentialManagerPrfCore.deriveSeeds].
+ */
+public data class PasskeyRegistration(
+    public val credential: PasskeyCredential,
+    public val seeds: List<ByteArray>?,
 )
 
 /**

--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -611,6 +611,20 @@ public class CredentialManagerPrfCore(
      */
     public suspend fun register(
         excludeCredentials: List<ByteArray> = emptyList(),
+    ): PasskeyCredential = registerWithPrf(excludeCredentials, emptyList()).credential
+
+    /**
+     * [register] that also asks the create ceremony to evaluate PRF for
+     * [salts]. An authenticator that answers makes registration a single
+     * ceremony, so no assertion follows it into the window where the new
+     * credential is not yet resolvable.
+     *
+     * `PasskeyRegistration.seeds` is null when the authenticator reported
+     * PRF support without evaluating, and when it returned fewer outputs
+     * than salts. Callers derive through [deriveSeeds] in both cases.
+     */
+    public suspend fun registerWithPrf(
+        excludeCredentials: List<ByteArray> = emptyList(),
         salts: List<String> = emptyList(),
     ): PasskeyRegistration = withContext(Dispatchers.Main) {
         val startedAtMs = System.currentTimeMillis()

--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -611,20 +611,6 @@ public class CredentialManagerPrfCore(
      */
     public suspend fun register(
         excludeCredentials: List<ByteArray> = emptyList(),
-    ): PasskeyCredential = registerWithPrf(excludeCredentials, emptyList()).credential
-
-    /**
-     * [register] that also asks the create ceremony to evaluate PRF for
-     * [salts]. An authenticator that answers makes registration a single
-     * ceremony, so no assertion follows it into the window where the new
-     * credential is not yet resolvable.
-     *
-     * `PasskeyRegistration.seeds` is null when the authenticator reported
-     * PRF support without evaluating, and when it returned fewer outputs
-     * than salts. Callers derive through [deriveSeeds] in both cases.
-     */
-    public suspend fun registerWithPrf(
-        excludeCredentials: List<ByteArray> = emptyList(),
         salts: List<String> = emptyList(),
     ): PasskeyRegistration = withContext(Dispatchers.Main) {
         val startedAtMs = System.currentTimeMillis()
@@ -722,11 +708,13 @@ public class CredentialManagerPrfCore(
             // partial derive is no derive at all.
             val seeds = readRegistrationPrfResults(responseJson)
                 ?.takeIf { it.size == salts.size }
-            // Arm the post-create grace so a fallback derive doesn't race
-            // the credential's PRF-readiness window (see grace tracker).
-            // Unnecessary when seeds came back inline, but harmless: the
-            // window is consumed without waiting when nothing asserts.
-            graceTracker.arm(postCreateGraceMs)
+            // Arm the post-create grace only when a derive still has to
+            // run: the window exists for that assertion. Arming it on the
+            // inline-seeds path would leave it set for whatever derive
+            // came next, which is a different ceremony entirely.
+            if (seeds == null) {
+                graceTracker.arm(postCreateGraceMs)
+            }
             PasskeyRegistration(
                 PasskeyCredential(credentialId, userIdBytes, aaguid, backupEligible),
                 seeds,

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyAssertionCore.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyAssertionCore.swift
@@ -90,6 +90,20 @@ public struct IosPasskeyCredential {
     }
 }
 
+/// A created credential, plus the PRF outputs when the authenticator
+/// evaluated them during the create ceremony. `seeds` is nil when it did
+/// not, so the caller derives through `deriveSeeds` as before.
+@available(iOS 18.0, macOS 15.0, *)
+public struct IosPasskeyRegistration {
+    public let credential: IosPasskeyCredential
+    public let seeds: [Data]?
+
+    public init(credential: IosPasskeyCredential, seeds: [Data]?) {
+        self.credential = credential
+        self.seeds = seeds
+    }
+}
+
 /// Result of `deriveSeeds`: one 32-byte PRF output per salt (input
 /// order) plus the asserted credential ID. `credentialId` is `nil` when
 /// no assertion ran (empty `salts`).
@@ -551,10 +565,17 @@ public final class PasskeyAssertionCore {
     /// tracker is armed on success. `userId` is never host-supplied: the
     /// core mints a fresh random 16-byte value and returns it on
     /// `IosPasskeyCredential.userId`.
+    /// Asking the create ceremony to evaluate PRF for `salts` makes
+    /// registration a single ceremony, so no assertion follows it.
+    ///
+    /// `IosPasskeyRegistration.seeds` is nil when the authenticator
+    /// reported PRF support without evaluating, and when it returned fewer
+    /// outputs than salts. Callers derive through `deriveSeeds` in both.
     @discardableResult
     public func register(
-        excludeCredentials: [Data] = []
-    ) async throws -> IosPasskeyCredential {
+        excludeCredentials: [Data] = [],
+        salts: [String] = []
+    ) async throws -> IosPasskeyRegistration {
         let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
         let challenge = Self.randomBytes(count: 32)
         let resolvedUserId = Self.randomBytes(count: 16)
@@ -575,7 +596,13 @@ public final class PasskeyAssertionCore {
             }
         }
 
-        PasskeyPRFHelper.setRegistrationPRFOn(request)
+        // Asking the create ceremony to evaluate PRF removes the
+        // assertion that would otherwise follow it.
+        PasskeyPRFHelper.setRegistrationPRFOn(
+            request,
+            withSalt1: salts.first.map { Data($0.utf8) },
+            salt2: salts.count > 1 ? Data(salts[1].utf8) : nil
+        )
 
         let delegate = PasskeyDelegate()
         let controller = ASAuthorizationController(authorizationRequests: [request])
@@ -586,8 +613,9 @@ public final class PasskeyAssertionCore {
         // our minted handle to attach to the returned credential.
         delegate.registrationUserId = resolvedUserId
 
-        let credential: IosPasskeyCredential = try await withCheckedThrowingContinuation { continuation in
+        let registration: IosPasskeyRegistration = try await withCheckedThrowingContinuation { continuation in
             delegate.registrationContinuation = continuation
+            delegate.registrationSaltCount = salts.count
             delegate.extractPrf = false
             DispatchQueue.main.async {
                 // Capture start time inside the closure so the wait for
@@ -600,7 +628,7 @@ public final class PasskeyAssertionCore {
         // Arm the post-create grace so the immediate derive doesn't race
         // the credential's PRF-readiness window (see grace tracker).
         await graceTracker.arm(after: postCreateGraceTotal)
-        return credential
+        return registration
     }
 
     public static func randomBytes(count: Int) -> Data {
@@ -682,7 +710,10 @@ private final class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate
     /// Resolves `(first, second?, credentialId)`; `second` is nil for a
     /// single salt or a dropped `saltInput2`.
     var assertionContinuation: CheckedContinuation<(Data, Data?, Data), Error>?
-    var registrationContinuation: CheckedContinuation<IosPasskeyCredential, Error>?
+    var registrationContinuation: CheckedContinuation<IosPasskeyRegistration, Error>?
+    /// Salts requested at create, so the delegate knows how many PRF
+    /// outputs a complete result carries.
+    var registrationSaltCount: Int = 0
     /// User handle the core minted for the in-flight registration; copied
     /// into the returned `IosPasskeyCredential.userId` (the platform
     /// never echoes `user.id` back).
@@ -739,12 +770,32 @@ private final class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate
                 aaguid = meta.aaguid
                 backupEligible = meta.backupEligible
             }
+            // Only usable as a complete set: Apple Passwords is known to
+            // drop `prf.second` on assertions, and a partial derive is no
+            // derive at all, so anything short of one output per salt
+            // falls back to the assertion path.
+            var seeds: [Data]? = nil
+            if registrationSaltCount > 0 {
+                var collected: [Data] = []
+                if let first = PasskeyPRFHelper.extractPRFOutput(from: credential) {
+                    collected.append(first)
+                    if let second = PasskeyPRFHelper.extractSecondPRFOutput(from: credential) {
+                        collected.append(second)
+                    }
+                }
+                if collected.count == registrationSaltCount {
+                    seeds = collected
+                }
+            }
             registrationContinuation?.resume(
-                returning: IosPasskeyCredential(
-                    credentialId: credential.credentialID,
-                    userId: registrationUserId,
-                    aaguid: aaguid,
-                    backupEligible: backupEligible
+                returning: IosPasskeyRegistration(
+                    credential: IosPasskeyCredential(
+                        credentialId: credential.credentialID,
+                        userId: registrationUserId,
+                        aaguid: aaguid,
+                        backupEligible: backupEligible
+                    ),
+                    seeds: seeds
                 ))
         }
     }

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyAssertionCore.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyAssertionCore.swift
@@ -559,10 +559,11 @@ public final class PasskeyAssertionCore {
         }
     }
 
-    /// Register a new passkey with PRF support (one platform prompt, no
-    /// seed derivation). `excludeCredentials` lists already-registered IDs
-    /// the platform must refuse as duplicates. The post-create grace
-    /// tracker is armed on success. `userId` is never host-supplied: the
+    /// Register a new passkey with PRF support. `excludeCredentials` lists
+    /// already-registered IDs the platform must refuse as duplicates.
+    /// Evaluating PRF for `salts` in the same ceremony returns the seeds
+    /// inline; the post-create grace tracker is armed only when it did
+    /// not, so a following derive still has its window. `userId` is never host-supplied: the
     /// core mints a fresh random 16-byte value and returns it on
     /// `IosPasskeyCredential.userId`.
     /// Asking the create ceremony to evaluate PRF for `salts` makes
@@ -625,9 +626,13 @@ public final class PasskeyAssertionCore {
             }
         }
 
-        // Arm the post-create grace so the immediate derive doesn't race
-        // the credential's PRF-readiness window (see grace tracker).
-        await graceTracker.arm(after: postCreateGraceTotal)
+        // Arm the post-create grace only when a derive still has to run:
+        // the window exists for that assertion. Arming it on the
+        // inline-seeds path would leave it set for whatever derive came
+        // next, which is a different ceremony entirely.
+        if registration.seeds == nil {
+            await graceTracker.arm(after: postCreateGraceTotal)
+        }
         return registration
     }
 

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyAssertionCore.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyAssertionCore.swift
@@ -561,17 +561,15 @@ public final class PasskeyAssertionCore {
 
     /// Register a new passkey with PRF support. `excludeCredentials` lists
     /// already-registered IDs the platform must refuse as duplicates.
-    /// Evaluating PRF for `salts` in the same ceremony returns the seeds
-    /// inline; the post-create grace tracker is armed only when it did
-    /// not, so a following derive still has its window. `userId` is never host-supplied: the
-    /// core mints a fresh random 16-byte value and returns it on
-    /// `IosPasskeyCredential.userId`.
+    /// `userId` is never host-supplied: the core mints a fresh random
+    /// 16-byte value and returns it on `IosPasskeyCredential.userId`.
+    ///
     /// Asking the create ceremony to evaluate PRF for `salts` makes
     /// registration a single ceremony, so no assertion follows it.
-    ///
     /// `IosPasskeyRegistration.seeds` is nil when the authenticator
     /// reported PRF support without evaluating, and when it returned fewer
-    /// outputs than salts. Callers derive through `deriveSeeds` in both.
+    /// outputs than salts; callers derive through `deriveSeeds` in both,
+    /// and the post-create grace tracker is armed only in those cases.
     @discardableResult
     public func register(
         excludeCredentials: [Data] = [],

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyProvider.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyProvider.swift
@@ -147,15 +147,26 @@ public class PasskeyProvider: PrfProvider {
     /// 16-byte handle and returns it as `PasskeyCredential.userId`. Pass
     /// already-registered IDs in `excludeCredentials` so the platform
     /// refuses a duplicate even after reinstall.
+    ///
+    /// `seeds` is always nil here: evaluating PRF during the create
+    /// ceremony is not wired up on this platform yet, so the caller
+    /// derives through `deriveSeeds` as before.
     @discardableResult
-    public func createPasskey(excludeCredentials: [Data]) async throws -> PasskeyCredential {
+    public func createPasskey(
+        excludeCredentials: [Data],
+        salts: [String]
+    ) async throws -> CreatePasskeyOutput {
+        let _ = salts
         do {
             let credential = try await core.register(excludeCredentials: excludeCredentials)
-            return PasskeyCredential(
-                credentialId: credential.credentialId,
-                userId: credential.userId,
-                aaguid: credential.aaguid,
-                backupEligible: credential.backupEligible
+            return CreatePasskeyOutput(
+                credential: PasskeyCredential(
+                    credentialId: credential.credentialId,
+                    userId: credential.userId,
+                    aaguid: credential.aaguid,
+                    backupEligible: credential.backupEligible
+                ),
+                seeds: nil
             )
         } catch let err as PasskeyAssertionError {
             throw Self.toPrfProviderError(err)

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyProvider.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyProvider.swift
@@ -148,25 +148,28 @@ public class PasskeyProvider: PrfProvider {
     /// already-registered IDs in `excludeCredentials` so the platform
     /// refuses a duplicate even after reinstall.
     ///
-    /// `seeds` is always nil here: evaluating PRF during the create
-    /// ceremony is not wired up on this platform yet, so the caller
-    /// derives through `deriveSeeds` as before.
+    /// `seeds` stays nil on authenticators that report PRF support without
+    /// evaluating, and on a partial result: Apple Passwords is known to
+    /// drop the second output on assertions, and a partial derive is no
+    /// derive at all. The caller then derives as it always has.
     @discardableResult
     public func createPasskey(
         excludeCredentials: [Data],
         salts: [String]
     ) async throws -> CreatePasskeyOutput {
-        let _ = salts
         do {
-            let credential = try await core.register(excludeCredentials: excludeCredentials)
+            let registration = try await core.register(
+                excludeCredentials: excludeCredentials,
+                salts: salts
+            )
             return CreatePasskeyOutput(
                 credential: PasskeyCredential(
-                    credentialId: credential.credentialId,
-                    userId: credential.userId,
-                    aaguid: credential.aaguid,
-                    backupEligible: credential.backupEligible
+                    credentialId: registration.credential.credentialId,
+                    userId: registration.credential.userId,
+                    aaguid: registration.credential.aaguid,
+                    backupEligible: registration.credential.backupEligible
                 ),
-                seeds: nil
+                seeds: registration.seeds
             )
         } catch let err as PasskeyAssertionError {
             throw Self.toPrfProviderError(err)

--- a/crates/breez-sdk/bindings/langs/swift/Sources/PasskeyPRFHelperObjC/PasskeyPRFHelper.h
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/PasskeyPRFHelperObjC/PasskeyPRFHelper.h
@@ -20,8 +20,23 @@ API_AVAILABLE(ios(18.0), macos(15.0))
                        withSalt1:(NSData *)salt1
                            salt2:(NSData * _Nullable)salt2;
 
-/// Set PRF registration input on a registration request.
+/// Set PRF registration input on a registration request, support-only.
 + (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request;
+
+/// Set PRF registration input asking the create ceremony to evaluate up
+/// to two salts. Pass nil for `salt1` to only probe support, nil for
+/// `salt2` to evaluate one.
++ (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request
+                          withSalt1:(NSData * _Nullable)salt1
+                              salt2:(NSData * _Nullable)salt2;
+
+/// Extract the PRF output (first salt result) from a registration
+/// credential. Returns nil when the authenticator evaluated nothing at
+/// create, which is the pre-eval-at-create behavior.
++ (NSData * _Nullable)extractPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential;
+
+/// Extract the second PRF output from a registration credential.
++ (NSData * _Nullable)extractSecondPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential;
 
 /// Extract the PRF output (first salt result) from an assertion credential.
 /// Returns nil if PRF output is not available.

--- a/crates/breez-sdk/bindings/langs/swift/Sources/PasskeyPRFHelperObjC/PasskeyPRFHelper.m
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/PasskeyPRFHelperObjC/PasskeyPRFHelper.m
@@ -19,9 +19,39 @@ API_AVAILABLE(ios(18.0), macos(15.0))
 }
 
 + (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request {
+    [self setRegistrationPRFOnRequest:request withSalt1:nil salt2:nil];
+}
+
++ (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request
+                          withSalt1:(NSData * _Nullable)salt1
+                              salt2:(NSData * _Nullable)salt2 {
+    // nil salt1 asks only whether PRF is supported. Non-nil asks the
+    // create ceremony to evaluate it too, which removes the assertion
+    // that would otherwise follow.
+    ASAuthorizationPublicKeyCredentialPRFAssertionInputValues *values = nil;
+    if (salt1 != nil) {
+        values = [[ASAuthorizationPublicKeyCredentialPRFAssertionInputValues alloc]
+                     initWithSaltInput1:salt1 saltInput2:salt2];
+    }
     ASAuthorizationPublicKeyCredentialPRFRegistrationInput *input =
-        [[ASAuthorizationPublicKeyCredentialPRFRegistrationInput alloc] initWithInputValues:nil];
+        [[ASAuthorizationPublicKeyCredentialPRFRegistrationInput alloc] initWithInputValues:values];
     request.prf = input;
+}
+
++ (NSData * _Nullable)extractPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential {
+    ASAuthorizationPublicKeyCredentialPRFRegistrationOutput *output = credential.prf;
+    if (output == nil) {
+        return nil;
+    }
+    return output.first;
+}
+
++ (NSData * _Nullable)extractSecondPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential {
+    ASAuthorizationPublicKeyCredentialPRFRegistrationOutput *output = credential.prf;
+    if (output == nil) {
+        return nil;
+    }
+    return output.second;
 }
 
 + (NSData * _Nullable)extractPRFOutputFromAssertion:(ASAuthorizationPlatformPublicKeyCredentialAssertion *)credential {

--- a/crates/breez-sdk/core/src/passkey/mod.rs
+++ b/crates/breez-sdk/core/src/passkey/mod.rs
@@ -267,12 +267,6 @@ impl Passkey {
         vec![ACCOUNT_MASTER_SALT.to_string(), label.to_string()]
     }
 
-    pub(crate) fn resolve_label(&self, label: Option<String>) -> Result<String, PasskeyError> {
-        let label = label.unwrap_or_else(|| self.default_label.clone());
-        validate_label(&label)?;
-        Ok(label)
-    }
-
     /// Everything after the PRF outputs exist, so a caller that already
     /// has them (a create ceremony that evaluated PRF inline) reaches the
     /// same wallet without a second ceremony.

--- a/crates/breez-sdk/core/src/passkey/mod.rs
+++ b/crates/breez-sdk/core/src/passkey/mod.rs
@@ -56,7 +56,7 @@ pub use derivation::ACCOUNT_MASTER_SALT;
 use derivation::prf_to_mnemonic;
 pub use error::{ErrorKind, PasskeyError, PrfProviderError};
 pub use models::{
-    DeriveSeedsOutput, PasskeyConfig, PasskeyCredential, PasskeyProviderOptions,
+    CreatePasskeyOutput, DeriveSeedsOutput, PasskeyConfig, PasskeyCredential, PasskeyProviderOptions,
     SetupWalletRequest, Wallet, WalletSetup,
 };
 pub use passkey_client::{
@@ -234,10 +234,7 @@ impl Passkey {
         request: SetupWalletRequest,
     ) -> Result<WalletSetup, PasskeyError> {
         let label = self.resolve_label(request.label)?;
-
-        // [account_master, label]: dual-salt single ceremony where the
-        // platform supports it, fallback to two prompts otherwise.
-        let salts = vec![ACCOUNT_MASTER_SALT.to_string(), label.clone()];
+        let salts = Self::wallet_salts(&label);
         let expected = salts.len();
 
         let DeriveSeedsOutput {
@@ -259,6 +256,33 @@ impl Passkey {
             ))));
         }
 
+        self.finish_wallet_setup(label, seeds, credential_id, request.publish_label)
+            .await
+    }
+
+    /// Salts backing one wallet, in the order `finish_wallet_setup`
+    /// consumes them: `[account_master, label]`. A dual-salt ceremony
+    /// covers both at once where the platform supports it.
+    pub(crate) fn wallet_salts(label: &str) -> Vec<String> {
+        vec![ACCOUNT_MASTER_SALT.to_string(), label.to_string()]
+    }
+
+    pub(crate) fn resolve_label(&self, label: Option<String>) -> Result<String, PasskeyError> {
+        let label = label.unwrap_or_else(|| self.default_label.clone());
+        validate_label(&label)?;
+        Ok(label)
+    }
+
+    /// Everything after the PRF outputs exist, so a caller that already
+    /// has them (a create ceremony that evaluated PRF inline) reaches the
+    /// same wallet without a second ceremony.
+    pub(crate) async fn finish_wallet_setup(
+        &self,
+        label: String,
+        seeds: Vec<Vec<u8>>,
+        credential_id: Option<Vec<u8>>,
+        publish_label: bool,
+    ) -> Result<WalletSetup, PasskeyError> {
         // Prime (or rebind) the Nostr client cache with the keys derived
         // in this ceremony so subsequent label ops don't trigger another
         // PRF, even when this `PasskeyClient` is reused across credentials
@@ -278,7 +302,7 @@ impl Passkey {
             label: label.clone(),
         };
 
-        if request.publish_label
+        if publish_label
             && let Ok(client) = self.nostr_client().await
         {
             // The label publish is a non-fatal discovery convenience, so run

--- a/crates/breez-sdk/core/src/passkey/mod.rs
+++ b/crates/breez-sdk/core/src/passkey/mod.rs
@@ -56,8 +56,8 @@ pub use derivation::ACCOUNT_MASTER_SALT;
 use derivation::prf_to_mnemonic;
 pub use error::{ErrorKind, PasskeyError, PrfProviderError};
 pub use models::{
-    CreatePasskeyOutput, DeriveSeedsOutput, PasskeyConfig, PasskeyCredential, PasskeyProviderOptions,
-    SetupWalletRequest, Wallet, WalletSetup,
+    CreatePasskeyOutput, DeriveSeedsOutput, PasskeyConfig, PasskeyCredential,
+    PasskeyProviderOptions, SetupWalletRequest, Wallet, WalletSetup,
 };
 pub use passkey_client::{
     ConnectWithPasskeyRequest, ConnectWithPasskeyResponse, PasskeyAvailability, PasskeyClient,
@@ -302,9 +302,7 @@ impl Passkey {
             label: label.clone(),
         };
 
-        if publish_label
-            && let Ok(client) = self.nostr_client().await
-        {
+        if publish_label && let Ok(client) = self.nostr_client().await {
             // The label publish is a non-fatal discovery convenience, so run
             // it off the critical path rather than blocking on slow relays.
             // store_label is idempotent, so the bounded retry is safe.

--- a/crates/breez-sdk/core/src/passkey/models.rs
+++ b/crates/breez-sdk/core/src/passkey/models.rs
@@ -51,6 +51,22 @@ pub struct DeriveSeedsOutput {
     pub credential_id: Option<Vec<u8>>,
 }
 
+/// A newly created credential, plus the PRF outputs when the platform
+/// evaluated them during the create ceremony itself.
+///
+/// `seeds` present means no assertion is needed: the caller skips the
+/// second ceremony, and with it the window in which a credential exists
+/// but is not yet resolvable. Absent means the platform returned no PRF
+/// results at create (or dropped one of a pair), so the caller derives
+/// through [`super::PrfProvider::derive_seeds`] as before.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct CreatePasskeyOutput {
+    pub credential: PasskeyCredential,
+    /// One output per requested salt, in request order.
+    pub seeds: Option<Vec<Vec<u8>>>,
+}
+
 /// A passkey credential from a register or sign-in ceremony.
 /// `credential_id` is always set; the attestation fields are
 /// populated on registration and absent on sign-in (an assertion

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -198,10 +198,12 @@ impl PasskeyClient {
         self.passkey.check_availability().await
     }
 
-    /// First-time setup. Drives [`PrfProvider::create_passkey`] (one
-    /// ceremony) followed by the wallet-derivation flow that backs
-    /// [`Passkey::setup_wallet`] (one ceremony, dual-salt where
-    /// supported). The label is always published on success.
+    /// First-time setup. Drives [`PrfProvider::create_passkey`], which
+    /// returns the seeds inline where the platform evaluates PRF during
+    /// the create ceremony; otherwise the wallet-derivation flow behind
+    /// [`Passkey::setup_wallet`] runs as a second ceremony. The label is
+    /// validated before anything is created, and published in the
+    /// background: it may still be in flight when this returns `Ok`.
     pub async fn register(
         &self,
         request: RegisterRequest,
@@ -230,7 +232,17 @@ impl PasskeyClient {
             let setup = self
                 .passkey
                 .finish_wallet_setup(label, seeds, Some(credential.credential_id.clone()), true)
-                .await?;
+                .await
+                // Same contract as the fallback below: the passkey exists
+                // from here on, so an authenticator failure has to carry it
+                // or the host's recovery strands it.
+                .map_err(|e| match e {
+                    PasskeyError::Prf(source) => PasskeyError::CreatedButNotDerived {
+                        credential_id: credential.credential_id.clone(),
+                        source,
+                    },
+                    other => other,
+                })?;
             return Ok(RegisterResponse {
                 wallet: setup.wallet,
                 credential: Some(credential),
@@ -463,6 +475,9 @@ mod tests {
         /// Return PRF outputs from the create ceremony, as an
         /// authenticator supporting `prf.eval` at registration does.
         prf_at_create: bool,
+        /// Return fewer outputs than salts, as an authenticator that drops
+        /// `prf.eval.second` does.
+        partial_prf_at_create: bool,
     }
 
     impl MockProvider {
@@ -476,6 +491,7 @@ mod tests {
                 derive_credential_id: None,
                 derive_allow: Mutex::new(Vec::new()),
                 prf_at_create: false,
+                partial_prf_at_create: false,
             }
         }
 
@@ -501,6 +517,14 @@ mod tests {
         /// ceremony, so `register` needs no assertion.
         fn with_prf_at_create(mut self) -> Self {
             self.prf_at_create = true;
+            self
+        }
+
+        /// Mimic an authenticator that evaluates PRF at create but drops
+        /// all but the first output, which is not a usable derive.
+        fn with_partial_prf_at_create(mut self) -> Self {
+            self.prf_at_create = true;
+            self.partial_prf_at_create = true;
             self
         }
 
@@ -568,9 +592,18 @@ mod tests {
                 let mut count = self.create_calls.lock().unwrap();
                 *count = count.checked_add(1).expect("create_calls overflow");
             }
-            let seeds = self
-                .prf_at_create
-                .then(|| salts.iter().map(|s| self.output_for(s)).collect());
+            let seeds = self.prf_at_create.then(|| {
+                let take = if self.partial_prf_at_create {
+                    1
+                } else {
+                    salts.len()
+                };
+                salts
+                    .iter()
+                    .take(take)
+                    .map(|s| self.output_for(s))
+                    .collect()
+            });
             Ok(CreatePasskeyOutput {
                 credential: PasskeyCredential {
                     credential_id: vec![0xab, 0xcd, 0xef],
@@ -774,6 +807,33 @@ mod tests {
         assert!(!fallback_provider.derive_allow.lock().unwrap().is_empty());
         assert_eq!(mnemonic_of(&with_prf.wallet), mnemonic_of(&fallback.wallet));
         assert_eq!(with_prf.wallet.label, fallback.wallet.label);
+    }
+
+    #[macros::async_test_all]
+    async fn register_falls_back_when_create_returns_partial_seeds() {
+        // One output for two salts is not a usable derive, so the guard
+        // must reject it rather than deriving from a short set.
+        let provider = Arc::new(MockProvider::new([7u8; 32]).with_partial_prf_at_create());
+        let partial = test_client(provider.clone(), None)
+            .register(RegisterRequest {
+                label: Some("alice".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        // The assertion ran, so the fallback path produced this wallet.
+        assert!(!provider.derive_allow.lock().unwrap().is_empty());
+
+        let full_provider = Arc::new(MockProvider::new([7u8; 32]));
+        let full = test_client(full_provider.clone(), None)
+            .register(RegisterRequest {
+                label: Some("alice".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(mnemonic_of(&partial.wallet), mnemonic_of(&full.wallet));
     }
 
     fn mnemonic_of(wallet: &Wallet) -> String {

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -221,7 +221,7 @@ impl PasskeyClient {
         let created = self
             .passkey
             .prf_provider()
-            .create_passkey_with_prf(
+            .create_passkey(
                 request.exclude_credentials.unwrap_or_default(),
                 salts.clone(),
             )
@@ -566,30 +566,27 @@ mod tests {
         async fn create_passkey(
             &self,
             _exclude_credentials: Vec<Vec<u8>>,
-        ) -> Result<PasskeyCredential, PrfProviderError> {
+            salts: Vec<String>,
+        ) -> Result<CreatePasskeyOutput, PrfProviderError> {
             if self.fail_create {
                 return Err(PrfProviderError::PrfNotSupported);
             }
-            let mut count = self.create_calls.lock().unwrap();
-            *count = count.checked_add(1).expect("create_calls overflow");
-            Ok(PasskeyCredential {
-                credential_id: vec![0xab, 0xcd, 0xef],
-                user_id: Some(vec![0u8; 16]),
-                aaguid: Some(vec![0; 16]),
-                backup_eligible: Some(true),
-            })
-        }
-
-        async fn create_passkey_with_prf(
-            &self,
-            exclude_credentials: Vec<Vec<u8>>,
-            salts: Vec<String>,
-        ) -> Result<CreatePasskeyOutput, PrfProviderError> {
-            let credential = self.create_passkey(exclude_credentials).await?;
+            {
+                let mut count = self.create_calls.lock().unwrap();
+                *count = count.checked_add(1).expect("create_calls overflow");
+            }
             let seeds = self
                 .prf_at_create
                 .then(|| salts.iter().map(|s| self.output_for(s)).collect());
-            Ok(CreatePasskeyOutput { credential, seeds })
+            Ok(CreatePasskeyOutput {
+                credential: PasskeyCredential {
+                    credential_id: vec![0xab, 0xcd, 0xef],
+                    user_id: Some(vec![0u8; 16]),
+                    aaguid: Some(vec![0; 16]),
+                    backup_eligible: Some(true),
+                },
+                seeds,
+            })
         }
     }
 

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 
 use super::Passkey;
 use super::error::{PasskeyError, PrfProviderError};
-use super::models::{PasskeyConfig, PasskeyCredential, SetupWalletRequest, Wallet};
+use super::models::{
+    CreatePasskeyOutput, PasskeyConfig, PasskeyCredential, SetupWalletRequest, Wallet,
+};
 use super::passkey_prf_provider::PrfProvider;
 #[cfg(test)]
 use super::{LabelStore, LabelStoreBuilder};
@@ -211,12 +213,36 @@ impl PasskeyClient {
         // recovery that failure points at runs the same validation on the
         // same label.
         let label = self.passkey.resolve_label(request.label)?;
+        let salts = Passkey::wallet_salts(&label);
 
-        let credential = self
+        // Ask for the PRF outputs in the create ceremony itself. A platform
+        // that returns them removes the assertion below, and with it the
+        // window where the credential exists but is not yet resolvable.
+        let created = self
             .passkey
             .prf_provider()
-            .create_passkey(request.exclude_credentials.unwrap_or_default())
+            .create_passkey_with_prf(
+                request.exclude_credentials.unwrap_or_default(),
+                salts.clone(),
+            )
             .await?;
+        let credential = created.credential;
+
+        if let Some(seeds) = created.seeds.filter(|seeds| seeds.len() == salts.len()) {
+            let setup = self
+                .passkey
+                .finish_wallet_setup(label, seeds, Some(credential.credential_id.clone()), true)
+                .await
+                .map_err(|e| PasskeyError::CreatedButNotDerived {
+                    credential_id: credential.credential_id.clone(),
+                    kind: e.kind(),
+                    reason: e.to_string(),
+                })?;
+            return Ok(RegisterResponse {
+                wallet: setup.wallet,
+                credential: Some(credential),
+            });
+        }
 
         let setup = match self
             .passkey
@@ -441,6 +467,9 @@ mod tests {
         /// `allow_credentials` seen on each `derive_seeds` call, so tests
         /// can assert pinning.
         derive_allow: Mutex<Vec<Vec<Vec<u8>>>>,
+        /// Return PRF outputs from the create ceremony, as an
+        /// authenticator supporting `prf.eval` at registration does.
+        prf_at_create: bool,
     }
 
     impl MockProvider {
@@ -453,6 +482,7 @@ mod tests {
                 derive_errors: Mutex::new(Vec::new()),
                 derive_credential_id: None,
                 derive_allow: Mutex::new(Vec::new()),
+                prf_at_create: false,
             }
         }
 
@@ -472,6 +502,13 @@ mod tests {
 
         fn queue_derive_error(&self, err: PrfProviderError) {
             self.derive_errors.lock().unwrap().push(err);
+        }
+
+        /// Mimic an authenticator that evaluates PRF during the create
+        /// ceremony, so `register` needs no assertion.
+        fn with_prf_at_create(mut self) -> Self {
+            self.prf_at_create = true;
+            self
         }
 
         fn output_for(&self, salt: &str) -> Vec<u8> {
@@ -541,6 +578,18 @@ mod tests {
                 aaguid: Some(vec![0; 16]),
                 backup_eligible: Some(true),
             })
+        }
+
+        async fn create_passkey_with_prf(
+            &self,
+            exclude_credentials: Vec<Vec<u8>>,
+            salts: Vec<String>,
+        ) -> Result<CreatePasskeyOutput, PrfProviderError> {
+            let credential = self.create_passkey(exclude_credentials).await?;
+            let seeds = self
+                .prf_at_create
+                .then(|| salts.iter().map(|s| self.output_for(s)).collect());
+            Ok(CreatePasskeyOutput { credential, seeds })
         }
     }
 
@@ -702,6 +751,45 @@ mod tests {
         assert!(!allow.is_empty());
         for call in allow.iter() {
             assert_eq!(call, &vec![vec![0xab, 0xcd, 0xef]]);
+        }
+    }
+
+    #[macros::async_test_all]
+    async fn register_skips_the_assertion_when_create_evaluates_prf() {
+        let provider = Arc::new(MockProvider::new([7u8; 32]).with_prf_at_create());
+        let client = test_client(provider.clone(), None);
+        let with_prf = client
+            .register(RegisterRequest {
+                label: Some("alice".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        // No assertion ran, so nothing can race the new credential
+        // becoming resolvable.
+        assert!(provider.derive_allow.lock().unwrap().is_empty());
+        assert!(with_prf.credential.is_some());
+
+        // Same wallet either way: the fast path is a shortcut, not a
+        // different derivation.
+        let fallback_provider = Arc::new(MockProvider::new([7u8; 32]));
+        let fallback = test_client(fallback_provider.clone(), None)
+            .register(RegisterRequest {
+                label: Some("alice".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert!(!fallback_provider.derive_allow.lock().unwrap().is_empty());
+        assert_eq!(mnemonic_of(&with_prf.wallet), mnemonic_of(&fallback.wallet));
+        assert_eq!(with_prf.wallet.label, fallback.wallet.label);
+    }
+
+    fn mnemonic_of(wallet: &Wallet) -> String {
+        match &wallet.seed {
+            crate::Seed::Mnemonic { mnemonic, .. } => mnemonic.clone(),
+            other => panic!("expected a mnemonic seed, got {other:?}"),
         }
     }
 

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -7,9 +7,7 @@ use std::sync::Arc;
 
 use super::Passkey;
 use super::error::{PasskeyError, PrfProviderError};
-use super::models::{
-    CreatePasskeyOutput, PasskeyConfig, PasskeyCredential, SetupWalletRequest, Wallet,
-};
+use super::models::{PasskeyConfig, PasskeyCredential, SetupWalletRequest, Wallet};
 use super::passkey_prf_provider::PrfProvider;
 #[cfg(test)]
 use super::{LabelStore, LabelStoreBuilder};
@@ -232,12 +230,7 @@ impl PasskeyClient {
             let setup = self
                 .passkey
                 .finish_wallet_setup(label, seeds, Some(credential.credential_id.clone()), true)
-                .await
-                .map_err(|e| PasskeyError::CreatedButNotDerived {
-                    credential_id: credential.credential_id.clone(),
-                    kind: e.kind(),
-                    reason: e.to_string(),
-                })?;
+                .await?;
             return Ok(RegisterResponse {
                 wallet: setup.wallet,
                 credential: Some(credential),
@@ -442,7 +435,7 @@ mod tests {
     use std::sync::Mutex;
 
     use super::super::error::PrfProviderError;
-    use super::super::{DeriveSeedsOutput, DeriveSeedsRequest};
+    use super::super::{CreatePasskeyOutput, DeriveSeedsOutput, DeriveSeedsRequest};
     // Wasm-safe tokio (tokio_with_wasm under wasm-bindgen-test) so the sleep in
     // wait_for_stored uses web timers instead of std::time, which is unsupported
     // on wasm32-unknown-unknown.
@@ -786,7 +779,9 @@ mod tests {
     fn mnemonic_of(wallet: &Wallet) -> String {
         match &wallet.seed {
             crate::Seed::Mnemonic { mnemonic, .. } => mnemonic.clone(),
-            other => panic!("expected a mnemonic seed, got {other:?}"),
+            other @ crate::Seed::Entropy(_) => {
+                panic!("expected a mnemonic seed, got {other:?}")
+            }
         }
     }
 

--- a/crates/breez-sdk/core/src/passkey/passkey_prf_provider.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_prf_provider.rs
@@ -1,5 +1,5 @@
 use super::error::PrfProviderError;
-use super::models::{CreatePasskeyOutput, DeriveSeedsOutput, PasskeyCredential};
+use super::models::{CreatePasskeyOutput, DeriveSeedsOutput};
 
 /// Per-call inputs for [`PrfProvider::derive_seeds`]. Hosts that
 /// don't need per-ceremony overrides fall back to [`Default`]
@@ -78,47 +78,36 @@ pub trait PrfProvider: Send + Sync {
     /// device. Hosts gate UX on the result.
     async fn is_supported(&self) -> Result<bool, PrfProviderError>;
 
-    /// Explicit registration. Platform passkey providers override this to
-    /// drive the OS create ceremony and surface the credential metadata
-    /// hosts need for `exclude_credentials` bookkeeping. CLI / hardware
-    /// providers register lazily in [`Self::derive_seeds`] and inherit the
-    /// default `PrfNotSupported`.
+    /// Explicit registration: drive the OS create ceremony, and where the
+    /// platform supports it, evaluate PRF for `salts` in the same
+    /// ceremony. Platform passkey providers override this to surface the
+    /// credential metadata hosts need for `exclude_credentials`
+    /// bookkeeping. CLI / hardware providers register lazily in
+    /// [`Self::derive_seeds`] and inherit the default `PrfNotSupported`.
     ///
     /// `exclude_credentials` lists already-registered IDs and surfaces
     /// duplicates as `CredentialAlreadyExists`. The `user.id` is always
     /// provider-minted and returned on `PasskeyCredential.user_id`.
-    async fn create_passkey(
-        &self,
-        exclude_credentials: Vec<Vec<u8>>,
-    ) -> Result<PasskeyCredential, PrfProviderError> {
-        let _ = exclude_credentials;
-        Err(PrfProviderError::PrfNotSupported)
-    }
-
-    /// [`Self::create_passkey`] that also evaluates PRF for `salts` in the
-    /// create ceremony, where the platform supports it.
     ///
-    /// Worth overriding because the assertion that would otherwise follow
-    /// a create can outrun the platform's own credential bookkeeping: on
-    /// Android the new credential is briefly not resolvable, and the miss
-    /// is indistinguishable from a deleted passkey. Returning seeds here
-    /// removes that second ceremony, so the window cannot be hit.
-    ///
-    /// The default keeps the two-ceremony flow, so a provider that cannot
-    /// evaluate PRF at create needs no changes. Return `seeds: None` for
+    /// Returning seeds removes the assertion that would otherwise follow
+    /// a create, and with it the window where the new credential exists
+    /// but the platform cannot yet resolve it. Return `seeds: None` for
     /// anything short of one output per salt (some authenticators drop
     /// `prf.eval.second`): a partial result is not usable, and the caller
-    /// falls back to [`Self::derive_seeds`].
-    async fn create_passkey_with_prf(
+    /// falls back to [`Self::derive_seeds`]. Empty `salts` means the
+    /// caller wants the credential only.
+    ///
+    /// Seeds returned here must equal what [`Self::derive_seeds`] would
+    /// return for the same salts. The wallet is derived from them either
+    /// way, so a mismatch means register and sign-in land on different
+    /// wallets, and the one register created is unreachable.
+    async fn create_passkey(
         &self,
         exclude_credentials: Vec<Vec<u8>>,
         salts: Vec<String>,
     ) -> Result<CreatePasskeyOutput, PrfProviderError> {
-        let _ = salts;
-        Ok(CreatePasskeyOutput {
-            credential: self.create_passkey(exclude_credentials).await?,
-            seeds: None,
-        })
+        let _ = (exclude_credentials, salts);
+        Err(PrfProviderError::PrfNotSupported)
     }
 
     /// Advisory check against the platform's out-of-band verification

--- a/crates/breez-sdk/core/src/passkey/passkey_prf_provider.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_prf_provider.rs
@@ -1,5 +1,5 @@
 use super::error::PrfProviderError;
-use super::models::{DeriveSeedsOutput, PasskeyCredential};
+use super::models::{CreatePasskeyOutput, DeriveSeedsOutput, PasskeyCredential};
 
 /// Per-call inputs for [`PrfProvider::derive_seeds`]. Hosts that
 /// don't need per-ceremony overrides fall back to [`Default`]
@@ -93,6 +93,32 @@ pub trait PrfProvider: Send + Sync {
     ) -> Result<PasskeyCredential, PrfProviderError> {
         let _ = exclude_credentials;
         Err(PrfProviderError::PrfNotSupported)
+    }
+
+    /// [`Self::create_passkey`] that also evaluates PRF for `salts` in the
+    /// create ceremony, where the platform supports it.
+    ///
+    /// Worth overriding because the assertion that would otherwise follow
+    /// a create can outrun the platform's own credential bookkeeping: on
+    /// Android the new credential is briefly not resolvable, and the miss
+    /// is indistinguishable from a deleted passkey. Returning seeds here
+    /// removes that second ceremony, so the window cannot be hit.
+    ///
+    /// The default keeps the two-ceremony flow, so a provider that cannot
+    /// evaluate PRF at create needs no changes. Return `seeds: None` for
+    /// anything short of one output per salt (some authenticators drop
+    /// `prf.eval.second`): a partial result is not usable, and the caller
+    /// falls back to [`Self::derive_seeds`].
+    async fn create_passkey_with_prf(
+        &self,
+        exclude_credentials: Vec<Vec<u8>>,
+        salts: Vec<String>,
+    ) -> Result<CreatePasskeyOutput, PrfProviderError> {
+        let _ = salts;
+        Ok(CreatePasskeyOutput {
+            credential: self.create_passkey(exclude_credentials).await?,
+            seeds: None,
+        })
     }
 
     /// Advisory check against the platform's out-of-band verification

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.d.ts
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.d.ts
@@ -4,11 +4,18 @@ import type {
     PasskeyProviderOptions,
     PrfProvider,
     PasskeyCredential,
+    CreatePasskeyOutput,
     DeriveSeedsResult,
     DeriveSeedOptions
 } from '../breez_sdk_spark_wasm.js';
 
-export type { PasskeyCredential, DeriveSeedsResult, DeriveSeedOptions, PasskeyProviderOptions };
+export type {
+    PasskeyCredential,
+    CreatePasskeyOutput,
+    DeriveSeedsResult,
+    DeriveSeedOptions,
+    PasskeyProviderOptions
+};
 
 /**
  * Outcome of a domain-association check: whether `rpId` is a valid

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.d.ts
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.d.ts
@@ -135,7 +135,7 @@ export declare class PasskeyProvider {
      *   `excludeCredentials` already exists on the device.
      * @throws If the user cancels or PRF is not supported.
      */
-    createPasskey(excludeCredentials?: Uint8Array[]): Promise<PasskeyCredential>;
+    createPasskey(excludeCredentials?: Uint8Array[], salts?: string[]): Promise<CreatePasskeyOutput>;
 
     /**
      * Check if a PRF-capable passkey is available on this device.

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
@@ -511,7 +511,9 @@ export class PasskeyProvider {
      * @param {Uint8Array[]} [excludeCredentials=[]] - Already-registered
      *   IDs; a match makes the authenticator refuse, preventing a
      *   duplicate registration on the same device.
-     * @returns {Promise<{ credentialId: Uint8Array, userId: Uint8Array, aaguid: Uint8Array | null, backupEligible: boolean | null }>}
+     * @param {string[]} [salts=[]] - Salts to evaluate during the create
+     *   ceremony; omit to register without deriving.
+     * @returns {Promise<{ credential: { credentialId: Uint8Array, userId: Uint8Array, aaguid: Uint8Array | null, backupEligible: boolean | null }, seeds: Uint8Array[] | null }>}
      * @private
      */
     async _registerCredential(excludeCredentials = [], salts = []) {

--- a/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
+++ b/crates/breez-sdk/wasm/js/passkey-prf-provider/index.js
@@ -259,12 +259,19 @@ export class PasskeyProvider {
      * `excludeCredentials` (already-registered IDs) to surface a repeat
      * registration as `PasskeyAlreadyExistsError`.
      *
+     * Asking the create ceremony to evaluate PRF for `salts` removes the
+     * assertion that would otherwise follow it, so registration costs one
+     * prompt instead of two. Browsers that acknowledge PRF without
+     * evaluating return `seeds: null` and the caller derives as before.
+     *
      * @param {Uint8Array[]} [excludeCredentials]
-     * @returns {Promise<PasskeyCredential>} `aaguid`/`backupEligible`
-     *   are null on browsers without `getAuthenticatorData()`.
+     * @param {string[]} [salts] Salts to evaluate during the ceremony.
+     * @returns {Promise<CreatePasskeyOutput>} `aaguid`/`backupEligible`
+     *   are null on browsers without `getAuthenticatorData()`. `seeds` is
+     *   null unless the browser returned one output per salt.
      */
-    async createPasskey(excludeCredentials = []) {
-        return await this._registerCredential(excludeCredentials);
+    async createPasskey(excludeCredentials = [], salts = []) {
+        return await this._registerCredential(excludeCredentials, salts);
     }
 
     /**
@@ -507,7 +514,7 @@ export class PasskeyProvider {
      * @returns {Promise<{ credentialId: Uint8Array, userId: Uint8Array, aaguid: Uint8Array | null, backupEligible: boolean | null }>}
      * @private
      */
-    async _registerCredential(excludeCredentials = []) {
+    async _registerCredential(excludeCredentials = [], salts = []) {
         // Fresh per-call user.id: reusing one across creates on the same
         // rpId silently overwrites the prior credential on some
         // authenticators. (WebAuthn requires 1 to 64 bytes.)
@@ -540,7 +547,18 @@ export class PasskeyProvider {
             authenticatorSelection,
             // Explicit so future security review can't read it as ambient.
             attestation: 'none',
-            extensions: { prf: {} },
+            extensions: {
+                prf: salts.length > 0
+                    ? {
+                        eval: {
+                            first: new TextEncoder().encode(salts[0]),
+                            ...(salts.length > 1
+                                ? { second: new TextEncoder().encode(salts[1]) }
+                                : {}),
+                        },
+                    }
+                    : {},
+            },
         };
 
         if (Array.isArray(this.hints) && this.hints.length > 0) {
@@ -599,12 +617,30 @@ export class PasskeyProvider {
             );
         }
 
+        // Only usable as a complete set: a browser that drops the second
+        // output leaves a partial derive, which is no derive at all, so
+        // fall back to the assertion path rather than half-deriving.
+        let seeds = null;
+        const results = extensionResults.prf.results;
+        if (salts.length > 0 && results && results.first) {
+            const collected = [new Uint8Array(results.first)];
+            if (results.second) {
+                collected.push(new Uint8Array(results.second));
+            }
+            if (collected.length === salts.length) {
+                seeds = collected;
+            }
+        }
+
         const meta = extractRegistrationMetadata(credential);
         return {
-            credentialId: new Uint8Array(credential.rawId),
-            userId: resolvedUserId,
-            aaguid: meta ? meta.aaguid : null,
-            backupEligible: meta ? meta.backupEligible : null,
+            credential: {
+                credentialId: new Uint8Array(credential.rawId),
+                userId: resolvedUserId,
+                aaguid: meta ? meta.aaguid : null,
+                backupEligible: meta ? meta.backupEligible : null,
+            },
+            seeds,
         };
     }
 

--- a/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
+++ b/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
@@ -5,7 +5,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{JsFuture, js_sys::Promise};
 
 use breez_sdk_spark::passkey::{
-    DeriveSeedsOutput, DeriveSeedsRequest, PasskeyCredential, PrfProviderError,
+    CreatePasskeyOutput, DeriveSeedsOutput, DeriveSeedsRequest, PasskeyCredential, PrfProviderError,
 };
 
 pub(crate) fn js_error_to_prf_provider_error(js_error: JsValue) -> PrfProviderError {
@@ -161,7 +161,12 @@ impl breez_sdk_spark::passkey::PrfProvider for WasmPrfProvider {
     async fn create_passkey(
         &self,
         exclude_credentials: Vec<Vec<u8>>,
-    ) -> Result<PasskeyCredential, PrfProviderError> {
+        salts: Vec<String>,
+    ) -> Result<CreatePasskeyOutput, PrfProviderError> {
+        // The JS provider contract has no eval-at-create hook, so the
+        // browser keeps the two-ceremony flow and the caller derives
+        // through `derive_seeds` as before.
+        let _ = salts;
         // Custom providers may not implement explicit creation; fall
         // back to the trait default (`PrfNotSupported`).
         if !self.js_has_method("createPasskey", &self.supports_create) {
@@ -177,7 +182,10 @@ impl breez_sdk_spark::passkey::PrfProvider for WasmPrfProvider {
             .await
             .map_err(js_error_to_prf_provider_error)?;
 
-        parse_passkey_credential(&result)
+        Ok(CreatePasskeyOutput {
+            credential: parse_passkey_credential(&result)?,
+            seeds: None,
+        })
     }
 }
 

--- a/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
+++ b/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
@@ -163,10 +163,6 @@ impl breez_sdk_spark::passkey::PrfProvider for WasmPrfProvider {
         exclude_credentials: Vec<Vec<u8>>,
         salts: Vec<String>,
     ) -> Result<CreatePasskeyOutput, PrfProviderError> {
-        // The JS provider contract has no eval-at-create hook, so the
-        // browser keeps the two-ceremony flow and the caller derives
-        // through `derive_seeds` as before.
-        let _ = salts;
         // Custom providers may not implement explicit creation; fall
         // back to the trait default (`PrfNotSupported`).
         if !self.js_has_method("createPasskey", &self.supports_create) {
@@ -174,17 +170,38 @@ impl breez_sdk_spark::passkey::PrfProvider for WasmPrfProvider {
         }
 
         let js_exclude = build_exclude_credentials(&exclude_credentials);
+        let js_salts = js_sys::Array::new();
+        for salt in &salts {
+            js_salts.push(&JsValue::from_str(salt));
+        }
         let result_promise = self
             .inner
-            .create_passkey(js_exclude)
+            .create_passkey(js_exclude, js_salts.into())
             .map_err(js_error_to_prf_provider_error)?;
         let result = JsFuture::from(result_promise)
             .await
             .map_err(js_error_to_prf_provider_error)?;
 
+        let credential_raw = js_sys::Reflect::get(&result, &JsValue::from_str("credential"))
+            .map_err(js_error_to_prf_provider_error)?;
+        // Only a complete set is usable; anything else falls back to the
+        // assertion path rather than half-deriving.
+        let seeds_raw = js_sys::Reflect::get(&result, &JsValue::from_str("seeds"))
+            .map_err(js_error_to_prf_provider_error)?;
+        let seeds = if seeds_raw.is_undefined() || seeds_raw.is_null() {
+            None
+        } else {
+            let array = js_sys::Array::from(&seeds_raw);
+            let collected: Vec<Vec<u8>> = array
+                .iter()
+                .map(|v| js_sys::Uint8Array::new(&v).to_vec())
+                .collect();
+            (collected.len() == salts.len()).then_some(collected)
+        };
+
         Ok(CreatePasskeyOutput {
-            credential: parse_passkey_credential(&result)?,
-            seeds: None,
+            credential: parse_passkey_credential(&credential_raw)?,
+            seeds,
         })
     }
 }
@@ -377,6 +394,7 @@ extern "C" {
     pub fn create_passkey(
         this: &PrfProvider,
         exclude_credentials: JsValue,
+        salts: JsValue,
     ) -> Result<Promise, JsValue>;
 
     // Optional method. Custom providers may omit it (then treated as

--- a/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
+++ b/crates/breez-sdk/wasm/src/models/passkey_prf_provider.rs
@@ -320,10 +320,14 @@ export interface PrfProvider {
      * `excludeCredentials` lists already-registered IDs; a match raises
      * `PasskeyAlreadyExistsError`.
      *
+     * Evaluating PRF for `salts` in the same ceremony returns the seeds on
+     * `seeds`, and the caller then needs no assertion. Return `seeds: null`
+     * when the authenticator evaluated none, or fewer than one per salt.
+     *
      * @throws `PasskeyAlreadyExistsError` when an entry in
      *   `excludeCredentials` matches a credential already on the device.
      */
-    createPasskey?(excludeCredentials: Uint8Array[]): Promise<PasskeyCredential>;
+    createPasskey?(excludeCredentials: Uint8Array[], salts: string[]): Promise<CreatePasskeyOutput>;
 
     /**
      * Whether this provider can produce PRF outputs on the current

--- a/crates/breez-sdk/wasm/src/passkey.rs
+++ b/crates/breez-sdk/wasm/src/passkey.rs
@@ -76,6 +76,20 @@ pub struct PasskeyCredential {
     pub backup_eligible: Option<bool>,
 }
 
+/// A created credential, plus the PRF outputs when the browser evaluated
+/// them during the create ceremony. `seeds` is null when it did not, so
+/// the caller derives through `deriveSeeds`.
+///
+/// Seeds returned here must equal what `deriveSeeds` returns for the same
+/// salts: the wallet is derived from them either way, so a mismatch means
+/// register and sign-in land on different wallets.
+#[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::CreatePasskeyOutput)]
+pub struct CreatePasskeyOutput {
+    pub credential: PasskeyCredential,
+    #[tsify(type = "Uint8Array[] | null")]
+    pub seeds: Option<Vec<Vec<u8>>>,
+}
+
 /// Request shape for `PasskeyClient.register`.
 #[macros::extern_wasm_bindgen(breez_sdk_spark::passkey::RegisterRequest)]
 pub struct RegisterRequest {

--- a/docs/breez-sdk/snippets/csharp/Passkey.cs
+++ b/docs/breez-sdk/snippets/csharp/Passkey.cs
@@ -4,7 +4,8 @@ namespace BreezSdkSnippets
 {
     // ANCHOR: implement-prf-provider
     // Implement PrfProvider for a custom authenticator (hardware key, FIDO2,
-    // file-backed). Only DeriveSeeds and IsSupported are required.
+    // file-backed). Every method is required: interface members are
+    // bodiless, unlike the Rust trait's defaults.
     class CustomPrfProvider : PrfProvider
     {
         public async Task<DeriveSeedsOutput> DeriveSeeds(DeriveSeedsRequest request)

--- a/docs/breez-sdk/snippets/csharp/Passkey.cs
+++ b/docs/breez-sdk/snippets/csharp/Passkey.cs
@@ -18,9 +18,13 @@ namespace BreezSdkSnippets
             throw new NotImplementedException("Check platform passkey availability");
         }
 
-        public async Task<PasskeyCredential> CreatePasskey(byte[][] excludeCredentials)
+        public async Task<CreatePasskeyOutput> CreatePasskey(byte[][] excludeCredentials, string[] salts)
         {
             // Register a credential and return its ID plus attestation.
+            //
+            // Return a null Seeds unless the platform evaluated PRF during the
+            // create ceremony and gave one output per salt. Seeds returned here
+            // must equal what DeriveSeeds returns for the same salts.
             throw new NotImplementedException("Implement registration via native passkey API");
         }
 

--- a/docs/breez-sdk/snippets/flutter/lib/passkey.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/passkey.dart
@@ -10,8 +10,15 @@ Future<DeriveSeedsOutput> deriveSeeds(DeriveSeedsRequest request) async {
   throw UnimplementedError('Implement using platform passkey APIs');
 }
 
-Future<PasskeyCredential> createPasskey(List<Uint8List> excludeCredentials) async {
+Future<CreatePasskeyOutput> createPasskey(
+  List<Uint8List> excludeCredentials,
+  List<String> salts,
+) async {
   // Register a credential and return its ID plus attestation.
+  //
+  // Return `seeds` null unless the platform evaluated PRF during the create
+  // ceremony and gave one output per salt. Seeds returned here must equal
+  // what `deriveSeeds` returns for the same salts.
   throw UnimplementedError('Implement registration via native passkey API');
 }
 

--- a/docs/breez-sdk/snippets/flutter/pubspec.lock
+++ b/docs/breez-sdk/snippets/flutter/pubspec.lock
@@ -582,5 +582,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.29.0"

--- a/docs/breez-sdk/snippets/go/passkey.go
+++ b/docs/breez-sdk/snippets/go/passkey.go
@@ -9,7 +9,8 @@ import (
 
 // ANCHOR: implement-prf-provider
 // Implement the PrfProvider interface for a custom authenticator (hardware
-// key, FIDO2, file-backed). Only DeriveSeeds and IsSupported are required.
+// key, FIDO2, file-backed). Every method is required: satisfying a Go
+// interface has no defaults, unlike the Rust trait.
 type CustomPrfProvider struct{}
 
 func (p *CustomPrfProvider) DeriveSeeds(

--- a/docs/breez-sdk/snippets/go/passkey.go
+++ b/docs/breez-sdk/snippets/go/passkey.go
@@ -25,8 +25,13 @@ func (p *CustomPrfProvider) IsSupported() (bool, error) {
 
 func (p *CustomPrfProvider) CreatePasskey(
 	excludeCredentials [][]byte,
-) (breez_sdk_spark.PasskeyCredential, error) {
+	salts []string,
+) (breez_sdk_spark.CreatePasskeyOutput, error) {
 	// Register a credential and return its ID plus attestation.
+	//
+	// Return a nil Seeds unless the platform evaluated PRF during the create
+	// ceremony and gave one output per salt. Seeds returned here must equal
+	// what DeriveSeeds returns for the same salts.
 	panic("Implement registration via native passkey API")
 }
 

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
@@ -18,8 +18,15 @@ class CustomPrfProvider : PrfProvider {
         TODO("Check platform passkey availability")
     }
 
-    override suspend fun createPasskey(excludeCredentials: List<ByteArray>): PasskeyCredential {
+    override suspend fun createPasskey(
+        excludeCredentials: List<ByteArray>,
+        salts: List<String>,
+    ): CreatePasskeyOutput {
         // Register a credential and return its ID plus attestation.
+        //
+        // Return `seeds = null` unless the platform evaluated PRF during the
+        // create ceremony and gave one output per salt. Seeds returned here
+        // must equal what `deriveSeeds` returns for the same salts.
         TODO("Implement registration via native passkey API")
     }
 

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/androidMain/kotlin/com/example/kotlinmpplib/Passkey.kt
@@ -6,8 +6,8 @@ import technology.breez.spark.passkey.PasskeyClient
 import technology.breez.spark.passkey.PasskeyProvider
 
 // ANCHOR: implement-prf-provider
-// Implement PrfProvider for a custom authenticator. Only deriveSeeds and
-// isSupported are required.
+// Implement PrfProvider for a custom authenticator. Every method is
+// required: the generated interface has no defaults, unlike the Rust trait.
 class CustomPrfProvider : PrfProvider {
     override suspend fun deriveSeeds(request: DeriveSeedsRequest): DeriveSeedsOutput {
         // Return one 32-byte PRF output per salt, in input order.

--- a/docs/breez-sdk/snippets/python/src/passkey.py
+++ b/docs/breez-sdk/snippets/python/src/passkey.py
@@ -12,7 +12,7 @@ from breez_sdk_spark import (
     PasskeyClient,
     PrfProvider,
     PrfProviderError,
-    PasskeyCredential,
+    CreatePasskeyOutput,
     RegisterRequest,
     SignInRequest,
     connect,
@@ -33,8 +33,14 @@ class CustomPrfProvider(PrfProvider):
     async def is_supported(self) -> bool:
         raise NotImplementedError("Check platform passkey availability")
 
-    async def create_passkey(self, exclude_credentials: list[bytes]) -> PasskeyCredential:
+    async def create_passkey(
+        self, exclude_credentials: list[bytes], salts: list[str]
+    ) -> CreatePasskeyOutput:
         # Register a credential and return its ID plus attestation.
+        #
+        # Return seeds=None unless the platform evaluated PRF during the create
+        # ceremony and gave one output per salt. Seeds returned here must equal
+        # what derive_seeds returns for the same salts.
         raise NotImplementedError("Implement registration via native passkey API")
 
     async def check_domain_association(self) -> DomainAssociation:

--- a/docs/breez-sdk/snippets/python/src/passkey.py
+++ b/docs/breez-sdk/snippets/python/src/passkey.py
@@ -22,9 +22,10 @@ from breez_sdk_spark import (
 
 # ANCHOR: implement-prf-provider
 # Implement the PrfProvider trait for custom logic if no built-in
-# PasskeyProvider ships for your target. Three required methods:
-# derive_seeds for derivation, is_supported for the capability probe;
-# create_passkey for registration is optional.
+# PasskeyProvider ships for your target. Every method is required:
+# derive_seeds for derivation, is_supported for the capability probe,
+# create_passkey for registration, check_domain_association for the
+# advisory RP check.
 class CustomPrfProvider(PrfProvider):
     async def derive_seeds(self, request: DeriveSeedsRequest) -> DeriveSeedsOutput:
         # Return one 32-byte PRF output per salt, in input order.

--- a/docs/breez-sdk/snippets/react-native/passkey.ts
+++ b/docs/breez-sdk/snippets/react-native/passkey.ts
@@ -27,9 +27,14 @@ class CustomPrfProvider {
   }
 
   createPasskey = async (
-    _excludeCredentials: Uint8Array[]
-  ): Promise<PasskeyCredential> => {
+    _excludeCredentials: Uint8Array[],
+    _salts: string[]
+  ): Promise<CreatePasskeyOutput> => {
     // Register a credential and return its ID plus attestation.
+    //
+    // Return `seeds: null` unless the platform evaluated PRF during the
+    // create ceremony and gave one output per salt. Seeds returned here
+    // must equal what `deriveSeeds` returns for the same salts.
     throw new Error('Implement registration via native passkey API')
   }
 

--- a/docs/breez-sdk/snippets/react-native/passkey.ts
+++ b/docs/breez-sdk/snippets/react-native/passkey.ts
@@ -1,5 +1,5 @@
 import type {
-  PasskeyCredential
+  CreatePasskeyOutput
 } from '@breeztech/breez-sdk-spark-react-native'
 import {
   PasskeyAvailability_Tags,

--- a/docs/breez-sdk/snippets/react-native/passkey.ts
+++ b/docs/breez-sdk/snippets/react-native/passkey.ts
@@ -17,7 +17,8 @@ import {
 
 // ANCHOR: implement-prf-provider
 // Implement PrfProvider for a custom authenticator (hardware key, FIDO2,
-// file-backed). Only deriveSeeds and isSupported are required.
+// file-backed). Every method is required: the generated interface has no
+// defaults, unlike the Rust trait.
 class CustomPrfProvider {
   deriveSeeds = async (
     _request: { salts: string[] }
@@ -32,7 +33,7 @@ class CustomPrfProvider {
   ): Promise<CreatePasskeyOutput> => {
     // Register a credential and return its ID plus attestation.
     //
-    // Return `seeds: null` unless the platform evaluated PRF during the
+    // Return `seeds: null` (the field is nullable) unless the platform evaluated PRF during the
     // create ceremony and gave one output per salt. Seeds returned here
     // must equal what `deriveSeeds` returns for the same salts.
     throw new Error('Implement registration via native passkey API')

--- a/docs/breez-sdk/snippets/rust/src/passkey.rs
+++ b/docs/breez-sdk/snippets/rust/src/passkey.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use breez_sdk_spark::passkey::{
     ConnectWithPasskeyRequest, DeriveSeedsOutput, DeriveSeedsRequest, DomainAssociation, ErrorKind,
-    CreatePasskeyOutput, PasskeyAvailability, PasskeyClient, PasskeyCredential, PrfProvider,
-    PrfProviderError,
+    CreatePasskeyOutput, PasskeyAvailability, PasskeyClient, PrfProvider, PrfProviderError,
     RegisterRequest, SignInRequest, SignInResponse, Wallet,
 };
 use breez_sdk_spark::{connect, default_config, ConnectRequest, Network};

--- a/docs/breez-sdk/snippets/rust/src/passkey.rs
+++ b/docs/breez-sdk/snippets/rust/src/passkey.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use breez_sdk_spark::passkey::{
     ConnectWithPasskeyRequest, DeriveSeedsOutput, DeriveSeedsRequest, DomainAssociation, ErrorKind,
-    PasskeyAvailability, PasskeyClient, PasskeyCredential, PrfProvider, PrfProviderError,
+    CreatePasskeyOutput, PasskeyAvailability, PasskeyClient, PasskeyCredential, PrfProvider,
+    PrfProviderError,
     RegisterRequest, SignInRequest, SignInResponse, Wallet,
 };
 use breez_sdk_spark::{connect, default_config, ConnectRequest, Network};
@@ -29,8 +30,13 @@ impl PrfProvider for CustomPrfProvider {
     async fn create_passkey(
         &self,
         _exclude_credentials: Vec<Vec<u8>>,
-    ) -> Result<PasskeyCredential, PrfProviderError> {
+        _salts: Vec<String>,
+    ) -> Result<CreatePasskeyOutput, PrfProviderError> {
         // Register a credential and return its ID plus attestation.
+        //
+        // Return `seeds: None` unless the platform evaluated PRF during the
+        // create ceremony and gave one output per salt. Seeds returned here
+        // must equal what `derive_seeds` returns for the same salts.
         todo!("Implement registration via WebAuthn create() / native API")
     }
 

--- a/docs/breez-sdk/snippets/rust/src/passkey.rs
+++ b/docs/breez-sdk/snippets/rust/src/passkey.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use breez_sdk_spark::passkey::{
-    ConnectWithPasskeyRequest, DeriveSeedsOutput, DeriveSeedsRequest, DomainAssociation, ErrorKind,
-    CreatePasskeyOutput, PasskeyAvailability, PasskeyClient, PrfProvider, PrfProviderError,
-    RegisterRequest, SignInRequest, SignInResponse, Wallet,
+    ConnectWithPasskeyRequest, CreatePasskeyOutput, DeriveSeedsOutput, DeriveSeedsRequest,
+    DomainAssociation, ErrorKind, PasskeyAvailability, PasskeyClient, PrfProvider,
+    PrfProviderError, RegisterRequest, SignInRequest, SignInResponse, Wallet,
 };
 use breez_sdk_spark::{connect, default_config, ConnectRequest, Network};
 use std::sync::Arc;

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
@@ -14,8 +14,15 @@ class CustomPrfProvider: PrfProvider {
         fatalError("Check platform passkey availability")
     }
 
-    func createPasskey(excludeCredentials: [Data]) async throws -> PasskeyCredential {
+    func createPasskey(
+        excludeCredentials: [Data],
+        salts: [String]
+    ) async throws -> CreatePasskeyOutput {
         // Register a credential and return its ID plus attestation.
+        //
+        // Return `seeds: nil` unless the platform evaluated PRF during the
+        // create ceremony and gave one output per salt. Seeds returned here
+        // must equal what `deriveSeeds` returns for the same salts.
         fatalError("Implement registration via WebAuthn create() / native API")
     }
 

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
@@ -3,7 +3,8 @@ import Foundation
 
 // ANCHOR: implement-prf-provider
 // Implement PrfProvider for a custom authenticator (hardware key, FIDO2,
-// file-backed). Only deriveSeeds and isSupported are required.
+// file-backed). Every method is required: Swift conformance has no
+// defaults, unlike the Rust trait.
 class CustomPrfProvider: PrfProvider {
     func deriveSeeds(request: DeriveSeedsRequest) async throws -> DeriveSeedsOutput {
         // Return one 32-byte PRF output per salt, in input order.

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -21,9 +21,14 @@ class CustomPrfProvider {
   }
 
   createPasskey = async (
-    _excludeCredentials: Uint8Array[]
-  ): Promise<PasskeyCredential> => {
+    _excludeCredentials: Uint8Array[],
+    _salts: string[]
+  ): Promise<CreatePasskeyOutput> => {
     // Register a credential and return its ID plus attestation.
+    //
+    // Return `seeds: null` unless the browser evaluated PRF during the
+    // create ceremony and gave one output per salt. Seeds returned here
+    // must equal what `deriveSeeds` returns for the same salts.
     throw new Error('Implement registration via WebAuthn create() / native API')
   }
 

--- a/docs/breez-sdk/snippets/wasm/passkey.ts
+++ b/docs/breez-sdk/snippets/wasm/passkey.ts
@@ -1,5 +1,5 @@
 import type {
-  PasskeyCredential
+  CreatePasskeyOutput
 } from '@breeztech/breez-sdk-spark'
 import { connect, defaultConfig } from '@breeztech/breez-sdk-spark'
 import {

--- a/docs/breez-sdk/src/guide/uxguide_login.md
+++ b/docs/breez-sdk/src/guide/uxguide_login.md
@@ -41,7 +41,11 @@ Browsers and native authenticators expose different error semantics, so the reco
 | Path | OS prompts |
 |---|---|
 | Returning user | **1** (one assertion derives master + label) |
-| New user | **2** (1 create, 1 assertion) |
+| New user | **1** (the create ceremony derives master + label) |
+
+A new user costs **2** (1 create, 1 assertion) on authenticators that
+report PRF support without evaluating it during creation, where the SDK
+falls back to a follow-up assertion.
 
 **Web:** where the browser supports immediate mediation ({{#name PasskeyClient.supports_immediate_mediation}}), a single "Use Passkey" button; otherwise "Create a new passkey" and "Sign in with a passkey" as separate actions. {{#name PasskeyClient.connect_with_passkey}} is not surfaced on the WASM target.
 

--- a/packages/flutter/android/src/main/kotlin/technology/breez/spark/BreezSdkSparkPasskeyPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/technology/breez/spark/BreezSdkSparkPasskeyPlugin.kt
@@ -222,7 +222,7 @@ class BreezSdkSparkPasskeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
                     userDisplayName = userDisplayName,
                     activityProvider = { currentActivity },
                     graceTracker = graceTracker,
-                ).register(excludeIds)
+                ).register(excludeIds).credential
                 // The core's `register` arms the shared grace tracker so the
                 // next `deriveSeeds` call holds out the credential's
                 // PRF-readiness window without the wrapper having to.

--- a/packages/flutter/android/src/main/kotlin/technology/breez/spark/BreezSdkSparkPasskeyPlugin.kt
+++ b/packages/flutter/android/src/main/kotlin/technology/breez/spark/BreezSdkSparkPasskeyPlugin.kt
@@ -212,25 +212,33 @@ class BreezSdkSparkPasskeyPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
             (call.argument<List<String>>("excludeCredentials") ?: emptyList()).map {
                 Base64.decode(it, Base64.NO_WRAP)
             }
+        val salts: List<String> = call.argument<List<String>>("salts") ?: emptyList()
 
         scope.launch {
             try {
-                val credential = CredentialManagerPrfCore(
+                val registration = CredentialManagerPrfCore(
                     rpId = rpId,
                     rpName = rpName,
                     userName = userName,
                     userDisplayName = userDisplayName,
                     activityProvider = { currentActivity },
                     graceTracker = graceTracker,
-                ).register(excludeIds).credential
+                ).register(excludeIds, salts)
+                val credential = registration.credential
                 // The core's `register` arms the shared grace tracker so the
                 // next `deriveSeeds` call holds out the credential's
-                // PRF-readiness window without the wrapper having to.
+                // PRF-readiness window without the wrapper having to, and
+                // skips arming it when seeds came back inline.
                 result.success(mapOf(
                     "credentialId" to Base64.encodeToString(credential.credentialId, Base64.NO_WRAP),
                     "userId" to Base64.encodeToString(credential.userId, Base64.NO_WRAP),
                     "aaguid" to credential.aaguid?.let { Base64.encodeToString(it, Base64.NO_WRAP) },
                     "backupEligible" to credential.backupEligible,
+                    // Null unless the authenticator evaluated PRF during the
+                    // create ceremony and returned one output per salt.
+                    "seeds" to registration.seeds?.map {
+                        Base64.encodeToString(it, Base64.NO_WRAP)
+                    },
                 ))
             } catch (e: CredentialManagerPrfCoreException) {
                 result.error(e.errorCode, e.message ?: e.defaultMessage, null)

--- a/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -475,6 +475,10 @@ public class CredentialManagerPrfCore(
             ?.optJSONObject("prf")
             ?.optJSONObject("results")
             ?: return null
+        // Never throw: the passkey exists by now, so a decode failure that
+        // escapes fails the whole registration, and the caller's natural
+        // recovery is to register again and strand this one. Null falls
+        // back to the assertion path, which derives from the same passkey.
         val first = results.optString("first").takeIf { it.isNotEmpty() } ?: return null
         val out = ArrayList<ByteArray>(2)
         out.add(decodeBase64UrlOrNull(first, "registration prf.first") ?: return null)

--- a/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -461,13 +461,29 @@ public class CredentialManagerPrfCore(
     // ------------------------------------------------------------------
 
     /**
-     * Run one assertion ceremony for [salts] (1 or 2): build the WebAuthn
-     * request (cross-device hybrid suppressed unless
-     * [preferImmediatelyAvailableCredentials] is false), evaluate PRF, and
-     * return one 32-byte output per salt the authenticator evaluated plus
-     * the asserted credential ID. A dropped `results.second` yields a
-     * single-element list.
+     * PRF outputs carried on a registration response, or null when the
+     * authenticator reported support without evaluating (`prf.enabled`
+     * with no `results`), which is the pre-eval-at-create behavior.
      */
+    private fun readRegistrationPrfResults(responseJson: JSONObject): List<ByteArray>? {
+        // Never throw: the passkey exists by now, so a decode failure that
+        // escapes fails the whole registration, and the caller's natural
+        // recovery is to register again and strand this one. Null falls
+        // back to the assertion path, which derives from the same passkey.
+        val results = responseJson
+            .optJSONObject("clientExtensionResults")
+            ?.optJSONObject("prf")
+            ?.optJSONObject("results")
+            ?: return null
+        val first = results.optString("first").takeIf { it.isNotEmpty() } ?: return null
+        val out = ArrayList<ByteArray>(2)
+        out.add(decodeBase64UrlOrNull(first, "registration prf.first") ?: return null)
+        results.optString("second").takeIf { it.isNotEmpty() }?.let {
+            out.add(decodeBase64UrlOrNull(it, "registration prf.second") ?: return null)
+        }
+        return out
+    }
+
     /**
      * [assertPrf], re-asking until [retryUntilMs] while Credential Manager
      * still reports no credential. A passkey that exists but is not yet
@@ -499,6 +515,15 @@ public class CredentialManagerPrfCore(
             }
         }
     }
+
+    /**
+     * Run one assertion ceremony for [salts] (1 or 2): build the WebAuthn
+     * request (cross-device hybrid suppressed unless
+     * [preferImmediatelyAvailableCredentials] is false), evaluate PRF, and
+     * return one 32-byte output per salt the authenticator evaluated plus
+     * the asserted credential ID. A dropped `results.second` yields a
+     * single-element list.
+     */
 
     private suspend fun assertPrf(
         salts: List<String>,
@@ -586,7 +611,8 @@ public class CredentialManagerPrfCore(
      */
     public suspend fun register(
         excludeCredentials: List<ByteArray> = emptyList(),
-    ): PasskeyCredential = withContext(Dispatchers.Main) {
+        salts: List<String> = emptyList(),
+    ): PasskeyRegistration = withContext(Dispatchers.Main) {
         val startedAtMs = System.currentTimeMillis()
         try {
             val activity = activityProvider()
@@ -629,7 +655,25 @@ public class CredentialManagerPrfCore(
                     put("userVerification", "required")
                 })
                 put("extensions", JSONObject().apply {
-                    put("prf", JSONObject())
+                    // Ask the create ceremony to evaluate PRF as well as
+                    // report support. An authenticator that answers turns
+                    // registration into a single ceremony, so no assertion
+                    // has to race the credential becoming resolvable. One
+                    // that ignores it returns `enabled` only, and the
+                    // caller falls back to `deriveSeeds`.
+                    put("prf", JSONObject().apply {
+                        if (salts.isNotEmpty()) {
+                            put("eval", JSONObject().apply {
+                                put("first", encodeBase64Url(salts[0].toByteArray(Charsets.UTF_8)))
+                                if (salts.size > 1) {
+                                    put(
+                                        "second",
+                                        encodeBase64Url(salts[1].toByteArray(Charsets.UTF_8)),
+                                    )
+                                }
+                            })
+                        }
+                    })
                 })
             }.toString()
 
@@ -659,10 +703,20 @@ public class CredentialManagerPrfCore(
                     backupEligible = meta.second
                 }
             }
-            // Arm the post-create grace so the immediate derive doesn't
-            // race the credential's PRF-readiness window (see grace tracker).
+            // Only usable as a complete set: a dropped `prf.eval.second`
+            // yields one output where the caller asked for two, and a
+            // partial derive is no derive at all.
+            val seeds = readRegistrationPrfResults(responseJson)
+                ?.takeIf { it.size == salts.size }
+            // Arm the post-create grace so a fallback derive doesn't race
+            // the credential's PRF-readiness window (see grace tracker).
+            // Unnecessary when seeds came back inline, but harmless: the
+            // window is consumed without waiting when nothing asserts.
             graceTracker.arm(postCreateGraceMs)
-            PasskeyCredential(credentialId, userIdBytes, aaguid, backupEligible)
+            PasskeyRegistration(
+                PasskeyCredential(credentialId, userIdBytes, aaguid, backupEligible),
+                seeds,
+            )
         } catch (e: CredentialManagerPrfCoreException) {
             throw e
         } catch (e: Exception) {
@@ -857,6 +911,17 @@ public class CredentialManagerPrfCore(
 public data class PrfDerivation(
     public val seeds: List<ByteArray>,
     public val credentialId: ByteArray?,
+)
+
+/**
+ * A created credential, plus the PRF outputs when the authenticator
+ * evaluated them during the create ceremony. `seeds` null means it did
+ * not (or returned fewer than asked for), so the caller derives through
+ * [CredentialManagerPrfCore.deriveSeeds].
+ */
+public data class PasskeyRegistration(
+    public val credential: PasskeyCredential,
+    public val seeds: List<ByteArray>?,
 )
 
 /**

--- a/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -611,6 +611,20 @@ public class CredentialManagerPrfCore(
      */
     public suspend fun register(
         excludeCredentials: List<ByteArray> = emptyList(),
+    ): PasskeyCredential = registerWithPrf(excludeCredentials, emptyList()).credential
+
+    /**
+     * [register] that also asks the create ceremony to evaluate PRF for
+     * [salts]. An authenticator that answers makes registration a single
+     * ceremony, so no assertion follows it into the window where the new
+     * credential is not yet resolvable.
+     *
+     * `PasskeyRegistration.seeds` is null when the authenticator reported
+     * PRF support without evaluating, and when it returned fewer outputs
+     * than salts. Callers derive through [deriveSeeds] in both cases.
+     */
+    public suspend fun registerWithPrf(
+        excludeCredentials: List<ByteArray> = emptyList(),
         salts: List<String> = emptyList(),
     ): PasskeyRegistration = withContext(Dispatchers.Main) {
         val startedAtMs = System.currentTimeMillis()

--- a/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -611,20 +611,6 @@ public class CredentialManagerPrfCore(
      */
     public suspend fun register(
         excludeCredentials: List<ByteArray> = emptyList(),
-    ): PasskeyCredential = registerWithPrf(excludeCredentials, emptyList()).credential
-
-    /**
-     * [register] that also asks the create ceremony to evaluate PRF for
-     * [salts]. An authenticator that answers makes registration a single
-     * ceremony, so no assertion follows it into the window where the new
-     * credential is not yet resolvable.
-     *
-     * `PasskeyRegistration.seeds` is null when the authenticator reported
-     * PRF support without evaluating, and when it returned fewer outputs
-     * than salts. Callers derive through [deriveSeeds] in both cases.
-     */
-    public suspend fun registerWithPrf(
-        excludeCredentials: List<ByteArray> = emptyList(),
         salts: List<String> = emptyList(),
     ): PasskeyRegistration = withContext(Dispatchers.Main) {
         val startedAtMs = System.currentTimeMillis()
@@ -722,11 +708,13 @@ public class CredentialManagerPrfCore(
             // partial derive is no derive at all.
             val seeds = readRegistrationPrfResults(responseJson)
                 ?.takeIf { it.size == salts.size }
-            // Arm the post-create grace so a fallback derive doesn't race
-            // the credential's PRF-readiness window (see grace tracker).
-            // Unnecessary when seeds came back inline, but harmless: the
-            // window is consumed without waiting when nothing asserts.
-            graceTracker.arm(postCreateGraceMs)
+            // Arm the post-create grace only when a derive still has to
+            // run: the window exists for that assertion. Arming it on the
+            // inline-seeds path would leave it set for whatever derive
+            // came next, which is a different ceremony entirely.
+            if (seeds == null) {
+                graceTracker.arm(postCreateGraceMs)
+            }
             PasskeyRegistration(
                 PasskeyCredential(credentialId, userIdBytes, aaguid, backupEligible),
                 seeds,

--- a/packages/flutter/ios/Classes/BreezSdkSparkPasskeyPlugin.swift
+++ b/packages/flutter/ios/Classes/BreezSdkSparkPasskeyPlugin.swift
@@ -58,6 +58,8 @@ public class BreezSdkSparkPasskeyPlugin: NSObject, FlutterPlugin {
             return
         }
 
+        let salts = args["salts"] as? [String] ?? []
+
         var excludeCredentials: [Data] = []
         if let rawIds = args["excludeCredentials"] as? [FlutterStandardTypedData] {
             excludeCredentials = rawIds.map { $0.data }
@@ -71,12 +73,19 @@ public class BreezSdkSparkPasskeyPlugin: NSObject, FlutterPlugin {
         )
         Task { @MainActor in
             do {
-                let registered = try await core.register(excludeCredentials: excludeCredentials).credential
+                let registration = try await core.register(
+                    excludeCredentials: excludeCredentials,
+                    salts: salts
+                )
+                let registered = registration.credential
                 result([
                     "credentialId": registered.credentialId.base64EncodedString(),
                     "userId": registered.userId.base64EncodedString(),
                     "aaguid": registered.aaguid?.base64EncodedString() as Any?,
                     "backupEligible": registered.backupEligible as Any?,
+                    // Null unless the authenticator evaluated PRF during the
+                    // create ceremony and returned one output per salt.
+                    "seeds": registration.seeds?.map { $0.base64EncodedString() } as Any?,
                 ])
             } catch let err as PasskeyAssertionError {
                 result(Self.flutterError(from: err))

--- a/packages/flutter/ios/Classes/BreezSdkSparkPasskeyPlugin.swift
+++ b/packages/flutter/ios/Classes/BreezSdkSparkPasskeyPlugin.swift
@@ -71,7 +71,7 @@ public class BreezSdkSparkPasskeyPlugin: NSObject, FlutterPlugin {
         )
         Task { @MainActor in
             do {
-                let registered = try await core.register(excludeCredentials: excludeCredentials)
+                let registered = try await core.register(excludeCredentials: excludeCredentials).credential
                 result([
                     "credentialId": registered.credentialId.base64EncodedString(),
                     "userId": registered.userId.base64EncodedString(),

--- a/packages/flutter/ios/Classes/PasskeyAssertionCore.swift
+++ b/packages/flutter/ios/Classes/PasskeyAssertionCore.swift
@@ -90,6 +90,20 @@ public struct IosPasskeyCredential {
     }
 }
 
+/// A created credential, plus the PRF outputs when the authenticator
+/// evaluated them during the create ceremony. `seeds` is nil when it did
+/// not, so the caller derives through `deriveSeeds` as before.
+@available(iOS 18.0, macOS 15.0, *)
+public struct IosPasskeyRegistration {
+    public let credential: IosPasskeyCredential
+    public let seeds: [Data]?
+
+    public init(credential: IosPasskeyCredential, seeds: [Data]?) {
+        self.credential = credential
+        self.seeds = seeds
+    }
+}
+
 /// Result of `deriveSeeds`: one 32-byte PRF output per salt (input
 /// order) plus the asserted credential ID. `credentialId` is `nil` when
 /// no assertion ran (empty `salts`).
@@ -551,10 +565,17 @@ public final class PasskeyAssertionCore {
     /// tracker is armed on success. `userId` is never host-supplied: the
     /// core mints a fresh random 16-byte value and returns it on
     /// `IosPasskeyCredential.userId`.
+    /// Asking the create ceremony to evaluate PRF for `salts` makes
+    /// registration a single ceremony, so no assertion follows it.
+    ///
+    /// `IosPasskeyRegistration.seeds` is nil when the authenticator
+    /// reported PRF support without evaluating, and when it returned fewer
+    /// outputs than salts. Callers derive through `deriveSeeds` in both.
     @discardableResult
     public func register(
-        excludeCredentials: [Data] = []
-    ) async throws -> IosPasskeyCredential {
+        excludeCredentials: [Data] = [],
+        salts: [String] = []
+    ) async throws -> IosPasskeyRegistration {
         let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
         let challenge = Self.randomBytes(count: 32)
         let resolvedUserId = Self.randomBytes(count: 16)
@@ -575,7 +596,13 @@ public final class PasskeyAssertionCore {
             }
         }
 
-        PasskeyPRFHelper.setRegistrationPRFOn(request)
+        // Asking the create ceremony to evaluate PRF removes the
+        // assertion that would otherwise follow it.
+        PasskeyPRFHelper.setRegistrationPRFOn(
+            request,
+            withSalt1: salts.first.map { Data($0.utf8) },
+            salt2: salts.count > 1 ? Data(salts[1].utf8) : nil
+        )
 
         let delegate = PasskeyDelegate()
         let controller = ASAuthorizationController(authorizationRequests: [request])
@@ -586,8 +613,9 @@ public final class PasskeyAssertionCore {
         // our minted handle to attach to the returned credential.
         delegate.registrationUserId = resolvedUserId
 
-        let credential: IosPasskeyCredential = try await withCheckedThrowingContinuation { continuation in
+        let registration: IosPasskeyRegistration = try await withCheckedThrowingContinuation { continuation in
             delegate.registrationContinuation = continuation
+            delegate.registrationSaltCount = salts.count
             delegate.extractPrf = false
             DispatchQueue.main.async {
                 // Capture start time inside the closure so the wait for
@@ -600,7 +628,7 @@ public final class PasskeyAssertionCore {
         // Arm the post-create grace so the immediate derive doesn't race
         // the credential's PRF-readiness window (see grace tracker).
         await graceTracker.arm(after: postCreateGraceTotal)
-        return credential
+        return registration
     }
 
     public static func randomBytes(count: Int) -> Data {
@@ -682,7 +710,10 @@ private final class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate
     /// Resolves `(first, second?, credentialId)`; `second` is nil for a
     /// single salt or a dropped `saltInput2`.
     var assertionContinuation: CheckedContinuation<(Data, Data?, Data), Error>?
-    var registrationContinuation: CheckedContinuation<IosPasskeyCredential, Error>?
+    var registrationContinuation: CheckedContinuation<IosPasskeyRegistration, Error>?
+    /// Salts requested at create, so the delegate knows how many PRF
+    /// outputs a complete result carries.
+    var registrationSaltCount: Int = 0
     /// User handle the core minted for the in-flight registration; copied
     /// into the returned `IosPasskeyCredential.userId` (the platform
     /// never echoes `user.id` back).
@@ -739,12 +770,32 @@ private final class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate
                 aaguid = meta.aaguid
                 backupEligible = meta.backupEligible
             }
+            // Only usable as a complete set: Apple Passwords is known to
+            // drop `prf.second` on assertions, and a partial derive is no
+            // derive at all, so anything short of one output per salt
+            // falls back to the assertion path.
+            var seeds: [Data]? = nil
+            if registrationSaltCount > 0 {
+                var collected: [Data] = []
+                if let first = PasskeyPRFHelper.extractPRFOutput(from: credential) {
+                    collected.append(first)
+                    if let second = PasskeyPRFHelper.extractSecondPRFOutput(from: credential) {
+                        collected.append(second)
+                    }
+                }
+                if collected.count == registrationSaltCount {
+                    seeds = collected
+                }
+            }
             registrationContinuation?.resume(
-                returning: IosPasskeyCredential(
-                    credentialId: credential.credentialID,
-                    userId: registrationUserId,
-                    aaguid: aaguid,
-                    backupEligible: backupEligible
+                returning: IosPasskeyRegistration(
+                    credential: IosPasskeyCredential(
+                        credentialId: credential.credentialID,
+                        userId: registrationUserId,
+                        aaguid: aaguid,
+                        backupEligible: backupEligible
+                    ),
+                    seeds: seeds
                 ))
         }
     }

--- a/packages/flutter/ios/Classes/PasskeyAssertionCore.swift
+++ b/packages/flutter/ios/Classes/PasskeyAssertionCore.swift
@@ -559,10 +559,11 @@ public final class PasskeyAssertionCore {
         }
     }
 
-    /// Register a new passkey with PRF support (one platform prompt, no
-    /// seed derivation). `excludeCredentials` lists already-registered IDs
-    /// the platform must refuse as duplicates. The post-create grace
-    /// tracker is armed on success. `userId` is never host-supplied: the
+    /// Register a new passkey with PRF support. `excludeCredentials` lists
+    /// already-registered IDs the platform must refuse as duplicates.
+    /// Evaluating PRF for `salts` in the same ceremony returns the seeds
+    /// inline; the post-create grace tracker is armed only when it did
+    /// not, so a following derive still has its window. `userId` is never host-supplied: the
     /// core mints a fresh random 16-byte value and returns it on
     /// `IosPasskeyCredential.userId`.
     /// Asking the create ceremony to evaluate PRF for `salts` makes
@@ -625,9 +626,13 @@ public final class PasskeyAssertionCore {
             }
         }
 
-        // Arm the post-create grace so the immediate derive doesn't race
-        // the credential's PRF-readiness window (see grace tracker).
-        await graceTracker.arm(after: postCreateGraceTotal)
+        // Arm the post-create grace only when a derive still has to run:
+        // the window exists for that assertion. Arming it on the
+        // inline-seeds path would leave it set for whatever derive came
+        // next, which is a different ceremony entirely.
+        if registration.seeds == nil {
+            await graceTracker.arm(after: postCreateGraceTotal)
+        }
         return registration
     }
 

--- a/packages/flutter/ios/Classes/PasskeyAssertionCore.swift
+++ b/packages/flutter/ios/Classes/PasskeyAssertionCore.swift
@@ -561,17 +561,15 @@ public final class PasskeyAssertionCore {
 
     /// Register a new passkey with PRF support. `excludeCredentials` lists
     /// already-registered IDs the platform must refuse as duplicates.
-    /// Evaluating PRF for `salts` in the same ceremony returns the seeds
-    /// inline; the post-create grace tracker is armed only when it did
-    /// not, so a following derive still has its window. `userId` is never host-supplied: the
-    /// core mints a fresh random 16-byte value and returns it on
-    /// `IosPasskeyCredential.userId`.
+    /// `userId` is never host-supplied: the core mints a fresh random
+    /// 16-byte value and returns it on `IosPasskeyCredential.userId`.
+    ///
     /// Asking the create ceremony to evaluate PRF for `salts` makes
     /// registration a single ceremony, so no assertion follows it.
-    ///
     /// `IosPasskeyRegistration.seeds` is nil when the authenticator
     /// reported PRF support without evaluating, and when it returned fewer
-    /// outputs than salts. Callers derive through `deriveSeeds` in both.
+    /// outputs than salts; callers derive through `deriveSeeds` in both,
+    /// and the post-create grace tracker is armed only in those cases.
     @discardableResult
     public func register(
         excludeCredentials: [Data] = [],

--- a/packages/flutter/ios/Classes/PasskeyPRFHelper.h
+++ b/packages/flutter/ios/Classes/PasskeyPRFHelper.h
@@ -20,8 +20,23 @@ API_AVAILABLE(ios(18.0), macos(15.0))
                        withSalt1:(NSData *)salt1
                            salt2:(NSData * _Nullable)salt2;
 
-/// Set PRF registration input on a registration request.
+/// Set PRF registration input on a registration request, support-only.
 + (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request;
+
+/// Set PRF registration input asking the create ceremony to evaluate up
+/// to two salts. Pass nil for `salt1` to only probe support, nil for
+/// `salt2` to evaluate one.
++ (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request
+                          withSalt1:(NSData * _Nullable)salt1
+                              salt2:(NSData * _Nullable)salt2;
+
+/// Extract the PRF output (first salt result) from a registration
+/// credential. Returns nil when the authenticator evaluated nothing at
+/// create, which is the pre-eval-at-create behavior.
++ (NSData * _Nullable)extractPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential;
+
+/// Extract the second PRF output from a registration credential.
++ (NSData * _Nullable)extractSecondPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential;
 
 /// Extract the PRF output (first salt result) from an assertion credential.
 /// Returns nil if PRF output is not available.

--- a/packages/flutter/ios/Classes/PasskeyPRFHelper.m
+++ b/packages/flutter/ios/Classes/PasskeyPRFHelper.m
@@ -19,9 +19,39 @@ API_AVAILABLE(ios(18.0), macos(15.0))
 }
 
 + (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request {
+    [self setRegistrationPRFOnRequest:request withSalt1:nil salt2:nil];
+}
+
++ (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request
+                          withSalt1:(NSData * _Nullable)salt1
+                              salt2:(NSData * _Nullable)salt2 {
+    // nil salt1 asks only whether PRF is supported. Non-nil asks the
+    // create ceremony to evaluate it too, which removes the assertion
+    // that would otherwise follow.
+    ASAuthorizationPublicKeyCredentialPRFAssertionInputValues *values = nil;
+    if (salt1 != nil) {
+        values = [[ASAuthorizationPublicKeyCredentialPRFAssertionInputValues alloc]
+                     initWithSaltInput1:salt1 saltInput2:salt2];
+    }
     ASAuthorizationPublicKeyCredentialPRFRegistrationInput *input =
-        [[ASAuthorizationPublicKeyCredentialPRFRegistrationInput alloc] initWithInputValues:nil];
+        [[ASAuthorizationPublicKeyCredentialPRFRegistrationInput alloc] initWithInputValues:values];
     request.prf = input;
+}
+
++ (NSData * _Nullable)extractPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential {
+    ASAuthorizationPublicKeyCredentialPRFRegistrationOutput *output = credential.prf;
+    if (output == nil) {
+        return nil;
+    }
+    return output.first;
+}
+
++ (NSData * _Nullable)extractSecondPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential {
+    ASAuthorizationPublicKeyCredentialPRFRegistrationOutput *output = credential.prf;
+    if (output == nil) {
+        return nil;
+    }
+    return output.second;
 }
 
 + (NSData * _Nullable)extractPRFOutputFromAssertion:(ASAuthorizationPlatformPublicKeyCredentialAssertion *)credential {

--- a/packages/flutter/lib/src/passkey_client.dart
+++ b/packages/flutter/lib/src/passkey_client.dart
@@ -51,7 +51,8 @@ class PasskeyClient {
   PasskeyClient.fromCallbacks({
     required FutureOr<DeriveSeedsOutput> Function(DeriveSeedsRequest) deriveSeeds,
     required FutureOr<bool> Function() isSupported,
-    required FutureOr<PasskeyCredential> Function(List<Uint8List>) createPasskey,
+    required FutureOr<CreatePasskeyOutput> Function(List<Uint8List>, List<String>)
+        createPasskey,
     String? breezApiKey,
     PasskeyConfig? config,
   }) : _inner = rust.PasskeyClient(

--- a/packages/flutter/lib/src/passkey_client.dart
+++ b/packages/flutter/lib/src/passkey_client.dart
@@ -5,11 +5,11 @@ import 'rust/models.dart'
     show
         ConnectWithPasskeyRequest,
         ConnectWithPasskeyResponse,
+        CreatePasskeyOutput,
         DeriveSeedsOutput,
         DeriveSeedsRequest,
         PasskeyAvailability,
         PasskeyConfig,
-        PasskeyCredential,
         PasskeyProviderOptions,
         RegisterRequest,
         RegisterResponse,

--- a/packages/flutter/lib/src/passkey_client.dart
+++ b/packages/flutter/lib/src/passkey_client.dart
@@ -51,8 +51,7 @@ class PasskeyClient {
   PasskeyClient.fromCallbacks({
     required FutureOr<DeriveSeedsOutput> Function(DeriveSeedsRequest) deriveSeeds,
     required FutureOr<bool> Function() isSupported,
-    required FutureOr<CreatePasskeyOutput> Function(List<Uint8List>, List<String>)
-        createPasskey,
+    required FutureOr<CreatePasskeyOutput> Function(List<Uint8List>, List<String>) createPasskey,
     String? breezApiKey,
     PasskeyConfig? config,
   }) : _inner = rust.PasskeyClient(

--- a/packages/flutter/lib/src/passkey_prf_provider.dart
+++ b/packages/flutter/lib/src/passkey_prf_provider.dart
@@ -3,7 +3,12 @@ import 'dart:convert';
 import 'package:flutter/services.dart';
 
 import 'rust/models.dart'
-    show DeriveSeedsOutput, DeriveSeedsRequest, PasskeyCredential, PasskeyProviderOptions;
+    show
+        CreatePasskeyOutput,
+        DeriveSeedsOutput,
+        DeriveSeedsRequest,
+        PasskeyCredential,
+        PasskeyProviderOptions;
 
 /// Result of verifying that the app is associated with its RP domain.
 /// Switch on the subtype to handle each outcome.

--- a/packages/flutter/lib/src/passkey_prf_provider.dart
+++ b/packages/flutter/lib/src/passkey_prf_provider.dart
@@ -82,16 +82,6 @@ abstract class PrfProvider {
   );
 }
 
-/// A created credential, plus the PRF outputs when the authenticator
-/// evaluated them during the create ceremony.
-class CreatePasskeyOutput {
-  const CreatePasskeyOutput({required this.credential, this.seeds});
-
-  final PasskeyCredential credential;
-
-  /// One output per salt, or null when the ceremony evaluated none.
-  final List<Uint8List>? seeds;
-}
 
 /// Built-in Flutter passkey PRF provider using platform-native APIs
 /// (iOS AuthenticationServices, Android Credential Manager). The

--- a/packages/flutter/lib/src/passkey_prf_provider.dart
+++ b/packages/flutter/lib/src/passkey_prf_provider.dart
@@ -81,12 +81,8 @@ abstract class PrfProvider {
   ///
   /// Seeds returned here must equal what [deriveSeeds] returns for the same
   /// salts, or register and sign-in land on different wallets.
-  Future<CreatePasskeyOutput> createPasskey(
-    List<Uint8List> excludeCredentials,
-    List<String> salts,
-  );
+  Future<CreatePasskeyOutput> createPasskey(List<Uint8List> excludeCredentials, List<String> salts);
 }
-
 
 /// Built-in Flutter passkey PRF provider using platform-native APIs
 /// (iOS AuthenticationServices, Android Credential Manager). The
@@ -158,10 +154,7 @@ class PasskeyProvider implements PrfProvider {
   /// is minted fresh per call (never host-supplied) and returned via
   /// [PasskeyCredential.userId]. Throws [PasskeyPrfException] on failure.
   @override
-  Future<CreatePasskeyOutput> createPasskey(
-    List<Uint8List> excludeCredentials,
-    List<String> salts,
-  ) async {
+  Future<CreatePasskeyOutput> createPasskey(List<Uint8List> excludeCredentials, List<String> salts) async {
     final args = <String, Object?>{
       'rpId': _rpId,
       'rpName': _rpName,

--- a/packages/flutter/lib/src/passkey_prf_provider.dart
+++ b/packages/flutter/lib/src/passkey_prf_provider.dart
@@ -68,7 +68,29 @@ abstract class PrfProvider {
   /// Register a new PRF-capable credential. `excludeCredentials` blocks
   /// re-registering the same device, surfaced as a
   /// `credentialAlreadyExists` failure.
-  Future<PasskeyCredential> createPasskey(List<Uint8List> excludeCredentials);
+  /// Asking the create ceremony to evaluate PRF for `salts` removes the
+  /// assertion that would otherwise follow it. Return `seeds` null when the
+  /// authenticator reported PRF support without evaluating, or returned
+  /// fewer outputs than salts: a partial derive is no derive at all, and
+  /// the caller falls back to [deriveSeeds].
+  ///
+  /// Seeds returned here must equal what [deriveSeeds] returns for the same
+  /// salts, or register and sign-in land on different wallets.
+  Future<CreatePasskeyOutput> createPasskey(
+    List<Uint8List> excludeCredentials,
+    List<String> salts,
+  );
+}
+
+/// A created credential, plus the PRF outputs when the authenticator
+/// evaluated them during the create ceremony.
+class CreatePasskeyOutput {
+  const CreatePasskeyOutput({required this.credential, this.seeds});
+
+  final PasskeyCredential credential;
+
+  /// One output per salt, or null when the ceremony evaluated none.
+  final List<Uint8List>? seeds;
 }
 
 /// Built-in Flutter passkey PRF provider using platform-native APIs
@@ -141,12 +163,16 @@ class PasskeyProvider implements PrfProvider {
   /// is minted fresh per call (never host-supplied) and returned via
   /// [PasskeyCredential.userId]. Throws [PasskeyPrfException] on failure.
   @override
-  Future<PasskeyCredential> createPasskey(List<Uint8List> excludeCredentials) async {
+  Future<CreatePasskeyOutput> createPasskey(
+    List<Uint8List> excludeCredentials,
+    List<String> salts,
+  ) async {
     final args = <String, Object?>{
       'rpId': _rpId,
       'rpName': _rpName,
       'userName': _userName,
       'userDisplayName': _userDisplayName,
+      'salts': salts,
     };
     if (excludeCredentials.isNotEmpty) {
       args['excludeCredentials'] = excludeCredentials.map(base64Encode).toList();
@@ -159,11 +185,15 @@ class PasskeyProvider implements PrfProvider {
       final aaguidB64 = map['aaguid'] as String?;
       final aaguid = aaguidB64 == null ? null : base64Decode(aaguidB64);
       final backupEligible = map['backupEligible'] as bool?;
-      return PasskeyCredential(
-        credentialId: credentialId,
-        userId: userId,
-        aaguid: aaguid,
-        backupEligible: backupEligible,
+      final seedsB64 = (map['seeds'] as List<Object?>?)?.cast<String>();
+      return CreatePasskeyOutput(
+        credential: PasskeyCredential(
+          credentialId: credentialId,
+          userId: userId,
+          aaguid: aaguid,
+          backupEligible: backupEligible,
+        ),
+        seeds: seedsB64?.map(base64Decode).toList(),
       );
     } on PlatformException catch (e) {
       throw _mapPlatformException(e);

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -1915,6 +1915,12 @@ pub struct _PasskeyCredential {
     pub backup_eligible: Option<bool>,
 }
 
+#[frb(mirror(CreatePasskeyOutput))]
+pub struct _CreatePasskeyOutput {
+    pub credential: PasskeyCredential,
+    pub seeds: Option<Vec<Vec<u8>>>,
+}
+
 #[frb(mirror(RegisterRequest))]
 pub struct _RegisterRequest {
     pub label: Option<String>,

--- a/packages/flutter/rust/src/passkey.rs
+++ b/packages/flutter/rust/src/passkey.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use breez_sdk_spark::passkey::{
     ConnectWithPasskeyRequest, ConnectWithPasskeyResponse, CreatePasskeyOutput, DeriveSeedsOutput,
     DeriveSeedsRequest,
-    PasskeyAvailability, PasskeyConfig, PasskeyCredential, PasskeyError, PrfProvider,
+    PasskeyAvailability, PasskeyConfig, PasskeyError, PrfProvider,
     PrfProviderError, RegisterRequest, RegisterResponse, SignInRequest, SignInResponse,
 };
 use flutter_rust_bridge::{DartFnFuture, frb};
@@ -216,8 +216,8 @@ mod tests {
         CallbackPrfProvider {
             derive_seeds_fn: Arc::new(derive_bulk),
             is_supported_fn: Arc::new(is_available),
-            create_passkey_fn: Arc::new(|_req| {
-                panicking::<anyhow::Result<PasskeyCredential>>("create_passkey not used")
+            create_passkey_fn: Arc::new(|_req, _salts| {
+                panicking::<anyhow::Result<CreatePasskeyOutput>>("create_passkey not used")
             }),
         }
     }

--- a/packages/flutter/rust/src/passkey.rs
+++ b/packages/flutter/rust/src/passkey.rs
@@ -2,7 +2,8 @@ use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
 use breez_sdk_spark::passkey::{
-    ConnectWithPasskeyRequest, ConnectWithPasskeyResponse, DeriveSeedsOutput, DeriveSeedsRequest,
+    ConnectWithPasskeyRequest, ConnectWithPasskeyResponse, CreatePasskeyOutput, DeriveSeedsOutput,
+    DeriveSeedsRequest,
     PasskeyAvailability, PasskeyConfig, PasskeyCredential, PasskeyError, PrfProvider,
     PrfProviderError, RegisterRequest, RegisterResponse, SignInRequest, SignInResponse,
 };
@@ -86,12 +87,20 @@ impl PrfProvider for CallbackPrfProvider {
     async fn create_passkey(
         &self,
         exclude_credentials: Vec<Vec<u8>>,
-    ) -> Result<PasskeyCredential, PrfProviderError> {
+        salts: Vec<String>,
+    ) -> Result<CreatePasskeyOutput, PrfProviderError> {
+        // The Dart callback has no eval-at-create hook, so the Dart-facing
+        // contract stays as it was and the caller derives through
+        // `derive_seeds`.
+        let _ = salts;
         let result = AssertUnwindSafe((self.create_passkey_fn)(exclude_credentials))
             .catch_unwind()
             .await
             .map_err(|e| PrfProviderError::Generic(panic_message(e)))?;
-        result.map_err(dart_error_to_prf)
+        Ok(CreatePasskeyOutput {
+            credential: result.map_err(dart_error_to_prf)?,
+            seeds: None,
+        })
     }
 }
 

--- a/packages/flutter/rust/src/passkey.rs
+++ b/packages/flutter/rust/src/passkey.rs
@@ -32,8 +32,11 @@ struct CallbackPrfProvider {
         dyn Fn(DeriveSeedsRequest) -> DartFnFuture<anyhow::Result<DeriveSeedsOutput>> + Send + Sync,
     >,
     is_supported_fn: Arc<dyn Fn() -> DartFnFuture<anyhow::Result<bool>> + Send + Sync>,
-    create_passkey_fn:
-        Arc<dyn Fn(Vec<Vec<u8>>) -> DartFnFuture<anyhow::Result<PasskeyCredential>> + Send + Sync>,
+    create_passkey_fn: Arc<
+        dyn Fn(Vec<Vec<u8>>, Vec<String>) -> DartFnFuture<anyhow::Result<CreatePasskeyOutput>>
+            + Send
+            + Sync,
+    >,
 }
 
 /// Convert a Dart-thrown error into a [`PrfProviderError`]. The Dart
@@ -89,18 +92,11 @@ impl PrfProvider for CallbackPrfProvider {
         exclude_credentials: Vec<Vec<u8>>,
         salts: Vec<String>,
     ) -> Result<CreatePasskeyOutput, PrfProviderError> {
-        // The Dart callback has no eval-at-create hook, so the Dart-facing
-        // contract stays as it was and the caller derives through
-        // `derive_seeds`.
-        let _ = salts;
-        let result = AssertUnwindSafe((self.create_passkey_fn)(exclude_credentials))
+        let result = AssertUnwindSafe((self.create_passkey_fn)(exclude_credentials, salts))
             .catch_unwind()
             .await
             .map_err(|e| PrfProviderError::Generic(panic_message(e)))?;
-        Ok(CreatePasskeyOutput {
-            credential: result.map_err(dart_error_to_prf)?,
-            seeds: None,
-        })
+        result.map_err(dart_error_to_prf)
     }
 }
 
@@ -123,7 +119,7 @@ impl PasskeyClient {
         + Sync
         + 'static,
         is_supported: impl Fn() -> DartFnFuture<anyhow::Result<bool>> + Send + Sync + 'static,
-        create_passkey: impl Fn(Vec<Vec<u8>>) -> DartFnFuture<anyhow::Result<PasskeyCredential>>
+        create_passkey: impl Fn(Vec<Vec<u8>>, Vec<String>) -> DartFnFuture<anyhow::Result<CreatePasskeyOutput>>
         + Send
         + Sync
         + 'static,

--- a/packages/react-native/android/src/main/kotlin/com/breeztech/breezsdkspark/BreezSdkSparkPasskeyModule.kt
+++ b/packages/react-native/android/src/main/kotlin/com/breeztech/breezsdkspark/BreezSdkSparkPasskeyModule.kt
@@ -233,7 +233,8 @@ class BreezSdkSparkPasskeyModule(
                 val credential = registration.credential
                 // The core's `register` arms the shared grace tracker so the
                 // next `deriveSeeds` call holds out the credential's
-                // PRF-readiness window without the wrapper having to.
+                // PRF-readiness window without the wrapper having to, and
+                // skips arming it when seeds came back inline.
                 val map = Arguments.createMap()
                 map.putString("credentialId", Base64.encodeToString(credential.credentialId, Base64.NO_WRAP))
                 map.putString("userId", Base64.encodeToString(credential.userId, Base64.NO_WRAP))

--- a/packages/react-native/android/src/main/kotlin/com/breeztech/breezsdkspark/BreezSdkSparkPasskeyModule.kt
+++ b/packages/react-native/android/src/main/kotlin/com/breeztech/breezsdkspark/BreezSdkSparkPasskeyModule.kt
@@ -223,7 +223,7 @@ class BreezSdkSparkPasskeyModule(
                     userDisplayName = userDisplayName,
                     activityProvider = { activity },
                     graceTracker = graceTracker,
-                ).register(excludeIds)
+                ).register(excludeIds).credential
                 // The core's `register` arms the shared grace tracker so the
                 // next `deriveSeeds` call holds out the credential's
                 // PRF-readiness window without the wrapper having to.

--- a/packages/react-native/android/src/main/kotlin/com/breeztech/breezsdkspark/BreezSdkSparkPasskeyModule.kt
+++ b/packages/react-native/android/src/main/kotlin/com/breeztech/breezsdkspark/BreezSdkSparkPasskeyModule.kt
@@ -200,6 +200,7 @@ class BreezSdkSparkPasskeyModule(
         userName: String,
         userDisplayName: String,
         excludeCredentialsBase64: com.facebook.react.bridge.ReadableArray,
+        registerSaltsArg: com.facebook.react.bridge.ReadableArray,
         promise: Promise,
     ) {
         val activity = currentActivity
@@ -214,16 +215,22 @@ class BreezSdkSparkPasskeyModule(
             excludeIds.add(Base64.decode(b64, Base64.NO_WRAP))
         }
 
+        val registerSalts = mutableListOf<String>()
+        for (i in 0 until registerSaltsArg.size()) {
+            registerSaltsArg.getString(i)?.let { registerSalts.add(it) }
+        }
+
         scope.launch {
             try {
-                val credential = CredentialManagerPrfCore(
+                val registration = CredentialManagerPrfCore(
                     rpId = rpId,
                     rpName = rpName,
                     userName = userName,
                     userDisplayName = userDisplayName,
                     activityProvider = { activity },
                     graceTracker = graceTracker,
-                ).register(excludeIds).credential
+                ).register(excludeIds, registerSalts)
+                val credential = registration.credential
                 // The core's `register` arms the shared grace tracker so the
                 // next `deriveSeeds` call holds out the credential's
                 // PRF-readiness window without the wrapper having to.
@@ -239,6 +246,19 @@ class BreezSdkSparkPasskeyModule(
                     map.putBoolean("backupEligible", credential.backupEligible!!)
                 } else {
                     map.putNull("backupEligible")
+                }
+                // Null unless the authenticator evaluated PRF during the
+                // create ceremony and returned one output per salt. The JS
+                // side then skips the assertion entirely.
+                val seeds = registration.seeds
+                if (seeds != null) {
+                    val seedsArr = Arguments.createArray()
+                    for (seed in seeds) {
+                        seedsArr.pushString(Base64.encodeToString(seed, Base64.NO_WRAP))
+                    }
+                    map.putArray("seeds", seedsArr)
+                } else {
+                    map.putNull("seeds")
                 }
                 promise.resolve(map)
             } catch (e: CredentialManagerPrfCoreException) {

--- a/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -475,6 +475,10 @@ public class CredentialManagerPrfCore(
             ?.optJSONObject("prf")
             ?.optJSONObject("results")
             ?: return null
+        // Never throw: the passkey exists by now, so a decode failure that
+        // escapes fails the whole registration, and the caller's natural
+        // recovery is to register again and strand this one. Null falls
+        // back to the assertion path, which derives from the same passkey.
         val first = results.optString("first").takeIf { it.isNotEmpty() } ?: return null
         val out = ArrayList<ByteArray>(2)
         out.add(decodeBase64UrlOrNull(first, "registration prf.first") ?: return null)

--- a/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -461,13 +461,29 @@ public class CredentialManagerPrfCore(
     // ------------------------------------------------------------------
 
     /**
-     * Run one assertion ceremony for [salts] (1 or 2): build the WebAuthn
-     * request (cross-device hybrid suppressed unless
-     * [preferImmediatelyAvailableCredentials] is false), evaluate PRF, and
-     * return one 32-byte output per salt the authenticator evaluated plus
-     * the asserted credential ID. A dropped `results.second` yields a
-     * single-element list.
+     * PRF outputs carried on a registration response, or null when the
+     * authenticator reported support without evaluating (`prf.enabled`
+     * with no `results`), which is the pre-eval-at-create behavior.
      */
+    private fun readRegistrationPrfResults(responseJson: JSONObject): List<ByteArray>? {
+        // Never throw: the passkey exists by now, so a decode failure that
+        // escapes fails the whole registration, and the caller's natural
+        // recovery is to register again and strand this one. Null falls
+        // back to the assertion path, which derives from the same passkey.
+        val results = responseJson
+            .optJSONObject("clientExtensionResults")
+            ?.optJSONObject("prf")
+            ?.optJSONObject("results")
+            ?: return null
+        val first = results.optString("first").takeIf { it.isNotEmpty() } ?: return null
+        val out = ArrayList<ByteArray>(2)
+        out.add(decodeBase64UrlOrNull(first, "registration prf.first") ?: return null)
+        results.optString("second").takeIf { it.isNotEmpty() }?.let {
+            out.add(decodeBase64UrlOrNull(it, "registration prf.second") ?: return null)
+        }
+        return out
+    }
+
     /**
      * [assertPrf], re-asking until [retryUntilMs] while Credential Manager
      * still reports no credential. A passkey that exists but is not yet
@@ -499,6 +515,15 @@ public class CredentialManagerPrfCore(
             }
         }
     }
+
+    /**
+     * Run one assertion ceremony for [salts] (1 or 2): build the WebAuthn
+     * request (cross-device hybrid suppressed unless
+     * [preferImmediatelyAvailableCredentials] is false), evaluate PRF, and
+     * return one 32-byte output per salt the authenticator evaluated plus
+     * the asserted credential ID. A dropped `results.second` yields a
+     * single-element list.
+     */
 
     private suspend fun assertPrf(
         salts: List<String>,
@@ -586,7 +611,8 @@ public class CredentialManagerPrfCore(
      */
     public suspend fun register(
         excludeCredentials: List<ByteArray> = emptyList(),
-    ): PasskeyCredential = withContext(Dispatchers.Main) {
+        salts: List<String> = emptyList(),
+    ): PasskeyRegistration = withContext(Dispatchers.Main) {
         val startedAtMs = System.currentTimeMillis()
         try {
             val activity = activityProvider()
@@ -629,7 +655,25 @@ public class CredentialManagerPrfCore(
                     put("userVerification", "required")
                 })
                 put("extensions", JSONObject().apply {
-                    put("prf", JSONObject())
+                    // Ask the create ceremony to evaluate PRF as well as
+                    // report support. An authenticator that answers turns
+                    // registration into a single ceremony, so no assertion
+                    // has to race the credential becoming resolvable. One
+                    // that ignores it returns `enabled` only, and the
+                    // caller falls back to `deriveSeeds`.
+                    put("prf", JSONObject().apply {
+                        if (salts.isNotEmpty()) {
+                            put("eval", JSONObject().apply {
+                                put("first", encodeBase64Url(salts[0].toByteArray(Charsets.UTF_8)))
+                                if (salts.size > 1) {
+                                    put(
+                                        "second",
+                                        encodeBase64Url(salts[1].toByteArray(Charsets.UTF_8)),
+                                    )
+                                }
+                            })
+                        }
+                    })
                 })
             }.toString()
 
@@ -659,10 +703,20 @@ public class CredentialManagerPrfCore(
                     backupEligible = meta.second
                 }
             }
-            // Arm the post-create grace so the immediate derive doesn't
-            // race the credential's PRF-readiness window (see grace tracker).
+            // Only usable as a complete set: a dropped `prf.eval.second`
+            // yields one output where the caller asked for two, and a
+            // partial derive is no derive at all.
+            val seeds = readRegistrationPrfResults(responseJson)
+                ?.takeIf { it.size == salts.size }
+            // Arm the post-create grace so a fallback derive doesn't race
+            // the credential's PRF-readiness window (see grace tracker).
+            // Unnecessary when seeds came back inline, but harmless: the
+            // window is consumed without waiting when nothing asserts.
             graceTracker.arm(postCreateGraceMs)
-            PasskeyCredential(credentialId, userIdBytes, aaguid, backupEligible)
+            PasskeyRegistration(
+                PasskeyCredential(credentialId, userIdBytes, aaguid, backupEligible),
+                seeds,
+            )
         } catch (e: CredentialManagerPrfCoreException) {
             throw e
         } catch (e: Exception) {
@@ -857,6 +911,17 @@ public class CredentialManagerPrfCore(
 public data class PrfDerivation(
     public val seeds: List<ByteArray>,
     public val credentialId: ByteArray?,
+)
+
+/**
+ * A created credential, plus the PRF outputs when the authenticator
+ * evaluated them during the create ceremony. `seeds` null means it did
+ * not (or returned fewer than asked for), so the caller derives through
+ * [CredentialManagerPrfCore.deriveSeeds].
+ */
+public data class PasskeyRegistration(
+    public val credential: PasskeyCredential,
+    public val seeds: List<ByteArray>?,
 )
 
 /**

--- a/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -611,6 +611,20 @@ public class CredentialManagerPrfCore(
      */
     public suspend fun register(
         excludeCredentials: List<ByteArray> = emptyList(),
+    ): PasskeyCredential = registerWithPrf(excludeCredentials, emptyList()).credential
+
+    /**
+     * [register] that also asks the create ceremony to evaluate PRF for
+     * [salts]. An authenticator that answers makes registration a single
+     * ceremony, so no assertion follows it into the window where the new
+     * credential is not yet resolvable.
+     *
+     * `PasskeyRegistration.seeds` is null when the authenticator reported
+     * PRF support without evaluating, and when it returned fewer outputs
+     * than salts. Callers derive through [deriveSeeds] in both cases.
+     */
+    public suspend fun registerWithPrf(
+        excludeCredentials: List<ByteArray> = emptyList(),
         salts: List<String> = emptyList(),
     ): PasskeyRegistration = withContext(Dispatchers.Main) {
         val startedAtMs = System.currentTimeMillis()

--- a/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -611,20 +611,6 @@ public class CredentialManagerPrfCore(
      */
     public suspend fun register(
         excludeCredentials: List<ByteArray> = emptyList(),
-    ): PasskeyCredential = registerWithPrf(excludeCredentials, emptyList()).credential
-
-    /**
-     * [register] that also asks the create ceremony to evaluate PRF for
-     * [salts]. An authenticator that answers makes registration a single
-     * ceremony, so no assertion follows it into the window where the new
-     * credential is not yet resolvable.
-     *
-     * `PasskeyRegistration.seeds` is null when the authenticator reported
-     * PRF support without evaluating, and when it returned fewer outputs
-     * than salts. Callers derive through [deriveSeeds] in both cases.
-     */
-    public suspend fun registerWithPrf(
-        excludeCredentials: List<ByteArray> = emptyList(),
         salts: List<String> = emptyList(),
     ): PasskeyRegistration = withContext(Dispatchers.Main) {
         val startedAtMs = System.currentTimeMillis()
@@ -722,11 +708,13 @@ public class CredentialManagerPrfCore(
             // partial derive is no derive at all.
             val seeds = readRegistrationPrfResults(responseJson)
                 ?.takeIf { it.size == salts.size }
-            // Arm the post-create grace so a fallback derive doesn't race
-            // the credential's PRF-readiness window (see grace tracker).
-            // Unnecessary when seeds came back inline, but harmless: the
-            // window is consumed without waiting when nothing asserts.
-            graceTracker.arm(postCreateGraceMs)
+            // Arm the post-create grace only when a derive still has to
+            // run: the window exists for that assertion. Arming it on the
+            // inline-seeds path would leave it set for whatever derive
+            // came next, which is a different ceremony entirely.
+            if (seeds == null) {
+                graceTracker.arm(postCreateGraceMs)
+            }
             PasskeyRegistration(
                 PasskeyCredential(credentialId, userIdBytes, aaguid, backupEligible),
                 seeds,

--- a/packages/react-native/ios/BreezSdkSparkPasskey.m
+++ b/packages/react-native/ios/BreezSdkSparkPasskey.m
@@ -18,6 +18,7 @@ RCT_EXTERN_METHOD(createPasskey:(NSString *)rpId
                   userName:(NSString *)userName
                   userDisplayName:(NSString *)userDisplayName
                   excludeCredentials:(NSArray *)excludeCredentials
+                  registerSalts:(NSArray *)registerSalts
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/packages/react-native/ios/BreezSdkSparkPasskey.swift
+++ b/packages/react-native/ios/BreezSdkSparkPasskey.swift
@@ -101,7 +101,7 @@ class BreezSdkSparkPasskey: NSObject {
         )
         Task { @MainActor in
             do {
-                let registered = try await core.register(excludeCredentials: excludeIds)
+                let registered = try await core.register(excludeCredentials: excludeIds).credential
                 resolve([
                     "credentialId": registered.credentialId.base64EncodedString(),
                     "userId": registered.userId.base64EncodedString(),

--- a/packages/react-native/ios/BreezSdkSparkPasskey.swift
+++ b/packages/react-native/ios/BreezSdkSparkPasskey.swift
@@ -90,6 +90,7 @@ class BreezSdkSparkPasskey: NSObject {
         userName: String,
         userDisplayName: String,
         excludeCredentials: [String],
+        registerSalts: [String],
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock
     ) {
@@ -101,12 +102,20 @@ class BreezSdkSparkPasskey: NSObject {
         )
         Task { @MainActor in
             do {
-                let registered = try await core.register(excludeCredentials: excludeIds).credential
+                let registration = try await core.register(
+                    excludeCredentials: excludeIds,
+                    salts: registerSalts
+                )
+                let registered = registration.credential
+                // Null unless the authenticator evaluated PRF during the
+                // create ceremony and returned one output per salt. The JS
+                // side then skips the assertion entirely.
                 resolve([
                     "credentialId": registered.credentialId.base64EncodedString(),
                     "userId": registered.userId.base64EncodedString(),
                     "aaguid": registered.aaguid?.base64EncodedString() as Any?,
                     "backupEligible": registered.backupEligible as Any?,
+                    "seeds": registration.seeds?.map { $0.base64EncodedString() } as Any?,
                 ])
             } catch let err as PasskeyAssertionError {
                 Self.reject(err, reject: reject, defaultMessage: "User cancelled registration")

--- a/packages/react-native/ios/PasskeyAssertionCore.swift
+++ b/packages/react-native/ios/PasskeyAssertionCore.swift
@@ -90,6 +90,20 @@ public struct IosPasskeyCredential {
     }
 }
 
+/// A created credential, plus the PRF outputs when the authenticator
+/// evaluated them during the create ceremony. `seeds` is nil when it did
+/// not, so the caller derives through `deriveSeeds` as before.
+@available(iOS 18.0, macOS 15.0, *)
+public struct IosPasskeyRegistration {
+    public let credential: IosPasskeyCredential
+    public let seeds: [Data]?
+
+    public init(credential: IosPasskeyCredential, seeds: [Data]?) {
+        self.credential = credential
+        self.seeds = seeds
+    }
+}
+
 /// Result of `deriveSeeds`: one 32-byte PRF output per salt (input
 /// order) plus the asserted credential ID. `credentialId` is `nil` when
 /// no assertion ran (empty `salts`).
@@ -551,10 +565,17 @@ public final class PasskeyAssertionCore {
     /// tracker is armed on success. `userId` is never host-supplied: the
     /// core mints a fresh random 16-byte value and returns it on
     /// `IosPasskeyCredential.userId`.
+    /// Asking the create ceremony to evaluate PRF for `salts` makes
+    /// registration a single ceremony, so no assertion follows it.
+    ///
+    /// `IosPasskeyRegistration.seeds` is nil when the authenticator
+    /// reported PRF support without evaluating, and when it returned fewer
+    /// outputs than salts. Callers derive through `deriveSeeds` in both.
     @discardableResult
     public func register(
-        excludeCredentials: [Data] = []
-    ) async throws -> IosPasskeyCredential {
+        excludeCredentials: [Data] = [],
+        salts: [String] = []
+    ) async throws -> IosPasskeyRegistration {
         let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
         let challenge = Self.randomBytes(count: 32)
         let resolvedUserId = Self.randomBytes(count: 16)
@@ -575,7 +596,13 @@ public final class PasskeyAssertionCore {
             }
         }
 
-        PasskeyPRFHelper.setRegistrationPRFOn(request)
+        // Asking the create ceremony to evaluate PRF removes the
+        // assertion that would otherwise follow it.
+        PasskeyPRFHelper.setRegistrationPRFOn(
+            request,
+            withSalt1: salts.first.map { Data($0.utf8) },
+            salt2: salts.count > 1 ? Data(salts[1].utf8) : nil
+        )
 
         let delegate = PasskeyDelegate()
         let controller = ASAuthorizationController(authorizationRequests: [request])
@@ -586,8 +613,9 @@ public final class PasskeyAssertionCore {
         // our minted handle to attach to the returned credential.
         delegate.registrationUserId = resolvedUserId
 
-        let credential: IosPasskeyCredential = try await withCheckedThrowingContinuation { continuation in
+        let registration: IosPasskeyRegistration = try await withCheckedThrowingContinuation { continuation in
             delegate.registrationContinuation = continuation
+            delegate.registrationSaltCount = salts.count
             delegate.extractPrf = false
             DispatchQueue.main.async {
                 // Capture start time inside the closure so the wait for
@@ -600,7 +628,7 @@ public final class PasskeyAssertionCore {
         // Arm the post-create grace so the immediate derive doesn't race
         // the credential's PRF-readiness window (see grace tracker).
         await graceTracker.arm(after: postCreateGraceTotal)
-        return credential
+        return registration
     }
 
     public static func randomBytes(count: Int) -> Data {
@@ -682,7 +710,10 @@ private final class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate
     /// Resolves `(first, second?, credentialId)`; `second` is nil for a
     /// single salt or a dropped `saltInput2`.
     var assertionContinuation: CheckedContinuation<(Data, Data?, Data), Error>?
-    var registrationContinuation: CheckedContinuation<IosPasskeyCredential, Error>?
+    var registrationContinuation: CheckedContinuation<IosPasskeyRegistration, Error>?
+    /// Salts requested at create, so the delegate knows how many PRF
+    /// outputs a complete result carries.
+    var registrationSaltCount: Int = 0
     /// User handle the core minted for the in-flight registration; copied
     /// into the returned `IosPasskeyCredential.userId` (the platform
     /// never echoes `user.id` back).
@@ -739,12 +770,32 @@ private final class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate
                 aaguid = meta.aaguid
                 backupEligible = meta.backupEligible
             }
+            // Only usable as a complete set: Apple Passwords is known to
+            // drop `prf.second` on assertions, and a partial derive is no
+            // derive at all, so anything short of one output per salt
+            // falls back to the assertion path.
+            var seeds: [Data]? = nil
+            if registrationSaltCount > 0 {
+                var collected: [Data] = []
+                if let first = PasskeyPRFHelper.extractPRFOutput(from: credential) {
+                    collected.append(first)
+                    if let second = PasskeyPRFHelper.extractSecondPRFOutput(from: credential) {
+                        collected.append(second)
+                    }
+                }
+                if collected.count == registrationSaltCount {
+                    seeds = collected
+                }
+            }
             registrationContinuation?.resume(
-                returning: IosPasskeyCredential(
-                    credentialId: credential.credentialID,
-                    userId: registrationUserId,
-                    aaguid: aaguid,
-                    backupEligible: backupEligible
+                returning: IosPasskeyRegistration(
+                    credential: IosPasskeyCredential(
+                        credentialId: credential.credentialID,
+                        userId: registrationUserId,
+                        aaguid: aaguid,
+                        backupEligible: backupEligible
+                    ),
+                    seeds: seeds
                 ))
         }
     }

--- a/packages/react-native/ios/PasskeyAssertionCore.swift
+++ b/packages/react-native/ios/PasskeyAssertionCore.swift
@@ -559,10 +559,11 @@ public final class PasskeyAssertionCore {
         }
     }
 
-    /// Register a new passkey with PRF support (one platform prompt, no
-    /// seed derivation). `excludeCredentials` lists already-registered IDs
-    /// the platform must refuse as duplicates. The post-create grace
-    /// tracker is armed on success. `userId` is never host-supplied: the
+    /// Register a new passkey with PRF support. `excludeCredentials` lists
+    /// already-registered IDs the platform must refuse as duplicates.
+    /// Evaluating PRF for `salts` in the same ceremony returns the seeds
+    /// inline; the post-create grace tracker is armed only when it did
+    /// not, so a following derive still has its window. `userId` is never host-supplied: the
     /// core mints a fresh random 16-byte value and returns it on
     /// `IosPasskeyCredential.userId`.
     /// Asking the create ceremony to evaluate PRF for `salts` makes
@@ -625,9 +626,13 @@ public final class PasskeyAssertionCore {
             }
         }
 
-        // Arm the post-create grace so the immediate derive doesn't race
-        // the credential's PRF-readiness window (see grace tracker).
-        await graceTracker.arm(after: postCreateGraceTotal)
+        // Arm the post-create grace only when a derive still has to run:
+        // the window exists for that assertion. Arming it on the
+        // inline-seeds path would leave it set for whatever derive came
+        // next, which is a different ceremony entirely.
+        if registration.seeds == nil {
+            await graceTracker.arm(after: postCreateGraceTotal)
+        }
         return registration
     }
 

--- a/packages/react-native/ios/PasskeyAssertionCore.swift
+++ b/packages/react-native/ios/PasskeyAssertionCore.swift
@@ -561,17 +561,15 @@ public final class PasskeyAssertionCore {
 
     /// Register a new passkey with PRF support. `excludeCredentials` lists
     /// already-registered IDs the platform must refuse as duplicates.
-    /// Evaluating PRF for `salts` in the same ceremony returns the seeds
-    /// inline; the post-create grace tracker is armed only when it did
-    /// not, so a following derive still has its window. `userId` is never host-supplied: the
-    /// core mints a fresh random 16-byte value and returns it on
-    /// `IosPasskeyCredential.userId`.
+    /// `userId` is never host-supplied: the core mints a fresh random
+    /// 16-byte value and returns it on `IosPasskeyCredential.userId`.
+    ///
     /// Asking the create ceremony to evaluate PRF for `salts` makes
     /// registration a single ceremony, so no assertion follows it.
-    ///
     /// `IosPasskeyRegistration.seeds` is nil when the authenticator
     /// reported PRF support without evaluating, and when it returned fewer
-    /// outputs than salts. Callers derive through `deriveSeeds` in both.
+    /// outputs than salts; callers derive through `deriveSeeds` in both,
+    /// and the post-create grace tracker is armed only in those cases.
     @discardableResult
     public func register(
         excludeCredentials: [Data] = [],

--- a/packages/react-native/ios/PasskeyPRFHelper.h
+++ b/packages/react-native/ios/PasskeyPRFHelper.h
@@ -20,8 +20,23 @@ API_AVAILABLE(ios(18.0), macos(15.0))
                        withSalt1:(NSData *)salt1
                            salt2:(NSData * _Nullable)salt2;
 
-/// Set PRF registration input on a registration request.
+/// Set PRF registration input on a registration request, support-only.
 + (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request;
+
+/// Set PRF registration input asking the create ceremony to evaluate up
+/// to two salts. Pass nil for `salt1` to only probe support, nil for
+/// `salt2` to evaluate one.
++ (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request
+                          withSalt1:(NSData * _Nullable)salt1
+                              salt2:(NSData * _Nullable)salt2;
+
+/// Extract the PRF output (first salt result) from a registration
+/// credential. Returns nil when the authenticator evaluated nothing at
+/// create, which is the pre-eval-at-create behavior.
++ (NSData * _Nullable)extractPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential;
+
+/// Extract the second PRF output from a registration credential.
++ (NSData * _Nullable)extractSecondPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential;
 
 /// Extract the PRF output (first salt result) from an assertion credential.
 /// Returns nil if PRF output is not available.

--- a/packages/react-native/ios/PasskeyPRFHelper.m
+++ b/packages/react-native/ios/PasskeyPRFHelper.m
@@ -19,9 +19,39 @@ API_AVAILABLE(ios(18.0), macos(15.0))
 }
 
 + (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request {
+    [self setRegistrationPRFOnRequest:request withSalt1:nil salt2:nil];
+}
+
++ (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request
+                          withSalt1:(NSData * _Nullable)salt1
+                              salt2:(NSData * _Nullable)salt2 {
+    // nil salt1 asks only whether PRF is supported. Non-nil asks the
+    // create ceremony to evaluate it too, which removes the assertion
+    // that would otherwise follow.
+    ASAuthorizationPublicKeyCredentialPRFAssertionInputValues *values = nil;
+    if (salt1 != nil) {
+        values = [[ASAuthorizationPublicKeyCredentialPRFAssertionInputValues alloc]
+                     initWithSaltInput1:salt1 saltInput2:salt2];
+    }
     ASAuthorizationPublicKeyCredentialPRFRegistrationInput *input =
-        [[ASAuthorizationPublicKeyCredentialPRFRegistrationInput alloc] initWithInputValues:nil];
+        [[ASAuthorizationPublicKeyCredentialPRFRegistrationInput alloc] initWithInputValues:values];
     request.prf = input;
+}
+
++ (NSData * _Nullable)extractPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential {
+    ASAuthorizationPublicKeyCredentialPRFRegistrationOutput *output = credential.prf;
+    if (output == nil) {
+        return nil;
+    }
+    return output.first;
+}
+
++ (NSData * _Nullable)extractSecondPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential {
+    ASAuthorizationPublicKeyCredentialPRFRegistrationOutput *output = credential.prf;
+    if (output == nil) {
+        return nil;
+    }
+    return output.second;
 }
 
 + (NSData * _Nullable)extractPRFOutputFromAssertion:(ASAuthorizationPlatformPublicKeyCredentialAssertion *)credential {

--- a/packages/react-native/src/passkey-prf-provider.ts
+++ b/packages/react-native/src/passkey-prf-provider.ts
@@ -60,6 +60,21 @@ export interface PasskeyCredential {
 }
 
 /**
+ * Result of {@link PasskeyProvider.createPasskey}: the new credential, plus
+ * the PRF outputs when the authenticator evaluated them during the create
+ * ceremony. `seeds` null means it did not, so the caller derives through
+ * {@link PasskeyProvider.deriveSeeds}.
+ *
+ * Seeds returned here must equal what `deriveSeeds` returns for the same
+ * salts: the wallet is derived from them either way, so a mismatch means
+ * register and sign-in land on different wallets.
+ */
+export interface CreatePasskeyOutput {
+  credential: PasskeyCredential;
+  seeds: Uint8Array[] | null;
+}
+
+/**
  * Result of {@link PasskeyProvider.checkDomainAssociation}. Switch on `kind`
  * to handle each outcome.
  */
@@ -199,13 +214,18 @@ export class PasskeyProvider {
   }
 
   /**
-   * Register a new PRF-capable passkey (one prompt, no seed derivation): use
-   * it to split credential creation from derivation in multi-step onboarding.
-   * `excludeCredentials` blocks re-registering a device that already holds a
-   * credential, surfaced as a `credentialAlreadyExists` failure. The returned
-   * user handle is minted fresh per call (never host-supplied).
+   * Register a new PRF-capable passkey. `excludeCredentials` blocks
+   * re-registering a device that already holds a credential, surfaced as a
+   * `credentialAlreadyExists` failure. The returned user handle is minted
+   * fresh per call (never host-supplied).
+   *
+   * `salts` is accepted for parity with the trait but not evaluated here, so
+   * `seeds` is always null and the caller derives through `deriveSeeds`.
    */
-  async createPasskey(excludeCredentials: Uint8Array[] = []): Promise<PasskeyCredential> {
+  async createPasskey(
+    excludeCredentials: Uint8Array[] = [],
+    salts: string[] = []
+  ): Promise<CreatePasskeyOutput> {
     if (!BreezSdkSparkPasskey) {
       throw passkeyModuleUnavailableError('createPasskey');
     }
@@ -227,10 +247,15 @@ export class PasskeyProvider {
       );
 
       return {
-        credentialId: base64ToUint8Array(result.credentialId),
-        userId: base64ToUint8Array(result.userId),
-        aaguid: result.aaguid ? base64ToUint8Array(result.aaguid) : null,
-        backupEligible: result.backupEligible,
+        credential: {
+          credentialId: base64ToUint8Array(result.credentialId),
+          userId: base64ToUint8Array(result.userId),
+          aaguid: result.aaguid ? base64ToUint8Array(result.aaguid) : null,
+          backupEligible: result.backupEligible,
+        },
+        // The native module has no eval-at-create hook yet, so the caller
+        // derives through `deriveSeeds` as before.
+        seeds: null,
       };
     } catch (err) {
       throw mapNativeError(err);

--- a/packages/react-native/src/passkey-prf-provider.ts
+++ b/packages/react-native/src/passkey-prf-provider.ts
@@ -219,8 +219,10 @@ export class PasskeyProvider {
    * `credentialAlreadyExists` failure. The returned user handle is minted
    * fresh per call (never host-supplied).
    *
-   * `salts` is accepted for parity with the trait but not evaluated here, so
-   * `seeds` is always null and the caller derives through `deriveSeeds`.
+   * Asking the create ceremony to evaluate PRF for `salts` removes the
+   * assertion that would otherwise follow it. `seeds` is null when the
+   * authenticator reported PRF support without evaluating, or returned
+   * fewer outputs than salts; the caller then derives as before.
    */
   async createPasskey(
     excludeCredentials: Uint8Array[] = [],
@@ -238,12 +240,14 @@ export class PasskeyProvider {
         userId: string;
         aaguid: string | null;
         backupEligible: boolean | null;
+        seeds: string[] | null;
       } = await BreezSdkSparkPasskey.createPasskey(
         this.rpId,
         this.rpName,
         this.userName,
         this.userDisplayName,
-        excludeBase64
+        excludeBase64,
+        salts
       );
 
       return {
@@ -253,9 +257,9 @@ export class PasskeyProvider {
           aaguid: result.aaguid ? base64ToUint8Array(result.aaguid) : null,
           backupEligible: result.backupEligible,
         },
-        // The native module has no eval-at-create hook yet, so the caller
-        // derives through `deriveSeeds` as before.
-        seeds: null,
+        // Null unless the authenticator evaluated PRF during the create
+        // ceremony and returned one output per salt.
+        seeds: result.seeds ? result.seeds.map(base64ToUint8Array) : null,
       };
     } catch (err) {
       throw mapNativeError(err);


### PR DESCRIPTION
Passkey creation now requests the PRF value in the same ceremony, instead of requiring a follow-up assertion to derive from.

This removes the timing window where a newly created passkey exists but cannot yet be found, and costs one auth prompt instead of two where the authenticator evaluates PRF at create. An authenticator that returns nothing, or fewer outputs than salts, falls back to the existing assertion flow.

Supported on Android, iOS, web, React Native and Flutter.

#### Breaking changes:
- `PrfProvider.create_passkey` now takes salts and returns the credential plus optional seeds.
  - Rust implementations get a defaulted method; custom foreign implementations must match the new signature.
- The JS provider contract and the Dart `PrfProvider.createPasskey` change the same way.
  - Hosts using a built-in provider are unaffected on every platform.

#### Verified on device:
- Android and iOS both complete registration in a single prompt.
- Creating, logging out and signing back in resolves the same recovery phrase, so the value returned at create matches what an assertion returns for the same salts. A mismatch there would leave the wallet created at registration unreachable, and nothing in the code can detect it.