### PR TITLE
docs: correct two passkey comments that no longer match the code

### DIFF
--- a/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/crates/breez-sdk/bindings/langs/shared/android-passkey/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -96,7 +96,8 @@ private const val CORE_TAG = "PasskeyPrfCore"
  * queryable or taxes every registration. Retrying costs nothing once the
  * credential resolves.
  *
- * Mirrors iOS `PostCreateGraceTracker`; an instance lives inside
+ * Named after iOS's `PostCreateGraceTracker`, which still waits the
+ * window out rather than re-asking; an instance lives inside
  * [CredentialManagerPrfCore] so every consumer that holds onto a single
  * core (e.g. `PasskeyProvider` for UniFFI / KMM consumers) inherits the
  * grace without per-wrapper plumbing.

--- a/crates/breez-sdk/core/src/passkey/error.rs
+++ b/crates/breez-sdk/core/src/passkey/error.rs
@@ -138,9 +138,12 @@ pub enum PasskeyError {
 }
 
 impl PasskeyError {
-    /// Coarse classification of the failure. Non-PRF variants map to
-    /// `Internal`: they stem from SDK / network state, not the
-    /// authenticator, so surface a generic "try again later".
+    /// Coarse classification of the failure. `CreatedButNotDerived`
+    /// reports the classification of the `PrfProviderError` it wraps, so
+    /// it is indistinguishable here from the same failure before the
+    /// credential existed: match the variant itself to tell them apart.
+    /// The remaining variants map to `Internal`, since they stem from SDK
+    /// or network state rather than the authenticator.
     #[must_use]
     pub fn kind(&self) -> ErrorKind {
         match self {

--- a/crates/breez-sdk/core/src/passkey/error.rs
+++ b/crates/breez-sdk/core/src/passkey/error.rs
@@ -142,8 +142,8 @@ impl PasskeyError {
     /// reports the classification of the `PrfProviderError` it wraps, so
     /// it is indistinguishable here from the same failure before the
     /// credential existed: match the variant itself to tell them apart.
-    /// The remaining variants map to `Internal`, since they stem from SDK
-    /// or network state rather than the authenticator.
+    /// The remaining non-Prf variants map to `Internal`, since they stem
+    /// from SDK or network state rather than the authenticator.
     #[must_use]
     pub fn kind(&self) -> ErrorKind {
         match self {

--- a/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/flutter/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -96,7 +96,8 @@ private const val CORE_TAG = "PasskeyPrfCore"
  * queryable or taxes every registration. Retrying costs nothing once the
  * credential resolves.
  *
- * Mirrors iOS `PostCreateGraceTracker`; an instance lives inside
+ * Named after iOS's `PostCreateGraceTracker`, which still waits the
+ * window out rather than re-asking; an instance lives inside
  * [CredentialManagerPrfCore] so every consumer that holds onto a single
  * core (e.g. `PasskeyProvider` for UniFFI / KMM consumers) inherits the
  * grace without per-wrapper plumbing.

--- a/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
+++ b/packages/react-native/android/src/main/kotlin/technology/breez/spark/passkey/core/CredentialManagerPrfCore.kt
@@ -96,7 +96,8 @@ private const val CORE_TAG = "PasskeyPrfCore"
  * queryable or taxes every registration. Retrying costs nothing once the
  * credential resolves.
  *
- * Mirrors iOS `PostCreateGraceTracker`; an instance lives inside
+ * Named after iOS's `PostCreateGraceTracker`, which still waits the
+ * window out rather than re-asking; an instance lives inside
  * [CredentialManagerPrfCore] so every consumer that holds onto a single
  * core (e.g. `PasskeyProvider` for UniFFI / KMM consumers) inherits the
  * grace without per-wrapper plumbing.


### PR DESCRIPTION
Two comments left behind by #1022. Comments only, no behaviour change.

- `PasskeyError::kind()` says non-PRF variants map to `Internal`. `CreatedButNotDerived` delegates to the `PrfProviderError` it wraps, so it does not, and a caller branching on `kind()` alone cannot tell a post-creation failure from the same failure before the credential existed. The doc now says so and points at matching the variant.
- The Kotlin grace tracker says it mirrors iOS. iOS still waits the window out rather than re-asking, which is the fixed-sleep design the same comment rejects three lines above.

Found by an audit of the passkey docs against the code. Two further findings from that audit are already fixed in #1024, which touches the same lines, so they are left out here to avoid a conflict.