### PR TITLE
Persist Orchestra cross-chain send payment row synchronously

### DIFF
--- a/crates/breez-sdk/core/src/cross_chain/orchestra.rs
+++ b/crates/breez-sdk/core/src/cross_chain/orchestra.rs
@@ -918,18 +918,17 @@ impl CrossChainService for OrchestraService {
         })
         .await;
 
-        match polled {
+        let payment = match polled {
             // The poll builds the payment from the Spark transfer alone, which
             // carries no Orchestra metadata. The order id and read token are
             // what let a caller query the order's progress.
-            Ok(payment) => Ok(payment_with_conversion_info(payment, Some(conversion_info))),
+            Ok(payment) => payment_with_conversion_info(payment, Some(conversion_info)),
             Err(e) => {
-                // Operator sync still in flight — the metadata is already
-                // cached, and `poll_in_flight_orders` will reconcile the
-                // payment row as soon as it lands. Surface a payment built
-                // from the deposit transfer (with the Orchestra
-                // `ConversionInfo` attached) so callers see the send as
-                // submitted rather than failed.
+                // Operators haven't surfaced the transfer yet. Build the
+                // payment directly from the deposit transfer (with the
+                // Orchestra `ConversionInfo` attached) so callers see the
+                // send as submitted; the synchronous `apply_payment_update`
+                // below persists it either way.
                 debug!(
                     "Orchestra: payment row for {payment_id} not yet visible: {e}; returning fallback payment built from the deposit transfer"
                 );
@@ -945,9 +944,18 @@ impl CrossChainService for OrchestraService {
                         "Orchestra transfer produced no outgoing payment for {payment_id}"
                     ))
                 })?;
-                Ok(payment_with_conversion_info(payment, Some(conversion_info)))
+                payment_with_conversion_info(payment, Some(conversion_info))
             }
+        };
+
+        if let Err(e) = self.storage.apply_payment_update(payment.clone()).await {
+            error!(
+                "Failed to persist Orchestra payment row {}: {e:?}",
+                payment.id
+            );
         }
+
+        Ok(payment)
     }
 }
 


### PR DESCRIPTION
Orchestra's `send()` returns a Payment without persisting the row: `orchestrate_send` emits `PaymentSucceeded` for it, then an immediate `get_payment_by_id(returned_id)` errors with `Query returned no rows` until background sync catches up.

This PR closes that window by having Orchestra persist the row before returning.

### What changed

- **`orchestra::send()` now persists the Payment row synchronously** via `storage.apply_payment_update(payment.clone())` before returning. Same primitive as Boltz's initial persist in `lightning_sender::payment_from_pay_result`. For Orchestra specifically this leaves `orchestrate_send` as the emit path (still fires with the enriched payload after `complete_conversion_and_send` on the token-conversion path); Boltz's emit shape is unchanged.
- A local write failure here is logged and swallowed rather than propagated: the deposit transfer already went out and the Orchestra order is submitted, so failing the send on a local write would misreport a send that actually happened. Matches the `unwrap_or_else` on `resolve_and_insert_payment_metadata_for_transfer` above and the `warn!`-and-continue handling in `send/cross_chain.rs::enrich_payment_conversions`.