### PR TITLE
fix(cross-chain): unwire the Boltz provider

### DIFF
--- a/crates/breez-sdk/core/src/cross_chain/mod.rs
+++ b/crates/breez-sdk/core/src/cross_chain/mod.rs
@@ -132,9 +132,7 @@ pub(crate) fn derive_btc_leg_transfer_id(
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum CrossChainProvider {
     Orchestra,
-    /// Not operational: no routes are offered under this provider, and it is
-    /// unclear when or whether that will change. The variant is retained so
-    /// persisted payment history keeps decoding.
+    /// Not operational: no routes are currently offered under this provider.
     Boltz,
 }
 

--- a/crates/breez-sdk/core/src/cross_chain/mod.rs
+++ b/crates/breez-sdk/core/src/cross_chain/mod.rs
@@ -3,14 +3,19 @@
 //! The [`CrossChainService`] trait abstracts route discovery, quoting, and
 //! sending. Each provider module (e.g. `orchestra`, `boltz`) implements it.
 
+// Boltz is not registered as a provider (see `sdk_builder`): the service is not
+// operational, and it is unclear when or whether it will be again. The modules
+// stay compiled so the wiring can be restored in one place.
+#[allow(dead_code)]
 pub(crate) mod boltz;
+#[allow(dead_code)]
 pub(crate) mod boltz_event_listener;
+#[allow(dead_code)]
 pub(crate) mod boltz_storage_adapter;
 mod cached_fiat;
 mod orchestra;
 mod orchestra_storage_adapter;
 
-pub(crate) use boltz::BoltzService;
 pub(crate) use cached_fiat::{CachedFiatService, DEFAULT_FIAT_CACHE_TTL};
 pub(crate) use orchestra::{BreezServerOrchestraConfigResolver, OrchestraService};
 
@@ -127,6 +132,9 @@ pub(crate) fn derive_btc_leg_transfer_id(
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum CrossChainProvider {
     Orchestra,
+    /// Not operational: no routes are offered under this provider, and it is
+    /// unclear when or whether that will change. The variant is retained so
+    /// persisted payment history keeps decoding.
     Boltz,
 }
 

--- a/crates/breez-sdk/core/src/sdk_builder.rs
+++ b/crates/breez-sdk/core/src/sdk_builder.rs
@@ -612,9 +612,7 @@ impl SdkBuilder {
 
         let sync_coordinator = SyncCoordinator::new();
 
-        // Shared lightning-send helper used by `send_bolt11_invoice` and
-        // by cross-chain providers that pay LN invoices (currently: Boltz
-        // reverse swap).
+        // Shared lightning-send helper used by `send_bolt11_invoice`.
         let lightning_sender = Arc::new(crate::sdk::LightningSender::new(
             Arc::clone(&spark_wallet),
             Arc::clone(&storage),
@@ -628,8 +626,6 @@ impl SdkBuilder {
             &context.http_client,
             &spark_wallet,
             &storage,
-            signers.ecies.clone(),
-            &lightning_sender,
             Arc::clone(&fiat_service),
             shutdown_sender.subscribe(),
         );
@@ -1112,15 +1108,12 @@ async fn build_stable_balance(
 
 /// Builds the cross-chain context: provider registry + shared cached fiat
 /// service. Returns an empty registry when `config.cross_chain_config` is unset.
-#[allow(clippy::too_many_arguments)]
 fn build_cross_chain_context(
     config: &Config,
     breez_server: &Arc<BreezServer>,
     http_client: &Arc<dyn platform_utils::HttpClient>,
     spark_wallet: &Arc<SparkWallet>,
     storage: &Arc<dyn crate::persist::Storage>,
-    ecies: Option<Arc<dyn crate::signer::EciesSigner>>,
-    lightning_sender: &Arc<crate::sdk::LightningSender>,
     fiat_service: Arc<dyn breez_sdk_common::fiat::FiatService>,
     shutdown_receiver: watch::Receiver<()>,
 ) -> crate::cross_chain::CrossChainContext {
@@ -1151,33 +1144,9 @@ fn build_cross_chain_context(
                 Arc::clone(storage),
                 Arc::clone(&cached_fiat),
                 Arc::clone(http_client),
-                shutdown_receiver.clone(),
+                shutdown_receiver,
             )),
         );
-    }
-
-    match crate::cross_chain::BoltzService::build(
-        config.network,
-        Arc::clone(spark_wallet),
-        Arc::clone(storage),
-        ecies,
-        cached_fiat,
-        Arc::clone(lightning_sender),
-        config.proxy.as_ref(),
-        shutdown_receiver,
-    ) {
-        Ok(Some(service)) => {
-            providers.insert(crate::cross_chain::CrossChainProvider::Boltz, service);
-        }
-        Ok(None) => {
-            info!(
-                "Boltz provider skipped: no default configuration for network {:?}",
-                config.network
-            );
-        }
-        Err(e) => {
-            tracing::error!("Failed to initialize Boltz provider: {e:?}");
-        }
     }
 
     providers

--- a/docs/breez-sdk/src/guide/cross_chain.md
+++ b/docs/breez-sdk/src/guide/cross_chain.md
@@ -49,14 +49,13 @@ URIs whose recipient address doesn't match the scheme's address family (e.g. a `
 
 ## Providers
 
-The SDK ships with two cross-chain providers. {{#name get_cross_chain_routes}} returns the union of routes offered by each, tagged with {{#name CrossChainRoutePair.provider}}.
+{{#name get_cross_chain_routes}} returns the routes offered by each provider, tagged with {{#name CrossChainRoutePair.provider}}.
 
 | Provider     | Direction        | Spark side       | External side                                                | Mechanism                            |
 | ------------ | ---------------- | ---------------- | ------------------------------------------------------------ | ------------------------------------ |
 | **Orchestra** (Flashnet) | Send + Receive  | BTC sats + USDB | USDC / USDT on Ethereum chains (Arbitrum, Base), Solana, Tron | Spark transfer to a deposit address, then provider bridges to the destination chain |
-| **Boltz**    | Send             | BTC sats only    | USDC / USDT on Ethereum chains (Arbitrum, Base), Solana, Tron                 | Lightning reverse swap: SDK pays a hold invoice, provider claims the on-chain leg |
 
-The provider tag on each {{#name CrossChainRoutePair}} is the source of truth. When the same destination is offered by multiple providers, both routes are returned; the caller picks one based on supported source/destination assets, fees, or other preferences.
+The provider tag on each {{#name CrossChainRoutePair}} is the source of truth. When the same destination is offered by multiple providers, every route is returned; the caller picks one based on supported source/destination assets, fees, or other preferences.
 
 ## Slippage
 
@@ -114,7 +113,7 @@ Calling {{#name send_payment}} is safe to retry on transient errors **only when 
 
 #### Sends with no token leg
 
-When the first leg is a Spark sats transfer (Orchestra with BTC source, or Boltz funded directly from the sats balance), the SDK threads a deterministic transfer id through to the underlying Spark transfer. Retrying with the same {{#name PrepareSendPaymentResponse}} produces the same transfer id, and the Spark protocol returns the original transfer instead of firing a new one — no double-deposit.
+When the first leg is a Spark sats transfer (Orchestra with a BTC source), the SDK threads a deterministic transfer id through to the underlying Spark transfer. Retrying with the same {{#name PrepareSendPaymentResponse}} produces the same transfer id, and the Spark protocol returns the original transfer instead of firing a new one — no double-deposit.
 
 Two ways to drive idempotency:
 
@@ -128,7 +127,7 @@ When the first leg is a token transfer at the Spark protocol layer, there is no 
 This arises in two ways for a cross-chain send:
 
 - **Direct token send** — USDB source on Orchestra. The first leg is a USDB transfer to the provider deposit address.
-- **Token conversion** — USDB balance routed through a sats-only provider (e.g. Boltz). The SDK auto-converts USDB → BTC via the [stable-balance](./stable_balance.md) flow before the provider leg; that conversion is itself a token transfer.
+- **Token conversion** — USDB balance routed over a route whose Spark side takes only sats. The SDK auto-converts USDB → BTC via the [stable-balance](./stable_balance.md) flow before the provider leg; that conversion is itself a token transfer.
 
 This matches the existing contract for direct token sends.
 

--- a/docs/breez-sdk/src/guide/prepare_payment_link.md
+++ b/docs/breez-sdk/src/guide/prepare_payment_link.md
@@ -60,4 +60,4 @@ The {{#name amount}} on {{#name PreparePaymentLinkRequest}} is in the destinatio
 
 - **Mainnet only.** Cash App and the cross-chain providers operate against live networks. There is no testnet equivalent.
 - **Not tracked.** The purchase is funded outside the wallet, so it produces no {{#name Payment}} row and no event. If you need delivery confirmation, observe the recipient chain directly.
-- **Orchestra routes only.** Payment links quote against Orchestra, whose orders deliver without the SDK online. A Boltz route would need the wallet to stay online to claim the swap before the payer's payment settles, so {{#name get_cross_chain_routes}} with {{#enum CrossChainRouteFilter::PaymentLink}} returns only Orchestra routes and {{#name prepare_payment_link}} rejects a Boltz route.
+- **Orchestra routes only.** Payment links quote against Orchestra, whose orders deliver without the SDK online. A route that needs the wallet to stay online to claim before the payer's payment settles cannot back a link, so {{#name get_cross_chain_routes}} with {{#enum CrossChainRouteFilter::PaymentLink}} returns only Orchestra routes.


### PR DESCRIPTION
The Boltz service is not operational, and it is unclear when or whether
it will be again. Registering it also slowed route discovery: route
fetching retries a network-bound client construction cached only on
success, and providers are queried sequentially, so an unreachable
backend put a 60s timeout in front of every route list.

Stop registering the provider. The modules stay compiled and tested so
the wiring can be restored in one place. The public enum variants are
retained so persisted payment history keeps decoding.
