### PR TITLE
Docs: ask for the API key when registering an LNURL domain

### DIFF
--- a/docs/breez-sdk/src/guide/receive_lnurl_pay.md
+++ b/docs/breez-sdk/src/guide/receive_lnurl_pay.md
@@ -28,7 +28,7 @@ This points a subdomain like pay.yourdomain.com to the LNURL server.
 * **Type**: CNAME
 * **Value/Target**: breez.tips
 
-[Send us](mailto:contact@breez.technology) your domain name (e.g., yourdomain.com or pay.yourdomain.com).
+[Send us](mailto:contact@breez.technology) your domain name (e.g., yourdomain.com or pay.yourdomain.com), together with the Breez API key you want the LNURL payments on that domain to be associated with.
 
 We will verify and add it to our list of allowed domains.
 


### PR DESCRIPTION
Domain registrations now also need an API key to associate the LNURL payments with, but the custom domain section of the docs only asks people to send in their domain name. Registration emails come in without a key.

Updates the instruction in `receive_lnurl_pay.md` so the email includes the Breez API key the LNURL payments on that domain should be associated with.