### PR TITLE
Chunk leaf upserts in the SQL tree stores

### DIFF
--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -44,6 +44,16 @@ const RESERVATION_TIMEOUT_SECS = 300;
 const SPENT_MARKER_CLEANUP_THRESHOLD_MS = 5 * 60 * 1000;
 
 /**
+ * Leaves per INSERT when upserting a refreshed leaf set.
+ *
+ * Required for correctness, not just memory: this statement binds 6
+ * placeholders per leaf, and the MySQL protocol caps a prepared statement at
+ * 65535. A wallet holding six figures of leaves would otherwise exceed both
+ * that cap and max_allowed_packet.
+ */
+const LEAF_UPSERT_CHUNK_SIZE = 1000;
+
+/**
  * Slim projection: only (id, value) for leaves the selection might use.
  * Includes all leaves with value <= the max target (covers exact-match + the
  * small-leaf accumulators for the minimum-amount path) plus the single
@@ -958,32 +968,40 @@ class MysqlTreeStore {
 
     if (filtered.length === 0) return;
 
-    const valueClauses = new Array(filtered.length)
-      .fill("(?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))")
-      .join(", ");
-    const params = [];
-    for (const leaf of filtered) {
-      params.push(
-        this.identity,
-        leaf.id,
-        leaf.status,
-        isMissingFromOperators ? 1 : 0,
-        JSON.stringify(leaf),
-        leaf.value
+    // All chunks run inside the caller's transaction, so the full set still
+    // lands atomically. UTC_TIMESTAMP(6) is re-evaluated per statement, so
+    // added_at can differ by microseconds between chunks; every value is still
+    // after the caller's refreshStartedAt, which is all the timestamp-based
+    // deletion in setLeaves depends on.
+    for (let i = 0; i < filtered.length; i += LEAF_UPSERT_CHUNK_SIZE) {
+      const chunk = filtered.slice(i, i + LEAF_UPSERT_CHUNK_SIZE);
+      const valueClauses = new Array(chunk.length)
+        .fill("(?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))")
+        .join(", ");
+      const params = [];
+      for (const leaf of chunk) {
+        params.push(
+          this.identity,
+          leaf.id,
+          leaf.status,
+          isMissingFromOperators ? 1 : 0,
+          JSON.stringify(leaf),
+          leaf.value
+        );
+      }
+
+      await conn.query(
+        `INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, value, added_at)
+         VALUES ${valueClauses}
+         ON DUPLICATE KEY UPDATE
+           status = VALUES(status),
+           is_missing_from_operators = VALUES(is_missing_from_operators),
+           data = VALUES(data),
+           value = VALUES(value),
+           added_at = UTC_TIMESTAMP(6)`,
+        params
       );
     }
-
-    await conn.query(
-      `INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, value, added_at)
-       VALUES ${valueClauses}
-       ON DUPLICATE KEY UPDATE
-         status = VALUES(status),
-         is_missing_from_operators = VALUES(is_missing_from_operators),
-         data = VALUES(data),
-         value = VALUES(value),
-         added_at = UTC_TIMESTAMP(6)`,
-      params
-    );
   }
 
   async _batchSetReservationId(conn, reservationId, leafIds) {

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -41,6 +41,16 @@ const RESERVATION_TIMEOUT_SECS = 300; // 5 minutes
 const SPENT_MARKER_CLEANUP_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
+ * Leaves per INSERT when upserting a refreshed leaf set.
+ *
+ * A wallet can hold six figures of leaves, each serializing to a JSON blob
+ * carrying up to five transactions. Building that as a single statement
+ * materializes the whole set at once, which is the largest allocation in a
+ * refresh and lands at its very end.
+ */
+const LEAF_UPSERT_CHUNK_SIZE = 1000;
+
+/**
  * Slim projection: only (id, value) for leaves the selection might use.
  * Includes all leaves with value <= $2 (covers exact-match + the small-leaf
  * accumulators for the minimum-amount path) plus the single smallest leaf
@@ -1019,23 +1029,29 @@ class PostgresTreeStore {
 
     if (filtered.length === 0) return;
 
-    const ids = filtered.map((l) => l.id);
-    const statuses = filtered.map((l) => l.status);
-    const missingFlags = filtered.map(() => isMissingFromOperators);
-    const dataValues = filtered.map((l) => JSON.stringify(l));
+    // All chunks run inside the caller's transaction, and NOW() is the
+    // transaction timestamp, so every row still lands atomically with one
+    // shared added_at.
+    for (let i = 0; i < filtered.length; i += LEAF_UPSERT_CHUNK_SIZE) {
+      const chunk = filtered.slice(i, i + LEAF_UPSERT_CHUNK_SIZE);
+      const ids = chunk.map((l) => l.id);
+      const statuses = chunk.map((l) => l.status);
+      const missingFlags = chunk.map(() => isMissingFromOperators);
+      const dataValues = chunk.map((l) => JSON.stringify(l));
 
-    await client.query(
-      `INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, added_at)
-       SELECT $5, id, status, missing, data::jsonb, NOW()
-       FROM UNNEST($1::text[], $2::text[], $3::bool[], $4::text[])
-           AS t(id, status, missing, data)
-       ON CONFLICT (user_id, id) DO UPDATE SET
-         status = EXCLUDED.status,
-         is_missing_from_operators = EXCLUDED.is_missing_from_operators,
-         data = EXCLUDED.data,
-         added_at = NOW()`,
-      [ids, statuses, missingFlags, dataValues, this.identity]
-    );
+      await client.query(
+        `INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, added_at)
+         SELECT $5, id, status, missing, data::jsonb, NOW()
+         FROM UNNEST($1::text[], $2::text[], $3::bool[], $4::text[])
+             AS t(id, status, missing, data)
+         ON CONFLICT (user_id, id) DO UPDATE SET
+           status = EXCLUDED.status,
+           is_missing_from_operators = EXCLUDED.is_missing_from_operators,
+           data = EXCLUDED.data,
+           added_at = NOW()`,
+        [ids, statuses, missingFlags, dataValues, this.identity]
+      );
+    }
   }
 
   /**

--- a/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/mysql.rs
@@ -78,6 +78,12 @@ async fn test_set_leaves() {
 }
 
 #[wasm_bindgen_test]
+async fn test_set_leaves_across_chunk_boundary() {
+    let store = create_test_tree_store("mysql_tree_set_leaves_chunked").await;
+    breez_sdk_spark::tree_store_tests::test_set_leaves_across_chunk_boundary(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_set_leaves_with_reservations() {
     let store = create_test_tree_store("mysql_tree_set_leaves_res").await;
     breez_sdk_spark::tree_store_tests::test_set_leaves_with_reservations(&store).await;

--- a/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
+++ b/crates/breez-sdk/wasm/src/tree_store/tests/postgres.rs
@@ -78,6 +78,12 @@ async fn test_set_leaves() {
 }
 
 #[wasm_bindgen_test]
+async fn test_set_leaves_across_chunk_boundary() {
+    let store = create_test_tree_store("pg_tree_set_leaves_chunked").await;
+    breez_sdk_spark::tree_store_tests::test_set_leaves_across_chunk_boundary(&store).await;
+}
+
+#[wasm_bindgen_test]
 async fn test_set_leaves_with_reservations() {
     let store = create_test_tree_store("pg_tree_set_leaves_res").await;
     breez_sdk_spark::tree_store_tests::test_set_leaves_with_reservations(&store).await;

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -137,6 +137,14 @@ const RESERVATION_TIMEOUT_SECS: i64 = 300; // 5 minutes
 /// deployments where another instance may still be processing a refresh.
 const SPENT_MARKER_CLEANUP_THRESHOLD_MS: i64 = 5 * 60 * 1000;
 
+/// Leaves per `INSERT` when upserting a refreshed leaf set.
+///
+/// Required for correctness, not just memory: this statement binds 6
+/// placeholders per leaf, and the `MySQL` protocol caps a prepared statement at
+/// 65535. A wallet holding six figures of leaves would otherwise exceed both
+/// that cap and `max_allowed_packet`.
+const LEAF_UPSERT_CHUNK_SIZE: usize = 1_000;
+
 /// Slim projection of selection candidates: id + value only.
 /// Includes all leaves with value <= the max target (covers exact-match +
 /// minimum-amount accumulators) plus the smallest leaf with a larger value
@@ -1525,37 +1533,44 @@ impl MysqlTreeStore {
             return Ok(());
         }
 
-        // Build VALUES (?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6)), … with user_id as the first column.
-        let mut sql = String::from(
-            "INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, value, added_at) VALUES ",
-        );
-        let mut params: Vec<Value> = Vec::with_capacity(filtered.len() * 6);
-        for (i, leaf) in filtered.iter().enumerate() {
-            if i > 0 {
-                sql.push_str(", ");
+        // All chunks run inside the caller's transaction, so the full set still
+        // lands atomically. `UTC_TIMESTAMP(6)` is re-evaluated per statement, so
+        // `added_at` can differ by microseconds between chunks; every value is
+        // still after the caller's `refresh_started_at`, which is all the
+        // timestamp-based deletion in `set_leaves` depends on.
+        for chunk in filtered.chunks(LEAF_UPSERT_CHUNK_SIZE) {
+            // Build VALUES (?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6)), … with user_id as the first column.
+            let mut sql = String::from(
+                "INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, value, added_at) VALUES ",
+            );
+            let mut params: Vec<Value> = Vec::with_capacity(chunk.len() * 6);
+            for (i, leaf) in chunk.iter().enumerate() {
+                if i > 0 {
+                    sql.push_str(", ");
+                }
+                sql.push_str("(?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))");
+                #[allow(clippy::cast_possible_wrap)]
+                let value_i64 = leaf.value as i64;
+                params.push(Value::from(self.identity.clone()));
+                params.push(Value::from(leaf.id.to_string()));
+                params.push(Value::from(leaf.status.to_string()));
+                params.push(Value::from(is_missing_from_operators));
+                params.push(Value::from(Self::serialize_node(leaf)?));
+                params.push(Value::from(value_i64));
             }
-            sql.push_str("(?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(6))");
-            #[allow(clippy::cast_possible_wrap)]
-            let value_i64 = leaf.value as i64;
-            params.push(Value::from(self.identity.clone()));
-            params.push(Value::from(leaf.id.to_string()));
-            params.push(Value::from(leaf.status.to_string()));
-            params.push(Value::from(is_missing_from_operators));
-            params.push(Value::from(Self::serialize_node(leaf)?));
-            params.push(Value::from(value_i64));
-        }
-        sql.push_str(
-            " ON DUPLICATE KEY UPDATE
-                status = VALUES(status),
-                is_missing_from_operators = VALUES(is_missing_from_operators),
-                data = VALUES(data),
-                value = VALUES(value),
-                added_at = UTC_TIMESTAMP(6)",
-        );
+            sql.push_str(
+                " ON DUPLICATE KEY UPDATE
+                    status = VALUES(status),
+                    is_missing_from_operators = VALUES(is_missing_from_operators),
+                    data = VALUES(data),
+                    value = VALUES(value),
+                    added_at = UTC_TIMESTAMP(6)",
+            );
 
-        tx.exec_drop(&sql, Params::Positional(params))
-            .await
-            .map_err(map_err)?;
+            tx.exec_drop(&sql, Params::Positional(params))
+                .await
+                .map_err(map_err)?;
+        }
 
         Ok(())
     }
@@ -2264,6 +2279,12 @@ mod tests {
     async fn test_set_leaves_replaces_fully() {
         let fixture = MysqlTreeStoreTestFixture::new().await;
         shared_tests::test_set_leaves_replaces_fully(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_set_leaves_across_chunk_boundary() {
+        let fixture = MysqlTreeStoreTestFixture::new().await;
+        shared_tests::test_set_leaves_across_chunk_boundary(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -128,6 +128,14 @@ const RESERVATION_TIMEOUT_SECS: f64 = 300.0; // 5 minutes
 
 const SPENT_MARKER_CLEANUP_THRESHOLD_MS: i64 = 5 * 60 * 1000; // 5 minutes
 
+/// Leaves per `INSERT` when upserting a refreshed leaf set.
+///
+/// A wallet can hold six figures of leaves, and each one serializes to a JSON
+/// blob carrying up to five transactions. Building that as a single statement
+/// materializes the whole set as `serde_json::Value` plus its encoded form,
+/// which is the largest allocation in a refresh and lands at its very end.
+const LEAF_UPSERT_CHUNK_SIZE: usize = 1_000;
+
 /// Slim projection of selection candidates: id + value only.
 /// Includes all leaves with value <= `$2` (covers exact-match +
 /// minimum-amount accumulators) plus the smallest leaf with value >
@@ -1189,40 +1197,51 @@ impl PostgresTreeStore {
             return Ok(());
         }
 
-        let mut ids: Vec<String> = Vec::with_capacity(filtered.len());
-        let mut statuses: Vec<String> = Vec::with_capacity(filtered.len());
-        let mut missing_flags: Vec<bool> = Vec::with_capacity(filtered.len());
-        let mut data_values: Vec<serde_json::Value> = Vec::with_capacity(filtered.len());
+        let chunk_len = filtered.len().min(LEAF_UPSERT_CHUNK_SIZE);
+        let mut ids: Vec<String> = Vec::with_capacity(chunk_len);
+        let mut statuses: Vec<String> = Vec::with_capacity(chunk_len);
+        let mut missing_flags: Vec<bool> = Vec::with_capacity(chunk_len);
+        let mut data_values: Vec<serde_json::Value> = Vec::with_capacity(chunk_len);
 
-        for leaf in filtered {
-            ids.push(leaf.id.to_string());
-            statuses.push(leaf.status.to_string());
-            missing_flags.push(is_missing_from_operators);
-            data_values.push(Self::serialize_node(leaf)?);
+        // All chunks run inside the caller's transaction, and `NOW()` is the
+        // transaction timestamp, so every row still lands atomically with one
+        // shared `added_at`.
+        for chunk in filtered.chunks(LEAF_UPSERT_CHUNK_SIZE) {
+            ids.clear();
+            statuses.clear();
+            missing_flags.clear();
+            data_values.clear();
+
+            for leaf in chunk {
+                ids.push(leaf.id.to_string());
+                statuses.push(leaf.status.to_string());
+                missing_flags.push(is_missing_from_operators);
+                data_values.push(Self::serialize_node(leaf)?);
+            }
+
+            tx.execute(
+                r"
+                INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, added_at)
+                SELECT $5, id, status, missing, data, NOW()
+                FROM UNNEST($1::text[], $2::text[], $3::bool[], $4::jsonb[])
+                    AS t(id, status, missing, data)
+                ON CONFLICT (user_id, id) DO UPDATE SET
+                    status = EXCLUDED.status,
+                    is_missing_from_operators = EXCLUDED.is_missing_from_operators,
+                    data = EXCLUDED.data,
+                    added_at = NOW()
+                ",
+                &[
+                    &ids,
+                    &statuses,
+                    &missing_flags,
+                    &data_values,
+                    &self.identity,
+                ],
+            )
+            .await
+            .map_err(map_err)?;
         }
-
-        tx.execute(
-            r"
-            INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, added_at)
-            SELECT $5, id, status, missing, data, NOW()
-            FROM UNNEST($1::text[], $2::text[], $3::bool[], $4::jsonb[])
-                AS t(id, status, missing, data)
-            ON CONFLICT (user_id, id) DO UPDATE SET
-                status = EXCLUDED.status,
-                is_missing_from_operators = EXCLUDED.is_missing_from_operators,
-                data = EXCLUDED.data,
-                added_at = NOW()
-            ",
-            &[
-                &ids,
-                &statuses,
-                &missing_flags,
-                &data_values,
-                &self.identity,
-            ],
-        )
-        .await
-        .map_err(map_err)?;
 
         Ok(())
     }
@@ -1798,6 +1817,12 @@ mod tests {
     async fn test_notification_on_pending_balance_change() {
         let fixture = PostgresTreeStoreTestFixture::new().await;
         shared_tests::test_notification_on_pending_balance_change(&fixture.store).await;
+    }
+
+    #[tokio::test]
+    async fn test_set_leaves_across_chunk_boundary() {
+        let fixture = PostgresTreeStoreTestFixture::new().await;
+        shared_tests::test_set_leaves_across_chunk_boundary(&fixture.store).await;
     }
 
     #[tokio::test]

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -1203,6 +1203,26 @@ impl PostgresTreeStore {
         let mut missing_flags: Vec<bool> = Vec::with_capacity(chunk_len);
         let mut data_values: Vec<serde_json::Value> = Vec::with_capacity(chunk_len);
 
+        // Prepared once for the whole loop: passing the SQL as a string would
+        // make tokio-postgres re-prepare it per chunk, doubling the round trips
+        // taken while holding the write lock.
+        let stmt = tx
+            .prepare(
+                r"
+                INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, added_at)
+                SELECT $5, id, status, missing, data, NOW()
+                FROM UNNEST($1::text[], $2::text[], $3::bool[], $4::jsonb[])
+                    AS t(id, status, missing, data)
+                ON CONFLICT (user_id, id) DO UPDATE SET
+                    status = EXCLUDED.status,
+                    is_missing_from_operators = EXCLUDED.is_missing_from_operators,
+                    data = EXCLUDED.data,
+                    added_at = NOW()
+                ",
+            )
+            .await
+            .map_err(map_err)?;
+
         // All chunks run inside the caller's transaction, and `NOW()` is the
         // transaction timestamp, so every row still lands atomically with one
         // shared `added_at`.
@@ -1220,17 +1240,7 @@ impl PostgresTreeStore {
             }
 
             tx.execute(
-                r"
-                INSERT INTO brz_tree_leaves (user_id, id, status, is_missing_from_operators, data, added_at)
-                SELECT $5, id, status, missing, data, NOW()
-                FROM UNNEST($1::text[], $2::text[], $3::bool[], $4::jsonb[])
-                    AS t(id, status, missing, data)
-                ON CONFLICT (user_id, id) DO UPDATE SET
-                    status = EXCLUDED.status,
-                    is_missing_from_operators = EXCLUDED.is_missing_from_operators,
-                    data = EXCLUDED.data,
-                    added_at = NOW()
-                ",
+                &stmt,
                 &[
                     &ids,
                     &statuses,

--- a/crates/spark/src/tree/store.rs
+++ b/crates/spark/src/tree/store.rs
@@ -1085,6 +1085,11 @@ mod tests {
     }
 
     #[async_test_all]
+    async fn test_set_leaves_across_chunk_boundary() {
+        shared_tests::test_set_leaves_across_chunk_boundary(&InMemoryTreeStore::new()).await;
+    }
+
+    #[async_test_all]
     async fn test_set_leaves_with_reservations() {
         shared_tests::test_set_leaves_with_reservations(&InMemoryTreeStore::new()).await;
     }

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -249,10 +249,26 @@ pub async fn test_set_leaves_across_chunk_boundary(store: &dyn TreeStore) {
     );
     assert_eq!(store.get_available_balance().await.unwrap(), expected_total);
 
-    // Re-running must upsert in place rather than duplicate across chunks.
-    let refresh_start = future_refresh_start(store).await;
-    store.set_leaves(&leaves, &[], refresh_start).await.unwrap();
-    assert_eq!(get_available(store).await.len(), LEAF_COUNT);
+    // Re-run with new values to exercise the conflict path in every chunk. The
+    // refresh start must be in the past: a future one deletes the rows just
+    // written, leaving the second pass to insert into an empty table.
+    let updated: Vec<TreeNode> = (0..LEAF_COUNT)
+        .map(|i| create_test_tree_node(&format!("chunked{i}"), 1_000 + i as u64))
+        .collect();
+    let refresh_start = past_refresh_start(store).await;
+    store
+        .set_leaves(&updated, &[], refresh_start)
+        .await
+        .unwrap();
+
+    let stored = get_available(store).await;
+    assert_eq!(stored.len(), LEAF_COUNT);
+    let updated_total: u64 = updated.iter().map(|l| l.value).sum();
+    assert_eq!(
+        stored.iter().map(|l| l.value).sum::<u64>(),
+        updated_total,
+        "every chunk must update in place, not skip its conflicting rows"
+    );
 }
 
 pub async fn test_set_leaves_with_reservations(store: &dyn TreeStore) {

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -221,6 +221,40 @@ pub async fn test_set_leaves(store: &dyn TreeStore) {
     assert!(!stored.iter().any(|l| l.id.to_string() == "node1"));
 }
 
+/// Exercises a leaf set large enough to span many upsert chunks, so a dropped,
+/// duplicated or mis-ordered chunk shows up as a wrong count.
+pub async fn test_set_leaves_across_chunk_boundary(store: &dyn TreeStore) {
+    // Must exceed 10922 leaves: the MySQL backends bind 6 placeholders per leaf
+    // against a 65535 protocol cap, so an unchunked upsert fails outright there
+    // ("Prepared statement contains too many placeholders") rather than merely
+    // using too much memory. Deliberately not a multiple of the chunk size, so
+    // the final chunk is partial.
+    const LEAF_COUNT: usize = 12_345;
+
+    let leaves: Vec<TreeNode> = (0..LEAF_COUNT)
+        .map(|i| create_test_tree_node(&format!("chunked{i}"), 100 + i as u64))
+        .collect();
+
+    let refresh_start = future_refresh_start(store).await;
+    store.set_leaves(&leaves, &[], refresh_start).await.unwrap();
+
+    let stored = get_available(store).await;
+    assert_eq!(stored.len(), LEAF_COUNT);
+
+    let expected_total: u64 = leaves.iter().map(|l| l.value).sum();
+    assert_eq!(
+        stored.iter().map(|l| l.value).sum::<u64>(),
+        expected_total,
+        "every leaf must round-trip with its own value"
+    );
+    assert_eq!(store.get_available_balance().await.unwrap(), expected_total);
+
+    // Re-running must upsert in place rather than duplicate across chunks.
+    let refresh_start = future_refresh_start(store).await;
+    store.set_leaves(&leaves, &[], refresh_start).await.unwrap();
+    assert_eq!(get_available(store).await.len(), LEAF_COUNT);
+}
+
 pub async fn test_set_leaves_with_reservations(store: &dyn TreeStore) {
     let leaves = vec![
         create_test_tree_node("node1", 100),


### PR DESCRIPTION
`set_leaves` writes the entire leaf set in a single `INSERT`. At ~100k leaves:

- **Postgres**: one statement materializing 100k JSON blobs, holding a pooled connection and the advisory lock throughout. A partner deployment saw pool exhaustion, then `terminating connection because of crash of another server process` and cluster recovery.
- **MySQL**: 6 placeholders per leaf against a 65535 cap, so past ~10,922 leaves the write fails outright with `ERROR 1390: Prepared statement contains too many placeholders`.

Chunk at 1000 in all four backends that build such a statement (Rust and JS, both engines). Chunks run inside the caller's transaction, so the set still lands atomically.

Adds `test_set_leaves_across_chunk_boundary` to the shared suite, wired into all five harnesses. Sized at 12,345 leaves so it exceeds the MySQL cap and fails without the fix.