### PR TITLE
Fix 32-bit SIGABRT error on react native

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -97,7 +97,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "uniffi-bindgen-react-native": "^0.29.3-1"
+    "uniffi-bindgen-react-native": "git+https://github.com/breez/uniffi-bindgen-react-native.git#309bc8fa7fc56d4358dc75a78135a54d8225786b"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^17.0.2",

--- a/packages/react-native/yarn.lock
+++ b/packages/react-native/yarn.lock
@@ -2344,7 +2344,7 @@ __metadata:
     release-it: ^17.10.0
     turbo: ^1.10.7
     typescript: ^5.2.2
-    uniffi-bindgen-react-native: ^0.29.3-1
+    uniffi-bindgen-react-native: "git+https://github.com/breez/uniffi-bindgen-react-native.git#309bc8fa7fc56d4358dc75a78135a54d8225786b"
   peerDependencies:
     react: "*"
     react-native: "*"
@@ -16372,13 +16372,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uniffi-bindgen-react-native@npm:^0.29.3-1":
+"uniffi-bindgen-react-native@git+https://github.com/breez/uniffi-bindgen-react-native.git#309bc8fa7fc56d4358dc75a78135a54d8225786b":
   version: 0.29.3-1
-  resolution: "uniffi-bindgen-react-native@npm:0.29.3-1"
+  resolution: "uniffi-bindgen-react-native@https://github.com/breez/uniffi-bindgen-react-native.git#commit=309bc8fa7fc56d4358dc75a78135a54d8225786b"
   bin:
-    ubrn: bin/cli.cjs
-    uniffi-bindgen-react-native: bin/cli.cjs
-  checksum: 1cd0da57d11178823658c5e9a080570b65ec3f973ffac3c9ae131399681b5825727aa3ac397060e5e9aebe524194f9dddcd70acd14968d7c8f23f1bf66e7032b
+    ubrn: ./bin/cli.cjs
+    uniffi-bindgen-react-native: ./bin/cli.cjs
+  checksum: 27b1ab19485f342703f4f7d3811f9dbc17c50a0a53a2e6e33db947c50207a10328e524c7835228184ca34bfa65ed014e0cf661faf09b05abb3dfa323e1e5fc69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The SDK aborts on the first call on any 32-bit Android process (`armeabi-v7a`, `x86`). `RustBuffer` declares `capacity` and `len` as `u64` regardless of pointer width, but `uniffi-bindgen-react-native` 0.29.3-1 declares them `size_t`, so the C++/JSI bridge and Rust disagree on the struct layout.

### Change
One-file change is cherry-picked onto `breez/uniffi-bindgen-react-native` branch `0.29.3-1` from a later upstream fix in uniffi 0.30, and the dependency is pinned to that commit.

```c
 struct RustBuffer {
-  size_t capacity;
-  size_t len;
+  uint64_t capacity;
+  uint64_t len;
   uint8_t *data;
 };
```

### Verification
Firebase Test Lab:
| Device | ABI | `size_t` | `uint64_t` |
|---|---|---|---|
| RMX3231, API 30 | armeabi-v7a | SIGABRT | Passes |
| Galaxy A13, API 34 | armeabi-v7a | SIGABRT | Passes |
| MediumPhone.arm, API 34 | arm64-v8a | Passes | Passes |

The 64-bit control passing on the crashing APK confirms the diagnosis. The abort is `buffer capacity negative or overflowed` inside `uniffi_breez_sdk_spark_fn_func_default_config`.
