### PR TITLE
Docs: publish per-page markdown and fix version substitution

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Set latest tag in book
         working-directory: docs/breez-sdk/src/guide
         run: |
-          sed -i.bak "s/{VERSION}/${{ steps.get-latest-tag.outputs.tag }}/" install.md
-          rm -f install.md.bak
+          sed -i.bak "s/{VERSION}/${{ steps.get-latest-tag.outputs.tag }}/" install*.md
+          rm -f install*.md.bak
 
       - name: Build mdbook
         working-directory: docs/breez-sdk

--- a/docs/breez-sdk/book.toml
+++ b/docs/breez-sdk/book.toml
@@ -28,6 +28,10 @@ renderer = ["html"]
 [preprocessor.variables.variables]
 api_key_form_uri = "https://breez.technology/request-api-key/#contact-us-form-sdk"
 
+# Markdown output (post-preprocessor) so each page is also published as .md,
+# making the llms.txt links resolve and giving LLMs a clean-markdown version
+[output.markdown]
+
 # Basic llmstxt.org format output
 [output.llms-txt]
 


### PR DESCRIPTION
Two fixes to the docs build, verified with a local mdbook build.

## 1. Publish a `.md` for every docs page

`book.toml` already generates `llms.txt` — an index for AI assistants — but its ~54 links point at `guide/*.md` paths that the build never writes, so every link 404s on the live site.

This enables mdbook's built-in markdown renderer (`[output.markdown]`), which runs after the snippets/variables preprocessors. The existing flatten step in `docs.yml` then merges the output into `guide/` next to the `.html` files.

Verified locally:
- 67 `.md` pages generated, zero unexpanded `{{#tabs}}`/`{{#name}}` placeholders — all code snippets present in all languages
- every `llms.txt` link has a matching file
- flatten step simulated: `guide/` ends with 67 `.html` + 67 `.md`, no collisions

Note: the web server should serve `.md` (Caddy does by default); serving them as `text/plain` would additionally let browsers display rather than download them.

## 2. `{VERSION}` substitution misses the per-language install pages

The `sed` in `docs.yml` targets `install.md`, which no longer contains placeholders — they moved to the per-language pages when install was split up. 8 literal `{VERSION}` strings are live on the site right now (e.g. the Swift page shows `from: "{VERSION}"`).

Changed the glob to `install*.md`. Verified locally: all 8 placeholders replaced, including all 4 in `install_kotlin_multiplatform.md`.

Both changes apply to `main` as well — happy to open a follow-up PR there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)