### PR TITLE
Surface string details in React Native SDK errors

### DIFF
--- a/packages/react-native/patches/uniffi-bindgen-react-native+0.29.3-1.patch
+++ b/packages/react-native/patches/uniffi-bindgen-react-native+0.29.3-1.patch
@@ -1,3 +1,18 @@
+diff --git a/node_modules/uniffi-bindgen-react-native/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/TaggedEnumTemplate.ts b/node_modules/uniffi-bindgen-react-native/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/TaggedEnumTemplate.ts
+index 5c0060d..d2ac9d7 100644
+--- a/node_modules/uniffi-bindgen-react-native/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/TaggedEnumTemplate.ts
++++ b/node_modules/uniffi-bindgen-react-native/crates/ubrn_bindgen/src/bindings/gen_typescript/templates/TaggedEnumTemplate.ts
+@@ -76,6 +76,10 @@ export const {{ decl_type_name }} = (() => {
+         }
+         {%-   else %}
+         constructor({%- call ts::field_list_decl(variant, true) -%}) {
++            {%- if is_error %}
++            super("{{ type_name }}", "{{ external_name }}", typeof v0 === "string" ? v0 : undefined);
++            {%- else %}
+             super("{{ type_name }}", "{{ external_name }}");
++            {%- endif %}
+             this.inner = Object.freeze([{%- call ts::field_list(variant, true) -%}]);
+         }
 diff --git a/node_modules/uniffi-bindgen-react-native/crates/ubrn_cli/templates/jsi/android/CMakeLists.txt b/node_modules/uniffi-bindgen-react-native/crates/ubrn_cli/templates/jsi/android/CMakeLists.txt
 index 99baf67..cc4b8f3 100644
 --- a/node_modules/uniffi-bindgen-react-native/crates/ubrn_cli/templates/jsi/android/CMakeLists.txt
@@ -82,3 +97,16 @@ index 3de6fbc..1797e41 100644
    s.vendored_frameworks = "{{ framework }}"
    s.dependency    "uniffi-bindgen-react-native", "{{ self.config.project.ubrn_version() }}"
  
+diff --git a/node_modules/uniffi-bindgen-react-native/fixtures/error-types/tests/bindings/test_error_types.ts b/node_modules/uniffi-bindgen-react-native/fixtures/error-types/tests/bindings/test_error_types.ts
+index dc4dde3..8217f89 100644
+--- a/node_modules/uniffi-bindgen-react-native/fixtures/error-types/tests/bindings/test_error_types.ts
++++ b/node_modules/uniffi-bindgen-react-native/fixtures/error-types/tests/bindings/test_error_types.ts
+@@ -178,7 +178,7 @@ test("oopsEnum 5", (t) => {
+ test("oopsTuple 0 - throws enum variants containing tuples", (t) => {
+   t.assertThrows(
+     (error) => {
+-      t.assertEqual("Error: TupleError.Oops", error.toString());
++      t.assertEqual("Error: TupleError.Oops: oops", error.toString());
+       if (TupleError.Oops.instanceOf(error)) {
+         t.assertEqual("oops", error.inner[0]);
+         return true;


### PR DESCRIPTION
## Reason

Rich UniFFI error variants such as `SdkError.InvalidInput` keep their detail in `inner[0]`, but the generated JavaScript `Error.message` contains only the variant name. Apps and standard error logging therefore surface generic values such as `SdkError.InvalidInput` and hide the actionable reason.

## Overview

- Pass the first tuple payload to `UniffiError` when it is a string.
- Preserve the existing `tag` and `inner` representation.
- Leave non-string tuple errors unchanged.
- Update the upstream `error-types` fixture expectation for the surfaced message.

This is carried in the existing `uniffi-bindgen-react-native` patch so the next React Native package build receives the behavior without waiting for a new generator release.

## Test Plan

- Applied the patch successfully after a clean `yarn install --mode=skip-build` using `npx patch-package`.
- Generated and ran the upstream `error-types` WASM fixture with string and numeric tuple error cases.
- Ran `node ./scripts/post-ubrn.js --check`.
- Ran `git diff --check`.