### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Passkey.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Passkey.cs
@@ -195,9 +195,13 @@ public static class PasskeyResolver
         string? breezApiKey,
         string? label,
         bool listLabels,
-        bool storeLabel)
+        bool storeLabel,
+        ProxyConfig? proxy)
     {
-        var passkey = new PasskeyClient(provider, breezApiKey, config: null);
+        PasskeyConfig? sdkPasskeyConfig = proxy != null
+            ? new PasskeyConfig(proxy: proxy)
+            : null;
+        var passkey = new PasskeyClient(provider, breezApiKey, config: sdkPasskeyConfig);
 
         // --list-labels: discovery sign-in (null label) returns the
         // discovered label set; prompt user to pick.

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Program.cs
@@ -15,6 +15,9 @@ string? stableBalanceDefaultActiveLabel = null;
 ulong? stableBalanceThreshold = null;
 bool serverMode = false;
 string? lnurlDomain = null;
+string? proxyAddress = null;
+string? proxyUser = null;
+string? proxyPassword = null;
 string? passkeyProviderStr = null;
 string? label = null;
 bool listLabels = false;
@@ -71,6 +74,15 @@ for (int i = 0; i < args.Length; i++)
         case "--lnurl-domain":
             if (i + 1 < args.Length) lnurlDomain = args[++i];
             break;
+        case "--proxy":
+            if (i + 1 < args.Length) proxyAddress = args[++i];
+            break;
+        case "--proxy-user":
+            if (i + 1 < args.Length) proxyUser = args[++i];
+            break;
+        case "--proxy-password":
+            if (i + 1 < args.Length) proxyPassword = args[++i];
+            break;
         case "--help":
         case "-h":
             PrintUsage();
@@ -121,6 +133,24 @@ if (rpId != null && passkeyProviderStr == null)
 if (listLabels && (label != null || storeLabel))
 {
     Console.Error.WriteLine("Error: --list-labels conflicts with --label and --store-label");
+    return;
+}
+
+if (proxyUser != null && proxyAddress == null)
+{
+    Console.Error.WriteLine("Error: --proxy-user requires --proxy");
+    return;
+}
+
+if (proxyPassword != null && proxyAddress == null)
+{
+    Console.Error.WriteLine("Error: --proxy-password requires --proxy");
+    return;
+}
+
+if ((proxyUser != null) != (proxyPassword != null))
+{
+    Console.Error.WriteLine("Error: --proxy-user and --proxy-password must be specified together");
     return;
 }
 
@@ -185,6 +215,14 @@ if (passkeyProviderStr != null)
 }
 
 // ---------------------------------------------------------------------------
+// Parse proxy
+// ---------------------------------------------------------------------------
+
+ProxyConfig? proxy = proxyAddress != null
+    ? ParseProxy(proxyAddress, proxyUser, proxyPassword)
+    : null;
+
+// ---------------------------------------------------------------------------
 // Run interactive mode
 // ---------------------------------------------------------------------------
 
@@ -197,7 +235,8 @@ await RunInteractiveMode(
     mysqlConnectionString,
     stableBalanceConfig,
     passkeyConfig,
-    lnurlDomain
+    lnurlDomain,
+    proxy
 );
 
 return;
@@ -205,6 +244,22 @@ return;
 // ===========================================================================
 // Functions
 // ===========================================================================
+
+static ProxyConfig ParseProxy(string address, string? username, string? password)
+{
+    var lastColon = address.LastIndexOf(':');
+    if (lastColon < 0)
+    {
+        throw new ArgumentException($"Invalid proxy '{address}', expected HOST:PORT");
+    }
+    var host = address[..lastColon];
+    var portStr = address[(lastColon + 1)..];
+    if (!ushort.TryParse(portStr, out var port))
+    {
+        throw new ArgumentException($"Invalid proxy port '{portStr}'");
+    }
+    return new ProxyConfig(host: host, port: port, username: username, password: password);
+}
 
 static string ExpandPath(string path)
 {
@@ -238,6 +293,9 @@ static void PrintUsage()
     Console.WriteLine("  --rpid <RPID>                               Relying party ID for FIDO2 provider (requires --passkey)");
     Console.WriteLine("  --server-mode                               Run in server mode (background tasks disabled)");
     Console.WriteLine("  --lnurl-domain <DOMAIN>                     LNURL server domain for lightning address registration");
+    Console.WriteLine("  --proxy <HOST:PORT>                         Route connections through a SOCKS5 proxy");
+    Console.WriteLine("  --proxy-user <USER>                         SOCKS5 username (requires --proxy and --proxy-password)");
+    Console.WriteLine("  --proxy-password <PASS>                     SOCKS5 password (requires --proxy and --proxy-user)");
     Console.WriteLine("  -h, --help                                  Show this help");
 }
 
@@ -250,7 +308,8 @@ static async Task RunInteractiveMode(
     string? mysqlConnectionString,
     StableBalanceConfig? stableBalanceConfig,
     CliPasskeyConfig? passkeyConfig,
-    string? lnurlDomain)
+    string? lnurlDomain,
+    ProxyConfig? proxy)
 {
     // Init logging
     try
@@ -286,6 +345,10 @@ static async Task RunInteractiveMode(
     {
         config = config with { stableBalanceConfig = stableBalanceConfig };
     }
+    if (proxy != null)
+    {
+        config = config with { proxy = proxy };
+    }
     if (lnurlDomain != null)
     {
         config = config with { lnurlDomain = lnurlDomain };
@@ -308,7 +371,8 @@ static async Task RunInteractiveMode(
             apiKey,
             passkeyConfig.Label,
             passkeyConfig.ListLabels,
-            passkeyConfig.StoreLabel);
+            passkeyConfig.StoreLabel,
+            proxy);
     }
     else
     {

--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/README.md
@@ -46,6 +46,9 @@ dotnet run --project BreezCli.csproj -- [OPTIONS]
 | `--rpid` | - | Relying party ID for FIDO2 provider (requires `--passkey`) |
 | `--server-mode` | - | Run in server mode (background tasks disabled; drive `sync` manually) |
 | `--lnurl-domain` | network default | LNURL server domain for lightning address registration; accepts a plain domain or an `http://host:port` test server URL |
+| `--proxy` | - | Route connections through a SOCKS5 proxy (`HOST:PORT`, e.g. `127.0.0.1:9050`) |
+| `--proxy-user` | - | SOCKS5 username (requires `--proxy` and `--proxy-password`) |
+| `--proxy-password` | - | SOCKS5 password (requires `--proxy` and `--proxy-user`) |
 
 ### Passkey Support
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/README.md
@@ -58,6 +58,9 @@ make run-mainnet
     --rpid                              Relying party ID for FIDO2 provider (requires --passkey)
     --server-mode                       Run in server mode (background_tasks_enabled=false)
     --lnurl-domain                      LNURL server domain for lightning address registration
+    --proxy                             Route every connection through a SOCKS5 proxy (HOST:PORT)
+    --proxy-user                        Username for SOCKS5 authentication (requires --proxy-password)
+    --proxy-password                    Password for SOCKS5 authentication (requires --proxy-user)
 -h, --help                              Show usage
 ```
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/bin/breez_cli.dart
@@ -45,6 +45,13 @@ Future<void> main(List<String> arguments) async {
           help: 'Run in server mode (background_tasks_enabled=false)',
         )
         ..addOption('lnurl-domain', help: 'LNURL server domain for lightning address registration')
+        ..addOption(
+          'proxy',
+          help: 'Route every connection through a SOCKS5 proxy, as HOST:PORT',
+          valueHelp: 'HOST:PORT',
+        )
+        ..addOption('proxy-user', help: 'Username for SOCKS5 authentication (requires --proxy-password)')
+        ..addOption('proxy-password', help: 'Password for SOCKS5 authentication (requires --proxy-user)')
         ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage');
 
   final ArgResults results;
@@ -120,6 +127,28 @@ Future<void> main(List<String> arguments) async {
     exit(1);
   }
 
+  // Validate proxy-related flag constraints
+  final proxyAddress = results.option('proxy');
+  final proxyUser = results.option('proxy-user');
+  final proxyPassword = results.option('proxy-password');
+  if (proxyUser != null && proxyAddress == null) {
+    stderr.writeln('Error: --proxy-user requires --proxy');
+    exit(1);
+  }
+  if (proxyPassword != null && proxyAddress == null) {
+    stderr.writeln('Error: --proxy-password requires --proxy');
+    exit(1);
+  }
+  if ((proxyUser != null) != (proxyPassword != null)) {
+    stderr.writeln('Error: --proxy-user and --proxy-password must be specified together');
+    exit(1);
+  }
+
+  ProxyConfig? proxy;
+  if (proxyAddress != null) {
+    proxy = parseProxy(proxyAddress, proxyUser, proxyPassword);
+  }
+
   CliPasskeyConfig? passkeyConfig;
   if (passkeyProvider != null) {
     passkeyConfig = CliPasskeyConfig(
@@ -143,6 +172,7 @@ Future<void> main(List<String> arguments) async {
     passkeyConfig: passkeyConfig,
     serverMode: results.flag('server-mode'),
     lnurlDomain: results.option('lnurl-domain'),
+    proxy: proxy,
   );
 
   // Force exit — the native FFI library may keep background threads alive

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/cli.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/cli.dart
@@ -15,6 +15,22 @@ import 'serialization.dart';
 import 'stable_balance.dart';
 import 'webhooks.dart';
 
+/// Parses `HOST:PORT` into a [ProxyConfig]. Splits from the right so an IPv6
+/// literal keeps its colons.
+ProxyConfig parseProxy(String address, String? username, String? password) {
+  final lastColon = address.lastIndexOf(':');
+  if (lastColon < 0) {
+    throw FormatException("Invalid proxy '$address', expected HOST:PORT");
+  }
+  final host = address.substring(0, lastColon);
+  final portStr = address.substring(lastColon + 1);
+  final port = int.tryParse(portStr);
+  if (port == null) {
+    throw FormatException("Invalid proxy port '$portStr'");
+  }
+  return ProxyConfig(host: host, port: port, username: username, password: password);
+}
+
 Future<void> runCli({
   required String dataDir,
   required String network,
@@ -27,6 +43,7 @@ Future<void> runCli({
   CliPasskeyConfig? passkeyConfig,
   bool serverMode = false,
   String? lnurlDomain,
+  ProxyConfig? proxy,
 }) async {
   await BreezSdkSparkLib.init(externalLibrary: ExternalLibrary.open(_nativeLibPath()));
 
@@ -65,13 +82,17 @@ Future<void> runCli({
     config = config.copyWith(lnurlDomain: lnurlDomain);
   }
 
+  if (proxy != null) {
+    config = config.copyWith(proxy: proxy);
+  }
+
   if (networkEnum == Network.mainnet) {
     config = config.copyWith(crossChainConfig: CrossChainConfig());
   }
 
   Seed seed;
   if (passkeyConfig != null) {
-    seed = await resolvePasskeySeed(passkeyConfig, dataDir, apiKey);
+    seed = await resolvePasskeySeed(passkeyConfig, dataDir, apiKey, proxy);
   } else {
     final mnemonic = persistence.getOrCreateMnemonic();
     seed = Seed.mnemonic(mnemonic: mnemonic, passphrase: null);

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/passkey.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/passkey.dart
@@ -88,7 +88,12 @@ class CliPasskeyConfig {
 /// Resolve the seed using a passkey PRF provider.
 ///
 /// Mirrors the Rust CLI's `resolve_passkey_seed` function.
-Future<Seed> resolvePasskeySeed(CliPasskeyConfig config, String dataDir, String? breezApiKey) async {
+Future<Seed> resolvePasskeySeed(
+  CliPasskeyConfig config,
+  String dataDir,
+  String? breezApiKey,
+  ProxyConfig? proxy,
+) async {
   if (config.provider != 'file') {
     throw Exception(
       'Passkey provider "${config.provider}" is not yet supported in the Flutter CLI. '
@@ -97,7 +102,9 @@ Future<Seed> resolvePasskeySeed(CliPasskeyConfig config, String dataDir, String?
   }
 
   final filePrf = FilePrfProvider.create(dataDir);
-  final passkey = PasskeyClientBuilder(breezApiKey: breezApiKey).withPrfProvider(filePrf).build();
+  final passkeyConfig = proxy != null ? PasskeyConfig(proxy: proxy) : null;
+  final passkey =
+      PasskeyClientBuilder(breezApiKey: breezApiKey, config: passkeyConfig).withPrfProvider(filePrf).build();
 
   // --list-labels: discovery sign-in (no cached label) returns the
   // published label set; prompt the user to pick one.

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/README.md
@@ -66,6 +66,9 @@ make clean            Remove binary
 | `--list-labels` | false | Requires `--passkey`. Select label from Nostr |
 | `--store-label` | false | Requires `--passkey`. Publish label to Nostr |
 | `--rpid` | `keys.breez.technology` | Requires `--passkey`. Relying party ID for FIDO2 provider |
+| `--proxy` | - | Route every connection through a SOCKS5 proxy, as `HOST:PORT` (e.g. `127.0.0.1:9050` for a local Tor daemon) |
+| `--proxy-user` | - | Username for SOCKS5 authentication (requires `--proxy` and `--proxy-password`) |
+| `--proxy-password` | - | Password for SOCKS5 authentication (requires `--proxy` and `--proxy-user`) |
 
 ## Environment Variables
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/main.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/main.go
@@ -14,6 +14,32 @@ import (
 	"github.com/chzyer/readline"
 )
 
+// parseProxy parses HOST:PORT into a ProxyConfig. Split from the right so an
+// IPv6 literal keeps its colons.
+func parseProxy(address string, username, password *string) (*breez_sdk_spark.ProxyConfig, error) {
+	lastColon := strings.LastIndex(address, ":")
+	if lastColon < 0 {
+		return nil, fmt.Errorf("invalid proxy '%s', expected HOST:PORT", address)
+	}
+	host := address[:lastColon]
+	portStr := address[lastColon+1:]
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("invalid proxy port '%s'", portStr)
+	}
+	config := &breez_sdk_spark.ProxyConfig{
+		Host: host,
+		Port: uint16(port),
+	}
+	if *username != "" {
+		config.Username = username
+	}
+	if *password != "" {
+		config.Password = password
+	}
+	return config, nil
+}
+
 // expandPath expands a leading ~/ to the user's home directory.
 func expandPath(path string) string {
 	if strings.HasPrefix(path, "~/") {
@@ -91,6 +117,9 @@ func main() {
 	listLabels := flag.Bool("list-labels", false, "List and select from labels published to Nostr (requires --passkey)")
 	storeLabel := flag.Bool("store-label", false, "Publish the label to Nostr (requires --passkey and --label)")
 	_ = flag.String("rpid", "", "Relying party ID for FIDO2 provider (requires --passkey)")
+	proxyAddr := flag.String("proxy", "", "Route every connection through a SOCKS5 proxy, as HOST:PORT (e.g. 127.0.0.1:9050 for a local Tor daemon)")
+	proxyUser := flag.String("proxy-user", "", "Username for SOCKS5 authentication (requires --proxy-password)")
+	proxyPassword := flag.String("proxy-password", "", "Password for SOCKS5 authentication (requires --proxy-user)")
 	flag.Parse()
 
 	resolvedDir := expandPath(*dataDir)
@@ -107,6 +136,16 @@ func main() {
 		networkEnum = breez_sdk_spark.NetworkMainnet
 	default:
 		log.Fatalf("Invalid network. Use 'regtest' or 'mainnet'")
+	}
+
+	// Parse proxy
+	var proxy *breez_sdk_spark.ProxyConfig
+	if *proxyAddr != "" {
+		var err error
+		proxy, err = parseProxy(*proxyAddr, proxyUser, proxyPassword)
+		if err != nil {
+			log.Fatalf("Invalid proxy: %v", err)
+		}
 	}
 
 	// Init logging
@@ -129,6 +168,7 @@ func main() {
 	if *lnurlDomain != "" {
 		config.LnurlDomain = lnurlDomain
 	}
+	config.Proxy = proxy
 
 	// Cross-chain sends are opt-in by the caller and mainnet-only (enabling on
 	// other networks fails config validation). Enable with default slippage so
@@ -182,7 +222,7 @@ func main() {
 		if apiKey != "" {
 			apiKeyPtr = &apiKey
 		}
-		seed, err = resolvePasskeySeed(prfProvider, apiKeyPtr, wn, *listLabels, *storeLabel)
+		seed, err = resolvePasskeySeed(prfProvider, apiKeyPtr, wn, *listLabels, *storeLabel, proxy)
 		if err != nil {
 			log.Fatalf("Passkey seed resolution failed: %v", err)
 		}

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/passkey.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/passkey.go
@@ -160,8 +160,15 @@ func resolvePasskeySeed(
 	label *string,
 	listLabels bool,
 	storeLabel bool,
+	proxy *breez_sdk_spark.ProxyConfig,
 ) (breez_sdk_spark.Seed, error) {
-	passkey, err := breez_sdk_spark.NewPasskeyClient(provider, breezAPIKey, nil)
+	var passkeyConfig *breez_sdk_spark.PasskeyConfig
+	if proxy != nil {
+		passkeyConfig = &breez_sdk_spark.PasskeyConfig{
+			Proxy: proxy,
+		}
+	}
+	passkey, err := breez_sdk_spark.NewPasskeyClient(provider, breezAPIKey, passkeyConfig)
 	if err = liftError(err); err != nil {
 		return nil, err
 	}

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Main.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Main.kt
@@ -45,6 +45,26 @@ fun splitArgs(line: String): List<String> {
 }
 
 /**
+ * Parses `HOST:PORT` into a [ProxyConfig]. Splits from the right so an IPv6
+ * literal keeps its colons.
+ */
+fun parseProxy(address: String, username: String?, password: String?): ProxyConfig {
+    val lastColon = address.lastIndexOf(':')
+    if (lastColon < 0) {
+        error("Invalid proxy '$address', expected HOST:PORT")
+    }
+    val host = address.substring(0, lastColon)
+    val port = address.substring(lastColon + 1).toUShortOrNull()
+        ?: error("Invalid proxy port '${address.substring(lastColon + 1)}'")
+    return ProxyConfig(
+        host = host,
+        port = port,
+        username = username,
+        password = password,
+    )
+}
+
+/**
  * Expands a leading ~/ to the user's home directory.
  */
 fun expandPath(path: String): String {
@@ -72,6 +92,9 @@ fun main(args: Array<String>) {
     var rpId: String? = null
     var serverMode = false
     var lnurlDomain: String? = null
+    var proxyAddress: String? = null
+    var proxyUser: String? = null
+    var proxyPassword: String? = null
 
     // Simple argument parsing
     var i = 0
@@ -134,6 +157,18 @@ fun main(args: Array<String>) {
                 i++
                 if (i < args.size) lnurlDomain = args[i]
             }
+            "--proxy" -> {
+                i++
+                if (i < args.size) proxyAddress = args[i]
+            }
+            "--proxy-user" -> {
+                i++
+                if (i < args.size) proxyUser = args[i]
+            }
+            "--proxy-password" -> {
+                i++
+                if (i < args.size) proxyPassword = args[i]
+            }
             "--help", "-h" -> {
                 println("Usage: breez-sdk-spark-cli [OPTIONS]")
                 println()
@@ -153,6 +188,9 @@ fun main(args: Array<String>) {
                 println("  --rpid <ID>                                  Relying party ID for FIDO2 provider (requires --passkey)")
                 println("  --server-mode                                Run in server mode (no background tasks)")
                 println("  --lnurl-domain <DOMAIN>                      LNURL server domain for lightning address registration")
+                println("  --proxy <HOST:PORT>                          Route connections through a SOCKS5 proxy")
+                println("  --proxy-user <USER>                          Username for SOCKS5 authentication (requires --proxy-password)")
+                println("  --proxy-password <PASS>                      Password for SOCKS5 authentication (requires --proxy-user)")
                 println("  -h, --help                                   Show this help message")
                 return
             }
@@ -181,6 +219,14 @@ fun main(args: Array<String>) {
     }
     if (postgresConnectionString != null && mysqlConnectionString != null) {
         System.err.println("Error: --postgres-connection-string and --mysql-connection-string are mutually exclusive")
+        return
+    }
+    if (proxyUser != null && (proxyAddress == null || proxyPassword == null)) {
+        System.err.println("Error: --proxy-user requires --proxy and --proxy-password")
+        return
+    }
+    if (proxyPassword != null && (proxyAddress == null || proxyUser == null)) {
+        System.err.println("Error: --proxy-password requires --proxy and --proxy-user")
         return
     }
 
@@ -234,6 +280,8 @@ fun main(args: Array<String>) {
         }
     } else null
 
+    val proxy = proxyAddress?.let { parseProxy(it, proxyUser, proxyPassword) }
+
     runBlocking {
         runInteractiveMode(
             resolvedDir,
@@ -245,6 +293,7 @@ fun main(args: Array<String>) {
             stableBalanceConfig,
             passkeyConfig,
             lnurlDomain,
+            proxy,
         )
     }
 }
@@ -259,6 +308,7 @@ suspend fun runInteractiveMode(
     stableBalanceConfig: StableBalanceConfig?,
     passkeyConfig: PasskeyConfig?,
     lnurlDomain: String?,
+    proxy: ProxyConfig?,
 ) {
     // Init logging
     try {
@@ -282,6 +332,7 @@ suspend fun runInteractiveMode(
         config.apiKey = apiKey
     }
     config.stableBalanceConfig = stableBalanceConfig
+    config.proxy = proxy
     if (network == Network.MAINNET) {
         config.crossChainConfig = CrossChainConfig()
     }
@@ -298,6 +349,7 @@ suspend fun runInteractiveMode(
             passkeyConfig.label,
             passkeyConfig.listLabels,
             passkeyConfig.storeLabel,
+            proxy,
         )
     } else {
         val mnemonic = persistence.getOrCreateMnemonic()

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Passkey.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Passkey.kt
@@ -162,8 +162,12 @@ suspend fun resolvePasskeySeed(
     label: String?,
     listLabels: Boolean,
     storeLabel: Boolean,
+    proxy: ProxyConfig?,
 ): Seed {
-    val passkey = PasskeyClient(prfProvider = provider, breezApiKey = breezApiKey, config = null)
+    val sdkPasskeyConfig = proxy?.let {
+        breez_sdk_spark.PasskeyConfig(proxy = it)
+    }
+    val passkey = PasskeyClient(prfProvider = provider, breezApiKey = breezApiKey, config = sdkPasskeyConfig)
 
     // --list-labels: discovery sign-in (no cached label) returns the
     // discovered label set; prompt user to pick.

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/README.md
@@ -59,6 +59,9 @@ make clean            Remove venv and build artifacts
 | `--store-label` | false | Requires `--passkey`. Publish label to NOSTR |
 | `--rpid` | `keys.breez.technology` | Requires `--passkey`. Relying party ID for FIDO2 provider |
 | `--lnurl-domain` | network default | LNURL server domain for lightning address registration; accepts a plain domain or an `http://host:port` test server URL |
+| `--proxy` | - | Route every connection through a SOCKS5 proxy, as `HOST:PORT` (e.g. `127.0.0.1:9050` for a local Tor daemon) |
+| `--proxy-user` | - | Username for SOCKS5 authentication (requires `--proxy` and `--proxy-password`) |
+| `--proxy-password` | - | Password for SOCKS5 authentication (requires `--proxy` and `--proxy-user`) |
 
 ## Environment Variables
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -4,7 +4,6 @@ import math
 import os
 import time
 
-import breez_sdk_spark
 from breez_sdk_spark import (
     AssetFilter,
     AuthorizeTransferRequest,
@@ -22,6 +21,7 @@ from breez_sdk_spark import (
     FetchConversionLimitsRequest,
     GetInfoRequest,
     GetPaymentRequest,
+    GetSparkStatusRequest,
     GetTokensMetadataRequest,
     InputType,
     ListPaymentsRequest,
@@ -53,6 +53,7 @@ from breez_sdk_spark import (
     TokenTransactionType,
     TransferAuthorization,
     UpdateUserSettingsRequest,
+    get_spark_status,
 )
 
 from breez_cli.serialization import print_value
@@ -1032,7 +1033,7 @@ def _build_get_spark_status_parser():
     return _parser("get-spark-status", "Get Spark network service status")
 
 async def _handle_get_spark_status(_sdk, _token_issuer, _session, _args):
-    result = await breez_sdk_spark.get_spark_status()
+    result = await get_spark_status(request=GetSparkStatusRequest())
     print_value(result)
 
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/main.py
@@ -13,6 +13,7 @@ from breez_sdk_spark import (
     CrossChainConfig,
     EventListener,
     Network,
+    ProxyConfig,
     SdkBuilder,
     SdkEvent,
     Seed,
@@ -54,6 +55,19 @@ def expand_path(path: str) -> Path:
     return Path(path)
 
 
+def parse_proxy(address: str, username=None, password=None) -> ProxyConfig:
+    idx = address.rfind(":")
+    if idx < 0:
+        raise click.UsageError(f"Invalid proxy '{address}', expected HOST:PORT")
+    host = address[:idx]
+    port_str = address[idx + 1:]
+    try:
+        port = int(port_str)
+    except ValueError:
+        raise click.UsageError(f"Invalid proxy port '{port_str}'")
+    return ProxyConfig(host=host, port=port, username=username, password=password)
+
+
 @click.command()
 @click.option("-d", "--data-dir", default="./.data", help="Path to the data directory")
 @click.option(
@@ -79,13 +93,20 @@ def expand_path(path: str) -> Path:
 @click.option("--rpid", default=None, help="Relying party ID for FIDO2 provider (requires --passkey)")
 @click.option("--lnurl-domain", default=None,
               help="LNURL server domain for lightning address registration; accepts a plain domain or an http://host:port test server URL")
+@click.option("--proxy", default=None, metavar="HOST:PORT",
+              help="Route every connection through a SOCKS5 proxy (e.g. 127.0.0.1:9050 for a local Tor daemon)")
+@click.option("--proxy-user", default=None,
+              help="Username for SOCKS5 authentication (requires --proxy and --proxy-password)")
+@click.option("--proxy-password", default=None,
+              help="Password for SOCKS5 authentication (requires --proxy and --proxy-user)")
 async def main(data_dir, network, account_number, postgres_connection_string,
                mysql_connection_string,
                stable_balance_tokens, stable_balance_default_active_label,
                stable_balance_threshold,
                server_mode,
                passkey_provider, label, list_labels, store_label, rpid,
-               lnurl_domain):
+               lnurl_domain,
+               proxy, proxy_user, proxy_password):
     """CLI client for Breez SDK with Spark."""
     data_dir = expand_path(data_dir)
     data_dir.mkdir(parents=True, exist_ok=True)
@@ -107,6 +128,19 @@ async def main(data_dir, network, account_number, postgres_connection_string,
     if list_labels and (label or store_label):
         raise click.UsageError("--list-labels conflicts with --label and --store-label")
 
+    if proxy_user and not proxy:
+        raise click.UsageError("--proxy-user requires --proxy")
+    if proxy_password and not proxy:
+        raise click.UsageError("--proxy-password requires --proxy")
+    if proxy_user and not proxy_password:
+        raise click.UsageError("--proxy-user requires --proxy-password")
+    if proxy_password and not proxy_user:
+        raise click.UsageError("--proxy-password requires --proxy-user")
+
+    proxy_config = None
+    if proxy:
+        proxy_config = parse_proxy(proxy, proxy_user, proxy_password)
+
     init_logging(log_dir=str(data_dir), app_logger=None, log_filter=None)
 
     persistence = CliPersistence(data_dir)
@@ -119,6 +153,7 @@ async def main(data_dir, network, account_number, postgres_connection_string,
     else:
         config = default_config(network=network_enum)
     config.api_key = breez_api_key
+    config.proxy = proxy_config
     if lnurl_domain is not None:
         config.lnurl_domain = lnurl_domain
     if network_enum == Network.MAINNET:
@@ -143,7 +178,7 @@ async def main(data_dir, network, account_number, postgres_connection_string,
     if passkey_provider:
         provider = create_provider(passkey_provider, data_dir, rpid=rpid)
         seed = await resolve_passkey_seed(
-            provider, breez_api_key, label, list_labels, store_label,
+            provider, breez_api_key, label, list_labels, store_label, proxy_config,
         )
     else:
         mnemonic = persistence.get_or_create_mnemonic()

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/passkey.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/passkey.py
@@ -9,7 +9,9 @@ from breez_sdk_spark import (
     DeriveSeedsRequest,
     DomainAssociation,
     PasskeyClient,
+    PasskeyConfig,
     PrfProvider,
+    ProxyConfig,
     Seed,
     SignInRequest,
 )
@@ -131,9 +133,13 @@ async def resolve_passkey_seed(
     label,
     list_labels,
     store_label,
+    proxy=None,
 ) -> Seed:
     """Resolve a Seed from a passkey PRF provider, with optional Nostr label operations."""
-    client = PasskeyClient(provider, breez_api_key, None)
+    config = None
+    if proxy is not None:
+        config = PasskeyConfig(proxy=proxy)
+    client = PasskeyClient(provider, breez_api_key, config)
 
     if list_labels:
         print("Querying Nostr for available labels...")

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
@@ -92,6 +92,9 @@ declare module '@breeztech/breez-sdk-spark-react-native' {
   export const ConfirmationStatus: any;
   export type ConfirmationStatus = any;
 
+  // --- proxy ---
+  export type ProxyConfig = any;
+
   // --- passkey ---
   // Note: PasskeyProvider (concrete class) ships at the
   // `/passkey-prf-provider` subpath export, declared separately below.
@@ -102,6 +105,9 @@ declare module '@breeztech/breez-sdk-spark-react-native' {
 
   export const PasskeyClient: any;
   export type PasskeyClient = any;
+
+  export const PasskeyConfig: any;
+  export type PasskeyConfig = any;
 
   export const PasskeyCredential: any;
   export type PasskeyCredential = any;

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -1330,7 +1330,7 @@ async function handleSetUserSettings(sdk: BreezSdkInterface, _tokenIssuer: Token
 // --- get-spark-status ---
 
 async function handleGetSparkStatus(_sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, _args: string[]): Promise<string> {
-  const result = await getSparkStatus()
+  const result = await getSparkStatus({ proxy: undefined })
   return formatValue(result)
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/passkey.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/passkey.ts
@@ -17,7 +17,9 @@ import {
   type PrfProvider,
   type DeriveSeedsRequest,
   type DeriveSeedsOutput,
+  type ProxyConfig,
   DomainAssociation,
+  PasskeyConfig as SdkPasskeyConfig,
 } from '@breeztech/breez-sdk-spark-react-native'
 import { PasskeyProvider as PlatformPasskeyProvider } from '@breeztech/breez-sdk-spark-react-native/passkey-prf-provider'
 
@@ -323,8 +325,10 @@ export async function resolvePasskeySeed(
   label: string | undefined,
   listLabels: boolean,
   storeLabel: boolean,
+  proxy?: ProxyConfig,
 ): Promise<{ seed: SeedType; labels?: string[] }> {
-  const passkey = new PasskeyClient(provider, breezApiKey, undefined)
+  const config = proxy ? SdkPasskeyConfig.create({ proxy }) : undefined
+  const passkey = new PasskeyClient(provider, breezApiKey, config)
 
   // --list-labels: discovery sign-in (no cached label) returns the published
   // label set. App.tsx does not prompt for selection; default to the explicit

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/README.md
@@ -65,6 +65,9 @@ make clean            Remove build artifacts
 | `--store-label` | false | Requires `--passkey`. Publish label to Nostr |
 | `--rpid` | `keys.breez.technology` | Requires `--passkey`. Relying party ID for FIDO2 provider |
 | `--lnurl-domain` | network default | LNURL server domain for lightning address registration; accepts a plain domain or an `http://host:port` test server URL |
+| `--proxy` | - | Route every connection through a SOCKS5 proxy, as `HOST:PORT` (e.g. `127.0.0.1:9050` for a local Tor daemon) |
+| `--proxy-user` | - | Username for SOCKS5 authentication (requires `--proxy` and `--proxy-password`) |
+| `--proxy-password` | - | Password for SOCKS5 authentication (requires `--proxy` and `--proxy-user`) |
 
 ## Environment Variables
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Passkey.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Passkey.swift
@@ -192,9 +192,13 @@ func resolvePasskeySeed(
     breezApiKey: String?,
     label: String?,
     listLabels: Bool,
-    storeLabel: Bool
+    storeLabel: Bool,
+    proxy: ProxyConfig?
 ) async throws -> Seed {
-    let passkey = try PasskeyClient(prfProvider: provider, breezApiKey: breezApiKey, config: nil)
+    let sdkPasskeyConfig: BreezSdkSpark.PasskeyConfig? = proxy.map {
+        BreezSdkSpark.PasskeyConfig(proxy: $0)
+    }
+    let passkey = try PasskeyClient(prfProvider: provider, breezApiKey: breezApiKey, config: sdkPasskeyConfig)
 
     // --list-labels: discovery sign-in (no cached label) returns the
     // published label set; prompt the user to pick one.

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/main.swift
@@ -20,6 +20,9 @@ struct CliOptions {
     var rpid: String?
     var serverMode: Bool = false
     var lnurlDomain: String?
+    var proxy: String?
+    var proxyUser: String?
+    var proxyPassword: String?
 }
 
 func parseCliFlags() -> CliOptions {
@@ -70,6 +73,15 @@ func parseCliFlags() -> CliOptions {
         case "--lnurl-domain":
             i += 1
             if i < args.count { opts.lnurlDomain = args[i] }
+        case "--proxy":
+            i += 1
+            if i < args.count { opts.proxy = args[i] }
+        case "--proxy-user":
+            i += 1
+            if i < args.count { opts.proxyUser = args[i] }
+        case "--proxy-password":
+            i += 1
+            if i < args.count { opts.proxyPassword = args[i] }
         default:
             break
         }
@@ -85,6 +97,22 @@ func expandPath(_ path: String) -> String {
         return NSString(string: path).expandingTildeInPath
     }
     return path
+}
+
+/// Parses `HOST:PORT` into a `ProxyConfig`. Splits from the right so an
+/// IPv6 literal keeps its colons.
+func parseProxy(address: String, username: String?, password: String?) -> ProxyConfig {
+    guard let lastColon = address.lastIndex(of: ":") else {
+        print("Invalid proxy '\(address)', expected HOST:PORT")
+        exit(1)
+    }
+    let host = String(address[address.startIndex..<lastColon])
+    let portStr = String(address[address.index(after: lastColon)...])
+    guard let port = UInt16(portStr) else {
+        print("Invalid proxy port '\(portStr)'")
+        exit(1)
+    }
+    return ProxyConfig(host: host, port: port, username: username, password: password)
 }
 
 // MARK: - Argument splitting (shell-like)
@@ -233,6 +261,10 @@ config.apiKey = breezApiKey
 if network == .mainnet {
     config.crossChainConfig = CrossChainConfig()
 }
+let proxy: ProxyConfig? = opts.proxy.map {
+    parseProxy(address: $0, username: opts.proxyUser, password: opts.proxyPassword)
+}
+config.proxy = proxy
 if let lnurlDomain = opts.lnurlDomain {
     config.lnurlDomain = lnurlDomain
 }
@@ -268,7 +300,8 @@ if let passkeyStr = opts.passkey {
         breezApiKey: breezApiKey,
         label: opts.label,
         listLabels: opts.listLabels,
-        storeLabel: opts.storeLabel
+        storeLabel: opts.storeLabel,
+        proxy: proxy
     )
 } else {
     let mnemonic = try persistence.getOrCreateMnemonic()

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/README.md
@@ -63,6 +63,9 @@ node src/main.js [OPTIONS]
 | `--rpid` | `keys.breez.technology` | Requires `--passkey`. Relying party ID for FIDO2 provider |
 | `--server-mode` | false | Run in server mode (`background_tasks_enabled=false`) |
 | `--lnurl-domain` | network default | LNURL server domain for lightning address registration; accepts a plain domain or an `http://host:port` test server URL |
+| `--proxy` | - | Route every connection through a SOCKS5 proxy, as `HOST:PORT` |
+| `--proxy-user` | - | Username for SOCKS5 authentication (requires `--proxy` and `--proxy-password`) |
+| `--proxy-password` | - | Password for SOCKS5 authentication (requires `--proxy` and `--proxy-user`) |
 
 ### Examples
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/main.js
@@ -45,7 +45,10 @@ function parseCliArgs() {
     listLabels: false,
     storeLabel: false,
     rpid: undefined,
-    lnurlDomain: undefined
+    lnurlDomain: undefined,
+    proxy: undefined,
+    proxyUser: undefined,
+    proxyPassword: undefined
   }
 
   for (let i = 0; i < args.length; i++) {
@@ -96,6 +99,15 @@ function parseCliArgs() {
       case '--lnurl-domain':
         opts.lnurlDomain = args[++i]
         break
+      case '--proxy':
+        opts.proxy = args[++i]
+        break
+      case '--proxy-user':
+        opts.proxyUser = args[++i]
+        break
+      case '--proxy-password':
+        opts.proxyPassword = args[++i]
+        break
       case '-h':
       case '--help':
         console.log('Usage: node src/main.js [OPTIONS]')
@@ -116,6 +128,9 @@ function parseCliArgs() {
         console.log('  --rpid <id>                                  Relying party ID for FIDO2 provider (requires --passkey)')
         console.log('  --server-mode                                Run in server mode (background_tasks_enabled=false)')
         console.log('  --lnurl-domain <domain>                      LNURL server domain for lightning address registration')
+        console.log('  --proxy <HOST:PORT>                          Route every connection through a SOCKS5 proxy')
+        console.log('  --proxy-user <user>                          Username for SOCKS5 authentication (requires --proxy-password)')
+        console.log('  --proxy-password <password>                  Password for SOCKS5 authentication (requires --proxy-user)')
         console.log('  -h, --help                                   Show this help message')
         process.exit(0)
         break
@@ -160,6 +175,26 @@ function parseCliArgs() {
     process.exit(1)
   }
 
+  if (opts.proxyUser && !opts.proxy) {
+    console.error('--proxy-user requires --proxy')
+    process.exit(1)
+  }
+
+  if (opts.proxyPassword && !opts.proxy) {
+    console.error('--proxy-password requires --proxy')
+    process.exit(1)
+  }
+
+  if (opts.proxyUser && !opts.proxyPassword) {
+    console.error('--proxy-user requires --proxy-password')
+    process.exit(1)
+  }
+
+  if (opts.proxyPassword && !opts.proxyUser) {
+    console.error('--proxy-password requires --proxy-user')
+    process.exit(1)
+  }
+
   return opts
 }
 
@@ -171,6 +206,24 @@ function expandPath(p) {
     return path.join(require('os').homedir(), p.slice(2))
   }
   return p
+}
+
+/**
+ * Parse `HOST:PORT` into a ProxyConfig. Split from the right so an IPv6
+ * literal keeps its colons.
+ */
+function parseProxy(address, username, password) {
+  const idx = address.lastIndexOf(':')
+  if (idx === -1) {
+    throw new Error(`Invalid proxy '${address}', expected HOST:PORT`)
+  }
+  const host = address.slice(0, idx)
+  const portStr = address.slice(idx + 1)
+  const port = parseInt(portStr, 10)
+  if (isNaN(port)) {
+    throw new Error(`Invalid proxy port '${portStr}'`)
+  }
+  return { host, port, username, password }
 }
 
 // ---------------------------------------------------------------------------
@@ -250,6 +303,14 @@ async function main() {
     config.crossChainConfig = {}
   }
 
+  // Proxy
+  const proxy = opts.proxy
+    ? parseProxy(opts.proxy, opts.proxyUser, opts.proxyPassword)
+    : undefined
+  if (proxy) {
+    config.proxy = proxy
+  }
+
   if (opts.lnurlDomain !== undefined) {
     config.lnurlDomain = opts.lnurlDomain
   }
@@ -284,7 +345,8 @@ async function main() {
       breezApiKey,
       opts.label,
       opts.listLabels,
-      opts.storeLabel
+      opts.storeLabel,
+      proxy
     )
   } else {
     const mnemonic = persistence.getOrCreateMnemonic()

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/passkey.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/passkey.js
@@ -206,6 +206,7 @@ function promptStdin(prompt) {
  * @param {string|undefined} label - Optional label for seed derivation
  * @param {boolean} listLabels - Whether to list and select from labels on Nostr
  * @param {boolean} storeLabel - Whether to publish the label to Nostr
+ * @param {object|undefined} proxy - Optional ProxyConfig ({host, port, username, password})
  * @returns {Promise<object>} The seed object for use with SdkBuilder
  */
 async function resolvePasskeySeed(
@@ -213,9 +214,11 @@ async function resolvePasskeySeed(
   breezApiKey,
   label,
   listLabels,
-  storeLabel
+  storeLabel,
+  proxy
 ) {
-  const client = new PasskeyClient(provider, breezApiKey, undefined)
+  const config = proxy ? { proxy } : undefined
+  const client = new PasskeyClient(provider, breezApiKey, config)
 
   // --list-labels: discovery sign-in (no cached label) returns the
   // published label set; prompt the user to pick one.


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`d195f61`](https://github.com/breez/spark-sdk/commit/d195f619362486ce43bb45662a4bdb6dadadc8e9)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/32964287982)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :white_check_mark: React Native
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- C# CLI missing `--proxy`, `--proxy-user`, `--proxy-password` CLI flags (Rust added SOCKS5 proxy support)
- C# CLI not setting `config.proxy` from parsed proxy config
- C# `ResolvePasskeySeed` not accepting or forwarding proxy to `PasskeyClient` via `PasskeyConfig`
- C# README missing proxy CLI options documentation
- `GetSparkStatus` API change (`GetSparkStatusRequest::default()` vs parameterless call) already in sync

## Applied
- Added `--proxy`, `--proxy-user`, `--proxy-password` argument parsing with validation in `Program.cs`
- Added `ParseProxy` helper function to parse `HOST:PORT` into `ProxyConfig` in `Program.cs`
- Updated `RunInteractiveMode` signature and body to accept and apply `ProxyConfig` to SDK config in `Program.cs`
- Forwarded proxy to `PasskeyResolver.ResolvePasskeySeed` in `Program.cs`
- Updated `ResolvePasskeySeed` to construct `PasskeyConfig` with proxy and pass it to `PasskeyClient` in `Passkey.cs`
- Added proxy CLI options to the CLI Options table in `README.md`
- Added proxy options to `PrintUsage` help text in `Program.cs`

## Skipped
- Nothing skipped; all Rust CLI changes had direct C# equivalents using existing SDK types (`ProxyConfig`, `PasskeyConfig`)

### Dart
## Divergences
- Missing `--proxy`, `--proxy-user`, `--proxy-password` CLI flags for SOCKS5 proxy support
- Missing `ProxyConfig` propagation to `Config.proxy` in `runCli()`
- Missing proxy parameter in `resolvePasskeySeed()` and `PasskeyClientBuilder` config
- README CLI Options table missing proxy flags

## Applied
- Added `--proxy`, `--proxy-user`, `--proxy-password` CLI options with validation in `bin/breez_cli.dart`
- Added `parseProxy()` helper function and `proxy` parameter to `runCli()` in `lib/cli.dart`
- Applied `config.copyWith(proxy: proxy)` to propagate proxy to SDK config in `lib/cli.dart`
- Updated `resolvePasskeySeed()` in `lib/passkey.dart` to accept `ProxyConfig?` and pass it to `PasskeyClientBuilder` via `PasskeyConfig`
- Added proxy flags to CLI Options table in `README.md`

## Skipped
- (none)

### Go
## Divergences
- Go CLI missing `--proxy`, `--proxy-user`, `--proxy-password` flags for SOCKS5 proxy support (added in Rust CLI)
- Go CLI not setting `config.Proxy` from parsed proxy flags
- Go CLI `resolvePasskeySeed` not forwarding proxy to `PasskeyClient` via `PasskeyConfig`
- Go CLI README missing documentation for proxy flags

## Applied
- Added `--proxy`, `--proxy-user`, `--proxy-password` CLI flags in `main.go`
- Added `parseProxy` function to parse `HOST:PORT` into `ProxyConfig` in `main.go`
- Set `config.Proxy` on the SDK config from parsed proxy in `main.go`
- Updated `resolvePasskeySeed` in `passkey.go` to accept `*ProxyConfig` and forward it to `NewPasskeyClient` via `PasskeyConfig`
- Added proxy flags to the CLI Options table in `README.md`

## Skipped
- (none)

### Kotlin
## Divergences
- Missing `--proxy`, `--proxy-user`, `--proxy-password` CLI flags in Kotlin CLI (added in Rust CLI for SOCKS5 proxy support)
- Missing `config.proxy` assignment on SDK config in Kotlin `runInteractiveMode`
- `resolvePasskeySeed` missing `proxy` parameter; `PasskeyClient` constructed without SDK `PasskeyConfig` carrying proxy
- `getSparkStatus` already uses `GetSparkStatusRequest()` in Kotlin (in sync with Rust change to `GetSparkStatusRequest::default()`)

## Applied
- Added `--proxy`, `--proxy-user`, `--proxy-password` CLI flag parsing and validation in `Main.kt`
- Added `parseProxy()` function to parse `HOST:PORT` into `ProxyConfig` in `Main.kt`
- Added `proxy` parameter to `runInteractiveMode()` and set `config.proxy` in `Main.kt`
- Passed `proxy` through to `resolvePasskeySeed()` in `Main.kt`
- Added `proxy` parameter to `resolvePasskeySeed()` in `Passkey.kt`
- Constructed SDK `PasskeyConfig` with proxy and passed to `PasskeyClient` constructor in `Passkey.kt`
- Added help text for the three new proxy flags in `Main.kt`

## Skipped
- No items skipped

### Python
## Divergences
- `get_spark_status` called without `GetSparkStatusRequest` in Python CLI (commands.py), Rust now passes `GetSparkStatusRequest::default()`
- Python CLI missing `--proxy`, `--proxy-user`, `--proxy-password` CLI flags for SOCKS5 proxy support (main.py)
- Python CLI not setting `config.proxy` on the SDK config (main.py)
- `resolve_passkey_seed` in Python not accepting or forwarding proxy config (passkey.py)
- `PasskeyClient` created without `PasskeyConfig` containing proxy settings (passkey.py)
- Python README missing proxy CLI options in the CLI Options table (README.md)

## Applied
- Updated `get_spark_status` to pass `GetSparkStatusRequest()` and import it via `get_spark_status` function (commands.py)
- Added `--proxy`, `--proxy-user`, `--proxy-password` CLI options with mutual dependency validation (main.py)
- Added `parse_proxy` function to parse `HOST:PORT` into `ProxyConfig`, splitting from the right for IPv6 support (main.py)
- Set `config.proxy = proxy_config` on the SDK config (main.py)
- Added `proxy` parameter to `resolve_passkey_seed` and forwarded `proxy_config` from `main` (main.py, passkey.py)
- Created `PasskeyConfig(proxy=proxy)` when proxy is set, passed to `PasskeyClient` constructor (passkey.py)
- Added `ProxyConfig` and `PasskeyConfig` imports to passkey.py and `ProxyConfig` import to main.py
- Added proxy options to CLI Options table in README.md

## Skipped
- (none)

### React Native
## Divergences
- `getSparkStatus()` called without arguments in React Native CLI; Rust CLI now passes `GetSparkStatusRequest::default()` which includes a `proxy` field
- `resolvePasskeySeed()` in React Native CLI did not accept a proxy parameter; Rust CLI now passes `Option<ProxyConfig>` to `resolve_passkey_seed()` and forwards it to `PasskeyClient::new` via `SdkPasskeyConfig`
- Rust CLI added `--proxy`, `--proxy-user`, `--proxy-password` CLI flags and sets `config.proxy` on the SDK config; React Native CLI had no proxy support wired through

## Applied
- Updated `getSparkStatus()` to `getSparkStatus({ proxy: undefined })` in `src/commands.ts`
- Added `ProxyConfig` and `PasskeyConfig as SdkPasskeyConfig` imports to `src/passkey.ts`
- Added optional `proxy?: ProxyConfig` parameter to `resolvePasskeySeed()` in `src/passkey.ts`
- Created `SdkPasskeyConfig` with proxy when provided and passed it to `PasskeyClient` constructor in `src/passkey.ts`
- Added `ProxyConfig` and `PasskeyConfig` type stubs to `src/breez-sdk-spark-react-native.d.ts`

## Skipped
- No UI for proxy configuration in the React Native setup screen: the Rust CLI uses `--proxy HOST:PORT` command-line flags, which have no natural equivalent in a mobile app's setup screen. The code path is wired through (proxy parameter accepted and forwarded), but the setup screen does not expose proxy settings. A future enhancement could add proxy fields to the setup screen.

### Swift
## Divergences
- Rust CLI added `--proxy`, `--proxy-user`, `--proxy-password` CLI flags for SOCKS5 proxy support; Swift CLI was missing them
- Rust CLI sets `config.proxy` from the parsed proxy config; Swift CLI was not setting it
- Rust `resolve_passkey_seed()` now accepts a `proxy: Option<ProxyConfig>` parameter and forwards it to `PasskeyClient::new()` via `SdkPasskeyConfig`; Swift was not passing proxy to the passkey client
- Rust `get_spark_status()` now takes `GetSparkStatusRequest::default()`; Swift CLI already used `GetSparkStatusRequest()` (in sync)

## Applied
- Added `proxy`, `proxyUser`, `proxyPassword` fields to `CliOptions` and `parseCliFlags()` in `main.swift`
- Added `parseProxy()` function to parse `HOST:PORT` into `ProxyConfig` in `main.swift`
- Added proxy parsing and `config.proxy` assignment before SDK builder in `main.swift`
- Updated `resolvePasskeySeed()` call in `main.swift` to pass `proxy` parameter
- Updated `resolvePasskeySeed()` in `Passkey.swift` to accept `proxy: ProxyConfig?` and create `BreezSdkSpark.PasskeyConfig` with proxy for `PasskeyClient`
- Added `--proxy`, `--proxy-user`, `--proxy-password` to CLI Options table in `README.md`

## Skipped
- Nothing skipped; all Rust CLI changes were portable to Swift

### TypeScript
## Divergences
- Rust CLI added `--proxy`, `--proxy-user`, `--proxy-password` flags for SOCKS5 proxy support; TypeScript CLI was missing them
- Rust CLI sets `config.proxy` from the parsed proxy; TypeScript CLI was not setting it
- Rust CLI passes `proxy` to `resolve_passkey_seed()` which forwards it to `PasskeyClient` config; TypeScript CLI was passing `undefined`
- Rust `get_spark_status` changed to accept `GetSparkStatusRequest::default()`; WASM binding wraps this internally (still zero-arg), so no TypeScript change needed

## Applied
- Added `--proxy`, `--proxy-user`, `--proxy-password` CLI flags with validation in `main.js`
- Added `parseProxy()` function to parse `HOST:PORT` into a `ProxyConfig` object in `main.js`
- Set `config.proxy` from the parsed proxy config in `main.js`
- Updated `resolvePasskeySeed()` in `passkey.js` to accept an optional `proxy` parameter and pass it as `PasskeyClient` config
- Updated help text in `main.js` with the three new proxy flags
- Updated `README.md` CLI Options table with the three new proxy flags

## Skipped
- None

</details>

All languages synced cleanly. This PR merges automatically once the gating CI checks pass (integration test checks excluded).