### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Advanced.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Advanced.cs
@@ -20,6 +20,8 @@ public static class AdvancedCommandNames
     public static readonly string[] All =
     {
         "advanced unilateral-exit",
+        "advanced export-unilateral-exit-state",
+        "advanced import-unilateral-exit-state",
     };
 }
 
@@ -40,6 +42,18 @@ public static class AdvancedCommands
                 Name = "unilateral-exit",
                 Description = "Build and sign a unilateral exit",
                 Run = HandleUnilateralExit
+            },
+            ["export-unilateral-exit-state"] = new()
+            {
+                Name = "export-unilateral-exit-state",
+                Description = "Export the wallet's unilateral exit state to a file",
+                Run = HandleExportUnilateralExitState
+            },
+            ["import-unilateral-exit-state"] = new()
+            {
+                Name = "import-unilateral-exit-state",
+                Description = "Import a previously exported unilateral exit state",
+                Run = HandleImportUnilateralExitState
             },
         };
     }
@@ -212,6 +226,44 @@ public static class AdvancedCommands
                 txid: txid, vout: vout, value: value, pubkey: pubkey),
             _ => throw new ArgumentException($"Invalid funding kind: {kind}")
         };
+    }
+
+    // --- export-unilateral-exit-state ---
+
+    private static async Task HandleExportUnilateralExitState(BreezSdk sdk, Func<string, string?> readline, string[] args)
+    {
+        var outputFile = GetFlag(args, "--output-file");
+        if (outputFile == null)
+        {
+            Console.WriteLine("Usage: advanced export-unilateral-exit-state --output-file <path>");
+            return;
+        }
+
+        var exported = await sdk.ExportUnilateralExitState();
+        await File.WriteAllTextAsync(outputFile, exported.exitState);
+        Console.WriteLine($"Wrote {exported.exitState.Length} bytes to {outputFile}");
+    }
+
+    // --- import-unilateral-exit-state ---
+
+    private static async Task HandleImportUnilateralExitState(BreezSdk sdk, Func<string, string?> readline, string[] args)
+    {
+        var inputFile = GetFlag(args, "--input-file");
+        if (inputFile == null)
+        {
+            Console.WriteLine("Usage: advanced import-unilateral-exit-state --input-file <path>");
+            return;
+        }
+
+        var exitState = await File.ReadAllTextAsync(inputFile);
+        var imported = await sdk.ImportUnilateralExitState(
+            request: new ImportUnilateralExitStateRequest(exitState: exitState)
+        );
+        Console.WriteLine(
+            $"Imported {imported.importedLeaves} leaf(s), " +
+            $"skipped {imported.skippedForeignLeaves} leaf(s) from a different wallet " +
+            $"and {imported.skippedConflictingLeaves} that disagree with what this wallet holds, " +
+            $"left out the exit data of {imported.skippedChains} leaf(s)");
     }
 
     private static void PrintExitTransactions(UnilateralExitResponse response)

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
@@ -94,7 +94,7 @@ Once the CLI is running, type `help` to see all available commands:
 - `get-user-settings` — Get user settings
 - `set-user-settings` — Update user settings
 - `get-spark-status` — Get Spark network status
-- `advanced <subcommand>` — Expert-only commands (unilateral exit)
+- `advanced <subcommand>` — Expert-only commands (unilateral exit, exit state export/import)
 - `issuer <subcommand>` — Token issuer commands
 - `contacts <subcommand>` — Contacts commands (add, update, delete, list)
 - `webhooks <subcommand>` — Webhook commands (register, unregister, list)

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/advanced.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/advanced.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:args/args.dart';
@@ -7,7 +8,11 @@ import 'cli.dart';
 import 'serialization.dart';
 
 /// Advanced subcommand names (used for help and tab completion).
-const advancedCommandNames = ['advanced unilateral-exit'];
+const advancedCommandNames = [
+  'advanced unilateral-exit',
+  'advanced export-unilateral-exit-state',
+  'advanced import-unilateral-exit-state',
+];
 
 typedef AdvancedHandler = Future<void> Function(BreezSdk sdk, List<String> args);
 
@@ -24,6 +29,14 @@ Map<String, _AdvancedEntry> _getRegistry() {
     'unilateral-exit': _AdvancedEntry(
       'Build and sign a unilateral exit (expert-only)',
       _handleUnilateralExit,
+    ),
+    'export-unilateral-exit-state': _AdvancedEntry(
+      'Export the wallet\'s unilateral exit state to a file',
+      _handleExportUnilateralExitState,
+    ),
+    'import-unilateral-exit-state': _AdvancedEntry(
+      'Import a previously exported unilateral exit state',
+      _handleImportUnilateralExitState,
     ),
   };
 }
@@ -147,6 +160,41 @@ Future<void> _handleUnilateralExit(BreezSdk sdk, List<String> args) async {
     signerSecretKey: secretKeyBytes,
   );
   _printExitTransactions(response);
+}
+
+// --- export-unilateral-exit-state ---
+
+Future<void> _handleExportUnilateralExitState(BreezSdk sdk, List<String> args) async {
+  final parser = ArgParser(usageLineLength: 80)
+    ..addOption('output-file', mandatory: true, help: 'File to write the exit state to');
+  final results = _parseArgs(parser, args, 'advanced export-unilateral-exit-state --output-file <path>');
+  if (results == null) return;
+
+  final outputFile = results.option('output-file')!;
+  final exported = await sdk.exportUnilateralExitState();
+  File(outputFile).writeAsStringSync(exported.exitState);
+  print('Wrote ${exported.exitState.length} bytes to $outputFile');
+}
+
+// --- import-unilateral-exit-state ---
+
+Future<void> _handleImportUnilateralExitState(BreezSdk sdk, List<String> args) async {
+  final parser = ArgParser(usageLineLength: 80)
+    ..addOption('input-file', mandatory: true, help: 'File the exit state was exported to');
+  final results = _parseArgs(parser, args, 'advanced import-unilateral-exit-state --input-file <path>');
+  if (results == null) return;
+
+  final inputFile = results.option('input-file')!;
+  final exitState = File(inputFile).readAsStringSync();
+  final imported = await sdk.importUnilateralExitState(
+    request: ImportUnilateralExitStateRequest(exitState: exitState),
+  );
+  print(
+    'Imported ${imported.importedLeaves} leaf(s), '
+    'skipped ${imported.skippedForeignLeaves} leaf(s) from a different wallet '
+    'and ${imported.skippedConflictingLeaves} that disagree with what this wallet holds, '
+    'left out the exit data of ${imported.skippedChains} leaf(s)',
+  );
 }
 
 CpfpInput? _parseCpfpInput(String s, String kindStr) {

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/advanced.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/advanced.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -21,12 +22,24 @@ type AdvancedCommand struct {
 
 // AdvancedCommandNames lists all advanced subcommand names (used for REPL completion).
 var AdvancedCommandNames = []string{
+	"advanced export-unilateral-exit-state",
+	"advanced import-unilateral-exit-state",
 	"advanced unilateral-exit",
 }
 
 // BuildAdvancedRegistry returns a map of advanced subcommand name -> AdvancedCommand.
 func BuildAdvancedRegistry() map[string]AdvancedCommand {
 	return map[string]AdvancedCommand{
+		"export-unilateral-exit-state": {
+			Name:        "export-unilateral-exit-state",
+			Description: "Export the wallet's unilateral exit state to a file",
+			Run:         handleExportUnilateralExitState,
+		},
+		"import-unilateral-exit-state": {
+			Name:        "import-unilateral-exit-state",
+			Description: "Import a previously exported unilateral exit state",
+			Run:         handleImportUnilateralExitState,
+		},
 		"unilateral-exit": {
 			Name:        "unilateral-exit",
 			Description: "Build and sign a unilateral exit",
@@ -66,6 +79,69 @@ func DispatchAdvancedCommand(args []string, sdk *breez_sdk_spark.BreezSdk, rl *r
 	if err := cmd.Run(sdk, rl, subArgs); err != nil {
 		fmt.Printf("Error: %v\n", err)
 	}
+}
+
+// --- export-unilateral-exit-state ---
+
+func handleExportUnilateralExitState(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []string) error {
+	fs := flag.NewFlagSet("export-unilateral-exit-state", flag.ContinueOnError)
+	outputFile := fs.String("output-file", "", "File to write the exit state to")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *outputFile == "" {
+		fmt.Println("Usage: advanced export-unilateral-exit-state --output-file <path>")
+		return nil
+	}
+
+	exported, err := sdk.ExportUnilateralExitState()
+	if err = liftError(err); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(*outputFile, []byte(exported.ExitState), 0o644); err != nil {
+		return err
+	}
+	fmt.Printf("Wrote %d bytes to %s\n", len(exported.ExitState), *outputFile)
+	return nil
+}
+
+// --- import-unilateral-exit-state ---
+
+func handleImportUnilateralExitState(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []string) error {
+	fs := flag.NewFlagSet("import-unilateral-exit-state", flag.ContinueOnError)
+	inputFile := fs.String("input-file", "", "File the exit state was exported to")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *inputFile == "" {
+		fmt.Println("Usage: advanced import-unilateral-exit-state --input-file <path>")
+		return nil
+	}
+
+	exitStateBytes, err := os.ReadFile(*inputFile)
+	if err != nil {
+		return err
+	}
+
+	imported, err := sdk.ImportUnilateralExitState(breez_sdk_spark.ImportUnilateralExitStateRequest{
+		ExitState: string(exitStateBytes),
+	})
+	if err = liftError(err); err != nil {
+		return err
+	}
+
+	fmt.Printf("Imported %d leaf(s), skipped %d leaf(s) from a different wallet "+
+		"and %d that disagree with what this wallet holds, "+
+		"left out the exit data of %d leaf(s)\n",
+		imported.ImportedLeaves,
+		imported.SkippedForeignLeaves,
+		imported.SkippedConflictingLeaves,
+		imported.SkippedChains,
+	)
+	return nil
 }
 
 // --- unilateral-exit ---

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Advanced.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Advanced.kt
@@ -1,4 +1,5 @@
 import breez_sdk_spark.*
+import java.io.File
 import org.jline.reader.LineReader
 
 /**
@@ -15,6 +16,8 @@ data class AdvancedCliCommand(
  */
 val ADVANCED_COMMAND_NAMES = listOf(
     "unilateral-exit",
+    "export-unilateral-exit-state",
+    "import-unilateral-exit-state",
 )
 
 /**
@@ -26,6 +29,16 @@ fun buildAdvancedRegistry(): Map<String, AdvancedCliCommand> {
             "unilateral-exit",
             "Build and sign a unilateral exit",
             ::handleUnilateralExit,
+        ),
+        "export-unilateral-exit-state" to AdvancedCliCommand(
+            "export-unilateral-exit-state",
+            "Export the wallet's unilateral exit state to a file",
+            ::handleExportUnilateralExitState,
+        ),
+        "import-unilateral-exit-state" to AdvancedCliCommand(
+            "import-unilateral-exit-state",
+            "Import a unilateral exit state from a file",
+            ::handleImportUnilateralExitState,
         ),
     )
 }
@@ -180,6 +193,43 @@ fun parseCpfpInput(s: String, kind: CpfpFundingKind): CpfpInput {
         is CpfpFundingKind.Custom ->
             throw IllegalArgumentException("custom funding kind is not supported by this CLI")
     }
+}
+
+// --- export-unilateral-exit-state ---
+
+suspend fun handleExportUnilateralExitState(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    val fp = FlagParser(args)
+    val outputFile = fp.getString("output-file")
+
+    if (outputFile == null) {
+        println("Usage: advanced export-unilateral-exit-state --output-file <path>")
+        return
+    }
+
+    val exported = sdk.exportUnilateralExitState()
+    File(outputFile).writeText(exported.exitState)
+    println("Wrote ${exported.exitState.length} bytes to $outputFile")
+}
+
+// --- import-unilateral-exit-state ---
+
+suspend fun handleImportUnilateralExitState(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    val fp = FlagParser(args)
+    val inputFile = fp.getString("input-file")
+
+    if (inputFile == null) {
+        println("Usage: advanced import-unilateral-exit-state --input-file <path>")
+        return
+    }
+
+    val exitState = File(inputFile).readText()
+    val imported = sdk.importUnilateralExitState(ImportUnilateralExitStateRequest(exitState))
+    println(
+        "Imported ${imported.importedLeaves} leaf(s), " +
+        "skipped ${imported.skippedForeignLeaves} leaf(s) from a different wallet " +
+        "and ${imported.skippedConflictingLeaves} that disagree with what this wallet holds, " +
+        "left out the exit data of ${imported.skippedChains} leaf(s)"
+    )
 }
 
 fun printExitTransactions(response: UnilateralExitResponse) {

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/advanced.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/advanced.py
@@ -5,6 +5,7 @@ from breez_sdk_spark import (
     CpfpFundingKind,
     CpfpInput,
     ExitLeafSelection,
+    ImportUnilateralExitStateRequest,
     PrepareUnilateralExitRequest,
     UnilateralExitRequest,
     single_key_cpfp_signer,
@@ -15,6 +16,8 @@ from breez_cli.serialization import print_value
 # Advanced subcommand names (used for REPL completion)
 ADVANCED_COMMAND_NAMES = [
     "advanced unilateral-exit",
+    "advanced export-unilateral-exit-state",
+    "advanced import-unilateral-exit-state",
 ]
 
 
@@ -82,6 +85,49 @@ def _print_exit_transactions(response):
         print(f"      Package: {package}")
 
 
+def _build_export_unilateral_exit_state_parser():
+    p = _parser(
+        "export-unilateral-exit-state",
+        "Export the wallet's unilateral exit state to a file, for safekeeping outside the wallet's own storage.",
+    )
+    p.add_argument("--output-file", required=True,
+                   help="File to write the exit state to")
+    return p
+
+
+def _build_import_unilateral_exit_state_parser():
+    p = _parser(
+        "import-unilateral-exit-state",
+        "Import a unilateral exit state previously written by export-unilateral-exit-state, merging it into the wallet.",
+    )
+    p.add_argument("--input-file", required=True,
+                   help="File the exit state was exported to")
+    return p
+
+
+async def _handle_export_unilateral_exit_state(sdk, _session, args):
+    exported = await sdk.export_unilateral_exit_state()
+    with open(args.output_file, "w") as f:
+        f.write(exported.exit_state)
+    print(
+        f"Wrote {len(exported.exit_state)} bytes to {args.output_file}"
+    )
+
+
+async def _handle_import_unilateral_exit_state(sdk, _session, args):
+    with open(args.input_file) as f:
+        exit_state = f.read()
+    imported = await sdk.import_unilateral_exit_state(
+        request=ImportUnilateralExitStateRequest(exit_state=exit_state)
+    )
+    print(
+        f"Imported {imported.imported_leaves} leaf(s), "
+        f"skipped {imported.skipped_foreign_leaves} leaf(s) from a different wallet "
+        f"and {imported.skipped_conflicting_leaves} that disagree with what this wallet holds, "
+        f"left out the exit data of {imported.skipped_chains} leaf(s)"
+    )
+
+
 async def _handle_unilateral_exit(sdk, session, args):
     leaf_ids = args.leaf_ids or []
     if leaf_ids:
@@ -135,6 +181,8 @@ async def _handle_unilateral_exit(sdk, session, args):
 def _build_advanced_registry():
     return {
         "unilateral-exit": (_build_unilateral_exit_parser(), _handle_unilateral_exit),
+        "export-unilateral-exit-state": (_build_export_unilateral_exit_state_parser(), _handle_export_unilateral_exit_state),
+        "import-unilateral-exit-state": (_build_import_unilateral_exit_state_parser(), _handle_import_unilateral_exit_state),
     }
 
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/README.md
@@ -92,6 +92,8 @@ Once the app is running, type commands in the text input at the bottom:
 
 **Webhooks**: `webhooks <subcommand>`
 
+**Advanced**: `advanced unilateral-exit`, `advanced export-unilateral-exit-state`, `advanced import-unilateral-exit-state`
+
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 
 Type `help` for a full list of commands. Each command mirrors the Rust CLI behavior.
@@ -168,6 +170,30 @@ list-payments --tx-type mint
 list-payments --from-timestamp 1700000000 --to-timestamp 1710000000
 list-payments --sort-ascending true
 ```
+
+### Advanced Commands
+
+Expert-only commands that build raw transactions for you to broadcast yourself.
+Misuse can strand or lose funds.
+
+```
+# Quote a unilateral exit (no funding, shows the quote only)
+advanced unilateral-exit --fee-rate 2 --destination bc1q...
+
+# Build and sign a unilateral exit
+advanced unilateral-exit --fee-rate 2 --destination bc1q... --utxo txid:vout:value:pubkey --secret-key <hex>
+
+# Select specific leaves to exit
+advanced unilateral-exit --fee-rate 2 --destination bc1q... --leaf id1,id2
+
+# Export exit state to a file (for safekeeping outside the wallet)
+advanced export-unilateral-exit-state --output-file exit-state.json
+
+# Import exit state from a previously exported file
+advanced import-unilateral-exit-state --input-file exit-state.json
+```
+
+File paths are relative to the app's document directory unless an absolute path is given.
 
 ## TypeScript Validation
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/advanced.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/advanced.ts
@@ -1,0 +1,263 @@
+/**
+ * Advanced subcommands.
+ *
+ * Mirrors the Rust CLI `advanced` subcommands:
+ *   unilateral-exit, export-unilateral-exit-state, import-unilateral-exit-state
+ */
+
+import {
+  singleKeyCpfpSigner,
+  CpfpFundingKind,
+  CpfpInput,
+  ExitLeafSelection,
+  ConfirmationStatus,
+} from '@breeztech/breez-sdk-spark-react-native'
+import type {
+  BreezSdkInterface,
+} from '@breeztech/breez-sdk-spark-react-native'
+import RNFS from 'react-native-fs'
+import { formatValue } from './serialization'
+
+function hexToArrayBuffer(hex: string): ArrayBuffer {
+  const cleaned = hex.replace(/\s/g, '')
+  const bytes = new Uint8Array(cleaned.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(cleaned.substring(i * 2, i * 2 + 2), 16)
+  }
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+}
+
+/** All advanced subcommand names for help and completion. */
+export const ADVANCED_COMMAND_NAMES = [
+  'unilateral-exit',
+  'export-unilateral-exit-state',
+  'import-unilateral-exit-state',
+]
+
+/**
+ * Parse a named flag value from args. Returns the value after the flag, or undefined.
+ */
+function parseFlag(args: string[], ...flags: string[]): string | undefined {
+  for (const flag of flags) {
+    const idx = args.indexOf(flag)
+    if (idx !== -1 && idx + 1 < args.length) {
+      return args[idx + 1]
+    }
+  }
+  return undefined
+}
+
+/**
+ * Parse a multi-value flag (comma-separated). Returns undefined if not provided.
+ */
+function parseMultiFlag(args: string[], ...flags: string[]): string[] | undefined {
+  const val = parseFlag(args, ...flags)
+  if (val === undefined) return undefined
+  return val.split(',').map(s => s.trim()).filter(s => s.length > 0)
+}
+
+/**
+ * Parse repeated flags (each occurrence has its own value).
+ */
+function parseRepeatedFlag(args: string[], ...flags: string[]): string[] {
+  const values: string[] = []
+  for (let i = 0; i < args.length; i++) {
+    if (flags.includes(args[i]) && i + 1 < args.length) {
+      values.push(args[i + 1])
+      i++
+    }
+  }
+  return values
+}
+
+/**
+ * Dispatch an advanced subcommand.
+ *
+ * @param args - The arguments after "advanced" (e.g., ["unilateral-exit", "--fee-rate", "2", ...])
+ * @param sdk - The BreezSdkInterface instance
+ * @returns A string result to display
+ */
+export async function dispatchAdvancedCommand(
+  args: string[],
+  sdk: BreezSdkInterface
+): Promise<string> {
+  if (args.length === 0 || args[0] === 'help') {
+    return printAdvancedHelp()
+  }
+
+  const subcommand = args[0]
+  const subArgs = args.slice(1)
+
+  switch (subcommand) {
+    case 'unilateral-exit':
+      return handleUnilateralExit(sdk, subArgs)
+    case 'export-unilateral-exit-state':
+      return handleExportUnilateralExitState(sdk, subArgs)
+    case 'import-unilateral-exit-state':
+      return handleImportUnilateralExitState(sdk, subArgs)
+    default:
+      return `Unknown advanced subcommand: ${subcommand}. Use 'advanced help' for available commands.`
+  }
+}
+
+function printAdvancedHelp(): string {
+  const lines = [
+    '',
+    'Advanced subcommands (expert-only, misuse can strand or lose funds):',
+    '  advanced unilateral-exit --fee-rate <rate> --destination <addr>',
+    '    [--funding-kind p2wpkh|p2tr] [--leaf <id>,<id>,...]',
+    '    [--utxo txid:vout:value:pubkey ...] [--secret-key <hex>]',
+    '                                         Build and sign a unilateral exit',
+    '  advanced export-unilateral-exit-state --output-file <path>',
+    '                                         Export exit state to a file',
+    '  advanced import-unilateral-exit-state --input-file <path>',
+    '                                         Import exit state from a file',
+    '',
+  ]
+  return lines.join('\n')
+}
+
+// --- unilateral-exit ---
+
+function parseCpfpInput(s: string, kind: string): InstanceType<typeof CpfpInput.P2wpkh> | InstanceType<typeof CpfpInput.P2tr> {
+  const parts = s.split(':')
+  if (parts.length !== 4) {
+    throw new Error(`Invalid funding UTXO '${s}', expected txid:vout:value:pubkey`)
+  }
+  const txid = parts[0]
+  const vout = parseInt(parts[1], 10)
+  if (isNaN(vout)) {
+    throw new Error(`Invalid vout in '${s}'`)
+  }
+  const value = BigInt(parts[2])
+  const pubkey = parts[3]
+
+  if (kind === 'p2wpkh') {
+    return new CpfpInput.P2wpkh({ txid, vout, value, pubkey })
+  }
+  return new CpfpInput.P2tr({ txid, vout, value, pubkey })
+}
+
+async function handleUnilateralExit(sdk: BreezSdkInterface, args: string[]): Promise<string> {
+  const feeRateStr = parseFlag(args, '--fee-rate')
+  const destination = parseFlag(args, '--destination')
+
+  if (!feeRateStr || !destination) {
+    return 'Usage: advanced unilateral-exit --fee-rate <rate> --destination <addr> [--funding-kind p2wpkh|p2tr] [--leaf <id>,<id>,...] [--utxo txid:vout:value:pubkey ...] [--secret-key <hex>]'
+  }
+
+  const feeRate = BigInt(feeRateStr)
+  const fundingKindStr = parseFlag(args, '--funding-kind') ?? 'p2tr'
+  const leafIds = parseMultiFlag(args, '--leaf')
+
+  const fundingKind = fundingKindStr === 'p2wpkh'
+    ? new CpfpFundingKind.P2wpkh()
+    : new CpfpFundingKind.P2tr()
+
+  const selection = leafIds && leafIds.length > 0
+    ? new ExitLeafSelection.Specific({ leafIds })
+    : new ExitLeafSelection.Auto()
+
+  const prepared = await sdk.prepareUnilateralExit({
+    feeRateSatPerVbyte: feeRate,
+    fundingKind,
+    destination,
+    selection,
+  })
+
+  const lines: string[] = [formatValue(prepared)]
+
+  if (prepared.leaves.length === 0) {
+    lines.push('No leaves to exit.')
+    return lines.join('\n')
+  }
+
+  const utxoArgs = parseRepeatedFlag(args, '--utxo')
+  if (utxoArgs.length === 0) {
+    lines.push('No funding provided; showing the quote only.')
+    lines.push('Provide --utxo txid:vout:value:pubkey and --secret-key <hex> to sign.')
+    return lines.join('\n')
+  }
+
+  const secretKey = parseFlag(args, '--secret-key')
+  if (!secretKey) {
+    return 'Error: --secret-key is required when --utxo is provided'
+  }
+
+  const fundingInputs = utxoArgs.map(u => parseCpfpInput(u, fundingKindStr))
+  const signer = singleKeyCpfpSigner(hexToArrayBuffer(secretKey.trim()))
+
+  const response = await sdk.unilateralExit(
+    { prepared, fundingInputs },
+    signer
+  )
+
+  lines.push(
+    `Recoverable ${response.recoverableValueSat} sats, ` +
+    `total fee ${response.totalFeeSat} sats, ` +
+    `${response.transactions.length} transaction(s):`
+  )
+
+  for (let i = 0; i < response.transactions.length; i++) {
+    const tx = response.transactions[i]
+    const after = tx.dependsOn.length > 0
+      ? `, after ${tx.dependsOn.join(',')}`
+      : ''
+    const csv = tx.csvTimelockBlocks != null
+      ? `, csv ${tx.csvTimelockBlocks} blocks`
+      : ''
+    lines.push(`  [${i}] ${tx.kind} status=${tx.status} txid=${tx.txid}${after}${csv}`)
+
+    if (tx.status === ConfirmationStatus.Confirmed) {
+      lines.push('      (already confirmed, nothing to broadcast)')
+      continue
+    }
+
+    const pkg = tx.cpfpTxHex
+      ? `${tx.txHex},${tx.cpfpTxHex}`
+      : tx.txHex
+    lines.push(`      Package: ${pkg}`)
+  }
+
+  return lines.join('\n')
+}
+
+// --- export-unilateral-exit-state ---
+
+async function handleExportUnilateralExitState(sdk: BreezSdkInterface, args: string[]): Promise<string> {
+  const outputFile = parseFlag(args, '--output-file')
+  if (!outputFile) {
+    return 'Usage: advanced export-unilateral-exit-state --output-file <path>'
+  }
+
+  const exported = await sdk.exportUnilateralExitState()
+  const filePath = outputFile.startsWith('/')
+    ? outputFile
+    : `${RNFS.DocumentDirectoryPath}/${outputFile}`
+  await RNFS.writeFile(filePath, exported.exitState, 'utf8')
+
+  return `Wrote ${exported.exitState.length} bytes to ${filePath}`
+}
+
+// --- import-unilateral-exit-state ---
+
+async function handleImportUnilateralExitState(sdk: BreezSdkInterface, args: string[]): Promise<string> {
+  const inputFile = parseFlag(args, '--input-file')
+  if (!inputFile) {
+    return 'Usage: advanced import-unilateral-exit-state --input-file <path>'
+  }
+
+  const filePath = inputFile.startsWith('/')
+    ? inputFile
+    : `${RNFS.DocumentDirectoryPath}/${inputFile}`
+  const exitState = await RNFS.readFile(filePath, 'utf8')
+
+  const imported = await sdk.importUnilateralExitState({ exitState })
+
+  return (
+    `Imported ${imported.importedLeaves} leaf(s), ` +
+    `skipped ${imported.skippedForeignLeaves} leaf(s) from a different wallet ` +
+    `and ${imported.skippedConflictingLeaves} that disagree with what this wallet holds, ` +
+    `left out the exit data of ${imported.skippedChains} leaf(s)`
+  )
+}

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
@@ -81,6 +81,17 @@ declare module '@breeztech/breez-sdk-spark-react-native' {
   export type CrossChainRoutePair = any;
   export type CrossChainAddressDetails = any;
 
+  // --- advanced / unilateral exit ---
+  export const singleKeyCpfpSigner: any;
+  export const CpfpFundingKind: any;
+  export type CpfpFundingKind = any;
+  export const CpfpInput: any;
+  export type CpfpInput = any;
+  export const ExitLeafSelection: any;
+  export type ExitLeafSelection = any;
+  export const ConfirmationStatus: any;
+  export type ConfirmationStatus = any;
+
   // --- passkey ---
   // Note: PasskeyProvider (concrete class) ships at the
   // `/passkey-prf-provider` subpath export, declared separately below.

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -9,8 +9,8 @@
  *   register-lightning-address, delete-lightning-address, list-fiat-currencies,
  *   list-fiat-rates, recommended-fees, get-tokens-metadata,
  *   fetch-conversion-limits, get-user-settings, set-user-settings,
- *   get-spark-status, issuer (subcommand), contacts (subcommand),
- *   webhooks (subcommand)
+ *   get-spark-status, advanced (subcommand), issuer (subcommand),
+ *   contacts (subcommand), webhooks (subcommand)
  */
 
 import {
@@ -46,6 +46,7 @@ import type {
 } from '@breeztech/breez-sdk-spark-react-native'
 import { generateRandomBytes, sha256Hash, bytesToHex } from './crypto_utils'
 import { formatValue } from './serialization'
+import { dispatchAdvancedCommand } from './advanced'
 import { dispatchIssuerCommand } from './issuer'
 import { dispatchContactsCommand } from './contacts'
 import { dispatchWebhooksCommand } from './webhooks'
@@ -181,6 +182,7 @@ export const COMMAND_NAMES = [
   'get-user-settings',
   'set-user-settings',
   'get-spark-status',
+  'advanced',
   'issuer',
   'contacts',
   'webhooks',
@@ -225,6 +227,7 @@ export function buildCommandRegistry(): Map<string, CommandDef> {
     { name: 'get-user-settings', description: 'Get user settings', run: handleGetUserSettings },
     { name: 'set-user-settings', description: 'Update user settings', run: handleSetUserSettings },
     { name: 'get-spark-status', description: 'Get Spark network service status', run: handleGetSparkStatus },
+    { name: 'advanced', description: 'Expert-only commands (use "advanced help" for details)', run: handleAdvanced },
     { name: 'issuer', description: 'Token issuer commands (use "issuer help" for details)', run: handleIssuer },
     { name: 'contacts', description: 'Contacts commands (use "contacts help" for details)', run: handleContacts },
     { name: 'webhooks', description: 'Webhook commands (use "webhooks help" for details)', run: handleWebhooks },
@@ -1252,6 +1255,12 @@ async function handleSetUserSettings(sdk: BreezSdkInterface, _tokenIssuer: Token
 async function handleGetSparkStatus(_sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, _args: string[]): Promise<string> {
   const result = await getSparkStatus()
   return formatValue(result)
+}
+
+// --- advanced (delegation) ---
+
+async function handleAdvanced(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
+  return dispatchAdvancedCommand(args, sdk)
 }
 
 // --- issuer (delegation) ---

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
@@ -94,7 +94,7 @@ The CLI supports:
 
 **Stable balance**: `stable-balance get`, `stable-balance set`, `stable-balance unset`
 
-**Advanced**: `advanced unilateral-exit`
+**Advanced**: `advanced unilateral-exit`, `advanced export-unilateral-exit-state`, `advanced import-unilateral-exit-state`
 
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Advanced.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Advanced.swift
@@ -5,6 +5,8 @@ import BreezSdkSpark
 
 let advancedCommandNames: [String] = [
     "advanced unilateral-exit",
+    "advanced export-unilateral-exit-state",
+    "advanced import-unilateral-exit-state",
 ]
 
 // MARK: - Dispatch
@@ -22,6 +24,10 @@ func dispatchAdvancedCommand(_ args: [String], sdk: BreezSdk) async {
         switch subName {
         case "unilateral-exit":
             try await handleUnilateralExit(sdk, subArgs)
+        case "export-unilateral-exit-state":
+            try await handleExportUnilateralExitState(sdk, subArgs)
+        case "import-unilateral-exit-state":
+            try await handleImportUnilateralExitState(sdk, subArgs)
         default:
             print("Unknown advanced subcommand: \(subName). Use 'advanced help' for available commands.")
         }
@@ -34,7 +40,9 @@ func dispatchAdvancedCommand(_ args: [String], sdk: BreezSdk) async {
 
 private func printAdvancedHelp() {
     print("\nAdvanced subcommands (expert-only, misuse can strand or lose funds):")
-    print("  advanced \("unilateral-exit".padding(toLength: 30, withPad: " ", startingAt: 0))Build and sign a unilateral exit")
+    print("  advanced \("unilateral-exit".padding(toLength: 38, withPad: " ", startingAt: 0))Build and sign a unilateral exit")
+    print("  advanced \("export-unilateral-exit-state".padding(toLength: 38, withPad: " ", startingAt: 0))Export exit state to a file")
+    print("  advanced \("import-unilateral-exit-state".padding(toLength: 38, withPad: " ", startingAt: 0))Import exit state from a file")
     print()
 }
 
@@ -114,6 +122,39 @@ private func handleUnilateralExit(_ sdk: BreezSdk, _ args: [String]) async throw
         signer: signer
     )
     printExitTransactions(response)
+}
+
+private func handleExportUnilateralExitState(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let fp = FlagParser(args)
+    guard let outputFile = fp.get("output-file") else {
+        print("Usage: advanced export-unilateral-exit-state --output-file <path>")
+        return
+    }
+
+    let exported = try await sdk.exportUnilateralExitState()
+    let url = URL(fileURLWithPath: outputFile)
+    try exported.exitState.write(to: url, atomically: true, encoding: .utf8)
+    print("Wrote \(exported.exitState.count) bytes to \(outputFile)")
+}
+
+private func handleImportUnilateralExitState(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let fp = FlagParser(args)
+    guard let inputFile = fp.get("input-file") else {
+        print("Usage: advanced import-unilateral-exit-state --input-file <path>")
+        return
+    }
+
+    let url = URL(fileURLWithPath: inputFile)
+    let exitState = try String(contentsOf: url, encoding: .utf8)
+    let imported = try await sdk.importUnilateralExitState(
+        request: ImportUnilateralExitStateRequest(exitState: exitState)
+    )
+    print(
+        "Imported \(imported.importedLeaves) leaf(s), " +
+        "skipped \(imported.skippedForeignLeaves) leaf(s) from a different wallet " +
+        "and \(imported.skippedConflictingLeaves) that disagree with what this wallet holds, " +
+        "left out the exit data of \(imported.skippedChains) leaf(s)"
+    )
 }
 
 // MARK: - Helpers

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
@@ -100,7 +100,7 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **Stable Balance**: `stable-balance get`, `stable-balance set`, `stable-balance unset`
 
-**Advanced**: `advanced unilateral-exit`
+**Advanced**: `advanced unilateral-exit`, `advanced export-unilateral-exit-state`, `advanced import-unilateral-exit-state`
 
 **Other**: `parse`, `list-fiat-currencies`, `list-fiat-rates`, `get-user-settings`, `set-user-settings`, `get-spark-status`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/advanced.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/advanced.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const fs = require('fs')
 const { Command, Option } = require('commander')
 const { singleKeyCpfpSigner } = require('@breeztech/breez-sdk-spark/nodejs')
 const { printValue } = require('./serialization')
@@ -136,6 +137,35 @@ function registerAdvancedCommands(program, getSdk, rl) {
         signer
       )
       printExitTransactions(response)
+    })
+
+  // --- export-unilateral-exit-state ---
+  advanced
+    .command('export-unilateral-exit-state')
+    .description('Export the wallet\'s unilateral exit state to a file, for safekeeping outside the wallet\'s own storage')
+    .requiredOption('--output-file <path>', 'File to write the exit state to')
+    .action(async (options) => {
+      const sdk = getSdk()
+      const exported = await sdk.exportUnilateralExitState()
+      fs.writeFileSync(options.outputFile, exported.exitState)
+      console.log(`Wrote ${exported.exitState.length} bytes to ${options.outputFile}`)
+    })
+
+  // --- import-unilateral-exit-state ---
+  advanced
+    .command('import-unilateral-exit-state')
+    .description('Import a unilateral exit state previously written by export-unilateral-exit-state, merging it into the wallet')
+    .requiredOption('--input-file <path>', 'File the exit state was exported to')
+    .action(async (options) => {
+      const sdk = getSdk()
+      const exitState = fs.readFileSync(options.inputFile, 'utf-8')
+      const imported = await sdk.importUnilateralExitState({ exitState })
+      console.log(
+        `Imported ${imported.importedLeaves} leaf(s), ` +
+        `skipped ${imported.skippedForeignLeaves} leaf(s) from a different wallet ` +
+        `and ${imported.skippedConflictingLeaves} that disagree with what this wallet holds, ` +
+        `left out the exit data of ${imported.skippedChains} leaf(s)`
+      )
     })
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -64,7 +64,9 @@ const COMMAND_NAMES = [
   'stable-balance set',
   'stable-balance unset',
   'pay-batch',
-  'advanced unilateral-exit'
+  'advanced unilateral-exit',
+  'advanced export-unilateral-exit-state',
+  'advanced import-unilateral-exit-state'
 ]
 
 /**


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`92b7e93`](https://github.com/breez/spark-sdk/commit/92b7e9386d0c35d627c047715bea45df53a295fc)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/32340646086)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :white_check_mark: React Native
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- C# CLI missing `advanced export-unilateral-exit-state` command (Rust: `ExportUnilateralExitState` with `--output-file` flag)
- C# CLI missing `advanced import-unilateral-exit-state` command (Rust: `ImportUnilateralExitState` with `--input-file` flag)

## Applied
- Added `export-unilateral-exit-state` handler in `Advanced.cs`: calls `sdk.ExportUnilateralExitState()`, writes exit state to file
- Added `import-unilateral-exit-state` handler in `Advanced.cs`: reads file, calls `sdk.ImportUnilateralExitState()`, prints import summary including `skippedConflictingLeaves`
- Added both commands to `AdvancedCommandNames.All` and `BuildRegistry()` in `Advanced.cs`

## Skipped
- (none)

### Dart
## Divergences
- Dart CLI `advanced.dart` missing `export-unilateral-exit-state` command (present in Rust `advanced.rs`)
- Dart CLI `advanced.dart` missing `import-unilateral-exit-state` command (present in Rust `advanced.rs`)

## Applied
- Added `export-unilateral-exit-state` command to `advanced.dart` with `--output-file` option, calls `sdk.exportUnilateralExitState()` and writes exit state to file
- Added `import-unilateral-exit-state` command to `advanced.dart` with `--input-file` option, reads file and calls `sdk.importUnilateralExitState()`
- Added both new command names to `advancedCommandNames` list for tab completion
- Updated Dart CLI README to mention exit state export/import in the advanced commands description

## Skipped
- (none)

### Go
## Divergences
- Go CLI missing `export-unilateral-exit-state` command (Rust: `AdvancedCommand::ExportUnilateralExitState`)
- Go CLI missing `import-unilateral-exit-state` command (Rust: `AdvancedCommand::ImportUnilateralExitState`)

## Applied
- Added `handleExportUnilateralExitState` handler with `--output-file` flag to `advanced.go`
- Added `handleImportUnilateralExitState` handler with `--input-file` flag to `advanced.go`
- Registered both commands in `BuildAdvancedRegistry()` and `AdvancedCommandNames` in `advanced.go`
- Added `os` import for file I/O in `advanced.go`

## Skipped
- (none)

### Kotlin
## Divergences
- Kotlin Advanced.kt missing `export-unilateral-exit-state` command (Rust `AdvancedCommand::ExportUnilateralExitState`)
- Kotlin Advanced.kt missing `import-unilateral-exit-state` command (Rust `AdvancedCommand::ImportUnilateralExitState`)

## Applied
- Added `export-unilateral-exit-state` command to Advanced.kt: calls `sdk.exportUnilateralExitState()`, writes exit state to `--output-file`
- Added `import-unilateral-exit-state` command to Advanced.kt: reads exit state from `--input-file`, calls `sdk.importUnilateralExitState()`
- Added both commands to `ADVANCED_COMMAND_NAMES` and `buildAdvancedRegistry()` in Advanced.kt

## Skipped
- (none)

### Python
## Divergences
- Python CLI `advanced.py` was missing `export-unilateral-exit-state` and `import-unilateral-exit-state` commands added in Rust CLI `advanced.rs`

## Applied
- Added `ImportUnilateralExitStateRequest` to imports in `advanced.py`
- Added `export-unilateral-exit-state` command: parser with `--output-file` flag, handler calling `sdk.export_unilateral_exit_state()` and writing to file (`advanced.py`)
- Added `import-unilateral-exit-state` command: parser with `--input-file` flag, handler reading file and calling `sdk.import_unilateral_exit_state()` with matching output message (`advanced.py`)
- Added both commands to `ADVANCED_COMMAND_NAMES` for REPL completion (`advanced.py`)
- Added both commands to the advanced registry (`advanced.py`)

## Skipped
- (none)

### React Native
## Divergences
- The entire `advanced` subcommand group (unilateral-exit, export-unilateral-exit-state, import-unilateral-exit-state) exists in the Rust CLI but was missing from the React Native CLI

## Applied
- Created `crates/breez-sdk/bindings/examples/cli/langs/react-native/src/advanced.ts` with all three advanced subcommands: `unilateral-exit`, `export-unilateral-exit-state`, `import-unilateral-exit-state`
- Updated `commands.ts` to register the `advanced` command group and dispatch to `dispatchAdvancedCommand`
- Updated `breez-sdk-spark-react-native.d.ts` with type declarations for `singleKeyCpfpSigner`, `CpfpFundingKind`, `CpfpInput`, `ExitLeafSelection`, and `ConfirmationStatus`
- Updated `README.md` with Advanced commands section and documentation
- Used `Uint8Array`-based hex conversion instead of Node.js `Buffer` for React Native compatibility
- Used `react-native-fs` (RNFS) for file I/O in export/import commands, matching the Rust CLI's `fs::write`/`fs::read_to_string` pattern
- Adapted the Rust CLI's interactive UTXO/key prompts to flag-based arguments (`--utxo`, `--secret-key`) since the React Native terminal UI cannot do multi-step prompts within a single command

## Skipped
- Nothing skipped; all three advanced commands are fully implemented using SDK APIs available in the React Native bindings

### Swift
## Divergences
- Swift CLI missing `advanced export-unilateral-exit-state` command (added in Rust CLI advanced.rs)
- Swift CLI missing `advanced import-unilateral-exit-state` command (added in Rust CLI advanced.rs)

## Applied
- Added `export-unilateral-exit-state` and `import-unilateral-exit-state` handlers to `Advanced.swift`
- Added new command names to `advancedCommandNames` array in `Advanced.swift`
- Added new commands to the dispatch switch and help text in `Advanced.swift`
- Updated `README.md` Advanced section to list the new commands

## Skipped
- (none)

### TypeScript
## Divergences
- `advanced export-unilateral-exit-state` command missing from TypeScript CLI (present in Rust `advanced.rs`)
- `advanced import-unilateral-exit-state` command missing from TypeScript CLI (present in Rust `advanced.rs`)

## Applied
- Added `export-unilateral-exit-state` subcommand to `advanced.js` with `--output-file` option, calls `sdk.exportUnilateralExitState()` and writes the exit state to disk
- Added `import-unilateral-exit-state` subcommand to `advanced.js` with `--input-file` option, reads exit state from disk and calls `sdk.importUnilateralExitState()`
- Added `fs` require to `advanced.js` for file I/O
- Added both new command names to `COMMAND_NAMES` in `commands.js` for tab completion
- Updated `README.md` Advanced section to list the two new commands

## Skipped
- (none)

</details>

All languages synced cleanly. This PR merges automatically once the gating CI checks pass (integration test checks excluded).