### PR TITLE
feat(ios): derive wallet during passkey creation

### DIFF
--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyAssertionCore.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyAssertionCore.swift
@@ -90,6 +90,20 @@ public struct IosPasskeyCredential {
     }
 }
 
+/// A created credential, plus the PRF outputs when the authenticator
+/// evaluated them during the create ceremony. `seeds` is nil when it did
+/// not, so the caller derives through `deriveSeeds` as before.
+@available(iOS 18.0, macOS 15.0, *)
+public struct IosPasskeyRegistration {
+    public let credential: IosPasskeyCredential
+    public let seeds: [Data]?
+
+    public init(credential: IosPasskeyCredential, seeds: [Data]?) {
+        self.credential = credential
+        self.seeds = seeds
+    }
+}
+
 /// Result of `deriveSeeds`: one 32-byte PRF output per salt (input
 /// order) plus the asserted credential ID. `credentialId` is `nil` when
 /// no assertion ran (empty `salts`).
@@ -551,10 +565,17 @@ public final class PasskeyAssertionCore {
     /// tracker is armed on success. `userId` is never host-supplied: the
     /// core mints a fresh random 16-byte value and returns it on
     /// `IosPasskeyCredential.userId`.
+    /// Asking the create ceremony to evaluate PRF for `salts` makes
+    /// registration a single ceremony, so no assertion follows it.
+    ///
+    /// `IosPasskeyRegistration.seeds` is nil when the authenticator
+    /// reported PRF support without evaluating, and when it returned fewer
+    /// outputs than salts. Callers derive through `deriveSeeds` in both.
     @discardableResult
     public func register(
-        excludeCredentials: [Data] = []
-    ) async throws -> IosPasskeyCredential {
+        excludeCredentials: [Data] = [],
+        salts: [String] = []
+    ) async throws -> IosPasskeyRegistration {
         let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
         let challenge = Self.randomBytes(count: 32)
         let resolvedUserId = Self.randomBytes(count: 16)
@@ -575,7 +596,13 @@ public final class PasskeyAssertionCore {
             }
         }
 
-        PasskeyPRFHelper.setRegistrationPRFOn(request)
+        // Asking the create ceremony to evaluate PRF removes the
+        // assertion that would otherwise follow it.
+        PasskeyPRFHelper.setRegistrationPRFOn(
+            request,
+            withSalt1: salts.first.map { Data($0.utf8) },
+            salt2: salts.count > 1 ? Data(salts[1].utf8) : nil
+        )
 
         let delegate = PasskeyDelegate()
         let controller = ASAuthorizationController(authorizationRequests: [request])
@@ -586,8 +613,9 @@ public final class PasskeyAssertionCore {
         // our minted handle to attach to the returned credential.
         delegate.registrationUserId = resolvedUserId
 
-        let credential: IosPasskeyCredential = try await withCheckedThrowingContinuation { continuation in
+        let registration: IosPasskeyRegistration = try await withCheckedThrowingContinuation { continuation in
             delegate.registrationContinuation = continuation
+            delegate.registrationSaltCount = salts.count
             delegate.extractPrf = false
             DispatchQueue.main.async {
                 // Capture start time inside the closure so the wait for
@@ -600,7 +628,7 @@ public final class PasskeyAssertionCore {
         // Arm the post-create grace so the immediate derive doesn't race
         // the credential's PRF-readiness window (see grace tracker).
         await graceTracker.arm(after: postCreateGraceTotal)
-        return credential
+        return registration
     }
 
     public static func randomBytes(count: Int) -> Data {
@@ -682,7 +710,10 @@ private final class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate
     /// Resolves `(first, second?, credentialId)`; `second` is nil for a
     /// single salt or a dropped `saltInput2`.
     var assertionContinuation: CheckedContinuation<(Data, Data?, Data), Error>?
-    var registrationContinuation: CheckedContinuation<IosPasskeyCredential, Error>?
+    var registrationContinuation: CheckedContinuation<IosPasskeyRegistration, Error>?
+    /// Salts requested at create, so the delegate knows how many PRF
+    /// outputs a complete result carries.
+    var registrationSaltCount: Int = 0
     /// User handle the core minted for the in-flight registration; copied
     /// into the returned `IosPasskeyCredential.userId` (the platform
     /// never echoes `user.id` back).
@@ -739,12 +770,32 @@ private final class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate
                 aaguid = meta.aaguid
                 backupEligible = meta.backupEligible
             }
+            // Only usable as a complete set: Apple Passwords is known to
+            // drop `prf.second` on assertions, and a partial derive is no
+            // derive at all, so anything short of one output per salt
+            // falls back to the assertion path.
+            var seeds: [Data]? = nil
+            if registrationSaltCount > 0 {
+                var collected: [Data] = []
+                if let first = PasskeyPRFHelper.extractPRFOutput(from: credential) {
+                    collected.append(first)
+                    if let second = PasskeyPRFHelper.extractSecondPRFOutput(from: credential) {
+                        collected.append(second)
+                    }
+                }
+                if collected.count == registrationSaltCount {
+                    seeds = collected
+                }
+            }
             registrationContinuation?.resume(
-                returning: IosPasskeyCredential(
-                    credentialId: credential.credentialID,
-                    userId: registrationUserId,
-                    aaguid: aaguid,
-                    backupEligible: backupEligible
+                returning: IosPasskeyRegistration(
+                    credential: IosPasskeyCredential(
+                        credentialId: credential.credentialID,
+                        userId: registrationUserId,
+                        aaguid: aaguid,
+                        backupEligible: backupEligible
+                    ),
+                    seeds: seeds
                 ))
         }
     }

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyProvider.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyProvider.swift
@@ -148,25 +148,28 @@ public class PasskeyProvider: PrfProvider {
     /// already-registered IDs in `excludeCredentials` so the platform
     /// refuses a duplicate even after reinstall.
     ///
-    /// `seeds` is always nil here: evaluating PRF during the create
-    /// ceremony is not wired up on this platform yet, so the caller
-    /// derives through `deriveSeeds` as before.
+    /// `seeds` stays nil on authenticators that report PRF support without
+    /// evaluating, and on a partial result: Apple Passwords is known to
+    /// drop the second output on assertions, and a partial derive is no
+    /// derive at all. The caller then derives as it always has.
     @discardableResult
     public func createPasskey(
         excludeCredentials: [Data],
         salts: [String]
     ) async throws -> CreatePasskeyOutput {
-        let _ = salts
         do {
-            let credential = try await core.register(excludeCredentials: excludeCredentials)
+            let registration = try await core.register(
+                excludeCredentials: excludeCredentials,
+                salts: salts
+            )
             return CreatePasskeyOutput(
                 credential: PasskeyCredential(
-                    credentialId: credential.credentialId,
-                    userId: credential.userId,
-                    aaguid: credential.aaguid,
-                    backupEligible: credential.backupEligible
+                    credentialId: registration.credential.credentialId,
+                    userId: registration.credential.userId,
+                    aaguid: registration.credential.aaguid,
+                    backupEligible: registration.credential.backupEligible
                 ),
-                seeds: nil
+                seeds: registration.seeds
             )
         } catch let err as PasskeyAssertionError {
             throw Self.toPrfProviderError(err)

--- a/crates/breez-sdk/bindings/langs/swift/Sources/PasskeyPRFHelperObjC/PasskeyPRFHelper.h
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/PasskeyPRFHelperObjC/PasskeyPRFHelper.h
@@ -20,8 +20,23 @@ API_AVAILABLE(ios(18.0), macos(15.0))
                        withSalt1:(NSData *)salt1
                            salt2:(NSData * _Nullable)salt2;
 
-/// Set PRF registration input on a registration request.
+/// Set PRF registration input on a registration request, support-only.
 + (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request;
+
+/// Set PRF registration input asking the create ceremony to evaluate up
+/// to two salts. Pass nil for `salt1` to only probe support, nil for
+/// `salt2` to evaluate one.
++ (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request
+                          withSalt1:(NSData * _Nullable)salt1
+                              salt2:(NSData * _Nullable)salt2;
+
+/// Extract the PRF output (first salt result) from a registration
+/// credential. Returns nil when the authenticator evaluated nothing at
+/// create, which is the pre-eval-at-create behavior.
++ (NSData * _Nullable)extractPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential;
+
+/// Extract the second PRF output from a registration credential.
++ (NSData * _Nullable)extractSecondPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential;
 
 /// Extract the PRF output (first salt result) from an assertion credential.
 /// Returns nil if PRF output is not available.

--- a/crates/breez-sdk/bindings/langs/swift/Sources/PasskeyPRFHelperObjC/PasskeyPRFHelper.m
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/PasskeyPRFHelperObjC/PasskeyPRFHelper.m
@@ -19,9 +19,39 @@ API_AVAILABLE(ios(18.0), macos(15.0))
 }
 
 + (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request {
+    [self setRegistrationPRFOnRequest:request withSalt1:nil salt2:nil];
+}
+
++ (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request
+                          withSalt1:(NSData * _Nullable)salt1
+                              salt2:(NSData * _Nullable)salt2 {
+    // nil salt1 asks only whether PRF is supported. Non-nil asks the
+    // create ceremony to evaluate it too, which removes the assertion
+    // that would otherwise follow.
+    ASAuthorizationPublicKeyCredentialPRFAssertionInputValues *values = nil;
+    if (salt1 != nil) {
+        values = [[ASAuthorizationPublicKeyCredentialPRFAssertionInputValues alloc]
+                     initWithSaltInput1:salt1 saltInput2:salt2];
+    }
     ASAuthorizationPublicKeyCredentialPRFRegistrationInput *input =
-        [[ASAuthorizationPublicKeyCredentialPRFRegistrationInput alloc] initWithInputValues:nil];
+        [[ASAuthorizationPublicKeyCredentialPRFRegistrationInput alloc] initWithInputValues:values];
     request.prf = input;
+}
+
++ (NSData * _Nullable)extractPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential {
+    ASAuthorizationPublicKeyCredentialPRFRegistrationOutput *output = credential.prf;
+    if (output == nil) {
+        return nil;
+    }
+    return output.first;
+}
+
++ (NSData * _Nullable)extractSecondPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential {
+    ASAuthorizationPublicKeyCredentialPRFRegistrationOutput *output = credential.prf;
+    if (output == nil) {
+        return nil;
+    }
+    return output.second;
 }
 
 + (NSData * _Nullable)extractPRFOutputFromAssertion:(ASAuthorizationPlatformPublicKeyCredentialAssertion *)credential {

--- a/packages/flutter/ios/Classes/BreezSdkSparkPasskeyPlugin.swift
+++ b/packages/flutter/ios/Classes/BreezSdkSparkPasskeyPlugin.swift
@@ -71,7 +71,7 @@ public class BreezSdkSparkPasskeyPlugin: NSObject, FlutterPlugin {
         )
         Task { @MainActor in
             do {
-                let registered = try await core.register(excludeCredentials: excludeCredentials)
+                let registered = try await core.register(excludeCredentials: excludeCredentials).credential
                 result([
                     "credentialId": registered.credentialId.base64EncodedString(),
                     "userId": registered.userId.base64EncodedString(),

--- a/packages/flutter/ios/Classes/PasskeyAssertionCore.swift
+++ b/packages/flutter/ios/Classes/PasskeyAssertionCore.swift
@@ -90,6 +90,20 @@ public struct IosPasskeyCredential {
     }
 }
 
+/// A created credential, plus the PRF outputs when the authenticator
+/// evaluated them during the create ceremony. `seeds` is nil when it did
+/// not, so the caller derives through `deriveSeeds` as before.
+@available(iOS 18.0, macOS 15.0, *)
+public struct IosPasskeyRegistration {
+    public let credential: IosPasskeyCredential
+    public let seeds: [Data]?
+
+    public init(credential: IosPasskeyCredential, seeds: [Data]?) {
+        self.credential = credential
+        self.seeds = seeds
+    }
+}
+
 /// Result of `deriveSeeds`: one 32-byte PRF output per salt (input
 /// order) plus the asserted credential ID. `credentialId` is `nil` when
 /// no assertion ran (empty `salts`).
@@ -551,10 +565,17 @@ public final class PasskeyAssertionCore {
     /// tracker is armed on success. `userId` is never host-supplied: the
     /// core mints a fresh random 16-byte value and returns it on
     /// `IosPasskeyCredential.userId`.
+    /// Asking the create ceremony to evaluate PRF for `salts` makes
+    /// registration a single ceremony, so no assertion follows it.
+    ///
+    /// `IosPasskeyRegistration.seeds` is nil when the authenticator
+    /// reported PRF support without evaluating, and when it returned fewer
+    /// outputs than salts. Callers derive through `deriveSeeds` in both.
     @discardableResult
     public func register(
-        excludeCredentials: [Data] = []
-    ) async throws -> IosPasskeyCredential {
+        excludeCredentials: [Data] = [],
+        salts: [String] = []
+    ) async throws -> IosPasskeyRegistration {
         let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
         let challenge = Self.randomBytes(count: 32)
         let resolvedUserId = Self.randomBytes(count: 16)
@@ -575,7 +596,13 @@ public final class PasskeyAssertionCore {
             }
         }
 
-        PasskeyPRFHelper.setRegistrationPRFOn(request)
+        // Asking the create ceremony to evaluate PRF removes the
+        // assertion that would otherwise follow it.
+        PasskeyPRFHelper.setRegistrationPRFOn(
+            request,
+            withSalt1: salts.first.map { Data($0.utf8) },
+            salt2: salts.count > 1 ? Data(salts[1].utf8) : nil
+        )
 
         let delegate = PasskeyDelegate()
         let controller = ASAuthorizationController(authorizationRequests: [request])
@@ -586,8 +613,9 @@ public final class PasskeyAssertionCore {
         // our minted handle to attach to the returned credential.
         delegate.registrationUserId = resolvedUserId
 
-        let credential: IosPasskeyCredential = try await withCheckedThrowingContinuation { continuation in
+        let registration: IosPasskeyRegistration = try await withCheckedThrowingContinuation { continuation in
             delegate.registrationContinuation = continuation
+            delegate.registrationSaltCount = salts.count
             delegate.extractPrf = false
             DispatchQueue.main.async {
                 // Capture start time inside the closure so the wait for
@@ -600,7 +628,7 @@ public final class PasskeyAssertionCore {
         // Arm the post-create grace so the immediate derive doesn't race
         // the credential's PRF-readiness window (see grace tracker).
         await graceTracker.arm(after: postCreateGraceTotal)
-        return credential
+        return registration
     }
 
     public static func randomBytes(count: Int) -> Data {
@@ -682,7 +710,10 @@ private final class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate
     /// Resolves `(first, second?, credentialId)`; `second` is nil for a
     /// single salt or a dropped `saltInput2`.
     var assertionContinuation: CheckedContinuation<(Data, Data?, Data), Error>?
-    var registrationContinuation: CheckedContinuation<IosPasskeyCredential, Error>?
+    var registrationContinuation: CheckedContinuation<IosPasskeyRegistration, Error>?
+    /// Salts requested at create, so the delegate knows how many PRF
+    /// outputs a complete result carries.
+    var registrationSaltCount: Int = 0
     /// User handle the core minted for the in-flight registration; copied
     /// into the returned `IosPasskeyCredential.userId` (the platform
     /// never echoes `user.id` back).
@@ -739,12 +770,32 @@ private final class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate
                 aaguid = meta.aaguid
                 backupEligible = meta.backupEligible
             }
+            // Only usable as a complete set: Apple Passwords is known to
+            // drop `prf.second` on assertions, and a partial derive is no
+            // derive at all, so anything short of one output per salt
+            // falls back to the assertion path.
+            var seeds: [Data]? = nil
+            if registrationSaltCount > 0 {
+                var collected: [Data] = []
+                if let first = PasskeyPRFHelper.extractPRFOutput(from: credential) {
+                    collected.append(first)
+                    if let second = PasskeyPRFHelper.extractSecondPRFOutput(from: credential) {
+                        collected.append(second)
+                    }
+                }
+                if collected.count == registrationSaltCount {
+                    seeds = collected
+                }
+            }
             registrationContinuation?.resume(
-                returning: IosPasskeyCredential(
-                    credentialId: credential.credentialID,
-                    userId: registrationUserId,
-                    aaguid: aaguid,
-                    backupEligible: backupEligible
+                returning: IosPasskeyRegistration(
+                    credential: IosPasskeyCredential(
+                        credentialId: credential.credentialID,
+                        userId: registrationUserId,
+                        aaguid: aaguid,
+                        backupEligible: backupEligible
+                    ),
+                    seeds: seeds
                 ))
         }
     }

--- a/packages/flutter/ios/Classes/PasskeyPRFHelper.h
+++ b/packages/flutter/ios/Classes/PasskeyPRFHelper.h
@@ -20,8 +20,23 @@ API_AVAILABLE(ios(18.0), macos(15.0))
                        withSalt1:(NSData *)salt1
                            salt2:(NSData * _Nullable)salt2;
 
-/// Set PRF registration input on a registration request.
+/// Set PRF registration input on a registration request, support-only.
 + (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request;
+
+/// Set PRF registration input asking the create ceremony to evaluate up
+/// to two salts. Pass nil for `salt1` to only probe support, nil for
+/// `salt2` to evaluate one.
++ (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request
+                          withSalt1:(NSData * _Nullable)salt1
+                              salt2:(NSData * _Nullable)salt2;
+
+/// Extract the PRF output (first salt result) from a registration
+/// credential. Returns nil when the authenticator evaluated nothing at
+/// create, which is the pre-eval-at-create behavior.
++ (NSData * _Nullable)extractPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential;
+
+/// Extract the second PRF output from a registration credential.
++ (NSData * _Nullable)extractSecondPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential;
 
 /// Extract the PRF output (first salt result) from an assertion credential.
 /// Returns nil if PRF output is not available.

--- a/packages/flutter/ios/Classes/PasskeyPRFHelper.m
+++ b/packages/flutter/ios/Classes/PasskeyPRFHelper.m
@@ -19,9 +19,39 @@ API_AVAILABLE(ios(18.0), macos(15.0))
 }
 
 + (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request {
+    [self setRegistrationPRFOnRequest:request withSalt1:nil salt2:nil];
+}
+
++ (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request
+                          withSalt1:(NSData * _Nullable)salt1
+                              salt2:(NSData * _Nullable)salt2 {
+    // nil salt1 asks only whether PRF is supported. Non-nil asks the
+    // create ceremony to evaluate it too, which removes the assertion
+    // that would otherwise follow.
+    ASAuthorizationPublicKeyCredentialPRFAssertionInputValues *values = nil;
+    if (salt1 != nil) {
+        values = [[ASAuthorizationPublicKeyCredentialPRFAssertionInputValues alloc]
+                     initWithSaltInput1:salt1 saltInput2:salt2];
+    }
     ASAuthorizationPublicKeyCredentialPRFRegistrationInput *input =
-        [[ASAuthorizationPublicKeyCredentialPRFRegistrationInput alloc] initWithInputValues:nil];
+        [[ASAuthorizationPublicKeyCredentialPRFRegistrationInput alloc] initWithInputValues:values];
     request.prf = input;
+}
+
++ (NSData * _Nullable)extractPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential {
+    ASAuthorizationPublicKeyCredentialPRFRegistrationOutput *output = credential.prf;
+    if (output == nil) {
+        return nil;
+    }
+    return output.first;
+}
+
++ (NSData * _Nullable)extractSecondPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential {
+    ASAuthorizationPublicKeyCredentialPRFRegistrationOutput *output = credential.prf;
+    if (output == nil) {
+        return nil;
+    }
+    return output.second;
 }
 
 + (NSData * _Nullable)extractPRFOutputFromAssertion:(ASAuthorizationPlatformPublicKeyCredentialAssertion *)credential {

--- a/packages/react-native/ios/BreezSdkSparkPasskey.swift
+++ b/packages/react-native/ios/BreezSdkSparkPasskey.swift
@@ -101,7 +101,7 @@ class BreezSdkSparkPasskey: NSObject {
         )
         Task { @MainActor in
             do {
-                let registered = try await core.register(excludeCredentials: excludeIds)
+                let registered = try await core.register(excludeCredentials: excludeIds).credential
                 resolve([
                     "credentialId": registered.credentialId.base64EncodedString(),
                     "userId": registered.userId.base64EncodedString(),

--- a/packages/react-native/ios/PasskeyAssertionCore.swift
+++ b/packages/react-native/ios/PasskeyAssertionCore.swift
@@ -90,6 +90,20 @@ public struct IosPasskeyCredential {
     }
 }
 
+/// A created credential, plus the PRF outputs when the authenticator
+/// evaluated them during the create ceremony. `seeds` is nil when it did
+/// not, so the caller derives through `deriveSeeds` as before.
+@available(iOS 18.0, macOS 15.0, *)
+public struct IosPasskeyRegistration {
+    public let credential: IosPasskeyCredential
+    public let seeds: [Data]?
+
+    public init(credential: IosPasskeyCredential, seeds: [Data]?) {
+        self.credential = credential
+        self.seeds = seeds
+    }
+}
+
 /// Result of `deriveSeeds`: one 32-byte PRF output per salt (input
 /// order) plus the asserted credential ID. `credentialId` is `nil` when
 /// no assertion ran (empty `salts`).
@@ -551,10 +565,17 @@ public final class PasskeyAssertionCore {
     /// tracker is armed on success. `userId` is never host-supplied: the
     /// core mints a fresh random 16-byte value and returns it on
     /// `IosPasskeyCredential.userId`.
+    /// Asking the create ceremony to evaluate PRF for `salts` makes
+    /// registration a single ceremony, so no assertion follows it.
+    ///
+    /// `IosPasskeyRegistration.seeds` is nil when the authenticator
+    /// reported PRF support without evaluating, and when it returned fewer
+    /// outputs than salts. Callers derive through `deriveSeeds` in both.
     @discardableResult
     public func register(
-        excludeCredentials: [Data] = []
-    ) async throws -> IosPasskeyCredential {
+        excludeCredentials: [Data] = [],
+        salts: [String] = []
+    ) async throws -> IosPasskeyRegistration {
         let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
         let challenge = Self.randomBytes(count: 32)
         let resolvedUserId = Self.randomBytes(count: 16)
@@ -575,7 +596,13 @@ public final class PasskeyAssertionCore {
             }
         }
 
-        PasskeyPRFHelper.setRegistrationPRFOn(request)
+        // Asking the create ceremony to evaluate PRF removes the
+        // assertion that would otherwise follow it.
+        PasskeyPRFHelper.setRegistrationPRFOn(
+            request,
+            withSalt1: salts.first.map { Data($0.utf8) },
+            salt2: salts.count > 1 ? Data(salts[1].utf8) : nil
+        )
 
         let delegate = PasskeyDelegate()
         let controller = ASAuthorizationController(authorizationRequests: [request])
@@ -586,8 +613,9 @@ public final class PasskeyAssertionCore {
         // our minted handle to attach to the returned credential.
         delegate.registrationUserId = resolvedUserId
 
-        let credential: IosPasskeyCredential = try await withCheckedThrowingContinuation { continuation in
+        let registration: IosPasskeyRegistration = try await withCheckedThrowingContinuation { continuation in
             delegate.registrationContinuation = continuation
+            delegate.registrationSaltCount = salts.count
             delegate.extractPrf = false
             DispatchQueue.main.async {
                 // Capture start time inside the closure so the wait for
@@ -600,7 +628,7 @@ public final class PasskeyAssertionCore {
         // Arm the post-create grace so the immediate derive doesn't race
         // the credential's PRF-readiness window (see grace tracker).
         await graceTracker.arm(after: postCreateGraceTotal)
-        return credential
+        return registration
     }
 
     public static func randomBytes(count: Int) -> Data {
@@ -682,7 +710,10 @@ private final class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate
     /// Resolves `(first, second?, credentialId)`; `second` is nil for a
     /// single salt or a dropped `saltInput2`.
     var assertionContinuation: CheckedContinuation<(Data, Data?, Data), Error>?
-    var registrationContinuation: CheckedContinuation<IosPasskeyCredential, Error>?
+    var registrationContinuation: CheckedContinuation<IosPasskeyRegistration, Error>?
+    /// Salts requested at create, so the delegate knows how many PRF
+    /// outputs a complete result carries.
+    var registrationSaltCount: Int = 0
     /// User handle the core minted for the in-flight registration; copied
     /// into the returned `IosPasskeyCredential.userId` (the platform
     /// never echoes `user.id` back).
@@ -739,12 +770,32 @@ private final class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate
                 aaguid = meta.aaguid
                 backupEligible = meta.backupEligible
             }
+            // Only usable as a complete set: Apple Passwords is known to
+            // drop `prf.second` on assertions, and a partial derive is no
+            // derive at all, so anything short of one output per salt
+            // falls back to the assertion path.
+            var seeds: [Data]? = nil
+            if registrationSaltCount > 0 {
+                var collected: [Data] = []
+                if let first = PasskeyPRFHelper.extractPRFOutput(from: credential) {
+                    collected.append(first)
+                    if let second = PasskeyPRFHelper.extractSecondPRFOutput(from: credential) {
+                        collected.append(second)
+                    }
+                }
+                if collected.count == registrationSaltCount {
+                    seeds = collected
+                }
+            }
             registrationContinuation?.resume(
-                returning: IosPasskeyCredential(
-                    credentialId: credential.credentialID,
-                    userId: registrationUserId,
-                    aaguid: aaguid,
-                    backupEligible: backupEligible
+                returning: IosPasskeyRegistration(
+                    credential: IosPasskeyCredential(
+                        credentialId: credential.credentialID,
+                        userId: registrationUserId,
+                        aaguid: aaguid,
+                        backupEligible: backupEligible
+                    ),
+                    seeds: seeds
                 ))
         }
     }

--- a/packages/react-native/ios/PasskeyPRFHelper.h
+++ b/packages/react-native/ios/PasskeyPRFHelper.h
@@ -20,8 +20,23 @@ API_AVAILABLE(ios(18.0), macos(15.0))
                        withSalt1:(NSData *)salt1
                            salt2:(NSData * _Nullable)salt2;
 
-/// Set PRF registration input on a registration request.
+/// Set PRF registration input on a registration request, support-only.
 + (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request;
+
+/// Set PRF registration input asking the create ceremony to evaluate up
+/// to two salts. Pass nil for `salt1` to only probe support, nil for
+/// `salt2` to evaluate one.
++ (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request
+                          withSalt1:(NSData * _Nullable)salt1
+                              salt2:(NSData * _Nullable)salt2;
+
+/// Extract the PRF output (first salt result) from a registration
+/// credential. Returns nil when the authenticator evaluated nothing at
+/// create, which is the pre-eval-at-create behavior.
++ (NSData * _Nullable)extractPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential;
+
+/// Extract the second PRF output from a registration credential.
++ (NSData * _Nullable)extractSecondPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential;
 
 /// Extract the PRF output (first salt result) from an assertion credential.
 /// Returns nil if PRF output is not available.

--- a/packages/react-native/ios/PasskeyPRFHelper.m
+++ b/packages/react-native/ios/PasskeyPRFHelper.m
@@ -19,9 +19,39 @@ API_AVAILABLE(ios(18.0), macos(15.0))
 }
 
 + (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request {
+    [self setRegistrationPRFOnRequest:request withSalt1:nil salt2:nil];
+}
+
++ (void)setRegistrationPRFOnRequest:(ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *)request
+                          withSalt1:(NSData * _Nullable)salt1
+                              salt2:(NSData * _Nullable)salt2 {
+    // nil salt1 asks only whether PRF is supported. Non-nil asks the
+    // create ceremony to evaluate it too, which removes the assertion
+    // that would otherwise follow.
+    ASAuthorizationPublicKeyCredentialPRFAssertionInputValues *values = nil;
+    if (salt1 != nil) {
+        values = [[ASAuthorizationPublicKeyCredentialPRFAssertionInputValues alloc]
+                     initWithSaltInput1:salt1 saltInput2:salt2];
+    }
     ASAuthorizationPublicKeyCredentialPRFRegistrationInput *input =
-        [[ASAuthorizationPublicKeyCredentialPRFRegistrationInput alloc] initWithInputValues:nil];
+        [[ASAuthorizationPublicKeyCredentialPRFRegistrationInput alloc] initWithInputValues:values];
     request.prf = input;
+}
+
++ (NSData * _Nullable)extractPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential {
+    ASAuthorizationPublicKeyCredentialPRFRegistrationOutput *output = credential.prf;
+    if (output == nil) {
+        return nil;
+    }
+    return output.first;
+}
+
++ (NSData * _Nullable)extractSecondPRFOutputFromRegistration:(ASAuthorizationPlatformPublicKeyCredentialRegistration *)credential {
+    ASAuthorizationPublicKeyCredentialPRFRegistrationOutput *output = credential.prf;
+    if (output == nil) {
+        return nil;
+    }
+    return output.second;
 }
 
 + (NSData * _Nullable)extractPRFOutputFromAssertion:(ASAuthorizationPlatformPublicKeyCredentialAssertion *)credential {


### PR DESCRIPTION
iOS can now request the PRF value during passkey creation instead of requiring a follow-up assertion.

This reduces one auth prompt during account creation where supported. If PRF values cannot be returned during creation, the existing assertion flow remains unchanged.

#### Relationship to #1024:
This builds on the `create_passkey_with_prf` interface added in #1024. Android and iOS now use the same PRF-at-create flow.