### PR TITLE
stable_balance: back off and retry failed auto-convert and deactivation

### DIFF
--- a/crates/breez-sdk/core/src/stable_balance/queue.rs
+++ b/crates/breez-sdk/core/src/stable_balance/queue.rs
@@ -4,6 +4,7 @@
 //! through a single queue to eliminate race conditions between the paths.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use platform_utils::tokio;
 use serde::{Deserialize, Serialize};
@@ -43,6 +44,25 @@ pub(crate) enum PendingState {
 /// How long to keep a deferred task before marking it as failed (seconds).
 const DEFERRED_TASK_TIMEOUT_SECS: u64 = 120;
 
+/// Backoff between attempts of a failed auto-convert or deactivation
+/// conversion: 30 s, doubling to a cap of one hour. Without it a failed swap
+/// is refunded by the AMM as an incoming sats transfer, that receive re-queues
+/// the same conversion, and the loop runs every few seconds for as long as the
+/// wallet is open (observed at 127 attempts in 13 minutes on mainnet when the
+/// selected pool had no liquidity), leaving a pair of transfers in the history
+/// each time. The cap keeps a long outage self-healing: once liquidity is back
+/// the next hourly attempt goes through.
+const CONVERSION_BACKOFF_BASE_SECS: u64 = 30;
+const CONVERSION_BACKOFF_MAX_SECS: u64 = 3_600;
+
+/// Seconds to wait before the `consecutive_failures`-th retry.
+fn backoff_secs(consecutive_failures: u32) -> u64 {
+    let doublings = consecutive_failures.saturating_sub(1).min(20);
+    CONVERSION_BACKOFF_BASE_SECS
+        .saturating_mul(1_u64 << doublings)
+        .min(CONVERSION_BACKOFF_MAX_SECS)
+}
+
 /// A pending per-receive conversion with its processing state.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PendingConversion {
@@ -68,6 +88,18 @@ struct ConversionQueueState {
     per_receive: Vec<PendingConversion>,
     /// A pending non-per-receive task (auto-convert or deactivation).
     pending_task: Option<ConversionTask>,
+    /// How many times `pending_task` has failed in a row, and the unix time
+    /// before which it must not run again. Both reset when the task completes
+    /// or is replaced.
+    task_failures: u32,
+    task_not_before: Option<u64>,
+}
+
+impl ConversionQueueState {
+    fn reset_backoff(&mut self) {
+        self.task_failures = 0;
+        self.task_not_before = None;
+    }
 }
 
 /// A priority queue that serializes conversion tasks.
@@ -87,6 +119,8 @@ impl ConversionQueue {
             state: Mutex::new(ConversionQueueState {
                 per_receive: Vec::new(),
                 pending_task: None,
+                task_failures: 0,
+                task_not_before: None,
             }),
             notify: Arc::new(Notify::new()),
             storage,
@@ -118,11 +152,13 @@ impl ConversionQueue {
         }
     }
 
-    /// Queue a deactivation conversion task. Overrides any pending auto-convert.
+    /// Queue a deactivation conversion task. Overrides any pending auto-convert
+    /// and any backoff it was under: this is the user acting, so it runs now.
     pub async fn push_deactivation(&self, token_identifier: String) {
         let mut state = self.state.lock().await;
         debug!("Queuing deactivation conversion for token {token_identifier}");
         state.pending_task = Some(ConversionTask::Deactivation(token_identifier));
+        state.reset_backoff();
         self.notify.notify_one();
     }
 
@@ -151,6 +187,7 @@ impl ConversionQueue {
         let mut state = self.state.lock().await;
         let cleared: Vec<String> = state.per_receive.drain(..).map(|p| p.payment_id).collect();
         state.pending_task = None;
+        state.reset_backoff();
         self.persist_pending(&state).await;
         cleared
     }
@@ -183,10 +220,49 @@ impl ConversionQueue {
             // Only run auto-convert/deactivation when no per-receive tasks exist (including
             // deferred). Deferred tasks may still be resolved by a PaymentSucceeded event
             // and need those sats.
-            state.pending_task.clone()
+            //
+            // A task under backoff stays queued but is not due yet; the worker
+            // sleeps until `retry_delay` says it is.
+            let due = state
+                .task_not_before
+                .is_none_or(|not_before| now_secs() >= not_before);
+            if due {
+                state.pending_task.clone()
+            } else {
+                None
+            }
         } else {
             None
         }
+    }
+
+    /// How long until the pending auto-convert / deactivation task may run
+    /// again, when it is under backoff. `None` when nothing is waiting on time.
+    pub async fn retry_delay(&self) -> Option<Duration> {
+        let state = self.state.lock().await;
+        let not_before = state.task_not_before?;
+        state.pending_task.as_ref()?;
+        Some(Duration::from_secs(not_before.saturating_sub(now_secs())))
+    }
+
+    /// Keep the pending task queued after a failure and schedule its next
+    /// attempt. Returns the delay in seconds and the failure count so far.
+    pub async fn retry_later(&self, task: &ConversionTask) -> (u64, u32) {
+        let mut state = self.state.lock().await;
+        // The task may have been replaced while it ran (a deactivation
+        // arriving during an auto-convert); only back off the task that failed.
+        let same_task = match (&state.pending_task, task) {
+            (Some(ConversionTask::AutoConvert), ConversionTask::AutoConvert) => true,
+            (Some(ConversionTask::Deactivation(a)), ConversionTask::Deactivation(b)) => a == b,
+            _ => false,
+        };
+        if !same_task {
+            return (0, 0);
+        }
+        state.task_failures = state.task_failures.saturating_add(1);
+        let delay = backoff_secs(state.task_failures);
+        state.task_not_before = Some(now_secs().saturating_add(delay));
+        (delay, state.task_failures)
     }
 
     /// Remove a completed task from the queue.
@@ -200,6 +276,7 @@ impl ConversionQueue {
             }
             ConversionTask::AutoConvert | ConversionTask::Deactivation(_) => {
                 state.pending_task = None;
+                state.reset_backoff();
             }
         }
     }
@@ -308,64 +385,14 @@ impl StableBalance {
                     // Drain all available tasks
                     while let Some(task) = stable_balance.core.queue.next_task().await {
                         debug!("Conversion worker: processing task {task:?}");
-                        match &task {
-                            ConversionTask::PerReceive(payment_id) => {
-                                match stable_balance
-                                    .process_per_receive(payment_id.clone())
-                                    .await
-                                {
-                                    PerReceiveResult::Done { converted } => {
-                                        debug!("Conversion worker: completed task {task:?} (converted={converted})");
-                                        stable_balance.core.queue.complete_task(&task).await;
-                                        if converted {
-                                            // Clear any pending auto-convert — the local balance
-                                            // is stale until sync completes. The next Synced event
-                                            // will re-queue auto-convert if there's still excess.
-                                            stable_balance.core.queue.clear_pending_auto_convert().await;
-                                            stable_balance.emit_conversion_completed().await;
-                                        }
-                                    }
-                                    PerReceiveResult::Retry => {
-                                        // Mark as deferred so next_task skips it until
-                                        // resolved by a PaymentSucceeded event or timeout
-                                        debug!("Conversion worker: deferring task {task:?}");
-                                        stable_balance.core.queue.defer_task(payment_id).await;
-                                    }
-                                }
-                            }
-                            ConversionTask::AutoConvert => {
-                                let converted = match stable_balance.auto_convert().await {
-                                    Ok(converted) => converted,
-                                    Err(e) => {
-                                        warn!("Auto-conversion failed: {e:?}");
-                                        false
-                                    }
-                                };
-                                debug!("Conversion worker: auto-convert done (converted={converted})");
-                                stable_balance.core.queue.complete_task(&task).await;
-                                if converted {
-                                    stable_balance.emit_conversion_completed().await;
-                                }
-                            }
-                            ConversionTask::Deactivation(token_id) => {
-                                let converted =
-                                    match stable_balance.deactivation_convert(token_id).await {
-                                        Ok(converted) => converted,
-                                        Err(e) => {
-                                            warn!("Deactivation conversion failed: {e:?}");
-                                            false
-                                        }
-                                    };
-                                debug!("Conversion worker: completed task {task:?} (converted={converted})");
-                                stable_balance.core.queue.complete_task(&task).await;
-                                if converted {
-                                    stable_balance.emit_conversion_completed().await;
-                                }
-                            }
-                        }
+                        stable_balance.process_task(&task).await;
                     }
 
-                    debug!("Conversion worker: queue drained, waiting for new tasks");
+                    // A task under backoff is not returned by `next_task` until
+                    // it is due, and nothing notifies when the clock runs out —
+                    // so sleep for exactly that long alongside the usual wakeups.
+                    let retry_delay = stable_balance.core.queue.retry_delay().await;
+                    debug!("Conversion worker: queue drained, waiting for new tasks (retry in {retry_delay:?})");
                     tokio::select! {
                         _ = shutdown_receiver.changed() => {
                             info!("Conversion worker shutdown");
@@ -374,11 +401,78 @@ impl StableBalance {
                         () = notified => {
                             debug!("Conversion worker: woken by notify");
                         }
+                        () = async {
+                            match retry_delay {
+                                Some(delay) => tokio::time::sleep(delay).await,
+                                None => std::future::pending().await,
+                            }
+                        } => {
+                            debug!("Conversion worker: backoff elapsed");
+                        }
                     }
                 }
             }
             .instrument(span),
         );
+    }
+
+    /// Run one queued task to completion or to its next retry.
+    async fn process_task(&self, task: &ConversionTask) {
+        match task {
+            ConversionTask::PerReceive(payment_id) => {
+                match self.process_per_receive(payment_id.clone()).await {
+                    PerReceiveResult::Done { converted } => {
+                        debug!(
+                            "Conversion worker: completed task {task:?} (converted={converted})"
+                        );
+                        self.core.queue.complete_task(task).await;
+                        if converted {
+                            // Clear any pending auto-convert — the local balance
+                            // is stale until sync completes. The next Synced event
+                            // will re-queue auto-convert if there's still excess.
+                            self.core.queue.clear_pending_auto_convert().await;
+                            self.emit_conversion_completed().await;
+                        }
+                    }
+                    PerReceiveResult::Retry => {
+                        // Mark as deferred so next_task skips it until
+                        // resolved by a PaymentSucceeded event or timeout
+                        debug!("Conversion worker: deferring task {task:?}");
+                        self.core.queue.defer_task(payment_id).await;
+                    }
+                }
+            }
+            ConversionTask::AutoConvert => match self.auto_convert().await {
+                Ok(converted) => {
+                    debug!("Conversion worker: auto-convert done (converted={converted})");
+                    self.core.queue.complete_task(task).await;
+                    if converted {
+                        self.emit_conversion_completed().await;
+                    }
+                }
+                Err(e) => {
+                    self.schedule_retry(task, "Auto-convert", format!("{e:?}"))
+                        .await;
+                }
+            },
+            ConversionTask::Deactivation(token_id) => {
+                match self.deactivation_convert(token_id).await {
+                    Ok(converted) => {
+                        debug!(
+                            "Conversion worker: completed task {task:?} (converted={converted})"
+                        );
+                        self.core.queue.complete_task(task).await;
+                        if converted {
+                            self.emit_conversion_completed().await;
+                        }
+                    }
+                    Err(e) => {
+                        self.schedule_retry(task, "Deactivation", format!("{e:?}"))
+                            .await;
+                    }
+                }
+            }
+        }
     }
 
     /// Process a per-receive conversion task.
@@ -424,6 +518,16 @@ impl StableBalance {
         }
     }
 
+    /// A failed auto-convert or deactivation: keep it queued under backoff. The
+    /// AMM refunds a failed swap, so balances are unchanged.
+    async fn schedule_retry(&self, task: &ConversionTask, conversion: &str, error: String) {
+        let (retry_in_secs, failures) = self.core.queue.retry_later(task).await;
+        warn!(
+            "{conversion} conversion failed ({failures} in a row), retrying in \
+             {retry_in_secs}s: {error}"
+        );
+    }
+
     /// Recover pending per-receive conversions from a previous session.
     ///
     /// Loads persisted pending conversions and restores them into the queue.
@@ -457,5 +561,134 @@ impl StableBalance {
                 warn!("Failed to load pending conversions for recovery: {e:?}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod backoff_tests {
+    use super::*;
+
+    #[test]
+    fn backoff_doubles_from_thirty_seconds_and_caps_at_an_hour() {
+        assert_eq!(backoff_secs(1), 30);
+        assert_eq!(backoff_secs(2), 60);
+        assert_eq!(backoff_secs(3), 120);
+        assert_eq!(backoff_secs(7), 1_920);
+        assert_eq!(backoff_secs(8), 3_600);
+        assert_eq!(backoff_secs(9), 3_600);
+        // No overflow however long the outage.
+        assert_eq!(backoff_secs(u32::MAX), 3_600);
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod queue_tests {
+    use super::*;
+    use crate::persist::sqlite::SqliteStorage;
+    use std::path::PathBuf;
+
+    fn create_temp_dir(name: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!("breez-test-{}-{}", name, uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn queue(name: &str) -> (ConversionQueue, Arc<dyn Storage>) {
+        let storage: Arc<dyn Storage> =
+            Arc::new(SqliteStorage::new(&create_temp_dir(name)).unwrap());
+        (ConversionQueue::new(Arc::clone(&storage)), storage)
+    }
+
+    #[tokio::test]
+    async fn a_failed_auto_convert_stays_queued_but_is_not_due_until_the_backoff_elapses() {
+        let (queue, _storage) = queue("auto_convert_backoff");
+        queue.push_auto_convert().await;
+        assert!(matches!(
+            queue.next_task().await,
+            Some(ConversionTask::AutoConvert)
+        ));
+        assert_eq!(queue.retry_delay().await, None);
+
+        let (delay, failures) = queue.retry_later(&ConversionTask::AutoConvert).await;
+        assert_eq!((delay, failures), (30, 1));
+        // Still queued, so a fresh trigger collapses into it rather than
+        // starting a parallel attempt...
+        queue.push_auto_convert().await;
+        // ...but it is not handed out until it is due.
+        assert!(queue.next_task().await.is_none());
+        let remaining = queue.retry_delay().await.expect("under backoff");
+        assert!(remaining <= Duration::from_secs(30) && remaining > Duration::from_secs(25));
+
+        // Each further failure doubles the wait.
+        assert_eq!(
+            queue.retry_later(&ConversionTask::AutoConvert).await,
+            (60, 2)
+        );
+        assert_eq!(
+            queue.retry_later(&ConversionTask::AutoConvert).await,
+            (120, 3)
+        );
+
+        // Success clears everything.
+        queue.complete_task(&ConversionTask::AutoConvert).await;
+        assert_eq!(queue.retry_delay().await, None);
+        queue.push_auto_convert().await;
+        assert!(queue.next_task().await.is_some());
+        assert_eq!(
+            queue.retry_later(&ConversionTask::AutoConvert).await,
+            (30, 1)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_deactivation_runs_now_even_while_an_auto_convert_is_backing_off() {
+        let (queue, _storage) = queue("deactivation_now");
+        let token = "btkn1usdb".to_string();
+
+        // An auto-convert under backoff does not delay the user's deactivation.
+        queue.push_auto_convert().await;
+        let _ = queue.retry_later(&ConversionTask::AutoConvert).await;
+        queue.push_deactivation(token.clone()).await;
+        assert!(matches!(
+            queue.next_task().await,
+            Some(ConversionTask::Deactivation(ref t)) if *t == token
+        ));
+        assert_eq!(queue.retry_delay().await, None);
+
+        // A failure keeps it queued and backed off like an auto-convert.
+        let task = ConversionTask::Deactivation(token.clone());
+        assert_eq!(queue.retry_later(&task).await, (30, 1));
+        assert!(queue.next_task().await.is_none());
+        queue.complete_task(&task).await;
+        assert_eq!(queue.retry_delay().await, None);
+    }
+
+    #[tokio::test]
+    async fn clearing_the_queue_drops_the_backoff() {
+        let (queue, _storage) = queue("backoff_cleared");
+        queue.push_deactivation("btkn1usdb".to_string()).await;
+        let _ = queue
+            .retry_later(&ConversionTask::Deactivation("btkn1usdb".to_string()))
+            .await;
+
+        queue.clear_queue().await;
+        assert_eq!(queue.retry_delay().await, None);
+        assert!(queue.next_task().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_failure_reported_for_a_replaced_task_does_not_back_off_the_new_one() {
+        let (queue, _storage) = queue("replaced_task");
+        queue.push_auto_convert().await;
+        // The deactivation arrived while the auto-convert was running...
+        queue.push_deactivation("btkn1usdb".to_string()).await;
+        // ...and the auto-convert then failed.
+        assert_eq!(
+            queue.retry_later(&ConversionTask::AutoConvert).await,
+            (0, 0)
+        );
+        assert!(queue.next_task().await.is_some(), "deactivation is due now");
+        assert_eq!(queue.retry_delay().await, None);
     }
 }


### PR DESCRIPTION
The conversion worker treated a failed `AutoConvert` or `Deactivation` as done: `complete_task`, warn, move on. But a failed swap is refunded by the AMM as an incoming sats transfer, that receive re-queues `AutoConvert`, and the loop runs every few seconds for as long as the wallet is open. Observed on mainnet on 2026-09-11 while the selected pool had no liquidity: **127 attempts in 13 minutes**, each leaving a ±11,254-sat pair in the payment history:

```
WARN breez_sdk_spark::stable_balance::queue: Auto-conversion failed: ConversionFailed("Convert token failed, refund in progress: Pool has no liquidity")
```

A failed `Deactivation` was simply dropped, leaving the token holding in place behind a toggle that reads "off".

**Fix**: keep the failed task queued and schedule its next attempt with exponential backoff — 30 s, doubling, capped at one hour.
- `next_task` withholds a task until it is due; the worker sleeps for exactly the remaining delay alongside its usual notify/shutdown wakeups, since nothing else fires when the clock runs out.
- Success or replacement resets the backoff.
- A deactivation pushed while an auto-convert is backing off runs immediately, because it is the user acting.
- A failure reported for a task that has since been replaced is ignored, so the new task is not penalised for the old one's outcome.

The cap keeps a long outage self-healing: once liquidity is back, the next hourly attempt goes through with no restart.

Tests cover the schedule, due/not-due, reset on completion, deactivation preempting a backed-off auto-convert, and the replaced-task case. `spawn_conversion_worker`'s per-task match moved to `process_task` to stay under the line limit.

**Verified locally**: `cargo fmt`, `cargo clippy -p breez-sdk-spark --features sqlite --all-targets -- -D warnings`, `cargo test -p breez-sdk-spark --features sqlite`.

Related: #1113 (listing parse), and the follow-up that reports these failures as an event and persists a pending deactivation.
