### PR TITLE
Fix React Native passkey provider failing at runtime

### DIFF
--- a/.github/workflows/publish-react-native.yml
+++ b/.github/workflows/publish-react-native.yml
@@ -111,9 +111,17 @@ jobs:
           path: |
             packages/react-native/app.plugin.js
             packages/react-native/ubrn.config.yaml
+            packages/react-native/android/build.gradle
             packages/react-native/android/generated
             packages/react-native/android/CMakeLists.txt
             packages/react-native/android/proguard-rules.pro
+            packages/react-native/android/src/main/java
+            packages/react-native/android/src/main/kotlin
+            packages/react-native/ios/BreezSdkSparkPasskey.m
+            packages/react-native/ios/BreezSdkSparkPasskey.swift
+            packages/react-native/ios/PasskeyAssertionCore.swift
+            packages/react-native/ios/PasskeyPRFHelper.h
+            packages/react-native/ios/PasskeyPRFHelper.m
             packages/react-native/cpp
             packages/react-native/lib
             packages/react-native/plugin/build

--- a/.github/workflows/publish-react-native.yml
+++ b/.github/workflows/publish-react-native.yml
@@ -110,6 +110,8 @@ jobs:
           name: bindings-react-native
           path: |
             packages/react-native/app.plugin.js
+            packages/react-native/passkey-prf-provider.js
+            packages/react-native/passkey-prf-provider.d.ts
             packages/react-native/ubrn.config.yaml
             packages/react-native/android/build.gradle
             packages/react-native/android/generated

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -37,6 +37,8 @@
     "cpp",
     "*.podspec",
     "app.plugin.js",
+    "passkey-prf-provider.js",
+    "passkey-prf-provider.d.ts",
     "react-native.config.js",
     "swift",
     "scripts",

--- a/packages/react-native/passkey-prf-provider.d.ts
+++ b/packages/react-native/passkey-prf-provider.d.ts
@@ -1,0 +1,1 @@
+export * from './lib/typescript/commonjs/src/passkey-prf-provider';

--- a/packages/react-native/passkey-prf-provider.js
+++ b/packages/react-native/passkey-prf-provider.js
@@ -1,0 +1,5 @@
+// Root shim so `@breeztech/breez-sdk-spark-react-native/passkey-prf-provider`
+// resolves on React Native versions whose Metro ignores package `exports`
+// (RN < 0.79, which the package still supports). Metro versions that honour
+// `exports` map the subpath to lib/ directly and never read this file.
+module.exports = require('./lib/commonjs/passkey-prf-provider.js');


### PR DESCRIPTION
`0.21.0` shipped the passkey JS provider with no native implementation on either platform, so `PasskeyProvider` failed at runtime with "native module not registered".

### Changes
- **Distribute the passkey natives.** Adds the missing source paths to the bindings artifact: the five `ios/` passkey files, `android/src/main/kotlin`, `android/src/main/java` (carries the patched module registration) and `android/build.gradle` (carries the `srcDirs` and `androidx.credentials` patches).
- **Fix subpath resolution.** `PasskeyProvider` is reachable only through the `./passkey-prf-provider` export, and Metro ignores package `exports` before RN 0.79, so consumers across most of the supported `>= 0.76.9` range could not import it. Adds root shims that resolve under classic lookup and are unused once `exports` is honoured.
