### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -37,6 +37,7 @@ public static class CommandNames
         "refund-deposit",
         "list-unclaimed-deposits",
         "buy-bitcoin",
+        "prepare-payment-link",
         "check-lightning-address-available",
         "get-lightning-address",
         "register-lightning-address",
@@ -161,6 +162,12 @@ public static class Commands
                 Name = "buy-bitcoin",
                 Description = "Buy Bitcoin using an external provider",
                 Run = HandleBuyBitcoin
+            },
+            ["prepare-payment-link"] = new()
+            {
+                Name = "prepare-payment-link",
+                Description = "Prepare a payment link to send stablecoins to an external-chain recipient",
+                Run = HandlePreparePaymentLink
             },
             ["check-lightning-address-available"] = new()
             {
@@ -639,7 +646,7 @@ public static class Commands
         if (parsed is InputType.CrossChainAddress crossChainAddr)
         {
             var address = crossChainAddr.v1.address;
-            var route = await SelectCrossChainRoute(sdk, readline, crossChainAddr.v1);
+            var route = await SelectCrossChainRoute(sdk, readline, new CrossChainRouteFilter.Send(addressDetails: crossChainAddr.v1));
             if (route == null) return;
             paymentRequest = new PaymentRequest.CrossChain(
                 address: address,
@@ -1126,6 +1133,54 @@ public static class Commands
         Console.WriteLine(result.url);
     }
 
+    // --- prepare-payment-link ---
+
+    private static async Task HandlePreparePaymentLink(BreezSdk sdk, Func<string, string?> readline, string[] args)
+    {
+        var positional = GetPositionalArgs(args);
+        var amountStr = GetFlag(args, "-a", "--amount");
+        var feesIncluded = HasFlag(args, "--fees-included");
+        var maxSlippageStr = GetFlag(args, "--max-slippage-bps");
+
+        if (positional.Length < 1 || amountStr == null)
+        {
+            Console.WriteLine("Usage: prepare-payment-link <recipient> --amount <amount> [--fees-included] [--max-slippage-bps <bps>]");
+            return;
+        }
+
+        var recipient = positional[0];
+
+        var parsed = await sdk.Parse(recipient);
+        if (parsed is not InputType.CrossChainAddress crossChainAddr)
+        {
+            Console.Error.WriteLine("Recipient must be a cross-chain (EVM/Solana/Tron) address");
+            return;
+        }
+
+        var addressDetails = crossChainAddr.v1;
+        var address = addressDetails.address;
+        var filter = new CrossChainRouteFilter.PaymentLink(addressDetails: addressDetails);
+        var route = await SelectCrossChainRoute(sdk, readline, filter);
+        if (route == null) return;
+
+        FeePolicy? feePolicy = feesIncluded ? FeePolicy.FeesIncluded : null;
+
+        var response = await sdk.PreparePaymentLink(request: new PreparePaymentLinkRequest(
+            address: address,
+            route: route,
+            amount: BigInteger.Parse(amountStr),
+            feePolicy: feePolicy,
+            maxSlippageBps: ParseOptionalUint(maxSlippageStr)
+        ));
+
+        Console.WriteLine("Open this URL in a browser to complete the purchase:");
+        Console.WriteLine(response.url);
+        var serviceFeeDenom = response.serviceFeeAsset ?? "sats";
+        Console.WriteLine(
+            $"Deposit ~{response.amountSats} sats; recipient receives ~{response.estimatedOut} {response.asset}, " +
+            $"service fee {response.serviceFeeAmount} {serviceFeeDenom}, expires {response.expiresAt}");
+    }
+
     // --- check-lightning-address-available ---
 
     private static async Task HandleCheckLightningAddress(BreezSdk sdk, Func<string, string?> readline, string[] args)
@@ -1469,9 +1524,8 @@ public static class Commands
     private static async Task<CrossChainRoutePair?> SelectCrossChainRoute(
         BreezSdk sdk,
         Func<string, string?> readline,
-        CrossChainAddressDetails addressDetails)
+        CrossChainRouteFilter filter)
     {
-        var filter = new CrossChainRouteFilter.Send(addressDetails: addressDetails);
         var routes = await sdk.GetCrossChainRoutes(filter: filter);
         if (routes.Length == 0)
         {

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
@@ -80,6 +80,7 @@ Once the CLI is running, type `help` to see all available commands:
 - `refund-deposit` — Refund an on-chain deposit
 - `list-unclaimed-deposits` — List unclaimed deposits
 - `buy-bitcoin` — Get MoonPay URL to buy Bitcoin
+- `prepare-payment-link` — Prepare a payment link (USDC/USDT to EVM/Solana/Tron)
 - `check-lightning-address-available` — Check username availability
 - `get-lightning-address` — Get registered lightning address
 - `register-lightning-address` — Register a lightning address

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -26,6 +26,7 @@ const commandNames = [
   'refund-deposit',
   'list-unclaimed-deposits',
   'buy-bitcoin',
+  'prepare-payment-link',
   'check-lightning-address-available',
   'get-lightning-address',
   'register-lightning-address',
@@ -69,6 +70,10 @@ Map<String, CommandEntry> buildCommandRegistry() {
     'refund-deposit': CommandEntry('Refund an on-chain deposit', _handleRefundDeposit),
     'list-unclaimed-deposits': CommandEntry('List unclaimed on-chain deposits', _handleListUnclaimedDeposits),
     'buy-bitcoin': CommandEntry('Buy Bitcoin using an external provider', _handleBuyBitcoin),
+    'prepare-payment-link': CommandEntry(
+      'Prepare a payment link to send USDC/USDT to an external-chain recipient',
+      _handlePreparePaymentLink,
+    ),
     'check-lightning-address-available': CommandEntry(
       'Check if a lightning address username is available',
       _handleCheckLightningAddressAvailable,
@@ -428,7 +433,10 @@ Future<void> _handlePay(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args
   if (parsed is InputType_CrossChainAddress) {
     final addressDetails = parsed.field0;
     final address = addressDetails.address;
-    final route = await _selectCrossChainRoute(sdk, addressDetails);
+    final route = await _selectCrossChainRoute(
+      sdk,
+      CrossChainRouteFilter.send(addressDetails: addressDetails),
+    );
     if (route == null) return;
     paymentRequest = PaymentRequest.crossChain(
       address: address,
@@ -888,6 +896,64 @@ Future<void> _handleBuyBitcoin(BreezSdk sdk, TokenIssuer tokenIssuer, List<Strin
   print(result.url);
 }
 
+// --- prepare-payment-link ---
+
+Future<void> _handlePreparePaymentLink(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
+  final parser =
+      _parser('prepare-payment-link')
+        ..addOption(
+          'amount',
+          mandatory: true,
+          help: 'Amount in stablecoin base units (6 decimals for USDC/USDT)',
+        )
+        ..addFlag('fees-included', defaultsTo: false, help: 'Deduct fees from the amount')
+        ..addOption('max-slippage-bps', help: 'Maximum slippage in basis points');
+  final results = _parseArgs(parser, args, 'prepare-payment-link <recipient> --amount <amount> [options]');
+  if (results == null) return;
+
+  if (results.rest.isEmpty) {
+    print('Usage: prepare-payment-link <recipient> --amount <amount> [options]');
+    return;
+  }
+  final recipient = results.rest.first;
+  final amount = BigInt.parse(results.option('amount')!);
+  final feesIncluded = results.flag('fees-included');
+  final maxSlippageBpsStr = results.option('max-slippage-bps');
+  final maxSlippageBps = maxSlippageBpsStr != null ? int.parse(maxSlippageBpsStr) : null;
+
+  final parsed = await sdk.parse(input: recipient);
+  if (parsed is! InputType_CrossChainAddress) {
+    print('Recipient must be a cross-chain (EVM/Solana/Tron) address');
+    return;
+  }
+  final addressDetails = parsed.field0;
+  final address = addressDetails.address;
+  final route = await _selectCrossChainRoute(
+    sdk,
+    CrossChainRouteFilter.paymentLink(addressDetails: addressDetails),
+  );
+  if (route == null) return;
+
+  final feePolicy = feesIncluded ? FeePolicy.feesIncluded : null;
+
+  final response = await sdk.preparePaymentLink(
+    request: PreparePaymentLinkRequest(
+      address: address,
+      route: route,
+      amount: amount,
+      feePolicy: feePolicy,
+      maxSlippageBps: maxSlippageBps,
+    ),
+  );
+  print('Open this URL in a browser to complete the purchase:');
+  print(response.url);
+  print(
+    'Deposit ~${response.amountSats} sats; recipient receives ~${response.estimatedOut} '
+    '${response.asset}, service fee ${response.serviceFeeAmount} '
+    '${response.serviceFeeAsset ?? "sats"}, expires ${response.expiresAt}',
+  );
+}
+
 // --- check-lightning-address-available ---
 
 Future<void> _handleCheckLightningAddressAvailable(
@@ -1180,11 +1246,7 @@ SendPaymentOptions? _readPaymentOptions(SendPaymentMethod paymentMethod) {
 // Cross-chain route selection
 // ---------------------------------------------------------------------------
 
-Future<CrossChainRoutePair?> _selectCrossChainRoute(
-  BreezSdk sdk,
-  CrossChainAddressDetails addressDetails,
-) async {
-  final filter = CrossChainRouteFilter.send(addressDetails: addressDetails);
+Future<CrossChainRoutePair?> _selectCrossChainRoute(BreezSdk sdk, CrossChainRouteFilter filter) async {
   final routes = await sdk.getCrossChainRoutes(filter: filter);
   if (routes.isEmpty) {
     print('No cross-chain routes available for this address');

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/README.md
@@ -81,7 +81,7 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **Payments**: `receive`, `pay`, `lnurl-pay`, `lnurl-withdraw`, `lnurl-auth`, `claim-htlc-payment`
 
-**On-chain**: `claim-deposit`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
+**On-chain**: `claim-deposit`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`, `prepare-payment-link`
 
 **Lightning address**: `get-lightning-address`, `register-lightning-address`, `authorize-lightning-address-transfer`, `claim-lightning-address-transfer`, `delete-lightning-address`, `check-lightning-address-available`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -40,6 +40,7 @@ var CommandNames = []string{
 	"refund-deposit",
 	"list-unclaimed-deposits",
 	"buy-bitcoin",
+	"prepare-payment-link",
 	"check-lightning-address-available",
 	"get-lightning-address",
 	"register-lightning-address",
@@ -75,6 +76,7 @@ func BuildCommandRegistry() map[string]Command {
 		"refund-deposit":                       {Name: "refund-deposit", Description: "Refund an on-chain deposit", Run: handleRefundDeposit},
 		"list-unclaimed-deposits":              {Name: "list-unclaimed-deposits", Description: "List unclaimed on-chain deposits", Run: handleListUnclaimedDeposits},
 		"buy-bitcoin":                          {Name: "buy-bitcoin", Description: "Buy Bitcoin using an external provider", Run: handleBuyBitcoin},
+		"prepare-payment-link":                 {Name: "prepare-payment-link", Description: "Prepare a payment link to send stablecoins to an external-chain recipient", Run: handlePreparePaymentLink},
 		"check-lightning-address-available":    {Name: "check-lightning-address-available", Description: "Check if a lightning address username is available", Run: handleCheckLightningAddress},
 		"get-lightning-address":                {Name: "get-lightning-address", Description: "Get registered lightning address", Run: handleGetLightningAddress},
 		"register-lightning-address":           {Name: "register-lightning-address", Description: "Register a lightning address", Run: handleRegisterLightningAddress},
@@ -417,7 +419,7 @@ func handlePay(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []stri
 	if parseErr == nil {
 		if ccAddr, ok := parsed.(breez_sdk_spark.InputTypeCrossChainAddress); ok {
 			address := ccAddr.Field0.Address
-			route, err := selectCrossChainRoute(sdk, rl, ccAddr.Field0)
+			route, err := selectCrossChainRoute(sdk, rl, breez_sdk_spark.CrossChainRouteFilterSend{AddressDetails: ccAddr.Field0})
 			if err != nil {
 				return err
 			}
@@ -1079,6 +1081,82 @@ func handleBuyBitcoin(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args 
 	return nil
 }
 
+// --- prepare-payment-link ---
+
+func handlePreparePaymentLink(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []string) error {
+	fs := flag.NewFlagSet("prepare-payment-link", flag.ContinueOnError)
+	amountStr := fs.String("amount", "", "Amount in the destination stablecoin's base units (6 decimals for USDC/USDT)")
+	feesIncluded := fs.Bool("fees-included", false, "Deduct fees from the amount instead of adding them on top")
+	maxSlippageStr := fs.String("max-slippage-bps", "", "Maximum slippage in basis points")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	positional := fs.Args()
+	if len(positional) < 1 || *amountStr == "" {
+		fmt.Println("Usage: prepare-payment-link <recipient> --amount <amount> [--fees-included] [--max-slippage-bps <bps>]")
+		return nil
+	}
+	recipient := positional[0]
+
+	parsed, err := sdk.Parse(recipient)
+	if err = liftError(err); err != nil {
+		return err
+	}
+	ccAddr, ok := parsed.(breez_sdk_spark.InputTypeCrossChainAddress)
+	if !ok {
+		return fmt.Errorf("recipient must be a cross-chain (EVM/Solana/Tron) address")
+	}
+	addressDetails := ccAddr.Field0
+	address := addressDetails.Address
+
+	route, err := selectCrossChainRoute(sdk, rl, breez_sdk_spark.CrossChainRouteFilterPaymentLink{AddressDetails: addressDetails})
+	if err != nil {
+		return err
+	}
+
+	amount, ok := new(big.Int).SetString(*amountStr, 10)
+	if !ok {
+		return fmt.Errorf("invalid amount: %s", *amountStr)
+	}
+
+	req := breez_sdk_spark.PreparePaymentLinkRequest{
+		Address: address,
+		Route:   route,
+		Amount:  amount,
+	}
+
+	if *feesIncluded {
+		fp := breez_sdk_spark.FeePolicyFeesIncluded
+		req.FeePolicy = &fp
+	}
+
+	if *maxSlippageStr != "" {
+		val, err := strconv.ParseUint(*maxSlippageStr, 10, 32)
+		if err != nil {
+			return fmt.Errorf("invalid max slippage: %s", *maxSlippageStr)
+		}
+		val32 := uint32(val)
+		req.MaxSlippageBps = &val32
+	}
+
+	response, err := sdk.PreparePaymentLink(req)
+	if err = liftError(err); err != nil {
+		return err
+	}
+
+	fmt.Println("Open this URL in a browser to complete the purchase:")
+	fmt.Println(response.Url)
+	serviceFeeAsset := "sats"
+	if response.ServiceFeeAsset != nil {
+		serviceFeeAsset = *response.ServiceFeeAsset
+	}
+	fmt.Printf("Deposit ~%v sats; recipient receives ~%v %s, service fee %v %s, expires %s\n",
+		response.AmountSats, response.EstimatedOut, response.Asset,
+		response.ServiceFeeAmount, serviceFeeAsset, response.ExpiresAt)
+	return nil
+}
+
 // --- check-lightning-address-available ---
 
 func handleCheckLightningAddress(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []string) error {
@@ -1367,8 +1445,7 @@ func handleGetSparkStatus(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, _
 // selectCrossChainRoute — fetch routes and prompt the user to pick one
 // ---------------------------------------------------------------------------
 
-func selectCrossChainRoute(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, addressDetails breez_sdk_spark.CrossChainAddressDetails) (breez_sdk_spark.CrossChainRoutePair, error) {
-	var filter breez_sdk_spark.CrossChainRouteFilter = breez_sdk_spark.CrossChainRouteFilterSend{AddressDetails: addressDetails}
+func selectCrossChainRoute(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, filter breez_sdk_spark.CrossChainRouteFilter) (breez_sdk_spark.CrossChainRoutePair, error) {
 	routes, err := sdk.GetCrossChainRoutes(filter)
 	if err = liftError(err); err != nil {
 		return breez_sdk_spark.CrossChainRoutePair{}, err

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -31,6 +31,7 @@ val COMMAND_NAMES = listOf(
     "refund-deposit",
     "list-unclaimed-deposits",
     "buy-bitcoin",
+    "prepare-payment-link",
     "check-lightning-address-available",
     "get-lightning-address",
     "register-lightning-address",
@@ -68,6 +69,7 @@ fun buildCommandRegistry(): Map<String, CliCommand> {
         "refund-deposit" to CliCommand("refund-deposit", "Refund an on-chain deposit", ::handleRefundDeposit),
         "list-unclaimed-deposits" to CliCommand("list-unclaimed-deposits", "List unclaimed on-chain deposits", ::handleListUnclaimedDeposits),
         "buy-bitcoin" to CliCommand("buy-bitcoin", "Buy Bitcoin via an external provider", ::handleBuyBitcoin),
+        "prepare-payment-link" to CliCommand("prepare-payment-link", "Prepare a payment link for cross-chain stablecoin transfer", ::handlePreparePaymentLink),
         "check-lightning-address-available" to CliCommand("check-lightning-address-available", "Check if a lightning address username is available", ::handleCheckLightningAddress),
         "get-lightning-address" to CliCommand("get-lightning-address", "Get registered lightning address", ::handleGetLightningAddress),
         "register-lightning-address" to CliCommand("register-lightning-address", "Register a lightning address", ::handleRegisterLightningAddress),
@@ -456,7 +458,7 @@ suspend fun handlePay(sdk: BreezSdk, reader: LineReader, args: List<String>) {
         is InputType.CrossChainAddress -> {
             val addressDetails = parsed.v1
             val address = addressDetails.address
-            val route = selectCrossChainRoute(sdk, reader, addressDetails)
+            val route = selectCrossChainRoute(sdk, reader, CrossChainRouteFilter.Send(addressDetails = addressDetails))
             PaymentRequest.CrossChain(
                 address = address,
                 route = route,
@@ -904,6 +906,59 @@ suspend fun handleBuyBitcoin(sdk: BreezSdk, reader: LineReader, args: List<Strin
     println(result.url)
 }
 
+// --- prepare-payment-link ---
+
+suspend fun handlePreparePaymentLink(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    val fp = FlagParser(args)
+    val amountStr = fp.getString("amount")
+    val feesIncluded = fp.hasFlag("fees-included")
+    val maxSlippageBps = fp.getUInt("max-slippage-bps")
+
+    if (fp.positional.isEmpty() || amountStr == null) {
+        println("Usage: prepare-payment-link <recipient> --amount <amount> [--fees-included] [--max-slippage-bps <bps>]")
+        return
+    }
+
+    val recipient = fp.positional[0]
+    val amount = try {
+        BigInteger.parseString(amountStr)
+    } catch (e: Exception) {
+        println("Invalid amount: $amountStr")
+        return
+    }
+
+    val parsed = sdk.parse(recipient)
+    val addressDetails = when (parsed) {
+        is InputType.CrossChainAddress -> parsed.v1
+        else -> {
+            println("Error: Recipient must be a cross-chain (EVM/Solana/Tron) address")
+            return
+        }
+    }
+
+    val address = addressDetails.address
+    val route = selectCrossChainRoute(sdk, reader, CrossChainRouteFilter.PaymentLink(addressDetails = addressDetails))
+
+    val feePolicy = if (feesIncluded) FeePolicy.FEES_INCLUDED else null
+
+    val response = sdk.preparePaymentLink(
+        PreparePaymentLinkRequest(
+            address = address,
+            route = route,
+            amount = amount,
+            feePolicy = feePolicy,
+            maxSlippageBps = maxSlippageBps,
+        )
+    )
+    println("Open this URL in a browser to complete the purchase:")
+    println(response.url)
+    println(
+        "Deposit ~${response.amountSats} sats; recipient receives ~${response.estimatedOut} ${response.asset}, " +
+        "service fee ${response.serviceFeeAmount} ${response.serviceFeeAsset ?: "sats"}, " +
+        "expires ${response.expiresAt}"
+    )
+}
+
 // --- check-lightning-address-available ---
 
 suspend fun handleCheckLightningAddress(sdk: BreezSdk, reader: LineReader, args: List<String>) {
@@ -1114,9 +1169,8 @@ suspend fun handleGetSparkStatus(sdk: BreezSdk, reader: LineReader, args: List<S
 suspend fun selectCrossChainRoute(
     sdk: BreezSdk,
     reader: LineReader,
-    addressDetails: CrossChainAddressDetails,
+    filter: CrossChainRouteFilter,
 ): CrossChainRoutePair {
-    val filter = CrossChainRouteFilter.Send(addressDetails = addressDetails)
     val routes = sdk.getCrossChainRoutes(filter)
     if (routes.isEmpty()) {
         throw Exception("No cross-chain routes available for this address")

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -35,6 +35,7 @@ from breez_sdk_spark import (
     PaymentStatus,
     PaymentType,
     PrepareLnurlPayRequest,
+    PreparePaymentLinkRequest,
     PrepareSendBatchRequest,
     PrepareSendPaymentRequest,
     ReceivePaymentMethod,
@@ -74,6 +75,7 @@ COMMAND_NAMES = [
     "refund-deposit",
     "list-unclaimed-deposits",
     "buy-bitcoin",
+    "prepare-payment-link",
     "check-lightning-address-available",
     "get-lightning-address",
     "register-lightning-address",
@@ -349,7 +351,9 @@ async def _handle_pay(sdk, _token_issuer, session, args):
     if isinstance(parsed, InputType.CROSS_CHAIN_ADDRESS):
         address_details = parsed[0]
         address = address_details.address
-        route = await _select_cross_chain_route(sdk, session, address_details)
+        route = await _select_cross_chain_route(
+            sdk, session, CrossChainRouteFilter.SEND(address_details=address_details),
+        )
         payment_request = PaymentRequest.CROSS_CHAIN(
             address=address,
             route=route,
@@ -764,6 +768,50 @@ async def _handle_buy_bitcoin(sdk, _token_issuer, _session, args):
     print(result.url)
 
 
+# --- prepare-payment-link ---
+
+def _build_prepare_payment_link_parser():
+    p = _parser("prepare-payment-link",
+                "Prepare a payment link to send USDC/USDT to an external-chain recipient via a fiat rail")
+    p.add_argument("recipient", help="Recipient address on the destination chain (EVM/Solana/Tron)")
+    p.add_argument("--amount", type=int, required=True,
+                   help="Amount in the destination stablecoin's base units (6 decimals for USDC/USDT)")
+    p.add_argument("--fees-included", action="store_true", default=False,
+                   help="Deduct fees from the amount instead of adding them on top")
+    p.add_argument("--max-slippage-bps", type=int, default=None,
+                   help="Maximum slippage in basis points")
+    return p
+
+async def _handle_prepare_payment_link(sdk, _token_issuer, session, args):
+    parsed = await sdk.parse(input=args.recipient)
+    if not isinstance(parsed, InputType.CROSS_CHAIN_ADDRESS):
+        print("Recipient must be a cross-chain (EVM/Solana/Tron) address")
+        return
+    address_details = parsed[0]
+    address = address_details.address
+    route_filter = CrossChainRouteFilter.PAYMENT_LINK(address_details=address_details)
+    route = await _select_cross_chain_route(sdk, session, route_filter)
+    fee_policy = FeePolicy.FEES_INCLUDED if args.fees_included else None
+    response = await sdk.prepare_payment_link(
+        request=PreparePaymentLinkRequest(
+            address=address,
+            route=route,
+            amount=args.amount,
+            fee_policy=fee_policy,
+            max_slippage_bps=args.max_slippage_bps,
+        )
+    )
+    print("Open this URL in a browser to complete the purchase:")
+    print(response.url)
+    service_fee_asset = response.service_fee_asset if response.service_fee_asset else "sats"
+    print(
+        f"Deposit ~{response.amount_sats} sats; "
+        f"recipient receives ~{response.estimated_out} {response.asset}, "
+        f"service fee {response.service_fee_amount} {service_fee_asset}, "
+        f"expires {response.expires_at}"
+    )
+
+
 # --- check-lightning-address-available ---
 
 def _build_check_lightning_address_available_parser():
@@ -994,9 +1042,8 @@ def _maybe_truncate_address(addr):
     return f" ({addr})"
 
 
-async def _select_cross_chain_route(sdk, session, address_details):
+async def _select_cross_chain_route(sdk, session, route_filter):
     """Fetch cross-chain routes and prompt the user to select one."""
-    route_filter = CrossChainRouteFilter.SEND(address_details=address_details)
     routes = await sdk.get_cross_chain_routes(filter=route_filter)
     if not routes:
         raise ValueError("No cross-chain routes available for this address")
@@ -1129,6 +1176,7 @@ def build_command_registry():
         "refund-deposit": (_build_refund_deposit_parser(), _handle_refund_deposit),
         "list-unclaimed-deposits": (_build_list_unclaimed_deposits_parser(), _handle_list_unclaimed_deposits),
         "buy-bitcoin": (_build_buy_bitcoin_parser(), _handle_buy_bitcoin),
+        "prepare-payment-link": (_build_prepare_payment_link_parser(), _handle_prepare_payment_link),
         "check-lightning-address-available": (_build_check_lightning_address_available_parser(), _handle_check_lightning_address_available),
         "get-lightning-address": (_build_get_lightning_address_parser(), _handle_get_lightning_address),
         "register-lightning-address": (_build_register_lightning_address_parser(), _handle_register_lightning_address),

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -4,7 +4,7 @@
  * Mirrors ALL commands from the Rust CLI:
  *   get-info, get-payment, sync, list-payments, receive, pay, pay-batch, lnurl-pay,
  *   lnurl-withdraw, lnurl-auth, claim-htlc-payment, claim-deposit, parse,
- *   refund-deposit, list-unclaimed-deposits, buy-bitcoin,
+ *   refund-deposit, list-unclaimed-deposits, buy-bitcoin, prepare-payment-link,
  *   check-lightning-address-available, get-lightning-address,
  *   register-lightning-address, delete-lightning-address, list-fiat-currencies,
  *   list-fiat-rates, recommended-fees, get-tokens-metadata,
@@ -168,6 +168,7 @@ export const COMMAND_NAMES = [
   'refund-deposit',
   'list-unclaimed-deposits',
   'buy-bitcoin',
+  'prepare-payment-link',
   'check-lightning-address-available',
   'get-lightning-address',
   'register-lightning-address',
@@ -213,6 +214,7 @@ export function buildCommandRegistry(): Map<string, CommandDef> {
     { name: 'refund-deposit', description: 'Refund an on-chain deposit', run: handleRefundDeposit },
     { name: 'list-unclaimed-deposits', description: 'List unclaimed on-chain deposits', run: handleListUnclaimedDeposits },
     { name: 'buy-bitcoin', description: 'Buy Bitcoin via external provider', run: handleBuyBitcoin },
+    { name: 'prepare-payment-link', description: 'Prepare a payment link to send USDC/USDT to an external-chain recipient', run: handlePreparePaymentLink },
     { name: 'check-lightning-address-available', description: 'Check if a lightning address username is available', run: handleCheckLightningAddress },
     { name: 'get-lightning-address', description: 'Get registered lightning address', run: handleGetLightningAddress },
     { name: 'register-lightning-address', description: 'Register a lightning address', run: handleRegisterLightningAddress },
@@ -592,7 +594,11 @@ async function handlePay(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterf
   const parsed = await sdk.parse(paymentRequestInput)
   if (parsed.tag === InputType_Tags.CrossChainAddress) {
     const addressDetails: CrossChainAddressDetails = parsed.inner[0]
-    const routeResult = await selectCrossChainRoute(sdk, addressDetails, routeIndex)
+    const routeResult = await selectCrossChainRoute(
+      sdk,
+      new CrossChainRouteFilter.Send({ addressDetails }),
+      routeIndex,
+    )
     lines.push(routeResult.message)
     paymentRequest = new PaymentRequest.CrossChain({
       address: addressDetails.address,
@@ -1061,6 +1067,57 @@ async function handleBuyBitcoin(sdk: BreezSdkInterface, _tokenIssuer: TokenIssue
   return lines.join('\n')
 }
 
+// --- prepare-payment-link ---
+
+async function handlePreparePaymentLink(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
+  const positional = args.filter(a => !a.startsWith('-'))
+  if (positional.length < 1) {
+    return 'Usage: prepare-payment-link <recipient> --amount <amount> [--fees-included] [--max-slippage-bps <bps>] [--route <n>]'
+  }
+
+  const recipient = positional[0]
+  const amountStr = parseFlag(args, '--amount')
+  if (!amountStr) {
+    return 'Error: --amount is required'
+  }
+  const amount = BigInt(amountStr)
+  const feesIncluded = hasFlag(args, '--fees-included')
+  const maxSlippageBps = parseNumericFlag(args, '--max-slippage-bps')
+  const routeIndex = parseNumericFlag(args, '--route')
+
+  const parsed = await sdk.parse(recipient)
+  if (parsed.tag !== InputType_Tags.CrossChainAddress) {
+    return 'Error: Recipient must be a cross-chain (EVM/Solana/Tron) address'
+  }
+  const addressDetails = parsed.inner[0]
+
+  const routeResult = await selectCrossChainRoute(
+    sdk,
+    new CrossChainRouteFilter.PaymentLink({ addressDetails }),
+    routeIndex,
+  )
+
+  const feePolicy = feesIncluded ? FeePolicy.FeesIncluded : undefined
+
+  const response = await sdk.preparePaymentLink({
+    address: addressDetails.address,
+    route: routeResult.route,
+    amount,
+    feePolicy,
+    maxSlippageBps,
+  })
+
+  const lines = [routeResult.message]
+  lines.push('Open this URL in a browser to complete the purchase:')
+  lines.push(response.url)
+  const serviceFeeAsset = response.serviceFeeAsset ?? 'sats'
+  lines.push(
+    `Deposit ~${response.amountSats} sats; recipient receives ~${response.estimatedOut} ${response.asset}, ` +
+    `service fee ${response.serviceFeeAmount} ${serviceFeeAsset}, expires ${response.expiresAt}`
+  )
+  return lines.join('\n')
+}
+
 // --- check-lightning-address-available ---
 
 async function handleCheckLightningAddress(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
@@ -1301,10 +1358,9 @@ function maybeTruncateAddress(addr: string | undefined | null): string {
 
 async function selectCrossChainRoute(
   sdk: BreezSdkInterface,
-  addressDetails: CrossChainAddressDetails,
+  filter: InstanceType<typeof CrossChainRouteFilter.Send> | InstanceType<typeof CrossChainRouteFilter.PaymentLink>,
   preferredIndex: number | undefined,
 ): Promise<{ route: CrossChainRoutePair; message: string }> {
-  const filter = new CrossChainRouteFilter.Send({ addressDetails })
   const routes: CrossChainRoutePair[] = await sdk.getCrossChainRoutes(filter)
 
   if (routes.length === 0) {

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -88,6 +88,7 @@ let commandNames: [String] = [
     "refund-deposit",
     "list-unclaimed-deposits",
     "buy-bitcoin",
+    "prepare-payment-link",
     "check-lightning-address-available",
     "get-lightning-address",
     "register-lightning-address",
@@ -124,6 +125,7 @@ func buildCommandRegistry() -> [String: CommandEntry] {
         "refund-deposit":                    CommandEntry(name: "refund-deposit", description: "Refund an on-chain deposit", run: handleRefundDeposit),
         "list-unclaimed-deposits":           CommandEntry(name: "list-unclaimed-deposits", description: "List unclaimed on-chain deposits", run: handleListUnclaimedDeposits),
         "buy-bitcoin":                       CommandEntry(name: "buy-bitcoin", description: "Buy Bitcoin via MoonPay", run: handleBuyBitcoin),
+        "prepare-payment-link":              CommandEntry(name: "prepare-payment-link", description: "Prepare a payment link for cross-chain stablecoin send", run: handlePreparePaymentLink),
         "check-lightning-address-available": CommandEntry(name: "check-lightning-address-available", description: "Check if a lightning address username is available", run: handleCheckLightningAddress),
         "get-lightning-address":             CommandEntry(name: "get-lightning-address", description: "Get registered lightning address", run: handleGetLightningAddress),
         "register-lightning-address":        CommandEntry(name: "register-lightning-address", description: "Register a lightning address", run: handleRegisterLightningAddress),
@@ -474,7 +476,7 @@ func handlePay(_ sdk: BreezSdk, _ args: [String]) async throws {
     let parsed = try? await sdk.parse(input: paymentRequestStr)
     if case let .crossChainAddress(v1) = parsed {
         let address = v1.address
-        let route = try await selectCrossChainRoute(sdk: sdk, addressDetails: v1)
+        let route = try await selectCrossChainRoute(sdk: sdk, filter: .send(addressDetails: v1))
         paymentRequest = .crossChain(
             address: address,
             route: route,
@@ -885,6 +887,48 @@ func handleBuyBitcoin(_ sdk: BreezSdk, _ args: [String]) async throws {
     print(result.url)
 }
 
+// --- prepare-payment-link ---
+
+func handlePreparePaymentLink(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let fp = FlagParser(args)
+    guard let recipient = fp.positional.first,
+          let amountStr = fp.get("amount"),
+          let amount = BInt(amountStr) else {
+        print("Usage: prepare-payment-link <recipient> --amount <amount> [--fees-included] [--max-slippage-bps <bps>]")
+        return
+    }
+
+    let feesIncluded = fp.has("fees-included")
+    let maxSlippageBps = fp.get("max-slippage-bps").flatMap { UInt32($0) }
+
+    let parsed = try await sdk.parse(input: recipient)
+    guard case let .crossChainAddress(v1) = parsed else {
+        print("Error: Recipient must be a cross-chain (EVM/Solana/Tron) address")
+        return
+    }
+
+    let address = v1.address
+    let route = try await selectCrossChainRoute(
+        sdk: sdk,
+        filter: .paymentLink(addressDetails: v1)
+    )
+
+    let feePolicy: FeePolicy? = feesIncluded ? .feesIncluded : nil
+
+    let response = try await sdk.preparePaymentLink(
+        request: PreparePaymentLinkRequest(
+            address: address,
+            route: route,
+            amount: amount,
+            feePolicy: feePolicy,
+            maxSlippageBps: maxSlippageBps
+        ))
+
+    print("Open this URL in a browser to complete the purchase:")
+    print(response.url)
+    print("Deposit ~\(response.amountSats) sats; recipient receives ~\(response.estimatedOut) \(response.asset), service fee \(response.serviceFeeAmount) \(response.serviceFeeAsset ?? "sats"), expires \(response.expiresAt)")
+}
+
 // --- check-lightning-address-available ---
 
 func handleCheckLightningAddress(_ sdk: BreezSdk, _ args: [String]) async throws {
@@ -1096,9 +1140,8 @@ func handleGetSparkStatus(_ sdk: BreezSdk, _ args: [String]) async throws {
 
 func selectCrossChainRoute(
     sdk: BreezSdk,
-    addressDetails: CrossChainAddressDetails
+    filter: CrossChainRouteFilter
 ) async throws -> CrossChainRoutePair {
-    let filter = CrossChainRouteFilter.send(addressDetails: addressDetails)
     let routes = try await sdk.getCrossChainRoutes(filter: filter)
     if routes.isEmpty {
         throw NSError(domain: "BreezCLI", code: 1, userInfo: [

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -32,6 +32,7 @@ const COMMAND_NAMES = [
   'refund-deposit',
   'list-unclaimed-deposits',
   'buy-bitcoin',
+  'prepare-payment-link',
   'check-lightning-address-available',
   'get-lightning-address',
   'register-lightning-address',
@@ -333,7 +334,7 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
       const parsed = await sdk.parse(options.paymentRequest).catch(() => null)
       if (parsed && parsed.type === 'crossChainAddress') {
         const address = parsed.address
-        const route = await selectCrossChainRoute(sdk, rl, parsed)
+        const route = await selectCrossChainRoute(sdk, rl, { type: 'send', addressDetails: parsed })
         paymentRequest = {
           type: 'crossChain',
           address,
@@ -712,6 +713,39 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
       console.log(value.url)
     })
 
+  // --- prepare-payment-link ---
+  program
+    .command('prepare-payment-link')
+    .description('Prepare a payment link to send USDC/USDT to an external-chain recipient via a fiat rail')
+    .argument('<recipient>', 'Recipient address on the destination chain (EVM/Solana/Tron)')
+    .requiredOption('-a, --amount <number>', 'Amount in the destination stablecoin\'s base units (6 decimals for USDC/USDT)')
+    .option('--fees-included', 'Deduct fees from the amount instead of adding them on top', false)
+    .option('--max-slippage-bps <bps>', 'Maximum slippage in basis points', parseInt)
+    .action(async (recipient, options) => {
+      const sdk = getSdk()
+      const parsed = await sdk.parse(recipient)
+      if (!parsed || parsed.type !== 'crossChainAddress') {
+        throw new Error('Recipient must be a cross-chain (EVM/Solana/Tron) address')
+      }
+      const address = parsed.address
+      const route = await selectCrossChainRoute(sdk, rl, { type: 'paymentLink', addressDetails: parsed })
+      const feePolicy = options.feesIncluded ? 'feesIncluded' : undefined
+      const response = await sdk.preparePaymentLink({
+        address,
+        route,
+        amount: BigInt(options.amount),
+        feePolicy,
+        maxSlippageBps: options.maxSlippageBps
+      })
+      console.log('Open this URL in a browser to complete the purchase:')
+      console.log(response.url)
+      console.log(
+        `Deposit ~${response.amountSats} sats; recipient receives ~${response.estimatedOut} ${response.asset}, ` +
+        `service fee ${response.serviceFeeAmount} ${response.serviceFeeAsset || 'sats'}, ` +
+        `expires ${response.expiresAt}`
+      )
+    })
+
   // --- check-lightning-address-available ---
   program
     .command('check-lightning-address-available')
@@ -1039,8 +1073,7 @@ async function readPaymentOptions(paymentMethod, rl) {
  * Fetch cross-chain routes for an address and prompt the user to select one.
  * Auto-selects if only a single route is available.
  */
-async function selectCrossChainRoute(sdk, rl, addressDetails) {
-  const filter = { type: 'send', addressDetails }
+async function selectCrossChainRoute(sdk, rl, filter) {
   const routes = await sdk.getCrossChainRoutes(filter)
 
   if (!routes || routes.length === 0) {


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`59ffcfc`](https://github.com/breez/spark-sdk/commit/59ffcfcccb0583a594e39b4d90c38dbdf7168df8)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/32366308949)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :white_check_mark: React Native
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- Missing `prepare-payment-link` command: Rust CLI added a `PreparePaymentLink` command to create payment links for sending stablecoins to external-chain recipients; C# CLI did not have it
- `SelectCrossChainRoute` signature: Rust updated `select_cross_chain_route` to accept a `CrossChainRouteFilter` enum directly instead of `CrossChainAddressDetails`; C# still constructed the filter internally

## Applied
- Added `prepare-payment-link` to `CommandNames.All`, `BuildRegistry()`, and implemented `HandlePreparePaymentLink` handler in `Commands.cs`
- Updated `SelectCrossChainRoute` to accept `CrossChainRouteFilter` instead of `CrossChainAddressDetails`, matching the Rust refactor in `Commands.cs`
- Updated `HandlePay` cross-chain path to pass `new CrossChainRouteFilter.Send(addressDetails: ...)` to the updated `SelectCrossChainRoute` in `Commands.cs`

## Skipped
- (none)

### Dart
## Divergences
- Missing `prepare-payment-link` command in Dart CLI (new command in Rust CLI that prepares a payment link for sending USDC/USDT to EVM/Solana/Tron recipients via a fiat rail)
- `_selectCrossChainRoute` accepted `CrossChainAddressDetails` directly instead of `CrossChainRouteFilter`, which now has `Send` and `PaymentLink` variants

## Applied
- Added `prepare-payment-link` to `commandNames`, `buildCommandRegistry()`, and implemented `_handlePreparePaymentLink` handler in `commands.dart`
- Updated `_selectCrossChainRoute` signature to accept `CrossChainRouteFilter` instead of `CrossChainAddressDetails` in `commands.dart`
- Updated `_handlePay` to construct `CrossChainRouteFilter.send(addressDetails: addressDetails)` before calling `_selectCrossChainRoute` in `commands.dart`
- Added `prepare-payment-link` to the command list in `README.md`

## Skipped
- (none)

### Go
## Divergences
- New `prepare-payment-link` command in Rust CLI missing from Go CLI
- `selectCrossChainRoute` in Go hardcoded `CrossChainRouteFilterSend` instead of accepting a `CrossChainRouteFilter` parameter (needed for the new `PaymentLink` filter variant)
- Go README missing `prepare-payment-link` in Available Commands section

## Applied
- Added `handlePreparePaymentLink` handler with `--amount`, `--fees-included`, `--max-slippage-bps` flags (`commands.go`)
- Added `prepare-payment-link` to `CommandNames` and `BuildCommandRegistry()` (`commands.go`)
- Changed `selectCrossChainRoute` to accept `breez_sdk_spark.CrossChainRouteFilter` instead of `CrossChainAddressDetails` (`commands.go`)
- Updated `handlePay` to pass `CrossChainRouteFilterSend{AddressDetails: ...}` to `selectCrossChainRoute` (`commands.go`)
- Added `prepare-payment-link` to the On-chain commands list in `README.md`

## Skipped
- (none)

### Kotlin
## Divergences
- Missing `prepare-payment-link` command in Kotlin CLI (new command in Rust CLI)
- `selectCrossChainRoute` in Kotlin accepted `CrossChainAddressDetails` directly instead of `CrossChainRouteFilter` (Rust changed signature to accept the enum)

## Applied
- Added `prepare-payment-link` to `COMMAND_NAMES`, `buildCommandRegistry()`, and implemented `handlePreparePaymentLink` in `Commands.kt`
- Updated `selectCrossChainRoute` to accept `CrossChainRouteFilter` instead of `CrossChainAddressDetails` in `Commands.kt`
- Updated `handlePay` call site to pass `CrossChainRouteFilter.Send(addressDetails = addressDetails)` in `Commands.kt`

## Skipped
- (none)

### Python
## Divergences
- Missing `prepare-payment-link` command in Python CLI (present in Rust CLI since the `PreparePaymentLink` variant was added)
- `_select_cross_chain_route` in Python took `address_details` and constructed `CrossChainRouteFilter.SEND` internally, while Rust now accepts a `CrossChainRouteFilter` directly (needed for `PaymentLink` vs `Send` variants)

## Applied
- Added `PreparePaymentLinkRequest` import to `commands.py`
- Added `prepare-payment-link` to `COMMAND_NAMES` in `commands.py`
- Added `_build_prepare_payment_link_parser()` and `_handle_prepare_payment_link()` in `commands.py`
- Added `prepare-payment-link` entry to `build_command_registry()` in `commands.py`
- Updated `_select_cross_chain_route()` to accept `route_filter` parameter directly instead of `address_details` in `commands.py`
- Updated `_handle_pay()` call site to pass `CrossChainRouteFilter.SEND(address_details=address_details)` to the updated `_select_cross_chain_route()` in `commands.py`

## Skipped
- (none)

### React Native
## Divergences
- Missing `prepare-payment-link` command in React Native CLI (present in Rust CLI)
- `selectCrossChainRoute` hardcoded `CrossChainRouteFilter.Send` instead of accepting a filter parameter (Rust CLI now passes `CrossChainRouteFilter::Send` or `CrossChainRouteFilter::PaymentLink`)

## Applied
- Added `prepare-payment-link` command with handler, registry entry, and COMMAND_NAMES entry in `commands.ts`
- Refactored `selectCrossChainRoute` to accept a `CrossChainRouteFilter` parameter instead of building `CrossChainRouteFilter.Send` internally, matching the Rust CLI's `select_cross_chain_route(sdk, rl, filter)` signature
- Updated `handlePay` to pass `new CrossChainRouteFilter.Send({ addressDetails })` to the refactored `selectCrossChainRoute`

## Skipped
- (none)

### Swift
## Divergences
- New `PreparePaymentLink` command in Rust CLI with no equivalent in Swift CLI
- `select_cross_chain_route` in Rust now accepts `CrossChainRouteFilter` enum (supporting `.send` and `.paymentLink` variants) instead of `CrossChainAddressDetails` directly; Swift `selectCrossChainRoute` was still hardcoded to `.send`

## Applied
- Added `prepare-payment-link` command handler, registry entry, and command name in `Commands.swift`
- Updated `selectCrossChainRoute` to accept `CrossChainRouteFilter` parameter instead of `CrossChainAddressDetails` in `Commands.swift`
- Updated `handlePay` to pass `.send(addressDetails:)` explicitly to the updated `selectCrossChainRoute` in `Commands.swift`

## Skipped
- (none)

### TypeScript
## Divergences
- Missing `prepare-payment-link` command in TypeScript CLI (new in Rust CLI)
- `selectCrossChainRoute` accepted raw `addressDetails` instead of a `CrossChainRouteFilter` object, so it always constructed a `send` filter internally; Rust now passes the filter variant from the caller

## Applied
- Added `prepare-payment-link` command with `<recipient>`, `--amount`, `--fees-included`, and `--max-slippage-bps` options (`commands.js`)
- Updated `selectCrossChainRoute` to accept a filter object directly instead of wrapping `addressDetails` in a hardcoded `send` filter (`commands.js`)
- Updated `pay` command to pass `{ type: 'send', addressDetails: parsed }` to `selectCrossChainRoute` (`commands.js`)
- Added `prepare-payment-link` to `COMMAND_NAMES` for tab completion (`commands.js`)

## Skipped
- (none)

</details>

All languages synced cleanly. This PR merges automatically once the gating CI checks pass (integration test checks excluded).