### PR TITLE
Skip signature verification on unsigned direct refund transactions

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/unilateral_exit.rs
+++ b/crates/breez-sdk/breez-itest/tests/unilateral_exit.rs
@@ -40,7 +40,7 @@ use spark_itest::helpers::{
     fund_p2tr_utxo_with_key, fund_p2wpkh_utxo, fund_p2wpkh_utxo_with_key, sign_cpfp_psbt_p2tr,
     submit_package_with_csv_retry,
 };
-use spark_wallet::{RefundOutput, is_ephemeral_anchor_output};
+use spark_wallet::is_ephemeral_anchor_output;
 
 // The exit fee rate the tests build at, in sat/vByte (the public API unit). 1
 // sat/vByte is the mainnet min-relay floor.
@@ -2331,122 +2331,6 @@ async fn test_unconfirmed_funding_accepted(#[case] backend: SignerBackend) -> Re
     assert!(
         spends_funding,
         "a CPFP child spends the unconfirmed funding UTXO"
-    );
-    Ok(())
-}
-
-/// Mine a self-fee transaction's relative CSV, then broadcast it on its own (no
-/// package). Used to broadcast a pre-signed self-fee refund (the watchtower
-/// path), which pays its own fee and so needs no CPFP child.
-async fn mine_csv_then_broadcast(sdk: &LocalSdk, tx: &Transaction) -> Result<()> {
-    let csv = tx
-        .input
-        .iter()
-        .filter_map(|i| match i.sequence.to_relative_lock_time()? {
-            bitcoin::relative::LockTime::Blocks(h) => Some(u32::from(h.value())),
-            bitcoin::relative::LockTime::Time(_) => None,
-        })
-        .max()
-        .unwrap_or(0);
-    if csv > 0 {
-        sdk.fixtures.bitcoind.generate_blocks(csv.into()).await?;
-    }
-    sdk.fixtures
-        .bitcoind
-        .broadcast_transaction_no_fee_check(tx)
-        .await?;
-    sdk.fixtures.bitcoind.generate_blocks(1).await?;
-    Ok(())
-}
-
-/// A leaf's self-fee `direct_from_cpfp_refund_tx` is a valid exit path to the
-/// user's key that needs no CPFP child. After the cpfp node chain confirms, this
-/// refund broadcasts on its own; the exit's sweep then recovers it to the
-/// destination, recognized by the leaf's refund address (the same address every
-/// refund variant pays). This exercises the address-based recovery against a
-/// non-cpfp refund actually on-chain.
-#[apply(each_backend)]
-#[test_log::test(tokio::test)]
-async fn test_sweep_recovers_direct_from_cpfp_refund(#[case] backend: SignerBackend) -> Result<()> {
-    let sdk = new_local_sdk(backend).await?;
-    deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
-
-    // Capture the leaf's pre-signed self-fee refund up front (it spends the
-    // leaf's own cpfp node_tx output and pays the user's key).
-    let leaf = sdk
-        .spark_wallet
-        .list_leaves()
-        .await?
-        .available
-        .into_iter()
-        .next()
-        .expect("a claimed leaf");
-    let leaf_id = leaf.id.clone();
-    let refund = leaf
-        .direct_from_cpfp_refund_tx
-        .clone()
-        .expect("a claimed leaf carries a direct_from_cpfp refund");
-    assert_eq!(
-        refund.input[0].previous_output.txid,
-        leaf.node_tx.compute_txid(),
-        "the direct_from_cpfp refund must spend the leaf's node_tx"
-    );
-
-    // Drive the cpfp chain so the leaf's node_tx output is on-chain, then
-    // broadcast the self-fee refund instead of the cpfp refund.
-    let cpfp = fund_p2tr_utxo(&sdk.fixtures.bitcoind, Amount::from_sat(CPFP_SATS)).await?;
-    let quote = sdk
-        .sdk
-        .prepare_unilateral_exit(PrepareUnilateralExitRequest {
-            fee_rate_sat_per_vbyte: FEE_RATE,
-            funding_kind: CpfpFundingKind::P2tr,
-            destination: cpfp.address.to_string(),
-            selection: ExitLeafSelection::Auto,
-        })
-        .await?;
-    let resp = sdk
-        .sdk
-        .unilateral_exit(
-            UnilateralExitRequest {
-                prepared: quote,
-                funding_inputs: vec![cpfp_input(&cpfp)],
-            },
-            signer_for(&cpfp.secret_key.secret_bytes())?,
-        )
-        .await?;
-    for entry in &resp.transactions {
-        if matches!(entry.kind, UnilateralExitTxKind::Node) {
-            broadcast_and_mine(&sdk, entry).await?;
-        }
-    }
-    mine_csv_then_broadcast(&sdk, &refund).await?;
-
-    // The sweep recovers that on-chain refund to the destination.
-    let dest = cpfp.address.clone();
-    let refund_output = RefundOutput {
-        outpoint: OutPoint {
-            txid: refund.compute_txid(),
-            vout: 0,
-        },
-        leaf_id,
-        value: refund.output[0].value.to_sat(),
-    };
-    let sweep_psbt = sdk
-        .spark_wallet
-        .create_refund_sweep_transaction(vec![refund_output], vec![], dest.clone(), FEE_RATE_KW)
-        .await?;
-    let sweep = sweep_psbt.extract_tx_unchecked_fee_rate();
-    let sweep_txid = sdk.fixtures.bitcoind.broadcast_transaction(&sweep).await?;
-    sdk.fixtures.bitcoind.generate_blocks(1).await?;
-
-    let confirmed = sdk.fixtures.bitcoind.get_transaction(&sweep_txid).await?;
-    assert_eq!(confirmed.compute_txid(), sweep_txid);
-    assert!(
-        confirmed
-            .output
-            .iter()
-            .any(|o| o.script_pubkey == dest.script_pubkey()),
-        "the sweep pays the destination"
     );
     Ok(())
 }

--- a/crates/spark-itest/docker/migrations.dockerfile
+++ b/crates/spark-itest/docker/migrations.dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=e8ceff40979d27c1c19e31899901b7b47bd591bc
+ARG VERSION=ee60d305b756d466647567c93ba47f0a65c0767e
 ARG REPOSITORY=https://github.com/buildonspark/spark.git
 
 FROM debian:bookworm-20250721-slim AS downloader

--- a/crates/spark-itest/docker/so.config.yaml
+++ b/crates/spark-itest/docker/so.config.yaml
@@ -14,6 +14,10 @@ bitcoind:
     rpcuser: rpcuser
     rpcpassword: rpcpassword
     zmqpubrawblock: tcp://127.0.0.1:28332
+    # Tests confirm a deposit with a single block. The operator default is 3,
+    # which no test mines up to, so a non-static deposit would never be marked
+    # available.
+    non_static_confirmation_threshold: 1
 token:
   disconnect_lrc20_node: true
 database:

--- a/crates/spark-itest/docker/spark-so.dockerfile
+++ b/crates/spark-itest/docker/spark-so.dockerfile
@@ -1,6 +1,6 @@
 # $USER name to be used in the `final` image
 ARG USER=so
-ARG VERSION=e8ceff40979d27c1c19e31899901b7b47bd591bc
+ARG VERSION=ee60d305b756d466647567c93ba47f0a65c0767e
 ARG REPOSITORY=https://github.com/buildonspark/spark.git
 
 FROM debian:bookworm-20250721-slim AS downloader
@@ -21,7 +21,7 @@ RUN git init && \
     git checkout FETCH_HEAD
 
 
-FROM golang:1.25.1-bookworm AS operator-builder
+FROM golang:1.26.3-bookworm AS operator-builder
 
 # Install required dependencies for building
 RUN apt-get update -qq && \

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, str::FromStr, sync::Arc};
 use bitcoin::{
     Address, Amount, OutPoint, Transaction, TxOut, Txid, Witness,
     address::NetworkUnchecked,
-    consensus::serialize,
+    consensus::{deserialize, serialize},
     hashes::{Hash, sha256},
     params::Params,
     secp256k1::{Message, PublicKey, ecdsa::Signature, schnorr},
@@ -754,8 +754,8 @@ impl DepositService {
         // that we aggregated locally; the package flow aggregates server-side,
         // so we re-derive the same security guarantees here:
         //  1) the verifying key we used really is the tree's verifying key,
-        //  2) each returned transaction carries a valid Schnorr signature
-        //     under that key for the sighashes we computed.
+        //  2) each returned transaction that carries a signature carries a valid
+        //     Schnorr one under that key for the sighashes we computed.
         let returned_verifying_key = PublicKey::from_slice(&root_node.verifying_public_key)
             .map_err(|_| ServiceError::InvalidVerifyingKey)?;
         if &returned_verifying_key != verifying_public_key {
@@ -773,12 +773,25 @@ impl DepositService {
             cpfp_refund_sighash.as_byte_array(),
             verifying_public_key,
         )?;
-        verify_finalized_taproot_signature(
-            &self.bitcoin_service,
-            &root_node.direct_from_cpfp_refund_tx,
-            direct_from_cpfp_refund_sighash.as_byte_array(),
-            verifying_public_key,
-        )?;
+        // Operators re-encode `direct_*` transactions without witness data at the
+        // public gRPC boundary, and clear the field outright when that fails, so
+        // this one can arrive with no signature to check. See
+        // github.com/buildonspark/spark/commit/64272c0d1. A malformed non-empty
+        // transaction is still rejected by the conversion below.
+        let direct_from_cpfp_refund_is_signed =
+            deserialize::<Transaction>(&root_node.direct_from_cpfp_refund_tx).is_ok_and(|tx| {
+                tx.input
+                    .first()
+                    .is_some_and(|input| !input.witness.is_empty())
+            });
+        if direct_from_cpfp_refund_is_signed {
+            verify_finalized_taproot_signature(
+                &self.bitcoin_service,
+                &root_node.direct_from_cpfp_refund_tx,
+                direct_from_cpfp_refund_sighash.as_byte_array(),
+                verifying_public_key,
+            )?;
+        }
 
         Ok(vec![root_node.try_into()?])
     }

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, str::FromStr, sync::Arc};
 use bitcoin::{
     Address, Amount, OutPoint, Transaction, TxOut, Txid, Witness,
     address::NetworkUnchecked,
-    consensus::{deserialize, serialize},
+    consensus::serialize,
     hashes::{Hash, sha256},
     params::Params,
     secp256k1::{Message, PublicKey, ecdsa::Signature, schnorr},
@@ -754,8 +754,9 @@ impl DepositService {
         // that we aggregated locally; the package flow aggregates server-side,
         // so we re-derive the same security guarantees here:
         //  1) the verifying key we used really is the tree's verifying key,
-        //  2) each returned transaction that carries a signature carries a valid
-        //     Schnorr one under that key for the sighashes we computed.
+        //  2) the returned cpfp transactions carry a valid Schnorr signature
+        //     under that key for the sighashes we computed.
+        // `direct_from_cpfp_refund_tx` carries no signature to verify.
         let returned_verifying_key = PublicKey::from_slice(&root_node.verifying_public_key)
             .map_err(|_| ServiceError::InvalidVerifyingKey)?;
         if &returned_verifying_key != verifying_public_key {
@@ -773,25 +774,6 @@ impl DepositService {
             cpfp_refund_sighash.as_byte_array(),
             verifying_public_key,
         )?;
-        // Operators re-encode `direct_*` transactions without witness data at the
-        // public gRPC boundary, and clear the field outright when that fails, so
-        // this one can arrive with no signature to check. See
-        // github.com/buildonspark/spark/commit/64272c0d1. A malformed non-empty
-        // transaction is still rejected by the conversion below.
-        let direct_from_cpfp_refund_is_signed =
-            deserialize::<Transaction>(&root_node.direct_from_cpfp_refund_tx).is_ok_and(|tx| {
-                tx.input
-                    .first()
-                    .is_some_and(|input| !input.witness.is_empty())
-            });
-        if direct_from_cpfp_refund_is_signed {
-            verify_finalized_taproot_signature(
-                &self.bitcoin_service,
-                &root_node.direct_from_cpfp_refund_tx,
-                direct_from_cpfp_refund_sighash.as_byte_array(),
-                verifying_public_key,
-            )?;
-        }
 
         Ok(vec![root_node.try_into()?])
     }


### PR DESCRIPTION
The three `spark-itest` deposit tests have failed on every `main` run since 2026-08-07, across all storage backends (in-memory, postgres, mysql):

- `deployed_deposit_tests::test_non_static_deposit_with_faucet`
- `deployed_deposit_tests::test_non_static_deposit_then_coop_withdraw`
- `deployed_wallet_settings_tests::test_master_identity_grants_read_access`

All fail in `claim_deposit` with:
```
Service error: bitcoin error: invalid transaction: signed tx input has empty witness
```

### Cause

Spark operator commit [`64272c0d1`](https://github.com/buildonspark/spark/commit/64272c0d12755fc805c010c11cfb29adf9a3e6bf), "Strip direct transaction witnesses from public API (#7898)", added a gRPC interceptor that strips witnesses from every nested `TreeNode` direct transaction on `SparkService`, to stop callers broadcasting paths meant to remain operator-controlled. The interceptor re-encodes the field with `SerializeTxNoWitness`, so it still decodes but carries no signature.

`FinalizeDepositTreeCreation` is a `SparkService` RPC, so its returned `direct_from_cpfp_refund_tx` now arrives unsigned, and `create_tree_root` verified it unconditionally. The CPFP `node_tx` and `refund_tx` are untouched by the interceptor and still verify.

### Change

Verify `direct_from_cpfp_refund_tx` only when it carries a witness. `node_tx` and `refund_tx` stay unconditional.

Conditional rather than removed so the check still runs against operators predating [`64272c0d1`](https://github.com/buildonspark/spark/commit/64272c0d12755fc805c010c11cfb29adf9a3e6bf), which is where the local itests exercise it. No security is lost: current operators strip that witness for every caller, so no client can validate the field either way. A malformed non-empty transaction is still rejected by the `TreeNode` conversion.
