### PR TITLE
fix(react-native): resolve currentActivity on RN 0.80+

### DIFF
--- a/packages/react-native/android/src/main/kotlin/com/breeztech/breezsdkspark/BreezSdkSparkPasskeyModule.kt
+++ b/packages/react-native/android/src/main/kotlin/com/breeztech/breezsdkspark/BreezSdkSparkPasskeyModule.kt
@@ -78,7 +78,7 @@ class BreezSdkSparkPasskeyModule(
         preferImmediatelyAvailableCredentials: Boolean?,
         promise: Promise,
     ) {
-        val activity = currentActivity
+        val activity = reactContext.currentActivity
         if (activity == null) {
             promise.reject("ERR_NO_ACTIVITY", "No current activity available")
             return
@@ -147,7 +147,7 @@ class BreezSdkSparkPasskeyModule(
      */
     @ReactMethod
     fun checkDomainAssociation(rpId: String, promise: Promise) {
-        val activity = currentActivity
+        val activity = reactContext.currentActivity
         if (activity == null) {
             promise.reject("ERR_NO_ACTIVITY", "No current activity available")
             return
@@ -203,7 +203,7 @@ class BreezSdkSparkPasskeyModule(
         registerSaltsArg: com.facebook.react.bridge.ReadableArray,
         promise: Promise,
     ) {
-        val activity = currentActivity
+        val activity = reactContext.currentActivity
         if (activity == null) {
             promise.reject("ERR_NO_ACTIVITY", "No current activity available")
             return


### PR DESCRIPTION
## Problem

The Android passkey module does not compile on React Native 0.85: `currentActivity` is an unresolved reference, and the `Any` vs `Activity` errors follow from it.

RN 0.80 converted `ReactContextBaseJavaModule` to Kotlin, so `getCurrentActivity()` is now a Kotlin function rather than a Java getter. Kotlin synthetic property access does not apply, so the bare reference no longer resolves.

## Change

Use `reactContext.currentActivity` at the 3 call sites. `ReactContext` is still Java, so the property form resolves on RN 0.78 (the current devDependency) and on 0.85. This is the replacement RN's own deprecation notice gives.