### PR TITLE
Fix conversions failing on a null hostname in the Flashnet pool listing

### DIFF
--- a/crates/breez-sdk/core/src/token_conversion/flashnet.rs
+++ b/crates/breez-sdk/core/src/token_conversion/flashnet.rs
@@ -537,13 +537,16 @@ impl FlashnetTokenConverter {
                 res.skipped = res.skipped.saturating_add(1);
                 continue;
             }
+            let Some(pool_id) = self.resolve_clawback_pool(&transfer).await else {
+                warn!(
+                    "Reconcile: cannot claw back {}: no pool in the listing or the local record",
+                    transfer.id
+                );
+                res.failed = res.failed.saturating_add(1);
+                continue;
+            };
             match self
-                .clawback_and_record_refunded(
-                    &transfer.id,
-                    transfer.lp_identity_public_key,
-                    None,
-                    None,
-                )
+                .clawback_and_record_refunded(&transfer.id, pool_id, None, None)
                 .await
             {
                 Ok(true) => res.refunded = res.refunded.saturating_add(1),
@@ -565,6 +568,22 @@ impl FlashnetTokenConverter {
     /// rejected, local state untouched for a retry; `Err` = the clawback call
     /// failed (funds not returned). `payment_id` skips row-id resolution;
     /// `prior_info` skips the metadata re-read.
+    /// The pool a listed clawback transfer belongs to, taken from the listing
+    /// or, when it omits one, from the conversion record for that transfer.
+    async fn resolve_clawback_pool(&self, transfer: &ClawbackTransfer) -> Option<PublicKey> {
+        if let Some(pool_id) = transfer.lp_identity_public_key {
+            return Some(pool_id);
+        }
+        let payment_id = resolve_payment_id(&transfer.id, &self.spark_wallet, &self.storage, true)
+            .await
+            .ok()?;
+        let payment = self.storage.get_payment_by_id(payment_id).await.ok()?;
+        match crate::utils::conversions::extract_conversion_info(payment.details)? {
+            ConversionInfo::Amm { pool_id, .. } => PublicKey::from_str(&pool_id).ok(),
+            _ => None,
+        }
+    }
+
     async fn clawback_and_record_refunded(
         &self,
         clawback_id: &str,
@@ -693,15 +712,16 @@ impl FlashnetTokenConverter {
         });
         let (a_in_pools_res, b_in_pools_res) = tokio::join!(a_in_pools_fut, b_in_pools_fut);
 
-        // Merge pools by pool_id to avoid duplicates
-        let mut pools = a_in_pools_res.map_or(HashMap::new(), |res| {
-            res.pools
-                .into_iter()
-                .map(|pool| (pool.lp_public_key, pool))
-                .collect::<HashMap<_, _>>()
-        });
-        if let Ok(res) = b_in_pools_res {
-            pools.extend(res.pools.into_iter().map(|pool| (pool.lp_public_key, pool)));
+        // Merge pools by pool_id to avoid duplicates. A failed listing is
+        // logged rather than read as an empty one.
+        let mut pools = HashMap::new();
+        for res in [a_in_pools_res, b_in_pools_res] {
+            match res {
+                Ok(res) => {
+                    pools.extend(res.pools.into_iter().map(|pool| (pool.lp_public_key, pool)));
+                }
+                Err(e) => warn!("Failed to list conversion pools: {e}"),
+            }
         }
         let pools = pools.into_values().collect::<Vec<_>>();
 
@@ -1788,10 +1808,12 @@ mod tests {
     fn transfer(id: &str, created_at: Option<&str>) -> ClawbackTransfer {
         ClawbackTransfer {
             id: id.to_string(),
-            lp_identity_public_key: PublicKey::from_str(
-                "02894808873b896e21d29856a6d7bb346fb13c019739adb9bf0b6a8b7e28da53da",
-            )
-            .unwrap(),
+            lp_identity_public_key: Some(
+                PublicKey::from_str(
+                    "02894808873b896e21d29856a6d7bb346fb13c019739adb9bf0b6a8b7e28da53da",
+                )
+                .unwrap(),
+            ),
             created_at: created_at.map(str::to_string),
         }
     }

--- a/crates/flashnet/src/amm/api.rs
+++ b/crates/flashnet/src/amm/api.rs
@@ -156,7 +156,14 @@ impl FlashnetClient {
             return Ok(list_pools_cache);
         }
         // If it's not in the cache, make an API request
-        let response = self.get_request("v1/pools", Some(request)).await?;
+        let response: ListPoolsResponse = self.get_request("v1/pools", Some(request)).await?;
+        // Every pool dropped is a schema problem, not an empty market.
+        if response.pools.is_empty() && response.total_count > 0 {
+            warn!(
+                "Listing reported {} pools, none of which could be parsed",
+                response.total_count
+            );
+        }
         self.cache_store
             .set(&cache_key, &response, LIST_POOLS_TTL_MS.into())
             .await?;

--- a/crates/flashnet/src/amm/models.rs
+++ b/crates/flashnet/src/amm/models.rs
@@ -6,6 +6,7 @@ use serde_with::DisplayFromStr;
 use serde_with::serde_as;
 use spark::Network;
 use spark_wallet::{PublicKey, TransferId};
+use tracing::warn;
 
 use super::api::BTC_ASSET_ADDRESS;
 use super::utils::decode_token_identifier;
@@ -99,8 +100,10 @@ pub struct ListClawbackTransfersResponse {
 pub struct ClawbackTransfer {
     /// Spark `transfer_id` for BTC swaps, or token transaction hash for token swaps.
     pub id: String,
-    #[serde_as(as = "DisplayFromStr")]
-    pub lp_identity_public_key: PublicKey,
+    /// The pool holding the transfer. Omitted when the backend cannot
+    /// attribute it.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub lp_identity_public_key: Option<PublicKey>,
     /// Optional RFC 3339 timestamp emitted by the Flashnet backend.
     pub created_at: Option<String>,
 }
@@ -473,6 +476,7 @@ impl ListPoolsRequest {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ListPoolsResponse {
+    #[serde(deserialize_with = "deserialize_pools")]
     pub pools: Vec<Pool>,
     pub total_count: u32,
 }
@@ -551,7 +555,7 @@ pub(crate) struct PingResponse {
 pub struct Pool {
     #[serde_as(as = "DisplayFromStr")]
     pub lp_public_key: PublicKey,
-    pub host_name: String,
+    pub host_name: Option<String>,
     pub host_fee_bps: u32,
     pub lp_fee_bps: u32,
     pub asset_a_address: String,
@@ -580,10 +584,10 @@ pub struct Pool {
     pub bonding_progress_percent: Option<f64>,
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub graduation_threshold_amount: Option<u64>,
-    /// RFC 3339 timestamp emitted by the Flashnet backend.
-    pub created_at: String,
-    /// RFC 3339 timestamp emitted by the Flashnet backend.
-    pub updated_at: String,
+    /// Matches `time::OffsetDateTime`'s Display, e.g.
+    /// `2026-02-08 2:27:34.451349 +00:00:00`.
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
     /// The pool's price, as the exponent in `1.0001^tick`. Sent only for
     /// concentrated-liquidity pools, as are the two fields below.
     pub current_tick: Option<i32>,
@@ -768,10 +772,21 @@ impl Pool {
         } else {
             self.asset_a_reserve
         };
-        if held_out.is_some_and(|held| amount_out_before_output_fees >= held) {
-            return Err(FlashnetError::Generic(format!(
-                "Amount out {amount_out_before_output_fees} is more than the pool holds"
-            )));
+        match held_out {
+            Some(held) if amount_out_before_output_fees >= held => {
+                return Err(FlashnetError::Generic(format!(
+                    "Amount out {amount_out_before_output_fees} is more than the pool holds"
+                )));
+            }
+            // V3 is priced from the advertised price alone, so quoting it
+            // needs reserves or liquidity.
+            None if is_v3 && self.total_liquidity.is_none_or(|liquidity| liquidity == 0) => {
+                return Err(FlashnetError::Generic(format!(
+                    "Pool {} advertises no depth to quote against",
+                    self.lp_public_key
+                )));
+            }
+            _ => {}
         }
 
         // Calculate amount_in before input fees
@@ -1050,6 +1065,24 @@ where
     }
 }
 
+/// Drops pools that fail to deserialize instead of failing the whole listing.
+fn deserialize_pools<'de, D>(deserializer: D) -> Result<Vec<Pool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let values: Vec<serde_json::Value> = Deserialize::deserialize(deserializer)?;
+    Ok(values
+        .into_iter()
+        .filter_map(|value| match serde_json::from_value(value) {
+            Ok(pool) => Some(pool),
+            Err(e) => {
+                warn!("Skipping unparsable pool: {e}");
+                None
+            }
+        })
+        .collect())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -1081,7 +1114,7 @@ mod test {
                 "02894808873b896e21d29856a6d7bb346fb13c019739adb9bf0b6a8b7e28da53da",
             )
             .unwrap(),
-            host_name: "flashnet".to_string(),
+            host_name: Some("flashnet".to_string()),
             host_fee_bps,
             lp_fee_bps,
             asset_a_address: a_address.to_string(),
@@ -1099,12 +1132,31 @@ mod test {
             initial_reserve_a: None,
             bonding_progress_percent: None,
             graduation_threshold_amount: None,
-            created_at: "2025-09-22T19:09:36.661269Z".to_string(),
-            updated_at: "2025-12-03T12:43:53.903531Z".to_string(),
+            created_at: Some("2025-09-22T19:09:36.661269Z".to_string()),
+            updated_at: Some("2025-12-03T12:43:53.903531Z".to_string()),
             current_tick: None,
             tick_spacing: None,
             total_liquidity: None,
         }
+    }
+
+    #[test]
+    fn a_clawback_listing_survives_an_omitted_pool() {
+        // The pool is optional in the listing, and a row missing it must not
+        // deny the reconcile pass every other row it returned.
+        let json = r#"{"transfers":[
+          {"id":"transfer123",
+           "lpIdentityPublicKey":"02894808873b896e21d29856a6d7bb346fb13c019739adb9bf0b6a8b7e28da53da",
+           "createdAt":"2025-11-21T12:34:56Z"},
+          {"id":"transfer456","createdAt":"2025-11-21T12:34:56Z"},
+          {"id":"transfer789","lpIdentityPublicKey":null}
+         ]}"#;
+        let listing: ListClawbackTransfersResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(listing.transfers.len(), 3);
+        assert!(listing.transfers[0].lp_identity_public_key.is_some());
+        assert!(listing.transfers[1].lp_identity_public_key.is_none());
+        assert!(listing.transfers[2].lp_identity_public_key.is_none());
+        assert!(listing.transfers[2].created_at.is_none());
     }
 
     #[test]
@@ -1289,6 +1341,7 @@ mod test {
 
         // Only concentrated liquidity is priced off the advertised price.
         pool.curve_type = Some(CurveType::V3Concentrated);
+        pool.total_liquidity = Some(5_150_839_635_149);
         let result = pool.calculate_amount_in(
             "020202020202020202020202020202020202020202020202020202020202020202",
             amount_out,
@@ -1327,6 +1380,7 @@ mod test {
 
         // Only concentrated liquidity is priced off the advertised price.
         pool.curve_type = Some(CurveType::V3Concentrated);
+        pool.total_liquidity = Some(5_150_839_635_149);
         let result = pool.calculate_amount_in(
             "3206c93b24a4d18ea19d0a9a213204af2c7e74a6d16c7535cc5d33eca4ad1eca",
             amount_out,
@@ -1365,6 +1419,7 @@ mod test {
 
         // Only concentrated liquidity is priced off the advertised price.
         pool.curve_type = Some(CurveType::V3Concentrated);
+        pool.total_liquidity = Some(5_150_839_635_149);
         let result = pool.calculate_amount_in(
             "3206c93b24a4d18ea19d0a9a213204af2c7e74a6d16c7535cc5d33eca4ad1eca",
             amount_out,
@@ -1408,6 +1463,7 @@ mod test {
         // Swapping A→B (token → BTC)
         // Only concentrated liquidity is priced off the advertised price.
         pool.curve_type = Some(CurveType::V3Concentrated);
+        pool.total_liquidity = Some(5_150_839_635_149);
         let result = pool.calculate_amount_in(
             "3206c93b24a4d18ea19d0a9a213204af2c7e74a6d16c7535cc5d33eca4ad1eca",
             amount_out,

--- a/crates/flashnet/src/amm/pool_selection.rs
+++ b/crates/flashnet/src/amm/pool_selection.rs
@@ -283,7 +283,7 @@ mod tests {
     ) -> Pool {
         Pool {
             lp_public_key: pubkey.parse().unwrap(),
-            host_name: "test".to_string(),
+            host_name: Some("test".to_string()),
             host_fee_bps,
             lp_fee_bps,
             asset_a_address: crate::BTC_ASSET_ADDRESS.to_string(),
@@ -301,8 +301,8 @@ mod tests {
             initial_reserve_a: None,
             bonding_progress_percent: None,
             graduation_threshold_amount: None,
-            created_at: "2024-01-01T00:00:00Z".to_string(),
-            updated_at: "2024-01-01T00:00:00Z".to_string(),
+            created_at: Some("2024-01-01T00:00:00Z".to_string()),
+            updated_at: Some("2024-01-01T00:00:00Z".to_string()),
             current_tick: None,
             tick_spacing: None,
             total_liquidity: None,
@@ -316,7 +316,7 @@ mod tests {
             lp_public_key: "02894808873b896e21d29856a6d7bb346fb13c019739adb9bf0b6a8b7e28da53da"
                 .parse()
                 .unwrap(),
-            host_name: "test".to_string(),
+            host_name: Some("test".to_string()),
             host_fee_bps: 50,
             lp_fee_bps: 100,
             asset_a_address: "asset_a".to_string(),
@@ -334,8 +334,8 @@ mod tests {
             initial_reserve_a: None,
             bonding_progress_percent: None,
             graduation_threshold_amount: None,
-            created_at: "2024-01-01T00:00:00Z".to_string(),
-            updated_at: "2024-01-01T00:00:00Z".to_string(),
+            created_at: Some("2024-01-01T00:00:00Z".to_string()),
+            updated_at: Some("2024-01-01T00:00:00Z".to_string()),
             current_tick: None,
             tick_spacing: None,
             total_liquidity: None,
@@ -357,7 +357,7 @@ mod tests {
             lp_public_key: "0315299b3f9f4e2beb8576ea2bf72ea1bc741eb255bfc3f6387de4d47b5c05972d"
                 .parse()
                 .unwrap(),
-            host_name: "test".to_string(),
+            host_name: Some("test".to_string()),
             host_fee_bps: 50,
             lp_fee_bps: 100,
             asset_a_address: "asset_a".to_string(),
@@ -375,8 +375,8 @@ mod tests {
             initial_reserve_a: None,
             bonding_progress_percent: None,
             graduation_threshold_amount: None,
-            created_at: "2024-01-01T00:00:00Z".to_string(),
-            updated_at: "2024-01-01T00:00:00Z".to_string(),
+            created_at: Some("2024-01-01T00:00:00Z".to_string()),
+            updated_at: Some("2024-01-01T00:00:00Z".to_string()),
             current_tick: None,
             tick_spacing: None,
             total_liquidity: None,
@@ -395,7 +395,7 @@ mod tests {
             lp_public_key: "02a1633caf0d6d2a8b3f4e1f5e6d7c8b9a0b1c2d3e4f5061728394a5b6c7d8e9fa"
                 .parse()
                 .unwrap(),
-            host_name: "test".to_string(),
+            host_name: Some("test".to_string()),
             host_fee_bps: 50,
             lp_fee_bps: 100,
             asset_a_address: "asset_a".to_string(),
@@ -413,8 +413,8 @@ mod tests {
             initial_reserve_a: None,
             bonding_progress_percent: None,
             graduation_threshold_amount: None,
-            created_at: "2024-01-01T00:00:00Z".to_string(),
-            updated_at: "2024-01-01T00:00:00Z".to_string(),
+            created_at: Some("2024-01-01T00:00:00Z".to_string()),
+            updated_at: Some("2024-01-01T00:00:00Z".to_string()),
             current_tick: None,
             tick_spacing: None,
             total_liquidity: None,

--- a/crates/flashnet/src/amm/pool_validation.rs
+++ b/crates/flashnet/src/amm/pool_validation.rs
@@ -262,7 +262,7 @@ mod tests {
                 "02894808873b896e21d29856a6d7bb346fb13c019739adb9bf0b6a8b7e28da53da",
             )
             .unwrap(),
-            host_name: "flashnet".to_string(),
+            host_name: Some("flashnet".to_string()),
             host_fee_bps: 0,
             lp_fee_bps: 20,
             asset_a_address: BTC_ASSET_ADDRESS.to_string(),
@@ -280,8 +280,8 @@ mod tests {
             initial_reserve_a: None,
             bonding_progress_percent: None,
             graduation_threshold_amount: None,
-            created_at: "2025-09-22 19:09:36".to_string(),
-            updated_at: "2026-08-04 15:03:38".to_string(),
+            created_at: Some("2025-09-22 19:09:36".to_string()),
+            updated_at: Some("2026-08-04 15:03:38".to_string()),
             current_tick: None,
             tick_spacing: None,
             total_liquidity: None,
@@ -535,6 +535,167 @@ mod tests {
             assert!(p.validate_for_swap(&a, &b, Network::Mainnet).is_ok());
             assert!(p.validate_for_swap(&b, &a, Network::Mainnet).is_ok());
         }
+    }
+
+    /// Verbatim mainnet `/v1/pools` entries for BTC <-> USDB on 2026-09-11,
+    /// one per distinct shape in the listing: the real V3 pool, the
+    /// constant-product pool, the two zero-liquidity V3 pools priced at the
+    /// ends of the tick range, a bonding curve, and a pool with a null host.
+    const POISONED_LISTING: &str = r#"{"pools":[
+      {"lpPublicKey":"037579aee81891fc3a28cbe7b13e565031d46248b420fb39dcb308598f472b4513",
+       "hostName":"flashnet","hostFeeBps":0,"lpFeeBps":5,
+       "assetAAddress":"020202020202020202020202020202020202020202020202020202020202020202",
+       "assetBAddress":"3206c93b24a4d18ea19d0a9a213204af2c7e74a6d16c7535cc5d33eca4ad1eca",
+       "assetAReserve":"130478433","assetBReserve":"211013962738",
+       "currentPriceAInB":"771.214383288967004757","tvlAssetB":"311640806977",
+       "volume24hAssetB":"106650467945223","priceChangePercent24h":"0.14",
+       "curveType":"V3_CONCENTRATED","createdAt":"2026-02-08","updatedAt":"2026-09-11",
+       "currentTick":66482,"tickSpacing":10,"totalLiquidity":"7482426271107"},
+      {"lpPublicKey":"02894808873b896e21d29856a6d7bb346fb13c019739adb9bf0b6a8b7e28da53da",
+       "hostName":"flashnet","hostFeeBps":0,"lpFeeBps":20,
+       "assetAAddress":"020202020202020202020202020202020202020202020202020202020202020202",
+       "assetBAddress":"3206c93b24a4d18ea19d0a9a213204af2c7e74a6d16c7535cc5d33eca4ad1eca",
+       "assetAReserve":"245114","assetBReserve":"182181589",
+       "currentPriceAInB":"743.251877296693857441","tvlAssetB":"364363030",
+       "volume24hAssetB":"0","priceChangePercent24h":"0.00",
+       "curveType":"CONSTANT_PRODUCT","createdAt":"2025-09-22","updatedAt":"2026-09-09"},
+      {"lpPublicKey":"0381f57ce8d84bf1d1e8023ea6048dba26e0975d526a4858286b561ca13e33f80a",
+       "hostName":"auditlab","hostFeeBps":50,"lpFeeBps":30,
+       "assetAAddress":"020202020202020202020202020202020202020202020202020202020202020202",
+       "assetBAddress":"3206c93b24a4d18ea19d0a9a213204af2c7e74a6d16c7535cc5d33eca4ad1eca",
+       "assetAReserve":"0","assetBReserve":"0",
+       "currentPriceAInB":"1.000000000000000000E-30","tvlAssetB":"0",
+       "volume24hAssetB":"0","priceChangePercent24h":"0.00",
+       "curveType":"V3_CONCENTRATED","createdAt":"2026-09-07","updatedAt":"2026-09-07",
+       "currentTick":-690811,"tickSpacing":10,"totalLiquidity":"0"},
+      {"lpPublicKey":"038e629c9de27f0b82ea9e649850ef46f3fa861fa9f7afb832ed386097305a8a5c",
+       "hostName":"auditlab","hostFeeBps":50,"lpFeeBps":30,
+       "assetAAddress":"020202020202020202020202020202020202020202020202020202020202020202",
+       "assetBAddress":"3206c93b24a4d18ea19d0a9a213204af2c7e74a6d16c7535cc5d33eca4ad1eca",
+       "assetAReserve":"0","assetBReserve":"0",
+       "currentPriceAInB":"1000000000000000000000000000000.000000000000000000","tvlAssetB":"0",
+       "volume24hAssetB":"0","priceChangePercent24h":"0.00",
+       "curveType":"V3_CONCENTRATED","createdAt":"2026-09-07","updatedAt":"2026-09-07",
+       "currentTick":690810,"tickSpacing":10,"totalLiquidity":"0"},
+      {"lpPublicKey":"024bb431d831dd165aec35570f07ae5ad2a3a5b8e04c714048cbe290fac5757125",
+       "hostName":"race5cef3583","hostFeeBps":100,"lpFeeBps":100,
+       "assetAAddress":"3206c93b24a4d18ea19d0a9a213204af2c7e74a6d16c7535cc5d33eca4ad1eca",
+       "assetBAddress":"020202020202020202020202020202020202020202020202020202020202020202",
+       "assetAReserve":"100000","assetBReserve":"0",
+       "currentPriceAInB":"0.000444444444444444","tvlAssetB":"44",
+       "volume24hAssetB":"0","priceChangePercent24h":"0.00",
+       "curveType":"SINGLE_SIDED","createdAt":"2026-09-10","updatedAt":"2026-09-10",
+       "virtualReserveA":"112500","virtualReserveB":"50","thresholdPct":75,
+       "initialReserveA":"100000","bondingProgressPercent":"0.0000",
+       "graduationThresholdAmount":"75000"},
+      {"lpPublicKey":"034f31eb0f56231f4eef456e3729c6c0ea38b22bd17dde67381347013db86e5bad",
+       "hostName":null,"hostFeeBps":10,"lpFeeBps":30,
+       "assetAAddress":"3206c93b24a4d18ea19d0a9a213204af2c7e74a6d16c7535cc5d33eca4ad1eca",
+       "assetBAddress":"020202020202020202020202020202020202020202020202020202020202020202",
+       "assetAReserve":"0","assetBReserve":"0",
+       "currentPriceAInB":"1.000000000000000000","tvlAssetB":"0",
+       "volume24hAssetB":"0","priceChangePercent24h":"0.00",
+       "curveType":"V3_CONCENTRATED","createdAt":"2026-09-11","updatedAt":"2026-09-11",
+       "currentTick":0,"tickSpacing":60,"totalLiquidity":"0"}
+     ],"totalCount":6}"#;
+
+    /// A null host took down every conversion on the pair: the API documents
+    /// the field as nullable, and one pool rejecting it failed the listing.
+    #[test]
+    fn a_null_host_name_does_not_fail_the_listing() {
+        let listing: crate::ListPoolsResponse = serde_json::from_str(POISONED_LISTING).unwrap();
+        assert_eq!(listing.pools.len(), 6);
+        assert!(
+            listing
+                .pools
+                .iter()
+                .any(|p| p.host_name.is_none() && p.tick_spacing == Some(60))
+        );
+    }
+
+    #[test]
+    fn an_unparsable_pool_is_skipped_rather_than_failing_the_listing() {
+        let broken = POISONED_LISTING.replacen(
+            r#""lpPublicKey":"037579aee81891fc3a28cbe7b13e565031d46248b420fb39dcb308598f472b4513""#,
+            r#""lpPublicKey":null"#,
+            1,
+        );
+        let listing: crate::ListPoolsResponse = serde_json::from_str(&broken).unwrap();
+        assert_eq!(listing.pools.len(), 5);
+        // The count is the server's, so it still reports what was sent.
+        assert_eq!(listing.total_count, 6);
+    }
+
+    #[test]
+    fn the_zero_liquidity_pools_are_refused_by_the_quote_not_by_validate() {
+        let listing: crate::ListPoolsResponse = serde_json::from_str(POISONED_LISTING).unwrap();
+        let btc = BTC_ASSET_ADDRESS;
+        let zero_liquidity: Vec<_> = listing
+            .pools
+            .iter()
+            .filter(|p| p.total_liquidity == Some(0))
+            .collect();
+        assert_eq!(zero_liquidity.len(), 3);
+        for p in zero_liquidity {
+            // Their prices sit exactly on MIN_PRICE / MAX_PRICE and their ticks
+            // corroborate them, so structural validation cannot be what rejects
+            // them. Tightening the price bound would reject real tiny-priced
+            // tokens instead.
+            assert!(p.validate().is_ok(), "{} failed validate", p.lp_public_key);
+            assert!(
+                p.calculate_amount_in(USDB, 50_000, 10, 0, Network::Mainnet)
+                    .is_err(),
+                "{} quoted a swap it cannot honour",
+                p.lp_public_key
+            );
+            assert!(
+                p.calculate_amount_in(btc, 50_000, 10, 0, Network::Mainnet)
+                    .is_err(),
+                "{} quoted a swap it cannot honour",
+                p.lp_public_key
+            );
+        }
+    }
+
+    #[test]
+    fn selection_takes_the_real_pool_over_the_zero_liquidity_ones() {
+        let listing: crate::ListPoolsResponse = serde_json::from_str(POISONED_LISTING).unwrap();
+        let best = crate::select_best_pool(
+            &listing.pools,
+            USDB,
+            BTC_ASSET_ADDRESS,
+            50_000,
+            10,
+            0,
+            Network::Mainnet,
+        )
+        .unwrap();
+        assert_eq!(
+            best.lp_public_key.to_string(),
+            "037579aee81891fc3a28cbe7b13e565031d46248b420fb39dcb308598f472b4513"
+        );
+    }
+
+    #[test]
+    fn a_v3_pool_advertising_no_depth_at_all_is_refused() {
+        let mut p = v3_pool();
+        p.asset_a_reserve = None;
+        p.asset_b_reserve = None;
+
+        p.total_liquidity = None;
+        assert!(
+            p.calculate_amount_in(USDB, 50_000, 10, 0, Network::Mainnet)
+                .is_err(),
+            "quoted a pool that advertises neither reserves nor liquidity"
+        );
+
+        // Liquidity alone still prices: reserves are not always populated for
+        // this curve, and refusing on their absence would drop real pools.
+        p.total_liquidity = Some(5_150_839_635_149);
+        assert!(
+            p.calculate_amount_in(USDB, 50_000, 10, 0, Network::Mainnet)
+                .is_ok()
+        );
     }
 
     /// The live V3 pool, whose tick and price are both real.


### PR DESCRIPTION
Mainnet BTC/USDB conversions failed with `No conversion pools available` while `GET /v1/pools` returned 200 with 11 pools. A pool created 2026-09-11 carries `"hostName": null`, which the Flashnet API documents as nullable, but
`Pool::host_name` was a required `String`. One pool failed the whole `ListPoolsResponse`, and the resulting error was discarded, so an unparseable listing was reported as an absence of liquidity.

### Schema corrections
Audited the response models against the published schema. Three fields were declared required that the spec marks optional:

| Field | Was | Now |
|---|---|---|
| `Pool.host_name` | `String` | `Option<String>` |
| `Pool.created_at` / `updated_at` | `String` | `Option<String>` |
| `ClawbackTransfer.lp_identity_public_key` | `PublicKey` | `Option<PublicKey>` |

### Hardening

- `ListPoolsResponse.pools` skips individual pools that fail to deserialize, logging each, rather than failing the listing.
- `list_pools` warns when the server reports pools but none parsed.
- `get_conversion_pool` logs the underlying `FlashnetError` instead of discarding it.

### Pool selection

A V3 pool is quoted from its advertised price rather than from reserves, so one omitting reserves was priced against nothing. Quoting now requires a covering output reserve or a non-zero `total_liquidity`.

### Refund path

`lp_identity_public_key` is signed into the clawback intent, so a transfer cannot be clawed back without it. Reconcile falls back to the pool recorded on our own conversion (`ConversionInfo::Amm`), and skips a row it cannot address instead of aborting the pass.
