### PR TITLE
Fix iOS CocoaPods builds for the Flutter and React Native packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,25 @@ jobs:
       - name: Verify CredentialManagerPrfCore copies are in sync
         run: cargo xtask sync-passkey-core --check
 
+  ios-cocoapods-compile:
+    name: iOS CocoaPods compile
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Only Flutter.xcframework is needed, so this job skips setup-build.
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: 3.41.3
+
+      - name: Fetch Flutter iOS artifacts
+        run: flutter precache --ios
+
+      - name: Typecheck Flutter & React Native iOS sources as CocoaPods builds them
+        run: ./scripts/check-ios-cocoapods.sh
+
   rn-post-ubrn-check:
     name: RN post-ubrn sync
     runs-on: ubuntu-latest

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyAssertionCore.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyAssertionCore.swift
@@ -1,6 +1,11 @@
 import AuthenticationServices
 import Foundation
+// PasskeyPRFHelperObjC is a module only under SPM. The Flutter and React
+// Native podspecs compile PasskeyPRFHelper.h/.m into the same pod as this
+// file, where the helper arrives via the pod's umbrella header instead.
+#if canImport(PasskeyPRFHelperObjC)
 import PasskeyPRFHelperObjC
+#endif
 import Security
 #if canImport(UIKit)
 import UIKit

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyProvider.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyProvider.swift
@@ -1,8 +1,6 @@
 import AuthenticationServices
 import Foundation
-#if canImport(PasskeyPRFHelperObjC)
 import PasskeyPRFHelperObjC
-#endif
 import Security
 
 /// iOS / macOS platform-specific options for [`PasskeyProvider`].

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyProvider.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyProvider.swift
@@ -1,6 +1,8 @@
 import AuthenticationServices
 import Foundation
+#if canImport(PasskeyPRFHelperObjC)
 import PasskeyPRFHelperObjC
+#endif
 import Security
 
 /// iOS / macOS platform-specific options for [`PasskeyProvider`].

--- a/packages/flutter/ios/Classes/BreezSdkSparkPasskeyPlugin.swift
+++ b/packages/flutter/ios/Classes/BreezSdkSparkPasskeyPlugin.swift
@@ -80,7 +80,7 @@ public class BreezSdkSparkPasskeyPlugin: NSObject, FlutterPlugin {
                 let registered = registration.credential
                 result([
                     "credentialId": registered.credentialId.base64EncodedString(),
-                    "userId": registered.userId.base64EncodedString(),
+                    "userId": registered.userId?.base64EncodedString() as Any?,
                     "aaguid": registered.aaguid?.base64EncodedString() as Any?,
                     "backupEligible": registered.backupEligible as Any?,
                     // Null unless the authenticator evaluated PRF during the

--- a/packages/flutter/ios/Classes/PasskeyAssertionCore.swift
+++ b/packages/flutter/ios/Classes/PasskeyAssertionCore.swift
@@ -1,6 +1,11 @@
 import AuthenticationServices
 import Foundation
+// PasskeyPRFHelperObjC is a module only under SPM. The Flutter and React
+// Native podspecs compile PasskeyPRFHelper.h/.m into the same pod as this
+// file, where the helper arrives via the pod's umbrella header instead.
+#if canImport(PasskeyPRFHelperObjC)
 import PasskeyPRFHelperObjC
+#endif
 import Security
 #if canImport(UIKit)
 import UIKit

--- a/packages/flutter/lib/src/passkey_prf_provider.dart
+++ b/packages/flutter/lib/src/passkey_prf_provider.dart
@@ -169,7 +169,8 @@ class PasskeyProvider implements PrfProvider {
       final result = await _channel.invokeMethod<Map<Object?, Object?>>('createPasskey', args);
       final map = result!;
       final credentialId = base64Decode(map['credentialId'] as String);
-      final userId = base64Decode(map['userId'] as String);
+      final userIdB64 = map['userId'] as String?;
+      final userId = userIdB64 == null ? null : base64Decode(userIdB64);
       final aaguidB64 = map['aaguid'] as String?;
       final aaguid = aaguidB64 == null ? null : base64Decode(aaguidB64);
       final backupEligible = map['backupEligible'] as bool?;

--- a/packages/react-native/BreezSdkSparkReactNative.podspec
+++ b/packages/react-native/BreezSdkSparkReactNative.podspec
@@ -16,6 +16,12 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/breez/spark-sdk.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/*.{h,m,mm,swift}", "ios/generated/**/*.{h}", "cpp/**/*.{hpp,cpp,c,h}", "cpp/generated/**/*.{hpp,cpp,c,h}"
+  # The pod contains Swift, so CocoaPods builds an ObjC module from the umbrella
+  # header, which is parsed as ObjC and not ObjC++. Every other header here is
+  # C++ or reaches it transitively (BreezSdkSparkReactNative.h imports the
+  # ObjC++ codegen spec under RCT_NEW_ARCH_ENABLED), so only the helper the
+  # Swift sources need is public.
+  s.public_header_files = "ios/PasskeyPRFHelper.h"
   s.vendored_frameworks = "build/RnBreezSdkSpark.xcframework"
   s.dependency    "uniffi-bindgen-react-native", "0.29.3-1"
 

--- a/packages/react-native/ios/BreezSdkSparkPasskey.swift
+++ b/packages/react-native/ios/BreezSdkSparkPasskey.swift
@@ -112,7 +112,7 @@ class BreezSdkSparkPasskey: NSObject {
                 // side then skips the assertion entirely.
                 resolve([
                     "credentialId": registered.credentialId.base64EncodedString(),
-                    "userId": registered.userId.base64EncodedString(),
+                    "userId": registered.userId?.base64EncodedString() as Any?,
                     "aaguid": registered.aaguid?.base64EncodedString() as Any?,
                     "backupEligible": registered.backupEligible as Any?,
                     "seeds": registration.seeds?.map { $0.base64EncodedString() } as Any?,

--- a/packages/react-native/ios/PasskeyAssertionCore.swift
+++ b/packages/react-native/ios/PasskeyAssertionCore.swift
@@ -1,6 +1,11 @@
 import AuthenticationServices
 import Foundation
+// PasskeyPRFHelperObjC is a module only under SPM. The Flutter and React
+// Native podspecs compile PasskeyPRFHelper.h/.m into the same pod as this
+// file, where the helper arrives via the pod's umbrella header instead.
+#if canImport(PasskeyPRFHelperObjC)
 import PasskeyPRFHelperObjC
+#endif
 import Security
 #if canImport(UIKit)
 import UIKit

--- a/packages/react-native/scripts/post-ubrn.js
+++ b/packages/react-native/scripts/post-ubrn.js
@@ -196,6 +196,32 @@ patchFile(
   }
 );
 
+// ---------------------------------------------------------------------------
+// 3. BreezSdkSparkReactNative.podspec
+// ---------------------------------------------------------------------------
+
+patchFile(
+  'BreezSdkSparkReactNative.podspec',
+  'public_header_files (keep C++ out of the ObjC umbrella)',
+  (content, label, relPath) => {
+    if (content.includes('s.public_header_files')) {
+      return content;
+    }
+    const anchor = '  s.vendored_frameworks = "build/RnBreezSdkSpark.xcframework"';
+    requireAnchor(content, anchor, label, relPath);
+    const injected = [
+      '  # The pod contains Swift, so CocoaPods builds an ObjC module from the umbrella',
+      '  # header, which is parsed as ObjC and not ObjC++. Every other header here is',
+      '  # C++ or reaches it transitively (BreezSdkSparkReactNative.h imports the',
+      '  # ObjC++ codegen spec under RCT_NEW_ARCH_ENABLED), so only the helper the',
+      '  # Swift sources need is public.',
+      '  s.public_header_files = "ios/PasskeyPRFHelper.h"',
+      anchor,
+    ].join('\n');
+    return content.replace(anchor, injected);
+  }
+);
+
 if (errors.length > 0) {
   console.error('');
   console.error(`[post-ubrn] ${errors.length} patch(es) failed:`);

--- a/packages/react-native/scripts/post-ubrn.js
+++ b/packages/react-native/scripts/post-ubrn.js
@@ -20,6 +20,12 @@
  *        - register BreezSdkSparkPasskeyModule alongside the generated
  *          UniFFI TurboModule so React Native can find it at runtime
  *
+ *   3. BreezSdkSparkReactNative.podspec
+ *        - narrow `public_header_files` to the ObjC PRF helper. The pod
+ *          gained Swift with the passkey provider, so CocoaPods now builds
+ *          an ObjC module from the umbrella header, and the generated C++
+ *          and ObjC++ headers cannot be parsed as ObjC
+ *
  * The PasskeyProvider class is exposed via a subpath export
  * (`@breeztech/breez-sdk-spark-react-native/passkey-prf-provider`) declared
  * in package.json `exports`, so no edit to the generated `src/index.tsx`
@@ -204,8 +210,18 @@ patchFile(
   'BreezSdkSparkReactNative.podspec',
   'public_header_files (keep C++ out of the ObjC umbrella)',
   (content, label, relPath) => {
-    if (content.includes('s.public_header_files')) {
+    const declaration = '  s.public_header_files = "ios/PasskeyPRFHelper.h"';
+    if (content.includes(declaration)) {
       return content;
+    }
+    // Any other value silently re-widens the umbrella, so refuse to inject a
+    // second, conflicting assignment.
+    if (/^\s*s\.public_header_files\s*=/m.test(content)) {
+      throw new Error(
+        `podspec already declares s.public_header_files with an unexpected ` +
+          `value. The pod contains Swift, so its umbrella must stay ObjC-only. ` +
+          `Reconcile by hand before regenerating.`
+      );
     }
     const anchor = '  s.vendored_frameworks = "build/RnBreezSdkSpark.xcframework"';
     requireAnchor(content, anchor, label, relPath);
@@ -215,7 +231,7 @@ patchFile(
       '  # C++ or reaches it transitively (BreezSdkSparkReactNative.h imports the',
       '  # ObjC++ codegen spec under RCT_NEW_ARCH_ENABLED), so only the helper the',
       '  # Swift sources need is public.',
-      '  s.public_header_files = "ios/PasskeyPRFHelper.h"',
+      declaration,
       anchor,
     ].join('\n');
     return content.replace(anchor, injected);

--- a/packages/react-native/src/passkey-prf-provider.ts
+++ b/packages/react-native/src/passkey-prf-provider.ts
@@ -237,7 +237,7 @@ export class PasskeyProvider {
     try {
       const result: {
         credentialId: string;
-        userId: string;
+        userId: string | null;
         aaguid: string | null;
         backupEligible: boolean | null;
         seeds: string[] | null;
@@ -253,7 +253,7 @@ export class PasskeyProvider {
       return {
         credential: {
           credentialId: base64ToUint8Array(result.credentialId),
-          userId: base64ToUint8Array(result.userId),
+          userId: result.userId ? base64ToUint8Array(result.userId) : null,
           aaguid: result.aaguid ? base64ToUint8Array(result.aaguid) : null,
           backupEligible: result.backupEligible,
         },

--- a/scripts/check-ios-cocoapods.sh
+++ b/scripts/check-ios-cocoapods.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Typecheck the Flutter and React Native iOS sources the way CocoaPods
+# builds them: one pod module per plugin, with PasskeyPRFHelper.h reachable only
+# through the pod's umbrella header. `swift build` on the SPM package does not
+# cover this, because there PasskeyPRFHelperObjC is a real module.
+#
+# Requires macOS with Xcode. Skips cleanly elsewhere so `make check` still runs.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Matches `spec.platform = :ios, '13.0'` in the Flutter podspec. Applied to the
+# RN pod too: a lower floor only makes the availability checks stricter.
+DEPLOYMENT_TARGET="arm64-apple-ios13.0"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "check-ios-cocoapods: skipping, requires macOS (got $(uname -s))"
+  exit 0
+fi
+
+if ! command -v xcrun >/dev/null 2>&1; then
+  echo "check-ios-cocoapods: skipping, Xcode command line tools not found"
+  exit 0
+fi
+
+IOS_SDK="$(xcrun --sdk iphoneos --show-sdk-path)"
+
+# Flutter.framework ships inside the Flutter SDK. subosito/flutter-action sets
+# FLUTTER_ROOT; locally, derive it from whichever flutter is on PATH.
+if [[ -z "${FLUTTER_ROOT:-}" ]]; then
+  if command -v flutter >/dev/null 2>&1; then
+    FLUTTER_ROOT="$(cd "$(dirname "$(readlink -f "$(command -v flutter)" 2>/dev/null || command -v flutter)")/.." && pwd)"
+  else
+    echo "check-ios-cocoapods: FAIL - flutter not found and FLUTTER_ROOT unset" >&2
+    exit 1
+  fi
+fi
+
+FLUTTER_FW="${FLUTTER_ROOT}/bin/cache/artifacts/engine/ios/Flutter.xcframework/ios-arm64"
+if [[ ! -d "$FLUTTER_FW" ]]; then
+  echo "check-ios-cocoapods: FAIL - Flutter.xcframework missing at ${FLUTTER_FW}" >&2
+  echo "  run: flutter precache --ios" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# Stage a plugin's iOS sources into a scratch pod and typecheck them as one module.
+#   $1 pod module name, $2 staging subdir, $3 source dir relative to REPO_ROOT,
+#   $4 ObjC header relative to REPO_ROOT
+#
+# Every .swift in the source dir is compiled, so Swift added to either plugin is
+# covered without editing this script. The header goes into the umbrella rather
+# than the compile list, reproducing the header-visibility path CocoaPods builds.
+check_pod() {
+  local module="$1" subdir="$2" src_dir="$3" header="$4"
+  local dir="${WORK}/${subdir}"
+  mkdir -p "$dir"
+
+  if [[ ! -f "${REPO_ROOT}/${header}" ]]; then
+    echo "check-ios-cocoapods: FAIL - missing header ${header}" >&2
+    fail=1
+    return
+  fi
+  cp "${REPO_ROOT}/${header}" "$dir/"
+
+  local swift_files=()
+  local f
+  for f in "${REPO_ROOT}/${src_dir}"/*.swift; do
+    [[ -f "$f" ]] || continue
+    cp "$f" "$dir/"
+    swift_files+=("$(basename "$f")")
+  done
+  if [[ ${#swift_files[@]} -eq 0 ]]; then
+    echo "check-ios-cocoapods: FAIL - no .swift found in ${src_dir}" >&2
+    fail=1
+    return
+  fi
+
+  printf '#import "PasskeyPRFHelper.h"\n' >"${dir}/umbrella.h"
+  cat >"${dir}/module.modulemap" <<EOF
+module ${module} {
+  umbrella header "umbrella.h"
+  export *
+  module * { export * }
+}
+EOF
+
+  echo "check-ios-cocoapods: ${module} (${#swift_files[@]} swift sources)"
+  if ! (cd "$dir" && swiftc \
+    -target "$DEPLOYMENT_TARGET" \
+    -sdk "$IOS_SDK" \
+    -F "$FLUTTER_FW" \
+    -I . \
+    -I "${WORK}/ReactStub" \
+    -module-name "$module" \
+    -import-underlying-module \
+    -suppress-warnings \
+    -typecheck "${swift_files[@]}"); then
+    echo "check-ios-cocoapods: FAIL - ${module} did not typecheck" >&2
+    fail=1
+  fi
+}
+
+# The RN module's entire React surface is these two typealiases, so a stub
+# stands in for React-Core and no `pod install` is needed. If the module ever
+# reaches for another RCT symbol, the typecheck fails rather than silently
+# skipping, which is the intended signal to widen this stub.
+mkdir -p "${WORK}/ReactStub"
+cat >"${WORK}/ReactStub/React.h" <<'EOF'
+#import <Foundation/Foundation.h>
+typedef void (^RCTPromiseResolveBlock)(id _Nullable result);
+typedef void (^RCTPromiseRejectBlock)(NSString *_Nullable code, NSString *_Nullable message, NSError *_Nullable error);
+EOF
+printf 'module React { header "React.h" export * }\n' >"${WORK}/ReactStub/module.modulemap"
+
+check_pod breez_sdk_spark_flutter flutter \
+  packages/flutter/ios/Classes \
+  packages/flutter/ios/Classes/PasskeyPRFHelper.h
+
+check_pod BreezSdkSparkReactNative react-native \
+  packages/react-native/ios \
+  packages/react-native/ios/PasskeyPRFHelper.h
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "check-ios-cocoapods: FAILED" >&2
+  exit 1
+fi
+
+echo "check-ios-cocoapods: OK"

--- a/scripts/check-ios-cocoapods.sh
+++ b/scripts/check-ios-cocoapods.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 #
-# Typecheck the Flutter and React Native iOS sources the way CocoaPods
-# builds them: one pod module per plugin, with PasskeyPRFHelper.h reachable only
-# through the pod's umbrella header. `swift build` on the SPM package does not
-# cover this, because there PasskeyPRFHelperObjC is a real module.
+# Typecheck the Flutter and React Native iOS sources against an ObjC-only
+# umbrella header, the shape CocoaPods produces for a mixed ObjC/Swift pod.
+# `swift build` on the SPM package does not cover this, because there
+# PasskeyPRFHelperObjC is a real module rather than an umbrella import.
+#
+# The umbrella here is written by this script, not read from the podspecs, so
+# this does not detect a podspec that starts publishing other headers. Keeping
+# the podspecs' umbrella ObjC-only is enforced separately, by the RN post-ubrn
+# patch and its `--check` job.
 #
 # Requires macOS with Xcode. Skips cleanly elsewhere so `make check` still runs.
 
@@ -27,12 +32,17 @@ fi
 IOS_SDK="$(xcrun --sdk iphoneos --show-sdk-path)"
 
 # Flutter.framework ships inside the Flutter SDK. subosito/flutter-action sets
-# FLUTTER_ROOT; locally, derive it from whichever flutter is on PATH.
+# FLUTTER_ROOT; otherwise ask flutter itself. Deriving the root from the binary's
+# path on PATH breaks under version managers (asdf, mise, fvm, fenv), which put a
+# wrapper script there rather than the SDK's own bin/flutter.
 if [[ -z "${FLUTTER_ROOT:-}" ]]; then
-  if command -v flutter >/dev/null 2>&1; then
-    FLUTTER_ROOT="$(cd "$(dirname "$(readlink -f "$(command -v flutter)" 2>/dev/null || command -v flutter)")/.." && pwd)"
-  else
+  if ! command -v flutter >/dev/null 2>&1; then
     echo "check-ios-cocoapods: FAIL - flutter not found and FLUTTER_ROOT unset" >&2
+    exit 1
+  fi
+  FLUTTER_ROOT="$(flutter --version --machine | sed -n 's/.*"flutterRoot": *"\([^"]*\)".*/\1/p')"
+  if [[ -z "$FLUTTER_ROOT" ]]; then
+    echo "check-ios-cocoapods: FAIL - could not read flutterRoot from 'flutter --version --machine'" >&2
     exit 1
   fi
 fi
@@ -49,15 +59,24 @@ trap 'rm -rf "$WORK"' EXIT
 
 fail=0
 
-# Stage a plugin's iOS sources into a scratch pod and typecheck them as one module.
+# Stage a package's iOS sources into a scratch pod and typecheck them as one module.
 #   $1 pod module name, $2 staging subdir, $3 source dir relative to REPO_ROOT,
-#   $4 ObjC header relative to REPO_ROOT
+#   $4 ObjC header relative to REPO_ROOT, $5.. extra swiftc flags
 #
-# Every .swift in the source dir is compiled, so Swift added to either plugin is
+# Every .swift in the source dir is compiled, so Swift added to either package is
 # covered without editing this script. The header goes into the umbrella rather
 # than the compile list, reproducing the header-visibility path CocoaPods builds.
+# Extra flags are per-pod on purpose: giving one package the other's frameworks
+# would let a wrong import typecheck here and fail in a real build.
+#
+# Both pods get a plain `module`, though CocoaPods emits `framework module` for
+# the Flutter pod under use_frameworks!. A framework module resolves its umbrella
+# inside a .framework bundle, which this flat staging dir is not, and the two
+# forms are equivalent for the header visibility being checked here.
 check_pod() {
   local module="$1" subdir="$2" src_dir="$3" header="$4"
+  shift 4
+  local extra_flags=("$@")
   local dir="${WORK}/${subdir}"
   mkdir -p "$dir"
 
@@ -81,7 +100,7 @@ check_pod() {
     return
   fi
 
-  printf '#import "PasskeyPRFHelper.h"\n' >"${dir}/umbrella.h"
+  printf '#import "%s"\n' "$(basename "$header")" >"${dir}/umbrella.h"
   cat >"${dir}/module.modulemap" <<EOF
 module ${module} {
   umbrella header "umbrella.h"
@@ -94,9 +113,8 @@ EOF
   if ! (cd "$dir" && swiftc \
     -target "$DEPLOYMENT_TARGET" \
     -sdk "$IOS_SDK" \
-    -F "$FLUTTER_FW" \
     -I . \
-    -I "${WORK}/ReactStub" \
+    ${extra_flags[@]+"${extra_flags[@]}"} \
     -module-name "$module" \
     -import-underlying-module \
     -suppress-warnings \
@@ -120,11 +138,13 @@ printf 'module React { header "React.h" export * }\n' >"${WORK}/ReactStub/module
 
 check_pod breez_sdk_spark_flutter flutter \
   packages/flutter/ios/Classes \
-  packages/flutter/ios/Classes/PasskeyPRFHelper.h
+  packages/flutter/ios/Classes/PasskeyPRFHelper.h \
+  -F "$FLUTTER_FW"
 
 check_pod BreezSdkSparkReactNative react-native \
   packages/react-native/ios \
-  packages/react-native/ios/PasskeyPRFHelper.h
+  packages/react-native/ios/PasskeyPRFHelper.h \
+  -I "${WORK}/ReactStub"
 
 if [[ "$fail" -ne 0 ]]; then
   echo "check-ios-cocoapods: FAILED" >&2


### PR DESCRIPTION
Two iOS CocoaPods build failures reported against `breez_sdk_spark_flutter`. Both are present in React Native too, since the packages share the same passkey sources.

Fixes #1045

### 1. `import PasskeyPRFHelperObjC` does not resolve

`PasskeyPRFHelperObjC` is a module only under SPM. Both podspecs compile `PasskeyPRFHelper.h/.m` into the same pod as the Swift, where the helper arrives through the pod's umbrella header instead. The import is now conditional, so the shared file works on both paths.

### 2. `userId` not unwrapped

`IosPasskeyCredential.userId` is `Data?` (nil on sign-in, where an assertion carries no attestation) and was passed to `base64EncodedString()` directly. Now matches the `aaguid` line beside it. The Dart and TS decode sites are relaxed to accept null; both public models already typed it nullable.

### 3. C++ headers in the React Native pod umbrella

Found while validating RN. The podspec declared no `public_header_files`, so every C++ and ObjC++ header became public, including one carrying `#error This file must be compiled as Obj-C++`. That was inert until the passkey feature added the first Swift to the pod, which forces CocoaPods to build an ObjC module from the umbrella. `public_header_files` is now narrowed to the one header the Swift needs. The podspec is generated, so the edit is also re-applied by `scripts/post-ubrn.js`.

### Prevention

No CI job compiled these sources: the Flutter job runs on `ubuntu-latest` and does `dart analyze` only. Adds an `ios-cocoapods-compile` job that typechecks both packages' iOS Swift against an ObjC-only umbrella header, the shape CocoaPods produces for a mixed ObjC/Swift pod. That job checks the sources compile; keeping the podspecs' umbrella ObjC-only is enforced separately by `rn-post-ubrn-check`.

### Verification

Built for device through real `pod install` + Xcode, from deleted `Pods/`:

| | Flutter | React Native |
|---|---|---|
| Device build (arm64 Release) | `Runner.app` built | `BUILD SUCCEEDED` |
| Passkey symbols in shipped binary | yes | yes |
| Each fix reverted individually | fails with the reported error | fails with the reported error |
