### PR TITLE
feat: support BOLT11 invoices for external Spark recipients

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -572,7 +572,8 @@ public static class Commands
                     description: description ?? "",
                     amountSats: amountSats,
                     expirySecs: ParseOptionalUint(expirySecsStr),
-                    paymentHash: paymentHash
+                    paymentHash: paymentHash,
+                    receiverIdentityPublicKey: null
                 );
                 break;
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -360,6 +360,7 @@ Future<void> _handleReceive(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> 
         amountSats: amount,
         expirySecs: expirySecs,
         paymentHash: paymentHash,
+        receiverIdentityPublicKey: null,
       );
     default:
       print('Invalid payment method: $method');

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -379,6 +379,7 @@ suspend fun handleReceive(sdk: BreezSdk, reader: LineReader, args: List<String>)
                 amountSats = amountSats,
                 expirySecs = expirySecs,
                 paymentHash = paymentHash,
+                receiverIdentityPublicKey = null,
             )
         }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -298,6 +298,7 @@ async def _handle_receive(sdk, _token_issuer, _session, args):
             amount_sats=args.amount,
             expiry_secs=args.expiry_secs,
             payment_hash=payment_hash,
+            receiver_identity_public_key=None,
         )
     else:
         print(f"Invalid payment method: {method}")

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -522,6 +522,7 @@ async function handleReceive(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerIn
         amountSats,
         expirySecs,
         paymentHash,
+        receiverIdentityPublicKey: undefined,
       })
       break
     }

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -413,7 +413,8 @@ func handleReceive(_ sdk: BreezSdk, _ args: [String]) async throws {
             description: description ?? "",
             amountSats: amountSats,
             expirySecs: expirySecs,
-            paymentHash: paymentHash
+            paymentHash: paymentHash,
+            receiverIdentityPublicKey: nil
         )
 
     default:

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -273,7 +273,8 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
             description: options.description || '',
             amountSats: options.amount != null ? parseInt(options.amount, 10) : undefined,
             expirySecs: options.expirySecs,
-            paymentHash
+            paymentHash,
+            receiverIdentityPublicKey: undefined
           }
           break
         }

--- a/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
+++ b/crates/breez-sdk/breez-bench/src/bin/parallel_perf.rs
@@ -253,6 +253,7 @@ async fn main() -> Result<()> {
                     amount_sats: Some(amount),
                     expiry_secs: Some(3600),
                     payment_hash: None,
+                    receiver_identity_public_key: None,
                 },
             })
             .await?

--- a/crates/breez-sdk/breez-itest/tests/breez_sdk_tests.rs
+++ b/crates/breez-sdk/breez-itest/tests/breez_sdk_tests.rs
@@ -293,6 +293,7 @@ async fn test_03_lightning_invoice_payment(
                 amount_sats: invoice_amount_sats,
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?
@@ -534,6 +535,84 @@ async fn test_03_lightning_invoice_payment(
     Ok(())
 }
 
+/// Test 4: A wallet can create a Lightning invoice for another Spark identity.
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn test_04_lightning_invoice_for_external_recipient(
+    #[future] alice_sdk: Result<SdkInstance>,
+    #[future] bob_sdk: Result<SdkInstance>,
+) -> Result<()> {
+    let mut alice = alice_sdk.await?;
+    let mut bob = bob_sdk.await?;
+    let invoice_amount_sats = 2_000u64;
+
+    ensure_funded(&mut bob, 50_000).await?;
+    alice.sdk.sync_wallet(SyncWalletRequest {}).await?;
+    let alice_initial_balance = alice
+        .sdk
+        .get_info(GetInfoRequest {
+            ensure_synced: Some(false),
+        })
+        .await?
+        .balance_sats;
+    let alice_identity_pubkey = alice
+        .sdk
+        .get_info(GetInfoRequest {
+            ensure_synced: Some(false),
+        })
+        .await?
+        .identity_pubkey;
+
+    let invoice = bob
+        .sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::Bolt11Invoice {
+                description: "Invoice for an external recipient".to_string(),
+                amount_sats: Some(invoice_amount_sats),
+                expiry_secs: None,
+                payment_hash: None,
+                receiver_identity_public_key: Some(alice_identity_pubkey),
+            },
+        })
+        .await?
+        .payment_request;
+
+    let prepared = bob
+        .sdk
+        .prepare_send_payment(PrepareSendPaymentRequest {
+            payment_request: PaymentRequest::Input { input: invoice },
+            amount: None,
+            token_identifier: None,
+            conversion_options: None,
+            fee_policy: None,
+        })
+        .await?;
+    bob.sdk
+        .send_payment(SendPaymentRequest {
+            prepare_response: prepared,
+            options: Some(SendPaymentOptions::Bolt11Invoice {
+                prefer_spark: false,
+                completion_timeout_secs: Some(10),
+            }),
+            idempotency_key: None,
+        })
+        .await?;
+
+    let received =
+        wait_for_payment_succeeded_event(&mut alice.events, PaymentType::Receive, 60).await?;
+    wait_for_balance(
+        &alice.sdk,
+        Some(alice_initial_balance + invoice_amount_sats),
+        None,
+        20,
+    )
+    .await?;
+
+    assert_eq!(received.amount, invoice_amount_sats as u128);
+    assert_eq!(received.method, PaymentMethod::Lightning);
+    Ok(())
+}
+
 /// Test 5: Lightning invoice with prefer_spark true should use spark fee path
 #[rstest]
 #[test_log::test(tokio::test)]
@@ -559,6 +638,7 @@ async fn test_05_lightning_invoice_prefer_spark_fee_path(
                 amount_sats: Some(invoice_amount_sats),
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?
@@ -657,6 +737,7 @@ async fn test_06_lightning_timeout_and_wait(
                 amount_sats: None,
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?
@@ -905,6 +986,7 @@ async fn test_08_lightning_invoice_expiry_secs(
                 amount_sats: Some(invoice_amount_sats),
                 expiry_secs: Some(custom_expiry_secs),
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?;
@@ -1062,6 +1144,7 @@ async fn test_09_bolt11_send_all_with_fee_overpayment(
                 amount_sats: None,
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?
@@ -1356,6 +1439,7 @@ async fn test_10_lightning_completion_timeout_resolves_to_completed(
                 amount_sats: Some(invoice_amount_sats),
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/client_signing_send.rs
+++ b/crates/breez-sdk/breez-itest/tests/client_signing_send.rs
@@ -1056,6 +1056,7 @@ async fn test_client_signing_lightning_send() -> Result<()> {
                 amount_sats: Some(invoice_sats),
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?
@@ -1181,6 +1182,7 @@ async fn test_client_signing_lightning_send_fees_included() -> Result<()> {
                 amount_sats: None,
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/idempotency_tests.rs
+++ b/crates/breez-sdk/breez-itest/tests/idempotency_tests.rs
@@ -215,6 +215,7 @@ async fn test_02_lightning_idempotency_key(
                 amount_sats: Some(5),
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/lightning_hodl.rs
+++ b/crates/breez-sdk/breez-itest/tests/lightning_hodl.rs
@@ -16,13 +16,20 @@ async fn test_01_lightning_hodl_success(
     let mut alice = alice_sdk.await?;
     let mut bob = bob_sdk.await?;
 
-    ensure_funded(&mut alice, 60_000).await?;
+    ensure_funded(&mut bob, 60_000).await?;
 
-    // Bob generates a preimage/hash pair and creates a HODL invoice
+    // Bob generates a preimage/hash pair and creates a HODL invoice for Alice.
     let (preimage, payment_hash) = generate_preimage_hash_pair();
     info!("Generated payment_hash: {payment_hash}");
+    let alice_identity_pubkey = alice
+        .sdk
+        .get_info(GetInfoRequest {
+            ensure_synced: Some(false),
+        })
+        .await?
+        .identity_pubkey;
 
-    let bob_invoice = bob
+    let invoice = bob
         .sdk
         .receive_payment(ReceivePaymentRequest {
             payment_method: ReceivePaymentMethod::Bolt11Invoice {
@@ -30,20 +37,19 @@ async fn test_01_lightning_hodl_success(
                 amount_sats: Some(10_000),
                 expiry_secs: None,
                 payment_hash: Some(payment_hash.clone()),
+                receiver_identity_public_key: Some(alice_identity_pubkey),
             },
         })
         .await?
         .payment_request;
 
-    info!("Bob's HODL invoice: {bob_invoice}");
+    info!("HODL invoice for Alice: {invoice}");
 
-    // Alice prepares and sends — use short timeout so it returns while still pending
-    let prepare = alice
+    // Bob prepares and sends. Use a short timeout so it returns while still pending.
+    let prepare = bob
         .sdk
         .prepare_send_payment(PrepareSendPaymentRequest {
-            payment_request: PaymentRequest::Input {
-                input: bob_invoice.clone(),
-            },
+            payment_request: PaymentRequest::Input { input: invoice },
             amount: None,
             token_identifier: None,
             conversion_options: None,
@@ -51,9 +57,9 @@ async fn test_01_lightning_hodl_success(
         })
         .await?;
 
-    info!("Sending 10_000 sats from Alice to Bob via Lightning HODL...");
+    info!("Sending 10_000 sats from Bob to Alice via Lightning HODL...");
 
-    let send_resp = alice
+    let send_resp = bob
         .sdk
         .send_payment(SendPaymentRequest {
             prepare_response: prepare,
@@ -65,16 +71,16 @@ async fn test_01_lightning_hodl_success(
         })
         .await?;
 
-    info!("Alice send payment status: {:?}", send_resp.payment.status);
+    info!("Bob send payment status: {:?}", send_resp.payment.status);
     assert!(
         matches!(send_resp.payment.status, PaymentStatus::Pending),
         "Payment should be pending (HODL invoice not yet claimed)"
     );
 
-    // Bob syncs and verifies the pending HODL receive
-    bob.sdk.sync_wallet(SyncWalletRequest {}).await?;
+    // Alice syncs and verifies the pending HODL receive.
+    alice.sdk.sync_wallet(SyncWalletRequest {}).await?;
 
-    let bob_pending = bob
+    let alice_pending = alice
         .sdk
         .list_payments(ListPaymentsRequest {
             status_filter: Some(vec![PaymentStatus::Pending]),
@@ -86,17 +92,17 @@ async fn test_01_lightning_hodl_success(
         })
         .await?;
 
-    let bob_pending_payment = bob_pending
+    let alice_pending_payment = alice_pending
         .payments
         .first()
-        .ok_or(anyhow::anyhow!("No pending HODL payment found for Bob"))?;
+        .ok_or(anyhow::anyhow!("No pending HODL payment found for Alice"))?;
 
-    info!("Verifying Bob's pending HODL payment...");
-    assert_eq!(bob_pending_payment.status, PaymentStatus::Pending);
-    assert_eq!(bob_pending_payment.payment_type, PaymentType::Receive);
-    assert_eq!(bob_pending_payment.amount, 10_000);
+    info!("Verifying Alice's pending HODL payment...");
+    assert_eq!(alice_pending_payment.status, PaymentStatus::Pending);
+    assert_eq!(alice_pending_payment.payment_type, PaymentType::Receive);
+    assert_eq!(alice_pending_payment.amount, 10_000);
     assert!(matches!(
-        &bob_pending_payment.details,
+        &alice_pending_payment.details,
         Some(PaymentDetails::Lightning {
             htlc_details: details, ..
         })
@@ -105,21 +111,22 @@ async fn test_01_lightning_hodl_success(
             && details.status == SparkHtlcStatus::WaitingForPreimage
     ));
 
-    // Bob claims the HODL payment with the preimage
-    info!("Bob claiming HODL payment with preimage...");
-    bob.sdk
+    // Alice claims the HODL payment with the preimage.
+    info!("Alice claiming HODL payment with preimage...");
+    alice
+        .sdk
         .claim_htlc_payment(ClaimHtlcPaymentRequest {
             preimage: preimage.clone(),
         })
         .await?;
 
-    // Wait for Bob's payment succeeded event
-    info!("Waiting for Bob to receive payment succeeded event...");
+    // Wait for Alice's payment succeeded event.
+    info!("Waiting for Alice to receive payment succeeded event...");
     let received_payment =
-        wait_for_payment_succeeded_event(&mut bob.events, PaymentType::Receive, 60).await?;
+        wait_for_payment_succeeded_event(&mut alice.events, PaymentType::Receive, 60).await?;
 
     // Verify the completed payment details
-    let bob_completed = bob
+    let alice_completed = alice
         .sdk
         .get_payment(GetPaymentRequest {
             payment_id: received_payment.id,
@@ -127,11 +134,11 @@ async fn test_01_lightning_hodl_success(
         .await?
         .payment;
 
-    assert_eq!(bob_completed.status, PaymentStatus::Completed);
-    assert_eq!(bob_completed.payment_type, PaymentType::Receive);
-    assert_eq!(bob_completed.amount, 10_000);
+    assert_eq!(alice_completed.status, PaymentStatus::Completed);
+    assert_eq!(alice_completed.payment_type, PaymentType::Receive);
+    assert_eq!(alice_completed.amount, 10_000);
     assert!(matches!(
-        &bob_completed.details,
+        &alice_completed.details,
         Some(PaymentDetails::Lightning {
             htlc_details: details, ..
         })
@@ -140,18 +147,18 @@ async fn test_01_lightning_hodl_success(
             && details.status == SparkHtlcStatus::PreimageShared
     ));
 
-    // Wait for Alice's payment succeeded event
-    info!("Waiting for Alice's send payment to complete...");
-    let alice_completed_payment =
-        wait_for_payment_succeeded_event(&mut alice.events, PaymentType::Send, 60).await?;
+    // Wait for Bob's payment succeeded event.
+    info!("Waiting for Bob's send payment to complete...");
+    let bob_completed_payment =
+        wait_for_payment_succeeded_event(&mut bob.events, PaymentType::Send, 60).await?;
 
-    assert_eq!(alice_completed_payment.status, PaymentStatus::Completed);
-    assert_eq!(alice_completed_payment.payment_type, PaymentType::Send);
-    assert_eq!(alice_completed_payment.amount, 10_000);
+    assert_eq!(bob_completed_payment.status, PaymentStatus::Completed);
+    assert_eq!(bob_completed_payment.payment_type, PaymentType::Send);
+    assert_eq!(bob_completed_payment.amount, 10_000);
 
-    // Verify Bob's balance increased
-    bob.sdk.sync_wallet(SyncWalletRequest {}).await?;
-    let bob_final_balance = bob
+    // Verify Alice's balance increased.
+    alice.sdk.sync_wallet(SyncWalletRequest {}).await?;
+    let alice_final_balance = alice
         .sdk
         .get_info(GetInfoRequest {
             ensure_synced: Some(false),
@@ -159,7 +166,7 @@ async fn test_01_lightning_hodl_success(
         .await?
         .balance_sats;
 
-    assert_eq!(bob_final_balance, 10_000);
+    assert_eq!(alice_final_balance, 10_000);
 
     info!("=== Test test_01_lightning_hodl_success PASSED ===");
     Ok(())

--- a/crates/breez-sdk/breez-itest/tests/lightning_send_server_mode.rs
+++ b/crates/breez-sdk/breez-itest/tests/lightning_send_server_mode.rs
@@ -66,6 +66,7 @@ async fn test_send_bolt11_invoice_server_mode(
                 amount_sats: Some(invoice_amount_sats),
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/mainnet_server_mode_conversion.rs
+++ b/crates/breez-sdk/breez-itest/tests/mainnet_server_mode_conversion.rs
@@ -259,6 +259,7 @@ async fn test_server_mode_token_to_bitcoin() -> Result<()> {
                 amount_sats: Some(invoice_sats),
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/mainnet_stable_balance.rs
+++ b/crates/breez-sdk/breez-itest/tests/mainnet_stable_balance.rs
@@ -291,6 +291,7 @@ async fn test_stable_balance_auto_conversion() -> Result<()> {
                 amount_sats: Some(invoice_sats),
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/mainnet_token_conversion.rs
+++ b/crates/breez-sdk/breez-itest/tests/mainnet_token_conversion.rs
@@ -263,6 +263,7 @@ async fn test_token_conversion_success() -> Result<()> {
                 amount_sats: Some(invoice_sats),
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/recovery.rs
+++ b/crates/breez-sdk/breez-itest/tests/recovery.rs
@@ -402,6 +402,7 @@ async fn test_setup_recovery_wallet() -> Result<()> {
                 amount_sats: Some(1_000),
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?
@@ -442,6 +443,7 @@ async fn test_setup_recovery_wallet() -> Result<()> {
                 amount_sats: Some(800),
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?

--- a/crates/breez-sdk/breez-itest/tests/signer_backends.rs
+++ b/crates/breez-sdk/breez-itest/tests/signer_backends.rs
@@ -163,6 +163,7 @@ async fn lightning_receive(#[case] backend: SignerBackend) -> Result<()> {
                 amount_sats: Some(100),
                 expiry_secs: None,
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -716,6 +716,7 @@ pub(crate) async fn execute_command(
                         amount_sats: amount.map(TryInto::try_into).transpose()?,
                         expiry_secs,
                         payment_hash,
+                        receiver_identity_public_key: None,
                     }
                 }
             };

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1305,6 +1305,9 @@ pub enum ReceivePaymentMethod {
         /// The payer's HTLC will be held until the preimage is provided via
         /// `claim_htlc_payment` or the HTLC expires.
         payment_hash: Option<String>,
+        /// Spark identity public key that will receive the payment.
+        /// If absent, the connected wallet's identity public key is used.
+        receiver_identity_public_key: Option<String>,
     },
 }
 

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -427,6 +427,7 @@ impl BreezSdk {
                         Some(amount_sats),
                         None,
                         None,
+                        None,
                     )
                     .await?;
                 CashAppProvider::build_url(&receive_response.payment_request)

--- a/crates/breez-sdk/core/src/sdk/lnurl/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/lnurl/mod.rs
@@ -95,6 +95,7 @@ impl BreezSdk {
                 Some(amount_sats),
                 None,
                 None,
+                None,
             )
             .await?;
         let payment_request = receive.invoice.clone();

--- a/crates/breez-sdk/core/src/sdk/payments/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/mod.rs
@@ -293,9 +293,17 @@ impl BreezSdk {
         amount_sats: Option<u64>,
         expiry_secs: Option<u32>,
         payment_hash: Option<String>,
+        receiver_identity_public_key: Option<String>,
     ) -> Result<ReceivePaymentResponse, SdkError> {
-        receive::receive_bolt11_invoice(self, description, amount_sats, expiry_secs, payment_hash)
-            .await
+        receive::receive_bolt11_invoice(
+            self,
+            description,
+            amount_sats,
+            expiry_secs,
+            payment_hash,
+            receiver_identity_public_key,
+        )
+        .await
     }
 
     pub(crate) async fn receive_bolt11_invoice_inner(
@@ -304,6 +312,7 @@ impl BreezSdk {
         amount_sats: Option<u64>,
         expiry_secs: Option<u32>,
         payment_hash: Option<String>,
+        receiver_identity_public_key: Option<String>,
     ) -> Result<LightningReceivePayment, SdkError> {
         receive::receive_bolt11_invoice_inner(
             self,
@@ -311,6 +320,7 @@ impl BreezSdk {
             amount_sats,
             expiry_secs,
             payment_hash,
+            receiver_identity_public_key,
         )
         .await
     }

--- a/crates/breez-sdk/core/src/sdk/payments/receive.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/receive.rs
@@ -74,7 +74,18 @@ pub(super) async fn receive_payment(
             amount_sats,
             expiry_secs,
             payment_hash,
-        } => receive_bolt11_invoice(sdk, description, amount_sats, expiry_secs, payment_hash).await,
+            receiver_identity_public_key,
+        } => {
+            receive_bolt11_invoice(
+                sdk,
+                description,
+                amount_sats,
+                expiry_secs,
+                payment_hash,
+                receiver_identity_public_key,
+            )
+            .await
+        }
     }
 }
 
@@ -113,10 +124,17 @@ pub(super) async fn receive_bolt11_invoice(
     amount_sats: Option<u64>,
     expiry_secs: Option<u32>,
     payment_hash: Option<String>,
+    receiver_identity_public_key: Option<String>,
 ) -> Result<ReceivePaymentResponse, SdkError> {
-    let receive =
-        receive_bolt11_invoice_inner(sdk, description, amount_sats, expiry_secs, payment_hash)
-            .await?;
+    let receive = receive_bolt11_invoice_inner(
+        sdk,
+        description,
+        amount_sats,
+        expiry_secs,
+        payment_hash,
+        receiver_identity_public_key,
+    )
+    .await?;
     Ok(ReceivePaymentResponse {
         payment_request: receive.invoice,
         fee: 0,
@@ -133,7 +151,12 @@ pub(super) async fn receive_bolt11_invoice_inner(
     amount_sats: Option<u64>,
     expiry_secs: Option<u32>,
     payment_hash: Option<String>,
+    receiver_identity_public_key: Option<String>,
 ) -> Result<LightningReceivePayment, SdkError> {
+    let receiver_identity_public_key = receiver_identity_public_key
+        .map(|key| PublicKey::from_str(&key))
+        .transpose()
+        .map_err(|_| SdkError::InvalidInput("Invalid receiver identity public key".to_string()))?;
     let receive = if let Some(payment_hash_hex) = payment_hash {
         let hash = sha256::Hash::from_str(&payment_hash_hex)
             .map_err(|e| SdkError::InvalidInput(format!("Invalid payment hash: {e}")))?;
@@ -142,7 +165,7 @@ pub(super) async fn receive_bolt11_invoice_inner(
                 amount_sats.unwrap_or_default(),
                 Some(InvoiceDescription::Memo(description.clone())),
                 hash,
-                None,
+                receiver_identity_public_key,
                 expiry_secs,
             )
             .await?
@@ -151,7 +174,7 @@ pub(super) async fn receive_bolt11_invoice_inner(
             .create_lightning_invoice(
                 amount_sats.unwrap_or_default(),
                 Some(InvoiceDescription::Memo(description.clone())),
-                None,
+                receiver_identity_public_key,
                 expiry_secs,
                 sdk.config.prefer_spark_over_lightning,
             )

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -935,6 +935,7 @@ pub enum ReceivePaymentMethod {
         amount_sats: Option<u64>,
         expiry_secs: Option<u32>,
         payment_hash: Option<String>,
+        receiver_identity_public_key: Option<String>,
     },
 }
 

--- a/docs/breez-sdk/snippets/csharp/Htlcs.cs
+++ b/docs/breez-sdk/snippets/csharp/Htlcs.cs
@@ -62,7 +62,8 @@ namespace BreezSdkSnippets
                         description: "HODL invoice",
                         amountSats: 50_000UL,
                         expirySecs: null,
-                        paymentHash: paymentHash
+                        paymentHash: paymentHash,
+                        receiverIdentityPublicKey: null
                     )
                 )
             );

--- a/docs/breez-sdk/snippets/csharp/ReceivePayment.cs
+++ b/docs/breez-sdk/snippets/csharp/ReceivePayment.cs
@@ -13,11 +13,13 @@ namespace BreezSdkSnippets
             var optionalAmountSats = 5_000UL;
             // Optionally set the expiry duration in seconds
             var optionalExpirySecs = 3600U;
+            string? optionalReceiverIdentityPublicKey = null;
             var paymentMethod = new ReceivePaymentMethod.Bolt11Invoice(
                 description: description,
                 amountSats: optionalAmountSats,
                 expirySecs: optionalExpirySecs,
-                paymentHash: null
+                paymentHash: null,
+                receiverIdentityPublicKey: optionalReceiverIdentityPublicKey
             );
             var request = new ReceivePaymentRequest(paymentMethod: paymentMethod);
             var response = await sdk.ReceivePayment(request: request);

--- a/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
+++ b/docs/breez-sdk/snippets/csharp/SdkBuilding.cs
@@ -241,7 +241,8 @@ namespace BreezSdkSnippets
                 description: "<invoice description>",
                 amountSats: 5_000UL,
                 expirySecs: 3600U,
-                paymentHash: null
+                paymentHash: null,
+                receiverIdentityPublicKey: null
             );
             var response = await sdk.ReceivePayment(
                 request: new ReceivePaymentRequest(paymentMethod: paymentMethod)

--- a/docs/breez-sdk/snippets/flutter/lib/receive_payment.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/receive_payment.dart
@@ -9,7 +9,7 @@ Future<ReceivePaymentResponse> receivePaymentLightning(
   // Optionally set the expiry duration in seconds
   int optionalExpirySecs = 3600;
   // Set this to create an invoice for another Spark identity
-  String? optionalReceiverIdentityPublicKey = null;
+  String? optionalReceiverIdentityPublicKey;
 
   // Create an invoice and set the amount you wish the payer to send
   ReceivePaymentRequest request = ReceivePaymentRequest(

--- a/docs/breez-sdk/snippets/flutter/lib/receive_payment.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/receive_payment.dart
@@ -8,6 +8,8 @@ Future<ReceivePaymentResponse> receivePaymentLightning(
   BigInt optionalAmountSats = BigInt.from(5000);
   // Optionally set the expiry duration in seconds
   int optionalExpirySecs = 3600;
+  // Set this to create an invoice for another Spark identity
+  String? optionalReceiverIdentityPublicKey = null;
 
   // Create an invoice and set the amount you wish the payer to send
   ReceivePaymentRequest request = ReceivePaymentRequest(
@@ -15,7 +17,8 @@ Future<ReceivePaymentResponse> receivePaymentLightning(
           description: description,
           amountSats: optionalAmountSats,
           expirySecs: optionalExpirySecs,
-          paymentHash: null));
+          paymentHash: null,
+          receiverIdentityPublicKey: optionalReceiverIdentityPublicKey));
   ReceivePaymentResponse response = await sdk.receivePayment(
     request: request,
   );

--- a/docs/breez-sdk/snippets/go/receive_payment.go
+++ b/docs/breez-sdk/snippets/go/receive_payment.go
@@ -15,6 +15,8 @@ func ReceiveLightningBolt11(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.Rec
 	optionalAmountSats := uint64(5_000)
 	// Optionally set the expiry duration in seconds
 	optionalExpirySecs := uint32(3600)
+	// Set this to create an invoice for another Spark identity
+	var optionalReceiverIdentityPublicKey *string
 
 	request := breez_sdk_spark.ReceivePaymentRequest{
 		PaymentMethod: breez_sdk_spark.ReceivePaymentMethodBolt11Invoice{
@@ -22,6 +24,7 @@ func ReceiveLightningBolt11(sdk *breez_sdk_spark.BreezSdk) (*breez_sdk_spark.Rec
 			AmountSats:  &optionalAmountSats,
 			ExpirySecs:  &optionalExpirySecs,
 			PaymentHash: nil,
+			ReceiverIdentityPublicKey: optionalReceiverIdentityPublicKey,
 		},
 	}
 

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Htlcs.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Htlcs.kt
@@ -74,7 +74,8 @@ class Htlcs {
                         description = "HODL invoice",
                         amountSats = 50_000u,
                         expirySecs = null,
-                        paymentHash = paymentHash
+                        paymentHash = paymentHash,
+                        receiverIdentityPublicKey = null
                     )
                 )
             )

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
@@ -12,13 +12,15 @@ class ReceivePayment {
             val optionalAmountSats = 5_000.toULong()
             // Optionally set the expiry duration in seconds
             val optionalExpirySecs = 3600.toUInt()
+            val optionalReceiverIdentityPublicKey: String? = null
 
             val request = ReceivePaymentRequest(
                 ReceivePaymentMethod.Bolt11Invoice(
                     description,
                     optionalAmountSats,
                     optionalExpirySecs,
-                    null
+                    null,
+                    optionalReceiverIdentityPublicKey
                 )
             )
             val response = sdk.receivePayment(request)

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SdkBuilding.kt
@@ -216,6 +216,7 @@ class SdkBuilding {
                     5_000.toULong(),
                     3600.toUInt(),
                     null,
+                    null,
                 )
             )
         )

--- a/docs/breez-sdk/snippets/python/src/htlcs.py
+++ b/docs/breez-sdk/snippets/python/src/htlcs.py
@@ -73,6 +73,7 @@ async def receive_hodl_invoice_payment(sdk: BreezSdk):
                 amount_sats=50_000,
                 expiry_secs=None,
                 payment_hash=payment_hash,
+                receiver_identity_public_key=None,
             )
         )
     )

--- a/docs/breez-sdk/snippets/python/src/receive_payment.py
+++ b/docs/breez-sdk/snippets/python/src/receive_payment.py
@@ -15,11 +15,14 @@ async def receive_lightning(sdk: BreezSdk):
         optional_amount_sats = 5_000
         # Optionally set the expiry duration in seconds
         optional_expiry_secs = 3600
+        # Set this to create an invoice for another Spark identity
+        optional_receiver_identity_public_key = None
         payment_method = ReceivePaymentMethod.BOLT11_INVOICE(
             description=description,
             amount_sats=optional_amount_sats,
             expiry_secs=optional_expiry_secs,
             payment_hash=None,
+            receiver_identity_public_key=optional_receiver_identity_public_key,
         )
         request = ReceivePaymentRequest(payment_method=payment_method)
         response = await sdk.receive_payment(request=request)

--- a/docs/breez-sdk/snippets/python/src/sdk_building.py
+++ b/docs/breez-sdk/snippets/python/src/sdk_building.py
@@ -244,6 +244,7 @@ async def server_mode_request_handler(sdk: BreezSdk):
         amount_sats=5_000,
         expiry_secs=3600,
         payment_hash=None,
+        receiver_identity_public_key=None,
     )
     response = await sdk.receive_payment(
         request=ReceivePaymentRequest(payment_method=payment_method)

--- a/docs/breez-sdk/snippets/react-native/htlcs.ts
+++ b/docs/breez-sdk/snippets/react-native/htlcs.ts
@@ -67,7 +67,8 @@ const exampleReceiveHodlInvoicePayment = async (sdk: BreezSdk) => {
       description: 'HODL invoice',
       amountSats: BigInt(50_000),
       expirySecs: undefined,
-      paymentHash
+      paymentHash,
+      receiverIdentityPublicKey: undefined
     })
   })
 

--- a/docs/breez-sdk/snippets/react-native/receive_payment.ts
+++ b/docs/breez-sdk/snippets/react-native/receive_payment.ts
@@ -10,13 +10,16 @@ const exampleReceiveLightningPayment = async (sdk: BreezSdk) => {
   const optionalAmountSats = BigInt(5_000)
   // Optionally set the expiry duration in seconds
   const optionalExpirySecs = 3600
+  // Set this to create an invoice for another Spark identity
+  const optionalReceiverIdentityPublicKey = undefined
 
   const response = await sdk.receivePayment({
     paymentMethod: new ReceivePaymentMethod.Bolt11Invoice({
       description,
       amountSats: optionalAmountSats,
       expirySecs: optionalExpirySecs,
-      paymentHash: undefined
+      paymentHash: undefined,
+      receiverIdentityPublicKey: optionalReceiverIdentityPublicKey
     })
   })
 

--- a/docs/breez-sdk/snippets/react-native/sdk_building.ts
+++ b/docs/breez-sdk/snippets/react-native/sdk_building.ts
@@ -152,7 +152,8 @@ const exampleServerModeRequestHandler = async (sdk: BreezSdk) => {
       description: '<invoice description>',
       amountSats: BigInt(5_000),
       expirySecs: 3600,
-      paymentHash: undefined
+      paymentHash: undefined,
+      receiverIdentityPublicKey: undefined
     })
   })
 

--- a/docs/breez-sdk/snippets/rust/src/htlcs.rs
+++ b/docs/breez-sdk/snippets/rust/src/htlcs.rs
@@ -61,6 +61,7 @@ async fn receive_hodl_invoice_payment(sdk: &BreezSdk) -> Result<()> {
                 amount_sats: Some(50_000),
                 expiry_secs: None,
                 payment_hash: Some(payment_hash),
+                receiver_identity_public_key: None,
             },
         })
         .await?;

--- a/docs/breez-sdk/snippets/rust/src/receive_payment.rs
+++ b/docs/breez-sdk/snippets/rust/src/receive_payment.rs
@@ -9,6 +9,8 @@ async fn receive_lightning_bolt11(sdk: &BreezSdk) -> Result<()> {
     let optional_amount_sats = Some(5_000);
     // Optionally set the expiry duration in seconds
     let optional_expiry_secs = Some(3600_u32);
+    // Set this to create an invoice for another Spark identity
+    let optional_receiver_identity_public_key = None;
 
     let response = sdk
         .receive_payment(ReceivePaymentRequest {
@@ -17,6 +19,7 @@ async fn receive_lightning_bolt11(sdk: &BreezSdk) -> Result<()> {
                 amount_sats: optional_amount_sats,
                 expiry_secs: optional_expiry_secs,
                 payment_hash: None,
+                receiver_identity_public_key: optional_receiver_identity_public_key,
             },
         })
         .await?;

--- a/docs/breez-sdk/snippets/rust/src/sdk_building.rs
+++ b/docs/breez-sdk/snippets/rust/src/sdk_building.rs
@@ -247,6 +247,7 @@ pub(crate) async fn server_mode_request_handler(sdk: &BreezSdk) -> Result<String
                 amount_sats: Some(5_000),
                 expiry_secs: Some(3600),
                 payment_hash: None,
+                receiver_identity_public_key: None,
             },
         })
         .await?;

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Htlcs.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Htlcs.swift
@@ -77,7 +77,8 @@ func receiveHodlInvoicePayment(sdk: BreezSdk) async throws {
                 description: "HODL invoice",
                 amountSats: 50_000,
                 expirySecs: nil,
-                paymentHash: paymentHash
+                paymentHash: paymentHash,
+                receiverIdentityPublicKey: nil
             )
         )
     )

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ReceivePayment.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/ReceivePayment.swift
@@ -8,6 +8,7 @@ func receiveLightning(sdk: BreezSdk) async throws -> ReceivePaymentResponse {
     let optionalAmountSats: UInt64 = 5_000
     // Optionally set the expiry duration in seconds
     let optionalExpirySecs: UInt32 = 3600
+    let optionalReceiverIdentityPublicKey: String? = nil
     let response =
         try await sdk
         .receivePayment(
@@ -16,7 +17,8 @@ func receiveLightning(sdk: BreezSdk) async throws -> ReceivePaymentResponse {
                     description: description,
                     amountSats: optionalAmountSats,
                     expirySecs: optionalExpirySecs,
-                    paymentHash: nil
+                    paymentHash: nil,
+                    receiverIdentityPublicKey: optionalReceiverIdentityPublicKey
                 )
             ))
 

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/SdkBuilding.swift
@@ -214,7 +214,8 @@ func serverModeRequestHandler(sdk: BreezSdk) async throws -> String {
                 description: "<invoice description>",
                 amountSats: 5_000,
                 expirySecs: 3600,
-                paymentHash: nil
+                paymentHash: nil,
+                receiverIdentityPublicKey: nil
             )
         ))
 

--- a/docs/breez-sdk/snippets/wasm/htlcs.ts
+++ b/docs/breez-sdk/snippets/wasm/htlcs.ts
@@ -52,7 +52,8 @@ const exampleReceiveHodlInvoicePayment = async (sdk: BreezSdk) => {
       description: 'HODL invoice',
       amountSats: 50_000,
       expirySecs: undefined,
-      paymentHash
+      paymentHash,
+      receiverIdentityPublicKey: undefined
     }
   })
 

--- a/docs/breez-sdk/snippets/wasm/receive_payment.ts
+++ b/docs/breez-sdk/snippets/wasm/receive_payment.ts
@@ -7,6 +7,8 @@ const exampleReceiveLightningPayment = async (sdk: BreezSdk) => {
   const optionalAmountSats = 5_000
   // Optionally set the expiry duration in seconds
   const optionalExpirySecs = 3600
+  // Set this to create an invoice for another Spark identity
+  const optionalReceiverIdentityPublicKey = undefined
 
   const response = await sdk.receivePayment({
     paymentMethod: {
@@ -14,7 +16,8 @@ const exampleReceiveLightningPayment = async (sdk: BreezSdk) => {
       description,
       amountSats: optionalAmountSats,
       expirySecs: optionalExpirySecs,
-      paymentHash: undefined
+      paymentHash: undefined,
+      receiverIdentityPublicKey: optionalReceiverIdentityPublicKey
     }
   })
 

--- a/docs/breez-sdk/snippets/wasm/sdk_building.ts
+++ b/docs/breez-sdk/snippets/wasm/sdk_building.ts
@@ -176,7 +176,8 @@ const exampleServerModeRequestHandler = async (sdk: BreezSdk): Promise<string> =
       description: '<invoice description>',
       amountSats: 5_000,
       expirySecs: 3600,
-      paymentHash: undefined
+      paymentHash: undefined,
+      receiverIdentityPublicKey: undefined
     }
   })
 

--- a/docs/breez-sdk/src/guide/receive_payment.md
+++ b/docs/breez-sdk/src/guide/receive_payment.md
@@ -11,6 +11,8 @@ Once the SDK is initialized, you can directly begin receiving payments. The SDK 
 
 When receiving via Lightning, we can generate a BOLT11 invoice to be paid. Setting the invoice amount fixes the amount the sender should pay.
 
+To create an invoice for another Spark wallet, set {{#name receiver_identity_public_key}} to that wallet's identity public key. Creating the invoice does not require the receiving wallet's mnemonic.
+
 **Note:** the payment may fallback to a direct Spark payment (if the payer's client supports this).
 
 {{#tabs receive_payment:receive-payment-lightning-bolt11}}

--- a/docs/breez-sdk/src/guide/receive_payment.md
+++ b/docs/breez-sdk/src/guide/receive_payment.md
@@ -11,7 +11,7 @@ Once the SDK is initialized, you can directly begin receiving payments. The SDK 
 
 When receiving via Lightning, we can generate a BOLT11 invoice to be paid. Setting the invoice amount fixes the amount the sender should pay.
 
-To create an invoice for another Spark wallet, set {{#name receiver_identity_public_key}} to that wallet's identity public key. Creating the invoice does not require the receiving wallet's mnemonic.
+To create an invoice for another Spark wallet, set {{#name receiver_identity_public_key}} to that wallet's identity public key. Creating the invoice requires only the receiver's public key, not their private keys.
 
 **Note:** the payment may fallback to a direct Spark payment (if the payer's client supports this).
 

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -787,6 +787,7 @@ pub enum _ReceivePaymentMethod {
         amount_sats: Option<u64>,
         expiry_secs: Option<u32>,
         payment_hash: Option<String>,
+        receiver_identity_public_key: Option<String>,
     },
 }
 


### PR DESCRIPTION
## Summary

- add an optional `receiver_identity_public_key` to BOLT11 invoice creation
- direct standard and HODL Lightning invoices to that Spark identity when supplied, while preserving the connected-wallet behavior when it is absent
- update binding CLI examples and documentation, and cover external recipients in both standard and HODL integration flows

### Breaking Change

This adds a field to the BOLT11 invoice enum variant. Regenerate bindings and pass an absent receiver identity key where the connected wallet should remain the receiver.

## Testing

- `mise exec rust@1.92.0 -- cargo check -p cli`
- `mise exec rust@1.92.0 -- cargo test -p breez-sdk-itest --test lightning_hodl --no-run --quiet`
- `mise exec rust@1.92.0 -- cargo test -p breez-sdk-itest --test breez_sdk_tests --no-run --quiet`
- `mise exec rust@1.92.0 -- cargo check -p breez-sdk-bindings --quiet`
- `mise exec rust@1.92.0 -- cargo fmt --check`

## Public

Adds support for creating BOLT11 invoices that credit another Spark identity without requiring the receiving wallet mnemonic.