### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -973,11 +973,12 @@ public static class Commands
         var feeSatStr = GetFlag(args, "--fee-sat");
         var satPerVbyteStr = GetFlag(args, "--sat-per-vbyte");
         var recFeeLeewayStr = GetFlag(args, "--recommended-fee-leeway");
+        var instantFeeBpsStr = GetFlag(args, "--instant-fee-bps");
         var positional = GetPositionalArgs(args);
 
         if (positional.Length < 2)
         {
-            Console.WriteLine("Usage: claim-deposit <txid> <vout> [--fee-sat N | --sat-per-vbyte N | --recommended-fee-leeway N]");
+            Console.WriteLine("Usage: claim-deposit <txid> <vout> [--fee-sat N | --sat-per-vbyte N | --recommended-fee-leeway N] [--instant-fee-bps N]");
             return;
         }
 
@@ -1008,10 +1009,13 @@ public static class Commands
             maxFee = new MaxFee.Rate(satPerVbyte: ulong.Parse(satPerVbyteStr));
         }
 
+        uint? instantFeeBps = instantFeeBpsStr != null ? uint.Parse(instantFeeBpsStr) : null;
+
         var result = await sdk.ClaimDeposit(new ClaimDepositRequest(
             txid: txid,
             vout: vout,
-            maxFee: maxFee
+            maxFee: maxFee,
+            maxInstantFeeBps: instantFeeBps
         ));
         Serialization.PrintValue(result);
     }

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -751,7 +751,11 @@ Future<void> _handleClaimDeposit(BreezSdk sdk, TokenIssuer tokenIssuer, List<Str
       _parser('claim-deposit')
         ..addOption('fee-sat')
         ..addOption('sat-per-vbyte')
-        ..addOption('recommended-fee-leeway');
+        ..addOption('recommended-fee-leeway')
+        ..addOption(
+          'instant-fee-bps',
+          help: 'Claim instantly (0-conf) with this max SSP spread in basis points (e.g. 400 = 4%)',
+        );
   final results = _parseArgs(parser, args, 'claim-deposit <txid> <vout> [options]');
   if (results == null) return;
 
@@ -765,6 +769,7 @@ Future<void> _handleClaimDeposit(BreezSdk sdk, TokenIssuer tokenIssuer, List<Str
   final feeSatStr = results.option('fee-sat');
   final satPerVbyteStr = results.option('sat-per-vbyte');
   final leewayStr = results.option('recommended-fee-leeway');
+  final instantFeeBpsStr = results.option('instant-fee-bps');
 
   MaxFee? maxFee;
   if (leewayStr != null) {
@@ -782,7 +787,10 @@ Future<void> _handleClaimDeposit(BreezSdk sdk, TokenIssuer tokenIssuer, List<Str
     maxFee = MaxFee.rate(satPerVbyte: BigInt.parse(satPerVbyteStr));
   }
 
-  final result = await sdk.claimDeposit(request: ClaimDepositRequest(txid: txid, vout: vout, maxFee: maxFee));
+  final maxInstantFeeBps = instantFeeBpsStr != null ? int.parse(instantFeeBpsStr) : null;
+  final result = await sdk.claimDeposit(
+    request: ClaimDepositRequest(txid: txid, vout: vout, maxFee: maxFee, maxInstantFeeBps: maxInstantFeeBps),
+  );
   printValue(result);
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -914,13 +914,14 @@ func handleClaimDeposit(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, arg
 	feeSat := fs.Uint64("fee-sat", 0, "Max fee in sats (fixed)")
 	satPerVbyte := fs.Uint64("sat-per-vbyte", 0, "Max fee per vbyte (rate)")
 	recommendedFeeLeeway := fs.Uint64("recommended-fee-leeway", 0, "Use fastest recommended fee plus this leeway (sat/vbyte)")
+	instantFeeBps := fs.Uint64("instant-fee-bps", 0, "Claim instantly (0-conf) with this max SSP spread in basis points of the deposit value (e.g. 400 = 4%)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
 	positional := fs.Args()
 	if len(positional) < 2 {
-		fmt.Println("Usage: claim-deposit <txid> <vout> [--fee-sat N | --sat-per-vbyte N | --recommended-fee-leeway N]")
+		fmt.Println("Usage: claim-deposit <txid> <vout> [--fee-sat N | --sat-per-vbyte N | --recommended-fee-leeway N] [--instant-fee-bps N]")
 		return nil
 	}
 
@@ -950,6 +951,10 @@ func handleClaimDeposit(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, arg
 	}
 	if maxFee != nil {
 		req.MaxFee = &maxFee
+	}
+	if *instantFeeBps > 0 {
+		v := uint32(*instantFeeBps)
+		req.MaxInstantFeeBps = &v
 	}
 
 	result, err := sdk.ClaimDeposit(req)

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -772,9 +772,10 @@ suspend fun handleClaimDeposit(sdk: BreezSdk, reader: LineReader, args: List<Str
     val feeSat = fp.getULong("fee-sat")
     val satPerVbyte = fp.getULong("sat-per-vbyte")
     val recommendedFeeLeeway = fp.getULong("recommended-fee-leeway")
+    val instantFeeBps = fp.getUInt("instant-fee-bps")
 
     if (fp.positional.size < 2) {
-        println("Usage: claim-deposit <txid> <vout> [--fee-sat N | --sat-per-vbyte N | --recommended-fee-leeway N]")
+        println("Usage: claim-deposit <txid> <vout> [--fee-sat N | --sat-per-vbyte N | --recommended-fee-leeway N | --instant-fee-bps N]")
         return
     }
 
@@ -807,6 +808,7 @@ suspend fun handleClaimDeposit(sdk: BreezSdk, reader: LineReader, args: List<Str
             txid = txid,
             vout = vout,
             maxFee = maxFee,
+            maxInstantFeeBps = instantFeeBps,
         )
     )
     printValue(result)

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -652,6 +652,8 @@ def _build_claim_deposit_parser():
     p.add_argument("--sat-per-vbyte", type=int, default=None, help="Max fee per vbyte")
     p.add_argument("--recommended-fee-leeway", type=int, default=None,
                    help="Use recommended fee + leeway")
+    p.add_argument("--instant-fee-bps", type=int, default=None,
+                   help="Claim instantly (0-conf) with this max SSP spread in basis points of the deposit value (e.g. 400 = 4%)")
     return p
 
 async def _handle_claim_deposit(sdk, _token_issuer, _session, args):
@@ -674,6 +676,7 @@ async def _handle_claim_deposit(sdk, _token_issuer, _session, args):
         txid=args.txid,
         vout=args.vout,
         max_fee=max_fee,
+        max_instant_fee_bps=args.instant_fee_bps,
     ))
     print_value(result)
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -924,7 +924,7 @@ async function handleClaimHtlcPayment(sdk: BreezSdkInterface, _tokenIssuer: Toke
 async function handleClaimDeposit(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
   const positional = args.filter(a => !a.startsWith('-'))
   if (positional.length < 2) {
-    return 'Usage: claim-deposit <txid> <vout> [--fee-sat N | --sat-per-vbyte N | --recommended-fee-leeway N]'
+    return 'Usage: claim-deposit <txid> <vout> [--fee-sat N | --sat-per-vbyte N | --recommended-fee-leeway N] [--instant-fee-bps N]'
   }
 
   const txid = positional[0]
@@ -936,6 +936,7 @@ async function handleClaimDeposit(sdk: BreezSdkInterface, _tokenIssuer: TokenIss
   const feeSatStr = parseFlag(args, '--fee-sat')
   const satPerVbyteStr = parseFlag(args, '--sat-per-vbyte')
   const recommendedFeeLeewayStr = parseFlag(args, '--recommended-fee-leeway')
+  const instantFeeBpsStr = parseFlag(args, '--instant-fee-bps')
 
   let maxFee: MaxFee | undefined
 
@@ -952,10 +953,13 @@ async function handleClaimDeposit(sdk: BreezSdkInterface, _tokenIssuer: TokenIss
     maxFee = new MaxFee.Rate({ satPerVbyte: BigInt(satPerVbyteStr) })
   }
 
+  const maxInstantFeeBps = instantFeeBpsStr !== undefined ? parseInt(instantFeeBpsStr, 10) : undefined
+
   const result = await sdk.claimDeposit({
     txid,
     vout,
     maxFee,
+    maxInstantFeeBps: maxInstantFeeBps,
   })
   return formatValue(result)
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -767,7 +767,7 @@ func handleClaimDeposit(_ sdk: BreezSdk, _ args: [String]) async throws {
     let fp = FlagParser(args)
     guard fp.positional.count >= 2,
           let vout = UInt32(fp.positional[1]) else {
-        print("Usage: claim-deposit <txid> <vout> [--fee-sat N | --sat-per-vbyte N | --recommended-fee-leeway N]")
+        print("Usage: claim-deposit <txid> <vout> [--fee-sat N | --sat-per-vbyte N | --recommended-fee-leeway N] [--instant-fee-bps N]")
         return
     }
 
@@ -775,6 +775,7 @@ func handleClaimDeposit(_ sdk: BreezSdk, _ args: [String]) async throws {
     let feeSat = fp.get("fee-sat").flatMap { UInt64($0) }
     let satPerVbyte = fp.get("sat-per-vbyte").flatMap { UInt64($0) }
     let recommendedFeeLeeway = fp.get("recommended-fee-leeway").flatMap { UInt64($0) }
+    let instantFeeBps = fp.get("instant-fee-bps").flatMap { UInt32($0) }
 
     let maxFee: MaxFee?
     if let leeway = recommendedFeeLeeway {
@@ -797,7 +798,8 @@ func handleClaimDeposit(_ sdk: BreezSdk, _ args: [String]) async throws {
     let result = try await sdk.claimDeposit(request: ClaimDepositRequest(
         txid: txid,
         vout: vout,
-        maxFee: maxFee
+        maxFee: maxFee,
+        maxInstantFeeBps: instantFeeBps
     ))
     printValue(result)
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -604,6 +604,7 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
     .option('--fee-sat <amount>', 'The max fee to claim the deposit', parseInt)
     .option('--sat-per-vbyte <rate>', 'The max fee per vbyte to claim the deposit', parseInt)
     .option('--recommended-fee-leeway <amount>', 'Use recommended fee with this leeway in sat/vbyte', parseInt)
+    .option('--instant-fee-bps <bps>', 'Claim instantly (0-conf) with this max SSP spread in basis points of the deposit value (e.g. 400 = 4%)', parseInt)
     .action(async (txid, vout, options) => {
       const sdk = getSdk()
       const voutNum = parseInt(vout, 10)
@@ -625,7 +626,8 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
       const value = await sdk.claimDeposit({
         txid,
         vout: voutNum,
-        maxFee
+        maxFee,
+        maxInstantFeeBps: options.instantFeeBps
       })
       printValue(value)
     })


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`39f1213`](https://github.com/breez/spark-sdk/commit/39f12135e220e52850be54ac7428628196af9f53)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/32029113476)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :white_check_mark: React Native
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- `claim-deposit` command missing `--instant-fee-bps` flag and `maxInstantFeeBps` parameter on `ClaimDepositRequest`

## Applied
- Added `--instant-fee-bps` flag parsing, usage text update, and `maxInstantFeeBps` parameter to `HandleClaimDeposit` in `Commands.cs`

## Skipped
- (none)

### Dart
## Divergences
- `claim-deposit` command missing `--instant-fee-bps` option that maps to `ClaimDepositRequest.maxInstantFeeBps` for 0-conf instant claims

## Applied
- Added `--instant-fee-bps` option to `claim-deposit` command parser in `commands.dart`
- Parse the option value and pass it as `maxInstantFeeBps` to `ClaimDepositRequest` in `commands.dart`

## Skipped
- (none)

### Go
## Divergences
- `claim-deposit` command missing `--instant-fee-bps` flag and `MaxInstantFeeBps` field on `ClaimDepositRequest` (added in Rust CLI for 0-conf instant deposit claims)

## Applied
- Added `--instant-fee-bps` flag to `handleClaimDeposit` in `commands.go`, sets `MaxInstantFeeBps` on the request when provided

## Skipped
- `grammar_tests.rs` changes: test-only code, not ported per policy

### Kotlin
## Divergences
- `claim-deposit` command missing `--instant-fee-bps` flag and `maxInstantFeeBps` field in `ClaimDepositRequest`

## Applied
- Added `--instant-fee-bps` flag parsing via `fp.getUInt("instant-fee-bps")` and passed `maxInstantFeeBps = instantFeeBps` to `ClaimDepositRequest` in `Commands.kt`
- Updated usage string to include `--instant-fee-bps N`

## Skipped
- (none)

### Python
## Divergences
- `claim-deposit` command missing `--instant-fee-bps` flag and `max_instant_fee_bps` field in `ClaimDepositRequest`

## Applied
- Added `--instant-fee-bps` argument to `_build_claim_deposit_parser()` in `commands.py`
- Added `max_instant_fee_bps=args.instant_fee_bps` to `ClaimDepositRequest` in `_handle_claim_deposit()` in `commands.py`

## Skipped
- Nothing skipped

### React Native
## Divergences
- `claim-deposit` command missing `--instant-fee-bps` flag (maps to `maxInstantFeeBps` in `ClaimDepositRequest`)

## Applied
- Added `--instant-fee-bps` flag parsing and `maxInstantFeeBps` field to `handleClaimDeposit` in `commands.ts`

## Skipped
- (none)

### Swift
## Divergences
- `claim-deposit` command missing `--instant-fee-bps` flag (added in Rust CLI for 0-conf instant deposit claims)

## Applied
- Added `--instant-fee-bps` flag parsing (`UInt32`) to `handleClaimDeposit` in `Commands.swift`
- Passed `maxInstantFeeBps: instantFeeBps` to `ClaimDepositRequest` constructor in `Commands.swift`
- Updated usage string to include `[--instant-fee-bps N]` in `Commands.swift`

## Skipped
- (none)

### TypeScript
## Divergences
- `claim-deposit` command missing `--instant-fee-bps` option for 0-conf instant claims (added in Rust CLI)

## Applied
- Added `--instant-fee-bps <bps>` option to `claim-deposit` command in `commands.js`, passed as `maxInstantFeeBps` to `sdk.claimDeposit()`

## Skipped
- (none)

</details>

All languages synced cleanly. This PR merges automatically once the gating CI checks pass (integration test checks excluded).