### PR TITLE
Raise the operator gRPC decode limit to 20 MiB

### DIFF
--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -25,6 +25,11 @@ use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
 use tracing::{debug, instrument};
 
+/// Transfer pages embed full leaf data, so a page of leaf-heavy transfers can
+/// exceed tonic's 4 MiB decode default and permanently wedge payment syncing.
+/// 20 MiB matches the limit used by the Spark JS SDK.
+const MAX_DECODING_MESSAGE_SIZE: usize = 20 * 1024 * 1024;
+
 #[derive(Clone, Default)]
 pub struct QueryNodesPaginatedRequest {
     pub include_parents: bool,
@@ -683,6 +688,7 @@ impl SparkRpcClient {
         interceptor: HeaderInterceptor,
     ) -> SparkServiceClient<InterceptedService<Transport, HeaderInterceptor>> {
         SparkServiceClient::with_interceptor(self.transport.clone(), interceptor)
+            .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE)
     }
 
     fn spark_token_service_client(
@@ -690,6 +696,7 @@ impl SparkRpcClient {
         interceptor: HeaderInterceptor,
     ) -> SparkTokenServiceClient<InterceptedService<Transport, HeaderInterceptor>> {
         SparkTokenServiceClient::with_interceptor(self.transport.clone(), interceptor)
+            .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE)
     }
 
     async fn build_interceptor(&self, force_refresh: bool) -> Result<HeaderInterceptor> {


### PR DESCRIPTION
Transfer pages embed full leaf data, so a page of leaf-heavy transfers can exceed tonic's 4 MiB decode default. The failure repeats on the same page every sync, so the payment sync offset stops advancing. Observed in production.

Raises the decode limit on the operator Spark and token service clients to 20 MiB, matching the Spark JS SDK.