### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/README.md
@@ -113,7 +113,7 @@ Transfer a lightning address to another user:
 authorize-lightning-address-transfer <transferee_pubkey>
 
 # New owner claims the transfer
-claim-lightning-address-transfer <username> [<description>] --from-pubkey <pubkey> --from-signature <signature>
+claim-lightning-address-transfer <username> [<description>] --from-pubkey <pubkey> --from-signature <signature> --from-domain <domain> --from-timestamp <secs>
 ```
 
 ### HODL Invoices


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`9d294a0`](https://github.com/breez/spark-sdk/commit/9d294a0d7c0e1214998c03fd97dc7948318707cd)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/32469562140)

**Language status:**
- :next_track_button: C# (no changes needed)
- :next_track_button: Dart (no changes needed)
- :next_track_button: Go (no changes needed)
- :next_track_button: Kotlin (no changes needed)
- :next_track_button: Python (no changes needed)
- :white_check_mark: React Native
- :next_track_button: Swift (no changes needed)
- :next_track_button: TypeScript (no changes needed)

<details>
<summary>Sync findings</summary>

### C#
No differences found: CLIs are in sync.

### Dart
## Divergences
- None: the Dart CLI already includes `--from-domain` and `--from-timestamp` on `claim-lightning-address-transfer`, matching the Rust CLI changes.

## Applied
- No changes applied: Dart CLI is already in sync with the Rust CLI.

## Skipped
- Rust README is outdated relative to the actual Rust code (stale flag names, missing commands/flags), but this is a Rust-side issue outside the Dart sync scope.

### Go
No differences found: CLIs are in sync.

### Kotlin
No differences found: CLIs are in sync.

### Python
No differences found: CLIs are in sync.

### React Native
## Divergences
- React Native README `claim-lightning-address-transfer` example was missing `--from-domain` and `--from-timestamp` flags that are now required in the Rust CLI

## Applied
- Updated `crates/breez-sdk/bindings/examples/cli/langs/react-native/README.md`: added `--from-domain <domain> --from-timestamp <secs>` to the `claim-lightning-address-transfer` usage example

## Skipped
- (none)

### Swift
No differences found: CLIs are in sync.

### TypeScript
No differences found: CLIs are in sync.

</details>

All languages synced cleanly. This PR merges automatically once the gating CI checks pass (integration test checks excluded).