### PR TITLE
chore: sync CLI languages with Rust CLI changes

### DIFF
--- a/crates/breez-sdk/bindings/examples/cli/langs/csharp/Advanced.cs
+++ b/crates/breez-sdk/bindings/examples/cli/langs/csharp/Advanced.cs
@@ -270,7 +270,8 @@ public static class AdvancedCommands
     {
         Console.WriteLine(
             $"Recoverable {response.recoverableValueSat} sats, " +
-            $"total fee {response.totalFeeSat} sats, " +
+            $"total fee {response.totalFeeSat} sats " +
+            $"(cpfp {response.cpfpFeeSat}, fanout {response.fanoutFeeSat}, sweep {response.sweepFeeSat}), " +
             $"{response.transactions.Length} transaction(s):");
 
         for (int i = 0; i < response.transactions.Length; i++)
@@ -285,10 +286,36 @@ public static class AdvancedCommands
             Console.WriteLine(
                 $"  [{i}] {tx.kind} status={tx.status} txid={tx.txid}{after}{csv}");
 
-            if (tx.status is ExitTransactionStatus.Confirmed)
+            switch (tx.status)
             {
-                Console.WriteLine("      (already confirmed, nothing to broadcast)");
-                continue;
+                case ExitTransactionStatus.Confirmed confirmed:
+                    if (confirmed.blockHeight != null)
+                    {
+                        Console.WriteLine(
+                            $"      (confirmed in block {confirmed.blockHeight}, nothing to broadcast)");
+                    }
+                    else
+                    {
+                        Console.WriteLine("      (already confirmed, nothing to broadcast)");
+                    }
+                    continue;
+                case ExitTransactionStatus.WaitingForDependencies:
+                    Console.WriteLine("      (waiting on the transactions it depends on)");
+                    break;
+                case ExitTransactionStatus.WaitingForTimelock wft:
+                    if (wft.spendableAtHeight != null)
+                    {
+                        Console.WriteLine(
+                            $"      (waiting for its timelock, until block {wft.spendableAtHeight})");
+                    }
+                    else
+                    {
+                        Console.WriteLine("      (waiting for its timelock)");
+                    }
+                    break;
+                case ExitTransactionStatus.Ready:
+                case ExitTransactionStatus.Unverified:
+                    break;
             }
 
             var package = tx.cpfpTxHex != null

--- a/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/advanced.dart
+++ b/crates/breez-sdk/bindings/examples/cli/langs/flutter/lib/advanced.dart
@@ -225,7 +225,9 @@ CpfpInput? _parseCpfpInput(String s, String kindStr) {
 void _printExitTransactions(UnilateralExitResponse response) {
   print(
     'Recoverable ${response.recoverableValueSat} sats, '
-    'total fee ${response.totalFeeSat} sats, '
+    'total fee ${response.totalFeeSat} sats '
+    '(cpfp ${response.cpfpFeeSat}, fanout ${response.fanoutFeeSat}, '
+    'sweep ${response.sweepFeeSat}), '
     '${response.transactions.length} transaction(s):',
   );
   for (var i = 0; i < response.transactions.length; i++) {
@@ -233,9 +235,24 @@ void _printExitTransactions(UnilateralExitResponse response) {
     final after = tx.dependsOn.isEmpty ? '' : ', after ${tx.dependsOn.join(",")}';
     final csv = tx.csvTimelockBlocks != null ? ', csv ${tx.csvTimelockBlocks} blocks' : '';
     print('  [$i] ${tx.kind} status=${tx.status} txid=${tx.txid}$after$csv');
-    if (tx.status is ExitTransactionStatus_Confirmed) {
-      print('      (already confirmed, nothing to broadcast)');
+    final status = tx.status;
+    if (status is ExitTransactionStatus_Confirmed) {
+      final height = status.blockHeight;
+      if (height != null) {
+        print('      (confirmed in block $height, nothing to broadcast)');
+      } else {
+        print('      (already confirmed, nothing to broadcast)');
+      }
       continue;
+    } else if (status is ExitTransactionStatus_WaitingForDependencies) {
+      print('      (waiting on the transactions it depends on)');
+    } else if (status is ExitTransactionStatus_WaitingForTimelock) {
+      final height = status.spendableAtHeight;
+      if (height != null) {
+        print('      (waiting for its timelock, until block $height)');
+      } else {
+        print('      (waiting for its timelock)');
+      }
     }
     final package = tx.cpfpTxHex != null ? '${tx.txHex},${tx.cpfpTxHex}' : tx.txHex;
     print('      Package: $package');

--- a/crates/breez-sdk/bindings/examples/cli/langs/golang/advanced.go
+++ b/crates/breez-sdk/bindings/examples/cli/langs/golang/advanced.go
@@ -272,8 +272,10 @@ func parseCpfpInput(s string, kindStr string) (breez_sdk_spark.CpfpInput, error)
 }
 
 func printExitTransactions(response breez_sdk_spark.UnilateralExitResponse) {
-	fmt.Printf("Recoverable %d sats, total fee %d sats, %d transaction(s):\n",
-		response.RecoverableValueSat, response.TotalFeeSat, len(response.Transactions))
+	fmt.Printf("Recoverable %d sats, total fee %d sats (cpfp %d, fanout %d, sweep %d), %d transaction(s):\n",
+		response.RecoverableValueSat, response.TotalFeeSat,
+		response.CpfpFeeSat, response.FanoutFeeSat, response.SweepFeeSat,
+		len(response.Transactions))
 	for i, tx := range response.Transactions {
 		after := ""
 		if len(tx.DependsOn) > 0 {
@@ -285,9 +287,25 @@ func printExitTransactions(response breez_sdk_spark.UnilateralExitResponse) {
 		}
 		fmt.Printf("  [%d] %v status=%v txid=%s%s%s\n",
 			i, tx.Kind, tx.Status, tx.Txid, after, csv)
-		if _, ok := tx.Status.(breez_sdk_spark.ExitTransactionStatusConfirmed); ok {
-			fmt.Println("      (already confirmed, nothing to broadcast)")
+		switch s := tx.Status.(type) {
+		case breez_sdk_spark.ExitTransactionStatusConfirmed:
+			if s.BlockHeight != nil {
+				fmt.Printf("      (confirmed in block %d, nothing to broadcast)\n", *s.BlockHeight)
+			} else {
+				fmt.Println("      (already confirmed, nothing to broadcast)")
+			}
 			continue
+		case breez_sdk_spark.ExitTransactionStatusWaitingForDependencies:
+			fmt.Println("      (waiting on the transactions it depends on)")
+		case breez_sdk_spark.ExitTransactionStatusWaitingForTimelock:
+			if s.SpendableAtHeight != nil {
+				fmt.Printf("      (waiting for its timelock, until block %d)\n", *s.SpendableAtHeight)
+			} else {
+				fmt.Println("      (waiting for its timelock)")
+			}
+		case breez_sdk_spark.ExitTransactionStatusReady:
+		case breez_sdk_spark.ExitTransactionStatusUnverified:
+		default:
 		}
 		pkg := tx.TxHex
 		if tx.CpfpTxHex != nil {

--- a/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Advanced.kt
+++ b/crates/breez-sdk/bindings/examples/cli/langs/kotlin-multiplatform/src/main/kotlin/Advanced.kt
@@ -235,7 +235,8 @@ suspend fun handleImportUnilateralExitState(sdk: BreezSdk, reader: LineReader, a
 fun printExitTransactions(response: UnilateralExitResponse) {
     println(
         "Recoverable ${response.recoverableValueSat} sats, " +
-        "total fee ${response.totalFeeSat} sats, " +
+        "total fee ${response.totalFeeSat} sats " +
+        "(cpfp ${response.cpfpFeeSat}, fanout ${response.fanoutFeeSat}, sweep ${response.sweepFeeSat}), " +
         "${response.transactions.size} transaction(s):"
     )
     for ((i, tx) in response.transactions.withIndex()) {
@@ -246,9 +247,29 @@ fun printExitTransactions(response: UnilateralExitResponse) {
         }
         val csv = tx.csvTimelockBlocks?.let { ", csv $it blocks" } ?: ""
         println("  [$i] ${tx.kind} status=${tx.status} txid=${tx.txid}$after$csv")
-        if (tx.status is ExitTransactionStatus.Confirmed) {
-            println("      (already confirmed, nothing to broadcast)")
-            continue
+        when (val status = tx.status) {
+            is ExitTransactionStatus.Confirmed -> {
+                val height = status.blockHeight
+                if (height != null) {
+                    println("      (confirmed in block $height, nothing to broadcast)")
+                } else {
+                    println("      (already confirmed, nothing to broadcast)")
+                }
+                continue
+            }
+            is ExitTransactionStatus.WaitingForDependencies -> {
+                println("      (waiting on the transactions it depends on)")
+            }
+            is ExitTransactionStatus.WaitingForTimelock -> {
+                val height = status.spendableAtHeight
+                if (height != null) {
+                    println("      (waiting for its timelock, until block $height)")
+                } else {
+                    println("      (waiting for its timelock)")
+                }
+            }
+            is ExitTransactionStatus.Ready,
+            is ExitTransactionStatus.Unverified -> {}
         }
         val pkg = if (tx.cpfpTxHex != null) {
             "${tx.txHex},${tx.cpfpTxHex}"

--- a/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/advanced.py
+++ b/crates/breez-sdk/bindings/examples/cli/langs/python/src/breez_cli/advanced.py
@@ -64,7 +64,9 @@ def _parse_cpfp_input(s, funding_kind_str):
 def _print_exit_transactions(response):
     print(
         f"Recoverable {response.recoverable_value_sat} sats, "
-        f"total fee {response.total_fee_sat} sats, "
+        f"total fee {response.total_fee_sat} sats "
+        f"(cpfp {response.cpfp_fee_sat}, fanout {response.fanout_fee_sat}, "
+        f"sweep {response.sweep_fee_sat}), "
         f"{len(response.transactions)} transaction(s):"
     )
     for i, tx in enumerate(response.transactions):
@@ -76,8 +78,20 @@ def _print_exit_transactions(response):
             csv = f", csv {tx.csv_timelock_blocks} blocks"
         print(f"  [{i}] {tx.kind} status={tx.status} txid={tx.txid}{after}{csv}")
         if isinstance(tx.status, ExitTransactionStatus.CONFIRMED):
-            print("      (already confirmed, nothing to broadcast)")
+            block_height = tx.status.block_height
+            if block_height is not None:
+                print(f"      (confirmed in block {block_height}, nothing to broadcast)")
+            else:
+                print("      (already confirmed, nothing to broadcast)")
             continue
+        if isinstance(tx.status, ExitTransactionStatus.WAITING_FOR_DEPENDENCIES):
+            print("      (waiting on the transactions it depends on)")
+        elif isinstance(tx.status, ExitTransactionStatus.WAITING_FOR_TIMELOCK):
+            spendable_at_height = tx.status.spendable_at_height
+            if spendable_at_height is not None:
+                print(f"      (waiting for its timelock, until block {spendable_at_height})")
+            else:
+                print("      (waiting for its timelock)")
         if tx.cpfp_tx_hex is not None:
             package = f"{tx.tx_hex},{tx.cpfp_tx_hex}"
         else:

--- a/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/advanced.ts
+++ b/crates/breez-sdk/bindings/examples/cli/langs/react-native/src/advanced.ts
@@ -194,7 +194,8 @@ async function handleUnilateralExit(sdk: BreezSdkInterface, args: string[]): Pro
 
   lines.push(
     `Recoverable ${response.recoverableValueSat} sats, ` +
-    `total fee ${response.totalFeeSat} sats, ` +
+    `total fee ${response.totalFeeSat} sats ` +
+    `(cpfp ${response.cpfpFeeSat}, fanout ${response.fanoutFeeSat}, sweep ${response.sweepFeeSat}), ` +
     `${response.transactions.length} transaction(s):`
   )
 
@@ -209,8 +210,24 @@ async function handleUnilateralExit(sdk: BreezSdkInterface, args: string[]): Pro
     lines.push(`  [${i}] ${tx.kind} status=${tx.status} txid=${tx.txid}${after}${csv}`)
 
     if (tx.status.tag === ExitTransactionStatus_Tags.Confirmed) {
-      lines.push('      (already confirmed, nothing to broadcast)')
+      const blockHeight = tx.status.inner?.blockHeight
+      if (blockHeight != null) {
+        lines.push(`      (confirmed in block ${blockHeight}, nothing to broadcast)`)
+      } else {
+        lines.push('      (already confirmed, nothing to broadcast)')
+      }
       continue
+    }
+    if (tx.status.tag === ExitTransactionStatus_Tags.WaitingForDependencies) {
+      lines.push('      (waiting on the transactions it depends on)')
+    }
+    if (tx.status.tag === ExitTransactionStatus_Tags.WaitingForTimelock) {
+      const spendableAtHeight = tx.status.inner?.spendableAtHeight
+      if (spendableAtHeight != null) {
+        lines.push(`      (waiting for its timelock, until block ${spendableAtHeight})`)
+      } else {
+        lines.push('      (waiting for its timelock)')
+      }
     }
 
     const pkg = tx.cpfpTxHex

--- a/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Advanced.swift
+++ b/crates/breez-sdk/bindings/examples/cli/langs/swift/Sources/BreezCLI/Advanced.swift
@@ -194,16 +194,32 @@ private func parseCpfpInput(_ s: String, _ kind: CpfpFundingKind) -> CpfpInput? 
 private func printExitTransactions(_ response: UnilateralExitResponse) {
     print(
         "Recoverable \(response.recoverableValueSat) sats, " +
-        "total fee \(response.totalFeeSat) sats, " +
+        "total fee \(response.totalFeeSat) sats " +
+        "(cpfp \(response.cpfpFeeSat), fanout \(response.fanoutFeeSat), sweep \(response.sweepFeeSat)), " +
         "\(response.transactions.count) transaction(s):"
     )
     for (i, tx) in response.transactions.enumerated() {
         let after = tx.dependsOn.isEmpty ? "" : ", after \(tx.dependsOn.joined(separator: ","))"
         let csv = tx.csvTimelockBlocks.map { ", csv \($0) blocks" } ?? ""
         print("  [\(i)] \(tx.kind) status=\(tx.status) txid=\(tx.txid)\(after)\(csv)")
-        if case .confirmed = tx.status {
-            print("      (already confirmed, nothing to broadcast)")
+        switch tx.status {
+        case let .confirmed(blockHeight):
+            if let height = blockHeight {
+                print("      (confirmed in block \(height), nothing to broadcast)")
+            } else {
+                print("      (already confirmed, nothing to broadcast)")
+            }
             continue
+        case .waitingForDependencies:
+            print("      (waiting on the transactions it depends on)")
+        case let .waitingForTimelock(spendableAtHeight):
+            if let height = spendableAtHeight {
+                print("      (waiting for its timelock, until block \(height))")
+            } else {
+                print("      (waiting for its timelock)")
+            }
+        case .ready, .unverified:
+            break
         }
         let package: String
         if let cpfp = tx.cpfpTxHex {

--- a/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/advanced.js
+++ b/crates/breez-sdk/bindings/examples/cli/langs/wasm/src/advanced.js
@@ -49,7 +49,10 @@ function parseCpfpInput(s, kind) {
  */
 function printExitTransactions(response) {
   console.log(
-    `Recoverable ${response.recoverableValueSat} sats, total fee ${response.totalFeeSat} sats, ${response.transactions.length} transaction(s):`
+    `Recoverable ${response.recoverableValueSat} sats, ` +
+    `total fee ${response.totalFeeSat} sats ` +
+    `(cpfp ${response.cpfpFeeSat}, fanout ${response.fanoutFeeSat}, sweep ${response.sweepFeeSat}), ` +
+    `${response.transactions.length} transaction(s):`
   )
   for (let i = 0; i < response.transactions.length; i++) {
     const tx = response.transactions[i]
@@ -59,10 +62,24 @@ function printExitTransactions(response) {
     const csv = tx.csvTimelockBlocks != null
       ? `, csv ${tx.csvTimelockBlocks} blocks`
       : ''
-    console.log(`  [${i}] ${tx.kind} status=${tx.status} txid=${tx.txid}${after}${csv}`)
+    console.log(`  [${i}] ${tx.kind} status=${JSON.stringify(tx.status)} txid=${tx.txid}${after}${csv}`)
     if (tx.status.type === 'confirmed') {
-      console.log('      (already confirmed, nothing to broadcast)')
+      if (tx.status.blockHeight != null) {
+        console.log(`      (confirmed in block ${tx.status.blockHeight}, nothing to broadcast)`)
+      } else {
+        console.log('      (already confirmed, nothing to broadcast)')
+      }
       continue
+    }
+    if (tx.status.type === 'waitingForDependencies') {
+      console.log('      (waiting on the transactions it depends on)')
+    }
+    if (tx.status.type === 'waitingForTimelock') {
+      if (tx.status.spendableAtHeight != null) {
+        console.log(`      (waiting for its timelock, until block ${tx.status.spendableAtHeight})`)
+      } else {
+        console.log('      (waiting for its timelock)')
+      }
     }
     const pkg = tx.cpfpTxHex
       ? `${tx.txHex},${tx.cpfpTxHex}`


### PR DESCRIPTION
Automated sync of language CLIs from Rust CLI changes.

**Source commit:** [`75740dd`](https://github.com/breez/spark-sdk/commit/75740ddcc182fcf31873e763d218b066f5e683f5)
**Workflow run:** [View logs](https://github.com/breez/spark-sdk/actions/runs/34447529788)

**Language status:**
- :white_check_mark: C#
- :white_check_mark: Dart
- :white_check_mark: Go
- :white_check_mark: Kotlin
- :white_check_mark: Python
- :white_check_mark: React Native
- :white_check_mark: Swift
- :white_check_mark: TypeScript

<details>
<summary>Sync findings</summary>

### C#
## Divergences
- `PrintExitTransactions` summary line missing fee breakdown (cpfp, fanout, sweep) present in Rust
- `PrintExitTransactions` only checked `ExitTransactionStatus.Confirmed` without block height; Rust now matches all `ExitTransactionStatus` variants (`Confirmed` with optional `blockHeight`, `WaitingForDependencies`, `WaitingForTimelock` with optional `spendableAtHeight`, `Ready`, `Unverified`)

## Applied
- Added fee breakdown fields (`cpfpFeeSat`, `fanoutFeeSat`, `sweepFeeSat`) to the summary line in `Advanced.cs`
- Replaced simple `Confirmed` check with full `ExitTransactionStatus` pattern match in `Advanced.cs`, handling `Confirmed` with block height, `WaitingForDependencies`, `WaitingForTimelock` with spendable-at height, and `Ready`/`Unverified` pass-through

## Skipped
- (none)

### Dart
## Divergences
- `_printExitTransactions` summary line was missing the fee breakdown (`cpfpFeeSat`, `fanoutFeeSat`, `sweepFeeSat`)
- `_printExitTransactions` only handled `ExitTransactionStatus_Confirmed` with a generic message; Rust now matches all status variants (`Confirmed` with optional `block_height`, `WaitingForDependencies`, `WaitingForTimelock` with optional `spendable_at_height`, `Ready`, `Unverified`)

## Applied
- Updated `_printExitTransactions` in `advanced.dart` to include fee breakdown (cpfp, fanout, sweep) in the summary line
- Updated `_printExitTransactions` in `advanced.dart` to handle all `ExitTransactionStatus` variants: `Confirmed` with block height, `WaitingForDependencies`, `WaitingForTimelock` with spendable_at_height

## Skipped
- (none)

### Go
## Divergences
- `printExitTransactions` summary line missing fee breakdown (cpfp, fanout, sweep) fields added in Rust
- `printExitTransactions` only checked `ExitTransactionStatusConfirmed`; Rust now matches all `ExitTransactionStatus` variants (`Confirmed` with optional `block_height`, `WaitingForDependencies`, `WaitingForTimelock` with optional `spendable_at_height`, `Ready`, `Unverified`)

## Applied
- Updated `printExitTransactions` summary line to include `CpfpFeeSat`, `FanoutFeeSat`, `SweepFeeSat` in `advanced.go`
- Replaced simple `Confirmed` type assertion with full type switch over all `ExitTransactionStatus` variants, matching Rust behavior including block height display and status-specific messages in `advanced.go`

## Skipped
- (none)

### Kotlin
## Divergences
- `printExitTransactions` missing fee breakdown fields (`cpfpFeeSat`, `fanoutFeeSat`, `sweepFeeSat`) in the summary line
- `printExitTransactions` only handled `ExitTransactionStatus.Confirmed` with a generic message; missing `block_height` detail, `WaitingForDependencies`, `WaitingForTimelock`, and `Unverified` variants

## Applied
- Updated `Advanced.kt`: added fee breakdown (cpfp, fanout, sweep) to the summary line in `printExitTransactions`
- Updated `Advanced.kt`: replaced simple `is Confirmed` check with full `when` match on all `ExitTransactionStatus` variants, including `block_height` in `Confirmed`, `WaitingForDependencies`, `WaitingForTimelock` with `spendableAtHeight`, and `Ready`/`Unverified`

## Skipped
- (none)

### Python
## Divergences
- `_print_exit_transactions` summary line was missing fee breakdown (cpfp, fanout, sweep)
- `_print_exit_transactions` status handling only checked `CONFIRMED`; Rust now matches on `CONFIRMED` (with `block_height`), `WAITING_FOR_DEPENDENCIES`, `WAITING_FOR_TIMELOCK` (with `spendable_at_height`), `READY`, and `UNVERIFIED`

## Applied
- Updated `_print_exit_transactions` in `advanced.py` to print fee breakdown: `(cpfp N, fanout N, sweep N)`
- Updated `_print_exit_transactions` in `advanced.py` to handle all `ExitTransactionStatus` variants with their associated data fields

## Skipped
- (none)

### React Native
## Divergences
- Fee breakdown (cpfp, fanout, sweep) missing from unilateral exit summary line in `advanced.ts`
- `ExitTransactionStatus` handling incomplete: `Confirmed` variant missing `blockHeight` display; `WaitingForDependencies` and `WaitingForTimelock` variants not handled

## Applied
- Added fee breakdown fields (`cpfpFeeSat`, `fanoutFeeSat`, `sweepFeeSat`) to the summary line in `advanced.ts`
- Added `blockHeight` display for `Confirmed` status in `advanced.ts`
- Added `WaitingForDependencies` status handling in `advanced.ts`
- Added `WaitingForTimelock` status handling with optional `spendableAtHeight` in `advanced.ts`

## Skipped
- (none)

### Swift
## Divergences
- `printExitTransactions` summary line missing fee breakdown (cpfp, fanout, sweep) present in Rust CLI
- `printExitTransactions` used simple `if case .confirmed` check instead of full `switch` on `ExitTransactionStatus` variants (Confirmed with blockHeight, WaitingForDependencies, WaitingForTimelock with spendableAtHeight, Ready, Unverified)

## Applied
- Updated `printExitTransactions` in `Advanced.swift` to include `cpfpFeeSat`, `fanoutFeeSat`, `sweepFeeSat` in the summary line
- Updated `printExitTransactions` in `Advanced.swift` to use `switch tx.status` with all `ExitTransactionStatus` variants, matching the Rust CLI's `match` block

## Skipped
- (none)

### TypeScript
## Divergences
- `printExitTransactions` summary line was missing the fee breakdown fields (`cpfpFeeSat`, `fanoutFeeSat`, `sweepFeeSat`) added to `UnilateralExitResponse`
- `printExitTransactions` status handling used a flat `confirmed` check instead of matching all `ExitTransactionStatus` variants (`Confirmed` with optional `blockHeight`, `WaitingForDependencies`, `WaitingForTimelock` with optional `spendableAtHeight`, `Ready`, `Unverified`)
- Status debug output used `${tx.status}` (renders as `[object Object]`) instead of `JSON.stringify(tx.status)` to match Rust's `{:?}` format

## Applied
- Updated `printExitTransactions` in `advanced.js` to include `cpfpFeeSat`, `fanoutFeeSat`, `sweepFeeSat` in the summary line
- Updated `printExitTransactions` in `advanced.js` to handle `confirmed` status with optional `blockHeight`, `waitingForDependencies`, and `waitingForTimelock` with optional `spendableAtHeight`
- Changed status display from `${tx.status}` to `JSON.stringify(tx.status)` for proper object rendering

## Skipped
- Nothing skipped; all changes were portable

</details>

All languages synced cleanly. This PR merges automatically once the gating CI checks pass (integration test checks excluded).