### PR TITLE
Exit any leaf that is ours, in any status

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/unilateral_exit.rs
+++ b/crates/breez-sdk/breez-itest/tests/unilateral_exit.rs
@@ -784,6 +784,68 @@ async fn test_exit_leaf_received_by_transfer(#[case] backend: SignerBackend) -> 
     Ok(())
 }
 
+/// A leaf sent from elsewhere is retired here, but only on the operators' proof
+/// that it went. The side-channel wallet and the SDK share an identity and keep
+/// separate stores, so they stand in for two devices: one sends the leaf, and
+/// the other has to work out that it is gone.
+///
+/// This is the only coverage of the purge against real operators, and what it
+/// pins is that they answer for a node its owner has changed: the proof is a
+/// lookup by node id, and a wallet asking after a leaf it no longer owns is
+/// exactly the case that has to come back. If it did not, nothing would ever be
+/// provable and every sent leaf would be kept forever.
+///
+/// It is also the only test here that fails when the refresh itself is broken.
+/// Every other exit test plans from the local store and treats a refresh error
+/// as non-fatal, so all of them pass against operators the refresh cannot even
+/// query; this one needs the leaf to have gone from the store, which takes a
+/// refresh that worked.
+#[apply(each_backend)]
+#[test_log::test(tokio::test)]
+async fn test_leaf_sent_from_another_device_is_purged(
+    #[case] backend: SignerBackend,
+) -> Result<()> {
+    let (sender, receiver) = new_local_sdk_pair(backend).await?;
+    deposit_and_claim(&sender, Amount::from_sat(LEAF_SATS)).await?;
+    // Waiting on the SDK's balance is what puts the leaf in the SDK's own store,
+    // which is the store the purge later has to clear.
+    wait_for_balance(&sender.sdk, Some(LEAF_SATS), None, 60).await?;
+
+    // The other device sends it on, and the receiver's claim re-signs the refund
+    // at a lower timelock. That re-signed refund is the proof.
+    let receiver_address = receiver.spark_wallet.get_spark_address()?;
+    sender
+        .spark_wallet
+        .transfer(LEAF_SATS, &receiver_address, None)
+        .await?;
+    wait_for_balance(&receiver.sdk, Some(LEAF_SATS), None, 60).await?;
+
+    // Quoting refreshes, which finds the leaf gone from every operator and keeps
+    // it for its chain, and then purges it once they all report the replacement.
+    let quote = sender
+        .sdk
+        .prepare_unilateral_exit(PrepareUnilateralExitRequest {
+            fee_rate_sat_per_vbyte: FEE_RATE,
+            funding_kind: CpfpFundingKind::P2tr,
+            destination: fund_p2tr_utxo(&sender.fixtures.bitcoind, Amount::from_sat(CPFP_SATS))
+                .await?
+                .address
+                .to_string(),
+            selection: ExitLeafSelection::Auto,
+        })
+        .await?;
+    assert!(
+        quote.leaves.is_empty(),
+        "a leaf every operator reports as someone else's is not ours to exit, and \
+         a quote still offering it would spend fees driving a leaf that is gone"
+    );
+    assert_eq!(
+        quote.recoverable_value_sat, 0,
+        "nothing is recoverable once the leaf has been proven spent"
+    );
+    Ok(())
+}
+
 /// Re-running a completed exit re-drives nothing. `Auto` drops the exited leaf
 /// from the available set once the exit is mined, but it is still sourceable by
 /// id, so forcing it back in with `Specific` runs the build rather than the

--- a/crates/breez-sdk/breez-itest/tests/unilateral_exit.rs
+++ b/crates/breez-sdk/breez-itest/tests/unilateral_exit.rs
@@ -74,6 +74,16 @@ async fn new_local_sdk(backend: SignerBackend) -> Result<LocalSdk> {
     build_local_sdk(fixtures, backend).await
 }
 
+/// Two wallets sharing one operator pool and bitcoind, so a leaf can be sent
+/// from one to the other. Each call to `build_local_sdk` derives its own
+/// identity, which is what makes them distinct parties.
+async fn new_local_sdk_pair(backend: SignerBackend) -> Result<(LocalSdk, LocalSdk)> {
+    let fixtures = Arc::new(TestFixtures::new().await?);
+    let sender = build_local_sdk(Arc::clone(&fixtures), backend).await?;
+    let receiver = build_local_sdk(fixtures, backend).await?;
+    Ok((sender, receiver))
+}
+
 /// Claims through the side-channel `SparkWallet`: the fixture's SSP stub has no
 /// URL, so the public claim path (which fetches a fee quote) can't be used.
 async fn deposit_and_claim(sdk: &LocalSdk, amount: Amount) -> Result<()> {
@@ -665,6 +675,111 @@ async fn test_full_exit_and_sweep(#[case] backend: SignerBackend) -> Result<()> 
         "swept {swept} must equal funding ({CPFP_SATS}) + recoverable \
          ({}) - total fee ({})",
         built.recoverable_value_sat, built.total_fee_sat
+    );
+    Ok(())
+}
+
+/// A leaf received through a Spark transfer exits like any other. Every other
+/// exit here drives a leaf its own wallet deposited; a received leaf reaches the
+/// wallet by a different route, and carries a refund the claim re-signed rather
+/// than the one the deposit produced. This drives that refund on chain and
+/// spends its output, which is what shows the claim's refund is broadcastable
+/// and the exit can spend what it pays to.
+#[apply(each_backend)]
+#[test_log::test(tokio::test)]
+async fn test_exit_leaf_received_by_transfer(#[case] backend: SignerBackend) -> Result<()> {
+    let (sender, receiver) = new_local_sdk_pair(backend).await?;
+    deposit_and_claim(&sender, Amount::from_sat(LEAF_SATS)).await?;
+    wait_for_balance(&sender.sdk, Some(LEAF_SATS), None, 60).await?;
+
+    let receiver_address = receiver.spark_wallet.get_spark_address()?;
+    sender
+        .spark_wallet
+        .transfer(LEAF_SATS, &receiver_address, None)
+        .await?;
+
+    // The receiver claims in the background, and claiming is what re-signs the
+    // refund to its own leaf key. Waiting on the balance waits for that.
+    wait_for_balance(&receiver.sdk, Some(LEAF_SATS), None, 60).await?;
+
+    let cpfp = fund_p2tr_utxo(&receiver.fixtures.bitcoind, Amount::from_sat(CPFP_SATS)).await?;
+    let destination = cpfp.address.clone();
+
+    let quote = receiver
+        .sdk
+        .prepare_unilateral_exit(PrepareUnilateralExitRequest {
+            fee_rate_sat_per_vbyte: FEE_RATE,
+            funding_kind: CpfpFundingKind::P2tr,
+            destination: destination.to_string(),
+            selection: ExitLeafSelection::Auto,
+        })
+        .await?;
+    assert_quote_consistent(&quote, FEE_RATE, &destination.to_string(), p2tr_dust());
+    assert_eq!(
+        quote.leaves.len(),
+        1,
+        "the receiver holds exactly the transferred leaf"
+    );
+
+    let signer = signer_for(&cpfp.secret_key.secret_bytes())?;
+    let built = receiver
+        .sdk
+        .unilateral_exit(
+            UnilateralExitRequest {
+                prepared: quote.clone(),
+                funding_inputs: vec![cpfp_input(&cpfp)],
+            },
+            signer,
+        )
+        .await?;
+    assert_build_matches_quote(&quote, &built);
+
+    // The refund being driven is the one the claim signed, not the one the
+    // deposit produced. A deposited leaf's refund is timelocked at 2000 blocks
+    // and each transfer hands the leaf on one 100-block interval lower, so 1900
+    // is what a leaf that has moved exactly once carries. Without this the test
+    // would still pass on a leaf that never moved.
+    let refund = built
+        .transactions
+        .iter()
+        .find(|t| t.kind == UnilateralExitTxKind::Refund)
+        .expect("the exit drives the leaf's refund");
+    let refund_sequence = decode_tx(&refund.tx_hex)?.input[0]
+        .sequence
+        .to_consensus_u32()
+        & 0xFFFF;
+    assert_eq!(
+        refund_sequence, 1900,
+        "a leaf transferred once carries a refund one interval below a deposit's 2000"
+    );
+
+    assert_all_mined(&receiver, &built, &destination).await?;
+
+    let sweep_txid = built
+        .transactions
+        .iter()
+        .find(|t| t.kind == UnilateralExitTxKind::Sweep)
+        .map(|t| Txid::from_str(&t.txid))
+        .expect("the built set terminates in a sweep")?;
+    let sweep = receiver
+        .fixtures
+        .bitcoind
+        .get_transaction(&sweep_txid)
+        .await?;
+    let swept = sweep
+        .output
+        .iter()
+        .find(|o| o.script_pubkey == destination.script_pubkey())
+        .map(|o| o.value.to_sat())
+        .expect("the sweep pays the destination");
+    assert_eq!(
+        built.recoverable_value_sat, LEAF_SATS,
+        "the whole transferred leaf is what was recovered"
+    );
+    assert_eq!(
+        swept,
+        CPFP_SATS + built.recoverable_value_sat - built.total_fee_sat,
+        "the transferred value lands at the destination"
     );
     Ok(())
 }

--- a/crates/breez-sdk/breez-itest/tests/unilateral_exit.rs
+++ b/crates/breez-sdk/breez-itest/tests/unilateral_exit.rs
@@ -678,7 +678,6 @@ async fn test_full_exit_and_sweep(#[case] backend: SignerBackend) -> Result<()> 
 /// scan would re-drive the refund (with a fresh CPFP child) and rebuild the sweep.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
-#[ignore = "resume needs the leaf in local storage, but a refresh deletes it once no operator reports it Available; fix by querying the operators for more statuses, or by not deleting leaves absent from a refresh"]
 async fn test_completed_exit_rerun_redrives_nothing(#[case] backend: SignerBackend) -> Result<()> {
     let sdk = new_local_sdk(backend).await?;
     deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
@@ -759,7 +758,6 @@ async fn test_completed_exit_rerun_redrives_nothing(#[case] backend: SignerBacke
 /// with no CPFP child, while later entries stay unconfirmed with their children.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
-#[ignore = "resume needs the leaf in local storage, but a refresh deletes it once no operator reports it Available; fix by querying the operators for more statuses, or by not deleting leaves absent from a refresh"]
 async fn test_first_package_confirmed_resumes(#[case] backend: SignerBackend) -> Result<()> {
     let sdk = new_local_sdk(backend).await?;
     deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
@@ -841,7 +839,6 @@ async fn test_first_package_confirmed_resumes(#[case] backend: SignerBackend) ->
 /// this would fail if the sweep inputs fell back to the default (non-RBF) sequence.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
-#[ignore = "resume needs the leaf in local storage, but a refresh deletes it once no operator reports it Available; fix by querying the operators for more statuses, or by not deleting leaves absent from a refresh"]
 async fn test_sweep_is_rbf_replaceable(#[case] backend: SignerBackend) -> Result<()> {
     let sdk = new_local_sdk(backend).await?;
     deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
@@ -2438,7 +2435,6 @@ async fn test_custom_funding_input(#[case] backend: SignerBackend) -> Result<()>
 /// the refund's CPFP resumes off the last confirmed node's on-chain change.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
-#[ignore = "resume needs the leaf in local storage, but a refresh deletes it once no operator reports it Available; fix by querying the operators for more statuses, or by not deleting leaves absent from a refresh"]
 async fn test_all_nodes_confirmed_resumes_at_refund(#[case] backend: SignerBackend) -> Result<()> {
     let sdk = new_local_sdk(backend).await?;
     deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
@@ -2753,7 +2749,6 @@ async fn assert_resumed_all_mined(
 /// of the "not ours" path.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
-#[ignore = "resume needs the leaf in local storage, but a refresh deletes it once no operator reports it Available; fix by querying the operators for more statuses, or by not deleting leaves absent from a refresh"]
 async fn test_node_confirmed_by_foreign_cpfp_resumes(#[case] backend: SignerBackend) -> Result<()> {
     let sdk = new_local_sdk(backend).await?;
     deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
@@ -2869,7 +2864,6 @@ async fn test_node_confirmed_by_foreign_cpfp_resumes(#[case] backend: SignerBack
 /// coverage.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
-#[ignore = "resume needs the leaf in local storage, but a refresh deletes it once no operator reports it Available; fix by querying the operators for more statuses, or by not deleting leaves absent from a refresh"]
 async fn test_refund_confirmed_by_foreign_cpfp_is_adopted(
     #[case] backend: SignerBackend,
 ) -> Result<()> {

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -468,6 +468,42 @@ class MysqlTreeStore {
     }
   }
 
+  async getDeletedLeaves() {
+    try {
+      const [rows] = await this.pool.query(
+        "SELECT data FROM brz_tree_leaves WHERE user_id = ? AND is_deleted = 1",
+        [this.identity]
+      );
+      return rows.map((row) =>
+        typeof row.data === "string" ? JSON.parse(row.data) : row.data
+      );
+    } catch (error) {
+      throw new TreeStoreError(`Failed to get deleted leaves: ${error.message}`);
+    }
+  }
+
+  async removeLeaves(leafIds) {
+    try {
+      if (!leafIds || leafIds.length === 0) return;
+      await this._withWriteTransaction(async (conn) => {
+        // Each leaf owns its chain, so its ancestor rows go with it, and in
+        // that order so no ancestor row is ever left without its leaf.
+        const placeholders = leafIds.map(() => "?").join(", ");
+        await conn.query(
+          `DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id IN (${placeholders})`,
+          [this.identity, ...leafIds]
+        );
+        await conn.query(
+          `DELETE FROM brz_tree_leaves WHERE user_id = ? AND id IN (${placeholders})`,
+          [this.identity, ...leafIds]
+        );
+      });
+    } catch (error) {
+      if (error instanceof TreeStoreError) throw error;
+      throw new TreeStoreError(`Failed to remove leaves: ${error.message}`);
+    }
+  }
+
   async getLeaves() {
     try {
       const [rows] = await this.pool.query(

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -608,19 +608,23 @@ class MysqlTreeStore {
         // its ancestor rows stay with it. The upserts below clear the mark on
         // whatever came back.
         await conn.query(
-          "UPDATE brz_tree_leaves SET is_deleted = 1 WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
+          "UPDATE brz_tree_leaves SET is_deleted = 1 WHERE user_id = ? AND reservation_id IS NULL AND added_at < ? AND is_deleted = 0",
           [this.identity, refreshTimestamp]
         );
 
         // A leaf we spent ourselves is the one absence already accounted for, so
-        // it goes for good and takes its ancestor rows with it below.
-        const deletedIds = Array.from(spentIds);
-        if (deletedIds.length > 0) {
-          await conn.query(
+        // it goes for good and takes its ancestor rows with it.
+        // Per id, so the ids whose rows actually went are the ones whose chains
+        // go too: a spent leaf still held by a reservation keeps its row, and a
+        // row without its chain is the one thing this store must never produce.
+        const deletedIds = [];
+        for (const id of spentIds) {
+          const [res] = await conn.query(
             `DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id IS NULL
-               AND id IN (${buildPlaceholders(deletedIds.length)})`,
-            [this.identity, ...deletedIds]
+               AND id = ?`,
+            [this.identity, id]
           );
+          if (res.affectedRows > 0) deletedIds.push(id);
         }
 
         await this._batchUpsertLeaves(conn, leaves, false, spentIds);

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -488,15 +488,22 @@ class MysqlTreeStore {
       await this._withWriteTransaction(async (conn) => {
         // Each leaf owns its chain, so its ancestor rows go with it, and in
         // that order so no ancestor row is ever left without its leaf.
-        const placeholders = leafIds.map(() => "?").join(", ");
-        await conn.query(
-          `DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id IN (${placeholders})`,
-          [this.identity, ...leafIds]
-        );
-        await conn.query(
-          `DELETE FROM brz_tree_leaves WHERE user_id = ? AND id IN (${placeholders})`,
-          [this.identity, ...leafIds]
-        );
+        // Only a row still marked and still unreserved goes: the purge read its
+        // list, then spent seconds asking the operators, and a refresh landing in
+        // that window may have brought the leaf back or a payment reserved it.
+        for (const id of leafIds) {
+          const [res] = await conn.query(
+            `DELETE FROM brz_tree_leaves WHERE user_id = ? AND id = ?
+               AND is_deleted = 1 AND reservation_id IS NULL`,
+            [this.identity, id]
+          );
+          if (res.affectedRows > 0) {
+            await conn.query(
+              "DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id = ?",
+              [this.identity, id]
+            );
+          }
+        }
       });
     } catch (error) {
       if (error instanceof TreeStoreError) throw error;

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -657,32 +657,18 @@ class MysqlTreeStore {
         // Return leavesToKeep to the pool even when the reservation is already
         // gone (e.g. released by stale cleanup): dropping them here would lose
         // the leaves until the next refresh. The deletes no-op in that case.
-        // Only the leaves are re-inserted: a kept leaf's ancestor rows stay put
-        // (they are not touched below); a dropped leaf's are removed with it.
-        const keepIds = new Set((leavesToKeep || []).map((l) => l.id));
-        const [reservedRows] = await conn.query(
-          "SELECT id FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
-          [this.identity, id]
-        );
-        const droppedIds = reservedRows
-          .map((r) => r.id)
-          .filter((rid) => !keepIds.has(rid));
-
+        // A leaf the verification would not vouch for is marked, not dropped:
+        // one operator declining to confirm it is not proof it was spent, and
+        // its chain is the only way to exit it if it is still ours. The upsert
+        // below clears the mark on everything kept.
         await conn.query(
-          "DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
+          "UPDATE brz_tree_leaves SET reservation_id = NULL, is_deleted = 1 WHERE user_id = ? AND reservation_id = ?",
           [this.identity, id]
         );
         await conn.query(
           "DELETE FROM brz_tree_reservations WHERE user_id = ? AND id = ?",
           [this.identity, id]
         );
-        if (droppedIds.length > 0) {
-          const placeholders = buildPlaceholders(droppedIds.length);
-          await conn.query(
-            `DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id IN (${placeholders})`,
-            [this.identity, ...droppedIds]
-          );
-        }
 
         if (leavesToKeep && leavesToKeep.length > 0) {
           await this._batchUpsertLeaves(conn, leavesToKeep, false, null);

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -78,6 +78,7 @@ const SLIM_LEAF_CANDIDATES_SQL = `SELECT id, value
   WHERE user_id = ?
     AND status = 'Available'
     AND is_missing_from_operators = 0
+    AND is_deleted = 0
     AND reservation_id IS NULL
     AND (
       value <= ?
@@ -87,6 +88,7 @@ const SLIM_LEAF_CANDIDATES_SQL = `SELECT id, value
           WHERE user_id = ?
             AND status = 'Available'
             AND is_missing_from_operators = 0
+            AND is_deleted = 0
             AND reservation_id IS NULL
             AND value > ?
           ORDER BY value
@@ -423,6 +425,7 @@ class MysqlTreeStore {
          LEFT JOIN brz_tree_reservations r
            ON l.reservation_id = r.id AND l.user_id = r.user_id
          WHERE l.user_id = ?
+           AND l.is_deleted = 0
            AND (
              (l.reservation_id IS NULL AND l.status = 'Available')
              OR r.purpose = 'Swap'
@@ -452,6 +455,7 @@ class MysqlTreeStore {
          LEFT JOIN brz_tree_reservations r
            ON l.reservation_id = r.id AND l.user_id = r.user_id
          WHERE l.user_id = ?
+           AND l.is_deleted = 0
            AND (r.purpose IS NOT NULL OR l.status = 'Available')`,
         [this.identity]
       );
@@ -472,7 +476,7 @@ class MysqlTreeStore {
          FROM brz_tree_leaves l
          LEFT JOIN brz_tree_reservations r
            ON l.reservation_id = r.id AND l.user_id = r.user_id
-         WHERE l.user_id = ?`,
+         WHERE l.user_id = ? AND l.is_deleted = 0`,
         [this.identity]
       );
 
@@ -555,19 +559,26 @@ class MysqlTreeStore {
         );
         const spentIds = new Set(spentRows.map((r) => r.leaf_id));
 
-        // Includes leaves released earlier in this transaction by
-        // _cleanupStaleReservations (which now NULLs reservation_id explicitly,
-        // since the composite FK uses NO ACTION). MySQL has no DELETE ...
-        // RETURNING, so the ids are read first.
-        const [oldLeafRows] = await conn.query(
-          "SELECT id FROM brz_tree_leaves WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
-          [this.identity, refreshTimestamp]
-        );
-        const deletedIds = oldLeafRows.map((r) => r.id);
+        // Mark, rather than remove, the non-reserved leaves added before this
+        // refresh started. A leaf no operator reports may still be ours, and its
+        // stored transactions are the only way to exit it, so the row stays, and
+        // its ancestor rows stay with it. The upserts below clear the mark on
+        // whatever came back.
         await conn.query(
-          "DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
+          "UPDATE brz_tree_leaves SET is_deleted = 1 WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
           [this.identity, refreshTimestamp]
         );
+
+        // A leaf we spent ourselves is the one absence already accounted for, so
+        // it goes for good and takes its ancestor rows with it below.
+        const deletedIds = Array.from(spentIds);
+        if (deletedIds.length > 0) {
+          await conn.query(
+            `DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id IS NULL
+               AND id IN (${buildPlaceholders(deletedIds.length)})`,
+            [this.identity, ...deletedIds]
+          );
+        }
 
         await this._batchUpsertLeaves(conn, leaves, false, spentIds);
         await this._batchUpsertLeaves(conn, missingLeaves, true, spentIds);
@@ -719,6 +730,7 @@ class MysqlTreeStore {
            WHERE user_id = ?
              AND status = 'Available'
              AND is_missing_from_operators = 0
+             AND is_deleted = 0
              AND reservation_id IS NULL`,
           [this.identity]
         );
@@ -884,6 +896,7 @@ class MysqlTreeStore {
            WHERE user_id = ? AND id IN (${placeholders})
              AND status = 'Available'
              AND is_missing_from_operators = 0
+             AND is_deleted = 0
              AND reservation_id IS NULL`,
           [this.identity, ...leafIds]
         );
@@ -1186,7 +1199,7 @@ class MysqlTreeStore {
     for (let i = 0; i < leafNodes.length; i += LEAF_UPSERT_CHUNK_SIZE) {
       const chunk = leafNodes.slice(i, i + LEAF_UPSERT_CHUNK_SIZE);
       const valueClauses = new Array(chunk.length)
-        .fill("(?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))")
+        .fill("(?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6), 0)")
         .join(", ");
       const params = [];
       for (const leaf of chunk) {
@@ -1206,7 +1219,8 @@ class MysqlTreeStore {
       await conn.query(
         `INSERT INTO brz_tree_leaves
              (user_id, id, status, is_missing_from_operators, data, value,
-              parent_node_id, verifying_public_key, signing_public_key, added_at)
+              parent_node_id, verifying_public_key, signing_public_key, added_at,
+              is_deleted)
          VALUES ${valueClauses}
          ON DUPLICATE KEY UPDATE
            status = VALUES(status),
@@ -1216,7 +1230,8 @@ class MysqlTreeStore {
            parent_node_id = VALUES(parent_node_id),
            verifying_public_key = VALUES(verifying_public_key),
            signing_public_key = VALUES(signing_public_key),
-           added_at = UTC_TIMESTAMP(6)`,
+           added_at = UTC_TIMESTAMP(6),
+           is_deleted = 0`,
         params
       );
     }

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/migrations.cjs
@@ -536,6 +536,35 @@ class MysqlTreeStoreMigrationManager {
            WHERE verifying_public_key = ''`,
         ],
       },
+      {
+        // Serves the root half of leavesMissingExitChains, which otherwise
+        // seeks a leaf's ancestor rows and reads each one to find the
+        // parentless node. MySQL has no partial indexes, so `parent_node_id`
+        // sits second: it resolves IS NULL as an equality, which keeps every
+        // term of the lookup an equality. Leading with `leaf_id` would not
+        // help, since the clustered primary key already carries
+        // `parent_node_id` once seeked by leaf.
+        name: "Index the root of each leaf's chain",
+        sql: [
+          {
+            op: "createIndex",
+            table: "brz_tree_ancestors",
+            name: "brz_idx_tree_ancestors_root",
+            definition: "(user_id, parent_node_id, leaf_id)",
+          },
+        ],
+      },
+      {
+        name: "Keep a leaf no operator reports, for its exit chain",
+        sql: [
+          {
+            op: "addColumn",
+            table: "brz_tree_leaves",
+            name: "is_deleted",
+            definition: "BOOLEAN NOT NULL DEFAULT FALSE",
+          },
+        ],
+      },
     ];
   }
 }

--- a/crates/breez-sdk/wasm/js/node-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/node-tree-store/index.cjs
@@ -501,7 +501,7 @@ class NodeTreeStore {
         // whatever came back.
         this.db
           .prepare(
-            "UPDATE brz_tree_leaves SET is_deleted = 1 WHERE reservation_id IS NULL AND added_at < ?"
+            "UPDATE brz_tree_leaves SET is_deleted = 1 WHERE reservation_id IS NULL AND added_at < ? AND is_deleted = 0"
           )
           .run(refreshMs);
 

--- a/crates/breez-sdk/wasm/js/node-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/node-tree-store/index.cjs
@@ -79,6 +79,7 @@ const SLIM_LEAF_CANDIDATES_SQL = `
   SELECT id, value FROM brz_tree_leaves
   WHERE status = 'Available'
     AND is_missing_from_operators = 0
+    AND is_deleted = 0
     AND reservation_id IS NULL
     AND (
       value <= ?
@@ -86,6 +87,7 @@ const SLIM_LEAF_CANDIDATES_SQL = `
         SELECT id FROM brz_tree_leaves
         WHERE status = 'Available'
           AND is_missing_from_operators = 0
+          AND is_deleted = 0
           AND reservation_id IS NULL
           AND value > ?
         ORDER BY value
@@ -323,8 +325,9 @@ class NodeTreeStore {
           `SELECT COALESCE(SUM(l.value), 0) AS balance
            FROM brz_tree_leaves l
            LEFT JOIN brz_tree_reservations r ON l.reservation_id = r.id
-           WHERE (l.reservation_id IS NULL AND l.status = 'Available')
-              OR r.purpose = 'Swap'`
+           WHERE l.is_deleted = 0
+             AND ((l.reservation_id IS NULL AND l.status = 'Available')
+                  OR r.purpose = 'Swap')`
         )
         .get();
       return BigInt(row.balance);
@@ -351,7 +354,8 @@ class NodeTreeStore {
                   l.signing_public_key AS keyshare
            FROM brz_tree_leaves l
            LEFT JOIN brz_tree_reservations r ON l.reservation_id = r.id
-           WHERE r.purpose IS NOT NULL OR l.status = 'Available'`
+           WHERE l.is_deleted = 0
+             AND (r.purpose IS NOT NULL OR l.status = 'Available')`
         )
         .all();
       return rows.map((row) => [row.id, row.verifying, row.keyshare]);
@@ -374,7 +378,8 @@ class NodeTreeStore {
           `SELECT l.status, l.is_missing_from_operators, l.data,
                   l.reservation_id, r.purpose
            FROM brz_tree_leaves l
-           LEFT JOIN brz_tree_reservations r ON l.reservation_id = r.id`
+           LEFT JOIN brz_tree_reservations r ON l.reservation_id = r.id
+           WHERE l.is_deleted = 0`
         )
         .all();
 
@@ -452,17 +457,26 @@ class NodeTreeStore {
         this._cleanupSpentMarkers(refreshMs);
         const spentIds = this._spentIdsSince(refreshMs);
 
-        // Delete non-reserved pool leaves older than the refresh; reserved and
-        // after-refresh leaves are immune. A leaf reported again in this same
-        // refresh is re-inserted below, so its ancestor rows must survive: only
-        // ids that do NOT reappear in this refresh (truly gone, e.g. spent) get
-        // their ancestor rows dropped alongside them.
-        const deletedIds = this.db
+        // Mark, rather than remove, the non-reserved leaves older than the
+        // refresh. A leaf no operator reports may still be ours, and its stored
+        // transactions are the only way to exit it, so the row stays, and its
+        // ancestor rows stay with it. The upserts below clear the mark on
+        // whatever came back.
+        this.db
           .prepare(
-            "DELETE FROM brz_tree_leaves WHERE reservation_id IS NULL AND added_at < ? RETURNING id"
+            "UPDATE brz_tree_leaves SET is_deleted = 1 WHERE reservation_id IS NULL AND added_at < ?"
           )
-          .all(refreshMs)
-          .map((r) => r.id);
+          .run(refreshMs);
+
+        // A leaf we spent ourselves is the one absence already accounted for, so
+        // it goes for good, and its ancestor rows go with it below.
+        const deleteSpent = this.db.prepare(
+          "DELETE FROM brz_tree_leaves WHERE id = ? AND reservation_id IS NULL"
+        );
+        const deletedIds = [];
+        for (const id of spentIds) {
+          if (deleteSpent.run(id).changes > 0) deletedIds.push(id);
+        }
 
         this._upsertLeaves(leaves, false, spentIds);
         this._upsertLeaves(missingLeaves, true, spentIds);
@@ -683,7 +697,7 @@ class NodeTreeStore {
           .prepare(
             `SELECT DISTINCT id FROM brz_tree_leaves
              WHERE id IN (${placeholders}) AND status = 'Available'
-               AND is_missing_from_operators = 0 AND reservation_id IS NULL`
+               AND is_missing_from_operators = 0 AND is_deleted = 0 AND reservation_id IS NULL`
           )
           .all(...leafIds);
         if (matched.length !== leafIds.length) {
@@ -779,8 +793,9 @@ class NodeTreeStore {
     const stmt = this.db.prepare(
       `INSERT INTO brz_tree_leaves
            (id, parent_node_id, status, value, verifying_public_key,
-            signing_public_key, data, is_missing_from_operators, added_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            signing_public_key, data, is_missing_from_operators, added_at,
+            is_deleted)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
        ON CONFLICT(id) DO UPDATE SET
            parent_node_id = excluded.parent_node_id,
            status = excluded.status,
@@ -789,7 +804,8 @@ class NodeTreeStore {
            signing_public_key = excluded.signing_public_key,
            data = excluded.data,
            is_missing_from_operators = excluded.is_missing_from_operators,
-           added_at = excluded.added_at`
+           added_at = excluded.added_at,
+           is_deleted = 0`
     );
     const now = Date.now();
     for (const leaf of leaves) {
@@ -949,7 +965,7 @@ class NodeTreeStore {
       .prepare(
         `SELECT COALESCE(SUM(value), 0) AS total FROM brz_tree_leaves
          WHERE status = 'Available'
-           AND is_missing_from_operators = 0 AND reservation_id IS NULL`
+           AND is_missing_from_operators = 0 AND is_deleted = 0 AND reservation_id IS NULL`
       )
       .get().total;
   }

--- a/crates/breez-sdk/wasm/js/node-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/node-tree-store/index.cjs
@@ -532,9 +532,10 @@ class NodeTreeStore {
   }
 
   /**
-   * Cancel a reservation. Its leaves are deleted from the pool and the row is
-   * dropped. `leavesToKeep` are re-inserted into the available pool; their
-   * ancestors are already stored (they stayed while the leaves were reserved).
+   * Cancel a reservation. Its leaves are marked rather than dropped, and the row
+   * is deleted. `leavesToKeep` are re-inserted into the available pool, clearing
+   * the mark; their ancestors are already stored (they stayed while the leaves
+   * were reserved).
    * @param {string} id
    * @param {Array} leavesToKeep - TreeNode leaves to return to the available pool
    */
@@ -544,18 +545,16 @@ class NodeTreeStore {
         // Return leavesToKeep to the pool even when the reservation is already
         // gone (e.g. released by stale cleanup): dropping them here would lose
         // the leaves until the next refresh. The deletes no-op in that case.
-        // Only the leaves are re-inserted: a kept leaf's ancestor rows stay put
-        // (they are not touched below); a dropped leaf's are removed with it.
-        const keepIds = new Set((leavesToKeep || []).map((l) => l.id));
-        const droppedIds = this.db
-          .prepare("SELECT id FROM brz_tree_leaves WHERE reservation_id = ?")
-          .all(id)
-          .map((r) => r.id)
-          .filter((rid) => !keepIds.has(rid));
-
-        this.db.prepare("DELETE FROM brz_tree_leaves WHERE reservation_id = ?").run(id);
+        // A leaf the verification would not vouch for is marked, not dropped:
+        // one operator declining to confirm it is not proof it was spent, and
+        // its chain is the only way to exit it if it is still ours. The upsert
+        // below clears the mark on everything kept.
+        this.db
+          .prepare(
+            "UPDATE brz_tree_leaves SET reservation_id = NULL, is_deleted = 1 WHERE reservation_id = ?"
+          )
+          .run(id);
         this.db.prepare("DELETE FROM brz_tree_reservations WHERE id = ?").run(id);
-        this._deleteAncestorsForLeaves(droppedIds);
         this._upsertLeaves(leavesToKeep, false, null);
       })();
     } catch (error) {

--- a/crates/breez-sdk/wasm/js/node-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/node-tree-store/index.cjs
@@ -371,6 +371,36 @@ class NodeTreeStore {
    * Return all pool leaves categorized by status and reservation purpose.
    * @returns {Promise<Object>}
    */
+  async getDeletedLeaves() {
+    try {
+      const rows = this.db
+        .prepare("SELECT data FROM brz_tree_leaves WHERE is_deleted = 1")
+        .all();
+      return rows.map((row) => JSON.parse(row.data));
+    } catch (error) {
+      throw new TreeStoreError(`Failed to get deleted leaves: ${error.message}`);
+    }
+  }
+
+  async removeLeaves(leafIds) {
+    try {
+      if (!leafIds || leafIds.length === 0) return;
+      this.db.transaction(() => {
+        // Each leaf owns its chain, so its ancestor rows go with it, and in
+        // that order so no ancestor row is ever left without its leaf.
+        const placeholders = leafIds.map(() => "?").join(",");
+        this.db
+          .prepare(`DELETE FROM brz_tree_ancestors WHERE leaf_id IN (${placeholders})`)
+          .run(...leafIds);
+        this.db
+          .prepare(`DELETE FROM brz_tree_leaves WHERE id IN (${placeholders})`)
+          .run(...leafIds);
+      })();
+    } catch (error) {
+      throw new TreeStoreError(`Failed to remove leaves: ${error.message}`);
+    }
+  }
+
   async getLeaves() {
     try {
       const rows = this.db

--- a/crates/breez-sdk/wasm/js/node-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/node-tree-store/index.cjs
@@ -388,13 +388,20 @@ class NodeTreeStore {
       this.db.transaction(() => {
         // Each leaf owns its chain, so its ancestor rows go with it, and in
         // that order so no ancestor row is ever left without its leaf.
-        const placeholders = leafIds.map(() => "?").join(",");
-        this.db
-          .prepare(`DELETE FROM brz_tree_ancestors WHERE leaf_id IN (${placeholders})`)
-          .run(...leafIds);
-        this.db
-          .prepare(`DELETE FROM brz_tree_leaves WHERE id IN (${placeholders})`)
-          .run(...leafIds);
+        // Only a row still marked and still unreserved goes: the purge read its
+        // list, then spent seconds asking the operators, and a refresh landing in
+        // that window may have brought the leaf back or a payment reserved it.
+        const removed = this.db
+          .prepare(
+            `DELETE FROM brz_tree_leaves WHERE id = ? AND is_deleted = 1
+               AND reservation_id IS NULL RETURNING id`
+          );
+        const deleteAncestors = this.db.prepare(
+          "DELETE FROM brz_tree_ancestors WHERE leaf_id = ?"
+        );
+        for (const id of leafIds) {
+          if (removed.all(id).length > 0) deleteAncestors.run(id);
+        }
       })();
     } catch (error) {
       throw new TreeStoreError(`Failed to remove leaves: ${error.message}`);

--- a/crates/breez-sdk/wasm/js/node-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/node-tree-store/migrations.cjs
@@ -178,6 +178,23 @@ class TreeStoreMigrationManager {
                         WHERE reservation_id IS NULL`,
         ],
       },
+      {
+        // Serves the root half of leavesMissingExitChains, which otherwise
+        // seeks a leaf's ancestor rows and reads each one to find the
+        // parentless node. SQLite indexes IS NULL as an equality, so both
+        // terms bind and the answer comes from the index.
+        name: "Index the root of each leaf's chain",
+        sql: [
+          `CREATE INDEX IF NOT EXISTS brz_idx_tree_ancestors_root
+                        ON brz_tree_ancestors (leaf_id, parent_node_id)`,
+        ],
+      },
+      {
+        name: "Keep a leaf no operator reports, for its exit chain",
+        sql: [
+          `ALTER TABLE brz_tree_leaves ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0`,
+        ],
+      },
     ];
   }
 }

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -635,19 +635,12 @@ class PostgresTreeStore {
         // Return leavesToKeep to the pool even when the reservation is already
         // gone (e.g. released by stale cleanup): dropping them here would lose
         // the leaves until the next refresh. The deletes no-op in that case.
-        // Only the leaves are re-inserted: a kept leaf's ancestor rows stay put
-        // (they are not touched below); a dropped leaf's are removed with it.
-        const keepIds = new Set((leavesToKeep || []).map((l) => l.id));
-        const reservedResult = await client.query(
-          "SELECT id FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
-          [this.identity, id]
-        );
-        const droppedIds = reservedResult.rows
-          .map((r) => r.id)
-          .filter((rid) => !keepIds.has(rid));
-
+        // A leaf the verification would not vouch for is marked, not dropped:
+        // one operator declining to confirm it is not proof it was spent, and
+        // its chain is the only way to exit it if it is still ours. The upsert
+        // below clears the mark on everything kept.
         await client.query(
-          "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+          "UPDATE brz_tree_leaves SET reservation_id = NULL, is_deleted = TRUE WHERE user_id = $1 AND reservation_id = $2",
           [this.identity, id]
         );
 
@@ -655,13 +648,6 @@ class PostgresTreeStore {
           "DELETE FROM brz_tree_reservations WHERE user_id = $1 AND id = $2",
           [this.identity, id]
         );
-
-        if (droppedIds.length > 0) {
-          await client.query(
-            "DELETE FROM brz_tree_ancestors WHERE user_id = $1 AND leaf_id = ANY($2)",
-            [this.identity, droppedIds]
-          );
-        }
 
         if (leavesToKeep && leavesToKeep.length > 0) {
           await this._batchUpsertLeaves(client, leavesToKeep, false, null);

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -63,6 +63,7 @@ const SLIM_LEAF_CANDIDATES_SQL = `
   WHERE user_id = $1
     AND status = 'Available'
     AND is_missing_from_operators = FALSE
+    AND is_deleted = FALSE
     AND reservation_id IS NULL
     AND (
       value <= $2
@@ -71,6 +72,7 @@ const SLIM_LEAF_CANDIDATES_SQL = `
         WHERE user_id = $1
           AND status = 'Available'
           AND is_missing_from_operators = FALSE
+          AND is_deleted = FALSE
           AND reservation_id IS NULL
           AND value > $2
         ORDER BY value
@@ -377,6 +379,7 @@ class PostgresTreeStore {
         LEFT JOIN brz_tree_reservations r
           ON l.reservation_id = r.id AND l.user_id = r.user_id
         WHERE l.user_id = $1
+          AND l.is_deleted = FALSE
           AND (
             (l.reservation_id IS NULL AND l.status = 'Available')
             OR r.purpose = 'Swap'
@@ -408,6 +411,7 @@ class PostgresTreeStore {
         LEFT JOIN brz_tree_reservations r
           ON l.reservation_id = r.id AND l.user_id = r.user_id
         WHERE l.user_id = $1
+          AND l.is_deleted = FALSE
           AND (r.purpose IS NOT NULL OR l.status = 'Available')
       `,
         [this.identity]
@@ -431,6 +435,7 @@ class PostgresTreeStore {
         LEFT JOIN brz_tree_reservations r
           ON l.reservation_id = r.id AND l.user_id = r.user_id
         WHERE l.user_id = $1
+          AND l.is_deleted = FALSE
       `,
         [this.identity]
       );
@@ -525,14 +530,23 @@ class PostgresTreeStore {
         );
         const spentIds = new Set(spentResult.rows.map((r) => r.leaf_id));
 
-        // Delete non-reserved leaves added before refresh started.
-        // Includes leaves released earlier in this transaction by
-        // _cleanupStaleReservations (which now NULLs reservation_id explicitly,
-        // since the composite FK uses NO ACTION).
-        const deleted = await client.query(
-          "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2 RETURNING id",
+        // Mark, rather than remove, the non-reserved leaves added before this
+        // refresh started. A leaf no operator reports may still be ours, and its
+        // stored transactions are the only way to exit it, so the row stays, and
+        // its ancestor rows stay with it. The upserts below clear the mark on
+        // whatever came back.
+        await client.query(
+          "UPDATE brz_tree_leaves SET is_deleted = TRUE WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
           [this.identity, refreshTimestamp]
         );
+
+        // A leaf we spent ourselves is the one absence already accounted for, so
+        // it goes for good and takes its ancestor rows with it below.
+        const deleted = await client.query(
+          "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id IS NULL AND id = ANY($2) RETURNING id",
+          [this.identity, Array.from(spentIds)]
+        );
+
 
         // Upsert all leaves (filtering spent)
         await this._batchUpsertLeaves(client, leaves, false, spentIds);
@@ -717,6 +731,7 @@ class PostgresTreeStore {
           WHERE user_id = $1
             AND status = 'Available'
             AND is_missing_from_operators = FALSE
+            AND is_deleted = FALSE
             AND reservation_id IS NULL
         `,
           [this.identity]
@@ -867,6 +882,7 @@ class PostgresTreeStore {
             AND id = ANY($2)
             AND status = 'Available'
             AND is_missing_from_operators = FALSE
+            AND is_deleted = FALSE
             AND reservation_id IS NULL
         `,
           [this.identity, leafIds]
@@ -1228,9 +1244,10 @@ class PostgresTreeStore {
       await client.query(
         `INSERT INTO brz_tree_leaves
              (user_id, id, status, is_missing_from_operators, data, added_at,
-              value, parent_node_id, verifying_public_key, signing_public_key)
+              value, parent_node_id, verifying_public_key, signing_public_key,
+              is_deleted)
          SELECT $5, id, status, missing, data::jsonb, NOW(),
-                value, parent_node_id, verifying, signing
+                value, parent_node_id, verifying, signing, FALSE
          FROM UNNEST($1::text[], $2::text[], $3::bool[], $4::text[],
                      $6::bigint[], $7::text[], $8::text[], $9::text[])
              AS t(id, status, missing, data, value, parent_node_id, verifying, signing)
@@ -1242,7 +1259,8 @@ class PostgresTreeStore {
            value = EXCLUDED.value,
            parent_node_id = EXCLUDED.parent_node_id,
            verifying_public_key = EXCLUDED.verifying_public_key,
-           signing_public_key = EXCLUDED.signing_public_key`,
+           signing_public_key = EXCLUDED.signing_public_key,
+           is_deleted = FALSE`,
         [
           ids,
           statuses,

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -576,7 +576,7 @@ class PostgresTreeStore {
         // its ancestor rows stay with it. The upserts below clear the mark on
         // whatever came back.
         await client.query(
-          "UPDATE brz_tree_leaves SET is_deleted = TRUE WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
+          "UPDATE brz_tree_leaves SET is_deleted = TRUE WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2 AND is_deleted = FALSE",
           [this.identity, refreshTimestamp]
         );
 

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -425,6 +425,39 @@ class PostgresTreeStore {
     }
   }
 
+  async getDeletedLeaves() {
+    try {
+      const result = await this.pool.query(
+        "SELECT data FROM brz_tree_leaves WHERE user_id = $1 AND is_deleted = TRUE",
+        [this.identity]
+      );
+      return result.rows.map((row) => row.data);
+    } catch (error) {
+      throw new TreeStoreError(`Failed to get deleted leaves: ${error.message}`);
+    }
+  }
+
+  async removeLeaves(leafIds) {
+    try {
+      if (!leafIds || leafIds.length === 0) return;
+      await this._withWriteTransaction(async (client) => {
+        // Each leaf owns its chain, so its ancestor rows go with it, and in
+        // that order so no ancestor row is ever left without its leaf.
+        await client.query(
+          "DELETE FROM brz_tree_ancestors WHERE user_id = $1 AND leaf_id = ANY($2)",
+          [this.identity, leafIds]
+        );
+        await client.query(
+          "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND id = ANY($2)",
+          [this.identity, leafIds]
+        );
+      });
+    } catch (error) {
+      if (error instanceof TreeStoreError) throw error;
+      throw new TreeStoreError(`Failed to remove leaves: ${error.message}`);
+    }
+  }
+
   async getLeaves() {
     try {
       const result = await this.pool.query(

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -443,14 +443,21 @@ class PostgresTreeStore {
       await this._withWriteTransaction(async (client) => {
         // Each leaf owns its chain, so its ancestor rows go with it, and in
         // that order so no ancestor row is ever left without its leaf.
-        await client.query(
-          "DELETE FROM brz_tree_ancestors WHERE user_id = $1 AND leaf_id = ANY($2)",
+        // Only a row still marked and still unreserved goes: the purge read its
+        // list, then spent seconds asking the operators, and a refresh landing in
+        // that window may have brought the leaf back or a payment reserved it.
+        const removed = await client.query(
+          `DELETE FROM brz_tree_leaves WHERE user_id = $1 AND id = ANY($2)
+             AND is_deleted = TRUE AND reservation_id IS NULL RETURNING id`,
           [this.identity, leafIds]
         );
-        await client.query(
-          "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND id = ANY($2)",
-          [this.identity, leafIds]
-        );
+        const removedIds = removed.rows.map((r) => r.id);
+        if (removedIds.length > 0) {
+          await client.query(
+            "DELETE FROM brz_tree_ancestors WHERE user_id = $1 AND leaf_id = ANY($2)",
+            [this.identity, removedIds]
+          );
+        }
       });
     } catch (error) {
       if (error instanceof TreeStoreError) throw error;

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/migrations.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/migrations.cjs
@@ -346,6 +346,24 @@ class TreeStoreMigrationManager {
              signing_public_key = data->'signing_keyshare'->>'public_key'`,
         ],
       },
+      {
+        // Serves the root half of leavesMissingExitChains, which otherwise
+        // seeks a leaf's ancestor rows and reads each one to find the
+        // parentless node. Partial, so it holds one entry per leaf whose chain
+        // reaches a root and can answer index-only.
+        name: "Index the root of each leaf's chain",
+        sql: [
+          `CREATE INDEX IF NOT EXISTS brz_idx_tree_ancestors_root
+             ON brz_tree_ancestors (user_id, leaf_id)
+             WHERE parent_node_id IS NULL`,
+        ],
+      },
+      {
+        name: "Keep a leaf no operator reports, for its exit chain",
+        sql: [
+          `ALTER TABLE brz_tree_leaves ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN NOT NULL DEFAULT FALSE`,
+        ],
+      },
     ];
   }
 }

--- a/crates/breez-sdk/wasm/js/web-tree-store/index.js
+++ b/crates/breez-sdk/wasm/js/web-tree-store/index.js
@@ -870,26 +870,27 @@ class WebTreeStore {
           // gone (e.g. released by stale cleanup): dropping them here would lose
           // the leaves until the next refresh. The deletes below no-op in that case.
           const leavesStore = tx.objectStore(STORE_LEAVES);
-          const ancestorsStore = tx.objectStore(STORE_ANCESTORS);
           const reservationsStore = tx.objectStore(STORE_RESERVATIONS);
 
           const keepIds = new Set(keep.map((l) => l.id));
-          const ancestorRowsByLeaf = this._ancestorRowsByLeaf(res.ancestors);
           const leafMap = new Map(res.leaves.map((r) => [r.id, r]));
           // A kept leaf keeps its ancestor rows, so the row rebuilt below has to
           // keep the flag that describes them.
           const priorRows = new Map(leafMap);
+          // A leaf the verification would not vouch for is marked, not dropped:
+          // one operator declining to confirm it is not proof it was spent, and
+          // its chain is the only way to exit it if it is still ours. The
+          // re-insert below clears the mark on everything kept.
           for (const l of res.leaves) {
             if (l.reservation_id !== id) continue;
-            leavesStore.delete(l.id);
-            leafMap.delete(l.id);
-            // A kept leaf's ancestor rows stay put; a dropped leaf's are
-            // removed with it.
-            if (!keepIds.has(l.id)) {
-              for (const existingId of (ancestorRowsByLeaf.get(l.id) || new Map()).keys()) {
-                ancestorsStore.delete([l.id, existingId]);
-              }
+            if (keepIds.has(l.id)) {
+              leavesStore.delete(l.id);
+              leafMap.delete(l.id);
+              continue;
             }
+            const marked = { ...l, reservation_id: null, is_deleted: true };
+            leavesStore.put(marked);
+            leafMap.set(marked.id, marked);
           }
           reservationsStore.delete(id);
 

--- a/crates/breez-sdk/wasm/js/web-tree-store/index.js
+++ b/crates/breez-sdk/wasm/js/web-tree-store/index.js
@@ -804,13 +804,17 @@ class WebTreeStore {
           // rows are dropped alongside it.
           const deletedIds = [];
           for (const row of Array.from(leafMap.values())) {
-            if (row.reservation_id != null || row.added_at >= refreshMs) continue;
+            if (row.reservation_id != null) continue;
+            // A leaf we spent goes whenever its marker is live, as on every
+            // other backend: the row being newer than this refresh does not
+            // make the spend any less ours.
             if (spentIds.has(row.id)) {
               leavesStore.delete(row.id);
               leafMap.delete(row.id);
               deletedIds.push(row.id);
               continue;
             }
+            if (row.added_at >= refreshMs) continue;
             if (!row.is_deleted) {
               const marked = { ...row, is_deleted: true };
               leavesStore.put(marked);

--- a/crates/breez-sdk/wasm/js/web-tree-store/index.js
+++ b/crates/breez-sdk/wasm/js/web-tree-store/index.js
@@ -455,6 +455,7 @@ class WebTreeStore {
                 ? resMap.get(row.reservation_id)?.purpose
                 : undefined;
 
+            if (row.is_deleted) continue;
             const spendable = node.status === "Available";
             if (purpose) {
               if (purpose === "Payment") reservedForPayment.push(node);
@@ -504,8 +505,9 @@ class WebTreeStore {
                 ? resMap.get(row.reservation_id)?.purpose
                 : undefined;
             const included =
-              (row.reservation_id == null && row.status === "Available") ||
-              purpose === "Swap";
+              !row.is_deleted &&
+              ((row.reservation_id == null && row.status === "Available") ||
+                purpose === "Swap");
             if (included) balance += BigInt(row.value);
           }
           return balance;
@@ -537,7 +539,7 @@ class WebTreeStore {
               row.reservation_id != null && resIds.has(row.reservation_id);
             // Every reserved leaf plus every Available one; nothing that is
             // neither reserved nor Available.
-            if (hasReservation || row.status === "Available") {
+            if (!row.is_deleted && (hasReservation || row.status === "Available")) {
               out.push([
                 row.id,
                 row.verifying_public_key,
@@ -735,24 +737,32 @@ class WebTreeStore {
             res.spent.filter((s) => s.spent_at >= refreshMs).map((s) => s.id)
           );
 
-          // Delete non-reserved leaves added before the refresh started (this
-          // includes leaves released just above by the stale-reservation
-          // cleanup). A leaf reported again in this same refresh is re-inserted
-          // below, so its ancestor rows must survive: only ids that do NOT
-          // reappear (truly gone, e.g. spent) get their ancestor rows dropped
-          // alongside them.
-          // Taken before the deletion below: a refresh carries leaves alone, so
-          // the chain-complete flag a reported leaf keeps has to come from the
-          // row it already had, or every refresh would report every leaf as
-          // missing its chain.
+          // Taken before the marking below, because a leaf reported again is
+          // rebuilt from its pedigree and a refresh carries no chains. An empty
+          // chain means "unknown", so the flag the row already held has to come
+          // from here, or every refresh would report every leaf as missing one.
           const priorRows = new Map(leafMap);
 
+          // Mark, rather than remove, the non-reserved leaves added before the
+          // refresh started. A leaf no operator reports may still be ours, and
+          // its stored transactions are the only way to exit it, so the row
+          // stays, and its ancestor rows stay with it; the puts below clear the
+          // mark on whatever came back. A leaf we spent ourselves is the one
+          // absence already accounted for, so it goes for good and its ancestor
+          // rows are dropped alongside it.
           const deletedIds = [];
           for (const row of Array.from(leafMap.values())) {
-            if (row.reservation_id == null && row.added_at < refreshMs) {
+            if (row.reservation_id != null || row.added_at >= refreshMs) continue;
+            if (spentIds.has(row.id)) {
               leavesStore.delete(row.id);
               leafMap.delete(row.id);
               deletedIds.push(row.id);
+              continue;
+            }
+            if (!row.is_deleted) {
+              const marked = { ...row, is_deleted: true };
+              leavesStore.put(marked);
+              leafMap.set(marked.id, marked);
             }
           }
 
@@ -1103,6 +1113,7 @@ class WebTreeStore {
                 (r) =>
                   r.status === "Available" &&
                   !r.is_missing_from_operators &&
+                  !r.is_deleted &&
                   r.reservation_id == null
               )
               .map((r) => r.id)
@@ -1205,6 +1216,7 @@ class WebTreeStore {
       verifying_public_key: node.verifying_public_key,
       signing_public_key: node.signing_keyshare.public_key,
       is_missing_from_operators: !!isMissing,
+      is_deleted: false,
       reservation_id: existingRow ? existingRow.reservation_id ?? null : null,
       added_at: this._nowMs(),
       // Denormalized and indexed so leavesMissingExitChains reads only the ids
@@ -1330,6 +1342,7 @@ class WebTreeStore {
         (r) =>
           r.status === "Available" &&
           !r.is_missing_from_operators &&
+          !r.is_deleted &&
           r.reservation_id == null
       )
       .map((r) => ({ id: r.id, value: r.value }));

--- a/crates/breez-sdk/wasm/js/web-tree-store/index.js
+++ b/crates/breez-sdk/wasm/js/web-tree-store/index.js
@@ -462,12 +462,17 @@ class WebTreeStore {
           const leafMap = new Map(res.leaves.map((r) => [r.id, r]));
           // Each leaf owns its chain, so its ancestor rows go with it. They are
           // keyed by [leaf_id, id], so the leaf's own id selects exactly its own.
+          // Only a row still marked and still unreserved goes: the purge read
+          // its list, then spent seconds asking the operators, and a refresh
+          // landing in that window may have brought the leaf back or a payment
+          // reserved it.
           for (const id of ids) {
-            if (!leafMap.has(id)) continue;
+            const row = leafMap.get(id);
+            if (!row || !row.is_deleted || row.reservation_id != null) continue;
             leavesStore.delete(id);
             leafMap.delete(id);
-            for (const row of res.ancestors) {
-              if (row.leaf_id === id) ancestorsStore.delete([row.leaf_id, row.id]);
+            for (const anc of res.ancestors) {
+              if (anc.leaf_id === id) ancestorsStore.delete([anc.leaf_id, anc.id]);
             }
           }
         }

--- a/crates/breez-sdk/wasm/js/web-tree-store/index.js
+++ b/crates/breez-sdk/wasm/js/web-tree-store/index.js
@@ -431,6 +431,53 @@ class WebTreeStore {
     }
   }
 
+  async getDeletedLeaves() {
+    try {
+      return await this._txRun(
+        [STORE_LEAVES],
+        "readonly",
+        [{ name: "leaves", store: STORE_LEAVES }],
+        (res) => res.leaves.filter((row) => row.is_deleted).map((row) => row.data)
+      );
+    } catch (error) {
+      if (error instanceof TreeStoreError) throw error;
+      throw new TreeStoreError(`Failed to get deleted leaves: ${error.message}`);
+    }
+  }
+
+  async removeLeaves(leafIds) {
+    try {
+      if (!leafIds || leafIds.length === 0) return;
+      const ids = new Set(leafIds);
+      await this._txRun(
+        [STORE_LEAVES, STORE_ANCESTORS],
+        "readwrite",
+        [
+          { name: "leaves", store: STORE_LEAVES },
+          { name: "ancestors", store: STORE_ANCESTORS },
+        ],
+        (res, tx) => {
+          const leavesStore = tx.objectStore(STORE_LEAVES);
+          const ancestorsStore = tx.objectStore(STORE_ANCESTORS);
+          const leafMap = new Map(res.leaves.map((r) => [r.id, r]));
+          // Each leaf owns its chain, so its ancestor rows go with it. They are
+          // keyed by [leaf_id, id], so the leaf's own id selects exactly its own.
+          for (const id of ids) {
+            if (!leafMap.has(id)) continue;
+            leavesStore.delete(id);
+            leafMap.delete(id);
+            for (const row of res.ancestors) {
+              if (row.leaf_id === id) ancestorsStore.delete([row.leaf_id, row.id]);
+            }
+          }
+        }
+      );
+    } catch (error) {
+      if (error instanceof TreeStoreError) throw error;
+      throw new TreeStoreError(`Failed to remove leaves: ${error.message}`);
+    }
+  }
+
   async getLeaves() {
     try {
       return await this._txRun(

--- a/crates/breez-sdk/wasm/src/tree_store/mod.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/mod.rs
@@ -258,6 +258,34 @@ impl TreeStore for WasmTreeStore {
         Ok(pedigrees)
     }
 
+    async fn get_deleted_leaves(&self) -> Result<Vec<TreeNode>, TreeServiceError> {
+        let promise = self
+            .tree_store
+            .get_deleted_leaves()
+            .map_err(js_error_to_tree_error)?;
+        let result = JsFuture::from(promise)
+            .await
+            .map_err(js_error_to_tree_error)?;
+        serde_wasm_bindgen::from_value(result).map_err(|e| TreeServiceError::Generic(e.to_string()))
+    }
+
+    async fn remove_leaves(&self, leaf_ids: &[TreeNodeId]) -> Result<(), TreeServiceError> {
+        if leaf_ids.is_empty() {
+            return Ok(());
+        }
+        let ids: Vec<String> = leaf_ids.iter().map(ToString::to_string).collect();
+        let ids_js = serde_wasm_bindgen::to_value(&ids)
+            .map_err(|e| TreeServiceError::Generic(e.to_string()))?;
+        let promise = self
+            .tree_store
+            .remove_leaves(ids_js)
+            .map_err(js_error_to_tree_error)?;
+        JsFuture::from(promise)
+            .await
+            .map_err(js_error_to_tree_error)?;
+        Ok(())
+    }
+
     async fn get_available_balance(&self) -> Result<u64, TreeServiceError> {
         let promise = self
             .tree_store
@@ -592,6 +620,8 @@ export interface TreeStore {
     leavesMissingExitChains: () => Promise<string[]>;
     getLeaves: () => Promise<Leaves>;
     getExitChains: (leafIds: string[]) => Promise<LeafPedigree[]>;
+    getDeletedLeaves: () => Promise<TreeNode[]>;
+    removeLeaves: (leafIds: string[]) => Promise<void>;
     getAvailableBalance: () => Promise<bigint>;
     getVerifiedLeafKeys: () => Promise<[string, string, string][]>;
     setLeaves: (leaves: TreeNode[], missingLeaves: TreeNode[], refreshStartedAtMs: number) => Promise<void>;
@@ -623,6 +653,12 @@ extern "C" {
 
     #[wasm_bindgen(structural, method, js_name = getExitChains, catch)]
     pub fn get_exit_chains(this: &TreeStoreJs, leaf_ids: JsValue) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(structural, method, js_name = getDeletedLeaves, catch)]
+    pub fn get_deleted_leaves(this: &TreeStoreJs) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(structural, method, js_name = removeLeaves, catch)]
+    pub fn remove_leaves(this: &TreeStoreJs, leaf_ids: JsValue) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, js_name = getAvailableBalance, catch)]
     pub fn get_available_balance(this: &TreeStoreJs) -> Result<Promise, JsValue>;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
@@ -155,6 +155,12 @@ async fn test_remove_leaves_spares_a_revived_leaf() {
 }
 
 #[wasm_bindgen_test]
+async fn test_kept_leaf_cannot_back_a_payment() {
+    let store = create_test_tree_store("mysql_tree_ancestor_deleted").await;
+    breez_sdk_spark::tree_store_tests::test_kept_leaf_cannot_back_a_payment(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_deleted_leaves_are_listed_and_removable() {
     let store = create_test_tree_store("mysql_tree_ancestor_deleted").await;
     breez_sdk_spark::tree_store_tests::test_deleted_leaves_are_listed_and_removable(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
@@ -149,6 +149,12 @@ async fn test_absent_leaf_is_kept_for_its_exit_chain() {
 }
 
 #[wasm_bindgen_test]
+async fn test_deleted_leaves_are_listed_and_removable() {
+    let store = create_test_tree_store("mysql_tree_ancestor_deleted").await;
+    breez_sdk_spark::tree_store_tests::test_deleted_leaves_are_listed_and_removable(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_absent_leaf_keeps_shared_ancestor() {
     let store = create_test_tree_store("mysql_tree_ancestor_shared").await;
     breez_sdk_spark::tree_store_tests::test_absent_leaf_keeps_shared_ancestor(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
@@ -149,6 +149,12 @@ async fn test_absent_leaf_is_kept_for_its_exit_chain() {
 }
 
 #[wasm_bindgen_test]
+async fn test_remove_leaves_spares_a_revived_leaf() {
+    let store = create_test_tree_store("mysql_tree_ancestor_deleted").await;
+    breez_sdk_spark::tree_store_tests::test_remove_leaves_spares_a_revived_leaf(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_deleted_leaves_are_listed_and_removable() {
     let store = create_test_tree_store("mysql_tree_ancestor_deleted").await;
     breez_sdk_spark::tree_store_tests::test_deleted_leaves_are_listed_and_removable(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
@@ -142,15 +142,16 @@ async fn test_store_ancestors_for_absent_leaf() {
 }
 
 #[wasm_bindgen_test]
-async fn test_unshared_ancestor_deleted_with_leaf() {
+
+async fn test_absent_leaf_is_kept_for_its_exit_chain() {
     let store = create_test_tree_store("mysql_tree_ancestor_deleted").await;
-    breez_sdk_spark::tree_store_tests::test_unshared_ancestor_deleted_with_leaf(&store).await;
+    breez_sdk_spark::tree_store_tests::test_absent_leaf_is_kept_for_its_exit_chain(&store).await;
 }
 
 #[wasm_bindgen_test]
-async fn test_shared_ancestor_survives_leaf_deletion() {
+async fn test_absent_leaf_keeps_shared_ancestor() {
     let store = create_test_tree_store("mysql_tree_ancestor_shared").await;
-    breez_sdk_spark::tree_store_tests::test_shared_ancestor_survives_leaf_deletion(&store).await;
+    breez_sdk_spark::tree_store_tests::test_absent_leaf_keeps_shared_ancestor(&store).await;
 }
 
 #[wasm_bindgen_test]

--- a/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
@@ -161,6 +161,12 @@ async fn test_kept_leaf_cannot_back_a_payment() {
 }
 
 #[wasm_bindgen_test]
+async fn test_cancel_keeps_an_unverified_leaf() {
+    let store = create_test_tree_store("mysql_tree_ancestor_deleted").await;
+    breez_sdk_spark::tree_store_tests::test_cancel_keeps_an_unverified_leaf(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_deleted_leaves_are_listed_and_removable() {
     let store = create_test_tree_store("mysql_tree_ancestor_deleted").await;
     breez_sdk_spark::tree_store_tests::test_deleted_leaves_are_listed_and_removable(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
@@ -142,7 +142,6 @@ async fn test_store_ancestors_for_absent_leaf() {
 }
 
 #[wasm_bindgen_test]
-
 async fn test_absent_leaf_is_kept_for_its_exit_chain() {
     let store = create_test_tree_store("mysql_tree_ancestor_deleted").await;
     breez_sdk_spark::tree_store_tests::test_absent_leaf_is_kept_for_its_exit_chain(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/node.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/node.rs
@@ -408,9 +408,9 @@ async fn test_set_leaves_with_reservations() {
 }
 
 #[wasm_bindgen_test]
-async fn test_shared_ancestor_survives_leaf_deletion() {
+async fn test_absent_leaf_keeps_shared_ancestor() {
     let store = create_test_tree_store().await;
-    breez_sdk_spark::tree_store_tests::test_shared_ancestor_survives_leaf_deletion(&store).await;
+    breez_sdk_spark::tree_store_tests::test_absent_leaf_keeps_shared_ancestor(&store).await;
 }
 
 #[wasm_bindgen_test]
@@ -510,9 +510,9 @@ async fn test_try_select_leaves() {
 }
 
 #[wasm_bindgen_test]
-async fn test_unshared_ancestor_deleted_with_leaf() {
+async fn test_absent_leaf_is_kept_for_its_exit_chain() {
     let store = create_test_tree_store().await;
-    breez_sdk_spark::tree_store_tests::test_unshared_ancestor_deleted_with_leaf(&store).await;
+    breez_sdk_spark::tree_store_tests::test_absent_leaf_is_kept_for_its_exit_chain(&store).await;
 }
 
 #[wasm_bindgen_test]

--- a/crates/breez-sdk/wasm/src/tree_store/tests/node.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/node.rs
@@ -528,6 +528,12 @@ async fn test_kept_leaf_cannot_back_a_payment() {
 }
 
 #[wasm_bindgen_test]
+async fn test_cancel_keeps_an_unverified_leaf() {
+    let store = create_test_tree_store().await;
+    breez_sdk_spark::tree_store_tests::test_cancel_keeps_an_unverified_leaf(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_empty_pedigree_keeps_stored_chain() {
     let store = create_test_tree_store().await;
     breez_sdk_spark::tree_store_tests::test_empty_pedigree_keeps_stored_chain(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/node.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/node.rs
@@ -516,6 +516,12 @@ async fn test_absent_leaf_is_kept_for_its_exit_chain() {
 }
 
 #[wasm_bindgen_test]
+async fn test_remove_leaves_spares_a_revived_leaf() {
+    let store = create_test_tree_store().await;
+    breez_sdk_spark::tree_store_tests::test_remove_leaves_spares_a_revived_leaf(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_empty_pedigree_keeps_stored_chain() {
     let store = create_test_tree_store().await;
     breez_sdk_spark::tree_store_tests::test_empty_pedigree_keeps_stored_chain(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/node.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/node.rs
@@ -522,6 +522,12 @@ async fn test_remove_leaves_spares_a_revived_leaf() {
 }
 
 #[wasm_bindgen_test]
+async fn test_kept_leaf_cannot_back_a_payment() {
+    let store = create_test_tree_store().await;
+    breez_sdk_spark::tree_store_tests::test_kept_leaf_cannot_back_a_payment(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_empty_pedigree_keeps_stored_chain() {
     let store = create_test_tree_store().await;
     breez_sdk_spark::tree_store_tests::test_empty_pedigree_keeps_stored_chain(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/node.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/node.rs
@@ -528,6 +528,12 @@ async fn test_stored_chain_replaces_previous() {
 }
 
 #[wasm_bindgen_test]
+async fn test_deleted_leaves_are_listed_and_removable() {
+    let store = create_test_tree_store().await;
+    breez_sdk_spark::tree_store_tests::test_deleted_leaves_are_listed_and_removable(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_update_reservation_basic() {
     let store = create_test_tree_store().await;
     breez_sdk_spark::tree_store_tests::test_update_reservation_basic(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
@@ -142,15 +142,16 @@ async fn test_store_ancestors_for_absent_leaf() {
 }
 
 #[wasm_bindgen_test]
-async fn test_unshared_ancestor_deleted_with_leaf() {
+
+async fn test_absent_leaf_is_kept_for_its_exit_chain() {
     let store = create_test_tree_store("pg_tree_ancestor_deleted").await;
-    breez_sdk_spark::tree_store_tests::test_unshared_ancestor_deleted_with_leaf(&store).await;
+    breez_sdk_spark::tree_store_tests::test_absent_leaf_is_kept_for_its_exit_chain(&store).await;
 }
 
 #[wasm_bindgen_test]
-async fn test_shared_ancestor_survives_leaf_deletion() {
+async fn test_absent_leaf_keeps_shared_ancestor() {
     let store = create_test_tree_store("pg_tree_ancestor_shared").await;
-    breez_sdk_spark::tree_store_tests::test_shared_ancestor_survives_leaf_deletion(&store).await;
+    breez_sdk_spark::tree_store_tests::test_absent_leaf_keeps_shared_ancestor(&store).await;
 }
 
 #[wasm_bindgen_test]

--- a/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
@@ -142,7 +142,6 @@ async fn test_store_ancestors_for_absent_leaf() {
 }
 
 #[wasm_bindgen_test]
-
 async fn test_absent_leaf_is_kept_for_its_exit_chain() {
     let store = create_test_tree_store("pg_tree_ancestor_deleted").await;
     breez_sdk_spark::tree_store_tests::test_absent_leaf_is_kept_for_its_exit_chain(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
@@ -155,6 +155,12 @@ async fn test_remove_leaves_spares_a_revived_leaf() {
 }
 
 #[wasm_bindgen_test]
+async fn test_kept_leaf_cannot_back_a_payment() {
+    let store = create_test_tree_store("pg_tree_ancestor_deleted").await;
+    breez_sdk_spark::tree_store_tests::test_kept_leaf_cannot_back_a_payment(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_deleted_leaves_are_listed_and_removable() {
     let store = create_test_tree_store("pg_tree_ancestor_deleted").await;
     breez_sdk_spark::tree_store_tests::test_deleted_leaves_are_listed_and_removable(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
@@ -161,6 +161,12 @@ async fn test_kept_leaf_cannot_back_a_payment() {
 }
 
 #[wasm_bindgen_test]
+async fn test_cancel_keeps_an_unverified_leaf() {
+    let store = create_test_tree_store("pg_tree_ancestor_deleted").await;
+    breez_sdk_spark::tree_store_tests::test_cancel_keeps_an_unverified_leaf(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_deleted_leaves_are_listed_and_removable() {
     let store = create_test_tree_store("pg_tree_ancestor_deleted").await;
     breez_sdk_spark::tree_store_tests::test_deleted_leaves_are_listed_and_removable(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
@@ -149,6 +149,12 @@ async fn test_absent_leaf_is_kept_for_its_exit_chain() {
 }
 
 #[wasm_bindgen_test]
+async fn test_deleted_leaves_are_listed_and_removable() {
+    let store = create_test_tree_store("pg_tree_ancestor_deleted").await;
+    breez_sdk_spark::tree_store_tests::test_deleted_leaves_are_listed_and_removable(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_absent_leaf_keeps_shared_ancestor() {
     let store = create_test_tree_store("pg_tree_ancestor_shared").await;
     breez_sdk_spark::tree_store_tests::test_absent_leaf_keeps_shared_ancestor(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
@@ -149,6 +149,12 @@ async fn test_absent_leaf_is_kept_for_its_exit_chain() {
 }
 
 #[wasm_bindgen_test]
+async fn test_remove_leaves_spares_a_revived_leaf() {
+    let store = create_test_tree_store("pg_tree_ancestor_deleted").await;
+    breez_sdk_spark::tree_store_tests::test_remove_leaves_spares_a_revived_leaf(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_deleted_leaves_are_listed_and_removable() {
     let store = create_test_tree_store("pg_tree_ancestor_deleted").await;
     breez_sdk_spark::tree_store_tests::test_deleted_leaves_are_listed_and_removable(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/web.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/web.rs
@@ -507,6 +507,12 @@ async fn test_absent_leaf_is_kept_for_its_exit_chain() {
 }
 
 #[wasm_bindgen_test]
+async fn test_remove_leaves_spares_a_revived_leaf() {
+    let store = create_test_tree_store("wtree_test_remove_leaves_spares_a_revived_leaf").await;
+    breez_sdk_spark::tree_store_tests::test_remove_leaves_spares_a_revived_leaf(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_empty_pedigree_keeps_stored_chain() {
     let store = create_test_tree_store("wtree_test_empty_pedigree_keeps_stored_chain").await;
     breez_sdk_spark::tree_store_tests::test_empty_pedigree_keeps_stored_chain(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/web.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/web.rs
@@ -513,6 +513,12 @@ async fn test_remove_leaves_spares_a_revived_leaf() {
 }
 
 #[wasm_bindgen_test]
+async fn test_kept_leaf_cannot_back_a_payment() {
+    let store = create_test_tree_store("wtree_test_kept_leaf_cannot_back_a_payment").await;
+    breez_sdk_spark::tree_store_tests::test_kept_leaf_cannot_back_a_payment(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_empty_pedigree_keeps_stored_chain() {
     let store = create_test_tree_store("wtree_test_empty_pedigree_keeps_stored_chain").await;
     breez_sdk_spark::tree_store_tests::test_empty_pedigree_keeps_stored_chain(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/web.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/web.rs
@@ -519,6 +519,12 @@ async fn test_kept_leaf_cannot_back_a_payment() {
 }
 
 #[wasm_bindgen_test]
+async fn test_cancel_keeps_an_unverified_leaf() {
+    let store = create_test_tree_store("wtree_test_cancel_keeps_an_unverified_leaf").await;
+    breez_sdk_spark::tree_store_tests::test_cancel_keeps_an_unverified_leaf(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_empty_pedigree_keeps_stored_chain() {
     let store = create_test_tree_store("wtree_test_empty_pedigree_keeps_stored_chain").await;
     breez_sdk_spark::tree_store_tests::test_empty_pedigree_keeps_stored_chain(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/web.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/web.rs
@@ -391,9 +391,9 @@ async fn test_set_leaves_with_reservations() {
 }
 
 #[wasm_bindgen_test]
-async fn test_shared_ancestor_survives_leaf_deletion() {
-    let store = create_test_tree_store("wtree_test_shared_ancestor_survives_leaf_deletion").await;
-    breez_sdk_spark::tree_store_tests::test_shared_ancestor_survives_leaf_deletion(&store).await;
+async fn test_absent_leaf_keeps_shared_ancestor() {
+    let store = create_test_tree_store("wtree_test_absent_leaf_keeps_shared_ancestor").await;
+    breez_sdk_spark::tree_store_tests::test_absent_leaf_keeps_shared_ancestor(&store).await;
 }
 
 #[wasm_bindgen_test]
@@ -501,9 +501,9 @@ async fn test_try_select_leaves() {
 }
 
 #[wasm_bindgen_test]
-async fn test_unshared_ancestor_deleted_with_leaf() {
-    let store = create_test_tree_store("wtree_test_unshared_ancestor_deleted_with_leaf").await;
-    breez_sdk_spark::tree_store_tests::test_unshared_ancestor_deleted_with_leaf(&store).await;
+async fn test_absent_leaf_is_kept_for_its_exit_chain() {
+    let store = create_test_tree_store("wtree_test_absent_leaf_is_kept_for_its_exit_chain").await;
+    breez_sdk_spark::tree_store_tests::test_absent_leaf_is_kept_for_its_exit_chain(&store).await;
 }
 
 #[wasm_bindgen_test]

--- a/crates/breez-sdk/wasm/src/tree_store/tests/web.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/web.rs
@@ -519,6 +519,12 @@ async fn test_stored_chain_replaces_previous() {
 }
 
 #[wasm_bindgen_test]
+async fn test_deleted_leaves_are_listed_and_removable() {
+    let store = create_test_tree_store("wtree_test_deleted_leaves_are_listed_and_removable").await;
+    breez_sdk_spark::tree_store_tests::test_deleted_leaves_are_listed_and_removable(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_update_reservation_basic() {
     let store = create_test_tree_store("wtree_test_update_reservation_basic").await;
     breez_sdk_spark::tree_store_tests::test_update_reservation_basic(&store).await;

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -1395,25 +1395,14 @@ impl MysqlTreeStore {
             id, prior_leaf_ids, keep_ids, dropped_ids
         );
 
-        // A dropped leaf leaves the pool for good, so its ancestor rows go with
-        // it; a kept leaf's ancestor rows are left untouched, having stayed in
-        // the store the whole time it was reserved.
-        if !dropped_ids.is_empty() {
-            let placeholders = build_placeholders(dropped_ids.len());
-            let sql = format!(
-                "DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id IN ({placeholders})"
-            );
-            let mut params: Vec<Value> = Vec::with_capacity(dropped_ids.len().saturating_add(1));
-            params.push(Value::from(self.identity.clone()));
-            params.extend(dropped_ids.iter().cloned().map(Value::from));
-            tx.exec_drop(&sql, Params::Positional(params))
-                .await
-                .map_err(map_err)?;
-        }
-
+        // A leaf the verification would not vouch for is marked, not dropped:
+        // one operator declining to confirm it is not proof it was spent, and
+        // its chain is the only way to exit it if it is still ours. The upsert
+        // below clears the mark on everything kept.
         tx.exec_drop(
-            "DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id = ?",
-            (self.identity.clone(), id),
+            "UPDATE brz_tree_leaves SET reservation_id = NULL, is_deleted = 1 \
+             WHERE user_id = ? AND reservation_id = ?",
+            (self.identity.clone(), id.clone()),
         )
         .await
         .map_err(map_err)?;
@@ -2528,6 +2517,12 @@ mod tests {
     async fn test_kept_leaf_cannot_back_a_payment() {
         let fixture = MysqlTreeStoreTestFixture::new().await;
         shared_tests::test_kept_leaf_cannot_back_a_payment(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_cancel_keeps_an_unverified_leaf() {
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        shared_tests::test_cancel_keeps_an_unverified_leaf(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -584,30 +584,11 @@ impl TreeStore for MysqlTreeStore {
         }
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
         self.acquire_write_lock(&mut conn).await?;
-        let mut tx = conn.start_transaction(tx_opts()).await.map_err(map_err)?;
-        // Each leaf owns its chain, so its ancestor rows go with it, and in that
-        // order so no ancestor row is ever left without its leaf.
-        // Only a row still marked and still unreserved goes: the purge read its
-        // list, then spent seconds asking the operators, and a refresh landing in
-        // that window may have brought the leaf back or a payment reserved it.
-        for id in leaf_ids {
-            tx.exec_drop(
-                "DELETE FROM brz_tree_leaves \
-                 WHERE user_id = ? AND id = ? AND is_deleted = 1 AND reservation_id IS NULL",
-                (self.identity.clone(), id.to_string()),
-            )
-            .await
-            .map_err(map_err)?;
-            if tx.affected_rows() > 0 {
-                tx.exec_drop(
-                    "DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id = ?",
-                    (self.identity.clone(), id.to_string()),
-                )
-                .await
-                .map_err(map_err)?;
-            }
-        }
-        tx.commit().await.map_err(map_err)?;
+        let result = self.remove_leaves_inner(&mut conn, leaf_ids).await;
+        // Released on every path: a lock left held travels back to the pool with
+        // the connection and stalls the next writer until it times out.
+        self.release_write_lock_quiet(&mut conn).await;
+        result?;
         self.notify_balance_change();
         Ok(())
     }
@@ -1322,7 +1303,8 @@ impl MysqlTreeStore {
         // back.
         tx.exec_drop(
             "UPDATE brz_tree_leaves SET is_deleted = 1 \
-             WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
+             WHERE user_id = ? AND reservation_id IS NULL AND added_at < ? \
+             AND is_deleted = 0",
             (self.identity.clone(), refresh_timestamp.naive_utc()),
         )
         .await
@@ -1362,6 +1344,38 @@ impl MysqlTreeStore {
         )
         .await?;
 
+        tx.commit().await.map_err(map_err)?;
+        Ok(())
+    }
+
+    async fn remove_leaves_inner(
+        &self,
+        conn: &mut Conn,
+        leaf_ids: &[TreeNodeId],
+    ) -> Result<(), TreeServiceError> {
+        let mut tx = conn.start_transaction(tx_opts()).await.map_err(map_err)?;
+        // Each leaf owns its chain, so its ancestor rows go with it, and in that
+        // order so no ancestor row is ever left without its leaf.
+        // Only a row still marked and still unreserved goes: the purge read its
+        // list, then spent seconds asking the operators, and a refresh landing in
+        // that window may have brought the leaf back or a payment reserved it.
+        for id in leaf_ids {
+            tx.exec_drop(
+                "DELETE FROM brz_tree_leaves \
+                 WHERE user_id = ? AND id = ? AND is_deleted = 1 AND reservation_id IS NULL",
+                (self.identity.clone(), id.to_string()),
+            )
+            .await
+            .map_err(map_err)?;
+            if tx.affected_rows() > 0 {
+                tx.exec_drop(
+                    "DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id = ?",
+                    (self.identity.clone(), id.to_string()),
+                )
+                .await
+                .map_err(map_err)?;
+            }
+        }
         tx.commit().await.map_err(map_err)?;
         Ok(())
     }

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -587,19 +587,25 @@ impl TreeStore for MysqlTreeStore {
         let mut tx = conn.start_transaction(tx_opts()).await.map_err(map_err)?;
         // Each leaf owns its chain, so its ancestor rows go with it, and in that
         // order so no ancestor row is ever left without its leaf.
+        // Only a row still marked and still unreserved goes: the purge read its
+        // list, then spent seconds asking the operators, and a refresh landing in
+        // that window may have brought the leaf back or a payment reserved it.
         for id in leaf_ids {
             tx.exec_drop(
-                "DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id = ?",
+                "DELETE FROM brz_tree_leaves \
+                 WHERE user_id = ? AND id = ? AND is_deleted = 1 AND reservation_id IS NULL",
                 (self.identity.clone(), id.to_string()),
             )
             .await
             .map_err(map_err)?;
-            tx.exec_drop(
-                "DELETE FROM brz_tree_leaves WHERE user_id = ? AND id = ?",
-                (self.identity.clone(), id.to_string()),
-            )
-            .await
-            .map_err(map_err)?;
+            if tx.affected_rows() > 0 {
+                tx.exec_drop(
+                    "DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id = ?",
+                    (self.identity.clone(), id.to_string()),
+                )
+                .await
+                .map_err(map_err)?;
+            }
         }
         tx.commit().await.map_err(map_err)?;
         self.notify_balance_change();
@@ -2505,6 +2511,12 @@ mod tests {
     async fn test_absent_leaf_is_kept_for_its_exit_chain() {
         let fixture = MysqlTreeStoreTestFixture::new().await;
         shared_tests::test_absent_leaf_is_kept_for_its_exit_chain(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_remove_leaves_spares_a_revived_leaf() {
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        shared_tests::test_remove_leaves_spares_a_revived_leaf(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -562,6 +562,50 @@ impl TreeStore for MysqlTreeStore {
         Ok(keys)
     }
 
+    async fn get_deleted_leaves(&self) -> Result<Vec<TreeNode>, TreeServiceError> {
+        let mut conn = self.pool.get_conn().await.map_err(map_err)?;
+        let rows: Vec<String> = conn
+            .exec(
+                "SELECT data FROM brz_tree_leaves WHERE user_id = ? AND is_deleted = 1",
+                (self.identity.clone(),),
+            )
+            .await
+            .map_err(map_err)?;
+        rows.iter()
+            .map(|data| {
+                serde_json::from_str(data).map_err(|e| TreeServiceError::Generic(e.to_string()))
+            })
+            .collect()
+    }
+
+    async fn remove_leaves(&self, leaf_ids: &[TreeNodeId]) -> Result<(), TreeServiceError> {
+        if leaf_ids.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.pool.get_conn().await.map_err(map_err)?;
+        self.acquire_write_lock(&mut conn).await?;
+        let mut tx = conn.start_transaction(tx_opts()).await.map_err(map_err)?;
+        // Each leaf owns its chain, so its ancestor rows go with it, and in that
+        // order so no ancestor row is ever left without its leaf.
+        for id in leaf_ids {
+            tx.exec_drop(
+                "DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id = ?",
+                (self.identity.clone(), id.to_string()),
+            )
+            .await
+            .map_err(map_err)?;
+            tx.exec_drop(
+                "DELETE FROM brz_tree_leaves WHERE user_id = ? AND id = ?",
+                (self.identity.clone(), id.to_string()),
+            )
+            .await
+            .map_err(map_err)?;
+        }
+        tx.commit().await.map_err(map_err)?;
+        self.notify_balance_change();
+        Ok(())
+    }
+
     async fn get_leaves(&self) -> Result<Leaves, TreeServiceError> {
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
 
@@ -2461,6 +2505,12 @@ mod tests {
     async fn test_absent_leaf_is_kept_for_its_exit_chain() {
         let fixture = MysqlTreeStoreTestFixture::new().await;
         shared_tests::test_absent_leaf_is_kept_for_its_exit_chain(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_deleted_leaves_are_listed_and_removable() {
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        shared_tests::test_deleted_leaves_are_listed_and_removable(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -1333,18 +1333,23 @@ impl MysqlTreeStore {
         // no ancestor row is ever left without its leaf.
         for id in &spent_ids {
             tx.exec_drop(
-                "DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id = ?",
-                (self.identity.clone(), id.clone()),
-            )
-            .await
-            .map_err(map_err)?;
-            tx.exec_drop(
                 "DELETE FROM brz_tree_leaves \
                  WHERE user_id = ? AND reservation_id IS NULL AND id = ?",
                 (self.identity.clone(), id.clone()),
             )
             .await
             .map_err(map_err)?;
+            // Only if the row actually went: a spent leaf still held by a
+            // reservation keeps its row, and a row without its chain is the one
+            // thing this store must never produce.
+            if tx.affected_rows() > 0 {
+                tx.exec_drop(
+                    "DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id = ?",
+                    (self.identity.clone(), id.clone()),
+                )
+                .await
+                .map_err(map_err)?;
+            }
         }
 
         self.batch_upsert_leaves(&mut tx, leaves.iter(), false, Some(&spent_ids))
@@ -2517,6 +2522,12 @@ mod tests {
     async fn test_remove_leaves_spares_a_revived_leaf() {
         let fixture = MysqlTreeStoreTestFixture::new().await;
         shared_tests::test_remove_leaves_spares_a_revived_leaf(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_kept_leaf_cannot_back_a_payment() {
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        shared_tests::test_kept_leaf_cannot_back_a_payment(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -162,6 +162,7 @@ const SLIM_LEAF_CANDIDATES_SQL: &str = r"SELECT id, value
     WHERE user_id = ?
       AND status = 'Available'
       AND is_missing_from_operators = 0
+      AND is_deleted = 0
       AND reservation_id IS NULL
       AND (
         value <= ?
@@ -171,6 +172,7 @@ const SLIM_LEAF_CANDIDATES_SQL: &str = r"SELECT id, value
             WHERE user_id = ?
               AND status = 'Available'
               AND is_missing_from_operators = 0
+              AND is_deleted = 0
               AND reservation_id IS NULL
               AND value > ?
             ORDER BY value
@@ -504,6 +506,7 @@ impl TreeStore for MysqlTreeStore {
                   LEFT JOIN brz_tree_reservations r
                     ON l.reservation_id = r.id AND l.user_id = r.user_id
                   WHERE l.user_id = ?
+                    AND l.is_deleted = 0
                     AND (
                         (l.reservation_id IS NULL AND l.status = 'Available')
                         OR r.purpose = 'Swap'
@@ -534,6 +537,7 @@ impl TreeStore for MysqlTreeStore {
                   LEFT JOIN brz_tree_reservations r
                     ON l.reservation_id = r.id AND l.user_id = r.user_id
                   WHERE l.user_id = ?
+                    AND l.is_deleted = 0
                     AND (r.purpose IS NOT NULL OR l.status = 'Available')",
                 (self.identity.clone(),),
             )
@@ -568,7 +572,7 @@ impl TreeStore for MysqlTreeStore {
                   FROM brz_tree_leaves l
                   LEFT JOIN brz_tree_reservations r
                     ON l.reservation_id = r.id AND l.user_id = r.user_id
-                  WHERE l.user_id = ?",
+                  WHERE l.user_id = ? AND l.is_deleted = 0",
                 (self.identity.clone(),),
             )
             .await
@@ -1067,6 +1071,26 @@ impl MysqlTreeStore {
                         signing_public_key = data->>'$.signing_keyshare.public_key'",
                 ),
             ],
+            // Migration 8: serve the root half of leaves_missing_exit_chains,
+            // which otherwise seeks a leaf's ancestor rows and reads each one to
+            // find the parentless node. MySQL has no partial indexes, so
+            // `parent_node_id` sits second: it resolves IS NULL as an equality,
+            // which keeps every term of the lookup an equality. Leading with
+            // `leaf_id` instead would not help, since the clustered primary key
+            // already carries `parent_node_id` once seeked by leaf.
+            vec![Migration::CreateIndex {
+                name: "brz_idx_tree_ancestors_root",
+                table: "brz_tree_ancestors",
+                columns: "(user_id, parent_node_id, leaf_id)",
+            }],
+            // Migration 9: Keep a leaf no operator reports rather than removing
+            // it, so the chain that would exit it survives until a spend has
+            // actually been proven.
+            vec![Migration::AddColumn {
+                table: "brz_tree_leaves",
+                column: "is_deleted",
+                definition: "BOOLEAN NOT NULL DEFAULT FALSE",
+            }],
         ]
     }
 
@@ -1240,51 +1264,37 @@ impl MysqlTreeStore {
             spent_ids
         );
 
-        // Ids the delete below is about to remove. MySQL has no RETURNING, so
-        // they are read first and matched against the refresh in Rust.
-        let stale_ids: Vec<String> = tx
-            .exec(
-                "SELECT id FROM brz_tree_leaves \
-                 WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
-                (self.identity.clone(), refresh_timestamp.naive_utc()),
-            )
-            .await
-            .map_err(map_err)?;
-
-        // Delete non-reserved leaves added before refresh started. Includes
-        // leaves released earlier in this transaction by
-        // `cleanup_stale_reservations` (which clears `reservation_id`
-        // explicitly because the composite FK uses NO ACTION).
+        // Mark, rather than remove, the non-reserved leaves added before this
+        // refresh started. A leaf no operator reports may still be ours, and its
+        // stored transactions are the only way to exit it, so the row stays, and
+        // its ancestor rows stay with it: the chain is the whole reason for
+        // keeping the leaf. The upserts below clear the mark on whatever came
+        // back.
         tx.exec_drop(
-            "DELETE FROM brz_tree_leaves WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
+            "UPDATE brz_tree_leaves SET is_deleted = 1 \
+             WHERE user_id = ? AND reservation_id IS NULL AND added_at < ?",
             (self.identity.clone(), refresh_timestamp.naive_utc()),
         )
         .await
         .map_err(map_err)?;
 
-        // A chain is only ever removed with its leaf. A leaf the refresh reports
-        // is re-inserted below, so only an id this refresh does not bring back is
-        // truly gone, and in the steady state there is no statement to run.
-        let fresh_ids: HashSet<String> = leaves
-            .iter()
-            .chain(missing_operators_leaves.iter())
-            .map(|leaf| leaf.id.to_string())
-            .collect();
-        let departed: Vec<String> = stale_ids
-            .into_iter()
-            .filter(|id| !fresh_ids.contains(id))
-            .collect();
-        for chunk in departed.chunks(IDS_PER_STATEMENT) {
-            let sql = format!(
-                "DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id IN ({})",
-                build_placeholders(chunk.len())
-            );
-            let mut params: Vec<Value> = Vec::with_capacity(chunk.len().saturating_add(1));
-            params.push(Value::from(self.identity.clone()));
-            params.extend(chunk.iter().cloned().map(Value::from));
-            tx.exec_drop(&sql, Params::Positional(params))
-                .await
-                .map_err(map_err)?;
+        // A leaf we spent ourselves is the one absence already accounted for, so
+        // it goes for good and takes its ancestor rows with it, in that order so
+        // no ancestor row is ever left without its leaf.
+        for id in &spent_ids {
+            tx.exec_drop(
+                "DELETE FROM brz_tree_ancestors WHERE user_id = ? AND leaf_id = ?",
+                (self.identity.clone(), id.clone()),
+            )
+            .await
+            .map_err(map_err)?;
+            tx.exec_drop(
+                "DELETE FROM brz_tree_leaves \
+                 WHERE user_id = ? AND reservation_id IS NULL AND id = ?",
+                (self.identity.clone(), id.clone()),
+            )
+            .await
+            .map_err(map_err)?;
         }
 
         self.batch_upsert_leaves(&mut tx, leaves.iter(), false, Some(&spent_ids))
@@ -1491,6 +1501,7 @@ impl MysqlTreeStore {
                   WHERE user_id = ?
                     AND status = 'Available'
                     AND is_missing_from_operators = 0
+                    AND is_deleted = 0
                     AND reservation_id IS NULL
                    ",
                 (self.identity.clone(),),
@@ -1629,6 +1640,7 @@ impl MysqlTreeStore {
             "SELECT id FROM brz_tree_leaves \
              WHERE user_id = ? AND id IN ({placeholders}) \
                AND status = 'Available' AND is_missing_from_operators = 0 \
+               AND is_deleted = 0 \
                AND reservation_id IS NULL"
         );
         let mut params: Vec<Value> = Vec::with_capacity(ids.len().saturating_add(1));
@@ -1842,14 +1854,15 @@ impl MysqlTreeStore {
             let mut sql = String::from(
                 "INSERT INTO brz_tree_leaves \
                  (user_id, id, status, is_missing_from_operators, data, \
-                  value, parent_node_id, verifying_public_key, signing_public_key, added_at) VALUES ",
+                  value, parent_node_id, verifying_public_key, signing_public_key, added_at, \
+                  is_deleted) VALUES ",
             );
             let mut params: Vec<Value> = Vec::with_capacity(chunk.len() * 9);
             for (i, &leaf) in chunk.iter().enumerate() {
                 if i > 0 {
                     sql.push_str(", ");
                 }
-                sql.push_str("(?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))");
+                sql.push_str("(?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6), 0)");
                 #[allow(clippy::cast_possible_wrap)]
                 let value_i64 = leaf.value as i64;
                 params.push(Value::from(self.identity.clone()));
@@ -1873,7 +1886,8 @@ impl MysqlTreeStore {
                     parent_node_id = VALUES(parent_node_id),
                     verifying_public_key = VALUES(verifying_public_key),
                     signing_public_key = VALUES(signing_public_key),
-                    added_at = UTC_TIMESTAMP(6)",
+                    added_at = UTC_TIMESTAMP(6),
+                    is_deleted = 0",
             );
 
             tx.exec_drop(&sql, Params::Positional(params))
@@ -2444,15 +2458,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unshared_ancestor_deleted_with_leaf() {
+    async fn test_absent_leaf_is_kept_for_its_exit_chain() {
         let fixture = MysqlTreeStoreTestFixture::new().await;
-        shared_tests::test_unshared_ancestor_deleted_with_leaf(&fixture.store).await;
+        shared_tests::test_absent_leaf_is_kept_for_its_exit_chain(&fixture.store).await;
     }
 
     #[tokio::test]
-    async fn test_shared_ancestor_survives_leaf_deletion() {
+    async fn test_absent_leaf_keeps_shared_ancestor() {
         let fixture = MysqlTreeStoreTestFixture::new().await;
-        shared_tests::test_shared_ancestor_survives_leaf_deletion(&fixture.store).await;
+        shared_tests::test_absent_leaf_keeps_shared_ancestor(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -496,15 +496,23 @@ impl TreeStore for PostgresTreeStore {
         let tx = client.transaction().await.map_err(map_err)?;
         // Each leaf owns its chain, so its ancestor rows go with it, and in that
         // order so no ancestor row is ever left without its leaf.
+        // Only a row still marked and still unreserved goes: the purge read its
+        // list, then spent seconds asking the operators, and a refresh landing in
+        // that window may have brought the leaf back or a payment reserved it.
+        let removed = tx
+            .query(
+                "DELETE FROM brz_tree_leaves \
+                 WHERE user_id = $1 AND id = ANY($2) \
+                   AND is_deleted = TRUE AND reservation_id IS NULL \
+                 RETURNING id",
+                &[&self.identity, &ids],
+            )
+            .await
+            .map_err(map_err)?;
+        let removed_ids: Vec<String> = removed.iter().map(|row| row.get("id")).collect();
         tx.execute(
             "DELETE FROM brz_tree_ancestors WHERE user_id = $1 AND leaf_id = ANY($2)",
-            &[&self.identity, &ids],
-        )
-        .await
-        .map_err(map_err)?;
-        tx.execute(
-            "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND id = ANY($2)",
-            &[&self.identity, &ids],
+            &[&self.identity, &removed_ids],
         )
         .await
         .map_err(map_err)?;
@@ -2151,6 +2159,12 @@ mod tests {
     async fn test_absent_leaf_is_kept_for_its_exit_chain() {
         let fixture = PostgresTreeStoreTestFixture::new().await;
         shared_tests::test_absent_leaf_is_kept_for_its_exit_chain(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_remove_leaves_spares_a_revived_leaf() {
+        let fixture = PostgresTreeStoreTestFixture::new().await;
+        shared_tests::test_remove_leaves_spares_a_revived_leaf(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -470,6 +470,49 @@ impl TreeStore for PostgresTreeStore {
         Ok(keys)
     }
 
+    async fn get_deleted_leaves(&self) -> Result<Vec<TreeNode>, TreeServiceError> {
+        let client = self.pool.get().await.map_err(map_err)?;
+        let rows = client
+            .query(
+                "SELECT data FROM brz_tree_leaves WHERE user_id = $1 AND is_deleted = TRUE",
+                &[&self.identity],
+            )
+            .await
+            .map_err(map_err)?;
+        rows.iter()
+            .map(|row| {
+                serde_json::from_value(row.get("data"))
+                    .map_err(|e| TreeServiceError::Generic(e.to_string()))
+            })
+            .collect()
+    }
+
+    async fn remove_leaves(&self, leaf_ids: &[TreeNodeId]) -> Result<(), TreeServiceError> {
+        if leaf_ids.is_empty() {
+            return Ok(());
+        }
+        let ids: Vec<String> = leaf_ids.iter().map(ToString::to_string).collect();
+        let mut client = self.pool.get().await.map_err(map_err)?;
+        let tx = client.transaction().await.map_err(map_err)?;
+        // Each leaf owns its chain, so its ancestor rows go with it, and in that
+        // order so no ancestor row is ever left without its leaf.
+        tx.execute(
+            "DELETE FROM brz_tree_ancestors WHERE user_id = $1 AND leaf_id = ANY($2)",
+            &[&self.identity, &ids],
+        )
+        .await
+        .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND id = ANY($2)",
+            &[&self.identity, &ids],
+        )
+        .await
+        .map_err(map_err)?;
+        tx.commit().await.map_err(map_err)?;
+        self.notify_balance_change();
+        Ok(())
+    }
+
     async fn get_leaves(&self) -> Result<Leaves, TreeServiceError> {
         let client = self.pool.get().await.map_err(map_err)?;
 
@@ -2108,6 +2151,12 @@ mod tests {
     async fn test_absent_leaf_is_kept_for_its_exit_chain() {
         let fixture = PostgresTreeStoreTestFixture::new().await;
         shared_tests::test_absent_leaf_is_kept_for_its_exit_chain(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_deleted_leaves_are_listed_and_removable() {
+        let fixture = PostgresTreeStoreTestFixture::new().await;
+        shared_tests::test_deleted_leaves_are_listed_and_removable(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -494,6 +494,9 @@ impl TreeStore for PostgresTreeStore {
         let ids: Vec<String> = leaf_ids.iter().map(ToString::to_string).collect();
         let mut client = self.pool.get().await.map_err(map_err)?;
         let tx = client.transaction().await.map_err(map_err)?;
+        // This walks the same two tables as a refresh, in the opposite order, so
+        // it takes the same lock every other write here takes.
+        self.acquire_write_lock(&tx).await?;
         // Each leaf owns its chain, so its ancestor rows go with it, and in that
         // order so no ancestor row is ever left without its leaf.
         // Only a row still marked and still unreserved goes: the purge read its
@@ -675,16 +678,22 @@ impl TreeStore for PostgresTreeStore {
         // it goes for good and takes its ancestor rows with it, in that order so
         // no ancestor row is ever left without its leaf.
         let spent_vec: Vec<String> = spent_ids.iter().cloned().collect();
+        let dropped = tx
+            .query(
+                "DELETE FROM brz_tree_leaves \
+                 WHERE user_id = $1 AND reservation_id IS NULL AND id = ANY($2) \
+                 RETURNING id",
+                &[&self.identity, &spent_vec],
+            )
+            .await
+            .map_err(map_err)?;
+        // Only the rows that actually went: a spent leaf still held by a
+        // reservation keeps its row, and a row without its chain is the one
+        // thing this store must never produce.
+        let dropped_ids: Vec<String> = dropped.iter().map(|row| row.get("id")).collect();
         tx.execute(
             "DELETE FROM brz_tree_ancestors WHERE user_id = $1 AND leaf_id = ANY($2)",
-            &[&self.identity, &spent_vec],
-        )
-        .await
-        .map_err(map_err)?;
-        tx.execute(
-            "DELETE FROM brz_tree_leaves \
-             WHERE user_id = $1 AND reservation_id IS NULL AND id = ANY($2)",
-            &[&self.identity, &spent_vec],
+            &[&self.identity, &dropped_ids],
         )
         .await
         .map_err(map_err)?;
@@ -2165,6 +2174,12 @@ mod tests {
     async fn test_remove_leaves_spares_a_revived_leaf() {
         let fixture = PostgresTreeStoreTestFixture::new().await;
         shared_tests::test_remove_leaves_spares_a_revived_leaf(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_kept_leaf_cannot_back_a_payment() {
+        let fixture = PostgresTreeStoreTestFixture::new().await;
+        shared_tests::test_kept_leaf_cannot_back_a_payment(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -668,7 +668,8 @@ impl TreeStore for PostgresTreeStore {
         // prevents deadlocks.
         tx.execute(
             "UPDATE brz_tree_leaves SET is_deleted = TRUE \
-             WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
+             WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2 \
+               AND is_deleted = FALSE",
             &[&self.identity, &refresh_timestamp],
         )
         .await

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -148,6 +148,7 @@ const SLIM_LEAF_CANDIDATES_SQL: &str = r"
     WHERE user_id = $1
       AND status = 'Available'
       AND is_missing_from_operators = FALSE
+      AND is_deleted = FALSE
       AND reservation_id IS NULL
       AND (
         value <= $2
@@ -156,6 +157,7 @@ const SLIM_LEAF_CANDIDATES_SQL: &str = r"
           WHERE user_id = $1
             AND status = 'Available'
             AND is_missing_from_operators = FALSE
+            AND is_deleted = FALSE
             AND reservation_id IS NULL
             AND value > $2
           ORDER BY value
@@ -405,6 +407,7 @@ impl TreeStore for PostgresTreeStore {
                 LEFT JOIN brz_tree_reservations r
                   ON l.reservation_id = r.id AND l.user_id = r.user_id
                 WHERE l.user_id = $1
+                  AND l.is_deleted = FALSE
                   AND (
                     (l.reservation_id IS NULL AND l.status = 'Available')
                     OR r.purpose = 'Swap'
@@ -438,6 +441,7 @@ impl TreeStore for PostgresTreeStore {
                 LEFT JOIN brz_tree_reservations r
                   ON l.reservation_id = r.id AND l.user_id = r.user_id
                 WHERE l.user_id = $1
+                  AND l.is_deleted = FALSE
                   AND (r.purpose IS NOT NULL OR l.status = 'Available')
                 ",
                 &[&self.identity],
@@ -478,6 +482,7 @@ impl TreeStore for PostgresTreeStore {
                 LEFT JOIN brz_tree_reservations r
                   ON l.reservation_id = r.id AND l.user_id = r.user_id
                 WHERE l.user_id = $1
+                  AND l.is_deleted = FALSE
                 ",
                 &[&self.identity],
             )
@@ -600,45 +605,38 @@ impl TreeStore for PostgresTreeStore {
             spent_ids
         );
 
-        // Delete non-reserved leaves that were added BEFORE refresh started.
-        // The advisory lock acquired at the start of this transaction prevents deadlocks.
-        // Includes leaves released earlier in this transaction by cleanup_stale_reservations
-        // (FK ON DELETE SET NULL) - those rows kept their old added_at, so they are
-        // dropped here and re-fetched from the operator response in the upsert below.
-        let deleted_ids: Vec<String> = tx
-            .query(
-                "DELETE FROM brz_tree_leaves \
-                 WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2 \
-                 RETURNING id",
-                &[&self.identity, &refresh_timestamp],
-            )
-            .await
-            .map_err(map_err)?
-            .iter()
-            .map(|row| row.get(0))
-            .collect();
+        // Mark, rather than remove, the non-reserved leaves added before this
+        // refresh started. A leaf no operator reports may still be ours, and its
+        // stored transactions are the only way to exit it, so the row stays, and
+        // its ancestor rows stay with it: the chain is the whole reason for
+        // keeping the leaf. The upserts below clear the mark on whatever came
+        // back. The advisory lock taken at the start of this transaction
+        // prevents deadlocks.
+        tx.execute(
+            "UPDATE brz_tree_leaves SET is_deleted = TRUE \
+             WHERE user_id = $1 AND reservation_id IS NULL AND added_at < $2",
+            &[&self.identity, &refresh_timestamp],
+        )
+        .await
+        .map_err(map_err)?;
 
-        // A chain is only ever removed with its leaf. A leaf the refresh reports
-        // is re-inserted below, so only an id this refresh does not bring back is
-        // truly gone: matching in Rust keeps the id set off the wire, and in the
-        // steady state (nothing departed) there is no statement to run at all.
-        let fresh_ids: HashSet<String> = leaves
-            .iter()
-            .chain(missing_operators_leaves.iter())
-            .map(|leaf| leaf.id.to_string())
-            .collect();
-        let departed: Vec<String> = deleted_ids
-            .into_iter()
-            .filter(|id| !fresh_ids.contains(id))
-            .collect();
-        if !departed.is_empty() {
-            tx.execute(
-                "DELETE FROM brz_tree_ancestors WHERE user_id = $1 AND leaf_id = ANY($2)",
-                &[&self.identity, &departed],
-            )
-            .await
-            .map_err(map_err)?;
-        }
+        // A leaf we spent ourselves is the one absence already accounted for, so
+        // it goes for good and takes its ancestor rows with it, in that order so
+        // no ancestor row is ever left without its leaf.
+        let spent_vec: Vec<String> = spent_ids.iter().cloned().collect();
+        tx.execute(
+            "DELETE FROM brz_tree_ancestors WHERE user_id = $1 AND leaf_id = ANY($2)",
+            &[&self.identity, &spent_vec],
+        )
+        .await
+        .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM brz_tree_leaves \
+             WHERE user_id = $1 AND reservation_id IS NULL AND id = ANY($2)",
+            &[&self.identity, &spent_vec],
+        )
+        .await
+        .map_err(map_err)?;
 
         // Upsert all leaves. batch_upsert_leaves handles spent filtering via skip_ids,
         // and its ON CONFLICT clause preserves reservation_id (not in the UPDATE SET list).
@@ -859,6 +857,7 @@ impl TreeStore for PostgresTreeStore {
                 WHERE user_id = $1
                   AND status = 'Available'
                   AND is_missing_from_operators = FALSE
+                  AND is_deleted = FALSE
                   AND reservation_id IS NULL
                 ",
                 &[&self.identity],
@@ -1061,6 +1060,7 @@ impl TreeStore for PostgresTreeStore {
                   AND id = ANY($2)
                   AND status = 'Available'
                   AND is_missing_from_operators = FALSE
+                  AND is_deleted = FALSE
                   AND reservation_id IS NULL
                 ",
                 &[&self.identity, &ids],
@@ -1329,6 +1329,24 @@ impl PostgresTreeStore {
                     signing_public_key = data->'signing_keyshare'->>'public_key'"
                     .to_string(),
             ],
+            // Migration 6: serve the root half of leaves_missing_exit_chains,
+            // which otherwise seeks a leaf's ancestor rows and reads each one to
+            // find the parentless node. Partial, so it holds one entry per leaf
+            // whose chain reaches a root and can answer index-only.
+            vec![
+                "CREATE INDEX IF NOT EXISTS brz_idx_tree_ancestors_root \
+                 ON brz_tree_ancestors (user_id, leaf_id) \
+                 WHERE parent_node_id IS NULL"
+                    .to_string(),
+            ],
+            // Migration 7: Keep a leaf no operator reports rather than removing
+            // it, so the chain that would exit it survives until a spend has
+            // actually been proven.
+            vec![
+                "ALTER TABLE brz_tree_leaves \
+                 ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN NOT NULL DEFAULT FALSE"
+                    .to_string(),
+            ],
         ]
     }
 
@@ -1421,9 +1439,11 @@ impl PostgresTreeStore {
                 r"
                 INSERT INTO brz_tree_leaves
                     (user_id, id, status, is_missing_from_operators, data,
-                     value, parent_node_id, verifying_public_key, signing_public_key, added_at)
+                     value, parent_node_id, verifying_public_key, signing_public_key, added_at,
+                     is_deleted)
                 SELECT $9, id, status, missing, data,
-                       value, parent_node_id, verifying_public_key, signing_public_key, NOW()
+                       value, parent_node_id, verifying_public_key, signing_public_key, NOW(),
+                       FALSE
                 FROM UNNEST($1::text[], $2::text[], $3::bool[], $4::jsonb[],
                             $5::bigint[], $6::text[], $7::text[], $8::text[])
                     AS t(id, status, missing, data,
@@ -1436,7 +1456,8 @@ impl PostgresTreeStore {
                     parent_node_id = EXCLUDED.parent_node_id,
                     verifying_public_key = EXCLUDED.verifying_public_key,
                     signing_public_key = EXCLUDED.signing_public_key,
-                    added_at = NOW()
+                    added_at = NOW(),
+                    is_deleted = FALSE
                 ",
             )
             .await
@@ -2084,15 +2105,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unshared_ancestor_deleted_with_leaf() {
+    async fn test_absent_leaf_is_kept_for_its_exit_chain() {
         let fixture = PostgresTreeStoreTestFixture::new().await;
-        shared_tests::test_unshared_ancestor_deleted_with_leaf(&fixture.store).await;
+        shared_tests::test_absent_leaf_is_kept_for_its_exit_chain(&fixture.store).await;
     }
 
     #[tokio::test]
-    async fn test_shared_ancestor_survives_leaf_deletion() {
+    async fn test_absent_leaf_keeps_shared_ancestor() {
         let fixture = PostgresTreeStoreTestFixture::new().await;
-        shared_tests::test_shared_ancestor_survives_leaf_deletion(&fixture.store).await;
+        shared_tests::test_absent_leaf_keeps_shared_ancestor(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -746,20 +746,13 @@ impl TreeStore for PostgresTreeStore {
             id, prior_leaf_ids, keep_ids, dropped_ids
         );
 
-        // A dropped leaf leaves the pool for good, so its ancestor rows go with
-        // it; a kept leaf's ancestor rows are left untouched, having stayed in
-        // the store the whole time it was reserved.
-        if !dropped_ids.is_empty() {
-            tx.execute(
-                "DELETE FROM brz_tree_ancestors WHERE user_id = $1 AND leaf_id = ANY($2)",
-                &[&self.identity, &dropped_ids],
-            )
-            .await
-            .map_err(map_err)?;
-        }
-
+        // A leaf the verification would not vouch for is marked, not dropped:
+        // one operator declining to confirm it is not proof it was spent, and
+        // its chain is the only way to exit it if it is still ours. The upsert
+        // below clears the mark on everything kept.
         tx.execute(
-            "DELETE FROM brz_tree_leaves WHERE user_id = $1 AND reservation_id = $2",
+            "UPDATE brz_tree_leaves SET reservation_id = NULL, is_deleted = TRUE \
+             WHERE user_id = $1 AND reservation_id = $2",
             &[&self.identity, id],
         )
         .await
@@ -2180,6 +2173,12 @@ mod tests {
     async fn test_kept_leaf_cannot_back_a_payment() {
         let fixture = PostgresTreeStoreTestFixture::new().await;
         shared_tests::test_kept_leaf_cannot_back_a_payment(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_cancel_keeps_an_unverified_leaf() {
+        let fixture = PostgresTreeStoreTestFixture::new().await;
+        shared_tests::test_cancel_keeps_an_unverified_leaf(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-sqlite/src/lib.rs
+++ b/crates/spark-sqlite/src/lib.rs
@@ -113,6 +113,15 @@ const TREE_MIGRATIONS: &[&str] = &[
         last_completed_at INTEGER
     );
     INSERT INTO brz_tree_swap_status (id, last_completed_at) VALUES (1, NULL);",
+    // v2: serve the root half of leaves_missing_exit_chains, which otherwise
+    // seeks a leaf's ancestor rows and reads each one to find the parentless
+    // node. SQLite indexes IS NULL as an equality, so both terms bind and the
+    // answer comes from the index without touching the row.
+    "CREATE INDEX IF NOT EXISTS brz_idx_tree_ancestors_root
+        ON brz_tree_ancestors (leaf_id, parent_node_id);",
+    // v3: keep a leaf no operator reports rather than removing it, so the chain
+    // that would exit it survives until a spend has actually been proven.
+    "ALTER TABLE brz_tree_leaves ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0;",
 ];
 
 /// Applies pending migrations, tracking the version in its own table rather than
@@ -336,15 +345,17 @@ impl SqliteTreeStore {
             conn.execute(
                 "INSERT INTO brz_tree_leaves
                      (id, parent_node_id, status, value, verifying_public_key,
-                      signing_public_key, data, is_missing_from_operators, added_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                      signing_public_key, data, is_missing_from_operators, added_at,
+                      is_deleted)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0)
                  ON CONFLICT(id) DO UPDATE SET
                      parent_node_id = excluded.parent_node_id,
                      status = excluded.status,
                      value = excluded.value,
                      data = excluded.data,
                      is_missing_from_operators = excluded.is_missing_from_operators,
-                     added_at = excluded.added_at",
+                     added_at = excluded.added_at,
+                     is_deleted = 0",
                 params![
                     id,
                     leaf.parent_node_id.as_ref().map(ToString::to_string),
@@ -534,7 +545,7 @@ impl SqliteTreeStore {
             .query_row(
                 "SELECT COALESCE(SUM(value), 0) FROM brz_tree_leaves
                  WHERE status = ?1
-                   AND is_missing_from_operators = 0 AND reservation_id IS NULL",
+                   AND is_missing_from_operators = 0 AND is_deleted = 0 AND reservation_id IS NULL",
                 params![available],
                 |row| row.get(0),
             )
@@ -565,13 +576,13 @@ impl SqliteTreeStore {
             .prepare(
                 "SELECT id, value FROM brz_tree_leaves
                  WHERE status = ?1
-                   AND is_missing_from_operators = 0 AND reservation_id IS NULL
+                   AND is_missing_from_operators = 0 AND is_deleted = 0 AND reservation_id IS NULL
                    AND (
                      value <= ?2
                      OR id = (
                        SELECT id FROM brz_tree_leaves
                        WHERE status = ?1
-                         AND is_missing_from_operators = 0 AND reservation_id IS NULL
+                         AND is_missing_from_operators = 0 AND is_deleted = 0 AND reservation_id IS NULL
                          AND value > ?2
                        ORDER BY value LIMIT 1
                      )
@@ -764,7 +775,8 @@ impl TreeStore for SqliteTreeStore {
             .prepare(
                 "SELECT n.data, n.is_missing_from_operators, r.purpose
                  FROM brz_tree_leaves n
-                 LEFT JOIN brz_tree_reservations r ON n.reservation_id = r.id",
+                 LEFT JOIN brz_tree_reservations r ON n.reservation_id = r.id
+                 WHERE n.is_deleted = 0",
             )
             .map_err(|e| generic("prepare get_leaves", e))?;
         let rows = stmt
@@ -814,8 +826,9 @@ impl TreeStore for SqliteTreeStore {
             .query_row(
                 "SELECT COALESCE(SUM(l.value), 0) FROM brz_tree_leaves l
                  LEFT JOIN brz_tree_reservations r ON l.reservation_id = r.id
-                 WHERE (l.reservation_id IS NULL AND l.status = ?1)
-                    OR r.purpose = ?2",
+                 WHERE l.is_deleted = 0
+                   AND ((l.reservation_id IS NULL AND l.status = ?1)
+                        OR r.purpose = ?2)",
                 params![available, ReservationPurpose::Swap.to_string()],
                 |row| row.get(0),
             )
@@ -836,7 +849,8 @@ impl TreeStore for SqliteTreeStore {
                 "SELECT l.id, l.verifying_public_key, l.signing_public_key
                  FROM brz_tree_leaves l
                  LEFT JOIN brz_tree_reservations r ON l.reservation_id = r.id
-                 WHERE r.purpose IS NOT NULL OR l.status = ?1",
+                 WHERE l.is_deleted = 0
+                   AND (r.purpose IS NOT NULL OR l.status = ?1)",
             )
             .map_err(|e| generic("prepare verified leaf keys", e))?;
         let rows = stmt
@@ -900,13 +914,24 @@ impl TreeStore for SqliteTreeStore {
 
         // Delete non-reserved pool leaves older than the refresh; reserved and
         // after-refresh leaves are immune. Leaves present in the refresh below are
-        // re-inserted, and any candidate that does not come back is dropped below.
+        // re-inserted, which clears the mark again. A marked leaf stays a row, so
+        // the orphan sweep below leaves its ancestors alone.
         tx.execute(
-            "DELETE FROM brz_tree_leaves
+            "UPDATE brz_tree_leaves SET is_deleted = 1
              WHERE reservation_id IS NULL AND added_at < ?1",
             params![refresh_ms],
         )
-        .map_err(|e| generic("delete old leaves", e))?;
+        .map_err(|e| generic("mark unreported leaves", e))?;
+
+        // A leaf we spent ourselves is the one absence already accounted for, so
+        // it goes for good and takes its ancestor rows with it.
+        for id in &spent {
+            tx.execute(
+                "DELETE FROM brz_tree_leaves WHERE id = ?1 AND reservation_id IS NULL",
+                params![id],
+            )
+            .map_err(|e| generic("delete spent leaf", e))?;
+        }
 
         Self::upsert_leaves(&tx, leaves.iter(), false, Some(&spent))?;
         Self::upsert_leaves(&tx, missing_operators_leaves.iter(), true, Some(&spent))?;
@@ -1123,7 +1148,7 @@ impl TreeStore for SqliteTreeStore {
                 .query_row(
                     "SELECT 1 FROM brz_tree_leaves
                      WHERE id = ?1 AND status = ?2
-                       AND is_missing_from_operators = 0 AND reservation_id IS NULL",
+                       AND is_missing_from_operators = 0 AND is_deleted = 0 AND reservation_id IS NULL",
                     params![id, available],
                     |_| Ok(()),
                 )
@@ -1259,8 +1284,8 @@ mod tests {
         test_node_update_in_place,
         test_leaf_reparented_by_renewal,
         test_ancestor_not_returned_as_leaf,
-        test_unshared_ancestor_deleted_with_leaf,
-        test_shared_ancestor_survives_leaf_deletion,
+        test_absent_leaf_is_kept_for_its_exit_chain,
+        test_absent_leaf_keeps_shared_ancestor,
         test_incomplete_pedigree_still_spendable,
         test_exit_chain_after_swap_update,
         test_exit_chain_after_cancel_reparent,

--- a/crates/spark-sqlite/src/lib.rs
+++ b/crates/spark-sqlite/src/lib.rs
@@ -769,6 +769,52 @@ impl TreeStore for SqliteTreeStore {
         Ok(())
     }
 
+    async fn get_deleted_leaves(&self) -> Result<Vec<TreeNode>, TreeServiceError> {
+        let conn = self.get_connection()?;
+        let mut stmt = conn
+            .prepare("SELECT data FROM brz_tree_leaves WHERE is_deleted = 1")
+            .map_err(|e| generic("prepare deleted leaves", e))?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|e| generic("query deleted leaves", e))?;
+        let mut leaves = Vec::new();
+        for row in rows {
+            let data = row.map_err(|e| generic("read deleted leaf", e))?;
+            leaves.push(
+                serde_json::from_str(&data).map_err(|e| generic("deserialize deleted leaf", e))?,
+            );
+        }
+        Ok(leaves)
+    }
+
+    async fn remove_leaves(&self, leaf_ids: &[TreeNodeId]) -> Result<(), TreeServiceError> {
+        if leaf_ids.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.get_connection()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|e| generic("begin remove_leaves", e))?;
+        // Each leaf owns its chain, so its ancestor rows go with it, and in that
+        // order so no ancestor row is ever left without its leaf.
+        for id in leaf_ids {
+            tx.execute(
+                "DELETE FROM brz_tree_ancestors WHERE leaf_id = ?1",
+                params![id.to_string()],
+            )
+            .map_err(|e| generic("remove leaf ancestors", e))?;
+            tx.execute(
+                "DELETE FROM brz_tree_leaves WHERE id = ?1",
+                params![id.to_string()],
+            )
+            .map_err(|e| generic("remove leaf", e))?;
+        }
+        tx.commit()
+            .map_err(|e| generic("commit remove_leaves", e))?;
+        self.notify();
+        Ok(())
+    }
+
     async fn get_leaves(&self) -> Result<Leaves, TreeServiceError> {
         let conn = self.get_connection()?;
         let mut stmt = conn
@@ -1285,6 +1331,7 @@ mod tests {
         test_leaf_reparented_by_renewal,
         test_ancestor_not_returned_as_leaf,
         test_absent_leaf_is_kept_for_its_exit_chain,
+        test_deleted_leaves_are_listed_and_removable,
         test_absent_leaf_keeps_shared_ancestor,
         test_incomplete_pedigree_still_spendable,
         test_exit_chain_after_swap_update,

--- a/crates/spark-sqlite/src/lib.rs
+++ b/crates/spark-sqlite/src/lib.rs
@@ -1007,21 +1007,21 @@ impl TreeStore for SqliteTreeStore {
         // Return leaves_to_keep to the pool even when the reservation is already
         // gone (e.g. released by stale cleanup): dropping them here would lose the
         // leaves until the next refresh. The deletes below no-op in that case.
-        let prior_ids = Self::reserved_leaf_ids(&tx, id)?;
-        let keep_ids: HashSet<String> = leaves_to_keep.iter().map(|l| l.id.to_string()).collect();
-        let dropped_ids: Vec<String> = prior_ids
-            .into_iter()
-            .filter(|pid| !keep_ids.contains(pid))
-            .collect();
-        Self::delete_reserved(&tx, id)?;
+        // A leaf the verification would not vouch for is marked, not dropped:
+        // one operator declining to confirm it is not proof it was spent, and
+        // its chain is the only way to exit it if it is still ours. The upsert
+        // below clears the mark on everything kept.
+        tx.execute(
+            "UPDATE brz_tree_leaves SET reservation_id = NULL, is_deleted = 1
+             WHERE reservation_id = ?1",
+            params![id],
+        )
+        .map_err(|e| generic("release reserved leaves", e))?;
         tx.execute(
             "DELETE FROM brz_tree_reservations WHERE id = ?1",
             params![id],
         )
         .map_err(|e| generic("delete reservation", e))?;
-        // A kept leaf's ancestor rows are untouched here; only a dropped leaf's
-        // chain goes with it. The kept leaf rows are re-inserted below.
-        Self::delete_ancestors_for_leaves(&tx, &dropped_ids)?;
         Self::upsert_leaves(&tx, leaves_to_keep, false, None)?;
         tx.commit().map_err(|e| generic("commit cancel", e))?;
         self.notify();
@@ -1340,6 +1340,7 @@ mod tests {
         test_absent_leaf_is_kept_for_its_exit_chain,
         test_remove_leaves_spares_a_revived_leaf,
         test_kept_leaf_cannot_back_a_payment,
+        test_cancel_keeps_an_unverified_leaf,
         test_deleted_leaves_are_listed_and_removable,
         test_absent_leaf_keeps_shared_ancestor,
         test_incomplete_pedigree_still_spendable,

--- a/crates/spark-sqlite/src/lib.rs
+++ b/crates/spark-sqlite/src/lib.rs
@@ -1339,6 +1339,7 @@ mod tests {
         test_ancestor_not_returned_as_leaf,
         test_absent_leaf_is_kept_for_its_exit_chain,
         test_remove_leaves_spares_a_revived_leaf,
+        test_kept_leaf_cannot_back_a_payment,
         test_deleted_leaves_are_listed_and_removable,
         test_absent_leaf_keeps_shared_ancestor,
         test_incomplete_pedigree_still_spendable,

--- a/crates/spark-sqlite/src/lib.rs
+++ b/crates/spark-sqlite/src/lib.rs
@@ -797,17 +797,24 @@ impl TreeStore for SqliteTreeStore {
             .map_err(|e| generic("begin remove_leaves", e))?;
         // Each leaf owns its chain, so its ancestor rows go with it, and in that
         // order so no ancestor row is ever left without its leaf.
+        // Only a row still marked and still unreserved goes: the purge read its
+        // list, then spent seconds asking the operators, and a refresh landing in
+        // that window may have brought the leaf back or a payment reserved it.
         for id in leaf_ids {
-            tx.execute(
-                "DELETE FROM brz_tree_ancestors WHERE leaf_id = ?1",
-                params![id.to_string()],
-            )
-            .map_err(|e| generic("remove leaf ancestors", e))?;
-            tx.execute(
-                "DELETE FROM brz_tree_leaves WHERE id = ?1",
-                params![id.to_string()],
-            )
-            .map_err(|e| generic("remove leaf", e))?;
+            let removed = tx
+                .execute(
+                    "DELETE FROM brz_tree_leaves
+                     WHERE id = ?1 AND is_deleted = 1 AND reservation_id IS NULL",
+                    params![id.to_string()],
+                )
+                .map_err(|e| generic("remove leaf", e))?;
+            if removed > 0 {
+                tx.execute(
+                    "DELETE FROM brz_tree_ancestors WHERE leaf_id = ?1",
+                    params![id.to_string()],
+                )
+                .map_err(|e| generic("remove leaf ancestors", e))?;
+            }
         }
         tx.commit()
             .map_err(|e| generic("commit remove_leaves", e))?;
@@ -1331,6 +1338,7 @@ mod tests {
         test_leaf_reparented_by_renewal,
         test_ancestor_not_returned_as_leaf,
         test_absent_leaf_is_kept_for_its_exit_chain,
+        test_remove_leaves_spares_a_revived_leaf,
         test_deleted_leaves_are_listed_and_removable,
         test_absent_leaf_keeps_shared_ancestor,
         test_incomplete_pedigree_still_spendable,

--- a/crates/spark-sqlite/src/lib.rs
+++ b/crates/spark-sqlite/src/lib.rs
@@ -965,25 +965,37 @@ impl TreeStore for SqliteTreeStore {
         Self::cleanup_spent_markers(&tx, refresh_ms)?;
         let spent = Self::spent_ids_since(&tx, refresh_ms)?;
 
-        // Delete non-reserved pool leaves older than the refresh; reserved and
+        // Mark the non-reserved pool leaves older than the refresh; reserved and
         // after-refresh leaves are immune. Leaves present in the refresh below are
         // re-inserted, which clears the mark again. A marked leaf stays a row, so
-        // the orphan sweep below leaves its ancestors alone.
+        // the orphan sweep below leaves its ancestors alone. Already-marked rows
+        // are skipped: they match this predicate forever, and rewriting them on
+        // every refresh is pure churn.
         tx.execute(
             "UPDATE brz_tree_leaves SET is_deleted = 1
-             WHERE reservation_id IS NULL AND added_at < ?1",
+             WHERE reservation_id IS NULL AND added_at < ?1 AND is_deleted = 0",
             params![refresh_ms],
         )
         .map_err(|e| generic("mark unreported leaves", e))?;
 
         // A leaf we spent ourselves is the one absence already accounted for, so
-        // it goes for good and takes its ancestor rows with it.
+        // it goes for good and takes its ancestor rows with it, and only when its
+        // row actually went: a row without its chain is the one thing this store
+        // must never produce.
         for id in &spent {
-            tx.execute(
-                "DELETE FROM brz_tree_leaves WHERE id = ?1 AND reservation_id IS NULL",
-                params![id],
-            )
-            .map_err(|e| generic("delete spent leaf", e))?;
+            let removed = tx
+                .execute(
+                    "DELETE FROM brz_tree_leaves WHERE id = ?1 AND reservation_id IS NULL",
+                    params![id],
+                )
+                .map_err(|e| generic("delete spent leaf", e))?;
+            if removed > 0 {
+                tx.execute(
+                    "DELETE FROM brz_tree_ancestors WHERE leaf_id = ?1",
+                    params![id],
+                )
+                .map_err(|e| generic("delete spent leaf ancestors", e))?;
+            }
         }
 
         Self::upsert_leaves(&tx, leaves.iter(), false, Some(&spent))?;

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1587,7 +1587,17 @@ impl SparkWallet {
                 // are asked for separately: their row exists to be exitable, which
                 // takes something actually selecting them.
                 let leaves = self.tree_service.list_leaves().await?;
-                let kept_for_exit = self.tree_service.list_leaves_kept_for_exit().await?;
+                // Best-effort: a store that cannot list them still gets to exit
+                // everything else, which matters most on the path that exists for
+                // when things are already going wrong.
+                let kept_for_exit = self
+                    .tree_service
+                    .list_leaves_kept_for_exit()
+                    .await
+                    .unwrap_or_else(|e| {
+                        warn!("unilateral exit: listing leaves kept for exit failed: {e:?}");
+                        Vec::new()
+                    });
                 let mut leaf_ids: Vec<TreeNodeId> = leaves
                     .available
                     .into_iter()
@@ -1628,6 +1638,13 @@ impl SparkWallet {
             warn!(
                 "unilateral exit: resolving exit chains failed, planning from local state: {e:?}"
             );
+        }
+        // The kept leaves are quoted and driven like any other, and the hourly
+        // purge is the only thing that retires the ones that really are gone. An
+        // exit planned between two of its rounds would otherwise price in leaves
+        // every operator already agrees left us, and then pay to drive them.
+        if let Err(e) = self.tree_service.purge_proven_spent_leaves().await {
+            warn!("unilateral exit: purging spent leaves failed: {e:?}");
         }
     }
 

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1567,7 +1567,7 @@ impl SparkWallet {
     }
 
     /// Resolves an [`ExitLeafSelection`] into concrete leaf IDs and the
-    /// profitability filter. `Auto` sweeps every available leaf and keeps only
+    /// profitability filter. `Auto` sweeps every stored leaf and keeps only
     /// profitable ones; `Specific` exits exactly the requested leaves regardless
     /// of profitability.
     async fn resolve_leaf_selection(

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1576,15 +1576,19 @@ impl SparkWallet {
     ) -> Result<(Vec<TreeNodeId>, UnilateralExitLeafFilter), SparkWalletError> {
         match selection {
             ExitLeafSelection::Auto => {
-                // Include non-available leaves (e.g. a mid-exit leaf the operators
-                // now report OnChain) so Auto resumes a partially-exited leaf, not
-                // just fresh ones. The planner skips any that turn out un-exitable
-                // under ProfitableOnly.
+                // Every stored leaf is one of ours, so Auto sweeps all of them and
+                // lets the planner drop the few that are unexitable (terminal status,
+                // no refund) or unprofitable. That includes the non-available ones (a
+                // mid-exit leaf the operators now report OnChain, so Auto resumes it)
+                // and the missing-from-operators ones, which are the operator-dropped
+                // case unilateral exit exists for: they count towards the balance, so
+                // omitting them would strand exactly the funds most at risk.
                 let leaves = self.tree_service.list_leaves().await?;
                 let mut leaf_ids: Vec<TreeNodeId> = leaves
                     .available
                     .into_iter()
                     .chain(leaves.not_available)
+                    .chain(leaves.available_missing_from_operators)
                     .map(|l| l.id)
                     .collect();
                 leaf_ids.sort();

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1582,13 +1582,18 @@ impl SparkWallet {
                 // mid-exit leaf the operators now report OnChain, so Auto resumes it)
                 // and the missing-from-operators ones, which are the operator-dropped
                 // case unilateral exit exists for: they count towards the balance, so
-                // omitting them would strand exactly the funds most at risk.
+                // omitting them would strand exactly the funds most at risk. The
+                // leaves kept only for their chain are in no bucket at all, so they
+                // are asked for separately: their row exists to be exitable, which
+                // takes something actually selecting them.
                 let leaves = self.tree_service.list_leaves().await?;
+                let kept_for_exit = self.tree_service.list_leaves_kept_for_exit().await?;
                 let mut leaf_ids: Vec<TreeNodeId> = leaves
                     .available
                     .into_iter()
                     .chain(leaves.not_available)
                     .chain(leaves.available_missing_from_operators)
+                    .chain(kept_for_exit)
                     .map(|l| l.id)
                     .collect();
                 leaf_ids.sort();

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -2856,6 +2856,11 @@ impl AutoOptimizationEventHandler for WalletAutoOptimizationEventHandler {
     }
 }
 
+/// How often to check whether the leaves kept for their exit chain have been
+/// spent. They leave the balance the moment the operators stop reporting them,
+/// so this only bounds how long their rows outlive them.
+const SPENT_LEAF_PURGE_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
 struct BackgroundProcessor {
     operator_pool: Arc<OperatorPool>,
     event_manager: Arc<EventManager>,
@@ -2968,6 +2973,20 @@ impl BackgroundProcessor {
 
         if let Err(e) = self.token_service.refresh_tokens_outputs().await {
             error!("Error refreshing token outputs on startup: {:?}", e);
+        }
+
+        {
+            let cloned_self = Arc::clone(self);
+            let cancellation_token_clone = cancellation_token.clone();
+            let span = tracing::Span::current();
+            tokio::spawn(
+                async move {
+                    cloned_self
+                        .run_spent_leaf_purge(cancellation_token_clone)
+                        .await;
+                }
+                .instrument(span),
+            );
         }
 
         // Start token output optimization background task if configured
@@ -3219,6 +3238,36 @@ impl BackgroundProcessor {
                 }
                 _ = cancellation_token.changed() => {
                     info!("Stopping exit state forwarding");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Clears out the leaves kept only for their exit chain once the operators
+    /// can prove they were spent. Housekeeping, not book-keeping: such a leaf is
+    /// already out of the balance and out of selection, so nothing waits on this
+    /// and it runs on its own slow timer rather than on the refresh, which sits
+    /// on the payment path. When there is nothing lingering it costs one local
+    /// read and no network at all.
+    async fn run_spent_leaf_purge(&self, mut cancellation_token: watch::Receiver<()>) {
+        let run_purge = || async {
+            match self.tree_service.purge_proven_spent_leaves().await {
+                Ok(0) => {}
+                Ok(removed) => info!("Removed {removed} leaves proven spent"),
+                Err(e) => debug!("Could not check whether kept leaves were spent: {e:?}"),
+            }
+        };
+
+        run_purge().await;
+
+        loop {
+            tokio::select! {
+                () = tokio::time::sleep(SPENT_LEAF_PURGE_INTERVAL) => {
+                    run_purge().await;
+                }
+                _ = cancellation_token.changed() => {
+                    debug!("Stopping the spent-leaf purge");
                     break;
                 }
             }

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1651,7 +1651,21 @@ impl SparkWallet {
     /// Reads out the wallet's whole unilateral exit state: every stored leaf
     /// with its ancestor chain.
     pub async fn export_exit_state(&self) -> Result<ExitStateExport, SparkWalletError> {
-        let leaf_ids = self.tree_service.list_leaves().await?.leaf_ids();
+        let mut leaf_ids = self.tree_service.list_leaves().await?.leaf_ids();
+        // The leaves kept only for their chain are in no bucket, so they are
+        // asked for separately. They are the ones an export exists for: no
+        // operator reports them any more, which leaves the stored chain as the
+        // only way to get the funds back, and an export without them would look
+        // complete while omitting exactly what cannot be recovered any other way.
+        leaf_ids.extend(
+            self.tree_service
+                .list_leaves_kept_for_exit()
+                .await?
+                .into_iter()
+                .map(|leaf| leaf.id),
+        );
+        leaf_ids.sort();
+        leaf_ids.dedup();
         let pedigrees = self.tree_service.load_exit_chains(&leaf_ids).await?;
         debug!(
             leaves = leaf_ids.len(),
@@ -4096,6 +4110,44 @@ mod tests {
         );
         let export = wallet.export_exit_state().await.unwrap();
         assert_eq!(chain_ids(&export.pedigrees), vec![vec!["leaf".to_string()]]);
+    }
+
+    /// A leaf no operator reports any more is in no bucket, so nothing that
+    /// walks the buckets sees it. It is also the one leaf whose stored chain is
+    /// the only way to get the funds back, so an export that missed it would
+    /// look complete while leaving out precisely what cannot be recovered any
+    /// other way.
+    #[macros::async_test_all]
+    async fn export_exit_state_includes_a_leaf_kept_only_for_its_chain() {
+        let store = Arc::new(InMemoryTreeStore::new());
+        let wallet = wallet_over(Arc::clone(&store) as Arc<dyn TreeStore>).await;
+        let owner = wallet.get_identity_public_key();
+
+        let root = create_test_node_with_parent("root", None, TreeNodeStatus::Splitted);
+        let leaf = create_test_node_with_parent("leaf", Some("root"), TreeNodeStatus::Available);
+        seed_pedigrees(
+            store.as_ref(),
+            &[pedigree_owned_by(owner, leaf, vec![root])],
+        )
+        .await;
+
+        // A refresh no operator answered for marks the leaf, taking it out of
+        // the balance and out of every bucket. Its start comes from the store's
+        // own clock, and sits ahead of it, so the leaf just added counts as
+        // older than the refresh whatever clock the store runs on.
+        let refresh_start = store.now().await.unwrap() + Duration::from_secs(10);
+        store.set_leaves(&[], &[], refresh_start).await.unwrap();
+        assert!(
+            store.get_leaves().await.unwrap().leaf_ids().is_empty(),
+            "the leaf is in no bucket once it is kept only for its chain"
+        );
+
+        let export = wallet.export_exit_state().await.unwrap();
+        assert_eq!(
+            chain_ids(&export.pedigrees),
+            vec![vec!["root".to_string(), "leaf".to_string()]],
+            "the export carries the kept leaf and its whole chain"
+        );
     }
 
     #[macros::async_test_all]

--- a/crates/spark/src/bitcoin/service.rs
+++ b/crates/spark/src/bitcoin/service.rs
@@ -138,6 +138,17 @@ pub fn verify_finalized_taproot_signature(
     let tx: Transaction = bitcoin::consensus::deserialize(signed_tx_bytes).map_err(|e| {
         BitcoinError::InvalidTransaction(format!("failed to decode signed tx: {e}"))
     })?;
+    verify_finalized_taproot_signature_tx(bitcoin_service, &tx, sighash_bytes, verifying_public_key)
+}
+
+/// [`verify_finalized_taproot_signature`] for a transaction that is already
+/// decoded.
+pub fn verify_finalized_taproot_signature_tx(
+    bitcoin_service: &BitcoinService,
+    tx: &Transaction,
+    sighash_bytes: &[u8; 32],
+    verifying_public_key: &PublicKey,
+) -> Result<(), BitcoinError> {
     let witness_sig = tx
         .input
         .first()

--- a/crates/spark/src/services/unilateral_exit.rs
+++ b/crates/spark/src/services/unilateral_exit.rs
@@ -15,20 +15,12 @@ use crate::{
     utils::transactions::is_ephemeral_anchor_output,
 };
 
-/// Statuses where a node still belongs to an exit chain. `OnChain` is kept
-/// (the SO marks a node `ON_CHAIN` once its tx confirms, still mid-exit);
-/// `SplitLocked` is kept because a timelock renewal leaves a permanent
-/// `SplitLocked` node above the renewed leaf that the walk must cross.
-const EXIT_CHAIN_STATUSES: [TreeNodeStatus; 4] = [
-    TreeNodeStatus::Available,
-    TreeNodeStatus::Splitted,
-    TreeNodeStatus::SplitLocked,
-    TreeNodeStatus::OnChain,
-];
-
-/// Returns a leaf's ancestor chain, root → leaf, stopping above any node outside
-/// [`EXIT_CHAIN_STATUSES`]. `Err(parent_id)` names the first ancestor missing
-/// from `node_map` for the caller to re-fetch.
+/// Returns a leaf's ancestor chain, root → leaf. The walk is purely structural:
+/// it crosses a node whatever its status, because what the exit broadcasts is the
+/// pre-signed transaction lineage, not the operator's label for it. An ancestor
+/// that is `TransferLocked`, `RenewLocked` or under `Investigation` still holds an
+/// unspent output whose `node_tx` every node below it spends. `Err(parent_id)`
+/// names the first ancestor missing from `node_map` for the caller to re-fetch.
 pub fn walk_unilateral_exit_chain<'a>(
     node_map: &'a HashMap<TreeNodeId, TreeNode>,
     leaf: &'a TreeNode,
@@ -37,9 +29,6 @@ pub fn walk_unilateral_exit_chain<'a>(
     let mut visited: HashSet<TreeNodeId> = HashSet::new();
     let mut current = leaf;
     loop {
-        if !EXIT_CHAIN_STATUSES.contains(&current.status) {
-            break;
-        }
         // Cycle guard on semi-trusted parent ids. Returning an id already in the
         // map is how a caller tells a cycle from a missing parent.
         if !visited.insert(current.id.clone()) {
@@ -513,6 +502,12 @@ pub fn evaluate_unilateral_exit_leaf_costs(
     let mut covered_txids: HashSet<bitcoin::Txid> = HashSet::new();
 
     for (leaf_id, leaf) in &leaves {
+        // No status gate here on purpose. A leaf's status is the operators' label
+        // for it, not the state of its output: an already-exited leaf still has to
+        // be selectable so a re-run resolves it as swept and drives nothing, and a
+        // locked or degraded one is still perfectly exitable from its stored
+        // transactions. What can and cannot be driven is settled by the on-chain
+        // observation, which sees the real spends.
         let Some(refund_tx) = &leaf.refund_tx else {
             report_unexitable(filter, leaf_id, "no refund transaction")?;
             continue;
@@ -1061,28 +1056,37 @@ mod tests {
             assert_eq!(chain_ids(&chain), vec![ROOT, MID, LEAF]);
         }
 
+        /// The walk is structural, so an ancestor is crossed whatever its status:
+        /// every node below it spends its `node_tx`, so dropping one would build a
+        /// silently unbroadcastable package. `SplitLocked` is the load-bearing case
+        /// (a timelock renewal leaves one permanently above the renewed leaf) and
+        /// `Splitted` is the ordinary intermediate node.
         #[test_all]
-        fn walks_through_split_locked_parent() {
-            let root = node(ROOT, None, TreeNodeStatus::Available);
-            let mid = node(MID, Some(ROOT), TreeNodeStatus::SplitLocked);
-            let leaf = node(LEAF, Some(MID), TreeNodeStatus::Available);
-            let map = node_map(&[&root, &mid, &leaf]);
+        fn walks_through_any_ancestor_status() {
+            for status in [
+                TreeNodeStatus::SplitLocked,
+                TreeNodeStatus::Splitted,
+                TreeNodeStatus::TransferLocked,
+                TreeNodeStatus::RenewLocked,
+                TreeNodeStatus::Investigation,
+                TreeNodeStatus::Lost,
+                TreeNodeStatus::ParentExited,
+                TreeNodeStatus::Exited,
+                TreeNodeStatus::Unknown,
+            ] {
+                let root = node(ROOT, None, TreeNodeStatus::Available);
+                let mid = node(MID, Some(ROOT), status);
+                let leaf = node(LEAF, Some(MID), TreeNodeStatus::Available);
+                let map = node_map(&[&root, &mid, &leaf]);
 
-            let chain = walk_unilateral_exit_chain(&map, &leaf).unwrap();
+                let chain = walk_unilateral_exit_chain(&map, &leaf).unwrap();
 
-            assert_eq!(chain_ids(&chain), vec![ROOT, MID, LEAF]);
-        }
-
-        #[test_all]
-        fn stops_on_non_exit_status() {
-            let root = node(ROOT, None, TreeNodeStatus::Available);
-            let mid = node(MID, Some(ROOT), TreeNodeStatus::Exited);
-            let leaf = node(LEAF, Some(MID), TreeNodeStatus::Available);
-            let map = node_map(&[&root, &mid, &leaf]);
-
-            let chain = walk_unilateral_exit_chain(&map, &leaf).unwrap();
-
-            assert_eq!(chain_ids(&chain), vec![LEAF]);
+                assert_eq!(
+                    chain_ids(&chain),
+                    vec![ROOT, MID, LEAF],
+                    "a {status} ancestor must not truncate the chain"
+                );
+            }
         }
 
         #[test_all]
@@ -1499,6 +1503,45 @@ mod tests {
             )
             .unwrap();
             assert!(sel.is_empty());
+        }
+
+        /// Selection never consults the status. Gating on the operators' label used
+        /// to strand a `TransferLocked` or `Lost` leaf whose pre-signed refund was
+        /// still perfectly broadcastable, and an already-`Exited` one has to stay
+        /// selectable too so re-running a finished exit can resolve it as swept
+        /// instead of failing.
+        #[test_all]
+        fn selects_leaf_in_any_status() {
+            for status in [
+                TreeNodeStatus::Available,
+                TreeNodeStatus::TransferLocked,
+                TreeNodeStatus::SplitLocked,
+                TreeNodeStatus::Splitted,
+                TreeNodeStatus::RenewLocked,
+                TreeNodeStatus::Investigation,
+                TreeNodeStatus::Lost,
+                TreeNodeStatus::OnChain,
+                TreeNodeStatus::Exited,
+                TreeNodeStatus::Aggregated,
+                TreeNodeStatus::Reimbursed,
+                TreeNodeStatus::ParentExited,
+                TreeNodeStatus::Unknown,
+            ] {
+                let mut node = leaf_node("leaf", 1_000_000);
+                node.status = status;
+                let id = node.id.clone();
+                let nodes: HashMap<TreeNodeId, TreeNode> =
+                    [(id.clone(), node)].into_iter().collect();
+
+                let sel = evaluate_unilateral_exit_leaf_costs(
+                    &nodes,
+                    std::slice::from_ref(&id),
+                    &cost_params(),
+                    UnilateralExitLeafFilter::ProfitableOnly,
+                )
+                .unwrap();
+                assert_eq!(sel.len(), 1, "a {status} leaf must stay exitable");
+            }
         }
 
         #[test_all]

--- a/crates/spark/src/tree/exit_chain_resolver.rs
+++ b/crates/spark/src/tree/exit_chain_resolver.rs
@@ -281,6 +281,10 @@ mod tests {
             unimplemented!("not exercised by ExitChainResolver")
         }
 
+        async fn list_leaves_kept_for_exit(&self) -> Result<Vec<TreeNode>, TreeServiceError> {
+            unimplemented!("not exercised by ExitChainResolver")
+        }
+
         async fn purge_proven_spent_leaves(&self) -> Result<usize, TreeServiceError> {
             unimplemented!("not exercised by ExitChainResolver")
         }

--- a/crates/spark/src/tree/exit_chain_resolver.rs
+++ b/crates/spark/src/tree/exit_chain_resolver.rs
@@ -281,6 +281,10 @@ mod tests {
             unimplemented!("not exercised by ExitChainResolver")
         }
 
+        async fn purge_proven_spent_leaves(&self) -> Result<usize, TreeServiceError> {
+            unimplemented!("not exercised by ExitChainResolver")
+        }
+
         async fn list_leaves(&self) -> Result<Leaves, TreeServiceError> {
             unimplemented!("not exercised by ExitChainResolver")
         }

--- a/crates/spark/src/tree/mod.rs
+++ b/crates/spark/src/tree/mod.rs
@@ -615,11 +615,23 @@ pub trait TreeStore: Send + Sync {
         Ok(verified_leaf_keys_from_leaves(&self.get_leaves().await?))
     }
 
-    /// Replaces the leaf pool with `leaves`, removing any prior leaf not in the
-    /// set. A leaf added after `refresh_started_at` is kept even when absent, so
-    /// a leaf added mid-refresh (e.g. from a payment) is not lost. A removed
-    /// leaf's chain is removed with it; a surviving leaf keeps the chain
-    /// [`Self::store_ancestors`] wrote for it.
+    /// Returns the leaves no operator reports any more, which are kept for their
+    /// exit chain alone and so belong to none of [`TreeStore::get_leaves`]'s
+    /// buckets. This is the only way to reach them, and it exists for the check
+    /// that decides whether one of them was really spent.
+    async fn get_deleted_leaves(&self) -> Result<Vec<TreeNode>, TreeServiceError>;
+
+    /// Removes `leaf_ids`, and any ancestor left unreachable, for good. Reserved
+    /// for a leaf whose spend has been proven: anything else keeps its row, since
+    /// a leaf that is still ours is exitable from its stored transactions alone.
+    async fn remove_leaves(&self, leaf_ids: &[TreeNodeId]) -> Result<(), TreeServiceError>;
+
+    /// Refreshes the leaf pool from `leaves`. A prior leaf absent from the set is
+    /// marked rather than removed: it leaves the balance and the selection pool
+    /// but keeps its row and the chain [`Self::store_ancestors`] wrote for it,
+    /// because absence is not proof of a spend. A leaf added after
+    /// `refresh_started_at` is kept unmarked, so a leaf added mid-refresh (e.g.
+    /// from a payment) is not held back.
     async fn set_leaves(
         &self,
         leaves: &[TreeNode],
@@ -912,6 +924,12 @@ pub trait TreeService: Send + Sync {
     /// # }
     /// ```
     async fn refresh_leaves(&self) -> Result<(), TreeServiceError>;
+
+    /// Removes the leaves kept only for their exit chain whose spend the
+    /// operators can now prove, and returns how many went. Deliberately separate
+    /// from [`TreeService::refresh_leaves`]: proving a spend costs a query per
+    /// batch, and a refresh sits on the payment path.
+    async fn purge_proven_spent_leaves(&self) -> Result<usize, TreeServiceError>;
 
     /// Inserts new leaves into the tree, each with the ancestors the caller
     /// already knows.

--- a/crates/spark/src/tree/mod.rs
+++ b/crates/spark/src/tree/mod.rs
@@ -929,6 +929,11 @@ pub trait TreeService: Send + Sync {
     /// operators can now prove, and returns how many went. Deliberately separate
     /// from [`TreeService::refresh_leaves`]: proving a spend costs a query per
     /// batch, and a refresh sits on the payment path.
+    /// The leaves kept only for their exit chain. They belong to none of
+    /// [`Leaves`]'s buckets, so this is the only way an exit can reach them, and
+    /// keeping the row would be pointless if nothing could.
+    async fn list_leaves_kept_for_exit(&self) -> Result<Vec<TreeNode>, TreeServiceError>;
+
     async fn purge_proven_spent_leaves(&self) -> Result<usize, TreeServiceError>;
 
     /// Inserts new leaves into the tree, each with the ancestors the caller

--- a/crates/spark/src/tree/mod.rs
+++ b/crates/spark/src/tree/mod.rs
@@ -925,15 +925,15 @@ pub trait TreeService: Send + Sync {
     /// ```
     async fn refresh_leaves(&self) -> Result<(), TreeServiceError>;
 
-    /// Removes the leaves kept only for their exit chain whose spend the
-    /// operators can now prove, and returns how many went. Deliberately separate
-    /// from [`TreeService::refresh_leaves`]: proving a spend costs a query per
-    /// batch, and a refresh sits on the payment path.
     /// The leaves kept only for their exit chain. They belong to none of
     /// [`Leaves`]'s buckets, so this is the only way an exit can reach them, and
     /// keeping the row would be pointless if nothing could.
     async fn list_leaves_kept_for_exit(&self) -> Result<Vec<TreeNode>, TreeServiceError>;
 
+    /// Removes the leaves kept only for their exit chain whose spend the
+    /// operators can now prove, and returns how many went. Deliberately separate
+    /// from [`TreeService::refresh_leaves`]: proving a spend costs a query per
+    /// batch, and a refresh sits on the payment path.
     async fn purge_proven_spent_leaves(&self) -> Result<usize, TreeServiceError>;
 
     /// Inserts new leaves into the tree, each with the ancestors the caller

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -505,28 +505,62 @@ impl TreeService for SynchronousTreeService {
             return Ok(0);
         }
         let ids: Vec<TreeNodeId> = deleted.iter().map(|leaf| leaf.id.clone()).collect();
-        // By id rather than by owner. An owner query is status-filtered, and the
-        // operators drop Investigation, Lost and Reimbursed from it whatever we
-        // ask for, so it cannot tell a spent leaf from one it will not talk
-        // about. A lookup by id answers for a node in any status.
-        let theirs: HashMap<TreeNodeId, TreeNode> = self
-            .fetch_nodes(&ids, false)
-            .await?
-            .into_iter()
-            .map(|node| (node.id.clone(), node))
+        let source = Source::NodeIds(TreeNodeIds {
+            node_ids: ids.iter().map(ToString::to_string).collect(),
+        });
+
+        // Ask every operator, by id. By id because an owner query is
+        // status-filtered, and the operators drop Investigation, Lost and
+        // Reimbursed from it whatever statuses we ask for, so it cannot tell a
+        // spent leaf from one it will not talk about; a lookup by id answers for
+        // a node in any status. Every operator because this ends in a deletion,
+        // and no single one of them, coordinator included, gets to decide that on
+        // its own.
+        let operators: Vec<_> = self
+            .operator_pool
+            .get_all_operators()
+            .map(|op| (op.id, op.client.clone()))
             .collect();
-        let proven: Vec<TreeNodeId> = deleted
-            .iter()
-            .filter(|leaf| {
-                theirs
+        let operator_count = operators.len();
+        let responses = join_all(operators.iter().map(|(id, client)| {
+            let source = source.clone();
+            async move {
+                (
+                    *id,
+                    self.query_nodes(client, false, Some(source), vec![]).await,
+                )
+            }
+        }))
+        .await;
+
+        // An operator we could not reach has not vouched for anything, so its
+        // silence holds the leaves rather than counting towards a deletion.
+        let mut agreeing: HashMap<TreeNodeId, usize> = HashMap::new();
+        for (id, res) in responses {
+            let Ok(nodes) = res else {
+                debug!("purge: operator {id} unreachable, keeping every leaf this round");
+                return Ok(0);
+            };
+            let theirs: HashMap<TreeNodeId, TreeNode> =
+                nodes.into_iter().map(|n| (n.id.clone(), n)).collect();
+            for leaf in &deleted {
+                if theirs
                     .get(&leaf.id)
                     .is_some_and(|theirs| refund_timelock_dropped(leaf, theirs))
-            })
+                {
+                    *agreeing.entry(leaf.id.clone()).or_default() += 1;
+                }
+            }
+        }
+
+        let proven: Vec<TreeNodeId> = deleted
+            .iter()
+            .filter(|leaf| agreeing.get(&leaf.id) == Some(&operator_count))
             .map(|leaf| leaf.id.clone())
             .collect();
         if !proven.is_empty() {
             info!(
-                "Removing {} of {} kept leaves: their refunds were replaced at a lower timelock",
+                "Removing {} of {} kept leaves: every operator reports their refund replaced at a lower timelock",
                 proven.len(),
                 deleted.len()
             );
@@ -1596,6 +1630,29 @@ mod tests {
             output: vec![],
         });
         node
+    }
+
+    /// Deleting takes every operator. Counting agreement per leaf is what
+    /// enforces that, so a leaf only one of them vouches for stays put.
+    #[test_all]
+    fn a_leaf_is_only_proven_when_every_operator_agrees() {
+        let ours = leaf_with_refund_sequence(2000);
+        let lower = leaf_with_refund_sequence(1900);
+        let unchanged = leaf_with_refund_sequence(2000);
+
+        // Three operators, two of which report the replacement.
+        let agreeing = [&lower, &lower, &unchanged]
+            .iter()
+            .filter(|theirs| refund_timelock_dropped(&ours, theirs))
+            .count();
+        assert_eq!(agreeing, 2);
+        assert_ne!(agreeing, 3, "a leaf one operator still vouches for is kept");
+
+        let all = [&lower, &lower, &lower]
+            .iter()
+            .filter(|theirs| refund_timelock_dropped(&ours, theirs))
+            .count();
+        assert_eq!(all, 3, "unanimous replacement is what proves the spend");
     }
 
     /// A transfer decrements the refund timelock to hand the leaf to its next

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -392,14 +392,18 @@ impl TreeService for SynchronousTreeService {
             else {
                 continue;
             };
-            let agreed = copies.len() == operator_count
+            // Count distinct operators: a paged query can return the same node
+            // twice for one of them, which would otherwise pass for agreement
+            // that another operator never gave.
+            let reporting: HashSet<usize> = copies.iter().map(|(id, _)| *id).collect();
+            let agreed = reporting.len() == operator_count
                 && copies
                     .iter()
                     .all(|(_, node)| leaf_copies_agree(node, &representative));
             if !agreed {
                 warn!(
                     "Leaf {leaf_id} reported by {} of {operator_count} operators, and not identically by all of them; holding it back from payments",
-                    copies.len()
+                    reporting.len()
                 );
                 missing_operator_leaves_map.insert(leaf_id.clone(), representative.clone());
             }
@@ -475,10 +479,20 @@ impl TreeService for SynchronousTreeService {
         // A refresh writes no chains, so an already-stored one is left alone
         // rather than rewritten every minute. Collecting the chains of anything
         // newly reported is what the notification below sets off.
+
+        // Only a spendable leaf goes through the renewal check. The statuses
+        // added for the exit are either mid-exit or already locked by the
+        // operators: renewing one is at best refused, and a node that no longer
+        // carries a refund fails the check outright, which would take the whole
+        // refresh down with it.
+        let (renewable, held): (Vec<TreeNode>, Vec<TreeNode>) = new_leaves
+            .into_iter()
+            .partition(|leaf| leaf.status == TreeNodeStatus::Available);
         let RenewalOutcome {
-            pedigrees,
+            mut pedigrees,
             any_renewal_landed,
-        } = self.check_renew_nodes(bare_pedigrees(new_leaves)).await?;
+        } = self.check_renew_nodes(bare_pedigrees(renewable)).await?;
+        pedigrees.extend(bare_pedigrees(held));
         let renewed_leaves: Vec<TreeNode> = pedigrees.iter().map(|p| p.leaf.clone()).collect();
         self.state
             .set_leaves(
@@ -553,7 +567,7 @@ impl TreeService for SynchronousTreeService {
             for leaf in &deleted {
                 if theirs
                     .get(&leaf.id)
-                    .is_some_and(|theirs| refund_timelock_dropped(leaf, theirs))
+                    .is_some_and(|theirs| refund_left_us(&self.identity_pubkey, leaf, theirs))
                 {
                     *agreeing.entry(leaf.id.clone()).or_default() += 1;
                 }
@@ -577,16 +591,28 @@ impl TreeService for SynchronousTreeService {
     }
 }
 
-/// Whether the operators' copy of a leaf carries a refund that replaced ours at a
-/// lower timelock. Only a transfer decrements it, one interval per hop, and it
-/// does so to hand the leaf to its next owner, so a drop is proof the leaf is no
-/// longer ours. A renewal moves the timelock the other way, and anything else,
-/// including a leaf the operators will not report at all, proves nothing and
-/// leaves the leaf exactly where it is.
-fn refund_timelock_dropped(ours: &TreeNode, theirs: &TreeNode) -> bool {
-    // Compare refunds only once the node itself matches. A reported node that
-    // funds a different transaction is not the leaf we are asking about, and its
-    // timelock says nothing about ours.
+/// Whether the operators' copy of a leaf says it has left us: it funds the same
+/// node, it is owned by somebody else, and its refund replaced ours at a lower
+/// timelock.
+///
+/// The owner is what makes this directional. A lower timelock on its own does
+/// not mean the leaf was handed on: a claim re-signs at `enforce_timelock`,
+/// which rounds down to the interval, so a leaf coming back to us can carry a
+/// lower one too (an HTLC refund sits at a 70-block offset and rounds down on
+/// claim). Requiring both means a leaf that returned to us is never mistaken for
+/// one that left, and anything the operators will not talk about proves nothing
+/// and stays exactly where it is.
+fn refund_left_us(identity: &PublicKey, ours: &TreeNode, theirs: &TreeNode) -> bool {
+    // Their copy has to name an owner, and it has to be someone else. An absent
+    // owner is not evidence either way, so it keeps the leaf.
+    let Some(owner) = theirs.owner_identity_public_key else {
+        return false;
+    };
+    if owner == *identity {
+        return false;
+    }
+    // And it has to be the same node: one that funds a different transaction is
+    // not the leaf we asked about, so its timelock says nothing about ours.
     if ours.node_tx != theirs.node_tx {
         return false;
     }
@@ -1637,10 +1663,24 @@ mod tests {
         assert!(!rx.has_changed().unwrap());
     }
 
-    /// A leaf whose refund tx carries `seq`, for comparing two copies of the
-    /// same leaf by their refund timelock.
-    fn leaf_with_refund_timelock(seq: u32) -> TreeNode {
+    fn pubkey_from(byte: u8) -> PublicKey {
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let sk = bitcoin::secp256k1::SecretKey::from_slice(&[byte; 32]).unwrap();
+        PublicKey::from_secret_key(&secp, &sk)
+    }
+
+    fn other_owner() -> PublicKey {
+        pubkey_from(0x22)
+    }
+
+    fn us() -> PublicKey {
+        pubkey_from(0x11)
+    }
+
+    /// A node at `seq`, owned by `owner`.
+    fn leaf_owned_at(owner: PublicKey, seq: u32) -> TreeNode {
         let mut node = create_test_leaves(&[1_000]).remove(0);
+        node.owner_identity_public_key = Some(owner);
         node.refund_tx = Some(Transaction {
             version: Version::non_standard(3),
             lock_time: LockTime::ZERO,
@@ -1657,49 +1697,72 @@ mod tests {
     /// enforces that, so a leaf only one of them vouches for stays put.
     #[test_all]
     fn a_leaf_is_only_proven_when_every_operator_agrees() {
-        let ours = leaf_with_refund_sequence(2000);
-        let lower = leaf_with_refund_sequence(1900);
-        let unchanged = leaf_with_refund_sequence(2000);
+        let ours = leaf_owned_at(us(), 2000);
+        let gone = leaf_owned_at(other_owner(), 1900);
+        let unchanged = leaf_owned_at(other_owner(), 2000);
 
         // Three operators, two of which report the replacement.
-        let agreeing = [&lower, &lower, &unchanged]
+        let agreeing = [&gone, &gone, &unchanged]
             .iter()
-            .filter(|theirs| refund_timelock_dropped(&ours, theirs))
+            .filter(|theirs| refund_left_us(&us(), &ours, theirs))
             .count();
         assert_eq!(agreeing, 2);
         assert_ne!(agreeing, 3, "a leaf one operator still vouches for is kept");
 
-        let all = [&lower, &lower, &lower]
+        let all = [&gone, &gone, &gone]
             .iter()
-            .filter(|theirs| refund_timelock_dropped(&ours, theirs))
+            .filter(|theirs| refund_left_us(&us(), &ours, theirs))
             .count();
         assert_eq!(all, 3, "unanimous replacement is what proves the spend");
     }
 
-    /// A transfer decrements the refund timelock to hand the leaf to its next
-    /// owner, so a lower one on the operators' copy is the proof that it left us.
-    /// A renewal moves it the other way, and an unchanged or absent refund says
-    /// nothing either way.
+    /// A leaf has left us only when somebody else owns it AND its refund
+    /// replaced ours at a lower timelock. The owner is what makes the test
+    /// directional: a claim re-signs through `enforce_timelock`, which rounds
+    /// down to the interval, so a leaf coming back to us carries a lower
+    /// timelock too and must not be mistaken for one that left.
     #[test_all]
-    fn only_a_lower_refund_timelock_proves_the_leaf_left() {
-        let ours = leaf_with_refund_timelock(2000);
+    fn a_leaf_left_only_when_someone_else_owns_it_at_a_lower_timelock() {
+        let ours = leaf_owned_at(us(), 2000);
 
-        assert!(refund_timelock_dropped(
+        assert!(refund_left_us(
+            &us(),
             &ours,
-            &leaf_with_refund_timelock(1900)
-        ));
-        assert!(!refund_timelock_dropped(
-            &ours,
-            &leaf_with_refund_timelock(2000)
-        ));
-        assert!(!refund_timelock_dropped(
-            &ours,
-            &leaf_with_refund_timelock(2100)
+            &leaf_owned_at(other_owner(), 1900)
         ));
 
-        let mut no_refund = leaf_with_refund_timelock(1900);
+        // The HTLC shape that rounds down on a claim back to us: lower, but ours.
+        let ours_htlc = leaf_owned_at(us(), 1970);
+        assert!(
+            !refund_left_us(&us(), &ours_htlc, &leaf_owned_at(us(), 1900)),
+            "a leaf claimed back to us is not a leaf that left"
+        );
+
+        // Someone else owns it, but the refund did not move.
+        assert!(!refund_left_us(
+            &us(),
+            &ours,
+            &leaf_owned_at(other_owner(), 2000)
+        ));
+        // A renewal moves the timelock the other way.
+        assert!(!refund_left_us(
+            &us(),
+            &ours,
+            &leaf_owned_at(other_owner(), 2100)
+        ));
+
+        let mut no_owner = leaf_owned_at(other_owner(), 1900);
+        no_owner.owner_identity_public_key = None;
+        assert!(!refund_left_us(&us(), &ours, &no_owner));
+
+        let mut no_refund = leaf_owned_at(other_owner(), 1900);
         no_refund.refund_tx = None;
-        assert!(!refund_timelock_dropped(&ours, &no_refund));
+        assert!(!refund_left_us(&us(), &ours, &no_refund));
+
+        // A different node entirely says nothing about ours.
+        let mut other_node = leaf_owned_at(other_owner(), 1900);
+        other_node.node_tx.lock_time = bitcoin::absolute::LockTime::from_height(7).unwrap();
+        assert!(!refund_left_us(&us(), &ours, &other_node));
     }
 
     #[test_all]

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -1224,20 +1224,24 @@ fn leaf_copies_agree(a: &TreeNode, b: &TreeNode) -> bool {
 /// spendable one. `OnChain` and `Exited` are the two an exit drives a leaf
 /// through, and they have to be asked for: a refresh that requested only
 /// `Available` lost the leaf from every operator's response at once the moment
-/// its node txs confirmed, and the store, reading that absence as a spend,
-/// deleted the chain the exit still needed to resume. `ParentExited` is the same
-/// problem one level down: exiting one leaf puts every other leaf under that
-/// parent into it, so a partial exit would drop the siblings it did not touch.
+/// its node txs confirmed, and the leaf then counted as one nobody reports.
 /// `RenewLocked` is the transient equivalent during a timelock renewal.
 ///
 /// `TransferLocked` is deliberately absent: a leaf of ours in that status is one
 /// we are sending, and re-reading it would undo the send.
+///
+/// `ParentExited` belongs here on the same reasoning as `OnChain`, and cannot be
+/// asked for: the operator rejects the whole query with `unknown tree node
+/// status`, so one unrecognised status costs every leaf in the refresh rather
+/// than the ones in that status. Leaving it out is the graceful half of that
+/// trade: a leaf under an exited parent is reported by nobody, so it is kept for
+/// its chain and stays exitable, out of the balance rather than out of reach.
+/// Nothing here may name a status the operators do not know.
 fn held_leaf_statuses() -> Vec<i32> {
     vec![
         ProtoTreeNodeStatus::Available as i32,
         ProtoTreeNodeStatus::OnChain as i32,
         ProtoTreeNodeStatus::Exited as i32,
-        ProtoTreeNodeStatus::ParentExited as i32,
         ProtoTreeNodeStatus::RenewLocked as i32,
     ]
 }
@@ -1793,13 +1797,19 @@ mod tests {
                 ProtoTreeNodeStatus::Available as i32,
                 ProtoTreeNodeStatus::OnChain as i32,
                 ProtoTreeNodeStatus::Exited as i32,
-                ProtoTreeNodeStatus::ParentExited as i32,
                 ProtoTreeNodeStatus::RenewLocked as i32,
             ]
         );
         assert!(
             !req.statuses
                 .contains(&(ProtoTreeNodeStatus::TransferLocked as i32))
+        );
+        // The operator rejects the entire query on a status it does not know,
+        // which costs every leaf in the refresh and not just the ones in that
+        // status. `ParentExited` is the one our proto has and it does not.
+        assert!(
+            !req.statuses
+                .contains(&(ProtoTreeNodeStatus::ParentExited as i32))
         );
         assert!(matches!(req.source, Some(Source::OwnerIdentityPubkey(_))));
     }

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -1771,6 +1771,11 @@ mod tests {
         assert!(!refund_left_us(&us(), &ours, &other_node));
     }
 
+    /// The refresh asks for the statuses a leaf we hold can be reported in, so a
+    /// leaf part-way through an exit keeps coming back instead of vanishing from
+    /// every operator at once. `TransferLocked` is deliberately not among them: a
+    /// leaf of ours in that status is one we are sending, and re-reading it would
+    /// undo the send.
     #[test_all]
     fn refresh_query_requests_held_leaf_statuses() {
         let owner = PublicKey::from_slice(&[2; 33]).unwrap();

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -499,6 +499,10 @@ impl TreeService for SynchronousTreeService {
         self.state.get_available_balance().await
     }
 
+    async fn list_leaves_kept_for_exit(&self) -> Result<Vec<TreeNode>, TreeServiceError> {
+        self.state.get_deleted_leaves().await
+    }
+
     async fn purge_proven_spent_leaves(&self) -> Result<usize, TreeServiceError> {
         let deleted = self.state.get_deleted_leaves().await?;
         if deleted.is_empty() {
@@ -522,6 +526,9 @@ impl TreeService for SynchronousTreeService {
             .map(|op| (op.id, op.client.clone()))
             .collect();
         let operator_count = operators.len();
+        if operator_count == 0 {
+            return Ok(0);
+        }
         let responses = join_all(operators.iter().map(|(id, client)| {
             let source = source.clone();
             async move {
@@ -577,6 +584,12 @@ impl TreeService for SynchronousTreeService {
 /// including a leaf the operators will not report at all, proves nothing and
 /// leaves the leaf exactly where it is.
 fn refund_timelock_dropped(ours: &TreeNode, theirs: &TreeNode) -> bool {
+    // Compare refunds only once the node itself matches. A reported node that
+    // funds a different transaction is not the leaf we are asking about, and its
+    // timelock says nothing about ours.
+    if ours.node_tx != theirs.node_tx {
+        return false;
+    }
     let (Some(ours), Some(theirs)) = (&ours.refund_tx, &theirs.refund_tx) else {
         return false;
     };
@@ -1180,12 +1193,20 @@ fn leaf_copies_agree(a: &TreeNode, b: &TreeNode) -> bool {
 /// through, and they have to be asked for: a refresh that requested only
 /// `Available` lost the leaf from every operator's response at once the moment
 /// its node txs confirmed, and the store, reading that absence as a spend,
-/// deleted the chain the exit still needed to resume.
+/// deleted the chain the exit still needed to resume. `ParentExited` is the same
+/// problem one level down: exiting one leaf puts every other leaf under that
+/// parent into it, so a partial exit would drop the siblings it did not touch.
+/// `RenewLocked` is the transient equivalent during a timelock renewal.
+///
+/// `TransferLocked` is deliberately absent: a leaf of ours in that status is one
+/// we are sending, and re-reading it would undo the send.
 fn held_leaf_statuses() -> Vec<i32> {
     vec![
         ProtoTreeNodeStatus::Available as i32,
         ProtoTreeNodeStatus::OnChain as i32,
         ProtoTreeNodeStatus::Exited as i32,
+        ProtoTreeNodeStatus::ParentExited as i32,
+        ProtoTreeNodeStatus::RenewLocked as i32,
     ]
 }
 
@@ -1698,6 +1719,8 @@ mod tests {
                 ProtoTreeNodeStatus::Available as i32,
                 ProtoTreeNodeStatus::OnChain as i32,
                 ProtoTreeNodeStatus::Exited as i32,
+                ProtoTreeNodeStatus::ParentExited as i32,
+                ProtoTreeNodeStatus::RenewLocked as i32,
             ]
         );
         assert!(

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -923,11 +923,17 @@ impl SynchronousTreeService {
             }
         }
 
+        // The query is what tells us anything about these leaves, so failing it
+        // tells us nothing. Hand them all back: the operators being unreachable
+        // is the case this whole store exists for, and it is not a reason to
+        // stop believing in leaves we hold.
         warn!(
-            "leaf_lifecycle cancel_verify_dropped_all: reservation={} reason=query_failed error={:?}",
-            reservation.id, last_err
+            "leaf_lifecycle cancel_verify_query_failed: reservation={} keeping={} error={:?}",
+            reservation.id,
+            reservation.leaves.len(),
+            last_err
         );
-        Vec::new()
+        reservation.leaves.clone()
     }
 
     async fn query_nodes_inner(

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -423,7 +423,7 @@ impl TreeService for SynchronousTreeService {
         // payments behind its rate limiter on large wallets. For remote signers we
         // skip leaves already stored with matching keys (see `VerifiedLeafKeys`),
         // re-checking only new or changed leaves. Local signers derive cheaply, so
-        // they skip the store read and verify every available leaf. Remaining
+        // they skip the store read and verify every reported leaf. Remaining
         // fetches run concurrently, leaving the signer to bound its own
         // concurrency; order is preserved for the zip below.
         let already_verified = if self.spark_signer.is_remote() {

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -8,6 +8,7 @@ use platform_utils::tokio;
 use platform_utils::tokio::sync::broadcast;
 use tracing::{debug, error, info, trace, warn};
 
+use crate::services::csv_timelock;
 use crate::tree::{
     LeafPedigree, LeafSelection, Leaves, ReservationPurpose, ReserveResult, SelectLeavesOptions,
     TreeNodeStatus,
@@ -496,6 +497,58 @@ impl TreeService for SynchronousTreeService {
 
     async fn get_available_balance(&self) -> Result<u64, TreeServiceError> {
         self.state.get_available_balance().await
+    }
+
+    async fn purge_proven_spent_leaves(&self) -> Result<usize, TreeServiceError> {
+        let deleted = self.state.get_deleted_leaves().await?;
+        if deleted.is_empty() {
+            return Ok(0);
+        }
+        let ids: Vec<TreeNodeId> = deleted.iter().map(|leaf| leaf.id.clone()).collect();
+        // By id rather than by owner. An owner query is status-filtered, and the
+        // operators drop Investigation, Lost and Reimbursed from it whatever we
+        // ask for, so it cannot tell a spent leaf from one it will not talk
+        // about. A lookup by id answers for a node in any status.
+        let theirs: HashMap<TreeNodeId, TreeNode> = self
+            .fetch_nodes(&ids, false)
+            .await?
+            .into_iter()
+            .map(|node| (node.id.clone(), node))
+            .collect();
+        let proven: Vec<TreeNodeId> = deleted
+            .iter()
+            .filter(|leaf| {
+                theirs
+                    .get(&leaf.id)
+                    .is_some_and(|theirs| refund_timelock_dropped(leaf, theirs))
+            })
+            .map(|leaf| leaf.id.clone())
+            .collect();
+        if !proven.is_empty() {
+            info!(
+                "Removing {} of {} kept leaves: their refunds were replaced at a lower timelock",
+                proven.len(),
+                deleted.len()
+            );
+            self.state.remove_leaves(&proven).await?;
+        }
+        Ok(proven.len())
+    }
+}
+
+/// Whether the operators' copy of a leaf carries a refund that replaced ours at a
+/// lower timelock. Only a transfer decrements it, one interval per hop, and it
+/// does so to hand the leaf to its next owner, so a drop is proof the leaf is no
+/// longer ours. A renewal moves the timelock the other way, and anything else,
+/// including a leaf the operators will not report at all, proves nothing and
+/// leaves the leaf exactly where it is.
+fn refund_timelock_dropped(ours: &TreeNode, theirs: &TreeNode) -> bool {
+    let (Some(ours), Some(theirs)) = (&ours.refund_tx, &theirs.refund_tx) else {
+        return false;
+    };
+    match (csv_timelock(ours), csv_timelock(theirs)) {
+        (Some(ours), Some(theirs)) => theirs < ours,
+        _ => false,
     }
 }
 
@@ -1529,11 +1582,48 @@ mod tests {
         assert!(!rx.has_changed().unwrap());
     }
 
-    /// The refresh asks for the statuses a leaf we hold can be reported in, so a
-    /// leaf part-way through an exit keeps coming back instead of vanishing from
-    /// every operator at once. `TransferLocked` is deliberately not among them: a
-    /// leaf of ours in that status is one we are sending, and re-reading it would
-    /// undo the send.
+    /// A leaf whose refund tx carries `seq`, for comparing two copies of the
+    /// same leaf by their refund timelock.
+    fn leaf_with_refund_timelock(seq: u32) -> TreeNode {
+        let mut node = create_test_leaves(&[1_000]).remove(0);
+        node.refund_tx = Some(Transaction {
+            version: Version::non_standard(3),
+            lock_time: LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                sequence: bitcoin::Sequence::from_consensus(seq),
+                ..Default::default()
+            }],
+            output: vec![],
+        });
+        node
+    }
+
+    /// A transfer decrements the refund timelock to hand the leaf to its next
+    /// owner, so a lower one on the operators' copy is the proof that it left us.
+    /// A renewal moves it the other way, and an unchanged or absent refund says
+    /// nothing either way.
+    #[test_all]
+    fn only_a_lower_refund_timelock_proves_the_leaf_left() {
+        let ours = leaf_with_refund_timelock(2000);
+
+        assert!(refund_timelock_dropped(
+            &ours,
+            &leaf_with_refund_timelock(1900)
+        ));
+        assert!(!refund_timelock_dropped(
+            &ours,
+            &leaf_with_refund_timelock(2000)
+        ));
+        assert!(!refund_timelock_dropped(
+            &ours,
+            &leaf_with_refund_timelock(2100)
+        ));
+
+        let mut no_refund = leaf_with_refund_timelock(1900);
+        no_refund.refund_tx = None;
+        assert!(!refund_timelock_dropped(&ours, &no_refund));
+    }
+
     #[test_all]
     fn refresh_query_requests_held_leaf_statuses() {
         let owner = PublicKey::from_slice(&[2; 33]).unwrap();

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -318,20 +318,29 @@ impl TreeService for SynchronousTreeService {
 
         // Leaves only. Asking for each leaf's ancestors here would re-download every
         // chain on every refresh, including the ones already stored.
-        let coord_fut =
-            self.query_nodes(&coordinator_client, false, None, available_leaf_statuses());
+        let coord_fut = self.query_nodes(&coordinator_client, false, None, held_leaf_statuses());
         let op_futs = operators.iter().map(|(id, client)| async move {
             (
                 *id,
-                self.query_nodes(client, false, None, available_leaf_statuses())
+                self.query_nodes(client, false, None, held_leaf_statuses())
                     .await,
             )
         });
 
         let (coordinator_leaves_res, operator_results) = tokio::join!(coord_fut, join_all(op_futs));
-        let coordinator_leaves: Vec<TreeNode> = coordinator_leaves_res?
+        // Status cannot pick the leaves out of the response any more: now that a
+        // mid-exit leaf is asked for, an ancestor of one is just as able to come
+        // back `OnChain` as the leaf below it. Go by shape instead, and drop what
+        // another node in the same response calls its parent: an ancestor is not
+        // a leaf, whatever status it is in.
+        let coordinator_nodes = coordinator_leaves_res?;
+        let parent_ids: HashSet<TreeNodeId> = coordinator_nodes
+            .iter()
+            .filter_map(|n| n.parent_node_id.clone())
+            .collect();
+        let coordinator_leaves: Vec<TreeNode> = coordinator_nodes
             .into_iter()
-            .filter(|n| n.status == TreeNodeStatus::Available)
+            .filter(|n| !parent_ids.contains(&n.id))
             .collect();
         debug!(
             leaves = coordinator_leaves.len(),
@@ -394,21 +403,11 @@ impl TreeService for SynchronousTreeService {
             }
         }
 
-        // Leaves not Available are ignored outright; the rest need an ownership
-        // check (our signing share + the operators' share must equal the
-        // verifying key).
-        let available_leaves: Vec<&TreeNode> = coordinator_leaves
-            .iter()
-            .filter(|leaf| {
-                if leaf.status == TreeNodeStatus::Available {
-                    true
-                } else {
-                    info!("Ignoring leaf {} due to status: {:?}", leaf.id, leaf.status);
-                    ignored_leaves_map.insert(leaf.id.clone(), (*leaf).clone());
-                    false
-                }
-            })
-            .collect();
+        // Every reported leaf needs an ownership check (our signing share plus the
+        // operators' share must equal the verifying key). The check is not gated on
+        // status: a leaf part-way through an exit is still ours, and dropping it
+        // here would strand the chain that exit resumes from.
+        let reported_leaves: Vec<&TreeNode> = coordinator_leaves.iter().collect();
 
         // Deriving our leaf pubkey is a network round-trip on a remote signer, so
         // re-deriving every leaf each refresh would flood the signer and stall
@@ -423,7 +422,7 @@ impl TreeService for SynchronousTreeService {
         } else {
             HashMap::new()
         };
-        let unverified_leaves: Vec<&TreeNode> = available_leaves
+        let unverified_leaves: Vec<&TreeNode> = reported_leaves
             .iter()
             .copied()
             .filter(|leaf| {
@@ -1077,8 +1076,18 @@ fn bare_pedigrees(leaves: Vec<TreeNode>) -> Vec<LeafPedigree> {
         .collect()
 }
 
-fn available_leaf_statuses() -> Vec<i32> {
-    vec![ProtoTreeNodeStatus::Available as i32]
+/// The statuses a leaf we still hold can be reported in. `Available` is the
+/// spendable one. `OnChain` and `Exited` are the two an exit drives a leaf
+/// through, and they have to be asked for: a refresh that requested only
+/// `Available` lost the leaf from every operator's response at once the moment
+/// its node txs confirmed, and the store, reading that absence as a spend,
+/// deleted the chain the exit still needed to resume.
+fn held_leaf_statuses() -> Vec<i32> {
+    vec![
+        ProtoTreeNodeStatus::Available as i32,
+        ProtoTreeNodeStatus::OnChain as i32,
+        ProtoTreeNodeStatus::Exited as i32,
+    ]
 }
 
 fn query_nodes_request(
@@ -1508,8 +1517,13 @@ mod tests {
         assert!(!rx.has_changed().unwrap());
     }
 
+    /// The refresh asks for the statuses a leaf we hold can be reported in, so a
+    /// leaf part-way through an exit keeps coming back instead of vanishing from
+    /// every operator at once. `TransferLocked` is deliberately not among them: a
+    /// leaf of ours in that status is one we are sending, and re-reading it would
+    /// undo the send.
     #[test_all]
-    fn refresh_query_requests_only_available_leaves() {
+    fn refresh_query_requests_held_leaf_statuses() {
         let owner = PublicKey::from_slice(&[2; 33]).unwrap();
         let req = query_nodes_request(
             &owner,
@@ -1517,9 +1531,16 @@ mod tests {
             false,
             Network::Mainnet,
             &PagingFilter::default(),
-            available_leaf_statuses(),
+            held_leaf_statuses(),
         );
-        assert_eq!(req.statuses, vec![ProtoTreeNodeStatus::Available as i32]);
+        assert_eq!(
+            req.statuses,
+            vec![
+                ProtoTreeNodeStatus::Available as i32,
+                ProtoTreeNodeStatus::OnChain as i32,
+                ProtoTreeNodeStatus::Exited as i32,
+            ]
+        );
         assert!(
             !req.statuses
                 .contains(&(ProtoTreeNodeStatus::TransferLocked as i32))

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -308,51 +308,33 @@ impl TreeService for SynchronousTreeService {
         // Leaves added after this time will be preserved even if not in the refresh data.
         let refresh_started_at = self.state.now().await?;
 
-        // Prepare queries for coordinator and all operators and run them in parallel
-        let coordinator_client = self.operator_pool.get_coordinator().client.clone();
+        // Query every operator the same way. The coordinator gets no special say in
+        // which leaves are ours, so it takes part in the same comparison as the rest.
+        // Leaves only: asking for each leaf's ancestors here would re-download every
+        // chain on every refresh, including the ones already stored.
         let operators: Vec<_> = self
             .operator_pool
-            .get_non_coordinator_operators()
+            .get_all_operators()
             .map(|op| (op.id, op.client.clone()))
             .collect();
-
-        // Leaves only. Asking for each leaf's ancestors here would re-download every
-        // chain on every refresh, including the ones already stored.
-        let coord_fut = self.query_nodes(&coordinator_client, false, None, held_leaf_statuses());
-        let op_futs = operators.iter().map(|(id, client)| async move {
+        let coordinator_id = self.operator_pool.get_coordinator().id;
+        let operator_count = operators.len();
+        let responses = join_all(operators.iter().map(|(id, client)| async move {
             (
                 *id,
                 self.query_nodes(client, false, None, held_leaf_statuses())
                     .await,
             )
-        });
+        }))
+        .await;
 
-        let (coordinator_leaves_res, operator_results) = tokio::join!(coord_fut, join_all(op_futs));
-        // Status cannot pick the leaves out of the response any more: now that a
-        // mid-exit leaf is asked for, an ancestor of one is just as able to come
-        // back `OnChain` as the leaf below it. Go by shape instead, and drop what
-        // another node in the same response calls its parent: an ancestor is not
-        // a leaf, whatever status it is in.
-        let coordinator_nodes = coordinator_leaves_res?;
-        let parent_ids: HashSet<TreeNodeId> = coordinator_nodes
-            .iter()
-            .filter_map(|n| n.parent_node_id.clone())
-            .collect();
-        let coordinator_leaves: Vec<TreeNode> = coordinator_nodes
-            .into_iter()
-            .filter(|n| !parent_ids.contains(&n.id))
-            .collect();
-        debug!(
-            leaves = coordinator_leaves.len(),
-            "refresh_leaves: fetched leaves"
-        );
-
-        // Propagate any operator query error to preserve original behavior and
-        // collect successful operator leaves for later comparison
-        let mut operator_leaves_vec: Vec<Vec<TreeNode>> = Vec::new();
-        for (id, res) in operator_results {
+        // One unreachable operator would shrink the comparison below, making the
+        // leaves only it still reports look dropped by everyone, so a refresh is all
+        // or nothing.
+        let mut per_operator = Vec::with_capacity(responses.len());
+        for (id, res) in responses {
             match res {
-                Ok(leaves) => operator_leaves_vec.push(leaves),
+                Ok(nodes) => per_operator.push((id, nodes)),
                 Err(e) => {
                     error!("Failed to query operator {id}: {e:?}");
                     return Err(e);
@@ -360,54 +342,74 @@ impl TreeService for SynchronousTreeService {
             }
         }
 
+        // Status cannot pick the leaves out of a response any more: now that a
+        // mid-exit leaf is asked for, an ancestor of one is just as able to come
+        // back `OnChain` as the leaf below it. Go by shape instead, and drop what
+        // another node in the same response calls its parent: an ancestor is not a
+        // leaf, whatever status it is in.
+        let mut reported: HashMap<TreeNodeId, Vec<(usize, TreeNode)>> = HashMap::new();
+        for (id, nodes) in per_operator {
+            let parent_ids: HashSet<TreeNodeId> = nodes
+                .iter()
+                .filter_map(|n| n.parent_node_id.clone())
+                .collect();
+            for node in nodes {
+                if parent_ids.contains(&node.id) {
+                    continue;
+                }
+                reported
+                    .entry(node.id.clone())
+                    .or_default()
+                    .push((id, node));
+            }
+        }
+        debug!(
+            leaves = reported.len(),
+            operators = operator_count,
+            "refresh_leaves: fetched leaves from every operator"
+        );
+
         let mut missing_operator_leaves_map: HashMap<TreeNodeId, TreeNode> = HashMap::new();
         let mut ignored_leaves_map: HashMap<TreeNodeId, TreeNode> = HashMap::new();
 
-        // For each operator's leaves, compare against coordinator in the same way as before
-        for (operator_id, operator_leaves) in operators.into_iter().zip(operator_leaves_vec) {
-            // Paging over a set the operator is concurrently mutating can return the
-            // same leaf on more than one page, so keep the first occurrence.
-            let mut operator_leaves_by_id: HashMap<&TreeNodeId, &TreeNode> =
-                HashMap::with_capacity(operator_leaves.len());
-            for operator_leaf in &operator_leaves {
-                operator_leaves_by_id
-                    .entry(&operator_leaf.id)
-                    .or_insert(operator_leaf);
+        // A leaf every operator reported identically is clean. One that some of them
+        // dropped, or described differently, is still ours and still counts towards
+        // the balance, but it is held back from payments until they agree again. A
+        // leaf no operator reports is simply absent from here, and that absence is
+        // what the store reads as a deletion: it now takes every operator to drop a
+        // leaf, where before the coordinator alone decided.
+        let mut union_leaves: Vec<TreeNode> = Vec::with_capacity(reported.len());
+        for (leaf_id, copies) in reported {
+            // Where the operators disagree no copy is the right one, so keep the
+            // coordinator's, the one the rest of the client transacts against. The
+            // leaf is held back either way.
+            let Some(representative) = copies
+                .iter()
+                .find(|(id, _)| *id == coordinator_id)
+                .or_else(|| copies.first())
+                .map(|(_, node)| node.clone())
+            else {
+                continue;
+            };
+            let agreed = copies.len() == operator_count
+                && copies
+                    .iter()
+                    .all(|(_, node)| leaf_copies_agree(node, &representative));
+            if !agreed {
+                warn!(
+                    "Leaf {leaf_id} reported by {} of {operator_count} operators, and not identically by all of them; holding it back from payments",
+                    copies.len()
+                );
+                missing_operator_leaves_map.insert(leaf_id.clone(), representative.clone());
             }
-
-            for leaf in &coordinator_leaves {
-                match operator_leaves_by_id.get(&leaf.id).copied() {
-                    Some(operator_leaf) => {
-                        // TODO: move this logic to TreeNode method
-                        if operator_leaf.status != leaf.status
-                            || operator_leaf.signing_keyshare.public_key
-                                != leaf.signing_keyshare.public_key
-                            || operator_leaf.node_tx != leaf.node_tx
-                            || operator_leaf.refund_tx != leaf.refund_tx
-                        {
-                            warn!(
-                                "Ignoring leaf due to mismatch between coordinator and operator {}. Coordinator: {:?}, Operator: {:?}",
-                                operator_id.0, leaf, operator_leaf
-                            );
-                            missing_operator_leaves_map.insert(leaf.id.clone(), leaf.clone());
-                        }
-                    }
-                    None => {
-                        warn!(
-                            "Ignoring leaf due to missing from operator {}: {:?}",
-                            operator_id.0, leaf.id
-                        );
-                        missing_operator_leaves_map.insert(leaf.id.clone(), leaf.clone());
-                    }
-                }
-            }
+            union_leaves.push(representative);
         }
 
         // Every reported leaf needs an ownership check (our signing share plus the
         // operators' share must equal the verifying key). The check is not gated on
         // status: a leaf part-way through an exit is still ours, and dropping it
         // here would strand the chain that exit resumes from.
-        let reported_leaves: Vec<&TreeNode> = coordinator_leaves.iter().collect();
+        let reported_leaves: Vec<&TreeNode> = union_leaves.iter().collect();
 
         // Deriving our leaf pubkey is a network round-trip on a remote signer, so
         // re-deriving every leaf each refresh would flood the signer and stall
@@ -457,7 +459,7 @@ impl TreeService for SynchronousTreeService {
             }
         }
 
-        let new_leaves = coordinator_leaves
+        let new_leaves = union_leaves
             .into_iter()
             .filter(|leaf| {
                 !missing_operator_leaves_map.contains_key(&leaf.id)
@@ -1074,6 +1076,16 @@ fn bare_pedigrees(leaves: Vec<TreeNode>) -> Vec<LeafPedigree> {
             ancestors: Vec::new(),
         })
         .collect()
+}
+
+/// Whether two operators' views of one leaf describe the same leaf. Compares what
+/// a client goes on to act upon: the status, the operators' share of the signing
+/// key, and the two transactions an exit broadcasts.
+fn leaf_copies_agree(a: &TreeNode, b: &TreeNode) -> bool {
+    a.status == b.status
+        && a.signing_keyshare.public_key == b.signing_keyshare.public_key
+        && a.node_tx == b.node_tx
+        && a.refund_tx == b.refund_tx
 }
 
 /// The statuses a leaf we still hold can be reported in. `Available` is the

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -3,11 +3,13 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
+use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::PublicKey;
 use platform_utils::tokio;
 use platform_utils::tokio::sync::broadcast;
 use tracing::{debug, error, info, trace, warn};
 
+use crate::bitcoin::{BitcoinService, sighash_from_tx, verify_finalized_taproot_signature_tx};
 use crate::services::csv_timelock;
 use crate::tree::{
     LeafPedigree, LeafSelection, Leaves, ReservationPurpose, ReserveResult, SelectLeavesOptions,
@@ -523,9 +525,6 @@ impl TreeService for SynchronousTreeService {
             return Ok(0);
         }
         let ids: Vec<TreeNodeId> = deleted.iter().map(|leaf| leaf.id.clone()).collect();
-        let source = Source::NodeIds(TreeNodeIds {
-            node_ids: ids.iter().map(ToString::to_string).collect(),
-        });
 
         // Ask every operator, by id. By id because an owner query is
         // status-filtered, and the operators drop Investigation, Lost and
@@ -539,49 +538,27 @@ impl TreeService for SynchronousTreeService {
             .get_all_operators()
             .map(|op| (op.id, op.client.clone()))
             .collect();
-        let operator_count = operators.len();
-        if operator_count == 0 {
+        if operators.is_empty() {
             return Ok(0);
         }
-        let responses = join_all(operators.iter().map(|(id, client)| {
-            let source = source.clone();
-            async move {
-                (
-                    *id,
-                    self.query_nodes(client, false, Some(source), vec![]).await,
-                )
-            }
+        let ids = &ids;
+        let responses = join_all(operators.iter().map(|(id, client)| async move {
+            (*id, self.query_nodes_by_id_batched(client, ids).await)
         }))
         .await;
 
-        // An operator we could not reach has not vouched for anything, so its
-        // silence holds the leaves rather than counting towards a deletion.
-        let mut agreeing: HashMap<TreeNodeId, usize> = HashMap::new();
-        for (id, res) in responses {
-            let Ok(nodes) = res else {
-                debug!("purge: operator {id} unreachable, keeping every leaf this round");
-                return Ok(0);
-            };
-            let theirs: HashMap<TreeNodeId, TreeNode> =
-                nodes.into_iter().map(|n| (n.id.clone(), n)).collect();
-            for leaf in &deleted {
-                if theirs
-                    .get(&leaf.id)
-                    .is_some_and(|theirs| refund_left_us(&self.identity_pubkey, leaf, theirs))
-                {
-                    *agreeing.entry(leaf.id.clone()).or_default() += 1;
-                }
-            }
-        }
-
-        let proven: Vec<TreeNodeId> = deleted
-            .iter()
-            .filter(|leaf| agreeing.get(&leaf.id) == Some(&operator_count))
-            .map(|leaf| leaf.id.clone())
-            .collect();
+        let bitcoin_service = BitcoinService::new(self.network);
+        let Some(proven) = prove_spent_leaves(
+            &bitcoin_service,
+            &self.identity_pubkey,
+            &deleted,
+            &responses,
+        ) else {
+            return Ok(0);
+        };
         if !proven.is_empty() {
             info!(
-                "Removing {} of {} kept leaves: every operator reports their refund replaced at a lower timelock",
+                "Removing {} of {} kept leaves: every operator reports their refund replaced, at a lower timelock, by one we co-signed",
                 proven.len(),
                 deleted.len()
             );
@@ -591,9 +568,61 @@ impl TreeService for SynchronousTreeService {
     }
 }
 
-/// Whether the operators' copy of a leaf says it has left us: it funds the same
-/// node, it is owned by somebody else, and its refund replaced ours at a lower
-/// timelock.
+/// How many node ids go into one `QueryNodes` request. The kept set has no
+/// bound: a leaf the operators will not talk about is never proven and stays
+/// forever, so the set only grows and cannot be sent in a single message.
+const PURGE_QUERY_BATCH: usize = 100;
+
+/// The ids every operator agrees have left us.
+///
+/// `None` when any operator failed to answer: silence has not vouched for
+/// anything, so it holds every leaf rather than counting towards a deletion.
+/// Agreement is counted per distinct operator, so a pool that answered twice for
+/// one of them cannot pass for agreement another never gave.
+fn prove_spent_leaves<E>(
+    bitcoin_service: &BitcoinService,
+    identity: &PublicKey,
+    deleted: &[TreeNode],
+    responses: &[(usize, Result<Vec<TreeNode>, E>)],
+) -> Option<Vec<TreeNodeId>> {
+    let mut agreeing: HashMap<&TreeNodeId, HashSet<usize>> = HashMap::new();
+    let mut answered: HashSet<usize> = HashSet::new();
+    for (id, res) in responses {
+        let Ok(nodes) = res else {
+            debug!("purge: operator {id} unreachable, keeping every leaf this round");
+            return None;
+        };
+        answered.insert(*id);
+        let theirs: HashMap<&TreeNodeId, &TreeNode> = nodes.iter().map(|n| (&n.id, n)).collect();
+        for leaf in deleted {
+            if theirs
+                .get(&leaf.id)
+                .is_some_and(|theirs| refund_left_us(bitcoin_service, identity, leaf, theirs))
+            {
+                agreeing.entry(&leaf.id).or_default().insert(*id);
+            }
+        }
+    }
+    let operator_count = answered.len();
+    if operator_count == 0 {
+        return None;
+    }
+    Some(
+        deleted
+            .iter()
+            .filter(|leaf| {
+                agreeing
+                    .get(&leaf.id)
+                    .is_some_and(|ops| ops.len() == operator_count)
+            })
+            .map(|leaf| leaf.id.clone())
+            .collect(),
+    )
+}
+
+/// Whether the operators' copy of a leaf proves it has left us: it is owned by
+/// somebody else, and it replaces our refund, spending the same node output at a
+/// lower timelock under a signature we must have taken part in.
 ///
 /// The owner is what makes this directional. A lower timelock on its own does
 /// not mean the leaf was handed on: a claim re-signs at `enforce_timelock`,
@@ -602,7 +631,19 @@ impl TreeService for SynchronousTreeService {
 /// claim). Requiring both means a leaf that returned to us is never mistaken for
 /// one that left, and anything the operators will not talk about proves nothing
 /// and stays exactly where it is.
-fn refund_left_us(identity: &PublicKey, ours: &TreeNode, theirs: &TreeNode) -> bool {
+///
+/// The signature is what makes it evidence rather than testimony. Everything
+/// else here is read straight off a response, so an operator set that answers in
+/// concert could otherwise hand us a bare transaction and have us delete the
+/// chain we keep in order to survive exactly that party. A leaf is 2-of-2, so a
+/// signature that verifies under our own `verifying_public_key` is one we took
+/// part in producing, and no operator can forge it.
+fn refund_left_us(
+    bitcoin_service: &BitcoinService,
+    identity: &PublicKey,
+    ours: &TreeNode,
+    theirs: &TreeNode,
+) -> bool {
     // Their copy has to name an owner, and it has to be someone else. An absent
     // owner is not evidence either way, so it keeps the leaf.
     let Some(owner) = theirs.owner_identity_public_key else {
@@ -611,18 +652,37 @@ fn refund_left_us(identity: &PublicKey, ours: &TreeNode, theirs: &TreeNode) -> b
     if owner == *identity {
         return false;
     }
-    // And it has to be the same node: one that funds a different transaction is
-    // not the leaf we asked about, so its timelock says nothing about ours.
-    if ours.node_tx != theirs.node_tx {
-        return false;
-    }
-    let (Some(ours), Some(theirs)) = (&ours.refund_tx, &theirs.refund_tx) else {
+    let (Some(our_refund), Some(their_refund)) = (&ours.refund_tx, &theirs.refund_tx) else {
         return false;
     };
-    match (csv_timelock(ours), csv_timelock(theirs)) {
-        (Some(ours), Some(theirs)) => theirs < ours,
-        _ => false,
+    // A replacement spends the output ours does. Checking it against our own
+    // stored node tx, rather than against the copy they sent, is what stops a
+    // rewritten node tx carrying a rewritten refund past this.
+    let funding = bitcoin::OutPoint::new(ours.node_tx.compute_txid(), 0);
+    if their_refund
+        .input
+        .first()
+        .is_none_or(|input| input.previous_output != funding)
+    {
+        return false;
     }
+    match (csv_timelock(our_refund), csv_timelock(their_refund)) {
+        (Some(ours), Some(theirs)) if theirs < ours => {}
+        _ => return false,
+    }
+    let Some(funded) = ours.node_tx.output.first() else {
+        return false;
+    };
+    let Ok(sighash) = sighash_from_tx(their_refund, 0, funded) else {
+        return false;
+    };
+    verify_finalized_taproot_signature_tx(
+        bitcoin_service,
+        their_refund,
+        &sighash.to_raw_hash().to_byte_array(),
+        &ours.verifying_public_key,
+    )
+    .is_ok()
 }
 
 impl SynchronousTreeService {
@@ -967,6 +1027,26 @@ impl SynchronousTreeService {
             items,
             next: paging.next_from_offset(nodes.offset),
         })
+    }
+
+    /// Looks nodes up by id in batches, so a caller holding an unbounded set of
+    /// ids does not put all of them in one request.
+    async fn query_nodes_by_id_batched(
+        &self,
+        client: &SparkRpcClient,
+        ids: &[TreeNodeId],
+    ) -> Result<Vec<TreeNode>, TreeServiceError> {
+        let mut nodes = Vec::with_capacity(ids.len());
+        for batch in ids.chunks(PURGE_QUERY_BATCH) {
+            let source = Source::NodeIds(TreeNodeIds {
+                node_ids: batch.iter().map(ToString::to_string).collect(),
+            });
+            nodes.extend(
+                self.query_nodes(client, false, Some(source), vec![])
+                    .await?,
+            );
+        }
+        Ok(nodes)
     }
 
     async fn query_nodes(
@@ -1687,43 +1767,148 @@ mod tests {
         pubkey_from(0x11)
     }
 
-    /// A node at `seq`, owned by `owner`.
-    fn leaf_owned_at(owner: PublicKey, seq: u32) -> TreeNode {
+    fn keypair_from(byte: u8) -> bitcoin::secp256k1::Keypair {
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        bitcoin::secp256k1::Keypair::from_seckey_slice(&secp, &[byte; 32]).unwrap()
+    }
+
+    /// The signing group of the leaf under test. A leaf is 2-of-2, so this one
+    /// keypair stands in for the whole group: a refund only verifies under it if
+    /// we took part in signing.
+    fn leaf_signer() -> bitcoin::secp256k1::Keypair {
+        keypair_from(0x33)
+    }
+
+    /// A leaf of ours, funded by a node output and refunded at `seq`.
+    fn our_leaf(seq: u32) -> TreeNode {
         let mut node = create_test_leaves(&[1_000]).remove(0);
-        node.owner_identity_public_key = Some(owner);
-        node.refund_tx = Some(Transaction {
-            version: Version::non_standard(3),
-            lock_time: LockTime::ZERO,
-            input: vec![bitcoin::TxIn {
-                sequence: bitcoin::Sequence::from_consensus(seq),
-                ..Default::default()
-            }],
-            output: vec![],
-        });
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let verifying = leaf_signer().public_key();
+        node.verifying_public_key = verifying;
+        node.owner_identity_public_key = Some(us());
+        let (x_only, _) = verifying.x_only_public_key();
+        node.node_tx.output = vec![bitcoin::TxOut {
+            value: bitcoin::Amount::from_sat(1_000),
+            script_pubkey: bitcoin::ScriptBuf::new_p2tr(&secp, x_only, None),
+        }];
+        node.refund_tx = Some(refund_spending(&node, seq));
         node
     }
 
-    /// Deleting takes every operator. Counting agreement per leaf is what
-    /// enforces that, so a leaf only one of them vouches for stays put.
+    /// An unsigned refund of `leaf` at `seq`.
+    fn refund_spending(leaf: &TreeNode, seq: u32) -> Transaction {
+        Transaction {
+            version: Version::non_standard(3),
+            lock_time: LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::new(leaf.node_tx.compute_txid(), 0),
+                sequence: bitcoin::Sequence::from_consensus(seq),
+                ..Default::default()
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(900),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        }
+    }
+
+    /// Signs `refund` against the output of `funded` it spends.
+    fn sign_refund(refund: &mut Transaction, funded: &TreeNode, kp: &bitcoin::secp256k1::Keypair) {
+        use bitcoin::key::TapTweak;
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let sighash = sighash_from_tx(refund, 0, &funded.node_tx.output[0]).unwrap();
+        let tweaked = kp.tap_tweak(&secp, None).to_keypair();
+        let sig = secp.sign_schnorr_no_aux_rand(
+            &bitcoin::secp256k1::Message::from_digest(sighash.to_raw_hash().to_byte_array()),
+            &tweaked,
+        );
+        refund.input[0].witness = bitcoin::Witness::from_slice(&[sig.serialize()]);
+    }
+
+    /// The operators' copy of `ours`: same node, owned by `owner`, refunded at
+    /// `seq` under a signature `signer` produced.
+    fn their_copy(
+        ours: &TreeNode,
+        owner: PublicKey,
+        seq: u32,
+        signer: &bitcoin::secp256k1::Keypair,
+    ) -> TreeNode {
+        let mut theirs = ours.clone();
+        theirs.owner_identity_public_key = Some(owner);
+        let mut refund = refund_spending(ours, seq);
+        sign_refund(&mut refund, ours, signer);
+        theirs.refund_tx = Some(refund);
+        theirs
+    }
+
+    fn service() -> BitcoinService {
+        BitcoinService::new(Network::Regtest)
+    }
+
+    /// Deleting takes every operator, counted per distinct operator: a leaf one
+    /// of them still vouches for stays put, and an operator answering twice does
+    /// not cover for one that disagreed.
     #[test_all]
     fn a_leaf_is_only_proven_when_every_operator_agrees() {
-        let ours = leaf_owned_at(us(), 2000);
-        let gone = leaf_owned_at(other_owner(), 1900);
-        let unchanged = leaf_owned_at(other_owner(), 2000);
+        let ours = our_leaf(2000);
+        let deleted = vec![ours.clone()];
+        let gone = their_copy(&ours, other_owner(), 1900, &leaf_signer());
+        let unchanged = their_copy(&ours, other_owner(), 2000, &leaf_signer());
+        let proven = |responses: &[(usize, Result<Vec<TreeNode>, ()>)]| {
+            prove_spent_leaves(&service(), &us(), &deleted, responses)
+        };
 
-        // Three operators, two of which report the replacement.
-        let agreeing = [&gone, &gone, &unchanged]
-            .iter()
-            .filter(|theirs| refund_left_us(&us(), &ours, theirs))
-            .count();
-        assert_eq!(agreeing, 2);
-        assert_ne!(agreeing, 3, "a leaf one operator still vouches for is kept");
+        assert_eq!(
+            proven(&[
+                (0, Ok(vec![gone.clone()])),
+                (1, Ok(vec![gone.clone()])),
+                (2, Ok(vec![gone.clone()])),
+            ]),
+            Some(vec![ours.id.clone()]),
+            "unanimous replacement is what proves the spend"
+        );
 
-        let all = [&gone, &gone, &gone]
-            .iter()
-            .filter(|theirs| refund_left_us(&us(), &ours, theirs))
-            .count();
-        assert_eq!(all, 3, "unanimous replacement is what proves the spend");
+        assert_eq!(
+            proven(&[
+                (0, Ok(vec![gone.clone()])),
+                (1, Ok(vec![gone.clone()])),
+                (2, Ok(vec![unchanged.clone()])),
+            ]),
+            Some(Vec::new()),
+            "a leaf one operator still vouches for is kept"
+        );
+
+        assert_eq!(
+            proven(&[
+                (0, Ok(vec![gone.clone()])),
+                (1, Ok(vec![gone.clone()])),
+                (2, Ok(Vec::new())),
+            ]),
+            Some(Vec::new()),
+            "an operator that does not report the leaf has vouched for nothing"
+        );
+
+        assert_eq!(
+            proven(&[
+                (0, Ok(vec![gone.clone()])),
+                (1, Ok(vec![gone.clone()])),
+                (2, Err(())),
+            ]),
+            None,
+            "an unreachable operator holds every leaf, however the rest answered"
+        );
+
+        assert_eq!(
+            proven(&[
+                (0, Ok(vec![gone.clone()])),
+                (1, Ok(vec![unchanged])),
+                (0, Ok(vec![gone])),
+            ]),
+            Some(Vec::new()),
+            "one operator answering twice is not two operators agreeing"
+        );
+
+        assert_eq!(proven(&[]), None, "no operators prove nothing");
     }
 
     /// A leaf has left us only when somebody else owns it AND its refund
@@ -1733,46 +1918,83 @@ mod tests {
     /// timelock too and must not be mistaken for one that left.
     #[test_all]
     fn a_leaf_left_only_when_someone_else_owns_it_at_a_lower_timelock() {
-        let ours = leaf_owned_at(us(), 2000);
+        let ours = our_leaf(2000);
+        let signer = leaf_signer();
+        let left = |theirs: &TreeNode| refund_left_us(&service(), &us(), &ours, theirs);
 
-        assert!(refund_left_us(
-            &us(),
-            &ours,
-            &leaf_owned_at(other_owner(), 1900)
-        ));
+        assert!(left(&their_copy(&ours, other_owner(), 1900, &signer)));
 
         // The HTLC shape that rounds down on a claim back to us: lower, but ours.
-        let ours_htlc = leaf_owned_at(us(), 1970);
+        let ours_htlc = our_leaf(1970);
         assert!(
-            !refund_left_us(&us(), &ours_htlc, &leaf_owned_at(us(), 1900)),
+            !refund_left_us(
+                &service(),
+                &us(),
+                &ours_htlc,
+                &their_copy(&ours_htlc, us(), 1900, &signer)
+            ),
             "a leaf claimed back to us is not a leaf that left"
         );
 
         // Someone else owns it, but the refund did not move.
-        assert!(!refund_left_us(
-            &us(),
-            &ours,
-            &leaf_owned_at(other_owner(), 2000)
-        ));
+        assert!(!left(&their_copy(&ours, other_owner(), 2000, &signer)));
         // A renewal moves the timelock the other way.
-        assert!(!refund_left_us(
-            &us(),
-            &ours,
-            &leaf_owned_at(other_owner(), 2100)
-        ));
+        assert!(!left(&their_copy(&ours, other_owner(), 2100, &signer)));
 
-        let mut no_owner = leaf_owned_at(other_owner(), 1900);
+        let mut no_owner = their_copy(&ours, other_owner(), 1900, &signer);
         no_owner.owner_identity_public_key = None;
-        assert!(!refund_left_us(&us(), &ours, &no_owner));
+        assert!(!left(&no_owner));
 
-        let mut no_refund = leaf_owned_at(other_owner(), 1900);
+        let mut no_refund = their_copy(&ours, other_owner(), 1900, &signer);
         no_refund.refund_tx = None;
-        assert!(!refund_left_us(&us(), &ours, &no_refund));
+        assert!(!left(&no_refund));
+    }
 
-        // A different node entirely says nothing about ours.
-        let mut other_node = leaf_owned_at(other_owner(), 1900);
-        other_node.node_tx.lock_time = bitcoin::absolute::LockTime::from_height(7).unwrap();
-        assert!(!refund_left_us(&us(), &ours, &other_node));
+    /// The replacement has to be evidence, not testimony. Every other condition
+    /// is read straight off an operator's response, so an operator set answering
+    /// in concert could hand us a fabricated one; the signature is what they
+    /// cannot produce without us.
+    #[test_all]
+    fn a_replacement_we_did_not_sign_proves_nothing() {
+        let ours = our_leaf(2000);
+        let left = |theirs: &TreeNode| refund_left_us(&service(), &us(), &ours, theirs);
+
+        // Everything a response controls, and no witness at all.
+        let mut unsigned = their_copy(&ours, other_owner(), 1900, &leaf_signer());
+        unsigned.refund_tx.as_mut().unwrap().input[0].witness = bitcoin::Witness::new();
+        assert!(!left(&unsigned), "an unwitnessed refund is not proof");
+
+        // Signed, but by a key that is not the leaf's signing group.
+        assert!(
+            !left(&their_copy(&ours, other_owner(), 1900, &keypair_from(0x44))),
+            "a refund signed by someone else is not proof"
+        );
+
+        // A well-formed, correctly signed refund of a different node. Its own
+        // chain is fine, but it says nothing about the leaf we asked about.
+        let mut elsewhere = our_leaf(2000);
+        elsewhere.node_tx.lock_time = bitcoin::absolute::LockTime::from_height(7).unwrap();
+        elsewhere.refund_tx = Some(refund_spending(&elsewhere, 2000));
+        assert_ne!(
+            elsewhere.node_tx.compute_txid(),
+            ours.node_tx.compute_txid()
+        );
+        let mut foreign = their_copy(&elsewhere, other_owner(), 1900, &leaf_signer());
+        foreign.id = ours.id.clone();
+        assert!(
+            !left(&foreign),
+            "a refund spending another node's output is not proof"
+        );
+
+        // The same refund, relabelled to claim it funds our node. The outpoint
+        // is checked against our own stored node tx, so relabelling theirs does
+        // not help, and the signature commits to the real one regardless.
+        let mut relabelled = foreign.clone();
+        relabelled.node_tx = ours.node_tx.clone();
+        assert!(
+            !left(&relabelled),
+            "a rewritten node tx does not make a foreign refund ours"
+        );
     }
 
     /// The refresh asks for the statuses a leaf we hold can be reported in, so a

--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -307,10 +307,15 @@ impl InMemoryTreeStore {
                     response_tx,
                 } => {
                     // Each leaf owns its chain, so a removed leaf takes its
-                    // ancestors with it and nothing else can be orphaned.
+                    // ancestors with it and nothing else can be orphaned. Only a
+                    // leaf still marked goes: the purge read its list, then spent
+                    // seconds asking the operators, and a refresh landing in that
+                    // window may have brought this one back.
                     for id in &leaf_ids {
-                        state.leaves.remove(id);
-                        state.ancestors.remove(id);
+                        if state.leaves.get(id).is_some_and(|stored| stored.deleted) {
+                            state.leaves.remove(id);
+                            state.ancestors.remove(id);
+                        }
                     }
                     let _ = response_tx.send(Ok(()));
                 }
@@ -1074,8 +1079,12 @@ impl InMemoryTreeStore {
                 .get(id)
                 .ok_or(TreeServiceError::NonReservableLeaves)?;
             // A leaf the operators no longer report cannot back a payment or a
-            // swap, even though it still counts towards the balance.
-            if stored.node.status != TreeNodeStatus::Available || stored.missing_from_operators {
+            // swap, even though it still counts towards the balance. Nor can one
+            // kept only for its exit chain, which counts towards nothing.
+            if stored.node.status != TreeNodeStatus::Available
+                || stored.missing_from_operators
+                || stored.deleted
+            {
                 return Err(TreeServiceError::NonReservableLeaves);
             }
             selected.push(stored.node.clone());
@@ -1397,6 +1406,11 @@ mod tests {
     #[async_test_all]
     async fn test_absent_leaf_is_kept_for_its_exit_chain() {
         shared_tests::test_absent_leaf_is_kept_for_its_exit_chain(&InMemoryTreeStore::new()).await;
+    }
+
+    #[async_test_all]
+    async fn test_remove_leaves_spares_a_revived_leaf() {
+        shared_tests::test_remove_leaves_spares_a_revived_leaf(&InMemoryTreeStore::new()).await;
     }
 
     #[async_test_all]

--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -28,11 +28,20 @@ pub const DEFAULT_RESERVATION_TIMEOUT: Duration = Duration::from_secs(60);
 struct StoredLeaf {
     node: TreeNode,
     added_at: SystemTime,
-    /// The coordinator returned this leaf but at least one operator did not.
-    /// It still counts towards the wallet balance, but cannot be selected to
-    /// back a payment or a swap until every operator reports it again.
+    /// Some operator returned this leaf but at least one other did not. It still
+    /// counts towards the wallet balance, but cannot be selected to back a payment
+    /// or a swap until every operator reports it again.
     /// Mirrors the `is_missing_from_operators` column of the SQL stores.
     missing_from_operators: bool,
+    /// No operator reports this leaf any more. The row is kept rather than
+    /// removed, because absence is not proof of a spend and the stored
+    /// transactions are the only way to exit the leaf should it still be ours.
+    /// The operators cannot even report some of the statuses a leaf of ours can
+    /// reach: a `Lost` leaf is filtered out of every owner query, and `Lost` is
+    /// exactly the state where they will no longer co-sign a fresh refund. Kept
+    /// out of the balance and out of selection, still resolvable for an exit
+    /// chain, and removed for good only once a spend has actually been proven.
+    deleted: bool,
 }
 
 impl StoredLeaf {
@@ -41,6 +50,7 @@ impl StoredLeaf {
             node: node.clone(),
             added_at,
             missing_from_operators: false,
+            deleted: false,
         }
     }
 
@@ -49,6 +59,7 @@ impl StoredLeaf {
             node: node.clone(),
             added_at,
             missing_from_operators: true,
+            deleted: false,
         }
     }
 }
@@ -91,7 +102,9 @@ impl LeavesState {
     /// by every operator.
     fn selectable_leaves(&self) -> impl Iterator<Item = &StoredLeaf> {
         self.leaves.values().filter(|stored| {
-            stored.node.status == TreeNodeStatus::Available && !stored.missing_from_operators
+            stored.node.status == TreeNodeStatus::Available
+                && !stored.missing_from_operators
+                && !stored.deleted
         })
     }
 
@@ -439,6 +452,12 @@ impl InMemoryTreeStore {
         let mut not_available = Vec::new();
         let mut available_missing_from_operators = Vec::new();
         for stored in state.leaves.values() {
+            // A leaf no operator reports any more is kept for its exit chain
+            // alone, so it belongs to no bucket: out of the balance, out of
+            // selection, still exitable.
+            if stored.deleted {
+                continue;
+            }
             if stored.node.status != TreeNodeStatus::Available {
                 not_available.push(stored.node.clone());
             } else if stored.missing_from_operators {
@@ -616,15 +635,39 @@ impl InMemoryTreeStore {
         }
 
         let mut preserved_count = 0u32;
-        for (id, stored) in old_leaves {
-            if stored.added_at >= refresh_started_at && !state.leaves.contains_key(&id) {
+        let mut deleted_count = 0u32;
+        for (id, mut stored) in old_leaves {
+            if state.leaves.contains_key(&id) {
+                continue;
+            }
+            // We spent this one ourselves, so its absence is already accounted for
+            // and the row can go.
+            if state.spent_leaf_ids.contains_key(&id) {
+                continue;
+            }
+            if stored.added_at >= refresh_started_at {
                 trace!(
                     "leaf_lifecycle set_leaves: preserved old leaf={} value={} missing_from_operators={} (added after refresh started)",
                     id, stored.node.value, stored.missing_from_operators
                 );
                 state.leaves.insert(id, stored);
                 preserved_count += 1;
+                continue;
             }
+            // No operator reported it, which is not proof that it was spent. The
+            // query cannot even ask for every status a leaf of ours can reach, so
+            // an absence may say more about the question than the leaf. Keep the
+            // row and its chain, out of the balance and out of selection, until a
+            // spend is actually proven.
+            if !stored.deleted {
+                info!(
+                    "leaf_lifecycle set_leaves: marking leaf={} value={} deleted (no operator reports it)",
+                    id, stored.node.value
+                );
+            }
+            stored.deleted = true;
+            state.leaves.insert(id, stored);
+            deleted_count += 1;
         }
 
         // Update reserved leaves with fresh data, removing them from the unreserved pool
@@ -646,14 +689,20 @@ impl InMemoryTreeStore {
         }
 
         trace!(
-            "set_leaves: {} leaves ({} missing from operators), {} preserved from previous state",
+            "set_leaves: {} leaves ({} missing from operators, {} kept for their exit chain only), {} preserved from previous state, {} newly unreported",
             state.leaves.len(),
             state
                 .leaves
                 .values()
                 .filter(|stored| stored.missing_from_operators)
                 .count(),
-            preserved_count
+            state
+                .leaves
+                .values()
+                .filter(|stored| stored.deleted)
+                .count(),
+            preserved_count,
+            deleted_count
         );
 
         Ok(())
@@ -1301,13 +1350,13 @@ mod tests {
     }
 
     #[async_test_all]
-    async fn test_unshared_ancestor_deleted_with_leaf() {
-        shared_tests::test_unshared_ancestor_deleted_with_leaf(&InMemoryTreeStore::new()).await;
+    async fn test_absent_leaf_is_kept_for_its_exit_chain() {
+        shared_tests::test_absent_leaf_is_kept_for_its_exit_chain(&InMemoryTreeStore::new()).await;
     }
 
     #[async_test_all]
-    async fn test_shared_ancestor_survives_leaf_deletion() {
-        shared_tests::test_shared_ancestor_survives_leaf_deletion(&InMemoryTreeStore::new()).await;
+    async fn test_absent_leaf_keeps_shared_ancestor() {
+        shared_tests::test_absent_leaf_keeps_shared_ancestor(&InMemoryTreeStore::new()).await;
     }
 
     #[async_test_all]

--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -1414,6 +1414,11 @@ mod tests {
     }
 
     #[async_test_all]
+    async fn test_kept_leaf_cannot_back_a_payment() {
+        shared_tests::test_kept_leaf_cannot_back_a_payment(&InMemoryTreeStore::new()).await;
+    }
+
+    #[async_test_all]
     async fn test_deleted_leaves_are_listed_and_removable() {
         shared_tests::test_deleted_leaves_are_listed_and_removable(&InMemoryTreeStore::new()).await;
     }

--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -899,13 +899,21 @@ impl InMemoryTreeStore {
             "leaf_lifecycle cancel: reservation={} purpose={:?} prior_leaves={:?} keeping={:?} dropping={:?}",
             id, purpose, prior_ids, keep_ids, dropped_ids
         );
-        // A kept leaf's ancestor chain (owned by its own id) is untouched here;
-        // only a dropped leaf's chain goes with it.
-        for dropped in &dropped_ids {
-            state.ancestors.remove(*dropped);
-        }
-
         let now = SystemTime::now();
+        // A leaf the verification would not vouch for is marked, not dropped.
+        // One operator declining to confirm it is not proof it was spent, and
+        // its chain is the only way to exit it if it is still ours. The purge
+        // decides that later, once every operator agrees.
+        let dropped: HashSet<TreeNodeId> = dropped_ids.into_iter().cloned().collect();
+        if let Some(entry) = removed {
+            for stored in entry.leaves {
+                if dropped.contains(&stored.node.id) {
+                    let mut kept = stored;
+                    kept.deleted = true;
+                    state.leaves.insert(kept.node.id.clone(), kept);
+                }
+            }
+        }
         for leaf in leaves_to_keep {
             state
                 .leaves
@@ -1416,6 +1424,11 @@ mod tests {
     #[async_test_all]
     async fn test_kept_leaf_cannot_back_a_payment() {
         shared_tests::test_kept_leaf_cannot_back_a_payment(&InMemoryTreeStore::new()).await;
+    }
+
+    #[async_test_all]
+    async fn test_cancel_keeps_an_unverified_leaf() {
+        shared_tests::test_cancel_keeps_an_unverified_leaf(&InMemoryTreeStore::new()).await;
     }
 
     #[async_test_all]

--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -139,6 +139,13 @@ enum StoreCommand {
     GetLeaves {
         response_tx: oneshot::Sender<Result<Leaves, TreeServiceError>>,
     },
+    GetDeletedLeaves {
+        response_tx: oneshot::Sender<Result<Vec<TreeNode>, TreeServiceError>>,
+    },
+    RemoveLeaves {
+        leaf_ids: Vec<TreeNodeId>,
+        response_tx: oneshot::Sender<Result<(), TreeServiceError>>,
+    },
     GetExitChains {
         leaf_ids: Vec<TreeNodeId>,
         response_tx: oneshot::Sender<Result<Vec<LeafPedigree>, TreeServiceError>>,
@@ -285,6 +292,27 @@ impl InMemoryTreeStore {
                 StoreCommand::GetLeaves { response_tx } => {
                     let result = Self::process_get_leaves(&state);
                     let _ = response_tx.send(result);
+                }
+                StoreCommand::GetDeletedLeaves { response_tx } => {
+                    let leaves = state
+                        .leaves
+                        .values()
+                        .filter(|stored| stored.deleted)
+                        .map(|stored| stored.node.clone())
+                        .collect();
+                    let _ = response_tx.send(Ok(leaves));
+                }
+                StoreCommand::RemoveLeaves {
+                    leaf_ids,
+                    response_tx,
+                } => {
+                    // Each leaf owns its chain, so a removed leaf takes its
+                    // ancestors with it and nothing else can be orphaned.
+                    for id in &leaf_ids {
+                        state.leaves.remove(id);
+                        state.ancestors.remove(id);
+                    }
+                    let _ = response_tx.send(Ok(()));
                 }
                 StoreCommand::GetExitChains {
                     leaf_ids,
@@ -1103,6 +1131,23 @@ impl TreeStore for InMemoryTreeStore {
             .await
     }
 
+    async fn get_deleted_leaves(&self) -> Result<Vec<TreeNode>, TreeServiceError> {
+        self.send_command(|tx| StoreCommand::GetDeletedLeaves { response_tx: tx })
+            .await
+    }
+
+    async fn remove_leaves(&self, leaf_ids: &[TreeNodeId]) -> Result<(), TreeServiceError> {
+        if leaf_ids.is_empty() {
+            return Ok(());
+        }
+        let leaf_ids = leaf_ids.to_vec();
+        self.send_command(|tx| StoreCommand::RemoveLeaves {
+            leaf_ids,
+            response_tx: tx,
+        })
+        .await
+    }
+
     async fn get_exit_chains(
         &self,
         leaf_ids: &[TreeNodeId],
@@ -1352,6 +1397,11 @@ mod tests {
     #[async_test_all]
     async fn test_absent_leaf_is_kept_for_its_exit_chain() {
         shared_tests::test_absent_leaf_is_kept_for_its_exit_chain(&InMemoryTreeStore::new()).await;
+    }
+
+    #[async_test_all]
+    async fn test_deleted_leaves_are_listed_and_removable() {
+        shared_tests::test_deleted_leaves_are_listed_and_removable(&InMemoryTreeStore::new()).await;
     }
 
     #[async_test_all]

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -694,6 +694,41 @@ pub async fn test_kept_leaf_cannot_back_a_payment(store: &dyn TreeStore) {
     assert_eq!(store.get_deleted_leaves().await.unwrap().len(), 1);
 }
 
+/// Cancelling a reservation keeps a leaf the verification would not vouch for,
+/// chain and all. One operator declining to confirm a leaf is not proof it was
+/// spent, and with the operators unreachable the verification returns nothing at
+/// all: that is the case this store exists for, not a reason to destroy chains.
+pub async fn test_cancel_keeps_an_unverified_leaf(store: &dyn TreeStore) {
+    let root = create_test_node_with_parent("root", None, TreeNodeStatus::Splitted);
+    let leaf = create_test_node_with_parent("leaf", Some("root"), TreeNodeStatus::Available);
+    store
+        .add_leaves(&[LeafPedigree {
+            leaf: leaf.clone(),
+            ancestors: vec![root],
+        }])
+        .await
+        .unwrap();
+
+    let reservation = reserve_leaves(store, None, false, ReservationPurpose::Payment)
+        .await
+        .unwrap();
+    assert_eq!(reservation.leaves.len(), 1);
+
+    // The verification vouched for nothing, as it does when the operators cannot
+    // be reached at all.
+    store
+        .cancel_reservation(&reservation.id, &[])
+        .await
+        .unwrap();
+
+    // Out of the balance, since nothing confirmed it, but still ours to exit.
+    assert_eq!(store.get_available_balance().await.unwrap(), 0);
+    assert!(get_available(store).await.is_empty());
+    let kept = store.get_deleted_leaves().await.unwrap();
+    assert_eq!(kept.len(), 1, "the unverified leaf is kept, not dropped");
+    assert_eq!(exit_chain_ids(store, &leaf.id).await, vec!["root", "leaf"]);
+}
+
 /// A refresh reporting only one of two leaves keeps both, so the unreported one
 /// stays exitable and each leaf keeps its own copy of the ancestor they share.
 pub async fn test_absent_leaf_keeps_shared_ancestor(store: &dyn TreeStore) {

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -638,6 +638,45 @@ pub async fn test_deleted_leaves_are_listed_and_removable(store: &dyn TreeStore)
     assert!(exit_chain(store, &leaf.id).await.is_none());
 }
 
+/// `remove_leaves` only takes a leaf that is still marked. The purge reads its
+/// list, then spends seconds asking the operators, so a refresh that brings the
+/// leaf back in that window must survive the delete that was already in flight.
+pub async fn test_remove_leaves_spares_a_revived_leaf(store: &dyn TreeStore) {
+    let root = create_test_node_with_parent("root", None, TreeNodeStatus::Splitted);
+    let leaf = create_test_node_with_parent("leaf", Some("root"), TreeNodeStatus::Available);
+    let pedigree = LeafPedigree {
+        leaf: leaf.clone(),
+        ancestors: vec![root],
+    };
+    store
+        .add_leaves(std::slice::from_ref(&pedigree))
+        .await
+        .unwrap();
+
+    let refresh_start = future_refresh_start(store).await;
+    store.set_leaves(&[], &[], refresh_start).await.unwrap();
+    assert_eq!(store.get_deleted_leaves().await.unwrap().len(), 1);
+
+    // The refresh the purge raced with: the leaf is reported again, clearing the
+    // mark, before the delete it decided on lands.
+    store
+        .add_leaves(std::slice::from_ref(&pedigree))
+        .await
+        .unwrap();
+    store
+        .remove_leaves(std::slice::from_ref(&leaf.id))
+        .await
+        .unwrap();
+
+    let available = get_available(store).await;
+    assert_eq!(
+        available.len(),
+        1,
+        "a revived leaf survives the stale delete"
+    );
+    assert_eq!(exit_chain_ids(store, &leaf.id).await, vec!["root", "leaf"]);
+}
+
 /// A refresh reporting only one of two leaves keeps both, so the unreported one
 /// stays exitable and each leaf keeps its own copy of the ancestor they share.
 pub async fn test_absent_leaf_keeps_shared_ancestor(store: &dyn TreeStore) {

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -453,11 +453,14 @@ pub async fn test_store_ancestors_backfills_chain(store: &dyn TreeStore) {
 
 /// A stored chain outlives the refreshes that keep reporting its leaf, and is
 /// dropped only when the leaf itself leaves the pool. Refreshes carry leaves
-/// alone, so a chain the resolver wrote must not be collateral damage.
+/// alone, so a chain the resolver wrote must not be collateral damage, and a
+/// leaf merely going unreported does not leave the pool: only a spend does.
 pub async fn test_stored_chain_survives_refresh_and_dies_with_its_leaf(store: &dyn TreeStore) {
     let root = create_test_node_with_parent("root", None, TreeNodeStatus::Splitted);
-    let kept = create_test_node_with_parent("kept", Some("root"), TreeNodeStatus::Available);
-    let dropped = create_test_node_with_parent("dropped", Some("root"), TreeNodeStatus::Available);
+    let mut kept = create_test_node_with_parent("kept", Some("root"), TreeNodeStatus::Available);
+    kept.value = 100;
+    let mut spent = create_test_node_with_parent("spent", Some("root"), TreeNodeStatus::Available);
+    spent.value = 700;
     add_with_chains(
         store,
         &[
@@ -466,7 +469,7 @@ pub async fn test_stored_chain_survives_refresh_and_dies_with_its_leaf(store: &d
                 ancestors: vec![root.clone()],
             },
             LeafPedigree {
-                leaf: dropped.clone(),
+                leaf: spent.clone(),
                 ancestors: vec![root],
             },
         ],
@@ -476,24 +479,33 @@ pub async fn test_stored_chain_survives_refresh_and_dies_with_its_leaf(store: &d
     // A refresh reporting both leaves keeps both chains: it writes none itself.
     let refresh_start = future_refresh_start(store).await;
     store
-        .set_leaves(&[kept.clone(), dropped.clone()], &[], refresh_start)
+        .set_leaves(&[kept.clone(), spent.clone()], &[], refresh_start)
         .await
         .unwrap();
     assert_eq!(exit_chain_ids(store, &kept.id).await, vec!["root", "kept"]);
     assert_eq!(
-        exit_chain_ids(store, &dropped.id).await,
-        vec!["root", "dropped"]
+        exit_chain_ids(store, &spent.id).await,
+        vec!["root", "spent"]
     );
 
-    // A refresh that stops reporting `dropped` takes its chain with it, and
-    // leaves the surviving leaf's chain intact.
+    // Spending one leaf is the departure a refresh can act on, so its chain goes
+    // with it while the other leaf's stays.
+    let reservation = store
+        .try_reserve_leaves_by_ids(std::slice::from_ref(&spent.id), ReservationPurpose::Payment)
+        .await
+        .unwrap();
+    store
+        .finalize_reservation(&reservation.id, None)
+        .await
+        .unwrap();
     let refresh_start = future_refresh_start(store).await;
     store
         .set_leaves(std::slice::from_ref(&kept), &[], refresh_start)
         .await
         .unwrap();
+
     assert_eq!(exit_chain_ids(store, &kept.id).await, vec!["root", "kept"]);
-    assert!(exit_chain(store, &dropped.id).await.is_none());
+    assert!(exit_chain(store, &spent.id).await.is_none());
 }
 
 /// A leaf spent between its chain being resolved and stored stays spent: storing
@@ -568,8 +580,11 @@ pub async fn test_store_ancestors_for_absent_leaf(store: &dyn TreeStore) {
     );
 }
 
-/// Deleting a leaf also drops its unshared ancestors.
-pub async fn test_unshared_ancestor_deleted_with_leaf(store: &dyn TreeStore) {
+/// A refresh that stops reporting a leaf keeps it. Absence is not proof of a
+/// spend, and an owner query cannot even ask for every status a leaf of ours can
+/// reach, so the chain that would exit it has to survive. The leaf only stops
+/// counting: out of the balance and out of selection.
+pub async fn test_absent_leaf_is_kept_for_its_exit_chain(store: &dyn TreeStore) {
     let root = create_test_node_with_parent("root", None, TreeNodeStatus::Splitted);
     let leaf = create_test_node_with_parent("leaf", Some("root"), TreeNodeStatus::Available);
     add_with_chains(
@@ -581,21 +596,17 @@ pub async fn test_unshared_ancestor_deleted_with_leaf(store: &dyn TreeStore) {
     )
     .await;
 
-    // A refresh in the future drops the pre-existing leaf, taking its ancestors.
     let refresh_start = future_refresh_start(store).await;
     store.set_leaves(&[], &[], refresh_start).await.unwrap();
 
-    assert!(exit_chain(store, &leaf.id).await.is_none());
-
-    // Re-adding the leaf alone brings back no ancestors: the root went with it,
-    // so the walk up from the leaf has nothing to link to.
-    store.add_leaves(std::slice::from_ref(&leaf)).await.unwrap();
-    assert_eq!(exit_chain_ids(store, &leaf.id).await, vec!["leaf"]);
+    assert!(get_available(store).await.is_empty());
+    assert_eq!(store.get_available_balance().await.unwrap(), 0);
+    assert_eq!(exit_chain_ids(store, &leaf.id).await, vec!["root", "leaf"]);
 }
 
-/// Each leaf owns its own copy of a shared ancestor, so dropping one leaf leaves
-/// the other's chain intact.
-pub async fn test_shared_ancestor_survives_leaf_deletion(store: &dyn TreeStore) {
+/// A refresh reporting only one of two leaves keeps both, so the unreported one
+/// stays exitable and each leaf keeps its own copy of the ancestor they share.
+pub async fn test_absent_leaf_keeps_shared_ancestor(store: &dyn TreeStore) {
     let root = create_test_node_with_parent("root", None, TreeNodeStatus::Splitted);
     let leaf_a = create_test_node_with_parent("leaf-a", Some("root"), TreeNodeStatus::Available);
     let leaf_b = create_test_node_with_parent("leaf-b", Some("root"), TreeNodeStatus::Available);
@@ -614,14 +625,20 @@ pub async fn test_shared_ancestor_survives_leaf_deletion(store: &dyn TreeStore) 
     )
     .await;
 
-    // A refresh that keeps only leaf-b drops leaf-a and its copy of the root.
+    // A refresh that reports only leaf-b leaves leaf-a marked but intact.
     let refresh_start = future_refresh_start(store).await;
     store
         .set_leaves(std::slice::from_ref(&leaf_b), &[], refresh_start)
         .await
         .unwrap();
 
-    assert!(exit_chain(store, &leaf_a.id).await.is_none());
+    let available = get_available(store).await;
+    assert_eq!(available.len(), 1);
+    assert_eq!(available[0].id.to_string(), "leaf-b");
+    assert_eq!(
+        exit_chain_ids(store, &leaf_a.id).await,
+        vec!["root", "leaf-a"]
+    );
     assert_eq!(
         exit_chain_ids(store, &leaf_b.id).await,
         vec!["root", "leaf-b"]

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -696,18 +696,20 @@ pub async fn test_kept_leaf_cannot_back_a_payment(store: &dyn TreeStore) {
 
 /// Cancelling a reservation keeps a leaf the verification would not vouch for,
 /// chain and all. One operator declining to confirm a leaf is not proof it was
-/// spent, and with the operators unreachable the verification returns nothing at
-/// all: that is the case this store exists for, not a reason to destroy chains.
+/// spent, so it is held back from payments rather than destroyed, and the purge
+/// decides later on the evidence. (A verification that fails outright is the
+/// other half of this: it vouches for nothing, so it keeps every leaf instead.)
 pub async fn test_cancel_keeps_an_unverified_leaf(store: &dyn TreeStore) {
     let root = create_test_node_with_parent("root", None, TreeNodeStatus::Splitted);
     let leaf = create_test_node_with_parent("leaf", Some("root"), TreeNodeStatus::Available);
-    store
-        .add_leaves(&[LeafPedigree {
+    add_with_chains(
+        store,
+        &[LeafPedigree {
             leaf: leaf.clone(),
             ancestors: vec![root],
-        }])
-        .await
-        .unwrap();
+        }],
+    )
+    .await;
 
     let reservation = reserve_leaves(store, None, false, ReservationPurpose::Payment)
         .await

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -604,6 +604,40 @@ pub async fn test_absent_leaf_is_kept_for_its_exit_chain(store: &dyn TreeStore) 
     assert_eq!(exit_chain_ids(store, &leaf.id).await, vec!["root", "leaf"]);
 }
 
+/// A leaf kept only for its exit chain is reachable through `get_deleted_leaves`
+/// and nowhere else, and `remove_leaves` is what finally takes it, along with the
+/// ancestors it alone reached.
+pub async fn test_deleted_leaves_are_listed_and_removable(store: &dyn TreeStore) {
+    let root = create_test_node_with_parent("root", None, TreeNodeStatus::Splitted);
+    let leaf = create_test_node_with_parent("leaf", Some("root"), TreeNodeStatus::Available);
+    add_with_chains(
+        store,
+        &[LeafPedigree {
+            leaf: leaf.clone(),
+            ancestors: vec![root.clone()],
+        }],
+    )
+    .await;
+
+    // Nothing is marked while an operator still reports the leaf.
+    assert!(store.get_deleted_leaves().await.unwrap().is_empty());
+
+    let refresh_start = future_refresh_start(store).await;
+    store.set_leaves(&[], &[], refresh_start).await.unwrap();
+
+    let deleted = store.get_deleted_leaves().await.unwrap();
+    assert_eq!(deleted.len(), 1);
+    assert_eq!(deleted[0].id.to_string(), "leaf");
+    assert!(get_available(store).await.is_empty());
+
+    store
+        .remove_leaves(std::slice::from_ref(&leaf.id))
+        .await
+        .unwrap();
+    assert!(store.get_deleted_leaves().await.unwrap().is_empty());
+    assert!(exit_chain(store, &leaf.id).await.is_none());
+}
+
 /// A refresh reporting only one of two leaves keeps both, so the unreported one
 /// stays exitable and each leaf keeps its own copy of the ancestor they share.
 pub async fn test_absent_leaf_keeps_shared_ancestor(store: &dyn TreeStore) {

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -648,10 +648,7 @@ pub async fn test_remove_leaves_spares_a_revived_leaf(store: &dyn TreeStore) {
         leaf: leaf.clone(),
         ancestors: vec![root],
     };
-    store
-        .add_leaves(std::slice::from_ref(&pedigree))
-        .await
-        .unwrap();
+    add_with_chains(store, std::slice::from_ref(&pedigree)).await;
 
     let refresh_start = future_refresh_start(store).await;
     store.set_leaves(&[], &[], refresh_start).await.unwrap();
@@ -659,10 +656,7 @@ pub async fn test_remove_leaves_spares_a_revived_leaf(store: &dyn TreeStore) {
 
     // The refresh the purge raced with: the leaf is reported again, clearing the
     // mark, before the delete it decided on lands.
-    store
-        .add_leaves(std::slice::from_ref(&pedigree))
-        .await
-        .unwrap();
+    add_with_chains(store, std::slice::from_ref(&pedigree)).await;
     store
         .remove_leaves(std::slice::from_ref(&leaf.id))
         .await
@@ -675,6 +669,29 @@ pub async fn test_remove_leaves_spares_a_revived_leaf(store: &dyn TreeStore) {
         "a revived leaf survives the stale delete"
     );
     assert_eq!(exit_chain_ids(store, &leaf.id).await, vec!["root", "leaf"]);
+}
+
+/// A leaf kept only for its exit chain must never back a payment, by any route:
+/// not the balance, not selection, and not a reservation that names it outright.
+/// It regressed once on one backend, so every backend asserts it.
+pub async fn test_kept_leaf_cannot_back_a_payment(store: &dyn TreeStore) {
+    let leaf = create_test_node_with_parent("leaf", None, TreeNodeStatus::Available);
+    store.add_leaves(std::slice::from_ref(&leaf)).await.unwrap();
+
+    let refresh_start = future_refresh_start(store).await;
+    store.set_leaves(&[], &[], refresh_start).await.unwrap();
+
+    assert_eq!(store.get_available_balance().await.unwrap(), 0);
+    assert!(get_available(store).await.is_empty());
+    assert!(
+        store
+            .try_reserve_leaves_by_ids(std::slice::from_ref(&leaf.id), ReservationPurpose::Payment)
+            .await
+            .is_err(),
+        "a kept leaf cannot be reserved by id"
+    );
+    // Still there, and still exitable: that is the whole point of keeping it.
+    assert_eq!(store.get_deleted_leaves().await.unwrap().len(), 1);
 }
 
 /// A refresh reporting only one of two leaves keeps both, so the unreported one


### PR DESCRIPTION
Exit any leaf that is ours, whatever status the operators report it in, and
keep a leaf's chain until a spend is proven rather than deleting it on absence.

## API

`TreeStore` (Rust trait, all 5 backends, plus the JS `TreeStore` interface):

- `get_deleted_leaves()` / `getDeletedLeaves()` - the leaves kept only for their exit chain.
- `remove_leaves(leaf_ids)` / `removeLeaves(leafIds)` - drop a leaf and its chain for good.

`TreeService`:

- `list_leaves_kept_for_exit()` - the same leaves, for exit selection.
- `purge_proven_spent_leaves()` - retire the ones every operator proves have left us.

Storage gains an `is_deleted` column (SQLite, Postgres, MySQL, and the three
SQL-backed JS stores; IndexedDB needs no migration).

## Design

**Only exit leaves that are ours, but all of them.** `EXIT_CHAIN_STATUSES` is
gone. The chain walk is purely structural, and leaf selection consults no status
at all, so a leaf under a `RenewLocked` or `Investigation` ancestor is exitable
and an already-exited leaf stays selectable for a re-run to resolve as swept.

**Absence is not a spend.** A leaf no operator reports is marked rather than
deleted: it leaves the balance and payment selection but keeps its chain and
stays exitable. The operators cannot even report some of the statuses a leaf of
ours can reach, and `Lost` is exactly where they stop co-signing refunds.

**Every operator has an equal say.** The refresh queries all of them, not just
the coordinator. Adding a leaf takes one; dropping one takes unanimity.

**A deletion needs evidence, not testimony.** A leaf is only removed once every
operator returns a replacement refund that spends our stored node output, is
owned by somebody else, sits at a lower timelock, and carries a signature
verifying under our own verifying key. A leaf is 2-of-2, so that signature is
one we took part in producing and no operator set can forge it. Everything
weaker keeps the leaf: an unreachable operator holds the whole round.

The purge runs hourly in the background and before an exit is quoted.

## Note

The refresh cannot ask for `TREE_NODE_STATUS_PARENT_EXITED`: the operator
rejects the entire query with `unknown tree node status`, so one unrecognised
status costs every leaf rather than the ones in that status. Worth raising
separately; a leaf under an exited parent is meanwhile kept for its chain.
