### PR TITLE
Add SDK-wide SOCKS5 proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879#b5f4683aba10efd875d674f2bb9a5800b047a879"
+source = "git+https://github.com/breez/boltz-client?rev=82f55b8059f54e6e06a4a2d0a901743dc8f83949#82f55b8059f54e6e06a4a2d0a901743dc8f83949"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -1335,14 +1335,16 @@ dependencies = [
  "hex",
  "k256",
  "lightning-invoice 0.34.0",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879)",
- "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=82f55b8059f54e6e06a4a2d0a901743dc8f83949)",
+ "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=82f55b8059f54e6e06a4a2d0a901743dc8f83949)",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tiny-keccak",
  "tokio",
+ "tokio-socks",
+ "tokio-tungstenite 0.28.0",
  "tokio-tungstenite-wasm",
  "tracing",
  "url",
@@ -4336,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879#b5f4683aba10efd875d674f2bb9a5800b047a879"
+source = "git+https://github.com/breez/boltz-client?rev=82f55b8059f54e6e06a4a2d0a901743dc8f83949#82f55b8059f54e6e06a4a2d0a901743dc8f83949"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -5092,11 +5094,11 @@ dependencies = [
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879#b5f4683aba10efd875d674f2bb9a5800b047a879"
+source = "git+https://github.com/breez/boltz-client?rev=82f55b8059f54e6e06a4a2d0a901743dc8f83949#82f55b8059f54e6e06a4a2d0a901743dc8f83949"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=82f55b8059f54e6e06a4a2d0a901743dc8f83949)",
  "reqwest",
  "serde",
  "serde_json",
@@ -8564,7 +8566,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5074,13 +5074,17 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "http",
+ "hyper-util",
  "macros 0.1.0",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-socks",
  "tokio_with_wasm",
+ "tower-service",
  "tracing",
  "web-time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ rand = "0.8"
 rcgen = "0.14.5"
 secp256k1 = { version = "0.29", features = ["rand"] }
 regex-lite = "0.1.6"
-reqwest = { version = "0.12.23", default-features = false, features = ["json", "http2", "charset", "system-proxy", "rustls-tls"] }
+reqwest = { version = "0.12.23", default-features = false, features = ["json", "http2", "charset", "system-proxy", "socks", "rustls-tls"] }
 rstest = "0.26.1"
 rstest_reuse = "0.7.0"
 # We want to match the rusqlite version used by ldk-node and the rest of the ecosystem
@@ -233,6 +233,8 @@ tonic-build = { version = "0.12.3", features = ["prost"] }
 tonic-types = "0.12.3"
 tonic-web-wasm-client = "0.6"
 tower-service = "0.3.3"
+hyper-util = { version = "0.1.20", default-features = false, features = ["tokio"] }
+tokio-socks = "0.5.2"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 tsify-next = {version = "0.5.5", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ bech32 = "0.11.0"
 bip39 = "2.2.0"
 bitcoin = { version = "0.32.6", features = ["serde"] }
 bitflags = "2.10.0"
-boltz-client = { git = "https://github.com/breez/boltz-client", rev = "b5f4683aba10efd875d674f2bb9a5800b047a879" }
+boltz-client = { git = "https://github.com/breez/boltz-client", rev = "82f55b8059f54e6e06a4a2d0a901743dc8f83949" }
 breez-sdk-common = { path = "crates/breez-sdk/common", default-features = false }
 breez-sdk-spark = { path = "crates/breez-sdk/core" }
 built = { version = "0.8.0", features = ["git2"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,16 @@
+# Every outbound connection must be able to honour `Config.proxy`. A client
+# built straight from reqwest connects direct and cannot be routed, so build
+# new ones through `platform_utils::create_http_client_with_proxy` instead.
+#
+# `platform-utils` itself, and the DoH resolver (which needs binary response
+# bodies the `HttpClient` trait cannot carry), opt out locally with an
+# `#[allow]` carrying the reason.
+#
+# `DefaultHttpClient::default()` cannot be listed here: clippy does not match
+# trait-impl paths. It survives only in test and tooling crates, which are not
+# a leak vector for integrators.
+disallowed-methods = [
+  { path = "reqwest::Client::new", reason = "build clients via platform_utils::create_http_client_with_proxy so they honour Config.proxy" },
+  { path = "reqwest::Client::builder", reason = "build clients via platform_utils::create_http_client_with_proxy so they honour Config.proxy" },
+  { path = "reqwest::ClientBuilder::new", reason = "build clients via platform_utils::create_http_client_with_proxy so they honour Config.proxy" },
+]

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -1412,7 +1412,7 @@ public static class Commands
 
     private static async Task HandleGetSparkStatus(BreezSdk sdk, Func<string, string?> readline, string[] args)
     {
-        var result = await BreezSdkSparkMethods.GetSparkStatus();
+        var result = await BreezSdkSparkMethods.GetSparkStatus(new GetSparkStatusRequest());
         Serialization.PrintValue(result);
     }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -1182,7 +1182,7 @@ Future<void> _handleSetUserSettings(BreezSdk sdk, TokenIssuer tokenIssuer, List<
 // --- get-spark-status ---
 
 Future<void> _handleGetSparkStatus(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
-  final result = await getSparkStatus();
+  final result = await getSparkStatus(request: const GetSparkStatusRequest());
   printValue(result);
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -1437,7 +1437,7 @@ func handleSetUserSettings(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, 
 // --- get-spark-status ---
 
 func handleGetSparkStatus(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, _ []string) error {
-	result, err := breez_sdk_spark.GetSparkStatus()
+	result, err := breez_sdk_spark.GetSparkStatus(breez_sdk_spark.GetSparkStatusRequest{})
 	if err = liftError(err); err != nil {
 		return err
 	}

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/passkey.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/passkey.go
@@ -161,7 +161,10 @@ func resolvePasskeySeed(
 	listLabels bool,
 	storeLabel bool,
 ) (breez_sdk_spark.Seed, error) {
-	passkey := breez_sdk_spark.NewPasskeyClient(provider, breezAPIKey, nil)
+	passkey, err := breez_sdk_spark.NewPasskeyClient(provider, breezAPIKey, nil)
+	if err = liftError(err); err != nil {
+		return nil, err
+	}
 
 	// --list-labels: discovery sign-in (no cached label) returns the
 	// published label set; prompt the user to pick one.

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -1164,7 +1164,7 @@ suspend fun handleSetUserSettings(sdk: BreezSdk, reader: LineReader, args: List<
 // --- get-spark-status ---
 
 suspend fun handleGetSparkStatus(sdk: BreezSdk, reader: LineReader, args: List<String>) {
-    val result = getSparkStatus()
+    val result = getSparkStatus(GetSparkStatusRequest())
     printValue(result)
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -1142,7 +1142,7 @@ func handleSetUserSettings(_ sdk: BreezSdk, _ args: [String]) async throws {
 // --- get-spark-status ---
 
 func handleGetSparkStatus(_ sdk: BreezSdk, _ args: [String]) async throws {
-    let result = try await getSparkStatus()
+    let result = try await getSparkStatus(request: GetSparkStatusRequest())
     printValue(result)
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Passkey.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Passkey.swift
@@ -194,7 +194,7 @@ func resolvePasskeySeed(
     listLabels: Bool,
     storeLabel: Bool
 ) async throws -> Seed {
-    let passkey = PasskeyClient(prfProvider: provider, breezApiKey: breezApiKey, config: nil)
+    let passkey = try PasskeyClient(prfProvider: provider, breezApiKey: breezApiKey, config: nil)
 
     // --list-labels: discovery sign-in (no cached label) returns the
     // published label set; prompt the user to pick one.

--- a/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyClientBuilder.swift
+++ b/crates/breez-sdk/bindings/langs/swift/Sources/BreezSdkSpark/PasskeyClientBuilder.swift
@@ -39,9 +39,11 @@ public class PasskeyClientBuilder {
     /// Construct the client. Falls back to a default ``PasskeyProvider``
     /// on the config's `providerOptions` (default: the Breez RP) when no
     /// provider was injected.
-    public func build() -> PasskeyClient {
+    /// Throws when the config carries a proxy the relay transport cannot
+    /// honour.
+    public func build() throws -> PasskeyClient {
         let resolved = provider ?? PasskeyProvider(options: config?.providerOptions ?? PasskeyProviderOptions())
-        return PasskeyClient(prfProvider: resolved, breezApiKey: breezApiKey, config: config)
+        return try PasskeyClient(prfProvider: resolved, breezApiKey: breezApiKey, config: config)
     }
 }
 
@@ -59,9 +61,11 @@ public extension PasskeyClient {
     ///   - breezApiKey: Breez relay key for authenticated (NIP-42) label
     ///     storage. Pass `nil` for public relays only.
     ///   - config: Passkey client config (`providerOptions` / `defaultLabel`).
+    ///
+    /// Throws when `config` carries a proxy the relay transport cannot honour.
     @available(iOS 18.0, macOS 15.0, *)
-    convenience init(breezApiKey: String?, config: PasskeyConfig? = nil) {
-        self.init(
+    convenience init(breezApiKey: String?, config: PasskeyConfig? = nil) throws {
+        try self.init(
             prfProvider: PasskeyProvider(options: config?.providerOptions ?? PasskeyProviderOptions()),
             breezApiKey: breezApiKey,
             config: config

--- a/crates/breez-sdk/breez-itest/src/chain_service.rs
+++ b/crates/breez-sdk/breez-itest/src/chain_service.rs
@@ -41,7 +41,7 @@ impl BitcoindRpc {
             rpc_url: bitcoind.rpc_url.clone(),
             rpcuser: bitcoind.rpcuser.clone(),
             rpcpassword: bitcoind.rpcpassword.clone(),
-            http: DefaultHttpClient::default(),
+            http: DefaultHttpClient::new(None).expect("http client"),
         }
     }
 

--- a/crates/breez-sdk/breez-itest/src/faucet.rs
+++ b/crates/breez-sdk/breez-itest/src/faucet.rs
@@ -102,7 +102,7 @@ impl RegtestFaucet {
         info!("Initialized faucet client with URL: {}", config.url);
         Ok(Self {
             config,
-            http_client: DefaultHttpClient::default(),
+            http_client: DefaultHttpClient::new(None).expect("http client"),
         })
     }
 

--- a/crates/breez-sdk/breez-itest/src/fixtures/mod.rs
+++ b/crates/breez-sdk/breez-itest/src/fixtures/mod.rs
@@ -1,6 +1,7 @@
 pub mod data_sync;
 pub mod docker;
 pub mod lnurl;
+pub mod socks5;
 
 use anyhow::Result;
 use breez_sdk_spark::{

--- a/crates/breez-sdk/breez-itest/src/fixtures/socks5.rs
+++ b/crates/breez-sdk/breez-itest/src/fixtures/socks5.rs
@@ -1,0 +1,73 @@
+//! A real SOCKS5 proxy in a container, so proxy tests exercise the actual
+//! handshake rather than a stub.
+
+use anyhow::Result;
+use breez_sdk_spark::ProxyConfig;
+use testcontainers::{
+    ContainerAsync, ContainerRequest, GenericImage, ImageExt,
+    core::{ContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+const SOCKS_PORT: u16 = 1080;
+
+/// A running SOCKS5 proxy. The container stops when this is dropped, so keep it
+/// alive for as long as the SDK under test needs to reach the network.
+pub struct Socks5Proxy {
+    _container: ContainerAsync<GenericImage>,
+    config: ProxyConfig,
+}
+
+impl Socks5Proxy {
+    /// Starts a proxy with no authentication.
+    pub async fn start() -> Result<Self> {
+        Self::start_inner(None).await
+    }
+
+    /// Starts a proxy that requires the given credentials.
+    pub async fn start_with_credentials(user: &str, password: &str) -> Result<Self> {
+        Self::start_inner(Some((user.to_string(), password.to_string()))).await
+    }
+
+    async fn start_inner(credentials: Option<(String, String)>) -> Result<Self> {
+        let mut image: ContainerRequest<GenericImage> =
+            GenericImage::new("serjs/go-socks5-proxy", "latest")
+                .with_exposed_port(ContainerPort::Tcp(SOCKS_PORT))
+                // The image logs to stderr, including its ready line.
+                .with_wait_for(WaitFor::message_on_stderr("Start listening proxy service"))
+                .into();
+
+        image = match &credentials {
+            Some((user, password)) => image
+                .with_env_var("PROXY_USER", user)
+                .with_env_var("PROXY_PASSWORD", password),
+            // The image refuses to start unless authentication is either
+            // configured or explicitly waived.
+            None => image.with_env_var("REQUIRE_AUTH", "false"),
+        };
+
+        let container = image.start().await?;
+        let port = container.get_host_port_ipv4(SOCKS_PORT).await?;
+        let (username, password) = match credentials {
+            Some((user, password)) => (Some(user), Some(password)),
+            None => (None, None),
+        };
+
+        Ok(Self {
+            _container: container,
+            config: ProxyConfig {
+                // The container publishes on the host loopback, which is also
+                // what a real Tor or local proxy deployment looks like.
+                host: "127.0.0.1".to_string(),
+                port,
+                username,
+                password,
+            },
+        })
+    }
+
+    /// The config to put on `Config::proxy`.
+    pub fn config(&self) -> ProxyConfig {
+        self.config.clone()
+    }
+}

--- a/crates/breez-sdk/breez-itest/src/helpers/cross_chain_evm.rs
+++ b/crates/breez-sdk/breez-itest/src/helpers/cross_chain_evm.rs
@@ -35,6 +35,8 @@ const EVM_POLL_INTERVAL: Duration = Duration::from_secs(5);
 /// its connection pool / TLS setup) per call would be wasteful.
 fn http_client() -> &'static reqwest::Client {
     static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    // Test-only helper talking to a local EVM node; no SDK proxy applies.
+    #[allow(clippy::disallowed_methods)]
     CLIENT.get_or_init(reqwest::Client::new)
 }
 

--- a/crates/breez-sdk/breez-itest/tests/distributed_lock.rs
+++ b/crates/breez-sdk/breez-itest/tests/distributed_lock.rs
@@ -111,8 +111,12 @@ async fn test_distributed_lock_acquire_and_release(
     // Same signer key = same user (two instances of the same wallet)
     let signer_key: [u8; 32] = [1u8; 32];
 
-    let sync_client: Arc<dyn SyncerClient> =
-        Arc::new(BreezSyncerClient::new(grpc_url, None, "breez-sdk-itest")?);
+    let sync_client: Arc<dyn SyncerClient> = Arc::new(BreezSyncerClient::new(
+        grpc_url,
+        None,
+        "breez-sdk-itest",
+        None,
+    )?);
 
     let instance_a = create_signing_client(Arc::clone(&sync_client), &signer_key);
     let instance_b = create_signing_client(Arc::clone(&sync_client), &signer_key);
@@ -158,8 +162,12 @@ async fn test_distributed_lock_multiple_instances(
 
     let signer_key: [u8; 32] = [2u8; 32];
 
-    let sync_client: Arc<dyn SyncerClient> =
-        Arc::new(BreezSyncerClient::new(grpc_url, None, "breez-sdk-itest")?);
+    let sync_client: Arc<dyn SyncerClient> = Arc::new(BreezSyncerClient::new(
+        grpc_url,
+        None,
+        "breez-sdk-itest",
+        None,
+    )?);
 
     let instance_a = create_signing_client(Arc::clone(&sync_client), &signer_key);
     let instance_b = create_signing_client(Arc::clone(&sync_client), &signer_key);
@@ -212,8 +220,12 @@ async fn test_distributed_lock_expiration(
 
     let signer_key: [u8; 32] = [3u8; 32];
 
-    let sync_client: Arc<dyn SyncerClient> =
-        Arc::new(BreezSyncerClient::new(grpc_url, None, "breez-sdk-itest")?);
+    let sync_client: Arc<dyn SyncerClient> = Arc::new(BreezSyncerClient::new(
+        grpc_url,
+        None,
+        "breez-sdk-itest",
+        None,
+    )?);
 
     let instance_a = create_signing_client(Arc::clone(&sync_client), &signer_key);
     let instance_b = create_signing_client(Arc::clone(&sync_client), &signer_key);
@@ -249,8 +261,12 @@ async fn test_distributed_lock_release_idempotent(
 
     let signer_key: [u8; 32] = [4u8; 32];
 
-    let sync_client: Arc<dyn SyncerClient> =
-        Arc::new(BreezSyncerClient::new(grpc_url, None, "breez-sdk-itest")?);
+    let sync_client: Arc<dyn SyncerClient> = Arc::new(BreezSyncerClient::new(
+        grpc_url,
+        None,
+        "breez-sdk-itest",
+        None,
+    )?);
 
     let instance_a = create_signing_client(Arc::clone(&sync_client), &signer_key);
 
@@ -281,8 +297,12 @@ async fn test_distributed_lock_different_users(
     let user_a_key: [u8; 32] = [5u8; 32];
     let user_b_key: [u8; 32] = [6u8; 32];
 
-    let sync_client: Arc<dyn SyncerClient> =
-        Arc::new(BreezSyncerClient::new(grpc_url, None, "breez-sdk-itest")?);
+    let sync_client: Arc<dyn SyncerClient> = Arc::new(BreezSyncerClient::new(
+        grpc_url,
+        None,
+        "breez-sdk-itest",
+        None,
+    )?);
 
     let user_a = create_signing_client(Arc::clone(&sync_client), &user_a_key);
     let user_b = create_signing_client(Arc::clone(&sync_client), &user_b_key);
@@ -322,8 +342,12 @@ async fn test_distributed_lock_exclusive(
 
     let signer_key: [u8; 32] = [7u8; 32];
 
-    let sync_client: Arc<dyn SyncerClient> =
-        Arc::new(BreezSyncerClient::new(grpc_url, None, "breez-sdk-itest")?);
+    let sync_client: Arc<dyn SyncerClient> = Arc::new(BreezSyncerClient::new(
+        grpc_url,
+        None,
+        "breez-sdk-itest",
+        None,
+    )?);
 
     let instance_a = create_signing_client(Arc::clone(&sync_client), &signer_key);
     let instance_b = create_signing_client(Arc::clone(&sync_client), &signer_key);

--- a/crates/breez-sdk/breez-itest/tests/lnurl.rs
+++ b/crates/breez-sdk/breez-itest/tests/lnurl.rs
@@ -999,7 +999,7 @@ async fn test_09_invoice_expiry_parameter() -> Result<()> {
     let custom_expiry_secs = 600_u32;
 
     // Request invoice WITH custom expiry
-    let http_client = DefaultHttpClient::default();
+    let http_client = DefaultHttpClient::new(None).expect("http client");
     let url_with_expiry = format!("{callback}?amount={amount_msat}&expiry={custom_expiry_secs}");
     let response = http_client
         .get(url_with_expiry.clone(), None)
@@ -1698,7 +1698,8 @@ async fn test_16_client_signing_lnurl_pay_publish_twice() -> Result<()> {
 /// The `nostrPubkey` an address advertises in its LNURL-pay response.
 async fn user_nostr_pubkey(lnurl: &LnurlFixture, username: &str) -> Result<String> {
     let url = format!("{}/lnurlp/{username}", lnurl.http_url());
-    let response = DefaultHttpClient::default()
+    let response = DefaultHttpClient::new(None)
+        .expect("http client")
         .get(url, None)
         .await
         .map_err(|e| anyhow::anyhow!("lnurl-pay request failed: {e:?}"))?;
@@ -1750,7 +1751,8 @@ async fn request_zap_invoice(
         .append_pair("amount", &amount_msat.to_string())
         .append_pair("nostr", &zap_request.as_json());
 
-    let response = DefaultHttpClient::default()
+    let response = DefaultHttpClient::new(None)
+        .expect("http client")
         .get(url.to_string(), None)
         .await
         .map_err(|e| anyhow::anyhow!("invoice request failed: {e:?}"))?;

--- a/crates/breez-sdk/breez-itest/tests/lnurl_legacy_client.rs
+++ b/crates/breez-sdk/breez-itest/tests/lnurl_legacy_client.rs
@@ -102,7 +102,7 @@ impl LegacyClient {
             secp,
             secret,
             pubkey,
-            http: DefaultHttpClient::default(),
+            http: DefaultHttpClient::new(None).expect("http client"),
         }
     }
 

--- a/crates/breez-sdk/breez-itest/tests/proxy.rs
+++ b/crates/breez-sdk/breez-itest/tests/proxy.rs
@@ -1,0 +1,136 @@
+//! SDK-wide SOCKS5 proxy: traffic reaches the network through a real proxy,
+//! and never around it.
+
+use anyhow::Result;
+use breez_sdk_itest::fixtures::socks5::Socks5Proxy;
+use breez_sdk_itest::*;
+use breez_sdk_spark::*;
+use rand::RngCore;
+use rstest::*;
+use tempfile::Builder;
+use tracing::info;
+
+fn random_seed() -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+    seed
+}
+
+async fn build_proxied_sdk(prefix: &str, proxy: Option<ProxyConfig>) -> Result<SdkInstance> {
+    let dir = Builder::new().prefix(prefix).tempdir()?;
+    let mut config = default_config(Network::Regtest);
+    config.proxy = proxy;
+    build_sdk_with_custom_config(
+        dir.path().to_string_lossy().to_string(),
+        random_seed(),
+        config,
+        Some(dir),
+        true,
+    )
+    .await
+}
+
+/// Issues a Lightning invoice, which cannot be answered from local state: it
+/// needs the operators over gRPC and the SSP over HTTP.
+async fn request_invoice(sdk: &SdkInstance) -> Result<String> {
+    Ok(sdk
+        .sdk
+        .receive_payment(ReceivePaymentRequest {
+            payment_method: ReceivePaymentMethod::Bolt11Invoice {
+                description: "proxy itest".to_string(),
+                amount_sats: Some(1_000),
+                expiry_secs: None,
+                payment_hash: None,
+                receiver_identity_public_key: None,
+            },
+        })
+        .await?
+        .payment_request)
+}
+
+/// Issuing a Lightning invoice needs both the operator gRPC channels and the
+/// SSP over HTTP, so a success here means the SOCKS5 handshake works on both
+/// transports.
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn proxied_sdk_reaches_the_network() -> Result<()> {
+    let proxy = Socks5Proxy::start().await?;
+    info!("SOCKS5 proxy listening on {}", proxy.config().port);
+
+    let sdk = build_proxied_sdk("breez-sdk-proxy", Some(proxy.config())).await?;
+
+    let invoice = request_invoice(&sdk).await?;
+    info!("issued an invoice through the proxy: {invoice}");
+
+    // The status API is a plain HTTPS call made without an SDK instance, so it
+    // carries the proxy on its own request.
+    get_spark_status(GetSparkStatusRequest {
+        proxy: Some(proxy.config()),
+    })
+    .await?;
+
+    sdk.sdk.disconnect().await?;
+    Ok(())
+}
+
+/// The same, through a proxy that demands credentials, so the RFC 1929
+/// exchange is covered too.
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn proxied_sdk_authenticates_to_the_proxy() -> Result<()> {
+    let proxy = Socks5Proxy::start_with_credentials("breez", "hunter2").await?;
+
+    let sdk = build_proxied_sdk("breez-sdk-proxy-auth", Some(proxy.config())).await?;
+
+    request_invoice(&sdk).await?;
+
+    sdk.sdk.disconnect().await?;
+    Ok(())
+}
+
+/// The test that actually pins "fails closed": with the proxy pointed at a port
+/// nothing listens on, every network operation must fail. A success would mean
+/// the SDK reached the network directly, which is the leak this exists to
+/// prevent.
+///
+/// Deliberately probes operations that surface transport errors. `get_info`
+/// and `connect` would not do: both fall back to locally stored state by
+/// design, so they succeed whether or not anything reached the network.
+///
+/// Needs no proxy container, so it runs anywhere the rest of the suite does.
+#[rstest]
+#[test_log::test(tokio::test)]
+async fn unreachable_proxy_never_falls_back_to_a_direct_connection() -> Result<()> {
+    let dead_proxy = ProxyConfig {
+        host: "127.0.0.1".to_string(),
+        // Port 1 is reserved and never bound by the test environment.
+        port: 1,
+        username: None,
+        password: None,
+    };
+
+    // HTTP path, with no SDK involved.
+    let status = get_spark_status(GetSparkStatusRequest {
+        proxy: Some(dead_proxy.clone()),
+    })
+    .await;
+    assert!(
+        status.is_err(),
+        "the status API answered through an unreachable proxy, so it went direct"
+    );
+
+    // Connecting succeeds: startup sync failures are logged, not fatal, and the
+    // SDK serves stored state instead. So the guarantee has to be pinned on an
+    // operation that genuinely needs the network, below.
+    let sdk = build_proxied_sdk("breez-sdk-proxy-dead", Some(dead_proxy)).await?;
+
+    // Operator gRPC plus SSP HTTP, both of which propagate their errors.
+    let invoice = request_invoice(&sdk).await;
+    assert!(
+        invoice.is_err(),
+        "issued an invoice through an unreachable proxy, so traffic went direct"
+    );
+
+    sdk.sdk.disconnect().await?;
+    Ok(())
+}

--- a/crates/breez-sdk/cli/src/command/mod.rs
+++ b/crates/breez-sdk/cli/src/command/mod.rs
@@ -1266,7 +1266,10 @@ pub(crate) async fn execute_command(
             Ok(true)
         }
         Command::GetSparkStatus => {
-            let res = breez_sdk_spark::get_spark_status().await?;
+            let res = breez_sdk_spark::get_spark_status(
+                breez_sdk_spark::GetSparkStatusRequest::default(),
+            )
+            .await?;
             print_value(&res)?;
             Ok(true)
         }

--- a/crates/breez-sdk/cli/src/main.rs
+++ b/crates/breez-sdk/cli/src/main.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 
 use anyhow::{Result, anyhow};
 use breez_sdk_spark::{
-    CrossChainConfig, EventListener, Network, SdkBuilder, SdkEvent, Seed, StableBalanceConfig,
-    StableBalanceToken, default_config, default_mysql_storage_config,
+    CrossChainConfig, EventListener, Network, ProxyConfig, SdkBuilder, SdkEvent, Seed,
+    StableBalanceConfig, StableBalanceToken, default_config, default_mysql_storage_config,
     default_postgres_storage_config, default_server_config,
 };
 use clap::Parser;
@@ -92,6 +92,39 @@ struct Cli {
     /// (e.g. a local test server).
     #[arg(long)]
     lnurl_domain: Option<String>,
+
+    /// Route every connection through a SOCKS5 proxy, as `HOST:PORT`
+    /// (e.g. `127.0.0.1:9050` for a local Tor daemon).
+    #[arg(long, value_name = "HOST:PORT")]
+    proxy: Option<String>,
+
+    /// Username for SOCKS5 authentication. Requires `--proxy-password`.
+    #[arg(long, requires_all = ["proxy", "proxy_password"])]
+    proxy_user: Option<String>,
+
+    /// Password for SOCKS5 authentication. Requires `--proxy-user`.
+    #[arg(long, requires_all = ["proxy", "proxy_user"])]
+    proxy_password: Option<String>,
+}
+
+/// Parses `HOST:PORT` into a [`ProxyConfig`]. Split from the right so an IPv6
+/// literal keeps its colons.
+fn parse_proxy(
+    address: &str,
+    username: Option<String>,
+    password: Option<String>,
+) -> Result<ProxyConfig> {
+    let (host, port) = address
+        .rsplit_once(':')
+        .ok_or_else(|| anyhow!("Invalid proxy '{address}', expected HOST:PORT"))?;
+    Ok(ProxyConfig {
+        host: host.to_string(),
+        port: port
+            .parse()
+            .map_err(|_| anyhow!("Invalid proxy port '{port}'"))?,
+        username,
+        password,
+    })
 }
 
 fn expand_path(path: &str) -> PathBuf {
@@ -153,6 +186,7 @@ async fn run_interactive_mode(
     stable_balance_config: Option<StableBalanceConfig>,
     passkey_config: Option<PasskeyConfig>,
     lnurl_domain: Option<String>,
+    proxy: Option<ProxyConfig>,
 ) -> Result<()> {
     breez_sdk_spark::init_logging(Some(data_dir.to_string_lossy().into()), None, None)?;
     let persistence = CliPersistence {
@@ -181,6 +215,7 @@ async fn run_interactive_mode(
     };
     config.api_key.clone_from(&breez_api_key);
     config.stable_balance_config = stable_balance_config;
+    config.proxy.clone_from(&proxy);
     if lnurl_domain.is_some() {
         config.lnurl_domain = lnurl_domain;
     }
@@ -202,6 +237,7 @@ async fn run_interactive_mode(
             config.label,
             config.list_labels,
             config.store_label,
+            proxy,
         )
         .await?
     } else {
@@ -340,6 +376,11 @@ async fn main() -> Result<(), anyhow::Error> {
         rpid: cli.rpid,
     });
 
+    let proxy = cli
+        .proxy
+        .map(|address| parse_proxy(&address, cli.proxy_user, cli.proxy_password))
+        .transpose()?;
+
     Box::pin(run_interactive_mode(
         data_dir,
         network,
@@ -350,6 +391,7 @@ async fn main() -> Result<(), anyhow::Error> {
         stable_balance_config,
         passkey_config,
         cli.lnurl_domain,
+        proxy,
     ))
     .await?;
 

--- a/crates/breez-sdk/cli/src/passkey/mod.rs
+++ b/crates/breez-sdk/cli/src/passkey/mod.rs
@@ -4,8 +4,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
-use breez_sdk_spark::Seed;
-use breez_sdk_spark::passkey::{PasskeyClient, PrfProvider, PrfProviderError, SignInRequest};
+use breez_sdk_spark::passkey::{
+    PasskeyClient, PasskeyConfig as SdkPasskeyConfig, PrfProvider, PrfProviderError, SignInRequest,
+};
+use breez_sdk_spark::{ProxyConfig, Seed};
 
 #[cfg(feature = "fido2")]
 pub mod fido2_prf;
@@ -87,8 +89,14 @@ pub async fn resolve_passkey_seed(
     label: Option<String>,
     list_labels: bool,
     store_label: bool,
+    proxy: Option<ProxyConfig>,
 ) -> Result<Seed> {
-    let client = PasskeyClient::new(provider, breez_api_key, None);
+    // The relays storing wallet labels would otherwise connect direct.
+    let config = proxy.map(|proxy| SdkPasskeyConfig {
+        proxy: Some(proxy),
+        ..SdkPasskeyConfig::default()
+    });
+    let client = PasskeyClient::new(provider, breez_api_key, config)?;
 
     // --list-labels: discovery sign-in (no cached label) returns the
     // discovered label set; prompt user to pick.

--- a/crates/breez-sdk/cli/tests/harness/faucet.rs
+++ b/crates/breez-sdk/cli/tests/harness/faucet.rs
@@ -92,7 +92,8 @@ async fn try_fund_address(address: &str, amount_sats: u64) -> Result<String> {
         add_basic_auth_header(&mut headers, &username, &password);
     }
 
-    let response = DefaultHttpClient::default()
+    let response = DefaultHttpClient::new(None)
+        .expect("http client")
         .post(url, Some(headers), Some(body))
         .await
         .context("faucet request failed")?;

--- a/crates/breez-sdk/common/Cargo.toml
+++ b/crates/breez-sdk/common/Cargo.toml
@@ -29,6 +29,7 @@ lightning.workspace = true
 macros.workspace = true
 platform-utils.workspace = true
 prost.workspace = true
+reqwest.workspace = true
 regex-lite.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
@@ -58,7 +59,6 @@ tonic = { workspace = true, features = [
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 dnssec-prover = { workspace = true, features = ["validation"] }
 http.workspace = true
-reqwest.workspace = true
 tonic = { workspace = true, features = ["codegen", "prost"] }
 tonic-web-wasm-client.workspace = true
 tower-service.workspace = true

--- a/crates/breez-sdk/common/src/breez_server.rs
+++ b/crates/breez-sdk/common/src/breez_server.rs
@@ -1,3 +1,4 @@
+use platform_utils::ProxyConfig;
 use tokio::sync::Mutex;
 use tonic::codegen::InterceptedService;
 use tonic::metadata::errors::InvalidMetadataValue;
@@ -34,9 +35,10 @@ impl BreezServer {
         server_url: &str,
         api_key: Option<String>,
         user_agent: &str,
+        proxy: Option<&ProxyConfig>,
     ) -> anyhow::Result<Self> {
         Ok(Self {
-            grpc_client: Mutex::new(GrpcClient::new(server_url, user_agent)?),
+            grpc_client: Mutex::new(GrpcClient::new(server_url, user_agent, proxy)?),
             api_key,
         })
     }

--- a/crates/breez-sdk/common/src/dns/doh.rs
+++ b/crates/breez-sdk/common/src/dns/doh.rs
@@ -1,0 +1,94 @@
+//! DNS-over-HTTPS transport for the `DNSSEC` proof builder.
+//!
+//! Used on WASM, where raw DNS sockets don't exist, and on native whenever a
+//! proxy is configured: a plain DNS query would go out over UDP, outside the
+//! SOCKS5 tunnel, and leak exactly the hostname the proxy is meant to hide.
+//!
+//! This talks to `reqwest` directly rather than through
+//! [`HttpClient`](platform_utils::HttpClient) because `DoH` responses are binary
+//! wire-format DNS, and that trait carries bodies as `String`. The proxy is
+//! applied here so the exception can't become a leak.
+
+use anyhow::{Result, anyhow};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use dnssec_prover::query::{ProofBuilder, QueryBuf};
+use dnssec_prover::rr::Name;
+use platform_utils::ProxyConfig;
+use reqwest::Client;
+
+const DOH_ENDPOINT: &str = "https://cloudflare-dns.com/dns-query";
+
+/// TXT record type, per RFC 1035.
+const RR_TYPE_TXT: u16 = 16;
+
+/// Builds the `DoH` client, routing it through `proxy` when one is set.
+///
+/// `proxy` is unreachable on WASM: `reqwest` has no proxy support there, and
+/// the WASM resolver rejects a proxy before calling this.
+#[cfg_attr(
+    all(target_family = "wasm", target_os = "unknown"),
+    expect(unused_variables)
+)]
+pub(super) fn build_client(proxy: Option<&ProxyConfig>) -> Result<Client> {
+    // DoH responses are binary DNS wire format, which `HttpClient` cannot
+    // carry, so this builds its own client and applies the proxy itself.
+    #[allow(clippy::disallowed_methods)]
+    let builder = Client::builder();
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    let builder = match proxy {
+        Some(proxy) => builder.proxy(reqwest::Proxy::all(proxy.reqwest_url())?),
+        None => builder,
+    };
+    Ok(builder.build()?)
+}
+
+/// Builds a `DNSSEC` proof for `name`'s TXT records over `DoH`.
+///
+/// The proof is verified by the caller, so a hostile resolver can withhold an
+/// answer but cannot forge one.
+pub(super) async fn build_proof(client: &Client, name: &Name) -> Result<Vec<u8>> {
+    let (mut builder, initial_query) = ProofBuilder::new(name, RR_TYPE_TXT);
+    let mut pending_queries = vec![initial_query];
+
+    while builder.awaiting_responses() {
+        if pending_queries.is_empty() {
+            anyhow::bail!("ProofBuilder awaiting responses but no queries to send");
+        }
+
+        let mut new_queries = Vec::new();
+        for query in pending_queries {
+            let response_bytes = send_query(client, query.as_ref()).await?;
+
+            let mut response_buf = QueryBuf::new_zeroed(0);
+            response_buf.extend_from_slice(&response_bytes);
+
+            let queries = builder
+                .process_response(&response_buf)
+                .map_err(|e| anyhow!("Failed to process DNS response: {e:?}"))?;
+            new_queries.extend(queries);
+        }
+        pending_queries = new_queries;
+    }
+
+    let (proof, _ttl) = builder
+        .finish_proof()
+        .map_err(|e| anyhow!("Failed to finish DNSSEC proof: {e:?}"))?;
+
+    Ok(proof)
+}
+
+async fn send_query(client: &Client, query: &[u8]) -> Result<Vec<u8>> {
+    let encoded_query = URL_SAFE_NO_PAD.encode(query);
+
+    let response = client
+        .get(format!("{DOH_ENDPOINT}?dns={encoded_query}"))
+        .header("Accept", "application/dns-message")
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+
+    Ok(response.to_vec())
+}

--- a/crates/breez-sdk/common/src/dns/mod.rs
+++ b/crates/breez-sdk/common/src/dns/mod.rs
@@ -1,3 +1,5 @@
+mod doh;
+
 #[cfg_attr(
     all(target_family = "wasm", target_os = "unknown"),
     path = "resolver_wasm.rs"

--- a/crates/breez-sdk/common/src/dns/resolver.rs
+++ b/crates/breez-sdk/common/src/dns/resolver.rs
@@ -2,20 +2,45 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use anyhow::Result;
 use dnssec_prover::query::build_txt_proof_async;
+use platform_utils::ProxyConfig;
+use reqwest::Client;
 
-use super::{DnsResolver, normalize_dns_name, parse_dns_name, verify_proof_and_extract_txt};
+use super::{DnsResolver, doh, normalize_dns_name, parse_dns_name, verify_proof_and_extract_txt};
 
 /// Default DNS resolver address (Cloudflare's public DNS)
 const DEFAULT_RESOLVER: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 53);
 
+/// How queries reach a resolver.
+enum Transport {
+    /// Plain DNS straight to `SocketAddr`.
+    Plain(SocketAddr),
+    /// DNS-over-HTTPS, so the query rides the same proxied TLS path as every
+    /// other request instead of escaping over UDP.
+    Doh(Client),
+}
+
 pub struct Resolver {
-    resolver_addr: SocketAddr,
+    transport: Transport,
 }
 
 impl Resolver {
     pub fn new() -> Self {
         Self {
-            resolver_addr: DEFAULT_RESOLVER,
+            transport: Transport::Plain(DEFAULT_RESOLVER),
+        }
+    }
+
+    /// A resolver that respects `proxy`.
+    ///
+    /// With a proxy set this switches to `DoH`: plain DNS is UDP, which a SOCKS5
+    /// proxy does not carry, so the query would bypass the tunnel and reveal
+    /// the name being looked up. Without one, this is [`Self::new`].
+    pub fn with_proxy(proxy: Option<&ProxyConfig>) -> Result<Self> {
+        match proxy {
+            Some(proxy) => Ok(Self {
+                transport: Transport::Doh(doh::build_client(Some(proxy))?),
+            }),
+            None => Ok(Self::new()),
         }
     }
 }
@@ -32,10 +57,15 @@ impl DnsResolver for Resolver {
         let dns_name = normalize_dns_name(dns_name);
         let name = parse_dns_name(&dns_name)?;
 
-        // Build the DNSSEC proof by querying the resolver
-        let (proof, _ttl) = build_txt_proof_async(self.resolver_addr, &name)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to build DNSSEC proof: {e}"))?;
+        let proof = match &self.transport {
+            Transport::Plain(addr) => {
+                let (proof, _ttl) = build_txt_proof_async(*addr, &name)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to build DNSSEC proof: {e}"))?;
+                proof
+            }
+            Transport::Doh(client) => doh::build_proof(client, &name).await?,
+        };
 
         verify_proof_and_extract_txt(&proof, &name)
     }

--- a/crates/breez-sdk/common/src/dns/resolver_wasm.rs
+++ b/crates/breez-sdk/common/src/dns/resolver_wasm.rs
@@ -1,19 +1,33 @@
 use anyhow::{Result, anyhow};
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use dnssec_prover::query::{ProofBuilder, QueryBuf};
-use dnssec_prover::rr::Name;
+use platform_utils::ProxyConfig;
 use reqwest::Client;
 
-use super::{DnsResolver, normalize_dns_name, parse_dns_name, verify_proof_and_extract_txt};
+use super::{DnsResolver, doh, normalize_dns_name, parse_dns_name, verify_proof_and_extract_txt};
 
-const DOH_ENDPOINT: &str = "https://cloudflare-dns.com/dns-query";
-
-pub struct Resolver;
+pub struct Resolver {
+    /// A failed build is carried rather than unwrapped: this type is
+    /// constructed during `connect`, where a panic aborts the wasm module.
+    client: Result<Client, String>,
+}
 
 impl Resolver {
     pub fn new() -> Self {
-        Self
+        Self {
+            client: doh::build_client(None).map_err(|e| e.to_string()),
+        }
+    }
+
+    /// `proxy` must be `None`: browser fetch offers no proxy control, so the
+    /// lookup cannot be tunnelled and must not silently go direct.
+    pub fn with_proxy(proxy: Option<&ProxyConfig>) -> Result<Self> {
+        if proxy.is_some() {
+            return Err(anyhow!(
+                "a SOCKS5 proxy cannot be honoured on WASM: fetch exposes no proxy control"
+            ));
+        }
+        Ok(Self {
+            client: Ok(doh::build_client(None)?),
+        })
     }
 }
 
@@ -29,68 +43,12 @@ impl DnsResolver for Resolver {
         let dns_name = normalize_dns_name(dns_name);
         let name = parse_dns_name(&dns_name)?;
 
-        // Build DNSSEC proof using DoH
-        let proof = build_proof_doh(&name).await?;
+        let client = self
+            .client
+            .as_ref()
+            .map_err(|e| anyhow!("Failed to build DoH client: {e}"))?;
+        let proof = doh::build_proof(client, &name).await?;
 
         verify_proof_and_extract_txt(&proof, &name)
     }
-}
-
-/// Build a DNSSEC proof using DNS-over-HTTPS queries
-async fn build_proof_doh(name: &Name) -> Result<Vec<u8>> {
-    let client = Client::builder().build()?;
-
-    // TXT record type = 16
-    let (mut builder, initial_query) = ProofBuilder::new(name, 16);
-
-    // Send initial query
-    let mut pending_queries = vec![initial_query];
-
-    while builder.awaiting_responses() {
-        if pending_queries.is_empty() {
-            anyhow::bail!("ProofBuilder awaiting responses but no queries to send");
-        }
-
-        // Process each pending query
-        let mut new_queries = Vec::new();
-        for query in pending_queries {
-            // Send the query via DoH
-            let response_bytes = send_doh_query(&client, query.as_ref()).await?;
-
-            // Convert response bytes to QueryBuf
-            let mut response_buf = QueryBuf::new_zeroed(0);
-            response_buf.extend_from_slice(&response_bytes);
-
-            // Process the response and collect new queries
-            let queries = builder
-                .process_response(&response_buf)
-                .map_err(|e| anyhow!("Failed to process DNS response: {e:?}"))?;
-            new_queries.extend(queries);
-        }
-        pending_queries = new_queries;
-    }
-
-    // Finish and return the proof
-    let (proof, _ttl) = builder
-        .finish_proof()
-        .map_err(|e| anyhow!("Failed to finish DNSSEC proof: {e:?}"))?;
-
-    Ok(proof)
-}
-
-/// Send a DNS query via DNS-over-HTTPS
-async fn send_doh_query(client: &Client, query: &[u8]) -> Result<Vec<u8>> {
-    // Base64url encode the query for GET request
-    let encoded_query = URL_SAFE_NO_PAD.encode(query);
-
-    let response = client
-        .get(format!("{DOH_ENDPOINT}?dns={encoded_query}"))
-        .header("Accept", "application/dns-message")
-        .send()
-        .await?
-        .error_for_status()?
-        .bytes()
-        .await?;
-
-    Ok(response.to_vec())
 }

--- a/crates/breez-sdk/common/src/grpc/transport.rs
+++ b/crates/breez-sdk/common/src/grpc/transport.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use platform_utils::{ProxyConfig, Socks5Connector};
 use std::time::Duration;
 use tonic::transport::ClientTlsConfig;
 
@@ -10,10 +11,19 @@ pub struct GrpcClient {
 }
 
 impl GrpcClient {
-    pub fn new(url: &str, user_agent: &str) -> Result<Self> {
-        Ok(Self {
-            inner: Self::create_endpoint(url, user_agent)?.connect_lazy(),
-        })
+    /// A lazily-connected channel to `url`, tunnelled through `proxy` when one
+    /// is set.
+    ///
+    /// The proxy only replaces how the TCP connection is opened. Tonic still
+    /// applies the endpoint's TLS config on top, with the SNI name taken from
+    /// `url`, so certificate validation is unchanged either way.
+    pub fn new(url: &str, user_agent: &str, proxy: Option<&ProxyConfig>) -> Result<Self> {
+        let endpoint = Self::create_endpoint(url, user_agent)?;
+        let inner = match proxy {
+            Some(proxy) => endpoint.connect_with_connector_lazy(Socks5Connector::new(proxy)),
+            None => endpoint.connect_lazy(),
+        };
+        Ok(Self { inner })
     }
 
     pub fn into_inner(self) -> Transport {

--- a/crates/breez-sdk/common/src/grpc/transport_wasm.rs
+++ b/crates/breez-sdk/common/src/grpc/transport_wasm.rs
@@ -1,7 +1,8 @@
 use std::task::{Context, Poll};
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use http::HeaderValue;
+use platform_utils::ProxyConfig;
 use tower_service::Service;
 
 #[derive(Clone)]
@@ -39,7 +40,16 @@ pub struct GrpcClient {
 }
 
 impl GrpcClient {
-    pub fn new(url: &str, user_agent: &str) -> Result<Self> {
+    /// `proxy` must be `None` here: browser fetch offers no proxy control, so a
+    /// proxied channel cannot be built. Callers are expected to have rejected
+    /// the config already; this is the backstop that keeps an unhonoured proxy
+    /// from turning into silent direct traffic.
+    pub fn new(url: &str, user_agent: &str, proxy: Option<&ProxyConfig>) -> Result<Self> {
+        if proxy.is_some() {
+            return Err(anyhow!(
+                "a SOCKS5 proxy cannot be honoured on WASM: fetch exposes no proxy control"
+            ));
+        }
         let user_agent = HeaderValue::from_str(user_agent)?;
         Ok(Self {
             inner: Transport {

--- a/crates/breez-sdk/common/src/input/mod.rs
+++ b/crates/breez-sdk/common/src/input/mod.rs
@@ -10,4 +10,6 @@ pub use cross_chain::{
 };
 pub use error::*;
 pub use models::*;
-pub use parser::{parse, parse_invoice, parse_spark_address, validate_lightning_address_format};
+pub use parser::{
+    InputParser, parse_invoice, parse_spark_address, validate_lightning_address_format,
+};

--- a/crates/breez-sdk/common/src/input/parser/mod.rs
+++ b/crates/breez-sdk/common/src/input/parser/mod.rs
@@ -2,14 +2,14 @@ use std::ops::Not;
 
 use bitcoin::{Address, Denomination, address::NetworkUnchecked};
 use lightning::bolt11_invoice::Bolt11InvoiceDescriptionRef;
+use platform_utils::HttpClient;
 use platform_utils::time::UNIX_EPOCH;
-use platform_utils::{DefaultHttpClient, HttpClient};
 use regex_lite::Regex;
 use spark_wallet::{SparkAddress, SparkAddressPaymentType};
 use tracing::{debug, error, warn};
 
 use crate::{
-    dns::{self, DnsResolver},
+    dns::DnsResolver,
     input::{
         Bip21Extra, ExternalInputParser, LnurlRequestDetails, ParseError, PaymentRequestSource,
         SparkAddressDetails, SparkInvoiceDetails,
@@ -46,19 +46,6 @@ pub fn validate_lightning_address_format(input: &str) -> bool {
         return false;
     }
     url::Url::parse(&format!("https://{domain}")).is_ok()
-}
-
-pub async fn parse(
-    input: &str,
-    external_input_parsers: Option<Vec<ExternalInputParser>>,
-) -> Result<InputType, ParseError> {
-    InputParser::new(
-        dns::Resolver::new(),
-        DefaultHttpClient::default(),
-        external_input_parsers,
-    )
-    .parse(input)
-    .await
 }
 
 pub fn parse_invoice(input: &str) -> Option<Bolt11InvoiceDetails> {

--- a/crates/breez-sdk/common/src/input/parser/tests.rs
+++ b/crates/breez-sdk/common/src/input/parser/tests.rs
@@ -345,7 +345,7 @@ async fn test_bip353_real_dns() {
     use platform_utils::DefaultHttpClient;
 
     let dns_resolver = Resolver::new();
-    let rest_client = DefaultHttpClient::default();
+    let rest_client = DefaultHttpClient::new(None).expect("http client");
     let input_parser = InputParser::new(dns_resolver, rest_client, None);
 
     // Test BIP353 address with ₿ prefix

--- a/crates/breez-sdk/common/src/sync/client.rs
+++ b/crates/breez-sdk/common/src/sync/client.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, anyhow};
 
+use platform_utils::ProxyConfig;
 use tonic::{
     Request, Status, Streaming,
     metadata::{Ascii, MetadataValue},
@@ -32,7 +33,12 @@ pub struct BreezSyncerClient {
 
 impl BreezSyncerClient {
     #[allow(unused)]
-    pub fn new(server_url: &str, api_key: Option<&str>, user_agent: &str) -> anyhow::Result<Self> {
+    pub fn new(
+        server_url: &str,
+        api_key: Option<&str>,
+        user_agent: &str,
+        proxy: Option<&ProxyConfig>,
+    ) -> anyhow::Result<Self> {
         let api_key_metadata = match &api_key {
             Some(key) => Some(
                 format!("Bearer {key}")
@@ -43,7 +49,7 @@ impl BreezSyncerClient {
         };
 
         let client = ProtoSyncerClient::with_interceptor(
-            GrpcClient::new(server_url, user_agent)?.into_inner(),
+            GrpcClient::new(server_url, user_agent, proxy)?.into_inner(),
             ApiKeyInterceptor { api_key_metadata },
         );
         Ok(Self { client })

--- a/crates/breez-sdk/core/src/chain/mod.rs
+++ b/crates/breez-sdk/core/src/chain/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use platform_utils::{DefaultHttpClient, HttpClient};
+use platform_utils::HttpClient;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -144,6 +144,17 @@ impl Serialize for Outspend {
     }
 }
 
+/// Options for [`new_rest_chain_service`].
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct NewRestChainServiceRequest {
+    /// Routes the chain service through a SOCKS5 proxy. Pass the same value as
+    /// [`Config::proxy`](crate::Config::proxy): this service is built outside
+    /// the SDK, so it cannot pick the setting up on its own.
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub proxy: Option<crate::ProxyConfig>,
+}
+
 /// Constructs a shareable REST-based [`BitcoinChainService`].
 ///
 /// Pass the returned `Arc` to multiple [`SdkBuilder`](crate::SdkBuilder)s via
@@ -152,22 +163,33 @@ impl Serialize for Outspend {
 /// SDK instances. All SDKs sharing the service must use the same `network`.
 ///
 /// For one-off, non-shared use, prefer
-/// [`SdkBuilder::with_rest_chain_service`](crate::SdkBuilder::with_rest_chain_service).
+/// [`SdkBuilder::with_rest_chain_service`](crate::SdkBuilder::with_rest_chain_service),
+/// which builds on the SDK's own client and inherits its proxy automatically.
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
-#[must_use]
 pub async fn new_rest_chain_service(
     url: String,
     network: Network,
     api_type: ChainApiType,
     credentials: Option<Credentials>,
-) -> Arc<dyn BitcoinChainService> {
-    let http_client: Arc<dyn HttpClient> = Arc::new(DefaultHttpClient::default());
-    Arc::new(RestClientChainService::new(
+    request: NewRestChainServiceRequest,
+) -> Result<Arc<dyn BitcoinChainService>, crate::SdkError> {
+    if let Some(proxy) = &request.proxy {
+        proxy.validate()?;
+    }
+    let http_client: Arc<dyn HttpClient> = platform_utils::create_http_client_with_proxy(
+        None,
+        request
+            .proxy
+            .as_ref()
+            .map(platform_utils::ProxyConfig::from)
+            .as_ref(),
+    );
+    Ok(Arc::new(RestClientChainService::new(
         url,
         network,
         5,
         http_client,
         credentials.map(|c| BasicAuth::new(c.username, c.password)),
         api_type,
-    ))
+    )))
 }

--- a/crates/breez-sdk/core/src/chain/mod.rs
+++ b/crates/breez-sdk/core/src/chain/mod.rs
@@ -183,7 +183,10 @@ pub async fn new_rest_chain_service(
             .as_ref()
             .map(platform_utils::ProxyConfig::from)
             .as_ref(),
-    );
+    )
+    .map_err(|e| {
+        crate::SdkError::InvalidInput(format!("Failed to build proxied HTTP client: {e}"))
+    })?;
     Ok(Arc::new(RestClientChainService::new(
         url,
         network,

--- a/crates/breez-sdk/core/src/chain/mod.rs
+++ b/crates/breez-sdk/core/src/chain/mod.rs
@@ -173,20 +173,8 @@ pub async fn new_rest_chain_service(
     credentials: Option<Credentials>,
     request: NewRestChainServiceRequest,
 ) -> Result<Arc<dyn BitcoinChainService>, crate::SdkError> {
-    if let Some(proxy) = &request.proxy {
-        proxy.validate()?;
-    }
-    let http_client: Arc<dyn HttpClient> = platform_utils::create_http_client_with_proxy(
-        None,
-        request
-            .proxy
-            .as_ref()
-            .map(platform_utils::ProxyConfig::from)
-            .as_ref(),
-    )
-    .map_err(|e| {
-        crate::SdkError::InvalidInput(format!("Failed to build proxied HTTP client: {e}"))
-    })?;
+    let http_client: Arc<dyn HttpClient> =
+        crate::ProxyConfig::http_client(request.proxy.as_ref(), None)?;
     Ok(Arc::new(RestClientChainService::new(
         url,
         network,

--- a/crates/breez-sdk/core/src/common/models.rs
+++ b/crates/breez-sdk/core/src/common/models.rs
@@ -349,7 +349,7 @@ pub struct LnurlPayRequestDetails {
     pub nostr_pubkey: Option<String>,
 }
 
-/// Wrapped in a [`InputType::LnurlAuth`], this is the result of [`parse`](breez_sdk_common::input::parse) when given a LNURL-auth endpoint.
+/// Wrapped in a [`InputType::LnurlAuth`], this is the result of parsing a LNURL-auth endpoint.
 ///
 /// It represents the endpoint's parameters for the LNURL workflow.
 ///

--- a/crates/breez-sdk/core/src/cross_chain/boltz.rs
+++ b/crates/breez-sdk/core/src/cross_chain/boltz.rs
@@ -80,6 +80,7 @@ impl BoltzService {
     ///
     /// Only performs the build validation and builds the storage adapter,
     /// deferring the inner [`BoltzClient`] construction to first use.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn build(
         network: Network,
         spark_wallet: Arc<SparkWallet>,
@@ -87,11 +88,20 @@ impl BoltzService {
         ecies: Option<Arc<dyn crate::signer::EciesSigner>>,
         fiat_service: Arc<dyn FiatService>,
         lightning_sender: Arc<LightningSender>,
+        proxy: Option<&crate::ProxyConfig>,
         shutdown_receiver: watch::Receiver<()>,
     ) -> Result<Option<Arc<dyn CrossChainService>>, SdkError> {
-        let Some(config) = Self::default_client_config(network) else {
+        let Some(mut config) = Self::default_client_config(network) else {
             return Ok(None);
         };
+        // boltz-client opens its own HTTP and WebSocket connections, so the
+        // proxy has to reach it as config rather than as a shared client.
+        config.proxy = proxy.map(|proxy| boltz_client::ProxyConfig {
+            host: proxy.host.clone(),
+            port: proxy.port,
+            username: proxy.username.clone(),
+            password: proxy.password.clone(),
+        });
         // Boltz encrypts each swap's secrets, so it can't run without an ECIES
         // signer (a signing-only signer has none).
         let Some(ecies) = ecies else {

--- a/crates/breez-sdk/core/src/cross_chain/orchestra.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra.rs
@@ -132,11 +132,13 @@ impl OrchestraService {
         spark_wallet: Arc<SparkWallet>,
         storage: Arc<dyn Storage>,
         fiat_service: Arc<dyn FiatService>,
+        http_client: Arc<dyn platform_utils::HttpClient>,
         shutdown_receiver: watch::Receiver<()>,
     ) -> Self {
         let client = Arc::new(OrchestraClient::new(
             config_resolver,
             Arc::clone(&spark_wallet),
+            http_client,
         ));
         let (monitor_trigger, _) = broadcast::channel(10);
 

--- a/crates/breez-sdk/core/src/error.rs
+++ b/crates/breez-sdk/core/src/error.rs
@@ -143,7 +143,8 @@ impl From<boltz_client::BoltzError> for SdkError {
             | BoltzError::QuoteExpired
             | BoltzError::InvalidQuote(_)
             | BoltzError::QuoteDegradedBeyondSlippage { .. }
-            | BoltzError::DuplicatePreimage => SdkError::InvalidInput(e.to_string()),
+            | BoltzError::DuplicatePreimage
+            | BoltzError::InvalidConfig(_) => SdkError::InvalidInput(e.to_string()),
             _ => SdkError::Generic(format!("Boltz: {e}")),
         }
     }

--- a/crates/breez-sdk/core/src/jwt_header_provider.rs
+++ b/crates/breez-sdk/core/src/jwt_header_provider.rs
@@ -436,7 +436,7 @@ mod persistence_tests {
             token: RwLock::new(None),
             api_key: "test-key".to_string(),
             storage: cell,
-            http_client: create_http_client(Some("jwt-test")),
+            http_client: create_http_client(Some("jwt-test")).expect("http client"),
         }
     }
 

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -27,8 +27,8 @@ pub mod turnkey;
 mod utils;
 
 pub use chain::{
-    BitcoinChainService, ChainServiceError, Outspend, RecommendedFees, TxStatus, Utxo,
-    new_rest_chain_service,
+    BitcoinChainService, ChainServiceError, NewRestChainServiceRequest, Outspend, RecommendedFees,
+    TxStatus, Utxo, new_rest_chain_service,
     rest_client::{ChainApiType, RestClientChainService},
 };
 pub use common::rest::{RestClient, RestResponse};
@@ -52,7 +52,8 @@ pub use persist::{
     path::default_storage_path,
 };
 pub use sdk::{
-    BreezSdk, default_config, default_server_config, get_spark_status, init_logging, parse_input,
+    BreezSdk, GetSparkStatusRequest, default_config, default_server_config, get_spark_status,
+    init_logging,
 };
 pub use sdk_builder::SdkBuilder;
 pub use sdk_context::{SdkContext, SdkContextConfig, new_shared_sdk_context};

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -619,6 +619,23 @@ impl From<&ProxyConfig> for platform_utils::ProxyConfig {
 }
 
 impl ProxyConfig {
+    /// A validated HTTP client honouring `proxy`, for the components built
+    /// outside the SDK's shared context. Everything inside it takes the
+    /// context's pooled client instead and never sees a proxy.
+    pub(crate) fn http_client(
+        proxy: Option<&Self>,
+        user_agent: Option<&str>,
+    ) -> Result<std::sync::Arc<dyn platform_utils::HttpClient>, SdkError> {
+        if let Some(proxy) = proxy {
+            proxy.validate()?;
+        }
+        platform_utils::create_http_client_with_proxy(
+            user_agent,
+            proxy.map(platform_utils::ProxyConfig::from).as_ref(),
+        )
+        .map_err(|e| SdkError::InvalidInput(format!("Failed to build proxied HTTP client: {e}")))
+    }
+
     /// Rejects a proxy the SDK cannot honour end to end. Accepting one it can
     /// only partly apply would leave some traffic going direct, which is worse
     /// than refusing outright.

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -582,6 +582,74 @@ impl FromStr for Network {
     }
 }
 
+/// A SOCKS5 proxy carrying the connections the SDK opens.
+///
+/// Hostnames are resolved by the proxy rather than locally, so a DNS query
+/// never discloses which host is being reached. A connection that cannot be
+/// established through the proxy fails: the SDK never falls back to a direct
+/// one.
+///
+/// Not supported on WASM, where the browser owns connection setup and exposes
+/// no proxy control. In Node, route the SDK by installing a proxy dispatcher
+/// on the global `fetch` instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct ProxyConfig {
+    /// Proxy host. An IP address, or a name resolvable locally: reaching the
+    /// proxy is the one lookup that cannot itself go through the proxy.
+    pub host: String,
+    pub port: u16,
+    /// Username for SOCKS5 username/password authentication. Authentication is
+    /// only offered when both this and `password` are set.
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub username: Option<String>,
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub password: Option<String>,
+}
+
+impl From<&ProxyConfig> for platform_utils::ProxyConfig {
+    fn from(config: &ProxyConfig) -> Self {
+        Self {
+            host: config.host.clone(),
+            port: config.port,
+            username: config.username.clone(),
+            password: config.password.clone(),
+        }
+    }
+}
+
+impl ProxyConfig {
+    /// Rejects a proxy the SDK cannot honour end to end. Accepting one it can
+    /// only partly apply would leave some traffic going direct, which is worse
+    /// than refusing outright.
+    pub(crate) fn validate(&self) -> Result<(), SdkError> {
+        if cfg!(all(target_family = "wasm", target_os = "unknown")) {
+            return Err(SdkError::InvalidInput(
+                "A SOCKS5 proxy is not supported on WASM: the browser owns connection setup and \
+                 exposes no proxy control. In Node, install a proxy dispatcher on the global \
+                 fetch instead."
+                    .to_string(),
+            ));
+        }
+        if self.host.is_empty() {
+            return Err(SdkError::InvalidInput(
+                "Proxy host must not be empty".to_string(),
+            ));
+        }
+        if self.port == 0 {
+            return Err(SdkError::InvalidInput(
+                "Proxy port must not be 0".to_string(),
+            ));
+        }
+        if self.username.is_some() != self.password.is_some() {
+            return Err(SdkError::InvalidInput(
+                "Proxy username and password must be set together".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[allow(clippy::struct_excessive_bools)]
@@ -705,6 +773,16 @@ pub struct Config {
     /// must be `None`, and `optimization_config.auto_enabled` must be `false`.
     /// `default_server_config` already sets these compatible values.
     pub background_tasks_enabled: bool,
+
+    /// Routes the connections the SDK opens through a SOCKS5 proxy.
+    ///
+    /// Covers HTTP and gRPC alike, and resolves hostnames at the proxy so no
+    /// DNS query leaks the destination. `None` (default) connects directly.
+    ///
+    /// When an [`SdkContext`](crate::SdkContext) is supplied to the builder,
+    /// its proxy must match this one: the context owns the shared clients, so
+    /// a disagreement would mean part of the traffic bypassed the proxy.
+    pub proxy: Option<ProxyConfig>,
 
     /// Configuration for cross-chain sends via Orchestra and Boltz.
     ///
@@ -1001,6 +1079,8 @@ impl Config {
                 "token optimization target output count must be less than the minimum outputs threshold".to_string(),
             ));
         }
+
+        self.proxy.as_ref().map_or(Ok(()), ProxyConfig::validate)?;
 
         if let Some(cc) = &self.cross_chain_config {
             if self.network != Network::Mainnet {

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -646,6 +646,26 @@ impl ProxyConfig {
                 "Proxy username and password must be set together".to_string(),
             ));
         }
+        // The host ends up in a URL authority, so it has to survive being put
+        // there unchanged. Parsing is not enough on its own: a host carrying
+        // `@` parses, but as userinfo, which silently turns part of it into a
+        // username and moves the address. Checked here rather than at client
+        // build time so the error names the config that caused it.
+        let address = platform_utils::ProxyConfig::from(self).address();
+        let intact = url::Url::parse(&format!("socks5h://{address}")).is_ok_and(|url| {
+            url.username().is_empty()
+                && url.password().is_none()
+                && url.port() == Some(self.port)
+                && url.path().is_empty()
+                && url.query().is_none()
+                && url.fragment().is_none()
+        });
+        if !intact {
+            return Err(SdkError::InvalidInput(format!(
+                "Proxy host '{}' cannot be used in a proxy URL",
+                self.host
+            )));
+        }
         Ok(())
     }
 }

--- a/crates/breez-sdk/core/src/passkey/error.rs
+++ b/crates/breez-sdk/core/src/passkey/error.rs
@@ -133,6 +133,12 @@ pub enum PasskeyError {
         source: PrfProviderError,
     },
 
+    /// The client was configured in a way it cannot honour, so no
+    /// operation would succeed. Not retryable until the integrator
+    /// changes the configuration.
+    #[error("Invalid passkey configuration: {0}")]
+    InvalidConfig(String),
+
     #[error("Passkey error: {0}")]
     Generic(String),
 }
@@ -142,13 +148,16 @@ impl PasskeyError {
     /// reports the classification of the `PrfProviderError` it wraps, so
     /// it is indistinguishable here from the same failure before the
     /// credential existed: match the variant itself to tell them apart.
-    /// The remaining non-Prf variants map to `Internal`, since they stem
-    /// from SDK or network state rather than the authenticator.
+    /// `InvalidConfig` maps to `Configuration`: the integrator has to
+    /// change something before a retry can succeed. The remaining
+    /// non-Prf variants map to `Internal`, since they stem from SDK or
+    /// network state rather than the authenticator.
     #[must_use]
     pub fn kind(&self) -> ErrorKind {
         match self {
             Self::Prf(inner) => inner.kind(),
             Self::CreatedButNotDerived { source, .. } => source.kind(),
+            Self::InvalidConfig(_) => ErrorKind::Configuration,
             _ => ErrorKind::Internal,
         }
     }

--- a/crates/breez-sdk/core/src/passkey/mod.rs
+++ b/crates/breez-sdk/core/src/passkey/mod.rs
@@ -468,10 +468,13 @@ mod tests {
 
         match Passkey::new(prf_provider, None, Some(config)).err() {
             Some(PasskeyError::InvalidConfig(m)) => {
-                assert!(
-                    m.contains("proxy authentication"),
-                    "expected a proxy-auth rejection, got: {m}"
-                );
+                // WASM rejects any proxy before the credentials are looked at.
+                let expected = if cfg!(all(target_family = "wasm", target_os = "unknown")) {
+                    "not supported on WASM"
+                } else {
+                    "proxy authentication"
+                };
+                assert!(m.contains(expected), "expected {expected:?}, got: {m}");
             }
             other => panic!("expected an authenticated proxy to be rejected, got {other:?}"),
         }

--- a/crates/breez-sdk/core/src/passkey/mod.rs
+++ b/crates/breez-sdk/core/src/passkey/mod.rs
@@ -82,10 +82,11 @@ use nostr_client::{LabelStore, NostrSaltClient};
 type LabelStoreBuilder =
     Arc<dyn Fn(nostr::Keys, Option<String>) -> Arc<dyn LabelStore> + Send + Sync>;
 
-/// Default store builder: a network-backed [`NostrSaltClient`].
-fn default_label_store_builder() -> LabelStoreBuilder {
-    Arc::new(|keys, breez_api_key| {
-        Arc::new(NostrSaltClient::new(keys, breez_api_key)) as Arc<dyn LabelStore>
+/// Default store builder: a network-backed [`NostrSaltClient`] reaching the
+/// relays through `proxy`, when one is configured.
+fn default_label_store_builder(proxy: Option<crate::ProxyConfig>) -> LabelStoreBuilder {
+    Arc::new(move |keys, breez_api_key| {
+        Arc::new(NostrSaltClient::new(keys, breez_api_key, proxy.clone())) as Arc<dyn LabelStore>
     })
 }
 
@@ -142,9 +143,10 @@ impl Passkey {
         prf_provider: Arc<dyn PrfProvider>,
         breez_api_key: Option<String>,
         config: Option<PasskeyConfig>,
-    ) -> Self {
+    ) -> Result<Self, PasskeyError> {
         let config = config.unwrap_or_default();
-        Self {
+        config.validate()?;
+        Ok(Self {
             prf_provider,
             breez_api_key,
             default_label: config
@@ -152,8 +154,8 @@ impl Passkey {
                 .filter(|s| validate_label(s).is_ok())
                 .unwrap_or_else(|| DEFAULT_LABEL.to_string()),
             nostr_client: Arc::new(RwLock::new(None)),
-            store_builder: default_label_store_builder(),
-        }
+            store_builder: default_label_store_builder(config.proxy),
+        })
     }
 
     /// Construct with a custom [`LabelStore`] builder. Tests inject an
@@ -164,11 +166,11 @@ impl Passkey {
         breez_api_key: Option<String>,
         config: Option<PasskeyConfig>,
         store_builder: LabelStoreBuilder,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, PasskeyError> {
+        Ok(Self {
             store_builder,
-            ..Self::new(prf_provider, breez_api_key, config)
-        }
+            ..Self::new(prf_provider, breez_api_key, config)?
+        })
     }
 
     /// Returns a reference to the underlying [`PrfProvider`].
@@ -441,13 +443,71 @@ mod tests {
         let prf_provider = Arc::new(MockPrfProvider::new([0u8; 32]));
         let config = PasskeyConfig::default();
 
-        let _passkey = Passkey::new(prf_provider, None, Some(config));
+        let _passkey = Passkey::new(prf_provider, None, Some(config)).unwrap();
+    }
+
+    fn passkey_proxy(username: Option<&str>, password: Option<&str>) -> crate::ProxyConfig {
+        crate::ProxyConfig {
+            host: "127.0.0.1".to_string(),
+            port: 9050,
+            username: username.map(ToString::to_string),
+            password: password.map(ToString::to_string),
+        }
+    }
+
+    /// The label is a PRF salt the wallet seed derives from, and the relay
+    /// directory is the only copy of it, so an unpublishable label has to
+    /// fail before a wallet exists rather than at the first label op.
+    #[macros::test_all]
+    fn test_passkey_new_rejects_authenticated_proxy() {
+        let prf_provider = Arc::new(MockPrfProvider::new([0u8; 32]));
+        let config = PasskeyConfig {
+            proxy: Some(passkey_proxy(Some("user"), Some("pass"))),
+            ..PasskeyConfig::default()
+        };
+
+        match Passkey::new(prf_provider, None, Some(config)).err() {
+            Some(PasskeyError::InvalidConfig(m)) => {
+                assert!(
+                    m.contains("proxy authentication"),
+                    "expected a proxy-auth rejection, got: {m}"
+                );
+            }
+            other => panic!("expected an authenticated proxy to be rejected, got {other:?}"),
+        }
+    }
+
+    /// A permanent misconfiguration, not a transient failure: hosts branch
+    /// on `kind()` to decide whether a retry is worth offering.
+    #[macros::test_all]
+    fn test_invalid_config_is_not_retryable() {
+        assert_eq!(
+            PasskeyError::InvalidConfig("x".to_string()).kind(),
+            crate::passkey::ErrorKind::Configuration
+        );
+    }
+
+    #[macros::test_all]
+    fn test_passkey_new_accepts_unauthenticated_proxy() {
+        let prf_provider = Arc::new(MockPrfProvider::new([0u8; 32]));
+        let config = PasskeyConfig {
+            proxy: Some(passkey_proxy(None, None)),
+            ..PasskeyConfig::default()
+        };
+
+        // WASM cannot honour any proxy, so the accept case is native-only.
+        let result = Passkey::new(prf_provider, None, Some(config));
+        if cfg!(all(target_family = "wasm", target_os = "unknown")) {
+            assert!(matches!(result, Err(PasskeyError::InvalidConfig(_))));
+        } else {
+            assert!(result.is_ok());
+        }
     }
 
     #[macros::async_test_all]
     async fn test_check_availability_available() {
         let prf_provider = Arc::new(MockPrfProvider::new([0u8; 32]));
-        let passkey = Passkey::new(prf_provider, None, None);
+        let passkey = Passkey::new(prf_provider, None, None).unwrap();
 
         let availability = passkey.check_availability().await.unwrap();
         assert!(matches!(
@@ -459,7 +519,7 @@ mod tests {
     #[macros::async_test_all]
     async fn test_check_availability_prf_unsupported() {
         let prf_provider = Arc::new(UnavailablePrfProvider);
-        let passkey = Passkey::new(prf_provider, None, None);
+        let passkey = Passkey::new(prf_provider, None, None).unwrap();
 
         let availability = passkey.check_availability().await.unwrap();
         assert!(matches!(availability, PasskeyAvailability::PrfUnsupported));
@@ -470,7 +530,7 @@ mod tests {
         let prf_provider = Arc::new(FailingPrfProvider::new(
             PrfProviderError::AuthenticationFailed("Test error".to_string()),
         ));
-        let passkey = Passkey::new(prf_provider, None, None);
+        let passkey = Passkey::new(prf_provider, None, None).unwrap();
 
         let result = passkey.check_availability().await;
         assert!(result.is_err());
@@ -496,8 +556,8 @@ mod tests {
         let prf_provider1 = Arc::new(MockPrfProvider::new([99u8; 32]));
         let prf_provider2 = Arc::new(MockPrfProvider::new([99u8; 32]));
 
-        let passkey1 = Passkey::new(prf_provider1, None, None);
-        let passkey2 = Passkey::new(prf_provider2, None, None);
+        let passkey1 = Passkey::new(prf_provider1, None, None).unwrap();
+        let passkey2 = Passkey::new(prf_provider2, None, None).unwrap();
 
         let keys1 = passkey1.derive_keys().await.unwrap();
         let keys2 = passkey2.derive_keys().await.unwrap();
@@ -514,8 +574,8 @@ mod tests {
         let prf_provider1 = Arc::new(MockPrfProvider::new([1u8; 32]));
         let prf_provider2 = Arc::new(MockPrfProvider::new([2u8; 32]));
 
-        let passkey1 = Passkey::new(prf_provider1, None, None);
-        let passkey2 = Passkey::new(prf_provider2, None, None);
+        let passkey1 = Passkey::new(prf_provider1, None, None).unwrap();
+        let passkey2 = Passkey::new(prf_provider2, None, None).unwrap();
 
         let keys1 = passkey1.derive_keys().await.unwrap();
         let keys2 = passkey2.derive_keys().await.unwrap();

--- a/crates/breez-sdk/core/src/passkey/models.rs
+++ b/crates/breez-sdk/core/src/passkey/models.rs
@@ -146,4 +146,41 @@ pub struct PasskeyConfig {
     /// provider.
     #[cfg_attr(feature = "uniffi", uniffi(default = None))]
     pub provider_options: Option<PasskeyProviderOptions>,
+
+    /// Routes the Nostr relay connections that store wallet labels through a
+    /// SOCKS5 proxy. Pass the same value as [`Config::proxy`](crate::Config::proxy):
+    /// the passkey client is built before the SDK, so it cannot pick the setting
+    /// up on its own.
+    ///
+    /// Relay connections do not support proxy authentication, so a proxy
+    /// carrying a username and password is rejected when the client is
+    /// built.
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub proxy: Option<crate::ProxyConfig>,
+}
+
+impl PasskeyConfig {
+    /// Rejects a proxy the relay transport cannot honour.
+    ///
+    /// Checked when the client is built rather than at the first label
+    /// operation: a wallet label is one of the two PRF salts its seed is
+    /// derived from, and the relay directory is the only copy the SDK
+    /// keeps. Failing later would hand back a working wallet whose label
+    /// can never be published, and so can never be recovered.
+    pub(crate) fn validate(&self) -> Result<(), super::PasskeyError> {
+        let Some(proxy) = &self.proxy else {
+            return Ok(());
+        };
+        proxy
+            .validate()
+            .map_err(|e| super::PasskeyError::InvalidConfig(e.to_string()))?;
+        if proxy.username.is_some() || proxy.password.is_some() {
+            return Err(super::PasskeyError::InvalidConfig(
+                "Nostr relay connections do not support proxy authentication: \
+                 async-wsocket's ConnectionMode::Proxy carries only an address"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
 }

--- a/crates/breez-sdk/core/src/passkey/nostr_client.rs
+++ b/crates/breez-sdk/core/src/passkey/nostr_client.rs
@@ -6,11 +6,42 @@ use std::time::Duration;
 use nostr::nips::nip65;
 use nostr::{Event, Filter, Kind, PublicKey, RelayUrl};
 use nostr_sdk::Client;
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+use nostr_sdk::ClientOptions;
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+use nostr_sdk::client::Connection;
 use platform_utils::tokio;
 use tracing::{info, warn};
 
 use super::derivation::derive_nip42_keypair;
 use super::error::PasskeyError;
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+/// Resolves the proxy to the socket address the relay transport needs.
+///
+/// Only the proxy's own host is looked up here, which is the one name that
+/// cannot be resolved through the proxy. Relay hostnames still go to the proxy.
+///
+/// Relay connections speak plain SOCKS5 with no authentication. Credentials
+/// are already rejected when the client is built; this is the backstop that
+/// keeps them from being silently dropped on the way to the proxy.
+async fn resolve_proxy_addr(
+    proxy: &crate::ProxyConfig,
+) -> Result<std::net::SocketAddr, PasskeyError> {
+    if proxy.username.is_some() || proxy.password.is_some() {
+        return Err(PasskeyError::Generic(
+            "Nostr relay connections do not support proxy authentication".to_string(),
+        ));
+    }
+    let address = format!("{}:{}", proxy.host, proxy.port);
+    tokio::net::lookup_host(&address)
+        .await
+        .map_err(|e| PasskeyError::Generic(format!("Failed to resolve proxy address: {e}")))?
+        .next()
+        .ok_or_else(|| {
+            PasskeyError::Generic(format!("Proxy address {address} resolved to nothing"))
+        })
+}
 
 /// Public relays used as fallback when NIP-65 lists cannot be fetched.
 /// The first entry doubles as the preferred read relay for non-API-key users.
@@ -48,6 +79,8 @@ const BREEZ_NIP65_PUBKEY: &str = "0478caf9d25260b7603154c4227d4af5c2e4937092fbdb
 pub struct NostrSaltClient {
     keys: nostr::Keys,
     breez_api_key: Option<String>,
+    /// SOCKS5 proxy carrying every relay connection, when configured.
+    proxy: Option<crate::ProxyConfig>,
     /// Flag ensuring the NIP-65 relay sync is only spawned once per client lifetime.
     relay_sync_triggered: Arc<AtomicBool>,
     /// Server-provided relay list, set once by the relay sync task.
@@ -57,10 +90,17 @@ pub struct NostrSaltClient {
 impl NostrSaltClient {
     /// Create a new Nostr salt client owning the passkey-derived
     /// signing keys and an optional Breez API key.
-    pub fn new(keys: nostr::Keys, breez_api_key: Option<String>) -> Self {
+    ///
+    /// `proxy` routes every relay connection through a SOCKS5 proxy.
+    pub fn new(
+        keys: nostr::Keys,
+        breez_api_key: Option<String>,
+        proxy: Option<crate::ProxyConfig>,
+    ) -> Self {
         Self {
             keys,
             breez_api_key,
+            proxy,
             relay_sync_triggered: Arc::new(AtomicBool::new(false)),
             server_relays: Arc::new(OnceLock::new()),
         }
@@ -119,7 +159,7 @@ impl NostrSaltClient {
         let mut sync_events: Option<Vec<Event>> = None;
 
         for chunk in relays.chunks(2) {
-            let client = self.new_client()?;
+            let client = self.new_client().await?;
             let mut added = 0usize;
             for relay_url in chunk {
                 match client.add_relay(relay_url.as_str()).await {
@@ -401,7 +441,7 @@ impl NostrSaltClient {
         let mut last_err = None;
 
         for chunk in relays.chunks(2) {
-            let client = self.new_client()?;
+            let client = self.new_client().await?;
             let mut added = 0usize;
 
             for relay_url in chunk {
@@ -447,7 +487,7 @@ impl NostrSaltClient {
 
     /// Create a Nostr client connected to all relays for write operations.
     async fn create_write_client(&self) -> Result<Client, PasskeyError> {
-        let client = self.new_client()?;
+        let client = self.new_client().await?;
         let write_relays = self.ensure_server_relays().await;
 
         let mut added = 0usize;
@@ -476,13 +516,36 @@ impl NostrSaltClient {
     /// When an API key is configured, uses API key-derived keys for NIP-42
     /// authentication. Content events are signed manually with the owned
     /// passkey-derived keys via `sign_with_keys()`.
-    fn new_client(&self) -> Result<Client, PasskeyError> {
-        Ok(if let Some(ref api_key) = self.breez_api_key {
-            let auth_keys = derive_nip42_keypair(api_key)?;
-            Client::new(auth_keys)
+    // Only the native proxy path awaits, so on WASM this is async purely to
+    // keep one signature across targets.
+    #[cfg_attr(
+        all(target_family = "wasm", target_os = "unknown"),
+        allow(clippy::unused_async)
+    )]
+    async fn new_client(&self) -> Result<Client, PasskeyError> {
+        let mut builder = Client::builder();
+        builder = if let Some(ref api_key) = self.breez_api_key {
+            builder.signer(derive_nip42_keypair(api_key)?)
         } else {
-            Client::new(self.keys.clone())
-        })
+            builder.signer(self.keys.clone())
+        };
+
+        #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+        if let Some(proxy) = &self.proxy {
+            let addr = resolve_proxy_addr(proxy).await?;
+            builder = builder.opts(ClientOptions::new().connection(Connection::new().proxy(addr)));
+        }
+        // Relay connections run on browser WebSockets here, which cannot be
+        // proxied. Refuse rather than connect directly behind the caller's back.
+        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+        if self.proxy.is_some() {
+            return Err(PasskeyError::Generic(
+                "a SOCKS5 proxy cannot be honoured on WASM: the browser owns connection setup"
+                    .to_string(),
+            ));
+        }
+
+        Ok(builder.build())
     }
 }
 
@@ -534,21 +597,21 @@ mod tests {
 
     #[macros::test_all]
     fn test_nostr_salt_client_new_default() {
-        let client = NostrSaltClient::new(test_keys(), None);
+        let client = NostrSaltClient::new(test_keys(), None, None);
 
         assert!(client.breez_api_key.is_none());
     }
 
     #[macros::test_all]
     fn test_nostr_salt_client_with_api_key() {
-        let client = NostrSaltClient::new(test_keys(), Some("dGVzdC1hcGkta2V5".to_string()));
+        let client = NostrSaltClient::new(test_keys(), Some("dGVzdC1hcGkta2V5".to_string()), None);
 
         assert!(client.breez_api_key.is_some());
     }
 
     #[macros::test_all]
     fn test_relay_sync_state_shared_across_clones() {
-        let client1 = NostrSaltClient::new(test_keys(), None);
+        let client1 = NostrSaltClient::new(test_keys(), None, None);
         let client2 = client1.clone();
 
         assert!(Arc::ptr_eq(
@@ -574,7 +637,7 @@ mod tests {
 
     #[macros::test_all]
     fn test_read_relay_candidates_without_api_key() {
-        let client = NostrSaltClient::new(test_keys(), None);
+        let client = NostrSaltClient::new(test_keys(), None, None);
         let candidates = client.read_relay_candidates();
 
         assert_eq!(candidates.len(), STATIC_RELAYS.len());
@@ -584,7 +647,7 @@ mod tests {
 
     #[macros::test_all]
     fn test_read_relay_candidates_with_api_key() {
-        let client = NostrSaltClient::new(test_keys(), Some("dGVzdC1hcGkta2V5".to_string()));
+        let client = NostrSaltClient::new(test_keys(), Some("dGVzdC1hcGkta2V5".to_string()), None);
         let candidates = client.read_relay_candidates();
 
         // Breez relay should be first

--- a/crates/breez-sdk/core/src/passkey/nostr_client.rs
+++ b/crates/breez-sdk/core/src/passkey/nostr_client.rs
@@ -33,7 +33,9 @@ async fn resolve_proxy_addr(
             "Nostr relay connections do not support proxy authentication".to_string(),
         ));
     }
-    let address = format!("{}:{}", proxy.host, proxy.port);
+    // Via `platform_utils` so the one place that knows how to render an
+    // authority (bracketing a bare IPv6 literal) stays the only one.
+    let address = platform_utils::ProxyConfig::from(proxy).address();
     tokio::net::lookup_host(&address)
         .await
         .map_err(|e| PasskeyError::Generic(format!("Failed to resolve proxy address: {e}")))?

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -394,14 +394,26 @@ impl PasskeyClient {
 
 /// Convenience constructors that don't cross the `UniFFI` boundary.
 impl PasskeyClient {
-    /// Build from the SDK's [`crate::Config`], reusing its `api_key`
-    /// for the default Nostr-backed label store.
+    /// Build from the SDK's [`crate::Config`], reusing its `api_key` and
+    /// `proxy` for the default Nostr-backed label store.
+    ///
+    /// A proxy already set on `passkey_config` wins; otherwise the one on
+    /// `sdk_config` is inherited, so the label relays do not connect direct
+    /// while the rest of the SDK is tunnelled.
     pub fn from_config(
         prf_provider: Arc<dyn PrfProvider>,
         sdk_config: &crate::Config,
         passkey_config: Option<PasskeyConfig>,
     ) -> Result<Self, PasskeyError> {
-        Self::new(prf_provider, sdk_config.api_key.clone(), passkey_config)
+        let mut passkey_config = passkey_config.unwrap_or_default();
+        if passkey_config.proxy.is_none() {
+            passkey_config.proxy.clone_from(&sdk_config.proxy);
+        }
+        Self::new(
+            prf_provider,
+            sdk_config.api_key.clone(),
+            Some(passkey_config),
+        )
     }
 
     /// Test-only: construct with a custom [`LabelStore`] builder so unit
@@ -872,6 +884,58 @@ mod tests {
         assert!(credential.user_id.is_none());
         assert!(credential.aaguid.is_none());
         assert!(credential.backup_eligible.is_none());
+    }
+
+    fn sdk_config_with_proxy(username: Option<&str>, password: Option<&str>) -> crate::Config {
+        let mut config = crate::default_config(crate::Network::Mainnet);
+        config.proxy = Some(crate::ProxyConfig {
+            host: "127.0.0.1".to_string(),
+            port: 9050,
+            username: username.map(ToString::to_string),
+            password: password.map(ToString::to_string),
+        });
+        config
+    }
+
+    /// The relays would otherwise connect direct while the rest of the SDK is
+    /// tunnelled. Observed through the credentialed-proxy reject, which only
+    /// fires if the SDK proxy was read at all.
+    #[macros::test_all]
+    fn from_config_inherits_the_sdk_proxy() {
+        let provider = Arc::new(MockProvider::new([0u8; 32]));
+        let config = sdk_config_with_proxy(Some("user"), Some("pass"));
+
+        match PasskeyClient::from_config(provider, &config, None).err() {
+            Some(PasskeyError::InvalidConfig(_)) => {}
+            other => panic!("expected the SDK proxy to be inherited and rejected, got {other:?}"),
+        }
+    }
+
+    /// An explicit passkey proxy is not overwritten by the SDK's.
+    #[macros::test_all]
+    fn from_config_keeps_an_explicit_passkey_proxy() {
+        let provider = Arc::new(MockProvider::new([0u8; 32]));
+        let config = sdk_config_with_proxy(Some("user"), Some("pass"));
+        let passkey_config = PasskeyConfig {
+            proxy: Some(crate::ProxyConfig {
+                host: "127.0.0.1".to_string(),
+                port: 9050,
+                username: None,
+                password: None,
+            }),
+            ..PasskeyConfig::default()
+        };
+
+        let result = PasskeyClient::from_config(provider, &config, Some(passkey_config));
+        // WASM cannot honour any proxy, so the accept case is native-only.
+        if cfg!(all(target_family = "wasm", target_os = "unknown")) {
+            assert!(matches!(result.err(), Some(PasskeyError::InvalidConfig(_))));
+        } else {
+            assert!(
+                result.is_ok(),
+                "the uncredentialed passkey proxy should have won"
+            );
+        }
     }
 
     #[macros::async_test_all]

--- a/crates/breez-sdk/core/src/passkey/passkey_client.rs
+++ b/crates/breez-sdk/core/src/passkey/passkey_client.rs
@@ -179,15 +179,19 @@ pub struct PasskeyClient {
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl PasskeyClient {
     /// Construct with the default Nostr-backed label store.
+    ///
+    /// Fails when `config` carries a proxy the relay transport cannot
+    /// honour, rather than letting a wallet be created whose label can
+    /// never be published.
     #[cfg_attr(feature = "uniffi", uniffi::constructor)]
     pub fn new(
         prf_provider: Arc<dyn PrfProvider>,
         breez_api_key: Option<String>,
         config: Option<PasskeyConfig>,
-    ) -> Self {
-        Self {
-            passkey: Passkey::new(prf_provider, breez_api_key, config),
-        }
+    ) -> Result<Self, PasskeyError> {
+        Ok(Self {
+            passkey: Passkey::new(prf_provider, breez_api_key, config)?,
+        })
     }
 
     /// One-shot capability + configuration probe. Collapses
@@ -396,7 +400,7 @@ impl PasskeyClient {
         prf_provider: Arc<dyn PrfProvider>,
         sdk_config: &crate::Config,
         passkey_config: Option<PasskeyConfig>,
-    ) -> Self {
+    ) -> Result<Self, PasskeyError> {
         Self::new(prf_provider, sdk_config.api_key.clone(), passkey_config)
     }
 
@@ -415,7 +419,8 @@ impl PasskeyClient {
                 breez_api_key,
                 config,
                 store_builder,
-            ),
+            )
+            .expect("test config is valid"),
         }
     }
 }

--- a/crates/breez-sdk/core/src/realtime_sync/init.rs
+++ b/crates/breez-sdk/core/src/realtime_sync/init.rs
@@ -17,6 +17,7 @@ pub struct RealTimeSyncParams {
     pub server_url: String,
     pub api_key: Option<String>,
     pub user_agent: String,
+    pub proxy: Option<platform_utils::ProxyConfig>,
     pub signer: Arc<dyn breez_sdk_common::sync::SyncSigner>,
     pub storage: Arc<dyn Storage>,
     pub shutdown_receiver: tokio::sync::watch::Receiver<()>,
@@ -51,6 +52,7 @@ pub async fn init_and_start_real_time_sync(
             &params.server_url,
             params.api_key.as_deref(),
             &params.user_agent,
+            params.proxy.as_ref(),
         )
         .map_err(|e| SdkError::Generic(e.to_string()))?,
     );

--- a/crates/breez-sdk/core/src/sdk/api.rs
+++ b/crates/breez-sdk/core/src/sdk/api.rs
@@ -31,7 +31,7 @@ use super::payments::validation::{
     resolve_target_overpay_bps, validate_address_family_against_route, validate_amount,
     validate_recipient_not_contract_address,
 };
-use super::{BreezSdk, helpers::get_deposit_address, parse_input};
+use super::{BreezSdk, helpers::get_deposit_address};
 
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 #[allow(clippy::needless_pass_by_value)]
@@ -97,7 +97,7 @@ impl BreezSdk {
     }
 
     pub async fn parse(&self, input: &str) -> Result<InputType, SdkError> {
-        parse_input(input, Some(self.external_input_parsers.clone())).await
+        Ok(self.input_parser.parse(input).await?.into())
     }
 
     /// Returns the available cross-chain routes.

--- a/crates/breez-sdk/core/src/sdk/init.rs
+++ b/crates/breez-sdk/core/src/sdk/init.rs
@@ -19,7 +19,6 @@ impl BreezSdk {
             }
         }
         let (initial_synced_sender, initial_synced_watcher) = watch::channel(false);
-        let external_input_parsers = params.config.get_all_external_input_parsers();
 
         let sdk = Self {
             config: params.config,
@@ -36,7 +35,7 @@ impl BreezSdk {
             runtime: params.runtime,
             sync_coordinator: params.sync_coordinator,
             initial_synced_watcher,
-            external_input_parsers,
+            input_parser: params.input_parser,
             spark_private_mode_initialized: Arc::new(OnceCell::new()),
             token_converter: params.token_converter,
             stable_balance: params.stable_balance,

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -27,10 +27,10 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, OnceCell, oneshot, watch};
 
 use crate::{
-    BitcoinChainService, ExternalInputParser, InputType, LeafOptimizationConfig, Logger, Network,
-    TokenOptimizationConfig, error::SdkError, events::EventEmitter, lnurl::LnurlServerClient,
-    logger, models::Config, persist::Storage, signer::lnurl_auth::LnurlAuthSignerAdapter,
-    stable_balance::StableBalance, token_conversion::TokenConverter,
+    BitcoinChainService, LeafOptimizationConfig, Logger, Network, TokenOptimizationConfig,
+    error::SdkError, events::EventEmitter, lnurl::LnurlServerClient, logger, models::Config,
+    persist::Storage, signer::lnurl_auth::LnurlAuthSignerAdapter, stable_balance::StableBalance,
+    token_conversion::TokenConverter,
 };
 
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
@@ -99,7 +99,9 @@ pub struct BreezSdk {
     /// Coordinator for coalescing duplicate sync requests
     pub(crate) sync_coordinator: SyncCoordinator,
     pub(crate) initial_synced_watcher: watch::Receiver<bool>,
-    pub(crate) external_input_parsers: Vec<ExternalInputParser>,
+    /// Parses payment inputs over the SDK's own transports, so lightning-address
+    /// and LNURL lookups reuse the pooled HTTP client and honour the proxy.
+    pub(crate) input_parser: Arc<SdkInputParser>,
     pub(crate) spark_private_mode_initialized: Arc<OnceCell<()>>,
     pub(crate) token_converter: Arc<dyn TokenConverter>,
     pub(crate) stable_balance: Option<Arc<StableBalance>>,
@@ -112,8 +114,13 @@ pub struct BreezSdk {
     pub(crate) lightning_sender: Arc<LightningSender>,
 }
 
+/// The parser bound to the SDK's shared HTTP client and its DNS resolver.
+pub(crate) type SdkInputParser =
+    breez_sdk_common::input::InputParser<Arc<dyn HttpClient>, breez_sdk_common::dns::Resolver>;
+
 pub(crate) struct BreezSdkParams {
     pub config: Config,
+    pub input_parser: Arc<SdkInputParser>,
     pub storage: Arc<dyn Storage>,
     pub chain_service: Arc<dyn BitcoinChainService>,
     pub fiat_service: Arc<dyn FiatService>,
@@ -130,18 +137,6 @@ pub(crate) struct BreezSdkParams {
     pub sync_coordinator: SyncCoordinator,
     pub cross_chain_context: crate::cross_chain::CrossChainContext,
     pub lightning_sender: Arc<LightningSender>,
-}
-
-pub async fn parse_input(
-    input: &str,
-    external_input_parsers: Option<Vec<ExternalInputParser>>,
-) -> Result<InputType, SdkError> {
-    Ok(breez_sdk_common::input::parse(
-        input,
-        external_input_parsers.map(|parsers| parsers.into_iter().map(From::from).collect()),
-    )
-    .await?
-    .into())
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -260,6 +255,7 @@ pub fn default_config(network: Network) -> Config {
         max_concurrent_claims: 4,
         spark_config: Some(default_spark_config(network)),
         background_tasks_enabled: true,
+        proxy: None,
         cross_chain_config: None,
     }
 }
@@ -420,14 +416,26 @@ pub fn default_external_signers(
     })
 }
 
+/// Options for [`get_spark_status`].
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct GetSparkStatusRequest {
+    /// Routes the status request through a SOCKS5 proxy. Pass the same value as
+    /// [`Config::proxy`]: this call runs without an SDK instance, so it cannot
+    /// pick the setting up on its own.
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub proxy: Option<crate::ProxyConfig>,
+}
+
 /// Fetches the current status of Spark network services relevant to the SDK.
 ///
 /// This function queries the Spark status API and returns the worst status
 /// across the Spark Operators and SSP services.
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
-pub async fn get_spark_status() -> Result<crate::SparkStatus, SdkError> {
+pub async fn get_spark_status(
+    request: GetSparkStatusRequest,
+) -> Result<crate::SparkStatus, SdkError> {
     use chrono::DateTime;
-    use platform_utils::DefaultHttpClient;
 
     #[derive(serde::Deserialize)]
     struct StatusApiResponse {
@@ -455,7 +463,17 @@ pub async fn get_spark_status() -> Result<crate::SparkStatus, SdkError> {
         }
     }
 
-    let http_client = DefaultHttpClient::default();
+    if let Some(proxy) = &request.proxy {
+        proxy.validate()?;
+    }
+    let http_client = platform_utils::create_http_client_with_proxy(
+        None,
+        request
+            .proxy
+            .as_ref()
+            .map(platform_utils::ProxyConfig::from)
+            .as_ref(),
+    );
 
     let response = http_client
         .get("https://spark.money/api/v1/status".to_string(), None)

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -473,7 +473,8 @@ pub async fn get_spark_status(
             .as_ref()
             .map(platform_utils::ProxyConfig::from)
             .as_ref(),
-    );
+    )
+    .map_err(|e| SdkError::InvalidInput(format!("Failed to build proxied HTTP client: {e}")))?;
 
     let response = http_client
         .get("https://spark.money/api/v1/status".to_string(), None)

--- a/crates/breez-sdk/core/src/sdk/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/mod.rs
@@ -463,18 +463,7 @@ pub async fn get_spark_status(
         }
     }
 
-    if let Some(proxy) = &request.proxy {
-        proxy.validate()?;
-    }
-    let http_client = platform_utils::create_http_client_with_proxy(
-        None,
-        request
-            .proxy
-            .as_ref()
-            .map(platform_utils::ProxyConfig::from)
-            .as_ref(),
-    )
-    .map_err(|e| SdkError::InvalidInput(format!("Failed to build proxied HTTP client: {e}")))?;
+    let http_client = crate::ProxyConfig::http_client(request.proxy.as_ref(), None)?;
 
     let response = http_client
         .get("https://spark.money/api/v1/status".to_string(), None)

--- a/crates/breez-sdk/core/src/sdk/sync.rs
+++ b/crates/breez-sdk/core/src/sdk/sync.rs
@@ -6,7 +6,6 @@ use tracing::{debug, error, info, trace, warn};
 
 use super::{
     BreezSdk, CLAIM_TX_SIZE_VBYTES, SYNC_PAGING_LIMIT, SyncType, deposits::InstantClaimOutcome,
-    parse_input,
 };
 use crate::{
     DepositInfo, Fee, InputType, InstantClaimDeclineReason, InstantClaimStatus, MaxFee,
@@ -84,7 +83,7 @@ impl BreezSdk {
             return;
         }
 
-        let Ok(input) = parse_input(invoice, None).await else {
+        let Ok(input) = self.input_parser.parse(invoice).await.map(InputType::from) else {
             error!(
                 "Failed to parse invoice for lnurl metadata sync: {}",
                 invoice

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -1150,6 +1150,7 @@ fn build_cross_chain_context(
         ecies,
         cached_fiat,
         Arc::clone(lightning_sender),
+        config.proxy.as_ref(),
         shutdown_receiver,
     ) {
         Ok(Some(service)) => {
@@ -1614,8 +1615,8 @@ mod tests {
         }
     }
 
-    /// Orchestra runs on the shared proxied client, so cross-chain is accepted
-    /// alongside a proxy even though Boltz still connects direct.
+    /// Both cross-chain providers honour the proxy: Orchestra on the shared
+    /// client, Boltz through its own config.
     #[test]
     fn validate_accepts_proxy_with_cross_chain_config() {
         use crate::{CrossChainConfig, default_config};

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -1659,6 +1659,40 @@ mod tests {
         assert!(matches!(config.validate(), Err(SdkError::InvalidInput(_))));
     }
 
+    /// A host that cannot appear in a URL authority has to be caught at
+    /// connect: the client build downstream would otherwise be the first
+    /// thing to notice, far from the config that caused it.
+    #[test]
+    fn validate_rejects_proxy_host_that_cannot_form_a_url() {
+        use crate::{SdkError, default_config};
+        for host in ["local host", "user@host", "socks5://127.0.0.1", "[::g]"] {
+            let mut config = default_config(Network::Mainnet);
+            let mut proxy = test_proxy();
+            proxy.host = host.to_string();
+            config.proxy = Some(proxy);
+
+            match config.validate() {
+                Err(SdkError::InvalidInput(m)) => {
+                    assert!(m.contains(host), "expected the host in the error, got: {m}");
+                }
+                other => panic!("expected host {host:?} to be rejected, got {other:?}"),
+            }
+        }
+    }
+
+    /// A bare IPv6 literal is bracketed before it reaches a URL, so it stays
+    /// valid rather than tripping the check above.
+    #[test]
+    fn validate_accepts_bare_ipv6_proxy_host() {
+        use crate::default_config;
+        let mut config = default_config(Network::Mainnet);
+        let mut proxy = test_proxy();
+        proxy.host = "::1".to_string();
+        config.proxy = Some(proxy);
+
+        assert!(config.validate().is_ok());
+    }
+
     /// Balanced operator connections build their own connectors, so a proxy
     /// there would silently open the extra channels direct.
     #[tokio::test]

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -11,7 +11,7 @@ use spark_wallet::{
     InMemorySessionStore, SessionStore, SparkSigner, SparkWallet, SparkWalletConfig,
 };
 use tokio::sync::watch;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use flashnet::{FlashnetConfig, IntegratorConfig};
 
@@ -460,6 +460,32 @@ impl SdkBuilder {
         Ok(config)
     }
 
+    /// Warns when a proxy is configured alongside a caller-supplied service.
+    ///
+    /// Those arrive as trait objects that already own their transport, which
+    /// the SDK cannot inspect or re-route: honouring the proxy is the caller's
+    /// responsibility. `with_rest_chain_service` is not listed, since it builds
+    /// on the context's proxied client.
+    fn warn_about_unproxied_overrides(&self) {
+        if self.config.proxy.is_none() {
+            return;
+        }
+        let overrides = [
+            ("chain service", self.chain_service.is_some()),
+            ("fiat service", self.fiat_service.is_some()),
+            ("LNURL HTTP client", self.lnurl_client.is_some()),
+            ("LNURL server client", self.lnurl_server_client.is_some()),
+        ];
+        for (name, supplied) in overrides {
+            if supplied {
+                warn!(
+                    "A proxy is configured but a custom {name} was supplied. \
+                     The SDK cannot route it: make sure it connects through the proxy itself."
+                );
+            }
+        }
+    }
+
     /// Builds the `BreezSdk` instance from the configured components, reading
     /// top-to-bottom as a sequence of named assembly steps.
     #[allow(clippy::too_many_lines)]
@@ -469,6 +495,7 @@ impl SdkBuilder {
         let background_services_enabled = runtime.starts_background_services();
         validate_server_mode(&self.config, background_services_enabled)?;
 
+        self.warn_about_unproxied_overrides();
         let signers = build_signers(&self.config, self.signer_source)?;
         validate_signer_capabilities(&self.config, signers.ecies.is_some())?;
 
@@ -488,6 +515,28 @@ impl SdkBuilder {
             &context,
             self.config.network,
         );
+
+        // The parser reaches lightning-address and LNURL hosts, and resolves
+        // BIP353 names, so it has to ride the context's clients rather than
+        // build its own.
+        let input_parser = Arc::new(crate::sdk::SdkInputParser::new(
+            breez_sdk_common::dns::Resolver::with_proxy(
+                self.config
+                    .proxy
+                    .as_ref()
+                    .map(platform_utils::ProxyConfig::from)
+                    .as_ref(),
+            )
+            .map_err(|e| SdkError::Generic(format!("Failed to build DNS resolver: {e}")))?,
+            Arc::clone(&context.http_client),
+            Some(
+                self.config
+                    .get_all_external_input_parsers()
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+            ),
+        ));
 
         let user_agent = crate::default_user_agent();
         info!("Building sdk with user agent: {}", user_agent);
@@ -566,6 +615,7 @@ impl SdkBuilder {
         let cross_chain_context = build_cross_chain_context(
             &self.config,
             &context.breez_server,
+            &context.http_client,
             &spark_wallet,
             &storage,
             signers.ecies.clone(),
@@ -590,6 +640,7 @@ impl SdkBuilder {
             .await;
 
         let sdk = BreezSdk::init_and_start(BreezSdkParams {
+            input_parser,
             config: self.config,
             storage,
             chain_service,
@@ -761,6 +812,7 @@ async fn resolve_context(
         None => {
             new_shared_sdk_context(SdkContextConfig {
                 api_key: config.api_key.clone(),
+                proxy: config.proxy.clone(),
                 ..SdkContextConfig::new(config.network)
             })
             .await?
@@ -769,6 +821,13 @@ async fn resolve_context(
     if context.network != config.network || context.api_key != config.api_key {
         return Err(SdkError::Generic(
             "SdkContext network/api_key do not match SdkConfig".to_string(),
+        ));
+    }
+    // The context owns the shared HTTP and gRPC clients, so a proxy that
+    // disagrees with the config would leave part of the traffic unproxied.
+    if context.proxy != config.proxy {
+        return Err(SdkError::Generic(
+            "SdkContext proxy does not match SdkConfig proxy".to_string(),
         ));
     }
     Ok(context)
@@ -977,6 +1036,7 @@ async fn maybe_wrap_storage_with_real_time_sync(
                 server_url: server_url.clone(),
                 api_key: config.api_key.clone(),
                 user_agent,
+                proxy: config.proxy.as_ref().map(platform_utils::ProxyConfig::from),
                 signer,
                 storage,
                 shutdown_receiver,
@@ -1043,6 +1103,7 @@ async fn build_stable_balance(
 fn build_cross_chain_context(
     config: &Config,
     breez_server: &Arc<BreezServer>,
+    http_client: &Arc<dyn platform_utils::HttpClient>,
     spark_wallet: &Arc<SparkWallet>,
     storage: &Arc<dyn crate::persist::Storage>,
     ecies: Option<Arc<dyn crate::signer::EciesSigner>>,
@@ -1076,6 +1137,7 @@ fn build_cross_chain_context(
                 Arc::clone(spark_wallet),
                 Arc::clone(storage),
                 Arc::clone(&cached_fiat),
+                Arc::clone(http_client),
                 shutdown_receiver.clone(),
             )),
         );
@@ -1539,6 +1601,105 @@ mod tests {
             Err(err) => panic!("expected InvalidInput error, got {err:?}"),
             Ok(_) => panic!("expected server mode with optimization auto_enabled to fail"),
         }
+    }
+
+    // ---- proxy ----
+
+    fn test_proxy() -> crate::ProxyConfig {
+        crate::ProxyConfig {
+            host: "127.0.0.1".to_string(),
+            port: 9050,
+            username: None,
+            password: None,
+        }
+    }
+
+    /// Orchestra runs on the shared proxied client, so cross-chain is accepted
+    /// alongside a proxy even though Boltz still connects direct.
+    #[test]
+    fn validate_accepts_proxy_with_cross_chain_config() {
+        use crate::{CrossChainConfig, default_config};
+        let mut config = default_config(Network::Mainnet);
+        config.proxy = Some(test_proxy());
+        config.cross_chain_config = Some(CrossChainConfig::default());
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_half_specified_proxy_credentials() {
+        use crate::{SdkError, default_config};
+        let mut config = default_config(Network::Mainnet);
+        let mut proxy = test_proxy();
+        proxy.username = Some("user".to_string());
+        config.proxy = Some(proxy);
+
+        match config.validate() {
+            Err(SdkError::InvalidInput(m)) => assert!(
+                m.contains("username and password"),
+                "expected credential-pair rejection, got: {m}"
+            ),
+            other => panic!("expected a username without a password to fail, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_empty_proxy_host_and_zero_port() {
+        use crate::{SdkError, default_config};
+        let mut config = default_config(Network::Mainnet);
+
+        let mut proxy = test_proxy();
+        proxy.host = String::new();
+        config.proxy = Some(proxy);
+        assert!(matches!(config.validate(), Err(SdkError::InvalidInput(_))));
+
+        let mut proxy = test_proxy();
+        proxy.port = 0;
+        config.proxy = Some(proxy);
+        assert!(matches!(config.validate(), Err(SdkError::InvalidInput(_))));
+    }
+
+    /// Balanced operator connections build their own connectors, so a proxy
+    /// there would silently open the extra channels direct.
+    #[tokio::test]
+    async fn shared_context_rejects_proxy_with_balanced_connections() {
+        use crate::{SdkContextConfig, SdkError, new_shared_sdk_context};
+        let result = new_shared_sdk_context(SdkContextConfig {
+            proxy: Some(test_proxy()),
+            connections_per_operator: Some(4),
+            ..SdkContextConfig::new(Network::Regtest)
+        })
+        .await;
+
+        match result.err() {
+            Some(SdkError::InvalidInput(m)) => assert!(
+                m.contains("connections_per_operator"),
+                "expected balanced-connection rejection, got: {m}"
+            ),
+            other => panic!("expected proxy + balanced connections to fail, got {other:?}"),
+        }
+    }
+
+    /// The context owns the shared clients, so a config that disagrees with it
+    /// would leave part of the traffic unproxied.
+    #[tokio::test]
+    async fn resolve_context_errors_on_proxy_mismatch() {
+        use crate::{SdkContextConfig, default_config, new_shared_sdk_context};
+        let mut config = default_config(Network::Regtest);
+        config.proxy = Some(test_proxy());
+
+        let ctx = new_shared_sdk_context(SdkContextConfig::new(Network::Regtest))
+            .await
+            .expect("regtest context");
+
+        let err = super::resolve_context(Some(ctx), &config)
+            .await
+            .err()
+            .expect("expected mismatch error");
+        assert!(
+            err.to_string().contains("proxy does not match"),
+            "unexpected error: {err}"
+        );
     }
 
     /// Regtest + `cross_chain_config` trips the Mainnet-only gate in

--- a/crates/breez-sdk/core/src/sdk_context.rs
+++ b/crates/breez-sdk/core/src/sdk_context.rs
@@ -127,7 +127,8 @@ pub async fn new_shared_sdk_context(config: SdkContextConfig) -> Result<Arc<SdkC
         proxy.validate()?;
     }
     let transport_proxy = proxy.as_ref().map(platform_utils::ProxyConfig::from);
-    let http_client = create_http_client_with_proxy(Some(&user_agent), transport_proxy.as_ref());
+    let http_client = create_http_client_with_proxy(Some(&user_agent), transport_proxy.as_ref())
+        .map_err(|e| SdkError::InvalidInput(format!("Failed to build proxied HTTP client: {e}")))?;
     let breez_server = Arc::new(
         BreezServer::new(
             PRODUCTION_BREEZSERVER_URL,

--- a/crates/breez-sdk/core/src/sdk_context.rs
+++ b/crates/breez-sdk/core/src/sdk_context.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use breez_sdk_common::breez_server::{BreezServer, PRODUCTION_BREEZSERVER_URL};
-use platform_utils::{HttpClient, create_http_client};
+use platform_utils::{HttpClient, create_http_client_with_proxy};
 
 use spark_wallet::{BalancedConnectionManager, ConnectionManager, DefaultConnectionManager};
 
 use crate::{
-    Network, SdkError, default_user_agent, jwt_header_provider::BreezJwtHeaderProvider,
-    persist::backend::StorageBackend,
+    Network, ProxyConfig, SdkError, default_user_agent,
+    jwt_header_provider::BreezJwtHeaderProvider, persist::backend::StorageBackend,
 };
 
 /// Process-shared resources that can back many `BreezSdk` instances.
@@ -46,6 +46,11 @@ pub struct SdkContext {
     /// can cross-check against `Config.api_key` and refuse a mismatch.
     pub(crate) api_key: Option<String>,
     pub(crate) connection_manager: Arc<dyn ConnectionManager>,
+    /// The proxy every client in this context was built with. Kept so
+    /// `SdkBuilder::build()` can cross-check against `Config.proxy` and refuse
+    /// a mismatch, and so per-SDK components (DNS, relays) match the shared
+    /// clients.
+    pub(crate) proxy: Option<ProxyConfig>,
     /// The storage backend SDKs built from this context share. `None` when the
     /// context carries no storage; each `SdkBuilder` then supplies its own.
     pub(crate) storage_backend: Option<Arc<dyn StorageBackend>>,
@@ -73,6 +78,12 @@ pub struct SdkContextConfig {
     #[cfg_attr(feature = "uniffi", uniffi(default = None))]
     pub connections_per_operator: Option<u32>,
 
+    /// Routes the connections opened by this context's shared clients through
+    /// a SOCKS5 proxy. Must match the `proxy` on the `Config` of every SDK
+    /// built from this context.
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub proxy: Option<ProxyConfig>,
+
     /// Shared storage backend for SDKs built from this context. When set,
     /// every SDK built from the context reuses it (and its database
     /// connection pool). Construct via
@@ -95,6 +106,7 @@ impl SdkContextConfig {
             network,
             api_key: None,
             connections_per_operator: None,
+            proxy: None,
             storage: None,
         }
     }
@@ -110,10 +122,20 @@ impl SdkContextConfig {
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 pub async fn new_shared_sdk_context(config: SdkContextConfig) -> Result<Arc<SdkContext>, SdkError> {
     let user_agent = default_user_agent();
-    let http_client = create_http_client(Some(&user_agent));
+    let proxy = config.proxy;
+    if let Some(proxy) = &proxy {
+        proxy.validate()?;
+    }
+    let transport_proxy = proxy.as_ref().map(platform_utils::ProxyConfig::from);
+    let http_client = create_http_client_with_proxy(Some(&user_agent), transport_proxy.as_ref());
     let breez_server = Arc::new(
-        BreezServer::new(PRODUCTION_BREEZSERVER_URL, None, &user_agent)
-            .map_err(|e| SdkError::Generic(e.to_string()))?,
+        BreezServer::new(
+            PRODUCTION_BREEZSERVER_URL,
+            None,
+            &user_agent,
+            transport_proxy.as_ref(),
+        )
+        .map_err(|e| SdkError::Generic(e.to_string()))?,
     );
     // The Breez partner JWT is only issued by the mainnet Breez endpoint, and
     // only when an API key is configured. Skip the provider entirely otherwise
@@ -135,8 +157,20 @@ pub async fn new_shared_sdk_context(config: SdkContextConfig) -> Result<Arc<SdkC
     // open multiple connections per operator and balance requests across
     // them; `None` (or `Some(1)`) keeps a single multiplexed connection.
     let connection_manager: Arc<dyn ConnectionManager> = match config.connections_per_operator {
-        Some(n) if n > 1 => Arc::new(BalancedConnectionManager::new(n)),
-        _ => Arc::new(DefaultConnectionManager::new()),
+        Some(n) if n > 1 => {
+            // Balancing builds its own connectors, so there is nowhere to
+            // insert the SOCKS5 dialer. Refuse rather than open the extra
+            // connections unproxied.
+            if proxy.is_some() {
+                return Err(SdkError::InvalidInput(
+                    "A proxy cannot be combined with connections_per_operator > 1: balanced \
+                     operator connections cannot be routed through a proxy."
+                        .to_string(),
+                ));
+            }
+            Arc::new(BalancedConnectionManager::new(n))
+        }
+        _ => Arc::new(DefaultConnectionManager::with_proxy(transport_proxy)),
     };
 
     // Every SDK built from this context shares the one storage backend (and
@@ -150,6 +184,7 @@ pub async fn new_shared_sdk_context(config: SdkContextConfig) -> Result<Arc<SdkC
         network: config.network,
         api_key,
         connection_manager,
+        proxy,
         storage_backend,
     }))
 }

--- a/crates/breez-sdk/core/src/turnkey/config.rs
+++ b/crates/breez-sdk/core/src/turnkey/config.rs
@@ -110,4 +110,9 @@ pub struct TurnkeyConfig {
     /// greater than 0 when set: 0 is rejected at connect.
     #[cfg_attr(feature = "uniffi", uniffi(default = None))]
     pub max_rps: Option<u32>,
+    /// Routes Turnkey requests through a SOCKS5 proxy. Pass the same value as
+    /// [`Config::proxy`](crate::Config::proxy): the signer is built before the
+    /// SDK, so it cannot pick the setting up on its own.
+    #[cfg_attr(feature = "uniffi", uniffi(default = None))]
+    pub proxy: Option<crate::ProxyConfig>,
 }

--- a/crates/breez-sdk/core/src/turnkey/factory.rs
+++ b/crates/breez-sdk/core/src/turnkey/factory.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use bitcoin::secp256k1::PublicKey;
-use platform_utils::create_http_client_with_proxy;
 use spark_wallet::SparkAddress;
 
 use crate::error::SignerError;
@@ -54,18 +53,9 @@ async fn build_client(
 ) -> Result<(Arc<TurnkeyClient>, Network, u32), SignerError> {
     let network = config.network;
     let account = account_number(config);
-    if let Some(proxy) = &config.proxy {
-        proxy.validate().map_err(to_signer_err)?;
-    }
-    let http = create_http_client_with_proxy(
-        Some("breez-sdk-spark-turnkey"),
-        config
-            .proxy
-            .as_ref()
-            .map(platform_utils::ProxyConfig::from)
-            .as_ref(),
-    )
-    .map_err(|e| SignerError::Generic(format!("Failed to build proxied HTTP client: {e}")))?;
+    let http =
+        crate::ProxyConfig::http_client(config.proxy.as_ref(), Some("breez-sdk-spark-turnkey"))
+            .map_err(to_signer_err)?;
     let client = Arc::new(TurnkeyClient::new(config, http).map_err(to_signer_err)?);
     if config.identity_public_key.is_none() {
         client

--- a/crates/breez-sdk/core/src/turnkey/factory.rs
+++ b/crates/breez-sdk/core/src/turnkey/factory.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use bitcoin::secp256k1::PublicKey;
-use platform_utils::create_http_client;
+use platform_utils::create_http_client_with_proxy;
 use spark_wallet::SparkAddress;
 
 use crate::error::SignerError;
@@ -54,7 +54,17 @@ async fn build_client(
 ) -> Result<(Arc<TurnkeyClient>, Network, u32), SignerError> {
     let network = config.network;
     let account = account_number(config);
-    let http = create_http_client(Some("breez-sdk-spark-turnkey"));
+    if let Some(proxy) = &config.proxy {
+        proxy.validate().map_err(to_signer_err)?;
+    }
+    let http = create_http_client_with_proxy(
+        Some("breez-sdk-spark-turnkey"),
+        config
+            .proxy
+            .as_ref()
+            .map(platform_utils::ProxyConfig::from)
+            .as_ref(),
+    );
     let client = Arc::new(TurnkeyClient::new(config, http).map_err(to_signer_err)?);
     if config.identity_public_key.is_none() {
         client
@@ -163,6 +173,7 @@ mod tests {
             identity_public_key,
             retry: None,
             max_rps: None,
+            proxy: None,
         }
     }
 

--- a/crates/breez-sdk/core/src/turnkey/factory.rs
+++ b/crates/breez-sdk/core/src/turnkey/factory.rs
@@ -64,7 +64,8 @@ async fn build_client(
             .as_ref()
             .map(platform_utils::ProxyConfig::from)
             .as_ref(),
-    );
+    )
+    .map_err(|e| SignerError::Generic(format!("Failed to build proxied HTTP client: {e}")))?;
     let client = Arc::new(TurnkeyClient::new(config, http).map_err(to_signer_err)?);
     if config.identity_public_key.is_none() {
         client

--- a/crates/breez-sdk/core/src/turnkey/management.rs
+++ b/crates/breez-sdk/core/src/turnkey/management.rs
@@ -111,7 +111,8 @@ impl TurnkeyWalletManager {
     /// Builds a manager from `config`. Its `wallet_id` is unused: these calls are
     /// organization-scoped. Uses the default platform HTTP client.
     pub fn new(config: &TurnkeyConfig) -> Result<Self, TurnkeyError> {
-        let http = platform_utils::create_http_client(Some("breez-sdk-spark-turnkey-test"));
+        let http = platform_utils::create_http_client(Some("breez-sdk-spark-turnkey-test"))
+            .map_err(|e| TurnkeyError::Transport(e.to_string()))?;
         Ok(Self {
             client: TurnkeyClient::new(config, http)?,
             network: config.network,

--- a/crates/breez-sdk/core/src/turnkey/spark_signer.rs
+++ b/crates/breez-sdk/core/src/turnkey/spark_signer.rs
@@ -1003,6 +1003,7 @@ mod tests {
             identity_public_key: None,
             retry: None,
             max_rps: None,
+            proxy: None,
         };
         Arc::new(TurnkeyClient::new(&config, http).unwrap())
     }

--- a/crates/breez-sdk/lnurl/Cargo.lock
+++ b/crates/breez-sdk/lnurl/Cargo.lock
@@ -1467,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1647,9 +1647,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1662,7 +1662,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1700,14 +1699,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -2611,13 +2609,17 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",
+ "http",
+ "hyper-util",
  "macros",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
  "tokio",
+ "tokio-socks",
  "tokio_with_wasm",
+ "tower-service",
  "tracing",
  "web-time",
 ]
@@ -3834,9 +3836,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
  "core-foundation 0.9.4",

--- a/crates/breez-sdk/lnurl/Cargo.toml
+++ b/crates/breez-sdk/lnurl/Cargo.toml
@@ -50,3 +50,7 @@ clippy.missing_panics_doc = "allow"
 clippy.must_use_candidate = "allow"
 clippy.struct_field_names = "allow"
 clippy.arithmetic_side_effects = "warn"
+# The root clippy.toml bans direct reqwest clients so every SDK connection can
+# honour `Config.proxy`. This is the LNURL server, not the SDK: it has no such
+# config, and its clients are server-side.
+clippy.disallowed_methods = "allow"

--- a/crates/breez-sdk/lnurl/src/main.rs
+++ b/crates/breez-sdk/lnurl/src/main.rs
@@ -263,7 +263,7 @@ where
     let mut spark_config = SparkWalletConfig::default_config(args.network);
     spark_config.service_provider_config.schema_endpoint = Some("graphql/spark/rc".to_string());
     // One HTTP client (one connection pool) shared by all SSP traffic.
-    let ssp_http_client = platform_utils::create_http_client(Some(&default_user_agent()));
+    let ssp_http_client = platform_utils::create_http_client(Some(&default_user_agent()))?;
 
     // Create shared infrastructure components
     let signer = Arc::new(DefaultSigner::new(&auth_seed, args.network)?);

--- a/crates/breez-sdk/lnurl/src/partner_jwt.rs
+++ b/crates/breez-sdk/lnurl/src/partner_jwt.rs
@@ -787,7 +787,8 @@ mod tests {
             Arc::new(SparkSignerAdapter::new(signer)),
             session_store,
             Some(cache.provider_for("a.com".to_string()) as Arc<dyn HeaderProvider>),
-        );
+        )
+        .unwrap();
 
         let _ = ssp.get_swap_fee_estimate(1000).await;
 

--- a/crates/breez-sdk/wasm/src/chain_service.rs
+++ b/crates/breez-sdk/wasm/src/chain_service.rs
@@ -105,20 +105,21 @@ impl BitcoinChainServiceHandle {
     js_name = "newRestChainService",
     unchecked_return_type = "BitcoinChainService"
 )]
-#[must_use]
 pub async fn new_rest_chain_service(
     url: String,
     network: Network,
     api_type: ChainApiType,
     credentials: Option<Credentials>,
-) -> BitcoinChainServiceHandle {
-    BitcoinChainServiceHandle {
+) -> crate::error::WasmResult<BitcoinChainServiceHandle> {
+    // No proxy option here: a SOCKS5 proxy cannot be honoured on WASM.
+    Ok(BitcoinChainServiceHandle {
         inner: breez_sdk_spark::new_rest_chain_service(
             url,
             network.into(),
             api_type.into(),
             credentials.map(Into::into),
+            breez_sdk_spark::NewRestChainServiceRequest::default(),
         )
-        .await,
-    }
+        .await?,
+    })
 }

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -696,7 +696,20 @@ pub struct Config {
     pub max_concurrent_claims: u32,
     pub spark_config: Option<SparkConfig>,
     pub background_tasks_enabled: bool,
+    /// Routes the connections the SDK opens through a SOCKS5 proxy. Not
+    /// supported on WASM: setting this always fails validation, since the
+    /// browser owns connection setup and exposes no proxy control.
+    pub proxy: Option<ProxyConfig>,
     pub cross_chain_config: Option<CrossChainConfig>,
+}
+
+#[derive(Clone)]
+#[macros::extern_wasm_bindgen(breez_sdk_spark::ProxyConfig)]
+pub struct ProxyConfig {
+    pub host: String,
+    pub port: u16,
+    pub username: Option<String>,
+    pub password: Option<String>,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::CrossChainConfig)]

--- a/crates/breez-sdk/wasm/src/passkey.rs
+++ b/crates/breez-sdk/wasm/src/passkey.rs
@@ -35,6 +35,8 @@ pub struct PasskeyConfig {
     /// Relying Party and user identity for the built-in provider on the
     /// zero-config path.
     pub provider_options: Option<PasskeyProviderOptions>,
+    /// Always rejected here: a SOCKS5 proxy cannot be honoured on WASM.
+    pub proxy: Option<crate::models::ProxyConfig>,
 }
 
 /// One-shot capability + configuration probe returned by
@@ -162,16 +164,16 @@ impl PasskeyClient {
         prf_provider: PrfProvider,
         breez_api_key: Option<String>,
         config: Option<PasskeyConfig>,
-    ) -> Self {
+    ) -> WasmResult<PasskeyClient> {
         let provider = Arc::new(WasmPrfProvider::new(prf_provider));
-        Self {
+        Ok(Self {
             inner: breez_sdk_spark::passkey::PasskeyClient::new(
                 provider.clone(),
                 breez_api_key,
                 config.map(Into::into),
-            ),
+            )?,
             provider,
-        }
+        })
     }
 
     /// One-shot capability probe (PRF support + domain association)

--- a/crates/breez-sdk/wasm/src/sdk.rs
+++ b/crates/breez-sdk/wasm/src/sdk.rs
@@ -84,7 +84,11 @@ pub fn default_server_config(network: Network) -> Config {
 
 #[wasm_bindgen(js_name = "getSparkStatus")]
 pub async fn get_spark_status() -> WasmResult<SparkStatus> {
-    Ok(breez_sdk_spark::get_spark_status().await?.into())
+    Ok(
+        breez_sdk_spark::get_spark_status(breez_sdk_spark::GetSparkStatusRequest::default())
+            .await?
+            .into(),
+    )
 }
 
 /// The two external signers for the SDK's signer-based connect. Returned by

--- a/crates/breez-sdk/wasm/src/sdk_context.rs
+++ b/crates/breez-sdk/wasm/src/sdk_context.rs
@@ -72,6 +72,12 @@ pub struct WasmSdkContextConfig {
     /// context store their data in MySQL via the shared pool.
     #[tsify(optional)]
     pub mysql_config: Option<MysqlStorageConfig>,
+
+    /// Routes every connection opened by this context's shared clients
+    /// through a SOCKS5 proxy. Not supported on WASM: setting this always
+    /// fails validation.
+    #[tsify(optional)]
+    pub proxy: Option<crate::models::ProxyConfig>,
 }
 
 /// Constructs a [`WasmSdkContext`] from a `WasmSdkContextConfig`.
@@ -83,6 +89,7 @@ pub async fn new_shared_sdk_context(config: WasmSdkContextConfig) -> WasmResult<
         network: config.network.into(),
         api_key: config.api_key,
         connections_per_operator: config.connections_per_operator,
+        proxy: config.proxy.map(Into::into),
         storage: None,
     })
     .await?;

--- a/crates/breez-sdk/wasm/src/turnkey.rs
+++ b/crates/breez-sdk/wasm/src/turnkey.rs
@@ -33,6 +33,8 @@ pub struct TurnkeyConfig {
     pub identity_public_key: Option<String>,
     pub retry: Option<TurnkeyRetryConfig>,
     pub max_rps: Option<u32>,
+    /// Always rejected here: a SOCKS5 proxy cannot be honoured on WASM.
+    pub proxy: Option<crate::models::ProxyConfig>,
 }
 
 /// Builds the Turnkey-backed signers from `config`, then pass

--- a/crates/flashnet/src/orchestra/client.rs
+++ b/crates/flashnet/src/orchestra/client.rs
@@ -34,7 +34,7 @@ pub trait OrchestraConfigResolver: Send + Sync {
 pub struct OrchestraClient {
     config_resolver: Arc<dyn OrchestraConfigResolver>,
     config: OnceCell<OrchestraConfig>,
-    http_client: platform_utils::DefaultHttpClient,
+    http_client: Arc<dyn HttpClient>,
     cache_store: CacheStore,
     spark_wallet: Arc<SparkWallet>,
 }
@@ -43,11 +43,12 @@ impl OrchestraClient {
     pub fn new(
         config_resolver: Arc<dyn OrchestraConfigResolver>,
         spark_wallet: Arc<SparkWallet>,
+        http_client: Arc<dyn HttpClient>,
     ) -> Self {
         Self {
             config_resolver,
             config: OnceCell::new(),
-            http_client: platform_utils::DefaultHttpClient::default(),
+            http_client,
             cache_store: CacheStore::default(),
             spark_wallet,
         }

--- a/crates/internal/src/command/deposit.rs
+++ b/crates/internal/src/command/deposit.rs
@@ -190,7 +190,7 @@ async fn get_transaction(
         add_basic_auth_header(&mut headers, username, password);
     }
 
-    let http_client = DefaultHttpClient::default();
+    let http_client = DefaultHttpClient::new(None)?;
     let response = http_client
         .get(url, Some(headers))
         .await
@@ -213,7 +213,7 @@ async fn broadcast_transaction(
     }
     add_content_type_header(&mut headers, ContentType::TextPlain);
 
-    let http_client = DefaultHttpClient::default();
+    let http_client = DefaultHttpClient::new(None)?;
     let response = http_client
         .post(url, Some(headers), Some(tx_hex.clone()))
         .await

--- a/crates/platform-utils/Cargo.toml
+++ b/crates/platform-utils/Cargo.toml
@@ -17,6 +17,14 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
+# Native dependencies. The SOCKS5 connector for gRPC has no WASM counterpart:
+# the browser owns connection setup and exposes no proxy knob.
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+http.workspace = true
+hyper-util.workspace = true
+tokio-socks.workspace = true
+tower-service.workspace = true
+
 # WASM dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 web-time = { version = "1.1.0", features = ["serde"] }
@@ -26,3 +34,6 @@ tokio_with_wasm = { version = "0.8.7", features = [
   "sync",
   "time",
 ] }
+
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/platform-utils/src/http/client.rs
+++ b/crates/platform-utils/src/http/client.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use super::{HttpClient, HttpError, HttpResponse, REQUEST_TIMEOUT};
+use crate::proxy::ProxyConfig;
 
 /// Collects response headers into a map with lowercased names, skipping any
 /// header whose value is not valid UTF-8.
@@ -38,13 +39,27 @@ impl ReqwestHttpClient {
     /// (crbug.com/571722) while Firefox/Safari send it and then fail the
     /// preflight against an endpoint that doesn't allow it. The browser sends
     /// its own `User-Agent` regardless, so omitting it loses nothing.
+    pub fn new(user_agent: Option<String>) -> Self {
+        Self::with_proxy(user_agent, None)
+    }
+
+    /// Like [`Self::new`], but routes every request through `proxy`.
+    ///
+    /// Setting a proxy also switches reqwest off system-proxy autodetection, so
+    /// no environment variable can redirect traffic around it. A proxy that
+    /// can't be reached fails the request: there is no direct fallback.
+    ///
+    /// A proxy is rejected on WASM. `fetch` exposes no proxy control, so
+    /// honouring it is impossible and silently ignoring it would be worse.
     // `user_agent` is intentionally unused on WASM (see above); the signature
     // stays uniform across targets.
     #[cfg_attr(
         all(target_family = "wasm", target_os = "unknown"),
         expect(clippy::needless_pass_by_value, unused_variables)
     )]
-    pub fn new(user_agent: Option<String>) -> Self {
+    pub fn with_proxy(user_agent: Option<String>, proxy: Option<&ProxyConfig>) -> Self {
+        // The sanctioned place to build one: the proxy is applied right below.
+        #[allow(clippy::disallowed_methods)]
         let builder = reqwest::Client::builder();
         #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
         let builder = {
@@ -52,12 +67,29 @@ impl ReqwestHttpClient {
             if let Some(ua) = user_agent {
                 builder = builder.user_agent(ua);
             }
+            if let Some(proxy) = proxy {
+                match reqwest::Proxy::all(proxy.reqwest_url()) {
+                    Ok(proxy) => builder = builder.proxy(proxy),
+                    Err(e) => {
+                        // Continuing would build a client that connects
+                        // directly, which is the one outcome a proxied client
+                        // must never produce.
+                        tracing::error!("Failed to build SOCKS5 proxy: {e}");
+                        panic!("Failed to build SOCKS5 proxy: {e}");
+                    }
+                }
+            }
             builder
                 .tcp_keepalive(Some(Duration::from_mins(1)))
                 .http2_keep_alive_interval(Duration::from_secs(30))
                 .http2_keep_alive_timeout(Duration::from_secs(10))
                 .http2_keep_alive_while_idle(true)
         };
+        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+        assert!(
+            proxy.is_none(),
+            "a SOCKS5 proxy cannot be honoured on WASM: fetch exposes no proxy control"
+        );
         let client = match builder.build() {
             Ok(client) => client,
             Err(e) => {

--- a/crates/platform-utils/src/http/client.rs
+++ b/crates/platform-utils/src/http/client.rs
@@ -39,7 +39,11 @@ impl ReqwestHttpClient {
     /// (crbug.com/571722) while Firefox/Safari send it and then fail the
     /// preflight against an endpoint that doesn't allow it. The browser sends
     /// its own `User-Agent` regardless, so omitting it loses nothing.
-    pub fn new(user_agent: Option<String>) -> Self {
+    ///
+    /// Fails when reqwest cannot assemble a client: an invalid `user_agent`
+    /// (one that is not a valid header value), or a TLS backend or system
+    /// resolver that will not initialise.
+    pub fn new(user_agent: Option<String>) -> Result<Self, HttpError> {
         Self::with_proxy(user_agent, None)
     }
 
@@ -49,6 +53,11 @@ impl ReqwestHttpClient {
     /// no environment variable can redirect traffic around it. A proxy that
     /// can't be reached fails the request: there is no direct fallback.
     ///
+    /// Fails when `proxy` does not form a usable proxy URL, which in practice
+    /// means a `host` that cannot appear in a URL authority. Building a client
+    /// anyway would connect directly, the one outcome a proxied client must
+    /// never produce.
+    ///
     /// A proxy is rejected on WASM. `fetch` exposes no proxy control, so
     /// honouring it is impossible and silently ignoring it would be worse.
     // `user_agent` is intentionally unused on WASM (see above); the signature
@@ -57,7 +66,10 @@ impl ReqwestHttpClient {
         all(target_family = "wasm", target_os = "unknown"),
         expect(clippy::needless_pass_by_value, unused_variables)
     )]
-    pub fn with_proxy(user_agent: Option<String>, proxy: Option<&ProxyConfig>) -> Self {
+    pub fn with_proxy(
+        user_agent: Option<String>,
+        proxy: Option<&ProxyConfig>,
+    ) -> Result<Self, HttpError> {
         // The sanctioned place to build one: the proxy is applied right below.
         #[allow(clippy::disallowed_methods)]
         let builder = reqwest::Client::builder();
@@ -68,16 +80,7 @@ impl ReqwestHttpClient {
                 builder = builder.user_agent(ua);
             }
             if let Some(proxy) = proxy {
-                match reqwest::Proxy::all(proxy.reqwest_url()) {
-                    Ok(proxy) => builder = builder.proxy(proxy),
-                    Err(e) => {
-                        // Continuing would build a client that connects
-                        // directly, which is the one outcome a proxied client
-                        // must never produce.
-                        tracing::error!("Failed to build SOCKS5 proxy: {e}");
-                        panic!("Failed to build SOCKS5 proxy: {e}");
-                    }
-                }
+                builder = builder.proxy(reqwest::Proxy::all(proxy.reqwest_url())?);
             }
             builder
                 .tcp_keepalive(Some(Duration::from_mins(1)))
@@ -86,24 +89,15 @@ impl ReqwestHttpClient {
                 .http2_keep_alive_while_idle(true)
         };
         #[cfg(all(target_family = "wasm", target_os = "unknown"))]
-        assert!(
-            proxy.is_none(),
-            "a SOCKS5 proxy cannot be honoured on WASM: fetch exposes no proxy control"
-        );
-        let client = match builder.build() {
-            Ok(client) => client,
-            Err(e) => {
-                tracing::error!("Failed to create reqwest client: {e}");
-                panic!("Failed to create reqwest client: {e}");
-            }
-        };
-        Self { client }
-    }
-}
-
-impl Default for ReqwestHttpClient {
-    fn default() -> Self {
-        Self::new(None)
+        if proxy.is_some() {
+            return Err(HttpError::Builder(
+                "a SOCKS5 proxy cannot be honoured on WASM: fetch exposes no proxy control"
+                    .to_string(),
+            ));
+        }
+        Ok(Self {
+            client: builder.build()?,
+        })
     }
 }
 

--- a/crates/platform-utils/src/http/mod.rs
+++ b/crates/platform-utils/src/http/mod.rs
@@ -146,7 +146,50 @@ pub trait HttpClient: Send + Sync {
     ) -> Result<HttpResponse, HttpError>;
 }
 
+/// Lets a shared `Arc<dyn HttpClient>` satisfy generic `C: HttpClient` bounds,
+/// so callers can hand the SDK's one pooled client to components that own their
+/// client by value.
+#[macros::async_trait]
+impl HttpClient for Arc<dyn HttpClient> {
+    async fn get(
+        &self,
+        url: String,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<HttpResponse, HttpError> {
+        (**self).get(url, headers).await
+    }
+
+    async fn post(
+        &self,
+        url: String,
+        headers: Option<HashMap<String, String>>,
+        body: Option<String>,
+    ) -> Result<HttpResponse, HttpError> {
+        (**self).post(url, headers, body).await
+    }
+
+    async fn delete(
+        &self,
+        url: String,
+        headers: Option<HashMap<String, String>>,
+        body: Option<String>,
+    ) -> Result<HttpResponse, HttpError> {
+        (**self).delete(url, headers, body).await
+    }
+}
+
 /// Create a new HTTP client with the given user agent.
 pub fn create_http_client(user_agent: Option<&str>) -> Arc<dyn HttpClient> {
-    Arc::new(ReqwestHttpClient::new(user_agent.map(String::from)))
+    create_http_client_with_proxy(user_agent, None)
+}
+
+/// Create a new HTTP client that routes every request through `proxy`.
+pub fn create_http_client_with_proxy(
+    user_agent: Option<&str>,
+    proxy: Option<&crate::proxy::ProxyConfig>,
+) -> Arc<dyn HttpClient> {
+    Arc::new(ReqwestHttpClient::with_proxy(
+        user_agent.map(String::from),
+        proxy,
+    ))
 }

--- a/crates/platform-utils/src/http/mod.rs
+++ b/crates/platform-utils/src/http/mod.rs
@@ -179,17 +179,25 @@ impl HttpClient for Arc<dyn HttpClient> {
 }
 
 /// Create a new HTTP client with the given user agent.
-pub fn create_http_client(user_agent: Option<&str>) -> Arc<dyn HttpClient> {
-    create_http_client_with_proxy(user_agent, None)
+///
+/// Fails when reqwest cannot assemble a client, most reachably because
+/// `user_agent` is not a valid header value.
+pub fn create_http_client(user_agent: Option<&str>) -> Result<Arc<dyn HttpClient>, HttpError> {
+    Ok(Arc::new(ReqwestHttpClient::new(
+        user_agent.map(String::from),
+    )?))
 }
 
 /// Create a new HTTP client that routes every request through `proxy`.
+///
+/// Fails when `proxy` does not form a usable proxy URL, rather than falling
+/// back to a client that would connect directly.
 pub fn create_http_client_with_proxy(
     user_agent: Option<&str>,
     proxy: Option<&crate::proxy::ProxyConfig>,
-) -> Arc<dyn HttpClient> {
-    Arc::new(ReqwestHttpClient::with_proxy(
+) -> Result<Arc<dyn HttpClient>, HttpError> {
+    Ok(Arc::new(ReqwestHttpClient::with_proxy(
         user_agent.map(String::from),
         proxy,
-    ))
+    )?))
 }

--- a/crates/platform-utils/src/lib.rs
+++ b/crates/platform-utils/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod auth;
 pub mod http;
+pub mod proxy;
 
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 pub use tokio;
@@ -21,4 +22,11 @@ pub use std::time;
 pub use auth::{
     ContentType, add_basic_auth_header, add_content_type_header, make_basic_auth_header,
 };
-pub use http::{DefaultHttpClient, HttpClient, HttpError, HttpResponse, create_http_client};
+pub use http::{
+    DefaultHttpClient, HttpClient, HttpError, HttpResponse, create_http_client,
+    create_http_client_with_proxy,
+};
+pub use proxy::ProxyConfig;
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub use proxy::Socks5Connector;

--- a/crates/platform-utils/src/proxy/connector.rs
+++ b/crates/platform-utils/src/proxy/connector.rs
@@ -96,7 +96,13 @@ impl Service<Uri> for Socks5Connector {
                 source,
             })?;
 
-            Ok(TokioIo::new(stream.into_inner()))
+            // Tonic only sets `TCP_NODELAY` on the `HttpConnector` it builds
+            // itself, which a custom connector replaces, so a proxied channel
+            // would otherwise run with Nagle on and pay up to ~40ms per small
+            // gRPC write. Best-effort: matches tonic's own default.
+            let stream = stream.into_inner();
+            let _ = stream.set_nodelay(true);
+            Ok(TokioIo::new(stream))
         })
     }
 }

--- a/crates/platform-utils/src/proxy/connector.rs
+++ b/crates/platform-utils/src/proxy/connector.rs
@@ -1,0 +1,138 @@
+//! A `tower` connector that dials through a SOCKS5 proxy, for gRPC channels.
+//!
+//! `reqwest` handles its own proxying, so this exists for the tonic side,
+//! which only takes a connector. TLS is layered on top by tonic itself, so the
+//! stream handed back here is the plain tunnelled TCP connection.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use http::Uri;
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpStream;
+use tokio_socks::tcp::Socks5Stream;
+use tower_service::Service;
+
+use super::ProxyConfig;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProxyConnectError {
+    #[error("proxy target URI has no host")]
+    MissingHost,
+    #[error("proxy target URI has no port and its scheme has no default")]
+    MissingPort,
+    #[error("SOCKS5 connection to {target} via {proxy} failed: {source}")]
+    Connect {
+        proxy: String,
+        target: String,
+        #[source]
+        source: tokio_socks::Error,
+    },
+}
+
+/// Dials every target through the configured SOCKS5 proxy.
+///
+/// The target host is sent to the proxy as a name, so the proxy performs the
+/// lookup. Only the proxy's own address is resolved locally.
+#[derive(Debug, Clone)]
+pub struct Socks5Connector {
+    proxy: Arc<ProxyConfig>,
+}
+
+impl Socks5Connector {
+    #[must_use]
+    pub fn new(proxy: &ProxyConfig) -> Self {
+        Self {
+            proxy: Arc::new(proxy.clone()),
+        }
+    }
+}
+
+/// Port from the URI, falling back to the scheme default. gRPC endpoints are
+/// `http`/`https`, the only two schemes tonic hands a connector.
+fn target_port(uri: &Uri) -> Option<u16> {
+    uri.port_u16().or_else(|| match uri.scheme_str() {
+        Some("https") => Some(443),
+        Some("http") => Some(80),
+        _ => None,
+    })
+}
+
+impl Service<Uri> for Socks5Connector {
+    type Response = TokioIo<TcpStream>;
+    type Error = ProxyConnectError;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, uri: Uri) -> Self::Future {
+        let proxy = Arc::clone(&self.proxy);
+        Box::pin(async move {
+            let host = uri
+                .host()
+                .ok_or(ProxyConnectError::MissingHost)?
+                .to_string();
+            let port = target_port(&uri).ok_or(ProxyConnectError::MissingPort)?;
+            let proxy_addr = proxy.address();
+
+            // `(String, u16)` becomes a `TargetAddr::Domain`, which is what
+            // makes the proxy resolve the name instead of this process.
+            let target = (host.clone(), port);
+            let stream = match proxy.credentials() {
+                Some((user, pass)) => {
+                    Socks5Stream::connect_with_password(proxy_addr.as_str(), target, user, pass)
+                        .await
+                }
+                None => Socks5Stream::connect(proxy_addr.as_str(), target).await,
+            }
+            .map_err(|source| ProxyConnectError::Connect {
+                proxy: proxy_addr,
+                target: format!("{host}:{port}"),
+                source,
+            })?;
+
+            Ok(TokioIo::new(stream.into_inner()))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn port_falls_back_to_scheme_default() {
+        assert_eq!(
+            target_port(&Uri::from_static("https://example.com")),
+            Some(443)
+        );
+        assert_eq!(
+            target_port(&Uri::from_static("http://example.com")),
+            Some(80)
+        );
+        assert_eq!(
+            target_port(&Uri::from_static("https://example.com:8443")),
+            Some(8443)
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_failure_names_proxy_and_target() {
+        // Port 1 has nothing listening, so the dial fails before any SOCKS
+        // handshake and the error should still identify both endpoints.
+        let proxy = ProxyConfig::new("127.0.0.1", 1);
+        let mut connector = Socks5Connector::new(&proxy);
+        let err = connector
+            .call(Uri::from_static("https://example.com"))
+            .await
+            .expect_err("nothing is listening on 127.0.0.1:1");
+        let msg = err.to_string();
+        assert!(msg.contains("127.0.0.1:1"), "missing proxy: {msg}");
+        assert!(msg.contains("example.com:443"), "missing target: {msg}");
+    }
+}

--- a/crates/platform-utils/src/proxy/mod.rs
+++ b/crates/platform-utils/src/proxy/mod.rs
@@ -47,9 +47,16 @@ impl ProxyConfig {
 
     /// `host:port`, the form both the reqwest proxy URL and the SOCKS5
     /// connector dial.
+    ///
+    /// A bare IPv6 literal is bracketed: without brackets its own colons read
+    /// as the port separator, and neither a URL nor a socket address parses.
     #[must_use]
     pub fn address(&self) -> String {
-        format!("{}:{}", self.host, self.port)
+        if self.host.parse::<std::net::Ipv6Addr>().is_ok() {
+            format!("[{}]:{}", self.host, self.port)
+        } else {
+            format!("{}:{}", self.host, self.port)
+        }
     }
 
     /// The `socks5h` URL reqwest needs. The `h` suffix is what makes reqwest
@@ -95,6 +102,20 @@ mod tests {
     fn url_uses_socks5h_so_dns_stays_remote() {
         let proxy = ProxyConfig::new("127.0.0.1", 9050);
         assert_eq!(proxy.reqwest_url(), "socks5h://127.0.0.1:9050");
+    }
+
+    #[test]
+    fn ipv6_host_is_bracketed() {
+        let proxy = ProxyConfig::new("::1", 9050);
+        assert_eq!(proxy.address(), "[::1]:9050");
+        assert_eq!(proxy.reqwest_url(), "socks5h://[::1]:9050");
+        assert!(proxy.address().parse::<std::net::SocketAddr>().is_ok());
+    }
+
+    #[test]
+    fn already_bracketed_ipv6_host_is_left_alone() {
+        let proxy = ProxyConfig::new("[::1]", 9050);
+        assert_eq!(proxy.address(), "[::1]:9050");
     }
 
     #[test]

--- a/crates/platform-utils/src/proxy/mod.rs
+++ b/crates/platform-utils/src/proxy/mod.rs
@@ -1,0 +1,122 @@
+//! SOCKS5 proxy configuration shared by every transport the SDK opens.
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+mod connector;
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub use connector::Socks5Connector;
+
+/// A SOCKS5 proxy every SDK connection is routed through.
+///
+/// Hostnames are always resolved by the proxy, never locally, so a DNS query
+/// never reveals which host is being reached. There is deliberately no knob to
+/// turn that off.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProxyConfig {
+    /// Proxy host. An IP address or a name resolvable on the local network:
+    /// reaching the proxy itself is the one lookup that cannot go through it.
+    pub host: String,
+    pub port: u16,
+    /// Username for SOCKS5 username/password authentication (RFC 1929).
+    /// Both this and `password` must be set for authentication to be offered.
+    pub username: Option<String>,
+    pub password: Option<String>,
+}
+
+impl ProxyConfig {
+    /// A proxy at `host:port` with no authentication.
+    #[must_use]
+    pub fn new(host: impl Into<String>, port: u16) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            username: None,
+            password: None,
+        }
+    }
+
+    /// Credentials, when both halves are present. A username without a
+    /// password (or the reverse) is not a usable RFC 1929 exchange.
+    #[must_use]
+    pub fn credentials(&self) -> Option<(&str, &str)> {
+        match (&self.username, &self.password) {
+            (Some(user), Some(pass)) => Some((user.as_str(), pass.as_str())),
+            _ => None,
+        }
+    }
+
+    /// `host:port`, the form both the reqwest proxy URL and the SOCKS5
+    /// connector dial.
+    #[must_use]
+    pub fn address(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+
+    /// The `socks5h` URL reqwest needs. The `h` suffix is what makes reqwest
+    /// hand the hostname to the proxy instead of resolving it locally.
+    ///
+    /// Credentials are carried in the URL userinfo, percent-encoded so that a
+    /// password containing `:`, `@` or `/` cannot break out of its component.
+    #[must_use]
+    pub fn reqwest_url(&self) -> String {
+        match self.credentials() {
+            Some((user, pass)) => format!(
+                "socks5h://{}:{}@{}",
+                percent_encode_userinfo(user),
+                percent_encode_userinfo(pass),
+                self.address()
+            ),
+            None => format!("socks5h://{}", self.address()),
+        }
+    }
+}
+
+/// Percent-encodes everything outside the unreserved set, which is stricter
+/// than the userinfo grammar allows but keeps the encoding trivially correct.
+fn percent_encode_userinfo(value: &str) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            out.push(byte as char);
+        } else {
+            let _ = write!(out, "%{byte:02X}");
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_uses_socks5h_so_dns_stays_remote() {
+        let proxy = ProxyConfig::new("127.0.0.1", 9050);
+        assert_eq!(proxy.reqwest_url(), "socks5h://127.0.0.1:9050");
+    }
+
+    #[test]
+    fn credentials_need_both_halves() {
+        let mut proxy = ProxyConfig::new("127.0.0.1", 9050);
+        proxy.username = Some("user".to_string());
+        assert_eq!(proxy.credentials(), None);
+        proxy.password = Some("pass".to_string());
+        assert_eq!(proxy.credentials(), Some(("user", "pass")));
+    }
+
+    #[test]
+    fn userinfo_specials_are_encoded() {
+        let proxy = ProxyConfig {
+            host: "127.0.0.1".to_string(),
+            port: 9050,
+            username: Some("us er".to_string()),
+            password: Some("p@ss:/word".to_string()),
+        };
+        assert_eq!(
+            proxy.reqwest_url(),
+            "socks5h://us%20er:p%40ss%3A%2Fword@127.0.0.1:9050"
+        );
+    }
+}

--- a/crates/spark-itest/src/faucet.rs
+++ b/crates/spark-itest/src/faucet.rs
@@ -85,7 +85,7 @@ impl RegtestFaucet {
         info!("Initialized faucet client with URL: {}", config.url);
         Ok(Self {
             config,
-            http_client: DefaultHttpClient::default(),
+            http_client: DefaultHttpClient::new(None).expect("http client"),
         })
     }
 

--- a/crates/spark-itest/src/fixtures/bitcoind.rs
+++ b/crates/spark-itest/src/fixtures/bitcoind.rs
@@ -112,7 +112,7 @@ impl BitcoindFixture {
             rpcpassword: REGTEST_RPC_PASSWORD.to_string(),
             mining_address: Address::from_str(DEFAULT_MINING_ADDRESS)?
                 .require_network(Network::Regtest)?,
-            http_client: DefaultHttpClient::default(),
+            http_client: DefaultHttpClient::new(None).expect("http client"),
         };
 
         info!("Created bitcoind container. Ensure wallet created.");

--- a/crates/spark-itest/src/mempool.rs
+++ b/crates/spark-itest/src/mempool.rs
@@ -47,7 +47,7 @@ impl MempoolClient {
         info!("Initialized mempool client with URL: {}", config.url);
         Ok(Self {
             config,
-            http_client: DefaultHttpClient::default(),
+            http_client: DefaultHttpClient::new(None).expect("http client"),
         })
     }
 

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -430,7 +430,7 @@ impl SparkWallet {
                 Arc::clone(&spark_signer),
                 Arc::clone(&session_store),
                 ssp_extra_header_provider,
-            ),
+            )?,
         });
 
         let operator_pool = Arc::new(

--- a/crates/spark/src/operator/rpc/connection_manager/balanced.rs
+++ b/crates/spark/src/operator/rpc/connection_manager/balanced.rs
@@ -10,6 +10,13 @@ use crate::operator::rpc::transport::retry_channel::RetryChannel;
 
 use super::ConnectionManager;
 
+/// Opens several connections per operator and balances requests across them.
+///
+/// This manager cannot be proxied. Balancing goes through
+/// [`Channel::balance_list`], which builds its own connectors and has no
+/// connector-aware variant in any tonic release, so there is nowhere to insert
+/// a SOCKS5 dialer. The SDK rejects a config that asks for both; use
+/// [`DefaultConnectionManager`](super::DefaultConnectionManager) with a proxy.
 pub struct BalancedConnectionManager {
     connections_map: RwLock<HashMap<String, Transport>>,
     connections_per_operator: u32,

--- a/crates/spark/src/operator/rpc/connection_manager/default.rs
+++ b/crates/spark/src/operator/rpc/connection_manager/default.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+
+use platform_utils::ProxyConfig;
 use tokio::sync::RwLock;
 use tracing::debug;
 
@@ -10,6 +12,7 @@ use super::ConnectionManager;
 
 pub struct DefaultConnectionManager {
     connections_map: RwLock<HashMap<String, Transport>>,
+    proxy: Option<ProxyConfig>,
 }
 
 impl Default for DefaultConnectionManager {
@@ -20,8 +23,15 @@ impl Default for DefaultConnectionManager {
 
 impl DefaultConnectionManager {
     pub fn new() -> Self {
+        Self::with_proxy(None)
+    }
+
+    /// One connection per operator, tunnelled through `proxy` when set.
+    #[must_use]
+    pub fn with_proxy(proxy: Option<ProxyConfig>) -> Self {
         Self {
             connections_map: RwLock::new(HashMap::new()),
+            proxy,
         }
     }
 }
@@ -43,6 +53,7 @@ impl ConnectionManager for DefaultConnectionManager {
             operator.address.to_string(),
             operator.ca_cert.clone(),
             operator.user_agent.clone(),
+            self.proxy.as_ref(),
         )?
         .into_inner();
 

--- a/crates/spark/src/operator/rpc/spark_rpc_client.rs
+++ b/crates/spark/src/operator/rpc/spark_rpc_client.rs
@@ -805,7 +805,7 @@ mod tests {
     /// The transport is lazy and the test closures never touch the network,
     /// so the URL only has to parse.
     fn test_client(provider: Arc<FlakyProvider>) -> SparkRpcClient {
-        let transport = GrpcClient::new("http://127.0.0.1:1".to_string(), None, None)
+        let transport = GrpcClient::new("http://127.0.0.1:1".to_string(), None, None, None)
             .expect("transport")
             .into_inner();
         SparkRpcClient::new(transport, provider, 0)

--- a/crates/spark/src/operator/rpc/transport/grpc_client.rs
+++ b/crates/spark/src/operator/rpc/transport/grpc_client.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use platform_utils::{ProxyConfig, Socks5Connector};
 use tonic::transport::ClientTlsConfig;
 
 use super::retry_channel::RetryChannel;
@@ -13,14 +14,25 @@ pub struct GrpcClient {
 }
 
 impl GrpcClient {
+    /// A lazily-connected channel to the operator, tunnelled through `proxy`
+    /// when one is set.
+    ///
+    /// The proxy only replaces how the TCP connection is opened. Tonic still
+    /// applies the endpoint's TLS config on top, with the SNI name taken from
+    /// `url`, so certificate validation is unchanged either way.
     pub fn new(
         url: String,
         ca_cert: Option<Vec<u8>>,
         user_agent: Option<String>,
+        proxy: Option<&ProxyConfig>,
     ) -> Result<Self, OperatorRpcError> {
         let endpoint = EndpointTemplate::new(url, ca_cert, user_agent).build()?;
+        let channel = match proxy {
+            Some(proxy) => endpoint.connect_with_connector_lazy(Socks5Connector::new(proxy)),
+            None => endpoint.connect_lazy(),
+        };
         Ok(Self {
-            inner: RetryChannel::new(endpoint.connect_lazy()),
+            inner: RetryChannel::new(channel),
         })
     }
 

--- a/crates/spark/src/operator/rpc/transport/grpc_client_wasm.rs
+++ b/crates/spark/src/operator/rpc/transport/grpc_client_wasm.rs
@@ -1,6 +1,7 @@
 use std::task::{Context, Poll};
 
 use http::HeaderValue;
+use platform_utils::ProxyConfig;
 use tower_service::Service;
 
 use crate::{default_user_agent, operator::rpc::OperatorRpcError};
@@ -40,11 +41,22 @@ pub struct GrpcClient {
 }
 
 impl GrpcClient {
+    /// `proxy` must be `None` here: browser fetch offers no proxy control, so a
+    /// proxied channel cannot be built. Callers are expected to have rejected
+    /// the config already; this is the backstop that keeps an unhonoured proxy
+    /// from turning into silent direct traffic.
     pub fn new(
         url: String,
         _ca_cert: Option<Vec<u8>>,
         user_agent: Option<String>,
+        proxy: Option<&ProxyConfig>,
     ) -> Result<Self, OperatorRpcError> {
+        if proxy.is_some() {
+            return Err(OperatorRpcError::Transport(
+                "a SOCKS5 proxy cannot be honoured on WASM: fetch exposes no proxy control"
+                    .to_string(),
+            ));
+        }
         let user_agent = user_agent.unwrap_or_else(default_user_agent);
         let user_agent = HeaderValue::from_str(&user_agent)
             .map_err(|e| OperatorRpcError::Transport(e.to_string()))?;

--- a/crates/spark/src/ssp/service_provider.rs
+++ b/crates/spark/src/ssp/service_provider.rs
@@ -16,7 +16,7 @@ use crate::{
         RequestLightningReceiveInput, RequestLightningSendInput, RequestSwapInput,
         ServiceProviderConfig, SparkWalletWebhookEventType, SspAuthHeaderProvider, SspTransfer,
         StaticDepositQuote, WebhookEntry,
-        error::ServiceProviderResult,
+        error::{ServiceProviderError, ServiceProviderResult},
         graphql::{CoopExitRequest, GraphQLClient, LightningReceiveRequest, LightningSendRequest},
     },
 };
@@ -34,21 +34,28 @@ impl ServiceProvider {
     /// auth provider's headers are combined with it on every request — used,
     /// for example, to attach the Breez partner JWT alongside the SSP session
     /// token.
+    ///
+    /// Fails when the client cannot be built, which in practice means a
+    /// `user_agent` on `config` that is not a valid header value.
     pub fn new(
         config: ServiceProviderConfig,
         spark_signer: Arc<dyn SparkSigner>,
         session_store: Arc<dyn SessionStore>,
         extra_header_provider: Option<Arc<dyn HeaderProvider>>,
-    ) -> Self {
+    ) -> ServiceProviderResult<Self> {
         let user_agent = config.user_agent.clone().unwrap_or_else(default_user_agent);
-        let http_client = create_http_client(Some(&user_agent));
-        Self::new_with_client(
+        let http_client =
+            create_http_client(Some(&user_agent)).map_err(|e| ServiceProviderError::Network {
+                reason: e.to_string(),
+                code: None,
+            })?;
+        Ok(Self::new_with_client(
             config,
             spark_signer,
             session_store,
             extra_header_provider,
             http_client,
-        )
+        ))
     }
 
     /// Like [`ServiceProvider::new`], but uses a shared HTTP client so the

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -1227,18 +1227,21 @@ mod tests {
             .await
             .unwrap(),
         );
-        let ssp_client = Arc::new(ServiceProvider::new(
-            ServiceProviderConfig {
-                base_url: UNROUTABLE.to_string(),
-                schema_endpoint: None,
-                identity_public_key: identity_pubkey,
-                user_agent: None,
-                retry_config: RetryConfig::default(),
-            },
-            Arc::clone(&spark_signer),
-            session_store,
-            None,
-        ));
+        let ssp_client = Arc::new(
+            ServiceProvider::new(
+                ServiceProviderConfig {
+                    base_url: UNROUTABLE.to_string(),
+                    schema_endpoint: None,
+                    identity_public_key: identity_pubkey,
+                    user_agent: None,
+                    retry_config: RetryConfig::default(),
+                },
+                Arc::clone(&spark_signer),
+                session_store,
+                None,
+            )
+            .unwrap(),
+        );
         let transfer_service = Arc::new(TransferService::new(
             Arc::clone(&spark_signer),
             Network::Regtest,

--- a/docs/breez-sdk/snippets/csharp/Config.cs
+++ b/docs/breez-sdk/snippets/csharp/Config.cs
@@ -159,5 +159,24 @@ namespace BreezSdkSnippets
             // ANCHOR_END: cross-chain-config
             Console.WriteLine($"Config: {config}");
         }
+
+        public void ConfigureProxy()
+        {
+            // ANCHOR: config-proxy
+            // Route the SDK's connections through a SOCKS5 proxy, such as a local
+            // Tor daemon. Set username and password together for proxies that
+            // require RFC 1929 authentication.
+            var config = BreezSdkSparkMethods.DefaultConfig(Network.Mainnet) with
+            {
+                apiKey = "<breez api key>",
+                proxy = new ProxyConfig(
+                    host: "127.0.0.1",
+                    port: 9050,
+                    username: null,
+                    password: null)
+            };
+            // ANCHOR_END: config-proxy
+            Console.WriteLine($"Config: {config}");
+        }
     }
 }

--- a/docs/breez-sdk/snippets/csharp/GettingStarted.cs
+++ b/docs/breez-sdk/snippets/csharp/GettingStarted.cs
@@ -141,7 +141,9 @@ namespace BreezSdkSnippets
         // ANCHOR: spark-status
         async Task GetSparkStatus()
         {
-            var sparkStatus = await BreezSdkSparkMethods.GetSparkStatus();
+            var sparkStatus = await BreezSdkSparkMethods.GetSparkStatus(
+                request: new GetSparkStatusRequest()
+            );
 
             switch (sparkStatus.status)
             {

--- a/docs/breez-sdk/snippets/flutter/lib/config.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/config.dart
@@ -138,3 +138,21 @@ void configureCrossChain() {
   // ANCHOR_END: cross-chain-config
   print("Config: $config");
 }
+
+Future<void> configureProxy() async {
+  // ANCHOR: config-proxy
+  // Route the SDK's connections through a SOCKS5 proxy, such as a local Tor
+  // daemon. Set username and password together for proxies that require
+  // RFC 1929 authentication.
+  final config = defaultConfig(network: Network.mainnet).copyWith(
+    apiKey: "<breez api key>",
+    proxy: const ProxyConfig(
+      host: "127.0.0.1",
+      port: 9050,
+      username: null,
+      password: null,
+    ),
+  );
+  // ANCHOR_END: config-proxy
+  print("Config: $config");
+}

--- a/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
+++ b/docs/breez-sdk/snippets/flutter/lib/getting_started.dart
@@ -38,7 +38,7 @@ Future<void> fetchBalance(BreezSdk sdk) async {
 
 // ANCHOR: spark-status
 Future<void> gettingStartedSparkStatus() async {
-  final sparkStatus = await getSparkStatus();
+  final sparkStatus = await getSparkStatus(request: GetSparkStatusRequest());
 
   switch (sparkStatus.status) {
     case ServiceStatus.operational:

--- a/docs/breez-sdk/snippets/flutter/pubspec.lock
+++ b/docs/breez-sdk/snippets/flutter/pubspec.lock
@@ -582,5 +582,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.29.0"

--- a/docs/breez-sdk/snippets/go/config.go
+++ b/docs/breez-sdk/snippets/go/config.go
@@ -158,3 +158,22 @@ func ConfigureCrossChain() {
 	// ANCHOR_END: cross-chain-config
 	log.Printf("Config: %v", config)
 }
+
+func ConfigureProxy() {
+	// ANCHOR: config-proxy
+	config := breez_sdk_spark.DefaultConfig(breez_sdk_spark.NetworkMainnet)
+	apiKey := "<breez api key>"
+	config.ApiKey = &apiKey
+
+	// Route the SDK's connections through a SOCKS5 proxy, such as a local Tor
+	// daemon. Set username and password together for proxies that require
+	// RFC 1929 authentication.
+	config.Proxy = &breez_sdk_spark.ProxyConfig{
+		Host:     "127.0.0.1",
+		Port:     9050,
+		Username: nil,
+		Password: nil,
+	}
+	// ANCHOR_END: config-proxy
+	log.Printf("Config: %v", config)
+}

--- a/docs/breez-sdk/snippets/go/getting_started.go
+++ b/docs/breez-sdk/snippets/go/getting_started.go
@@ -144,7 +144,8 @@ func RemoveEventListener(sdk *breez_sdk_spark.BreezSdk, listenerId string) bool 
 
 // ANCHOR: spark-status
 func GetSparkStatus() error {
-	sparkStatus, err := breez_sdk_spark.GetSparkStatus()
+	request := breez_sdk_spark.GetSparkStatusRequest{}
+	sparkStatus, err := breez_sdk_spark.GetSparkStatus(request)
 	if err != nil {
 		return err
 	}

--- a/docs/breez-sdk/snippets/go/passkey.go
+++ b/docs/breez-sdk/snippets/go/passkey.go
@@ -46,7 +46,7 @@ func (p *CustomPrfProvider) CheckDomainAssociation() (breez_sdk_spark.DomainAsso
 
 func CheckAvailability() {
 	prfProvider := &CustomPrfProvider{}
-	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
+	passkey, _ := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
 
 	// ANCHOR: check-availability
 	availability, err := passkey.CheckAvailability()
@@ -69,17 +69,18 @@ func CheckAvailability() {
 	// ANCHOR_END: check-availability
 }
 
-func SetupPasskeyClient() *breez_sdk_spark.PasskeyClient {
+func SetupPasskeyClient() (*breez_sdk_spark.PasskeyClient, error) {
 	// ANCHOR: setup-client
 	prfProvider := &CustomPrfProvider{}
 	apiKey := "<breez api key>"
+	// Fails when the config carries a proxy the relay transport cannot honour.
 	return breez_sdk_spark.NewPasskeyClient(prfProvider, &apiKey, nil)
 	// ANCHOR_END: setup-client
 }
 
 func ConnectWithPasskey() (*breez_sdk_spark.BreezSdk, error) {
 	prfProvider := &CustomPrfProvider{}
-	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
+	passkey, _ := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
 
 	// ANCHOR: connect-with-passkey
 	// Silent sign-in for a returning user, fall-through to register on a fresh device.
@@ -109,7 +110,7 @@ func ConnectWithPasskey() (*breez_sdk_spark.BreezSdk, error) {
 
 func RegisterNewPasskey() (*breez_sdk_spark.BreezSdk, error) {
 	prfProvider := &CustomPrfProvider{}
-	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
+	passkey, _ := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
 
 	// ANCHOR: register-passkey
 	label := "personal"
@@ -133,7 +134,7 @@ func RegisterNewPasskey() (*breez_sdk_spark.BreezSdk, error) {
 
 func CredentialMetadata() error {
 	prfProvider := &CustomPrfProvider{}
-	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
+	passkey, _ := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
 
 	// ANCHOR: credential-metadata
 	label := "personal"
@@ -177,7 +178,7 @@ func CredentialMetadata() error {
 func ListLabels() ([]string, error) {
 	prfProvider := &CustomPrfProvider{}
 	breezApiKey := "<breez api key>"
-	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, &breezApiKey, nil)
+	passkey, _ := breez_sdk_spark.NewPasskeyClient(prfProvider, &breezApiKey, nil)
 	// ANCHOR: list-labels
 	labels, err := passkey.Labels().List()
 	if err != nil {
@@ -193,7 +194,7 @@ func ListLabels() ([]string, error) {
 func StoreLabel() error {
 	prfProvider := &CustomPrfProvider{}
 	breezApiKey := "<breez api key>"
-	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, &breezApiKey, nil)
+	passkey, _ := breez_sdk_spark.NewPasskeyClient(prfProvider, &breezApiKey, nil)
 	// ANCHOR: store-label
 	err := passkey.Labels().Store("personal")
 	if err != nil {
@@ -229,7 +230,7 @@ func CheckDomain() error {
 
 func RecoverFromAlreadyExists() (*breez_sdk_spark.Wallet, error) {
 	prfProvider := &CustomPrfProvider{}
-	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
+	passkey, _ := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
 
 	// ANCHOR: recover-already-exists
 	label := "personal"
@@ -258,7 +259,7 @@ func RecoverFromAlreadyExists() (*breez_sdk_spark.Wallet, error) {
 
 func HandleTimeout() (*breez_sdk_spark.SignInResponse, error) {
 	prfProvider := &CustomPrfProvider{}
-	passkey := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
+	passkey, _ := breez_sdk_spark.NewPasskeyClient(prfProvider, nil, nil)
 
 	// ANCHOR: handle-timeout
 	// Biometric inactivity timeout, distinct from a user cancel.

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Config.kt
@@ -141,4 +141,22 @@ class Config {
         // ANCHOR_END: cross-chain-config
         println("Config: $config")
     }
+
+    fun configureProxy() {
+        // ANCHOR: config-proxy
+        val config = defaultConfig(Network.MAINNET)
+        config.apiKey = "<breez api key>"
+
+        // Route the SDK's connections through a SOCKS5 proxy, such as a local Tor
+        // daemon. Set username and password together for proxies that require
+        // RFC 1929 authentication.
+        config.proxy = ProxyConfig(
+            host = "127.0.0.1",
+            port = 9050u,
+            username = null,
+            password = null,
+        )
+        // ANCHOR_END: config-proxy
+        println("Config: $config")
+    }
 }

--- a/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
+++ b/docs/breez-sdk/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/GettingStarted.kt
@@ -138,7 +138,7 @@ class GettingStarted {
     // ANCHOR: spark-status
     suspend fun gettingStartedSparkStatus() {
         try {
-            val sparkStatus = getSparkStatus()
+            val sparkStatus = getSparkStatus(GetSparkStatusRequest())
 
             when (sparkStatus.status) {
                 ServiceStatus.OPERATIONAL -> {

--- a/docs/breez-sdk/snippets/python/src/config.py
+++ b/docs/breez-sdk/snippets/python/src/config.py
@@ -2,6 +2,7 @@ import logging
 from breez_sdk_spark import (
     default_config,
     CrossChainConfig,
+    ProxyConfig,
     Network,
     LeafOptimizationConfig,
     MaxFee,
@@ -150,4 +151,22 @@ async def configure_cross_chain():
         default_target_overpay_bps=None,
     )
     # ANCHOR_END: cross-chain-config
+    logging.info(f"Config: {config}")
+
+
+def configure_proxy():
+    # ANCHOR: config-proxy
+    config = default_config(network=Network.MAINNET)
+    config.api_key = "<breez api key>"
+
+    # Route the SDK's connections through a SOCKS5 proxy, such as a local Tor
+    # daemon. Set username and password together for proxies that require
+    # RFC 1929 authentication.
+    config.proxy = ProxyConfig(
+        host="127.0.0.1",
+        port=9050,
+        username=None,
+        password=None,
+    )
+    # ANCHOR_END: config-proxy
     logging.info(f"Config: {config}")

--- a/docs/breez-sdk/snippets/python/src/getting_started.py
+++ b/docs/breez-sdk/snippets/python/src/getting_started.py
@@ -7,6 +7,7 @@ from breez_sdk_spark import (
     EventListener,
     get_spark_status,
     GetInfoRequest,
+    GetSparkStatusRequest,
     init_logging,
     LogEntry,
     Logger,
@@ -143,7 +144,7 @@ async def remove_event_listener(sdk: BreezSdk, listener_id: str):
 # ANCHOR: spark-status
 async def getting_started_spark_status():
     try:
-        spark_status = await get_spark_status()
+        spark_status = await get_spark_status(request=GetSparkStatusRequest())
 
         if spark_status.status == ServiceStatus.OPERATIONAL:
             logging.debug("Spark is fully operational")

--- a/docs/breez-sdk/snippets/react-native/config.ts
+++ b/docs/breez-sdk/snippets/react-native/config.ts
@@ -142,6 +142,24 @@ const exampleConfigureCrossChain = async () => {
   console.debug('Config:', config)
 }
 
+const exampleConfigureProxy = async () => {
+  // ANCHOR: config-proxy
+  const config = defaultConfig(Network.Mainnet)
+  config.apiKey = '<breez api key>'
+
+  // Route the SDK's connections through a SOCKS5 proxy, such as a local Tor
+  // daemon. Set username and password together for proxies that require
+  // RFC 1929 authentication.
+  config.proxy = {
+    host: '127.0.0.1',
+    port: 9050,
+    username: undefined,
+    password: undefined
+  }
+  // ANCHOR_END: config-proxy
+  console.debug('Config:', config)
+}
+
 export {
   exampleConfigureSdk,
   exampleConfigurePrivateEnabledDefault,
@@ -149,5 +167,6 @@ export {
   exampleConfigureStableBalance,
   exampleConfigureSparkConfig,
   exampleConfigureBackgroundTasks,
-  exampleConfigureCrossChain
+  exampleConfigureCrossChain,
+  exampleConfigureProxy
 }

--- a/docs/breez-sdk/snippets/react-native/getting_started.ts
+++ b/docs/breez-sdk/snippets/react-native/getting_started.ts
@@ -119,7 +119,7 @@ const exampleRemoveEventListener = async (sdk: BreezSdk, listenerId: string) => 
 
 const exampleGetSparkStatus = async () => {
   // ANCHOR: spark-status
-  const sparkStatus = await getSparkStatus()
+  const sparkStatus = await getSparkStatus({ proxy: undefined })
 
   switch (sparkStatus.status) {
     case ServiceStatus.Operational:

--- a/docs/breez-sdk/snippets/react-native/turnkey.ts
+++ b/docs/breez-sdk/snippets/react-native/turnkey.ts
@@ -20,7 +20,8 @@ const connectWithTurnkey = async () => {
     // Set after the first connect to make later signer setup network-free
     identityPublicKey: undefined,
     retry: undefined,
-    maxRps: undefined
+    maxRps: undefined,
+    proxy: undefined
   }
 
   const signers = await createTurnkeySigner(turnkeyConfig)

--- a/docs/breez-sdk/snippets/rust/Cargo.lock
+++ b/docs/breez-sdk/snippets/rust/Cargo.lock
@@ -1176,6 +1176,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "turnkey_enclave_encrypt",
+ "url",
  "utils",
  "uuid",
  "x509-cert",
@@ -2735,14 +2736,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -3226,6 +3226,7 @@ name = "lnurl-models"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "sha2",
 ]
 
 [[package]]
@@ -3777,13 +3778,17 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",
+ "http",
+ "hyper-util",
  "macros 0.1.0",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-socks",
  "tokio_with_wasm",
+ "tower-service",
  "tracing",
  "web-time",
 ]
@@ -5248,9 +5253,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
  "core-foundation 0.9.4",

--- a/docs/breez-sdk/snippets/rust/src/config.rs
+++ b/docs/breez-sdk/snippets/rust/src/config.rs
@@ -160,3 +160,22 @@ pub(crate) fn configure_cross_chain() -> Result<()> {
     info!("Config: {config:?}");
     Ok(())
 }
+
+pub(crate) fn configure_proxy() -> Result<()> {
+    // ANCHOR: config-proxy
+    let mut config = default_config(Network::Mainnet);
+    config.api_key = Some("<breez api key>".to_string());
+
+    // Route the SDK's connections through a SOCKS5 proxy, such as a local Tor
+    // daemon. Set username and password together for proxies that require
+    // RFC 1929 authentication.
+    config.proxy = Some(ProxyConfig {
+        host: "127.0.0.1".to_string(),
+        port: 9050,
+        username: None,
+        password: None,
+    });
+    // ANCHOR_END: config-proxy
+    info!("Config: {config:?}");
+    Ok(())
+}

--- a/docs/breez-sdk/snippets/rust/src/getting_started.rs
+++ b/docs/breez-sdk/snippets/rust/src/getting_started.rs
@@ -125,7 +125,7 @@ pub(crate) async fn remove_event_listener(sdk: &BreezSdk, listener_id: &str) -> 
 
 // ANCHOR: spark-status
 pub(crate) async fn getting_started_spark_status() -> Result<()> {
-    let spark_status = get_spark_status().await?;
+    let spark_status = get_spark_status(GetSparkStatusRequest::default()).await?;
 
     match spark_status.status {
         ServiceStatus::Operational => {

--- a/docs/breez-sdk/snippets/rust/src/passkey.rs
+++ b/docs/breez-sdk/snippets/rust/src/passkey.rs
@@ -50,7 +50,7 @@ impl PrfProvider for CustomPrfProvider {
 
 async fn check_availability() -> Result<()> {
     let prf_provider = Arc::new(CustomPrfProvider);
-    let passkey = PasskeyClient::new(prf_provider, None, None);
+    let passkey = PasskeyClient::new(prf_provider, None, None)?;
 
     // ANCHOR: check-availability
     match passkey.check_availability().await? {
@@ -73,16 +73,18 @@ async fn check_availability() -> Result<()> {
     Ok(())
 }
 
-fn setup_passkey_client() -> PasskeyClient {
+fn setup_passkey_client() -> Result<PasskeyClient> {
     // ANCHOR: setup-client
     let prf_provider = Arc::new(CustomPrfProvider);
-    PasskeyClient::new(prf_provider, Some("<breez api key>".to_string()), None)
+    // Fails when the config carries a proxy the relay transport cannot honour.
+    let passkey = PasskeyClient::new(prf_provider, Some("<breez api key>".to_string()), None)?;
     // ANCHOR_END: setup-client
+    Ok(passkey)
 }
 
 async fn connect_with_passkey_unified() -> Result<breez_sdk_spark::BreezSdk> {
     let prf_provider = Arc::new(CustomPrfProvider);
-    let passkey = PasskeyClient::new(prf_provider, None, None);
+    let passkey = PasskeyClient::new(prf_provider, None, None)?;
 
     // ANCHOR: connect-with-passkey
     // Single-CTA onboarding: silent sign-in, fall through to register.
@@ -109,7 +111,7 @@ async fn connect_with_passkey_unified() -> Result<breez_sdk_spark::BreezSdk> {
 
 async fn sign_in_existing_user() -> Result<SignInResponse> {
     let prf_provider = Arc::new(CustomPrfProvider);
-    let passkey = PasskeyClient::new(prf_provider, Some("<breez api key>".to_string()), None);
+    let passkey = PasskeyClient::new(prf_provider, Some("<breez api key>".to_string()), None)?;
 
     // ANCHOR: sign-in
     // Returning-user-only sign-in. No fall-through to register.
@@ -124,7 +126,7 @@ async fn sign_in_existing_user() -> Result<SignInResponse> {
 
 async fn register_new_passkey() -> Result<breez_sdk_spark::BreezSdk> {
     let prf_provider = Arc::new(CustomPrfProvider);
-    let passkey = PasskeyClient::new(prf_provider, None, None);
+    let passkey = PasskeyClient::new(prf_provider, None, None)?;
 
     // ANCHOR: register-passkey
     let response = passkey
@@ -147,7 +149,7 @@ async fn register_new_passkey() -> Result<breez_sdk_spark::BreezSdk> {
 
 async fn credential_metadata() -> Result<()> {
     let prf_provider = Arc::new(CustomPrfProvider);
-    let passkey = PasskeyClient::new(prf_provider, None, None);
+    let passkey = PasskeyClient::new(prf_provider, None, None)?;
 
     // ANCHOR: credential-metadata
     let response = passkey
@@ -189,7 +191,7 @@ async fn credential_metadata() -> Result<()> {
 
 async fn list_labels() -> Result<Vec<String>> {
     let prf_provider = Arc::new(CustomPrfProvider);
-    let passkey = PasskeyClient::new(prf_provider, Some("<breez api key>".to_string()), None);
+    let passkey = PasskeyClient::new(prf_provider, Some("<breez api key>".to_string()), None)?;
     // ANCHOR: list-labels
     let labels = passkey.labels().list().await?;
     for label in &labels {
@@ -201,7 +203,7 @@ async fn list_labels() -> Result<Vec<String>> {
 
 async fn store_label() -> Result<()> {
     let prf_provider = Arc::new(CustomPrfProvider);
-    let passkey = PasskeyClient::new(prf_provider, Some("<breez api key>".to_string()), None);
+    let passkey = PasskeyClient::new(prf_provider, Some("<breez api key>".to_string()), None)?;
     // ANCHOR: store-label
     passkey.labels().store("personal".to_string()).await?;
     // ANCHOR_END: store-label
@@ -233,7 +235,7 @@ async fn check_domain() -> Result<()> {
 
 async fn recover_from_already_exists() -> Result<Wallet> {
     let prf_provider = Arc::new(CustomPrfProvider);
-    let passkey = PasskeyClient::new(prf_provider, None, None);
+    let passkey = PasskeyClient::new(prf_provider, None, None)?;
 
     // ANCHOR: recover-already-exists
     match passkey
@@ -263,7 +265,7 @@ async fn recover_from_already_exists() -> Result<Wallet> {
 
 async fn handle_timeout() -> Result<SignInResponse> {
     let prf_provider = Arc::new(CustomPrfProvider);
-    let passkey = PasskeyClient::new(prf_provider, None, None);
+    let passkey = PasskeyClient::new(prf_provider, None, None)?;
 
     // ANCHOR: handle-timeout
     // Biometric inactivity timeout, distinct from a user cancel.

--- a/docs/breez-sdk/snippets/rust/src/turnkey.rs
+++ b/docs/breez-sdk/snippets/rust/src/turnkey.rs
@@ -16,6 +16,7 @@ async fn connect_with_turnkey() -> Result<BreezSdk> {
         identity_public_key: None,
         retry: None,
         max_rps: None,
+        proxy: None,
     };
 
     let signers = create_turnkey_signer(turnkey_config).await?;

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Config.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Config.swift
@@ -90,3 +90,21 @@ func configureCrossChain() {
     // ANCHOR_END: cross-chain-config
     print("Config: \(config)")
 }
+
+func configureProxy() async throws {
+    // ANCHOR: config-proxy
+    var config = defaultConfig(network: Network.mainnet)
+    config.apiKey = "<breez api key>"
+
+    // Route the SDK's connections through a SOCKS5 proxy, such as a local Tor
+    // daemon. Set username and password together for proxies that require
+    // RFC 1929 authentication.
+    config.proxy = ProxyConfig(
+        host: "127.0.0.1",
+        port: 9050,
+        username: nil,
+        password: nil
+    )
+    // ANCHOR_END: config-proxy
+    print("Config: \(config)")
+}

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/GettingStarted.swift
@@ -113,7 +113,7 @@ func removeEventListener(sdk: BreezSdk, listenerId: String) async {
 
 // ANCHOR: spark-status
 func gettingStartedSparkStatus() async throws {
-    let sparkStatus = try await getSparkStatus()
+    let sparkStatus = try await getSparkStatus(request: GetSparkStatusRequest())
 
     switch sparkStatus.status {
     case .operational:

--- a/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
+++ b/docs/breez-sdk/snippets/swift/BreezSdkSnippets/Sources/Passkey.swift
@@ -37,7 +37,7 @@ func checkAvailability() async throws {
     let prfProvider = PasskeyProvider(
         options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
     )
-    let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
+    let passkey = try PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: check-availability
     switch try await passkey.checkAvailability() {
@@ -56,9 +56,10 @@ func checkAvailability() async throws {
     // ANCHOR_END: check-availability
 }
 
-func setupPasskeyClient() -> PasskeyClient {
+func setupPasskeyClient() throws -> PasskeyClient {
     // ANCHOR: setup-client
-    let passkey = PasskeyClient(
+    // Throws when the config carries a proxy the relay transport cannot honour.
+    let passkey = try PasskeyClient(
         breezApiKey: "<breez api key>",
         config: PasskeyConfig(
             providerOptions: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
@@ -72,7 +73,7 @@ func connectWithPasskey() async throws -> BreezSdk {
     let prfProvider = PasskeyProvider(
         options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
     )
-    let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
+    let passkey = try PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: connect-with-passkey
     // Single-CTA onboarding: silent sign-in, fall through to register.
@@ -103,7 +104,7 @@ func signInExistingUser() async throws -> SignInResponse {
     let prfProvider = PasskeyProvider(
         options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
     )
-    let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
+    let passkey = try PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: sign-in
     // Returning-user sign-in. No fall-through to register.
@@ -115,7 +116,7 @@ func registerNewPasskey() async throws -> BreezSdk {
     let prfProvider = PasskeyProvider(
         options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
     )
-    let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
+    let passkey = try PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: register-passkey
     var config = defaultConfig(network: .mainnet)
@@ -139,7 +140,7 @@ func credentialMetadata() async throws {
     let prfProvider = PasskeyProvider(
         options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
     )
-    let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: nil, config: nil)
+    let passkey = try PasskeyClient(prfProvider: prfProvider, breezApiKey: nil, config: nil)
 
     // ANCHOR: credential-metadata
     let response = try await passkey.register(
@@ -180,7 +181,7 @@ func listLabels() async throws -> [String] {
     let prfProvider = PasskeyProvider(
         options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
     )
-    let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
+    let passkey = try PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
     // ANCHOR: list-labels
     let labels = try await passkey.labels().list()
     for label in labels {
@@ -194,7 +195,7 @@ func storeLabel() async throws {
     let prfProvider = PasskeyProvider(
         options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
     )
-    let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
+    let passkey = try PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
     // ANCHOR: store-label
     try await passkey.labels().store(label: "personal")
     // ANCHOR_END: store-label
@@ -224,7 +225,7 @@ func recoverFromAlreadyExists() async throws -> Wallet {
     let prfProvider = PasskeyProvider(
         options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
     )
-    let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
+    let passkey = try PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: recover-already-exists
     do {
@@ -251,7 +252,7 @@ func handleTimeout() async throws -> SignInResponse {
     let prfProvider = PasskeyProvider(
         options: PasskeyProviderOptions(rpId: "<your-rp-domain>", rpName: "Your App")
     )
-    let passkey = PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
+    let passkey = try PasskeyClient(prfProvider: prfProvider, breezApiKey: "<breez api key>", config: nil)
 
     // ANCHOR: handle-timeout
     do {

--- a/docs/breez-sdk/src/SUMMARY.md
+++ b/docs/breez-sdk/src/SUMMARY.md
@@ -56,6 +56,7 @@
   - [Issuing tokens](guide/issuing_tokens.md)
 - [Advanced features](guide/advanced.md)
   - [Custom configuration](guide/config.md)
+  - [SOCKS5 proxy](guide/proxy.md)
   - [Custom leaf optimization](guide/optimize.md)
   - [Conditional Payments](guide/htlcs.md)
   - [Using an External Signer](guide/external_signer.md)

--- a/docs/breez-sdk/src/guide/config.md
+++ b/docs/breez-sdk/src/guide/config.md
@@ -169,6 +169,15 @@ The SDK can convert Bitcoin to a stable token on receive and vice versa on send,
 
 {{#tabs config:stable-balance-config}}
 
+<h2 id="socks5-proxy">
+    <a class="header" href="#socks5-proxy">SOCKS5 proxy</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.ProxyConfig.html">API docs</a>
+</h2>
+
+Routes the connections the SDK opens through a SOCKS5 proxy, such as a local Tor daemon. Hostnames are resolved by the proxy rather than locally, and a connection that cannot be established through it fails rather than falling back to a direct one. Unset (the default) connects directly. Not supported on WASM. See the [SOCKS5 proxy](./proxy.md) page for what is covered and which combinations are rejected.
+
+{{#tabs config:config-proxy}}
+
 <h2 id="send-usdc-usdt">
     <a class="header" href="#send-usdc-usdt">Send USDC/USDT</a>
     <a class="tag" target="_blank" href="https://breez.github.io/spark-sdk/breez_sdk_spark/struct.CrossChainConfig.html">API docs</a>

--- a/docs/breez-sdk/src/guide/customizing.md
+++ b/docs/breez-sdk/src/guide/customizing.md
@@ -168,10 +168,12 @@ The {{#name connections_per_operator}} setting on {{#name SdkContextConfig}} con
 - `None` — one connection per operator, multiplexed across every SDK sharing this context. The right choice for almost every deployment.
 - `Some(n)` — opens `n` connections per operator and balances requests across them. Worth setting only if the single shared connection has become a bottleneck — for example, latency that climbs with throughput, or operators deployed behind an L7 load balancer where you want client-side fan-out across backend instances.
 
+To route a context's pooled connections through a SOCKS5 proxy, set {{#name proxy}} on {{#name SdkContextConfig}} as well as on each SDK's {{#name Config}}. See [SOCKS5 proxy](./proxy.md).
+
 <div class="warning">
 <h4>Developer note</h4>
 
-All SDK instances sharing an SDK Context must be configured for the same network and operator pool. The user agent of the first SDK to construct the context is reused for all subsequent instances.
+All SDK instances sharing an SDK Context must be configured for the same network and operator pool, and must agree on {{#name proxy}}. The user agent of the first SDK to construct the context is reused for all subsequent instances.
 
 </div>
 

--- a/docs/breez-sdk/src/guide/proxy.md
+++ b/docs/breez-sdk/src/guide/proxy.md
@@ -1,37 +1,24 @@
 # Routing traffic through a SOCKS5 proxy
 
-Set {{#name proxy}} on the [config](config.md) to send the connections the SDK
-opens through a SOCKS5 proxy, such as a local Tor daemon.
+Set {{#name proxy}} on the [config](config.md) to send the connections the SDK opens through a SOCKS5 proxy, such as a local Tor daemon.
 
 {{#tabs config:config-proxy}}
 
-Set {{#name username}} and {{#name password}} together for proxies that require
-RFC 1929 authentication. Setting only one of them is rejected.
+Set {{#name username}} and {{#name password}} together for proxies that require RFC 1929 authentication. Setting only one of them is rejected.
 
 ## What the proxy covers
 
-Both HTTP and gRPC traffic: the Spark operators and service provider, the Breez
-backend, real-time sync, the chain service, LNURL and Lightning address lookups,
-and external input parsers.
+Every connection the SDK opens through its own HTTP client and gRPC channels, which is all of its ordinary traffic: payments, sync, chain data, and address lookups.
 
-Hostnames are resolved **by the proxy**, never locally, so no DNS query reveals
-which host you are reaching. BIP353 name lookups switch from plain DNS to
-DNS-over-HTTPS for the same reason: plain DNS is UDP, which a SOCKS5 proxy does
-not carry, so those queries would otherwise escape the tunnel. They stay
-DNSSEC-verified either way.
+Hostnames are resolved **by the proxy**, never locally, so no DNS query reveals which host you are reaching. BIP353 name lookups switch from plain DNS to DNS-over-HTTPS for the same reason: plain DNS is UDP, which a SOCKS5 proxy does not carry, so those queries would otherwise escape the tunnel. They stay DNSSEC-verified either way.
 
-Only the proxy's own address is resolved locally, which is unavoidable: it is
-the one host that cannot be reached through itself.
+Only the proxy's own address is resolved locally, which is unavoidable: it is the one host that cannot be reached through itself.
 
 ## Failing closed
 
-A connection that cannot be established through the proxy fails. The SDK never
-retries it directly, and setting a proxy also disables system-proxy
-autodetection, so no environment variable can route traffic around it.
+A connection that cannot be established through the proxy fails. The SDK never retries it directly, and setting a proxy also disables system-proxy autodetection, so no environment variable can route traffic around it.
 
-A configuration the SDK cannot honour is rejected where it is supplied, rather
-than partly applied: at {{#name connect}}, or at the constructor of a component
-built outside the SDK.
+A configuration the SDK cannot honour is rejected where it is supplied, rather than partly applied: at {{#name connect}}, or at the constructor of a component built outside the SDK.
 
 | Rejected combination | Why |
 |---|---|
@@ -41,39 +28,24 @@ built outside the SDK.
 
 ## Shared SDK Context
 
-A [shared SDK Context](./customizing.md#with-shared-context) owns the pooled
-HTTP client and gRPC channels, so the proxy has to be set on
-{{#name SdkContextConfig}} as well. It must match the {{#name proxy}} on the
-{{#name Config}} of every SDK built from that context: the SDK rejects a
-mismatch at {{#name connect}}, since a disagreement would mean part of the
-traffic bypassed the proxy.
+A [shared SDK Context](./customizing.md#with-shared-context) owns the pooled HTTP client and gRPC channels, so the proxy has to be set on {{#name SdkContextConfig}} as well. It must match the {{#name proxy}} on the {{#name Config}} of every SDK built from that context: the SDK rejects a mismatch at {{#name connect}}, since a disagreement would mean part of the traffic bypassed the proxy.
 
 ## Components built outside the SDK
 
-A few APIs run without an SDK instance, so they cannot pick the setting up on
-their own. Pass the same proxy to each one you use:
+A few APIs run without an SDK instance, so they cannot pick the setting up on their own. Pass the same proxy to each one you use:
 
 - {{#name get_spark_status}}, via {{#name GetSparkStatusRequest}}
 - {{#name new_rest_chain_service}}, via {{#name NewRestChainServiceRequest}}
 - The Turnkey signer, via {{#name TurnkeyConfig}}
-- The passkey client, via {{#name PasskeyConfig}}. A proxy carrying credentials
-  is rejected when the client is constructed (see above).
+- The passkey client, via {{#name PasskeyConfig}}. A proxy carrying credentials is rejected when the client is constructed (see above).
 
-A service you supply yourself through {{#name with_chain_service}},
-{{#name with_fiat_service}}, {{#name with_lnurl_client}} or
-{{#name with_lnurl_server_client}} already owns its transport, which the SDK
-cannot inspect or re-route. Make it connect through the proxy yourself; the SDK
-logs a warning when it sees one alongside a proxy. {{#name with_rest_chain_service}}
-is built on the SDK's own client and is proxied automatically.
+A service you supply yourself through {{#name with_chain_service}}, {{#name with_fiat_service}}, {{#name with_lnurl_client}} or {{#name with_lnurl_server_client}} already owns its transport, which the SDK cannot inspect or re-route. Make it connect through the proxy yourself; the SDK logs a warning when it sees one alongside a proxy. {{#name with_rest_chain_service}} is built on the SDK's own client and is proxied automatically.
 
 ## JavaScript and WASM
 
-A SOCKS5 proxy cannot be honoured in a browser, and setting {{#name proxy}} on a
-WASM build is an error rather than a silent direct connection.
+A SOCKS5 proxy cannot be honoured in a browser, and setting {{#name proxy}} on a WASM build is an error rather than a silent direct connection.
 
-In Node, route the SDK by installing a proxy dispatcher on the global `fetch`
-before connecting, which covers both the HTTP and gRPC calls the WASM build
-makes:
+In Node, route the SDK by installing a proxy dispatcher on the global `fetch` before connecting, which covers both the HTTP and gRPC calls the WASM build makes:
 
 ```javascript
 import { setGlobalDispatcher, ProxyAgent } from 'undici'

--- a/docs/breez-sdk/src/guide/proxy.md
+++ b/docs/breez-sdk/src/guide/proxy.md
@@ -8,7 +8,7 @@ Set {{#name username}} and {{#name password}} together for proxies that require 
 
 ## What the proxy covers
 
-Every connection the SDK opens through its own HTTP client and gRPC channels, which is all of its ordinary traffic: payments, sync, chain data, and address lookups.
+Every connection the SDK opens, HTTP and gRPC alike.
 
 Hostnames are resolved **by the proxy**, never locally, so no DNS query reveals which host you are reaching. BIP353 name lookups switch from plain DNS to DNS-over-HTTPS for the same reason: plain DNS is UDP, which a SOCKS5 proxy does not carry, so those queries would otherwise escape the tunnel. They stay DNSSEC-verified either way.
 

--- a/docs/breez-sdk/src/guide/proxy.md
+++ b/docs/breez-sdk/src/guide/proxy.md
@@ -1,0 +1,82 @@
+# Routing traffic through a SOCKS5 proxy
+
+Set {{#name proxy}} on the [config](config.md) to send the connections the SDK
+opens through a SOCKS5 proxy, such as a local Tor daemon.
+
+{{#tabs config:config-proxy}}
+
+Set {{#name username}} and {{#name password}} together for proxies that require
+RFC 1929 authentication. Setting only one of them is rejected.
+
+## What the proxy covers
+
+Both HTTP and gRPC traffic: the Spark operators and service provider, the Breez
+backend, real-time sync, the chain service, LNURL and Lightning address lookups,
+and external input parsers.
+
+Hostnames are resolved **by the proxy**, never locally, so no DNS query reveals
+which host you are reaching. BIP353 name lookups switch from plain DNS to
+DNS-over-HTTPS for the same reason: plain DNS is UDP, which a SOCKS5 proxy does
+not carry, so those queries would otherwise escape the tunnel. They stay
+DNSSEC-verified either way.
+
+Only the proxy's own address is resolved locally, which is unavoidable: it is
+the one host that cannot be reached through itself.
+
+## Failing closed
+
+A connection that cannot be established through the proxy fails. The SDK never
+retries it directly, and setting a proxy also disables system-proxy
+autodetection, so no environment variable can route traffic around it.
+
+A configuration the SDK cannot honour is rejected where it is supplied, rather
+than partly applied: at {{#name connect}}, or at the constructor of a component
+built outside the SDK.
+
+| Rejected combination | Why |
+|---|---|
+| A proxy on WASM | The browser owns connection setup and exposes no proxy control. |
+| {{#name proxy}} with {{#name connections_per_operator}} above 1 | Balanced operator connections build their own connectors and cannot be routed. |
+| A proxy carrying credentials on {{#name PasskeyConfig}} | Nostr relay connections cannot authenticate to a proxy. Wallet labels live on those relays and are one of the salts a wallet seed derives from, so a label that cannot be published cannot be recovered: this fails before a wallet exists rather than after one is funded. |
+
+## Shared SDK Context
+
+A [shared SDK Context](./customizing.md#with-shared-context) owns the pooled
+HTTP client and gRPC channels, so the proxy has to be set on
+{{#name SdkContextConfig}} as well. It must match the {{#name proxy}} on the
+{{#name Config}} of every SDK built from that context: the SDK rejects a
+mismatch at {{#name connect}}, since a disagreement would mean part of the
+traffic bypassed the proxy.
+
+## Components built outside the SDK
+
+A few APIs run without an SDK instance, so they cannot pick the setting up on
+their own. Pass the same proxy to each one you use:
+
+- {{#name get_spark_status}}, via {{#name GetSparkStatusRequest}}
+- {{#name new_rest_chain_service}}, via {{#name NewRestChainServiceRequest}}
+- The Turnkey signer, via {{#name TurnkeyConfig}}
+- The passkey client, via {{#name PasskeyConfig}}. A proxy carrying credentials
+  is rejected when the client is constructed (see above).
+
+A service you supply yourself through {{#name with_chain_service}},
+{{#name with_fiat_service}}, {{#name with_lnurl_client}} or
+{{#name with_lnurl_server_client}} already owns its transport, which the SDK
+cannot inspect or re-route. Make it connect through the proxy yourself; the SDK
+logs a warning when it sees one alongside a proxy. {{#name with_rest_chain_service}}
+is built on the SDK's own client and is proxied automatically.
+
+## JavaScript and WASM
+
+A SOCKS5 proxy cannot be honoured in a browser, and setting {{#name proxy}} on a
+WASM build is an error rather than a silent direct connection.
+
+In Node, route the SDK by installing a proxy dispatcher on the global `fetch`
+before connecting, which covers both the HTTP and gRPC calls the WASM build
+makes:
+
+```javascript
+import { setGlobalDispatcher, ProxyAgent } from 'undici'
+
+setGlobalDispatcher(new ProxyAgent('socks5://127.0.0.1:9050'))
+```

--- a/packages/flutter/lib/src/config_extensions.dart
+++ b/packages/flutter/lib/src/config_extensions.dart
@@ -25,6 +25,7 @@ extension ConfigCopyWith on Config {
     int? maxConcurrentClaims,
     SparkConfig? sparkConfig,
     bool? backgroundTasksEnabled,
+    ProxyConfig? proxy,
     CrossChainConfig? crossChainConfig,
   }) {
     return Config(
@@ -46,6 +47,7 @@ extension ConfigCopyWith on Config {
       maxConcurrentClaims: maxConcurrentClaims ?? this.maxConcurrentClaims,
       sparkConfig: sparkConfig ?? this.sparkConfig,
       backgroundTasksEnabled: backgroundTasksEnabled ?? this.backgroundTasksEnabled,
+      proxy: proxy ?? this.proxy,
       crossChainConfig: crossChainConfig ?? this.crossChainConfig,
     );
   }

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -2681,14 +2681,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -3585,13 +3584,17 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",
+ "http",
+ "hyper-util",
  "macros 0.1.0",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-socks",
  "tokio_with_wasm",
+ "tower-service",
  "tracing",
  "web-time",
 ]
@@ -4884,9 +4887,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
  "core-foundation 0.9.4",

--- a/packages/flutter/rust/Cargo.lock
+++ b/packages/flutter/rust/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879#b5f4683aba10efd875d674f2bb9a5800b047a879"
+source = "git+https://github.com/breez/boltz-client?rev=82f55b8059f54e6e06a4a2d0a901743dc8f83949#82f55b8059f54e6e06a4a2d0a901743dc8f83949"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -1100,14 +1100,16 @@ dependencies = [
  "hex",
  "k256",
  "lightning-invoice 0.34.0",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879)",
- "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=82f55b8059f54e6e06a4a2d0a901743dc8f83949)",
+ "platform-utils 0.1.0 (git+https://github.com/breez/boltz-client?rev=82f55b8059f54e6e06a4a2d0a901743dc8f83949)",
  "serde",
  "serde_json",
  "sha2",
  "thiserror 2.0.17",
  "tiny-keccak",
  "tokio",
+ "tokio-socks",
+ "tokio-tungstenite 0.28.0",
  "tokio-tungstenite-wasm",
  "tracing",
  "url",
@@ -3190,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879#b5f4683aba10efd875d674f2bb9a5800b047a879"
+source = "git+https://github.com/breez/boltz-client?rev=82f55b8059f54e6e06a4a2d0a901743dc8f83949#82f55b8059f54e6e06a4a2d0a901743dc8f83949"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3602,11 +3604,11 @@ dependencies = [
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879#b5f4683aba10efd875d674f2bb9a5800b047a879"
+source = "git+https://github.com/breez/boltz-client?rev=82f55b8059f54e6e06a4a2d0a901743dc8f83949#82f55b8059f54e6e06a4a2d0a901743dc8f83949"
 dependencies = [
  "async-trait",
  "base64",
- "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=b5f4683aba10efd875d674f2bb9a5800b047a879)",
+ "macros 0.1.0 (git+https://github.com/breez/boltz-client?rev=82f55b8059f54e6e06a4a2d0a901743dc8f83949)",
  "reqwest",
  "serde",
  "serde_json",

--- a/packages/flutter/rust/src/chain_service.rs
+++ b/packages/flutter/rust/src/chain_service.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use breez_sdk_spark::{ChainApiType, Credentials, Network};
+use breez_sdk_spark::{
+    ChainApiType, Credentials, Network, NewRestChainServiceRequest, SdkError,
+};
 
 /// Rust-built handle to a [`breez_sdk_spark::BitcoinChainService`].
 ///
@@ -18,14 +20,21 @@ pub struct BitcoinChainServiceHandle {
 /// must use the same `network`.
 ///
 /// For one-off, non-shared use, prefer `with_rest_chain_service`.
-#[must_use]
 pub async fn new_rest_chain_service(
     url: String,
     network: Network,
     api_type: ChainApiType,
     credentials: Option<Credentials>,
-) -> BitcoinChainServiceHandle {
-    BitcoinChainServiceHandle {
-        inner: breez_sdk_spark::new_rest_chain_service(url, network, api_type, credentials).await,
-    }
+    request: NewRestChainServiceRequest,
+) -> Result<BitcoinChainServiceHandle, SdkError> {
+    Ok(BitcoinChainServiceHandle {
+        inner: breez_sdk_spark::new_rest_chain_service(
+            url,
+            network,
+            api_type,
+            credentials,
+            request,
+        )
+        .await?,
+    })
 }

--- a/packages/flutter/rust/src/errors.rs
+++ b/packages/flutter/rust/src/errors.rs
@@ -86,5 +86,6 @@ pub enum _PasskeyError {
         credential_id: Vec<u8>,
         source: PrfProviderError,
     },
+    InvalidConfig(String),
     Generic(String),
 }

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -47,7 +47,35 @@ pub struct _Config {
     pub max_concurrent_claims: u32,
     pub spark_config: Option<SparkConfig>,
     pub background_tasks_enabled: bool,
+    /// Routes the connections the SDK opens through a SOCKS5 proxy. Unset connects directly.
+    pub proxy: Option<ProxyConfig>,
     pub cross_chain_config: Option<CrossChainConfig>,
+}
+
+/// A SOCKS5 proxy carrying the connections the SDK opens. Not supported on web.
+#[frb(mirror(ProxyConfig))]
+pub struct _ProxyConfig {
+    pub host: String,
+    pub port: u16,
+    /// Set together with `password` for SOCKS5 authentication. Omit both for none.
+    pub username: Option<String>,
+    pub password: Option<String>,
+}
+
+/// Options for `get_spark_status`.
+#[frb(mirror(GetSparkStatusRequest))]
+pub struct _GetSparkStatusRequest {
+    /// Pass the same proxy as `Config.proxy`: this call runs without an SDK
+    /// instance, so it cannot pick the setting up on its own.
+    pub proxy: Option<ProxyConfig>,
+}
+
+/// Options for `new_rest_chain_service`.
+#[frb(mirror(NewRestChainServiceRequest))]
+pub struct _NewRestChainServiceRequest {
+    /// Pass the same proxy as `Config.proxy`: this service is built outside the
+    /// SDK, so it cannot pick the setting up on its own.
+    pub proxy: Option<ProxyConfig>,
 }
 
 #[frb(mirror(CrossChainConfig))]
@@ -1114,6 +1142,8 @@ pub struct SdkContextConfig {
     pub network: Network,
     pub api_key: Option<String>,
     pub connections_per_operator: Option<u32>,
+    /// Routes the connections opened by this context's shared clients through a SOCKS5 proxy.
+    pub proxy: Option<ProxyConfig>,
 }
 
 #[frb(mirror(Payment))]
@@ -1975,6 +2005,10 @@ pub struct _PasskeyProviderOptions {
 pub struct _PasskeyConfig {
     pub default_label: Option<String>,
     pub provider_options: Option<PasskeyProviderOptions>,
+    /// Routes the Nostr relay connections that store wallet labels through a
+    /// SOCKS5 proxy. Relay connections cannot authenticate to a proxy, so one
+    /// carrying credentials is rejected when the client is built.
+    pub proxy: Option<ProxyConfig>,
 }
 
 #[frb(mirror(PasskeyAvailability))]

--- a/packages/flutter/rust/src/passkey.rs
+++ b/packages/flutter/rust/src/passkey.rs
@@ -125,15 +125,15 @@ impl PasskeyClient {
         + 'static,
         breez_api_key: Option<String>,
         config: Option<PasskeyConfig>,
-    ) -> Self {
+    ) -> Result<Self, PasskeyError> {
         let provider = Arc::new(CallbackPrfProvider {
             derive_seeds_fn: Arc::new(derive_seeds),
             is_supported_fn: Arc::new(is_supported),
             create_passkey_fn: Arc::new(create_passkey),
         });
-        Self {
-            inner: breez_sdk_spark::passkey::PasskeyClient::new(provider, breez_api_key, config),
-        }
+        Ok(Self {
+            inner: breez_sdk_spark::passkey::PasskeyClient::new(provider, breez_api_key, config)?,
+        })
     }
 
     /// One-shot capability + configuration probe.

--- a/packages/flutter/rust/src/sdk.rs
+++ b/packages/flutter/rust/src/sdk.rs
@@ -8,8 +8,10 @@ use crate::exit_signer::CallbackCpfpSigner;
 use crate::frb_generated::StreamSink;
 use crate::logger::BindingLogger;
 
-pub async fn get_spark_status() -> Result<SparkStatus, SdkError> {
-    breez_sdk_spark::get_spark_status().await
+pub async fn get_spark_status(
+    request: GetSparkStatusRequest,
+) -> Result<SparkStatus, SdkError> {
+    breez_sdk_spark::get_spark_status(request).await
 }
 
 pub async fn connect(request: ConnectRequest) -> Result<BreezSdk, SdkError> {

--- a/packages/flutter/rust/src/sdk_context.rs
+++ b/packages/flutter/rust/src/sdk_context.rs
@@ -23,6 +23,7 @@ pub async fn new_shared_sdk_context(config: SdkContextConfig) -> Result<SdkConte
         network: config.network,
         api_key: config.api_key,
         connections_per_operator: config.connections_per_operator,
+        proxy: config.proxy,
         storage: None,
     })
     .await?;


### PR DESCRIPTION
Closes #1048. Native only, fail-closed, no global state.

- `proxy` on `Config` and `SdkContextConfig`, cross-checked in `resolve_context`.
- HTTP via reqwest `socks5h://` (remote DNS); gRPC via a tower connector, TLS untouched.
- BIP353 switches to DoH when proxied: plain DNS is UDP and would escape the tunnel.
- Rejected at `connect`: WASM, `connections_per_operator > 1`, half-specified credentials.
- Consolidated the ad-hoc clients so everything routes through one place. Bulk of the diff.
- `clippy.toml` bans direct `reqwest::Client` construction, so a new ad-hoc client fails the build.
- Passkey rejects a credentialed proxy at construction: relays can't authenticate to a proxy,
  and the label it would fail to publish is a PRF salt the wallet seed derives from.
- Boltz stays unproxied and is not rejected; Orchestra is on the shared client, so cross-chain works.
- CLI gains `--proxy`, `--proxy-user`, `--proxy-password`.
- Itests run against a real SOCKS5 container, including a dead-proxy case asserting no direct fallback.

API breaks: `get_spark_status` takes a request record, `PasskeyClient::new` / `from_config`
are fallible, `parse_input` removed.