### PR TITLE
Switch default mainnet chain service to mempool.space

### DIFF
--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -804,7 +804,7 @@ async fn resolve_storage(
 }
 
 /// Resolves the chain service: caller-supplied override → REST config → network
-/// default (Esplora on mainnet, mempool.space on regtest).
+/// default (mempool.space on mainnet, a hosted mempool instance on regtest).
 fn resolve_chain_service(
     supplied: Option<Arc<dyn BitcoinChainService>>,
     rest_config: Option<RestChainServiceConfig>,
@@ -828,12 +828,12 @@ fn resolve_chain_service(
     let inner_client: Arc<dyn platform_utils::HttpClient> = context.http_client.clone();
     match network {
         Network::Mainnet => Arc::new(RestClientChainService::new(
-            "https://blockstream.info/api".to_string(),
+            "https://mempool.space/api".to_string(),
             network,
             5,
             inner_client,
             None,
-            ChainApiType::Esplora,
+            ChainApiType::MempoolSpace,
         )),
         Network::Regtest => Arc::new(RestClientChainService::new(
             "https://regtest-mempool.us-west-2.sparkinfra.net/api".to_string(),


### PR DESCRIPTION
A user reported an on-chain deposit not showing up because chain requests were failing with rate-limit errors. Measurements against both providers (real \`/tx/:txid\` lookups, ramping request rate from a single IP) showed:

| | blockstream.info | mempool.space |
|---|---|---|
| First 429 | at 10 req/s | at 40 req/s |
| Recovery after backing off | ~1 hour (IP penalty box) | ~5 seconds |
| Median latency | ~495 ms | ~139 ms |

Blockstream's penalty box outlasts the SDK's ~8s retry budget by orders of magnitude, so a throttled device sees its deposit sync fail for the whole window. mempool.space's throttle clears within the existing retry budget.

The API surface is identical for every endpoint the SDK uses (verified against live responses, including spent/unspent outspends and broadcast). Mainnet now also uses the dedicated \`/v1/fees/recommended\` endpoint, as regtest already does.
