### PR TITLE
Add check-unilateral-exit CLI command

### DIFF
--- a/crates/breez-sdk/cli/src/command/advanced.rs
+++ b/crates/breez-sdk/cli/src/command/advanced.rs
@@ -1,11 +1,11 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use breez_sdk_spark::signer::single_key_cpfp_signer;
 use breez_sdk_spark::{
-    BreezSdk, CpfpFundingKind, CpfpInput, ExitLeafSelection, ExitTransactionStatus,
-    ImportUnilateralExitStateRequest, PrepareUnilateralExitRequest, UnilateralExitRequest,
-    UnilateralExitResponse,
+    BreezSdk, CheckUnilateralExitRequest, CpfpFundingKind, CpfpInput, ExitLeafSelection,
+    ExitTransactionStatus, ImportUnilateralExitStateRequest, PrepareUnilateralExitRequest,
+    UnilateralExitRequest, UnilateralExitResponse, UnilateralExitVerdict,
 };
 use clap::{Subcommand, ValueEnum};
 use rustyline::{Editor, history::DefaultHistory};
@@ -47,6 +47,21 @@ pub enum AdvancedCommand {
         /// Leaf id to exit (repeatable). Omit to auto-select every profitable leaf.
         #[arg(long = "leaf")]
         leaf_ids: Vec<String>,
+        /// File to write the signed exit to, for `check-unilateral-exit` to read
+        /// back once its transactions are on-chain.
+        #[arg(long)]
+        output_file: Option<PathBuf>,
+    },
+    /// Read a signed exit written by `unilateral-exit` back against the chain:
+    /// which of its transactions confirmed, what is ready to broadcast now, and
+    /// whether the exit still holds.
+    CheckUnilateralExit {
+        /// File the exit was written to.
+        #[arg(long)]
+        input_file: PathBuf,
+        /// File to write the updated exit to. Defaults to `--input-file`.
+        #[arg(long)]
+        output_file: Option<PathBuf>,
     },
     /// Export the wallet's unilateral exit state to a file, for safekeeping
     /// outside the wallet's own storage.
@@ -75,6 +90,7 @@ pub async fn handle_command(
             funding_kind,
             destination,
             leaf_ids,
+            output_file,
         } => {
             let prepared = sdk
                 .prepare_unilateral_exit(PrepareUnilateralExitRequest {
@@ -115,6 +131,25 @@ pub async fn handle_command(
                 )
                 .await?;
             print_exit_transactions(&response);
+            if let Some(output_file) = output_file {
+                write_exit(&output_file, &response)?;
+            }
+            Ok(true)
+        }
+        AdvancedCommand::CheckUnilateralExit {
+            input_file,
+            output_file,
+        } => {
+            let exit = read_exit(&input_file)?;
+            let checked = sdk
+                .check_unilateral_exit(CheckUnilateralExitRequest { exit })
+                .await?;
+            println!("Verdict: {:?}", checked.verdict);
+            if let UnilateralExitVerdict::Redo { .. } = checked.verdict {
+                println!("  (this exit cannot be finished, quote and build it again)");
+            }
+            print_exit_transactions(&checked.exit);
+            write_exit(output_file.as_deref().unwrap_or(&input_file), &checked.exit)?;
             Ok(true)
         }
         AdvancedCommand::ExportUnilateralExitState { output_file } => {
@@ -144,6 +179,18 @@ pub async fn handle_command(
             Ok(true)
         }
     }
+}
+
+/// Reads an exit written by [`write_exit`].
+fn read_exit(path: &Path) -> Result<UnilateralExitResponse, anyhow::Error> {
+    Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
+}
+
+/// Writes the exit as JSON, the form [`read_exit`] reads back.
+fn write_exit(path: &Path, exit: &UnilateralExitResponse) -> Result<(), anyhow::Error> {
+    fs::write(path, serde_json::to_string_pretty(exit)?)?;
+    println!("Wrote the exit to {}", path.display());
+    Ok(())
 }
 
 /// Auto when no leaves are named, otherwise exactly the given leaves.
@@ -238,5 +285,130 @@ fn print_exit_transactions(response: &UnilateralExitResponse) {
             None => tx.tx_hex.clone(),
         };
         println!("      Package: {package}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use breez_sdk_spark::{UnilateralExitLeaf, UnilateralExitTransaction, UnilateralExitTxKind};
+
+    use super::*;
+
+    /// Covers every status variant, both funding kinds, and each optional field
+    /// set and unset, so a field that stops round-tripping is caught here.
+    fn sample_exit() -> UnilateralExitResponse {
+        UnilateralExitResponse {
+            recoverable_value_sat: 100_000,
+            total_fee_sat: 1_500,
+            cpfp_fee_sat: 900,
+            fanout_fee_sat: 400,
+            sweep_fee_sat: 200,
+            leaves: vec![UnilateralExitLeaf {
+                leaf_id: "leaf-1".to_string(),
+                value: 100_000,
+            }],
+            transactions: vec![
+                UnilateralExitTransaction {
+                    kind: UnilateralExitTxKind::FanOut,
+                    node_id: None,
+                    txid: "aa".to_string(),
+                    tx_hex: "0200".to_string(),
+                    cpfp_tx_hex: None,
+                    csv_timelock_blocks: None,
+                    depends_on: vec![],
+                    status: ExitTransactionStatus::Confirmed {
+                        block_height: Some(101),
+                    },
+                },
+                UnilateralExitTransaction {
+                    kind: UnilateralExitTxKind::Node,
+                    node_id: Some("node-1".to_string()),
+                    txid: "bb".to_string(),
+                    tx_hex: "0201".to_string(),
+                    cpfp_tx_hex: Some("0301".to_string()),
+                    csv_timelock_blocks: Some(144),
+                    depends_on: vec!["aa".to_string()],
+                    status: ExitTransactionStatus::Confirmed { block_height: None },
+                },
+                UnilateralExitTransaction {
+                    kind: UnilateralExitTxKind::Refund,
+                    node_id: Some("node-1".to_string()),
+                    txid: "cc".to_string(),
+                    tx_hex: "0202".to_string(),
+                    cpfp_tx_hex: Some("0302".to_string()),
+                    csv_timelock_blocks: Some(2016),
+                    depends_on: vec!["bb".to_string()],
+                    status: ExitTransactionStatus::WaitingForTimelock {
+                        spendable_at_height: Some(245),
+                    },
+                },
+                UnilateralExitTransaction {
+                    kind: UnilateralExitTxKind::Refund,
+                    node_id: Some("node-2".to_string()),
+                    txid: "dd".to_string(),
+                    tx_hex: "0203".to_string(),
+                    cpfp_tx_hex: None,
+                    csv_timelock_blocks: None,
+                    depends_on: vec!["bb".to_string()],
+                    status: ExitTransactionStatus::WaitingForDependencies,
+                },
+                UnilateralExitTransaction {
+                    kind: UnilateralExitTxKind::Node,
+                    node_id: Some("node-3".to_string()),
+                    txid: "ee".to_string(),
+                    tx_hex: "0204".to_string(),
+                    cpfp_tx_hex: None,
+                    csv_timelock_blocks: None,
+                    depends_on: vec![],
+                    status: ExitTransactionStatus::Unverified,
+                },
+                UnilateralExitTransaction {
+                    kind: UnilateralExitTxKind::Sweep,
+                    node_id: None,
+                    txid: "ff".to_string(),
+                    tx_hex: "0205".to_string(),
+                    cpfp_tx_hex: None,
+                    csv_timelock_blocks: None,
+                    depends_on: vec!["cc".to_string(), "dd".to_string()],
+                    status: ExitTransactionStatus::Ready,
+                },
+            ],
+            funding_inputs: vec![
+                CpfpInput::P2tr {
+                    txid: "11".to_string(),
+                    vout: 0,
+                    value: 5_000,
+                    pubkey: "02ab".to_string(),
+                },
+                CpfpInput::P2wpkh {
+                    txid: "22".to_string(),
+                    vout: 3,
+                    value: 7_000,
+                    pubkey: "03cd".to_string(),
+                },
+                CpfpInput::Custom {
+                    txid: "33".to_string(),
+                    vout: 1,
+                    value: 9_000,
+                    script_pubkey_hex: "5120ef".to_string(),
+                    signed_input_weight: 230,
+                },
+            ],
+        }
+    }
+
+    /// What `unilateral-exit` writes is what `check-unilateral-exit` reads.
+    #[test]
+    fn exit_file_round_trips() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("exit.json");
+        let exit = sample_exit();
+
+        write_exit(&path, &exit).expect("write");
+        let read_back = read_exit(&path).expect("read");
+
+        // Debug rather than the serialized form: a field that serializes away
+        // on both sides would compare equal as JSON while losing its value.
+        assert_eq!(format!("{exit:?}"), format!("{read_back:?}"));
     }
 }

--- a/crates/breez-sdk/cli/src/command/grammar_tests.rs
+++ b/crates/breez-sdk/cli/src/command/grammar_tests.rs
@@ -2,11 +2,14 @@
 //! grammar (names, aliases, defaults, conflicts) that the language CLI ports
 //! mirror, so a grammar change here is a deliberate, reviewed act.
 
+use std::path::Path;
+
 use breez_sdk_spark::{
     AssetFilter, PaymentStatus, PaymentType, SparkHtlcStatus, TokenTransactionType,
 };
 use clap::Parser;
 
+use super::advanced::{AdvancedCommand, FundingKindArg};
 use super::contacts::ContactCommand;
 use super::issuer::IssuerCommand;
 use super::stable_balance::StableBalanceCommand;
@@ -845,6 +848,87 @@ fn stable_balance_subcommands() {
         parse_ok("stable-balance unset"),
         Command::StableBalance(StableBalanceCommand::Unset)
     ));
+}
+
+#[test]
+fn advanced_unilateral_exit() {
+    let Command::Advanced(AdvancedCommand::UnilateralExit {
+        fee_rate,
+        funding_kind,
+        destination,
+        leaf_ids,
+        output_file,
+    }) = parse_ok("advanced unilateral-exit --fee-rate 5 --destination bcrt1qdest")
+    else {
+        panic!("expected Advanced UnilateralExit");
+    };
+    assert_eq!(fee_rate, 5);
+    assert!(matches!(funding_kind, FundingKindArg::P2tr));
+    assert_eq!(destination, "bcrt1qdest");
+    assert!(leaf_ids.is_empty());
+    assert!(output_file.is_none());
+
+    let Command::Advanced(AdvancedCommand::UnilateralExit {
+        funding_kind,
+        leaf_ids,
+        output_file,
+        ..
+    }) = parse_ok(
+        "advanced unilateral-exit --fee-rate 1 --destination bcrt1qdest \
+         --funding-kind p2wpkh --leaf leaf-1 --leaf leaf-2 --output-file exit.json",
+    )
+    else {
+        panic!("expected Advanced UnilateralExit");
+    };
+    assert!(matches!(funding_kind, FundingKindArg::P2wpkh));
+    assert_eq!(leaf_ids, ["leaf-1", "leaf-2"]);
+    assert_eq!(output_file.as_deref(), Some(Path::new("exit.json")));
+
+    parse_err("advanced unilateral-exit --destination bcrt1qdest");
+    parse_err("advanced unilateral-exit --fee-rate 5");
+    parse_err("advanced unilateral-exit --fee-rate 5 --destination bcrt1qdest --funding-kind p2sh");
+}
+
+#[test]
+fn advanced_check_unilateral_exit() {
+    let Command::Advanced(AdvancedCommand::CheckUnilateralExit {
+        input_file,
+        output_file,
+    }) = parse_ok("advanced check-unilateral-exit --input-file exit.json")
+    else {
+        panic!("expected Advanced CheckUnilateralExit");
+    };
+    assert_eq!(input_file, Path::new("exit.json"));
+    assert!(output_file.is_none());
+
+    let Command::Advanced(AdvancedCommand::CheckUnilateralExit { output_file, .. }) = parse_ok(
+        "advanced check-unilateral-exit --input-file exit.json --output-file checked.json",
+    ) else {
+        panic!("expected Advanced CheckUnilateralExit");
+    };
+    assert_eq!(output_file.as_deref(), Some(Path::new("checked.json")));
+
+    parse_err("advanced check-unilateral-exit");
+}
+
+#[test]
+fn advanced_exit_state_files() {
+    let Command::Advanced(AdvancedCommand::ExportUnilateralExitState { output_file }) =
+        parse_ok("advanced export-unilateral-exit-state --output-file state.json")
+    else {
+        panic!("expected Advanced ExportUnilateralExitState");
+    };
+    assert_eq!(output_file, Path::new("state.json"));
+
+    let Command::Advanced(AdvancedCommand::ImportUnilateralExitState { input_file }) =
+        parse_ok("advanced import-unilateral-exit-state --input-file state.json")
+    else {
+        panic!("expected Advanced ImportUnilateralExitState");
+    };
+    assert_eq!(input_file, Path::new("state.json"));
+
+    parse_err("advanced export-unilateral-exit-state");
+    parse_err("advanced import-unilateral-exit-state");
 }
 
 #[test]


### PR DESCRIPTION
CLI command `unilateral-exit` gains `--output-file` to store the exit response, and the new `check-unilateral-exit` reads it back against the chain via `check_unilateral_exit`, reporting what confirmed, what is ready to broadcast now, and whether the exit still holds.

### Commands
| Command | Flags |
|---|---|
| `advanced unilateral-exit` | new optional `--output-file`, writes the `UnilateralExitResponse` as JSON |
| `advanced check-unilateral-exit` | `--input-file` to read it, optional `--output-file` (defaults to `--input-file`) |

The check writes the refreshed exit back by default, matching the API contract that the returned exit replaces the copy you passed in. A `Redo` verdict prints a line saying the exit has to be quoted and built again, which the per transaction statuses do not convey on their own.