### PR TITLE
Remove the use of axum_extra::extract::Host

### DIFF
--- a/crates/breez-sdk/lnurl/Cargo.lock
+++ b/crates/breez-sdk/lnurl/Cargo.lock
@@ -389,28 +389,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-extra"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
-dependencies = [
- "axum 0.8.4",
- "axum-core 0.5.2",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "serde",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "axum-macros"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,7 +2105,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.8.4",
- "axum-extra",
  "base64",
  "bitcoin",
  "clap",

--- a/crates/breez-sdk/lnurl/Cargo.toml
+++ b/crates/breez-sdk/lnurl/Cargo.toml
@@ -9,7 +9,6 @@ version = "0.1.0"
 anyhow = "1.0.98"
 async-trait = "0.1.88"
 axum = { version = "0.8.4", features = ["macros"] }
-axum-extra = { version = "0.10.1" }
 base64 = "0.22.1"
 bitcoin = { version = "0.32.6", features = ["serde"] }
 clap = { version = "4.5.40", features = ["derive"] }

--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -1493,7 +1493,7 @@ where
             return Ok(Host(host.to_string()));
         }
 
-        if let Some(authority) = parts.uri.authority().map(|a| a.as_str()) {
+        if let Some(authority) = parts.uri.authority() {
             return Ok(Host(authority.to_string()));
         }
 

--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -1,11 +1,10 @@
 use axum::{
     Extension, Json,
     body::Bytes,
-    extract::{Path, Query},
-    http::{HeaderMap, StatusCode},
+    extract::{FromRequestParts, Path, Query},
+    http::{HeaderMap, StatusCode, request::Parts},
     response::IntoResponse,
 };
-use axum_extra::extract::Host;
 use bitcoin::{
     bech32,
     hashes::{Hash, HashEngine, Hmac, HmacEngine, sha256},
@@ -1479,6 +1478,30 @@ async fn sanitize_domain<DB>(
     }
     warn!("domain not allowed: {}", domain);
     Err((StatusCode::NOT_FOUND, Json(Value::String(String::new()))))
+}
+
+pub struct Host(pub String);
+
+impl<S> FromRequestParts<S> for Host
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, Json<Value>);
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        if let Some(host) = parts.headers.get("host").and_then(|h| h.to_str().ok()) {
+            return Ok(Host(host.to_string()));
+        }
+
+        if let Some(authority) = parts.uri.authority().map(|a| a.as_str()) {
+            return Ok(Host(authority.to_string()));
+        }
+
+        Err((
+            StatusCode::BAD_REQUEST,
+            Json(Value::String("missing host header".into())),
+        ))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
It's deprecated and we can always assume that Host is the right host