### PR TITLE
Fix resuming a unilateral exit

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/unilateral_exit.rs
+++ b/crates/breez-sdk/breez-itest/tests/unilateral_exit.rs
@@ -669,13 +669,14 @@ async fn test_full_exit_and_sweep(#[case] backend: SignerBackend) -> Result<()> 
     Ok(())
 }
 
-/// Re-running a completed exit re-drives nothing. `Auto` drops the exited leaf
-/// from the available set once the exit is mined, but it is still sourceable by
-/// id, so forcing it back in with `Specific` runs the build rather than the
-/// empty-plan early return. Its refund address is then funded with no unspent
-/// output, so the exit resolves the refund as already-swept: it rebuilds no
-/// refund and re-attempts no sweep. Under the pre-fix behavior the empty address
-/// scan would re-drive the refund (with a fresh CPFP child) and rebuild the sweep.
+/// Re-running a completed exit re-drives nothing, and says so rather than going
+/// quiet. `Auto` drops the exited leaf from the available set once the exit is
+/// mined, but it is still sourceable by id, so forcing it back in with `Specific`
+/// runs the build rather than the empty-plan early return. The refund and the
+/// sweep that spent it come back `Confirmed` and carry no CPFP child: there is
+/// nothing left to broadcast. Reporting them is what lets a caller tell a
+/// finished exit from one that never started, rather than inferring it from
+/// their absence.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
 async fn test_completed_exit_rerun_redrives_nothing(#[case] backend: SignerBackend) -> Result<()> {
@@ -740,13 +741,24 @@ async fn test_completed_exit_rerun_redrives_nothing(#[case] backend: SignerBacke
         rerun.recoverable_value_sat, recoverable,
         "the forced-in leaf is re-selected, so the build runs the swept-refund path"
     );
-    assert!(
-        rerun.transactions.iter().all(|t| !matches!(
-            t.kind,
-            UnilateralExitTxKind::Refund | UnilateralExitTxKind::Sweep
-        )),
-        "a completed exit rebuilds no refund and re-attempts no sweep"
-    );
+    for kind in [UnilateralExitTxKind::Refund, UnilateralExitTxKind::Sweep] {
+        let reported: Vec<_> = rerun
+            .transactions
+            .iter()
+            .filter(|t| t.kind == kind)
+            .collect();
+        assert!(
+            !reported.is_empty(),
+            "a completed exit still reports its {kind:?}, so its caller can tell \
+             it finished"
+        );
+        assert!(
+            reported
+                .iter()
+                .all(|t| t.status == ConfirmationStatus::Confirmed),
+            "and reports it confirmed, not as work to redo"
+        );
+    }
     assert!(
         rerun.transactions.iter().all(|t| t.cpfp_tx_hex.is_none()),
         "no fresh CPFP child: nothing needs broadcasting on a completed exit"
@@ -1266,6 +1278,428 @@ async fn test_importing_another_wallets_state_takes_nothing(
         quote.leaves.is_empty(),
         "another wallet's leaf must not become exitable here"
     );
+    Ok(())
+}
+
+/// A single leaf carried to a confirmed refund, then resumed. Nothing is left to
+/// drive, so the resume asks for no fee money at all and goes straight to the
+/// sweep: the leaf's own steps come back confirmed and carry no child. The gate
+/// that would have priced a fresh exit is the one a nearly-finished exit used to
+/// be rejected by.
+#[apply(each_backend)]
+#[test_log::test(tokio::test)]
+async fn test_settled_single_branch_needs_no_further_funding(
+    #[case] backend: SignerBackend,
+) -> Result<()> {
+    let sdk = new_local_sdk(backend).await?;
+    deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
+    let cpfp = fund_p2tr_utxo(&sdk.fixtures.bitcoind, Amount::from_sat(CPFP_SATS)).await?;
+    let dest = cpfp.address.clone();
+
+    let quote = sdk
+        .sdk
+        .prepare_unilateral_exit(PrepareUnilateralExitRequest {
+            fee_rate_sat_per_vbyte: FEE_RATE,
+            funding_kind: CpfpFundingKind::P2tr,
+            destination: dest.to_string(),
+            selection: ExitLeafSelection::Auto,
+        })
+        .await?;
+    let leaf_ids: Vec<String> = quote.leaves.iter().map(|l| l.leaf_id.clone()).collect();
+    let built = sdk
+        .sdk
+        .unilateral_exit(
+            UnilateralExitRequest {
+                prepared: quote,
+                funding_inputs: vec![cpfp_input(&cpfp)],
+            },
+            signer_for(&cpfp.secret_key.secret_bytes())?,
+        )
+        .await?;
+
+    // Everything but the sweep: the refund lands, so the branch is finished while
+    // the money is still sitting in the refund output.
+    for entry in built
+        .transactions
+        .iter()
+        .filter(|t| t.kind != UnilateralExitTxKind::Sweep)
+    {
+        if entry.cpfp_tx_hex.is_some() {
+            broadcast_and_mine(&sdk, entry).await?;
+        } else {
+            // A step that pays its own fee goes out on its own.
+            let tx = decode_tx(&entry.tx_hex)?;
+            sdk.fixtures.bitcoind.broadcast_transaction(&tx).await?;
+            sdk.fixtures.bitcoind.generate_blocks(1).await?;
+        }
+    }
+
+    // A tiny UTXO, far below what a fresh exit of this leaf would cost. The resume
+    // has no children left to build, so it must not be asked for the difference.
+    let dust_funding = fund_p2tr_utxo(&sdk.fixtures.bitcoind, Amount::from_sat(p2tr_dust() + 1)).await?;
+    let resumed_quote = sdk
+        .sdk
+        .prepare_unilateral_exit(PrepareUnilateralExitRequest {
+            fee_rate_sat_per_vbyte: FEE_RATE,
+            funding_kind: CpfpFundingKind::P2tr,
+            destination: dest.to_string(),
+            selection: ExitLeafSelection::Specific { leaf_ids },
+        })
+        .await?;
+    let resumed = sdk
+        .sdk
+        .unilateral_exit(
+            UnilateralExitRequest {
+                prepared: resumed_quote,
+                funding_inputs: vec![cpfp_input(&dust_funding)],
+            },
+            signer_for(&dust_funding.secret_key.secret_bytes())?,
+        )
+        .await?;
+
+    assert!(
+        resumed
+            .transactions
+            .iter()
+            .filter(|t| t.kind != UnilateralExitTxKind::Sweep)
+            .all(|t| t.status == ConfirmationStatus::Confirmed && t.cpfp_tx_hex.is_none()),
+        "every step but the sweep is already on-chain and needs nothing sent"
+    );
+    let sweep = resumed
+        .transactions
+        .iter()
+        .find(|t| t.kind == UnilateralExitTxKind::Sweep)
+        .expect("the refund is on-chain and unspent, so there is a sweep to make");
+    assert_eq!(sweep.status, ConfirmationStatus::Unconfirmed);
+
+    // It is a real transaction the dust funding paid for: it lands, and the
+    // leaf's value arrives at the destination.
+    let tx = decode_tx(&sweep.tx_hex)?;
+    let sweep_txid = sdk.fixtures.bitcoind.broadcast_transaction(&tx).await?;
+    sdk.fixtures.bitcoind.generate_blocks(1).await?;
+    let mined = sdk.fixtures.bitcoind.get_transaction(&sweep_txid).await?;
+    assert!(
+        mined
+            .output
+            .iter()
+            .any(|o| o.script_pubkey == dest.script_pubkey()),
+        "the sweep pays the destination"
+    );
+    Ok(())
+}
+
+/// Several funding UTXOs put the affordability gate through a re-cost from the
+/// tree, which knows nothing of the chain. A branch part-way through its exit
+/// must be gated on the children it still builds: priced as a fresh exit, a
+/// resume is turned away over work that is already paid for.
+#[apply(each_backend)]
+#[test_log::test(tokio::test)]
+async fn test_partly_exited_branch_gated_on_what_it_still_builds(
+    #[case] backend: SignerBackend,
+) -> Result<()> {
+    let sdk = new_local_sdk(backend).await?;
+    deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
+    let key = fixed_key(0x2a);
+    let bitcoind = &sdk.fixtures.bitcoind;
+    let u1 = fund_p2tr_utxo_with_key(bitcoind, Amount::from_sat(CPFP_SATS), &key).await?;
+    let dest = u1.address.clone();
+
+    let quote = sdk
+        .sdk
+        .prepare_unilateral_exit(PrepareUnilateralExitRequest {
+            fee_rate_sat_per_vbyte: FEE_RATE,
+            funding_kind: CpfpFundingKind::P2tr,
+            destination: dest.to_string(),
+            selection: ExitLeafSelection::Auto,
+        })
+        .await?;
+    let leaf_ids: Vec<String> = quote.leaves.iter().map(|l| l.leaf_id.clone()).collect();
+    let built = sdk
+        .sdk
+        .unilateral_exit(
+            UnilateralExitRequest {
+                prepared: quote,
+                funding_inputs: vec![cpfp_input_for(&u1)],
+            },
+            signer_for(&key.secret_bytes())?,
+        )
+        .await?;
+
+    // The tree goes on-chain; the refund is still ahead of it.
+    for entry in built
+        .transactions
+        .iter()
+        .filter(|t| t.kind == UnilateralExitTxKind::Node && t.cpfp_tx_hex.is_some())
+    {
+        broadcast_and_mine(&sdk, entry).await?;
+    }
+
+    // Two small UTXOs, which is what routes the gate through the re-cost. Between
+    // them they cover the refund's child and no more: enough for the work left,
+    // short of what a fresh exit of this leaf would have been quoted.
+    let a = fund_p2tr_utxo_with_key(bitcoind, Amount::from_sat(p2tr_dust() + 400), &key).await?;
+    let b = fund_p2tr_utxo_with_key(bitcoind, Amount::from_sat(p2tr_dust() + 400), &key).await?;
+    let resumed_quote = sdk
+        .sdk
+        .prepare_unilateral_exit(PrepareUnilateralExitRequest {
+            fee_rate_sat_per_vbyte: FEE_RATE,
+            funding_kind: CpfpFundingKind::P2tr,
+            destination: dest.to_string(),
+            selection: ExitLeafSelection::Specific { leaf_ids },
+        })
+        .await?;
+    let resumed = sdk
+        .sdk
+        .unilateral_exit(
+            UnilateralExitRequest {
+                prepared: resumed_quote,
+                funding_inputs: vec![cpfp_input_for(&a), cpfp_input_for(&b)],
+            },
+            signer_for(&key.secret_bytes())?,
+        )
+        .await?;
+
+    // It was accepted, and what it built is real: the refund and its child land.
+    for entry in resumed
+        .transactions
+        .iter()
+        .filter(|t| t.status == ConfirmationStatus::Unconfirmed)
+    {
+        match entry.kind {
+            UnilateralExitTxKind::Node | UnilateralExitTxKind::Refund => {
+                broadcast_and_mine(&sdk, entry).await?;
+            }
+            _ => {
+                let tx = decode_tx(&entry.tx_hex)?;
+                sdk.fixtures.bitcoind.broadcast_transaction(&tx).await?;
+                sdk.fixtures.bitcoind.generate_blocks(1).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// A leaf whose nodes are on-chain is rebuilt for what it has left, not for a
+/// fresh exit: `unilateral_exit` reads the chain, so the steps already mined cost
+/// nothing and the fee it reports drops to match. The quote is not asserted here:
+/// it works from the operators' reported node state rather than a chain lookup,
+/// so it moves only once they have seen those blocks.
+#[apply(each_backend)]
+#[test_log::test(tokio::test)]
+async fn test_partly_exited_leaf_is_rebuilt_for_what_is_left(
+    #[case] backend: SignerBackend,
+) -> Result<()> {
+    let sdk = new_local_sdk(backend).await?;
+    deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
+    let cpfp = fund_p2tr_utxo(&sdk.fixtures.bitcoind, Amount::from_sat(CPFP_SATS)).await?;
+    let dest = cpfp.address.clone();
+
+    let quote = sdk
+        .sdk
+        .prepare_unilateral_exit(PrepareUnilateralExitRequest {
+            fee_rate_sat_per_vbyte: FEE_RATE,
+            funding_kind: CpfpFundingKind::P2tr,
+            destination: dest.to_string(),
+            selection: ExitLeafSelection::Auto,
+        })
+        .await?;
+    let leaf_ids: Vec<String> = quote.leaves.iter().map(|l| l.leaf_id.clone()).collect();
+    let fresh_fee = quote.total_fee_sat;
+    let built = sdk
+        .sdk
+        .unilateral_exit(
+            UnilateralExitRequest {
+                prepared: quote,
+                funding_inputs: vec![cpfp_input(&cpfp)],
+            },
+            signer_for(&cpfp.secret_key.secret_bytes())?,
+        )
+        .await?;
+
+    // Put the tree on-chain but stop before the refund.
+    for entry in built
+        .transactions
+        .iter()
+        .filter(|t| t.kind == UnilateralExitTxKind::Node && t.cpfp_tx_hex.is_some())
+    {
+        broadcast_and_mine(&sdk, entry).await?;
+    }
+
+    let resumed_quote = sdk
+        .sdk
+        .prepare_unilateral_exit(PrepareUnilateralExitRequest {
+            fee_rate_sat_per_vbyte: FEE_RATE,
+            funding_kind: CpfpFundingKind::P2tr,
+            destination: dest.to_string(),
+            selection: ExitLeafSelection::Specific { leaf_ids },
+        })
+        .await?;
+    assert_eq!(resumed_quote.leaves.len(), 1, "the leaf is still worth exiting");
+
+    let more_funding = fund_p2tr_utxo(&sdk.fixtures.bitcoind, Amount::from_sat(CPFP_SATS)).await?;
+    let resumed = sdk
+        .sdk
+        .unilateral_exit(
+            UnilateralExitRequest {
+                prepared: resumed_quote,
+                funding_inputs: vec![cpfp_input(&more_funding)],
+            },
+            signer_for(&more_funding.secret_key.secret_bytes())?,
+        )
+        .await?;
+    assert!(
+        resumed.total_fee_sat < fresh_fee,
+        "a resume is built for less than a fresh exit: {} vs {fresh_fee}",
+        resumed.total_fee_sat
+    );
+    assert!(
+        resumed
+            .transactions
+            .iter()
+            .filter(|t| t.kind == UnilateralExitTxKind::Node)
+            .all(|t| t.status == ConfirmationStatus::Confirmed && t.cpfp_tx_hex.is_none()),
+        "the nodes already mined are reported confirmed and cost nothing to redo"
+    );
+    Ok(())
+}
+
+/// One branch is driven all the way to a swept refund while the other is left
+/// untouched, then the exit is resumed. The branch that finished is reported
+/// confirmed rather than dropped, and the branch still going is funded from the
+/// fan-out output it was given at the start: its own, not the finished branch's.
+/// The fan-out keeps an output per branch for exactly this reason, so the order
+/// the outputs are read back in does not shift as branches settle.
+#[apply(each_backend)]
+#[test_log::test(tokio::test)]
+async fn test_one_settled_branch_leaves_the_other_on_its_own_output(
+    #[case] backend: SignerBackend,
+) -> Result<()> {
+    let sdk = new_local_sdk(backend).await?;
+    for _ in 0..3 {
+        deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
+    }
+    let cpfp = fund_p2tr_utxo(&sdk.fixtures.bitcoind, Amount::from_sat(CPFP_SATS * 6)).await?;
+    let funding = vec![cpfp_input(&cpfp)];
+    let key = cpfp.secret_key.secret_bytes();
+    let dest = cpfp.address.to_string();
+
+    let quote = sdk
+        .sdk
+        .prepare_unilateral_exit(PrepareUnilateralExitRequest {
+            fee_rate_sat_per_vbyte: FEE_RATE,
+            funding_kind: CpfpFundingKind::P2tr,
+            destination: dest.clone(),
+            selection: ExitLeafSelection::Auto,
+        })
+        .await?;
+    let leaf_ids: Vec<String> = quote.leaves.iter().map(|l| l.leaf_id.clone()).collect();
+    // Three, so settling one still leaves two driving and the exit keeps fanning
+    // out. With two, one settling drops it to a single branch, which takes a
+    // different path entirely.
+    assert_eq!(leaf_ids.len(), 3, "three leaves, so the exit fans out");
+    let built = sdk
+        .sdk
+        .unilateral_exit(
+            UnilateralExitRequest {
+                prepared: quote,
+                funding_inputs: funding.clone(),
+            },
+            signer_for(&key)?,
+        )
+        .await?;
+    let fan_out_txid = confirm_fan_out(&sdk, &built).await?;
+
+    // Drive one branch only, node then refund, leaving the other where it is.
+    let settled_leaf = leaf_ids[0].clone();
+    for entry in built
+        .transactions
+        .iter()
+        .filter(|t| t.node_id.as_deref() == Some(settled_leaf.as_str()))
+    {
+        if entry.cpfp_tx_hex.is_some() {
+            broadcast_and_mine(&sdk, entry).await?;
+        } else {
+            let tx = decode_tx(&entry.tx_hex)?;
+            sdk.fixtures.bitcoind.broadcast_transaction(&tx).await?;
+            sdk.fixtures.bitcoind.generate_blocks(1).await?;
+        }
+    }
+
+    let resumed_quote = sdk
+        .sdk
+        .prepare_unilateral_exit(PrepareUnilateralExitRequest {
+            fee_rate_sat_per_vbyte: FEE_RATE,
+            funding_kind: CpfpFundingKind::P2tr,
+            destination: dest.clone(),
+            selection: ExitLeafSelection::Specific {
+                leaf_ids: leaf_ids.clone(),
+            },
+        })
+        .await?;
+    let resumed = sdk
+        .sdk
+        .unilateral_exit(
+            UnilateralExitRequest {
+                prepared: resumed_quote,
+                funding_inputs: funding,
+            },
+            signer_for(&key)?,
+        )
+        .await?;
+
+    // The fan-out is recognised, not rebuilt: proof the resume read its own
+    // outputs rather than treating them as a stranger's spend.
+    let adopted = resumed
+        .transactions
+        .iter()
+        .find(|t| matches!(t.kind, UnilateralExitTxKind::FanOut))
+        .expect("the confirmed fan-out is still reported");
+    assert_eq!(adopted.txid, fan_out_txid, "adopted, not rebuilt");
+    assert!(matches!(adopted.status, ConfirmationStatus::Confirmed));
+
+    // What the settled branch already did comes back confirmed and needs nothing
+    // broadcast; the branch left alone still has work with a child to pay for it.
+    let settled: Vec<_> = resumed
+        .transactions
+        .iter()
+        .filter(|t| t.node_id.as_deref() == Some(settled_leaf.as_str()))
+        .collect();
+    assert!(!settled.is_empty(), "the driven branch is still reported");
+    assert!(
+        settled
+            .iter()
+            .all(|t| t.status == ConfirmationStatus::Confirmed && t.cpfp_tx_hex.is_none()),
+        "a branch already on-chain is confirmed, with nothing left to send"
+    );
+    for untouched in &leaf_ids[1..] {
+        assert!(
+            resumed
+                .transactions
+                .iter()
+                .filter(|t| t.node_id.as_deref() == Some(untouched.as_str()))
+                .any(|t| t.status == ConfirmationStatus::Unconfirmed),
+            "an untouched branch still has work to do"
+        );
+    }
+
+    // And they can be driven from here: each was handed real funding, which it
+    // would not have been had it been pointed at another branch's output.
+    for entry in resumed
+        .transactions
+        .iter()
+        .filter(|t| t.status == ConfirmationStatus::Unconfirmed)
+    {
+        match entry.kind {
+            UnilateralExitTxKind::Node | UnilateralExitTxKind::Refund => {
+                broadcast_and_mine(&sdk, entry).await?;
+            }
+            _ => {
+                let tx = decode_tx(&entry.tx_hex)?;
+                sdk.fixtures.bitcoind.broadcast_transaction(&tx).await?;
+                sdk.fixtures.bitcoind.generate_blocks(1).await?;
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/breez-sdk/breez-itest/tests/unilateral_exit.rs
+++ b/crates/breez-sdk/breez-itest/tests/unilateral_exit.rs
@@ -678,7 +678,6 @@ async fn test_full_exit_and_sweep(#[case] backend: SignerBackend) -> Result<()> 
 /// scan would re-drive the refund (with a fresh CPFP child) and rebuild the sweep.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
-#[ignore = "resume needs the leaf in local storage, but a refresh deletes it once no operator reports it Available; fix by querying the operators for more statuses, or by not deleting leaves absent from a refresh"]
 async fn test_completed_exit_rerun_redrives_nothing(#[case] backend: SignerBackend) -> Result<()> {
     let sdk = new_local_sdk(backend).await?;
     deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
@@ -759,7 +758,6 @@ async fn test_completed_exit_rerun_redrives_nothing(#[case] backend: SignerBacke
 /// with no CPFP child, while later entries stay unconfirmed with their children.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
-#[ignore = "resume needs the leaf in local storage, but a refresh deletes it once no operator reports it Available; fix by querying the operators for more statuses, or by not deleting leaves absent from a refresh"]
 async fn test_first_package_confirmed_resumes(#[case] backend: SignerBackend) -> Result<()> {
     let sdk = new_local_sdk(backend).await?;
     deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
@@ -841,7 +839,6 @@ async fn test_first_package_confirmed_resumes(#[case] backend: SignerBackend) ->
 /// this would fail if the sweep inputs fell back to the default (non-RBF) sequence.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
-#[ignore = "resume needs the leaf in local storage, but a refresh deletes it once no operator reports it Available; fix by querying the operators for more statuses, or by not deleting leaves absent from a refresh"]
 async fn test_sweep_is_rbf_replaceable(#[case] backend: SignerBackend) -> Result<()> {
     let sdk = new_local_sdk(backend).await?;
     deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
@@ -2438,7 +2435,6 @@ async fn test_custom_funding_input(#[case] backend: SignerBackend) -> Result<()>
 /// the refund's CPFP resumes off the last confirmed node's on-chain change.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
-#[ignore = "resume needs the leaf in local storage, but a refresh deletes it once no operator reports it Available; fix by querying the operators for more statuses, or by not deleting leaves absent from a refresh"]
 async fn test_all_nodes_confirmed_resumes_at_refund(#[case] backend: SignerBackend) -> Result<()> {
     let sdk = new_local_sdk(backend).await?;
     deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
@@ -2753,7 +2749,6 @@ async fn assert_resumed_all_mined(
 /// of the "not ours" path.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
-#[ignore = "resume needs the leaf in local storage, but a refresh deletes it once no operator reports it Available; fix by querying the operators for more statuses, or by not deleting leaves absent from a refresh"]
 async fn test_node_confirmed_by_foreign_cpfp_resumes(#[case] backend: SignerBackend) -> Result<()> {
     let sdk = new_local_sdk(backend).await?;
     deposit_and_claim(&sdk, Amount::from_sat(LEAF_SATS)).await?;
@@ -2869,7 +2864,6 @@ async fn test_node_confirmed_by_foreign_cpfp_resumes(#[case] backend: SignerBack
 /// coverage.
 #[apply(each_backend)]
 #[test_log::test(tokio::test)]
-#[ignore = "resume needs the leaf in local storage, but a refresh deletes it once no operator reports it Available; fix by querying the operators for more statuses, or by not deleting leaves absent from a refresh"]
 async fn test_refund_confirmed_by_foreign_cpfp_is_adopted(
     #[case] backend: SignerBackend,
 ) -> Result<()> {

--- a/crates/breez-sdk/core/src/sdk/unilateral_exit.rs
+++ b/crates/breez-sdk/core/src/sdk/unilateral_exit.rs
@@ -11,8 +11,8 @@ use bitcoin::{
 
 use spark_wallet::{
     AddressUtxo, ChainQuery, ChainResult, CpfpInput, ExitTxKind, ExitTxStatus, Observation,
-    PreparedUnilateralExit, SpendInfo, TreeNodeId, UnilateralExitBuild, build_unilateral_exit,
-    is_ephemeral_anchor_output, next_chain_queries,
+    PreparedUnilateralExit, SettledExitSteps, SpendInfo, TreeNodeId, UnilateralExitBuild,
+    build_unilateral_exit, is_ephemeral_anchor_output, next_chain_queries, scan_settlement,
 };
 
 use tracing::{debug, trace, warn};
@@ -197,15 +197,21 @@ impl BreezSdk {
         }
 
         let fee_rate_sat_per_kw = sat_per_kw_from_vbyte(prepared.fee_rate_sat_per_vbyte);
-        let prepared_exit = self
+        // Ask the chain what the exit has already done before sizing its funding:
+        // a step that is settled takes no CPFP child, and pricing one anyway can
+        // reject a nearly-finished exit at any amount its remaining work justifies.
+        let context = self
             .spark_wallet
-            .prepare_unilateral_exit_plan(
-                fee_rate_sat_per_kw,
-                spark_wallet::ExitLeafSelection::Specific(leaf_ids),
-                funding_inputs,
-                dest_script_len,
-            )
+            .load_exit_context(spark_wallet::ExitLeafSelection::Specific(leaf_ids))
             .await?;
+        let (settled, settlement_observations) = resolve_settled_steps(chain, &context).await?;
+        let prepared_exit = self.spark_wallet.plan_exit(
+            &context,
+            fee_rate_sat_per_kw,
+            funding_inputs,
+            dest_script_len,
+            Some(&settled),
+        )?;
         if prepared_exit.plan.selected_leaves.is_empty() {
             debug!("unilateral_exit: plan selected no leaves, returning empty result");
             return Ok(empty_exit_response());
@@ -227,7 +233,8 @@ impl BreezSdk {
             })
             .collect();
 
-        let observed = resolve_exit_observations(chain, &prepared_exit).await?;
+        let observed =
+            resolve_exit_observations(chain, &prepared_exit, settlement_observations).await?;
         let build = build_unilateral_exit(&prepared_exit, &observed, fee_rate_sat_per_kw)?;
         let recoverable_value_sat = build.recoverable_value_sat;
         let build_fee_sat = build.total_fee_sat;
@@ -526,14 +533,49 @@ fn parse_xonly(pubkey: &str) -> Result<XOnlyPublicKey, SdkError> {
     Ok(pk.x_only_public_key().0)
 }
 
+/// Drives the settlement scan to completion. Same shape as
+/// [`resolve_exit_observations`], but reads only what the chain has already done,
+/// so it can run before any funding is planned.
+/// Returns its observations alongside the answer so the full walk that follows
+/// can start from them: it asks a superset of these same questions, and would
+/// otherwise fetch every one of them a second time.
+async fn resolve_settled_steps(
+    chain: &dyn BitcoinChainService,
+    context: &spark_wallet::ExitContext,
+) -> Result<(SettledExitSteps, Vec<Observation>), SdkError> {
+    let mut observed: Vec<Observation> = Vec::new();
+    loop {
+        let scan = scan_settlement(
+            &context.tree_nodes,
+            &context.leaf_ids,
+            &context.leaf_refund_addresses,
+            &observed,
+        );
+        if scan.pending.is_empty() {
+            debug!(
+                settled_nodes = scan.settled.nodes.len(),
+                settled_refunds = scan.settled.refunds.len(),
+                observations = observed.len(),
+                "resolve_settled_steps: what the chain has already done"
+            );
+            return Ok((scan.settled, observed));
+        }
+        for query in scan.pending {
+            let result = execute_chain_query(chain, &query).await;
+            observed.push(Observation { query, result });
+        }
+    }
+}
+
 /// Drives the wallet's pure resolver to completion: it reports which chain
 /// lookups the exit needs, core performs them, and the results are fed back until
 /// nothing more is needed. Core never interprets the exit tree itself.
 async fn resolve_exit_observations(
     chain: &dyn BitcoinChainService,
     prepared: &PreparedUnilateralExit,
+    seed: Vec<Observation>,
 ) -> Result<Vec<Observation>, SdkError> {
-    let mut observed: Vec<Observation> = Vec::new();
+    let mut observed = seed;
     let mut round = 0u32;
     loop {
         let queries = next_chain_queries(prepared, &observed)?;

--- a/crates/breez-sdk/core/src/sdk/unilateral_exit.rs
+++ b/crates/breez-sdk/core/src/sdk/unilateral_exit.rs
@@ -311,10 +311,31 @@ impl BreezSdk {
             }
         }
 
-        // A sweep over zero inputs would error: return without one when no refund
-        // is on-chain yet. A later run sweeps any refund that surfaces.
+        // Nothing left to sweep means one of two opposite things: no refund has
+        // reached the chain yet, or every refund was already swept. Report a sweep
+        // that landed, so the caller reads a finished exit as finished instead of
+        // as one that never started.
         if build.refund_outputs.is_empty() {
-            debug!("unilateral_exit: no refund outputs to sweep, omitting the sweep");
+            for sweep in &build.confirmed_sweeps {
+                transactions.push(UnilateralExitTransaction {
+                    kind: UnilateralExitTxKind::Sweep,
+                    node_id: None,
+                    txid: sweep.compute_txid().to_string(),
+                    tx_hex: serialize_hex(sweep),
+                    cpfp_tx_hex: None,
+                    csv_timelock_blocks: None,
+                    depends_on: sweep
+                        .input
+                        .iter()
+                        .map(|i| i.previous_output.txid.to_string())
+                        .collect(),
+                    status: ConfirmationStatus::Confirmed,
+                });
+            }
+            debug!(
+                confirmed_sweeps = build.confirmed_sweeps.len(),
+                "unilateral_exit: nothing left to sweep"
+            );
             return Ok(UnilateralExitResponse {
                 recoverable_value_sat,
                 total_fee_sat: build_fee_sat,

--- a/crates/breez-sdk/core/src/sdk/unilateral_exit.rs
+++ b/crates/breez-sdk/core/src/sdk/unilateral_exit.rs
@@ -205,7 +205,7 @@ impl BreezSdk {
             .load_exit_context(spark_wallet::ExitLeafSelection::Specific(leaf_ids))
             .await?;
         let (settled, settlement_observations) = resolve_settled_steps(chain, &context).await?;
-        let prepared_exit = self.spark_wallet.plan_exit(
+        let prepared_exit = self.spark_wallet.plan_unilateral_exit(
             &context,
             fee_rate_sat_per_kw,
             funding_inputs,

--- a/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/mysql-tree-store/index.cjs
@@ -441,9 +441,9 @@ class MysqlTreeStore {
   async getVerifiedLeafKeys() {
     try {
       // Project just the two pubkeys out of the JSON, skipping each leaf's
-      // `data` blob (up to five transactions). The filter matches the verified
-      // categories the SDK expects: every reserved leaf plus every Available
-      // one, and nothing non-Available and unreserved.
+      // `data` blob (up to five transactions). Every stored leaf passed the
+      // ownership check on its way in, whatever its status, so all are
+      // projected.
       const [rows] = await this.pool.query(
         `SELECT l.id AS id,
                 l.verifying_public_key AS verifying,
@@ -451,8 +451,7 @@ class MysqlTreeStore {
          FROM brz_tree_leaves l
          LEFT JOIN brz_tree_reservations r
            ON l.reservation_id = r.id AND l.user_id = r.user_id
-         WHERE l.user_id = ?
-           AND (r.purpose IS NOT NULL OR l.status = 'Available')`,
+         WHERE l.user_id = ?`,
         [this.identity]
       );
       return rows.map((row) => [row.id, row.verifying, row.keyshare]);

--- a/crates/breez-sdk/wasm/js/node-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/node-tree-store/index.cjs
@@ -349,9 +349,7 @@ class NodeTreeStore {
           `SELECT l.id AS id,
                   l.verifying_public_key AS verifying,
                   l.signing_public_key AS keyshare
-           FROM brz_tree_leaves l
-           LEFT JOIN brz_tree_reservations r ON l.reservation_id = r.id
-           WHERE r.purpose IS NOT NULL OR l.status = 'Available'`
+           FROM brz_tree_leaves l`
         )
         .all();
       return rows.map((row) => [row.id, row.verifying, row.keyshare]);

--- a/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
+++ b/crates/breez-sdk/wasm/js/postgres-tree-store/index.cjs
@@ -396,9 +396,9 @@ class PostgresTreeStore {
   async getVerifiedLeafKeys() {
     try {
       // Project just the two pubkeys out of the JSON, skipping each leaf's
-      // `data` blob (up to five transactions). The filter matches the verified
-      // categories the SDK expects: every reserved leaf plus every Available
-      // one, and nothing non-Available and unreserved.
+      // `data` blob (up to five transactions). Every stored leaf passed the
+      // ownership check on its way in, whatever its status, so all are
+      // projected.
       const result = await this.pool.query(
         `
         SELECT l.id AS id,
@@ -408,7 +408,6 @@ class PostgresTreeStore {
         LEFT JOIN brz_tree_reservations r
           ON l.reservation_id = r.id AND l.user_id = r.user_id
         WHERE l.user_id = $1
-          AND (r.purpose IS NOT NULL OR l.status = 'Available')
       `,
         [this.identity]
       );

--- a/crates/breez-sdk/wasm/js/web-tree-store/index.js
+++ b/crates/breez-sdk/wasm/js/web-tree-store/index.js
@@ -522,31 +522,18 @@ class WebTreeStore {
 
   async getVerifiedLeafKeys() {
     try {
+      // Every stored leaf passed the ownership check on its way in, whatever
+      // its status, so all of them are projected.
       return await this._txRun(
-        [STORE_LEAVES, STORE_RESERVATIONS],
+        [STORE_LEAVES],
         "readonly",
-        [
-          { name: "leaves", store: STORE_LEAVES },
-          { name: "reservations", store: STORE_RESERVATIONS },
-        ],
-        (res) => {
-          const resIds = new Set(res.reservations.map((r) => r.id));
-          const out = [];
-          for (const row of res.leaves) {
-            const hasReservation =
-              row.reservation_id != null && resIds.has(row.reservation_id);
-            // Every reserved leaf plus every Available one; nothing that is
-            // neither reserved nor Available.
-            if (hasReservation || row.status === "Available") {
-              out.push([
-                row.id,
-                row.verifying_public_key,
-                row.signing_public_key,
-              ]);
-            }
-          }
-          return out;
-        }
+        [{ name: "leaves", store: STORE_LEAVES }],
+        (res) =>
+          res.leaves.map((row) => [
+            row.id,
+            row.verifying_public_key,
+            row.signing_public_key,
+          ])
       );
     } catch (error) {
       if (error instanceof TreeStoreError) throw error;

--- a/crates/internal/src/command/withdraw.rs
+++ b/crates/internal/src/command/withdraw.rs
@@ -147,18 +147,18 @@ pub async fn handle_command(
             } else {
                 ExitLeafSelection::Specific(leaf_ids)
             };
-            let prepared = wallet
-                .prepare_unilateral_exit_plan(
-                    fee_rate_sat_per_kw,
-                    selection,
-                    inputs,
-                    // Sweep destination is a P2TR address (34-byte scriptPubKey);
-                    // only used here to size the fan-out fee.
-                    34,
-                )
-                .await?;
-            // No chain access here, so pass no observations: the exit resolves to
-            // a fresh full build (nothing recognized as already on-chain).
+            let context = wallet.load_exit_context(selection).await?;
+            // No chain access here, so nothing is settled and no observations are
+            // passed: the exit is priced and resolved as a fresh full build.
+            let prepared = wallet.plan_unilateral_exit(
+                &context,
+                fee_rate_sat_per_kw,
+                inputs,
+                // Sweep destination is a P2TR address (34-byte scriptPubKey);
+                // only used here to size the fan-out fee.
+                34,
+                None,
+            )?;
             let exit = build_unilateral_exit(&prepared, &[], fee_rate_sat_per_kw)?;
 
             if let Some(fan_out) = &exit.fan_out

--- a/crates/spark-itest/src/fixtures/bitcoind.rs
+++ b/crates/spark-itest/src/fixtures/bitcoind.rs
@@ -196,6 +196,20 @@ impl BitcoindFixture {
             .await
     }
 
+    /// Mines blocks nobody spends, for advancing the chain past a timelock.
+    ///
+    /// Pays a fixed address outside the node's wallet: `generate_blocks` pays
+    /// the wallet, and a run that clears a relative timelock mines thousands of
+    /// blocks, so tracking a coinbase for each one slows the call until it
+    /// outruns the RPC timeout.
+    pub async fn generate_filler_blocks(&self, count: u64) -> Result<Vec<String>> {
+        self.rpc_call::<Vec<String>>(
+            "generatetoaddress",
+            &[json!(count), json!(DEFAULT_MINING_ADDRESS)],
+        )
+        .await
+    }
+
     pub async fn broadcast_transaction(&self, tx: &Transaction) -> Result<Txid> {
         let tx_hex = hex::encode(bitcoin::consensus::serialize(tx));
         self.rpc_call::<String>("sendrawtransaction", &[json!(tx_hex)])

--- a/crates/spark-itest/src/helpers.rs
+++ b/crates/spark-itest/src/helpers.rs
@@ -650,7 +650,7 @@ pub async fn submit_package_with_csv_retry(
         })
         .max()
         .unwrap_or(0);
-    bitcoind.generate_blocks(csv_blocks.into()).await?;
+    bitcoind.generate_filler_blocks(csv_blocks.into()).await?;
 
     let retry = bitcoind.submit_package(&[parent, child]).await?;
     let retry_msg = retry

--- a/crates/spark-mysql/src/tree_store.rs
+++ b/crates/spark-mysql/src/tree_store.rs
@@ -521,10 +521,9 @@ impl TreeStore for MysqlTreeStore {
         let mut conn = self.pool.get_conn().await.map_err(map_err)?;
 
         // Project just the two pubkeys straight out of the JSON, skipping the
-        // per-leaf `data` blob (up to five transactions). The filter mirrors the
-        // verified categories in `verified_leaf_keys_from_leaves`: every
-        // reserved leaf plus every Available one, and nothing non-Available and
-        // unreserved (never verified).
+        // per-leaf `data` blob (up to five transactions). Every stored leaf
+        // passed the ownership check on its way in, whatever its status, so all
+        // of them are projected: see `verified_leaf_keys_from_leaves`.
         let rows: Vec<(String, Option<String>, Option<String>)> = conn
             .exec(
                 r"SELECT l.id,
@@ -533,8 +532,7 @@ impl TreeStore for MysqlTreeStore {
                   FROM brz_tree_leaves l
                   LEFT JOIN brz_tree_reservations r
                     ON l.reservation_id = r.id AND l.user_id = r.user_id
-                  WHERE l.user_id = ?
-                    AND (r.purpose IS NOT NULL OR l.status = 'Available')",
+                  WHERE l.user_id = ?",
                 (self.identity.clone(),),
             )
             .await

--- a/crates/spark-postgres/src/tree_store.rs
+++ b/crates/spark-postgres/src/tree_store.rs
@@ -424,10 +424,9 @@ impl TreeStore for PostgresTreeStore {
         let client = self.pool.get().await.map_err(map_err)?;
 
         // Project just the two pubkeys straight out of the JSON, skipping the
-        // per-leaf `data` blob (up to five transactions). The filter mirrors the
-        // verified categories in `verified_leaf_keys_from_leaves`: every
-        // reserved leaf plus every Available one, and nothing non-Available and
-        // unreserved (never verified).
+        // per-leaf `data` blob (up to five transactions). Every stored leaf
+        // passed the ownership check on its way in, whatever its status, so all
+        // of them are projected: see `verified_leaf_keys_from_leaves`.
         let rows = client
             .query(
                 r"
@@ -438,7 +437,6 @@ impl TreeStore for PostgresTreeStore {
                 LEFT JOIN brz_tree_reservations r
                   ON l.reservation_id = r.id AND l.user_id = r.user_id
                 WHERE l.user_id = $1
-                  AND (r.purpose IS NOT NULL OR l.status = 'Available')
                 ",
                 &[&self.identity],
             )

--- a/crates/spark-sqlite/src/lib.rs
+++ b/crates/spark-sqlite/src/lib.rs
@@ -827,20 +827,17 @@ impl TreeStore for SqliteTreeStore {
         &self,
     ) -> Result<HashMap<TreeNodeId, VerifiedLeafKeys>, TreeServiceError> {
         let conn = self.get_connection()?;
-        let available = status_json(TreeNodeStatus::Available)?;
-        // Project the two pubkey columns, skipping each leaf's `data` blob. Covers
-        // the same categories as `verified_leaf_keys_from_leaves`: every reserved
-        // leaf plus every Available one, never a non-Available unreserved leaf.
+        // Project the two pubkey columns, skipping each leaf's `data` blob. Every
+        // stored leaf passed the ownership check on its way in, whatever its
+        // status, so all of them are projected.
         let mut stmt = conn
             .prepare(
                 "SELECT l.id, l.verifying_public_key, l.signing_public_key
-                 FROM brz_tree_leaves l
-                 LEFT JOIN brz_tree_reservations r ON l.reservation_id = r.id
-                 WHERE r.purpose IS NOT NULL OR l.status = ?1",
+                 FROM brz_tree_leaves l",
             )
             .map_err(|e| generic("prepare verified leaf keys", e))?;
         let rows = stmt
-            .query_map(params![available], |row| {
+            .query_map([], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,

--- a/crates/spark-wallet/src/lib.rs
+++ b/crates/spark-wallet/src/lib.rs
@@ -20,12 +20,12 @@ pub use spark::{
         CoopExitFeeQuote, CoopExitSpeedFeeQuote, CpfpChild, CpfpInput, ExitSpeed, Fee,
         FreezeIssuerTokenResponse, InvoiceDescription, LightningReceivePayment,
         LightningSendPayment, LightningSendStatus, Preimage, PreimageRequestStatus,
-        ReceiverTokenOutput, ServiceError, SingleUseDepositAddress, StaticDepositAddress,
-        TokenInputs, TokenMintInput, TokenOutputToSpend, TokenTransaction, TokenTransactionStatus,
-        TokenTransferInput, TransferId, TransferObserver, TransferObserverError, TransferStatus,
-        TransferTokenOutput, TransferType, UnilateralExitPlan, UnilateralExitSelectedLeaf, Utxo,
-        build_cpfp_child, compute_sweep_fee, csv_timelock, p2tr_key_path_input_weight,
-        p2wpkh_input_weight, walk_unilateral_exit_chain,
+        ReceiverTokenOutput, ServiceError, SettledExitSteps, SingleUseDepositAddress,
+        StaticDepositAddress, TokenInputs, TokenMintInput, TokenOutputToSpend, TokenTransaction,
+        TokenTransactionStatus, TokenTransferInput, TransferId, TransferObserver,
+        TransferObserverError, TransferStatus, TransferTokenOutput, TransferType,
+        UnilateralExitPlan, UnilateralExitSelectedLeaf, Utxo, build_cpfp_child, compute_sweep_fee,
+        csv_timelock, p2tr_key_path_input_weight, p2wpkh_input_weight, walk_unilateral_exit_chain,
     },
     session_store::*,
     signer::{
@@ -67,7 +67,7 @@ pub use spark::{
     },
 };
 pub use unilateral_exit::*;
-pub use wallet::{SendPackagePreparation, SparkWallet};
+pub use wallet::{ExitContext, SendPackagePreparation, SparkWallet};
 pub use wallet_builder::WalletBuilder;
 
 #[cfg(feature = "test-utils")]

--- a/crates/spark-wallet/src/unilateral_exit.rs
+++ b/crates/spark-wallet/src/unilateral_exit.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, HashSet};
 use bitcoin::{Address, Amount, OutPoint, ScriptBuf, Transaction, TxOut, Txid};
 use spark::{
     services::{
-        CpfpInput, ServiceError, UnilateralExitPlan, build_cpfp_child, csv_timelock,
-        walk_unilateral_exit_chain,
+        CpfpInput, ServiceError, UnilateralExitPlan, UnilateralExitSelectedLeaf, build_cpfp_child,
+        csv_timelock, walk_unilateral_exit_chain,
     },
     tree::{LeafPedigree, TreeNode, TreeNodeId, TreeNodeStatus},
     utils::transactions::is_ephemeral_anchor_output,
@@ -1252,6 +1252,24 @@ fn refund_output_value(
 type BranchFunding = Vec<(TreeNodeId, Vec<CpfpInput>)>;
 
 /// Resolves the fan-out step and the per-branch funding it feeds. A confirmed
+/// The part of a leaf's CPFP bill that is still to be paid. A node or refund the
+/// walk resolved is confirmed on-chain, or is driven by a transaction that pays
+/// its own fee, so neither takes a child. Anything the walk did not resolve is
+/// absent from `resolved` and stays charged.
+fn remaining_cpfp_cost(leaf: &UnilateralExitSelectedLeaf, resolved: &ResolvedExitState) -> u64 {
+    let nodes: u64 = leaf
+        .cpfp_node_costs
+        .iter()
+        .filter(|(node_id, _)| !resolved.nodes.contains_key(node_id))
+        .map(|(_, fee)| *fee)
+        .sum();
+    if resolved.refunds.contains_key(&leaf.id) {
+        nodes
+    } else {
+        nodes.saturating_add(leaf.cpfp_refund_cost)
+    }
+}
+
 /// fan-out replaces each branch's first input with its real output; a fresh one
 /// is returned unsigned to broadcast first; no fan-out assigns funding directly.
 fn resolve_fan_out_funding(
@@ -1294,12 +1312,14 @@ fn resolve_fan_out_funding(
         };
         // Dust from the branch's own funding script, not the plan's change_dust_limit.
         let dust = first.witness_utxo.script_pubkey.minimal_non_dust().to_sat();
-        // Gate on the physical CPFP floor (cpfp_cost), not the quote's estimated_cost:
-        // the sweep is paid from the swept value, not this output, so its sweep-fee
-        // headroom must not reject a higher-rate resume the CPFP fees can afford.
-        let required = leaf_by_id
-            .get(leaf_id)
-            .map_or(dust, |leaf| leaf.cpfp_cost.saturating_add(dust));
+        // Gate on the physical CPFP floor, not the quote's estimated_cost: the sweep
+        // is paid from the swept value, not this output, so its sweep-fee headroom
+        // must not reject a higher-rate resume the CPFP fees can afford. Only the
+        // steps still to be driven count: a step the walk found settled needs no
+        // child, and one it could not read is absent here and so still charged.
+        let required = leaf_by_id.get(leaf_id).map_or(dust, |leaf| {
+            remaining_cpfp_cost(leaf, resolved).saturating_add(dust)
+        });
         if adopted.value < required {
             return Err(SparkWalletError::ServiceError(
                 ServiceError::InsufficientCpfpBudget {
@@ -1438,6 +1458,8 @@ mod exit_build_tests {
                 value: 100_000,
                 estimated_cost: 2_000,
                 cpfp_cost: 2_000,
+                cpfp_node_costs: Vec::new(),
+                cpfp_refund_cost: 2_000,
             }],
             fan_out_psbt: None,
             per_branch_funding: vec![(leaf.id.clone(), vec![funding(100_000)])],
@@ -1473,6 +1495,57 @@ mod exit_build_tests {
         assert_eq!(build.cpfp_change_inputs.len(), 1);
     }
 
+    /// A leaf whose refund is already on-chain takes no refund child, so the
+    /// funding floor must not still charge for one. The watchtower drives its own
+    /// copy of a refund once the timelock matures, so this is the ordinary way a
+    /// resumed exit finds its refunds settled, not an edge case.
+    #[test]
+    fn a_settled_refund_is_not_charged_for_a_child_it_never_needs() {
+        let leaf = UnilateralExitSelectedLeaf {
+            id: id("leaf"),
+            value: 200_000,
+            estimated_cost: 6_000,
+            cpfp_cost: 5_339,
+            cpfp_node_costs: vec![(id("node"), 3_339)],
+            cpfp_refund_cost: 2_000,
+        };
+
+        let fresh = ResolvedExitState::default();
+        assert_eq!(remaining_cpfp_cost(&leaf, &fresh), 5_339);
+
+        let refund_settled = ResolvedExitState {
+            refunds: [(id("leaf"), RefundState::Swept)].into_iter().collect(),
+            ..Default::default()
+        };
+        assert_eq!(remaining_cpfp_cost(&leaf, &refund_settled), 3_339);
+
+        let all_settled = ResolvedExitState {
+            refunds: [(id("leaf"), RefundState::Swept)].into_iter().collect(),
+            nodes: [(id("node"), NodeState::ConfirmedDirect)]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        assert_eq!(remaining_cpfp_cost(&leaf, &all_settled), 0);
+    }
+
+    /// A step the walk could not read is absent from `resolved`, so it stays
+    /// charged: an unreadable chain must not lower the floor.
+    #[test]
+    fn a_step_the_walk_could_not_read_stays_charged() {
+        let leaf = UnilateralExitSelectedLeaf {
+            id: id("leaf"),
+            value: 200_000,
+            estimated_cost: 6_000,
+            cpfp_cost: 5_339,
+            cpfp_node_costs: vec![(id("node"), 3_339)],
+            cpfp_refund_cost: 2_000,
+        };
+        assert_eq!(
+            remaining_cpfp_cost(&leaf, &ResolvedExitState::default()),
+            leaf.cpfp_cost
+        );
+    }
     #[test]
     fn build_adopts_confirmed_refund() {
         let adopted_outpoint = OutPoint {
@@ -1643,6 +1716,8 @@ mod exit_build_tests {
                 value: 100_000,
                 estimated_cost: 2_000,
                 cpfp_cost: 2_000,
+                cpfp_node_costs: Vec::new(),
+                cpfp_refund_cost: 2_000,
             }],
             fan_out_psbt: Some(fan_out_psbt),
             per_branch_funding: vec![(leaf.id.clone(), vec![branch_output.clone()])],
@@ -1846,12 +1921,16 @@ mod exit_build_tests {
                     value: 100_000,
                     estimated_cost: 2_000,
                     cpfp_cost: 2_000,
+                    cpfp_node_costs: Vec::new(),
+                    cpfp_refund_cost: 2_000,
                 },
                 UnilateralExitSelectedLeaf {
                     id: leaf_b.id.clone(),
                     value: 100_000,
                     estimated_cost: 2_000,
                     cpfp_cost: 2_000,
+                    cpfp_node_costs: Vec::new(),
+                    cpfp_refund_cost: 2_000,
                 },
             ],
             fan_out_psbt: None,
@@ -1931,12 +2010,16 @@ mod exit_build_tests {
                     value: 100_000,
                     estimated_cost: 2_000,
                     cpfp_cost: 2_000,
+                    cpfp_node_costs: Vec::new(),
+                    cpfp_refund_cost: 2_000,
                 },
                 UnilateralExitSelectedLeaf {
                     id: leaf_b.id.clone(),
                     value: 100_000,
                     estimated_cost: 2_000,
                     cpfp_cost: 2_000,
+                    cpfp_node_costs: Vec::new(),
+                    cpfp_refund_cost: 2_000,
                 },
             ],
             fan_out_psbt: Some(fan_out_psbt),

--- a/crates/spark-wallet/src/unilateral_exit.rs
+++ b/crates/spark-wallet/src/unilateral_exit.rs
@@ -98,8 +98,10 @@ pub(crate) enum RefundState {
     /// Leaf went out via `direct_tx`; drive the self-fee `direct_refund_tx` as-is
     /// (pays its own fee, no CPFP child).
     DriveDirect,
-    /// Refund confirmed and already swept: nothing to drive or sweep.
-    Swept,
+    /// Refund confirmed and already swept: nothing left to drive, but both it and
+    /// the sweep that spent it are still reported so the caller can see the exit
+    /// finished rather than infer it from their absence.
+    Swept(SweptRefund),
 }
 
 /// An already-confirmed fan-out adopted in place of building a fresh one.
@@ -122,6 +124,14 @@ pub(crate) struct ConfirmedRefund {
     pub tx: Transaction,
     pub outpoint: bitcoin::OutPoint,
     pub value: u64,
+}
+
+/// A refund whose output a confirmed transaction already spent, with that
+/// spender: the sweep this exit was driving towards.
+#[derive(Clone, Debug)]
+pub(crate) struct SweptRefund {
+    pub refund: ConfirmedRefund,
+    pub sweep: Transaction,
 }
 
 /// One unilateral-exit transaction and, when it still needs fee-bumping, the
@@ -187,6 +197,9 @@ pub struct UnilateralExitBuild {
     /// CPFP-package fees of the txs built plus a fresh fan-out's fee; excludes the
     /// sweep fee (the caller adds that).
     pub total_fee_sat: u64,
+    /// Sweeps already on-chain, which is what an exit with nothing left to sweep
+    /// has to report so its caller can tell finished from not yet started.
+    pub confirmed_sweeps: Vec<Transaction>,
 }
 
 /// A refund output sitting on-chain after a unilateral exit.
@@ -938,21 +951,17 @@ fn interpret_refund(
         pending.push(outspend_query);
         return;
     };
-    match spend {
-        // Spent by a confirmed tx: the sweep landed, nothing to drive or sweep.
-        ChainResult::Spend(Some(info)) if info.confirmed => {
-            trace!(%leaf_id, txid = %txo.txid, "interpret_chain: refund swept");
-            refunds.insert(leaf_id.clone(), RefundState::Swept);
-            return;
-        }
+    let swept_by = match spend {
+        // Spent by a confirmed tx: the sweep landed.
+        ChainResult::Spend(Some(info)) if info.confirmed => Some(info.spender_txid),
         ChainResult::Unavailable => {
             unverified.insert(leaf_id.clone());
             return;
         }
         // Unspent, or spent only by an unconfirmed sweep: adopt so the sweep is
         // (re)built.
-        _ => {}
-    }
+        _ => None,
+    };
 
     let tx_query = ChainQuery::Transaction(txo.txid);
     let Some(result) = observed.get(&tx_query) else {
@@ -967,14 +976,36 @@ fn interpret_refund(
         }
         _ => return,
     };
-    trace!(%leaf_id, txid = %txo.txid, value = txo.value, "interpret_chain: adopting on-chain refund");
+    let refund = ConfirmedRefund {
+        tx,
+        outpoint: refund_outpoint,
+        value: txo.value,
+    };
+
+    let Some(sweep_txid) = swept_by else {
+        trace!(%leaf_id, txid = %txo.txid, value = txo.value, "interpret_chain: adopting on-chain refund");
+        refunds.insert(leaf_id.clone(), RefundState::Adopted(refund));
+        return;
+    };
+
+    // The sweep's own body, so it can be reported like any other confirmed step.
+    let sweep_query = ChainQuery::Transaction(sweep_txid);
+    let Some(result) = observed.get(&sweep_query) else {
+        pending.push(sweep_query);
+        return;
+    };
+    let sweep = match result {
+        ChainResult::Transaction(tx) => tx.clone(),
+        ChainResult::Unavailable => {
+            unverified.insert(leaf_id.clone());
+            return;
+        }
+        _ => return,
+    };
+    trace!(%leaf_id, txid = %txo.txid, sweep = %sweep_txid, "interpret_chain: refund swept");
     refunds.insert(
         leaf_id.clone(),
-        RefundState::Adopted(ConfirmedRefund {
-            tx,
-            outpoint: refund_outpoint,
-            value: txo.value,
-        }),
+        RefundState::Swept(SweptRefund { refund, sweep }),
     );
 }
 
@@ -1032,6 +1063,8 @@ pub(crate) fn build_exit(
     let mut emitted: HashSet<Txid> = HashSet::new();
     let mut branches = Vec::with_capacity(per_branch_funding.len());
     let mut refund_outputs: Vec<RefundOutput> = Vec::new();
+    // Sweeps that already landed, keyed by txid: several leaves share one.
+    let mut swept_sweeps: HashMap<Txid, Transaction> = HashMap::new();
     let mut cpfp_change_inputs: Vec<CpfpChangeInput> = Vec::new();
     let mut cpfp_fee_sat: u64 = 0;
 
@@ -1208,7 +1241,19 @@ pub(crate) fn build_exit(
                     status: ExitTxStatus::Unconfirmed,
                 });
             }
-            Some(RefundState::Swept) => {}
+            Some(RefundState::Swept(swept)) => {
+                swept_sweeps.insert(swept.sweep.compute_txid(), swept.sweep.clone());
+                txs.push(ExitTx {
+                    kind: ExitTxKind::Refund,
+                    node_id: Some(leaf_id.clone()),
+                    txid: swept.refund.outpoint.txid,
+                    csv_timelock_blocks: csv_timelock(&swept.refund.tx),
+                    base_tx: swept.refund.tx.clone(),
+                    to_sign: None,
+                    depends_on: vec![],
+                    status: ExitTxStatus::Confirmed,
+                });
+            }
             // Drive the cpfp refund with a fresh child; skipped on a stopped branch.
             None if !stopped => {
                 let refund_tx = leaf.refund_tx.clone().ok_or_else(|| {
@@ -1272,6 +1317,7 @@ pub(crate) fn build_exit(
         "build_unilateral_exit: assembled"
     );
     Ok(UnilateralExitBuild {
+        confirmed_sweeps: swept_sweeps.into_values().collect(),
         fan_out,
         branches,
         refund_outputs,
@@ -1541,6 +1587,20 @@ mod exit_build_tests {
         }
     }
 
+    fn swept_state() -> RefundState {
+        RefundState::Swept(SweptRefund {
+            refund: ConfirmedRefund {
+                tx: anchor_tx(9),
+                outpoint: OutPoint {
+                    txid: anchor_tx(9).compute_txid(),
+                    vout: 0,
+                },
+                value: 10_000,
+            },
+            sweep: anchor_tx(10),
+        })
+    }
+
     fn id(s: &str) -> TreeNodeId {
         TreeNodeId::from_str(s).unwrap()
     }
@@ -1588,13 +1648,13 @@ mod exit_build_tests {
         assert_eq!(remaining_cpfp_cost(&leaf, &fresh), 5_339);
 
         let refund_settled = ResolvedExitState {
-            refunds: [(id("leaf"), RefundState::Swept)].into_iter().collect(),
+            refunds: [(id("leaf"), swept_state())].into_iter().collect(),
             ..Default::default()
         };
         assert_eq!(remaining_cpfp_cost(&leaf, &refund_settled), 3_339);
 
         let all_settled = ResolvedExitState {
-            refunds: [(id("leaf"), RefundState::Swept)].into_iter().collect(),
+            refunds: [(id("leaf"), swept_state())].into_iter().collect(),
             nodes: [(id("node"), NodeState::ConfirmedDirect)]
                 .into_iter()
                 .collect(),
@@ -1957,7 +2017,7 @@ mod exit_build_tests {
     }
 
     #[test]
-    fn build_omits_swept_leaf_refund() {
+    fn build_reports_a_swept_leaf_as_confirmed() {
         let resolved = ResolvedExitState {
             nodes: [
                 (id("root"), NodeState::ConfirmedCpfp { change: None }),
@@ -1965,7 +2025,7 @@ mod exit_build_tests {
             ]
             .into_iter()
             .collect(),
-            refunds: [(id("leaf"), RefundState::Swept)].into_iter().collect(),
+            refunds: [(id("leaf"), swept_state())].into_iter().collect(),
             ..Default::default()
         };
         let build = build_exit(&single_leaf_plan(), &resolved, FEE_RATE).unwrap();
@@ -1973,12 +2033,20 @@ mod exit_build_tests {
             build.refund_outputs.is_empty(),
             "a swept leaf yields no refund output to sweep"
         );
-        assert!(
-            !build.branches[0]
-                .txs
-                .iter()
-                .any(|t| t.kind == ExitTxKind::Refund),
-            "a swept leaf emits no refund tx"
+        let refund = build.branches[0]
+            .txs
+            .iter()
+            .find(|t| t.kind == ExitTxKind::Refund)
+            .expect("a swept leaf still reports its refund");
+        assert_eq!(
+            refund.status,
+            ExitTxStatus::Confirmed,
+            "a swept refund is reported confirmed, not omitted"
+        );
+        assert_eq!(
+            build.confirmed_sweeps.len(),
+            1,
+            "the sweep that spent it is carried out of the build"
         );
         assert!(build.cpfp_change_inputs.is_empty());
     }
@@ -2160,6 +2228,7 @@ mod exit_build_tests {
             },
         };
         let mut build = UnilateralExitBuild {
+            confirmed_sweeps: vec![],
             fan_out: None,
             branches: vec![ExitBranch {
                 leaf_id: id("leaf"),
@@ -2983,11 +3052,22 @@ mod interpret_tests {
             vout: 0,
         };
         // The refund is confirmed and spent by a confirmed sweep: fully done.
+        let sweep_tx = tx_spending(refund_outpoint, 7);
+        let sweep_txid = sweep_tx.compute_txid();
+        let refund_tx = tx_spending(leaf_parent_out, 5);
         let observed = vec![
             spent(deposit, root_txid),
             spent(leaf_parent_out, leaf_cpfp_txid),
             refund_scan(&leaf_id, refund_txid, 42_000),
-            spent(refund_outpoint, Txid::from_byte_array([7u8; 32])),
+            spent(refund_outpoint, sweep_txid),
+            Observation {
+                query: ChainQuery::Transaction(refund_txid),
+                result: ChainResult::Transaction(refund_tx),
+            },
+            Observation {
+                query: ChainQuery::Transaction(sweep_txid),
+                result: ChainResult::Transaction(sweep_tx),
+            },
         ];
         let interp = interpret_chain(&prepared, &observed).unwrap();
 
@@ -2995,7 +3075,7 @@ mod interpret_tests {
         assert!(
             matches!(
                 interp.resolved.refunds.get(&leaf_id),
-                Some(RefundState::Swept)
+                Some(RefundState::Swept(_))
             ),
             "a refund spent by a confirmed sweep is swept"
         );

--- a/crates/spark-wallet/src/unilateral_exit.rs
+++ b/crates/spark-wallet/src/unilateral_exit.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, HashSet};
 use bitcoin::{Address, Amount, OutPoint, ScriptBuf, Transaction, TxOut, Txid};
 use spark::{
     services::{
-        CpfpInput, ServiceError, UnilateralExitPlan, UnilateralExitSelectedLeaf, build_cpfp_child,
-        csv_timelock, walk_unilateral_exit_chain,
+        CpfpInput, ServiceError, SettledExitSteps, UnilateralExitPlan, UnilateralExitSelectedLeaf,
+        build_cpfp_child, csv_timelock, walk_unilateral_exit_chain,
     },
     tree::{LeafPedigree, TreeNode, TreeNodeId, TreeNodeStatus},
     utils::transactions::is_ephemeral_anchor_output,
@@ -274,6 +274,80 @@ pub fn next_chain_queries(
         "next_chain_queries"
     );
     Ok(pending)
+}
+
+/// What the chain shows an exit has already done, answered without reference to
+/// any funding. Drive it like the full walk: perform `pending`, feed the results
+/// back, and repeat until nothing is pending.
+///
+/// This exists so funding can be planned against the work that is actually left.
+/// The full walk cannot answer it, because it reads a plan the funding is part of.
+pub struct SettlementScan {
+    pub settled: SettledExitSteps,
+    pub pending: Vec<ChainQuery>,
+}
+
+/// A step is reported settled only when the chain said so. One the lookups could
+/// not resolve is left out, so an unreadable chain can only overstate the work
+/// remaining, never understate it.
+pub fn scan_settlement(
+    tree_nodes: &HashMap<TreeNodeId, TreeNode>,
+    leaf_ids: &[TreeNodeId],
+    refund_addresses: &HashMap<TreeNodeId, Address>,
+    observed: &[Observation],
+) -> SettlementScan {
+    let index = ObservedIndex::new(observed);
+    let observed = &index;
+
+    let mut pending: Vec<ChainQuery> = Vec::new();
+    let mut nodes: HashMap<TreeNodeId, NodeState> = HashMap::new();
+    let mut refunds: HashMap<TreeNodeId, RefundState> = HashMap::new();
+    let mut stopped: HashSet<TreeNodeId> = HashSet::new();
+    let mut needs_change: HashSet<TreeNodeId> = HashSet::new();
+    let mut unverified: HashSet<TreeNodeId> = HashSet::new();
+    let mut unverifiable_confirmed: HashSet<TreeNodeId> = HashSet::new();
+
+    for leaf_id in leaf_ids {
+        walk_branch(
+            tree_nodes,
+            leaf_id,
+            observed,
+            &mut nodes,
+            &mut refunds,
+            &mut stopped,
+            &mut needs_change,
+            &mut unverified,
+            &mut unverifiable_confirmed,
+            &mut pending,
+        );
+    }
+    for (leaf_id, address) in refund_addresses {
+        interpret_refund(
+            leaf_id,
+            address,
+            observed,
+            &mut refunds,
+            &mut unverified,
+            &mut pending,
+        );
+    }
+
+    let mut seen: HashSet<ChainQuery> = HashSet::new();
+    pending.retain(|query| seen.insert(query.clone()));
+
+    SettlementScan {
+        settled: SettledExitSteps {
+            nodes: nodes
+                .into_keys()
+                .filter(|id| !unverified.contains(id) && !unverifiable_confirmed.contains(id))
+                .collect(),
+            refunds: refunds
+                .into_keys()
+                .filter(|id| !unverified.contains(id))
+                .collect(),
+        },
+        pending,
+    }
 }
 
 /// The outcome of interpreting the observations: resolved state plus the lookups
@@ -2217,6 +2291,7 @@ mod exit_build_tests {
                 vec![a, b],
                 FEE_RATE,
                 dest_len,
+                None,
             )
         };
         let one = |total: u64| {
@@ -2229,6 +2304,7 @@ mod exit_build_tests {
                 vec![only],
                 FEE_RATE,
                 dest_len,
+                None,
             )
         };
 
@@ -2313,6 +2389,7 @@ mod exit_build_tests {
             inputs,
             FEE_RATE,
             change_len,
+            None,
         )
         .unwrap();
         assert!(
@@ -2363,6 +2440,7 @@ mod exit_build_tests {
             two(50_000),
             FEE_RATE,
             change_len,
+            None,
         )
         .unwrap();
         assert!(
@@ -2510,6 +2588,67 @@ mod interpret_tests {
                 confirmed: false,
             })),
         }
+    }
+
+    /// The scan answers what is already done without being handed any funding.
+    /// That is the whole point of it: funding can then be planned against the
+    /// work that is left, instead of against a fresh exit's price.
+    #[test]
+    fn scan_settlement_needs_no_funding_to_report_a_settled_refund() {
+        let deposit = OutPoint {
+            txid: Txid::from_byte_array([7u8; 32]),
+            vout: 0,
+        };
+        let root = treenode("root", None, tx_spending(deposit, 1), 0);
+        let leaf = treenode(
+            "leaf",
+            Some("root"),
+            tx_spending(
+                OutPoint {
+                    txid: root.node_tx.compute_txid(),
+                    vout: 0,
+                },
+                2,
+            ),
+            0,
+        );
+        let leaf_id = leaf.id.clone();
+        let leaf_out = OutPoint {
+            txid: leaf.node_tx.compute_txid(),
+            vout: 0,
+        };
+        let tree = to_node_map(vec![root, leaf]);
+        let addresses: HashMap<TreeNodeId, Address> =
+            [(leaf_id.clone(), leaf_addr())].into_iter().collect();
+
+        // A refund on-chain, unspent: the three lookups the walk needs to adopt it.
+        let refund_tx = tx_spending(leaf_out, 3);
+        let refund_txid = refund_tx.compute_txid();
+        let observed = vec![
+            refund_scan(&leaf_id, refund_txid, 55_000),
+            unspent(OutPoint {
+                txid: refund_txid,
+                vout: 0,
+            }),
+            Observation {
+                query: ChainQuery::Transaction(refund_txid),
+                result: ChainResult::Transaction(refund_tx),
+            },
+        ];
+
+        let scan = scan_settlement(&tree, std::slice::from_ref(&leaf_id), &addresses, &observed);
+        assert!(
+            scan.settled.refunds.contains(&leaf_id),
+            "a refund already on-chain is settled: {:?}",
+            scan.settled.refunds
+        );
+
+        // With nothing observed it settles nothing and asks the chain instead, so
+        // an unreadable chain can only overstate the work left, never understate it.
+        let blind = scan_settlement(&tree, std::slice::from_ref(&leaf_id), &addresses, &[]);
+        assert!(blind.settled.refunds.is_empty());
+        assert!(blind.settled.nodes.is_empty());
+        assert!(!blind.pending.is_empty());
     }
 
     #[test]

--- a/crates/spark-wallet/src/unilateral_exit.rs
+++ b/crates/spark-wallet/src/unilateral_exit.rs
@@ -703,6 +703,10 @@ fn interpret_fan_out(
     else {
         return Ok((None, true));
     };
+    // Every branch, in plan order. A fan-out carries one output per branch for
+    // the life of an exit, settled or not, so this order is what identifies them:
+    // its outputs all pay the same script and position is the only thing telling
+    // them apart.
     let branch_leaf_ids: Vec<TreeNodeId> = plan
         .per_branch_funding
         .iter()
@@ -2627,6 +2631,21 @@ mod interpret_tests {
         }
     }
 
+    /// One branch's slot in a fan-out: the input it would be funded from.
+    fn fan_out_branch_input(vout: u32) -> CpfpInput {
+        CpfpInput {
+            outpoint: OutPoint {
+                txid: Txid::from_byte_array([9u8; 32]),
+                vout,
+            },
+            witness_utxo: TxOut {
+                value: Amount::from_sat(5_000),
+                script_pubkey: leaf_addr().script_pubkey(),
+            },
+            signed_input_weight: 272,
+        }
+    }
+
     fn refund_scan(leaf_id: &TreeNodeId, refund_txid: Txid, value: u64) -> Observation {
         Observation {
             query: ChainQuery::RefundAddress {
@@ -2802,6 +2821,139 @@ mod interpret_tests {
     }
 
     #[test]
+    fn adopting_a_wider_fan_out_keeps_each_branch_its_own_output() {
+        // The fan-out went out when all three branches were driving, so it has an
+        // output each. One has since settled. The two still driving must keep the
+        // outputs they were given, not slide onto the settled one's.
+        let funding_outpoint = OutPoint {
+            txid: Txid::from_byte_array([9u8; 32]),
+            vout: 0,
+        };
+        let funding_script = leaf_addr().script_pubkey();
+        let out = |value| TxOut {
+            value: Amount::from_sat(value),
+            script_pubkey: funding_script.clone(),
+        };
+        let fan_out_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: funding_outpoint,
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                ..Default::default()
+            }],
+            // Distinct values, so a branch landing on the wrong one is visible.
+            output: vec![out(5_000), out(6_000), out(7_000)],
+        };
+        let fan_out_txid = fan_out_tx.compute_txid();
+        let mut fan_out_psbt = bitcoin::Psbt::from_unsigned_tx(fan_out_tx.clone()).unwrap();
+        fan_out_psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(20_000),
+            script_pubkey: funding_script,
+        });
+
+        let prepared = PreparedUnilateralExit {
+            plan: UnilateralExitPlan {
+                selected_leaves: vec![],
+                fan_out_psbt: Some(fan_out_psbt),
+                // Branch order is the order the fan-out paid them in. The middle
+                // one is finished, so it holds no funding.
+                per_branch_funding: vec![
+                    (id("first"), vec![fan_out_branch_input(0)]),
+                    (id("settled"), vec![]),
+                    (id("last"), vec![fan_out_branch_input(2)]),
+                ],
+                tree_nodes: to_node_map(vec![]),
+            },
+            leaf_refund_addresses: HashMap::new(),
+        };
+
+        let observed = vec![
+            spent(funding_outpoint, fan_out_txid),
+            Observation {
+                query: ChainQuery::Transaction(fan_out_txid),
+                result: ChainResult::Transaction(fan_out_tx),
+            },
+        ];
+        let interp = interpret_chain(&prepared, &observed).expect("the fan-out is ours");
+        let adopted = interp.resolved.fan_out.expect("adopted");
+
+        assert_eq!(
+            adopted.branch_outputs.get(&id("first")).map(|o| o.value),
+            Some(5_000),
+            "the first branch keeps the output it was paid"
+        );
+        assert_eq!(
+            adopted.branch_outputs.get(&id("last")).map(|o| o.value),
+            Some(7_000),
+            "the last branch keeps its own output, not the settled branch's"
+        );
+    }
+
+    #[test]
+    fn a_settled_branch_still_holds_its_place_in_the_fan_out() {
+        // The fan-out keeps an output for a branch that has finished, so the
+        // branches still driving stay where they were. That output is never spent;
+        // it is there to hold the order the outputs are read back in.
+        let funding_outpoint = OutPoint {
+            txid: Txid::from_byte_array([9u8; 32]),
+            vout: 0,
+        };
+        let funding_script = leaf_addr().script_pubkey();
+        let out = |value| TxOut {
+            value: Amount::from_sat(value),
+            script_pubkey: funding_script.clone(),
+        };
+        let fan_out_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: funding_outpoint,
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                ..Default::default()
+            }],
+            output: vec![out(5_000), out(330), out(7_000)],
+        };
+        let fan_out_txid = fan_out_tx.compute_txid();
+        let mut fan_out_psbt = bitcoin::Psbt::from_unsigned_tx(fan_out_tx.clone()).unwrap();
+        fan_out_psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(20_000),
+            script_pubkey: funding_script,
+        });
+
+        let prepared = PreparedUnilateralExit {
+            plan: UnilateralExitPlan {
+                selected_leaves: vec![],
+                fan_out_psbt: Some(fan_out_psbt),
+                per_branch_funding: vec![
+                    (id("first"), vec![fan_out_branch_input(0)]),
+                    (id("settled"), vec![]),
+                    (id("last"), vec![fan_out_branch_input(2)]),
+                ],
+                tree_nodes: to_node_map(vec![]),
+            },
+            leaf_refund_addresses: HashMap::new(),
+        };
+
+        let observed = vec![
+            spent(funding_outpoint, fan_out_txid),
+            Observation {
+                query: ChainQuery::Transaction(fan_out_txid),
+                result: ChainResult::Transaction(fan_out_tx),
+            },
+        ];
+        let interp = interpret_chain(&prepared, &observed).expect("the fan-out is ours");
+        let adopted = interp.resolved.fan_out.expect("adopted");
+
+        assert_eq!(adopted.branch_outputs.len(), 3, "one output per branch");
+        assert_eq!(
+            adopted.branch_outputs.get(&id("last")).map(|o| o.value),
+            Some(7_000),
+            "the settled branch holding its place is what keeps this one in place"
+        );
+    }
+
+    #[test]
     fn interpret_flags_funding_conflict() {
         let funding_outpoint = OutPoint {
             txid: Txid::from_byte_array([9u8; 32]),
@@ -2838,7 +2990,12 @@ mod interpret_tests {
             plan: UnilateralExitPlan {
                 selected_leaves: vec![],
                 fan_out_psbt: Some(fan_out_psbt),
-                per_branch_funding: vec![(id("a"), vec![]), (id("b"), vec![])],
+                // A fan-out only exists because its branches are funded, so both
+                // carry an input: an empty branch claims no fan-out output.
+                per_branch_funding: vec![
+                    (id("a"), vec![fan_out_branch_input(0)]),
+                    (id("b"), vec![fan_out_branch_input(1)]),
+                ],
                 tree_nodes: to_node_map(vec![]),
             },
             leaf_refund_addresses: HashMap::new(),

--- a/crates/spark-wallet/src/unilateral_exit.rs
+++ b/crates/spark-wallet/src/unilateral_exit.rs
@@ -665,11 +665,29 @@ fn resolve_confirmed_changes(
             .find(|(_, o)| &o.script_pubkey == script)
             && let Ok(vout) = u32::try_from(vout)
         {
+            let outpoint = OutPoint {
+                txid: child_txid,
+                vout,
+            };
+            // Every branch's change pays the one funding script, and funding is
+            // handed out by cost rather than by which branch produced it, so this
+            // change may already have paid for another branch. Left in, the next
+            // child is built over an output that is gone and cannot be broadcast.
+            let spend_query = ChainQuery::Outspend(outpoint);
+            let Some(spend) = observed.get(&spend_query) else {
+                pending.push(spend_query);
+                continue;
+            };
+            match spend {
+                ChainResult::Spend(Some(info)) if info.confirmed => continue,
+                ChainResult::Unavailable => {
+                    unverifiable_confirmed.insert(node_id.clone());
+                    continue;
+                }
+                _ => {}
+            }
             *change = Some(ConfirmedOutput {
-                outpoint: OutPoint {
-                    txid: child_txid,
-                    vout,
-                },
+                outpoint,
                 value: out.value.to_sat(),
             });
         }
@@ -3474,6 +3492,124 @@ mod interpret_tests {
     }
 
     #[test]
+    fn interpret_drops_a_change_another_branch_already_spent() {
+        let anchor = ScriptBuf::from(vec![0x51, 0x02, 0x4e, 0x73]);
+        let funding_script = leaf_addr().script_pubkey();
+        let deposit = OutPoint {
+            txid: Txid::from_byte_array([1u8; 32]),
+            vout: 0,
+        };
+        let root_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::from_height(1).unwrap(),
+            input: vec![TxIn {
+                previous_output: deposit,
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                ..Default::default()
+            }],
+            output: vec![
+                TxOut {
+                    value: Amount::from_sat(99_000),
+                    script_pubkey: ScriptBuf::new(),
+                },
+                TxOut {
+                    value: Amount::from_sat(0),
+                    script_pubkey: anchor,
+                },
+            ],
+        };
+        let root_txid = root_tx.compute_txid();
+        let root = treenode("root", None, root_tx, 0);
+        let leaf_parent = OutPoint {
+            txid: root_txid,
+            vout: 0,
+        };
+        let leaf = treenode("leaf", Some("root"), tx_spending(leaf_parent, 2), 0);
+        let leaf_id = leaf.id.clone();
+
+        let child_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::from_height(3).unwrap(),
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: root_txid,
+                    vout: 1,
+                },
+                ..Default::default()
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(88_000),
+                script_pubkey: funding_script.clone(),
+            }],
+        };
+        let child_txid = child_tx.compute_txid();
+
+        let funding_input = CpfpInput {
+            outpoint: OutPoint {
+                txid: Txid::from_byte_array([7u8; 32]),
+                vout: 0,
+            },
+            witness_utxo: TxOut {
+                value: Amount::from_sat(100_000),
+                script_pubkey: funding_script,
+            },
+            signed_input_weight: 272,
+        };
+        let prepared = PreparedUnilateralExit {
+            plan: UnilateralExitPlan {
+                selected_leaves: vec![],
+                fan_out_psbt: None,
+                per_branch_funding: vec![(leaf_id.clone(), vec![funding_input])],
+                tree_nodes: to_node_map(vec![root, leaf]),
+            },
+            leaf_refund_addresses: [(leaf_id.clone(), leaf_addr())].into_iter().collect(),
+        };
+
+        let observed = vec![
+            spent(deposit, root_txid),
+            Observation {
+                query: ChainQuery::Outspend(leaf_parent),
+                result: ChainResult::Spend(None),
+            },
+            spent(
+                OutPoint {
+                    txid: root_txid,
+                    vout: 1,
+                },
+                child_txid,
+            ),
+            Observation {
+                query: ChainQuery::Transaction(child_txid),
+                result: ChainResult::Transaction(child_tx),
+            },
+            // Gone: some other branch's child was funded from it.
+            spent(
+                OutPoint {
+                    txid: child_txid,
+                    vout: 0,
+                },
+                Txid::from_byte_array([8u8; 32]),
+            ),
+            Observation {
+                query: ChainQuery::Outspend(OutPoint {
+                    txid: Txid::from_byte_array([7u8; 32]),
+                    vout: 0,
+                }),
+                result: ChainResult::Spend(None),
+            },
+            no_refund(&leaf_id),
+        ];
+        let interp = interpret_chain(&prepared, &observed).unwrap();
+
+        assert_eq!(
+            interp.resolved.nodes.get(&id("root")),
+            Some(&NodeState::ConfirmedCpfp { change: None }),
+            "a change that is already spent is no funding: the branch falls back \
+             to what it was supplied rather than building over an output that is gone"
+        );
+    }
+
+    #[test]
     fn interpret_resolves_confirmed_node_change() {
         let anchor = ScriptBuf::from(vec![0x51, 0x02, 0x4e, 0x73]);
         let funding_script = leaf_addr().script_pubkey();
@@ -3563,6 +3699,14 @@ mod interpret_tests {
             Observation {
                 query: ChainQuery::Transaction(child_txid),
                 result: ChainResult::Transaction(child_tx),
+            },
+            // The change is still there, so it is the branch's to spend.
+            Observation {
+                query: ChainQuery::Outspend(OutPoint {
+                    txid: child_txid,
+                    vout: 0,
+                }),
+                result: ChainResult::Spend(None),
             },
             Observation {
                 query: ChainQuery::Outspend(OutPoint {

--- a/crates/spark-wallet/src/unilateral_exit.rs
+++ b/crates/spark-wallet/src/unilateral_exit.rs
@@ -1393,7 +1393,6 @@ fn refund_output_value(
 /// shape of [`UnilateralExitPlan::per_branch_funding`]).
 type BranchFunding = Vec<(TreeNodeId, Vec<CpfpInput>)>;
 
-/// Resolves the fan-out step and the per-branch funding it feeds. A confirmed
 /// The part of a leaf's CPFP bill that is still to be paid. A node or refund the
 /// walk resolved is confirmed on-chain, or is driven by a transaction that pays
 /// its own fee, so neither takes a child. Anything the walk did not resolve is
@@ -1412,6 +1411,7 @@ fn remaining_cpfp_cost(leaf: &UnilateralExitSelectedLeaf, resolved: &ResolvedExi
     }
 }
 
+/// Resolves the fan-out step and the per-branch funding it feeds. A confirmed
 /// fan-out replaces each branch's first input with its real output; a fresh one
 /// is returned unsigned to broadcast first; no fan-out assigns funding directly.
 fn resolve_fan_out_funding(

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1797,9 +1797,6 @@ impl SparkWallet {
         )?)
     }
 
-    /// Prepares a unilateral exit of the selected leaves: loads the exit tree,
-    /// plans it, and derives each leaf's P2TR refund address. `Auto` keeps only
-    /// profitable leaves; `Specific` exits every requested one.
     /// The leaves an exit would move and the tree behind them, with no funding
     /// considered. Held apart from planning so the chain can be asked what is
     /// already settled first, which is what lets funding be sized to the work
@@ -1833,6 +1830,9 @@ impl SparkWallet {
 
     /// `settled` is what the chain has been observed to have done already; `None`
     /// prices a fresh exit.
+    /// Plans a unilateral exit over an already-loaded context and derives each
+    /// leaf's P2TR refund address. `Auto` keeps only profitable leaves;
+    /// `Specific` exits every requested one.
     pub fn plan_unilateral_exit(
         &self,
         context: &ExitContext,

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1833,7 +1833,7 @@ impl SparkWallet {
 
     /// `settled` is what the chain has been observed to have done already; `None`
     /// prices a fresh exit.
-    pub fn plan_exit(
+    pub fn plan_unilateral_exit(
         &self,
         context: &ExitContext,
         fee_rate_sat_per_kw: u64,
@@ -1855,7 +1855,7 @@ impl SparkWallet {
             selected_leaves = plan.selected_leaves.len(),
             settled_nodes = settled.map_or(0, |s| s.nodes.len()),
             settled_refunds = settled.map_or(0, |s| s.refunds.len()),
-            "plan_exit: planned"
+            "plan_unilateral_exit: planned with settled steps"
         );
         let leaf_refund_addresses = plan
             .selected_leaves
@@ -1871,23 +1871,6 @@ impl SparkWallet {
             plan,
             leaf_refund_addresses,
         })
-    }
-
-    pub async fn prepare_unilateral_exit_plan(
-        &self,
-        fee_rate_sat_per_kw: u64,
-        selection: ExitLeafSelection,
-        inputs: Vec<CpfpInput>,
-        destination_script_len: usize,
-    ) -> Result<PreparedUnilateralExit, SparkWalletError> {
-        let context = self.load_exit_context(selection).await?;
-        self.plan_exit(
-            &context,
-            fee_rate_sat_per_kw,
-            inputs,
-            destination_script_len,
-            None,
-        )
     }
 
     /// Builds a sweep PSBT that pulls every leaf's refund output and every

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -48,9 +48,9 @@ use spark::{
         Fee, FreezeIssuerTokenResponse, HtlcService, InvoiceDescription, LightningReceivePayment,
         LightningSendPayment, LightningService, PayLightningResult, Preimage,
         PreimageRequestStatus, PreimageRequestWithTransfer, QueryHtlcFilter,
-        QueryTokenTransactionsFilter, ServiceError, StaticDepositQuote, Swap, TimelockManager,
-        TokenTransaction, Transfer, TransferId, TransferObserver, TransferService, TransferStatus,
-        TransferTokenOutput, TransferType, UnilateralExitLeafFilter, Utxo,
+        QueryTokenTransactionsFilter, ServiceError, SettledExitSteps, StaticDepositQuote, Swap,
+        TimelockManager, TokenTransaction, Transfer, TransferId, TransferObserver, TransferService,
+        TransferStatus, TransferTokenOutput, TransferType, UnilateralExitLeafFilter, Utxo,
     },
     session_store::{InMemorySessionStore, SessionStore},
     signer::{PrepareTransferRequest, PreparedTransfer, SparkSigner},
@@ -376,6 +376,15 @@ pub struct SparkWallet {
     /// lifetime" is what we want here regardless of outcome — subsequent
     /// staleness is handled by the periodic + post-payment sync.
     select_leaves_refresh: tokio::sync::OnceCell<()>,
+}
+
+/// The leaves an exit would move and the tree behind them, before any funding is
+/// considered.
+pub struct ExitContext {
+    pub leaf_ids: Vec<TreeNodeId>,
+    pub filter: UnilateralExitLeafFilter,
+    pub tree_nodes: HashMap<TreeNodeId, TreeNode>,
+    pub leaf_refund_addresses: HashMap<TreeNodeId, Address>,
 }
 
 impl SparkWallet {
@@ -1791,6 +1800,79 @@ impl SparkWallet {
     /// Prepares a unilateral exit of the selected leaves: loads the exit tree,
     /// plans it, and derives each leaf's P2TR refund address. `Auto` keeps only
     /// profitable leaves; `Specific` exits every requested one.
+    /// The leaves an exit would move and the tree behind them, with no funding
+    /// considered. Held apart from planning so the chain can be asked what is
+    /// already settled first, which is what lets funding be sized to the work
+    /// that is actually left.
+    pub async fn load_exit_context(
+        &self,
+        selection: ExitLeafSelection,
+    ) -> Result<ExitContext, SparkWalletError> {
+        self.refresh_before_exit().await;
+        let (leaf_ids, filter) = self.resolve_leaf_selection(selection).await?;
+        let tree_nodes = self.load_exit_tree_nodes(&leaf_ids).await?;
+
+        // A P2TR address over the leaf's derived key recognizes an on-chain
+        // refund (any variant) and is where the sweep pulls from.
+        let secp = Secp256k1::new();
+        let network: bitcoin::Network = self.config.network.into();
+        let mut leaf_refund_addresses = HashMap::new();
+        for leaf_id in &leaf_ids {
+            let pubkey = self.spark_signer.get_public_key_for_leaf(leaf_id).await?;
+            let address = Address::p2tr(&secp, pubkey.x_only_public_key().0, None, network);
+            leaf_refund_addresses.insert(leaf_id.clone(), address);
+        }
+
+        Ok(ExitContext {
+            leaf_ids,
+            filter,
+            tree_nodes,
+            leaf_refund_addresses,
+        })
+    }
+
+    /// `settled` is what the chain has been observed to have done already; `None`
+    /// prices a fresh exit.
+    pub fn plan_exit(
+        &self,
+        context: &ExitContext,
+        fee_rate_sat_per_kw: u64,
+        inputs: Vec<CpfpInput>,
+        destination_script_len: usize,
+        settled: Option<&SettledExitSteps>,
+    ) -> Result<PreparedUnilateralExit, SparkWalletError> {
+        let plan = spark::services::plan_unilateral_exit(
+            context.tree_nodes.clone(),
+            &context.leaf_ids,
+            context.filter,
+            inputs,
+            fee_rate_sat_per_kw,
+            destination_script_len,
+            settled,
+        )?;
+        debug!(
+            fee_rate_sat_per_kw,
+            selected_leaves = plan.selected_leaves.len(),
+            settled_nodes = settled.map_or(0, |s| s.nodes.len()),
+            settled_refunds = settled.map_or(0, |s| s.refunds.len()),
+            "plan_exit: planned"
+        );
+        let leaf_refund_addresses = plan
+            .selected_leaves
+            .iter()
+            .filter_map(|leaf| {
+                context
+                    .leaf_refund_addresses
+                    .get(&leaf.id)
+                    .map(|address| (leaf.id.clone(), address.clone()))
+            })
+            .collect();
+        Ok(PreparedUnilateralExit {
+            plan,
+            leaf_refund_addresses,
+        })
+    }
+
     pub async fn prepare_unilateral_exit_plan(
         &self,
         fee_rate_sat_per_kw: u64,
@@ -1798,40 +1880,14 @@ impl SparkWallet {
         inputs: Vec<CpfpInput>,
         destination_script_len: usize,
     ) -> Result<PreparedUnilateralExit, SparkWalletError> {
-        self.refresh_before_exit().await;
-        let (leaf_ids, filter) = self.resolve_leaf_selection(selection).await?;
-        let tree_nodes = self.load_exit_tree_nodes(&leaf_ids).await?;
-        let plan = spark::services::plan_unilateral_exit(
-            tree_nodes,
-            &leaf_ids,
-            filter,
+        let context = self.load_exit_context(selection).await?;
+        self.plan_exit(
+            &context,
+            fee_rate_sat_per_kw,
             inputs,
-            fee_rate_sat_per_kw,
             destination_script_len,
-        )?;
-        debug!(
-            fee_rate_sat_per_kw,
-            selected_leaves = plan.selected_leaves.len(),
-            tree_nodes = plan.tree_nodes.len(),
-            has_fan_out = plan.fan_out_psbt.is_some(),
-            "prepare_unilateral_exit_plan: planned"
-        );
-
-        // A P2TR address over the leaf's derived key recognizes an on-chain
-        // refund (any variant) and is where the sweep pulls from.
-        let secp = Secp256k1::new();
-        let network: bitcoin::Network = self.config.network.into();
-        let mut leaf_refund_addresses = HashMap::new();
-        for leaf in &plan.selected_leaves {
-            let pubkey = self.spark_signer.get_public_key_for_leaf(&leaf.id).await?;
-            let address = Address::p2tr(&secp, pubkey.x_only_public_key().0, None, network);
-            leaf_refund_addresses.insert(leaf.id.clone(), address);
-        }
-
-        Ok(PreparedUnilateralExit {
-            plan,
-            leaf_refund_addresses,
-        })
+            None,
+        )
     }
 
     /// Builds a sweep PSBT that pulls every leaf's refund output and every

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -1575,15 +1575,19 @@ impl SparkWallet {
     ) -> Result<(Vec<TreeNodeId>, UnilateralExitLeafFilter), SparkWalletError> {
         match selection {
             ExitLeafSelection::Auto => {
-                // Include non-available leaves (e.g. a mid-exit leaf the operators
-                // now report OnChain) so Auto resumes a partially-exited leaf, not
-                // just fresh ones. The planner skips any that turn out un-exitable
-                // under ProfitableOnly.
+                // Every stored leaf is one of ours, so Auto sweeps all of them and
+                // lets the planner drop the few that are unexitable (terminal status,
+                // no refund) or unprofitable. That includes the non-available ones (a
+                // mid-exit leaf the operators now report OnChain, so Auto resumes it)
+                // and the missing-from-operators ones, which are the operator-dropped
+                // case unilateral exit exists for: they count towards the balance, so
+                // omitting them would strand exactly the funds most at risk.
                 let leaves = self.tree_service.list_leaves().await?;
                 let mut leaf_ids: Vec<TreeNodeId> = leaves
                     .available
                     .into_iter()
                     .chain(leaves.not_available)
+                    .chain(leaves.available_missing_from_operators)
                     .map(|l| l.id)
                     .collect();
                 leaf_ids.sort();

--- a/crates/spark/src/services/unilateral_exit.rs
+++ b/crates/spark/src/services/unilateral_exit.rs
@@ -15,20 +15,12 @@ use crate::{
     utils::transactions::is_ephemeral_anchor_output,
 };
 
-/// Statuses where a node still belongs to an exit chain. `OnChain` is kept
-/// (the SO marks a node `ON_CHAIN` once its tx confirms, still mid-exit);
-/// `SplitLocked` is kept because a timelock renewal leaves a permanent
-/// `SplitLocked` node above the renewed leaf that the walk must cross.
-const EXIT_CHAIN_STATUSES: [TreeNodeStatus; 4] = [
-    TreeNodeStatus::Available,
-    TreeNodeStatus::Splitted,
-    TreeNodeStatus::SplitLocked,
-    TreeNodeStatus::OnChain,
-];
-
-/// Returns a leaf's ancestor chain, root → leaf, stopping above any node outside
-/// [`EXIT_CHAIN_STATUSES`]. `Err(parent_id)` names the first ancestor missing
-/// from `node_map` for the caller to re-fetch.
+/// Returns a leaf's ancestor chain, root → leaf. The walk is purely structural:
+/// it crosses a node whatever its status, because what the exit broadcasts is the
+/// pre-signed transaction lineage, not the operator's label for it. An ancestor
+/// that is `TransferLocked`, `RenewLocked` or under `Investigation` still holds an
+/// unspent output whose `node_tx` every node below it spends. `Err(parent_id)`
+/// names the first ancestor missing from `node_map` for the caller to re-fetch.
 pub fn walk_unilateral_exit_chain<'a>(
     node_map: &'a HashMap<TreeNodeId, TreeNode>,
     leaf: &'a TreeNode,
@@ -37,9 +29,6 @@ pub fn walk_unilateral_exit_chain<'a>(
     let mut visited: HashSet<TreeNodeId> = HashSet::new();
     let mut current = leaf;
     loop {
-        if !EXIT_CHAIN_STATUSES.contains(&current.status) {
-            break;
-        }
         // Cycle guard on semi-trusted parent ids. Returning an id already in the
         // map is how a caller tells a cycle from a missing parent.
         if !visited.insert(current.id.clone()) {
@@ -513,6 +502,12 @@ pub fn evaluate_unilateral_exit_leaf_costs(
     let mut covered_txids: HashSet<bitcoin::Txid> = HashSet::new();
 
     for (leaf_id, leaf) in &leaves {
+        // No status gate here on purpose. A leaf's status is the operators' label
+        // for it, not the state of its output: an already-exited leaf still has to
+        // be selectable so a re-run resolves it as swept and drives nothing, and a
+        // locked or degraded one is still perfectly exitable from its stored
+        // transactions. What can and cannot be driven is settled by the on-chain
+        // observation, which sees the real spends.
         let Some(refund_tx) = &leaf.refund_tx else {
             report_unexitable(filter, leaf_id, "no refund transaction")?;
             continue;
@@ -1061,28 +1056,37 @@ mod tests {
             assert_eq!(chain_ids(&chain), vec![ROOT, MID, LEAF]);
         }
 
+        /// The walk is structural, so an ancestor is crossed whatever its status:
+        /// every node below it spends its `node_tx`, so dropping one would build a
+        /// silently unbroadcastable package. `SplitLocked` is the load-bearing case
+        /// (a timelock renewal leaves one permanently above the renewed leaf) and
+        /// `Splitted` is the ordinary intermediate node.
         #[test_all]
-        fn walks_through_split_locked_parent() {
-            let root = node(ROOT, None, TreeNodeStatus::Available);
-            let mid = node(MID, Some(ROOT), TreeNodeStatus::SplitLocked);
-            let leaf = node(LEAF, Some(MID), TreeNodeStatus::Available);
-            let map = node_map(&[&root, &mid, &leaf]);
+        fn walks_through_any_ancestor_status() {
+            for status in [
+                TreeNodeStatus::SplitLocked,
+                TreeNodeStatus::Splitted,
+                TreeNodeStatus::TransferLocked,
+                TreeNodeStatus::RenewLocked,
+                TreeNodeStatus::Investigation,
+                TreeNodeStatus::Lost,
+                TreeNodeStatus::ParentExited,
+                TreeNodeStatus::Exited,
+                TreeNodeStatus::Unknown,
+            ] {
+                let root = node(ROOT, None, TreeNodeStatus::Available);
+                let mid = node(MID, Some(ROOT), status);
+                let leaf = node(LEAF, Some(MID), TreeNodeStatus::Available);
+                let map = node_map(&[&root, &mid, &leaf]);
 
-            let chain = walk_unilateral_exit_chain(&map, &leaf).unwrap();
+                let chain = walk_unilateral_exit_chain(&map, &leaf).unwrap();
 
-            assert_eq!(chain_ids(&chain), vec![ROOT, MID, LEAF]);
-        }
-
-        #[test_all]
-        fn stops_on_non_exit_status() {
-            let root = node(ROOT, None, TreeNodeStatus::Available);
-            let mid = node(MID, Some(ROOT), TreeNodeStatus::Exited);
-            let leaf = node(LEAF, Some(MID), TreeNodeStatus::Available);
-            let map = node_map(&[&root, &mid, &leaf]);
-
-            let chain = walk_unilateral_exit_chain(&map, &leaf).unwrap();
-
-            assert_eq!(chain_ids(&chain), vec![LEAF]);
+                assert_eq!(
+                    chain_ids(&chain),
+                    vec![ROOT, MID, LEAF],
+                    "a {status} ancestor must not truncate the chain"
+                );
+            }
         }
 
         #[test_all]
@@ -1499,6 +1503,45 @@ mod tests {
             )
             .unwrap();
             assert!(sel.is_empty());
+        }
+
+        /// Selection never consults the status. Gating on the operators' label used
+        /// to strand a `TransferLocked` or `Lost` leaf whose pre-signed refund was
+        /// still perfectly broadcastable, and an already-`Exited` one has to stay
+        /// selectable too so re-running a finished exit can resolve it as swept
+        /// instead of failing.
+        #[test_all]
+        fn selects_leaf_in_any_status() {
+            for status in [
+                TreeNodeStatus::Available,
+                TreeNodeStatus::TransferLocked,
+                TreeNodeStatus::SplitLocked,
+                TreeNodeStatus::Splitted,
+                TreeNodeStatus::RenewLocked,
+                TreeNodeStatus::Investigation,
+                TreeNodeStatus::Lost,
+                TreeNodeStatus::OnChain,
+                TreeNodeStatus::Exited,
+                TreeNodeStatus::Aggregated,
+                TreeNodeStatus::Reimbursed,
+                TreeNodeStatus::ParentExited,
+                TreeNodeStatus::Unknown,
+            ] {
+                let mut node = leaf_node("leaf", 1_000_000);
+                node.status = status;
+                let id = node.id.clone();
+                let nodes: HashMap<TreeNodeId, TreeNode> =
+                    [(id.clone(), node)].into_iter().collect();
+
+                let sel = evaluate_unilateral_exit_leaf_costs(
+                    &nodes,
+                    std::slice::from_ref(&id),
+                    &cost_params(),
+                    UnilateralExitLeafFilter::ProfitableOnly,
+                )
+                .unwrap();
+                assert_eq!(sel.len(), 1, "a {status} leaf must stay exitable");
+            }
         }
 
         #[test_all]

--- a/crates/spark/src/services/unilateral_exit.rs
+++ b/crates/spark/src/services/unilateral_exit.rs
@@ -88,6 +88,17 @@ pub struct SettledExitSteps {
 }
 
 impl SettledExitSteps {
+    /// Whether the chain has settled every step this leaf would drive. Asked of
+    /// the steps themselves, never of what they cost: at a zero fee rate a leaf
+    /// with all its work still ahead of it costs nothing either.
+    fn covers(&self, leaf: &UnilateralExitSelectedLeaf) -> bool {
+        self.refunds.contains(&leaf.id)
+            && leaf
+                .cpfp_node_costs
+                .iter()
+                .all(|(node_id, _)| self.nodes.contains(node_id))
+    }
+
     /// What a leaf's remaining work costs once the settled steps are dropped.
     fn discount(&self, leaf: &UnilateralExitSelectedLeaf) -> u64 {
         leaf.cpfp_node_costs
@@ -156,7 +167,7 @@ pub fn plan_unilateral_exit(
     // never reaches the sweep.
     let driving: Vec<UnilateralExitSelectedLeaf> = selected
         .iter()
-        .filter(|leaf| leaf.cpfp_cost > 0)
+        .filter(|leaf| !settled.is_some_and(|settled| settled.covers(leaf)))
         .cloned()
         .collect();
 
@@ -211,8 +222,29 @@ pub fn plan_unilateral_exit(
     {
         (assignment, None)
     } else {
-        let (psbt, per_leaf) =
-            build_fan_out_psbt(&inputs, &driving, fee_rate_sat_per_kw, change_dust_limit)?;
+        // Fanned out over every branch, not just the driving ones. The fan-out's
+        // outputs all pay the same script, so a branch is recognised on a later
+        // run by its position among them: let that shape follow what is left to
+        // do and the positions shift as branches settle, pointing a resume at
+        // another branch's output. A settled branch needs no fee money, only a
+        // place in the order, so it is sized down to the dust its output must
+        // clear. On a first run nothing has settled and this costs nothing.
+        let fan_out_leaves: Vec<UnilateralExitSelectedLeaf> = selected
+            .iter()
+            .map(|leaf| {
+                let mut leaf = leaf.clone();
+                if settled.is_some_and(|settled| settled.covers(&leaf)) {
+                    leaf.estimated_cost = 0;
+                }
+                leaf
+            })
+            .collect();
+        let (psbt, per_leaf) = build_fan_out_psbt(
+            &inputs,
+            &fan_out_leaves,
+            fee_rate_sat_per_kw,
+            change_dust_limit,
+        )?;
         (
             per_leaf
                 .into_iter()
@@ -2191,6 +2223,116 @@ mod tests {
             assert!(
                 discounted < fresh,
                 "a settled node lowers the floor: {discounted} vs {fresh}"
+            );
+        }
+
+        #[test_all]
+        fn a_free_exit_is_still_an_exit_to_drive() {
+            // At a zero fee rate every step costs nothing, which must not read as
+            // every step being done: the leaf still has its whole exit ahead of it
+            // and still needs the funding its children are built from.
+            let a = leaf_node_n("a", 1_000_000, 1);
+            let id = a.id.clone();
+            let nodes: HashMap<TreeNodeId, TreeNode> = [(id.clone(), a)].into_iter().collect();
+
+            let plan = plan_unilateral_exit(
+                nodes,
+                std::slice::from_ref(&id),
+                UnilateralExitLeafFilter::ProfitableOnly,
+                vec![cpfp_input(10_000, 0)],
+                0,
+                22,
+                Some(&SettledExitSteps::default()),
+            )
+            .unwrap();
+
+            let funded = plan
+                .per_branch_funding
+                .iter()
+                .find(|(leaf_id, _)| *leaf_id == id)
+                .map(|(_, funding)| funding.len())
+                .unwrap_or(0);
+            assert_eq!(
+                funded, 1,
+                "a free exit is still funded, or it builds nothing"
+            );
+        }
+
+        #[test_all]
+        fn a_fan_out_keeps_its_shape_as_branches_settle() {
+            let a = leaf_node_n("a", 1_000_000, 1);
+            let b = leaf_node_n("b", 1_000_000, 3);
+            let c = leaf_node_n("c", 1_000_000, 5);
+            let (ida, idb, idc) = (a.id.clone(), b.id.clone(), c.id.clone());
+            let nodes: HashMap<TreeNodeId, TreeNode> =
+                [(ida.clone(), a), (idb.clone(), b), (idc.clone(), c)]
+                    .into_iter()
+                    .collect();
+            let ids = [ida.clone(), idb.clone(), idc.clone()];
+
+            let plan_with = |settled: Option<&SettledExitSteps>| {
+                plan_unilateral_exit(
+                    nodes.clone(),
+                    &ids,
+                    UnilateralExitLeafFilter::ProfitableOnly,
+                    vec![cpfp_input(40_000, 0)],
+                    250,
+                    22,
+                    settled,
+                )
+                .unwrap()
+            };
+
+            let fresh = plan_with(None);
+            let fresh_outputs = fresh
+                .fan_out_psbt
+                .as_ref()
+                .expect("one utxo, three branches: it fans out")
+                .unsigned_tx
+                .output
+                .len();
+            assert_eq!(fresh_outputs, 3);
+
+            // One branch finishes. The fan-out must still carry an output for it,
+            // or the two still driving would slide onto each other's outputs when
+            // a later run reads them back.
+            let settled = SettledExitSteps {
+                nodes: [idb.clone()].into_iter().collect(),
+                refunds: [idb.clone()].into_iter().collect(),
+            };
+            let resumed = plan_with(Some(&settled));
+            let fan_out = resumed
+                .fan_out_psbt
+                .as_ref()
+                .expect("still fans out")
+                .unsigned_tx
+                .clone();
+            assert_eq!(
+                fan_out.output.len(),
+                3,
+                "the settled branch keeps its place in the order"
+            );
+            assert_eq!(
+                resumed.per_branch_funding.len(),
+                3,
+                "and its branch, so its refund still reaches the sweep"
+            );
+
+            // It drives nothing, so its output only has to clear dust: the money
+            // that would have paid its fees is not asked for again.
+            let dust = fan_out.output[0].script_pubkey.minimal_non_dust().to_sat();
+            let settled_index = ids.iter().position(|id| *id == idb).unwrap();
+            let settled_output = fan_out.output[settled_index].value.to_sat();
+            assert!(
+                settled_output
+                    < fresh.fan_out_psbt.as_ref().unwrap().unsigned_tx.output[settled_index]
+                        .value
+                        .to_sat(),
+                "a settled branch is funded for less than a driving one"
+            );
+            assert!(
+                settled_output >= dust,
+                "but still enough to be a real output: {settled_output} vs {dust}"
             );
         }
 

--- a/crates/spark/src/services/unilateral_exit.rs
+++ b/crates/spark/src/services/unilateral_exit.rs
@@ -78,6 +78,33 @@ pub struct UnilateralExitPlan {
 /// Selects which leaves to exit and maps funding inputs to branches. Never
 /// fetches: works offline as long as `tree_nodes` holds each selected leaf's
 /// full ancestor chain.
+/// The steps an exit no longer has to drive, as the chain shows them. A node or
+/// refund named here is confirmed, or is driven by a transaction paying its own
+/// fee, so it takes no CPFP child and costs the funding nothing.
+#[derive(Debug, Default, Clone)]
+pub struct SettledExitSteps {
+    pub nodes: HashSet<TreeNodeId>,
+    pub refunds: HashSet<TreeNodeId>,
+}
+
+impl SettledExitSteps {
+    /// What a leaf's remaining work costs once the settled steps are dropped.
+    fn discount(&self, leaf: &UnilateralExitSelectedLeaf) -> u64 {
+        leaf.cpfp_node_costs
+            .iter()
+            .filter(|(node_id, _)| self.nodes.contains(node_id))
+            .map(|(_, fee)| *fee)
+            .sum::<u64>()
+            .saturating_add(if self.refunds.contains(&leaf.id) {
+                leaf.cpfp_refund_cost
+            } else {
+                0
+            })
+    }
+}
+
+/// `settled` is what the chain has already been observed to have done. `None`
+/// prices a fresh exit, which is what a caller with no chain access gets.
 pub fn plan_unilateral_exit(
     tree_nodes: HashMap<TreeNodeId, TreeNode>,
     leaf_ids: &[TreeNodeId],
@@ -85,6 +112,7 @@ pub fn plan_unilateral_exit(
     inputs: Vec<CpfpInput>,
     fee_rate_sat_per_kw: u64,
     destination_script_len: usize,
+    settled: Option<&SettledExitSteps>,
 ) -> Result<UnilateralExitPlan, ServiceError> {
     if inputs.is_empty() {
         return Err(ServiceError::ValidationError(
@@ -110,7 +138,14 @@ pub fn plan_unilateral_exit(
         fee_rate_sat_per_kw,
     };
 
-    let selected = evaluate_unilateral_exit_leaf_costs(&tree_nodes, leaf_ids, &params, filter)?;
+    let mut selected = evaluate_unilateral_exit_leaf_costs(&tree_nodes, leaf_ids, &params, filter)?;
+    if let Some(settled) = settled {
+        for leaf in &mut selected {
+            let discount = settled.discount(leaf);
+            leaf.cpfp_cost = leaf.cpfp_cost.saturating_sub(discount);
+            leaf.estimated_cost = leaf.estimated_cost.saturating_sub(discount);
+        }
+    }
     if selected.is_empty() {
         return Ok(UnilateralExitPlan {
             selected_leaves: vec![],
@@ -120,7 +155,20 @@ pub fn plan_unilateral_exit(
         });
     }
 
-    let (per_branch_funding, fan_out_psbt) = if selected.len() == 1 {
+    // Only leaves with CPFP work left take funding. One the chain has settled end
+    // to end drives no child, so it needs no input, no fan-out output and no
+    // change dust. It still gets a branch, funded with nothing, because the build
+    // walks per_branch_funding to collect refunds: drop the entry and its refund
+    // never reaches the sweep.
+    let driving: Vec<UnilateralExitSelectedLeaf> = selected
+        .iter()
+        .filter(|leaf| leaf.cpfp_cost > 0)
+        .cloned()
+        .collect();
+
+    let (assigned, fan_out_psbt) = if driving.is_empty() {
+        (Vec::new(), None)
+    } else if driving.len() == 1 {
         // The single-leaf arm hands every input to the one branch, so unlike the
         // multi-branch paths it has no partition step to reject underfunding. Gate
         // it on build_cpfp_child's physical floor (CPFP fees + dust); the sweep is
@@ -135,14 +183,14 @@ pub fn plan_unilateral_exit(
         let cpfp_cost = if inputs.len() > 1 {
             first_child_cpfp_floor(
                 &tree_nodes,
-                &selected[0].id,
+                &driving[0].id,
                 &inputs,
                 destination_script_len,
                 fee_rate_sat_per_kw,
             )
-            .unwrap_or(selected[0].cpfp_cost)
+            .unwrap_or(driving[0].cpfp_cost)
         } else {
-            selected[0].cpfp_cost
+            driving[0].cpfp_cost
         };
         let required = cpfp_cost.saturating_add(change_dust_limit);
         let available = inputs
@@ -154,8 +202,8 @@ pub fn plan_unilateral_exit(
                 required_sat: required,
             });
         }
-        (vec![(selected[0].id.clone(), inputs)], None)
-    } else if let Some(assignment) = assign_inputs_to_leaves(&inputs, &selected, change_dust_limit)
+        (vec![(driving[0].id.clone(), inputs)], None)
+    } else if let Some(assignment) = assign_inputs_to_leaves(&inputs, &driving, change_dust_limit)
         .filter(|a| {
             assignment_covers_first_child(
                 a,
@@ -168,7 +216,7 @@ pub fn plan_unilateral_exit(
         (assignment, None)
     } else {
         let (psbt, per_leaf) =
-            build_fan_out_psbt(&inputs, &selected, fee_rate_sat_per_kw, change_dust_limit)?;
+            build_fan_out_psbt(&inputs, &driving, fee_rate_sat_per_kw, change_dust_limit)?;
         (
             per_leaf
                 .into_iter()
@@ -177,6 +225,19 @@ pub fn plan_unilateral_exit(
             Some(psbt),
         )
     };
+
+    // Emitted in selected order: build_exit charges a shared ancestor to the first
+    // branch it iterates, which is the branch the funding was sized for.
+    let mut assigned: HashMap<TreeNodeId, Vec<CpfpInput>> = assigned.into_iter().collect();
+    let per_branch_funding: Vec<(TreeNodeId, Vec<CpfpInput>)> = selected
+        .iter()
+        .map(|leaf| {
+            (
+                leaf.id.clone(),
+                assigned.remove(&leaf.id).unwrap_or_default(),
+            )
+        })
+        .collect();
 
     let plan = UnilateralExitPlan {
         selected_leaves: selected,
@@ -187,6 +248,11 @@ pub fn plan_unilateral_exit(
     debug!(
         selected_leaves = plan.selected_leaves.len(),
         branches = plan.per_branch_funding.len(),
+        funded_branches = plan
+            .per_branch_funding
+            .iter()
+            .filter(|(_, f)| !f.is_empty())
+            .count(),
         has_fan_out = plan.fan_out_psbt.is_some(),
         tree_nodes = plan.tree_nodes.len(),
         "plan_unilateral_exit: planned"
@@ -1751,6 +1817,7 @@ mod tests {
                     vec![cpfp_input(a_sat, 0), cpfp_input(b_sat, 1)],
                     250,
                     22,
+                    None,
                 )
             };
 
@@ -1767,6 +1834,51 @@ mod tests {
             // One sat short on either branch and the exit can no longer be funded.
             assert!(fund_at(810, 770).is_err());
             assert!(fund_at(811, 769).is_err());
+        }
+
+        /// A leaf whose refund the chain already settled needs no refund child, so
+        /// the plan must not price one. Without this an exit that is nearly done
+        /// cannot be funded at any amount its remaining work justifies: the
+        /// operators' watchtower drives its own copy of a refund once the timelock
+        /// matures, which is the ordinary way a resumed exit finds them settled.
+        #[test_all]
+        fn a_settled_step_is_not_priced_into_the_plan() {
+            let a = leaf_node_n("a", 1_000_000, 1);
+            let id = a.id.clone();
+            let nodes: HashMap<TreeNodeId, TreeNode> = [(id.clone(), a)].into_iter().collect();
+
+            let plan_with = |settled: Option<&SettledExitSteps>, sats: u64| {
+                plan_unilateral_exit(
+                    nodes.clone(),
+                    std::slice::from_ref(&id),
+                    UnilateralExitLeafFilter::ProfitableOnly,
+                    vec![cpfp_input(sats, 0)],
+                    250,
+                    22,
+                    settled,
+                )
+            };
+
+            let floor = match plan_with(None, 0) {
+                Err(ServiceError::InsufficientCpfpBudget { required_sat }) => required_sat,
+                other => panic!("expected a floor, got {other:?}"),
+            };
+            assert!(plan_with(None, floor).is_ok());
+
+            let settled = SettledExitSteps {
+                refunds: [id.clone()].into_iter().collect(),
+                ..Default::default()
+            };
+            let cheaper = match plan_with(Some(&settled), 0) {
+                Err(ServiceError::InsufficientCpfpBudget { required_sat }) => required_sat,
+                other => panic!("expected a floor, got {other:?}"),
+            };
+            assert!(
+                cheaper < floor,
+                "a settled refund must lower the floor: {cheaper} vs {floor}"
+            );
+            // The amount a fresh exit would reject now funds the remaining work.
+            assert!(plan_with(Some(&settled), cheaper).is_ok());
         }
 
         #[test_all]
@@ -1800,6 +1912,7 @@ mod tests {
                     vec![cpfp_input(sat, 0)],
                     250,
                     22,
+                    None,
                 )
             };
 
@@ -1849,6 +1962,7 @@ mod tests {
                     vec![cpfp_input(sat, 0)],
                     250,
                     22,
+                    None,
                 )
             };
 
@@ -1916,6 +2030,7 @@ mod tests {
                 vec![cpfp_input(50_000, 0), heavy],
                 250,
                 22,
+                None,
             )
             .unwrap();
             assert!(
@@ -1947,6 +2062,7 @@ mod tests {
                 vec![cpfp_input(10_000, 0), cpfp_input(10_000, 1)],
                 250,
                 22,
+                None,
             )
             .unwrap();
             assert!(plan.fan_out_psbt.is_some());
@@ -1954,6 +2070,83 @@ mod tests {
             let fan_out = plan.fan_out_psbt.as_ref().unwrap();
             assert_eq!(fan_out.unsigned_tx.input.len(), 2);
             assert_eq!(fan_out.unsigned_tx.output.len(), 3);
+        }
+
+        #[test_all]
+        fn a_fully_settled_exit_takes_no_funding_and_no_fan_out() {
+            let a = leaf_node_n("a", 1_000_000, 1);
+            let b = leaf_node_n("b", 1_000_000, 3);
+            let c = leaf_node_n("c", 1_000_000, 5);
+            let (ida, idb, idc) = (a.id.clone(), b.id.clone(), c.id.clone());
+            let nodes: HashMap<TreeNodeId, TreeNode> =
+                [(ida.clone(), a), (idb.clone(), b), (idc.clone(), c)]
+                    .into_iter()
+                    .collect();
+            let ids = [ida, idb, idc];
+
+            let settled = SettledExitSteps {
+                nodes: ids.iter().cloned().collect(),
+                refunds: ids.iter().cloned().collect(),
+            };
+
+            // Every step is on-chain, so no branch drives a child. One satoshi of
+            // funding is enough: a fresh exit of the same tree would reject it.
+            let plan = plan_unilateral_exit(
+                nodes,
+                &ids,
+                UnilateralExitLeafFilter::ProfitableOnly,
+                vec![cpfp_input(1, 0)],
+                250,
+                22,
+                Some(&settled),
+            )
+            .unwrap();
+
+            assert!(plan.fan_out_psbt.is_none());
+            // Every leaf keeps a branch so the build still sweeps its refund.
+            assert_eq!(plan.per_branch_funding.len(), 3);
+            assert!(plan.per_branch_funding.iter().all(|(_, f)| f.is_empty()));
+        }
+
+        #[test_all]
+        fn only_the_leaves_with_work_left_take_funding() {
+            let a = leaf_node_n("a", 1_000_000, 1);
+            let b = leaf_node_n("b", 1_000_000, 3);
+            let c = leaf_node_n("c", 1_000_000, 5);
+            let (ida, idb, idc) = (a.id.clone(), b.id.clone(), c.id.clone());
+            let nodes: HashMap<TreeNodeId, TreeNode> =
+                [(ida.clone(), a), (idb.clone(), b), (idc.clone(), c)]
+                    .into_iter()
+                    .collect();
+
+            let settled = SettledExitSteps {
+                nodes: [ida.clone(), idb.clone()].into_iter().collect(),
+                refunds: [ida.clone(), idb.clone()].into_iter().collect(),
+            };
+
+            // Two of three leaves are settled, so the one still driving takes the
+            // whole UTXO: no fan-out, though three leaves and one input would need
+            // one if every leaf still had work.
+            let plan = plan_unilateral_exit(
+                nodes,
+                &[ida.clone(), idb.clone(), idc.clone()],
+                UnilateralExitLeafFilter::ProfitableOnly,
+                vec![cpfp_input(10_000, 0)],
+                250,
+                22,
+                Some(&settled),
+            )
+            .unwrap();
+
+            assert!(plan.fan_out_psbt.is_none());
+            assert_eq!(plan.per_branch_funding.len(), 3);
+            let funded: Vec<&TreeNodeId> = plan
+                .per_branch_funding
+                .iter()
+                .filter(|(_, f)| !f.is_empty())
+                .map(|(id, _)| id)
+                .collect();
+            assert_eq!(funded, vec![&idc]);
         }
 
         fn anchor_tx_n(nonce: u32) -> Transaction {

--- a/crates/spark/src/services/unilateral_exit.rs
+++ b/crates/spark/src/services/unilateral_exit.rs
@@ -304,6 +304,11 @@ pub struct UnilateralExitSelectedLeaf {
     /// floor, since the sweep is paid from the swept value rather than the funding
     /// UTXO. Always `<= estimated_cost`.
     pub cpfp_cost: u64,
+    /// What `cpfp_cost` is made of, per node whose child it pays for. A build that
+    /// has read the chain charges only the steps it is still going to drive.
+    pub cpfp_node_costs: Vec<(TreeNodeId, u64)>,
+    /// The part of `cpfp_cost` paying for the leaf's own refund child.
+    pub cpfp_refund_cost: u64,
 }
 
 pub struct UnilateralExitLeafCostParams {
@@ -527,6 +532,7 @@ pub fn evaluate_unilateral_exit_leaf_costs(
         };
 
         let mut cpfp_cost: u64 = 0;
+        let mut cpfp_node_costs: Vec<(TreeNodeId, u64)> = Vec::new();
         let mut already_funded_ancestor = false;
         for ancestor in &ancestors {
             let txid = ancestor.node_tx.compute_txid();
@@ -543,24 +549,27 @@ pub fn evaluate_unilateral_exit_leaf_costs(
                 already_funded_ancestor = true;
                 params.initial_cpfp_input_weight
             };
-            cpfp_cost = cpfp_cost.saturating_add(compute_cpfp_package_fee(
+            let fee = compute_cpfp_package_fee(
                 ancestor.node_tx.weight(),
                 input_weight,
                 params.change_script_len,
                 params.fee_rate_sat_per_kw,
-            ));
+            );
+            cpfp_node_costs.push((ancestor.id.clone(), fee));
+            cpfp_cost = cpfp_cost.saturating_add(fee);
         }
         let refund_input_weight = if already_funded_ancestor {
             params.single_cpfp_input_weight
         } else {
             params.initial_cpfp_input_weight
         };
-        cpfp_cost = cpfp_cost.saturating_add(compute_cpfp_package_fee(
+        let cpfp_refund_cost = compute_cpfp_package_fee(
             refund_tx.weight(),
             refund_input_weight,
             params.change_script_len,
             params.fee_rate_sat_per_kw,
-        ));
+        );
+        cpfp_cost = cpfp_cost.saturating_add(cpfp_refund_cost);
 
         let per_leaf_input_weight = p2tr_key_path_input_weight() + params.single_cpfp_input_weight;
         let sweep_input_weight =
@@ -593,6 +602,8 @@ pub fn evaluate_unilateral_exit_leaf_costs(
                 value: leaf.value,
                 estimated_cost: total_marginal_cost,
                 cpfp_cost,
+                cpfp_node_costs,
+                cpfp_refund_cost,
             });
             for ancestor in &ancestors {
                 covered_txids.insert(ancestor.node_tx.compute_txid());
@@ -1145,6 +1156,8 @@ mod tests {
                 value,
                 estimated_cost: cost,
                 cpfp_cost: cost,
+                cpfp_node_costs: Vec::new(),
+                cpfp_refund_cost: cost,
             }
         }
 

--- a/crates/spark/src/services/unilateral_exit.rs
+++ b/crates/spark/src/services/unilateral_exit.rs
@@ -138,14 +138,8 @@ pub fn plan_unilateral_exit(
         fee_rate_sat_per_kw,
     };
 
-    let mut selected = evaluate_unilateral_exit_leaf_costs(&tree_nodes, leaf_ids, &params, filter)?;
-    if let Some(settled) = settled {
-        for leaf in &mut selected {
-            let discount = settled.discount(leaf);
-            leaf.cpfp_cost = leaf.cpfp_cost.saturating_sub(discount);
-            leaf.estimated_cost = leaf.estimated_cost.saturating_sub(discount);
-        }
-    }
+    let selected =
+        evaluate_unilateral_exit_leaf_costs(&tree_nodes, leaf_ids, &params, filter, settled)?;
     if selected.is_empty() {
         return Ok(UnilateralExitPlan {
             selected_leaves: vec![],
@@ -187,6 +181,7 @@ pub fn plan_unilateral_exit(
                 &inputs,
                 destination_script_len,
                 fee_rate_sat_per_kw,
+                settled,
             )
             .unwrap_or(driving[0].cpfp_cost)
         } else {
@@ -210,6 +205,7 @@ pub fn plan_unilateral_exit(
                 &tree_nodes,
                 destination_script_len,
                 fee_rate_sat_per_kw,
+                settled,
             )
         })
     {
@@ -292,7 +288,8 @@ pub fn quote_unilateral_exit(
         fee_rate_sat_per_kw,
     };
 
-    let selected = evaluate_unilateral_exit_leaf_costs(tree_nodes, leaf_ids, &params, filter)?;
+    let selected =
+        evaluate_unilateral_exit_leaf_costs(tree_nodes, leaf_ids, &params, filter, None)?;
     if selected.is_empty() {
         return Ok(UnilateralExitQuote {
             selected_leaves: vec![],
@@ -400,12 +397,17 @@ pub fn branch_required_funding(leaf: &UnilateralExitSelectedLeaf, change_dust_li
 /// weight, each chained child on the first input. This is the physical floor
 /// `build_cpfp_child` enforces, independent of the sweep (paid from the swept
 /// value, not the funding UTXO). `None` only when the leaf cannot be costed.
+///
+/// Re-costing reads the tree, which knows nothing of what the chain has already
+/// done, so `settled` is applied again here: without it a half-exited branch is
+/// gated on the price of a fresh one.
 fn first_child_cpfp_floor(
     tree_nodes: &HashMap<TreeNodeId, TreeNode>,
     leaf_id: &TreeNodeId,
     branch_inputs: &[CpfpInput],
     destination_script_len: usize,
     fee_rate_sat_per_kw: u64,
+    settled: Option<&SettledExitSteps>,
 ) -> Option<u64> {
     let first = branch_inputs.first()?;
     let total_input_weight = branch_inputs
@@ -424,6 +426,7 @@ fn first_child_cpfp_floor(
         std::slice::from_ref(leaf_id),
         &params,
         UnilateralExitLeafFilter::All,
+        settled,
     )
     .ok()
     .and_then(|leaves| leaves.into_iter().next())
@@ -559,6 +562,7 @@ pub fn evaluate_unilateral_exit_leaf_costs(
     leaf_ids: &[TreeNodeId],
     params: &UnilateralExitLeafCostParams,
     filter: UnilateralExitLeafFilter,
+    settled: Option<&SettledExitSteps>,
 ) -> Result<Vec<UnilateralExitSelectedLeaf>, ServiceError> {
     let mut leaves: Vec<(&TreeNodeId, &TreeNode)> = Vec::with_capacity(leaf_ids.len());
     for id in leaf_ids {
@@ -660,17 +664,25 @@ pub fn evaluate_unilateral_exit_leaf_costs(
             ))
         };
 
-        let total_marginal_cost = cpfp_cost.saturating_add(sweep_cost);
+        let mut candidate = UnilateralExitSelectedLeaf {
+            id: (*leaf_id).clone(),
+            value: leaf.value,
+            estimated_cost: cpfp_cost.saturating_add(sweep_cost),
+            cpfp_cost,
+            cpfp_node_costs,
+            cpfp_refund_cost,
+        };
+        // Discounted before the profitability test, not after: a half-exited leaf
+        // priced as a fresh exit can look like it costs more than it is worth, and
+        // Auto would drop it for good over work it no longer has to do.
+        if let Some(settled) = settled {
+            let discount = settled.discount(&candidate);
+            candidate.cpfp_cost = candidate.cpfp_cost.saturating_sub(discount);
+            candidate.estimated_cost = candidate.estimated_cost.saturating_sub(discount);
+        }
 
-        if filter == UnilateralExitLeafFilter::All || leaf.value > total_marginal_cost {
-            selected.push(UnilateralExitSelectedLeaf {
-                id: (*leaf_id).clone(),
-                value: leaf.value,
-                estimated_cost: total_marginal_cost,
-                cpfp_cost,
-                cpfp_node_costs,
-                cpfp_refund_cost,
-            });
+        if filter == UnilateralExitLeafFilter::All || candidate.value > candidate.estimated_cost {
+            selected.push(candidate);
             for ancestor in &ancestors {
                 covered_txids.insert(ancestor.node_tx.compute_txid());
             }
@@ -758,6 +770,7 @@ fn assignment_covers_first_child(
     tree_nodes: &HashMap<TreeNodeId, TreeNode>,
     destination_script_len: usize,
     fee_rate_sat_per_kw: u64,
+    settled: Option<&SettledExitSteps>,
 ) -> bool {
     assignment.iter().all(|(leaf_id, branch_inputs)| {
         let Some(first) = branch_inputs.first() else {
@@ -774,6 +787,7 @@ fn assignment_covers_first_child(
             branch_inputs,
             destination_script_len,
             fee_rate_sat_per_kw,
+            settled,
         ) {
             Some(cpfp_cost) => available >= cpfp_cost.saturating_add(dust),
             None => false,
@@ -1362,6 +1376,7 @@ mod tests {
                     fee_rate_sat_per_kw: 250,
                 },
                 UnilateralExitLeafFilter::All,
+                None,
             )
             .unwrap()[0]
                 .cpfp_cost;
@@ -1384,13 +1399,15 @@ mod tests {
                 &four(floor),
                 &nodes,
                 change_len,
-                250
+                250,
+                None
             ));
             assert!(!assignment_covers_first_child(
                 &four(floor - 1),
                 &nodes,
                 change_len,
-                250
+                250,
+                None
             ));
             // A one-input branch is gated on its own weight too: funded above its
             // one-input floor it is covered.
@@ -1405,15 +1422,18 @@ mod tests {
                     fee_rate_sat_per_kw: 250,
                 },
                 UnilateralExitLeafFilter::All,
+                None,
             )
             .unwrap()[0]
                 .cpfp_cost
                 + dust;
             let one = vec![(leaf_id.clone(), vec![cpfp_input(one_floor, 0)])];
-            assert!(assignment_covers_first_child(&one, &nodes, change_len, 250));
+            assert!(assignment_covers_first_child(
+                &one, &nodes, change_len, 250, None
+            ));
             let one_short = vec![(leaf_id.clone(), vec![cpfp_input(one_floor - 1, 0)])];
             assert!(!assignment_covers_first_child(
-                &one_short, &nodes, change_len, 250
+                &one_short, &nodes, change_len, 250, None
             ));
 
             // A single input heavier than the reference kind (a Custom funding kind)
@@ -1426,7 +1446,8 @@ mod tests {
                 &heavy_branch,
                 &nodes,
                 change_len,
-                250
+                250,
+                None
             ));
         }
 
@@ -1566,6 +1587,7 @@ mod tests {
                 std::slice::from_ref(&id),
                 &cost_params(),
                 UnilateralExitLeafFilter::ProfitableOnly,
+                None,
             )
             .unwrap();
             assert_eq!(sel.len(), 1);
@@ -1579,6 +1601,7 @@ mod tests {
                 &[sid],
                 &cost_params(),
                 UnilateralExitLeafFilter::ProfitableOnly,
+                None,
             )
             .unwrap();
             assert!(sel.is_empty());
@@ -1617,6 +1640,7 @@ mod tests {
                     std::slice::from_ref(&id),
                     &cost_params(),
                     UnilateralExitLeafFilter::ProfitableOnly,
+                    None,
                 )
                 .unwrap();
                 assert_eq!(sel.len(), 1, "a {status} leaf must stay exitable");
@@ -1634,6 +1658,7 @@ mod tests {
                 &[pid],
                 &cost_params(),
                 UnilateralExitLeafFilter::All,
+                None,
             )
             .unwrap()[0]
                 .estimated_cost;
@@ -1648,7 +1673,8 @@ mod tests {
                     &at_nodes,
                     &[at_id],
                     &cost_params(),
-                    UnilateralExitLeafFilter::ProfitableOnly
+                    UnilateralExitLeafFilter::ProfitableOnly,
+                    None
                 )
                 .unwrap()
                 .is_empty(),
@@ -1664,6 +1690,7 @@ mod tests {
                 &[above_id],
                 &cost_params(),
                 UnilateralExitLeafFilter::ProfitableOnly,
+                None,
             )
             .unwrap();
             assert_eq!(
@@ -1684,6 +1711,7 @@ mod tests {
                 &[sid],
                 &cost_params(),
                 UnilateralExitLeafFilter::All,
+                None,
             )
             .unwrap();
             assert_eq!(sel.len(), 1);
@@ -1701,7 +1729,8 @@ mod tests {
                     &nodes,
                     std::slice::from_ref(&id),
                     &cost_params(),
-                    UnilateralExitLeafFilter::All
+                    UnilateralExitLeafFilter::All,
+                    None
                 )
                 .is_err()
             );
@@ -1710,6 +1739,7 @@ mod tests {
                 &[id],
                 &cost_params(),
                 UnilateralExitLeafFilter::ProfitableOnly,
+                None,
             )
             .unwrap();
             assert!(sel.is_empty());
@@ -2073,6 +2103,98 @@ mod tests {
         }
 
         #[test_all]
+        fn auto_keeps_a_half_exited_leaf_its_remaining_work_pays_for() {
+            // Worth less than a fresh exit costs, so Auto drops it: but most of that
+            // exit is already on-chain, and what is left is well within its value.
+            let params = cost_params();
+            let probe = leaf_node_n("probe", 1_000_000, 1);
+            let probe_id = probe.id.clone();
+            let probe_nodes: HashMap<TreeNodeId, TreeNode> =
+                [(probe_id.clone(), probe)].into_iter().collect();
+            let fresh_cost = evaluate_unilateral_exit_leaf_costs(
+                &probe_nodes,
+                std::slice::from_ref(&probe_id),
+                &params,
+                UnilateralExitLeafFilter::All,
+                None,
+            )
+            .unwrap()[0]
+                .estimated_cost;
+
+            // Priced as fresh this leaf is not worth exiting, by one satoshi.
+            let leaf = leaf_node_n("leaf", fresh_cost, 1);
+            let leaf_id = leaf.id.clone();
+            let nodes: HashMap<TreeNodeId, TreeNode> =
+                [(leaf_id.clone(), leaf)].into_iter().collect();
+            let ids = std::slice::from_ref(&leaf_id);
+
+            assert!(
+                evaluate_unilateral_exit_leaf_costs(
+                    &nodes,
+                    ids,
+                    &params,
+                    UnilateralExitLeafFilter::ProfitableOnly,
+                    None,
+                )
+                .unwrap()
+                .is_empty(),
+                "priced as a fresh exit it is not worth doing"
+            );
+
+            let settled = SettledExitSteps {
+                nodes: [leaf_id.clone()].into_iter().collect(),
+                refunds: [leaf_id.clone()].into_iter().collect(),
+            };
+            assert_eq!(
+                evaluate_unilateral_exit_leaf_costs(
+                    &nodes,
+                    ids,
+                    &params,
+                    UnilateralExitLeafFilter::ProfitableOnly,
+                    Some(&settled),
+                )
+                .unwrap()
+                .len(),
+                1,
+                "the work it has left is worth doing, so Auto must keep it"
+            );
+        }
+
+        #[test_all]
+        fn a_settled_step_lowers_the_multi_input_floor_too() {
+            // Two inputs put the single-leaf gate through first_child_cpfp_floor,
+            // which re-costs from the tree and so has to be told what is settled
+            // as well: otherwise a half-exited leaf is gated on a fresh price.
+            let a = leaf_node_n("a", 1_000_000, 1);
+            let id_a = a.id.clone();
+            let nodes: HashMap<TreeNodeId, TreeNode> = [(id_a.clone(), a)].into_iter().collect();
+
+            let settled = SettledExitSteps {
+                nodes: [id_a.clone()].into_iter().collect(),
+                ..Default::default()
+            };
+
+            let floor_of = |settled: Option<&SettledExitSteps>| {
+                first_child_cpfp_floor(
+                    &nodes,
+                    &id_a,
+                    &[cpfp_input(10_000, 0), cpfp_input(10_000, 1)],
+                    22,
+                    250,
+                    settled,
+                )
+                .expect("the leaf costs")
+            };
+
+            let fresh = floor_of(None);
+            let discounted = floor_of(Some(&settled));
+            assert!(
+                discounted < fresh,
+                "a settled node lowers the floor: {discounted} vs {fresh}"
+            );
+        }
+
+        #[test_all]
         fn a_fully_settled_exit_takes_no_funding_and_no_fan_out() {
             let a = leaf_node_n("a", 1_000_000, 1);
             let b = leaf_node_n("b", 1_000_000, 3);
@@ -2182,6 +2304,7 @@ mod tests {
                     std::slice::from_ref(&leaf_id),
                     &cost_params(),
                     UnilateralExitLeafFilter::All,
+                    None,
                 )
                 .unwrap()[0]
                     .estimated_cost

--- a/crates/spark/src/services/unilateral_exit.rs
+++ b/crates/spark/src/services/unilateral_exit.rs
@@ -75,9 +75,6 @@ pub struct UnilateralExitPlan {
     pub tree_nodes: HashMap<TreeNodeId, TreeNode>,
 }
 
-/// Selects which leaves to exit and maps funding inputs to branches. Never
-/// fetches: works offline as long as `tree_nodes` holds each selected leaf's
-/// full ancestor chain.
 /// The steps an exit no longer has to drive, as the chain shows them. A node or
 /// refund named here is confirmed, or is driven by a transaction paying its own
 /// fee, so it takes no CPFP child and costs the funding nothing.
@@ -114,6 +111,10 @@ impl SettledExitSteps {
     }
 }
 
+/// Selects which leaves to exit and maps funding inputs to branches. Never
+/// fetches: works offline as long as `tree_nodes` holds each selected leaf's
+/// full ancestor chain.
+///
 /// `settled` is what the chain has already been observed to have done. `None`
 /// prices a fresh exit, which is what a caller with no chain access gets.
 pub fn plan_unilateral_exit(

--- a/crates/spark/src/tree/mod.rs
+++ b/crates/spark/src/tree/mod.rs
@@ -97,14 +97,41 @@ pub struct VerifiedLeafKeys {
     pub signing_keyshare_public_key: PublicKey,
 }
 
+#[cfg(test)]
+mod verified_leaf_keys_tests {
+    use super::*;
+    use crate::tree::tests::create_test_tree_node;
+
+    #[test]
+    fn a_leaf_part_way_through_an_exit_counts_as_verified() {
+        // It reached the store, so it passed the ownership check. Leaving it out
+        // re-verifies it on every refresh for as long as the exit runs.
+        let exiting = create_test_tree_node("exiting", 1_000);
+        let leaves = Leaves {
+            available: vec![],
+            not_available: vec![exiting.clone()],
+            available_missing_from_operators: vec![],
+            reserved_for_payment: vec![],
+            reserved_for_swap: vec![],
+        };
+        let keys = verified_leaf_keys_from_leaves(&leaves);
+        assert_eq!(
+            keys.get(&exiting.id).map(|k| k.verifying_public_key),
+            Some(exiting.verifying_public_key)
+        );
+    }
+}
+
 /// Projects the verified-leaf categories of `leaves` into the keys keyed by id.
-/// The set mirrors `Leaves::balance` inputs plus payment-reserved leaves: every
-/// category whose leaves passed the ownership check before being stored, and
-/// deliberately excludes `not_available` (never verified).
+/// Every stored leaf passed the ownership check on its way in, whatever its
+/// status, so `not_available` belongs here too: a leaf part-way through an exit
+/// would otherwise be re-verified on every refresh, which costs a remote signer
+/// a round trip per leaf.
 pub fn verified_leaf_keys_from_leaves(leaves: &Leaves) -> HashMap<TreeNodeId, VerifiedLeafKeys> {
     leaves
         .available
         .iter()
+        .chain(&leaves.not_available)
         .chain(&leaves.available_missing_from_operators)
         .chain(&leaves.reserved_for_payment)
         .chain(&leaves.reserved_for_swap)

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -318,20 +318,29 @@ impl TreeService for SynchronousTreeService {
 
         // Leaves only. Asking for each leaf's ancestors here would re-download every
         // chain on every refresh, including the ones already stored.
-        let coord_fut =
-            self.query_nodes(&coordinator_client, false, None, available_leaf_statuses());
+        let coord_fut = self.query_nodes(&coordinator_client, false, None, held_leaf_statuses());
         let op_futs = operators.iter().map(|(id, client)| async move {
             (
                 *id,
-                self.query_nodes(client, false, None, available_leaf_statuses())
+                self.query_nodes(client, false, None, held_leaf_statuses())
                     .await,
             )
         });
 
         let (coordinator_leaves_res, operator_results) = tokio::join!(coord_fut, join_all(op_futs));
-        let coordinator_leaves: Vec<TreeNode> = coordinator_leaves_res?
+        // Status cannot pick the leaves out of the response any more: now that a
+        // mid-exit leaf is asked for, an ancestor of one is just as able to come
+        // back `OnChain` as the leaf below it. Go by shape instead, and drop what
+        // another node in the same response calls its parent: an ancestor is not
+        // a leaf, whatever status it is in.
+        let coordinator_nodes = coordinator_leaves_res?;
+        let parent_ids: HashSet<TreeNodeId> = coordinator_nodes
+            .iter()
+            .filter_map(|n| n.parent_node_id.clone())
+            .collect();
+        let coordinator_leaves: Vec<TreeNode> = coordinator_nodes
             .into_iter()
-            .filter(|n| n.status == TreeNodeStatus::Available)
+            .filter(|n| !parent_ids.contains(&n.id))
             .collect();
         debug!(
             leaves = coordinator_leaves.len(),
@@ -394,21 +403,11 @@ impl TreeService for SynchronousTreeService {
             }
         }
 
-        // Leaves not Available are ignored outright; the rest need an ownership
-        // check (our signing share + the operators' share must equal the
-        // verifying key).
-        let available_leaves: Vec<&TreeNode> = coordinator_leaves
-            .iter()
-            .filter(|leaf| {
-                if leaf.status == TreeNodeStatus::Available {
-                    true
-                } else {
-                    info!("Ignoring leaf {} due to status: {:?}", leaf.id, leaf.status);
-                    ignored_leaves_map.insert(leaf.id.clone(), (*leaf).clone());
-                    false
-                }
-            })
-            .collect();
+        // Every reported leaf needs an ownership check (our signing share plus the
+        // operators' share must equal the verifying key). The check is not gated on
+        // status: a leaf part-way through an exit is still ours, and dropping it
+        // here would strand the chain that exit resumes from.
+        let reported_leaves: Vec<&TreeNode> = coordinator_leaves.iter().collect();
 
         // Deriving our leaf pubkey is a network round-trip on a remote signer, so
         // re-deriving every leaf each refresh would flood the signer and stall
@@ -423,7 +422,7 @@ impl TreeService for SynchronousTreeService {
         } else {
             HashMap::new()
         };
-        let unverified_leaves: Vec<&TreeNode> = available_leaves
+        let unverified_leaves: Vec<&TreeNode> = reported_leaves
             .iter()
             .copied()
             .filter(|leaf| {
@@ -1077,8 +1076,18 @@ fn bare_pedigrees(leaves: Vec<TreeNode>) -> Vec<LeafPedigree> {
         .collect()
 }
 
-fn available_leaf_statuses() -> Vec<i32> {
-    vec![ProtoTreeNodeStatus::Available as i32]
+/// The statuses a leaf we still hold can be reported in. `Available` is the
+/// spendable one. `OnChain` and `Exited` are the two an exit drives a leaf
+/// through, and they have to be asked for: a refresh that requested only
+/// `Available` lost the leaf from every operator's response at once the moment
+/// its node txs confirmed, and the store, reading that absence as a spend,
+/// deleted the chain the exit still needed to resume.
+fn held_leaf_statuses() -> Vec<i32> {
+    vec![
+        ProtoTreeNodeStatus::Available as i32,
+        ProtoTreeNodeStatus::OnChain as i32,
+        ProtoTreeNodeStatus::Exited as i32,
+    ]
 }
 
 fn query_nodes_request(
@@ -1508,8 +1517,13 @@ mod tests {
         assert!(!rx.has_changed().unwrap());
     }
 
+    /// The refresh asks for the statuses a leaf we hold can be reported in, so a
+    /// leaf part-way through an exit keeps coming back instead of vanishing from
+    /// every operator at once. `TransferLocked` is deliberately not among them: a
+    /// leaf of ours in that status is one we are sending, and re-reading it would
+    /// undo the send.
     #[test_all]
-    fn refresh_query_requests_only_available_leaves() {
+    fn refresh_query_requests_held_leaf_statuses() {
         let owner = PublicKey::from_slice(&[2; 33]).unwrap();
         let req = query_nodes_request(
             &owner,
@@ -1517,9 +1531,16 @@ mod tests {
             false,
             Network::Mainnet,
             &PagingFilter::default(),
-            available_leaf_statuses(),
+            held_leaf_statuses(),
         );
-        assert_eq!(req.statuses, vec![ProtoTreeNodeStatus::Available as i32]);
+        assert_eq!(
+            req.statuses,
+            vec![
+                ProtoTreeNodeStatus::Available as i32,
+                ProtoTreeNodeStatus::OnChain as i32,
+                ProtoTreeNodeStatus::Exited as i32,
+            ]
+        );
         assert!(
             !req.statuses
                 .contains(&(ProtoTreeNodeStatus::TransferLocked as i32))

--- a/crates/spark/src/tree/service.rs
+++ b/crates/spark/src/tree/service.rs
@@ -68,6 +68,20 @@ struct RenewalOutcome {
     any_renewal_landed: bool,
 }
 
+/// Splits a refresh's leaves into the ones worth renewing and the ones already
+/// leaving. A leaf that is on-chain or exited only needs its timelock to outlast
+/// the exit driving it, so renewing asks the operators for a new one on every
+/// refresh until that exit finishes. Both halves are stored: the exiting leaf
+/// keeps its place in the pool, and its chain with it.
+fn partition_renewable(leaves: Vec<TreeNode>) -> (Vec<TreeNode>, Vec<TreeNode>) {
+    leaves.into_iter().partition(|leaf| {
+        !matches!(
+            leaf.status,
+            TreeNodeStatus::OnChain | TreeNodeStatus::Exited
+        )
+    })
+}
+
 /// Notifications buffered per listener before it starts missing them. Each one
 /// says only that the pool grew, so a listener that falls behind loses nothing
 /// a single later notification does not tell it just as well.
@@ -472,11 +486,13 @@ impl TreeService for SynchronousTreeService {
         // A refresh writes no chains, so an already-stored one is left alone
         // rather than rewritten every minute. Collecting the chains of anything
         // newly reported is what the notification below sets off.
+        let (renewable, exiting) = partition_renewable(new_leaves);
         let RenewalOutcome {
             pedigrees,
             any_renewal_landed,
-        } = self.check_renew_nodes(bare_pedigrees(new_leaves)).await?;
-        let renewed_leaves: Vec<TreeNode> = pedigrees.iter().map(|p| p.leaf.clone()).collect();
+        } = self.check_renew_nodes(bare_pedigrees(renewable)).await?;
+        let mut renewed_leaves: Vec<TreeNode> = pedigrees.iter().map(|p| p.leaf.clone()).collect();
+        renewed_leaves.extend(exiting);
         self.state
             .set_leaves(
                 &renewed_leaves,
@@ -1346,6 +1362,28 @@ mod tests {
                 pedigree
             })
             .collect()
+    }
+
+    #[test]
+    fn a_leaf_on_its_way_out_is_not_offered_for_renewal() {
+        let node = |id, status| create_test_node_with_parent(id, Some("root"), status);
+        let available = node("available", TreeNodeStatus::Available);
+        let on_chain = node("on-chain", TreeNodeStatus::OnChain);
+        let exited = node("exited", TreeNodeStatus::Exited);
+
+        let (renewable, exiting) =
+            partition_renewable(vec![available.clone(), on_chain.clone(), exited.clone()]);
+
+        assert_eq!(
+            renewable.iter().map(|l| l.id.clone()).collect::<Vec<_>>(),
+            vec![available.id],
+            "only a leaf that is staying is worth a new timelock"
+        );
+        assert_eq!(
+            exiting.iter().map(|l| l.id.clone()).collect::<Vec<_>>(),
+            vec![on_chain.id, exited.id],
+            "the ones leaving are still kept, just not renewed"
+        );
     }
 
     #[async_test_all]

--- a/crates/spark/src/tree/tests.rs
+++ b/crates/spark/src/tree/tests.rs
@@ -956,9 +956,11 @@ pub async fn test_get_verified_leaf_keys(store: &dyn TreeStore) {
         got.signing_keyshare_public_key,
         PublicKey::from_str(keyshare).unwrap()
     );
-    // Reserved leaf included; non-Available unreserved leaf excluded.
+    // Every stored leaf is a verified leaf, whatever its status: a leaf part-way
+    // through an exit is re-verified on every refresh if it is left out, which
+    // costs a remote signer a round trip per leaf.
     assert!(keys.contains_key(&reserved.id));
-    assert!(!keys.contains_key(&not_available.id));
+    assert!(keys.contains_key(&not_available.id));
 }
 
 pub async fn test_add_leaves(store: &dyn TreeStore) {


### PR DESCRIPTION
A caller can drive a unilateral exit in one shot: call it once, take the signed transactions, and broadcast them in order. The SDK also offers to track on-chain confirmations for you, so you don't have to. To use that, the caller re-calls the unilateral exit periodically and gets back whatever still needs broadcasting. That resume path was broken in two ways.

**The tree lost its exited leaves.** Every call refreshes leaves from the operators, and the query omitted the EXITED and ONCHAIN statuses. Leaves in those statuses were deleted from the store, so the next call no longer had the whole tree and the exit failed. The query now includes both statuses, and a leaf with an exit under way survives a refresh.

**A resumed exit asked for the full funding again.** Planning ran before any chain observation, so it priced a CPFP child for every node and every refund, including branches already confirmed. The caller was asked to fund the whole job a second time instead of just the work left. Chain observation now runs before the planner and is passed in as input, so the planner charges only for the children it still has to build. A leaf whose steps have all settled takes no funding at all.