### PR TITLE
stable_balance: report failed conversions as an event; persist a pending deactivation

### DIFF
--- a/crates/breez-sdk/core/src/events.rs
+++ b/crates/breez-sdk/core/src/events.rs
@@ -56,6 +56,28 @@ pub enum SdkEvent {
     /// Emitted when the data a unilateral exit is built from has changed, so an
     /// exit state exported earlier is out of date and should be exported again.
     UnilateralExitStateChanged,
+    /// Emitted when a Stable Balance conversion the SDK runs on its own failed:
+    /// sweeping received bitcoin into the stable token, or converting the token
+    /// back to bitcoin on deactivation. The SDK keeps retrying with backoff;
+    /// `retry_in_secs` is how long until the next attempt. Balances are
+    /// unchanged: the AMM refunds a failed swap. Integrators that would rather
+    /// stop than wait can deactivate Stable Balance in response.
+    StableBalanceConversionFailed {
+        conversion: StableBalanceConversionKind,
+        error: String,
+        retry_in_secs: u64,
+    },
+}
+
+/// Which Stable Balance conversion an [`SdkEvent::StableBalanceConversionFailed`]
+/// refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum StableBalanceConversionKind {
+    /// Bitcoin above the threshold being swept into the stable token.
+    AutoConvert,
+    /// The stable token being converted back to bitcoin after deactivation.
+    Deactivation,
 }
 
 impl SdkEvent {
@@ -99,6 +121,14 @@ impl fmt::Display for SdkEvent {
                 write!(f, "NewDeposits[{}]", new_deposits.len())
             }
             SdkEvent::UnilateralExitStateChanged => write!(f, "UnilateralExitStateChanged"),
+            SdkEvent::StableBalanceConversionFailed {
+                conversion,
+                retry_in_secs,
+                ..
+            } => write!(
+                f,
+                "StableBalanceConversionFailed({conversion:?}, retry in {retry_in_secs}s)"
+            ),
         }
     }
 }

--- a/crates/breez-sdk/core/src/lib.rs
+++ b/crates/breez-sdk/core/src/lib.rs
@@ -38,7 +38,9 @@ pub use cross_chain::{
     CrossChainRouteFilter, CrossChainRoutePair, DeliveryMethod, SparkAsset,
 };
 pub use error::{DepositClaimError, SdkError, SignerError};
-pub use events::{AutoOptimizationEvent, EventEmitter, EventListener, SdkEvent};
+pub use events::{
+    AutoOptimizationEvent, EventEmitter, EventListener, SdkEvent, StableBalanceConversionKind,
+};
 pub use issuer::*;
 pub use logger::DEFAULT_FILTER;
 pub use models::*;

--- a/crates/breez-sdk/core/src/persist/mod.rs
+++ b/crates/breez-sdk/core/src/persist/mod.rs
@@ -48,6 +48,7 @@ const PUBLISHED_PACKAGE_KEY_PREFIX: &str = "published_package_";
 const SPARK_PRIVATE_MODE_INITIALIZED_KEY: &str = "spark_private_mode_initialized";
 pub(crate) const STABLE_BALANCE_ACTIVE_LABEL_KEY: &str = "stable_balance_active_label";
 const PENDING_CONVERSIONS_KEY: &str = "pending_conversions";
+const PENDING_DEACTIVATION_KEY: &str = "pending_deactivation";
 const PENDING_LIGHTNING_SENDS_KEY: &str = "pending_lightning_sends";
 
 /// Wrapper stored in the cache that carries context about whether the value
@@ -928,6 +929,34 @@ impl ObjectCacheRepository {
     pub(crate) async fn delete_pending_conversions(&self) -> Result<(), StorageError> {
         self.storage
             .delete_cached_item(PENDING_CONVERSIONS_KEY.to_string())
+            .await
+    }
+
+    /// The token a deactivation conversion still has to move back to bitcoin.
+    /// Set when Stable Balance is switched off, cleared when the conversion
+    /// succeeds, so a conversion that keeps failing (or a restart in between)
+    /// doesn't strand the holding behind a toggle that reads "off".
+    pub(crate) async fn save_pending_deactivation(
+        &self,
+        token_identifier: &str,
+    ) -> Result<(), StorageError> {
+        self.storage
+            .set_cached_item(
+                PENDING_DEACTIVATION_KEY.to_string(),
+                token_identifier.to_string(),
+            )
+            .await
+    }
+
+    pub(crate) async fn fetch_pending_deactivation(&self) -> Result<Option<String>, StorageError> {
+        self.storage
+            .get_cached_item(PENDING_DEACTIVATION_KEY.to_string())
+            .await
+    }
+
+    pub(crate) async fn delete_pending_deactivation(&self) -> Result<(), StorageError> {
+        self.storage
+            .delete_cached_item(PENDING_DEACTIVATION_KEY.to_string())
             .await
     }
 

--- a/crates/breez-sdk/core/src/stable_balance/queue.rs
+++ b/crates/breez-sdk/core/src/stable_balance/queue.rs
@@ -4,6 +4,7 @@
 //! through a single queue to eliminate race conditions between the paths.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use platform_utils::tokio;
 use serde::{Deserialize, Serialize};
@@ -43,6 +44,25 @@ pub(crate) enum PendingState {
 /// How long to keep a deferred task before marking it as failed (seconds).
 const DEFERRED_TASK_TIMEOUT_SECS: u64 = 120;
 
+/// Backoff between attempts of a failed auto-convert or deactivation
+/// conversion: 30 s, doubling to a cap of one hour. Without it a failed swap
+/// is refunded by the AMM as an incoming sats transfer, that receive re-queues
+/// the same conversion, and the loop runs every few seconds for as long as the
+/// wallet is open (observed at 127 attempts in 13 minutes on mainnet when the
+/// selected pool had no liquidity), leaving a pair of transfers in the history
+/// each time. The cap keeps a long outage self-healing: once liquidity is back
+/// the next hourly attempt goes through.
+const CONVERSION_BACKOFF_BASE_SECS: u64 = 30;
+const CONVERSION_BACKOFF_MAX_SECS: u64 = 3_600;
+
+/// Seconds to wait before the `consecutive_failures`-th retry.
+fn backoff_secs(consecutive_failures: u32) -> u64 {
+    let doublings = consecutive_failures.saturating_sub(1).min(20);
+    CONVERSION_BACKOFF_BASE_SECS
+        .saturating_mul(1_u64 << doublings)
+        .min(CONVERSION_BACKOFF_MAX_SECS)
+}
+
 /// A pending per-receive conversion with its processing state.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PendingConversion {
@@ -68,6 +88,18 @@ struct ConversionQueueState {
     per_receive: Vec<PendingConversion>,
     /// A pending non-per-receive task (auto-convert or deactivation).
     pending_task: Option<ConversionTask>,
+    /// How many times `pending_task` has failed in a row, and the unix time
+    /// before which it must not run again. Both reset when the task completes
+    /// or is replaced.
+    task_failures: u32,
+    task_not_before: Option<u64>,
+}
+
+impl ConversionQueueState {
+    fn reset_backoff(&mut self) {
+        self.task_failures = 0;
+        self.task_not_before = None;
+    }
 }
 
 /// A priority queue that serializes conversion tasks.
@@ -87,6 +119,8 @@ impl ConversionQueue {
             state: Mutex::new(ConversionQueueState {
                 per_receive: Vec::new(),
                 pending_task: None,
+                task_failures: 0,
+                task_not_before: None,
             }),
             notify: Arc::new(Notify::new()),
             storage,
@@ -118,11 +152,13 @@ impl ConversionQueue {
         }
     }
 
-    /// Queue a deactivation conversion task. Overrides any pending auto-convert.
+    /// Queue a deactivation conversion task. Overrides any pending auto-convert
+    /// and any backoff it was under: this is the user acting, so it runs now.
     pub async fn push_deactivation(&self, token_identifier: String) {
         let mut state = self.state.lock().await;
         debug!("Queuing deactivation conversion for token {token_identifier}");
         state.pending_task = Some(ConversionTask::Deactivation(token_identifier));
+        state.reset_backoff();
         self.notify.notify_one();
     }
 
@@ -151,6 +187,7 @@ impl ConversionQueue {
         let mut state = self.state.lock().await;
         let cleared: Vec<String> = state.per_receive.drain(..).map(|p| p.payment_id).collect();
         state.pending_task = None;
+        state.reset_backoff();
         self.persist_pending(&state).await;
         cleared
     }
@@ -183,10 +220,49 @@ impl ConversionQueue {
             // Only run auto-convert/deactivation when no per-receive tasks exist (including
             // deferred). Deferred tasks may still be resolved by a PaymentSucceeded event
             // and need those sats.
-            state.pending_task.clone()
+            //
+            // A task under backoff stays queued but is not due yet; the worker
+            // sleeps until `retry_delay` says it is.
+            let due = state
+                .task_not_before
+                .is_none_or(|not_before| now_secs() >= not_before);
+            if due {
+                state.pending_task.clone()
+            } else {
+                None
+            }
         } else {
             None
         }
+    }
+
+    /// How long until the pending auto-convert / deactivation task may run
+    /// again, when it is under backoff. `None` when nothing is waiting on time.
+    pub async fn retry_delay(&self) -> Option<Duration> {
+        let state = self.state.lock().await;
+        let not_before = state.task_not_before?;
+        state.pending_task.as_ref()?;
+        Some(Duration::from_secs(not_before.saturating_sub(now_secs())))
+    }
+
+    /// Keep the pending task queued after a failure and schedule its next
+    /// attempt. Returns the delay in seconds and the failure count so far.
+    pub async fn retry_later(&self, task: &ConversionTask) -> (u64, u32) {
+        let mut state = self.state.lock().await;
+        // The task may have been replaced while it ran (a deactivation
+        // arriving during an auto-convert); only back off the task that failed.
+        let same_task = match (&state.pending_task, task) {
+            (Some(ConversionTask::AutoConvert), ConversionTask::AutoConvert) => true,
+            (Some(ConversionTask::Deactivation(a)), ConversionTask::Deactivation(b)) => a == b,
+            _ => false,
+        };
+        if !same_task {
+            return (0, 0);
+        }
+        state.task_failures = state.task_failures.saturating_add(1);
+        let delay = backoff_secs(state.task_failures);
+        state.task_not_before = Some(now_secs().saturating_add(delay));
+        (delay, state.task_failures)
     }
 
     /// Remove a completed task from the queue.
@@ -200,6 +276,7 @@ impl ConversionQueue {
             }
             ConversionTask::AutoConvert | ConversionTask::Deactivation(_) => {
                 state.pending_task = None;
+                state.reset_backoff();
             }
         }
     }
@@ -308,64 +385,14 @@ impl StableBalance {
                     // Drain all available tasks
                     while let Some(task) = stable_balance.core.queue.next_task().await {
                         debug!("Conversion worker: processing task {task:?}");
-                        match &task {
-                            ConversionTask::PerReceive(payment_id) => {
-                                match stable_balance
-                                    .process_per_receive(payment_id.clone())
-                                    .await
-                                {
-                                    PerReceiveResult::Done { converted } => {
-                                        debug!("Conversion worker: completed task {task:?} (converted={converted})");
-                                        stable_balance.core.queue.complete_task(&task).await;
-                                        if converted {
-                                            // Clear any pending auto-convert — the local balance
-                                            // is stale until sync completes. The next Synced event
-                                            // will re-queue auto-convert if there's still excess.
-                                            stable_balance.core.queue.clear_pending_auto_convert().await;
-                                            stable_balance.emit_conversion_completed().await;
-                                        }
-                                    }
-                                    PerReceiveResult::Retry => {
-                                        // Mark as deferred so next_task skips it until
-                                        // resolved by a PaymentSucceeded event or timeout
-                                        debug!("Conversion worker: deferring task {task:?}");
-                                        stable_balance.core.queue.defer_task(payment_id).await;
-                                    }
-                                }
-                            }
-                            ConversionTask::AutoConvert => {
-                                let converted = match stable_balance.auto_convert().await {
-                                    Ok(converted) => converted,
-                                    Err(e) => {
-                                        warn!("Auto-conversion failed: {e:?}");
-                                        false
-                                    }
-                                };
-                                debug!("Conversion worker: auto-convert done (converted={converted})");
-                                stable_balance.core.queue.complete_task(&task).await;
-                                if converted {
-                                    stable_balance.emit_conversion_completed().await;
-                                }
-                            }
-                            ConversionTask::Deactivation(token_id) => {
-                                let converted =
-                                    match stable_balance.deactivation_convert(token_id).await {
-                                        Ok(converted) => converted,
-                                        Err(e) => {
-                                            warn!("Deactivation conversion failed: {e:?}");
-                                            false
-                                        }
-                                    };
-                                debug!("Conversion worker: completed task {task:?} (converted={converted})");
-                                stable_balance.core.queue.complete_task(&task).await;
-                                if converted {
-                                    stable_balance.emit_conversion_completed().await;
-                                }
-                            }
-                        }
+                        stable_balance.process_task(&task).await;
                     }
 
-                    debug!("Conversion worker: queue drained, waiting for new tasks");
+                    // A task under backoff is not returned by `next_task` until
+                    // it is due, and nothing notifies when the clock runs out —
+                    // so sleep for exactly that long alongside the usual wakeups.
+                    let retry_delay = stable_balance.core.queue.retry_delay().await;
+                    debug!("Conversion worker: queue drained, waiting for new tasks (retry in {retry_delay:?})");
                     tokio::select! {
                         _ = shutdown_receiver.changed() => {
                             info!("Conversion worker shutdown");
@@ -374,11 +401,78 @@ impl StableBalance {
                         () = notified => {
                             debug!("Conversion worker: woken by notify");
                         }
+                        () = async {
+                            match retry_delay {
+                                Some(delay) => tokio::time::sleep(delay).await,
+                                None => std::future::pending().await,
+                            }
+                        } => {
+                            debug!("Conversion worker: backoff elapsed");
+                        }
                     }
                 }
             }
             .instrument(span),
         );
+    }
+
+    /// Run one queued task to completion or to its next retry.
+    async fn process_task(&self, task: &ConversionTask) {
+        match task {
+            ConversionTask::PerReceive(payment_id) => {
+                match self.process_per_receive(payment_id.clone()).await {
+                    PerReceiveResult::Done { converted } => {
+                        debug!(
+                            "Conversion worker: completed task {task:?} (converted={converted})"
+                        );
+                        self.core.queue.complete_task(task).await;
+                        if converted {
+                            // Clear any pending auto-convert — the local balance
+                            // is stale until sync completes. The next Synced event
+                            // will re-queue auto-convert if there's still excess.
+                            self.core.queue.clear_pending_auto_convert().await;
+                            self.emit_conversion_completed().await;
+                        }
+                    }
+                    PerReceiveResult::Retry => {
+                        // Mark as deferred so next_task skips it until
+                        // resolved by a PaymentSucceeded event or timeout
+                        debug!("Conversion worker: deferring task {task:?}");
+                        self.core.queue.defer_task(payment_id).await;
+                    }
+                }
+            }
+            ConversionTask::AutoConvert => match self.auto_convert().await {
+                Ok(converted) => {
+                    debug!("Conversion worker: auto-convert done (converted={converted})");
+                    self.core.queue.complete_task(task).await;
+                    if converted {
+                        self.emit_conversion_completed().await;
+                    }
+                }
+                Err(e) => {
+                    self.schedule_retry(task, "Auto-convert", format!("{e:?}"))
+                        .await;
+                }
+            },
+            ConversionTask::Deactivation(token_id) => {
+                match self.deactivation_convert(token_id).await {
+                    Ok(converted) => {
+                        debug!(
+                            "Conversion worker: completed task {task:?} (converted={converted})"
+                        );
+                        self.core.queue.complete_task(task).await;
+                        if converted {
+                            self.emit_conversion_completed().await;
+                        }
+                    }
+                    Err(e) => {
+                        self.schedule_retry(task, "Deactivation", format!("{e:?}"))
+                            .await;
+                    }
+                }
+            }
+        }
     }
 
     /// Process a per-receive conversion task.
@@ -424,6 +518,16 @@ impl StableBalance {
         }
     }
 
+    /// A failed auto-convert or deactivation: keep it queued under backoff. The
+    /// AMM refunds a failed swap, so balances are unchanged.
+    async fn schedule_retry(&self, task: &ConversionTask, conversion: &str, error: String) {
+        let (retry_in_secs, failures) = self.core.queue.retry_later(task).await;
+        warn!(
+            "{conversion} conversion failed ({failures} in a row), retrying in \
+             {retry_in_secs}s: {error}"
+        );
+    }
+
     /// Recover pending per-receive conversions from a previous session.
     ///
     /// Loads persisted pending conversions and restores them into the queue.
@@ -457,5 +561,134 @@ impl StableBalance {
                 warn!("Failed to load pending conversions for recovery: {e:?}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod backoff_tests {
+    use super::*;
+
+    #[test]
+    fn backoff_doubles_from_thirty_seconds_and_caps_at_an_hour() {
+        assert_eq!(backoff_secs(1), 30);
+        assert_eq!(backoff_secs(2), 60);
+        assert_eq!(backoff_secs(3), 120);
+        assert_eq!(backoff_secs(7), 1_920);
+        assert_eq!(backoff_secs(8), 3_600);
+        assert_eq!(backoff_secs(9), 3_600);
+        // No overflow however long the outage.
+        assert_eq!(backoff_secs(u32::MAX), 3_600);
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod queue_tests {
+    use super::*;
+    use crate::persist::sqlite::SqliteStorage;
+    use std::path::PathBuf;
+
+    fn create_temp_dir(name: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!("breez-test-{}-{}", name, uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn queue(name: &str) -> (ConversionQueue, Arc<dyn Storage>) {
+        let storage: Arc<dyn Storage> =
+            Arc::new(SqliteStorage::new(&create_temp_dir(name)).unwrap());
+        (ConversionQueue::new(Arc::clone(&storage)), storage)
+    }
+
+    #[tokio::test]
+    async fn a_failed_auto_convert_stays_queued_but_is_not_due_until_the_backoff_elapses() {
+        let (queue, _storage) = queue("auto_convert_backoff");
+        queue.push_auto_convert().await;
+        assert!(matches!(
+            queue.next_task().await,
+            Some(ConversionTask::AutoConvert)
+        ));
+        assert_eq!(queue.retry_delay().await, None);
+
+        let (delay, failures) = queue.retry_later(&ConversionTask::AutoConvert).await;
+        assert_eq!((delay, failures), (30, 1));
+        // Still queued, so a fresh trigger collapses into it rather than
+        // starting a parallel attempt...
+        queue.push_auto_convert().await;
+        // ...but it is not handed out until it is due.
+        assert!(queue.next_task().await.is_none());
+        let remaining = queue.retry_delay().await.expect("under backoff");
+        assert!(remaining <= Duration::from_secs(30) && remaining > Duration::from_secs(25));
+
+        // Each further failure doubles the wait.
+        assert_eq!(
+            queue.retry_later(&ConversionTask::AutoConvert).await,
+            (60, 2)
+        );
+        assert_eq!(
+            queue.retry_later(&ConversionTask::AutoConvert).await,
+            (120, 3)
+        );
+
+        // Success clears everything.
+        queue.complete_task(&ConversionTask::AutoConvert).await;
+        assert_eq!(queue.retry_delay().await, None);
+        queue.push_auto_convert().await;
+        assert!(queue.next_task().await.is_some());
+        assert_eq!(
+            queue.retry_later(&ConversionTask::AutoConvert).await,
+            (30, 1)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_deactivation_runs_now_even_while_an_auto_convert_is_backing_off() {
+        let (queue, _storage) = queue("deactivation_now");
+        let token = "btkn1usdb".to_string();
+
+        // An auto-convert under backoff does not delay the user's deactivation.
+        queue.push_auto_convert().await;
+        let _ = queue.retry_later(&ConversionTask::AutoConvert).await;
+        queue.push_deactivation(token.clone()).await;
+        assert!(matches!(
+            queue.next_task().await,
+            Some(ConversionTask::Deactivation(ref t)) if *t == token
+        ));
+        assert_eq!(queue.retry_delay().await, None);
+
+        // A failure keeps it queued and backed off like an auto-convert.
+        let task = ConversionTask::Deactivation(token.clone());
+        assert_eq!(queue.retry_later(&task).await, (30, 1));
+        assert!(queue.next_task().await.is_none());
+        queue.complete_task(&task).await;
+        assert_eq!(queue.retry_delay().await, None);
+    }
+
+    #[tokio::test]
+    async fn clearing_the_queue_drops_the_backoff() {
+        let (queue, _storage) = queue("backoff_cleared");
+        queue.push_deactivation("btkn1usdb".to_string()).await;
+        let _ = queue
+            .retry_later(&ConversionTask::Deactivation("btkn1usdb".to_string()))
+            .await;
+
+        queue.clear_queue().await;
+        assert_eq!(queue.retry_delay().await, None);
+        assert!(queue.next_task().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_failure_reported_for_a_replaced_task_does_not_back_off_the_new_one() {
+        let (queue, _storage) = queue("replaced_task");
+        queue.push_auto_convert().await;
+        // The deactivation arrived while the auto-convert was running...
+        queue.push_deactivation("btkn1usdb".to_string()).await;
+        // ...and the auto-convert then failed.
+        assert_eq!(
+            queue.retry_later(&ConversionTask::AutoConvert).await,
+            (0, 0)
+        );
+        assert!(queue.next_task().await.is_some(), "deactivation is due now");
+        assert_eq!(queue.retry_delay().await, None);
     }
 }

--- a/crates/breez-sdk/core/src/stable_balance/queue.rs
+++ b/crates/breez-sdk/core/src/stable_balance/queue.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, Notify, watch};
 use tracing::{Instrument, debug, info, warn};
 
+use crate::events::{SdkEvent, StableBalanceConversionKind};
 use crate::models::ConversionStatus;
 use crate::persist::{ObjectCacheRepository, PaymentMetadata, Storage};
 use crate::utils::time::now_secs;
@@ -154,9 +155,14 @@ impl ConversionQueue {
 
     /// Queue a deactivation conversion task. Overrides any pending auto-convert
     /// and any backoff it was under: this is the user acting, so it runs now.
+    /// Persisted so a conversion that has not yet succeeded survives a restart.
     pub async fn push_deactivation(&self, token_identifier: String) {
         let mut state = self.state.lock().await;
         debug!("Queuing deactivation conversion for token {token_identifier}");
+        let cache = ObjectCacheRepository::new(self.storage.clone());
+        if let Err(e) = cache.save_pending_deactivation(&token_identifier).await {
+            warn!("Failed to persist pending deactivation: {e:?}");
+        }
         state.pending_task = Some(ConversionTask::Deactivation(token_identifier));
         state.reset_backoff();
         self.notify.notify_one();
@@ -186,6 +192,9 @@ impl ConversionQueue {
     pub async fn clear_queue(&self) -> Vec<String> {
         let mut state = self.state.lock().await;
         let cleared: Vec<String> = state.per_receive.drain(..).map(|p| p.payment_id).collect();
+        if matches!(state.pending_task, Some(ConversionTask::Deactivation(_))) {
+            self.forget_pending_deactivation().await;
+        }
         state.pending_task = None;
         state.reset_backoff();
         self.persist_pending(&state).await;
@@ -265,6 +274,13 @@ impl ConversionQueue {
         (delay, state.task_failures)
     }
 
+    async fn forget_pending_deactivation(&self) {
+        let cache = ObjectCacheRepository::new(self.storage.clone());
+        if let Err(e) = cache.delete_pending_deactivation().await {
+            warn!("Failed to clear persisted pending deactivation: {e:?}");
+        }
+    }
+
     /// Remove a completed task from the queue.
     /// Persists the updated pending list for per-receive tasks.
     pub async fn complete_task(&self, task: &ConversionTask) {
@@ -274,9 +290,14 @@ impl ConversionQueue {
                 state.per_receive.retain(|p| p.payment_id != *id);
                 self.persist_pending(&state).await;
             }
-            ConversionTask::AutoConvert | ConversionTask::Deactivation(_) => {
+            ConversionTask::AutoConvert => {
                 state.pending_task = None;
                 state.reset_backoff();
+            }
+            ConversionTask::Deactivation(_) => {
+                state.pending_task = None;
+                state.reset_backoff();
+                self.forget_pending_deactivation().await;
             }
         }
     }
@@ -451,8 +472,12 @@ impl StableBalance {
                     }
                 }
                 Err(e) => {
-                    self.schedule_retry(task, "Auto-convert", format!("{e:?}"))
-                        .await;
+                    self.schedule_retry(
+                        task,
+                        StableBalanceConversionKind::AutoConvert,
+                        format!("{e:?}"),
+                    )
+                    .await;
                 }
             },
             ConversionTask::Deactivation(token_id) => {
@@ -467,8 +492,12 @@ impl StableBalance {
                         }
                     }
                     Err(e) => {
-                        self.schedule_retry(task, "Deactivation", format!("{e:?}"))
-                            .await;
+                        self.schedule_retry(
+                            task,
+                            StableBalanceConversionKind::Deactivation,
+                            format!("{e:?}"),
+                        )
+                        .await;
                     }
                 }
             }
@@ -518,23 +547,46 @@ impl StableBalance {
         }
     }
 
-    /// A failed auto-convert or deactivation: keep it queued under backoff. The
-    /// AMM refunds a failed swap, so balances are unchanged.
-    async fn schedule_retry(&self, task: &ConversionTask, conversion: &str, error: String) {
+    /// A failed auto-convert or deactivation: keep it queued under backoff and
+    /// tell the integrator. The AMM refunds a failed swap, so balances are
+    /// unchanged; what the user sees without this is a toggle that reads "off"
+    /// over a token holding that never moved, or a sweep that silently isn't.
+    async fn schedule_retry(
+        &self,
+        task: &ConversionTask,
+        conversion: StableBalanceConversionKind,
+        error: String,
+    ) {
         let (retry_in_secs, failures) = self.core.queue.retry_later(task).await;
         warn!(
-            "{conversion} conversion failed ({failures} in a row), retrying in \
+            "{conversion:?} conversion failed ({failures} in a row), retrying in \
              {retry_in_secs}s: {error}"
         );
+        self.event_emitter
+            .emit(&SdkEvent::StableBalanceConversionFailed {
+                conversion,
+                error,
+                retry_in_secs,
+            })
+            .await;
     }
 
     /// Recover pending per-receive conversions from a previous session.
     ///
     /// Loads persisted pending conversions and restores them into the queue.
     /// Stale deferred tasks are cleaned up by `clear_expired_tasks()` on the
-    /// first `Synced` event.
+    /// first `Synced` event. A deactivation that had not yet moved the token
+    /// back to bitcoin is re-queued too.
     async fn recover_pending_conversions(&self) {
         let cache = ObjectCacheRepository::new(self.core.storage.clone());
+        match cache.fetch_pending_deactivation().await {
+            Ok(Some(token_identifier)) => {
+                info!("Recovering pending deactivation conversion for {token_identifier}");
+                self.core.queue.push_deactivation(token_identifier).await;
+            }
+            Ok(None) => {}
+            Err(e) => warn!("Failed to load pending deactivation for recovery: {e:?}"),
+        }
         match cache.fetch_pending_conversions().await {
             Ok(Some(pending)) => {
                 if !pending.is_empty() {
@@ -642,8 +694,9 @@ mod queue_tests {
     }
 
     #[tokio::test]
-    async fn a_deactivation_runs_now_even_while_an_auto_convert_is_backing_off() {
-        let (queue, _storage) = queue("deactivation_now");
+    async fn a_deactivation_runs_now_and_is_persisted_until_it_succeeds() {
+        let (queue, storage) = queue("deactivation_persist");
+        let cache = ObjectCacheRepository::new(Arc::clone(&storage));
         let token = "btkn1usdb".to_string();
 
         // An auto-convert under backoff does not delay the user's deactivation.
@@ -655,24 +708,39 @@ mod queue_tests {
             Some(ConversionTask::Deactivation(ref t)) if *t == token
         ));
         assert_eq!(queue.retry_delay().await, None);
+        assert_eq!(
+            cache.fetch_pending_deactivation().await.unwrap().as_deref(),
+            Some("btkn1usdb")
+        );
 
-        // A failure keeps it queued and backed off like an auto-convert.
+        // A failure keeps it queued, backed off, and still persisted.
         let task = ConversionTask::Deactivation(token.clone());
         assert_eq!(queue.retry_later(&task).await, (30, 1));
         assert!(queue.next_task().await.is_none());
+        assert_eq!(
+            cache.fetch_pending_deactivation().await.unwrap().as_deref(),
+            Some("btkn1usdb")
+        );
+
+        // Success forgets it.
         queue.complete_task(&task).await;
+        assert_eq!(cache.fetch_pending_deactivation().await.unwrap(), None);
         assert_eq!(queue.retry_delay().await, None);
     }
 
     #[tokio::test]
-    async fn clearing_the_queue_drops_the_backoff() {
-        let (queue, _storage) = queue("backoff_cleared");
+    async fn clearing_the_queue_drops_the_persisted_deactivation_and_backoff() {
+        // The user re-activates a token while its deactivation is still being
+        // retried: the holding is wanted as the token again, so stop trying.
+        let (queue, storage) = queue("deactivation_cleared");
+        let cache = ObjectCacheRepository::new(Arc::clone(&storage));
         queue.push_deactivation("btkn1usdb".to_string()).await;
         let _ = queue
             .retry_later(&ConversionTask::Deactivation("btkn1usdb".to_string()))
             .await;
 
         queue.clear_queue().await;
+        assert_eq!(cache.fetch_pending_deactivation().await.unwrap(), None);
         assert_eq!(queue.retry_delay().await, None);
         assert!(queue.next_task().await.is_none());
     }

--- a/crates/breez-sdk/wasm/src/models/mod.rs
+++ b/crates/breez-sdk/wasm/src/models/mod.rs
@@ -87,6 +87,17 @@ pub enum SdkEvent {
         new_deposits: Vec<DepositInfo>,
     },
     UnilateralExitStateChanged,
+    StableBalanceConversionFailed {
+        conversion: StableBalanceConversionKind,
+        error: String,
+        retry_in_secs: u64,
+    },
+}
+
+#[macros::extern_wasm_bindgen(breez_sdk_spark::StableBalanceConversionKind)]
+pub enum StableBalanceConversionKind {
+    AutoConvert,
+    Deactivation,
 }
 
 #[macros::extern_wasm_bindgen(breez_sdk_spark::AutoOptimizationEvent)]

--- a/docs/breez-sdk/snippets/rust/src/getting_started.rs
+++ b/docs/breez-sdk/snippets/rust/src/getting_started.rs
@@ -103,6 +103,15 @@ impl EventListener for SdkEventListener {
                 // The unilateral exit state changed, so a previously exported
                 // one is now out of date. Export it again.
             }
+            SdkEvent::StableBalanceConversionFailed {
+                conversion,
+                error,
+                retry_in_secs,
+            } => {
+                // A Stable Balance sweep or deactivation conversion failed and
+                // will be retried after `retry_in_secs`. Balances are unchanged.
+                // Deactivate Stable Balance here to stop retrying instead.
+            }
         }
     }
 }

--- a/packages/flutter/rust/src/events.rs
+++ b/packages/flutter/rust/src/events.rs
@@ -1,6 +1,6 @@
 use crate::frb_generated::StreamSink;
 use breez_sdk_spark::{DepositInfo, EventListener, LightningAddressInfo, Payment};
-pub use breez_sdk_spark::{AutoOptimizationEvent, SdkEvent};
+pub use breez_sdk_spark::{AutoOptimizationEvent, SdkEvent, StableBalanceConversionKind};
 use flutter_rust_bridge::frb;
 
 #[frb(mirror(SdkEvent))]
@@ -31,6 +31,17 @@ pub enum _SdkEvent {
         new_deposits: Vec<DepositInfo>,
     },
     UnilateralExitStateChanged,
+    StableBalanceConversionFailed {
+        conversion: StableBalanceConversionKind,
+        error: String,
+        retry_in_secs: u64,
+    },
+}
+
+#[frb(mirror(StableBalanceConversionKind))]
+pub enum _StableBalanceConversionKind {
+    AutoConvert,
+    Deactivation,
 }
 
 #[frb(mirror(AutoOptimizationEvent))]


### PR DESCRIPTION
**Stacked on #1115** — the first commit here is that PR; only the second (`stable_balance: report failed conversions; persist a pending deactivation`) is new. Rebases to one commit once #1115 lands.

Two things an integrator could not see:

- **A failed sweep or deactivation conversion was only a WARN log line.** We currently detect them by scraping the log through a `tracing` layer, which is not a contract. Emit `SdkEvent::StableBalanceConversionFailed { conversion: AutoConvert | Deactivation, error, retry_in_secs }` each time one fails, so an app can show the user why the balance isn't moving, or deactivate Stable Balance rather than wait out the backoff. Balances are unchanged when it fires: the AMM refunds a failed swap. Mirrored in the wasm and flutter bindings and the Rust snippet.

- **A `Deactivation` task lived only in memory.** The active label is cleared the moment the user switches Stable Balance off, so after a failed conversion and a restart the wallet reported "off" with the whole token holding still in place and nothing left to move it. (That is the state one of our users was in: ~$15k USDB behind an "off" toggle, after `Deactivation conversion failed: … Pool has no liquidity`.) Persist the token to convert in the object cache when the deactivation is queued, clear it when the conversion succeeds — or when the user re-activates a token, which makes the holding wanted again — and re-queue it when the worker starts.

Tests cover persistence across queue/complete/clear and that a failure keeps the persisted entry.

**Verified locally**: `cargo fmt`, `cargo clippy -p breez-sdk-spark --features sqlite --all-targets -- -D warnings`, `cargo test -p breez-sdk-spark --features sqlite`, and the Rust doc snippet compiles. I could not build the wasm target on this machine (no rustup); the wasm mirror follows the existing `AutoOptimizationEvent` pattern exactly, so `xtask wasm-clippy` in CI is the check for that.
