### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Commands.cs
@@ -325,7 +325,7 @@ public static class Commands
     private static readonly HashSet<string> BooleanFlags = new()
     {
         "--fees-included", "--from-bitcoin", "--hodl", "-f", "--freezable",
-        "--new-address", "--clear-master-key"
+        "--new-address", "--clear-master-key", "--cross-chain-fees-included"
     };
 
     private static string[] GetPositionalArgs(string[] args)
@@ -525,11 +525,14 @@ public static class Commands
         var senderPubKey = GetFlag(args, "-s", "--sender-public-key");
         var hodl = HasFlag(args, "--hodl");
         var newAddress = HasFlag(args, "--new-address");
+        var crossChainMaxSlippageStr = GetFlag(args, "--cross-chain-max-slippage-bps");
+        var crossChainFeesIncluded = HasFlag(args, "--cross-chain-fees-included");
+        var crossChainTargetOverpayStr = GetFlag(args, "--cross-chain-target-overpay-bps");
 
         if (method == null)
         {
             Console.WriteLine("Usage: receive -m <method> [options]");
-            Console.WriteLine("Methods: sparkaddress, sparkinvoice, bitcoin, bolt11");
+            Console.WriteLine("Methods: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain");
             return;
         }
 
@@ -591,9 +594,35 @@ public static class Commands
                 );
                 break;
 
+            case "crosschain":
+                if (amountStr == null)
+                {
+                    Console.Error.WriteLine("--amount is required for cross-chain receive");
+                    return;
+                }
+                var crossChainAmount = BigInteger.Parse(amountStr);
+                var filter = new CrossChainRouteFilter.Receive(contractAddress: null);
+                var route = await SelectCrossChainRoute(sdk, readline, filter);
+                if (route == null) return;
+                CrossChainFeeMode? feeMode = crossChainFeesIncluded
+                    ? CrossChainFeeMode.FeesIncluded
+                    : null;
+                SparkAsset? destination = tokenIdentifier != null
+                    ? new SparkAsset.Token(tokenIdentifier: tokenIdentifier)
+                    : null;
+                paymentMethod = new ReceivePaymentMethod.CrossChain(
+                    route: route,
+                    amount: crossChainAmount,
+                    destination: destination,
+                    feeMode: feeMode,
+                    maxSlippageBps: ParseOptionalUint(crossChainMaxSlippageStr),
+                    targetOverpayBps: ParseOptionalUint(crossChainTargetOverpayStr)
+                );
+                break;
+
             default:
                 Console.WriteLine($"Invalid payment method: {method}");
-                Console.WriteLine("Available methods: sparkaddress, sparkinvoice, bitcoin, bolt11");
+                Console.WriteLine("Available methods: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain");
                 return;
         }
 
@@ -1559,7 +1588,7 @@ public static class Commands
         var routes = await sdk.GetCrossChainRoutes(filter: filter);
         if (routes.Length == 0)
         {
-            Console.WriteLine("No cross-chain routes available for this address");
+            Console.WriteLine("No cross-chain routes available");
             return null;
         }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/commands.dart
@@ -311,14 +311,25 @@ Future<void> _handleListPayments(BreezSdk sdk, TokenIssuer tokenIssuer, List<Str
 Future<void> _handleReceive(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> args) async {
   final parser =
       _parser('receive')
-        ..addOption('method', abbr: 'm', mandatory: true, help: 'sparkaddress, sparkinvoice, bitcoin, bolt11')
+        ..addOption(
+          'method',
+          abbr: 'm',
+          mandatory: true,
+          help: 'sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain',
+        )
         ..addOption('description', abbr: 'd')
         ..addOption('amount', abbr: 'a')
         ..addOption('token-identifier', abbr: 't')
         ..addOption('expiry-secs', abbr: 'e')
         ..addOption('sender-public-key', abbr: 's')
         ..addFlag('hodl', defaultsTo: false)
-        ..addFlag('new-address', defaultsTo: false, help: 'Get a new bitcoin deposit address');
+        ..addFlag('new-address', defaultsTo: false, help: 'Get a new bitcoin deposit address')
+        ..addOption(
+          'cross-chain-max-slippage-bps',
+          help: 'Max slippage in bps for cross-chain receives (10..500)',
+        )
+        ..addFlag('cross-chain-fees-included', defaultsTo: false, help: 'Deduct fees from the amount')
+        ..addOption('cross-chain-target-overpay-bps', help: 'Overpay buffer in bps (0..500)');
   final results = _parseArgs(parser, args, 'receive -m <method> [options]');
   if (results == null) return;
 
@@ -371,6 +382,31 @@ Future<void> _handleReceive(BreezSdk sdk, TokenIssuer tokenIssuer, List<String> 
         expirySecs: expirySecs,
         paymentHash: paymentHash,
         receiverIdentityPublicKey: null,
+      );
+    case 'crosschain':
+      if (amount == null) {
+        print('--amount is required for cross-chain receive');
+        return;
+      }
+      final route = await _selectCrossChainRoute(sdk, CrossChainRouteFilter.receive(contractAddress: null));
+      if (route == null) return;
+      final crossChainFeesIncluded = results.flag('cross-chain-fees-included');
+      final feeMode = crossChainFeesIncluded ? CrossChainFeeMode.feesIncluded : null;
+      final maxSlippageBpsStr = results.option('cross-chain-max-slippage-bps');
+      final maxSlippageBps = maxSlippageBpsStr != null ? int.parse(maxSlippageBpsStr) : null;
+      final targetOverpayBpsStr = results.option('cross-chain-target-overpay-bps');
+      final targetOverpayBps = targetOverpayBpsStr != null ? int.parse(targetOverpayBpsStr) : null;
+      SparkAsset? destination;
+      if (tokenIdentifier != null) {
+        destination = SparkAsset.token(tokenIdentifier: tokenIdentifier);
+      }
+      paymentMethod = ReceivePaymentMethod.crossChain(
+        route: route,
+        amount: amount,
+        destination: destination,
+        feeMode: feeMode,
+        maxSlippageBps: maxSlippageBps,
+        targetOverpayBps: targetOverpayBps,
       );
     default:
       print('Invalid payment method: $method');
@@ -1282,7 +1318,7 @@ SendPaymentOptions? _readPaymentOptions(SendPaymentMethod paymentMethod) {
 Future<CrossChainRoutePair?> _selectCrossChainRoute(BreezSdk sdk, CrossChainRouteFilter filter) async {
   final routes = await sdk.getCrossChainRoutes(filter: filter);
   if (routes.isEmpty) {
-    print('No cross-chain routes available for this address');
+    print('No cross-chain routes available');
     return null;
   }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/commands.go
@@ -271,9 +271,9 @@ func handleListPayments(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, arg
 
 // --- receive ---
 
-func handleReceive(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []string) error {
+func handleReceive(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance, args []string) error {
 	fs := flag.NewFlagSet("receive", flag.ContinueOnError)
-	method := fs.String("m", "", "Payment method: sparkaddress, sparkinvoice, bitcoin, bolt11")
+	method := fs.String("m", "", "Payment method: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain")
 	fs.StringVar(method, "method", "", "Payment method")
 	description := fs.String("d", "", "Optional description")
 	fs.StringVar(description, "description", "", "Optional description")
@@ -287,13 +287,16 @@ func handleReceive(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []s
 	fs.StringVar(senderPublicKey, "sender-public-key", "", "Optional sender public key")
 	hodl := fs.Bool("hodl", false, "Create a HODL invoice (bolt11 only)")
 	newAddress := fs.Bool("new-address", false, "Get a new bitcoin deposit address (bitcoin only)")
+	crossChainMaxSlippageStr := fs.String("cross-chain-max-slippage-bps", "", "Max slippage in basis points for cross-chain receives (10..500)")
+	crossChainFeesIncluded := fs.Bool("cross-chain-fees-included", false, "Deduct fees from amount instead of padding onto deposit")
+	crossChainTargetOverpayStr := fs.String("cross-chain-target-overpay-bps", "", "Override for the overpay buffer in basis points (0..500)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
 	if *method == "" {
 		fmt.Println("Usage: receive -m <method> [options]")
-		fmt.Println("Methods: sparkaddress, sparkinvoice, bitcoin, bolt11")
+		fmt.Println("Methods: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain")
 		return nil
 	}
 
@@ -365,9 +368,51 @@ func handleReceive(sdk *breez_sdk_spark.BreezSdk, _ *readline.Instance, args []s
 		}
 		paymentMethod = pm
 
+	case "crosschain":
+		if *amountStr == "" {
+			return fmt.Errorf("--amount is required for cross-chain receive")
+		}
+		amount, ok := new(big.Int).SetString(*amountStr, 10)
+		if !ok {
+			return fmt.Errorf("invalid amount: %s", *amountStr)
+		}
+		route, err := selectCrossChainRoute(sdk, rl, breez_sdk_spark.CrossChainRouteFilterReceive{ContractAddress: nil})
+		if err != nil {
+			return err
+		}
+		pm := breez_sdk_spark.ReceivePaymentMethodCrossChain{
+			Route:  route,
+			Amount: amount,
+		}
+		if *tokenId != "" {
+			var dest breez_sdk_spark.SparkAsset = breez_sdk_spark.SparkAssetToken{TokenIdentifier: *tokenId}
+			pm.Destination = &dest
+		}
+		if *crossChainFeesIncluded {
+			fm := breez_sdk_spark.CrossChainFeeModeFeesIncluded
+			pm.FeeMode = &fm
+		}
+		if *crossChainMaxSlippageStr != "" {
+			val, err := strconv.ParseUint(*crossChainMaxSlippageStr, 10, 32)
+			if err != nil {
+				return fmt.Errorf("invalid cross-chain max slippage: %s", *crossChainMaxSlippageStr)
+			}
+			val32 := uint32(val)
+			pm.MaxSlippageBps = &val32
+		}
+		if *crossChainTargetOverpayStr != "" {
+			val, err := strconv.ParseUint(*crossChainTargetOverpayStr, 10, 32)
+			if err != nil {
+				return fmt.Errorf("invalid cross-chain target overpay: %s", *crossChainTargetOverpayStr)
+			}
+			val32 := uint32(val)
+			pm.TargetOverpayBps = &val32
+		}
+		paymentMethod = pm
+
 	default:
 		fmt.Printf("Invalid payment method: %s\n", *method)
-		fmt.Println("Available methods: sparkaddress, sparkinvoice, bitcoin, bolt11")
+		fmt.Println("Available methods: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain")
 		return nil
 	}
 
@@ -1476,7 +1521,7 @@ func selectCrossChainRoute(sdk *breez_sdk_spark.BreezSdk, rl *readline.Instance,
 		return breez_sdk_spark.CrossChainRoutePair{}, err
 	}
 	if len(routes) == 0 {
-		return breez_sdk_spark.CrossChainRoutePair{}, fmt.Errorf("no cross-chain routes available for this address")
+		return breez_sdk_spark.CrossChainRoutePair{}, fmt.Errorf("no cross-chain routes available")
 	}
 
 	if len(routes) == 1 {

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Commands.kt
@@ -308,18 +308,24 @@ suspend fun handleReceive(sdk: BreezSdk, reader: LineReader, args: List<String>)
     val senderPublicKey = fp.getString("s", "sender-public-key")
     val hodl = fp.hasFlag("hodl")
     val newAddress = fp.hasFlag("new-address")
+    val crossChainMaxSlippageBps = fp.getUInt("cross-chain-max-slippage-bps")
+    val crossChainFeesIncluded = fp.hasFlag("cross-chain-fees-included")
+    val crossChainTargetOverpayBps = fp.getUInt("cross-chain-target-overpay-bps")
 
     if (method == null) {
         println("Usage: receive -m <method> [options]")
-        println("Methods: sparkaddress, sparkinvoice, bitcoin, bolt11")
+        println("Methods: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain")
         println("Options:")
-        println("  -d, --description <desc>        Optional description")
-        println("  -a, --amount <amount>            Amount in sats or token base units")
-        println("  -t, --token-identifier <id>      Token identifier (spark invoice only)")
-        println("  -e, --expiry-secs <secs>         Expiry in seconds")
-        println("  -s, --sender-public-key <key>    Sender public key (spark invoice only)")
-        println("  --hodl                           Create a HODL invoice (bolt11 only)")
-        println("  --new-address                    Get a new bitcoin deposit address")
+        println("  -d, --description <desc>                   Optional description")
+        println("  -a, --amount <amount>                      Amount in sats, token base units, or source asset base units")
+        println("  -t, --token-identifier <id>                Token identifier (spark invoice / cross-chain destination)")
+        println("  -e, --expiry-secs <secs>                   Expiry in seconds")
+        println("  -s, --sender-public-key <key>              Sender public key (spark invoice only)")
+        println("  --hodl                                     Create a HODL invoice (bolt11 only)")
+        println("  --new-address                              Get a new bitcoin deposit address")
+        println("  --cross-chain-max-slippage-bps <bps>       Max slippage in basis points (10..500, cross-chain only)")
+        println("  --cross-chain-fees-included                Deduct fees from amount (cross-chain only)")
+        println("  --cross-chain-target-overpay-bps <bps>     Overpay buffer in basis points (0..500, cross-chain only)")
         return
     }
 
@@ -387,9 +393,28 @@ suspend fun handleReceive(sdk: BreezSdk, reader: LineReader, args: List<String>)
             )
         }
 
+        "crosschain" -> {
+            if (amount == null) {
+                println("Error: --amount is required for cross-chain receive")
+                return
+            }
+            val filter = CrossChainRouteFilter.Receive(contractAddress = null)
+            val route = selectCrossChainRoute(sdk, reader, filter)
+            val feeMode = if (crossChainFeesIncluded) CrossChainFeeMode.FEES_INCLUDED else null
+            val destination = tokenIdentifier?.let { SparkAsset.Token(tokenIdentifier = it) }
+            ReceivePaymentMethod.CrossChain(
+                route = route,
+                amount = amount,
+                destination = destination,
+                feeMode = feeMode,
+                maxSlippageBps = crossChainMaxSlippageBps,
+                targetOverpayBps = crossChainTargetOverpayBps,
+            )
+        }
+
         else -> {
             println("Invalid payment method: $method")
-            println("Available methods: sparkaddress, sparkinvoice, bitcoin, bolt11")
+            println("Available methods: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain")
             return
         }
     }
@@ -1205,7 +1230,7 @@ suspend fun selectCrossChainRoute(
 ): CrossChainRoutePair {
     val routes = sdk.getCrossChainRoutes(filter)
     if (routes.isEmpty()) {
-        throw Exception("No cross-chain routes available for this address")
+        throw Exception("No cross-chain routes available")
     }
 
     if (routes.size == 1) {

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/commands.py
@@ -15,6 +15,7 @@ from breez_sdk_spark import (
     ClaimTransferRequest,
     ConversionOptions,
     ConversionType,
+    CrossChainFeeMode,
     CrossChainRouteFilter,
     Fee,
     FeePolicy,
@@ -47,6 +48,7 @@ from breez_sdk_spark import (
     SendPaymentMethod,
     SendPaymentOptions,
     SendPaymentRequest,
+    SparkAsset,
     SparkHtlcOptions,
     SparkHtlcStatus,
     SparkMasterIdentityPublicKey,
@@ -256,7 +258,7 @@ async def _handle_list_payments(sdk, _token_issuer, _session, args):
 def _build_receive_parser():
     p = _parser("receive", "Receive a payment")
     p.add_argument("-m", "--method", required=True,
-                   help="Payment method: sparkaddress, sparkinvoice, bitcoin, bolt11")
+                   help="Payment method: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain")
     p.add_argument("-d", "--description", default=None)
     p.add_argument("-a", "--amount", type=int, default=None)
     p.add_argument("-t", "--token-identifier", default=None)
@@ -266,9 +268,15 @@ def _build_receive_parser():
                    help="Create a HODL invoice (bolt11 only)")
     p.add_argument("--new-address", action="store_true", default=False,
                    help="Request a new bitcoin deposit address instead of reusing the current one")
+    p.add_argument("--cross-chain-max-slippage-bps", type=int, default=None,
+                   help="Max slippage in basis points for cross-chain receives (10..500)")
+    p.add_argument("--cross-chain-fees-included", action="store_true", default=False,
+                   help="Deduct fees from the amount instead of padding onto the deposit")
+    p.add_argument("--cross-chain-target-overpay-bps", type=int, default=None,
+                   help="Overpay buffer in basis points for fees-excluded mode (0..500)")
     return p
 
-async def _handle_receive(sdk, _token_issuer, _session, args):
+async def _handle_receive(sdk, _token_issuer, session, args):
     method = args.method.lower()
 
     if method == "sparkaddress":
@@ -304,6 +312,30 @@ async def _handle_receive(sdk, _token_issuer, _session, args):
             expiry_secs=args.expiry_secs,
             payment_hash=payment_hash,
             receiver_identity_public_key=None,
+        )
+    elif method == "crosschain":
+        if args.amount is None:
+            print("--amount is required for cross-chain receive")
+            return
+        route_filter = CrossChainRouteFilter.RECEIVE(contract_address=None)
+        route = await _select_cross_chain_route(sdk, session, route_filter)
+        fee_mode = (
+            CrossChainFeeMode.FEES_INCLUDED
+            if args.cross_chain_fees_included
+            else None
+        )
+        destination = (
+            SparkAsset.TOKEN(token_identifier=args.token_identifier)
+            if args.token_identifier
+            else None
+        )
+        payment_method = ReceivePaymentMethod.CROSS_CHAIN(
+            route=route,
+            amount=args.amount,
+            destination=destination,
+            fee_mode=fee_mode,
+            max_slippage_bps=args.cross_chain_max_slippage_bps,
+            target_overpay_bps=args.cross_chain_target_overpay_bps,
         )
     else:
         print(f"Invalid payment method: {method}")
@@ -1067,7 +1099,7 @@ async def _select_cross_chain_route(sdk, session, route_filter):
     """Fetch cross-chain routes and prompt the user to select one."""
     routes = await sdk.get_cross_chain_routes(filter=route_filter)
     if not routes:
-        raise ValueError("No cross-chain routes available for this address")
+        raise ValueError("No cross-chain routes available")
 
     if len(routes) == 1:
         route = routes[0]

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/breez-sdk-spark-react-native.d.ts
@@ -78,6 +78,10 @@ declare module '@breeztech/breez-sdk-spark-react-native' {
   export const PaymentRequest: any;
   export const CrossChainRouteFilter: any;
   export const CrossChainProvider: any;
+  export const CrossChainFeeMode: any;
+  export type CrossChainFeeMode = any;
+  export const SparkAsset: any;
+  export type SparkAsset = any;
   export type CrossChainRoutePair = any;
   export type CrossChainAddressDetails = any;
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/commands.ts
@@ -37,6 +37,8 @@ import {
   PaymentRequest,
   CrossChainRouteFilter,
   CrossChainProvider,
+  CrossChainFeeMode,
+  SparkAsset,
 } from '@breeztech/breez-sdk-spark-react-native'
 import type {
   BatchRecipient,
@@ -477,7 +479,7 @@ async function handleListPayments(sdk: BreezSdkInterface, _tokenIssuer: TokenIss
 async function handleReceive(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerInterface, args: string[]): Promise<string> {
   const method = parseFlag(args, '--method', '-m')
   if (!method) {
-    return 'Usage: receive -m <method> [options]\nMethods: sparkaddress, sparkinvoice, bitcoin, bolt11\n\nOptions:\n  -d, --description <desc>       Optional description\n  -a, --amount <amount>          Amount in sats or token base units\n  -t, --token-identifier <id>    Token identifier (sparkinvoice only)\n  -e, --expiry-secs <secs>       Expiry time in seconds from now\n  -s, --sender-public-key <key>  Sender public key (sparkinvoice only)\n  --hodl                         Create a HODL invoice (bolt11 only)'
+    return 'Usage: receive -m <method> [options]\nMethods: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain\n\nOptions:\n  -d, --description <desc>       Optional description\n  -a, --amount <amount>          Amount in sats or token base units\n  -t, --token-identifier <id>    Token identifier (sparkinvoice/crosschain)\n  -e, --expiry-secs <secs>       Expiry time in seconds from now\n  -s, --sender-public-key <key>  Sender public key (sparkinvoice only)\n  --hodl                         Create a HODL invoice (bolt11 only)\n  --cross-chain-max-slippage-bps   Max slippage bps (crosschain)\n  --cross-chain-fees-included      Deduct fees from amount (crosschain)\n  --cross-chain-target-overpay-bps Overpay buffer bps (crosschain)'
   }
 
   const description = parseFlag(args, '--description', '-d')
@@ -487,6 +489,10 @@ async function handleReceive(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerIn
   const senderPublicKey = parseFlag(args, '--sender-public-key', '-s')
   const hodl = hasFlag(args, '--hodl')
   const newAddress = hasFlag(args, '--new-address')
+  const crossChainMaxSlippageBps = parseNumericFlag(args, '--cross-chain-max-slippage-bps')
+  const crossChainFeesIncluded = hasFlag(args, '--cross-chain-fees-included')
+  const crossChainTargetOverpayBps = parseNumericFlag(args, '--cross-chain-target-overpay-bps')
+  const routeIndex = parseNumericFlag(args, '--route')
 
   const amount = amountStr !== undefined ? BigInt(amountStr) : undefined
   const expirySecs = expirySecsStr !== undefined ? parseInt(expirySecsStr, 10) : undefined
@@ -495,6 +501,7 @@ async function handleReceive(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerIn
     | InstanceType<typeof ReceivePaymentMethod.SparkInvoice>
     | InstanceType<typeof ReceivePaymentMethod.BitcoinAddress>
     | InstanceType<typeof ReceivePaymentMethod.Bolt11Invoice>
+    | InstanceType<typeof ReceivePaymentMethod.CrossChain>
 
   const lines: string[] = []
 
@@ -551,8 +558,34 @@ async function handleReceive(sdk: BreezSdkInterface, _tokenIssuer: TokenIssuerIn
       break
     }
 
+    case 'crosschain': {
+      if (amount === undefined) {
+        return 'Error: --amount is required for cross-chain receive'
+      }
+      const filter = new CrossChainRouteFilter.Receive({ contractAddress: undefined })
+      const routeResult = await selectCrossChainRoute(sdk, filter, routeIndex)
+      lines.push(routeResult.message)
+
+      const feeMode = crossChainFeesIncluded
+        ? CrossChainFeeMode.FeesIncluded
+        : undefined
+      const destination = tokenIdentifier
+        ? new SparkAsset.Token({ tokenIdentifier })
+        : undefined
+
+      paymentMethod = new ReceivePaymentMethod.CrossChain({
+        route: routeResult.route,
+        amount,
+        destination,
+        feeMode,
+        maxSlippageBps: crossChainMaxSlippageBps,
+        targetOverpayBps: crossChainTargetOverpayBps,
+      })
+      break
+    }
+
     default:
-      return `Invalid payment method: ${method}\nAvailable methods: sparkaddress, sparkinvoice, bitcoin, bolt11`
+      return `Invalid payment method: ${method}\nAvailable methods: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain`
   }
 
   const result = await sdk.receivePayment({ paymentMethod })
@@ -1395,13 +1428,13 @@ function maybeTruncateAddress(addr: string | undefined | null): string {
 
 async function selectCrossChainRoute(
   sdk: BreezSdkInterface,
-  filter: InstanceType<typeof CrossChainRouteFilter.Send> | InstanceType<typeof CrossChainRouteFilter.PaymentLink>,
+  filter: InstanceType<typeof CrossChainRouteFilter.Send> | InstanceType<typeof CrossChainRouteFilter.PaymentLink> | InstanceType<typeof CrossChainRouteFilter.Receive>,
   preferredIndex: number | undefined,
 ): Promise<{ route: CrossChainRoutePair; message: string }> {
   const routes: CrossChainRoutePair[] = await sdk.getCrossChainRoutes(filter)
 
   if (routes.length === 0) {
-    throw new Error('No cross-chain routes available for this address')
+    throw new Error('No cross-chain routes available')
   }
 
   if (routes.length === 1) {

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Commands.swift
@@ -369,7 +369,7 @@ func handleReceive(_ sdk: BreezSdk, _ args: [String]) async throws {
     let fp = FlagParser(args)
     guard let method = fp.get("m", "method") else {
         print("Usage: receive -m <method> [options]")
-        print("Methods: sparkaddress, sparkinvoice, bitcoin, bolt11")
+        print("Methods: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain")
         return
     }
 
@@ -380,6 +380,9 @@ func handleReceive(_ sdk: BreezSdk, _ args: [String]) async throws {
     let senderPublicKey = fp.get("s", "sender-public-key")
     let hodl = fp.has("hodl")
     let newAddress = fp.has("new-address")
+    let crossChainMaxSlippageBps = fp.get("cross-chain-max-slippage-bps").flatMap { UInt32($0) }
+    let crossChainFeesIncluded = fp.has("cross-chain-fees-included")
+    let crossChainTargetOverpayBps = fp.get("cross-chain-target-overpay-bps").flatMap { UInt32($0) }
 
     let paymentMethod: ReceivePaymentMethod
 
@@ -421,9 +424,32 @@ func handleReceive(_ sdk: BreezSdk, _ args: [String]) async throws {
             receiverIdentityPublicKey: nil
         )
 
+    case "crosschain":
+        guard let amountStr, let amount = BInt(amountStr) else {
+            print("--amount is required for cross-chain receive")
+            return
+        }
+        let route = try await selectCrossChainRoute(
+            sdk: sdk,
+            filter: .receive(contractAddress: nil)
+        )
+        let feeMode: CrossChainFeeMode? = crossChainFeesIncluded
+            ? .feesIncluded : nil
+        let destination: SparkAsset? = tokenIdentifier.map {
+            .token(tokenIdentifier: $0)
+        }
+        paymentMethod = .crossChain(
+            route: route,
+            amount: amount,
+            destination: destination,
+            feeMode: feeMode,
+            maxSlippageBps: crossChainMaxSlippageBps,
+            targetOverpayBps: crossChainTargetOverpayBps
+        )
+
     default:
         print("Invalid payment method: \(method)")
-        print("Available methods: sparkaddress, sparkinvoice, bitcoin, bolt11")
+        print("Available methods: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain")
         return
     }
 
@@ -1173,7 +1199,7 @@ func selectCrossChainRoute(
     let routes = try await sdk.getCrossChainRoutes(filter: filter)
     if routes.isEmpty {
         throw NSError(domain: "BreezCLI", code: 1, userInfo: [
-            NSLocalizedDescriptionKey: "No cross-chain routes available for this address",
+            NSLocalizedDescriptionKey: "No cross-chain routes available",
         ])
     }
 

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/commands.js
@@ -219,14 +219,17 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
   program
     .command('receive')
     .description('Receive a payment')
-    .requiredOption('-m, --method <method>', 'Payment method: sparkaddress, sparkinvoice, bitcoin, bolt11')
+    .requiredOption('-m, --method <method>', 'Payment method: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain')
     .option('-d, --description <text>', 'Optional description for the invoice')
-    .option('-a, --amount <number>', 'The amount the payer should send, in sats or token base units')
-    .option('-t, --token-identifier <id>', 'Optional token identifier (spark invoice only)')
+    .option('-a, --amount <number>', 'The amount the payer should send, in sats, token base units, or (for cross-chain receive) the source asset\'s base units')
+    .option('-t, --token-identifier <id>', 'Optional token identifier')
     .option('-e, --expiry-secs <seconds>', 'Optional expiry time in seconds from now', parseInt)
     .option('-s, --sender-public-key <key>', 'Optional sender public key (spark invoice only)')
     .option('--hodl', 'Create a HODL invoice (bolt11 only)', false)
     .option('--new-address', 'Request a new bitcoin deposit address instead of reusing the current one', false)
+    .option('--cross-chain-max-slippage-bps <bps>', 'Maximum slippage in basis points for cross-chain receives (10..500)', parseInt)
+    .option('--cross-chain-fees-included', 'Deduct fees from the specified amount for cross-chain receives', false)
+    .option('--cross-chain-target-overpay-bps <bps>', 'Overpay buffer in basis points for cross-chain receives (0..500)', parseInt)
     .action(async (options) => {
       const sdk = getSdk()
       let paymentMethod
@@ -282,8 +285,28 @@ function buildProgram(getSdk, getTokenIssuer, getGetSparkStatus, rl) {
           }
           break
         }
+        case 'crosschain': {
+          if (options.amount == null) {
+            throw new Error('--amount is required for cross-chain receive')
+          }
+          const route = await selectCrossChainRoute(sdk, rl, { type: 'receive', contractAddress: undefined })
+          const feeMode = options.crossChainFeesIncluded ? 'feesIncluded' : undefined
+          const destination = options.tokenIdentifier != null
+            ? { type: 'token', tokenIdentifier: options.tokenIdentifier }
+            : undefined
+          paymentMethod = {
+            type: 'crossChain',
+            route,
+            amount: options.amount,
+            destination,
+            feeMode,
+            maxSlippageBps: options.crossChainMaxSlippageBps,
+            targetOverpayBps: options.crossChainTargetOverpayBps
+          }
+          break
+        }
         default: {
-          throw new Error(`Invalid payment method: ${method}. Use: sparkaddress, sparkinvoice, bitcoin, bolt11`)
+          throw new Error(`Invalid payment method: ${method}. Use: sparkaddress, sparkinvoice, bitcoin, bolt11, crosschain`)
         }
       }
 
@@ -1093,7 +1116,7 @@ async function selectCrossChainRoute(sdk, rl, filter) {
   const routes = await sdk.getCrossChainRoutes(filter)
 
   if (!routes || routes.length === 0) {
-    throw new Error('No cross-chain routes available for this address')
+    throw new Error('No cross-chain routes available')
   }
 
   if (routes.length === 1) {


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`d743355`](https://github.com/breez/spark-sdk/commit/d743355edaa329e130e51888ec7538338cfd144e)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/34242909942)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :white_check_mark: React Native
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- Rust `receive` command supports `crosschain` payment method with `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, and `--cross-chain-target-overpay-bps` flags; C# CLI was missing all of these
- C# `SelectCrossChainRoute` error message said "No cross-chain routes available for this address" while Rust says "No cross-chain routes available"

## Applied
- Added `crosschain` case to `HandleReceive` in `Commands.cs` with route selection, fee mode, destination, and slippage/overpay support matching the Rust implementation
- Added `--cross-chain-fees-included` to `BooleanFlags` set in `Commands.cs` so positional arg parsing skips it correctly
- Added cross-chain flag parsing (`--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, `--cross-chain-target-overpay-bps`) in `HandleReceive` in `Commands.cs`
- Updated usage and error messages to include `crosschain` as a valid method in `Commands.cs`
- Updated `SelectCrossChainRoute` error message to match Rust ("No cross-chain routes available") in `Commands.cs`

## Skipped
- (none)

### Dart
## Divergences
- `receive` command missing `crosschain` payment method (Rust has `ReceivePaymentMethodArg::CrossChain`)
- `receive` command missing `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, `--cross-chain-target-overpay-bps` flags
- `receive` handler missing full `CrossChain` case (route selection, fee mode, destination asset, SDK call)
- `_selectCrossChainRoute` error message said "for this address" instead of matching Rust's generic "No cross-chain routes available"

## Applied
- Added `crosschain` to the receive method help text in `commands.dart`
- Added `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, `--cross-chain-target-overpay-bps` flags to the receive parser in `commands.dart`
- Added full `crosschain` case to the receive handler in `commands.dart`: requires `--amount`, calls `_selectCrossChainRoute` with `CrossChainRouteFilter.receive`, maps flags to `CrossChainFeeMode`/`SparkAsset`/slippage params, constructs `ReceivePaymentMethod.crossChain`
- Updated error message in `_selectCrossChainRoute` from "No cross-chain routes available for this address" to "No cross-chain routes available" in `commands.dart`

## Skipped
- (none)

### Go
## Divergences
- Go CLI `receive` command missing `crosschain` payment method (Rust added `ReceivePaymentMethodArg::CrossChain` with `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, `--cross-chain-target-overpay-bps` flags)
- Go CLI `selectCrossChainRoute` error message says "for this address" while Rust now says "No cross-chain routes available" (generic)

## Applied
- Added `crosschain` payment method to `handleReceive` in `commands.go` with three new flags: `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, `--cross-chain-target-overpay-bps`
- Updated `handleReceive` to accept `rl *readline.Instance` (was `_`) since cross-chain receive needs interactive route selection
- Updated help text for `receive` to list `crosschain` as a valid method
- Updated `selectCrossChainRoute` error message to "no cross-chain routes available" (matching Rust) in `commands.go`

## Skipped
- (none)

### Kotlin
## Divergences
- Kotlin `handleReceive` missing `crosschain` method and `CrossChainRouteFilter.Receive` receive flow
- Kotlin `handleReceive` missing `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, `--cross-chain-target-overpay-bps` flags
- Kotlin `selectCrossChainRoute` error message said "for this address" while Rust says "No cross-chain routes available"

## Applied
- Added `crosschain` method handler in `handleReceive` with route selection, fee mode, destination, and slippage/overpay flags (Commands.kt)
- Added parsing of `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, `--cross-chain-target-overpay-bps` flags in `handleReceive` (Commands.kt)
- Updated receive help text to include `crosschain` method and the three new flags (Commands.kt)
- Updated `selectCrossChainRoute` error message to match Rust: "No cross-chain routes available" (Commands.kt)

## Skipped
- (none)

### Python
## Divergences
- `receive` command missing `crosschain` payment method (Rust added `CrossChain` variant to `ReceivePaymentMethodArg` with full handler)
- `receive` command missing `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, `--cross-chain-target-overpay-bps` flags
- `_select_cross_chain_route` error message said "No cross-chain routes available for this address" instead of "No cross-chain routes available"

## Applied
- Added `CrossChainFeeMode` and `SparkAsset` imports to `commands.py`
- Added `crosschain` to the `--method` help text in `_build_receive_parser()` in `commands.py`
- Added `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, `--cross-chain-target-overpay-bps` flags to `_build_receive_parser()` in `commands.py`
- Added `crosschain` handler branch in `_handle_receive()` in `commands.py`: validates `--amount`, selects route via `_select_cross_chain_route`, maps fee mode and destination, constructs `ReceivePaymentMethod.CROSS_CHAIN`
- Changed `_handle_receive` parameter from `_session` to `session` (needed for route selection prompt)
- Updated `_select_cross_chain_route` error message from "No cross-chain routes available for this address" to "No cross-chain routes available" in `commands.py`

## Skipped
- (none)

### React Native
## Divergences
- Rust CLI added `crosschain` receive method with `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, and `--cross-chain-target-overpay-bps` flags; React Native CLI was missing this method entirely
- Rust CLI updated `select_cross_chain_route` error message from "No cross-chain routes available for this address" to "No cross-chain routes available"; React Native had the old message
- Rust CLI `selectCrossChainRoute` now accepts `CrossChainRouteFilter::Receive` (in addition to `Send` and `PaymentLink`); React Native type signature only allowed `Send` and `PaymentLink`

## Applied
- Added `CrossChainFeeMode` and `SparkAsset` imports and type stubs in `src/commands.ts` and `src/breez-sdk-spark-react-native.d.ts`
- Added `crosschain` case to `handleReceive` switch with route selection, fee mode, destination, and slippage/overpay flags in `src/commands.ts`
- Updated `selectCrossChainRoute` type signature to accept `CrossChainRouteFilter.Receive` and fixed error message to match Rust in `src/commands.ts`
- Updated usage and error messages in `handleReceive` to list `crosschain` as an available method in `src/commands.ts`

## Skipped
- (none)

### Swift
## Divergences
- `handleReceive` missing `crosschain` payment method with route selection, fee mode, destination, and slippage/overpay flags
- `handleReceive` usage and error strings listed only 4 methods, missing `crosschain`
- `selectCrossChainRoute` error message said "for this address" (stale, Rust dropped the suffix)

## Applied
- Added `crosschain` case to `handleReceive` with `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, `--cross-chain-target-overpay-bps` flags (Commands.swift)
- Updated usage/error strings to list `crosschain` as a valid method (Commands.swift)
- Updated `selectCrossChainRoute` error to "No cross-chain routes available" (Commands.swift)

## Skipped
- (none)

### TypeScript
## Divergences
- Rust CLI added `crosschain` receive method with `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, and `--cross-chain-target-overpay-bps` flags; TypeScript CLI was missing all of these
- Rust CLI updated `select_cross_chain_route` error message from "No cross-chain routes available for this address" to "No cross-chain routes available"; TypeScript had the old message

## Applied
- Added `crosschain` to the receive method options and updated the method description in `commands.js`
- Added `--cross-chain-max-slippage-bps`, `--cross-chain-fees-included`, and `--cross-chain-target-overpay-bps` options to the receive command in `commands.js`
- Added `crosschain` case handler that fetches receive routes, builds `CrossChainFeeMode`, `SparkAsset` destination, and constructs the `crossChain` payment method in `commands.js`
- Updated the `selectCrossChainRoute` error message to "No cross-chain routes available" in `commands.js`
- Updated the receive method description and token identifier description to match the Rust CLI in `commands.js`

## Skipped
- (none)

</details>

All languages synced cleanly. This PR merges automatically once the gating CI checks pass (integration test checks excluded).