### PR TITLE
Base the refund fee floor on the real transaction size

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/deposit_withdraw.rs
+++ b/crates/breez-sdk/breez-itest/tests/deposit_withdraw.rs
@@ -351,7 +351,7 @@ async fn test_send_all_to_bitcoin_address(
     Ok(())
 }
 
-/// Verify deposit no fee blocks auto-claim, refund below MIN_REFUND_FEE_SATS is rejected, then refund succeeds with valid fee
+/// Verify deposit no fee blocks auto-claim, refund below the minimum relay fee is rejected, then refund succeeds with valid fee
 #[rstest]
 #[ignore]
 #[test_log::test(tokio::test)]
@@ -390,7 +390,8 @@ async fn test_deposit_fee_refund(#[future] bob_no_fee_sdk: Result<SdkInstance>) 
         .cloned()
         .expect("unclaimed deposit not found");
 
-    // Refund to the same static address (acceptable for test), with fee below MIN_REFUND_FEE_SATS (194 sats)
+    // Refund to the same static address (acceptable for test), with a fee below
+    // 1 sat/vB for the 111 vbyte refund to a taproot address
     let refund_dest = addr.clone();
     let result_below_min = bob
         .sdk
@@ -398,7 +399,7 @@ async fn test_deposit_fee_refund(#[future] bob_no_fee_sdk: Result<SdkInstance>) 
             txid: dep.txid.clone(),
             vout: dep.vout,
             destination_address: refund_dest.clone(),
-            fee: Fee::Fixed { amount: 193 }, // Below minimum threshold
+            fee: Fee::Fixed { amount: 50 }, // Below minimum threshold
         })
         .await;
 
@@ -410,7 +411,7 @@ async fn test_deposit_fee_refund(#[future] bob_no_fee_sdk: Result<SdkInstance>) 
     let err = result_below_min.unwrap_err();
     let err_msg = format!("{:?}", err);
     assert!(
-        err_msg.contains("fee must be at least 194 sats"),
+        err_msg.contains("fee must be at least 111 sats"),
         "Expected error message about minimum fee, got: {}",
         err_msg
     );
@@ -523,14 +524,14 @@ async fn test_deposit_low_amount_refund_fee_rate(
         .cloned()
         .expect("unclaimed deposit not found");
 
-    // Refund with 2 sat/vB fee rate - this tests the vsize calculation fix
+    // Refund at the minimum relay fee rate, which the fee floor must accept
     let refund = bob
         .sdk
         .refund_deposit(RefundDepositRequest {
             txid: dep.txid.clone(),
             vout: dep.vout,
             destination_address: bob_address,
-            fee: Fee::Rate { sat_per_vbyte: 2 },
+            fee: Fee::Rate { sat_per_vbyte: 1 },
         })
         .await?;
     info!(

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -54,9 +54,10 @@ const INSTANT_UTXO_SWAP_REQUEST_TYPE: u64 = 3;
 /// changes the operators' share, not the user's.
 const STATIC_DEPOSIT_KEY_INDEX: u32 = 0;
 
-// Conservative minimum fee threshold for refund transactions
-// Based on 194 vbyte estimate for 1-in/1-out tx at 1 sat/vB minimum relay fee.
-const MIN_REFUND_FEE_SATS: u64 = 194;
+/// Bitcoin Core's default minimum relay fee rate. The refund fee floor is this
+/// rate applied to the real signed size of the refund transaction, which varies
+/// with the refund address type.
+const MIN_RELAY_FEE_SAT_PER_VBYTE: u64 = 1;
 
 /// Witness vbytes for a single Schnorr signature: ceil(66 witness bytes / 4)
 /// Witness structure: 1 (stack items) + 1 (sig length varint) + 64 (signature) = 66 bytes
@@ -400,10 +401,10 @@ impl DepositService {
         // Account for witness data that will be added after signing
         let signed_vsize = refund_tx.vsize() as u64 + SCHNORR_SIG_WITNESS_VBYTES;
         let fee_sats = fee.to_sats(signed_vsize);
-        if fee_sats < MIN_REFUND_FEE_SATS {
+        let min_fee_sats = signed_vsize * MIN_RELAY_FEE_SAT_PER_VBYTE;
+        if fee_sats < min_fee_sats {
             return Err(ServiceError::Generic(format!(
-                "fee must be at least {} sats",
-                MIN_REFUND_FEE_SATS
+                "fee must be at least {min_fee_sats} sats ({MIN_RELAY_FEE_SAT_PER_VBYTE} sat/vB over {signed_vsize} vbytes)"
             )));
         }
 
@@ -1542,5 +1543,34 @@ mod tests {
             ),
             Err(ServiceError::DepositAddressKeyMismatch)
         ));
+    }
+
+    /// The fee floor is `MIN_RELAY_FEE_SAT_PER_VBYTE * signed_vsize`, so the
+    /// unsigned vsize plus `SCHNORR_SIG_WITNESS_VBYTES` must equal the vsize the
+    /// transaction actually has once the key-path signature is attached.
+    #[test_all]
+    fn signed_vsize_estimate_matches_the_signed_transaction() {
+        let outpoint = OutPoint {
+            txid: Txid::from_slice(&[7u8; 32]).unwrap(),
+            vout: 0,
+        };
+        let key = test_key(1);
+        let refund_addresses = [
+            p2tr(&key),
+            Address::p2wpkh(
+                &CompressedPublicKey(bitcoin::PublicKey::new(key).inner),
+                NETWORK,
+            ),
+            Address::p2pkh(CompressedPublicKey(key), NETWORK),
+        ];
+
+        for address in refund_addresses {
+            let mut tx = create_static_deposit_refund_tx(outpoint, 0, &address);
+            let estimated = tx.vsize() as u64 + SCHNORR_SIG_WITNESS_VBYTES;
+
+            tx.input[0].witness = Witness::from_slice(&[[0u8; 64]]);
+
+            assert_eq!(estimated, tx.vsize() as u64, "address: {address}");
+        }
     }
 }

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -1557,10 +1557,7 @@ mod tests {
         let key = test_key(1);
         let refund_addresses = [
             p2tr(&key),
-            Address::p2wpkh(
-                &CompressedPublicKey(bitcoin::PublicKey::new(key).inner),
-                NETWORK,
-            ),
+            Address::p2wpkh(&CompressedPublicKey(key), NETWORK),
             Address::p2pkh(CompressedPublicKey(key), NETWORK),
         ];
 

--- a/crates/spark/src/services/deposit.rs
+++ b/crates/spark/src/services/deposit.rs
@@ -1497,10 +1497,7 @@ mod tests {
     fn rejects_non_taproot_output_for_the_verifying_key() {
         let service = BitcoinService::new(NETWORK);
         let verifying_key = test_key(1);
-        let p2wpkh = Address::p2wpkh(
-            &CompressedPublicKey(bitcoin::PublicKey::new(verifying_key).inner),
-            NETWORK,
-        );
+        let p2wpkh = Address::p2wpkh(&CompressedPublicKey(verifying_key), NETWORK);
 
         assert!(matches!(
             validate_address_pays_to_verifying_key(&service, &p2wpkh, &verifying_key),

--- a/docs/breez-sdk/src/guide/onchain_claims.md
+++ b/docs/breez-sdk/src/guide/onchain_claims.md
@@ -46,7 +46,7 @@ The [recommended fees](#recommended-fees) API is useful for determining appropri
 
 <div class="warning">
 <h4>Developer note</h4>
-The total fee must be at least 194 sats to ensure the transaction can be relayed by the Bitcoin network. If the fee is lower, the refund request will be rejected.
+The total fee must cover at least 1 sat/vB of the refund transaction so it can be relayed by the Bitcoin network. The exact minimum depends on the size of the transaction, which varies with the destination address type (around 111 sats for a taproot address). If the fee is lower, the refund request is rejected and the error states the required minimum.
 </div>
 
 ## Implementing a custom claim logic


### PR DESCRIPTION
Fixes #1049.

Now 1 sat/vB over the real signed size, matching the deposit claim path. The floor peaks at 111 sats, so no previously accepted fee is rejected.