### PR TITLE
RN: Cancel the passkey scope using invalidate

### DIFF
--- a/packages/react-native/android/src/main/kotlin/com/breeztech/breezsdkspark/BreezSdkSparkPasskeyModule.kt
+++ b/packages/react-native/android/src/main/kotlin/com/breeztech/breezsdkspark/BreezSdkSparkPasskeyModule.kt
@@ -36,10 +36,10 @@ class BreezSdkSparkPasskeyModule(
 ) : ReactContextBaseJavaModule(reactContext) {
 
     /**
-     * Module-scoped coroutine scope. Cancelled in [onCatalystInstanceDestroy]
-     * so any in-flight passkey ceremony does not outlive the React context
-     * and leak the captured Activity. SupervisorJob keeps siblings alive if
-     * one branch fails, matching the per-call try/catch pattern below.
+     * Module-scoped coroutine scope. Cancelled in [invalidate] so any
+     * in-flight passkey ceremony does not outlive the React context and leak
+     * the captured Activity. SupervisorJob keeps siblings alive if one branch
+     * fails, matching the per-call try/catch pattern below.
      */
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
@@ -53,9 +53,9 @@ class BreezSdkSparkPasskeyModule(
 
     override fun getName(): String = NAME
 
-    override fun onCatalystInstanceDestroy() {
+    override fun invalidate() {
         scope.cancel()
-        super.onCatalystInstanceDestroy()
+        super.invalidate()
     }
 
     /**


### PR DESCRIPTION
`BreezSdkSparkPasskeyModule` cancelled its coroutine scope from `onCatalystInstanceDestroy()`, which React Native has not called since 0.74. The scope was never cancelled, so an in-flight passkey ceremony could outlive the React context and hold the `Activity` it captured.

### Why the override was dead

Both teardown paths call `invalidate()`, and `BaseJavaModule.invalidate()` is an empty body that does not delegate to the deprecated method:

| Path | Call |
|---|---|
| Legacy bridge | `NativeModuleRegistry` to `ModuleHolder.destroy()` to `invalidate()` |
| TurboModuleManager | `TurboModuleManager.invalidate()` to `nativeModule.invalidate()` |

RN 0.68 to 0.73 kept a shim where `invalidate()` called `onCatalystInstanceDestroy()`, so the override still fired. That shim was deleted in 0.74 (facebook/react-native#41835). Removing it produced no compile error because the method survives as a deprecated default on `NativeModule`, so the override kept compiling and silently stopped running. This package pins 0.78, so the hook never fired here.

`NativeModule.onCatalystInstanceDestroy()` is also annotated `@Deprecated(forRemoval = true)`, so the override would eventually have broken the build.
