### PR TITLE
lnurl: limit address registrations per pubkey per domain

### DIFF
--- a/crates/breez-sdk/lnurl/README.md
+++ b/crates/breez-sdk/lnurl/README.md
@@ -110,6 +110,8 @@ db_url = "postgres://user:password@localhost:5432/lnurl_db"
 # LNURL payment configuration
 min_sendable = 1000                 # Minimum amount in millisatoshi (1 sat)
 max_sendable = 4000000000           # Maximum amount in millisatoshi (4,000,000 sats)
+max_registrations_per_day = 5       # Address registrations per pubkey per domain
+                                    # in a rolling 24h window (0 disables)
 domains = "yourdomain.com"          # Comma-separated list of allowed domains
 default_api_key = "<breez-api-key>" # Fallback Breez API key for partner attribution (required on mainnet)
 ```
@@ -127,6 +129,7 @@ default_api_key = "<breez-api-key>" # Fallback Breez API key for partner attribu
 | `--network` | Spark network (mainnet, testnet, regtest) | `mainnet` |
 | `--min-sendable` | Minimum payment amount (millisatoshi) | `1000` |
 | `--max-sendable` | Maximum payment amount (millisatoshi) | `4000000000` |
+| `--max-registrations-per-day` | Address registrations one pubkey may perform per domain in a rolling 24h window, refused with `429` past it (`0` disables) | `5` |
 | `--webhook-domain` | Domain for the webhook URL registered with the SSP | (none) |
 | `--ssp-auth-seed` | Hex-encoded 32-byte seed for SSP authentication | (random) |
 

--- a/crates/breez-sdk/lnurl/migrations/postgres/20260826120000_address_registrations.sql
+++ b/crates/breez-sdk/lnurl/migrations/postgres/20260826120000_address_registrations.sql
@@ -1,0 +1,16 @@
+-- One row per successful registration that changed the name a pubkey holds in
+-- a domain, counted to bound how fast one client can churn through addresses.
+-- Rows older than the counting window are pruned by the cleanup processor.
+CREATE TABLE address_registrations (
+	id BIGSERIAL PRIMARY KEY,
+	domain VARCHAR(255) NOT NULL,
+	pubkey VARCHAR(66) NOT NULL,
+	created_at BIGINT NOT NULL
+);
+
+CREATE INDEX idx_address_registrations_domain_pubkey_created
+	ON address_registrations (domain, pubkey, created_at);
+
+-- The pruner filters on created_at alone, which the index above cannot serve.
+CREATE INDEX idx_address_registrations_created_at
+	ON address_registrations (created_at);

--- a/crates/breez-sdk/lnurl/src/main.rs
+++ b/crates/breez-sdk/lnurl/src/main.rs
@@ -96,6 +96,11 @@ struct Args {
     #[arg(long, default_value = "4000000000")]
     pub max_sendable: u64,
 
+    /// Maximum successful address registrations one pubkey may perform per
+    /// domain in a rolling 24h window. 0 disables the limit.
+    #[arg(long, default_value = "5")]
+    pub max_registrations_per_day: u32,
+
     /// Whether to include the spark address in the invoices generated.
     /// If included this can reduce fees for wallets that support it at the
     /// cost of privacy.
@@ -405,6 +410,9 @@ where
     // a background refresher that keeps them in sync with the database.
     let webhook_config_cache = webhooks::config::start(repository.clone()).await?;
 
+    let registration_limit = (args.max_registrations_per_day > 0)
+        .then(|| repository::RegistrationLimit::daily(args.max_registrations_per_day));
+
     // Start background processors.
     zap::start_background_processor(
         repository.clone(),
@@ -418,7 +426,7 @@ where
         args.webhook_delivery_ttl_days,
         webhook_config_cache,
     );
-    repository::start_claim_cleanup_processor(repository.clone());
+    repository::start_claim_cleanup_processor(repository.clone(), registration_limit);
 
     // Get or create a shared webhook secret persisted in the database.
     // All instances share the same secret so webhooks verify correctly
@@ -445,6 +453,7 @@ where
         scheme: args.scheme,
         min_sendable: args.min_sendable,
         max_sendable: args.max_sendable,
+        registration_limit,
         include_spark_address: {
             #[cfg(feature = "dev")]
             {

--- a/crates/breez-sdk/lnurl/src/postgresql/repository.rs
+++ b/crates/breez-sdk/lnurl/src/postgresql/repository.rs
@@ -3,8 +3,8 @@ use lnurl_models::ListMetadataMetadata;
 use sqlx::{PgPool, Row};
 
 use crate::repository::{
-    DomainConfig, Invoice, LnurlSenderComment, NameStatus, PendingZapReceipt, TransferRequest,
-    WebhookPayloadData,
+    DomainConfig, Invoice, LnurlSenderComment, NameStatus, PendingZapReceipt, RegistrationLimit,
+    TransferRequest, WebhookPayloadData,
 };
 use crate::webhooks::repository::{
     NewWebhookDelivery, WebhookConfig, WebhookDelivery, WebhookRepositoryError,
@@ -139,6 +139,42 @@ where
     Ok(held.map(|(name,)| name))
 }
 
+/// Log a registration that changed the held name and enforce `limit`, all
+/// inside the caller's transaction: a refusal rolls back the registration and
+/// the log row together. The caller holds the registration lock for this
+/// pubkey, so the count cannot race a concurrent registration.
+async fn record_registration(
+    tx: &mut sqlx::PgConnection,
+    domain: &str,
+    pubkey: &str,
+    limit: RegistrationLimit,
+) -> Result<(), LnurlRepositoryError> {
+    sqlx::query(
+        "INSERT INTO address_registrations (domain, pubkey, created_at) VALUES ($1, $2, $3)",
+    )
+    .bind(domain)
+    .bind(pubkey)
+    .bind(now())
+    .execute(&mut *tx)
+    .await?;
+
+    let cutoff = now().saturating_sub(i64::try_from(limit.window_secs).unwrap_or(i64::MAX));
+    let (count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM address_registrations
+         WHERE domain = $1 AND pubkey = $2 AND created_at > $3",
+    )
+    .bind(domain)
+    .bind(pubkey)
+    .bind(cutoff)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    if count > i64::from(limit.max_per_window) {
+        return Err(LnurlRepositoryError::RegistrationLimitExceeded);
+    }
+    Ok(())
+}
+
 /// The advisory-lock key standing for one pubkey's registration on one domain.
 fn registration_lock_key(domain: &str, pubkey: &str) -> i64 {
     let mut engine = sha256::Hash::engine();
@@ -270,7 +306,11 @@ impl crate::repository::LnurlRepository for LnurlRepository {
         Ok(maybe_user)
     }
 
-    async fn upsert_user(&self, user: &User) -> Result<(), LnurlRepositoryError> {
+    async fn upsert_user(
+        &self,
+        user: &User,
+        limit: Option<RegistrationLimit>,
+    ) -> Result<(), LnurlRepositoryError> {
         let mut tx = self
             .pool
             .begin()
@@ -315,10 +355,15 @@ impl crate::repository::LnurlRepository for LnurlRepository {
             .execute(&mut *tx)
             .await?;
 
+        let name_changed = previous.as_deref() != Some(user.name.as_str());
         if let Some(previous) = previous
             && previous != user.name
         {
             reserve_name(&mut *tx, &user.domain, &previous, &user.pubkey).await?;
+        }
+
+        if name_changed && let Some(limit) = limit {
+            record_registration(&mut tx, &user.domain, &user.pubkey, limit).await?;
         }
 
         tx.commit()
@@ -439,6 +484,14 @@ impl crate::repository::LnurlRepository for LnurlRepository {
     async fn delete_expired_signed_messages(&self, now: i64) -> Result<u64, LnurlRepositoryError> {
         let result = sqlx::query("DELETE FROM used_signed_messages WHERE expires_at < $1")
             .bind(now)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
+    async fn delete_old_registrations(&self, cutoff: i64) -> Result<u64, LnurlRepositoryError> {
+        let result = sqlx::query("DELETE FROM address_registrations WHERE created_at < $1")
+            .bind(cutoff)
             .execute(&self.pool)
             .await?;
         Ok(result.rows_affected())
@@ -1148,6 +1201,55 @@ mod postgres_tests {
         shared_tests::a_transfer_holds_the_name_the_target_gave_up(&db).await;
     }
 
+    #[tokio::test]
+    async fn the_registration_limit_bounds_name_changes() {
+        let pool = test_pool("limit_bounds_name_changes").await;
+        let db = super::LnurlRepository::new(pool);
+        shared_tests::the_registration_limit_bounds_name_changes(&db).await;
+    }
+
+    #[tokio::test]
+    async fn re_registering_the_held_name_is_not_counted() {
+        let pool = test_pool("limit_rereg_not_counted").await;
+        let db = super::LnurlRepository::new(pool);
+        shared_tests::re_registering_the_held_name_is_not_counted(&db).await;
+    }
+
+    #[tokio::test]
+    async fn registrations_outside_the_window_do_not_count() {
+        let pool = test_pool("limit_window_expiry").await;
+        let db = super::LnurlRepository::new(pool);
+        shared_tests::registrations_outside_the_window_do_not_count(&db).await;
+    }
+
+    #[tokio::test]
+    async fn a_refused_registration_does_not_consume_quota() {
+        let pool = test_pool("limit_refused_no_quota").await;
+        let db = super::LnurlRepository::new(pool);
+        shared_tests::a_refused_registration_does_not_consume_quota(&db).await;
+    }
+
+    #[tokio::test]
+    async fn reclaiming_a_reserved_name_consumes_quota() {
+        let pool = test_pool("limit_reclaim_counts").await;
+        let db = super::LnurlRepository::new(pool);
+        shared_tests::reclaiming_a_reserved_name_consumes_quota(&db).await;
+    }
+
+    #[tokio::test]
+    async fn a_transfer_ignores_the_registration_limit() {
+        let pool = test_pool("limit_transfer_ignores").await;
+        let db = super::LnurlRepository::new(pool);
+        shared_tests::a_transfer_ignores_the_registration_limit(&db).await;
+    }
+
+    #[tokio::test]
+    async fn pruning_removes_only_old_registrations() {
+        let pool = test_pool("limit_prune_old_rows").await;
+        let db = super::LnurlRepository::new(pool);
+        shared_tests::pruning_removes_only_old_registrations(&db).await;
+    }
+
     /// A hold whose `reclaimable_from` has passed stops standing in anyone's
     /// way. Nothing writes a non-NULL `reclaimable_from` yet, so the row is
     /// seeded directly: the read side is what a cooldown policy would build on.
@@ -1173,12 +1275,15 @@ mod postgres_tests {
             NameStatus::Free,
             "a hold whose time has passed must read as free"
         );
-        db.upsert_user(&crate::user::User {
-            domain: domain.into(),
-            pubkey: "kkkk".into(),
-            name: "jane".into(),
-            description: "jane".into(),
-        })
+        db.upsert_user(
+            &crate::user::User {
+                domain: domain.into(),
+                pubkey: "kkkk".into(),
+                name: "jane".into(),
+                description: "jane".into(),
+            },
+            None,
+        )
         .await
         .expect("a lapsed hold must not refuse the registration");
         assert_eq!(

--- a/crates/breez-sdk/lnurl/src/repository.rs
+++ b/crates/breez-sdk/lnurl/src/repository.rs
@@ -16,8 +16,32 @@ pub enum LnurlRepositoryError {
     /// The signed statement authorizing this request has already been acted on.
     #[error("statement already used")]
     StatementAlreadyUsed,
+    /// The pubkey has registered as many addresses as its limit allows inside
+    /// the counting window.
+    #[error("registration limit exceeded")]
+    RegistrationLimitExceeded,
     #[error("database error: {0}")]
     General(anyhow::Error),
+}
+
+/// A cap on the successful registrations one pubkey may perform in one domain
+/// inside a rolling window.
+#[derive(Debug, Clone, Copy)]
+pub struct RegistrationLimit {
+    pub max_per_window: u32,
+    pub window_secs: u64,
+}
+
+impl RegistrationLimit {
+    /// The production window: one rolling day.
+    pub const DAY_SECS: u64 = 86_400;
+
+    pub fn daily(max_per_window: u32) -> Self {
+        Self {
+            max_per_window,
+            window_secs: Self::DAY_SECS,
+        }
+    }
 }
 
 pub struct LnurlSenderComment {
@@ -62,22 +86,37 @@ pub struct DomainConfig {
 /// How often expired signed-message claims are pruned.
 const CLAIM_CLEANUP_INTERVAL: std::time::Duration = std::time::Duration::from_hours(1);
 
-/// Start the background pruner for expired signed-message claims.
+/// Start the background pruner for expired signed-message claims and for
+/// registration-log rows that have aged out of the counting window.
 ///
 /// A claim only needs to outlive the window in which its message's timestamp is
-/// still accepted.
-pub fn start_claim_cleanup_processor<DB>(db: DB)
+/// still accepted. Registration rows are pruned on `registration_limit`'s own
+/// window: pruning sooner would hand back quota the count still charges for.
+/// With no limit, nothing writes new rows, and the default window clears what
+/// an earlier run left behind.
+pub fn start_claim_cleanup_processor<DB>(db: DB, registration_limit: Option<RegistrationLimit>)
 where
     DB: LnurlRepository + Send + Sync + 'static,
 {
+    let registration_window =
+        registration_limit.map_or(RegistrationLimit::DAY_SECS, |limit| limit.window_secs);
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(CLAIM_CLEANUP_INTERVAL);
         loop {
             interval.tick().await;
-            match db.delete_expired_signed_messages(crate::time::now()).await {
+            let now = crate::time::now();
+            match db.delete_expired_signed_messages(now).await {
                 Ok(0) => {}
                 Ok(count) => tracing::debug!("pruned {count} expired signed-message claims"),
                 Err(e) => tracing::error!("failed to prune signed-message claims: {e}"),
+            }
+            // A window too long to express prunes nothing, which is the
+            // side to fail on: the count keeps charging for every row.
+            let cutoff = now.saturating_sub(i64::try_from(registration_window).unwrap_or(i64::MAX));
+            match db.delete_old_registrations(cutoff).await {
+                Ok(0) => {}
+                Ok(count) => tracing::debug!("pruned {count} old registration-log rows"),
+                Err(e) => tracing::error!("failed to prune the registration log: {e}"),
             }
         }
     });
@@ -144,7 +183,18 @@ pub trait LnurlRepository {
     /// Returns [`LnurlRepositoryError::NameReserved`] if the name is held for
     /// another pubkey, and clears the reservation when `user.pubkey` is the one
     /// it is held for.
-    async fn upsert_user(&self, user: &User) -> Result<(), LnurlRepositoryError>;
+    ///
+    /// With a `limit`, a registration that changes the held name counts against
+    /// it and is refused with
+    /// [`LnurlRepositoryError::RegistrationLimitExceeded`] once the pubkey has
+    /// used up its window on this domain. Re-registering the held name (e.g. a
+    /// description update) never counts, and a refused registration leaves no
+    /// trace.
+    async fn upsert_user(
+        &self,
+        user: &User,
+        limit: Option<RegistrationLimit>,
+    ) -> Result<(), LnurlRepositoryError>;
 
     /// Whether `name` in `domain` is owned, held, or free, answered for
     /// `asking_pubkey`: a hold that pubkey may still reclaim reads as
@@ -191,6 +241,10 @@ pub trait LnurlRepository {
 
     /// Delete claimed statements whose `expires_at` has passed.
     async fn delete_expired_signed_messages(&self, now: i64) -> Result<u64, LnurlRepositoryError>;
+
+    /// Delete registration-log rows created before `cutoff`, returning how many
+    /// were removed.
+    async fn delete_old_registrations(&self, cutoff: i64) -> Result<u64, LnurlRepositoryError>;
 
     async fn upsert_zap(&self, zap: &Zap) -> Result<(), LnurlRepositoryError>;
     async fn insert_lnurl_sender_comment(
@@ -292,7 +346,8 @@ pub struct WebhookPayloadData {
 #[cfg(test)]
 pub mod shared_tests {
     use super::{
-        LnurlRepository, LnurlRepositoryError, NameStatus, StatementClaim, TransferRequest,
+        LnurlRepository, LnurlRepositoryError, NameStatus, RegistrationLimit, StatementClaim,
+        TransferRequest,
     };
     use crate::user::User;
 
@@ -316,7 +371,7 @@ pub mod shared_tests {
     where
         DB: LnurlRepository + Clone + Send + Sync + 'static,
     {
-        db.upsert_user(&user(domain, pubkey, name)).await
+        db.upsert_user(&user(domain, pubkey, name), None).await
     }
 
     /// Upserting a name already owned by a different pubkey returns `NameTaken`
@@ -328,12 +383,15 @@ pub mod shared_tests {
         register(db, "a.com", "aaaa", "alice").await.unwrap();
 
         let result = db
-            .upsert_user(&User {
-                domain: "a.com".into(),
-                pubkey: "bbbb".into(),
-                name: "alice".into(),
-                description: "bob".into(),
-            })
+            .upsert_user(
+                &User {
+                    domain: "a.com".into(),
+                    pubkey: "bbbb".into(),
+                    name: "alice".into(),
+                    description: "bob".into(),
+                },
+                None,
+            )
             .await;
         assert!(
             matches!(result, Err(LnurlRepositoryError::NameTaken)),
@@ -814,5 +872,249 @@ pub mod shared_tests {
                 .as_deref(),
             Some("tok")
         );
+    }
+
+    /// A limit inside a window that never expires during the test.
+    fn limit(max_per_window: u32) -> RegistrationLimit {
+        RegistrationLimit {
+            max_per_window,
+            window_secs: 3_600,
+        }
+    }
+
+    /// Register `name` to `pubkey` under `limit`.
+    async fn register_limited<DB>(
+        db: &DB,
+        domain: &str,
+        pubkey: &str,
+        name: &str,
+        limit: Option<RegistrationLimit>,
+    ) -> Result<(), LnurlRepositoryError>
+    where
+        DB: LnurlRepository + Clone + Send + Sync + 'static,
+    {
+        db.upsert_user(&user(domain, pubkey, name), limit).await
+    }
+
+    /// The limit refuses the registration past `max_per_window` name changes,
+    /// leaves the refused attempt without a trace, and binds one
+    /// `(domain, pubkey)` only: other pubkeys and other domains keep their own
+    /// budgets, and no limit enforces nothing.
+    pub async fn the_registration_limit_bounds_name_changes<DB>(db: &DB)
+    where
+        DB: LnurlRepository + Clone + Send + Sync + 'static,
+    {
+        let domain = "limit.com";
+        register_limited(db, domain, "aaaa", "ada1", Some(limit(2)))
+            .await
+            .unwrap();
+        register_limited(db, domain, "aaaa", "ada2", Some(limit(2)))
+            .await
+            .unwrap();
+
+        let third = register_limited(db, domain, "aaaa", "ada3", Some(limit(2))).await;
+        assert!(
+            matches!(third, Err(LnurlRepositoryError::RegistrationLimitExceeded)),
+            "expected RegistrationLimitExceeded, got {third:?}"
+        );
+        assert_eq!(
+            db.get_user_by_pubkey(domain, "aaaa")
+                .await
+                .unwrap()
+                .map(|u| u.name),
+            Some("ada2".to_string()),
+            "the refused registration must leave the held name alone"
+        );
+        assert_eq!(
+            db.name_status(domain, "ada3", None).await.unwrap(),
+            NameStatus::Free,
+            "the refused registration must not have taken or held the name"
+        );
+
+        register_limited(db, domain, "bbbb", "bea", Some(limit(2)))
+            .await
+            .expect("another pubkey must have its own budget");
+        register_limited(db, "limit-other.com", "aaaa", "ada1", Some(limit(2)))
+            .await
+            .expect("the same pubkey must have its own budget on another domain");
+        register_limited(db, domain, "aaaa", "ada3", None)
+            .await
+            .expect("no limit must enforce nothing");
+    }
+
+    /// Re-registering the held name is not a name change: it never consumes
+    /// quota, and it still applies the description.
+    pub async fn re_registering_the_held_name_is_not_counted<DB>(db: &DB)
+    where
+        DB: LnurlRepository + Clone + Send + Sync + 'static,
+    {
+        let domain = "limit-rereg.com";
+        register_limited(db, domain, "cccc", "cleo", Some(limit(1)))
+            .await
+            .unwrap();
+
+        db.upsert_user(
+            &User {
+                domain: domain.into(),
+                pubkey: "cccc".into(),
+                name: "cleo".into(),
+                description: "new description".into(),
+            },
+            Some(limit(1)),
+        )
+        .await
+        .expect("re-registering the held name must not consume quota");
+        assert_eq!(
+            db.get_user_by_pubkey(domain, "cccc")
+                .await
+                .unwrap()
+                .map(|u| u.description),
+            Some("new description".to_string())
+        );
+
+        let changed = register_limited(db, domain, "cccc", "cora", Some(limit(1))).await;
+        assert!(
+            matches!(
+                changed,
+                Err(LnurlRepositoryError::RegistrationLimitExceeded)
+            ),
+            "a name change must still count: got {changed:?}"
+        );
+    }
+
+    /// Only registrations inside the window count: with a zero-length window
+    /// every prior registration is out of it, so the same request passes.
+    pub async fn registrations_outside_the_window_do_not_count<DB>(db: &DB)
+    where
+        DB: LnurlRepository + Clone + Send + Sync + 'static,
+    {
+        let domain = "limit-window.com";
+        register_limited(db, domain, "dddd", "dot1", Some(limit(1)))
+            .await
+            .unwrap();
+        let refused = register_limited(db, domain, "dddd", "dot2", Some(limit(1))).await;
+        assert!(matches!(
+            refused,
+            Err(LnurlRepositoryError::RegistrationLimitExceeded)
+        ));
+
+        let expired_window = Some(RegistrationLimit {
+            max_per_window: 1,
+            window_secs: 0,
+        });
+        register_limited(db, domain, "dddd", "dot2", expired_window)
+            .await
+            .expect("a registration outside the window must not count");
+    }
+
+    /// A registration refused for a taken name consumes no quota.
+    pub async fn a_refused_registration_does_not_consume_quota<DB>(db: &DB)
+    where
+        DB: LnurlRepository + Clone + Send + Sync + 'static,
+    {
+        let domain = "limit-refused.com";
+        register(db, domain, "eeee", "elsa").await.unwrap();
+
+        let taken = register_limited(db, domain, "ffff", "elsa", Some(limit(1))).await;
+        assert!(
+            matches!(taken, Err(LnurlRepositoryError::NameTaken)),
+            "expected NameTaken, got {taken:?}"
+        );
+        register_limited(db, domain, "ffff", "faye", Some(limit(1)))
+            .await
+            .expect("the refused attempt must not have consumed the quota");
+    }
+
+    /// Reclaiming a name reserved for the pubkey is a name change like any
+    /// other. Exempting it would let a pubkey flap between two names it has
+    /// held without ever hitting the limit.
+    pub async fn reclaiming_a_reserved_name_consumes_quota<DB>(db: &DB)
+    where
+        DB: LnurlRepository + Clone + Send + Sync + 'static,
+    {
+        let domain = "limit-reclaim.com";
+        register_limited(db, domain, "gggg", "gwen", Some(limit(2)))
+            .await
+            .unwrap();
+        register_limited(db, domain, "gggg", "gail", Some(limit(2)))
+            .await
+            .unwrap();
+        assert_eq!(
+            db.name_status(domain, "gwen", None).await.unwrap(),
+            NameStatus::Reserved
+        );
+
+        let reclaimed = register_limited(db, domain, "gggg", "gwen", Some(limit(2))).await;
+        assert!(
+            matches!(
+                reclaimed,
+                Err(LnurlRepositoryError::RegistrationLimitExceeded)
+            ),
+            "expected RegistrationLimitExceeded, got {reclaimed:?}"
+        );
+    }
+
+    /// A transfer target at its registration limit still receives the name:
+    /// a transfer moves an existing address rather than consuming a new one.
+    pub async fn a_transfer_ignores_the_registration_limit<DB>(db: &DB)
+    where
+        DB: LnurlRepository + Clone + Send + Sync + 'static,
+    {
+        let domain = "limit-transfer.com";
+        register_limited(db, domain, "hhhh", "hana", Some(limit(1)))
+            .await
+            .unwrap();
+        register(db, domain, "iiii", "iris").await.unwrap();
+
+        let statement = transfer_statement("iiii", "hhhh", "iris");
+        db.transfer_username(
+            transfer(domain, "iiii", "hhhh", "iris"),
+            transfer_claim(&statement),
+        )
+        .await
+        .expect("a transfer to a pubkey at its limit must succeed");
+        assert_eq!(
+            db.get_user_by_pubkey(domain, "hhhh")
+                .await
+                .unwrap()
+                .map(|u| u.name),
+            Some("iris".to_string())
+        );
+    }
+
+    /// Pruning drops only rows created before the cutoff, and a pruned budget
+    /// frees the quota.
+    pub async fn pruning_removes_only_old_registrations<DB>(db: &DB)
+    where
+        DB: LnurlRepository + Clone + Send + Sync + 'static,
+    {
+        let domain = "limit-prune.com";
+        register_limited(db, domain, "jjjj", "june1", Some(limit(2)))
+            .await
+            .unwrap();
+        register_limited(db, domain, "jjjj", "june2", Some(limit(2)))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            db.delete_old_registrations(0).await.unwrap(),
+            0,
+            "a cutoff in the past must prune nothing"
+        );
+        let refused = register_limited(db, domain, "jjjj", "june3", Some(limit(2))).await;
+        assert!(matches!(
+            refused,
+            Err(LnurlRepositoryError::RegistrationLimitExceeded)
+        ));
+
+        // Far in the future, so both rows are older than it. Other tests may
+        // share the table, so assert at least this test's rows go.
+        assert!(
+            db.delete_old_registrations(i64::MAX).await.unwrap() >= 2,
+            "a cutoff past every row must prune them"
+        );
+        register_limited(db, domain, "jjjj", "june3", Some(limit(2)))
+            .await
+            .expect("pruned registrations must not count");
     }
 }

--- a/crates/breez-sdk/lnurl/src/routes.rs
+++ b/crates/breez-sdk/lnurl/src/routes.rs
@@ -220,7 +220,7 @@ where
             description,
         };
 
-        if let Err(e) = state.db.upsert_user(&user).await {
+        if let Err(e) = state.db.upsert_user(&user, state.registration_limit).await {
             match e {
                 LnurlRepositoryError::NameTaken => {
                     trace!("name already taken: {}", user.name);
@@ -237,6 +237,13 @@ where
                     return Err((
                         StatusCode::CONFLICT,
                         Json(Value::String("name is reserved".into())),
+                    ));
+                }
+                LnurlRepositoryError::RegistrationLimitExceeded => {
+                    debug!("registration limit reached for pubkey {}", user.pubkey);
+                    return Err((
+                        StatusCode::TOO_MANY_REQUESTS,
+                        Json(Value::String("registration limit reached".into())),
                     ));
                 }
                 e => {
@@ -361,10 +368,14 @@ where
                 }
                 // A held name has no owner to transfer it, so the source check
                 // inside the transfer answers first and a transfer never
-                // reports a name as reserved. Matched rather than folded into a
-                // catch-all, so a transfer that starts checking holds has to
-                // answer for the status code here.
-                LnurlRepositoryError::NameReserved | LnurlRepositoryError::General(_) => {
+                // reports a name as reserved. The registration limit binds the
+                // register route only, so a transfer never reports it either.
+                // Matched rather than folded into a catch-all, so a transfer
+                // that starts checking holds or quota has to answer for the
+                // status code here.
+                LnurlRepositoryError::NameReserved
+                | LnurlRepositoryError::RegistrationLimitExceeded
+                | LnurlRepositoryError::General(_) => {
                     error!("failed to execute transfer query: {e}");
                     (
                         StatusCode::INTERNAL_SERVER_ERROR,
@@ -2018,6 +2029,9 @@ mod tests {
         ) -> Result<u64, LnurlRepositoryError> {
             Ok(0)
         }
+        async fn delete_old_registrations(&self, _: i64) -> Result<u64, LnurlRepositoryError> {
+            Ok(0)
+        }
         async fn get_user_by_name(
             &self,
             _: &str,
@@ -2032,7 +2046,11 @@ mod tests {
         ) -> Result<Option<User>, LnurlRepositoryError> {
             Ok(None)
         }
-        async fn upsert_user(&self, _: &User) -> Result<(), LnurlRepositoryError> {
+        async fn upsert_user(
+            &self,
+            _: &User,
+            _: Option<crate::repository::RegistrationLimit>,
+        ) -> Result<(), LnurlRepositoryError> {
             Ok(())
         }
         async fn name_status(

--- a/crates/breez-sdk/lnurl/src/state.rs
+++ b/crates/breez-sdk/lnurl/src/state.rs
@@ -16,6 +16,8 @@ pub struct State<DB> {
     pub min_sendable: u64,
     pub max_sendable: u64,
     pub include_spark_address: bool,
+    /// `None` disables the per-pubkey registration limit.
+    pub registration_limit: Option<crate::repository::RegistrationLimit>,
     pub domains: Arc<RwLock<crate::domains::DomainMap>>,
     pub nostr_keys: Option<nostr::Keys>,
     pub ca_cert: Option<Vec<u8>>,
@@ -89,6 +91,7 @@ where
             min_sendable: self.min_sendable,
             max_sendable: self.max_sendable,
             include_spark_address: self.include_spark_address,
+            registration_limit: self.registration_limit,
             domains: Arc::clone(&self.domains),
             nostr_keys: self.nostr_keys.clone(),
             ca_cert: self.ca_cert.clone(),

--- a/crates/breez-sdk/lnurl/src/webhook_notify.rs
+++ b/crates/breez-sdk/lnurl/src/webhook_notify.rs
@@ -122,12 +122,15 @@ mod shared_tests {
         let domain = "enqueue-test.example.com";
 
         db.add_domain(domain).await.unwrap();
-        db.upsert_user(&crate::user::User {
-            name: "alice".to_string(),
-            pubkey: "enqueue_pubkey".to_string(),
-            domain: domain.to_string(),
-            description: String::new(),
-        })
+        db.upsert_user(
+            &crate::user::User {
+                name: "alice".to_string(),
+                pubkey: "enqueue_pubkey".to_string(),
+                domain: domain.to_string(),
+                description: String::new(),
+            },
+            None,
+        )
         .await
         .unwrap();
 


### PR DESCRIPTION
Adds an app-level rate limit to the LNURL server's register endpoint: each pubkey may perform at most 5 successful registrations per domain in a rolling 24h window (`--max-registrations-per-day`, 0 disables).

- Only registrations that change the held name count: description updates are free, reclaiming a reserved name counts, transfers don't.
- Enforced in Postgres inside the registration transaction, so it holds across instances and concurrent requests, and a refused registration (429) leaves no trace.
- Log rows are pruned hourly once they age out of the window.