### PR TITLE
Fix on-chain sends from a zero balance stable-balance

### DIFF
--- a/crates/breez-sdk/core/src/models/adaptors.rs
+++ b/crates/breez-sdk/core/src/models/adaptors.rs
@@ -435,6 +435,7 @@ impl From<CoopExitFeeQuote> for SendOnchainFeeQuote {
             speed_fast: value.speed_fast.into(),
             speed_medium: value.speed_medium.into(),
             speed_slow: value.speed_slow.into(),
+            is_estimate: false,
         }
     }
 }
@@ -608,5 +609,38 @@ impl From<spark_wallet::WebhookEntry> for crate::Webhook {
             url: value.url,
             event_types: value.event_types.into_iter().map(Into::into).collect(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::SendOnchainFeeQuote;
+    use macros::test_all;
+    use spark_wallet::{CoopExitFeeQuote, CoopExitSpeedFeeQuote};
+
+    #[cfg(feature = "browser-tests")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[test_all]
+    fn test_a_provider_quote_is_never_an_estimate() {
+        // What keeps a real quote distinguishable from a locally derived one.
+        // Marking it an estimate would give it an estimate's fee headroom and
+        // stop it being refreshed near expiry.
+        let speed = || CoopExitSpeedFeeQuote {
+            user_fee_sat: 750,
+            l1_broadcast_fee_sat: 960,
+        };
+        let quote: SendOnchainFeeQuote = CoopExitFeeQuote {
+            id: "SparkCoopExitFeeQuote:test".to_string(),
+            expires_at: 1_787_907_773,
+            speed_fast: speed(),
+            speed_medium: speed(),
+            speed_slow: speed(),
+        }
+        .into();
+
+        assert!(!quote.is_estimate);
+        assert_eq!(quote.id, "SparkCoopExitFeeQuote:test");
+        assert_eq!(quote.expires_at, 1_787_907_773);
     }
 }

--- a/crates/breez-sdk/core/src/models/mod.rs
+++ b/crates/breez-sdk/core/src/models/mod.rs
@@ -928,9 +928,8 @@ pub struct StableBalanceToken {
 /// Configuration for automatic conversion of Bitcoin to stable tokens.
 ///
 /// When configured, the SDK automatically monitors the Bitcoin balance after each
-/// wallet sync. When the balance exceeds the configured threshold plus the reserved
-/// amount, the SDK automatically converts the excess balance (above the reserve)
-/// to the active stable token.
+/// wallet sync. Once the balance reaches the configured threshold, the SDK converts
+/// the whole Bitcoin balance to the active stable token.
 ///
 /// When the balance is held in a stable token, Bitcoin payments can still be sent.
 /// The SDK automatically detects when there's not enough Bitcoin balance to cover a
@@ -1675,11 +1674,20 @@ pub enum SendPaymentMethod {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SendOnchainFeeQuote {
+    /// Identifies the quote to the provider when the payment is sent. Empty on
+    /// an estimate, which no provider has issued.
     pub id: String,
+    /// When the quote stops being honoured, as a Unix timestamp in seconds.
+    /// Zero on an estimate.
     pub expires_at: u64,
     pub speed_fast: SendOnchainSpeedFeeQuote,
     pub speed_medium: SendOnchainSpeedFeeQuote,
     pub speed_slow: SendOnchainSpeedFeeQuote,
+    /// Set when the wallet holds no bitcoin and a token conversion will fund the
+    /// send, because the provider will not quote without funds to price against.
+    /// The estimate is an upper bound: the payment quotes for real once the
+    /// conversion lands, and fails rather than spending more than this.
+    pub is_estimate: bool,
 }
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/crates/breez-sdk/core/src/sdk/payments/prepare/bitcoin_address.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/prepare/bitcoin_address.rs
@@ -1,6 +1,6 @@
 use crate::{
     BitcoinAddressDetails, ConversionOptions, ConversionType, FeePolicy, SendOnchainFeeQuote,
-    SendPaymentMethod,
+    SendOnchainSpeedFeeQuote, SendPaymentMethod,
     error::SdkError,
     models::{PrepareSendPaymentRequest, PrepareSendPaymentResponse},
     sdk::BreezSdk,
@@ -8,6 +8,23 @@ use crate::{
     token_conversion::ConversionAmount,
     utils::bitcoin_dust::get_dust_limit_sats,
 };
+
+// A wallet with nothing to price against cannot be quoted by the provider, which
+// is the state a stable-balance wallet is in until its token conversion runs.
+// These constants estimate the fee locally for that case.
+
+/// How far the provider's per-speed rates sit above a high-priority rate,
+/// indexed slow, medium, fast. Measured between 1 and 5 sat/vB, where the
+/// network's block targets converge. Under congestion the provider may price
+/// the speeds off targets further apart than this.
+const ESTIMATE_SPEED_PREMIUM_SAT_PER_VBYTE: [u64; 3] = [1, 2, 3];
+/// Headroom on top, for the rate moving while the conversion runs.
+const ESTIMATE_DRIFT_HEADROOM_SAT_PER_VBYTE: u64 = 1;
+/// The provider prices every withdrawal at this size whatever the input count:
+/// the wallet's funds are spent on the Spark side, not as on-chain inputs.
+const ESTIMATE_VSIZE_VBYTES: u64 = 240;
+/// The provider's flat service fee, the same for every speed and amount.
+const ESTIMATE_USER_FEE_SAT: u64 = 750;
 
 /// Validates a Bitcoin address request and returns the validated amount.
 fn validate_request(request: &PrepareSendPaymentRequest) -> Result<u128, SdkError> {
@@ -113,25 +130,37 @@ async fn prepare_sats_denominated(
         )));
     }
 
-    // When a token→sats conversion will run (either auto-filled by an active
-    // stable balance, or explicitly requested via `ToBitcoin` options), the
-    // destination sats don't exist yet — pass None to skip leaf selection.
+    // A wallet short of the amount funds the send by converting tokens, and the
+    // SSP will not price an exit before that conversion has produced the sats,
+    // so bound the fee locally and quote at send instead.
     let stable_balance_active = match &sdk.stable_balance {
         Some(sb) => sb.get_active_label().await.is_some(),
         None => false,
     };
-    let sats_from_conversion =
-        stable_balance_active || conversion::is_to_bitcoin(request.conversion_options.as_ref());
-    let fee_quote_amount = if sats_from_conversion {
-        None
+    let balance_sats = sdk.spark_wallet.get_balance().await?;
+    let conversion_funds_the_send = sats_from_conversion(
+        stable_balance_active,
+        request.conversion_options.as_ref(),
+        balance_sats,
+        amount_u64,
+    );
+    let fee_quote: SendOnchainFeeQuote = if conversion_funds_the_send && balance_sats == 0 {
+        estimate_coop_exit_fee_quote(sdk).await?
     } else {
-        Some(amount.try_into()?)
+        // Short of the amount but holding something, the wallet still has funds
+        // to price against, and the fee does not vary with what is selected.
+        // Asking for the amount when it cannot cover it is what surfaces
+        // insufficient funds on a send with no conversion behind it.
+        let target_sats = if conversion_funds_the_send {
+            None
+        } else {
+            Some(amount_u64)
+        };
+        sdk.spark_wallet
+            .fetch_coop_exit_fee_quote(&withdrawal_address.address, target_sats)
+            .await?
+            .into()
     };
-    let fee_quote: SendOnchainFeeQuote = sdk
-        .spark_wallet
-        .fetch_coop_exit_fee_quote(&withdrawal_address.address, fee_quote_amount)
-        .await?
-        .into();
 
     // For FeesIncluded, validate the output after fees using the best case
     // (slow/lowest fee). Only reject if even the cheapest option results in dust.
@@ -206,17 +235,20 @@ async fn prepare_token_denominated(
         )));
     }
 
-    // Pass None for amount — the sats don't exist yet (still tokens),
-    // so leaf selection would fail. Get a generic fee estimate instead.
-    let fee_quote: SendOnchainFeeQuote = sdk
-        .spark_wallet
-        .fetch_coop_exit_fee_quote(&withdrawal_address.address, None)
-        .await?
-        .into();
+    // Estimate only when the wallet holds nothing to price against. Any balance
+    // at all, as a send-all wallet holding both tokens and sats has, gives a
+    // real quote: the fee does not vary with what is selected.
+    let fee_quote: SendOnchainFeeQuote = if sdk.spark_wallet.get_balance().await? == 0 {
+        estimate_coop_exit_fee_quote(sdk).await?
+    } else {
+        sdk.spark_wallet
+            .fetch_coop_exit_fee_quote(&withdrawal_address.address, None)
+            .await?
+            .into()
+    };
 
     // Token-denominated converts the input into sats; fees come out of the
-    // converted output, which is the FeesIncluded shape — use the slow tier
-    // as the best case for the post-fee dust check.
+    // converted output, which is the FeesIncluded shape.
     validate_dust(
         total_u64,
         dust_limit_sats,
@@ -235,6 +267,54 @@ async fn prepare_token_denominated(
         conversion_estimate,
         fee_policy,
     })
+}
+
+/// Estimates what a withdrawal will cost at each speed, for a wallet holding
+/// nothing the provider can price against.
+///
+/// Each speed is estimated one rung high, so the estimate bounds the real fee
+/// and the payment can be sized against it.
+fn estimate_from_rate(fastest_fee_sat_per_vbyte: u64) -> SendOnchainFeeQuote {
+    let speed = |premium: u64| SendOnchainSpeedFeeQuote {
+        user_fee_sat: ESTIMATE_USER_FEE_SAT,
+        l1_broadcast_fee_sat: fastest_fee_sat_per_vbyte
+            .saturating_add(premium)
+            .saturating_add(ESTIMATE_DRIFT_HEADROOM_SAT_PER_VBYTE)
+            .saturating_mul(ESTIMATE_VSIZE_VBYTES),
+    };
+    SendOnchainFeeQuote {
+        id: String::new(),
+        expires_at: 0,
+        speed_slow: speed(ESTIMATE_SPEED_PREMIUM_SAT_PER_VBYTE[0]),
+        speed_medium: speed(ESTIMATE_SPEED_PREMIUM_SAT_PER_VBYTE[1]),
+        speed_fast: speed(ESTIMATE_SPEED_PREMIUM_SAT_PER_VBYTE[2]),
+        is_estimate: true,
+    }
+}
+
+async fn estimate_coop_exit_fee_quote(sdk: &BreezSdk) -> Result<SendOnchainFeeQuote, SdkError> {
+    let fees = sdk.chain_service.recommended_fees().await?;
+    Ok(estimate_from_rate(fees.fastest_fee))
+}
+
+/// Whether the sats being sent will have to come from a token conversion.
+///
+/// The provider cannot price a cooperative exit without funds to quote against,
+/// so this decides whether prepare quotes the fee or bounds it locally and
+/// leaves the send to fetch a quote.
+///
+/// A conversion has to be in play, either auto-filled by an active stable
+/// balance or asked for outright with `ToBitcoin` options, *and* the wallet has
+/// to be short of the amount today. A wallet that can already cover it has
+/// funds to quote against, whatever it converts afterwards.
+fn sats_from_conversion(
+    stable_balance_active: bool,
+    conversion_options: Option<&ConversionOptions>,
+    balance_sats: u64,
+    amount_sats: u64,
+) -> bool {
+    (stable_balance_active || conversion::is_to_bitcoin(conversion_options))
+        && balance_sats < amount_sats
 }
 
 /// Validates a Bitcoin send amount against the address dust limit.
@@ -269,8 +349,11 @@ fn validate_dust(
 #[cfg(test)]
 mod tests {
     use super::super::test_helpers::*;
-    use super::{validate_dust, validate_request};
-    use crate::{ConversionOptions, ConversionType, FeePolicy, error::SdkError};
+    use super::{estimate_from_rate, sats_from_conversion, validate_dust, validate_request};
+    use crate::{
+        ConversionOptions, ConversionType, FeePolicy, OnchainConfirmationSpeed,
+        SendOnchainFeeQuote, error::SdkError,
+    };
     use macros::test_all;
 
     #[cfg(feature = "browser-tests")]
@@ -366,6 +449,148 @@ mod tests {
             result.is_err(),
             "Should fail when conversion from Bitcoin is provided"
         );
+    }
+
+    // ============ coop-exit fee estimate ============
+
+    const SPEEDS: [OnchainConfirmationSpeed; 3] = [
+        OnchainConfirmationSpeed::Slow,
+        OnchainConfirmationSpeed::Medium,
+        OnchainConfirmationSpeed::Fast,
+    ];
+
+    fn fee_for(quote: &SendOnchainFeeQuote, speed: &OnchainConfirmationSpeed) -> u64 {
+        match speed {
+            OnchainConfirmationSpeed::Slow => quote.speed_slow.total_fee_sat(),
+            OnchainConfirmationSpeed::Medium => quote.speed_medium.total_fee_sat(),
+            OnchainConfirmationSpeed::Fast => quote.speed_fast.total_fee_sat(),
+        }
+    }
+
+    #[test_all]
+    fn test_estimate_holds_one_rung_over_every_measured_fee() {
+        // Total fees the mainnet provider quoted on 2026-08-28, by the
+        // mempool.space high-priority rate at the time. Written out rather than
+        // recomputed from the constants, so that changing any of them fails
+        // here instead of scaling both sides of the comparison together.
+        let measured: [(u64, [u64; 3]); 4] = [
+            (2, [1470, 1710, 1950]),
+            (3, [1710, 1950, 2190]),
+            (4, [1950, 2190, 2430]),
+            (5, [2190, 2430, 2670]),
+        ];
+
+        for (network_rate, fees) in measured {
+            let quote = estimate_from_rate(network_rate);
+            for (speed, measured_fee) in SPEEDS.iter().zip(fees) {
+                assert_eq!(
+                    fee_for(&quote, speed),
+                    measured_fee.saturating_add(240),
+                    "estimate should sit one rung over the {measured_fee} sat fee \
+                     measured at {network_rate} sat/vB for {speed:?}"
+                );
+            }
+        }
+    }
+
+    #[test_all]
+    fn test_estimate_covers_the_fee_the_production_send_paid() {
+        // The withdrawal that verified this fix paid 1,710 sats at the fast
+        // speed with the network rate at 1 sat/vB.
+        let quote = estimate_from_rate(1);
+        assert_eq!(
+            quote.speed_fast.total_fee_sat(),
+            1710_u64.saturating_add(240)
+        );
+    }
+
+    #[test_all]
+    fn test_estimate_speeds_are_ordered() {
+        let quote = estimate_from_rate(3);
+        assert!(quote.speed_slow.total_fee_sat() < quote.speed_medium.total_fee_sat());
+        assert!(quote.speed_medium.total_fee_sat() < quote.speed_fast.total_fee_sat());
+    }
+
+    #[test_all]
+    fn test_estimate_is_marked_and_carries_no_provider_identity() {
+        // `expires_at` of zero also reads as long expired, so the send refetches.
+        let quote = estimate_from_rate(3);
+        assert!(quote.is_estimate);
+        assert!(quote.id.is_empty());
+        assert_eq!(quote.expires_at, 0);
+    }
+
+    #[test_all]
+    fn test_estimate_saturates() {
+        let quote = estimate_from_rate(u64::MAX);
+        assert!(quote.speed_fast.total_fee_sat() > 0);
+    }
+
+    // ============ sats_from_conversion ============
+
+    // This predicate decides whether the prepare response carries a fee quote:
+    // true means the sats do not exist yet, so the quote is fetched at send.
+
+    fn to_bitcoin() -> ConversionOptions {
+        ConversionOptions {
+            conversion_type: ConversionType::ToBitcoin {
+                from_token_identifier: "token123".to_string(),
+            },
+            max_slippage_bps: None,
+            completion_timeout_secs: None,
+        }
+    }
+
+    #[test_all]
+    fn test_sats_from_conversion_stable_balance_and_short() {
+        // The reported case: stable balance holding no sats at all.
+        assert!(sats_from_conversion(true, None, 0, 10_000));
+    }
+
+    #[test_all]
+    fn test_sats_from_conversion_explicit_to_bitcoin_and_short() {
+        assert!(sats_from_conversion(false, Some(&to_bitcoin()), 0, 10_000));
+    }
+
+    #[test_all]
+    fn test_sats_from_conversion_covered_balance_still_quotes() {
+        // A wallet that can already cover the amount has funds to quote
+        // against, so it keeps its prepare-time fee quote whether or not stable
+        // balance is on or a conversion was asked for.
+        assert!(!sats_from_conversion(true, None, 50_000, 10_000));
+        assert!(!sats_from_conversion(
+            false,
+            Some(&to_bitcoin()),
+            50_000,
+            10_000
+        ));
+    }
+
+    #[test_all]
+    fn test_sats_from_conversion_boundary() {
+        // Exactly covering the amount is covered: the check is `<`.
+        assert!(!sats_from_conversion(true, None, 10_000, 10_000));
+        assert!(sats_from_conversion(true, None, 9_999, 10_000));
+    }
+
+    #[test_all]
+    fn test_sats_from_conversion_needs_a_conversion_in_play() {
+        // Short of the amount with nothing to convert from is insufficient
+        // funds, not a deferred quote.
+        assert!(!sats_from_conversion(false, None, 0, 10_000));
+    }
+
+    #[test_all]
+    fn test_sats_from_conversion_from_bitcoin_is_not_a_source() {
+        // FromBitcoin spends sats to buy tokens, so it does not produce the
+        // sats this send needs. `validate_request` rejects it for this
+        // destination anyway.
+        let options = ConversionOptions {
+            conversion_type: ConversionType::FromBitcoin,
+            max_slippage_bps: None,
+            completion_timeout_secs: None,
+        };
+        assert!(!sats_from_conversion(false, Some(&options), 0, 10_000));
     }
 
     // ============ validate_dust ============

--- a/crates/breez-sdk/core/src/sdk/payments/prepare/bitcoin_address.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/prepare/bitcoin_address.rs
@@ -20,9 +20,10 @@ use crate::{
 const ESTIMATE_SPEED_PREMIUM_SAT_PER_VBYTE: [u64; 3] = [1, 2, 3];
 /// Headroom on top, for the rate moving while the conversion runs.
 const ESTIMATE_DRIFT_HEADROOM_SAT_PER_VBYTE: u64 = 1;
-/// The provider prices every withdrawal at this size whatever the input count:
+/// The size the provider prices every withdrawal at, whatever the input count:
 /// the wallet's funds are spent on the Spark side, not as on-chain inputs.
-const ESTIMATE_VSIZE_VBYTES: u64 = 240;
+/// Documented at docs.spark.money/wallets/estimate-fees.
+const ESTIMATE_VSIZE_VBYTES: u64 = 250;
 /// The provider's flat service fee, the same for every speed and amount.
 const ESTIMATE_USER_FEE_SAT: u64 = 750;
 
@@ -149,8 +150,8 @@ async fn prepare_sats_denominated(
     } else {
         // Short of the amount but holding something, the wallet still has funds
         // to price against, and the fee does not vary with what is selected.
-        // Asking for the amount when it cannot cover it is what surfaces
-        // insufficient funds on a send with no conversion behind it.
+        // With no conversion behind it, the send is priced against the amount
+        // it will spend rather than every leaf the wallet holds.
         let target_sats = if conversion_funds_the_send {
             None
         } else {
@@ -467,8 +468,30 @@ mod tests {
         }
     }
 
+    /// The step between the provider's speeds, measured at 240 sats. The
+    /// estimate has to clear a real fee by at least this much to survive the
+    /// rate moving a rung while the conversion runs, and by no more than two of
+    /// them, or the conversion is sized against a fee nowhere near the real one.
+    const MEASURED_RUNG_SAT: u64 = 240;
+
+    /// Asserts the estimate bounds `measured` with between one and two rungs of
+    /// headroom, rather than pinning an exact margin, which the rate moves.
+    fn assert_bounds(estimated: u64, measured: u64, context: &str) {
+        let margin = estimated.saturating_sub(measured);
+        assert!(
+            estimated >= measured.saturating_add(MEASURED_RUNG_SAT),
+            "estimate of {estimated} should clear the {measured} sat fee by a \
+             rung, {context}"
+        );
+        assert!(
+            margin <= MEASURED_RUNG_SAT.saturating_mul(2),
+            "estimate of {estimated} overshoots the {measured} sat fee by \
+             {margin} sats, over two rungs, {context}"
+        );
+    }
+
     #[test_all]
-    fn test_estimate_holds_one_rung_over_every_measured_fee() {
+    fn test_estimate_bounds_every_measured_fee() {
         // Total fees the mainnet provider quoted on 2026-08-28, by the
         // mempool.space high-priority rate at the time. Written out rather than
         // recomputed from the constants, so that changing any of them fails
@@ -483,11 +506,10 @@ mod tests {
         for (network_rate, fees) in measured {
             let quote = estimate_from_rate(network_rate);
             for (speed, measured_fee) in SPEEDS.iter().zip(fees) {
-                assert_eq!(
+                assert_bounds(
                     fee_for(&quote, speed),
-                    measured_fee.saturating_add(240),
-                    "estimate should sit one rung over the {measured_fee} sat fee \
-                     measured at {network_rate} sat/vB for {speed:?}"
+                    measured_fee,
+                    &format!("measured at {network_rate} sat/vB for {speed:?}"),
                 );
             }
         }
@@ -498,9 +520,10 @@ mod tests {
         // The withdrawal that verified this fix paid 1,710 sats at the fast
         // speed with the network rate at 1 sat/vB.
         let quote = estimate_from_rate(1);
-        assert_eq!(
+        assert_bounds(
             quote.speed_fast.total_fee_sat(),
-            1710_u64.saturating_add(240)
+            1710,
+            "paid by the production send at 1 sat/vB for Fast",
         );
     }
 

--- a/crates/breez-sdk/core/src/sdk/payments/send/bitcoin_address.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/send/bitcoin_address.rs
@@ -1,6 +1,8 @@
 use std::str::FromStr;
 
+use platform_utils::time::{SystemTime, UNIX_EPOCH};
 use spark_wallet::{ExitSpeed, TransferId};
+use tracing::{info, warn};
 
 use crate::{
     BitcoinAddressDetails, ConversionOptions, ConversionPurpose, FeePolicy,
@@ -12,6 +14,12 @@ use crate::{
     token_conversion::{ConversionAmount, TokenConversionResponse},
     utils::bitcoin_dust::get_dust_limit_sats,
 };
+
+/// A quote within this buffer of expiry is treated as already dead and refetched.
+/// The provider only checks expiry when it receives the quote, which is the first
+/// call the withdrawal makes, so this covers the leaf reservation ahead of it and
+/// any skew between the client clock and the provider's.
+const FEE_QUOTE_EXPIRY_BUFFER_SECS: u64 = 10;
 
 pub(super) async fn send(
     sdk: &BreezSdk,
@@ -33,13 +41,18 @@ pub(super) async fn send(
         }
     };
 
-    let exit_speed: ExitSpeed = confirmation_speed.clone().into();
-
-    let fee_sats = fee_for_speed(fee_quote, &confirmation_speed);
-
     // Compute amount - for FeesIncluded, receiver gets total minus fees.
     // amount_override (send-all post-conversion) is always FeesIncluded.
     let total_sats: u64 = amount_override.unwrap_or(request.prepare_response.amount.try_into()?);
+
+    // What prepare put in front of the caller is the budget, whatever the quote
+    // costs by the time the withdrawal goes out.
+    let budget_sats = fee_for_speed(fee_quote, &confirmation_speed);
+    let fee_quote = refreshed_fee_quote(sdk, address, fee_quote, total_sats).await?;
+    let confirmation_speed = affordable_speed(&fee_quote, &confirmation_speed, budget_sats)?;
+    let exit_speed: ExitSpeed = confirmation_speed.clone().into();
+    let fee_sats = fee_for_speed(&fee_quote, &confirmation_speed);
+
     let amount_sats = if request.prepare_response.fee_policy == FeePolicy::FeesIncluded {
         total_sats.saturating_sub(fee_sats)
     } else {
@@ -65,7 +78,7 @@ pub(super) async fn send(
             &address.address,
             Some(amount_sats),
             exit_speed,
-            fee_quote.clone().into(),
+            fee_quote.into(),
             transfer_id,
         )
         .await?;
@@ -149,6 +162,102 @@ pub(super) async fn send_signed(
     Ok(SendPaymentResponse { payment })
 }
 
+/// Returns the quote to withdraw against, refetching the prepare-time one when it
+/// is at or near expiry.
+///
+/// A token conversion runs between prepare and send and can outlive the quote's
+/// roughly one-minute lifetime.
+async fn refreshed_fee_quote(
+    sdk: &BreezSdk,
+    address: &BitcoinAddressDetails,
+    prepared: &SendOnchainFeeQuote,
+    total_sats: u64,
+) -> Result<SendOnchainFeeQuote, SdkError> {
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| SdkError::Generic("Failed to read current time".to_string()))?
+        .as_secs();
+    if quote_is_valid(prepared.expires_at, now_secs, FEE_QUOTE_EXPIRY_BUFFER_SECS) {
+        return Ok(prepared.clone());
+    }
+
+    let refreshed: SendOnchainFeeQuote = match sdk
+        .spark_wallet
+        .fetch_coop_exit_fee_quote(&address.address, Some(total_sats))
+        .await
+    {
+        Ok(quote) => quote.into(),
+        Err(e) => {
+            // An estimate is not something the provider will honour, so there
+            // is nothing to fall back to. Otherwise leave the provider to
+            // adjudicate the old quote rather than stranding a balance a token
+            // conversion has already spent.
+            if prepared.is_estimate {
+                return Err(e.into());
+            }
+            warn!(
+                "Failed to refresh the expiring onchain fee quote, using the prepared one: {e:?}"
+            );
+            return Ok(prepared.clone());
+        }
+    };
+
+    Ok(refreshed)
+}
+
+/// Whether `expires_at` (Unix seconds) still leaves `buffer_secs` of headroom.
+fn quote_is_valid(expires_at: u64, now_secs: u64, buffer_secs: u64) -> bool {
+    expires_at > now_secs.saturating_add(buffer_secs)
+}
+
+/// The speed to withdraw at: the one the caller chose, or the fastest cheaper
+/// one that still fits the fee they were shown.
+///
+/// Speeds are priced relative to the current network rate, so when the rate
+/// rises the same fee buys a lower-labelled speed. Stepping down holds the
+/// caller to the fee they agreed while keeping the confirmation priority they
+/// paid for, as long as the provider's speeds stay evenly spaced. Once even the
+/// slowest speed costs more than that, failing is all
+/// that is left, and on a conversion-funded send their tokens are already spent
+/// by then.
+fn affordable_speed(
+    refreshed: &SendOnchainFeeQuote,
+    selected: &OnchainConfirmationSpeed,
+    budget_sats: u64,
+) -> Result<OnchainConfirmationSpeed, SdkError> {
+    let candidates: &[OnchainConfirmationSpeed] = match selected {
+        OnchainConfirmationSpeed::Fast => &[
+            OnchainConfirmationSpeed::Fast,
+            OnchainConfirmationSpeed::Medium,
+            OnchainConfirmationSpeed::Slow,
+        ],
+        OnchainConfirmationSpeed::Medium => &[
+            OnchainConfirmationSpeed::Medium,
+            OnchainConfirmationSpeed::Slow,
+        ],
+        OnchainConfirmationSpeed::Slow => &[OnchainConfirmationSpeed::Slow],
+    };
+
+    for (stepped_down, candidate) in candidates.iter().enumerate() {
+        let fee_sats = fee_for_speed(refreshed, candidate);
+        if fee_sats <= budget_sats {
+            if stepped_down > 0 {
+                info!(
+                    "Onchain fee rose past the {budget_sats} sats quoted for {selected:?}, \
+                     withdrawing at {candidate:?} for {fee_sats} sats instead"
+                );
+            }
+            return Ok(candidate.clone());
+        }
+    }
+
+    let slowest_fee_sats = fee_for_speed(refreshed, &OnchainConfirmationSpeed::Slow);
+    Err(SdkError::InvalidInput(format!(
+        "The onchain fee rose to {slowest_fee_sats} sats at the slowest speed, above the \
+         {budget_sats} sats quoted for this payment. Please re-prepare the payment."
+    )))
+}
+
 fn fee_for_speed(fee_quote: &SendOnchainFeeQuote, speed: &OnchainConfirmationSpeed) -> u64 {
     match speed {
         OnchainConfirmationSpeed::Fast => fee_quote.speed_fast.total_fee_sat(),
@@ -159,12 +268,20 @@ fn fee_for_speed(fee_quote: &SendOnchainFeeQuote, speed: &OnchainConfirmationSpe
 
 #[cfg(test)]
 mod tests {
-    use super::fee_for_speed;
-    use crate::{OnchainConfirmationSpeed, SendOnchainFeeQuote, SendOnchainSpeedFeeQuote};
+    use super::{FEE_QUOTE_EXPIRY_BUFFER_SECS, affordable_speed, fee_for_speed, quote_is_valid};
+    use crate::{
+        OnchainConfirmationSpeed, SendOnchainFeeQuote, SendOnchainSpeedFeeQuote, error::SdkError,
+    };
     use macros::test_all;
 
     #[cfg(feature = "browser-tests")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    const SPEEDS: [OnchainConfirmationSpeed; 3] = [
+        OnchainConfirmationSpeed::Slow,
+        OnchainConfirmationSpeed::Medium,
+        OnchainConfirmationSpeed::Fast,
+    ];
 
     fn quote_with_speeds(slow: u64, medium: u64, fast: u64) -> SendOnchainFeeQuote {
         let speed = |total: u64| SendOnchainSpeedFeeQuote {
@@ -177,6 +294,7 @@ mod tests {
             speed_slow: speed(slow),
             speed_medium: speed(medium),
             speed_fast: speed(fast),
+            is_estimate: false,
         }
     }
 
@@ -199,5 +317,124 @@ mod tests {
     fn test_fee_for_speed_fast() {
         let quote = quote_with_speeds(100, 200, 300);
         assert_eq!(fee_for_speed(&quote, &OnchainConfirmationSpeed::Fast), 300);
+    }
+
+    // ============ quote_is_valid ============
+
+    #[test_all]
+    fn test_quote_is_valid_outside_the_buffer() {
+        assert!(quote_is_valid(1000, 900, FEE_QUOTE_EXPIRY_BUFFER_SECS));
+    }
+
+    #[test_all]
+    fn test_quote_is_valid_inside_the_buffer() {
+        // Not yet expired, but dies mid-withdrawal.
+        assert!(!quote_is_valid(1000, 990, FEE_QUOTE_EXPIRY_BUFFER_SECS));
+    }
+
+    #[test_all]
+    fn test_quote_is_valid_boundary() {
+        // Exactly `buffer` of headroom is not enough (the check is `>`).
+        let now = 1000 - FEE_QUOTE_EXPIRY_BUFFER_SECS;
+        assert!(!quote_is_valid(1000, now, FEE_QUOTE_EXPIRY_BUFFER_SECS));
+        assert!(quote_is_valid(1000, now - 1, FEE_QUOTE_EXPIRY_BUFFER_SECS));
+    }
+
+    #[test_all]
+    fn test_quote_is_valid_expired() {
+        assert!(!quote_is_valid(1000, 1001, FEE_QUOTE_EXPIRY_BUFFER_SECS));
+    }
+
+    #[test_all]
+    fn test_quote_is_valid_unset_expiry() {
+        // An unset expiry reads as long dead, so the quote is refetched.
+        assert!(!quote_is_valid(0, 1000, FEE_QUOTE_EXPIRY_BUFFER_SECS));
+    }
+
+    #[test_all]
+    fn test_quote_is_valid_saturates() {
+        assert!(!quote_is_valid(u64::MAX, u64::MAX, 1));
+    }
+
+    // ============ affordable_speed ============
+
+    // Tiers sit one step (240 sats) apart, as the provider prices them.
+    fn ladder(network_rate: u64) -> SendOnchainFeeQuote {
+        let fee = |premium: u64| {
+            network_rate
+                .saturating_add(premium)
+                .saturating_mul(240)
+                .saturating_add(750)
+        };
+        quote_with_speeds(fee(1), fee(2), fee(3))
+    }
+
+    #[test_all]
+    fn test_affordable_speed_keeps_the_chosen_one_when_the_fee_holds() {
+        let refreshed = ladder(3);
+        for speed in &SPEEDS {
+            let budget = fee_for_speed(&refreshed, speed);
+            let chosen = affordable_speed(&refreshed, speed, budget).unwrap();
+            assert_eq!(fee_for_speed(&refreshed, &chosen), budget);
+        }
+    }
+
+    #[test_all]
+    fn test_affordable_speed_keeps_the_chosen_one_when_the_fee_falls() {
+        // A cheaper refreshed quote is spent as-is, not rounded up to the budget.
+        let prepared = ladder(3);
+        let refreshed = ladder(1);
+        let budget = fee_for_speed(&prepared, &OnchainConfirmationSpeed::Slow);
+        let chosen = affordable_speed(&refreshed, &OnchainConfirmationSpeed::Slow, budget).unwrap();
+        assert_eq!(
+            fee_for_speed(&refreshed, &chosen),
+            fee_for_speed(&refreshed, &OnchainConfirmationSpeed::Slow)
+        );
+    }
+
+    #[test_all]
+    fn test_affordable_speed_steps_down_rather_than_exceed_the_budget() {
+        // The rate rose a step, so the budget now buys the tier below. The sats
+        // per vbyte are the same as the caller paid for: only the label moves.
+        let prepared = ladder(3);
+        let refreshed = ladder(4);
+
+        let budget = fee_for_speed(&prepared, &OnchainConfirmationSpeed::Fast);
+        let chosen = affordable_speed(&refreshed, &OnchainConfirmationSpeed::Fast, budget).unwrap();
+        assert!(matches!(chosen, OnchainConfirmationSpeed::Medium));
+        assert_eq!(fee_for_speed(&refreshed, &chosen), budget);
+
+        let budget = fee_for_speed(&prepared, &OnchainConfirmationSpeed::Medium);
+        let chosen =
+            affordable_speed(&refreshed, &OnchainConfirmationSpeed::Medium, budget).unwrap();
+        assert!(matches!(chosen, OnchainConfirmationSpeed::Slow));
+        assert_eq!(fee_for_speed(&refreshed, &chosen), budget);
+    }
+
+    #[test_all]
+    fn test_affordable_speed_never_steps_up() {
+        // A generous budget does not buy a faster confirmation than was asked for.
+        let refreshed = ladder(3);
+        let budget = fee_for_speed(&refreshed, &OnchainConfirmationSpeed::Fast);
+        let chosen = affordable_speed(&refreshed, &OnchainConfirmationSpeed::Slow, budget).unwrap();
+        assert!(matches!(chosen, OnchainConfirmationSpeed::Slow));
+    }
+
+    #[test_all]
+    fn test_affordable_speed_fails_when_the_slowest_is_out_of_reach() {
+        // Slow has nothing below it, so a rise leaves no tier within budget.
+        let prepared = ladder(3);
+        let refreshed = ladder(4);
+        let budget = fee_for_speed(&prepared, &OnchainConfirmationSpeed::Slow);
+
+        let Err(SdkError::InvalidInput(msg)) =
+            affordable_speed(&refreshed, &OnchainConfirmationSpeed::Slow, budget)
+        else {
+            panic!("Expected InvalidInput when no speed fits the budget");
+        };
+        assert!(
+            msg.contains("re-prepare"),
+            "Error should tell the caller to re-prepare: {msg}"
+        );
     }
 }

--- a/crates/breez-sdk/core/src/sdk/payments/send/bitcoin_address.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/send/bitcoin_address.rs
@@ -238,10 +238,11 @@ fn affordable_speed(
         OnchainConfirmationSpeed::Slow => &[OnchainConfirmationSpeed::Slow],
     };
 
-    for (stepped_down, candidate) in candidates.iter().enumerate() {
+    for (index, candidate) in candidates.iter().enumerate() {
         let fee_sats = fee_for_speed(refreshed, candidate);
         if fee_sats <= budget_sats {
-            if stepped_down > 0 {
+            let stepped_down = index > 0;
+            if stepped_down {
                 info!(
                     "Onchain fee rose past the {budget_sats} sats quoted for {selected:?}, \
                      withdrawing at {candidate:?} for {fee_sats} sats instead"

--- a/crates/breez-sdk/core/src/sdk/payments/send/bitcoin_address.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/send/bitcoin_address.rs
@@ -438,4 +438,93 @@ mod tests {
             "Error should tell the caller to re-prepare: {msg}"
         );
     }
+
+    // ---- Budgets that do not land on a provider tier ----
+    //
+    // A budget from a real quote equals a tier. One from prepare's estimate
+    // clears it by a whole step plus part of another, the estimate being priced
+    // at a different vbyte size. Fees move in whole steps, so only the whole
+    // steps in that margin change which tier is affordable. The partial step is
+    // what makes a step down land under the budget rather than on it.
+
+    /// The gap between the provider's tiers, and the amount a 1 sat/vB move
+    /// shifts every tier by.
+    const TIER_STEP_SAT: u64 = 240;
+    /// The shape an estimated budget has: one whole step of tolerance, plus a
+    /// partial one.
+    const ESTIMATED_MARGIN_SAT: u64 = TIER_STEP_SAT + 50;
+
+    fn estimated_budget(
+        network_rate: u64,
+        speed: &OnchainConfirmationSpeed,
+        margin_sat: u64,
+    ) -> u64 {
+        fee_for_speed(&ladder(network_rate), speed).saturating_add(margin_sat)
+    }
+
+    fn speed_index(speed: &OnchainConfirmationSpeed) -> usize {
+        match speed {
+            OnchainConfirmationSpeed::Slow => 0,
+            OnchainConfirmationSpeed::Medium => 1,
+            OnchainConfirmationSpeed::Fast => 2,
+        }
+    }
+
+    #[test_all]
+    fn test_affordable_speed_steps_down_against_an_estimated_budget() {
+        // Two steps outrun the margin. The tier below fits, and fits with room
+        // to spare, since the budget does not sit on a tier boundary.
+        let budget = estimated_budget(3, &OnchainConfirmationSpeed::Fast, ESTIMATED_MARGIN_SAT);
+        let refreshed = ladder(5);
+        let chosen = affordable_speed(&refreshed, &OnchainConfirmationSpeed::Fast, budget).unwrap();
+
+        assert!(matches!(chosen, OnchainConfirmationSpeed::Medium));
+        assert!(
+            fee_for_speed(&refreshed, &chosen) < budget,
+            "a budget between tiers leaves the tier below strictly cheaper than it"
+        );
+    }
+
+    #[test_all]
+    fn test_affordable_speed_never_exceeds_an_estimated_budget() {
+        // The guarantee the caller is given: whatever comes back is within the
+        // fee prepare showed, and never faster than what they picked. It holds
+        // for any budget, so the margins span the whole band prepare is allowed
+        // to hand over rather than the values it derives at these rates.
+        let margins = [TIER_STEP_SAT, ESTIMATED_MARGIN_SAT, TIER_STEP_SAT * 2];
+        let (mut stepped_down, mut failed) = (0u32, 0u32);
+
+        for network_rate in 1..=10 {
+            for selected in &SPEEDS {
+                for margin_sat in margins {
+                    let budget = estimated_budget(network_rate, selected, margin_sat);
+                    for rise in 0..=5 {
+                        let refreshed = ladder(network_rate.saturating_add(rise));
+                        let Ok(chosen) = affordable_speed(&refreshed, selected, budget) else {
+                            failed = failed.saturating_add(1);
+                            continue;
+                        };
+                        if speed_index(&chosen) < speed_index(selected) {
+                            stepped_down = stepped_down.saturating_add(1);
+                        }
+                        assert!(
+                            fee_for_speed(&refreshed, &chosen) <= budget,
+                            "at {network_rate} sat/vB with a {rise} step rise and a \
+                             {margin_sat} sat margin, {chosen:?} costs more than the \
+                             {budget} sat budget"
+                        );
+                        assert!(
+                            speed_index(&chosen) <= speed_index(selected),
+                            "at {network_rate} sat/vB with a {rise} step rise and a \
+                             {margin_sat} sat margin, {chosen:?} is faster than the \
+                             {selected:?} asked for"
+                        );
+                    }
+                }
+            }
+        }
+        // Without these the sweep would still pass if every case errored.
+        assert!(stepped_down > 0, "the sweep never exercised a step down");
+        assert!(failed > 0, "the sweep never exercised an unaffordable rise");
+    }
 }

--- a/crates/breez-sdk/core/src/sdk/payments/send/mod.rs
+++ b/crates/breez-sdk/core/src/sdk/payments/send/mod.rs
@@ -411,7 +411,14 @@ pub(super) async fn send_internal(
             .await
         }
         SendPaymentMethod::BitcoinAddress { address, fee_quote } => {
-            bitcoin_address::send(sdk, address, fee_quote, request, amount_override).await
+            Box::pin(bitcoin_address::send(
+                sdk,
+                address,
+                fee_quote,
+                request,
+                amount_override,
+            ))
+            .await
         }
         method @ SendPaymentMethod::CrossChainAddress { .. } => {
             cross_chain::send(

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -1028,6 +1028,7 @@ pub struct SendOnchainFeeQuote {
     pub speed_fast: SendOnchainSpeedFeeQuote,
     pub speed_medium: SendOnchainSpeedFeeQuote,
     pub speed_slow: SendOnchainSpeedFeeQuote,
+    pub is_estimate: bool,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::SendOnchainSpeedFeeQuote)]

--- a/crates/spark-wallet/src/wallet.rs
+++ b/crates/spark-wallet/src/wallet.rs
@@ -764,6 +764,10 @@ impl SparkWallet {
             .await?)
     }
 
+    /// `amount_sats` prices the quote against the leaves that would fund a
+    /// withdrawal of that size. `None` prices it against every available leaf.
+    /// Either way the provider requires at least one: it rejects an empty set
+    /// with "No leaves are provided for this coop exit fee request."
     pub async fn fetch_coop_exit_fee_quote(
         &self,
         withdrawal_address: &str,
@@ -780,7 +784,7 @@ impl SparkWallet {
             .require_network(self.config.network.into())
             .map_err(|_| SparkWalletError::InvalidNetwork)?;
 
-        // Selects leaves totaling `amount_sat` if provided, otherwise retrieves all available leaves.
+        // Selects leaves totaling `amount_sats` if provided, otherwise retrieves all available leaves.
         let target_amounts =
             amount_sats.map(|amount| TargetAmounts::new_amount_and_fee(amount, None));
         let reservation = self

--- a/docs/breez-sdk/src/guide/send_payment.md
+++ b/docs/breez-sdk/src/guide/send_payment.md
@@ -36,7 +36,7 @@ If the invoice also contains a Spark address, the payment can be sent directly v
 
 For Bitcoin addresses, the amount must be set in the request. The prepare response includes fee quotes for three payment speeds: Slow, Medium, and Fast.
 
-The quote's {{#name is_estimate}} flag is set when your bitcoin balance is zero and a token conversion will fund the payment, which happens automatically when [Stable Balance](./stable_balance.md) is active. With no bitcoin to price the withdrawal against, the fees shown are derived from current on-chain rates and the real ones may differ. They are an upper bound: the SDK fetches a real quote once the conversion completes, and fails rather than spending more than it estimated. Present this as an estimate if you show it.
+The quote's {{#name is_estimate}} flag is set when your bitcoin balance is zero and a token conversion will fund the payment, which happens automatically when [Stable Balance](./stable_balance.md) is active. The fees shown are then derived from current on-chain rates rather than quoted by the provider, so the real ones may differ. They are an upper bound: the SDK fetches a real quote once the conversion completes, and fails rather than spending more than it estimated. Present this as an estimate if you show it.
 
 Fee quotes are short lived. If one is close to expiry by the time you send, the SDK fetches a fresh quote for you. It will not spend more than the payment allows, so a fee that rises beyond that fails the send and asks you to prepare again.
 

--- a/docs/breez-sdk/src/guide/send_payment.md
+++ b/docs/breez-sdk/src/guide/send_payment.md
@@ -36,6 +36,10 @@ If the invoice also contains a Spark address, the payment can be sent directly v
 
 For Bitcoin addresses, the amount must be set in the request. The prepare response includes fee quotes for three payment speeds: Slow, Medium, and Fast.
 
+The quote's {{#name is_estimate}} flag is set when your bitcoin balance is zero and a token conversion will fund the payment, which happens automatically when [Stable Balance](./stable_balance.md) is active. With no bitcoin to price the withdrawal against, the fees shown are derived from current on-chain rates and the real ones may differ. They are an upper bound: the SDK fetches a real quote once the conversion completes, and fails rather than spending more than it estimated. Present this as an estimate if you show it.
+
+Fee quotes are short lived. If one is close to expiry by the time you send, the SDK fetches a fresh quote for you. It will not spend more than the payment allows, so a fee that rises beyond that fails the send and asks you to prepare again.
+
 {{#tabs send_payment:prepare-send-payment-onchain}}
 
 ### Spark

--- a/docs/breez-sdk/src/guide/stable_balance.md
+++ b/docs/breez-sdk/src/guide/stable_balance.md
@@ -65,6 +65,8 @@ When you [prepare to send a payment](./send_payment.md#preparing-payments) witho
 1. If you have enough bitcoin balance, no conversion is needed
 2. If your bitcoin balance is insufficient, the SDK configures conversion options using your Stable Balance settings (token identifier and slippage)
 
+For [bitcoin address](./send_payment.md#bitcoin) destinations the prepare response marks its fee quote {{#name is_estimate}} when your bitcoin balance is zero, leaving nothing to price the withdrawal against. Any balance at all still gets a real quote. An estimate is always replaced with a real one before the payment goes out.
+
 The same flow extends to [USDC/USDT](./send_payment.md#usdc-usdt): when paying a recipient on USDC or USDT, the SDK can spend the user's USDB balance directly (Orchestra routes that accept USDB as source) or auto-convert it through bitcoin if the chosen route only accepts sats.
 
 <div class="warning">

--- a/docs/breez-sdk/src/guide/stable_balance.md
+++ b/docs/breez-sdk/src/guide/stable_balance.md
@@ -65,7 +65,7 @@ When you [prepare to send a payment](./send_payment.md#preparing-payments) witho
 1. If you have enough bitcoin balance, no conversion is needed
 2. If your bitcoin balance is insufficient, the SDK configures conversion options using your Stable Balance settings (token identifier and slippage)
 
-For [bitcoin address](./send_payment.md#bitcoin) destinations the prepare response marks its fee quote {{#name is_estimate}} when your bitcoin balance is zero, leaving nothing to price the withdrawal against. Any balance at all still gets a real quote. An estimate is always replaced with a real one before the payment goes out.
+For [bitcoin address](./send_payment.md#bitcoin) destinations the prepare response marks its fee quote {{#name is_estimate}} when your bitcoin balance is zero. Any balance at all still gets a real quote. An estimate is always replaced with a real one before the payment goes out.
 
 The same flow extends to [USDC/USDT](./send_payment.md#usdc-usdt): when paying a recipient on USDC or USDT, the SDK can spend the user's USDB balance directly (Orchestra routes that accept USDB as source) or auto-convert it through bitcoin if the chosen route only accepts sats.
 

--- a/packages/flutter/rust/src/models.rs
+++ b/packages/flutter/rust/src/models.rs
@@ -921,6 +921,7 @@ pub struct _SendOnchainFeeQuote {
     pub speed_fast: SendOnchainSpeedFeeQuote,
     pub speed_medium: SendOnchainSpeedFeeQuote,
     pub speed_slow: SendOnchainSpeedFeeQuote,
+    pub is_estimate: bool,
 }
 
 #[frb(mirror(SendOnchainSpeedFeeQuote))]


### PR DESCRIPTION
A on-chain send funded by USDB and zero sats balance failed at prepare with `NonReservableLeaves`, and once past that, could fail again at send with an expired fee quote after the conversion had already run.

The provider will not quote a withdrawal with no leaves. So prepare now estimates the fee locally when the balance is zero, and quotes for real whenever any leaves exist.

Fixes #1086

### Changes
- `SendOnchainFeeQuote.is_estimate`: New field, set when the wallet holds no bitcoin and a conversion will fund the send. Callers should present those fees as an estimate. 
- `Quote is refreshed before withdrawing`: Quotes live 60 seconds and the prepare-time one was previously carried across the conversion and spent unchecked. `send` now refetches near expiry and never exceeds the fee prepare quoted for the chosen speed. If the rate rose past it, the send steps down to the fastest speed still within that fee rather than overspending, and fails only if even the slowest is out of reach.
