### PR TITLE
Correct the MySQL chunk-size rationale in the JS tree store

### DIFF
--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -46,10 +46,11 @@ const SPENT_MARKER_CLEANUP_THRESHOLD_MS = 5 * 60 * 1000;
 /**
  * Leaves per INSERT when upserting a refreshed leaf set.
  *
- * Required for correctness, not just memory: this statement binds 6
- * placeholders per leaf, and the MySQL protocol caps a prepared statement at
- * 65535. A wallet holding six figures of leaves would otherwise exceed both
- * that cap and max_allowed_packet.
+ * A wallet can hold six figures of leaves, each serializing to a JSON blob
+ * carrying up to five transactions. The upsert goes through conn.query(),
+ * which interpolates its placeholders client-side, so the whole set would
+ * otherwise be built in memory as one statement and sent as one packet,
+ * against max_allowed_packet.
  */
 const LEAF_UPSERT_CHUNK_SIZE = 1000;
 

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -224,11 +224,13 @@ pub async fn test_set_leaves(store: &dyn TreeStore) {
 /// Exercises a leaf set large enough to span many upsert chunks, so a dropped,
 /// duplicated or mis-ordered chunk shows up as a wrong count.
 pub async fn test_set_leaves_across_chunk_boundary(store: &dyn TreeStore) {
-    // Must exceed 10922 leaves: the MySQL backends bind 6 placeholders per leaf
-    // against a 65535 protocol cap, so an unchunked upsert fails outright there
-    // ("Prepared statement contains too many placeholders") rather than merely
-    // using too much memory. Deliberately not a multiple of the chunk size, so
-    // the final chunk is partial.
+    // Must exceed 10922 leaves: the Rust MySQL store prepares its upsert and
+    // binds 6 placeholders per leaf against the protocol's 65535 cap, so an
+    // unchunked write fails outright there ("Prepared statement contains too
+    // many placeholders") rather than merely using too much memory. The JS
+    // MySQL store interpolates client-side instead, so it is bounded by
+    // max_allowed_packet rather than that cap. Deliberately not a multiple of
+    // the chunk size, so the final chunk is partial.
     const LEAF_COUNT: usize = 12_345;
 
     let leaves: Vec<TreeNode> = (0..LEAF_COUNT)


### PR DESCRIPTION
Follow-up to the review comment on #1034: https://github.com/breez/spark-sdk/pull/1034#discussion_r3730306632

`LEAF_UPSERT_CHUNK_SIZE` in the JS MySQL tree store was documented as required for correctness because "the MySQL protocol caps a prepared statement at 65535". That does not apply there. `_batchUpsertLeaves` goes through mysql2's `conn.query()`, which interpolates `?` client-side and sends a plain `COM_QUERY`, so no prepared statement is ever created (nothing in that file calls `.execute()`). The real bound is `max_allowed_packet` and memory.

The same wording in `crates/spark-mysql/src/tree_store.rs` is accurate and left alone: sqlx prepares every statement, so the cap genuinely applies to the Rust MySQL store, which is where an unchunked write failed with `ERROR 1390`.

Also narrows the shared test's comment, which said "the MySQL backends" fail on the cap when only the Rust one does.

Comment-only, no behavior change. The chunking is worth keeping in both backends.