### PR TITLE
docs: Publish per-language LLM markdown editions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,6 @@ jobs:
           cargo install --path ./snippets-processor
           cargo install mdbook-variables --vers "^0.2" --locked
           cargo install mdbook-pagetoc --vers "^0.2" --locked
-          cargo install mdbook-llms-txt-tools
 
       - name: Get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1

--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -19,38 +19,40 @@ use crate::{DepositInfo, LightningAddressInfo, Payment, sdk::RuntimeEvent};
 pub enum SdkEvent {
     /// Emitted when the wallet has been synchronized with the network
     Synced,
-    /// Emitted when the SDK was unable to claim deposits
+    /// Emitted when the SDK was unable to claim deposits. Each deposit carries a
+    /// `claim_error` with the reason.
     UnclaimedDeposits {
         unclaimed_deposits: Vec<DepositInfo>,
     },
-    ClaimedDeposits {
-        claimed_deposits: Vec<DepositInfo>,
-    },
-    PaymentSucceeded {
-        payment: Payment,
-    },
-    PaymentPending {
-        payment: Payment,
-    },
-    PaymentFailed {
-        payment: Payment,
-    },
+    /// Emitted when deposits were claimed into the wallet. The resulting payment
+    /// is emitted separately as `PaymentSucceeded`.
+    ClaimedDeposits { claimed_deposits: Vec<DepositInfo> },
+    /// Emitted when a payment completed. The cached balance is refreshed before
+    /// this event, so `get_info` returns the new value.
+    PaymentSucceeded { payment: Payment },
+    /// Emitted when a payment is in flight. The same payment is emitted again as
+    /// succeeded or failed once it settles.
+    PaymentPending { payment: Payment },
+    /// Emitted when a payment failed.
+    PaymentFailed { payment: Payment },
     /// Emitted while the background auto-optimizer is running.
     ///
     /// Only fired from the auto path (enabled via
     /// `LeafOptimizationConfig::auto_enabled`). Manually-triggered runs
-    /// via `BreezSdk::optimize_leaves` do not emit events — they return an
+    /// via `BreezSdk::optimize_leaves` do not emit events: they return an
     /// `OptimizationOutcome` instead.
     AutoOptimization {
         // Named with `optimization` prefix to avoid collision with `event` keyword in C#
         optimization_event: AutoOptimizationEvent,
     },
+    /// Emitted when the Lightning address changed on another device. The address
+    /// is unset when it was deleted.
     LightningAddressChanged {
         lightning_address: Option<LightningAddressInfo>,
     },
-    NewDeposits {
-        new_deposits: Vec<DepositInfo>,
-    },
+    /// Emitted when on-chain deposits are detected. Only deposits whose
+    /// `is_mature` is set have enough confirmations to be claimed.
+    NewDeposits { new_deposits: Vec<DepositInfo> },
     /// Emitted when the data a unilateral exit is built from has changed, so an
     /// exit state exported earlier is out of date and should be exported again.
     UnilateralExitStateChanged,

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -1141,12 +1141,19 @@ pub enum InstantClaimStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct DepositInfo {
+    /// Transaction id of the on-chain output the deposit came from.
     pub txid: String,
+    /// Index of that output within its transaction.
     pub vout: u32,
+    /// Deposit value in satoshis.
     pub amount_sats: u64,
+    /// Whether the deposit has enough confirmations to be claimed.
     pub is_mature: bool,
+    /// Raw refund transaction, once one has been created.
     pub refund_tx: Option<String>,
+    /// Transaction id of the refund, once one has been created.
     pub refund_tx_id: Option<String>,
+    /// Why the last claim attempt failed. Unset while none has failed.
     pub claim_error: Option<DepositClaimError>,
     /// Unset when no instant claim has been attempted.
     pub instant_claim_status: Option<InstantClaimStatus>,

--- a/docs/breez-sdk/README.md
+++ b/docs/breez-sdk/README.md
@@ -15,8 +15,25 @@ cargo install mdbook@0.4.52
 cargo install --path ./snippets-processor
 cargo install mdbook-variables
 cargo install mdbook-pagetoc
-cargo install mdbook-llms-txt-tools
 mdbook build
 mdbook serve --open
-
 ```
+
+`snippets-processor` installs two binaries: `mdbook-snippets`, the preprocessor that
+expands `{{#tabs}}`, `{{#name}}` and `{{#enum}}`, and `mdbook-llms`, the backend that
+writes the [llmstxt.org](https://llmstxt.org) files.
+
+## Build output
+
+`mdbook build` writes one directory per renderer under `book/`, which the publish
+workflow flattens to the site root:
+
+| Directory | Published as | Contents |
+|---|---|---|
+| `html` | `/` | the website |
+| `markdown` | `/guide/*.md` | every page as markdown, examples in all nine languages |
+| `llms-index` | `/llms.txt`, `/llms-full.txt` | the index and the all-language corpus |
+| `llms-<edition>` | `/llms-<edition>-full.txt`, `/llms/<edition>/` | one corpus and one page set per language |
+
+Editions carry examples in a single language, with identifiers in that language's naming
+convention. The list of them lives in `EDITIONS` in `snippets-processor/src/bin/mdbook-llms.rs`.

--- a/docs/breez-sdk/book.toml
+++ b/docs/breez-sdk/book.toml
@@ -32,8 +32,29 @@ api_key_form_uri = "https://breez.technology/request-api-key/#contact-us-form-sd
 # making the llms.txt links resolve and giving LLMs a clean-markdown version
 [output.markdown]
 
-# Basic llmstxt.org format output
-[output.llms-txt]
+# llmstxt.org index and the all-language corpus. Named `llms-index` so no
+# renderer directory is called `llms`, which the editions create when the
+# build output is flattened.
+[output.llms-index]
+command = "mdbook-llms"
 
-# Detailed llmstxt.org format output with additional information
-[output.llms-txt-full]
+# One corpus per language edition. Each renderer re-runs the snippets
+# preprocessor, which reduces that pass to a single language.
+[output.llms-rust]
+command = "mdbook-llms"
+[output.llms-swift]
+command = "mdbook-llms"
+[output.llms-kotlin]
+command = "mdbook-llms"
+[output.llms-csharp]
+command = "mdbook-llms"
+[output.llms-wasm]
+command = "mdbook-llms"
+[output.llms-react-native]
+command = "mdbook-llms"
+[output.llms-flutter]
+command = "mdbook-llms"
+[output.llms-python]
+command = "mdbook-llms"
+[output.llms-go]
+command = "mdbook-llms"

--- a/docs/breez-sdk/snippets-processor/src/bin/mdbook-llms.rs
+++ b/docs/breez-sdk/snippets-processor/src/bin/mdbook-llms.rs
@@ -1,0 +1,236 @@
+//! mdbook backend writing the llmstxt.org files.
+//!
+//! One binary serves every `[output.llms*]` renderer; the destination directory
+//! names which one is running. `book/llms` gets the index and the all-language
+//! corpus, `book/llms-<edition>` gets that edition's corpus. The snippets
+//! preprocessor has already reduced each edition to a single language.
+
+use mdbook::book::Chapter;
+use mdbook::errors::Result;
+use mdbook::renderer::RenderContext;
+use mdbook::BookItem;
+use regex::Regex;
+use std::fs;
+use std::io;
+
+/// Editions offered in the index: key, label, and the dependency an agent can
+/// see in the project it is working on.
+const EDITIONS: [(&str, &str, &str); 9] = [
+    ("rust", "Rust", "the `breez-sdk-spark` crate"),
+    ("swift", "Swift", "the `breez-sdk-spark-swift` Swift package"),
+    (
+        "kotlin",
+        "Kotlin",
+        "`technology.breez.spark:breez-sdk-spark-kmp` or `breez_sdk_spark:bindings-android`",
+    ),
+    ("csharp", "C#", "the `Breez.Sdk.Spark` NuGet package"),
+    (
+        "wasm",
+        "Javascript (Wasm)",
+        "the `@breeztech/breez-sdk-spark` npm package",
+    ),
+    (
+        "react-native",
+        "React Native",
+        "the `@breeztech/breez-sdk-spark-react-native` npm package",
+    ),
+    ("flutter", "Flutter", "the `breez_sdk_spark_flutter` pub package"),
+    ("python", "Python", "the `breez-sdk-spark` PyPI package"),
+    ("go", "Go", "the `github.com/breez/breez-sdk-spark-go` module"),
+];
+
+fn main() -> Result<()> {
+    let ctx = RenderContext::from_json(io::stdin())?;
+    fs::create_dir_all(&ctx.destination)?;
+
+    let title = ctx
+        .config
+        .book
+        .title
+        .clone()
+        .unwrap_or_else(|| "Documentation".to_string());
+
+    // `book/llms` -> None (all languages), `book/llms-rust` -> Some("rust").
+    let edition = ctx
+        .destination
+        .file_name()
+        .and_then(|n| n.to_str())
+        .and_then(|n| n.strip_prefix("llms-"))
+        .filter(|key| EDITIONS.iter().any(|(k, _, _)| k == key))
+        .map(str::to_string);
+
+    match &edition {
+        Some(key) => {
+            let name = format!("llms-{key}-full.txt");
+            fs::write(ctx.destination.join(name), corpus(&ctx, &title, Some(key)))?;
+
+            // One page per chapter, mirroring the site's own layout so the
+            // relative links between them keep working.
+            let root = ctx.destination.join("llms").join(key);
+            for item in ctx.book.iter() {
+                let BookItem::Chapter(chapter) = item else {
+                    continue;
+                };
+                let Some(path) = chapter.path.as_ref() else {
+                    continue;
+                };
+                let target = root.join(path.with_extension("md"));
+                if let Some(parent) = target.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                fs::write(target, chapter.content.trim().to_string() + "\n")?;
+            }
+            fs::write(root.join("llms.txt"), index(&ctx, &title, Some(key)))?;
+        }
+        None => {
+            fs::write(ctx.destination.join("llms.txt"), index(&ctx, &title, None))?;
+            fs::write(
+                ctx.destination.join("llms-full.txt"),
+                corpus(&ctx, &title, None),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Site path a chapter is published at. Editions live under `/llms/<key>/`,
+/// the all-language pages at the site root.
+fn chapter_path(chapter: &Chapter, edition: Option<&str>) -> Option<String> {
+    let path = chapter.path.as_ref()?;
+    let rel = path.with_extension("md");
+    Some(match edition {
+        Some(key) => format!("/llms/{key}/{}", rel.to_string_lossy()),
+        None => format!("/{}", rel.to_string_lossy()),
+    })
+}
+
+/// llmstxt.org index: H1, a summary blockquote, then one H2 per top-level
+/// chapter listing it and its descendants, then the edition list.
+fn index(ctx: &RenderContext, title: &str, edition: Option<&str>) -> String {
+    let label = edition.and_then(edition_label);
+    let mut out = match label {
+        Some(label) => format!("# {title}: {label}\n\n"),
+        None => format!("# {title}\n\n"),
+    };
+    out.push_str(&match label {
+        Some(label) => format!(
+            "> End-to-end SDK for instant, non-custodial bitcoin and stablecoin payments. \
+             This edition carries every example in {label}, with identifiers in that \
+             language's naming convention. The same pages carrying all nine languages are \
+             under `/guide/`.\n\n"
+        ),
+        None => "> End-to-end SDK for instant, non-custodial bitcoin and stablecoin payments, \
+             with bindings for nine languages. Start from the language edition matching \
+             your project's dependency, listed directly below. Every page is also published \
+             as markdown at the same path with a `.md` extension.\n\n"
+            .to_string(),
+    });
+
+    // First, so an agent picks its language before it starts fetching pages.
+    if edition.is_none() {
+        out.push_str("## Language editions\n\n");
+        out.push_str(
+            "Each edition carries every page listed below, with examples in one language \
+             only and identifiers in that language's naming convention.\n\n",
+        );
+        for (key, label, dependency) in EDITIONS {
+            out.push_str(&format!(
+                "- [{label}](/llms/{key}/llms.txt): for {dependency}. \
+                 [Whole book in one file](/llms-{key}-full.txt).\n"
+            ));
+        }
+        out.push('\n');
+    }
+
+    for item in &ctx.book.sections {
+        let BookItem::Chapter(chapter) = item else {
+            continue;
+        };
+        out.push_str(&format!("## {}\n\n", chapter.name));
+        let mut links = String::new();
+        collect_links(chapter, edition, &mut links);
+        out.push_str(&links);
+        out.push('\n');
+    }
+
+    out
+}
+
+fn edition_label(key: &str) -> Option<&'static str> {
+    EDITIONS
+        .iter()
+        .find(|(k, _, _)| *k == key)
+        .map(|(_, label, _)| *label)
+}
+
+/// A chapter's own link followed by its descendants', depth-first.
+fn collect_links(chapter: &Chapter, edition: Option<&str>, out: &mut String) {
+    if let Some(path) = chapter_path(chapter, edition) {
+        out.push_str(&format!("- [{}]({})\n", chapter.name, path));
+    }
+    for item in &chapter.sub_items {
+        if let BookItem::Chapter(child) = item {
+            collect_links(child, edition, out);
+        }
+    }
+}
+
+/// Make a page's relative links absolute.
+///
+/// A corpus is served from the site root, so the relative links a page uses to
+/// reach its neighbours would resolve against the wrong directory.
+fn absolutise(content: &str, base: &str) -> String {
+    let link = Regex::new(r"\]\(([^)]+)\)").unwrap();
+    let mut out = Vec::new();
+    let mut in_code = false;
+
+    for line in content.split('\n') {
+        if line.trim_start().starts_with("```") {
+            in_code = !in_code;
+            out.push(line.to_string());
+            continue;
+        }
+        if in_code {
+            out.push(line.to_string());
+            continue;
+        }
+        out.push(
+            link.replace_all(line, |caps: &regex::Captures| {
+                let target = &caps[1];
+                let already_resolved = target.starts_with('/')
+                    || target.starts_with('#')
+                    || target.starts_with("http://")
+                    || target.starts_with("https://")
+                    || target.starts_with("mailto:");
+                if already_resolved {
+                    return format!("]({target})");
+                }
+                format!("]({base}/{})", target.strip_prefix("./").unwrap_or(target))
+            })
+            .into_owned(),
+        );
+    }
+    out.join("\n")
+}
+
+/// Every chapter's content, each preceded by a link to its canonical page.
+fn corpus(ctx: &RenderContext, title: &str, edition: Option<&str>) -> String {
+    let mut out = format!("# {title}\n\n");
+    for item in ctx.book.iter() {
+        let BookItem::Chapter(chapter) = item else {
+            continue;
+        };
+        if chapter.content.trim().is_empty() {
+            continue;
+        }
+        let Some(path) = chapter_path(chapter, edition) else {
+            continue;
+        };
+        out.push_str(&format!("**→ [{}]({})**\n\n", chapter.name, path));
+
+        let base = path.rsplit_once('/').map_or("", |(dir, _)| dir);
+        out.push_str(absolutise(chapter.content.trim(), base).trim());
+        out.push_str("\n\n");
+    }
+    out
+}

--- a/docs/breez-sdk/snippets-processor/src/main.rs
+++ b/docs/breez-sdk/snippets-processor/src/main.rs
@@ -70,6 +70,100 @@ fn check_mdbook_version(version: &str) {
     }
 }
 
+/// Appended to non-HTML output, where `{{#name}}` and `{{#enum}}` render as one
+/// Rust-cased identifier rather than one span per language.
+const CASING_FOOTER: &str = "\n\n---\n\nIdentifier casing: `get_info` here is `getInfo` \
+in Swift, Kotlin, JavaScript, React Native and Flutter, and `GetInfo` in Go and C#. \
+Enum variants: `SdkEvent::Synced` is `SdkEvent.SYNCED` in Python, `SdkEvent.synced` in \
+Swift, `SdkEventSynced` in Go, and `SdkEvent.Synced` elsewhere.\n";
+
+/// A single-language edition: which snippet tab to keep, and how that
+/// language writes identifiers.
+#[derive(Clone, Copy)]
+struct Edition {
+    key: &'static str,
+    /// Matching tab label in `get_language_paths`.
+    tab: &'static str,
+}
+
+const EDITIONS: [Edition; 9] = [
+    Edition {
+        key: "rust",
+        tab: "Rust",
+    },
+    Edition {
+        key: "swift",
+        tab: "Swift",
+    },
+    Edition {
+        key: "kotlin",
+        tab: "Kotlin",
+    },
+    Edition {
+        key: "csharp",
+        tab: "C#",
+    },
+    Edition {
+        key: "wasm",
+        tab: "Javascript",
+    },
+    Edition {
+        key: "react-native",
+        tab: "React Native",
+    },
+    Edition {
+        key: "flutter",
+        tab: "Flutter",
+    },
+    Edition {
+        key: "python",
+        tab: "Python",
+    },
+    Edition {
+        key: "go",
+        tab: "Go",
+    },
+];
+
+impl Edition {
+    fn from_renderer(renderer: &str) -> Option<Edition> {
+        let key = renderer.strip_prefix("llms-")?;
+        EDITIONS.iter().copied().find(|e| e.key == key)
+    }
+
+    fn case(&self, s: &str) -> String {
+        match self.key {
+            "rust" | "python" => s.to_string(),
+            "go" | "csharp" => capitalize_first(s),
+            _ => SnippetsProcessor::to_camel_case(s),
+        }
+    }
+
+    fn name(&self, identifier: &str) -> String {
+        match identifier.split_once('.') {
+            // An uppercase-initial prefix is a type name, identical everywhere.
+            Some((prefix, method)) if prefix.starts_with(|c: char| c.is_uppercase()) => {
+                format!("{prefix}.{}", self.case(method))
+            }
+            Some((prefix, method)) => format!("{}.{}", self.case(prefix), self.case(method)),
+            None => self.case(identifier),
+        }
+    }
+
+    fn enum_variant(&self, type_name: &str, variant: &str) -> String {
+        match self.key {
+            "rust" => format!("{type_name}::{variant}"),
+            "python" => format!(
+                "{type_name}.{}",
+                SnippetsProcessor::to_screaming_snake(variant)
+            ),
+            "swift" => format!("{type_name}.{}", SnippetsProcessor::to_lower_camel(variant)),
+            "go" => format!("{type_name}{variant}"),
+            _ => format!("{type_name}.{variant}"),
+        }
+    }
+}
+
 struct SnippetsProcessor;
 impl SnippetsProcessor {
     /// Convert snake_case to camelCase
@@ -117,7 +211,14 @@ impl SnippetsProcessor {
     ///   name and emitted verbatim across all languages.
     /// - `field.subfield` — prefix starts lowercase, treated as a snake_case
     ///   field path and case-converted alongside the trailing segment.
-    fn expand_name(identifier: &str) -> String {
+    fn expand_name(identifier: &str, markdown: bool, edition: Option<Edition>) -> String {
+        if let Some(edition) = edition {
+            return format!("`{}`", edition.name(identifier));
+        }
+        if markdown {
+            return format!("`{identifier}`");
+        }
+
         let (type_prefix, method) = identifier
             .split_once('.')
             .map(|(t, m)| (Some(t), m))
@@ -172,7 +273,19 @@ impl SnippetsProcessor {
     }
 
     /// Expand {{#enum Type::Variant}} to language-aware HTML
-    fn expand_enum(enum_str: &str) -> String {
+    fn expand_enum(enum_str: &str, markdown: bool, edition: Option<Edition>) -> String {
+        if let Some(edition) = edition {
+            return match enum_str.split_once("::") {
+                Some((type_name, variant)) => {
+                    format!("`{}`", edition.enum_variant(type_name, variant))
+                }
+                None => format!("`{enum_str}`"),
+            };
+        }
+        if markdown {
+            return format!("`{enum_str}`");
+        }
+
         // Parse Type::Variant
         let (type_name, variant) = enum_str
             .split_once("::")
@@ -201,6 +314,67 @@ impl SnippetsProcessor {
             .collect();
 
         format!("<code class=\"lang-fn\">{}</code>", spans)
+    }
+
+    /// Rewrite the raw `<hN id=...>` blocks carrying the API-docs link into
+    /// markdown headings, so non-HTML output keeps its section structure.
+    fn html_headings_to_markdown(content: &str) -> String {
+        let re = regex::Regex::new(
+            r#"(?s)<h([1-6])\s+id="[^"]*"\s*>\s*<a\s+class="header"[^>]*>(.*?)</a>\s*(?:<a\s+class="tag"[^>]*?href="([^"]*)"[^>]*>.*?</a>\s*)?</h[1-6]\s*>"#,
+        )
+        .unwrap();
+
+        let expanded = re.replace_all(content, |caps: &regex::Captures| {
+            let level = caps[1].parse::<usize>().unwrap_or(2);
+            let mut out = format!("{} {}", "#".repeat(level), caps[2].trim());
+            if let Some(url) = caps.get(3) {
+                out.push_str(&format!("\n\nAPI docs: {}", url.as_str()));
+            }
+            out
+        });
+
+        // Plain `<hN id="...">Title</hN>`, used where there is no API-docs link.
+        let plain =
+            regex::Regex::new(r#"(?s)<h([1-6])\s+id="[^"]*"\s*>\s*(.*?)\s*</h[1-6]\s*>"#).unwrap();
+
+        plain
+            .replace_all(&expanded, |caps: &regex::Captures| {
+                let level = caps[1].parse::<usize>().unwrap_or(2);
+                format!("{} {}", "#".repeat(level), caps[2].trim())
+            })
+            .into_owned()
+    }
+
+    /// Point links at the edition's own pages, so following one from a Rust
+    /// page does not land on the multi-language version.
+    ///
+    /// Relative links already resolve inside the edition directory. Only
+    /// site-absolute `.md` links and image paths need moving; `.html` links
+    /// belong to the rendered site and are left alone.
+    fn rewrite_links(content: &str, edition: Edition) -> String {
+        let pages = regex::Regex::new(r"\]\(/guide/([^)]*\.md[^)]*)\)").unwrap();
+        let moved = pages.replace_all(
+            content,
+            format!("](/llms/{}/guide/$1)", edition.key).as_str(),
+        );
+
+        let images = regex::Regex::new(r"\]\(images/([^)]*)\)").unwrap();
+        images
+            .replace_all(&moved, "](/guide/images/$1)")
+            .into_owned()
+    }
+
+    /// Unwrap `<div class="warning">` blocks, keeping the markdown inside and
+    /// turning the `<h4>` title into bold text.
+    fn unwrap_warning_divs(content: &str) -> String {
+        let block = regex::Regex::new(r#"(?s)<div class="warning">\s*(.*?)\s*</div>"#).unwrap();
+        let title = regex::Regex::new(r"(?s)<h4>\s*(.*?)\s*</h4>\s*").unwrap();
+
+        block
+            .replace_all(content, |caps: &regex::Captures| {
+                title.replace_all(&caps[1], "**$1**\n\n").into_owned()
+            })
+            .into_owned()
     }
 
     fn get_language_paths(file_base: &str) -> Vec<(&'static str, &'static str, Vec<String>)> {
@@ -285,15 +459,36 @@ impl SnippetsProcessor {
         None
     }
 
+    /// The website tab reads "Javascript". In markdown, where React Native is
+    /// also TypeScript, the platform has to be explicit.
+    fn markdown_label(lang_name: &str) -> &str {
+        match lang_name {
+            "Javascript" => "Javascript (Wasm)",
+            other => other,
+        }
+    }
+
     fn expand_tabs(
         ctx: &PreprocessorContext,
         file_base: &str,
         snippet_name: &str,
+        markdown: bool,
+        section_level: usize,
+        edition: Option<Edition>,
     ) -> Result<String> {
         let config = Self::get_language_paths(file_base);
-        let mut result = String::from("<custom-tabs category=\"lang\">\n");
+        let mut result = if markdown {
+            String::new()
+        } else {
+            String::from("<custom-tabs category=\"lang\">\n")
+        };
 
         for (lang_name, lang_code, relative_paths) in &config {
+            // An edition keeps only its own language.
+            if edition.is_some_and(|e| e.tab != *lang_name) {
+                continue;
+            }
+
             // Try each candidate path in order and use the first one that both
             // exists and contains the requested snippet anchor.
             let snippet = relative_paths.iter().find_map(|relative_path| {
@@ -307,13 +502,26 @@ impl SnippetsProcessor {
                 continue;
             };
 
-            result.push_str(&format!(
-                "<div slot=\"title\">{}</div>\n<section>\n\n```{},ignore\n{}\n```\n\n</section>\n\n",
-                lang_name, lang_code, snippet
-            ));
+            if edition.is_some() {
+                // One language, so a heading naming it would be noise.
+                result.push_str(&format!("```{lang_code}\n{snippet}\n```\n\n"));
+            } else if markdown {
+                let hashes = "#".repeat((section_level + 1).min(6));
+                let label = Self::markdown_label(lang_name);
+                result.push_str(&format!(
+                    "{hashes} {label}\n\n```{lang_code}\n{snippet}\n```\n\n"
+                ));
+            } else {
+                result.push_str(&format!(
+                    "<div slot=\"title\">{}</div>\n<section>\n\n```{},ignore\n{}\n```\n\n</section>\n\n",
+                    lang_name, lang_code, snippet
+                ));
+            }
         }
 
-        result.push_str("</custom-tabs>\n");
+        if !markdown {
+            result.push_str("</custom-tabs>\n");
+        }
         Ok(result)
     }
 }
@@ -342,8 +550,33 @@ impl Preprocessor for SnippetsProcessor {
     }
 
     fn run(&self, ctx: &PreprocessorContext, mut book: Book) -> Result<Book> {
+        // Depth of a markdown ATX heading, or None if the line is not one.
+        fn heading_level(line: &str) -> Option<usize> {
+            let hashes = line.len() - line.trim_start_matches('#').len();
+            if (1..=6).contains(&hashes) && line[hashes..].starts_with(' ') {
+                Some(hashes)
+            } else {
+                None
+            }
+        }
+
+        // The HTML renderer gets language tabs and one identifier span per
+        // language. Every other renderer gets plain markdown instead.
+        let markdown = ctx.renderer != "html";
+        let edition = Edition::from_renderer(&ctx.renderer);
+
         book.for_each_mut(|item| {
             if let BookItem::Chapter(chapter) = item {
+                if markdown {
+                    chapter.content = Self::html_headings_to_markdown(&chapter.content);
+                    chapter.content = Self::unwrap_warning_divs(&chapter.content);
+                }
+                if let Some(edition) = edition {
+                    chapter.content = Self::rewrite_links(&chapter.content, edition);
+                }
+
+                let mut used_identifier_macro = false;
+                let mut section_level = 1usize;
                 let mut resulting_lines: Vec<String> = vec![];
                 let mut in_block = false;
                 let mut block_lines: Vec<String> = vec![];
@@ -362,8 +595,14 @@ impl Preprocessor for SnippetsProcessor {
                         if let (Some(file_base), Some(snippet_name)) =
                             (captures.get(1), captures.get(2))
                         {
-                            match Self::expand_tabs(ctx, file_base.as_str(), snippet_name.as_str())
-                            {
+                            match Self::expand_tabs(
+                                ctx,
+                                file_base.as_str(),
+                                snippet_name.as_str(),
+                                markdown,
+                                section_level,
+                                edition,
+                            ) {
                                 Ok(expanded) => {
                                     resulting_lines.push(expanded);
                                 }
@@ -383,12 +622,13 @@ impl Preprocessor for SnippetsProcessor {
                     let has_enum = enum_regex.is_match(line);
 
                     if has_name || has_enum {
+                        used_identifier_macro = true;
                         let mut new_line = line.to_string();
 
                         if has_name {
                             new_line = name_regex
                                 .replace_all(&new_line, |caps: &regex::Captures| {
-                                    Self::expand_name(&caps[1])
+                                    Self::expand_name(&caps[1], markdown, edition)
                                 })
                                 .to_string();
                         }
@@ -396,7 +636,7 @@ impl Preprocessor for SnippetsProcessor {
                         if has_enum {
                             new_line = enum_regex
                                 .replace_all(&new_line, |caps: &regex::Captures| {
-                                    Self::expand_enum(&caps[1])
+                                    Self::expand_enum(&caps[1], markdown, edition)
                                 })
                                 .to_string();
                         }
@@ -434,11 +674,18 @@ impl Preprocessor for SnippetsProcessor {
                                 std::cmp::min(min_indentation, line.len() - trimmed.len())
                         }
                     } else {
+                        if let Some(level) = heading_level(line) {
+                            section_level = level;
+                        }
                         resulting_lines.push(line.to_string());
                     }
                 }
 
                 chapter.content = resulting_lines.join("\n");
+                // An edition already writes identifiers in its own language.
+                if markdown && edition.is_none() && used_identifier_macro {
+                    chapter.content.push_str(CASING_FOOTER);
+                }
             }
         });
         Ok(book)

--- a/docs/breez-sdk/snippets/csharp/GettingStarted.cs
+++ b/docs/breez-sdk/snippets/csharp/GettingStarted.cs
@@ -77,8 +77,8 @@ namespace BreezSdkSnippets
                         break;
 
                     case SdkEvent.ClaimedDeposits claimedDepositsEvent:
-                        // Deposits claimed into the wallet. The resulting payment
-                        // arrives separately as its own event.
+                        // Deposits claimed into the wallet. An instant (0-conf) claim is
+                        // reported here on submission and settles shortly after.
                         var claimedDeposits = claimedDepositsEvent.claimedDeposits;
                         break;
 

--- a/docs/breez-sdk/snippets/csharp/GettingStarted.cs
+++ b/docs/breez-sdk/snippets/csharp/GettingStarted.cs
@@ -65,42 +65,50 @@ namespace BreezSdkSnippets
                         break;
 
                     case SdkEvent.NewDeposits newDepositsEvent:
-                        // New deposits were detected (may be pending or confirmed)
+                        // Detected deposits, as DepositInfo. Only those with IsMature set
+                        // have enough confirmations to be claimed. Show the rest as pending.
                         var newDeposits = newDepositsEvent.newDeposits;
                         break;
 
                     case SdkEvent.UnclaimedDeposits unclaimedDepositsEvent:
-                        // SDK was unable to claim some deposits automatically
+                        // Deposits the SDK could not claim. Each ClaimError says why,
+                        // most often the fee exceeded the configured maximum.
                         var unclaimedDeposits = unclaimedDepositsEvent.unclaimedDeposits;
                         break;
 
                     case SdkEvent.ClaimedDeposits claimedDepositsEvent:
-                        // Deposits were successfully claimed
+                        // Deposits claimed into the wallet. The resulting payment
+                        // arrives separately as its own event.
                         var claimedDeposits = claimedDepositsEvent.claimedDeposits;
                         break;
 
                     case SdkEvent.PaymentSucceeded paymentSucceededEvent:
-                        // A payment completed successfully
+                        // A payment completed. The cached balance is already refreshed,
+                        // so GetInfo returns the new value.
                         var payment = paymentSucceededEvent.payment;
                         break;
 
                     case SdkEvent.PaymentPending paymentPendingEvent:
-                        // A payment is pending (waiting for confirmation)
+                        // A payment is awaiting confirmation. It arrives again as
+                        // succeeded or failed once it settles.
                         var pendingPayment = paymentPendingEvent.payment;
                         break;
 
                     case SdkEvent.PaymentFailed paymentFailedEvent:
-                        // A payment failed
+                        // A payment failed. payment.Details carries the method-specific
+                        // context to show the user.
                         var failedPayment = paymentFailedEvent.payment;
                         break;
 
                     case SdkEvent.AutoOptimization optimizationEvent:
-                        // An auto-optimization event occurred
+                        // Background optimizer progress: started, round completed, or a
+                        // terminal outcome. Manual OptimizeLeaves calls do not emit these.
                         var optimization = optimizationEvent.optimizationEvent;
                         break;
 
                     case SdkEvent.LightningAddressChanged lightningAddressChangedEvent:
-                        // The lightning address has changed
+                        // The lightning address changed on another device. Unset when the
+                        // address was deleted.
                         var lightningAddress = lightningAddressChangedEvent.lightningAddress;
                         break;
 

--- a/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
@@ -119,35 +119,43 @@ class BreezSdkSpark {
           // it is recommended to refresh the payment list and wallet balance.
           break;
         case SdkEvent_NewDeposits(:final newDeposits):
-          // New deposits were detected (may be pending or confirmed)
+          // Detected deposits, as DepositInfo. Only those with isMature set
+          // have enough confirmations to be claimed. Show the rest as pending.
           final _ = newDeposits;
           break;
         case SdkEvent_UnclaimedDeposits(:final unclaimedDeposits):
-          // SDK was unable to claim some deposits automatically
+          // Deposits the SDK could not claim. Each claimError says why,
+          // most often the fee exceeded the configured maximum.
           final _ = unclaimedDeposits;
           break;
         case SdkEvent_ClaimedDeposits(:final claimedDeposits):
-          // Deposits were successfully claimed
+          // Deposits claimed into the wallet. The resulting payment
+          // arrives separately as its own event.
           final _ = claimedDeposits;
           break;
         case SdkEvent_PaymentSucceeded(:final payment):
-          // A payment completed successfully
+          // A payment completed. The cached balance is already refreshed,
+          // so getInfo returns the new value.
           final _ = payment;
           break;
         case SdkEvent_PaymentPending(:final payment):
-          // A payment is pending (waiting for confirmation)
+          // A payment is awaiting confirmation. It arrives again as
+          // succeeded or failed once it settles.
           final _ = payment;
           break;
         case SdkEvent_PaymentFailed(:final payment):
-          // A payment failed
+          // A payment failed. payment.details carries the method-specific
+          // context to show the user.
           final _ = payment;
           break;
         case SdkEvent_AutoOptimization(:final optimizationEvent):
-          // An auto-optimization event occurred
+          // Background optimizer progress: started, round completed, or a
+          // terminal outcome. Manual optimizeLeaves calls do not emit these.
           final _ = optimizationEvent;
           break;
         case SdkEvent_LightningAddressChanged(:final lightningAddress):
-          // The lightning address has changed
+          // The lightning address changed on another device. Unset when the
+          // address was deleted.
           final _ = lightningAddress;
           break;
         case SdkEvent_UnilateralExitStateChanged():

--- a/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
@@ -129,8 +129,8 @@ class BreezSdkSpark {
           final _ = unclaimedDeposits;
           break;
         case SdkEvent_ClaimedDeposits(:final claimedDeposits):
-          // Deposits claimed into the wallet. The resulting payment
-          // arrives separately as its own event.
+          // Deposits claimed into the wallet. An instant (0-conf) claim is
+          // reported here on submission and settles shortly after.
           final _ = claimedDeposits;
           break;
         case SdkEvent_PaymentSucceeded(:final payment):

--- a/docs/breez-sdk/snippets/go/getting_started.go
+++ b/docs/breez-sdk/snippets/go/getting_started.go
@@ -92,8 +92,8 @@ func (SdkListener) OnEvent(e breez_sdk_spark.SdkEvent) {
 		unclaimedDeposits := event.UnclaimedDeposits
 		_ = unclaimedDeposits
 	case breez_sdk_spark.SdkEventClaimedDeposits:
-		// Deposits claimed into the wallet. The resulting payment
-		// arrives separately as its own event.
+		// Deposits claimed into the wallet. An instant (0-conf) claim is
+		// reported here on submission and settles shortly after.
 		claimedDeposits := event.ClaimedDeposits
 		_ = claimedDeposits
 	case breez_sdk_spark.SdkEventPaymentSucceeded:

--- a/docs/breez-sdk/snippets/go/getting_started.go
+++ b/docs/breez-sdk/snippets/go/getting_started.go
@@ -82,35 +82,43 @@ func (SdkListener) OnEvent(e breez_sdk_spark.SdkEvent) {
 		// Data has been synchronized with the network. When this event is received,
 		// it is recommended to refresh the payment list and wallet balance.
 	case breez_sdk_spark.SdkEventNewDeposits:
-		// New deposits were detected (may be pending or confirmed)
+		// Detected deposits, as DepositInfo. Only those with IsMature set
+		// have enough confirmations to be claimed. Show the rest as pending.
 		newDeposits := event.NewDeposits
 		_ = newDeposits
 	case breez_sdk_spark.SdkEventUnclaimedDeposits:
-		// SDK was unable to claim some deposits automatically
+		// Deposits the SDK could not claim. Each ClaimError says why,
+		// most often the fee exceeded the configured maximum.
 		unclaimedDeposits := event.UnclaimedDeposits
 		_ = unclaimedDeposits
 	case breez_sdk_spark.SdkEventClaimedDeposits:
-		// Deposits were successfully claimed
+		// Deposits claimed into the wallet. The resulting payment
+		// arrives separately as its own event.
 		claimedDeposits := event.ClaimedDeposits
 		_ = claimedDeposits
 	case breez_sdk_spark.SdkEventPaymentSucceeded:
-		// A payment completed successfully
+		// A payment completed. The cached balance is already refreshed,
+		// so GetInfo returns the new value.
 		payment := event.Payment
 		_ = payment
 	case breez_sdk_spark.SdkEventPaymentPending:
-		// A payment is pending (waiting for confirmation)
+		// A payment is awaiting confirmation. It arrives again as
+		// succeeded or failed once it settles.
 		pendingPayment := event.Payment
 		_ = pendingPayment
 	case breez_sdk_spark.SdkEventPaymentFailed:
-		// A payment failed
+		// A payment failed. payment.Details carries the method-specific
+		// context to show the user.
 		failedPayment := event.Payment
 		_ = failedPayment
 	case breez_sdk_spark.SdkEventAutoOptimization:
-		// An auto-optimization event occurred
+		// Background optimizer progress: started, round completed, or a
+		// terminal outcome. Manual OptimizeLeaves calls do not emit these.
 		optimizationEvent := event.OptimizationEvent
 		_ = optimizationEvent
 	case breez_sdk_spark.SdkEventLightningAddressChanged:
-		// The lightning address has changed
+		// The lightning address changed on another device. Unset when the
+		// address was deleted.
 		lightningAddress := event.LightningAddress
 		_ = lightningAddress
 	case breez_sdk_spark.SdkEventUnilateralExitStateChanged:

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
@@ -64,35 +64,43 @@ class GettingStarted {
                     // it is recommended to refresh the payment list and wallet balance.
                 }
                 is SdkEvent.NewDeposits -> {
-                    // New deposits were detected (may be pending or confirmed)
+                    // Detected deposits, as DepositInfo. Only those with isMature set
+                    // have enough confirmations to be claimed. Show the rest as pending.
                     val newDeposits = e.newDeposits
                 }
                 is SdkEvent.UnclaimedDeposits -> {
-                    // SDK was unable to claim some deposits automatically
+                    // Deposits the SDK could not claim. Each claimError says why,
+                    // most often the fee exceeded the configured maximum.
                     val unclaimedDeposits = e.unclaimedDeposits
                 }
                 is SdkEvent.ClaimedDeposits -> {
-                    // Deposits were successfully claimed
+                    // Deposits claimed into the wallet. The resulting payment
+                    // arrives separately as its own event.
                     val claimedDeposits = e.claimedDeposits
                 }
                 is SdkEvent.PaymentSucceeded -> {
-                    // A payment completed successfully
+                    // A payment completed. The cached balance is already refreshed,
+                    // so getInfo returns the new value.
                     val payment = e.payment
                 }
                 is SdkEvent.PaymentPending -> {
-                    // A payment is pending (waiting for confirmation)
+                    // A payment is awaiting confirmation. It arrives again as
+                    // succeeded or failed once it settles.
                     val pendingPayment = e.payment
                 }
                 is SdkEvent.PaymentFailed -> {
-                    // A payment failed
+                    // A payment failed. payment.details carries the method-specific
+                    // context to show the user.
                     val failedPayment = e.payment
                 }
                 is SdkEvent.AutoOptimization -> {
-                    // An auto-optimization event occurred
+                    // Background optimizer progress: started, round completed, or a
+                    // terminal outcome. Manual optimizeLeaves calls do not emit these.
                     val optimizationEvent = e.optimizationEvent
                 }
                 is SdkEvent.LightningAddressChanged -> {
-                    // The lightning address has changed
+                    // The lightning address changed on another device. Unset when the
+                    // address was deleted.
                     val lightningAddress = e.lightningAddress
                 }
                 is SdkEvent.UnilateralExitStateChanged -> {

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
@@ -74,8 +74,8 @@ class GettingStarted {
                     val unclaimedDeposits = e.unclaimedDeposits
                 }
                 is SdkEvent.ClaimedDeposits -> {
-                    // Deposits claimed into the wallet. The resulting payment
-                    // arrives separately as its own event.
+                    // Deposits claimed into the wallet. An instant (0-conf) claim is
+                    // reported here on submission and settles shortly after.
                     val claimedDeposits = e.claimedDeposits
                 }
                 is SdkEvent.PaymentSucceeded -> {

--- a/docs/breez-sdk/snippets/python/src/getting_started.py
+++ b/docs/breez-sdk/snippets/python/src/getting_started.py
@@ -76,28 +76,36 @@ class SdkListener(EventListener):
             # it is recommended to refresh the payment list and wallet balance.
             pass
         elif isinstance(event, SdkEvent.NEW_DEPOSITS):
-            # New deposits were detected (may be pending or confirmed)
+            # Detected deposits, as DepositInfo. Only those with is_mature set
+            # have enough confirmations to be claimed. Show the rest as pending.
             new_deposits = event.new_deposits
         elif isinstance(event, SdkEvent.UNCLAIMED_DEPOSITS):
-            # SDK was unable to claim some deposits automatically
+            # Deposits the SDK could not claim. Each claim_error says why,
+            # most often the fee exceeded the configured maximum.
             unclaimed_deposits = event.unclaimed_deposits
         elif isinstance(event, SdkEvent.CLAIMED_DEPOSITS):
-            # Deposits were successfully claimed
+            # Deposits claimed into the wallet. The resulting payment
+            # arrives separately as its own event.
             claimed_deposits = event.claimed_deposits
         elif isinstance(event, SdkEvent.PAYMENT_SUCCEEDED):
-            # A payment completed successfully
+            # A payment completed. The cached balance is already refreshed,
+            # so get_info returns the new value.
             payment = event.payment
         elif isinstance(event, SdkEvent.PAYMENT_PENDING):
-            # A payment is pending (waiting for confirmation)
+            # A payment is awaiting confirmation. It arrives again as
+            # succeeded or failed once it settles.
             pending_payment = event.payment
         elif isinstance(event, SdkEvent.PAYMENT_FAILED):
-            # A payment failed
+            # A payment failed. payment.details carries the method-specific
+            # context to show the user.
             failed_payment = event.payment
         elif isinstance(event, SdkEvent.AUTO_OPTIMIZATION):
-            # An auto-optimization event occurred
+            # Background optimizer progress: started, round completed, or a
+            # terminal outcome. Manual optimize_leaves calls do not emit these.
             optimization_event = event.optimization_event
         elif isinstance(event, SdkEvent.LIGHTNING_ADDRESS_CHANGED):
-            # The lightning address has changed
+            # The lightning address changed on another device. Unset when the
+            # address was deleted.
             lightning_address = event.lightning_address
         elif isinstance(event, SdkEvent.UNILATERAL_EXIT_STATE_CHANGED):
             # The unilateral exit state changed, so a previously exported

--- a/docs/breez-sdk/snippets/python/src/getting_started.py
+++ b/docs/breez-sdk/snippets/python/src/getting_started.py
@@ -84,8 +84,8 @@ class SdkListener(EventListener):
             # most often the fee exceeded the configured maximum.
             unclaimed_deposits = event.unclaimed_deposits
         elif isinstance(event, SdkEvent.CLAIMED_DEPOSITS):
-            # Deposits claimed into the wallet. The resulting payment
-            # arrives separately as its own event.
+            # Deposits claimed into the wallet. An instant (0-conf) claim is
+            # reported here on submission and settles shortly after.
             claimed_deposits = event.claimed_deposits
         elif isinstance(event, SdkEvent.PAYMENT_SUCCEEDED):
             # A payment completed. The cached balance is already refreshed,

--- a/docs/breez-sdk/snippets/react-native/getting_started.ts
+++ b/docs/breez-sdk/snippets/react-native/getting_started.ts
@@ -65,28 +65,36 @@ const exampleAddEventListener = async (sdk: BreezSdk) => {
         // Data has been synchronized with the network. When this event is received,
         // it is recommended to refresh the payment list and wallet balance.
       } else if (event.tag === SdkEvent_Tags.NewDeposits) {
-        // New deposits were detected (may be pending or confirmed)
+        // Detected deposits, as DepositInfo. Only those with isMature set
+        // have enough confirmations to be claimed. Show the rest as pending.
         const newDeposits = event.inner.newDeposits
       } else if (event.tag === SdkEvent_Tags.UnclaimedDeposits) {
-        // SDK was unable to claim some deposits automatically
+        // Deposits the SDK could not claim. Each claimError says why,
+        // most often the fee exceeded the configured maximum.
         const unclaimedDeposits = event.inner.unclaimedDeposits
       } else if (event.tag === SdkEvent_Tags.ClaimedDeposits) {
-        // Deposits were successfully claimed
+        // Deposits claimed into the wallet. The resulting payment
+        // arrives separately as its own event.
         const claimedDeposits = event.inner.claimedDeposits
       } else if (event.tag === SdkEvent_Tags.PaymentSucceeded) {
-        // A payment completed successfully
+        // A payment completed. The cached balance is already refreshed,
+        // so getInfo returns the new value.
         const payment = event.inner.payment
       } else if (event.tag === SdkEvent_Tags.PaymentPending) {
-        // A payment is pending (waiting for confirmation)
+        // A payment is awaiting confirmation. It arrives again as
+        // succeeded or failed once it settles.
         const pendingPayment = event.inner.payment
       } else if (event.tag === SdkEvent_Tags.PaymentFailed) {
-        // A payment failed
+        // A payment failed. payment.details carries the method-specific
+        // context to show the user.
         const failedPayment = event.inner.payment
       } else if (event.tag === SdkEvent_Tags.AutoOptimization) {
-        // An auto-optimization event occurred
+        // Background optimizer progress: started, round completed, or a
+        // terminal outcome. Manual optimizeLeaves calls do not emit these.
         const optimizationEvent = event.inner.optimizationEvent
       } else if (event.tag === SdkEvent_Tags.LightningAddressChanged) {
-        // The lightning address has changed
+        // The lightning address changed on another device. Unset when the
+        // address was deleted.
         const lightningAddress = event.inner.lightningAddress
       } else if (event.tag === SdkEvent_Tags.UnilateralExitStateChanged) {
         // The unilateral exit state changed, so a previously exported

--- a/docs/breez-sdk/snippets/react-native/getting_started.ts
+++ b/docs/breez-sdk/snippets/react-native/getting_started.ts
@@ -73,8 +73,8 @@ const exampleAddEventListener = async (sdk: BreezSdk) => {
         // most often the fee exceeded the configured maximum.
         const unclaimedDeposits = event.inner.unclaimedDeposits
       } else if (event.tag === SdkEvent_Tags.ClaimedDeposits) {
-        // Deposits claimed into the wallet. The resulting payment
-        // arrives separately as its own event.
+        // Deposits claimed into the wallet. An instant (0-conf) claim is
+        // reported here on submission and settles shortly after.
         const claimedDeposits = event.inner.claimedDeposits
       } else if (event.tag === SdkEvent_Tags.PaymentSucceeded) {
         // A payment completed. The cached balance is already refreshed,

--- a/docs/breez-sdk/snippets/rust/src/getting_started.rs
+++ b/docs/breez-sdk/snippets/rust/src/getting_started.rs
@@ -68,28 +68,36 @@ impl EventListener for SdkEventListener {
                 // it is recommended to refresh the payment list and wallet balance.
             }
             SdkEvent::NewDeposits { new_deposits } => {
-                // New deposits were detected (may be pending or confirmed)
+                // Detected deposits, as DepositInfo. Only those with is_mature set
+                // have enough confirmations to be claimed. Show the rest as pending.
             }
             SdkEvent::UnclaimedDeposits { unclaimed_deposits } => {
-                // SDK was unable to claim some deposits automatically
+                // Deposits the SDK could not claim. Each claim_error says why,
+                // most often the fee exceeded the configured maximum.
             }
             SdkEvent::ClaimedDeposits { claimed_deposits } => {
-                // Deposits were successfully claimed
+                // Deposits claimed into the wallet. The resulting payment
+                // arrives separately as its own event.
             }
             SdkEvent::PaymentSucceeded { payment } => {
-                // A payment completed successfully
+                // A payment completed. The cached balance is already refreshed,
+                // so get_info returns the new value.
             }
             SdkEvent::PaymentPending { payment } => {
-                // A payment is pending (waiting for confirmation)
+                // A payment is awaiting confirmation. It arrives again as
+                // succeeded or failed once it settles.
             }
             SdkEvent::PaymentFailed { payment } => {
-                // A payment failed
+                // A payment failed. payment.details carries the method-specific
+                // context to show the user.
             }
             SdkEvent::AutoOptimization { optimization_event } => {
-                // An auto-optimization event occurred
+                // Background optimizer progress: started, round completed, or a
+                // terminal outcome. Manual optimize_leaves calls do not emit these.
             }
             SdkEvent::LightningAddressChanged { lightning_address } => {
-                // The lightning address has changed
+                // The lightning address changed on another device. Unset when the
+                // address was deleted.
             }
             SdkEvent::UnilateralExitStateChanged => {
                 // The unilateral exit state changed, so a previously exported

--- a/docs/breez-sdk/snippets/rust/src/getting_started.rs
+++ b/docs/breez-sdk/snippets/rust/src/getting_started.rs
@@ -76,8 +76,8 @@ impl EventListener for SdkEventListener {
                 // most often the fee exceeded the configured maximum.
             }
             SdkEvent::ClaimedDeposits { claimed_deposits } => {
-                // Deposits claimed into the wallet. The resulting payment
-                // arrives separately as its own event.
+                // Deposits claimed into the wallet. An instant (0-conf) claim is
+                // reported here on submission and settles shortly after.
             }
             SdkEvent::PaymentSucceeded { payment } => {
                 // A payment completed. The cached balance is already refreshed,

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
@@ -65,8 +65,8 @@ class SdkEventListener: EventListener {
             // most often the fee exceeded the configured maximum.
             let _ = unclaimedDeposits
         case .claimedDeposits(let claimedDeposits):
-            // Deposits claimed into the wallet. The resulting payment
-            // arrives separately as its own event.
+            // Deposits claimed into the wallet. An instant (0-conf) claim is
+            // reported here on submission and settles shortly after.
             let _ = claimedDeposits
         case .paymentSucceeded(let paymentSucceeded):
             // A payment completed. The cached balance is already refreshed,

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
@@ -57,28 +57,36 @@ class SdkEventListener: EventListener {
             // it is recommended to refresh the payment list and wallet balance.
             break
         case .newDeposits(let newDeposits):
-            // New deposits were detected (may be pending or confirmed)
+            // Detected deposits, as DepositInfo. Only those with isMature set
+            // have enough confirmations to be claimed. Show the rest as pending.
             let _ = newDeposits
         case .unclaimedDeposits(let unclaimedDeposits):
-            // SDK was unable to claim some deposits automatically
+            // Deposits the SDK could not claim. Each claimError says why,
+            // most often the fee exceeded the configured maximum.
             let _ = unclaimedDeposits
         case .claimedDeposits(let claimedDeposits):
-            // Deposits were successfully claimed
+            // Deposits claimed into the wallet. The resulting payment
+            // arrives separately as its own event.
             let _ = claimedDeposits
         case .paymentSucceeded(let paymentSucceeded):
-            // A payment completed successfully
+            // A payment completed. The cached balance is already refreshed,
+            // so getInfo returns the new value.
             let _ = paymentSucceeded
         case .paymentPending(let paymentPending):
-            // A payment is pending (waiting for confirmation)
+            // A payment is awaiting confirmation. It arrives again as
+            // succeeded or failed once it settles.
             let _ = paymentPending
         case .paymentFailed(let paymentFailed):
-            // A payment failed
+            // A payment failed. payment.details carries the method-specific
+            // context to show the user.
             let _ = paymentFailed
         case .autoOptimization(let optimizationEvent):
-            // An auto-optimization event occurred
+            // Background optimizer progress: started, round completed, or a
+            // terminal outcome. Manual optimizeLeaves calls do not emit these.
             let _ = optimizationEvent
         case .lightningAddressChanged(let lightningAddress):
-            // The lightning address has changed
+            // The lightning address changed on another device. Unset when the
+            // address was deleted.
             let _ = lightningAddress
         case .unilateralExitStateChanged:
             // The unilateral exit state changed, so a previously exported

--- a/docs/breez-sdk/snippets/wasm/getting_started.ts
+++ b/docs/breez-sdk/snippets/wasm/getting_started.ts
@@ -79,42 +79,50 @@ const exampleAddEventListener = async (sdk: BreezSdk) => {
           break
         }
         case 'newDeposits': {
-          // New deposits were detected (may be pending or confirmed)
+          // Detected deposits, as DepositInfo. Only those with isMature set
+          // have enough confirmations to be claimed. Show the rest as pending.
           const newDeposits = event.newDeposits
           break
         }
         case 'unclaimedDeposits': {
-          // SDK was unable to claim some deposits automatically
+          // Deposits the SDK could not claim. Each claimError says why,
+          // most often the fee exceeded the configured maximum.
           const unclaimedDeposits = event.unclaimedDeposits
           break
         }
         case 'claimedDeposits': {
-          // Deposits were successfully claimed
+          // Deposits claimed into the wallet. The resulting payment
+          // arrives separately as its own event.
           const claimedDeposits = event.claimedDeposits
           break
         }
         case 'paymentSucceeded': {
-          // A payment completed successfully
+          // A payment completed. The cached balance is already refreshed,
+          // so getInfo returns the new value.
           const payment = event.payment
           break
         }
         case 'paymentPending': {
-          // A payment is pending (waiting for confirmation)
+          // A payment is awaiting confirmation. It arrives again as
+          // succeeded or failed once it settles.
           const pendingPayment = event.payment
           break
         }
         case 'paymentFailed': {
-          // A payment failed
+          // A payment failed. payment.details carries the method-specific
+          // context to show the user.
           const failedPayment = event.payment
           break
         }
         case 'autoOptimization': {
-          // An auto-optimization event occurred
+          // Background optimizer progress: started, round completed, or a
+          // terminal outcome. Manual optimizeLeaves calls do not emit these.
           const optimizationEvent = event.optimizationEvent
           break
         }
         case 'lightningAddressChanged': {
-          // The lightning address has changed
+          // The lightning address changed on another device. Unset when the
+          // address was deleted.
           const lightningAddress = event.lightningAddress
           break
         }

--- a/docs/breez-sdk/snippets/wasm/getting_started.ts
+++ b/docs/breez-sdk/snippets/wasm/getting_started.ts
@@ -91,8 +91,8 @@ const exampleAddEventListener = async (sdk: BreezSdk) => {
           break
         }
         case 'claimedDeposits': {
-          // Deposits claimed into the wallet. The resulting payment
-          // arrives separately as its own event.
+          // Deposits claimed into the wallet. An instant (0-conf) claim is
+          // reported here on submission and settles shortly after.
           const claimedDeposits = event.claimedDeposits
           break
         }

--- a/docs/breez-sdk/src/guide/events.md
+++ b/docs/breez-sdk/src/guide/events.md
@@ -2,6 +2,37 @@
 
 The SDK emits several events to provide the application with an up-to-date state of the SDK or ongoing payments.
 
+## Event reference
+
+| Event | Payload | What it means and what to do |
+| --- | --- | --- |
+| {{#enum SdkEvent::Synced}} | none | The wallet finished syncing with the network. Refresh the balance and the payment list. See [getting the SDK info](get_info.md). |
+| {{#enum SdkEvent::PaymentSucceeded}} | {{#name Payment}} | A payment completed. The SDK refreshes its cached balance before emitting this, so {{#name get_info}} returns the new value. |
+| {{#enum SdkEvent::PaymentPending}} | {{#name Payment}} | A payment is in flight. The same payment is emitted again as succeeded or failed once it settles. |
+| {{#enum SdkEvent::PaymentFailed}} | {{#name Payment}} | A payment failed. Its {{#name details}} carry the method-specific context to show the user. |
+| {{#enum SdkEvent::NewDeposits}} | {{#name DepositInfo}} list | On-chain deposits were detected. Only deposits whose {{#name is_mature}} is true can be claimed, so show the rest as pending. |
+| {{#enum SdkEvent::ClaimedDeposits}} | {{#name DepositInfo}} list | Deposits were claimed into the wallet. The matching payment is emitted separately as {{#enum SdkEvent::PaymentSucceeded}}. |
+| {{#enum SdkEvent::UnclaimedDeposits}} | {{#name DepositInfo}} list | The SDK could not claim these. Read {{#name claim_error}} for the reason, then claim manually or refund. See [claiming on-chain deposits](onchain_claims.md). |
+| {{#enum SdkEvent::AutoOptimization}} | {{#name AutoOptimizationEvent}} | Progress of the background leaf optimizer. Manual {{#name optimize_leaves}} calls do not emit this. See [custom leaf optimization](optimize.md). |
+| {{#enum SdkEvent::LightningAddressChanged}} | {{#name LightningAddressInfo}}, unset when the address was deleted | The Lightning address changed on another device. See [receiving payments using LNURL-Pay](receive_lnurl_pay.md). |
+
+The fields of {{#name Payment}} are described in [listing payments](list_payments.md). For
+the order in which these events arrive during a receive, see
+[receiving payments](receive_payment.md).
+
+### Deposit fields
+
+The three deposit events each carry a list of {{#name DepositInfo}}, whose fields determine
+what to do next.
+
+| Field | Meaning |
+| --- | --- |
+| {{#name txid}}, {{#name vout}} | The on-chain output the deposit came from. |
+| {{#name amount_sats}} | Deposit value in satoshis. |
+| {{#name is_mature}} | Whether the deposit has enough confirmations to be claimed. |
+| {{#name claim_error}} | Why the last claim attempt failed. Set on {{#enum SdkEvent::UnclaimedDeposits}}. |
+| {{#name refund_tx}}, {{#name refund_tx_id}} | The refund transaction, once one has been created. |
+
 <h2 id="add-event-listener">
     <a class="header" href="#add-event-listener">Add event listener</a>
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.BreezSdk.html#method.add_event_listener">API docs</a>

--- a/docs/breez-sdk/src/guide/events.md
+++ b/docs/breez-sdk/src/guide/events.md
@@ -15,6 +15,7 @@ The SDK emits several events to provide the application with an up-to-date state
 | {{#enum SdkEvent::UnclaimedDeposits}} | {{#name DepositInfo}} list | The SDK could not claim these. Read {{#name claim_error}} for the reason, then claim manually or refund. See [claiming on-chain deposits](onchain_claims.md). |
 | {{#enum SdkEvent::AutoOptimization}} | {{#name AutoOptimizationEvent}} | Progress of the background leaf optimizer. Manual {{#name optimize_leaves}} calls do not emit this. See [custom leaf optimization](optimize.md). |
 | {{#enum SdkEvent::LightningAddressChanged}} | {{#name LightningAddressInfo}}, unset when the address was deleted | The Lightning address changed on another device. See [receiving payments using LNURL-Pay](receive_lnurl_pay.md). |
+| {{#enum SdkEvent::UnilateralExitStateChanged}} | none | An exit state exported earlier is now out of date. Export it again. See [unilateral exit](unilateral_exit.md). |
 
 The fields of {{#name Payment}} are described in [listing payments](list_payments.md). For
 the order in which these events arrive during a receive, see
@@ -32,6 +33,7 @@ what to do next.
 | {{#name is_mature}} | Whether the deposit has enough confirmations to be claimed. |
 | {{#name claim_error}} | Why the last claim attempt failed. Set on {{#enum SdkEvent::UnclaimedDeposits}}. |
 | {{#name refund_tx}}, {{#name refund_tx_id}} | The refund transaction, once one has been created. |
+| {{#name instant_claim_status}} | State of an instant (0-conf) claim attempt. Unset when none was attempted. |
 
 <h2 id="add-event-listener">
     <a class="header" href="#add-event-listener">Add event listener</a>


### PR DESCRIPTION
The `.md` files we publish for LLMs were expanded HTML in a markdown wrapper: 274 `<custom-tabs>` widgets, 5,112 nine-way `<span>` copies of identifiers, and 67 section headings that were raw `<h2>` so no heading existed at all. 

This PR makes the preprocessor renderer-aware, so the website keeps its tabs and language spans while every other
renderer gets real markdown, and adds a per-language edition of the whole book. It also documents what each `SdkEvent` actually carries, which is what prompted the work.

### Published structure
Additive. `/guide/*.md` and `/llms-full.txt` keep their current paths and shape.

| Path | Contents |
| --- | --- |
| `/llms.txt` | Index. Language editions listed first, each tagged with the dependency it matches |
| `/guide/events.md` | Canonical page, examples in all nine languages (unchanged) |
| `/llms-full.txt` | Whole book, all languages |
| `/llms-rust-full.txt` | Whole book, one language. Nine of these, around 330 KB against 1.01 MB |
| `/llms/rust/llms.txt` | Per-edition index |
| `/llms/rust/guide/events.md` | Per-edition page, 69 per edition |

An edition carries one language throughout, with identifiers in that language's naming convention: `get_info` in Rust, `GetInfo` in Go, `getInfo` in Kotlin.

### Before and after

`guide/get_info.md` opened with a raw `<h1>`, so the page had no title, and its first sentence cost 473 bytes.

Before:

    <h1 id="getting-the-sdk-info">
        <a class="header" href="#getting-the-sdk-info">Getting the SDK info</a>
        <a class="tag" href="...#method.get_info">API docs</a>
    </h1>

    Once connected, you can retrieve the current state of the SDK at any time using <code
    class="lang-fn"><span class="fn-rust">get_info</span><span class="fn-python">get_info
    </span><span class="fn-swift">getInfo</span> ...six more spans... </code>. This returns:

After, 106 bytes:

    # Getting the SDK info

    API docs: https://breez.github.io/spark-sdk/...#method.get_info

    Once connected, you can retrieve the current state of the SDK at any time using
    `get_info`. This returns:

Snippet blocks were bold paragraphs, invisible to any outline or chunker. They are now headings nested under the enclosing section.

Before:

    <h2 id="add-event-listener">
        <a class="header" href="#add-event-listener">Add event listener</a>
        <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/...#method.add_event_listener">API docs</a>
    </h2>

    <custom-tabs category="lang">
    <div slot="title">Rust</div>
    <section>

    ```rust,ignore

After:

    ## Add event listener

    API docs: https://breez.github.io/spark-sdk/...#method.add_event_listener

    ### Rust

    ```rust

### Events

`events.md` gains a payload reference: all ten events with their payload type and what to do, plus the `DepositInfo` fields that drive the decisions. Six `SdkEvent` variants had no doc comment at all and `DepositInfo` fields were undocumented. Snippet comments across all nine languages now name the payload and the field that matters, so `NewDeposits` explains what `is_mature` means rather than restating the variant name.
