### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -281,7 +281,7 @@ async def _handle_receive(sdk, _token_issuer, _session, args):
         )
     elif method == "bitcoin":
         payment_method = ReceivePaymentMethod.BITCOIN_ADDRESS(
-            new_address=args.new_address if args.new_address else None,
+            new_address=args.new_address,
         )
     elif method == "bolt11":
         payment_hash = None
@@ -747,6 +747,9 @@ def _build_buy_bitcoin_parser():
 async def _handle_buy_bitcoin(sdk, _token_issuer, _session, args):
     provider = (args.provider or "moonpay").lower()
     if provider in ("cashapp", "cash_app", "cash-app"):
+        if args.amount_sat is None:
+            print("--amount-sat is required when --provider is cashapp")
+            return
         request = BuyBitcoinRequest.CASH_APP(amount_sats=args.amount_sat)
     else:
         request = BuyBitcoinRequest.MOONPAY(


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`76efc8f`](https://github.com/breez/spark-sdk/commit/76efc8f552cf44c66f970e52ab0c5445049bef7c)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/32019105429)

**Language status:**
- :next_track_button: C# (no changes needed)
- :next_track_button: Dart (no changes needed)
- :next_track_button: Go (no changes needed)
- :next_track_button: Kotlin (no changes needed)
- :white_check_mark: Python
- :next_track_button: React Native (no changes needed)
- :next_track_button: Swift (no changes needed)
- :next_track_button: TypeScript (no changes needed)

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- `receiver_identity_public_key: None` added to Rust `Bolt11Invoice` construction: C# already has `receiverIdentityPublicKey: null`
- `issuer create-token`: Rust uses positional args (`<name> <ticker> <decimals> <max_supply>`), C# uses flags (`--name`, `--ticker`, `--decimals`, `--max-supply`) with defaults for decimals (6) and max_supply (0)
- `issuer create-token` freezable flag: Rust long flag is `--is-freezable`, C# is `--freezable` (short flag `-f` matches)
- `fetch-conversion-limits`: C# accepts an extra `--token` flag not in Rust (also supports positional form)
- `delete-lightning-address`: C# prints "Lightning address deleted" confirmation, Rust has no output
- `get-lightning-address`: C# checks for null and prints "No lightning address registered", Rust passes null through print_value
- `set-user-settings`: C# prints "User settings updated" confirmation, Rust has no output
- Bitcoin address fee display: Rust calls `total_fee_sat()` method, C# manually sums `userFeeSat + l1BroadcastFeeSat`

## Applied
- (none: the only recent Rust change was already present in the C# CLI)

## Skipped
- C# UX additions (confirmation messages, null handling, extra `--token` flag) kept per sync policy: C# additions not in Rust are preserved as suggestions for the Rust CLI
- `issuer create-token` argument style difference (positional vs flags) kept: pre-existing design choice, flag-based interface is arguably better UX for integrators, both produce the same SDK call
- Fee calculation method difference kept: pre-existing, both sum the same components in practice

### Go
## Divergences
- `receiver_identity_public_key: None` added to Bolt11Invoice in Rust receive-payment command. Go's nil zero-value for pointer fields is functionally equivalent; no explicit change needed.

## Applied
(none)

## Skipped
(none)

### Kotlin
No differences found: CLIs are in sync.

### Python
## Divergences
- `buy-bitcoin`: Python CLI missing validation that `--amount-sat` is required when `--provider` is cashapp (Rust returns clear error, Python passed `None` to SDK)
- `receive`: Python CLI sent `None` for `new_address` when `--new-address` flag not provided; Rust always sends `Some(false)` or `Some(true)`
- `read_payment_options` Bitcoin fee display: Python manually sums `user_fee_sat + l1_broadcast_fee_sat`; Rust uses `total_fee_sat()` method (not a real divergence: `total_fee_sat()` is a Rust impl method not exported via UniFFI bindings)

## Applied
- Added CashApp `--amount-sat` validation in `commands.py` (lines 750-752) matching Rust's `ok_or_else` check
- Changed `new_address` argument from `args.new_address if args.new_address else None` to `args.new_address` in `commands.py` to match Rust's `Some(new_address)` behavior

## Skipped
- Fee calculation difference in `read_payment_options`: `total_fee_sat()` is a Rust `impl SendOnchainSpeedFeeQuote` method not available in Python UniFFI bindings; the manual sum is functionally equivalent
- YubiKey and FIDO2 passkey providers: intentionally stubbed in Python CLI and documented in README as "Not yet available"

### React Native
No differences found: CLIs are in sync.

### Swift
## Divergences
- `receiver_identity_public_key: None` added to Bolt11Invoice in Rust `command/mod.rs`: Swift already has `receiverIdentityPublicKey: nil` on Commands.swift:417. No divergence.

## Applied
- (none: Swift CLI already matches the Rust change)

## Skipped
- (none)

### TypeScript
## Divergences
- None found. The Rust CLI change (adding `receiver_identity_public_key: None` to Bolt11Invoice in receive handler) is already present in the TypeScript CLI as `receiverIdentityPublicKey: undefined`.

## Applied
- No changes applied.

## Skipped
- Nothing skipped.

</details>

All languages synced cleanly. This PR merges automatically once the gating CI checks pass (integration test checks excluded).