### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -33,6 +33,7 @@ public static class CommandNames
         "lnurl-auth",
         "claim-htlc-payment",
         "claim-deposit",
+        "fetch-claim-deposit-quote",
         "parse",
         "refund-deposit",
         "list-unclaimed-deposits",
@@ -138,6 +139,12 @@ public static class Commands
                 Name = "claim-deposit",
                 Description = "Claim an on-chain deposit",
                 Run = HandleClaimDeposit
+            },
+            ["fetch-claim-deposit-quote"] = new()
+            {
+                Name = "fetch-claim-deposit-quote",
+                Description = "Quote both ways of claiming a deposit",
+                Run = HandleFetchClaimDepositQuote
             },
             ["parse"] = new()
             {
@@ -1019,6 +1026,28 @@ public static class Commands
             txid: txid,
             vout: vout,
             maxFee: maxFee
+        ));
+        Serialization.PrintValue(result);
+    }
+
+    // --- fetch-claim-deposit-quote ---
+
+    private static async Task HandleFetchClaimDepositQuote(BreezSdk sdk, Func<string, string?> readline, string[] args)
+    {
+        var positional = GetPositionalArgs(args);
+
+        if (positional.Length < 2)
+        {
+            Console.WriteLine("Usage: fetch-claim-deposit-quote <txid> <vout>");
+            return;
+        }
+
+        var txid = positional[0];
+        var vout = uint.Parse(positional[1]);
+
+        var result = await sdk.FetchClaimDepositQuote(request: new FetchClaimDepositQuoteRequest(
+            txid: txid,
+            vout: vout
         ));
         Serialization.PrintValue(result);
     }

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -22,6 +22,7 @@ const commandNames = [
   'lnurl-auth',
   'claim-htlc-payment',
   'claim-deposit',
+  'fetch-claim-deposit-quote',
   'parse',
   'refund-deposit',
   'list-unclaimed-deposits',
@@ -66,6 +67,10 @@ Map<String, CommandEntry> buildCommandRegistry() {
     'lnurl-auth': CommandEntry('Authenticate using LNURL', _handleLnurlAuth),
     'claim-htlc-payment': CommandEntry('Claim an HTLC payment', _handleClaimHtlcPayment),
     'claim-deposit': CommandEntry('Claim an on-chain deposit', _handleClaimDeposit),
+    'fetch-claim-deposit-quote': CommandEntry(
+      'Quote both ways of claiming a deposit',
+      _handleFetchClaimDepositQuote,
+    ),
     'parse': CommandEntry('Parse an input (invoice, address, LNURL)', _handleParse),
     'refund-deposit': CommandEntry('Refund an on-chain deposit', _handleRefundDeposit),
     'list-unclaimed-deposits': CommandEntry('List unclaimed on-chain deposits', _handleListUnclaimedDeposits),
@@ -791,6 +796,26 @@ Future<void> _handleClaimDeposit(BreezSdk sdk, TokenIssuer tokenIssuer, List<Str
   }
 
   final result = await sdk.claimDeposit(request: ClaimDepositRequest(txid: txid, vout: vout, maxFee: maxFee));
+  printValue(result);
+}
+
+// --- fetch-claim-deposit-quote ---
+
+Future<void> _handleFetchClaimDepositQuote(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
+  if (args.isEmpty || args.first == 'help' || args.first == '--help') {
+    print('Usage: fetch-claim-deposit-quote <txid> <vout>');
+    return;
+  }
+  if (args.length < 2) {
+    print('Usage: fetch-claim-deposit-quote <txid> <vout>');
+    return;
+  }
+  final txid = args[0];
+  final vout = int.parse(args[1]);
+
+  final result = await sdk.fetchClaimDepositQuote(
+    request: FetchClaimDepositQuoteRequest(txid: txid, vout: vout),
+  );
   printValue(result);
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -36,6 +36,7 @@ var CommandNames = []string{
 	"lnurl-auth",
 	"claim-htlc-payment",
 	"claim-deposit",
+	"fetch-claim-deposit-quote",
 	"parse",
 	"refund-deposit",
 	"list-unclaimed-deposits",
@@ -72,6 +73,7 @@ func BuildCommandRegistry() map[string]Command {
 		"lnurl-auth":                           {Name: "lnurl-auth", Description: "Authenticate using LNURL", Run: handleLnurlAuth},
 		"claim-htlc-payment":                   {Name: "claim-htlc-payment", Description: "Claim an HTLC payment", Run: handleClaimHtlcPayment},
 		"claim-deposit":                        {Name: "claim-deposit", Description: "Claim an on-chain deposit", Run: handleClaimDeposit},
+		"fetch-claim-deposit-quote":            {Name: "fetch-claim-deposit-quote", Description: "Quote both ways of claiming a deposit", Run: handleFetchClaimDepositQuote},
 		"parse":                                {Name: "parse", Description: "Parse an input (invoice, address, LNURL)", Run: handleParse},
 		"refund-deposit":                       {Name: "refund-deposit", Description: "Refund an on-chain deposit", Run: handleRefundDeposit},
 		"list-unclaimed-deposits":              {Name: "list-unclaimed-deposits", Description: "List unclaimed on-chain deposits", Run: handleListUnclaimedDeposits},
@@ -954,6 +956,31 @@ func handleClaimDeposit(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, arg
 		req.MaxFee = &maxFee
 	}
 	result, err := sdk.ClaimDeposit(req)
+	if err = liftError(err); err != nil {
+		return err
+	}
+	printValue(result)
+	return nil
+}
+
+// --- fetch-claim-deposit-quote ---
+
+func handleFetchClaimDepositQuote(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []string) error {
+	if len(args) < 2 {
+		fmt.Println("Usage: fetch-claim-deposit-quote <txid> <vout>")
+		return nil
+	}
+
+	txid := args[0]
+	vout, err := strconv.ParseUint(args[1], 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid vout: %w", err)
+	}
+
+	result, err := sdk.FetchClaimDepositQuote(breez_sdk_spark.FetchClaimDepositQuoteRequest{
+		Txid: txid,
+		Vout: uint32(vout),
+	})
 	if err = liftError(err); err != nil {
 		return err
 	}

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/README.md
@@ -112,7 +112,7 @@ Once inside the REPL, type `help` to see all commands. The CLI supports:
 
 **Payments**: `receive`, `pay`, `lnurl-pay`, `lnurl-withdraw`, `lnurl-auth`, `claim-htlc-payment`
 
-**On-chain**: `claim-deposit`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
+**On-chain**: `claim-deposit`, `fetch-claim-deposit-quote`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
 
 **Lightning address**: `get-lightning-address`, `register-lightning-address`, `authorize-lightning-address-transfer`, `claim-lightning-address-transfer`, `delete-lightning-address`, `check-lightning-address-available`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -27,6 +27,7 @@ val COMMAND_NAMES = listOf(
     "lnurl-auth",
     "claim-htlc-payment",
     "claim-deposit",
+    "fetch-claim-deposit-quote",
     "parse",
     "refund-deposit",
     "list-unclaimed-deposits",
@@ -65,6 +66,7 @@ fun buildCommandRegistry(): Map<String, CliCommand> {
         "lnurl-auth" to CliCommand("lnurl-auth", "Authenticate using LNURL", ::handleLnurlAuth),
         "claim-htlc-payment" to CliCommand("claim-htlc-payment", "Claim an HTLC payment", ::handleClaimHtlcPayment),
         "claim-deposit" to CliCommand("claim-deposit", "Claim an on-chain deposit", ::handleClaimDeposit),
+        "fetch-claim-deposit-quote" to CliCommand("fetch-claim-deposit-quote", "Quote both ways of claiming a deposit", ::handleFetchClaimDepositQuote),
         "parse" to CliCommand("parse", "Parse an input (invoice, address, LNURL)", ::handleParse),
         "refund-deposit" to CliCommand("refund-deposit", "Refund an on-chain deposit", ::handleRefundDeposit),
         "list-unclaimed-deposits" to CliCommand("list-unclaimed-deposits", "List unclaimed on-chain deposits", ::handleListUnclaimedDeposits),
@@ -809,6 +811,32 @@ suspend fun handleClaimDeposit(sdk: BreezSdk, reader: LineReader, args: List<Str
             txid = txid,
             vout = vout,
             maxFee = maxFee,
+        )
+    )
+    printValue(result)
+}
+
+// --- fetch-claim-deposit-quote ---
+
+suspend fun handleFetchClaimDepositQuote(sdk: BreezSdk, reader: LineReader, args: List<String>) {
+    val fp = FlagParser(args)
+
+    if (fp.positional.size < 2) {
+        println("Usage: fetch-claim-deposit-quote <txid> <vout>")
+        return
+    }
+
+    val txid = fp.positional[0]
+    val vout = fp.positional[1].toUIntOrNull()
+    if (vout == null) {
+        println("Invalid vout: ${fp.positional[1]}")
+        return
+    }
+
+    val result = sdk.fetchClaimDepositQuote(
+        FetchClaimDepositQuoteRequest(
+            txid = txid,
+            vout = vout,
         )
     )
     printValue(result)

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -18,6 +18,7 @@ from breez_sdk_spark import (
     CrossChainRouteFilter,
     Fee,
     FeePolicy,
+    FetchClaimDepositQuoteRequest,
     FetchConversionLimitsRequest,
     GetInfoRequest,
     GetPaymentRequest,
@@ -72,6 +73,7 @@ COMMAND_NAMES = [
     "lnurl-auth",
     "claim-htlc-payment",
     "claim-deposit",
+    "fetch-claim-deposit-quote",
     "parse",
     "refund-deposit",
     "list-unclaimed-deposits",
@@ -683,6 +685,21 @@ async def _handle_claim_deposit(sdk, _token_issuer, _session, args):
     print_value(result)
 
 
+# --- fetch-claim-deposit-quote ---
+
+def _build_fetch_claim_deposit_quote_parser():
+    p = _parser("fetch-claim-deposit-quote", "Quote both ways of claiming a deposit")
+    p.add_argument("txid", help="The txid of the deposit")
+    p.add_argument("vout", type=int, help="The vout of the deposit")
+    return p
+
+async def _handle_fetch_claim_deposit_quote(sdk, _token_issuer, _session, args):
+    result = await sdk.fetch_claim_deposit_quote(
+        request=FetchClaimDepositQuoteRequest(txid=args.txid, vout=args.vout)
+    )
+    print_value(result)
+
+
 # --- parse ---
 
 def _build_parse_parser():
@@ -1176,6 +1193,7 @@ def build_command_registry():
         "lnurl-auth": (_build_lnurl_auth_parser(), _handle_lnurl_auth),
         "claim-htlc-payment": (_build_claim_htlc_payment_parser(), _handle_claim_htlc_payment),
         "claim-deposit": (_build_claim_deposit_parser(), _handle_claim_deposit),
+        "fetch-claim-deposit-quote": (_build_fetch_claim_deposit_quote_parser(), _handle_fetch_claim_deposit_quote),
         "parse": (_build_parse_parser(), _handle_parse),
         "refund-deposit": (_build_refund_deposit_parser(), _handle_refund_deposit),
         "list-unclaimed-deposits": (_build_list_unclaimed_deposits_parser(), _handle_list_unclaimed_deposits),

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/README.md
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/README.md
@@ -80,7 +80,7 @@ Once the app is running, type commands in the text input at the bottom:
 
 **Payments**: `receive`, `pay`, `lnurl-pay`, `lnurl-withdraw`, `lnurl-auth`, `claim-htlc-payment`
 
-**On-chain**: `claim-deposit`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
+**On-chain**: `claim-deposit`, `fetch-claim-deposit-quote`, `refund-deposit`, `list-unclaimed-deposits`, `buy-bitcoin`
 
 **Lightning address**: `get-lightning-address`, `register-lightning-address`, `authorize-lightning-address-transfer`, `claim-lightning-address-transfer`, `delete-lightning-address`, `check-lightning-address-available`
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -3,8 +3,9 @@
  *
  * Mirrors ALL commands from the Rust CLI:
  *   get-info, get-payment, sync, list-payments, receive, pay, pay-batch, lnurl-pay,
- *   lnurl-withdraw, lnurl-auth, claim-htlc-payment, claim-deposit, parse,
- *   refund-deposit, list-unclaimed-deposits, buy-bitcoin, prepare-payment-link,
+ *   lnurl-withdraw, lnurl-auth, claim-htlc-payment, claim-deposit,
+ *   fetch-claim-deposit-quote, parse, refund-deposit, list-unclaimed-deposits,
+ *   buy-bitcoin, prepare-payment-link,
  *   check-lightning-address-available, get-lightning-address,
  *   register-lightning-address, delete-lightning-address, list-fiat-currencies,
  *   list-fiat-rates, recommended-fees, get-tokens-metadata,
@@ -180,6 +181,7 @@ export const COMMAND_NAMES = [
   'lnurl-auth',
   'claim-htlc-payment',
   'claim-deposit',
+  'fetch-claim-deposit-quote',
   'parse',
   'refund-deposit',
   'list-unclaimed-deposits',
@@ -226,6 +228,7 @@ export function buildCommandRegistry(): Map<string, CommandDef> {
     { name: 'lnurl-auth', description: 'Authenticate using LNURL', run: handleLnurlAuth },
     { name: 'claim-htlc-payment', description: 'Claim an HTLC payment', run: handleClaimHtlcPayment },
     { name: 'claim-deposit', description: 'Claim an on-chain deposit', run: handleClaimDeposit },
+    { name: 'fetch-claim-deposit-quote', description: 'Quote both ways of claiming a deposit', run: handleFetchClaimDepositQuote },
     { name: 'parse', description: 'Parse an input (invoice, address, LNURL)', run: handleParse },
     { name: 'refund-deposit', description: 'Refund an on-chain deposit', run: handleRefundDeposit },
     { name: 'list-unclaimed-deposits', description: 'List unclaimed on-chain deposits', run: handleListUnclaimedDeposits },
@@ -982,6 +985,24 @@ async function handleClaimDeposit(sdk: BreezSdkInterface, _tokenIssuer: TokenIss
     vout,
     maxFee,
   })
+  return formatValue(result)
+}
+
+// --- fetch-claim-deposit-quote ---
+
+async function handleFetchClaimDepositQuote(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
+  const positional = positionalArgs(args)
+  if (positional.length < 2) {
+    return 'Usage: fetch-claim-deposit-quote <txid> <vout>'
+  }
+
+  const txid = positional[0]
+  const vout = parseInt(positional[1], 10)
+  if (isNaN(vout)) {
+    return `Invalid vout: ${positional[1]}`
+  }
+
+  const result = await sdk.fetchClaimDepositQuote({ txid, vout })
   return formatValue(result)
 }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -84,6 +84,7 @@ let commandNames: [String] = [
     "lnurl-auth",
     "claim-htlc-payment",
     "claim-deposit",
+    "fetch-claim-deposit-quote",
     "parse",
     "refund-deposit",
     "list-unclaimed-deposits",
@@ -121,6 +122,7 @@ func buildCommandRegistry() -> [String: CommandEntry] {
         "lnurl-auth":                        CommandEntry(name: "lnurl-auth", description: "Authenticate using LNURL", run: handleLnurlAuth),
         "claim-htlc-payment":                CommandEntry(name: "claim-htlc-payment", description: "Claim an HTLC payment", run: handleClaimHtlcPayment),
         "claim-deposit":                     CommandEntry(name: "claim-deposit", description: "Claim an on-chain deposit", run: handleClaimDeposit),
+        "fetch-claim-deposit-quote":         CommandEntry(name: "fetch-claim-deposit-quote", description: "Quote both ways of claiming a deposit", run: handleFetchClaimDepositQuote),
         "parse":                             CommandEntry(name: "parse", description: "Parse an input (invoice, address, LNURL)", run: handleParse),
         "refund-deposit":                    CommandEntry(name: "refund-deposit", description: "Refund an on-chain deposit", run: handleRefundDeposit),
         "list-unclaimed-deposits":           CommandEntry(name: "list-unclaimed-deposits", description: "List unclaimed on-chain deposits", run: handleListUnclaimedDeposits),
@@ -800,6 +802,24 @@ func handleClaimDeposit(_ sdk: BreezSdk, _ args: [String]) async throws {
         txid: txid,
         vout: vout,
         maxFee: maxFee
+    ))
+    printValue(result)
+}
+
+// --- fetch-claim-deposit-quote ---
+
+func handleFetchClaimDepositQuote(_ sdk: BreezSdk, _ args: [String]) async throws {
+    let fp = FlagParser(args)
+    guard fp.positional.count >= 2,
+          let vout = UInt32(fp.positional[1]) else {
+        print("Usage: fetch-claim-deposit-quote <txid> <vout>")
+        return
+    }
+
+    let txid = fp.positional[0]
+    let result = try await sdk.fetchClaimDepositQuote(request: FetchClaimDepositQuoteRequest(
+        txid: txid,
+        vout: vout
     ))
     printValue(result)
 }

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -28,6 +28,7 @@ const COMMAND_NAMES = [
   'lnurl-auth',
   'claim-htlc-payment',
   'claim-deposit',
+  'fetch-claim-deposit-quote',
   'parse',
   'refund-deposit',
   'list-unclaimed-deposits',
@@ -630,6 +631,19 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
         vout: voutNum,
         maxFee
       })
+      printValue(value)
+    })
+
+  // --- fetch-claim-deposit-quote ---
+  program
+    .command('fetch-claim-deposit-quote')
+    .description('Quote both ways of claiming a deposit')
+    .argument('<txid>', 'The txid of the deposit')
+    .argument('<vout>', 'The vout of the deposit')
+    .action(async (txid, vout) => {
+      const sdk = getSdk()
+      const voutNum = parseInt(vout, 10)
+      const value = await sdk.fetchClaimDepositQuote({ txid, vout: voutNum })
       printValue(value)
     })
 


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`1ed3ee0`](https://github.com/breez/spark-sdk/commit/1ed3ee02e63e212ad05cd8f5a4a8ac0440bdcd10)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/33053393018)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :white_check_mark: React Native
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- C# CLI was missing the `fetch-claim-deposit-quote` command added in Rust CLI (calls `sdk.FetchClaimDepositQuote` with txid and vout positional args)
- Rust CLI removed `--instant-fee-bps` flag from `claim-deposit` command (C# CLI already did not have this flag, so no change needed)

## Applied
- Added `fetch-claim-deposit-quote` command to `Commands.cs`: registry entry, `CommandNames` list entry, and `HandleFetchClaimDepositQuote` handler method

## Skipped
- (none)

### Dart
## Divergences
- Dart CLI was missing the `fetch-claim-deposit-quote` command (added in Rust CLI, calls `sdk.fetch_claim_deposit_quote` with `txid` and `vout`)
- Rust CLI removed `instant_fee_bps` from `ClaimDeposit` (Dart CLI already did not have it, no action needed)

## Applied
- Added `fetch-claim-deposit-quote` command to `commands.dart`: handler function, command registry entry, and `commandNames` list entry

## Skipped
- (none)

### Go
## Divergences
- Go CLI missing `fetch-claim-deposit-quote` command (added in Rust CLI to quote both ways of claiming a deposit)
- Rust CLI removed `instant_fee_bps` / `max_instant_fee_bps` from `ClaimDeposit` command (Go CLI never had it, already in sync)

## Applied
- Added `fetch-claim-deposit-quote` command to Go CLI: handler, registry entry, and command name in `commands.go`

## Skipped
- None

### Kotlin
## Divergences
- Kotlin CLI missing `fetch-claim-deposit-quote` command (added in Rust CLI to quote both ways of claiming a deposit)
- Rust CLI removed `instant_fee_bps` from `ClaimDeposit` (Kotlin CLI already did not have it, no change needed)

## Applied
- Added `fetch-claim-deposit-quote` command to `Commands.kt`: handler function, command registry entry, and command name list entry
- Added `fetch-claim-deposit-quote` to the "On-chain" section of the Kotlin CLI README

## Skipped
- (none)

### Python
## Divergences
- Python CLI was missing the `fetch-claim-deposit-quote` command (added in Rust to quote both ways of claiming a deposit)

## Applied
- Added `FetchClaimDepositQuoteRequest` import to `commands.py`
- Added `fetch-claim-deposit-quote` to `COMMAND_NAMES` in `commands.py`
- Added `_build_fetch_claim_deposit_quote_parser()` and `_handle_fetch_claim_deposit_quote()` in `commands.py`
- Added `fetch-claim-deposit-quote` entry to `build_command_registry()` in `commands.py`

## Skipped
- Nothing skipped

### React Native
## Divergences
- Missing `fetch-claim-deposit-quote` command in React Native CLI (added in Rust CLI as `FetchClaimDepositQuote` with `txid` and `vout` positional args)
- Rust CLI removed `instant_fee_bps` / `max_instant_fee_bps` from `claim-deposit` command, but the React Native CLI never had it (already in sync)

## Applied
- Added `fetch-claim-deposit-quote` command handler in `commands.ts` calling `sdk.fetchClaimDepositQuote({ txid, vout })`
- Added `fetch-claim-deposit-quote` to `COMMAND_NAMES` array and command registry in `commands.ts`
- Updated file header comment in `commands.ts` to list the new command
- Updated `README.md` On-chain commands list to include `fetch-claim-deposit-quote`

## Skipped
- (none)

### Swift
## Divergences
- Missing `fetch-claim-deposit-quote` command in Swift CLI (added in Rust as `FetchClaimDepositQuote` with `txid` and `vout` positional args, calling `sdk.fetch_claim_deposit_quote(FetchClaimDepositQuoteRequest)`)
- Rust removed `instant_fee_bps` from `ClaimDeposit` and `ClaimDepositRequest`: Swift CLI already did not have this field, so no change needed

## Applied
- Added `fetch-claim-deposit-quote` to `commandNames`, `buildCommandRegistry()`, and new `handleFetchClaimDepositQuote` handler in `Commands.swift`

## Skipped
- Nothing skipped

### TypeScript
## Divergences
- Missing `fetch-claim-deposit-quote` command in TypeScript CLI (new command in Rust CLI)
- Rust CLI removed `--instant-fee-bps` flag from `claim-deposit`; TypeScript CLI never had it (no action needed)

## Applied
- Added `fetch-claim-deposit-quote` command with `txid` and `vout` arguments to `commands.js`
- Added `fetch-claim-deposit-quote` to `COMMAND_NAMES` array for tab completion

## Skipped
- Nothing skipped

</details>

All languages synced cleanly. This PR merges automatically once the gating CI checks pass (integration test checks excluded).