### PR TITLE
Retry transient chain service errors, disable the Spark HTLC tests

### DIFF
--- a/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
+++ b/crates/breez-sdk/breez-itest/tests/spark_htlcs.rs
@@ -191,7 +191,13 @@ async fn test_01_htlc_success(
 }
 
 /// Test 2: Send payment from Alice to Bob using Spark transfer and fail to claim before expiry
+///
+/// TODO: re-enable once direct HTLCs are available again. While they are
+/// disabled, the operators stop serving a returned HTLC's preimage request, so
+/// the refunded transfer syncs with no HTLC details and the
+/// `SparkHtlcStatus::Returned` filter below matches nothing.
 #[rstest]
+#[ignore = "direct HTLCs are disabled; the refund carries no HTLC details"]
 #[test_log::test(tokio::test)]
 async fn test_02_htlc_refund(
     #[future] alice_sdk: Result<SdkInstance>,

--- a/crates/breez-sdk/core/src/chain/rest_client.rs
+++ b/crates/breez-sdk/core/src/chain/rest_client.rs
@@ -200,6 +200,18 @@ impl RestClientChainServiceInner {
         Ok(response)
     }
 
+    /// Sleeps out the current backoff and charges an attempt, or reports that
+    /// the budget is spent so the caller surfaces the error it is holding.
+    async fn backoff(&self, attempts: &mut usize, delay: &mut Duration) -> bool {
+        if *attempts >= self.max_retries {
+            return false;
+        }
+        tokio::time::sleep(*delay).await;
+        *attempts = attempts.saturating_add(1);
+        *delay = delay.saturating_mul(2);
+        true
+    }
+
     async fn get_with_retry(
         &self,
         url: &str,
@@ -214,45 +226,68 @@ impl RestClientChainServiceInner {
                 add_basic_auth_header(&mut headers, &basic_auth.username, &basic_auth.password);
             }
 
-            let HttpResponse { body, status, .. } =
-                client.get(url.to_string(), Some(headers)).await?;
-            match status {
-                status if attempts < self.max_retries && is_status_retryable(status) => {
-                    tokio::time::sleep(delay).await;
-                    attempts = attempts.saturating_add(1);
-                    delay = delay.saturating_mul(2);
-                }
-                _ => {
-                    if !(200..300).contains(&status) {
-                        return Err(HttpError::Status { status, body }.into());
+            let response = match client.get(url.to_string(), Some(headers)).await {
+                Ok(response) => response,
+                Err(e) => {
+                    if is_transport_retryable(&e) && self.backoff(&mut attempts, &mut delay).await {
+                        continue;
                     }
-                    return Ok((body, status));
+                    return Err(e.into());
                 }
+            };
+
+            let HttpResponse { body, status, .. } = response;
+            if is_status_retryable(status) && self.backoff(&mut attempts, &mut delay).await {
+                continue;
             }
+            if !(200..300).contains(&status) {
+                return Err(HttpError::Status { status, body }.into());
+            }
+            return Ok((body, status));
         }
     }
 
     async fn post(&self, url: &str, body: Option<String>) -> Result<String, ChainServiceError> {
-        let mut headers: HashMap<String, String> = HashMap::new();
-        add_content_type_header(&mut headers, ContentType::TextPlain);
-        if let Some(basic_auth) = &self.basic_auth {
-            add_basic_auth_header(&mut headers, &basic_auth.username, &basic_auth.password);
-        }
         info!("Posting to {}", url);
         debug!(
             "Posting to {} with body {}",
             url,
             body.clone().unwrap_or_default()
         );
-        let HttpResponse { body, status, .. } = self
-            .client
-            .post(url.to_string(), Some(headers), body)
-            .await?;
-        if !(200..300).contains(&status) {
-            return Err(HttpError::Status { status, body }.into());
-        }
 
-        Ok(body)
+        let mut delay = BASE_BACKOFF_MILLIS;
+        let mut attempts = 0;
+
+        loop {
+            let mut headers: HashMap<String, String> = HashMap::new();
+            add_content_type_header(&mut headers, ContentType::TextPlain);
+            if let Some(basic_auth) = &self.basic_auth {
+                add_basic_auth_header(&mut headers, &basic_auth.username, &basic_auth.password);
+            }
+
+            let response = match self
+                .client
+                .post(url.to_string(), Some(headers), body.clone())
+                .await
+            {
+                Ok(response) => response,
+                Err(e) => {
+                    if is_transport_retryable(&e) && self.backoff(&mut attempts, &mut delay).await {
+                        continue;
+                    }
+                    return Err(e.into());
+                }
+            };
+
+            let HttpResponse { body, status, .. } = response;
+            if is_status_retryable(status) && self.backoff(&mut attempts, &mut delay).await {
+                continue;
+            }
+            if !(200..300).contains(&status) {
+                return Err(HttpError::Status { status, body }.into());
+            }
+            return Ok(body);
+        }
     }
 
     async fn recommended_fees_esplora(&self) -> Result<RecommendedFees, ChainServiceError> {
@@ -423,10 +458,25 @@ fn is_status_retryable(status: u16) -> bool {
     RETRYABLE_ERROR_CODES.contains(&status)
 }
 
+/// Whether a failure that produced no response at all is worth another attempt.
+///
+/// A shared esplora endpoint reaping idle HTTP/2 flows answers the next request
+/// off that connection with a broken pipe, which reqwest reports as a request
+/// error. Retrying the POST is safe for the same reason: the caller was about to
+/// see an error either way, and a re-broadcast of a transaction the server did
+/// accept is answered "already known" rather than acted on twice.
+fn is_transport_retryable(error: &HttpError) -> bool {
+    matches!(
+        error,
+        HttpError::Request(_) | HttpError::Connect(_) | HttpError::Timeout(_) | HttpError::Body(_)
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::Network;
+    use std::sync::Mutex;
 
     use macros::async_test_all;
 
@@ -600,5 +650,116 @@ mod tests {
         assert_eq!(result[0].vout, 0);
         assert_eq!(result[0].value, 50000);
         assert!(result[0].status.confirmed);
+    }
+
+    /// Answers with `failures` transport errors before serving `response`.
+    struct FlakyTransport {
+        remaining_failures: Mutex<usize>,
+        response: String,
+    }
+
+    impl FlakyTransport {
+        fn new(failures: usize, response: &str) -> Self {
+            Self {
+                remaining_failures: Mutex::new(failures),
+                response: response.to_string(),
+            }
+        }
+
+        fn answer(&self) -> Result<HttpResponse, HttpError> {
+            let mut remaining = self.remaining_failures.lock().unwrap();
+            if *remaining > 0 {
+                *remaining = remaining.saturating_sub(1);
+                return Err(HttpError::Request(
+                    "client error (SendRequest) : connection error : stream closed because of a \
+                     broken pipe"
+                        .to_string(),
+                ));
+            }
+            Ok(HttpResponse {
+                status: 200,
+                body: self.response.clone(),
+                headers: HashMap::new(),
+            })
+        }
+    }
+
+    #[macros::async_trait]
+    impl HttpClient for FlakyTransport {
+        async fn get(
+            &self,
+            _url: String,
+            _headers: Option<HashMap<String, String>>,
+        ) -> Result<HttpResponse, HttpError> {
+            self.answer()
+        }
+
+        async fn post(
+            &self,
+            _url: String,
+            _headers: Option<HashMap<String, String>>,
+            _body: Option<String>,
+        ) -> Result<HttpResponse, HttpError> {
+            self.answer()
+        }
+
+        async fn delete(
+            &self,
+            _url: String,
+            _headers: Option<HashMap<String, String>>,
+            _body: Option<String>,
+        ) -> Result<HttpResponse, HttpError> {
+            self.answer()
+        }
+    }
+
+    fn flaky_service(failures: usize, response: &str) -> RestClientChainService {
+        RestClientChainService::new(
+            "http://localhost:8080".to_string(),
+            Network::Mainnet,
+            3,
+            Arc::new(FlakyTransport::new(failures, response)),
+            None,
+            ChainApiType::Esplora,
+        )
+    }
+
+    const TX_STATUS_RESPONSE: &str = r#"{
+        "txid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "status": { "confirmed": true, "block_height": 100 }
+    }"#;
+
+    #[async_test_all]
+    async fn test_get_retries_transport_errors() {
+        let service = flaky_service(3, TX_STATUS_RESPONSE);
+
+        let status = service
+            .get_transaction_status("aaaa".to_string())
+            .await
+            .unwrap();
+
+        assert!(status.confirmed);
+    }
+
+    #[async_test_all]
+    async fn test_get_gives_up_past_the_retry_budget() {
+        let service = flaky_service(4, TX_STATUS_RESPONSE);
+
+        let result = service.get_transaction_status("aaaa".to_string()).await;
+
+        assert!(matches!(
+            result,
+            Err(ChainServiceError::ServiceConnectivity(_))
+        ));
+    }
+
+    #[async_test_all]
+    async fn test_broadcast_retries_transport_errors() {
+        let service = flaky_service(3, "aaaa");
+
+        service
+            .broadcast_transaction("00".to_string())
+            .await
+            .unwrap();
     }
 }

--- a/crates/spark-itest/src/helpers.rs
+++ b/crates/spark-itest/src/helpers.rs
@@ -402,8 +402,11 @@ pub async fn deposit_with_amount(
 /// Funds `wallet` through its static deposit address and returns the credited
 /// amount, which is the deposited amount minus the SSP's claim fee.
 ///
-/// The SSP will not quote a claim until it has seen the funding transaction,
-/// so the quote is retried until it is served or `quote_timeout_secs` elapses.
+/// Neither the SSP nor the operators are ready the moment the faucet funds the
+/// address: the SSP will not quote a claim until it has seen the funding
+/// transaction, and the operators refuse the claim until every one of them has
+/// the UTXO at the required depth. Both are retried, with a fresh quote each
+/// round, until the claim goes through or `quote_timeout_secs` elapses.
 pub async fn fund_wallet_via_static_deposit(
     wallet: &SparkWallet,
     faucet: &RegtestFaucet,
@@ -431,31 +434,33 @@ pub async fn fund_wallet_via_static_deposit(
         as u32;
 
     let deadline = tokio::time::Instant::now() + Duration::from_secs(quote_timeout_secs);
-    let quote = loop {
-        match wallet
-            .fetch_static_deposit_claim_quote(tx.clone(), Some(vout))
-            .await
-        {
-            Ok(quote) => break quote,
+    loop {
+        let attempt = async {
+            let quote = wallet
+                .fetch_static_deposit_claim_quote(tx.clone(), Some(vout))
+                .await?;
+            let credit_amount_sats = quote.credit_amount_sats;
+            let transfer_id = wallet.claim_static_deposit(&tx, quote).await?;
+            Ok::<_, anyhow::Error>((credit_amount_sats, transfer_id))
+        };
+
+        match attempt.await {
+            Ok((credit_amount_sats, transfer_id)) => {
+                info!(
+                    "Claimed static deposit {txid}:{vout} for {credit_amount_sats} sats, \
+                     transfer {transfer_id}"
+                );
+                return Ok(credit_amount_sats);
+            }
             Err(e) if tokio::time::Instant::now() < deadline => {
-                debug!("Claim quote for {txid}:{vout} not ready yet ({e}), retrying");
+                debug!("Claim of {txid}:{vout} not ready yet ({e}), retrying");
                 tokio::time::sleep(Duration::from_secs(5)).await;
             }
-            Err(e) => bail!(
-                "Timeout after {quote_timeout_secs}s waiting for a claim quote for \
-                 {txid}:{vout}: {e}"
-            ),
+            Err(e) => {
+                bail!("Timeout after {quote_timeout_secs}s waiting to claim {txid}:{vout}: {e}")
+            }
         }
-    };
-
-    let credit_amount_sats = quote.credit_amount_sats;
-    let transfer_id = wallet.claim_static_deposit(&tx, quote).await?;
-    info!(
-        "Claimed static deposit {txid}:{vout} for {credit_amount_sats} sats, \
-         transfer {transfer_id}"
-    );
-
-    Ok(credit_amount_sats)
+    }
 }
 
 /// Polls a condition function every 50ms until it returns true or the timeout is reached.

--- a/crates/spark-itest/src/mempool.rs
+++ b/crates/spark-itest/src/mempool.rs
@@ -1,9 +1,14 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use bitcoin::{Transaction, consensus::encode::deserialize_hex};
-use platform_utils::{DefaultHttpClient, HttpClient, add_basic_auth_header};
+use platform_utils::{DefaultHttpClient, HttpClient, HttpResponse, add_basic_auth_header};
 use tracing::info;
+
+const MAX_RETRIES: usize = 5;
+const BASE_BACKOFF: Duration = Duration::from_millis(256);
+const RETRYABLE_STATUSES: [u16; 3] = [429, 500, 503];
 
 /// Configuration for the mempool/esplora API client
 #[derive(Debug, Clone)]
@@ -62,14 +67,7 @@ impl MempoolClient {
         let url = format!("{}/tx/{}/hex", self.config.url, txid);
         info!("Fetching transaction from: {}", url);
 
-        let mut headers = HashMap::new();
-        add_basic_auth_header(&mut headers, &self.config.username, &self.config.password);
-
-        let response = self
-            .http_client
-            .get(url.clone(), Some(headers))
-            .await
-            .context("Failed to fetch transaction")?;
+        let response = self.get_with_retry(&url).await?;
 
         if !response.is_success() {
             bail!(
@@ -86,6 +84,39 @@ impl MempoolClient {
 
         info!("Successfully fetched transaction: {}", txid);
         Ok(tx)
+    }
+
+    /// The shared regtest esplora reaps idle HTTP/2 flows, so the next request
+    /// off a pooled connection can come back as a broken pipe with no response
+    /// at all. Those, and the endpoint's own transient statuses, get another
+    /// attempt before the caller sees a failure.
+    async fn get_with_retry(&self, url: &str) -> Result<HttpResponse> {
+        let mut delay = BASE_BACKOFF;
+        let mut last_error;
+
+        for attempt in 0..=MAX_RETRIES {
+            let mut headers = HashMap::new();
+            add_basic_auth_header(&mut headers, &self.config.username, &self.config.password);
+
+            match self.http_client.get(url.to_string(), Some(headers)).await {
+                Ok(response) if !RETRYABLE_STATUSES.contains(&response.status) => {
+                    return Ok(response);
+                }
+                Ok(response) => {
+                    last_error =
+                        anyhow::anyhow!("status {}, body: {}", response.status, response.body);
+                }
+                Err(e) => last_error = anyhow::anyhow!("{e}"),
+            }
+
+            if attempt == MAX_RETRIES {
+                return Err(last_error).context("Failed to fetch transaction");
+            }
+            tokio::time::sleep(delay).await;
+            delay = delay.saturating_mul(2);
+        }
+
+        unreachable!("the loop returns on its final attempt")
     }
 }
 


### PR DESCRIPTION
The itests have been failing on most runs for the past week. This fixes both causes.

Most of the failures were connection-level. The shared regtest esplora reaps idle connections, and the chain service only retried on HTTP status codes, so the next request off a reaped connection surfaced a broken pipe to the caller. Those are now retried, on the existing backoff and within a single request timeout.

The rest are the direct Spark HTLC tests, which cannot pass while HTLCs are restricted to transfers to and from the SSP. They are `#[ignore]`d and tracked in #1123.

Only `rest_client.rs` is production code; everything else here is test-only.
